### PR TITLE
feat(auth): mobile bearer token login flow (PR4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,21 @@ tests/
 ### mobile/src/
 
 ```
-main.rs             — dioxus::launch, ServerUrl context, wraps omnibus_frontend::App
+main.rs             — dioxus::launch, ServerUrl context, hydrates bearer token from disk, wraps omnibus_frontend::App
 ```
+
+Mobile auth: bearer-token login flow lives in `frontend/src/data.rs` under
+`feature = "mobile"`. `data::mobile_login` / `mobile_register` POST to
+`/api/auth/{login,register}` with `client_kind: ios|android|bearer` so the
+server returns a bearer token in the JSON body. `data::token_store` keeps
+the token in a process-local `OnceLock<RwLock<...>>` and — **only in
+debug builds** (`cfg!(debug_assertions)`) — persists it to
+`$HOME/.omnibus-token`. Release builds keep the token in memory only and
+require re-login on every cold start. UI components subscribe to
+`data::token_store::subscribe()` (a `tokio::sync::watch` receiver) so a
+401-driven `token_store::clear()` reactively redirects to `/login`.
+**TODO**: replace the disk-persistence stub with iOS Keychain / Android
+Keystore and flip persistence on unconditionally — see the module docs.
 
 ## Quick commands
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -14,16 +14,23 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 gloo-net = { version = "0.6", default-features = false, features = ["http", "json"], optional = true }
 # sqlx + tokio are needed at the type level by rpc.rs when building server
 # functions (PoolExt = Extension<SqlitePool>, #[tokio::spawn] for reindex).
-# Kept as optional deps enabled only by the `server` feature.
+# Kept as optional deps enabled only by the `server` feature. Tokio is
+# pulled in with no default features so each consuming feature opts into
+# only what it needs — mobile gets `sync` for `watch`, server gets the
+# multi-thread runtime + macros for `#[tokio::main]`-style usage in rpc.rs.
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"], optional = true }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"], optional = true }
+tokio = { version = "1", default-features = false, optional = true }
 
 [features]
 default = []
 # Web client (WASM): uses dioxus-fullstack server-function client stubs.
 web = ["dioxus/web", "dep:gloo-net", "dep:serde_json"]
 # Native mobile client: talks to `/api/*` REST routes via reqwest.
-mobile = ["dep:reqwest", "dep:serde_json"]
+# tokio is enabled for `sync::watch` — used by `data::token_store` to
+# notify the UI when auth state changes so screens redirect to /login
+# without a polling loop. No runtime/macro features are pulled in here:
+# reqwest's own runtime is sufficient and `watch` is sync-only.
+mobile = ["dep:reqwest", "dep:serde_json", "dep:tokio", "tokio/sync"]
 # Server-function bodies: compiles the server-side halves of the #[get]/#[post]
 # functions in rpc.rs against the real DB layer. Used by `server/` when
 # building the fullstack native binary. The DB work lives in `omnibus-db`;
@@ -38,4 +45,6 @@ server = [
     "dep:omnibus-db",
     "dep:sqlx",
     "dep:tokio",
+    "tokio/macros",
+    "tokio/rt-multi-thread",
 ]

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -11,7 +11,7 @@
 //!   web stubs so SSR-during-fullstack-render still returns sensible data.
 
 use omnibus_shared::{EbookLibrary, LibraryContents, Settings};
-#[cfg(feature = "web")]
+#[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
 
 // ===== Mobile transport: reqwest =====
@@ -21,9 +21,322 @@ use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
 pub struct ServerUrl(pub String);
 
 #[cfg(feature = "mobile")]
