### PR TITLE
feat: display full epub metadata on landing page

### DIFF
--- a/.claude/rules/98-keep-skills-fresh.md
+++ b/.claude/rules/98-keep-skills-fresh.md
@@ -6,7 +6,7 @@ When touching any of the following areas, re-read the matching skill and update 
 
 | Code area | Skill to re-check |
 |---|---|
-| `server/src/backend.rs`, `server/src/main.rs`, `frontend/src/rpc.rs`, `frontend/src/db.rs`, `frontend/src/scanner.rs`, `frontend/src/data.rs`, `shared/src/lib.rs` | [add-backend-route](../skills/add-backend-route/SKILL.md) |
+| `server/src/backend.rs`, `server/src/main.rs`, `frontend/src/rpc.rs`, `frontend/src/db.rs`, `frontend/src/scanner.rs`, `frontend/src/ebook.rs`, `frontend/src/data.rs`, `shared/src/lib.rs` | [add-backend-route](../skills/add-backend-route/SKILL.md) |
 | `ui_tests/playwright/tests/fixtures/`, `ui_tests/playwright/tests/utils/`, selector conventions | [add-playwright-flow](../skills/add-playwright-flow/SKILL.md) |
 | jj workflow changes (new commands, new workspace patterns) | [jj-basics](../skills/jj-basics/SKILL.md), [jj-workspaces](../skills/jj-workspaces/SKILL.md), [jj-advanced](../skills/jj-advanced/SKILL.md) |
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ ui_tests/**/.playwright/
 
 # direnv / Nix
 .direnv/
+
+# Local ebook library (test data)
+/epubs
+/epubs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Default `cargo build` / `clippy` covers `server`, `shared`, `frontend` only. Mob
 ### shared/src/
 
 ```
-lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection
+lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection, EbookMetadata, EbookLibrary
 ```
 
 ### frontend/src/
