### PR TITLE
ci: skip rust workflow when no rust files changed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,14 @@ name: Rust
 
 on:
   pull_request:
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "flake.nix"
+      - "flake.lock"
+      - "rust-toolchain*"
+      - ".github/workflows/rust.yml"
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Add a `paths` filter to the `pull_request` trigger in `.github/workflows/rust.yml` so fmt/clippy/test only runs when Rust-relevant files change.
- Watched paths: `**/*.rs`, `**/Cargo.toml`, `Cargo.lock`, `flake.nix`, `flake.lock`, `rust-toolchain*`, and the workflow file itself.
- `push` to `main` is unchanged — main always runs the full check.

## Test plan
- [ ] Open a docs-only PR and confirm the Rust workflow is skipped.
- [ ] Open a PR touching a `.rs` file and confirm the Rust workflow runs.