### PR TITLE
chore: uses snake_case for all frontend components

### DIFF
--- a/frontend/src/components/bottom_nav.rs
+++ b/frontend/src/components/bottom_nav.rs
@@ -4,7 +4,7 @@ use dioxus_router::Link;
 use crate::Route;
 
 #[component]
-pub fn BottomNav() -> Element {
+pub fn bottom_nav() -> Element {
     rsx! {
         nav { class: "bottom-nav",
             Link { to: Route::Landing {}, "Home" }

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -25,4 +25,4 @@ pub use top_nav::TopNav as Nav;
 #[cfg(feature = "mobile")]
 mod bottom_nav;
 #[cfg(feature = "mobile")]
-pub use bottom_nav::BottomNav as Nav;
+pub use bottom_nav::bottom_nav as Nav;

--- a/frontend/src/components/top_nav.rs
+++ b/frontend/src/components/top_nav.rs
@@ -4,7 +4,7 @@ use dioxus_router::Link;
 use crate::Route;
 
 #[component]
-pub fn TopNav() -> Element {
+pub fn top_nav() -> Element {
     rsx! {
         nav { class: "top-nav",
             Link { to: Route::Landing {}, "Home" }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -21,7 +21,7 @@ pub mod ebook;
 pub mod scanner;
 
 pub use components::Nav;
-pub use pages::{LandingPage, SettingsPage};
+pub use pages::{landing_page, settings_page};
 
 #[cfg(feature = "mobile")]
 pub use data::ServerUrl;

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -6,7 +6,7 @@ use crate::{data, use_server_url};
 /// Landing page — loads the configured ebook library and renders every
 /// metadata field the parser was able to pull, plus the raw OPF dump.
 #[component]
-pub fn LandingPage() -> Element {
+pub fn landing_page() -> Element {
     let server_url = use_server_url();
     let mut library = use_signal(EbookLibrary::default);
     let mut loading = use_signal(|| true);

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,5 +1,5 @@
 mod landing;
 mod settings;
 
-pub use landing::LandingPage;
-pub use settings::SettingsPage;
+pub use landing::landing_page;
+pub use settings::settings_page;

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -5,7 +5,7 @@ use crate::{data, use_server_url};
 
 /// Library paths settings form + live recursive file-count summaries.
 #[component]
-pub fn SettingsPage() -> Element {
+pub fn settings_page() -> Element {
     let server_url = use_server_url();
 
     let mut ebook_path = use_signal(String::new);


### PR DESCRIPTION
## Summary
- A bunch of components on the frontend were TitleCase as opposed to snake_case

## Notes
- N/A

<!--
Use the following for callouts:

>[!NOTE]
> Blue message!

>[!WARNING]
> Yello message!

>[!IMPORTANT]
> Purple message!

>[!CAUTION]
> Red message!

>[!TIP]
> Green message!
-->