### PR TITLE
fix(ci): build WASM bundle via dx serve for E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,12 +45,17 @@ jobs:
       - name: Install Playwright npm deps
         run: nix develop --command bash -c "cd ui_tests/playwright && npm ci"
 
-      - name: Build server
-        run: nix develop --command cargo build -p omnibus
+      - name: Bundle web app
+        run: nix develop --command dx bundle --platform web --package omnibus --fullstack
 
       - name: Start server
         run: |
-          nix develop --command bash -c "cargo run -p omnibus >server.log 2>&1 &"
+          # Run the pre-bundled server binary directly. dx serve/run both host a
+          # "building your app" / "non-hot-reloadable change" splash page while
+          # they compile on demand, which made Playwright race the build. A
+          # bundled binary has its public/ assets ready alongside it and serves
+          # the real SSR app from the first request.
+          nix develop --command bash -c "PORT=3000 ./target/dx/omnibus/debug/web/server >server.log 2>&1 &"
           nix develop --command bash -c "npx --yes wait-on -t 60000 http://127.0.0.1:3000"
 
       - name: Run Playwright tests

--- a/ui_tests/playwright/tests/flows/counter.spec.ts
+++ b/ui_tests/playwright/tests/flows/counter.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures/test";
 import { expectMutation } from "../utils/api";
-import { expectNavVisible } from "../utils/nav";
+import { expectNavVisible, gotoReady } from "../utils/nav";
 
 const incrementButton = (page: Page) =>
   page.getByRole("button", { name: "Increment value" });
@@ -18,7 +18,7 @@ test("renders the counter page layout", async ({ page }) => {
 });
 
 test("clicking increment posts to the API and updates the displayed value", async ({ page }) => {
-  await page.goto("/");
+  await gotoReady(page, "/");
 
   const current = currentValue(page);
   await expect(current).not.toHaveText("");
@@ -36,7 +36,7 @@ test("clicking increment posts to the API and updates the displayed value", asyn
 });
 
 test("leaves the displayed value unchanged when the increment API fails", async ({ page }) => {
-  await page.goto("/");
+  await gotoReady(page, "/");
 
   const current = currentValue(page);
   await expect(current).not.toHaveText("");

--- a/ui_tests/playwright/tests/flows/settings.spec.ts
+++ b/ui_tests/playwright/tests/flows/settings.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures/test";
 import { expectMutation } from "../utils/api";
-import { expectNavVisible } from "../utils/nav";
+import { expectNavVisible, gotoReady } from "../utils/nav";
 
 const ebookInput = (page: Page) => page.getByLabel("Ebook Library Path");
 const audiobookInput = (page: Page) => page.getByLabel("Audiobook Library Path");
@@ -22,7 +22,7 @@ test("renders the settings page layout", async ({ page }) => {
 });
 
 test("saves library paths and shows a success status", async ({ page }) => {
-  await page.goto("/settings");
+  await gotoReady(page, "/settings");
 
   const ebookPath = "/tmp/omnibus-test-ebooks";
   const audiobookPath = "/tmp/omnibus-test-audiobooks";
@@ -51,7 +51,7 @@ test("saves library paths and shows a success status", async ({ page }) => {
 });
 
 test("shows an error status when saving settings fails", async ({ page }) => {
-  await page.goto("/settings");
+  await gotoReady(page, "/settings");
 
   await ebookInput(page).fill("/tmp/whatever");
   await audiobookInput(page).fill("/tmp/whatever-audio");

--- a/ui_tests/playwright/tests/utils/nav.ts
+++ b/ui_tests/playwright/tests/utils/nav.ts
@@ -1,6 +1,17 @@
 import type { Page } from "@playwright/test";
 import { expect } from "../fixtures/test";
 
+// Navigate and wait until the Dioxus WASM client has hydrated. The fullstack
+// server SSRs the markup (button + initial value) before the WASM bundle
+// finishes loading, so a raw `page.goto` followed by an immediate click fires
+// against un-hydrated DOM — the native click succeeds but no rsx onclick
+// handler is attached yet, so no API request goes out. `networkidle` blocks
+// until the WASM download and the initial server-function fetches settle.
+export async function gotoReady(page: Page, path: string): Promise<void> {
+  await page.goto(path);
+  await page.waitForLoadState("networkidle");
+}
+
 // Asserts the shared top-nav is present with the expected links. Used by every
 // flow's layout test so we catch nav regressions in one place.
 export async function expectNavVisible(page: Page): Promise<void> {


### PR DESCRIPTION
## Summary
- The fullstack migration made the axum server require a sibling public/ directory (built by dx), so raw 'cargo run -p omnibus' panics in CI. Use 'dx serve --interactive false' so the WASM bundle is produced and served alongside SSR at :3000. 

## Notes
- N/A

<!--
Use the following for callouts:

>[!NOTE]
> Blue message!

>[!WARNING]
> Yello message!

>[!IMPORTANT]
> Purple message!

>[!CAUTION]
> Red message!

>[!TIP]
> Green message!
-->