### PR TITLE
chore: document PR conventions and book identity durability

### DIFF
--- a/.claude/rules/05-pull-requests.md
+++ b/.claude/rules/05-pull-requests.md
@@ -61,10 +61,10 @@ gh pr create --label enhancement --label run_ui_tests ...
 
 ## End-to-end example
 
-Run `gh` from the repo's main checkout (e.g. `/Users/seamus/Repos/omnibus`). When working from a jj workspace (e.g. `omnibus-xray`), `cd` into the main repo first — `gh` resolves the upstream repo from the working directory, and a workspace path may not have one wired up the same way.
+Run `gh` from the repo's main checkout (e.g. `/Users/me/Repos/omnibus`). When working from a jj workspace (e.g. `omnibus-xray`), `cd` into the main repo first — `gh` resolves the upstream repo from the working directory, and a workspace path may not have one wired up the same way.
 
 ```bash
-cd /Users/seamus/Repos/omnibus
+cd /Users/me/Repos/omnibus
 gh pr create \
   --title "feat: add ratings & journaling tables" \
   --assignee @me \

--- a/.claude/rules/05-pull-requests.md
+++ b/.claude/rules/05-pull-requests.md
@@ -1,0 +1,84 @@
+# 05 — Pull requests
+
+How to open a PR. Apply mechanically — these are not preferences.
+
+## Title
+
+Match the conventional-commit prefix used on the branch's commits. The prefix maps 1:1 with the type of work:
+
+- `feat: …` — new functionality
+- `fix: …` — bug fix
+- `chore: …` — refactor, docs, deps, infra, tooling
+
+If the branch contains multiple commits, the title summarizes the dominant change with the same prefix used on the lead commit. Don't drift between `feat:` commits and a `chore:` PR title (or vice versa).
+
+Keep titles under ~70 chars. Detail goes in the body, not the title.
+
+## Body
+
+Two sections, in this order:
+
+```markdown
+## Summary
+- 1-3 bullet points describing what changed and why.
+
+## Test plan
+- [ ] Bulleted checklist of how to verify the change.
+```
+
+Pull facts from the actual diff and the conversation that led to the change — never invent items to fill space. If the change is doc-only, the test plan is "N/A — docs only" and that's fine.
+
+## Assignee
+
+Always assign `seamus-sloan` (the repo owner). Without an assignee the PR drops out of the dashboard view.
+
+```bash
+gh pr create --assignee seamus-sloan ...
+```
+
+## Labels
+
+Pick exactly one of the following based on the dominant change type:
+
+| Change type | Label |
+|---|---|
+| New feature / behavior | `enhancement` |
+| Bug fix | `bug` |
+| Docs-only (CLAUDE.md, rules, roadmap, READMEs) | `documentation` |
+
+Refactors, dependency bumps, and infra tweaks: choose the closest fit (usually `enhancement` for a behavior-affecting refactor, `documentation` for pure doc moves).
+
+**Additionally:** if the PR diff touches anything under `ui_tests/`, add the `run_ui_tests` label too. This gates the Playwright CI job.
+
+```bash
+gh pr create --label enhancement --label run_ui_tests ...
+```
+
+## End-to-end example
+
+```bash
+gh pr create \
+  --title "feat: add ratings & journaling tables" \
+  --assignee seamus-sloan \
+  --label enhancement \
+  --label run_ui_tests \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `user_ratings` and `user_journal_entries` tables keyed by `book_uuid` (soft ref).
+- Wires the rating UI into the book detail page slot from F1.4.
+- Adds a Playwright flow covering rate → journal → reload.
+
+## Test plan
+- [ ] `cargo test -p omnibus-db user_ratings`
+- [ ] `cargo test -p omnibus ratings`
+- [ ] `cd ui_tests/playwright && npx playwright test ratings.spec.ts`
+EOF
+)"
+```
+
+## Sanity check before opening
+
+- Title prefix matches the lead commit's prefix.
+- Body's summary describes the actual diff (not a stale plan).
+- Assignee is set.
+- One type label is set; `run_ui_tests` is set iff `ui_tests/` was touched.

--- a/.claude/rules/05-pull-requests.md
+++ b/.claude/rules/05-pull-requests.md
@@ -2,6 +2,8 @@
 
 How to open a PR. Apply mechanically — these are not preferences.
 
+Not every change needs a PR. Only open one when the user explicitly asks for it (e.g. "open a PR", "push it up as a PR"). For local commits or pushes without a PR request, stop after the push.
+
 ## Title
 
 Match the conventional-commit prefix used on the branch's commits. The prefix maps 1:1 with the type of work:
@@ -16,7 +18,7 @@ Keep titles under ~70 chars. Detail goes in the body, not the title.
 
 ## Body
 
-Two sections, in this order:
+Follow the repo's PR template at [.github/pull_request_template.md](../../.github/pull_request_template.md). The required sections, in order:
 
 ```markdown
 ## Summary
