### PR TITLE
chore: audiobookshelf inspection

### DIFF
--- a/docs/audiobookshelf-inspection/0-overview.md
+++ b/docs/audiobookshelf-inspection/0-overview.md
@@ -1,0 +1,27 @@
+# AudioBookShelf deep-dive for Omnibus
+
+A source-level study of [advplyr/audiobookshelf](https://github.com/advplyr/audiobookshelf) v2.33.2 (Node.js + Express + Sequelize + Nuxt 2) intended to guide Omnibus' Rust/Dioxus reimplementation on the audiobook/podcast side. Omnibus' existing EPUB-oriented foundation is not in conflict with ABS's approach — ABS is strongest exactly where Omnibus is weakest (audio chunking, HLS, podcast RSS, playback sessions, cross-device progress sync) and makes several architectural choices we should *not* copy.
+
+This analysis is split across several documents for navigability. Start here; jump to sections as needed. The [roadmap](../roadmap/0-0-summary.md) consumes these findings and maps them onto concrete initiatives.
+
+## Contents
+
+1. [Where Omnibus stands today](1-omnibus-state.md)
+2. [AudioBookShelf feature inventory](2-feature-inventory.md)
+3. [Performance pain points in AudioBookShelf](3-performance-pain-points.md)
+4. [Where Dioxus / Rust wins](4-dioxus-rust-wins.md)
+5. [Schema details worth copying (and improving)](5-schema-details.md)
+6. [API surface](6-api-surface.md)
+7. [Recommendations for Omnibus](7-recommendations.md)
+
+## Unconfirmed claims
+
+Items that needed further source-reading out of scope for this pass:
+
+- Whether the `nusqlite3` extension path (see `Database.loadExtension`) is actually shipped on the default Docker image, or a power-user opt-in.
+- The precise retry/back-off characteristics of the single-slot `PodcastManager.currentDownload` pipeline on flaky feeds.
+- Whether the experimental Next.js client under `REACT_CLIENT_PATH` is production-ready or still a spike.
+
+---
+
+[← Back to roadmap summary](../roadmap/0-0-summary.md)

--- a/docs/audiobookshelf-inspection/1-omnibus-state.md
+++ b/docs/audiobookshelf-inspection/1-omnibus-state.md
@@ -1,0 +1,15 @@
+# 1. Where Omnibus stands today
+
+Single SQLite DB, created inline at startup in [frontend/src/db.rs](../../frontend/src/db.rs):
+
+- `books` — one row per file, keyed by `(library_path, filename)`. Dublin Core fields as columns; contributors/identifiers/subjects as **JSON blobs**.
+- `book_covers` — BLOBs with FK + ON DELETE CASCADE (manually enforced in `replace_books`).
+- `settings`, `library_index_state`, `app_state` (placeholder from the counter demo).
+
+Data flow: [scanner.rs](../../frontend/src/scanner.rs) walks the library path → [ebook.rs](../../frontend/src/ebook.rs) opens each epub with the `epub` crate and pulls DC metadata + cover bytes → [indexer.rs](../../frontend/src/indexer.rs) performs an atomic `replace_books()` every 60 minutes of staleness. The filesystem is **read-only**; the DB is a rebuildable cache.
+
+The gap between this and AudioBookShelf is large — but it's the gap we want to close deliberately, not by cloning ABS's schema mistakes.
+
+---
+
+[← Overview](0-overview.md) · [Next: feature inventory →](2-feature-inventory.md)

--- a/docs/audiobookshelf-inspection/2-feature-inventory.md
+++ b/docs/audiobookshelf-inspection/2-feature-inventory.md
@@ -1,0 +1,71 @@
+# 2. AudioBookShelf feature inventory
+
+## Tech stack
+
+From [package.json](https://github.com/advplyr/audiobookshelf/blob/master/package.json): Node.js 20, **Express 4.17** as the HTTP layer, **Sequelize 6.35** ORM on top of **sqlite3 5.1**, **socket.io 4.5** for real-time events, **Passport 0.6** + `passport-jwt` + `openid-client` for auth, `fluent-ffmpeg` (vendored under `server/libs/fluentFfmpeg`) shelling out to ffmpeg/ffprobe binaries, `node-cron` for scheduling, `nodemailer` for SMTP, `xml2js` + `rss` for feed I/O, `umzug` + custom `MigrationManager` for versioned migrations. The Nuxt 2 + Vue 2 client ([client/package.json](https://github.com/advplyr/audiobookshelf/blob/master/client/package.json)) ships `hls.js`, `epubjs`, `@teckel/vue-pdf`, `libarchive.js` (CBZ/CBR), `nuxt-socket-io`, `vuedraggable`. Tests: mocha + chai + sinon + nyc; client tests use Cypress component mode.
+
+## Libraries (multi, per media type)
+
+[server/models/Library.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Library.js) is keyed on `mediaType` = `book` or `podcast`. Each library owns many `LibraryFolder` rows. Per-library `settings` JSON carries `coverAspectRatio`, `autoScanCronExpression`, `skipMatchingMediaWithAsin/Isbn`, `audiobooksOnly`, `hideSingleBookSeries`, `onlyShowLaterBooksInContinueSeries`, `metadataPrecedence` (ordered list: `folderStructure`, `audioMetatags`, `nfoFile`, `txtFiles`, `opfFile`, `absMetadata`), and `markAsFinishedPercentComplete` / `markAsFinishedTimeRemaining`. Cron is per-library, not global — so each library runs on its own schedule.
+
+## Browse / filter / sort / search
+
+Primary endpoint is `GET /api/libraries/:id/items` in [LibraryController.getLibraryItems](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/LibraryController.js). Query params: `limit`, `page`, `sort`, `desc=1`, `filter` (dotted `group.value`, e.g. `authors.<id>`, `genres.<genre>`, `progress.finished`, `series.<id>`, `issues`, `feed-open`), `collapseseries`, `include=rssfeed,progress,media,authors,series,numEpisodes`. The actual work is composed in [server/utils/queries/libraryItemsBookFilters.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/queries/libraryItemsBookFilters.js) (~1000 lines of Sequelize literal-SQL), which issues separate find queries for filter groups and then joins with `include`. There is `GET /api/libraries/:id/search` (fuse.js + LIKE; see [SearchController](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/SearchController.js)) and an optional accent/case-folding path if the user ships the `nusqlite3` extension (`Database.supportsUnaccent`, [Database.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Database.js)). **There is no FTS5 virtual table.**
+
+Personalized home shelves (`continue-listening`, `continue-series`, `newest-authors`, `recently-added`, `listen-again`, etc.) are assembled in [server/utils/queries/libraryFilters.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/queries/libraryFilters.js) + [seriesFilters.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/queries/seriesFilters.js) via `GET /api/libraries/:id/personalized`.
+
+## LibraryItem detail, metadata edit
+
+`GET /api/items/:id` → [LibraryItemController.findOne](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/LibraryItemController.js). `PATCH /api/items/:id/media` edits the embedded Book/Podcast (title, subtitle, description, authors, narrators, series, tags, genres, publishedYear, isbn/asin, language, chapters). `POST /api/items/:id/match` fans out to the configured provider and overwrites fields based on per-field precedence. Cover: `POST/PATCH/DELETE /api/items/:id/cover` (upload or URL), handled by [CoverManager](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/CoverManager.js).
+
+## Upload / scan / matching
+
+Scanner lives under [server/scanner/](https://github.com/advplyr/audiobookshelf/tree/master/server/scanner): `LibraryScanner` (orchestrator, ~700 lines), `LibraryItemScanner` (single item), `BookScanner` (999 lines — the metadata-precedence engine), `PodcastScanner`, `AudioFileScanner` (ffprobe wrapper with chapter extraction), `OpfFileScanner`, `NfoFileScanner`, `AbsMetadataFileScanner` (reads/writes `.abs` JSON sidecar). `POST /api/libraries/:id/scan` triggers via [LibraryController.scan](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/LibraryController.js). "Quick match" at `POST /api/items/:id/match` and `POST /api/libraries/:id/matchall` call [BookFinder](https://github.com/advplyr/audiobookshelf/blob/master/server/finders/BookFinder.js) or [PodcastFinder](https://github.com/advplyr/audiobookshelf/blob/master/server/finders/PodcastFinder.js). Live filesystem changes are picked up by [Watcher.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Watcher.js) (the `watcher` npm package, 10s debounce).
+
+## Audio metadata / chapters
+
+[server/scanner/AudioFileScanner.js](https://github.com/advplyr/audiobookshelf/blob/master/server/scanner/AudioFileScanner.js) invokes `ffprobe` via [server/utils/prober.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/prober.js) to read tags (title/artist/album/year/track/disc/narrator/composer/description/comment) and embedded chapters. Fallbacks: overdrive MediaMarkers in [parseOverdriveMediaMarkers.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/parsers/parseOverdriveMediaMarkers.js), one-chapter-per-file for multi-file books. Writing tags back into m4b/mp3 is [AudioMetadataManager](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/AudioMetadataManager.js), exposed through `POST /api/tools/item/:id/embed-metadata`.
+
+## Ebook support
+
+Per [server/utils/globals.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/globals.js): `SupportedEbookTypes = ['epub','pdf','mobi','azw3','cbr','cbz']`. Ebook reading is client-side (`epubjs`, `@teckel/vue-pdf`, `libarchive.js`). `GET /api/items/:id/ebook/:fileid?` streams the raw file ([LibraryItemController.getEBookFile](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/LibraryItemController.js)); per-user ebook progress (`ebookLocation`, `ebookProgress`) lives on `MediaProgress`. "Supplementary" ebooks (a PDF accompanying an m4b) are flagged `isSupplementary` on the `LibraryFile`.
+
+## Podcasts — RSS ingestion, auto-download
+
+[server/utils/podcastUtils.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/podcastUtils.js) has `getPodcastFeed(feedUrl)` (axios GET, iso-8859-1 fallback, `xml2js` → normalized JSON) and `parsePodcastRssFeedXml`. [PodcastManager](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/PodcastManager.js) holds a `downloadQueue` with a **single `currentDownload`** — all podcast episodes download one at a time. `autoDownloadEpisodes` + `autoDownloadSchedule` (cron) on `Podcast` drive scheduled polling via [CronManager.initPodcastCrons](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/CronManager.js). `maxEpisodesToKeep` + `maxNewEpisodesToDownload` cap volume. OPML import/export: `POST /api/podcasts/opml/parse`, `/opml/create`, `GET /api/libraries/:id/opml`.
+
+## Streaming / HLS / direct play / transcoding
+
+[server/objects/Stream.js](https://github.com/advplyr/audiobookshelf/blob/master/server/objects/Stream.js) builds an ffmpeg concat input from the book's audio files and emits HLS (`.m3u8` + `.ts` or fMP4). Segment length 6s; AAC is forced for FLAC and certain ac3/eac3 sources. `GET /hls/:stream/:file` ([HlsRouter](https://github.com/advplyr/audiobookshelf/blob/master/server/routers/HlsRouter.js)) serves segments from `<MetadataPath>/streams/<streamId>/`. Clients that support the native codec can "direct play" by hitting `GET /public/session/:id/track/:index` ([PublicRouter](https://github.com/advplyr/audiobookshelf/blob/master/server/routers/PublicRouter.js)) — no transcode. `X-Accel-Redirect` offload is supported via `USE_X_ACCEL` env var.
+
+## Progress sync, bookmarks, playback sessions
+
+`MediaProgress` (user × book-or-episode) tracks `currentTime`, `duration`, `isFinished`, `hideFromContinueListening`, `finishedAt`, `ebookLocation`, `ebookProgress`. `PATCH /api/me/progress/:libraryItemId/:episodeId?` is the hot path; `PATCH /api/me/progress/batch/update` supports offline sync. Bookmarks are per-user JSON blobs on the user row (`bookmarks` column on [User.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/User.js)) keyed by library item id + time. `PlaybackSession` records one row per listening session for stats (displayTitle, timeListening, date, dayOfWeek, mediaPlayer). Mobile apps do their own local sessions and POST them up via `POST /api/session/local` and `/session/local-all` in [SessionController](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/SessionController.js).
+
+## OPDS / RSS feed output
+
+No OPDS. The `Feed` model + [RssFeedManager](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/RssFeedManager.js) publishes **podcast-style RSS** for arbitrary audiobooks/collections/series/playlists so they can be consumed by regular podcast apps. Endpoints: `POST /api/feeds/item/:itemId/open`, `/collection/:collectionId/open`, `/series/:seriesId/open`, `POST /api/feeds/:id/close`. Public delivery at `GET /feed/:slug`, `/feed/:slug/cover*`, `/feed/:slug/item/:episodeId/*` (registered in [Server.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Server.js)).
+
+## Auth — local + OIDC
+
+[server/Auth.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Auth.js) mounts passport-jwt as the middleware at `/api`. [LocalAuthStrategy.js](https://github.com/advplyr/audiobookshelf/blob/master/server/auth/LocalAuthStrategy.js) uses bcryptjs. [OidcAuthStrategy.js](https://github.com/advplyr/audiobookshelf/blob/master/server/auth/OidcAuthStrategy.js) uses `openid-client` with full PKCE + session-state map. [TokenManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/auth/TokenManager.js) mints access + refresh JWTs; the secret is persisted in the Setting table. API keys are a separate `ApiKey` model + [ApiKeyController](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/ApiKeyController.js). User roles are strings (`root`, `admin`, `user`, `guest`) with a `permissions` JSON blob (download, update, delete, upload, accessExplicitContent, accessAllLibraries, accessAllTags, selectedTagsNotAccessible, allowedLibraries[], itemTagsSelected[]).
+
+## Collections, Playlists, Series, Authors, Tags, Genres
+
+Proper Sequelize models + m2m link tables: `Collection`+`CollectionBook`, `Playlist`+`PlaylistMediaItem` (user-scoped), `Series`+`BookSeries` (with `sequence` column), `Author`+`BookAuthor`. Tags and genres are **JSON arrays** on `Book`/`Podcast` (not tables) — renaming a tag requires scanning all rows (`POST /api/tags/rename` in [MiscController](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/MiscController.js)).
+
+## Metadata providers
+
+[server/providers/](https://github.com/advplyr/audiobookshelf/tree/master/server/providers): `Audible.js`, `Audnexus.js` (authors+series), `iTunes.js`, `GoogleBooks.js`, `OpenLibrary.js`, `MusicBrainz.js`, `FantLab.js` (Russian), `AudiobookCovers.js`, `CustomProviderAdapter.js` (user-registered HTTP endpoint, schema in [custom-metadata-provider-specification.yaml](https://github.com/advplyr/audiobookshelf/blob/master/custom-metadata-provider-specification.yaml)). Aggregated by [BookFinder.js](https://github.com/advplyr/audiobookshelf/blob/master/server/finders/BookFinder.js) (702 lines) with levenshtein-distance ranking.
+
+## Stats, notifications, backups, sharing
+
+Per-user stats at `GET /api/me/listening-stats` and `/me/stats/year/:year` ([MeController](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/MeController.js)); admin aggregates at `/api/stats/server`. Notifications use **Apprise** via HTTP POST to `Database.notificationSettings.appriseApiUrl` ([NotificationManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/NotificationManager.js)) — events: `onPodcastEpisodeDownloaded`, `onBackupCompleted`, `onBackupFailed`, `onRSSFeedFailed`, `onRSSFeedDisabled`, `onTest`. Backups tar the SQLite file + metadata ([BackupManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/BackupManager.js)). Public share links for individual media items via `MediaItemShare` + [PublicRouter](https://github.com/advplyr/audiobookshelf/blob/master/server/routers/PublicRouter.js).
+
+## Web player
+
+Nuxt 2 SPA under [client/](https://github.com/advplyr/audiobookshelf/tree/master/client). HLS playback via `hls.js`, native `<audio>` for direct play. Cypress component tests. A `REACT_CLIENT_PATH` env var swaps in an experimental Next.js client (see [Server.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Server.js)).
+
+---
+
+[← Omnibus state](1-omnibus-state.md) · [Next: performance pain points →](3-performance-pain-points.md)

--- a/docs/audiobookshelf-inspection/3-performance-pain-points.md
+++ b/docs/audiobookshelf-inspection/3-performance-pain-points.md
@@ -1,0 +1,37 @@
+# 3. Performance pain points in AudioBookShelf
+
+## Single-threaded everything
+
+Node.js is one event loop. [PodcastManager.startPodcastEpisodeDownload](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/PodcastManager.js) serializes through `this.currentDownload` — a feed with 200 new episodes downloads them one at a time, and new items in the queue wait behind the active one. Library scans in [LibraryScanner.scanLibrary](https://github.com/advplyr/audiobookshelf/blob/master/server/scanner/LibraryScanner.js) do per-item ffprobe invocations serially; ffprobe on a long audiobook with many chapter atoms can take multiple seconds, and a fresh scan of a 5000-audiobook library can run for hours on a Synology. The Watcher's 10-second debounce ([Watcher.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Watcher.js)) masks it but doesn't fix it.
+
+## HLS transcode is per-session
+
+[Stream.js](https://github.com/advplyr/audiobookshelf/blob/master/server/objects/Stream.js) spawns one ffmpeg per open session. Two users listening to two FLAC books = two simultaneous `libfdk_aac` encodes. There's no segment cache — if the same user re-opens the book on a different device they re-transcode. Segments live under `<MetadataPath>/streams/<streamId>/` and are only cleaned up by the `closeStaleOpenSessions` cron ([CronManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/CronManager.js)) at `30 0 * * *`.
+
+## Sequelize N+1 hotspots + heavy literal SQL
+
+Per [server/utils/queries/libraryItemsBookFilters.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/queries/libraryItemsBookFilters.js) the authors have explicitly left `// TODO: Reduce queries` for the continue-series shelf. The same file issues raw correlated subqueries per row (`Sequelize.literal('(SELECT max(mp.updatedAt) FROM bookSeries bs, mediaProgresses mp WHERE mp.mediaItemId = bs.bookId AND mp.userId = :userId AND bs.seriesId = series.id)')`). Filter data is computed on every request unless cached in `Database.libraryFilterData` (an in-memory map with ad-hoc mutation — `replaceTagInFilterData`, `addTagsToFilterData`, etc. in [Database.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Database.js)). Cache invalidation is manual per-mutation — see the `// TODO: Keep cached filter data up-to-date on updates` in [libraryFilters.js](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/queries/libraryFilters.js).
+
+## Tags/genres are JSON arrays
+
+`Book.tags` and `Book.genres` are `DataTypes.JSON` ([Book.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Book.js)). Renaming a tag requires scanning every Book row and rewriting JSON — see [MiscController.renameTag](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/MiscController.js). `GET /api/tags` aggregates in memory across all books.
+
+## Socket.io broadcast fan-out
+
+[SocketAuthority.emitter](https://github.com/advplyr/audiobookshelf/blob/master/server/SocketAuthority.js) iterates every connected client on every event. `libraryItemEmitter` calls `toOldJSONExpanded()` per client — a full library item re-serialization per recipient. With 20 clients watching a 500-item bulk scan, that's 10,000 serializations. No rooms, no per-library filtering at the socket layer.
+
+## No FTS, no unaccent by default
+
+Search uses `LIKE '%term%'` unless the operator installs the `nusqlite3` extension out-of-band (see `process.env.NUSQLITE3_PATH` in [Database.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Database.js)). No FTS5 tables, no triggers, no bm25 ranking. Client-side `fuse.js` picks up the slack but at the cost of shipping the whole library to the browser.
+
+## Runtime migration on startup
+
+[Database.buildModels](https://github.com/advplyr/audiobookshelf/blob/master/server/Database.js) calls `this.sequelize.sync({ force, alter: false })` every boot. `alter: false` is deliberate; real migrations run via [MigrationManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/MigrationManager.js) using `umzug`. `ANALYZE` is run on every boot — fine for query planning but adds seconds on a large DB.
+
+## Memory footprint
+
+Running with Sequelize's ORM-object hydration + `xml2js` + `libarchive.js` in-worker + Nuxt SSR at dev time, the server idles around 150–200 MB RSS on small libraries and grows linearly with the in-memory `libraryFilterData` cache and `playbackSessionManager.sessions` array ([PlaybackSessionManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/PlaybackSessionManager.js)).
+
+---
+
+[← Feature inventory](2-feature-inventory.md) · [Next: Dioxus / Rust wins →](4-dioxus-rust-wins.md)

--- a/docs/audiobookshelf-inspection/4-dioxus-rust-wins.md
+++ b/docs/audiobookshelf-inspection/4-dioxus-rust-wins.md
@@ -1,0 +1,27 @@
+# 4. Where Dioxus / Rust wins
+
+Given Omnibus' stack (axum + sqlx + Dioxus fullstack):
+
+- **True parallelism on scans.** ABS's library scan is bottlenecked on serial `ffprobe` invocations in a single event loop. Omnibus can run N ffprobes concurrently via `tokio::process::Command` + `JoinSet` bounded by a `Semaphore(num_cpus)`. A 5000-item library drops from "go make coffee" to minutes. The Watcher pattern in [Watcher.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Watcher.js) maps cleanly onto the `notify` crate with a debounced channel.
+
+- **FFmpeg orchestration parallelism.** ABS spawns one ffmpeg per HLS session with no cache. Omnibus can share HLS segments across sessions keyed on `(book_id, codec_profile, segment_index)`, store them under `<data_dir>/hls-cache/`, and let two users on the same book pull from the same segment files. The `image` crate + `symphonia` can even probe without shelling out for common formats, reserving ffmpeg for actual transcode.
+
+- **sqlx vs Sequelize.** The 1000-line `libraryItemsBookFilters.js` composes raw SQL through `Sequelize.literal` anyway — Omnibus can write the same SQL with compile-time verification and `#[derive(FromRow)]` structs, skipping ORM object graph hydration. No `toOldJSON()` / `toOldJSONExpanded()` conversion layers like ABS carries as a v1-compat tax ([SocketAuthority.js](https://github.com/advplyr/audiobookshelf/blob/master/server/SocketAuthority.js), [PlaybackSession.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/PlaybackSession.js)).
+
+- **FTS5 unconditionally.** ABS makes operators install `nusqlite3` out-of-band for accent-folding and never ships FTS. Omnibus creates `CREATE VIRTUAL TABLE library_items_fts USING fts5(title, subtitle, authors, narrators, series, description, tokenize='unicode61 remove_diacritics 2', content='library_items', content_rowid='rowid')` with AFTER INSERT/UPDATE/DELETE triggers at `initialize_schema` time. bm25 ranking comes for free.
+
+- **SSR + WASM hydration for the web player.** Nuxt 2 is end-of-life (Vue 2 sunset reached Dec 2023). Dioxus fullstack renders the library grid server-side and hydrates; Dioxus signals can re-filter a pre-fetched `Signal<Vec<LibraryItem>>` without network round-trips. The `hls.js` dependency stays — there's no WASM replacement yet — but everything else becomes typed Rust.
+
+- **Proper socket scoping.** ABS iterates every client per event. axum + `tokio::sync::broadcast` scoped per library id means a bulk scan broadcasts once to subscribers, not N² to everyone. And with typed `ServerEvent` enums there's no "toOldJSONExpanded" duplication.
+
+- **No Sequelize auto-sync at boot.** `Database.sequelize.sync({ force, alter: false })` at boot + `ANALYZE` costs seconds. sqlx with `sqlx-migrate` (or `refinery`) runs versioned migrations only on change; the rest of boot is connect-and-ping.
+
+- **Memory & startup.** ABS idles at 150–200 MB RSS; an equivalent Rust binary idles at 20–40 MB. On a Synology DS220+ that's the difference between "ABS + Jellyfin + Immich" and "ABS *or* Jellyfin."
+
+- **Typed schema across the wire.** Omnibus can share `#[derive(Serialize)]` structs between `server/`, `frontend/`, and `mobile/` (already the pattern in [omnibus-shared](../../shared/src/lib.rs)), so a `MediaProgress` mismatch is a build break, not an integration-test discovery. ABS's mobile protocol is kept stable through `toOldJSON*` methods precisely because there's no shared contract.
+
+- **Streaming OPML / feed responses.** ABS generates OPML and RSS as whole-string buffers. axum's `StreamBody` + `quick-xml` writer emits chunks progressively; a 500-podcast OPML export becomes constant-memory.
+
+---
+
+[← Performance pain points](3-performance-pain-points.md) · [Next: schema details →](5-schema-details.md)

--- a/docs/audiobookshelf-inspection/5-schema-details.md
+++ b/docs/audiobookshelf-inspection/5-schema-details.md
@@ -1,0 +1,119 @@
+# 5. Schema details worth copying (and improving)
+
+ABS uses a **single SQLite database** (`absdatabase.sqlite` in ConfigPath, see [Database.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Database.js)) with **Sequelize-managed tables**, every PK a UUIDv4, every mutable sub-structure a JSON column. Migrations via `umzug` + the files in [server/migrations/](https://github.com/advplyr/audiobookshelf/tree/master/server/migrations).
+
+## Core media tables
+
+From [server/models/Book.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Book.js):
+
+```js
+// book
+id UUID PK
+title STRING, titleIgnorePrefix STRING, subtitle STRING
+publishedYear STRING, publishedDate STRING, publisher STRING
+description TEXT, isbn STRING, asin STRING, language STRING
+explicit BOOLEAN, abridged BOOLEAN
+coverPath STRING, duration FLOAT
+narrators JSON, audioFiles JSON, ebookFile JSON, chapters JSON
+tags JSON, genres JSON
+// indexes: title NOCASE, publishedYear, duration
+```
+
+From [LibraryItem.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/LibraryItem.js):
+
+```js
+// libraryItem — the filesystem-backed envelope around a book/podcast
+id UUID PK
+ino STRING (filesystem inode — scan continuity)
+path STRING, relPath STRING
+mediaId UUID, mediaType STRING ('book' | 'podcast')
+isFile BOOLEAN, isMissing BOOLEAN, isInvalid BOOLEAN
+mtime/ctime/birthtime DATE(6)
+size BIGINT
+lastScan DATE, lastScanVersion STRING
+libraryFiles JSON, extraData JSON
+title STRING (denormalized for sorting)
+titleIgnorePrefix STRING
+authorNamesFirstLast STRING, authorNamesLastFirst STRING
+libraryId FK, libraryFolderId FK
+```
+
+The `libraryItem → book` relation uses `foreignKey: 'mediaId', constraints: false` ([LibraryItem.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/LibraryItem.js)) because `mediaId` polymorphically points at `book` or `podcast`. No DB-level FK enforcement on that edge — a known footgun. **Omnibus should split into two tables (`audiobook_items`, `podcast_items`) or use a discriminator with separate real FKs**, not polymorphic no-constraint links.
+
+## Podcasts
+
+```js
+// podcast (from Podcast.js)
+id UUID PK
+title, titleIgnorePrefix, author, releaseDate
+feedURL, imageURL, itunesPageURL, itunesId, itunesArtistId
+description TEXT, language, podcastType, explicit
+autoDownloadEpisodes BOOLEAN, autoDownloadSchedule STRING (cron)
+lastEpisodeCheck DATE, maxEpisodesToKeep INTEGER, maxNewEpisodesToDownload INTEGER
+coverPath, tags JSON, genres JSON, numEpisodes INTEGER
+
+// podcastEpisode (from PodcastEpisode.js)
+id UUID PK, podcastId FK
+index INTEGER, season STRING, episode STRING, episodeType STRING
+title, subtitle STRING(1000), description TEXT, pubDate STRING
+enclosureURL, enclosureSize BIGINT, enclosureType
+publishedAt DATE
+audioFile JSON, chapters JSON, extraData JSON
+```
+
+## User + progress + sessions
+
+```js
+// user (User.js)
+id UUID PK, username, email, pash, type ('root'|'admin'|'user'|'guest'), token
+isActive BOOLEAN, isLocked BOOLEAN, lastSeen DATE
+permissions JSON, bookmarks JSON, extraData JSON
+
+// mediaProgress (MediaProgress.js)
+id UUID PK, userId FK
+mediaItemId UUID, mediaItemType STRING (polymorphic, no FK)
+duration FLOAT, currentTime FLOAT
+isFinished BOOLEAN, hideFromContinueListening BOOLEAN
+ebookLocation STRING, ebookProgress FLOAT
+finishedAt DATE, extraData JSON, podcastId UUID
+
+// playbackSession (PlaybackSession.js) — one row per listening session, kept for stats
+id UUID PK, userId FK, deviceId FK, libraryId FK
+mediaItemId UUID, mediaItemType STRING (polymorphic)
+displayTitle, displayAuthor STRING, duration FLOAT
+playMethod INTEGER, mediaPlayer STRING
+startTime/currentTime FLOAT
+timeListening INTEGER, mediaMetadata JSON
+date STRING, dayOfWeek STRING
+```
+
+Bookmarks live in `user.bookmarks` as a JSON array rather than their own table — which means a full row-rewrite on every bookmark add/remove and no FK to library items. **Omnibus should normalize** to a `bookmarks(user_id, library_item_id, time_seconds, title, created_at)` table with indices.
+
+## Organization
+
+- **Series** (UUID + name + nameIgnorePrefix + description, per-library), m2m link via **BookSeries** with a `sequence` TEXT column — [Series.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Series.js), [BookSeries.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/BookSeries.js).
+- **Author** (name, lastFirst, asin, description, imagePath, per-library) m2m via **BookAuthor** ([Author.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Author.js)).
+- **Collection** (library-scoped, admin-curated) + **CollectionBook** (ordered).
+- **Playlist** (user-scoped, can mix books and podcast episodes) + **PlaylistMediaItem** with polymorphic `mediaItemId/mediaItemType`.
+- **Tags** and **Genres**: *not tables*; JSON arrays on Book/Podcast. Renames scan every row.
+
+## Infrastructure tables
+
+- **ApiKey** — programmatic access tokens separate from user sessions.
+- **Device** — `deviceId`, `clientName` ("Abs Web", "Abs Android"), `clientVersion`, `deviceName`, `ipAddress` ([Device.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Device.js)). One row per registered client.
+- **Feed** + **FeedEpisode** — published RSS catalog for any entity (`entityType` = book/collection/series/playlist; [Feed.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Feed.js)).
+- **MediaItemShare** — public share links.
+- **Setting** — generic key/value for `ServerSettings`, `EmailSettings`, `NotificationSettings` serialized into JSON.
+- **Session** — auth refresh-token store (rows per browser/device; see [v2.26.0-create-auth-tables.js](https://github.com/advplyr/audiobookshelf/blob/master/server/migrations/v2.26.0-create-auth-tables.js)).
+
+## Indexes
+
+Declared inline in each model's `indexes:` option — [Book indexes](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Book.js) on `title NOCASE`, `publishedYear`, `duration`. Retrofitted indexes in [v2.15.2-index-creation.js](https://github.com/advplyr/audiobookshelf/blob/master/server/migrations/v2.15.2-index-creation.js), [v2.17.7-add-indices.js](https://github.com/advplyr/audiobookshelf/blob/master/server/migrations/v2.17.7-add-indices.js), [v2.33.0-add-discover-query-indexes.js](https://github.com/advplyr/audiobookshelf/blob/master/server/migrations/v2.33.0-add-discover-query-indexes.js) — the retrofit trail is a map of which queries hurt in production.
+
+## Migration approach
+
+`umzug`-driven with filename convention `v<server-version>-<name>.js`, each exporting `up` and `down` as required by [migrations/readme.md](https://github.com/advplyr/audiobookshelf/blob/master/server/migrations/readme.md). Orchestrator in [MigrationManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/MigrationManager.js). Run automatically on startup when `package.json.version` differs from the persisted `Setting.version` — down migrations when downgrading. This is a solid pattern Omnibus should mirror with `sqlx migrate` or `refinery` once the schema stabilizes.
+
+---
+
+[← Dioxus / Rust wins](4-dioxus-rust-wins.md) · [Next: API surface →](6-api-surface.md)

--- a/docs/audiobookshelf-inspection/6-api-surface.md
+++ b/docs/audiobookshelf-inspection/6-api-surface.md
@@ -1,0 +1,56 @@
+# 6. API surface
+
+## REST — single `/api/*` router
+
+[server/routers/ApiRouter.js](https://github.com/advplyr/audiobookshelf/blob/master/server/routers/ApiRouter.js) mounts ~150 routes, grouped by controller. Authentication is `passport.authenticate('jwt', { session: false })` for everything except `GET /api/items/:id/cover` and `GET /api/authors/:id/image` (unauth via [Auth.authNotNeeded](https://github.com/advplyr/audiobookshelf/blob/master/server/Auth.js)).
+
+Notable route families:
+
+- **Libraries**: `/libraries` CRUD, `/libraries/:id/items`, `/search`, `/personalized`, `/filterdata`, `/series`, `/collections`, `/playlists`, `/authors`, `/narrators`, `/scan`, `/matchall`, `/recent-episodes`, `/opml`, `/stats`, `/download`, `/remove-metadata`, `/podcast-titles`.
+- **Library items**: `/items/:id` (GET/DELETE), `/media` (PATCH), `/cover` (GET/POST/PATCH/DELETE), `/match`, `/play`, `/play/:episodeId`, `/tracks`, `/scan`, `/chapters`, `/ffprobe/:fileid`, `/file/:fileid`, `/ebook/:fileid?`, `/ebook/:fileid/status`, plus `/items/batch/{delete,update,get,quickmatch,scan}`.
+- **Me**: `/me`, `/me/listening-sessions`, `/me/listening-stats`, `/me/progress/:id/:episodeId?`, `/me/progress/batch/update`, `/me/item/:id/bookmark` (POST/PATCH/DELETE), `/me/password`, `/me/items-in-progress`, `/me/stats/year/:year`, `/me/ereader-devices`.
+- **Users**: `/users` CRUD, `/users/online`, `/users/:id/listening-sessions`, `/users/:id/listening-stats`, `/users/:id/openid-unlink`.
+- **Collections / Playlists / Series / Authors**: CRUD + batch add/remove, author `match`, author `image`.
+- **Podcasts**: `/podcasts` POST, `/podcasts/feed`, `/podcasts/opml/parse`, `/podcasts/opml/create`, `/podcasts/:id/checknew`, `/downloads`, `/clear-queue`, `/search-episode`, `/download-episodes`, `/match-episodes`, `/episode/:episodeId` (GET/PATCH/DELETE).
+- **Search (metadata providers)**: `/search/covers`, `/search/books`, `/search/podcast`, `/search/authors`, `/search/chapters`, `/search/providers`.
+- **Sessions**: `/sessions` (admin), `/session/:id` open-session sync/close, `/session/local`, `/session/local-all`.
+- **Tools**: `/tools/item/:id/encode-m4b`, `/tools/item/:id/embed-metadata`, `/tools/batch/embed-metadata`.
+- **Feeds (RSS publish)**: `/feeds`, `/feeds/item/:itemId/open`, `/feeds/collection/:collectionId/open`, `/feeds/series/:seriesId/open`, `/feeds/:id/close`.
+- **Admin**: `/notifications*`, `/emails/settings`, `/emails/test`, `/emails/send-ebook-to-device`, `/emails/ereader-devices`, `/cache/purge`, `/cache/items/purge`, `/backups*`, `/api-keys*`, `/custom-metadata-providers*`, `/stats/server`, `/stats/year/:year`, `/share/mediaitem`, `/auth-settings`, `/watcher/update`, `/tags*`, `/genres*`, `/validate-cron`, `/logger-data`, `/settings`, `/sorting-prefixes`.
+
+## HLS router
+
+[server/routers/HlsRouter.js](https://github.com/advplyr/audiobookshelf/blob/master/server/routers/HlsRouter.js) mounts one path: `GET /hls/:stream/:file` (`.m3u8` or `.ts`). Auth is the same JWT middleware at the parent `/hls` mount ([Server.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Server.js)). Missing segments trigger a `SocketAuthority.emitter('stream_reset', …)` so clients seek to the new start.
+
+## Public router
+
+[server/routers/PublicRouter.js](https://github.com/advplyr/audiobookshelf/blob/master/server/routers/PublicRouter.js) serves unauthenticated shares:
+
+- `GET /public/share/:slug` (landing)
+- `GET /public/share/:slug/track/:index` (direct-play audio)
+- `GET /public/share/:slug/cover`
+- `GET /public/share/:slug/download`
+- `PATCH /public/share/:slug/progress`
+- `GET /public/session/:id/track/:index` (direct-play for an active session)
+
+## Feed delivery
+
+Registered directly on the root router in [Server.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Server.js):
+
+- `GET /feed/:slug` — RSS XML
+- `GET /feed/:slug/cover*`
+- `GET /feed/:slug/item/:episodeId/*`
+
+## Socket.io events
+
+Two socket.io servers mounted — one at `/socket.io`, one at `${RouterBasePath}/socket.io` for reverse-proxy setups ([SocketAuthority.js](https://github.com/advplyr/audiobookshelf/blob/master/server/SocketAuthority.js)). Client-to-server events: `auth`, `cancel_scan`, `search_covers`, `cancel_cover_search`, `set_log_listener`, `remove_log_listener`, `message_all_users` (admin), `ping`. Server-to-client events (sampled): `init`, `auth_failed`, `admin_message`, `pong`, `stream_reset`, `user_offline`, `user_online`, `item_added`, `item_updated`, `item_removed`, `items_added`, `items_updated`, `author_added`, `author_updated`, `author_removed`, `series_added`, `series_removed`, `collection_added`, `collection_updated`, `collection_removed`, `rss_feed_open`, `rss_feed_closed`, `episode_download_queued`, `episode_download_started`, `episode_download_finished`, `episode_download_queue_cleared`, `metadata_embed_queue_update`, `scan_start`, `scan_complete`.
+
+## No OPDS, no Kobo sync
+
+Unlike Calibre-Web, ABS publishes content-as-podcast-RSS and relies on first-party mobile apps + web player. Mobile apps are first-class consumers of the same `/api/*` surface (not a separate protocol) — the only bespoke mobile endpoints are `/api/session/local*` for offline playback sync and a `X-API-KEY` header pattern.
+
+Omnibus' dual plan — `/api/*` as primary REST contract plus Dioxus server functions at `/api/rpc/*` for the web client — is consistent with ABS's "one REST surface for everything." Mount OPDS and a Kobo-sync compatibility layer on top later; don't build parallel contracts.
+
+---
+
+[← Schema details](5-schema-details.md) · [Next: recommendations →](7-recommendations.md)

--- a/docs/audiobookshelf-inspection/7-recommendations.md
+++ b/docs/audiobookshelf-inspection/7-recommendations.md
@@ -1,0 +1,56 @@
+# 7. Recommendations for Omnibus
+
+Ordered roughly by payoff vs. cost. These compose with the Calibre-Web recommendations — where they conflict, the ABS recommendation wins for audiobook/podcast paths.
+
+1. **Split `library_items` polymorphism into concrete tables.** ABS's `libraryItem.mediaId` points at either `book.id` or `podcast.id` with `constraints: false` ([LibraryItem.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/LibraryItem.js)) — no FK enforcement, same bug surface as Calibre's cross-DB orphan issue. Use two tables (`audiobook_items`, `podcast_items`) with real FKs, or a discriminator column plus concrete `book_id` / `podcast_id` nullable FKs with a CHECK constraint. Same argument for `mediaProgress.mediaItemId` and `playbackSession.mediaItemId`.
+
+2. **Normalize tags and genres into tables.** ABS stores both as JSON arrays on Book/Podcast ([Book.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Book.js)) and pays for it at rename time ([MiscController.renameTag](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/MiscController.js)). A `tags(id, name)` + `item_tags(item_id, tag_id)` design makes `GET /api/tags` a single query, renames an `UPDATE tags SET name = ?`, and enables indexed filter-by-tag without JSON functions.
+
+3. **FTS5 at startup with triggers.** ABS defers full-text to an optional `nusqlite3` extension ([Database.js](https://github.com/advplyr/audiobookshelf/blob/master/server/Database.js)) and falls back to LIKE/fuse.js. Omnibus creates `library_items_fts(title, subtitle, authors, narrators, series, description)` unconditionally with `tokenize='unicode61 remove_diacritics 2'` and AFTER INSERT/UPDATE/DELETE triggers. Ship bm25 as the primary search path; drop client-side fuse.
+
+4. **Shared HLS segment cache keyed by `(book_id, codec_profile, segment_index)`.** ABS spawns one ffmpeg per session ([Stream.js](https://github.com/advplyr/audiobookshelf/blob/master/server/objects/Stream.js)) with no cache. Store segments under `<data_dir>/hls/<book_id>/<profile>/seg-NNN.ts`, serve from disk, populate on miss with a `tokio::sync::Mutex` per (book, profile) so only one ffmpeg runs per unique stream. Two users on the same book = one transcode.
+
+5. **Scanner = `JoinSet` + `Semaphore(num_cpus)`.** Mirror BookScanner's metadata-precedence engine ([BookScanner.js](https://github.com/advplyr/audiobookshelf/blob/master/server/scanner/BookScanner.js)) but parallelize `ffprobe` invocations. On a 5000-item library, the walltime gap vs. ABS's serial scan is ~linear in `num_cpus`. Keep the precedence list itself (folderStructure → audioMetatags → nfoFile → opfFile → absMetadata → providerOverride) — it's well-thought-out.
+
+6. **Persist bookmarks in their own table.** ABS's `user.bookmarks` JSON column rewrites the whole user row on every add/remove ([User.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/User.js)). Omnibus: `bookmarks(id, user_id, library_item_id, time_seconds, title, created_at)` with `(user_id, library_item_id)` index.
+
+7. **Typed Socket protocol over broadcast channels.** Replace ABS's `toOldJSONExpanded()` per-client serialization loop ([SocketAuthority.js](https://github.com/advplyr/audiobookshelf/blob/master/server/SocketAuthority.js)) with `ServerEvent` enum + `tokio::sync::broadcast` scoped per library. Subscribers filter at receive time; payloads serialize once per event. Same shape across server/frontend/mobile from a shared crate (already the pattern in [omnibus-shared](../../shared/src/lib.rs)).
+
+8. **Podcast downloads: concurrent with per-feed fairness.** ABS serializes through `currentDownload` ([PodcastManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/PodcastManager.js)). Omnibus: a bounded `JoinSet` with a per-feed guard so one slow feed can't starve others. Round-robin pull from `downloadQueue` grouped by `podcast_id`.
+
+9. **Adopt the Metadata Precedence list as a user-facing setting.** ABS's per-library `metadataPrecedence` JSON array is one of its best UX decisions ([Library.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Library.js)). Copy verbatim: the user controls which source wins per field and per library, not a hard-coded priority.
+
+10. **Copy ABS's `umzug`-style migration approach, not Calibre-Web's runtime ALTER.** Filename convention `v<version>-<name>.rs` with `up`/`down`, run on boot when the stored version differs from `cargo.toml`. `refinery` or `sqlx migrate` both do this cleanly. See ABS's [MigrationManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/MigrationManager.js) and the index-retrofit trail in [server/migrations/](https://github.com/advplyr/audiobookshelf/tree/master/server/migrations) — that list is a free hint sheet for indexes you'll need.
+
+11. **OIDC from day one, not a bolt-on.** [OidcAuthStrategy.js](https://github.com/advplyr/audiobookshelf/blob/master/server/auth/OidcAuthStrategy.js) is ~560 lines; the patterns (PKCE, state map, group-based role mapping, mobile redirect subfolder handling) are worth copying structurally. Rust: `openidconnect` crate.
+
+12. **Publish `/api/*` as the canonical REST contract and document it.** ABS's unified `/api/*` for both mobile and web ([ApiRouter.js](https://github.com/advplyr/audiobookshelf/blob/master/server/routers/ApiRouter.js)) is better than Calibre-Web's "OPDS + Kobo + ad-hoc /ajax" split. Use `utoipa` or `aide` to emit OpenAPI from the axum handlers so the mobile team doesn't have to read source.
+
+13. **Ship podcast-as-RSS publishing.** [RssFeedManager](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/RssFeedManager.js) lets any audiobook/collection/series look like a podcast to Overcast/AntennaPod. Low-cost to implement on top of `quick-xml`, high user value for commute-during-audiobook use cases. Mount under `/feed/:slug` outside the auth middleware.
+
+14. **Apprise for notifications, not bespoke integrations.** ABS POSTs a simple `{ urls, title, body }` payload to an operator-run Apprise HTTP server ([NotificationManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/NotificationManager.js)). Omnibus inherits 80+ notification targets for one HTTP client call.
+
+15. **Streaming responses for OPML, feed, bulk-download.** ABS generates OPML as whole-string buffers. axum `StreamBody` + `quick-xml` writer on `tokio::io::DuplexStream` — constant memory for a 10k-podcast export. Same technique for bulk ZIP download (`/api/libraries/:id/download`) using `async-zip`.
+
+## Cross-reference to roadmap
+
+| Roadmap initiative | Recommendations above |
+|---|---|
+| [F0.1 Schema refactor](../roadmap/0-1-schema-refactor.md) | 1, 2, 6 |
+| [F0.2 Migrations](../roadmap/0-2-migrations.md) | 10 |
+| [F0.3 Auth](../roadmap/0-3-auth.md) | 11 |
+| [F0.4 FTS5](../roadmap/0-4-fts5.md) | 3 |
+| [F0.5 Background worker](../roadmap/0-5-background-worker.md) | 5, 8 |
+| [F0.6 Library filesystem](../roadmap/0-6-library-filesystem.md) | 5, 9 |
+| [F1.1 Search](../roadmap/1-1-search.md) | 3 |
+| [F1.3 Library views](../roadmap/1-3-library-views.md) | 7 |
+| [F2.x Audio streaming / HLS](../roadmap/0-0-summary.md) | 4, 15 |
+| [F2.x Podcasts](../roadmap/0-0-summary.md) | 8, 13 |
+| [F3.x Progress sync](../roadmap/0-0-summary.md) | 6, 7 |
+| [F4.x Feeds / sharing](../roadmap/0-0-summary.md) | 13, 15 |
+| [F5.1 Metadata edit](../roadmap/5-1-metadata-edit.md) | 9 |
+| Admin | 12, 14 |
+
+---
+
+[← API surface](6-api-surface.md) · [Overview](0-overview.md) · [Roadmap summary](../roadmap/0-0-summary.md)

--- a/docs/roadmap/0-3-auth.md
+++ b/docs/roadmap/0-3-auth.md
@@ -19,6 +19,8 @@ Every feature touching user state needs it. Building those first and retrofittin
 - Explicit permission **columns** (`is_admin BOOL`, `can_upload BOOL`, `can_edit BOOL`, `can_download BOOL`) rather than a role bitmask — bitmasks are opaque and migration-hostile (see [calibre-inspection recommendation #9](../calibre-inspection/7-recommendations.md)).
 - `auth_required` / `admin_required` axum extractors, mirroring the shape of `StateExtractor`.
 - Unified auth model across web (cookies) and mobile (bearer tokens) — both flow into the same session table.
+- **OIDC/SSO as a day-one extension point, not a v2 bolt-on.** Shape the auth layer so a second `AuthStrategy` (OIDC via the `openidconnect` crate, full PKCE, group→role mapping) slots in without schema rework. ABS's [OidcAuthStrategy.js](https://github.com/advplyr/audiobookshelf/blob/master/server/auth/OidcAuthStrategy.js) is ~560 lines because it was bolted on — designing the trait up front avoids that cost. See [ABS recommendation #11](../audiobookshelf-inspection/7-recommendations.md).
+- **Device rows** for registered clients (`device_id`, `client_name`, `client_version`, `last_seen`, `ip_address`) so admin can see who's connected and revoke a specific phone. ABS pattern: [Device.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Device.js).
 
 ## Dependencies
 

--- a/docs/roadmap/0-5-background-worker.md
+++ b/docs/roadmap/0-5-background-worker.md
@@ -16,6 +16,7 @@ Avoids Calibre-Web's single-`WorkerThread` ceiling (see [performance pain points
 
 - Typed `enum Task { Scan(..), Thumbnail(..), SendEmail(..), ConvertFormat(..) }` — designing this enum conservatively is the main design cost (additions easy, renames painful).
 - `JoinSet` + `Semaphore::new(max_concurrency)` where concurrency is per-task-type (e.g. `max(1, num_cpus / 2)` for conversions; more for thumbnails).
+- **Per-resource fairness guards**, not just global concurrency. When a future task type works against multiple independent resources (e.g. per-library scan, per-provider metadata lookup), one slow resource shouldn't starve the others — hold a per-resource guard inside the task so concurrent work on *different* resources proceeds while the same resource queues serially. ABS serializes all podcast downloads through a single `currentDownload` slot and this is its most-complained-about backlog — the shape of the warning applies even though Omnibus won't fetch media from the web ([ABS recommendation #8](../audiobookshelf-inspection/7-recommendations.md), [PodcastManager.js](https://github.com/advplyr/audiobookshelf/blob/master/server/managers/PodcastManager.js)).
 - In-memory queue initially — acceptable because we own the single-process model. Persist to a `background_tasks` table when [F5.2 observability](5-2-observability.md) arrives so admins can see status and history.
 - Task API: `worker.post(Task::Thumbnail { … }) -> TaskId`; optional `worker.await_completion(id)`.
 

--- a/docs/roadmap/2-1-progress-sync.md
+++ b/docs/roadmap/2-1-progress-sync.md
@@ -18,6 +18,8 @@ Building reader ([F2.2](2-2-epub-reader.md)) and audio player ([F2.3](2-3-audiob
 - Last-write-wins on `(user_id, book_id, format)`; conflicts reconcile client-side so we don't need CRDT infrastructure.
 - Client-side debounce (~5s for reading, ~15s for audio) and offline queue in IndexedDB (web) / SQLite (mobile).
 - Endpoint returns the server's authoritative position so a newly opened client syncs forward.
+- **Bookmarks as their own table**, not a JSON blob on `users`: `bookmarks(id, user_id, book_id, position, title, created_at)` with `(user_id, book_id)` index. ABS stores bookmarks as a JSON array on the user row and rewrites the whole row on every add/remove — no FK to books, no concurrent-write safety ([ABS recommendation #6](../audiobookshelf-inspection/7-recommendations.md), [User.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/User.js)).
+- **`listening_sessions` table** (one row per playback session: `user_id`, `book_id`, `started_at`, `ended_at`, `seconds_listened`, `device_id`) to feed stats/year-in-review without re-deriving from progress writes. Mirrors ABS's [PlaybackSession model](https://github.com/advplyr/audiobookshelf/blob/master/server/models/PlaybackSession.js). Mobile posts batched sessions on reconnect via a `POST /api/progress/sessions` companion route. Pair with an analogous `reading_sessions` table for the epub reader so stats can aggregate audiobooks listened, epubs read, and (future) journal entries across week / month / 6-month / year / lifetime windows — designing the session shape now is what makes that feature cheap later.
 
 ## Dependencies
 

--- a/docs/roadmap/2-3-audiobook-player.md
+++ b/docs/roadmap/2-3-audiobook-player.md
@@ -14,10 +14,12 @@ Audiobook support is the feature AudioBookShelf users currently leave for — la
 
 ## Technical considerations
 
-- HTML5 `<audio>` is sufficient — no need for SoundManager or third-party players.
-- Chapters come from the m4b container via `mp4ameta`. Persist into a `file_chapters` table keyed on `book_file_id`, populated during scan.
+- HTML5 `<audio>` is sufficient for direct-play (m4a/m4b/mp3). Add `hls.js` only when we need to transcode FLAC or multi-file m4b stitching — follow the AudioBookShelf pattern without copying the per-session ffmpeg ([ABS pain points](../audiobookshelf-inspection/3-performance-pain-points.md)).
+- **Shared HLS segment cache** keyed on `(book_id, codec_profile, segment_index)`, stored under `<data_dir>/hls/<book_id>/<profile>/seg-NNN.ts`. One `tokio::sync::Mutex` per `(book, profile)` so two users on the same audiobook trigger one transcode, not two ([ABS recommendation #4](../audiobookshelf-inspection/7-recommendations.md)).
+- Chapters come from the m4b container via `mp4ameta` for native atoms; fall back to ffprobe for mp3/flac embedded chapters. Persist into a `file_chapters` table keyed on `book_file_id`, populated during scan via [F0.5 background worker](0-5-background-worker.md). Use `JoinSet` + `Semaphore(num_cpus)` — ABS's serial ffprobe loop is the single biggest scanner bottleneck.
 - Position is seconds (float); writes through F2.1 on debounce + on pause/unload.
 - Playback speed lives in localStorage per-user — not synced (device-specific preference).
+- Metadata embed tool (write ID3/m4b tags back) is deferred — admin-only feature for a later phase; see ABS's `/api/tools/item/:id/embed-metadata`.
 
 ## Dependencies
 

--- a/docs/roadmap/5-1-metadata-edit.md
+++ b/docs/roadmap/5-1-metadata-edit.md
@@ -16,6 +16,7 @@ Closes [gap G7](0-0-summary.md#gaps). Self-hosted libraries are messy; fixing me
 
 - **Edits go to DB only, never to disk.** No folder renames, no file mutation, no OPF rewrites. See [recommendations #7, #8](../calibre-inspection/7-recommendations.md) — Calibre-Web's folder-rename-on-edit path races with readers and scanners and is the wrong shape to copy.
 - `books.metadata_overrides` JSON merged on read: scanned values form the base; override keys win.
+- **Per-library metadata precedence as a user setting.** Order the metadata sources (`folder_structure`, `embedded_tags`, `opf_sidecar`, `omnibus_overrides`, `provider_match`) in a JSON array on the library row; the scanner / merge path walks the list for each field. Adopted from AudioBookShelf's per-library `metadataPrecedence` — their best UX decision, verbatim copy ([ABS recommendation #9](../audiobookshelf-inspection/7-recommendations.md), [Library.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Library.js)).
 - Cover replace writes to the [F1.2 thumbnail cache](1-2-thumbnails.md) and bumps `last_modified` to invalidate downstream caches.
 - OPF export exists only as a per-book download action (courtesy to users leaving Omnibus), never as a source-of-truth sync target.
 


### PR DESCRIPTION
## Summary
- Investigated how AudioBookShelf works to document areas that we want to organize similarly or differently
- Updated roadmap features based off of inspection and findings

## Notes
- AudioBookShelf has a lot about podcasts and RSS feeds that aren't explicitly in our roadmap (nor did I ever really... desire those features). Pretty interesting to see how they did that stuff alongside ebooks/audiobooks.

<!--
Use the following for callouts:

>[!NOTE]
> Blue message!

>[!WARNING]
> Yello message!

>[!IMPORTANT]
> Purple message!

>[!CAUTION]
> Red message!

>[!TIP]
> Green message!
-->