### PR TITLE
feat: setting library paths

### DIFF
--- a/mobile/src/main.rs
+++ b/mobile/src/main.rs
@@ -102,6 +102,20 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 }
 
 .bottom-nav a.active { color: #22d3ee; }
+
+.settings-form { display: flex; flex-direction: column; gap: 1.25rem; margin-top: 1rem; }
+.settings-field { display: flex; flex-direction: column; gap: 0.4rem; }
+.settings-label { font-size: 0.875rem; font-weight: 500; color: #cbd5e1; }
+.settings-input {
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(100, 116, 139, 0.4);
+  border-radius: 8px;
+  color: #e5e7eb;
+  font-size: 0.95rem;
+  padding: 0.55rem 0.75rem;
+  width: 100%;
+}
+.success-msg { color: #34d399; font-size: 0.85rem; margin-top: 0.75rem; }
 "#;
 
 #[component]

--- a/mobile/src/main.rs
+++ b/mobile/src/main.rs
@@ -116,6 +116,20 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   width: 100%;
 }
 .success-msg { color: #34d399; font-size: 0.85rem; margin-top: 0.75rem; }
+.library-card { margin-top: 1rem; }
+.library-title { font-size: 1rem; font-weight: 600; margin-bottom: 0.75rem; color: #cbd5e1; }
+.library-path { font-size: 0.75rem; color: #64748b; font-family: monospace; margin-bottom: 0.4rem; }
+.library-count { font-size: 0.85rem; color: #94a3b8; margin-bottom: 0.5rem; }
+.library-empty { color: #64748b; font-size: 0.875rem; }
+.library-file-list { display: flex; flex-direction: column; gap: 0.25rem; }
+.library-file {
+  font-size: 0.85rem;
+  font-family: monospace;
+  padding: 0.3rem 0.5rem;
+  background: rgba(30, 41, 59, 0.5);
+  border-radius: 6px;
+  color: #e2e8f0;
+}
 "#;
 
 #[component]

--- a/mobile/src/pages/settings.rs
+++ b/mobile/src/pages/settings.rs
@@ -2,18 +2,35 @@ use dioxus::prelude::*;
 
 use crate::ServerUrl;
 
+#[derive(Clone, Debug, Default, PartialEq)]
+struct LibrarySection {
+    path: Option<String>,
+    files: Vec<String>,
+    error: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+struct LibraryContents {
+    ebooks: LibrarySection,
+    audiobooks: LibrarySection,
+}
+
 #[component]
 pub fn SettingsPage() -> Element {
     let server_url = use_context::<ServerUrl>();
-    let server_url_for_effect = server_url.clone();
+    let server_url_for_settings = server_url.clone();
+    let server_url_for_library = server_url.clone();
 
     let mut ebook_path = use_signal(String::new);
     let mut audiobook_path = use_signal(String::new);
     let mut status = use_signal(|| None::<String>);
     let mut status_is_error = use_signal(|| false);
+    let mut library = use_signal(LibraryContents::default);
+    // Incrementing this triggers a library refresh.
+    let mut library_refresh = use_signal(|| 0u32);
 
     use_effect(move || {
-        let url = server_url_for_effect.0.clone();
+        let url = server_url_for_settings.0.clone();
         spawn(async move {
             match fetch_settings(&url).await {
                 Ok((ebook, audiobook)) => {
@@ -24,6 +41,16 @@ pub fn SettingsPage() -> Element {
                     status.set(Some(e));
                     status_is_error.set(true);
                 }
+            }
+        });
+    });
+
+    use_effect(move || {
+        let _ = library_refresh();
+        let url = server_url_for_library.0.clone();
+        spawn(async move {
+            if let Ok(contents) = fetch_library(&url).await {
+                library.set(contents);
             }
         });
     });
@@ -69,6 +96,7 @@ pub fn SettingsPage() -> Element {
                                 Ok(()) => {
                                     status.set(Some("Settings saved.".to_string()));
                                     status_is_error.set(false);
+                                    library_refresh.set(library_refresh() + 1);
                                 }
                                 Err(e) => {
                                     status.set(Some(e));
@@ -88,18 +116,50 @@ pub fn SettingsPage() -> Element {
                 }
             }
         }
+
+        LibrarySectionView {
+            title: "Ebook Library",
+            section: library().ebooks,
+        }
+        LibrarySectionView {
+            title: "Audiobook Library",
+            section: library().audiobooks,
+        }
+    }
+}
+
+#[component]
+fn LibrarySectionView(title: String, section: LibrarySection) -> Element {
+    rsx! {
+        div { class: "card library-card",
+            h2 { class: "library-title", "{title}" }
+
+            if section.path.is_none() {
+                p { class: "library-empty", "No path configured." }
+            } else if let Some(err) = &section.error {
+                p { class: "error", "⚠ {err}" }
+            } else if section.files.is_empty() {
+                p { class: "library-empty",
+                    "No files found in "
+                    span { class: "library-path", "{section.path.as_deref().unwrap_or_default()}" }
+                }
+            } else {
+                p { class: "library-path", "{section.path.as_deref().unwrap_or_default()}" }
+                p { class: "library-count", "{section.files.len()} file(s)" }
+                div { class: "library-file-list",
+                    for file in &section.files {
+                        p { class: "library-file", "{file}" }
+                    }
+                }
+            }
+        }
     }
 }
 
 async fn fetch_settings(server_url: &str) -> Result<(String, String), String> {
     let url = format!("{server_url}/api/settings");
     eprintln!("[mobile] GET {url}");
-    let response = reqwest::get(&url).await.map_err(|e| {
-        let msg = format!("{e:#}");
-        eprintln!("[mobile] GET {url} failed: {msg}");
-        msg
-    })?;
-    eprintln!("[mobile] GET {url} -> {}", response.status());
+    let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
     let payload: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
     let ebook = payload["ebook_library_path"]
         .as_str()
@@ -110,6 +170,32 @@ async fn fetch_settings(server_url: &str) -> Result<(String, String), String> {
         .unwrap_or("")
         .to_string();
     Ok((ebook, audiobook))
+}
+
+async fn fetch_library(server_url: &str) -> Result<LibraryContents, String> {
+    let url = format!("{server_url}/api/library");
+    eprintln!("[mobile] GET {url}");
+    let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
+    let payload: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+    Ok(LibraryContents {
+        ebooks: parse_section(&payload["ebooks"]),
+        audiobooks: parse_section(&payload["audiobooks"]),
+    })
+}
+
+fn parse_section(v: &serde_json::Value) -> LibrarySection {
+    LibrarySection {
+        path: v["path"].as_str().map(str::to_string),
+        files: v["files"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|f| f.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        error: v["error"].as_str().map(str::to_string),
+    }
 }
 
 async fn save_settings(
@@ -129,12 +215,7 @@ async fn save_settings(
         .json(&body)
         .send()
         .await
-        .map_err(|e| {
-            let msg = format!("{e:#}");
-            eprintln!("[mobile] POST {url} failed: {msg}");
-            msg
-        })?;
-    eprintln!("[mobile] POST {url} -> {}", response.status());
+        .map_err(|e| format!("{e:#}"))?;
     if response.status().is_success() {
         Ok(())
     } else {

--- a/mobile/src/pages/settings.rs
+++ b/mobile/src/pages/settings.rs
@@ -5,11 +5,139 @@ use crate::ServerUrl;
 #[component]
 pub fn SettingsPage() -> Element {
     let server_url = use_context::<ServerUrl>();
+    let server_url_for_effect = server_url.clone();
+
+    let mut ebook_path = use_signal(String::new);
+    let mut audiobook_path = use_signal(String::new);
+    let mut status = use_signal(|| None::<String>);
+    let mut status_is_error = use_signal(|| false);
+
+    use_effect(move || {
+        let url = server_url_for_effect.0.clone();
+        spawn(async move {
+            match fetch_settings(&url).await {
+                Ok((ebook, audiobook)) => {
+                    ebook_path.set(ebook);
+                    audiobook_path.set(audiobook);
+                }
+                Err(e) => {
+                    status.set(Some(e));
+                    status_is_error.set(true);
+                }
+            }
+        });
+    });
 
     rsx! {
         div { class: "card",
             h1 { "Settings" }
             p { class: "subtitle", "Connected to: {server_url.0}" }
+
+            div { class: "settings-form",
+                div { class: "settings-field",
+                    label { class: "settings-label", "Ebook Library Path" }
+                    input {
+                        class: "settings-input",
+                        value: "{ebook_path}",
+                        placeholder: "/path/to/ebooks",
+                        oninput: move |evt| ebook_path.set(evt.value()),
+                    }
+                }
+                div { class: "settings-field",
+                    label { class: "settings-label", "Audiobook Library Path" }
+                    input {
+                        class: "settings-input",
+                        value: "{audiobook_path}",
+                        placeholder: "/path/to/audiobooks",
+                        oninput: move |evt| audiobook_path.set(evt.value()),
+                    }
+                }
+                button {
+                    class: "btn",
+                    onclick: move |_| {
+                        let url = server_url.0.clone();
+                        let ebook = ebook_path().trim().to_string();
+                        let audiobook = audiobook_path().trim().to_string();
+                        spawn(async move {
+                            match save_settings(
+                                &url,
+                                if ebook.is_empty() { None } else { Some(ebook) },
+                                if audiobook.is_empty() { None } else { Some(audiobook) },
+                            )
+                            .await
+                            {
+                                Ok(()) => {
+                                    status.set(Some("Settings saved.".to_string()));
+                                    status_is_error.set(false);
+                                }
+                                Err(e) => {
+                                    status.set(Some(e));
+                                    status_is_error.set(true);
+                                }
+                            }
+                        });
+                    },
+                    "Save"
+                }
+            }
+
+            if let Some(msg) = status() {
+                p {
+                    class: if status_is_error() { "error" } else { "success-msg" },
+                    "{msg}"
+                }
+            }
         }
+    }
+}
+
+async fn fetch_settings(server_url: &str) -> Result<(String, String), String> {
+    let url = format!("{server_url}/api/settings");
+    eprintln!("[mobile] GET {url}");
+    let response = reqwest::get(&url).await.map_err(|e| {
+        let msg = format!("{e:#}");
+        eprintln!("[mobile] GET {url} failed: {msg}");
+        msg
+    })?;
+    eprintln!("[mobile] GET {url} -> {}", response.status());
+    let payload: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+    let ebook = payload["ebook_library_path"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    let audiobook = payload["audiobook_library_path"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    Ok((ebook, audiobook))
+}
+
+async fn save_settings(
+    server_url: &str,
+    ebook_library_path: Option<String>,
+    audiobook_library_path: Option<String>,
+) -> Result<(), String> {
+    let url = format!("{server_url}/api/settings");
+    eprintln!("[mobile] POST {url}");
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "ebook_library_path": ebook_library_path,
+        "audiobook_library_path": audiobook_library_path,
+    });
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| {
+            let msg = format!("{e:#}");
+            eprintln!("[mobile] POST {url} failed: {msg}");
+            msg
+        })?;
+    eprintln!("[mobile] POST {url} -> {}", response.status());
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(format!("Server error: {}", response.status()))
     }
 }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -8,7 +8,7 @@ use tower_http::trace::TraceLayer;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 
-use crate::{db, frontend::Route};
+use crate::{db, frontend::Route, scanner};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -34,6 +34,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/value/increment", post(increment_value))
         .route("/api/settings", get(get_settings))
         .route("/api/settings", post(post_settings))
+        .route("/api/library", get(get_library))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
@@ -122,6 +123,23 @@ async fn post_settings(
         Err(error) => (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to save settings: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn get_library(State(state): State<AppState>) -> Response {
+    match db::get_settings(&state.pool).await {
+        Ok(settings) => {
+            let contents = scanner::scan_libraries(
+                settings.ebook_library_path.as_deref(),
+                settings.audiobook_library_path.as_deref(),
+            );
+            Json(contents).into_response()
+        }
+        Err(error) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to read settings: {error}"),
         )
             .into_response(),
     }
@@ -273,5 +291,64 @@ mod tests {
         let settings: db::Settings = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(settings.ebook_library_path, Some("/my/ebooks".to_string()));
         assert_eq!(settings.audiobook_library_path, None);
+    }
+
+    #[tokio::test]
+    async fn api_get_library_returns_empty_sections_when_paths_not_configured() {
+        let pool = db::init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let app = router(AppState::new(pool));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/library")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let contents: scanner::LibraryContents = serde_json::from_slice(&bytes).unwrap();
+        assert!(contents.ebooks.path.is_none());
+        assert!(contents.ebooks.files.is_empty());
+        assert!(contents.audiobooks.path.is_none());
+        assert!(contents.audiobooks.files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn api_get_library_reports_error_for_nonexistent_path() {
+        let pool = db::init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        db::set_settings(
+            &pool,
+            &db::Settings {
+                ebook_library_path: Some("/does/not/exist/omnibus_test".to_string()),
+                audiobook_library_path: None,
+            },
+        )
+        .await
+        .expect("set should succeed");
+        let app = router(AppState::new(pool));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/library")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let contents: scanner::LibraryContents = serde_json::from_slice(&bytes).unwrap();
+        assert!(contents.ebooks.error.is_some());
+        assert!(contents.audiobooks.path.is_none());
     }
 }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -32,27 +32,45 @@ pub fn router(state: AppState) -> Router {
         .route("/settings", get(settings_page))
         .route("/api/value", get(get_value))
         .route("/api/value/increment", post(increment_value))
+        .route("/api/settings", get(get_settings))
+        .route("/api/settings", post(post_settings))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
 
 async fn index_page(State(state): State<AppState>) -> Response {
-    render_page(&state.pool, Route::Landing {}).await
-}
-
-async fn settings_page(State(state): State<AppState>) -> Response {
-    render_page(&state.pool, Route::Settings {}).await
-}
-
-async fn render_page(pool: &SqlitePool, route: Route) -> Response {
-    match db::get_value(pool).await {
-        Ok(value) => Html(crate::frontend::render_document(route, value)).into_response(),
+    match db::get_value(&state.pool).await {
+        Ok(value) => Html(crate::frontend::render_document(
+            Route::Landing {},
+            value,
+            db::Settings::default(),
+        ))
+        .into_response(),
         Err(error) => (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to load value: {error}"),
         )
             .into_response(),
     }
+}
+
+async fn settings_page(State(state): State<AppState>) -> Response {
+    let settings = match db::get_settings(&state.pool).await {
+        Ok(s) => s,
+        Err(error) => {
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to load settings: {error}"),
+            )
+                .into_response();
+        }
+    };
+    Html(crate::frontend::render_document(
+        Route::Settings {},
+        0,
+        settings,
+    ))
+    .into_response()
 }
 
 async fn get_value(State(state): State<AppState>) -> Response {
@@ -72,6 +90,38 @@ async fn increment_value(State(state): State<AppState>) -> Response {
         Err(error) => (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to increment value: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn get_settings(State(state): State<AppState>) -> Response {
+    match db::get_settings(&state.pool).await {
+        Ok(settings) => Json(settings).into_response(),
+        Err(error) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to read settings: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn post_settings(
+    State(state): State<AppState>,
+    Json(settings): Json<db::Settings>,
+) -> Response {
+    match db::set_settings(&state.pool, &settings).await {
+        Ok(()) => match db::get_settings(&state.pool).await {
+            Ok(updated) => Json(updated).into_response(),
+            Err(error) => (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to read updated settings: {error}"),
+            )
+                .into_response(),
+        },
+        Err(error) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to save settings: {error}"),
         )
             .into_response(),
     }
@@ -123,5 +173,105 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let payload: ValueResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(payload.value, 1);
+    }
+
+    #[tokio::test]
+    async fn api_get_settings_returns_null_defaults() {
+        let pool = db::init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let app = router(AppState::new(pool));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/settings")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let settings: db::Settings = serde_json::from_slice(&body).unwrap();
+        assert_eq!(settings.ebook_library_path, None);
+        assert_eq!(settings.audiobook_library_path, None);
+    }
+
+    #[tokio::test]
+    async fn api_post_settings_persists_and_returns_saved_values() {
+        let pool = db::init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let app = router(AppState::new(pool));
+
+        let body = serde_json::json!({
+            "ebook_library_path": "/books/ebooks",
+            "audiobook_library_path": "/books/audio"
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/settings")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let settings: db::Settings = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            settings.ebook_library_path,
+            Some("/books/ebooks".to_string())
+        );
+        assert_eq!(
+            settings.audiobook_library_path,
+            Some("/books/audio".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn api_get_settings_after_post_reflects_saved_values() {
+        let pool = db::init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let app = router(AppState::new(pool));
+
+        let body = serde_json::json!({
+            "ebook_library_path": "/my/ebooks",
+            "audiobook_library_path": null
+        });
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/settings")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .expect("POST should succeed");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/settings")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("GET should succeed");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let settings: db::Settings = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(settings.ebook_library_path, Some("/my/ebooks".to_string()));
+        assert_eq!(settings.audiobook_library_path, None);
     }
 }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,4 +1,11 @@
+use serde::{Deserialize, Serialize};
 use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Settings {
+    pub ebook_library_path: Option<String>,
+    pub audiobook_library_path: Option<String>,
+}
 
 pub async fn init_db(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
     let pool = SqlitePoolOptions::new()
@@ -32,6 +39,17 @@ pub async fn initialize_schema(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS settings (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
     Ok(())
 }
 
@@ -56,6 +74,76 @@ pub async fn increment_value(pool: &SqlitePool) -> Result<i64, sqlx::Error> {
 
     tx.commit().await?;
     Ok(value)
+}
+
+pub async fn get_settings(pool: &SqlitePool) -> Result<Settings, sqlx::Error> {
+    let ebook_library_path =
+        sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = 'ebook_library_path'")
+            .fetch_optional(pool)
+            .await?;
+
+    let audiobook_library_path = sqlx::query_scalar::<_, String>(
+        "SELECT value FROM settings WHERE key = 'audiobook_library_path'",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(Settings {
+        ebook_library_path,
+        audiobook_library_path,
+    })
+}
+
+pub async fn set_settings(pool: &SqlitePool, settings: &Settings) -> Result<(), sqlx::Error> {
+    match &settings.ebook_library_path {
+        Some(path) => {
+            sqlx::query(
+                "INSERT OR REPLACE INTO settings (key, value) VALUES ('ebook_library_path', ?)",
+            )
+            .bind(path)
+            .execute(pool)
+            .await?;
+        }
+        None => {
+            sqlx::query("DELETE FROM settings WHERE key = 'ebook_library_path'")
+                .execute(pool)
+                .await?;
+        }
+    }
+
+    match &settings.audiobook_library_path {
+        Some(path) => {
+            sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('audiobook_library_path', ?)")
+                .bind(path)
+                .execute(pool)
+                .await?;
+        }
+        None => {
+            sqlx::query("DELETE FROM settings WHERE key = 'audiobook_library_path'")
+                .execute(pool)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn seed_settings_from_env(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    let ebook_library_path = std::env::var("EBOOK_LIBRARY_PATH").ok();
+    let audiobook_library_path = std::env::var("AUDIOBOOK_LIBRARY_PATH").ok();
+
+    if ebook_library_path.is_some() || audiobook_library_path.is_some() {
+        set_settings(
+            pool,
+            &Settings {
+                ebook_library_path,
+                audiobook_library_path,
+            },
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -84,5 +172,122 @@ mod tests {
 
         let value = get_value(&pool).await.expect("value should be persisted");
         assert_eq!(value, 1);
+    }
+
+    #[tokio::test]
+    async fn get_settings_returns_none_for_empty_db() {
+        let pool = init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let settings = get_settings(&pool).await.expect("should succeed");
+        assert_eq!(settings.ebook_library_path, None);
+        assert_eq!(settings.audiobook_library_path, None);
+    }
+
+    #[tokio::test]
+    async fn set_and_get_settings_roundtrips() {
+        let pool = init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let input = Settings {
+            ebook_library_path: Some("/books/ebooks".to_string()),
+            audiobook_library_path: Some("/books/audio".to_string()),
+        };
+        set_settings(&pool, &input).await.expect("set should succeed");
+        let result = get_settings(&pool).await.expect("get should succeed");
+        assert_eq!(result, input);
+    }
+
+    #[tokio::test]
+    async fn set_settings_updates_existing_values() {
+        let pool = init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        set_settings(
+            &pool,
+            &Settings {
+                ebook_library_path: Some("/old".to_string()),
+                audiobook_library_path: None,
+            },
+        )
+        .await
+        .expect("first set should succeed");
+        set_settings(
+            &pool,
+            &Settings {
+                ebook_library_path: Some("/new".to_string()),
+                audiobook_library_path: Some("/audio".to_string()),
+            },
+        )
+        .await
+        .expect("second set should succeed");
+        let result = get_settings(&pool).await.expect("get should succeed");
+        assert_eq!(result.ebook_library_path, Some("/new".to_string()));
+        assert_eq!(result.audiobook_library_path, Some("/audio".to_string()));
+    }
+
+    #[tokio::test]
+    async fn set_settings_none_clears_existing_value() {
+        let pool = init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        set_settings(
+            &pool,
+            &Settings {
+                ebook_library_path: Some("/books".to_string()),
+                audiobook_library_path: Some("/audio".to_string()),
+            },
+        )
+        .await
+        .expect("set should succeed");
+        set_settings(
+            &pool,
+            &Settings {
+                ebook_library_path: None,
+                audiobook_library_path: None,
+            },
+        )
+        .await
+        .expect("clear should succeed");
+        let result = get_settings(&pool).await.expect("get should succeed");
+        assert_eq!(result.ebook_library_path, None);
+        assert_eq!(result.audiobook_library_path, None);
+    }
+
+    #[tokio::test]
+    async fn seed_settings_from_env_writes_env_vars_to_db() {
+        let pool = init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        // Use unique env var names per test to avoid cross-test pollution
+        std::env::set_var("EBOOK_LIBRARY_PATH", "/env/books");
+        std::env::set_var("AUDIOBOOK_LIBRARY_PATH", "/env/audio");
+        seed_settings_from_env(&pool)
+            .await
+            .expect("seed should succeed");
+        std::env::remove_var("EBOOK_LIBRARY_PATH");
+        std::env::remove_var("AUDIOBOOK_LIBRARY_PATH");
+        let result = get_settings(&pool).await.expect("get should succeed");
+        assert_eq!(result.ebook_library_path, Some("/env/books".to_string()));
+        assert_eq!(
+            result.audiobook_library_path,
+            Some("/env/audio".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn seed_settings_from_env_is_noop_when_vars_unset() {
+        let pool = init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        // Ensure the vars aren't set (they shouldn't be in a clean test env)
+        std::env::remove_var("EBOOK_LIBRARY_PATH");
+        std::env::remove_var("AUDIOBOOK_LIBRARY_PATH");
+        seed_settings_from_env(&pool)
+            .await
+            .expect("seed should succeed");
+        let result = get_settings(&pool).await.expect("get should succeed");
+        assert_eq!(result.ebook_library_path, None);
+        assert_eq!(result.audiobook_library_path, None);
     }
 }

--- a/server/src/frontend/mod.rs
+++ b/server/src/frontend/mod.rs
@@ -161,6 +161,31 @@ body {
 }
 .settings-status.success { color: #34d399; }
 .settings-status.error   { color: #f87171; }
+.library-card { margin-top: 1.25rem; }
+.library-card h2 { font-size: 1rem; font-weight: 600; margin-bottom: 0.75rem; color: #cbd5e1; }
+.library-path { font-size: 0.8rem; color: #64748b; margin-bottom: 0.4rem; font-family: monospace; }
+.library-count { font-size: 0.85rem; color: #94a3b8; margin-bottom: 0.5rem; }
+.library-loading { color: #64748b; font-size: 0.875rem; }
+.library-empty { color: #64748b; font-size: 0.875rem; }
+.library-error { color: #f87171; font-size: 0.875rem; }
+.library-file-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.library-file-list li {
+  font-size: 0.875rem;
+  font-family: monospace;
+  padding: 0.3rem 0.5rem;
+  background: rgba(30, 41, 59, 0.5);
+  border-radius: 6px;
+  color: #e2e8f0;
+}
 "#
 }
 
@@ -201,6 +226,7 @@ async function saveSettings(event) {
     if (response.ok) {
       status.textContent = 'Settings saved.';
       status.className = 'settings-status success';
+      loadLibrary();
     } else {
       status.textContent = 'Failed to save settings.';
       status.className = 'settings-status error';
@@ -208,6 +234,43 @@ async function saveSettings(event) {
   } catch {
     status.textContent = 'Network error.';
     status.className = 'settings-status error';
+  }
+}
+
+function renderLibrarySection(containerId, section) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  if (!section.path) {
+    container.innerHTML = '<p class="library-empty">No path configured.</p>';
+    return;
+  }
+  if (section.error) {
+    container.innerHTML = '<p class="library-error">\u26a0 ' + section.error + '</p>';
+    return;
+  }
+  if (section.files.length === 0) {
+    container.innerHTML = '<p class="library-empty">No files found in <code>' + section.path + '</code></p>';
+    return;
+  }
+  const items = section.files.map(function(f) { return '<li>' + f + '</li>'; }).join('');
+  container.innerHTML =
+    '<p class="library-path">' + section.path + '</p>' +
+    '<p class="library-count">' + section.files.length + ' file(s)</p>' +
+    '<ul class="library-file-list">' + items + '</ul>';
+}
+
+async function loadLibrary() {
+  const ebookEl = document.getElementById('ebook-library-contents');
+  const audiobookEl = document.getElementById('audiobook-library-contents');
+  if (!ebookEl && !audiobookEl) return;
+  try {
+    const response = await fetch('/api/library');
+    const data = await response.json();
+    renderLibrarySection('ebook-library-contents', data.ebooks);
+    renderLibrarySection('audiobook-library-contents', data.audiobooks);
+  } catch (e) {
+    if (ebookEl) ebookEl.innerHTML = '<p class="library-error">Failed to load library.</p>';
+    if (audiobookEl) audiobookEl.innerHTML = '<p class="library-error">Failed to load library.</p>';
   }
 }
 
@@ -221,6 +284,7 @@ window.addEventListener('DOMContentLoaded', () => {
     settingsForm.addEventListener('submit', saveSettings);
   }
   syncValue();
+  loadLibrary();
 });
 "#
 }
@@ -243,6 +307,8 @@ mod tests {
         assert!(html.contains("id=\"settings-form\""));
         assert!(html.contains("id=\"ebook-library-path\""));
         assert!(html.contains("id=\"audiobook-library-path\""));
+        assert!(html.contains("id=\"ebook-library-contents\""));
+        assert!(html.contains("id=\"audiobook-library-contents\""));
     }
 
     #[test]

--- a/server/src/frontend/mod.rs
+++ b/server/src/frontend/mod.rs
@@ -7,6 +7,8 @@ use dioxus_router::Routable;
 use components::TopNav;
 use pages::{LandingPage, SettingsPage};
 
+use crate::db::Settings;
+
 #[derive(Clone, Debug, PartialEq, Eq, Routable)]
 pub enum Route {
     #[route("/", LandingPage)]
@@ -19,6 +21,7 @@ pub enum Route {
 pub struct AppProps {
     pub route: Route,
     pub value: i64,
+    pub settings: Settings,
 }
 
 #[component]
@@ -37,7 +40,7 @@ pub fn App(props: AppProps) -> Element {
             main {
                 match props.route {
                     Route::Landing {} => rsx! { LandingPage { value: Some(props.value) } },
-                    Route::Settings {} => rsx! { SettingsPage {} },
+                    Route::Settings {} => rsx! { SettingsPage { settings: Some(props.settings.clone()) } },
                 }
             }
         }
@@ -53,9 +56,9 @@ pub fn next_value_after_increment(current: i64, response_value: i64) -> i64 {
     }
 }
 
-pub fn render_document(route: Route, value: i64) -> String {
+pub fn render_document(route: Route, value: i64, settings: Settings) -> String {
     let body = dioxus_ssr::render_element(rsx! {
-        App { route: route.clone(), value }
+        App { route: route.clone(), value, settings }
     });
 
     format!(
@@ -121,6 +124,43 @@ body {
 .btn:hover {
   filter: brightness(1.08);
 }
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+}
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.settings-field label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #cbd5e1;
+}
+.settings-field input[type="text"] {
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(100, 116, 139, 0.4);
+  border-radius: 8px;
+  color: #e5e7eb;
+  font-size: 0.95rem;
+  padding: 0.55rem 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+.settings-field input[type="text"]:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+.settings-status {
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  min-height: 1.2em;
+}
+.settings-status.success { color: #34d399; }
+.settings-status.error   { color: #f87171; }
 "#
 }
 
@@ -144,10 +184,41 @@ async function incrementValue() {
   }
 }
 
+async function saveSettings(event) {
+  event.preventDefault();
+  const status = document.getElementById('settings-status');
+  const ebookVal = document.getElementById('ebook-library-path').value.trim();
+  const audiobookVal = document.getElementById('audiobook-library-path').value.trim();
+  try {
+    const response = await fetch('/api/settings', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ebook_library_path: ebookVal || null,
+        audiobook_library_path: audiobookVal || null
+      })
+    });
+    if (response.ok) {
+      status.textContent = 'Settings saved.';
+      status.className = 'settings-status success';
+    } else {
+      status.textContent = 'Failed to save settings.';
+      status.className = 'settings-status error';
+    }
+  } catch {
+    status.textContent = 'Network error.';
+    status.className = 'settings-status error';
+  }
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   const button = document.getElementById('increment-button');
   if (button) {
     button.addEventListener('click', incrementValue);
+  }
+  const settingsForm = document.getElementById('settings-form');
+  if (settingsForm) {
+    settingsForm.addEventListener('submit', saveSettings);
   }
   syncValue();
 });
@@ -160,16 +231,29 @@ mod tests {
 
     #[test]
     fn renders_landing_content() {
-        let html = render_document(Route::Landing {}, 7);
+        let html = render_document(Route::Landing {}, 7, Settings::default());
         assert!(html.contains("Minimal Rust Full-Stack Counter"));
         assert!(html.contains("id=\"current-value\""));
         assert!(html.contains(">7<"));
     }
 
     #[test]
-    fn renders_settings_content() {
-        let html = render_document(Route::Settings {}, 0);
-        assert!(html.contains("Sample settings route"));
+    fn renders_settings_form_with_empty_inputs_by_default() {
+        let html = render_document(Route::Settings {}, 0, Settings::default());
+        assert!(html.contains("id=\"settings-form\""));
+        assert!(html.contains("id=\"ebook-library-path\""));
+        assert!(html.contains("id=\"audiobook-library-path\""));
+    }
+
+    #[test]
+    fn renders_settings_form_with_populated_values() {
+        let settings = Settings {
+            ebook_library_path: Some("/srv/ebooks".to_string()),
+            audiobook_library_path: Some("/srv/audio".to_string()),
+        };
+        let html = render_document(Route::Settings {}, 0, settings);
+        assert!(html.contains("/srv/ebooks"));
+        assert!(html.contains("/srv/audio"));
     }
 
     #[test]

--- a/server/src/frontend/pages/settings.rs
+++ b/server/src/frontend/pages/settings.rs
@@ -1,11 +1,43 @@
 use dioxus::prelude::*;
 
+use crate::db::Settings;
+
 #[component]
-pub fn SettingsPage() -> Element {
+pub fn SettingsPage(settings: Option<Settings>) -> Element {
+    let settings = settings.unwrap_or_default();
+    let ebook_value = settings.ebook_library_path.unwrap_or_default();
+    let audiobook_value = settings.audiobook_library_path.unwrap_or_default();
+
     rsx! {
         section { class: "card",
             h1 { "Settings" }
-            p { class: "subtitle", "Sample settings route" }
+            p { class: "subtitle", "Configure your library paths on the server." }
+
+            form { id: "settings-form", class: "settings-form",
+                div { class: "settings-field",
+                    label { r#for: "ebook-library-path", "Ebook Library Path" }
+                    input {
+                        r#type: "text",
+                        id: "ebook-library-path",
+                        name: "ebook_library_path",
+                        value: "{ebook_value}",
+                        placeholder: "/path/to/ebooks"
+                    }
+                }
+                div { class: "settings-field",
+                    label { r#for: "audiobook-library-path", "Audiobook Library Path" }
+                    input {
+                        r#type: "text",
+                        id: "audiobook-library-path",
+                        name: "audiobook_library_path",
+                        value: "{audiobook_value}",
+                        placeholder: "/path/to/audiobooks"
+                    }
+                }
+                button { r#type: "submit", class: "btn", "Save" }
+            }
+
+            p { id: "settings-status", class: "settings-status" }
         }
     }
 }

--- a/server/src/frontend/pages/settings.rs
+++ b/server/src/frontend/pages/settings.rs
@@ -39,5 +39,19 @@ pub fn SettingsPage(settings: Option<Settings>) -> Element {
 
             p { id: "settings-status", class: "settings-status" }
         }
+
+        section { class: "card library-card",
+            h2 { "Ebook Library" }
+            div { id: "ebook-library-contents", class: "library-contents",
+                p { class: "library-loading", "Loading…" }
+            }
+        }
+
+        section { class: "card library-card",
+            h2 { "Audiobook Library" }
+            div { id: "audiobook-library-contents", class: "library-contents",
+                p { class: "library-loading", "Loading…" }
+            }
+        }
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod backend;
 pub mod db;
 pub mod frontend;
+pub mod scanner;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -20,6 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let pool = db::init_db(&database_url).await?;
+    db::seed_settings_from_env(&pool).await?;
     let state = backend::AppState::new(pool);
     let app = backend::router(state);
 

--- a/server/src/scanner.rs
+++ b/server/src/scanner.rs
@@ -1,0 +1,117 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LibrarySection {
+    pub path: Option<String>,
+    pub files: Vec<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LibraryContents {
+    pub ebooks: LibrarySection,
+    pub audiobooks: LibrarySection,
+}
+
+pub fn list_files(path: Option<&str>) -> LibrarySection {
+    let Some(path_str) = path else {
+        return LibrarySection::default();
+    };
+
+    let path = std::path::Path::new(path_str);
+    if !path.exists() {
+        return LibrarySection {
+            path: Some(path_str.to_string()),
+            files: vec![],
+            error: Some(format!("path not found: {path_str}")),
+        };
+    }
+
+    match std::fs::read_dir(path) {
+        Err(e) => LibrarySection {
+            path: Some(path_str.to_string()),
+            files: vec![],
+            error: Some(format!("could not read directory: {e}")),
+        },
+        Ok(entries) => {
+            let mut files: Vec<String> = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+                .filter_map(|e| e.file_name().into_string().ok())
+                .collect();
+            files.sort();
+            LibrarySection {
+                path: Some(path_str.to_string()),
+                files,
+                error: None,
+            }
+        }
+    }
+}
+
+pub fn scan_libraries(ebook_path: Option<&str>, audiobook_path: Option<&str>) -> LibraryContents {
+    LibraryContents {
+        ebooks: list_files(ebook_path),
+        audiobooks: list_files(audiobook_path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_test_dir(suffix: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("omnibus_scanner_test_{suffix}"));
+        fs::create_dir_all(&dir).expect("should create test dir");
+        dir
+    }
+
+    #[test]
+    fn list_files_with_no_path_returns_empty() {
+        let result = list_files(None);
+        assert_eq!(result.path, None);
+        assert!(result.files.is_empty());
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn list_files_with_nonexistent_path_returns_error() {
+        let result = list_files(Some("/definitely/does/not/exist/omnibus_test"));
+        assert!(result.error.is_some());
+        assert!(result.files.is_empty());
+    }
+
+    #[test]
+    fn list_files_returns_sorted_filenames() {
+        let dir = make_test_dir("sorted");
+        fs::write(dir.join("c.epub"), b"").unwrap();
+        fs::write(dir.join("a.epub"), b"").unwrap();
+        fs::write(dir.join("b.m4b"), b"").unwrap();
+        let result = list_files(Some(dir.to_str().unwrap()));
+        fs::remove_dir_all(&dir).unwrap();
+        assert!(result.error.is_none());
+        assert_eq!(result.files, vec!["a.epub", "b.m4b", "c.epub"]);
+    }
+
+    #[test]
+    fn list_files_does_not_include_subdirectories() {
+        let dir = make_test_dir("subdirs");
+        fs::write(dir.join("book.epub"), b"").unwrap();
+        fs::create_dir(dir.join("subdir")).unwrap();
+        let result = list_files(Some(dir.to_str().unwrap()));
+        fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(result.files, vec!["book.epub"]);
+    }
+
+    #[test]
+    fn scan_libraries_combines_both_sections() {
+        let dir = make_test_dir("combined");
+        fs::write(dir.join("novel.epub"), b"").unwrap();
+        let path = dir.to_str().unwrap();
+        let result = scan_libraries(Some(path), None);
+        fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(result.ebooks.files, vec!["novel.epub"]);
+        assert!(result.audiobooks.path.is_none());
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> These values will be how you set the path to your NAS so that we can access your epubs, m4as, and whatnot. The fact that it displays the current contents of that folder in the settings menu right now is just for debugging -- in the future this will probably just show a quick count of how many items it was able to detect in that folder so you can quickly test if your paths are set correctly.

- Allows for setting library paths via env var
- Adds a line for the ebook library path in settings
- Adds a line for the audiobook library path in settings
- Adds endpoints to update these settings in the database
<img width="867" height="997" alt="image" src="https://github.com/user-attachments/assets/58510abf-caa9-4602-a0d0-19fc3a4300de" />
