### PR TITLE
feat: nixify playwright install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ cargo clippy                                                # lint all crates
 cargo fmt                                                   # format all crates
 
 # E2E UI tests (TypeScript Playwright, against a running local server)
-cd ui_tests/playwright && npm install && npx playwright install --with-deps chromium   # first-time setup
+cd ui_tests/playwright && npm install                       # first-time setup (Chromium comes from Nix)
 cd ui_tests/playwright && npm test                          # run all E2E tests
 cd ui_tests/playwright && npm run test:ui                   # interactive UI mode
 
@@ -153,6 +153,8 @@ Testing is a first-class requirement. Every meaningful behavior should have a te
 ### Playwright E2E conventions
 
 These rules exist so every flow is tested the same way; don't diverge without updating this section first.
+
+**Chromium comes from Nix, not npm.** The `playwright-driver.browsers` package in [flake.nix](flake.nix) provides the browser bundle, and the shellHook exports `PLAYWRIGHT_BROWSERS_PATH` into the Nix store. Do not run `npx playwright install` — it would re-download Chromium into `~/Library/Caches/ms-playwright/` and diverge from the flake. `@playwright/test` is pinned with a tilde range (`~1.58.0`) so npm stays on the same minor as nixpkgs; when bumping the version, update both together since each Playwright minor expects a specific Chromium build number.
 
 **Style — functional helpers + fixtures, never page-object classes.** Import `test` and `expect` from `tests/fixtures/test.ts` (not directly from `@playwright/test`) so shared fixtures apply uniformly. Factor reusable selectors and actions into plain functions, not classes.
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             pkgs.jdk21
             pkgs-unstable.dioxus-cli
             pkgs-unstable.nodejs_22
+            pkgs-unstable.playwright-driver.browsers
           ];
 
           DATABASE_URL = "sqlite://omnibus.db?mode=rwc";
@@ -50,6 +51,12 @@
             echo "Nix dev shell ready."
             echo "Run: cargo test -p omnibus"
             echo "Run: cargo run -p omnibus"
+
+            # Pin Playwright's Chromium to the Nix store so no per-user
+            # download lands in ~/Library/Caches/ms-playwright/. The npm
+            # @playwright/test version must match this bundle's version.
+            export PLAYWRIGHT_BROWSERS_PATH="${pkgs-unstable.playwright-driver.browsers}"
+            export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
             # Nix injects xcbuild's fake xcrun and its own cc wrapper, both of which
             # break iOS builds. Fix: prepend /usr/bin so the real Xcode xcrun and

--- a/ui_tests/playwright/package-lock.json
+++ b/ui_tests/playwright/package-lock.json
@@ -8,19 +8,19 @@
       "name": "omnibus-ui-tests-playwright",
       "version": "0.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.49.0",
+        "@playwright/test": "~1.58.0",
         "@types/node": "^22.10.0",
         "typescript": "^5.7.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/ui_tests/playwright/package.json
+++ b/ui_tests/playwright/package.json
@@ -5,11 +5,10 @@
   "description": "End-to-end UI tests for the omnibus server, using Playwright.",
   "scripts": {
     "test": "playwright test",
-    "test:ui": "playwright test --ui",
-    "install-browsers": "playwright install --with-deps chromium"
+    "test:ui": "playwright test --ui"
   },
   "devDependencies": {
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "~1.58.0",
     "@types/node": "^22.10.0",
     "typescript": "^5.7.0"
   }


### PR DESCRIPTION
NodeJS was pinned inside the Nix flake, but the browser installation was still being done directly to the host machine. 