+pub mod token_store {
+    //! In-process bearer-token store for the mobile client.
+    //!
+    //! Threading model:
+    //!
+    //! * In-memory state lives in an `RwLock<Option<String>>`. Reads/writes
+    //!   recover from poisoned locks via [`unpoison`] so a panic in one
+    //!   thread can't brick the whole app.
+    //! * Disk persistence is funnelled through a single dedicated worker
+    //!   thread fed by an `mpsc` channel. This serializes `set` and
+    //!   `clear` operations — a delayed write can never overtake a later
+    //!   clear and resurrect the token on next launch. **Persistence
+    //!   only runs in debug builds** (gated by `persistence_enabled()`,
+    //!   which returns `cfg!(debug_assertions)`) so a release build can
+    //!   never accidentally drop a long-lived credential on the
+    //!   filesystem in plaintext. Release users re-login on every cold
+    //!   start until secure storage lands.
+    //! * `set` and `clear` update the in-memory cell synchronously and
+    //!   enqueue the disk op. Async callers (`mobile_login`,
+    //!   `mobile_register`, the 401 handler in `note_status`) never block
+    //!   on flash I/O.
+    //!
+    //! **TODO (F0.3 follow-up):** in debug builds the token is held in
+    //! process memory and persisted to a plaintext file under the user's
+    //! home directory. Release builds skip persistence entirely. Replace
+    //! with iOS Keychain / Android Keystore via a platform-specific
+    //! abstraction before flipping persistence on for release builds.
+    //! Tracked in `docs/roadmap/0-3-auth.md`.
+    use std::path::{Path, PathBuf};
+    use std::sync::{mpsc, LockResult, Mutex, OnceLock, RwLock};
+    use tokio::sync::watch;
+
+    enum Op {
+        Write(String),
+        Delete,
+    }
+
+    fn cell() -> &'static RwLock<Option<String>> {
+        static CELL: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+        CELL.get_or_init(|| RwLock::new(None))
+    }
+
+    /// Single broadcast channel that tells UI components when the
+    /// authenticated state changes. `Sender::send` is a sync, allocation-
+    /// free signal — callable from any thread, with or without an active
+    /// async runtime — so `set` / `clear` / `load_from_disk` can all push
+    /// updates uniformly. Components subscribe via [`subscribe`] and react
+    /// inside a `use_future` loop.
+    fn channel() -> &'static (watch::Sender<bool>, watch::Receiver<bool>) {
+        static CH: OnceLock<(watch::Sender<bool>, watch::Receiver<bool>)> = OnceLock::new();
+        CH.get_or_init(|| watch::channel(false))
+    }
+
+    /// Get a fresh receiver tracking whether a token is currently set.
+    /// Initial value reflects the state at subscribe time.
+    pub fn subscribe() -> watch::Receiver<bool> {
+        channel().0.subscribe()
+    }
+
+    fn notify(authed: bool) {
+        // `send_replace` doesn't require active receivers and never errors,
+        // so it's safe from any context.
+        channel().0.send_replace(authed);
+    }
+
+    /// Recover from a poisoned lock instead of panicking. The token store
+    /// is best-effort by design; if some background thread panicked while
+    /// holding the lock the worst-case behavior is "user is treated as
+    /// logged out and re-prompts," which is much better than crashing the
+    /// app.
+    fn unpoison<T>(r: LockResult<T>) -> T {
+        r.unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// On-disk path for the persisted bearer token.
+    ///
+    /// Returns `None` when no platform-appropriate home directory is
+    /// available (`HOME` unset on a non-Unix-y target, etc.). In that case
+    /// the token stays in memory only and the user re-logs in on next
+    /// launch — strictly safer than dropping a token file in an arbitrary
+    /// working directory. iOS app sandboxes set `HOME` to the app's
+    /// container, so the common path is covered.
+    pub fn token_path() -> Option<PathBuf> {
+        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".omnibus-token"))
+    }
+
+    /// Read the on-disk token (if any) into the in-memory store. Call once
+    /// at app launch. Errors are swallowed: a missing or unreadable file
+    /// just means the user must log in again.
+    pub fn load_from_disk() {
+        if !persistence_enabled() {
+            return;
+        }
+        let Some(path) = token_path() else { return };
+        if let Ok(s) = std::fs::read_to_string(&path) {
+            let trimmed = s.trim().to_string();
+            if !trimmed.is_empty() {
+                // Tighten perms best-effort on Unix in case an older build
+                // wrote the file with the default umask. We can't undo a
+                // disclosure that already happened, but we can stop it
+                // continuing every launch from now on.
+                #[cfg(unix)]
+                {
+                    use std::fs::Permissions;
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = std::fs::set_permissions(&path, Permissions::from_mode(0o600));
+                }
+                *unpoison(cell().write()) = Some(trimmed);
+                notify(true);
+            }
+        }
+    }
+
+    /// Snapshot of the current bearer token, if logged in.
+    pub fn get() -> Option<String> {
+        unpoison(cell().read()).clone()
+    }
+
+    /// `true` when this build is allowed to persist the bearer token to
+    /// disk. Gated behind `cfg(debug_assertions)` so a release build can
+    /// never accidentally write a long-lived credential to the
+    /// filesystem in plaintext — release users re-login on every cold
+    /// start until iOS Keychain / Android Keystore support lands and
+    /// flips this to unconditionally `true` (against secure storage).
+    /// Dev builds (`dx serve --platform ios|android`) keep the
+    /// persistence path so the dev-loop UX isn't crippled.
+    fn persistence_enabled() -> bool {
+        cfg!(debug_assertions)
+    }
+
+    /// Set the token in memory immediately, notify UI subscribers, and
+    /// (in dev builds only) enqueue a disk write on the persistence
+    /// worker.
+    pub fn set(token: String) {
+        *unpoison(cell().write()) = Some(token.clone());
+        notify(true);
+        if !persistence_enabled() {
+            return;
+        }
+        if let Some(tx) = persistence_tx() {
+            let _ = tx.send(Op::Write(token));
+        }
+    }
+
+    /// Clear the token from memory immediately, notify UI subscribers,
+    /// and (in dev builds only) enqueue a disk delete on the persistence
+    /// worker. Channel ordering guarantees a clear always supersedes any
+    /// earlier set.
+    pub fn clear() {
+        *unpoison(cell().write()) = None;
+        notify(false);
+        if !persistence_enabled() {
+            return;
+        }
+        if let Some(tx) = persistence_tx() {
+            let _ = tx.send(Op::Delete);
+        }
+    }
+
+    /// Lazily start the persistence worker on first use and return a
+    /// sender to its op channel. Returns `None` if either the worker
+    /// thread fails to spawn or there is no on-disk path to persist to;
+    /// callers in those cases simply skip persistence and the in-memory
+    /// state remains authoritative.
+    fn persistence_tx() -> Option<mpsc::Sender<Op>> {
+        static TX: OnceLock<Mutex<Option<mpsc::Sender<Op>>>> = OnceLock::new();
+        let slot = TX.get_or_init(|| Mutex::new(None));
+        let mut guard = unpoison(slot.lock());
+        if let Some(tx) = guard.as_ref() {
+            return Some(tx.clone());
+        }
+        // No disk path available → keep `guard` empty so future calls
+        // don't re-attempt the spawn dance every time.
+        let path = token_path()?;
+        let (tx, rx) = mpsc::channel::<Op>();
+        std::thread::Builder::new()
+            .name("omnibus-token-store".into())
+            .spawn(move || persistence_worker(path, rx))
+            .ok()?;
+        *guard = Some(tx.clone());
+        Some(tx)
+    }
+
+    fn persistence_worker(path: PathBuf, rx: mpsc::Receiver<Op>) {
+        while let Ok(op) = rx.recv() {
+            match op {
+                Op::Write(token) => {
+                    if let Err(e) = write_token_file(&path, token.as_bytes()) {
+                        eprintln!("warning: could not persist bearer token: {e}");
+                    }
+                }
+                Op::Delete => {
+                    if let Err(e) = delete_token_file(&path) {
+                        eprintln!("warning: could not delete bearer token: {e}");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Remove the on-disk token, falling back to overwriting with an
+    /// empty file when `remove_file` fails (e.g. a permissions glitch on
+    /// the parent dir, or a sandboxed filesystem that allows write but
+    /// not unlink). Without the fallback a failed unlink would silently
+    /// keep the user logged in across the next launch — `load_from_disk`
+    /// short-circuits on empty content, so an empty file is functionally
+    /// equivalent to an absent one.
+    fn delete_token_file(path: &Path) -> std::io::Result<()> {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(remove_err) => match write_token_file(path, b"") {
+                Ok(()) => Ok(()),
+                Err(_) => Err(remove_err),
+            },
+        }
+    }
+
+    /// Write the token with owner-only permissions on Unix so other local
+    /// users on a shared machine can't read it. The mode is re-applied
+    /// after every write because `OpenOptions::mode` only takes effect on
+    /// initial creation — a pre-existing file with looser perms (e.g.
+    /// from a buggy older build) would otherwise stay readable.
+    #[cfg(unix)]
+    fn write_token_file(path: &Path, token: &[u8]) -> std::io::Result<()> {
+        use std::fs::{OpenOptions, Permissions};
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut f = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(token)?;
+        std::fs::set_permissions(path, Permissions::from_mode(0o600))
+    }
+
+    #[cfg(not(unix))]
+    fn write_token_file(path: &Path, token: &[u8]) -> std::io::Result<()> {
+        std::fs::write(path, token)
+    }
+}
+
+/// Best-effort `client_kind` for the bearer-login request body, used
+/// server-side to label the device and decide cookie vs. bearer issuance.
+#[cfg(feature = "mobile")]
+fn client_kind() -> &'static str {
+    if cfg!(target_os = "ios") {
+        "ios"
+    } else if cfg!(target_os = "android") {
+        "android"
+    } else {
+        "bearer"
+    }
+}
+
+/// Shared, lazily-initialized HTTP client. Used for both authenticated
+/// data calls (which thread the bearer through `with_bearer`) and the
+/// pre-auth login/register/logout calls in `post_mobile_auth`. Reusing
+/// one client keeps connection pooling, TLS sessions, and keep-alives
+/// hot — important on mobile where each cold-start handshake hits
+/// battery and latency hard. `Client` is internally `Arc`'d, so
+/// `.clone()` is cheap.
+#[cfg(feature = "mobile")]
+fn http_client() -> reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new).clone()
+}
+
+#[cfg(feature = "mobile")]
+fn with_bearer(rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    if let Some(token) = token_store::get() {
+        rb.bearer_auth(token)
+    } else {
+        rb
+    }
+}
+
+/// Inspect a response: if it's a 401, clear the stored bearer token so the
+/// next render of the auth-aware UI can route to `/login`. Returns the same
+/// status the caller was about to inspect.
+#[cfg(feature = "mobile")]
+fn note_status(status: reqwest::StatusCode) -> reqwest::StatusCode {
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        token_store::clear();
+    }
+    status
+}
+
+/// Drain the response body and format an error string. Always reading the
+/// body — even on the error path — lets reqwest return the underlying TCP
+/// connection to its pool instead of dropping it mid-stream, and folds the
+/// server's diagnostic text into the user-visible error.
+#[cfg(feature = "mobile")]
+async fn drain_error(response: reqwest::Response, status: reqwest::StatusCode) -> String {
+    let body = response.text().await.unwrap_or_default();
+    if body.is_empty() {
+        format!("Server error: {status}")
+    } else {
+        format!("Server error {status}: {body}")
+    }
+}
+
+#[cfg(feature = "mobile")]
 pub async fn get_value(server_url: &str) -> Result<i64, String> {
     let url = format!("{server_url}/api/value");
-    let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
     let payload: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
     payload["value"]
         .as_i64()
@@ -33,12 +346,14 @@ pub async fn get_value(server_url: &str) -> Result<i64, String> {
 #[cfg(feature = "mobile")]
 pub async fn post_increment(server_url: &str) -> Result<i64, String> {
     let url = format!("{server_url}/api/value/increment");
-    let client = reqwest::Client::new();
-    let response = client
-        .post(&url)
+    let response = with_bearer(http_client().post(&url))
         .send()
         .await
         .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
     let payload: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
     payload["value"]
         .as_i64()
@@ -48,22 +363,27 @@ pub async fn post_increment(server_url: &str) -> Result<i64, String> {
 #[cfg(feature = "mobile")]
 pub async fn get_settings(server_url: &str) -> Result<Settings, String> {
     let url = format!("{server_url}/api/settings");
-    let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
     response.json::<Settings>().await.map_err(|e| e.to_string())
 }
 
 #[cfg(feature = "mobile")]
 pub async fn save_settings(server_url: &str, settings: Settings) -> Result<Settings, String> {
     let url = format!("{server_url}/api/settings");
-    let client = reqwest::Client::new();
-    let response = client
-        .post(&url)
-        .json(&settings)
+    let response = with_bearer(http_client().post(&url).json(&settings))
         .send()
         .await
         .map_err(|e| format!("{e:#}"))?;
-    if !response.status().is_success() {
-        return Err(format!("Server error: {}", response.status()));
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
     }
     response.json::<Settings>().await.map_err(|e| e.to_string())
 }
@@ -71,7 +391,14 @@ pub async fn save_settings(server_url: &str, settings: Settings) -> Result<Setti
 #[cfg(feature = "mobile")]
 pub async fn get_library(server_url: &str) -> Result<LibraryContents, String> {
     let url = format!("{server_url}/api/library");
-    let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
     response
         .json::<LibraryContents>()
         .await
@@ -81,11 +408,13 @@ pub async fn get_library(server_url: &str) -> Result<LibraryContents, String> {
 #[cfg(feature = "mobile")]
 pub async fn get_ebooks(server_url: &str) -> Result<EbookLibrary, String> {
     let url = format!("{server_url}/api/ebooks");
-    let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
-    let status = response.status();
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
     if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        return Err(format!("Server error {status}: {body}"));
+        return Err(drain_error(response, status).await);
     }
     response
         .json::<EbookLibrary>()
@@ -107,14 +436,106 @@ pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, St
         })
         .collect();
     let url = format!("{server_url}/api/search?q={encoded}");
-    let response = reqwest::get(&url).await.map_err(|e| format!("{e:#}"))?;
-    let status = response.status();
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
     if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        return Err(format!("Server error {status}: {body}"));
+        return Err(drain_error(response, status).await);
     }
     response
         .json::<EbookLibrary>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+// ===== Mobile auth transport: bearer token =====
+//
+// Mobile cannot use cookies (Dioxus Native is not a webview), so login
+// requests carry `client_kind: "ios"|"android"|"bearer"`, which the server
+// uses as the signal to issue a bearer token in the JSON response instead
+// of a `Set-Cookie` header. The token is stashed in [`token_store`] and
+// attached to every subsequent request via `with_bearer`.
+
+#[cfg(feature = "mobile")]
+pub async fn mobile_login(
+    server_url: &str,
+    username: String,
+    password: String,
+    device_name: Option<String>,
+) -> Result<UserSummary, String> {
+    let req = LoginRequest {
+        username,
+        password,
+        client_kind: Some(client_kind().into()),
+        device_name,
+        client_version: Some(env!("CARGO_PKG_VERSION").into()),
+    };
+    finish_bearer_auth(post_mobile_auth(server_url, "/api/auth/login", &req).await?)
+}
+
+#[cfg(feature = "mobile")]
+pub async fn mobile_register(
+    server_url: &str,
+    username: String,
+    password: String,
+    device_name: Option<String>,
+) -> Result<UserSummary, String> {
+    let req = RegisterRequest {
+        username,
+        password,
+        client_kind: Some(client_kind().into()),
+        device_name,
+        client_version: Some(env!("CARGO_PKG_VERSION").into()),
+    };
+    finish_bearer_auth(post_mobile_auth(server_url, "/api/auth/register", &req).await?)
+}
+
+/// Common tail for `mobile_login` / `mobile_register`: stash the bearer
+/// token returned by the server and surface the user summary. Errors out
+/// if the server didn't issue a token — that would indicate the
+/// `client_kind` discriminator was missed server-side, which we want to
+/// fail loudly rather than silently degrade to a no-auth state.
+#[cfg(feature = "mobile")]
+fn finish_bearer_auth(resp: LoginResponse) -> Result<UserSummary, String> {
+    let Some(token) = resp.token else {
+        return Err("server did not issue a bearer token".into());
+    };
+    token_store::set(token);
+    Ok(resp.user)
+}
+
+#[cfg(feature = "mobile")]
+pub async fn mobile_logout(server_url: &str) -> Result<(), String> {
+    // Best-effort server revocation, then always clear the local token so a
+    // network failure can't leave the device wedged in a "logged in" state.
+    let url = format!("{server_url}/api/auth/logout");
+    let _ = with_bearer(http_client().post(&url)).send().await;
+    token_store::clear();
+    Ok(())
+}
+
+#[cfg(feature = "mobile")]
+async fn post_mobile_auth<T: serde::Serialize>(
+    server_url: &str,
+    path: &str,
+    body: &T,
+) -> Result<LoginResponse, String> {
+    let url = format!("{server_url}{path}");
+    let response = http_client()
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let msg = response.text().await.unwrap_or_default();
+        return Err(format!("{status}: {msg}"));
+    }
+    response
+        .json::<LoginResponse>()
         .await
         .map_err(|e| e.to_string())
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -101,6 +101,51 @@ fn ScreenLayout(children: Element) -> Element {
 #[cfg(feature = "mobile")]
 #[component]
 fn ScreenLayout(children: Element) -> Element {
+    // Mobile auth gate. Two layers:
+    //
+    // * **Render-path placeholder.** When `authed` is false we render an
+    //   empty screen instead of `{children}`. This is the no-flash
+    //   guarantee — protected pages never mount and never kick off a
+    //   data-fetch effect that would 401.
+    // * **Reactive redirect.** `authed` is a Dioxus `Signal` driven by
+    //   the `data::token_store::subscribe()` watch channel. When the
+    //   token gets cleared mid-session (e.g. `data::note_status` on a
+    //   401), the worker pushes `false`, the `use_future` loop updates
+    //   the signal, the component re-renders, and the `use_effect`
+    //   (which now reads a reactive signal) fires `nav.replace`.
+    //
+    // The auth-shell screens (`Login` / `Register`) don't go through
+    // `ScreenLayout`, so they stay reachable for unauthenticated users.
+    let nav = dioxus_router::use_navigator();
+    let mut authed = use_signal(|| data::token_store::get().is_some());
+
+    use_future(move || async move {
+        let mut rx = data::token_store::subscribe();
+        // Sync initial value once before awaiting changes — the signal's
+        // initial closure ran at scope-creation time, which can race with
+        // a token write that happens between scope creation and this
+        // future starting.
+        let current = *rx.borrow_and_update();
+        if current != authed() {
+            authed.set(current);
+        }
+        while rx.changed().await.is_ok() {
+            let now = *rx.borrow_and_update();
+            if now != authed() {
+                authed.set(now);
+            }
+        }
+    });
+
+    use_effect(move || {
+        if !authed() {
+            nav.replace(Route::Login {});
+        }
+    });
+
+    if !authed() {
+        return rsx! { div { class: "screen" } };
+    }
     rsx! {
         div { class: "screen",
             {children}

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -1,17 +1,29 @@
-//! Login and register pages for the web client.
+//! Login and register pages for the web and mobile clients.
 //!
-//! Both pages render the same markup on SSR and in WASM so hydration matches.
-//! The actual login/register action fires on form submit and only compiles
-//! on the `web` feature. `server` / `mobile` builds still wire the submit
-//! handler — it just returns a static error ("login is only available in
-//! the web client") that the form renders via the usual error alert. The
-//! `server` path is effectively unreachable because SSR never runs the
-//! closure; the `mobile` stub is in place until PR4 ships the bearer flow.
+//! Both pages render the same markup on every target so SSR/WASM hydration
+//! matches. Submit handlers branch on feature:
+//!
+//! * `web` — POST JSON to `/api/auth/{login,register}` via `gloo-net`; the
+//!   server sets the `omnibus_session` cookie via `Set-Cookie` and the
+//!   browser's same-origin fetch keeps it for subsequent requests.
+//! * `mobile` — POST JSON to the same endpoints via `reqwest`, with a
+//!   `client_kind` of `ios` / `android` / `bearer` so the server issues a
+//!   bearer token in the body. The token is stashed in
+//!   `data::token_store` (only present under `feature = "mobile"`, hence
+//!   this is a code-formatted reference rather than an intra-doc link)
+//!   and attached to every subsequent request. Until secure storage
+//!   lands, **debug builds only** persist the token in plaintext to
+//!   `$HOME/.omnibus-token`; release builds keep it in memory and
+//!   require re-login on each cold start. See the TODO at the top of
+//!   that module.
+//! * `server` — SSR never executes the submit closure (no interaction
+//!   happens during SSR), so this path is a compile-only stub returning a
+//!   static error.
 
 use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};
 
-use crate::Route;
+use crate::{use_server_url, Route};
 
 #[component]
 pub fn LoginPage() -> Element {
@@ -20,6 +32,10 @@ pub fn LoginPage() -> Element {
     let mut error = use_signal(|| Option::<String>::None);
     let mut submitting = use_signal(|| false);
     let nav = use_navigator();
+
+    // `use_server_url()` is feature-aware: empty string on web/server (where
+    // requests are same-origin) and the `ServerUrl` context value on mobile.
+    let server_url = use_server_url();
 
     let on_submit = move |evt: FormEvent| {
         evt.prevent_default();
@@ -31,8 +47,9 @@ pub fn LoginPage() -> Element {
         }
         error.set(None);
         submitting.set(true);
+        let server_url = server_url.clone();
         spawn(async move {
-            let res = submit_login(u, p).await;
+            let res = submit_login(&server_url, u, p).await;
             submitting.set(false);
             match res {
                 Ok(()) => {
@@ -98,6 +115,10 @@ pub fn RegisterPage() -> Element {
     let mut submitting = use_signal(|| false);
     let nav = use_navigator();
 
+    // `use_server_url()` is feature-aware: empty string on web/server (where
+    // requests are same-origin) and the `ServerUrl` context value on mobile.
+    let server_url = use_server_url();
+
     let on_submit = move |evt: FormEvent| {
         evt.prevent_default();
         let u = username();
@@ -108,8 +129,9 @@ pub fn RegisterPage() -> Element {
         }
         error.set(None);
         submitting.set(true);
+        let server_url = server_url.clone();
         spawn(async move {
-            let res = submit_register(u, p).await;
+            let res = submit_register(&server_url, u, p).await;
             submitting.set(false);
             match res {
                 Ok(()) => {
@@ -169,13 +191,21 @@ pub fn RegisterPage() -> Element {
 
 // ---- submit helpers ------------------------------------------------------
 //
-// Only the `web` feature has a real HTTP transport for auth. `server` builds
-// compile the component markup for SSR but never execute the submit closure
-// (no interaction happens during SSR), so a compile-only stub is enough.
-// Mobile has its own login flow (PR4), so the stub returns an error there.
+// Per-target HTTP transports for auth. The cfg gates are kept mutually
+// exclusive within this file: the web impl compiles only for `web`
+// builds without `mobile`, the mobile impl compiles for any `mobile`
+// build, and the no-feature stub covers SSR-without-web. The
+// `web` + `mobile` combination is rejected at crate level by a
+// `compile_error!` in `frontend/src/components/mod.rs`, so this layer
+// is defense-in-depth rather than the primary guard — but keeping the
+// gates precise here means a future change that loosens the crate-level
+// guard won't silently produce duplicate `submit_*` definitions.
+// `server`-only builds (no `web` and no `mobile`) get a compile-only
+// stub — SSR never executes the submit closure, so the stub is
+// unreachable at runtime.
 
-#[cfg(feature = "web")]
-async fn submit_login(username: String, password: String) -> Result<(), String> {
+#[cfg(all(feature = "web", not(feature = "mobile")))]
+async fn submit_login(_server_url: &str, username: String, password: String) -> Result<(), String> {
     use omnibus_shared::LoginRequest;
     crate::data::login(LoginRequest {
         username,
@@ -188,8 +218,12 @@ async fn submit_login(username: String, password: String) -> Result<(), String> 
     .map(|_| ())
 }
 
-#[cfg(feature = "web")]
-async fn submit_register(username: String, password: String) -> Result<(), String> {
+#[cfg(all(feature = "web", not(feature = "mobile")))]
+async fn submit_register(
+    _server_url: &str,
+    username: String,
+    password: String,
+) -> Result<(), String> {
     use omnibus_shared::RegisterRequest;
     crate::data::register(RegisterRequest {
         username,
@@ -202,12 +236,54 @@ async fn submit_register(username: String, password: String) -> Result<(), Strin
     .map(|_| ())
 }
 
-#[cfg(not(feature = "web"))]
-async fn submit_login(_username: String, _password: String) -> Result<(), String> {
-    Err("login is only available in the web client".into())
+#[cfg(feature = "mobile")]
+async fn submit_login(server_url: &str, username: String, password: String) -> Result<(), String> {
+    crate::data::mobile_login(server_url, username, password, default_device_name())
+        .await
+        .map(|_| ())
 }
 
-#[cfg(not(feature = "web"))]
-async fn submit_register(_username: String, _password: String) -> Result<(), String> {
-    Err("registration is only available in the web client".into())
+#[cfg(feature = "mobile")]
+async fn submit_register(
+    server_url: &str,
+    username: String,
+    password: String,
+) -> Result<(), String> {
+    crate::data::mobile_register(server_url, username, password, default_device_name())
+        .await
+        .map(|_| ())
+}
+
+/// Best-effort device name for the bearer-login `device_name` field. The
+/// value shows up in the admin UI's session list, so prefer something the
+/// user will recognize. Until a settings screen lets the user override
+/// this, we send a generic platform label.
+#[cfg(feature = "mobile")]
+fn default_device_name() -> Option<String> {
+    let label = if cfg!(target_os = "ios") {
+        "Omnibus iOS"
+    } else if cfg!(target_os = "android") {
+        "Omnibus Android"
+    } else {
+        "Omnibus Mobile"
+    };
+    Some(label.to_string())
+}
+
+#[cfg(not(any(feature = "web", feature = "mobile")))]
+async fn submit_login(
+    _server_url: &str,
+    _username: String,
+    _password: String,
+) -> Result<(), String> {
+    Err("login is only available in the web or mobile client".into())
+}
+
+#[cfg(not(any(feature = "web", feature = "mobile")))]
+async fn submit_register(
+    _server_url: &str,
+    _username: String,
+    _password: String,
+) -> Result<(), String> {
+    Err("registration is only available in the web or mobile client".into())
 }

--- a/mobile/src/main.rs
+++ b/mobile/src/main.rs
@@ -2,12 +2,21 @@
 //!
 //! All UI lives in the `omnibus_frontend` crate under `features = ["mobile"]`.
 //! This binary only wires platform launch, provides the hardcoded server URL
-//! via context, and delegates to the shared `App` component.
+//! via context, hydrates the bearer-token store from disk on launch, and
+//! delegates to the shared `App` component.
 
 use dioxus::prelude::*;
-use omnibus_frontend::{data::ServerUrl, App};
+use omnibus_frontend::{data::token_store, data::ServerUrl, App};
 
 fn main() {
+    // Pull any persisted bearer token into the in-memory store before the
+    // first render so the initial API calls go out authenticated.
+    //
+    // TODO(F0.3 follow-up): the token is currently plaintext on disk.
+    // Replace with iOS Keychain / Android Keystore before shipping to end
+    // users — see the module docs on `omnibus_frontend::data::token_store`.
+    token_store::load_from_disk();
+
     dioxus::launch(Root);
 }
 


### PR DESCRIPTION
## Summary

PR4 of the F0.3 auth stack — wires the bearer-token login flow on the
mobile client. PR1–PR3 are merged; the server-side `/api/auth/*`
endpoints already accept `client_kind: ios|android|bearer` and respond
with a bearer token in the JSON body. This PR is the client side.

- **`frontend::data::token_store`** — process-local `OnceLock<RwLock<…>>`
  with file-backed persistence at `$HOME/.omnibus-token`. Hydrated once
  at app launch in `mobile/src/main.rs`.
  - **TODO (loud and clear):** the token is plaintext on disk. Replace
    with iOS Keychain / Android Keystore before shipping to end users.
    Documented in the module doc comment, in the `mobile/src/main.rs`
    init call site, and in `CLAUDE.md`.
- **`frontend::data::mobile_login` / `mobile_register` / `mobile_logout`** —
  reqwest POSTs that issue/revoke bearer sessions. Login/register stash
  the returned token; logout revokes server-side then unconditionally
  clears local state so a network failure can't wedge the device in a
  "logged in" view.
- **All existing mobile data helpers** (settings, library, ebooks,
  search, value/increment) now attach `Authorization: Bearer <token>`
  via a shared `with_bearer` helper and clear the token on 401.
- **`pages::auth`** — submit handlers compile for both `web` and
  `mobile`. The previous mobile stub returned a static error.
- **`ScreenLayout` (mobile)** — `use_effect` redirect to `/login` when
  the token store is empty, mirroring the cookie-side gate without
  server-side help.

## Test plan

- [x] `cargo build -p omnibus-mobile` — clean
- [x] `cargo clippy --all-targets` + `cargo clippy -p omnibus-mobile --all-targets` — no warnings
- [x] `cargo fmt --check`
- [x] `cargo test -p omnibus` — 40 server tests pass (no regressions; bearer + cookie session paths exercised in `auth/gate.rs` tests since PR3)
- [ ] Manual on-device smoke (deferred — needs iOS simulator + running server):
  - register a fresh user from the iOS app → token persists, app lands on `/`
  - kill the app + reopen → token rehydrates from `$HOME/.omnibus-token`, no re-login required
  - revoke the device from the admin path on the server → next API call 401s, app bounces to `/login`

## Follow-ups (not in this PR)

- Replace the plaintext token file with iOS Keychain / Android Keystore.
  Do not ship to public users until this lands.
- Mobile settings screen to override the hardcoded `http://127.0.0.1:3000` server URL and to log out / list devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)