### PR TITLE
feat(f0.2): migration framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Default `cargo build` / `clippy` covers `server`, `shared`, `frontend` only. Mob
 
 **Mobile data flow:** Dioxus signal/effect → `reqwest` call to `/api/*` (hand-written handlers in `server/src/backend.rs`) → signal update → re-render. Mobile deliberately does **not** use the `/api/rpc/*` server functions.
 
-**Database:** schema is created inline at startup in `frontend::db::initialize_schema`. No migrations framework yet. All tests use `sqlite::memory:` for isolation.
+**Database:** schema ships as numbered SQL migrations under [frontend/migrations/](frontend/migrations/), embedded via `sqlx::migrate!` and run on pool init in `frontend::db::init_db`. Applied versions are recorded in the `_sqlx_migrations` table. Add new migrations as `NNNN_description.sql` — never edit an applied file. All tests use `sqlite::memory:` for isolation; the migrator runs against them the same as production.
 
 **Server URL (mobile):** hardcoded to `http://127.0.0.1:3000` in `mobile/src/main.rs` via `use_context_provider`. Will become a first-launch setup screen.
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -10,7 +10,7 @@ omnibus-shared = { path = "../shared" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"], optional = true }
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate"], optional = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"], optional = true }
 anyhow = { version = "1", optional = true }
 epub = { version = "2", optional = true }

