### PR TITLE
feat: recursive file counts on settings page

### DIFF
--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -3,7 +3,7 @@ use omnibus_shared::{LibraryContents, LibrarySection, Settings};
 
 use crate::{data, use_server_url};
 
-/// Library paths settings form + live directory listings.
+/// Library paths settings form + live recursive file-count summaries.
 #[component]
 pub fn SettingsPage() -> Element {
     let server_url = use_server_url();
@@ -85,6 +85,10 @@ pub fn SettingsPage() -> Element {
                         placeholder: "/path/to/ebooks",
                         oninput: move |evt| ebook_path.set(evt.value()),
                     }
+                    LibrarySummary {
+                        testid: "ebook-library-summary",
+                        section: library().ebooks,
+                    }
                 }
                 div { class: "settings-field",
                     label { r#for: "audiobook-library-path", "Audiobook Library Path" }
@@ -95,6 +99,10 @@ pub fn SettingsPage() -> Element {
                         value: "{audiobook_path}",
                         placeholder: "/path/to/audiobooks",
                         oninput: move |evt| audiobook_path.set(evt.value()),
+                    }
+                    LibrarySummary {
+                        testid: "audiobook-library-summary",
+                        section: library().audiobooks,
                     }
                 }
                 button { r#type: "submit", class: "btn", "Save" }
@@ -107,48 +115,43 @@ pub fn SettingsPage() -> Element {
                 if let Some(msg) = status() { "{msg}" }
             }
         }
-
-        LibrarySectionView {
-            title: "Ebook Library",
-            testid: "ebook-library-contents",
-            section: library().ebooks,
-        }
-        LibrarySectionView {
-            title: "Audiobook Library",
-            testid: "audiobook-library-contents",
-            section: library().audiobooks,
-        }
     }
 }
 
 #[component]
