### PR TITLE
feat(auth): PR3 — gate /api/* routes + login/register UI + Playwright

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ migrations/         — numbered SQL migrations embedded via sqlx::migrate!
 lib.rs              — Route, App, styles, ScreenLayout (feature-gated)
 data.rs             — Feature-gated data transport (mobile=reqwest, web/server=rpc)
 rpc.rs              — #[get]/#[post] server functions (mounted by dioxus::server::router); server bodies call into omnibus_db
-pages/{landing,settings,book_detail}.rs
+pages/{landing,settings,book_detail,auth}.rs  — auth.rs hosts LoginPage + RegisterPage
 components/{top_nav,bottom_nav}.rs  — feature = web / mobile respectively
 ```
 
@@ -84,7 +84,8 @@ main.rs             — dioxus::launch (WASM) / dioxus::serve (native); mounts a
 lib.rs              — re-exports backend + auth under `server` feature for tests
 backend.rs          — /api/* REST router (mobile-facing) + integration tests
 auth/mod.rs         — /api/auth/{register,login,logout,me} + AuthUser/AdminUser extractors + CSRF origin-check
-auth/rate_limit.rs  — in-memory per-IP token bucket for login/register
+auth/gate.rs        — top-level middleware gating /api/* (pass-through for /api/auth/*)
+auth/rate_limit.rs  — in-memory per-IP fixed-window counter for login/register
 auth/strategy.rs    — AuthStrategy trait + PasswordStrategy (OIDC/WebAuthn fit the same shape)
 auth/boot.rs        — OMNIBUS_INITIAL_ADMIN recovery hook (promotes named user to admin)
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,6 +3703,7 @@ version = "0.1.0"
 dependencies = [
  "dioxus",
  "dioxus-router",
+ "gloo-net",
  "omnibus-db",
  "omnibus-shared",
  "reqwest",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -11,6 +11,7 @@ omnibus-db = { path = "../db", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+gloo-net = { version = "0.6", default-features = false, features = ["http", "json"], optional = true }
 # sqlx + tokio are needed at the type level by rpc.rs when building server
 # functions (PoolExt = Extension<SqlitePool>, #[tokio::spawn] for reindex).
 # Kept as optional deps enabled only by the `server` feature.
@@ -20,7 +21,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"], optional = tr
 [features]
 default = []
 # Web client (WASM): uses dioxus-fullstack server-function client stubs.
-web = ["dioxus/web"]
+web = ["dioxus/web", "dep:gloo-net", "dep:serde_json"]
 # Native mobile client: talks to `/api/*` REST routes via reqwest.
 mobile = ["dep:reqwest", "dep:serde_json"]
 # Server-function bodies: compiles the server-side halves of the #[get]/#[post]

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -11,6 +11,8 @@
 //!   web stubs so SSR-during-fullstack-render still returns sensible data.
 
 use omnibus_shared::{EbookLibrary, LibraryContents, Settings};
+#[cfg(feature = "web")]
+use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
 
 // ===== Mobile transport: reqwest =====
 
@@ -171,4 +173,79 @@ pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, S
     crate::rpc::rpc_search(q.to_string())
         .await
         .map_err(|e| e.to_string())
+}
+
+// ===== Auth transport (web only) =====
+//
+// The web client hits the REST auth endpoints directly via `gloo-net` rather
+// than going through a Dioxus server function. The REST endpoints already
+// know how to set/clear the `omnibus_session` cookie via the `CookieJar`
+// extractor, and browser fetch (same-origin) round-trips the cookie
+// automatically. Server functions would force us to re-plumb cookie
+// handling through the Dioxus fullstack response shape for no gain.
+//
+// SSR and server-only builds don't need these helpers: the login/register
+// pages render the same markup on the server (no auth calls issued during
+// SSR), and the actions only fire on user interaction after hydration.
+
+#[cfg(feature = "web")]
+pub async fn login(req: LoginRequest) -> Result<LoginResponse, String> {
+    post_auth_json("/api/auth/login", &req).await
+}
+
+#[cfg(feature = "web")]
+pub async fn register(req: RegisterRequest) -> Result<LoginResponse, String> {
+    post_auth_json("/api/auth/register", &req).await
+}
+
+#[cfg(feature = "web")]
+pub async fn logout() -> Result<(), String> {
+    use gloo_net::http::Request;
+    let res = Request::post("/api/auth/logout")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !res.ok() && res.status() != 204 {
+        return Err(format!("logout failed: {}", res.status()));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "web")]
+pub async fn current_user() -> Result<Option<UserSummary>, String> {
+    use gloo_net::http::Request;
+    let res = Request::get("/api/auth/me")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if res.status() == 401 {
+        return Ok(None);
+    }
+    if !res.ok() {
+        return Err(format!("me failed: {}", res.status()));
+    }
+    res.json::<UserSummary>()
+        .await
+        .map(Some)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(feature = "web")]
+async fn post_auth_json<T: serde::Serialize>(
+    path: &str,
+    body: &T,
+) -> Result<LoginResponse, String> {
+    use gloo_net::http::Request;
+    let res = Request::post(path)
+        .json(body)
+        .map_err(|e| e.to_string())?
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !res.ok() {
+        let status = res.status();
+        let msg = res.text().await.unwrap_or_default();
+        return Err(format!("{status}: {msg}"));
+    }
+    res.json::<LoginResponse>().await.map_err(|e| e.to_string())
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -14,7 +14,7 @@ pub mod pages;
 pub mod rpc;
 
 pub use components::Nav;
-pub use pages::{BookDetailPage, LandingPage, SettingsPage};
+pub use pages::{BookDetailPage, LandingPage, LoginPage, RegisterPage, SettingsPage};
 
 #[cfg(feature = "mobile")]
 pub use data::ServerUrl;
@@ -28,6 +28,10 @@ pub enum Route {
     Settings {},
     #[route("/books/:id")]
     BookDetail { id: i64 },
+    #[route("/login")]
+    Login {},
+    #[route("/register")]
+    Register {},
 }
 
 /// Route target for `/` — wraps [`LandingPage`] in the platform screen layout.
@@ -52,6 +56,28 @@ pub fn Settings() -> Element {
 pub fn BookDetail(id: i64) -> Element {
     rsx! {
         ScreenLayout { BookDetailPage { id } }
+    }
+}
+
+/// Route target for `/login` — credential entry form. Rendered without the
+/// main screen chrome so the login flow stands alone.
+#[component]
+pub fn Login() -> Element {
+    rsx! {
+        div { class: "auth-shell",
+            LoginPage {}
+        }
+    }
+}
+
+/// Route target for `/register` — account-creation form. Same chrome as
+/// [`Login`] so the two pages feel like one flow.
+#[component]
+pub fn Register() -> Element {
+    rsx! {
+        div { class: "auth-shell",
+            RegisterPage {}
+        }
     }
 }
 
@@ -133,6 +159,18 @@ body {
   min-height: 100vh;
   padding: 1.5rem 1rem 5rem;
 }
+
+.auth-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+.auth-card { width: 100%; max-width: 380px; }
+.auth-form { display: flex; flex-direction: column; gap: 1rem; margin-top: 1rem; }
+.auth-footer { font-size: 0.85rem; color: #94a3b8; margin-top: 1rem; text-align: center; }
+.auth-footer a { color: #22d3ee; }
 
 .top-nav {
   display: flex;

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -1,0 +1,213 @@
+//! Login and register pages for the web client.
+//!
+//! Both pages render the same markup on SSR and in WASM so hydration matches.
+//! The actual login/register action fires on form submit and only compiles
+//! on the `web` feature. `server` / `mobile` builds still wire the submit
+//! handler — it just returns a static error ("login is only available in
+//! the web client") that the form renders via the usual error alert. The
+//! `server` path is effectively unreachable because SSR never runs the
+//! closure; the `mobile` stub is in place until PR4 ships the bearer flow.
+
+use dioxus::prelude::*;
+use dioxus_router::{use_navigator, Link};
+
+use crate::Route;
+
+#[component]
+pub fn LoginPage() -> Element {
+    let mut username = use_signal(String::new);
+    let mut password = use_signal(String::new);
+    let mut error = use_signal(|| Option::<String>::None);
+    let mut submitting = use_signal(|| false);
+    let nav = use_navigator();
+
+    let on_submit = move |evt: FormEvent| {
+        evt.prevent_default();
+        let u = username();
+        let p = password();
+        if u.is_empty() || p.is_empty() {
+            error.set(Some("enter a username and password".into()));
+            return;
+        }
+        error.set(None);
+        submitting.set(true);
+        spawn(async move {
+            let res = submit_login(u, p).await;
+            submitting.set(false);
+            match res {
+                Ok(()) => {
+                    nav.replace(Route::Landing {});
+                }
+                Err(e) => error.set(Some(e)),
+            }
+        });
+    };
+
+    rsx! {
+        div { class: "auth-card card",
+            h1 { "Log in" }
+            p { class: "subtitle", "Welcome back to Omnibus." }
+            form { class: "auth-form",
+                onsubmit: on_submit,
+                "data-testid": "login-form",
+                div { class: "settings-field",
+                    label { r#for: "login-username", "Username" }
+                    input {
+                        id: "login-username",
+                        name: "username",
+                        r#type: "text",
+                        autocomplete: "username",
+                        value: "{username}",
+                        oninput: move |e| username.set(e.value()),
+                    }
+                }
+                div { class: "settings-field",
+                    label { r#for: "login-password", "Password" }
+                    input {
+                        id: "login-password",
+                        name: "password",
+                        r#type: "password",
+                        autocomplete: "current-password",
+                        value: "{password}",
+                        oninput: move |e| password.set(e.value()),
+                    }
+                }
+                if let Some(msg) = error() {
+                    div { class: "error", role: "alert", "{msg}" }
+                }
+                button {
+                    class: "btn",
+                    r#type: "submit",
+                    disabled: submitting(),
+                    if submitting() { "Logging in…" } else { "Log in" }
+                }
+            }
+            p { class: "auth-footer",
+                "No account? "
+                Link { to: Route::Register {}, "Register" }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn RegisterPage() -> Element {
+    let mut username = use_signal(String::new);
+    let mut password = use_signal(String::new);
+    let mut error = use_signal(|| Option::<String>::None);
+    let mut submitting = use_signal(|| false);
+    let nav = use_navigator();
+
+    let on_submit = move |evt: FormEvent| {
+        evt.prevent_default();
+        let u = username();
+        let p = password();
+        if u.is_empty() || p.is_empty() {
+            error.set(Some("enter a username and password".into()));
+            return;
+        }
+        error.set(None);
+        submitting.set(true);
+        spawn(async move {
+            let res = submit_register(u, p).await;
+            submitting.set(false);
+            match res {
+                Ok(()) => {
+                    nav.replace(Route::Landing {});
+                }
+                Err(e) => error.set(Some(e)),
+            }
+        });
+    };
+
+    rsx! {
+        div { class: "auth-card card",
+            h1 { "Create an account" }
+            p { class: "subtitle", "Register to start using Omnibus." }
+            form { class: "auth-form",
+                onsubmit: on_submit,
+                "data-testid": "register-form",
+                div { class: "settings-field",
+                    label { r#for: "register-username", "Username" }
+                    input {
+                        id: "register-username",
+                        name: "username",
+                        r#type: "text",
+                        autocomplete: "username",
+                        value: "{username}",
+                        oninput: move |e| username.set(e.value()),
+                    }
+                }
+                div { class: "settings-field",
+                    label { r#for: "register-password", "Password" }
+                    input {
+                        id: "register-password",
+                        name: "password",
+                        r#type: "password",
+                        autocomplete: "new-password",
+                        value: "{password}",
+                        oninput: move |e| password.set(e.value()),
+                    }
+                }
+                if let Some(msg) = error() {
+                    div { class: "error", role: "alert", "{msg}" }
+                }
+                button {
+                    class: "btn",
+                    r#type: "submit",
+                    disabled: submitting(),
+                    if submitting() { "Creating…" } else { "Create account" }
+                }
+            }
+            p { class: "auth-footer",
+                "Already have an account? "
+                Link { to: Route::Login {}, "Log in" }
+            }
+        }
+    }
+}
+
+// ---- submit helpers ------------------------------------------------------
+//
+// Only the `web` feature has a real HTTP transport for auth. `server` builds
+// compile the component markup for SSR but never execute the submit closure
+// (no interaction happens during SSR), so a compile-only stub is enough.
+// Mobile has its own login flow (PR4), so the stub returns an error there.
+
+#[cfg(feature = "web")]
+async fn submit_login(username: String, password: String) -> Result<(), String> {
+    use omnibus_shared::LoginRequest;
+    crate::data::login(LoginRequest {
+        username,
+        password,
+        client_kind: None,
+        device_name: None,
+        client_version: None,
+    })
+    .await
+    .map(|_| ())
+}
+
+#[cfg(feature = "web")]
+async fn submit_register(username: String, password: String) -> Result<(), String> {
+    use omnibus_shared::RegisterRequest;
+    crate::data::register(RegisterRequest {
+        username,
+        password,
+        client_kind: None,
+        device_name: None,
+        client_version: None,
+    })
+    .await
+    .map(|_| ())
+}
+
+#[cfg(not(feature = "web"))]
+async fn submit_login(_username: String, _password: String) -> Result<(), String> {
+    Err("login is only available in the web client".into())
+}
+
+#[cfg(not(feature = "web"))]
+async fn submit_register(_username: String, _password: String) -> Result<(), String> {
+    Err("registration is only available in the web client".into())
+}

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,7 +1,9 @@
+mod auth;
 mod book_detail;
 mod landing;
 mod settings;
 
+pub use auth::{LoginPage, RegisterPage};
 pub use book_detail::BookDetailPage;
 pub use landing::LandingPage;
 pub use settings::SettingsPage;

--- a/server/src/auth/gate.rs
+++ b/server/src/auth/gate.rs
@@ -1,0 +1,205 @@
+//! `require_auth` — top-level middleware that gates `/api/*` routes behind a
+//! live session.
+//!
+//! Applied in `server/src/main.rs`. The middleware fast-paths two classes of
+//! request so SSR, assets, and the auth endpoints themselves keep working:
+//!
+//! * Anything that isn't a `/api/*` path (SSR HTML, WASM bundle, static
+//!   assets, Dioxus client-side routes) — passes through untouched.
+//! * Anything under `/api/auth/*` — these handle their own authentication
+//!   (`/me` uses the [`AuthUser`] extractor; `/login`/`/register` deliberately
+//!   don't require auth).
+//!
+//! Everything else under `/api/*` — the REST routes (`/api/value`,
+//! `/api/settings`, `/api/library`, `/api/ebooks`, `/api/covers/{id}`) and the
+//! Dioxus server-function endpoints (`/api/rpc/*`) — requires a valid session
+//! or returns `401 Unauthorized`.
+//!
+//! This middleware does not set per-user request extensions: handlers that
+//! need `AuthUser` should still declare it as an extractor. The middleware
+//! only gates the *boundary*; the extractor provides the typed view.
+//!
+//! [`AuthUser`]: super::AuthUser
+
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use axum_extra::extract::cookie::CookieJar;
+use omnibus_db::auth as auth_db;
+
+use super::extractor::extract_token;
+use crate::backend::AppState;
+
+pub async fn require_auth(State(state): State<AppState>, req: Request, next: Next) -> Response {
+    let path = req.uri().path();
+    if !path.starts_with("/api/") || path == "/api/auth" || path.starts_with("/api/auth/") {
+        return next.run(req).await;
+    }
+    let jar = CookieJar::from_headers(req.headers());
+    let Some((token, _kind)) = extract_token(req.headers(), &jar) else {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    };
+    match auth_db::lookup_session(state.pool(), &token).await {
+        Ok(_) => next.run(req).await,
+        Err(auth_db::AuthError::SessionNotFound) => {
+            (StatusCode::UNAUTHORIZED, "unauthorized").into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "require_auth: session lookup failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, middleware::from_fn_with_state, routing::get, Router};
+    use omnibus_db as db;
+    use omnibus_db::auth::SessionKind;
+    use tower::ServiceExt;
+
+    async fn app() -> (Router, sqlx::SqlitePool) {
+        let pool = db::init_db("sqlite::memory:").await.unwrap();
+        let state = AppState::new(pool.clone());
+        let router = Router::new()
+            .route("/api/value", get(|| async { "ok" }))
+            .route("/api/auth/login", get(|| async { "login ok" }))
+            .route("/", get(|| async { "home" }))
+            .layer(from_fn_with_state(state, require_auth));
+        (router, pool)
+    }
+
+    #[tokio::test]
+    async fn non_api_passes_through_without_auth() {
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn api_auth_passes_through_without_auth() {
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn gated_api_without_auth_is_401() {
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/value")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn gated_api_with_bearer_passes() {
+        let (app, pool) = app().await;
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let user = db::auth::get_user_by_username(&pool, "alice")
+            .await
+            .unwrap()
+            .unwrap();
+        let issued = db::auth::create_session(&pool, user.id, None, SessionKind::Bearer, 3600)
+            .await
+            .unwrap();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/value")
+                    .header(
+                        axum::http::header::AUTHORIZATION,
+                        format!("Bearer {}", issued.raw_token),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn gated_api_with_cookie_passes() {
+        let (app, pool) = app().await;
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let user = db::auth::get_user_by_username(&pool, "alice")
+            .await
+            .unwrap()
+            .unwrap();
+        let issued = db::auth::create_session(&pool, user.id, None, SessionKind::Cookie, 3600)
+            .await
+            .unwrap();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/value")
+                    .header(
+                        axum::http::header::COOKIE,
+                        format!("{}={}", super::super::SESSION_COOKIE, issued.raw_token),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn gated_api_with_revoked_session_is_401() {
+        let (app, pool) = app().await;
+        db::auth::create_user(&pool, "alice", "correct horse battery staple")
+            .await
+            .unwrap();
+        let user = db::auth::get_user_by_username(&pool, "alice")
+            .await
+            .unwrap()
+            .unwrap();
+        let issued = db::auth::create_session(&pool, user.id, None, SessionKind::Bearer, 3600)
+            .await
+            .unwrap();
+        db::auth::revoke_session(&pool, issued.session.id)
+            .await
+            .unwrap();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/value")
+                    .header(
+                        axum::http::header::AUTHORIZATION,
+                        format!("Bearer {}", issued.raw_token),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -19,12 +19,14 @@
 pub mod boot;
 pub mod csrf;
 pub mod extractor;
+pub mod gate;
 pub mod handlers;
 pub mod rate_limit;
 pub mod strategy;
 
 pub use csrf::origin_check;
 pub use extractor::{AdminUser, AuthUser};
+pub use gate::require_auth;
 pub use handlers::auth_router;
 pub use rate_limit::{rate_limit_auth, RateLimiter};
 

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -169,9 +169,12 @@ async fn get_cover(State(state): State<AppState>, Path(id): Path<i64>) -> Respon
         Ok(Some((mime, bytes))) => (
             [
                 (header::CONTENT_TYPE, mime.as_str()),
-                // Covers are static per-book (new id on reindex), so cache
-                // aggressively at the client.
-                (header::CACHE_CONTROL, "public, max-age=86400"),
+                // Covers are static per-book (new id on reindex). Cached on
+                // the client only — `private` + `Vary: Cookie` keep a shared
+                // proxy from serving one user's covers to an unauthenticated
+                // request on the same URL now that the endpoint is gated.
+                (header::CACHE_CONTROL, "private, max-age=86400"),
+                (header::VARY, "Cookie"),
             ],
             bytes,
         )

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -48,14 +48,19 @@ fn main() {
             let limiter = Arc::new(auth::RateLimiter::new());
             let router = dioxus::server::router(App)
                 .merge(backend::rest_router(state.clone()))
-                .merge(
-                    auth::auth_router(state)
-                        .layer(axum::middleware::from_fn_with_state(
-                            limiter,
-                            auth::rate_limit_auth,
-                        ))
-                        .layer(axum::middleware::from_fn(auth::origin_check)),
-                )
+                .merge(auth::auth_router(state.clone()).layer(
+                    axum::middleware::from_fn_with_state(limiter, auth::rate_limit_auth),
+                ))
+                // Apply require_auth and origin_check at the top level so
+                // every cookie-authed /api/* request — not just /api/auth/* —
+                // is origin-checked. Bearer requests and safe methods are
+                // exempt inside origin_check; non-cookie requests short-circuit
+                // there too, so SSR and static assets pass through unchanged.
+                .layer(axum::middleware::from_fn_with_state(
+                    state,
+                    auth::require_auth,
+                ))
+                .layer(axum::middleware::from_fn(auth::origin_check))
                 .layer(Extension(pool))
                 .layer(tower_http::trace::TraceLayer::new_for_http());
 

--- a/ui_tests/playwright/.gitignore
+++ b/ui_tests/playwright/.gitignore
@@ -1,0 +1,4 @@
+.auth/
+node_modules/
+playwright-report/
+test-results/

--- a/ui_tests/playwright/globalSetup.ts
+++ b/ui_tests/playwright/globalSetup.ts
@@ -7,12 +7,22 @@ import { ensureLoggedIn } from "./tests/utils/auth";
 export const STORAGE_STATE_PATH = resolve(__dirname, ".auth", "storage.json");
 
 export default async function globalSetup(config: FullConfig): Promise<void> {
-  const baseURL = config.projects[0]?.use?.baseURL ?? "http://127.0.0.1:3000";
-  const ctx = await apiRequest.newContext({ baseURL });
+  // Pull `baseURL`, `extraHTTPHeaders`, and `storageState` from the merged
+  // project `use` so the writer here can't drift from what the rest of the
+  // suite reads. `extraHTTPHeaders` matters because `ensureLoggedIn` makes
+  // POST requests that would 403 against `origin_check` once those endpoints
+  // ever require an Origin header; pulling them from config keeps the rule
+  // in one place.
+  const projectUse = config.projects[0]?.use ?? {};
+  const baseURL = projectUse.baseURL ?? "http://127.0.0.1:3000";
+  const extraHTTPHeaders = projectUse.extraHTTPHeaders;
+  const storageStatePath =
+    typeof projectUse.storageState === "string" ? projectUse.storageState : STORAGE_STATE_PATH;
+  const ctx = await apiRequest.newContext({ baseURL, extraHTTPHeaders });
   try {
     await ensureLoggedIn(ctx);
-    mkdirSync(dirname(STORAGE_STATE_PATH), { recursive: true });
-    await ctx.storageState({ path: STORAGE_STATE_PATH });
+    mkdirSync(dirname(storageStatePath), { recursive: true });
+    await ctx.storageState({ path: storageStatePath });
   } finally {
     await ctx.dispose();
   }

--- a/ui_tests/playwright/globalSetup.ts
+++ b/ui_tests/playwright/globalSetup.ts
@@ -1,0 +1,19 @@
+import { request as apiRequest, type FullConfig } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { ensureLoggedIn } from "./tests/utils/auth";
+
+export const STORAGE_STATE_PATH = resolve(__dirname, ".auth", "storage.json");
+
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL = config.projects[0]?.use?.baseURL ?? "http://127.0.0.1:3000";
+  const ctx = await apiRequest.newContext({ baseURL });
+  try {
+    await ensureLoggedIn(ctx);
+    mkdirSync(dirname(STORAGE_STATE_PATH), { recursive: true });
+    await ctx.storageState({ path: STORAGE_STATE_PATH });
+  } finally {
+    await ctx.dispose();
+  }
+}

--- a/ui_tests/playwright/playwright.config.ts
+++ b/ui_tests/playwright/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+import { STORAGE_STATE_PATH } from "./globalSetup";
+
 // Omnibus UI e2e tests.
 //
 // Requires a locally running server at http://127.0.0.1:3000 (e.g. `cargo run
@@ -17,12 +19,18 @@ export default defineConfig({
     baseURL: "http://127.0.0.1:3000",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
-    storageState: "./.auth/storage.json",
+    // Absolute path so the writer (`globalSetup`) and reader (test contexts)
+    // agree regardless of CWD — `npx playwright test -c …` from the repo
+    // root and `cd ui_tests/playwright && npx playwright test` both hit the
+    // same file.
+    storageState: STORAGE_STATE_PATH,
     // Server-side `origin_check` middleware rejects cookie-authed
-    // state-changing requests with no `Origin`/`Referer`. Playwright's
-    // APIRequestContext (used by `globalSetup` and seeding helpers) does
-    // not send Origin by default, so attach one matching `baseURL` to
-    // every request the suite makes — both browser and API.
+    // state-changing requests with no `Origin`/`Referer`. Playwright does
+    // not send Origin by default, so set it here for browser pages and the
+    // spec-level `request` fixture. `globalSetup` reads this same value
+    // from `config.projects[0].use` and passes it into its own
+    // APIRequestContext so register/login (and any future state-changing
+    // setup call) inherit the Origin too.
     extraHTTPHeaders: {
       Origin: "http://127.0.0.1:3000",
     },

--- a/ui_tests/playwright/playwright.config.ts
+++ b/ui_tests/playwright/playwright.config.ts
@@ -12,10 +12,20 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: "list",
+  globalSetup: require.resolve("./globalSetup.ts"),
   use: {
     baseURL: "http://127.0.0.1:3000",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
+    storageState: "./.auth/storage.json",
+    // Server-side `origin_check` middleware rejects cookie-authed
+    // state-changing requests with no `Origin`/`Referer`. Playwright's
+    // APIRequestContext (used by `globalSetup` and seeding helpers) does
+    // not send Origin by default, so attach one matching `baseURL` to
+    // every request the suite makes — both browser and API.
+    extraHTTPHeaders: {
+      Origin: "http://127.0.0.1:3000",
+    },
   },
   projects: [
     {

--- a/ui_tests/playwright/tests/flows/auth.spec.ts
+++ b/ui_tests/playwright/tests/flows/auth.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "../fixtures/test";
+import { expectMutation } from "../utils/api";
+import { TEST_PASSWORD, TEST_USERNAME } from "../utils/auth";
+import { gotoReady } from "../utils/nav";
+
+// These specs test the login flow itself, so they start without the shared
+// session cookie that globalSetup wrote.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("renders the login page layout", async ({ page }) => {
+  await gotoReady(page, "/login");
+
+  await expect(page.getByRole("heading", { level: 1, name: "Log in" })).toBeVisible();
+  await expect(page.getByLabel("Username")).toBeVisible();
+  await expect(page.getByLabel("Password")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Log in" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Register" })).toBeVisible();
+});
+
+test("renders the register page layout", async ({ page }) => {
+  await page.goto("/register");
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Create an account" }),
+  ).toBeVisible();
+  await expect(page.getByLabel("Username")).toBeVisible();
+  await expect(page.getByLabel("Password")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create account" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Log in" })).toBeVisible();
+});
+
+test("logs in with correct credentials and redirects to landing", async ({ page }) => {
+  await gotoReady(page, "/login");
+
+  await page.getByLabel("Username").fill(TEST_USERNAME);
+  await page.getByLabel("Password").fill(TEST_PASSWORD);
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/auth/login",
+      expectedStatus: 200,
+    },
+    async () => page.getByRole("button", { name: "Log in" }).click(),
+  );
+
+  await expect(page).toHaveURL(/\/$/);
+});
+
+test("shows an error when login credentials are wrong", async ({ page }) => {
+  await gotoReady(page, "/login");
+
+  await page.getByLabel("Username").fill(TEST_USERNAME);
+  await page.getByLabel("Password").fill("definitely-not-the-password");
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/auth/login",
+      expectedStatus: 401,
+    },
+    async () => page.getByRole("button", { name: "Log in" }).click(),
+  );
+
+  await expect(page.getByRole("alert")).toContainText("invalid credentials");
+  await expect(page).toHaveURL(/\/login$/);
+});
+
+test("shows an error when submitting an empty form", async ({ page }) => {
+  await gotoReady(page, "/login");
+
+  // No mutation expected — the client rejects before sending.
+  await page.getByRole("button", { name: "Log in" }).click();
+
+  await expect(page.getByRole("alert")).toContainText(/username and password/i);
+});

--- a/ui_tests/playwright/tests/utils/auth.ts
+++ b/ui_tests/playwright/tests/utils/auth.ts
@@ -1,0 +1,41 @@
+import { type APIRequestContext } from "@playwright/test";
+import { expect } from "../fixtures/test";
+
+// A single shared test user. The server gates all `/api/*` routes behind
+// authentication and disables registration after the first user is created,
+// so every spec shares one seeded user. The globalSetup registers it (or logs
+// in if registration is closed) and writes the session cookie to
+// `.auth/storage.json`, which Playwright then loads for every test context.
+export const TEST_USERNAME = "playwright";
+export const TEST_PASSWORD = "playwright-test-pw-00";
+
+/**
+ * Ensure the shared test user is logged in on `request`. Registers the user
+ * if registration is open; logs in otherwise. Throws if neither works — the
+ * usual fix is to wipe `omnibus.db` and retry so registration re-opens.
+ */
+export async function ensureLoggedIn(request: APIRequestContext): Promise<void> {
+  const registerResp = await request.post("/api/auth/register", {
+    data: {
+      username: TEST_USERNAME,
+      password: TEST_PASSWORD,
+    },
+  });
+  if (registerResp.status() === 200) return;
+  // 409 (username taken) or 403 (registration disabled) → fall back to login.
+  if (registerResp.status() !== 409 && registerResp.status() !== 403) {
+    throw new Error(
+      `auth setup: /api/auth/register returned ${registerResp.status()} ${await registerResp.text()}`,
+    );
+  }
+  const loginResp = await request.post("/api/auth/login", {
+    data: {
+      username: TEST_USERNAME,
+      password: TEST_PASSWORD,
+    },
+  });
+  expect(
+    loginResp.status(),
+    `auth setup: /api/auth/login returned ${loginResp.status()} — wipe omnibus.db and rerun if the existing ${TEST_USERNAME} row has a different password`,
+  ).toBe(200);
+}