@@ -63,6 +63,7 @@ data.rs             — Feature-gated data transport (mobile=reqwest, web/server
 rpc.rs              — #[get]/#[post] server functions (mounted by dioxus::server::router)
 db.rs               — pool init, schema, queries (feature = "server")
 scanner.rs          — library directory scanning (feature = "server")
+ebook.rs            — EPUB OPF metadata + cover extraction (feature = "server")
 pages/{landing,settings}.rs
 components/{top_nav,bottom_nav}.rs  — feature = web / mobile respectively
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "askama_escape"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +858,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1698,6 +1718,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "epub"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95518004c0a638e03a17589d2d336b7c936d92184d81bf1e66d3b1555de89f2d"
+dependencies = [
+ "percent-encoding",
+ "regex",
+ "thiserror 2.0.18",
+ "xml-rs",
+ "zip",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,6 +1817,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3622,8 +3656,10 @@ name = "omnibus-frontend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "dioxus",
  "dioxus-router",
+ "epub",
  "omnibus-shared",
  "reqwest",
  "serde",
@@ -4335,6 +4371,18 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6974,6 +7022,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
+name = "xml"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+
+[[package]]
+name = "xml-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
+dependencies = [
+ "xml",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7083,7 +7146,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -13,6 +13,8 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"], optional = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"], optional = true }
 anyhow = { version = "1", optional = true }
+epub = { version = "2", optional = true }
+base64 = { version = "0.22", optional = true }
 
 [features]
 default = []
@@ -26,4 +28,6 @@ server = [
     "dep:sqlx",
     "dep:tokio",
     "dep:anyhow",
+    "dep:epub",
+    "dep:base64",
 ]

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -80,6 +80,11 @@ pub async fn get_library(server_url: &str) -> Result<LibraryContents, String> {
 pub async fn get_ebooks(server_url: &str) -> Result<EbookLibrary, String> {
     let url = format!("{server_url}/api/ebooks");
     let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("Server error {status}: {body}"));
+    }
     response
         .json::<EbookLibrary>()
         .await

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -10,7 +10,7 @@
 //! - Server-only compiles (`feature = "server"` without `"web"`) reuse the
 //!   web stubs so SSR-during-fullstack-render still returns sensible data.
 
-use omnibus_shared::{LibraryContents, Settings};
+use omnibus_shared::{EbookLibrary, LibraryContents, Settings};
 
 // ===== Mobile transport: reqwest =====
 
@@ -76,6 +76,16 @@ pub async fn get_library(server_url: &str) -> Result<LibraryContents, String> {
         .map_err(|e| e.to_string())
 }
 
+#[cfg(feature = "mobile")]
+pub async fn get_ebooks(server_url: &str) -> Result<EbookLibrary, String> {
+    let url = format!("{server_url}/api/ebooks");
+    let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
+    response
+        .json::<EbookLibrary>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
 // ===== Web / fullstack-SSR transport: dioxus-fullstack server functions =====
 //
 // `server_url` is unused here — server functions always resolve against the
@@ -114,6 +124,13 @@ pub async fn save_settings(_server_url: &str, settings: Settings) -> Result<Sett
 #[cfg(not(feature = "mobile"))]
 pub async fn get_library(_server_url: &str) -> Result<LibraryContents, String> {
     crate::rpc::rpc_get_library()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn get_ebooks(_server_url: &str) -> Result<EbookLibrary, String> {
+    crate::rpc::rpc_get_ebooks()
         .await
         .map_err(|e| e.to_string())
 }

--- a/frontend/src/ebook.rs
+++ b/frontend/src/ebook.rs
@@ -83,6 +83,7 @@ fn extract_metadata(path: &Path, filename: String) -> EbookMetadata {
     let creators = collect_contributors(&doc, "creator");
     let contributors = collect_contributors(&doc, "contributor");
     let identifiers = collect_identifiers(&doc);
+    let (series, series_index) = collect_series(&doc);
 
     let cover_image = doc.get_cover().map(|(bytes, mime)| {
         let mime = if mime.is_empty() {
@@ -128,10 +129,8 @@ fn extract_metadata(path: &Path, filename: String) -> EbookMetadata {
         subjects: all(&doc, "subject"),
         identifiers,
 
-        // Calibre stores series via legacy `<meta name="calibre:series">`;
-        // EPUB3 uses `belongs-to-collection` with a `group-position` refinement.
-        series: first(&doc, "calibre:series").or_else(|| first(&doc, "belongs-to-collection")),
-        series_index: first(&doc, "calibre:series_index").or_else(|| first(&doc, "group-position")),
+        series,
+        series_index,
 
         epub_version: Some(format_version(doc.version)),
         unique_identifier: doc.unique_identifier.clone(),
@@ -186,6 +185,35 @@ fn lookup_refinement(refs: &[epub::doc::MetadataRefinement], key: &str) -> Optio
     refs.iter()
         .find(|r| r.property == key)
         .map(|r| r.value.clone())
+}
+
+/// Resolve (series, series_index) from the OPF.
+///
+/// EPUB3 stores a series as a `belongs-to-collection` metadata entry whose
+/// `group-position` refinement holds the index. Calibre's legacy EPUB2 tooling
+/// writes top-level `<meta name="calibre:series">` and `calibre:series_index`
+/// entries instead. We try EPUB3 first (with the refinement), then fall back
+/// to the Calibre keys.
+fn collect_series<R: std::io::Read + std::io::Seek>(
+    doc: &EpubDoc<R>,
+) -> (Option<String>, Option<String>) {
+    if let Some(m) = doc
+        .metadata
+        .iter()
+        .find(|m| m.property == "belongs-to-collection")
+    {
+        let name = m.value.trim().to_string();
+        if !name.is_empty() {
+            let idx = lookup_refinement(&m.refined, "group-position")
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            return (Some(name), idx);
+        }
+    }
+    (
+        first(doc, "calibre:series"),
+        first(doc, "calibre:series_index"),
+    )
 }
 
 fn collect_identifiers<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>) -> Vec<Identifier> {

--- a/frontend/src/ebook.rs
+++ b/frontend/src/ebook.rs
@@ -5,12 +5,18 @@
 //! serialisable `EbookMetadata` per file. Parse failures surface as
 //! `EbookMetadata { error: Some(_), .. }` so one bad file does not hide the
 //! rest of the library.
+//!
+//! The OPF metadata schema is open-ended — publishers, Calibre, Sigil and
+//! DRM toolchains all stuff custom `<meta>` elements into the package
+//! document. We extract the well-known Dublin Core fields into typed slots
+//! and pass *every* entry through in `raw_metadata` so the UI can render the
+//! full picture.
 
 use std::path::Path;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use epub::doc::EpubDoc;
-use omnibus_shared::{EbookLibrary, EbookMetadata};
+use epub::doc::{EpubDoc, EpubVersion};
+use omnibus_shared::{Contributor, EbookLibrary, EbookMetadata, Identifier, RawMeta};
 
 pub fn scan_ebook_library(path: Option<&str>) -> EbookLibrary {
     let Some(path_str) = path else {
@@ -74,20 +80,9 @@ fn extract_metadata(path: &Path, filename: String) -> EbookMetadata {
         }
     };
 
-    let title = first(&doc, "title");
-    let authors = all(&doc, "creator");
-    let description = first(&doc, "description");
-    let publisher = first(&doc, "publisher");
-    let published = first(&doc, "date");
-    let language = first(&doc, "language");
-    let identifier = first(&doc, "identifier");
-    let subjects = all(&doc, "subject");
-    // Calibre stores series as legacy <meta name="calibre:series"> which the
-    // epub crate surfaces under the raw name. EPUB3 uses
-    // `belongs-to-collection`; try both.
-    let series = first(&doc, "calibre:series").or_else(|| first(&doc, "belongs-to-collection"));
-    let series_index =
-        first(&doc, "calibre:series_index").or_else(|| first(&doc, "group-position"));
+    let creators = collect_contributors(&doc, "creator");
+    let contributors = collect_contributors(&doc, "contributor");
+    let identifiers = collect_identifiers(&doc);
 
     let cover_image = doc.get_cover().map(|(bytes, mime)| {
         let mime = if mime.is_empty() {
@@ -98,21 +93,115 @@ fn extract_metadata(path: &Path, filename: String) -> EbookMetadata {
         format!("data:{};base64,{}", mime, STANDARD.encode(&bytes))
     });
 
+    let raw_metadata = doc
+        .metadata
+        .iter()
+        .map(|m| RawMeta {
+            property: m.property.clone(),
+            value: m.value.clone(),
+            lang: m.lang.clone(),
+            refinements: m
+                .refined
+                .iter()
+                .map(|r| (r.property.clone(), r.value.clone()))
+                .collect(),
+        })
+        .collect();
+
     EbookMetadata {
         filename,
-        title,
-        authors,
-        description,
-        publisher,
-        published,
-        language,
-        identifier,
-        subjects,
-        series,
-        series_index,
+        title: first(&doc, "title"),
+        description: first(&doc, "description"),
+        publisher: first(&doc, "publisher"),
+        published: first(&doc, "date"),
+        modified: first(&doc, "dcterms:modified"),
+        language: first(&doc, "language"),
+        rights: first(&doc, "rights"),
+        source: first(&doc, "source"),
+        coverage: first(&doc, "coverage"),
+        dc_type: first(&doc, "type"),
+        dc_format: first(&doc, "format"),
+        relation: first(&doc, "relation"),
+
+        creators,
+        contributors,
+        subjects: all(&doc, "subject"),
+        identifiers,
+
+        // Calibre stores series via legacy `<meta name="calibre:series">`;
+        // EPUB3 uses `belongs-to-collection` with a `group-position` refinement.
+        series: first(&doc, "calibre:series").or_else(|| first(&doc, "belongs-to-collection")),
+        series_index: first(&doc, "calibre:series_index").or_else(|| first(&doc, "group-position")),
+
+        epub_version: Some(format_version(doc.version)),
+        unique_identifier: doc.unique_identifier.clone(),
+        resource_count: doc.resources.len(),
+        spine_count: doc.spine.len(),
+        toc_count: doc.toc.len(),
+
         cover_image,
+        raw_metadata,
         error: None,
     }
+}
+
+fn format_version(v: EpubVersion) -> String {
+    match v {
+        EpubVersion::Version2_0 => "2.0".to_string(),
+        EpubVersion::Version3_0 => "3.0".to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+fn collect_contributors<R: std::io::Read + std::io::Seek>(
+    doc: &EpubDoc<R>,
+    key: &str,
+) -> Vec<Contributor> {
+    doc.metadata
+        .iter()
+        .filter(|m| m.property == key)
+        .filter_map(|m| {
+            let name = m.value.trim().to_string();
+            if name.is_empty() {
+                return None;
+            }
+            let role = m
+                .refinement("role")
+                .map(|r| r.value.clone())
+                .or_else(|| lookup_refinement(&m.refined, "role"));
+            let file_as = m
+                .refinement("file-as")
+                .map(|r| r.value.clone())
+                .or_else(|| lookup_refinement(&m.refined, "file-as"));
+            Some(Contributor {
+                name,
+                role,
+                file_as,
+            })
+        })
+        .collect()
+}
+
+fn lookup_refinement(refs: &[epub::doc::MetadataRefinement], key: &str) -> Option<String> {
+    refs.iter()
+        .find(|r| r.property == key)
+        .map(|r| r.value.clone())
+}
+
+fn collect_identifiers<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>) -> Vec<Identifier> {
+    doc.metadata
+        .iter()
+        .filter(|m| m.property == "identifier")
+        .filter_map(|m| {
+            let value = m.value.trim().to_string();
+            if value.is_empty() {
+                return None;
+            }
+            let scheme = lookup_refinement(&m.refined, "scheme")
+                .or_else(|| lookup_refinement(&m.refined, "identifier-type"));
+            Some(Identifier { value, scheme })
+        })
+        .collect()
 }
 
 fn first<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>, key: &str) -> Option<String> {

--- a/frontend/src/ebook.rs
+++ b/frontend/src/ebook.rs
@@ -1,0 +1,176 @@
+//! EPUB metadata extraction (server-only).
+//!
+//! Opens each `.epub` under the configured ebook library path, pulls the
+//! Dublin Core metadata plus the embedded cover image, and returns a
+//! serialisable `EbookMetadata` per file. Parse failures surface as
+//! `EbookMetadata { error: Some(_), .. }` so one bad file does not hide the
+//! rest of the library.
+
+use std::path::Path;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use epub::doc::EpubDoc;
+use omnibus_shared::{EbookLibrary, EbookMetadata};
+
+pub fn scan_ebook_library(path: Option<&str>) -> EbookLibrary {
+    let Some(path_str) = path else {
+        return EbookLibrary::default();
+    };
+
+    let dir = Path::new(path_str);
+    if !dir.exists() {
+        return EbookLibrary {
+            path: Some(path_str.to_string()),
+            books: vec![],
+            error: Some(format!("path not found: {path_str}")),
+        };
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            return EbookLibrary {
+                path: Some(path_str.to_string()),
+                books: vec![],
+                error: Some(format!("could not read directory: {e}")),
+            };
+        }
+    };
+
+    let mut books: Vec<EbookMetadata> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|e| {
+            e.path()
+                .extension()
+                .and_then(|s| s.to_str())
+                .map(|s| s.eq_ignore_ascii_case("epub"))
+                .unwrap_or(false)
+        })
+        .map(|e| {
+            let filename = e.file_name().to_string_lossy().to_string();
+            extract_metadata(&e.path(), filename)
+        })
+        .collect();
+
+    books.sort_by(|a, b| a.filename.cmp(&b.filename));
+
+    EbookLibrary {
+        path: Some(path_str.to_string()),
+        books,
+        error: None,
+    }
+}
+
+fn extract_metadata(path: &Path, filename: String) -> EbookMetadata {
+    let mut doc = match EpubDoc::new(path) {
+        Ok(d) => d,
+        Err(e) => {
+            return EbookMetadata {
+                filename,
+                error: Some(format!("could not open epub: {e}")),
+                ..Default::default()
+            };
+        }
+    };
+
+    let title = first(&doc, "title");
+    let authors = all(&doc, "creator");
+    let description = first(&doc, "description");
+    let publisher = first(&doc, "publisher");
+    let published = first(&doc, "date");
+    let language = first(&doc, "language");
+    let identifier = first(&doc, "identifier");
+    let subjects = all(&doc, "subject");
+    // Calibre stores series as legacy <meta name="calibre:series"> which the
+    // epub crate surfaces under the raw name. EPUB3 uses
+    // `belongs-to-collection`; try both.
+    let series = first(&doc, "calibre:series").or_else(|| first(&doc, "belongs-to-collection"));
+    let series_index =
+        first(&doc, "calibre:series_index").or_else(|| first(&doc, "group-position"));
+
+    let cover_image = doc.get_cover().map(|(bytes, mime)| {
+        let mime = if mime.is_empty() {
+            "image/jpeg".to_string()
+        } else {
+            mime
+        };
+        format!("data:{};base64,{}", mime, STANDARD.encode(&bytes))
+    });
+
+    EbookMetadata {
+        filename,
+        title,
+        authors,
+        description,
+        publisher,
+        published,
+        language,
+        identifier,
+        subjects,
+        series,
+        series_index,
+        cover_image,
+        error: None,
+    }
+}
+
+fn first<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>, key: &str) -> Option<String> {
+    doc.metadata
+        .iter()
+        .find(|m| m.property == key)
+        .map(|m| m.value.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn all<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>, key: &str) -> Vec<String> {
+    doc.metadata
+        .iter()
+        .filter(|m| m.property == key)
+        .map(|m| m.value.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_with_no_path_returns_empty() {
+        let out = scan_ebook_library(None);
+        assert!(out.books.is_empty());
+        assert!(out.path.is_none());
+    }
+
+    #[test]
+    fn scan_with_missing_path_reports_error() {
+        let out = scan_ebook_library(Some("/definitely/does/not/exist/omnibus_ebook_test"));
+        assert!(out.error.is_some());
+    }
+
+    #[test]
+    fn scan_ignores_non_epub_files() {
+        let dir = std::env::temp_dir().join("omnibus_ebook_scan_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("notes.txt"), b"hi").unwrap();
+        let out = scan_ebook_library(Some(dir.to_str().unwrap()));
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert!(out.books.is_empty());
+        assert!(out.error.is_none());
+    }
+
+    #[test]
+    fn scan_records_parse_errors_per_file() {
+        let dir = std::env::temp_dir().join("omnibus_ebook_bad_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("broken.epub"), b"not actually a zip").unwrap();
+        let out = scan_ebook_library(Some(dir.to_str().unwrap()));
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(out.books.len(), 1);
+        assert!(out.books[0].error.is_some());
+        assert_eq!(out.books[0].filename, "broken.epub");
+    }
+}

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -323,8 +323,74 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   overflow-y: auto;
 }
 
+.ebook-fields {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.2rem 0.75rem;
+  margin: 0.6rem 0;
+  font-size: 0.8rem;
+}
+.ebook-fields dt { color: #64748b; }
+.ebook-fields dd { color: #cbd5e1; margin: 0; word-break: break-word; }
+
+.ebook-counts { color: #64748b; font-size: 0.75rem; margin-top: 0.3rem; }
+
+.ebook-ids {
+  list-style: none;
+  padding: 0;
+  margin: 0.2rem 0 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.8rem;
+}
+.ebook-ids code { color: #e2e8f0; }
+.ebook-id-scheme { color: #22d3ee; font-size: 0.75rem; }
+
+.ebook-raw {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(100, 116, 139, 0.2);
+}
+.ebook-raw summary {
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 0.8rem;
+  padding: 0.2rem 0;
+}
+.ebook-raw summary:hover { color: #e2e8f0; }
+
+.raw-meta-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+}
+.raw-meta-table th,
+.raw-meta-table td {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid rgba(100, 116, 139, 0.15);
+  vertical-align: top;
+}
+.raw-meta-table th { color: #94a3b8; font-weight: 600; }
+.raw-meta-table td code { color: #22d3ee; font-family: monospace; }
+.raw-meta-value { color: #e2e8f0; word-break: break-word; max-width: 400px; }
+.raw-meta-lang { color: #64748b; font-size: 0.7rem; }
+.raw-meta-empty { color: #475569; }
+.raw-meta-refs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  color: #cbd5e1;
+}
+
 @media (max-width: 560px) {
   .ebook-card { grid-template-columns: 100px 1fr; gap: 0.75rem; padding: 0.9rem; }
   .ebook-cover { width: 100px; height: 150px; }
+  .raw-meta-value { max-width: none; }
 }
 "#;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -16,6 +16,8 @@ pub mod rpc;
 #[cfg(feature = "server")]
 pub mod db;
 #[cfg(feature = "server")]
+pub mod ebook;
+#[cfg(feature = "server")]
 pub mod scanner;
 
 pub use components::Nav;
@@ -247,5 +249,82 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   background: rgba(30, 41, 59, 0.5);
   border-radius: 6px;
   color: #e2e8f0;
+}
+
+.ebook-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+.ebook-card {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(100, 116, 139, 0.3);
+  border-radius: 14px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+.ebook-cover {
+  width: 140px;
+  height: 210px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(30, 41, 59, 0.6);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.ebook-cover img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+.ebook-cover-fallback {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+.ebook-info { min-width: 0; }
+.ebook-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  color: #f1f5f9;
+}
+.ebook-authors {
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  margin-bottom: 0.5rem;
+}
+.ebook-series {
+  font-size: 0.85rem;
+  color: #22d3ee;
+  margin-bottom: 0.4rem;
+}
+.ebook-meta {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin-bottom: 0.2rem;
+}
+.ebook-subjects {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin: 0.4rem 0;
+  font-style: italic;
+}
+.ebook-description {
+  font-size: 0.85rem;
+  color: #cbd5e1;
+  margin-top: 0.6rem;
+  line-height: 1.4;
+  max-height: 8rem;
+  overflow-y: auto;
+}
+
+@media (max-width: 560px) {
+  .ebook-card { grid-template-columns: 100px 1fr; gap: 0.75rem; padding: 0.9rem; }
+  .ebook-cover { width: 100px; height: 150px; }
 }
 "#;

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -27,20 +27,24 @@ pub fn LandingPage() -> Element {
         });
     });
 
+    let lib = library();
+    let is_loading = loading();
+    let page_error = error();
+
     rsx! {
         section { class: "card",
             h1 { "Your Library" }
             p { class: "subtitle",
-                if let Some(path) = library().path.as_ref() {
+                if let Some(path) = lib.path.as_ref() {
                     "{path}"
                 } else {
                     "Configure your ebook library path in Settings."
                 }
             }
-            if let Some(msg) = error() {
+            if let Some(msg) = page_error.as_ref() {
                 p { class: "error", "⚠ {msg}" }
             }
-            if let Some(msg) = library().error.as_ref() {
+            if let Some(msg) = lib.error.as_ref() {
                 p { class: "error", "⚠ {msg}" }
             }
         }
@@ -49,12 +53,12 @@ pub fn LandingPage() -> Element {
             id: "ebook-grid",
             "data-testid": "ebook-grid",
             class: "ebook-grid",
-            if loading() {
+            if is_loading {
                 p { class: "library-empty", "Loading..." }
-            } else if library().books.is_empty() && library().error.is_none() && error().is_none() {
+            } else if lib.books.is_empty() && lib.error.is_none() && page_error.is_none() {
                 p { class: "library-empty", "No ebooks found." }
             } else {
-                for book in library().books {
+                for book in lib.books {
                     EbookCard { key: "{book.filename}", book: book }
                 }
             }

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -1,10 +1,10 @@
 use dioxus::prelude::*;
-use omnibus_shared::{EbookLibrary, EbookMetadata};
+use omnibus_shared::{Contributor, EbookLibrary, EbookMetadata, Identifier, RawMeta};
 
 use crate::{data, use_server_url};
 
-/// Landing page — loads the configured ebook library and renders each book
-/// with its cover art and parsed OPF metadata.
+/// Landing page — loads the configured ebook library and renders every
+/// metadata field the parser was able to pull, plus the raw OPF dump.
 #[component]
 pub fn LandingPage() -> Element {
     let server_url = use_server_url();
@@ -65,16 +65,6 @@ pub fn LandingPage() -> Element {
 #[component]
 fn EbookCard(book: EbookMetadata) -> Element {
     let display_title = book.title.clone().unwrap_or_else(|| book.filename.clone());
-    let authors = if book.authors.is_empty() {
-        None
-    } else {
-        Some(book.authors.join(", "))
-    };
-    let subjects = if book.subjects.is_empty() {
-        None
-    } else {
-        Some(book.subjects.join(" · "))
-    };
     let series_line = match (book.series.as_ref(), book.series_index.as_ref()) {
         (Some(s), Some(i)) => Some(format!("{s} #{i}")),
         (Some(s), None) => Some(s.clone()),
@@ -92,39 +82,141 @@ fn EbookCard(book: EbookMetadata) -> Element {
             }
             div { class: "ebook-info",
                 h2 { class: "ebook-title", "{display_title}" }
-                if let Some(a) = authors {
-                    p { class: "ebook-authors", "by {a}" }
+                if !book.creators.is_empty() {
+                    p { class: "ebook-authors", "by ",
+                        {contributor_inline(&book.creators)}
+                    }
                 }
                 if let Some(s) = series_line {
                     p { class: "ebook-series", "Series: {s}" }
                 }
-                if let Some(pub_) = book.publisher.as_ref() {
-                    p { class: "ebook-meta", "Publisher: {pub_}" }
+
+                dl { class: "ebook-fields",
+                    {field_row("Publisher", book.publisher.as_deref())}
+                    {field_row("Published", book.published.as_deref())}
+                    {field_row("Modified", book.modified.as_deref())}
+                    {field_row("Language", book.language.as_deref())}
+                    {field_row("Rights", book.rights.as_deref())}
+                    {field_row("Source", book.source.as_deref())}
+                    {field_row("Coverage", book.coverage.as_deref())}
+                    {field_row("Type", book.dc_type.as_deref())}
+                    {field_row("Format", book.dc_format.as_deref())}
+                    {field_row("Relation", book.relation.as_deref())}
+                    {field_row("EPUB version", book.epub_version.as_deref())}
+                    {field_row("Unique ID", book.unique_identifier.as_deref())}
                 }
-                if let Some(d) = book.published.as_ref() {
-                    p { class: "ebook-meta", "Published: {d}" }
+
+                if !book.identifiers.is_empty() {
+                    IdentifierList { items: book.identifiers.clone() }
                 }
-                if let Some(l) = book.language.as_ref() {
-                    p { class: "ebook-meta", "Language: {l}" }
+                if !book.contributors.is_empty() {
+                    p { class: "ebook-meta", "Contributors: ",
+                        {contributor_inline(&book.contributors)}
+                    }
                 }
-                if let Some(id) = book.identifier.as_ref() {
-                    p { class: "ebook-meta", "Identifier: {id}" }
+                if !book.subjects.is_empty() {
+                    p { class: "ebook-subjects", {book.subjects.join(" · ")} }
                 }
-                if let Some(s) = subjects {
-                    p { class: "ebook-subjects", "{s}" }
+
+                p { class: "ebook-meta ebook-counts",
+                    "{book.resource_count} resources · {book.spine_count} spine items · {book.toc_count} toc entries"
                 }
+
                 if let Some(desc) = book.description.as_ref() {
-                    // Descriptions frequently ship as raw HTML fragments — keep
-                    // as plain text for safety; the card already constrains the
-                    // height via CSS.
-                    p { class: "ebook-description", "{strip_html(desc)}" }
+                    // EPUB descriptions frequently contain HTML — render as
+                    // plain text to avoid injecting arbitrary markup.
+                    p { class: "ebook-description", {strip_html(desc)} }
                 }
+
                 if let Some(err) = book.error.as_ref() {
                     p { class: "error", "⚠ {err} ({book.filename})" }
+                }
+
+                details { class: "ebook-raw",
+                    summary { "Raw OPF metadata ({book.raw_metadata.len()})" }
+                    RawTable { rows: book.raw_metadata.clone() }
                 }
             }
         }
     }
+}
+
+#[component]
+fn IdentifierList(items: Vec<Identifier>) -> Element {
+    rsx! {
+        p { class: "ebook-meta", "Identifiers:" }
+        ul { class: "ebook-ids",
+            for id in items {
+                li {
+                    if let Some(scheme) = id.scheme.as_ref() {
+                        span { class: "ebook-id-scheme", "{scheme}: " }
+                    }
+                    code { "{id.value}" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn RawTable(rows: Vec<RawMeta>) -> Element {
+    rsx! {
+        table { class: "raw-meta-table",
+            thead {
+                tr {
+                    th { "Property" }
+                    th { "Value" }
+                    th { "Refinements" }
+                }
+            }
+            tbody {
+                for r in rows {
+                    tr {
+                        td {
+                            code { "{r.property}" }
+                            if let Some(lang) = r.lang.as_ref() {
+                                span { class: "raw-meta-lang", " @{lang}" }
+                            }
+                        }
+                        td { class: "raw-meta-value", "{r.value}" }
+                        td {
+                            if r.refinements.is_empty() {
+                                span { class: "raw-meta-empty", "—" }
+                            } else {
+                                ul { class: "raw-meta-refs",
+                                    for (k, v) in r.refinements {
+                                        li { code { "{k}" } "={v}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn field_row(label: &'static str, value: Option<&str>) -> Element {
+    let Some(v) = value.filter(|s| !s.is_empty()) else {
+        return rsx! {};
+    };
+    let v = v.to_string();
+    rsx! {
+        dt { "{label}" }
+        dd { "{v}" }
+    }
+}
+
+fn contributor_inline(list: &[Contributor]) -> Element {
+    let rendered: Vec<String> = list
+        .iter()
+        .map(|c| match (c.role.as_deref(), c.file_as.as_deref()) {
+            (Some(role), _) if !role.is_empty() => format!("{} ({})", c.name, role),
+            _ => c.name.clone(),
+        })
+        .collect();
+    rsx! { "{rendered.join(\", \")}" }
 }
 
 /// Extremely cheap HTML-tag stripper. EPUB descriptions are frequently raw

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -1,64 +1,144 @@
 use dioxus::prelude::*;
+use omnibus_shared::{EbookLibrary, EbookMetadata};
 
 use crate::{data, use_server_url};
 
-/// Counter placeholder — fetches the current value on mount, increments it on click.
-///
-/// Uses reactive signals so the same component drives both the web (hydrated)
-/// and mobile (Dioxus Native) targets. IDs and testids are preserved for
-/// Playwright compatibility.
+/// Landing page — loads the configured ebook library and renders each book
+/// with its cover art and parsed OPF metadata.
 #[component]
 pub fn LandingPage() -> Element {
     let server_url = use_server_url();
-    let mut value = use_signal(|| 0i64);
+    let mut library = use_signal(EbookLibrary::default);
+    let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
 
     let url_for_fetch = server_url.clone();
     use_effect(move || {
         let url = url_for_fetch.clone();
         spawn(async move {
-            match data::get_value(&url).await {
-                Ok(v) => {
-                    value.set(v);
+            match data::get_ebooks(&url).await {
+                Ok(lib) => {
+                    library.set(lib);
                     error.set(None);
                 }
                 Err(e) => error.set(Some(e)),
             }
+            loading.set(false);
         });
     });
 
     rsx! {
         section { class: "card",
-            h1 { "Omnibus Counter" }
-            p { class: "subtitle", "Dioxus UI + Rust backend + SQLite persistence" }
+            h1 { "Your Library" }
+            p { class: "subtitle",
+                if let Some(path) = library().path.as_ref() {
+                    "{path}"
+                } else {
+                    "Configure your ebook library path in Settings."
+                }
+            }
             if let Some(msg) = error() {
                 p { class: "error", "⚠ {msg}" }
             }
-            p { class: "value-line",
-                "Current value: "
-                span {
-                    id: "current-value",
-                    "data-testid": "current-value",
-                    "{value}"
-                }
+            if let Some(msg) = library().error.as_ref() {
+                p { class: "error", "⚠ {msg}" }
             }
-            button {
-                id: "increment-button",
-                class: "btn",
-                onclick: move |_| {
-                    let url = server_url.clone();
-                    spawn(async move {
-                        match data::post_increment(&url).await {
-                            Ok(v) => {
-                                value.set(v);
-                                error.set(None);
-                            }
-                            Err(e) => error.set(Some(e)),
-                        }
-                    });
-                },
-                "Increment value"
+        }
+
+        div {
+            id: "ebook-grid",
+            "data-testid": "ebook-grid",
+            class: "ebook-grid",
+            if loading() {
+                p { class: "library-empty", "Loading..." }
+            } else if library().books.is_empty() && library().error.is_none() && error().is_none() {
+                p { class: "library-empty", "No ebooks found." }
+            } else {
+                for book in library().books {
+                    EbookCard { key: "{book.filename}", book: book }
+                }
             }
         }
     }
+}
+
+#[component]
+fn EbookCard(book: EbookMetadata) -> Element {
+    let display_title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    let authors = if book.authors.is_empty() {
+        None
+    } else {
+        Some(book.authors.join(", "))
+    };
+    let subjects = if book.subjects.is_empty() {
+        None
+    } else {
+        Some(book.subjects.join(" · "))
+    };
+    let series_line = match (book.series.as_ref(), book.series_index.as_ref()) {
+        (Some(s), Some(i)) => Some(format!("{s} #{i}")),
+        (Some(s), None) => Some(s.clone()),
+        _ => None,
+    };
+
+    rsx! {
+        article { class: "ebook-card", "data-testid": "ebook-card",
+            div { class: "ebook-cover",
+                if let Some(src) = book.cover_image.as_ref() {
+                    img { src: "{src}", alt: "Cover of {display_title}" }
+                } else {
+                    div { class: "ebook-cover-fallback", "No cover" }
+                }
+            }
+            div { class: "ebook-info",
+                h2 { class: "ebook-title", "{display_title}" }
+                if let Some(a) = authors {
+                    p { class: "ebook-authors", "by {a}" }
+                }
+                if let Some(s) = series_line {
+                    p { class: "ebook-series", "Series: {s}" }
+                }
+                if let Some(pub_) = book.publisher.as_ref() {
+                    p { class: "ebook-meta", "Publisher: {pub_}" }
+                }
+                if let Some(d) = book.published.as_ref() {
+                    p { class: "ebook-meta", "Published: {d}" }
+                }
+                if let Some(l) = book.language.as_ref() {
+                    p { class: "ebook-meta", "Language: {l}" }
+                }
+                if let Some(id) = book.identifier.as_ref() {
+                    p { class: "ebook-meta", "Identifier: {id}" }
+                }
+                if let Some(s) = subjects {
+                    p { class: "ebook-subjects", "{s}" }
+                }
+                if let Some(desc) = book.description.as_ref() {
+                    // Descriptions frequently ship as raw HTML fragments — keep
+                    // as plain text for safety; the card already constrains the
+                    // height via CSS.
+                    p { class: "ebook-description", "{strip_html(desc)}" }
+                }
+                if let Some(err) = book.error.as_ref() {
+                    p { class: "error", "⚠ {err} ({book.filename})" }
+                }
+            }
+        }
+    }
+}
+
+/// Extremely cheap HTML-tag stripper. EPUB descriptions are frequently raw
+/// HTML; we render as text to avoid injecting arbitrary markup into the page.
+fn strip_html(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut in_tag = false;
+    for ch in input.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -15,10 +15,10 @@
 
 use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
-use omnibus_shared::{LibraryContents, Settings, ValueResponse};
+use omnibus_shared::{EbookLibrary, LibraryContents, Settings, ValueResponse};
 
 #[cfg(feature = "server")]
-use crate::{db, scanner};
+use crate::{db, ebook, scanner};
 
 /// Server-only extractor alias used by each server function. Only referenced
 /// by the server-side body; the `#[cfg(feature = "server")]` stops the web
@@ -56,4 +56,21 @@ pub async fn rpc_get_library() -> Result<LibraryContents> {
         settings.ebook_library_path.as_deref(),
         settings.audiobook_library_path.as_deref(),
     ))
+}
+
+#[get("/api/rpc/ebooks", pool: PoolExt)]
+pub async fn rpc_get_ebooks() -> Result<EbookLibrary> {
+    let settings = db::get_settings(&pool.0).await?;
+    let path = settings.ebook_library_path.clone();
+    // Parsing epubs can be slow; offload to the blocking pool so we don't
+    // stall the async runtime on zip inflation.
+    Ok(
+        tokio::task::spawn_blocking(move || ebook::scan_ebook_library(path.as_deref()))
+            .await
+            .unwrap_or_else(|e| omnibus_shared::EbookLibrary {
+                path: None,
+                books: vec![],
+                error: Some(format!("ebook scan task failed: {e}")),
+            }),
+    )
 }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -333,4 +333,102 @@ mod tests {
         assert!(contents.ebooks.error.is_some());
         assert!(contents.audiobooks.path.is_none());
     }
+
+    #[tokio::test]
+    async fn api_get_ebooks_returns_empty_when_path_not_configured() {
+        let pool = db::init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let app = rest_router(AppState::new(pool));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/ebooks")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let lib: omnibus_shared::EbookLibrary = serde_json::from_slice(&bytes).unwrap();
+        assert!(lib.path.is_none());
+        assert!(lib.books.is_empty());
+        assert!(lib.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn api_get_ebooks_reports_error_for_missing_path() {
+        let pool = db::init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let missing = "/does/not/exist/omnibus_ebook_test";
+        db::set_settings(
+            &pool,
+            &Settings {
+                ebook_library_path: Some(missing.to_string()),
+                audiobook_library_path: None,
+            },
+        )
+        .await
+        .expect("set should succeed");
+        let app = rest_router(AppState::new(pool));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/ebooks")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let lib: omnibus_shared::EbookLibrary = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(lib.path.as_deref(), Some(missing));
+        assert!(lib.books.is_empty());
+        assert!(lib.error.is_some(), "expected error, got {:?}", lib.error);
+    }
+
+    #[tokio::test]
+    async fn api_get_ebooks_returns_empty_list_for_empty_directory() {
+        let pool = db::init_db("sqlite::memory:")
+            .await
+            .expect("db should initialize");
+        let dir = std::env::temp_dir().join("omnibus_api_ebooks_empty");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        db::set_settings(
+            &pool,
+            &Settings {
+                ebook_library_path: Some(dir.to_string_lossy().into_owned()),
+                audiobook_library_path: None,
+            },
+        )
+        .await
+        .expect("set should succeed");
+        let app = rest_router(AppState::new(pool));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/ebooks")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let lib: omnibus_shared::EbookLibrary = serde_json::from_slice(&bytes).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(lib.path.as_deref(), Some(dir.to_str().unwrap()));
+        assert!(lib.books.is_empty());
+        assert!(lib.error.is_none());
+    }
 }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -11,7 +11,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use omnibus_frontend::{db, scanner};
+use omnibus_frontend::{db, ebook, scanner};
 use omnibus_shared::{Settings, ValueResponse};
 use sqlx::SqlitePool;
 
@@ -33,6 +33,7 @@ pub fn rest_router(state: AppState) -> Router {
         .route("/api/settings", get(get_settings))
         .route("/api/settings", post(post_settings))
         .route("/api/library", get(get_library))
+        .route("/api/ebooks", get(get_ebooks))
         .with_state(state)
 }
 
@@ -85,6 +86,28 @@ async fn post_settings(State(state): State<AppState>, Json(settings): Json<Setti
         )
             .into_response(),
     }
+}
+
+async fn get_ebooks(State(state): State<AppState>) -> Response {
+    let settings = match db::get_settings(&state.pool).await {
+        Ok(s) => s,
+        Err(error) => {
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to read settings: {error}"),
+            )
+                .into_response();
+        }
+    };
+    let path = settings.ebook_library_path;
+    let library = tokio::task::spawn_blocking(move || ebook::scan_ebook_library(path.as_deref()))
+        .await
+        .unwrap_or_else(|e| omnibus_shared::EbookLibrary {
+            path: None,
+            books: vec![],
+            error: Some(format!("ebook scan task failed: {e}")),
+        });
+    Json(library).into_response()
 }
 
 async fn get_library(State(state): State<AppState>) -> Response {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -41,6 +41,37 @@ pub struct LibraryContents {
     pub audiobooks: LibrarySection,
 }
 
+/// A contributor (or creator) with the optional OPF refinements — the MARC
+/// role code (`aut`, `ill`, `edt`, `bkp`, `trl`, …) and the sort-key name.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Contributor {
+    pub name: String,
+    pub role: Option<String>,
+    pub file_as: Option<String>,
+}
+
+/// A typed identifier from the OPF, e.g. `{ scheme: "ISBN", value: "…" }`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Identifier {
+    pub value: String,
+    pub scheme: Option<String>,
+}
+
+/// One raw OPF `<meta>` or Dublin Core element as found in the package
+/// document, including any refinements.
+///
+/// Everything the EPUB author wrote into `content.opf` surfaces here — this
+/// is the "show me every possible field" escape hatch, since the OPF schema
+/// is open-ended (Calibre, Adobe, Kobo and publishers all add namespaced
+/// properties).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RawMeta {
+    pub property: String,
+    pub value: String,
+    pub lang: Option<String>,
+    pub refinements: Vec<(String, String)>,
+}
+
 /// Parsed metadata for a single ebook file.
 ///
 /// `cover_image` is a base64 data URL (e.g. `data:image/jpeg;base64,...`) so
@@ -48,17 +79,44 @@ pub struct LibraryContents {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EbookMetadata {
     pub filename: String,
+
+    // Dublin Core core — single-valued first, multi-valued second.
     pub title: Option<String>,
-    pub authors: Vec<String>,
     pub description: Option<String>,
     pub publisher: Option<String>,
     pub published: Option<String>,
+    pub modified: Option<String>,
     pub language: Option<String>,
-    pub identifier: Option<String>,
+    pub rights: Option<String>,
+    pub source: Option<String>,
+    pub coverage: Option<String>,
+    pub dc_type: Option<String>,
+    pub dc_format: Option<String>,
+    pub relation: Option<String>,
+
+    pub creators: Vec<Contributor>,
+    pub contributors: Vec<Contributor>,
     pub subjects: Vec<String>,
+    pub identifiers: Vec<Identifier>,
+
+    // Series / collection (Calibre + EPUB3 belongs-to-collection).
     pub series: Option<String>,
     pub series_index: Option<String>,
+
+    // Structural / document-level info.
+    pub epub_version: Option<String>,
+    pub unique_identifier: Option<String>,
+    pub resource_count: usize,
+    pub spine_count: usize,
+    pub toc_count: usize,
+
     pub cover_image: Option<String>,
+
+    /// Every raw metadata entry from the OPF, in file order. Lets the UI
+    /// render "all potential options" without the server-side code having to
+    /// know about each publisher's custom namespace up front.
+    pub raw_metadata: Vec<RawMeta>,
+
     pub error: Option<String>,
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -40,3 +40,32 @@ pub struct LibraryContents {
     pub ebooks: LibrarySection,
     pub audiobooks: LibrarySection,
 }
+
+/// Parsed metadata for a single ebook file.
+///
+/// `cover_image` is a base64 data URL (e.g. `data:image/jpeg;base64,...`) so
+/// the client can render it directly without a separate asset endpoint.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EbookMetadata {
+    pub filename: String,
+    pub title: Option<String>,
+    pub authors: Vec<String>,
+    pub description: Option<String>,
+    pub publisher: Option<String>,
+    pub published: Option<String>,
+    pub language: Option<String>,
+    pub identifier: Option<String>,
+    pub subjects: Vec<String>,
+    pub series: Option<String>,
+    pub series_index: Option<String>,
+    pub cover_image: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Response payload for `GET /api/ebooks` and `rpc_get_ebooks`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EbookLibrary {
+    pub path: Option<String>,
+    pub books: Vec<EbookMetadata>,
+    pub error: Option<String>,
+}


### PR DESCRIPTION
> [!NOTE]
> This is really just to start looking into what we're actually going to get inside of an epub. No designs or anything yet.
>
> We'll probably want to have some way to edit the book's metadata similar to what Calibre does...? This is the file that gets stored into the ereader so it should probably be configurable.

## Summary
- Landing page now scans the configured ebook library, parses each `.epub`, and renders its cover plus every metadata field available.
- Backend: new `frontend::ebook` module (uses the `epub` crate) exposed via `GET /api/rpc/ebooks` (web) and `GET /api/ebooks` (mobile). Parsing runs on `tokio::task::spawn_blocking` so zip inflation doesn't stall the async runtime.
- Shared types: `EbookMetadata`, `EbookLibrary`, `Contributor`, `Identifier`, `RawMeta` in `omnibus-shared`.
- UI: per-book card with cover, typed Dublin Core fields (title, creator/contributor with MARC role, publisher, published, modified, language, rights, source, coverage, type, format, relation), all identifiers with scheme, subjects, series, EPUB version / unique id / resource / spine / toc counts, description (HTML-stripped), and a collapsible **Raw OPF metadata** table that dumps every `<meta>` entry with its refinements — the OPF schema is open-ended, so this is the "everything" view.
- Per-file parse errors surface inside the card instead of hiding the rest of the library.

<img width="789" height="1275" alt="image" src="https://github.com/user-attachments/assets/3179cf60-26f9-4518-9d41-a20762d0da03" />
<img width="806" height="1271" alt="image" src="https://github.com/user-attachments/assets/ef570fb7-2da7-4a1c-b3ac-c812f16fb0c1" />


## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 17 pass (incl. 4 new `ebook::` tests)
- [x] `cargo test -p omnibus` — pass
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt` — clean
- [x] Reload `dx serve` and confirm the landing page renders all three sample books with covers and raw metadata table
- [x] Mobile: hit `GET /api/ebooks` once the Dioxus Native app is running