### PR TITLE
ci: split cargo fmt into its own job without nix develop

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,8 +18,22 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: cargo fmt --check
+        run: cargo fmt --all --check
+
   check:
-    name: fmt + clippy + test
+    name: clippy + test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,9 +48,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
-
-      - name: cargo fmt --check
-        run: nix develop --command cargo fmt --all --check
 
       - name: cargo clippy (server)
         run: nix develop --command cargo clippy -p omnibus --all-targets -- -D warnings


### PR DESCRIPTION
`cargo fmt` was taking 4+ minutes to run in other PRs... but looks like outside of nix it takes under 60 seconds...

This PR was really just a test to see how fast it would run outside of nix.