-fn LibrarySectionView(title: String, testid: String, section: LibrarySection) -> Element {
-    rsx! {
-        section { class: "card library-card",
-            h2 { "{title}" }
-            div {
+fn LibrarySummary(testid: String, section: LibrarySection) -> Element {
+    if section.path.is_none() {
+        return rsx! {
+            p {
                 id: "{testid}",
                 "data-testid": "{testid}",
-                class: "library-contents",
-                if section.path.is_none() {
-                    p { class: "library-empty", "No path configured." }
-                } else if let Some(err) = &section.error {
-                    p { class: "library-error", "⚠ {err}" }
-                } else if section.files.is_empty() {
-                    p { class: "library-empty",
-                        "No files found in "
-                        code { "{section.path.as_deref().unwrap_or_default()}" }
-                    }
-                } else {
-                    p { class: "library-path", "{section.path.as_deref().unwrap_or_default()}" }
-                    p { class: "library-count", "{section.files.len()} file(s)" }
-                    ul { class: "library-file-list",
-                        for file in &section.files {
-                            li { "{file}" }
-                        }
-                    }
-                }
+                class: "library-summary empty",
             }
+        };
+    }
+
+    if let Some(err) = &section.error {
+        return rsx! {
+            p {
+                id: "{testid}",
+                "data-testid": "{testid}",
+                class: "library-summary error",
+                "⚠ {err}"
+            }
+        };
+    }
+
+    let mut line = format!("{} file(s) found.", section.total_files);
+    for (ext, count) in &section.counts_by_ext {
+        line.push_str(&format!(" {count} .{ext} found."));
+    }
+
+    rsx! {
+        p {
+            id: "{testid}",
+            "data-testid": "{testid}",
+            class: "library-summary",
+            "{line}"
         }
     }
 }

--- a/frontend/src/scanner.rs
+++ b/frontend/src/scanner.rs
@@ -1,45 +1,79 @@
 pub use omnibus_shared::{LibraryContents, LibrarySection};
 
-pub fn list_files(path: Option<&str>) -> LibrarySection {
+/// Recursively walk `path` and return total file count plus per-extension
+/// counts for each extension in `extensions` (compared case-insensitively,
+/// without leading dot — e.g. `&["epub", "pdf"]`).
+pub fn list_files(path: Option<&str>, extensions: &[&str]) -> LibrarySection {
     let Some(path_str) = path else {
         return LibrarySection::default();
     };
 
-    let path = std::path::Path::new(path_str);
-    if !path.exists() {
+    let root = std::path::Path::new(path_str);
+    if !root.exists() {
         return LibrarySection {
             path: Some(path_str.to_string()),
-            files: vec![],
+            total_files: 0,
+            counts_by_ext: extensions.iter().map(|e| (e.to_string(), 0)).collect(),
             error: Some(format!("path not found: {path_str}")),
         };
     }
 
-    match std::fs::read_dir(path) {
-        Err(e) => LibrarySection {
-            path: Some(path_str.to_string()),
-            files: vec![],
-            error: Some(format!("could not read directory: {e}")),
-        },
-        Ok(entries) => {
-            let mut files: Vec<String> = entries
-                .filter_map(|e| e.ok())
-                .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
-                .filter_map(|e| e.file_name().into_string().ok())
-                .collect();
-            files.sort();
-            LibrarySection {
-                path: Some(path_str.to_string()),
-                files,
-                error: None,
+    let mut total_files: usize = 0;
+    let mut counts: Vec<(String, usize)> = extensions
+        .iter()
+        .map(|e| (e.to_lowercase(), 0usize))
+        .collect();
+
+    let mut stack: Vec<std::path::PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                return LibrarySection {
+                    path: Some(path_str.to_string()),
+                    total_files: 0,
+                    counts_by_ext: extensions.iter().map(|e| (e.to_string(), 0)).collect(),
+                    error: Some(format!("could not read directory: {e}")),
+                };
+            }
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                total_files += 1;
+                if let Some(ext) = entry
+                    .path()
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(|e| e.to_lowercase())
+                {
+                    if let Some(slot) = counts.iter_mut().find(|(key, _)| key == &ext) {
+                        slot.1 += 1;
+                    }
+                }
             }
         }
     }
+
+    LibrarySection {
+        path: Some(path_str.to_string()),
+        total_files,
+        counts_by_ext: counts,
+        error: None,
+    }
 }
+
+pub const EBOOK_EXTENSIONS: &[&str] = &["epub", "pdf"];
+pub const AUDIOBOOK_EXTENSIONS: &[&str] = &["m4b", "mp3"];
 
 pub fn scan_libraries(ebook_path: Option<&str>, audiobook_path: Option<&str>) -> LibraryContents {
     LibraryContents {
-        ebooks: list_files(ebook_path),
-        audiobooks: list_files(audiobook_path),
+        ebooks: list_files(ebook_path, EBOOK_EXTENSIONS),
+        audiobooks: list_files(audiobook_path, AUDIOBOOK_EXTENSIONS),
     }
 }
 
@@ -50,55 +84,91 @@ mod tests {
 
     fn make_test_dir(suffix: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!("omnibus_scanner_test_{suffix}"));
+        let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).expect("should create test dir");
         dir
     }
 
     #[test]
     fn list_files_with_no_path_returns_empty() {
-        let result = list_files(None);
+        let result = list_files(None, EBOOK_EXTENSIONS);
         assert_eq!(result.path, None);
-        assert!(result.files.is_empty());
+        assert_eq!(result.total_files, 0);
+        assert!(result.counts_by_ext.is_empty());
         assert!(result.error.is_none());
     }
 
     #[test]
     fn list_files_with_nonexistent_path_returns_error() {
-        let result = list_files(Some("/definitely/does/not/exist/omnibus_test"));
+        let result = list_files(
+            Some("/definitely/does/not/exist/omnibus_test"),
+            EBOOK_EXTENSIONS,
+        );
         assert!(result.error.is_some());
-        assert!(result.files.is_empty());
+        assert_eq!(result.total_files, 0);
     }
 
     #[test]
-    fn list_files_returns_sorted_filenames() {
-        let dir = make_test_dir("sorted");
-        fs::write(dir.join("c.epub"), b"").unwrap();
+    fn list_files_counts_by_extension() {
+        let dir = make_test_dir("counts");
         fs::write(dir.join("a.epub"), b"").unwrap();
-        fs::write(dir.join("b.m4b"), b"").unwrap();
-        let result = list_files(Some(dir.to_str().unwrap()));
+        fs::write(dir.join("b.epub"), b"").unwrap();
+        fs::write(dir.join("c.pdf"), b"").unwrap();
+        fs::write(dir.join("d.txt"), b"").unwrap();
+        let result = list_files(Some(dir.to_str().unwrap()), EBOOK_EXTENSIONS);
         fs::remove_dir_all(&dir).unwrap();
         assert!(result.error.is_none());
-        assert_eq!(result.files, vec!["a.epub", "b.m4b", "c.epub"]);
+        assert_eq!(result.total_files, 4);
+        assert_eq!(
+            result.counts_by_ext,
+            vec![("epub".to_string(), 2), ("pdf".to_string(), 1)]
+        );
     }
 
     #[test]
-    fn list_files_does_not_include_subdirectories() {
-        let dir = make_test_dir("subdirs");
-        fs::write(dir.join("book.epub"), b"").unwrap();
-        fs::create_dir(dir.join("subdir")).unwrap();
-        let result = list_files(Some(dir.to_str().unwrap()));
+    fn list_files_recurses_into_subdirectories() {
+        let dir = make_test_dir("recursive");
+        fs::write(dir.join("top.epub"), b"").unwrap();
+        let nested = dir.join("series").join("vol1");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("deep.epub"), b"").unwrap();
+        fs::write(nested.join("cover.jpg"), b"").unwrap();
+        let result = list_files(Some(dir.to_str().unwrap()), EBOOK_EXTENSIONS);
         fs::remove_dir_all(&dir).unwrap();
-        assert_eq!(result.files, vec!["book.epub"]);
+        assert_eq!(result.total_files, 3);
+        assert_eq!(
+            result.counts_by_ext,
+            vec![("epub".to_string(), 2), ("pdf".to_string(), 0)]
+        );
     }
 
     #[test]
-    fn scan_libraries_combines_both_sections() {
-        let dir = make_test_dir("combined");
-        fs::write(dir.join("novel.epub"), b"").unwrap();
+    fn list_files_extension_match_is_case_insensitive() {
+        let dir = make_test_dir("case");
+        fs::write(dir.join("A.EPUB"), b"").unwrap();
+        fs::write(dir.join("b.Pdf"), b"").unwrap();
+        let result = list_files(Some(dir.to_str().unwrap()), EBOOK_EXTENSIONS);
+        fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(
+            result.counts_by_ext,
+            vec![("epub".to_string(), 1), ("pdf".to_string(), 1)]
+        );
+    }
+
+    #[test]
+    fn scan_libraries_uses_audiobook_extensions() {
+        let dir = make_test_dir("audiobooks");
+        fs::write(dir.join("chapter1.m4b"), b"").unwrap();
+        fs::write(dir.join("chapter2.mp3"), b"").unwrap();
+        fs::write(dir.join("chapter3.mp3"), b"").unwrap();
         let path = dir.to_str().unwrap();
-        let result = scan_libraries(Some(path), None);
+        let result = scan_libraries(None, Some(path));
         fs::remove_dir_all(&dir).unwrap();
-        assert_eq!(result.ebooks.files, vec!["novel.epub"]);
-        assert!(result.audiobooks.path.is_none());
+        assert!(result.ebooks.path.is_none());
+        assert_eq!(result.audiobooks.total_files, 3);
+        assert_eq!(
+            result.audiobooks.counts_by_ext,
+            vec![("m4b".to_string(), 1), ("mp3".to_string(), 2)]
+        );
     }
 }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -273,9 +273,9 @@ mod tests {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let contents: omnibus_shared::LibraryContents = serde_json::from_slice(&bytes).unwrap();
         assert!(contents.ebooks.path.is_none());
-        assert!(contents.ebooks.files.is_empty());
+        assert_eq!(contents.ebooks.total_files, 0);
         assert!(contents.audiobooks.path.is_none());
-        assert!(contents.audiobooks.files.is_empty());
+        assert_eq!(contents.audiobooks.total_files, 0);
     }
 
     #[tokio::test]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -21,10 +21,16 @@ pub struct ValueResponse {
 }
 
 /// One half of the library listing (either ebooks or audiobooks).
+///
+/// `counts_by_ext` is an ordered list of `(extension, count)` pairs for the
+/// extensions the caller asked the scanner to track. Order matches the
+/// caller-provided extension list so the UI can render a predictable summary
+/// line.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LibrarySection {
     pub path: Option<String>,
-    pub files: Vec<String>,
+    pub total_files: usize,
+    pub counts_by_ext: Vec<(String, usize)>,
     pub error: Option<String>,
 }
 

--- a/ui_tests/playwright/tests/flows/settings.spec.ts
+++ b/ui_tests/playwright/tests/flows/settings.spec.ts
@@ -16,8 +16,8 @@ test("renders the settings page layout", async ({ page }) => {
   await expect(audiobookInput(page)).toBeVisible();
   await expect(saveButton(page)).toBeVisible();
   await expect(settingsStatus(page)).toBeAttached();
-  await expect(page.getByTestId("ebook-library-contents")).toBeVisible();
-  await expect(page.getByTestId("audiobook-library-contents")).toBeVisible();
+  await expect(page.getByTestId("ebook-library-summary")).toBeAttached();
+  await expect(page.getByTestId("audiobook-library-summary")).toBeAttached();
   await expectNavVisible(page);
 });
 

--- a/ui_tests/playwright/tests/utils/api.ts
+++ b/ui_tests/playwright/tests/utils/api.ts
@@ -31,6 +31,7 @@ export async function expectMutation<T>(
 
   const requestPromise = page.waitForRequest(
     (r) => r.method() === opts.method && matchesUrl(r.url()),
+    {timeout: 5_000}
   );
 
   const result = await action();


### PR DESCRIPTION
## Summary
- Makes the file paths set in the settings page show the recursive file counts
- The ebook file path will also show a count of how many epubs and pdf files were found in that path
- The audiobook path will also show a count of how many m4b and mp3 files were found in that path

## Notes
- N/A

<!--
Use the following for callouts:

>[!NOTE]
> Blue message!

>[!WARNING]
> Yello message!

>[!IMPORTANT]
> Purple message!

>[!CAUTION]
> Red message!

>[!TIP]
> Green message!
-->