### PR TITLE
chore: ignore .direnv/ and untrack local nix profile symlinks

### DIFF
--- a/.direnv/flake-profile
+++ b/.direnv/flake-profile
@@ -1,1 +1,0 @@
-flake-profile-18-link

--- a/.direnv/flake-profile-18-link
+++ b/.direnv/flake-profile-18-link
@@ -1,1 +1,0 @@
-/nix/store/1ahhgvfjimb3z8g7ff14s8y7nkd1632k-nix-shell-env

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ ui_tests/**/test-results/
 ui_tests/**/playwright-report/
 ui_tests/**/blob-report/
 ui_tests/**/.playwright/
+
+# direnv / Nix
+.direnv/


### PR DESCRIPTION
## Summary
- Add `.direnv/` to `.gitignore` (direnv/Nix profile state; per-machine, should never be tracked).
- Remove the two previously-tracked symlinks under `.direnv/` from the repo so `git status` stops churning on every Nix profile rebuild.

## Test plan
- [x] `git check-ignore .direnv/flake-profile` returns the path
- [x] `jj st` / `git status` is clean after a fresh `nix develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)