### PR TITLE
chore(nix): export CARGO_TARGET_DIR to keep target/ out of /nix/store

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -10,6 +10,7 @@ nix develop                 # also works; spawns a bash subshell
 The shell hook sets:
 
 - `DATABASE_URL=sqlite://omnibus.db?mode=rwc`
+- `CARGO_TARGET_DIR=$HOME/.cache/cargo-target/<worktree-root-name>` — keeps `target/` outside the repo so flake evaluations don't snapshot multi-GB build artifacts into `/nix/store` on every direnv reload. The worktree root is resolved via `git rev-parse --show-toplevel` (so `nix develop` from a subdir picks the same dir), and the basename keeps it per-worktree to avoid races between parallel jj workspaces.
 - `PLAYWRIGHT_BROWSERS_PATH` → Nix-provided Chromium (don't run `npx playwright install`)
 - `ANDROID_HOME` and `ANDROID_NDK_HOME` (auto-detected from standard Android Studio install paths)
 

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,14 @@
             echo "Run: cargo test -p omnibus"
             echo "Run: cargo run -p omnibus"
 
+            # Keep target/ out of the repo so flake evaluations don't snapshot
+            # ~12GB of build artifacts into /nix/store on every direnv reload.
+            # Resolve the repo root so `nix develop` from a subdir lands in the
+            # same target dir; basename keeps it per-worktree so parallel jj
+            # workspaces don't race.
+            _cargo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+            export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/$(basename "$_cargo_root")"
+
             # Pin Playwright's Chromium to the Nix store so no per-user
             # download lands in ~/Library/Caches/ms-playwright/. The npm
             # @playwright/test version must match this bundle's version.


### PR DESCRIPTION
## Summary
- Add `export CARGO_TARGET_DIR=$HOME/.cache/cargo-target/<worktree>` to the dev-shell `shellHook` so `target/` lives outside the repo.
- Document the new env var in [01-dev-environment.md](.claude/rules/01-dev-environment.md).

## Why

Every `direnv reload` (or `nix develop`) on a "dirty" working tree re-evaluates the flake and snapshots the entire repo into `/nix/store` as a `<hash>-source` path. With `target/` inside the repo, each snapshot was 8–25 GB.

On my machine, **67 such snapshots had accumulated to ~445 GB** across 4 jj worktrees (`omnibus`, `omnibus-zulu`, `omnibus-xray`, `omnibus-yankee`) — most of `/nix/store`'s 452 GB total, with the `/nix` volume at 99% full.

Moving `CARGO_TARGET_DIR` outside the repo drops the dominant ~12 GB contributor from each future snapshot. The path is per-worktree (`$(basename "$PWD")`) so parallel jj workspaces don't race on a shared target dir.

>[!NOTE]
> This change does not free existing store snapshots — those need `nix-collect-garbage -d` plus clearing each worktree's `.direnv/`. This PR only prevents future regrowth.

## Test plan
- [x] Exit any active `nix develop` shell.
- [x] `direnv reload` (or `nix develop --command zsh`) in `/Users/seamus/Repos/omnibus`.
- [x] Confirm `echo $CARGO_TARGET_DIR` prints `~/.cache/cargo-target/omnibus`.
- [x] Run `cargo build -p omnibus` and confirm artifacts land under `~/.cache/cargo-target/omnibus/`, not `./target/`.
- [x] After the next direnv reload, verify the new `*-source` path in `/nix/store` no longer contains a `target/` subdir (`ls /nix/store/<hash>-source/target` → not found).

## Notes
- The `.gitignore` already lists `target/`, but Nix flakes only honor it when the working tree is clean from git's POV. jj-driven trees are usually "dirty" with untracked artifacts (`omnibus.db`, `covers/`, etc.), so Nix copies everything regardless.
- Stale `target/` directories in each worktree become orphaned after this lands — safe to `rm -rf target` once builds are working from the new location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)