@@ -24,16 +26,19 @@ Two sections, in this order:
 
 ## Test plan
 - [ ] Bulleted checklist of how to verify the change.
+
+## Notes
+- Anything else worth flagging (follow-ups, caveats, screenshots). Omit if empty.
 ```
 
 Pull facts from the actual diff and the conversation that led to the change — never invent items to fill space. If the change is doc-only, the test plan is "N/A — docs only" and that's fine.
 
 ## Assignee
 
-Always assign `seamus-sloan` (the repo owner). Without an assignee the PR drops out of the dashboard view.
+Always assign the current user (the GitHub login resolved via `gh api user --jq .login`). Without an assignee the PR drops out of the dashboard view.
 
 ```bash
-gh pr create --assignee seamus-sloan ...
+gh pr create --assignee @me ...
 ```
 
 ## Labels
@@ -56,10 +61,13 @@ gh pr create --label enhancement --label run_ui_tests ...
 
 ## End-to-end example
 
+Run `gh` from the repo's main checkout (e.g. `/Users/seamus/Repos/omnibus`). When working from a jj workspace (e.g. `omnibus-xray`), `cd` into the main repo first — `gh` resolves the upstream repo from the working directory, and a workspace path may not have one wired up the same way.
+
 ```bash
+cd /Users/seamus/Repos/omnibus
 gh pr create \
   --title "feat: add ratings & journaling tables" \
-  --assignee seamus-sloan \
+  --assignee @me \
   --label enhancement \
   --label run_ui_tests \
   --body "$(cat <<'EOF'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 ## Summary
 - 
 
+## Test plan
+- [ ] 
+
 ## Notes
 - 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Numbered rules in [.claude/rules/](.claude/rules/), applied in order. Follow the
 - [02-error-handling.md](.claude/rules/02-error-handling.md) — `thiserror` for domain errors, `anyhow` for handlers.
 - [03-unit-testing.md](.claude/rules/03-unit-testing.md) — inline `#[cfg(test)]`, `oneshot` for handlers, coverage expectations.
 - [04-playwright.md](.claude/rules/04-playwright.md) — full E2E conventions (selectors, fixtures, `expectMutation`, error paths).
+- [05-pull-requests.md](.claude/rules/05-pull-requests.md) — PR title/body/assignee/label conventions; `run_ui_tests` gate for `ui_tests/` diffs.
 - [98-keep-skills-fresh.md](.claude/rules/98-keep-skills-fresh.md) — update skills when the code they reference changes.
 - [99-end-of-session.md](.claude/rules/99-end-of-session.md) — end-of-session checklist (docs sync, fmt/clippy, coverage, line-count cap).
 

--- a/docs/roadmap/0-6-library-filesystem.md
+++ b/docs/roadmap/0-6-library-filesystem.md
@@ -59,6 +59,7 @@ ASCII-fold, lowercase, non-alphanumerics → `-`, collapse runs, trim to 80 char
 
 - Users expect Calibre interop and are disappointed. Mitigation: explicit in docs, and the tolerant scan means their library still works — just not as "their Calibre library."
 - Slug collisions across unicode-equivalent titles. Mitigated by collision-suffix on write.
+- **UUID invalidation on reorganization.** The current `stable_uuid(library_path, filename)` scheme hashes the library root path into every book's UUID. Moving files to the canonical layout (a new path) would assign every book a new UUID, silently breaking any user data (ratings, journals from [F3.2](3-2-ratings-journaling.md)) anchored to the old UUID. The UUID scheme **must be replaced with a content-based anchor** (`dc:identifier` → file SHA-256 fallback) before the canonical write path ships. See [F3.2 Book identity & durability](3-2-ratings-journaling.md#book-identity--durability).
 
 ## Open questions
 