--- a/frontend/migrations/0001_initial_schema.sql
+++ b/frontend/migrations/0001_initial_schema.sql
@@ -1,0 +1,62 @@
+-- Baseline schema for Omnibus. Verbatim lift from the former
+-- `frontend::db::initialize_schema` so existing databases migrate in-place
+-- (sqlx records this version as already-applied only when the checksum matches,
+-- so for existing deployments this migration is effectively a no-op thanks to
+-- the `IF NOT EXISTS` guards).
+
+CREATE TABLE IF NOT EXISTS app_state (
+    id INTEGER PRIMARY KEY CHECK(id = 1),
+    value INTEGER NOT NULL
+);
+
+INSERT INTO app_state (id, value)
+SELECT 1, 0
+WHERE NOT EXISTS (SELECT 1 FROM app_state WHERE id = 1);
+
+CREATE TABLE IF NOT EXISTS settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS books (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    library_path      TEXT NOT NULL,
+    filename          TEXT NOT NULL,
+    title             TEXT,
+    description       TEXT,
+    publisher         TEXT,
+    published         TEXT,
+    modified          TEXT,
+    language          TEXT,
+    rights            TEXT,
+    source            TEXT,
+    coverage          TEXT,
+    dc_type           TEXT,
+    dc_format         TEXT,
+    relation          TEXT,
+    creators_json     TEXT NOT NULL DEFAULT '[]',
+    contributors_json TEXT NOT NULL DEFAULT '[]',
+    subjects_json     TEXT NOT NULL DEFAULT '[]',
+    identifiers_json  TEXT NOT NULL DEFAULT '[]',
+    series            TEXT,
+    series_index      TEXT,
+    epub_version      TEXT,
+    unique_identifier TEXT,
+    resource_count    INTEGER NOT NULL DEFAULT 0,
+    spine_count       INTEGER NOT NULL DEFAULT 0,
+    toc_count         INTEGER NOT NULL DEFAULT 0,
+    has_cover         INTEGER NOT NULL DEFAULT 0,
+    error             TEXT,
+    UNIQUE(library_path, filename)
+);
+
+CREATE TABLE IF NOT EXISTS book_covers (
+    book_id INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE,
+    mime    TEXT NOT NULL,
+    bytes   BLOB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS library_index_state (
+    library_path TEXT PRIMARY KEY,
+    last_indexed INTEGER NOT NULL
+);

--- a/frontend/src/db.rs
+++ b/frontend/src/db.rs
@@ -3,117 +3,22 @@ use sqlx::{sqlite::SqlitePoolOptions, Row, SqlitePool};
 pub use omnibus_shared::Settings;
 use omnibus_shared::{Contributor, EbookLibrary, EbookMetadata, Identifier};
 
+/// Schema migrations embedded at compile time from `frontend/migrations/`.
+/// Every schema change ships as a new numbered `.sql` file there; applied
+/// versions are recorded in the `_sqlx_migrations` table.
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
 pub async fn init_db(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
         .connect(database_url)
         .await?;
 
-    initialize_schema(&pool).await?;
+    MIGRATOR
+        .run(&pool)
+        .await
+        .map_err(|e| sqlx::Error::Migrate(Box::new(e)))?;
     Ok(pool)
-}
-
-pub async fn initialize_schema(pool: &SqlitePool) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS app_state (
-            id INTEGER PRIMARY KEY CHECK(id = 1),
-            value INTEGER NOT NULL
-        )
-        "#,
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        r#"
-        INSERT INTO app_state (id, value)
-        SELECT 1, 0
-        WHERE NOT EXISTS (SELECT 1 FROM app_state WHERE id = 1)
-        "#,
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS settings (
-            key   TEXT PRIMARY KEY,
-            value TEXT NOT NULL
-        )
-        "#,
-    )
-    .execute(pool)
-    .await?;
-
-    // Cached book metadata. The landing page queries this table instead of
-    // walking the filesystem on every request. Rows are keyed by the library
-    // root they were indexed under + the file's relative path so indexing a
-    // new library (via settings change) doesn't conflict with an old one.
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS books (
-            id                INTEGER PRIMARY KEY AUTOINCREMENT,
-            library_path      TEXT NOT NULL,
-            filename          TEXT NOT NULL,
-            title             TEXT,
-            description       TEXT,
-            publisher         TEXT,
-            published         TEXT,
-            modified          TEXT,
-            language          TEXT,
-            rights            TEXT,
-            source            TEXT,
-            coverage          TEXT,
-            dc_type           TEXT,
-            dc_format         TEXT,
-            relation          TEXT,
-            creators_json     TEXT NOT NULL DEFAULT '[]',
-            contributors_json TEXT NOT NULL DEFAULT '[]',
-            subjects_json     TEXT NOT NULL DEFAULT '[]',
-            identifiers_json  TEXT NOT NULL DEFAULT '[]',
-            series            TEXT,
-            series_index      TEXT,
-            epub_version      TEXT,
-            unique_identifier TEXT,
-            resource_count    INTEGER NOT NULL DEFAULT 0,
-            spine_count       INTEGER NOT NULL DEFAULT 0,
-            toc_count         INTEGER NOT NULL DEFAULT 0,
-            has_cover         INTEGER NOT NULL DEFAULT 0,
-            error             TEXT,
-            UNIQUE(library_path, filename)
-        )
-        "#,
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS book_covers (
-            book_id INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE,
-            mime    TEXT NOT NULL,
-            bytes   BLOB NOT NULL
-        )
-        "#,
-    )
-    .execute(pool)
-    .await?;
-
-    // Tracks the last successful index per library path so callers can
-    // decide when to kick off a refresh.
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS library_index_state (
-            library_path TEXT PRIMARY KEY,
-            last_indexed INTEGER NOT NULL
-        )
-        "#,
-    )
-    .execute(pool)
-    .await?;
-
-    Ok(())
 }
 
 fn decode_json<T: serde::de::DeserializeOwned + Default>(s: &str) -> T {

--- a/frontend/src/db.rs
+++ b/frontend/src/db.rs
@@ -353,6 +353,44 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn migrator_records_applied_versions() {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let versions: Vec<i64> =
+            sqlx::query_scalar("SELECT version FROM _sqlx_migrations ORDER BY version")
+                .fetch_all(&pool)
+                .await
+                .expect("_sqlx_migrations should exist after init_db");
+        assert!(
+            versions.contains(&1),
+            "baseline migration 0001 should be recorded, got {versions:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn migrator_is_idempotent_on_rerun() {
+        // sqlx::migrate! against a file-backed DB so a second init_db call
+        // exercises the "already applied" path. In-memory DBs are discarded
+        // between pool connections so they can't test re-runs.
+        let tmp = std::env::temp_dir().join(format!("omnibus-migrate-{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        let url = format!("sqlite://{}?mode=rwc", tmp.display());
+
+        let pool1 = init_db(&url).await.expect("first init should succeed");
+        drop(pool1);
+        let pool2 = init_db(&url).await.expect("second init should be a no-op");
+
+        // After two runs there should still be exactly one row per migration.
+        let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations")
+            .fetch_one(&pool2)
+            .await
+            .unwrap();
+        assert_eq!(row_count, 1, "baseline should be recorded exactly once");
+
+        drop(pool2);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[tokio::test]
     async fn initializes_and_seeds_default_value() {
         let pool = init_db("sqlite::memory:")
             .await


### PR DESCRIPTION
## Summary

Implements [F0.2 — Migration framework](docs/roadmap/0-2-migrations.md). Replaces the inline `initialize_schema` with versioned, embedded SQL migrations under `frontend/migrations/`, run automatically on pool init via `sqlx::migrate!`. Applied versions are recorded in `_sqlx_migrations`. Unblocks F0.1 (schema refactor) and every schema change after it.

- `chore(f0.2): add sqlx migrate feature and migrations directory`
- `feat(f0.2): add baseline migration 0001_initial_schema` — verbatim lift of the former inline schema, so existing DBs migrate in-place.
- `feat(f0.2): run sqlx::migrate! on pool init and remove inline initialize_schema`
- `test(f0.2): smoke tests for migrator table and idempotent re-run`
- `docs(f0.2): document migration workflow in CLAUDE.md`

## Test plan

- [x] `cargo test -p omnibus-frontend --features server` — 25 passing (including 2 new migrator smoke tests)
- [x] `cargo test -p omnibus` — 9 passing
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Smoke against a running `dx serve` (reviewer)