### PR TITLE
feat: add zellij + process-compose dev launchers

### DIFF
--- a/.zellij/layout.kdl
+++ b/.zellij/layout.kdl
@@ -1,0 +1,32 @@
+layout {
+    default_tab_template {
+        pane size=2 borderless=true {
+            plugin location="zellij:tab-bar"
+        }
+        children
+        pane size=1 borderless=true {
+            plugin location="zellij:status-bar"
+        }
+    }
+
+    tab name="server" focus=true {
+        pane command="dx" {
+            args "serve" "--port" "3000" "--package" "omnibus"
+        }
+    }
+    tab name="android" {
+        pane command="dx" start_suspended=true {
+            args "serve" "--platform" "android" "--package" "omnibus-mobile"
+        }
+    }
+    tab name="ios" {
+        pane command="dx" start_suspended=true {
+            args "serve" "--platform" "ios" "--package" "omnibus-mobile"
+        }
+    }
+    tab name="playwright" {
+        pane cwd="ui_tests/playwright" command="npx" start_suspended=true {
+            args "playwright" "test" "--ui"
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,17 @@ nix develop                  # also works; spawns a bash subshell
 
 ## Common commands
 
+### Quick launch
+
+Run all dev services inside a single multiplexer session. Must be inside `nix develop`. Two flavors are provided; pick whichever you prefer:
+
+```bash
+just serve            # Zellij: 4 tabs (server, android, ios, playwright). Server auto-runs; others suspended until you press Enter in their pane.
+just serve-pc         # process-compose: TUI with logs. Server auto-runs; android/ios/playwright are disabled — select one and press F7 to start.
+```
+
+Zellij tips: `Alt+<N>` jumps to tab N, `Ctrl-q` quits. process-compose tips: `F4` attach/detach, `F7` start, `F9` stop, `F10` quit.
+
 ```bash
 # Server
 cargo run -p omnibus                                        # start the server at http://0.0.0.0:3000

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,9 @@
+# Launch the dev multiplexer with Zellij. Server tab auto-starts; android/ios/playwright
+# tabs are preloaded with their commands suspended — press Enter in the pane to start them.
+serve:
+    zellij --layout .zellij/layout.kdl
+
+# Launch the dev multiplexer with process-compose. Server process auto-starts;
+# android/ios/playwright are disabled by default — select one in the TUI and press F7 to start.
+serve-pc:
+    process-compose up

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,9 @@
             pkgs-unstable.dioxus-cli
             pkgs-unstable.nodejs_22
             pkgs-unstable.playwright-driver.browsers
+            pkgs.zellij
+            pkgs.process-compose
+            pkgs.just
           ];
 
           DATABASE_URL = "sqlite://omnibus.db?mode=rwc";

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,0 +1,18 @@
+version: "0.5"
+
+processes:
+  server:
+    command: dx serve --port 3000 --package omnibus
+
+  android:
+    command: dx serve --platform android --package omnibus-mobile
+    disabled: true
+
+  ios:
+    command: dx serve --platform ios --package omnibus-mobile
+    disabled: true
+
+  playwright:
+    command: npx playwright test --ui
+    working_dir: ui_tests/playwright
+    disabled: true


### PR DESCRIPTION
## Summary

> [!NOTE]
> ZelliJ is the clear winner here since you can actually still use all the commands through TTY that `dx serve` allows you to do.

- Add a single-command dev launcher with two multiplexer flavors. Both run the stack from inside `nix develop`:
  - `just serve` — Zellij session with four tabs (`server`, `android`, `ios`, `playwright`). The server tab auto-starts `dx serve --port 3000 --package omnibus`; the other three tabs preload their commands as suspended panes, so pressing Enter in the pane kicks them off on demand.
  - `just serve-pc` — process-compose TUI. The `server` process auto-starts; `android`, `ios`, and `playwright` are declared but `disabled: true`, so they show up in the TUI and can be started on demand with `F7`.
- Pin `zellij`, `process-compose`, and `just` into the Nix devshell in [flake.nix](flake.nix) so the launchers work without a separate install step.
- Document both commands under a new "Quick launch" subsection in [CLAUDE.md](CLAUDE.md).

## Process Compose
<img width="2053" height="1150" alt="image" src="https://github.com/user-attachments/assets/f1dd4854-1fee-4d13-905c-cb104cd5b749" />


## ZelliJ
<img width="1804" height="1121" alt="image" src="https://github.com/user-attachments/assets/671c1bc5-27fc-427d-ba21-4523d3ad71b2" />


## Test plan

- [x] `nix develop --command zsh` → `which zellij`, `which process-compose`, `which just` all resolve.
- [x] `just serve` opens Zellij; the `server` tab auto-runs `dx serve` and reaches `http://0.0.0.0:3000`.
- [x] Switching to the `android` tab and pressing Enter starts `dx serve --platform android --package omnibus-mobile`.
- [x] Same for the `ios` tab.
- [x] Same for the `playwright` tab (opens the Playwright UI window).
- [x] `Ctrl-q` exits cleanly with no orphan `dx` processes (`pgrep dx`).
- [x] `just serve-pc` opens the process-compose TUI; `server` logs stream in the log pane.
- [x] Starting `android` / `ios` / `playwright` from the TUI with `F7` works.
- [x] `F10` exits cleanly.