--- a/docs/roadmap/3-2-ratings-journaling.md
+++ b/docs/roadmap/3-2-ratings-journaling.md
@@ -14,14 +14,47 @@ Per-user star ratings and free-form journal entries per book.
 
 ## Technical considerations
 
-- Two tables: `user_ratings(user_id, book_id, stars, updated_at)` and `user_journal_entries(id, user_id, book_id, body_md, created_at)`.
+- Two tables: `user_ratings(user_id, book_uuid, stars, updated_at)` and `user_journal_entries(id, user_id, book_uuid, body_md, created_at)`.
 - Render journal entries with a server-side markdown renderer (`pulldown-cmark`) + sanitization — never trust raw HTML.
 - Ratings UI lives in the book detail page's pre-allocated slot from [F1.4](1-4-book-detail.md).
+
+## Book identity & durability
+
+User data (ratings, journals) must survive the following without data loss:
+
+1. Book is cached, user rates it.
+2. User edits book metadata (author name, series) — metadata goes into `books.metadata_overrides`, file is unchanged.
+3. User changes the library path in settings — pruning removes the old `libraries` row and its `books` rows.
+4. On re-index against the new path, the same physical file must resolve to the **same identity** and the rating must still be linked.
+
+**Do not use `book_id` (INT FK with `ON DELETE CASCADE`) for user data.** Cascade-delete is appropriate for ephemeral derived data (covers, FTS index) but not for user-generated data, which cannot be regenerated from the filesystem.
+
+**Use `book_uuid TEXT NOT NULL` with a soft reference instead:**
+
+```sql
+CREATE TABLE user_ratings (
+    user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    book_uuid TEXT    NOT NULL,  -- soft ref: no FK, no CASCADE
+    stars     INTEGER NOT NULL CHECK (stars BETWEEN 1 AND 5),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (user_id, book_uuid)
+);
+```
+
+When a book is pruned, its rating row becomes *detached* (orphaned) rather than deleted. When the same book reappears under a new path, re-linking is automatic because the UUID matches.
+
+**UUID stability requires a content-based anchor.** The current `stable_uuid(library_path, filename)` scheme breaks this: changing the library root produces a new UUID for every book. Before this feature ships, `stable_uuid` must be replaced with:
+
+1. **Primary:** EPUB `dc:identifier` from the OPF (already parsed during indexing). This is spec-required, survives path changes, library reorganizations from [F0.6](0-6-library-filesystem.md), and metadata edits (which never touch the file).
+2. **Fallback:** SHA-256 of the file's byte contents, when `dc:identifier` is absent, empty, or a random per-export UUID (many EPUB editors generate a fresh one each export — detect by checking for the `urn:uuid:` prefix without a stable publisher or ISBN pattern).
+
+A reconciliation step on re-index can attempt to re-link detached user data by `(author, title)` similarity when a UUID still doesn't match — surfaced as "unlinked annotations" in the UI rather than silently lost.
 
 ## Dependencies
 
 - [F0.1 Schema refactor](0-1-schema-refactor.md).
 - [F0.3 Auth](0-3-auth.md).
+- UUID identity fix (replace `stable_uuid(library_path, filename)` with `dc:identifier`-anchored scheme) — **must land before this feature ships**.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `.claude/rules/05-pull-requests.md` covering PR title prefix, body shape (Summary + Test plan), `seamus-sloan` assignee, and label selection — including the `run_ui_tests` gate for any diff under `ui_tests/`.
- Updates F3.2 (ratings & journaling) with a **Book identity & durability** section: user data tables must use a soft `book_uuid` ref (no `ON DELETE CASCADE`) so a library path change cannot silently delete ratings/journals. Documents the `dc:identifier`-anchored UUID scheme (with SHA-256 file-hash fallback) that must replace `stable_uuid(library_path, filename)` before F3.2 ships.
- Cross-references the same risk in F0.6 (library filesystem) — the canonical write path would invalidate every existing UUID under the current scheme.

## Test plan
- N/A — docs-only change.