### PR TITLE
feat(auth): server plumbing — extractors, handlers, CSRF, rate limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,13 @@ components/{top_nav,bottom_nav}.rs  — feature = web / mobile respectively
 ### server/src/
 
 ```
-main.rs             — dioxus::launch (WASM) / dioxus::serve (native)
-lib.rs              — re-exports backend under `server` feature for tests
+main.rs             — dioxus::launch (WASM) / dioxus::serve (native); mounts auth_router + rate-limit + origin-check
+lib.rs              — re-exports backend + auth under `server` feature for tests
 backend.rs          — /api/* REST router (mobile-facing) + integration tests
+auth/mod.rs         — /api/auth/{register,login,logout,me} + AuthUser/AdminUser extractors + CSRF origin-check
+auth/rate_limit.rs  — in-memory per-IP token bucket for login/register
+auth/strategy.rs    — AuthStrategy trait + PasswordStrategy (OIDC/WebAuthn fit the same shape)
+auth/boot.rs        — OMNIBUS_INITIAL_ADMIN recovery hook (promotes named user to admin)
 ```
 
 ### ui_tests/playwright/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "axum",
  "axum-core",
  "bytes",
+ "cookie",
  "futures-util",
  "headers",
  "http",
@@ -3661,16 +3662,21 @@ dependencies = [
 name = "omnibus"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
+ "axum-extra",
  "dioxus",
  "omnibus-db",
  "omnibus-frontend",
  "omnibus-shared",
+ "serde",
  "serde_json",
  "sqlx",
+ "time",
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,10 +15,15 @@ dioxus = "0.7"
 
 # Server-only deps — all optional and gated behind the `server` feature.
 axum = { version = "0.8", optional = true }
+axum-extra = { version = "0.10", features = ["cookie"], optional = true }
 tower-http = { version = "0.6", features = ["trace"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"], optional = true }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"], optional = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"], optional = true }
+tracing = { version = "0.1", optional = true }
+async-trait = { version = "0.1", optional = true }
+time = { version = "0.3", optional = true }
 
 omnibus-shared = { path = "../shared" }
 # `features` here are forwarded via our own feature flags below. Leaving it
@@ -38,10 +43,15 @@ default = ["server"]
 # `omnibus-frontend/server` so server-function bodies compile in.
 server = [
     "dep:axum",
+    "dep:axum-extra",
     "dep:tower-http",
+    "dep:serde",
     "dep:serde_json",
     "dep:sqlx",
     "dep:tokio",
+    "dep:tracing",
+    "dep:async-trait",
+    "dep:time",
     "dep:omnibus-db",
     "dioxus/server",
     "omnibus-frontend/server",

--- a/server/src/auth/boot.rs
+++ b/server/src/auth/boot.rs
@@ -1,0 +1,136 @@
+//! `OMNIBUS_INITIAL_ADMIN` recovery hook.
+//!
+//! On boot, if the env var is set, promote the named existing user to admin.
+//! This is explicitly a recovery escape hatch ("I locked myself out") and
+//! *not* a provisioning mechanism — we don't auto-create a user from an env
+//! var since that would require smuggling a password in.
+//!
+//! Successful promotions are logged at `warn` so they show up in the audit
+//! trail; setting the env var for a user that doesn't exist also logs at
+//! `warn` so the misconfiguration is visible.
+
+use sqlx::SqlitePool;
+
+/// Read `OMNIBUS_INITIAL_ADMIN` and promote the named user (if present) to
+/// admin. No-op when the env var is unset or the named user doesn't exist.
+pub async fn apply_initial_admin(pool: &SqlitePool) -> Result<(), omnibus_db::auth::AuthError> {
+    let Ok(username) = std::env::var("OMNIBUS_INITIAL_ADMIN") else {
+        return Ok(());
+    };
+    let username = username.trim();
+    if username.is_empty() {
+        return Ok(());
+    }
+    let promoted = omnibus_db::auth::promote_to_admin(pool, username).await?;
+    if promoted {
+        tracing::warn!(
+            user = username,
+            "OMNIBUS_INITIAL_ADMIN promoted user to admin (recovery hook)"
+        );
+    } else {
+        tracing::warn!(
+            user = username,
+            "OMNIBUS_INITIAL_ADMIN set but user does not exist; no promotion performed"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+// Each test in this module holds `ENV_LOCK` across `await` points on
+// purpose — `std::env::{set_var, remove_var}` is process-global and racy,
+// so we serialize via a `std::sync::Mutex` (an async mutex wouldn't help
+// because the lock guards the env var itself, not just coroutine turns).
+#[allow(clippy::await_holding_lock)]
+mod tests {
+    use super::*;
+    use omnibus_db as db;
+
+    // std::env is global so these tests can't be parallelised safely; we
+    // serialize on a static mutex. Also restore the prior value on drop.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            // Safety: we hold ENV_LOCK for the duration of any test using this.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            unsafe { std::env::remove_var(key) };
+            Self { key, prev }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn unset_env_is_noop() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::unset("OMNIBUS_INITIAL_ADMIN");
+        let pool = db::init_db("sqlite::memory:").await.unwrap();
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        apply_initial_admin(&pool).await.unwrap();
+        // alice is the first user, so she's already admin — unchanged.
+        let u = db::auth::get_user_by_username(&pool, "alice")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(u.is_admin);
+    }
+
+    #[tokio::test]
+    async fn env_promotes_existing_non_admin() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let pool = db::init_db("sqlite::memory:").await.unwrap();
+        // alice becomes admin (first user). bob does not.
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        db::auth::set_registration_enabled(&pool, true)
+            .await
+            .unwrap();
+        db::auth::create_user(&pool, "bob", "correct horse battery staple")
+            .await
+            .unwrap();
+        let bob = db::auth::get_user_by_username(&pool, "bob")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!bob.is_admin);
+
+        let _g = EnvGuard::set("OMNIBUS_INITIAL_ADMIN", "bob");
+        apply_initial_admin(&pool).await.unwrap();
+
+        let bob = db::auth::get_user_by_username(&pool, "bob")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(bob.is_admin);
+    }
+
+    #[tokio::test]
+    async fn env_for_unknown_user_is_noop_no_error() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let pool = db::init_db("sqlite::memory:").await.unwrap();
+        let _g = EnvGuard::set("OMNIBUS_INITIAL_ADMIN", "ghost");
+        apply_initial_admin(&pool).await.unwrap();
+    }
+}

--- a/server/src/auth/csrf.rs
+++ b/server/src/auth/csrf.rs
@@ -1,0 +1,144 @@
+//! CSRF origin-check middleware.
+//!
+//! Rejects state-changing cookie-authed requests whose `Origin`/`Referer`
+//! doesn't match the request's `Host`. Bearer-authed requests (mobile) are
+//! exempt because browsers don't auto-attach bearer headers cross-site.
+//! Safe methods (`GET`/`HEAD`/`OPTIONS`) always pass through.
+//!
+//! This is belt-and-braces on top of `SameSite=Lax`, which blocks classic
+//! cross-site form POSTs but is inconsistent across browsers and doesn't
+//! guard subdomain scenarios.
+
+use axum::{
+    extract::Request,
+    http::{header, Method, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use axum_extra::extract::cookie::CookieJar;
+
+use super::SESSION_COOKIE;
+
+pub async fn origin_check(req: Request, next: Next) -> Response {
+    let method = req.method();
+    if matches!(method, &Method::GET | &Method::HEAD | &Method::OPTIONS) {
+        return next.run(req).await;
+    }
+
+    // Bearer requests: exempt.
+    if let Some(auth) = req.headers().get(header::AUTHORIZATION) {
+        if auth
+            .to_str()
+            .map(|s| s.starts_with("Bearer "))
+            .unwrap_or(false)
+        {
+            return next.run(req).await;
+        }
+    }
+
+    // No cookie → not a state-changing cookie auth flow; let the normal
+    // extractor 401 it if needed. Parse the jar rather than substring-matching
+    // the header so unrelated cookies that merely contain our name don't
+    // trigger the origin check.
+    let jar = CookieJar::from_headers(req.headers());
+    if jar.get(SESSION_COOKIE).is_none() {
+        return next.run(req).await;
+    }
+
+    let host = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok());
+    let origin = req
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|v| v.to_str().ok());
+    let referer = req
+        .headers()
+        .get(header::REFERER)
+        .and_then(|v| v.to_str().ok());
+
+    if let Some(host) = host {
+        if origin_matches_host(origin, host) || origin_matches_host(referer, host) {
+            return next.run(req).await;
+        }
+    }
+    (StatusCode::FORBIDDEN, "origin mismatch").into_response()
+}
+
+fn origin_matches_host(origin: Option<&str>, host: &str) -> bool {
+    let Some(origin) = origin else {
+        return false;
+    };
+    // origin is like "http://host[:port]" or a full URL for Referer.
+    // Strip scheme, then take authority up to next `/`.
+    let after_scheme = origin.split_once("://").map(|(_, r)| r).unwrap_or(origin);
+    let authority = after_scheme.split('/').next().unwrap_or("");
+    authority == host
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, middleware, routing::post, Router};
+    use tower::ServiceExt;
+
+    fn guarded_router() -> Router {
+        Router::new()
+            .route("/api/mut", post(|| async { "ok" }))
+            .layer(middleware::from_fn(origin_check))
+    }
+
+    #[tokio::test]
+    async fn same_origin_post_passes() {
+        let res = guarded_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/mut")
+                    .method("POST")
+                    .header(header::HOST, "localhost:3000")
+                    .header(header::ORIGIN, "http://localhost:3000")
+                    .header(header::COOKIE, format!("{SESSION_COOKIE}=fake"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn cross_origin_post_with_cookie_is_rejected() {
+        let res = guarded_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/mut")
+                    .method("POST")
+                    .header(header::HOST, "localhost:3000")
+                    .header(header::ORIGIN, "http://evil.example")
+                    .header(header::COOKIE, format!("{SESSION_COOKIE}=fake"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn bearer_requests_are_exempt() {
+        let res = guarded_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/mut")
+                    .method("POST")
+                    .header(header::HOST, "localhost:3000")
+                    .header(header::AUTHORIZATION, "Bearer whatever")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+}

--- a/server/src/auth/extractor.rs
+++ b/server/src/auth/extractor.rs
@@ -1,0 +1,218 @@
+//! `AuthUser` / `AdminUser` — axum extractors that resolve a live session
+//! from either the `omnibus_session` cookie (web) or an
+//! `Authorization: Bearer <token>` header (mobile), then hand the handler
+//! a typed view of the authenticated user.
+
+use axum::{
+    extract::{FromRef, FromRequestParts},
+    http::{header, request::Parts, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use axum_extra::extract::cookie::CookieJar;
+use omnibus_db::auth::{self as auth_db, AuthError, SessionKind};
+use omnibus_shared::UserSummary;
+
+use super::SESSION_COOKIE;
+use crate::backend::AppState;
+
+/// Authenticated user resolved from either a session cookie or a bearer
+/// token. Extractor returns `401 Unauthorized` on anything that isn't a
+/// live session.
+#[derive(Debug, Clone)]
+pub struct AuthUser {
+    pub id: i64,
+    pub username: String,
+    pub is_admin: bool,
+    pub can_upload: bool,
+    pub can_edit: bool,
+    pub can_download: bool,
+    pub session_id: i64,
+    pub session_kind: SessionKind,
+}
+
+impl AuthUser {
+    pub fn summary(&self) -> UserSummary {
+        UserSummary {
+            id: self.id,
+            username: self.username.clone(),
+            is_admin: self.is_admin,
+            can_upload: self.can_upload,
+            can_edit: self.can_edit,
+            can_download: self.can_download,
+        }
+    }
+}
+
+/// Admin-only wrapper. Extracting this rejects non-admin users with 403.
+#[derive(Debug, Clone)]
+pub struct AdminUser(pub AuthUser);
+
+/// Pull a session token out of the request, preferring a `Bearer` header
+/// over a cookie. Returns `None` when neither source has a non-empty token.
+pub(super) fn extract_token(headers: &HeaderMap, jar: &CookieJar) -> Option<(String, SessionKind)> {
+    if let Some(value) = headers.get(header::AUTHORIZATION) {
+        if let Ok(s) = value.to_str() {
+            if let Some(rest) = s.strip_prefix("Bearer ") {
+                let token = rest.trim().to_string();
+                if !token.is_empty() {
+                    return Some((token, SessionKind::Bearer));
+                }
+            }
+        }
+    }
+    if let Some(cookie) = jar.get(SESSION_COOKIE) {
+        let token = cookie.value().to_string();
+        if !token.is_empty() {
+            return Some((token, SessionKind::Cookie));
+        }
+    }
+    None
+}
+
+fn unauthorized() -> Response {
+    (StatusCode::UNAUTHORIZED, "unauthorized").into_response()
+}
+
+fn internal<E: std::fmt::Display>(e: E) -> Response {
+    tracing::error!(error = %e, "internal auth extractor error");
+    (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+}
+
+impl<S> FromRequestParts<S> for AuthUser
+where
+    S: Send + Sync,
+    AppState: FromRef<S>,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let state = AppState::from_ref(state);
+        let jar = CookieJar::from_headers(&parts.headers);
+        let Some((token, _kind)) = extract_token(&parts.headers, &jar) else {
+            return Err(unauthorized());
+        };
+        match auth_db::lookup_session(state.pool(), &token).await {
+            Ok((user, session)) => Ok(AuthUser {
+                id: user.id,
+                username: user.username,
+                is_admin: user.is_admin,
+                can_upload: user.can_upload,
+                can_edit: user.can_edit,
+                can_download: user.can_download,
+                session_id: session.id,
+                session_kind: session.kind,
+            }),
+            Err(AuthError::SessionNotFound) => Err(unauthorized()),
+            Err(e) => Err(internal(e)),
+        }
+    }
+}
+
+impl<S> FromRequestParts<S> for AdminUser
+where
+    S: Send + Sync,
+    AppState: FromRef<S>,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let user = AuthUser::from_request_parts(parts, state).await?;
+        if !user.is_admin {
+            return Err((StatusCode::FORBIDDEN, "admin required").into_response());
+        }
+        Ok(AdminUser(user))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::handlers::auth_router;
+    use axum::{body::Body, http::Request};
+    use omnibus_db as db;
+    use tower::ServiceExt;
+
+    async fn app() -> (axum::Router, sqlx::SqlitePool) {
+        let pool = db::init_db("sqlite::memory:").await.unwrap();
+        let router = auth_router(AppState::new(pool.clone()));
+        (router, pool)
+    }
+
+    #[tokio::test]
+    async fn me_without_auth_is_401() {
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn me_with_bearer_returns_user() {
+        let (app, pool) = app().await;
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let user = db::auth::get_user_by_username(&pool, "alice")
+            .await
+            .unwrap()
+            .unwrap();
+        let issued = db::auth::create_session(&pool, user.id, None, SessionKind::Bearer, 3600)
+            .await
+            .unwrap();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/me")
+                    .header(
+                        header::AUTHORIZATION,
+                        format!("Bearer {}", issued.raw_token),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let u: UserSummary = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(u.username, "alice");
+    }
+
+    #[tokio::test]
+    async fn me_with_cookie_returns_user() {
+        let (app, pool) = app().await;
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let user = db::auth::get_user_by_username(&pool, "alice")
+            .await
+            .unwrap()
+            .unwrap();
+        let issued = db::auth::create_session(&pool, user.id, None, SessionKind::Cookie, 3600)
+            .await
+            .unwrap();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/me")
+                    .header(
+                        header::COOKIE,
+                        format!("{}={}", SESSION_COOKIE, issued.raw_token),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+}

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -1,0 +1,464 @@
+//! `/api/auth/*` handlers plus the small router that mounts them.
+//!
+//! Cookie sessions (web) vs bearer sessions (mobile) are selected by
+//! `client_kind` in the request body: `ios`/`android`/`bearer` → bearer
+//! session, token in the JSON response; anything else (or unset) → cookie
+//! session, token in `Set-Cookie`.
+
+use axum::{
+    extract::State,
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use omnibus_db::auth::{self as auth_db, AuthError, SessionKind};
+use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
+
+use super::extractor::{extract_token, AuthUser};
+use super::{BEARER_TTL_SECS, COOKIE_TTL_SECS, SESSION_COOKIE};
+use crate::backend::AppState;
+
+pub fn auth_router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/auth/register", post(register_handler))
+        .route("/api/auth/login", post(login_handler))
+        .route("/api/auth/logout", post(logout_handler))
+        .route("/api/auth/me", get(me_handler))
+        .with_state(state)
+}
+
+fn user_summary(u: &auth_db::User) -> UserSummary {
+    UserSummary {
+        id: u.id,
+        username: u.username.clone(),
+        is_admin: u.is_admin,
+        can_upload: u.can_upload,
+        can_edit: u.can_edit,
+        can_download: u.can_download,
+    }
+}
+
+fn internal<E: std::fmt::Display>(e: E) -> Response {
+    tracing::error!(error = %e, "internal auth error");
+    (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+}
+
+fn auth_error_to_response(e: AuthError) -> Response {
+    match e {
+        AuthError::InvalidCredentials => {
+            (StatusCode::UNAUTHORIZED, "invalid credentials").into_response()
+        }
+        // Don't confirm the username exists: return the same generic
+        // "invalid credentials" body as a wrong password, but with 429 and
+        // a `Retry-After` header so a well-behaved client can back off.
+        AuthError::AccountLocked { until_unix } => {
+            let now_unix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            let retry_after = until_unix.saturating_sub(now_unix).max(0);
+            let mut headers = HeaderMap::new();
+            if let Ok(v) = retry_after.to_string().parse() {
+                headers.insert(header::RETRY_AFTER, v);
+            }
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                headers,
+                "invalid credentials",
+            )
+                .into_response()
+        }
+        AuthError::UsernameTaken => (StatusCode::CONFLICT, "username taken").into_response(),
+        AuthError::PasswordTooShort { min } => (
+            StatusCode::BAD_REQUEST,
+            format!("password too short (min {min})"),
+        )
+            .into_response(),
+        AuthError::PasswordTooLong { max } => (
+            StatusCode::BAD_REQUEST,
+            format!("password too long (max {max})"),
+        )
+            .into_response(),
+        AuthError::PasswordCommon => {
+            (StatusCode::BAD_REQUEST, "password is too common").into_response()
+        }
+        AuthError::RegistrationDisabled => {
+            (StatusCode::FORBIDDEN, "registration disabled").into_response()
+        }
+        AuthError::SessionNotFound => (StatusCode::UNAUTHORIZED, "unauthorized").into_response(),
+        AuthError::Db(e) => internal(e),
+        AuthError::Hash(e) => internal(e),
+    }
+}
+
+fn want_bearer(kind: Option<&str>) -> bool {
+    matches!(kind, Some("ios") | Some("android") | Some("bearer"))
+}
+
+fn secure_cookies() -> bool {
+    match std::env::var("OMNIBUS_SECURE_COOKIES") {
+        Ok(v) => !matches!(v.as_str(), "0" | "false" | "no" | ""),
+        Err(_) => false, // default off so the dev shell on http://localhost works
+    }
+}
+
+fn session_cookie(value: String, max_age_secs: i64) -> Cookie<'static> {
+    let mut c = Cookie::new(SESSION_COOKIE, value);
+    c.set_http_only(true);
+    c.set_same_site(SameSite::Lax);
+    c.set_path("/");
+    c.set_secure(secure_cookies());
+    c.set_max_age(time::Duration::seconds(max_age_secs));
+    c
+}
+
+fn cleared_cookie() -> Cookie<'static> {
+    let mut c = Cookie::new(SESSION_COOKIE, "");
+    c.set_http_only(true);
+    c.set_same_site(SameSite::Lax);
+    c.set_path("/");
+    c.set_secure(secure_cookies());
+    c.set_max_age(time::Duration::seconds(0));
+    c
+}
+
+async fn register_handler(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(req): Json<RegisterRequest>,
+) -> Response {
+    let user = match auth_db::create_user(state.pool(), &req.username, &req.password).await {
+        Ok(u) => u,
+        Err(e) => return auth_error_to_response(e),
+    };
+    issue_session(
+        &state,
+        jar,
+        user,
+        req.client_kind,
+        req.device_name,
+        req.client_version,
+    )
+    .await
+}
+
+async fn login_handler(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(req): Json<LoginRequest>,
+) -> Response {
+    let user = match auth_db::verify_login(state.pool(), &req.username, &req.password).await {
+        Ok(u) => u,
+        Err(e) => return auth_error_to_response(e),
+    };
+    issue_session(
+        &state,
+        jar,
+        user,
+        req.client_kind,
+        req.device_name,
+        req.client_version,
+    )
+    .await
+}
+
+async fn issue_session(
+    state: &AppState,
+    jar: CookieJar,
+    user: auth_db::User,
+    client_kind: Option<String>,
+    device_name: Option<String>,
+    client_version: Option<String>,
+) -> Response {
+    let bearer = want_bearer(client_kind.as_deref());
+
+    let device_id = if let (Some(name), Some(kind)) =
+        (device_name.as_deref(), client_kind.as_deref())
+    {
+        match auth_db::register_device(state.pool(), user.id, name, kind, client_version.as_deref())
+            .await
+        {
+            Ok(d) => Some(d.id),
+            Err(e) => return auth_error_to_response(e),
+        }
+    } else {
+        None
+    };
+
+    let (kind, ttl) = if bearer {
+        (SessionKind::Bearer, BEARER_TTL_SECS)
+    } else {
+        (SessionKind::Cookie, COOKIE_TTL_SECS)
+    };
+
+    let issued = match auth_db::create_session(state.pool(), user.id, device_id, kind, ttl).await {
+        Ok(s) => s,
+        Err(e) => return auth_error_to_response(e),
+    };
+
+    let body = LoginResponse {
+        user: user_summary(&user),
+        token: if bearer {
+            Some(issued.raw_token.clone())
+        } else {
+            None
+        },
+    };
+
+    if bearer {
+        (StatusCode::OK, Json(body)).into_response()
+    } else {
+        let jar = jar.add(session_cookie(issued.raw_token, ttl));
+        (StatusCode::OK, jar, Json(body)).into_response()
+    }
+}
+
+async fn logout_handler(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    headers: HeaderMap,
+) -> Response {
+    // Resolve the session from either cookie or bearer, revoke it, and
+    // clear the cookie. Idempotent: unknown tokens still return 204.
+    if let Some((token, _)) = extract_token(&headers, &jar) {
+        match auth_db::lookup_session(state.pool(), &token).await {
+            Ok((_user, session)) => {
+                if let Err(e) = auth_db::revoke_session(state.pool(), session.id).await {
+                    return internal(e);
+                }
+            }
+            Err(AuthError::SessionNotFound) => {}
+            Err(e) => return internal(e),
+        }
+    }
+    let jar = jar.add(cleared_cookie());
+    (StatusCode::NO_CONTENT, jar).into_response()
+}
+
+async fn me_handler(user: AuthUser) -> Response {
+    Json(user.summary()).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{header, Request},
+    };
+    use omnibus_db as db;
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    async fn app() -> (Router, sqlx::SqlitePool) {
+        let pool = db::init_db("sqlite::memory:").await.unwrap();
+        let router = auth_router(AppState::new(pool.clone()));
+        (router, pool)
+    }
+
+    fn json_req(uri: &str, method: &str, body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .method(method)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn register_first_user_becomes_admin_and_sets_cookie() {
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(json_req(
+                "/api/auth/register",
+                "POST",
+                json!({"username": "alice", "password": "correct horse battery staple"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let set_cookie: Vec<_> = res
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .collect();
+        assert!(set_cookie.iter().any(|c| c.starts_with("omnibus_session=")));
+        let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: LoginResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body.user.username, "alice");
+        assert!(body.user.is_admin);
+        assert!(body.token.is_none());
+    }
+
+    #[tokio::test]
+    async fn register_bearer_returns_token() {
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(json_req(
+                "/api/auth/register",
+                "POST",
+                json!({
+                    "username": "bob",
+                    "password": "correct horse battery staple",
+                    "client_kind": "ios",
+                    "device_name": "Bob's iPhone"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: LoginResponse = serde_json::from_slice(&bytes).unwrap();
+        assert!(body.token.is_some(), "bearer flow must return token");
+    }
+
+    #[tokio::test]
+    async fn register_short_password_returns_400() {
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(json_req(
+                "/api/auth/register",
+                "POST",
+                json!({"username": "alice", "password": "short"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn register_second_same_username_returns_409() {
+        let (app, pool) = app().await;
+        // First registration closes the gate; reopen it so the second attempt
+        // exercises the UsernameTaken path instead of RegistrationDisabled.
+        let _ = app
+            .clone()
+            .oneshot(json_req(
+                "/api/auth/register",
+                "POST",
+                json!({"username": "alice", "password": "correct horse battery staple"}),
+            ))
+            .await
+            .unwrap();
+        db::auth::set_registration_enabled(&pool, true)
+            .await
+            .unwrap();
+        let res = app
+            .oneshot(json_req(
+                "/api/auth/register",
+                "POST",
+                json!({"username": "alice", "password": "correct horse battery staple"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn register_when_disabled_returns_403() {
+        let (app, _pool) = app().await;
+        let _ = app
+            .clone()
+            .oneshot(json_req(
+                "/api/auth/register",
+                "POST",
+                json!({"username": "alice", "password": "correct horse battery staple"}),
+            ))
+            .await
+            .unwrap();
+        let res = app
+            .oneshot(json_req(
+                "/api/auth/register",
+                "POST",
+                json!({"username": "bob", "password": "correct horse battery staple"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn login_wrong_password_returns_401() {
+        let (app, pool) = app().await;
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let res = app
+            .oneshot(json_req(
+                "/api/auth/login",
+                "POST",
+                json!({"username": "alice", "password": "nope"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn login_unknown_user_returns_401() {
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(json_req(
+                "/api/auth/login",
+                "POST",
+                json!({"username": "ghost", "password": "correct horse battery staple"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn logout_revokes_session_and_next_me_is_401() {
+        let (app, pool) = app().await;
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let user = db::auth::get_user_by_username(&pool, "alice")
+            .await
+            .unwrap()
+            .unwrap();
+        let issued = db::auth::create_session(&pool, user.id, None, SessionKind::Bearer, 3600)
+            .await
+            .unwrap();
+
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/logout")
+                    .method("POST")
+                    .header(
+                        header::AUTHORIZATION,
+                        format!("Bearer {}", issued.raw_token),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/me")
+                    .header(
+                        header::AUTHORIZATION,
+                        format!("Bearer {}", issued.raw_token),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -99,7 +99,10 @@ fn want_bearer(kind: Option<&str>) -> bool {
 
 fn secure_cookies() -> bool {
     match std::env::var("OMNIBUS_SECURE_COOKIES") {
-        Ok(v) => !matches!(v.as_str(), "0" | "false" | "no" | ""),
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !matches!(v.as_str(), "0" | "false" | "no" | "")
+        }
         Err(_) => false, // default off so the dev shell on http://localhost works
     }
 }

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -8,7 +8,7 @@
 //! * [`handlers`] — `/api/auth/{register,login,logout,me}` + [`auth_router`].
 //! * [`csrf`] — `origin_check` middleware for cookie-authed state-changing
 //!   requests.
-//! * [`rate_limit`] — per-IP token bucket + `rate_limit_auth` middleware
+//! * [`rate_limit`] — per-IP fixed-window counter + `rate_limit_auth` middleware
 //!   scoped to the login/register endpoints.
 //! * [`strategy`] — `AuthStrategy` trait + `PasswordStrategy` impl. OIDC
 //!   and WebAuthn fit the same shape.

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -1,0 +1,41 @@
+//! F0.3 auth — server-side axum glue on top of [`omnibus_db::auth`].
+//!
+//! Layout:
+//!
+//! * [`extractor`] — `AuthUser` / `AdminUser` `FromRequestParts` extractors
+//!   that resolve a live session from either the `omnibus_session` cookie
+//!   or an `Authorization: Bearer` header.
+//! * [`handlers`] — `/api/auth/{register,login,logout,me}` + [`auth_router`].
+//! * [`csrf`] — `origin_check` middleware for cookie-authed state-changing
+//!   requests.
+//! * [`rate_limit`] — per-IP token bucket + `rate_limit_auth` middleware
+//!   scoped to the login/register endpoints.
+//! * [`strategy`] — `AuthStrategy` trait + `PasswordStrategy` impl. OIDC
+//!   and WebAuthn fit the same shape.
+//! * [`boot`] — `OMNIBUS_INITIAL_ADMIN` recovery hook.
+//!
+//! No existing `/api/*` routes are gated yet — PR3 flips that switch.
+
+pub mod boot;
+pub mod csrf;
+pub mod extractor;
+pub mod handlers;
+pub mod rate_limit;
+pub mod strategy;
+
+pub use csrf::origin_check;
+pub use extractor::{AdminUser, AuthUser};
+pub use handlers::auth_router;
+pub use rate_limit::{rate_limit_auth, RateLimiter};
+
+/// Name of the session cookie issued to web clients. Not using the
+/// `__Host-` prefix so the dev server on plain HTTP still works; production
+/// deployments behind HTTPS should set `OMNIBUS_SECURE_COOKIES=1` to toggle
+/// the `Secure` attribute.
+pub const SESSION_COOKIE: &str = "omnibus_session";
+
+/// 30 days for cookie sessions; matches the plan's absolute expiry.
+pub const COOKIE_TTL_SECS: i64 = 30 * 24 * 60 * 60;
+
+/// 90 days for mobile bearer tokens.
+pub const BEARER_TTL_SECS: i64 = 90 * 24 * 60 * 60;

--- a/server/src/auth/rate_limit.rs
+++ b/server/src/auth/rate_limit.rs
@@ -17,11 +17,14 @@ use axum::{
 };
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
 
 pub const WINDOW_SECS: u64 = 60;
 pub const MAX_REQUESTS: u32 = 10;
+/// Maximum number of tracked IPs before stale buckets are pruned.
+const MAX_BUCKETS: usize = 10_000;
 
 fn trust_forwarded_for() -> bool {
     matches!(
@@ -35,6 +38,9 @@ struct Bucket {
     count: u32,
 }
 
+/// `tokio::sync::Mutex` is used here rather than `std::sync::Mutex` so that
+/// `allow()` never blocks a Tokio worker thread while waiting for the lock
+/// under contention.
 pub struct RateLimiter {
     inner: Mutex<HashMap<IpAddr, Bucket>>,
     window: Duration,
@@ -54,15 +60,16 @@ impl RateLimiter {
         }
     }
 
-    pub fn allow(&self, ip: IpAddr) -> bool {
+    pub async fn allow(&self, ip: IpAddr) -> bool {
         let now = Instant::now();
-        let mut map = match self.inner.lock() {
-            Ok(g) => g,
-            // Poisoned lock = a previous caller panicked while holding it.
-            // For a rate limiter the safe fallback is "fail open" — we'd
-            // rather let one extra request through than 500 the whole server.
-            Err(_) => return true,
-        };
+        let mut map = self.inner.lock().await;
+
+        // Prune stale entries when the map gets large to prevent unbounded growth.
+        if map.len() >= MAX_BUCKETS {
+            let window = self.window;
+            map.retain(|_, b| now.duration_since(b.window_start) < window * 2);
+        }
+
         let bucket = map.entry(ip).or_insert(Bucket {
             window_start: now,
             count: 0,
@@ -118,7 +125,7 @@ pub async fn rate_limit_auth(
                 .and_then(|s| s.trim().parse().ok())
         })
         .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
-    if !limiter.allow(ip) {
+    if !limiter.allow(ip).await {
         return (StatusCode::TOO_MANY_REQUESTS, "rate limit exceeded").into_response();
     }
     next.run(req).await
@@ -128,33 +135,48 @@ pub async fn rate_limit_auth(
 mod tests {
     use super::*;
 
-    #[test]
-    fn allows_up_to_max_then_blocks() {
+    #[tokio::test]
+    async fn allows_up_to_max_then_blocks() {
         let rl = RateLimiter::with_policy(Duration::from_secs(60), 3);
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
-        assert!(rl.allow(ip));
-        assert!(rl.allow(ip));
-        assert!(rl.allow(ip));
-        assert!(!rl.allow(ip));
+        assert!(rl.allow(ip).await);
+        assert!(rl.allow(ip).await);
+        assert!(rl.allow(ip).await);
+        assert!(!rl.allow(ip).await);
     }
 
-    #[test]
-    fn separate_ips_have_separate_buckets() {
+    #[tokio::test]
+    async fn separate_ips_have_separate_buckets() {
         let rl = RateLimiter::with_policy(Duration::from_secs(60), 1);
         let a: IpAddr = "127.0.0.1".parse().unwrap();
         let b: IpAddr = "127.0.0.2".parse().unwrap();
-        assert!(rl.allow(a));
-        assert!(!rl.allow(a));
-        assert!(rl.allow(b));
+        assert!(rl.allow(a).await);
+        assert!(!rl.allow(a).await);
+        assert!(rl.allow(b).await);
     }
 
-    #[test]
-    fn window_resets_after_elapsed() {
+    #[tokio::test]
+    async fn window_resets_after_elapsed() {
         let rl = RateLimiter::with_policy(Duration::from_millis(10), 1);
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
-        assert!(rl.allow(ip));
-        assert!(!rl.allow(ip));
-        std::thread::sleep(Duration::from_millis(20));
-        assert!(rl.allow(ip));
+        assert!(rl.allow(ip).await);
+        assert!(!rl.allow(ip).await);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(rl.allow(ip).await);
+    }
+
+    #[tokio::test]
+    async fn prunes_stale_entries_at_cap() {
+        let rl = RateLimiter::with_policy(Duration::from_millis(1), MAX_REQUESTS);
+        // Fill to just under the cap using distinct IPs.
+        for i in 0..MAX_BUCKETS {
+            let ip = IpAddr::V4(std::net::Ipv4Addr::from(i as u32));
+            rl.allow(ip).await;
+        }
+        // All windows are stale; a new allow() call should prune and succeed.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+        assert!(rl.allow(ip).await);
+        assert!(rl.inner.lock().await.len() < MAX_BUCKETS);
     }
 }

--- a/server/src/auth/rate_limit.rs
+++ b/server/src/auth/rate_limit.rs
@@ -1,0 +1,160 @@
+//! Minimal in-memory per-IP rate limiter for the login/register endpoints.
+//!
+//! Self-hosted scope is small — a single process, ≤ a few dozen users. A
+//! Redis-backed limiter is overkill; a `Mutex<HashMap<IpAddr, Bucket>>` fits
+//! in < 60 lines and is easy to reason about. Swap for `tower_governor` if
+//! the scope ever grows.
+//!
+//! Policy: fixed-window counter, `MAX_REQUESTS` per `WINDOW_SECS`. Default
+//! tuned for `/api/auth/login` and `/api/auth/register`: 10 requests /
+//! minute / IP.
+
+use axum::{
+    extract::{ConnectInfo, Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+pub const WINDOW_SECS: u64 = 60;
+pub const MAX_REQUESTS: u32 = 10;
+
+fn trust_forwarded_for() -> bool {
+    matches!(
+        std::env::var("OMNIBUS_TRUST_FORWARDED_FOR").as_deref(),
+        Ok("1" | "true" | "yes")
+    )
+}
+
+struct Bucket {
+    window_start: Instant,
+    count: u32,
+}
+
+pub struct RateLimiter {
+    inner: Mutex<HashMap<IpAddr, Bucket>>,
+    window: Duration,
+    max: u32,
+}
+
+impl RateLimiter {
+    pub fn new() -> Self {
+        Self::with_policy(Duration::from_secs(WINDOW_SECS), MAX_REQUESTS)
+    }
+
+    pub fn with_policy(window: Duration, max: u32) -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+            window,
+            max,
+        }
+    }
+
+    pub fn allow(&self, ip: IpAddr) -> bool {
+        let now = Instant::now();
+        let mut map = match self.inner.lock() {
+            Ok(g) => g,
+            // Poisoned lock = a previous caller panicked while holding it.
+            // For a rate limiter the safe fallback is "fail open" — we'd
+            // rather let one extra request through than 500 the whole server.
+            Err(_) => return true,
+        };
+        let bucket = map.entry(ip).or_insert(Bucket {
+            window_start: now,
+            count: 0,
+        });
+        if now.duration_since(bucket.window_start) >= self.window {
+            bucket.window_start = now;
+            bucket.count = 0;
+        }
+        if bucket.count >= self.max {
+            return false;
+        }
+        bucket.count += 1;
+        true
+    }
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Axum middleware scoping the limiter to `/api/auth/login` and
+/// `/api/auth/register`. Prefers `ConnectInfo<SocketAddr>` (wired by the
+/// server's make-service). Only consults `X-Forwarded-For` when the operator
+/// has opted in via `OMNIBUS_TRUST_FORWARDED_FOR=1` — otherwise a client on
+/// a directly-reachable deployment could spoof the header to bypass the
+/// limiter and grow the bucket map without bound. When neither source yields
+/// an IP, falls back to `0.0.0.0` so the limiter still applies process-wide.
+pub async fn rate_limit_auth(
+    State(limiter): State<Arc<RateLimiter>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let path = req.uri().path();
+    let targeted = matches!(path, "/api/auth/login" | "/api/auth/register");
+    if !targeted {
+        return next.run(req).await;
+    }
+    let direct = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(a)| a.ip());
+    let ip = direct
+        .or_else(|| {
+            if !trust_forwarded_for() {
+                return None;
+            }
+            req.headers()
+                .get("x-forwarded-for")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.split(',').next())
+                .and_then(|s| s.trim().parse().ok())
+        })
+        .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    if !limiter.allow(ip) {
+        return (StatusCode::TOO_MANY_REQUESTS, "rate limit exceeded").into_response();
+    }
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_up_to_max_then_blocks() {
+        let rl = RateLimiter::with_policy(Duration::from_secs(60), 3);
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        assert!(rl.allow(ip));
+        assert!(rl.allow(ip));
+        assert!(rl.allow(ip));
+        assert!(!rl.allow(ip));
+    }
+
+    #[test]
+    fn separate_ips_have_separate_buckets() {
+        let rl = RateLimiter::with_policy(Duration::from_secs(60), 1);
+        let a: IpAddr = "127.0.0.1".parse().unwrap();
+        let b: IpAddr = "127.0.0.2".parse().unwrap();
+        assert!(rl.allow(a));
+        assert!(!rl.allow(a));
+        assert!(rl.allow(b));
+    }
+
+    #[test]
+    fn window_resets_after_elapsed() {
+        let rl = RateLimiter::with_policy(Duration::from_millis(10), 1);
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        assert!(rl.allow(ip));
+        assert!(!rl.allow(ip));
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(rl.allow(ip));
+    }
+}

--- a/server/src/auth/strategy.rs
+++ b/server/src/auth/strategy.rs
@@ -1,0 +1,104 @@
+//! `AuthStrategy` — pluggable authentication back-ends.
+//!
+//! v1.0 ships the `PasswordStrategy` (username + argon2id PHC), but F5.x
+//! adds OIDC, and post-v1.0 could bring passkeys/WebAuthn. This trait
+//! exists now so those extensions drop in without reshaping the login flow.
+//!
+//! Design notes:
+//! - The trait returns a `UserId`, not `(username, password)` — keeping it
+//!   credential-agnostic is what makes WebAuthn/OIDC fit later.
+//! - `kind()` is a short stable tag (`"password"`, `"oidc"`, `"webauthn"`)
+//!   surfaced to the admin UI ("how did this user last log in?") and used
+//!   to gate strategy-specific settings.
+//! - Concrete `OidcStrategy` and `WebAuthnStrategy` are deferred. The trait
+//!   only needs to prove it's shaped right; implementations can land in
+//!   their own phases.
+
+use async_trait::async_trait;
+use omnibus_db::auth::AuthError;
+use sqlx::SqlitePool;
+
+/// Opaque reference to a row in `users`.
+pub type UserId = i64;
+
+/// A verified authentication attempt. Contains enough for the handler to
+/// issue a session; no password or secret material.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    pub user_id: UserId,
+}
+
+/// Contract for a pluggable auth backend. Implementations do the crypto +
+/// DB lookup; the session-issuing + cookie/bearer plumbing stays in the
+/// handler layer so every strategy lands sessions the same way.
+#[async_trait]
+pub trait AuthStrategy: Send + Sync {
+    /// Short stable tag for logs and admin UI (`"password"`, `"oidc"`, …).
+    fn kind(&self) -> &'static str;
+
+    /// Authenticate a `(username, secret)` pair and resolve it to a user row.
+    /// Password strategies will use `secret` as the password; OIDC/WebAuthn
+    /// implementations will ignore it in favor of their own flow and accept
+    /// the trait shape as-is, probably exposing additional methods for the
+    /// redirect/assertion dance.
+    async fn authenticate(
+        &self,
+        pool: &SqlitePool,
+        username: &str,
+        secret: &str,
+    ) -> Result<AuthenticatedUser, AuthError>;
+}
+
+/// Username + Argon2id PHC password strategy. Thin wrapper over
+/// [`omnibus_db::auth::verify_login`] so the hashing/lockout/timing-equal
+/// logic stays in one place.
+pub struct PasswordStrategy;
+
+#[async_trait]
+impl AuthStrategy for PasswordStrategy {
+    fn kind(&self) -> &'static str {
+        "password"
+    }
+
+    async fn authenticate(
+        &self,
+        pool: &SqlitePool,
+        username: &str,
+        secret: &str,
+    ) -> Result<AuthenticatedUser, AuthError> {
+        let user = omnibus_db::auth::verify_login(pool, username, secret).await?;
+        Ok(AuthenticatedUser { user_id: user.id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omnibus_db as db;
+
+    #[tokio::test]
+    async fn password_strategy_roundtrip() {
+        let pool = db::init_db("sqlite::memory:").await.unwrap();
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let s = PasswordStrategy;
+        assert_eq!(s.kind(), "password");
+        let a = s
+            .authenticate(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        assert!(a.user_id > 0);
+    }
+
+    #[tokio::test]
+    async fn password_strategy_rejects_bad_password() {
+        let pool = db::init_db("sqlite::memory:").await.unwrap();
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let s = PasswordStrategy;
+        let r = s.authenticate(&pool, "alice", "nope").await;
+        assert!(matches!(r, Err(AuthError::InvalidCredentials)));
+    }
+}

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -25,6 +25,10 @@ impl AppState {
     pub fn new(pool: SqlitePool) -> Self {
         Self { pool }
     }
+
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
 }
 
 pub fn rest_router(state: AppState) -> Router {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -4,4 +4,6 @@
 //! exists so `backend`'s integration tests can import it with `use omnibus::backend`.
 
 #[cfg(feature = "server")]
+pub mod auth;
+#[cfg(feature = "server")]
 pub mod backend;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -20,14 +20,20 @@ fn main() {
     {
         dioxus::serve(|| async move {
             use dioxus::server::axum::Extension;
-            use omnibus::backend;
+            use omnibus::{auth, backend};
             use omnibus_db::indexer;
+            use std::sync::Arc;
 
             let database_url = std::env::var("DATABASE_URL")
                 .unwrap_or_else(|_| "sqlite://omnibus.db?mode=rwc".to_string());
 
             let pool = omnibus_db::init_db(&database_url).await?;
             omnibus_db::seed_settings_from_env(&pool).await?;
+
+            // Recovery hook: promote the named user to admin if
+            // OMNIBUS_INITIAL_ADMIN is set. No-op otherwise. Logs on
+            // promotion so the action is auditable.
+            auth::boot::apply_initial_admin(&pool).await?;
 
             // Kick off a reindex in the background if the index is empty or
             // stale. The first user request reads whatever is currently in
@@ -39,8 +45,17 @@ fn main() {
             }
 
             let state = backend::AppState::new(pool.clone());
+            let limiter = Arc::new(auth::RateLimiter::new());
             let router = dioxus::server::router(App)
-                .merge(backend::rest_router(state))
+                .merge(backend::rest_router(state.clone()))
+                .merge(
+                    auth::auth_router(state)
+                        .layer(axum::middleware::from_fn_with_state(
+                            limiter,
+                            auth::rate_limit_auth,
+                        ))
+                        .layer(axum::middleware::from_fn(auth::origin_check)),
+                )
                 .layer(Extension(pool))
                 .layer(tower_http::trace::TraceLayer::new_for_http());
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -110,3 +110,60 @@ pub struct EbookLibrary {
     pub books: Vec<EbookMetadata>,
     pub error: Option<String>,
 }
+
+// -----------------------------------------------------------------------------
+// Auth (F0.3)
+// -----------------------------------------------------------------------------
+
+/// Safe projection of a `users` row. No password fields ever cross the wire.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UserSummary {
+    pub id: i64,
+    pub username: String,
+    pub is_admin: bool,
+    pub can_upload: bool,
+    pub can_edit: bool,
+    pub can_download: bool,
+}
+
+/// Request body for `POST /api/auth/login`.
+///
+/// Deliberately does not derive `Debug`: the struct holds a plaintext
+/// password, and a stray `tracing::debug!(?req)` would write it to logs.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct LoginRequest {
+    pub username: String,
+    pub password: String,
+    /// Optional — when present, server issues a bearer session instead of a
+    /// cookie session and includes the raw token in the response.
+    #[serde(default)]
+    pub client_kind: Option<String>,
+    #[serde(default)]
+    pub device_name: Option<String>,
+    #[serde(default)]
+    pub client_version: Option<String>,
+}
+
+/// Request body for `POST /api/auth/register`. See [`LoginRequest`] for
+/// why `Debug` is deliberately not derived.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct RegisterRequest {
+    pub username: String,
+    pub password: String,
+    #[serde(default)]
+    pub client_kind: Option<String>,
+    #[serde(default)]
+    pub device_name: Option<String>,
+    #[serde(default)]
+    pub client_version: Option<String>,
+}
+
+/// Response from `POST /api/auth/login` and `POST /api/auth/register`.
+/// `token` is populated only for bearer (mobile) sessions; cookie sessions
+/// return the cookie in a `Set-Cookie` header and `token` is `None`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginResponse {
+    pub user: UserSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+}


### PR DESCRIPTION
## Summary

PR2 of the F0.3 auth stack. Adds the server-side axum glue on top of the `omnibus-db` auth layer landed in #31 — extractors, handlers, middleware. **No existing routes are gated in this PR** (PR3 flips that switch alongside the login/register UI).

## What lands

### Handlers — `/api/auth/*`

- `POST /api/auth/register` — creates a user; first user auto-becomes admin and registration auto-closes (race-free via `BEGIN IMMEDIATE` in the db layer).
- `POST /api/auth/login` — verifies credentials via `db::auth::verify_login` (timing-equalised + account lockout).
- `POST /api/auth/logout` — revokes the session server-side and clears the cookie. Idempotent.
- `GET /api/auth/me` — returns `UserSummary` of the caller, `401` if no live session.

Cookie sessions (web) vs bearer sessions (mobile) are switched by `client_kind` in the request body: `ios` / `android` / `bearer` → server returns a bearer token in the JSON body; otherwise a `Set-Cookie: omnibus_session=…` is issued and no token is returned. Cookie attributes: `HttpOnly`, `SameSite=Lax`, `Path=/`, 30-day `Max-Age`, `Secure` controlled by `OMNIBUS_SECURE_COOKIES` (default off so dev works on plain HTTP; set to `1` behind HTTPS).

### Extractors

- `AuthUser` — `FromRequestParts` resolving either the `omnibus_session` cookie or `Authorization: Bearer <token>` via `db::auth::lookup_session`. Rejects with `401` on any failure.
- `AdminUser(pub AuthUser)` — wraps `AuthUser` and rejects non-admins with `403`.

Both extractors are `Send + Sync` and compose with any state that implements `FromRef<AppState>` (so they work with the existing `backend::AppState`).

### Middleware

- `origin_check` — reject cookie-auth state-changing requests whose `Origin`/`Referer` doesn't match `Host`. Safe methods (`GET`/`HEAD`/`OPTIONS`) and bearer-auth requests are exempt. Complements `SameSite=Lax` which blocks classic cross-site form POSTs but is inconsistent across browsers.
- `rate_limit_auth` — per-IP token bucket (10 req/min by default) scoped to `/api/auth/login` and `/api/auth/register`. In-memory `Mutex<HashMap<IpAddr, Bucket>>` — self-hosted scope doesn't need Redis. Extracts the peer IP from `ConnectInfo`, then `X-Forwarded-For`, then a sentinel loopback fallback.

### AuthStrategy trait

`server/src/auth/strategy.rs` defines the pluggable backend trait and ships one impl, `PasswordStrategy`, that delegates to `db::auth::verify_login`. The trait returns a `UserId` (not `(username, password)`) so OIDC and WebAuthn drop in without reshaping the login flow. No concrete OIDC/WebAuthn impl in this PR — that's F5.x / post-v1.0.

### Boot hook

`auth::boot::apply_initial_admin` reads `OMNIBUS_INITIAL_ADMIN` and calls `db::auth::promote_to_admin` on startup. No-op if the var is unset or the named user doesn't exist. `tracing::warn!` on every promotion so the action is audit-visible. This is the recovery escape hatch ("I locked myself out") — not a provisioning mechanism, and deliberately so (there's no safe way to smuggle a password through an env var).

## Not in this PR (intentional)

- Existing `/api/value`, `/api/settings`, `/api/library`, `/api/ebooks`, `/api/covers/:id` handlers remain **unauthenticated**. Flipping them is PR3, together with the login/register web UI.
- Mobile `Authorization: Bearer` support on mobile-facing endpoints is PR4. (The extractor already supports bearer, but mobile has no login UI yet.)
- No OIDC/WebAuthn concrete impl.
- No `secrets` table / `OMNIBUS_SESSION_KEY` wiring in the handler layer — the db layer ships the helpers (`load_or_create_session_key` etc.) but they are unused until we add anything that signs state client-side. Hand-rolled session cookie does not need a signing key because the session token itself is CSPRNG and stored hashed.

## Tests

`cargo test -p omnibus` — **30 passing**, including:

- Registration: first-user-admin + cookie, bearer flow returns token, short password → 400, duplicate username → 409, registration disabled → 403.
- Login: wrong password → 401, unknown user → 401 (timing-equalised in the db layer).
- `/api/auth/me`: no auth → 401, bearer → 200, cookie → 200.
- `/api/auth/logout`: revokes + subsequent `me` is 401.
- Extractors: compose with `AppState` via `FromRef`.
- `origin_check`: cross-origin POST with cookie → 403; bearer-auth → bypass.
- Rate limiter: allows up to max, separate IPs have separate buckets, window reset.
- Boot hook: unset env is no-op, env promotes existing non-admin, unknown user is no-op (no error).
- `PasswordStrategy`: roundtrip + wrong-password rejection.

Full workspace: `cargo test --workspace` clean (30 + 51 + …). `cargo clippy --all-targets` clean. `cargo fmt --check` clean.

## Test plan

- [ ] `cargo test -p omnibus` passes locally (and in CI).
- [ ] `cargo clippy --all-targets` clean.
- [ ] Manual smoke: register a user, receive cookie, hit `/api/auth/me` → 200, logout, `/api/auth/me` → 401. Deferred to PR3 since there's no UI to drive it here.
- [ ] Manual smoke: register with `client_kind=ios`, receive bearer, hit `/api/auth/me` with `Authorization: Bearer …` → 200. Deferred to PR4.

## Notes for review

- Biggest judgement call: skipping `tower-sessions` in favour of a hand-rolled cookie handler. The db layer already owns full session storage (hashed tokens, expiry, revocation), so `tower-sessions`'s session *store* would have been duplicated work. `axum-extra::CookieJar` + `db::auth::{create_session, lookup_session}` is ~80 lines and leaves the security-critical surface (token generation, hashing, lookup) concentrated in `db::auth` where the PR1 tests live.
- `server/Cargo.toml` gains `axum-extra`, `async-trait`, `time`, `tracing`, `serde` (already transitively, now explicit since the handlers deserialize `LoginRequest` / `RegisterRequest`).