### PR TITLE
fix: upgrade git in nix devshell to satisfy jj >= 2.41.0 requirement

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
       in {
         devShells.default = pkgs.mkShell {
           packages = [
-            pkgs.git
+            pkgs-unstable.git
             pkgs.sqlite
             pkgs.pkg-config
             pkgs.openssl


### PR DESCRIPTION
## Summary
- Switches `pkgs.git` to `pkgs-unstable.git` in `flake.nix` so the devshell provides git ≥ 2.41.0
- Fixes `jj git fetch` failing with: *Git does not recognize required option: porcelain*

## Test plan
- [x] Enter the devshell: `nix develop --command zsh`
- [x] Verify `git --version` reports ≥ 2.41.0
- [x] Verify `jj git fetch` succeeds without the porcelain error

🤖 Generated with [Claude Code](https://claude.com/claude-code)