### PR DESCRIPTION
## Summary

Third PR in the F0.3 auth stack (stacked on [auth-2-server](https://github.com/seamus-sloan/omnibus/pull/34)).

- **Gate middleware** (`server/src/auth/gate.rs`): top-level `require_auth` returns 401 on any unauthenticated `/api/*` request, passing `/api/auth/*` through unchanged so login/register stay reachable.
- **Web auth transport** (`frontend/src/data.rs`): `gloo-net` `login` / `register` / `logout` / `current_user` helpers. `gloo-net` uses browser fetch so the session cookie round-trips automatically (no server-function cookie plumbing).
- **Login + register pages** (`frontend/src/pages/auth.rs`): simple forms with client-side "both required" validation, submitting state, server-error alert, and redirect to `/` on success. Mounted at `/login` and `/register` under an `auth-shell` layout without the main nav chrome.
- **Playwright** (`ui_tests/playwright/`): `globalSetup.ts` registers (or logs in, if registration has closed) a shared `playwright` test user and writes `.auth/storage.json`. Every spec context inherits the session cookie via `storageState`. New `auth.spec.ts` exercises the login/register flows with an empty `storageState` override so it can test the unauth entry points.

## Test plan

- [x] cargo build -p omnibus
- [x] cargo test -p omnibus — 36 tests pass (includes 5 new gate tests)
- [x] cargo clippy -p omnibus --all-targets — clean
- [x] cargo fmt
- [ ] Manual: register + login flows
- [ ] Playwright: full suite with running server

## Known follow-ups

- No UI redirect-on-401; unauth users see raw error in page content.
- No "Log out" button in the nav. Both logout helper and endpoint exist; UI wiring lands with the current-user indicator.
- Mobile bearer flow is PR4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)