### PR TITLE
docs(roadmap): split per-route authorization into F0.7 and reframe F0.3 device rows

### DIFF
--- a/docs/roadmap/0-0-summary.md
+++ b/docs/roadmap/0-0-summary.md
@@ -78,7 +78,7 @@ Phase 6  Mobile                   (feature parity on native)
 
 | Phase | Theme | v1 features inside | New initiatives | Target horizon |
 |---|---|---|---|---|
-| 0 | Foundations | — | F0.1–F0.6 | short-term |
+| 0 | Foundations | — | F0.1–F0.7 | short-term |
 | 1 | Browse & discovery | #4 Views, #5 Detail | F1.1 Search, F1.2 Thumbnails | short-term |
 | 2 | Reading & listening | #8 Reader, #9 Audio | F2.1 Progress sync service | medium-term |
 | 3 | Personalization | #3 Libraries, #6 Ratings/journal, #12 Suggestions | — | medium-term |
@@ -98,6 +98,7 @@ Phase 6  Mobile                   (feature parity on native)
 - [F0.4 FTS5 index](0-4-fts5.md)
 - [F0.5 Background worker primitive](0-5-background-worker.md)
 - [F0.6 Library filesystem convention](0-6-library-filesystem.md)
+- [F0.7 Per-route authorization](0-7-route-authorization.md)
 
 ### Phase 1 — Browse & discovery
 
@@ -210,7 +211,7 @@ Phase 6  Mobile                   (feature parity on native)
 
 ## 8. Immediate next steps
 
-1. Review and approve Phase 0 scope ([F0.1](0-1-schema-refactor.md) – [F0.6](0-6-library-filesystem.md)).
+1. Review and approve Phase 0 scope ([F0.1](0-1-schema-refactor.md) – [F0.7](0-7-route-authorization.md)).
 2. File GitHub issues for each F-number, porting acceptance criteria from the prior roadmap where the feature survives into v2.
 3. Resolve open questions 1 (covers) and 2 (scan paths) before [F0.1](0-1-schema-refactor.md) kicks off — both block schema design.
 4. Spike [F0.3](0-3-auth.md) session cookies on web + bearer tokens on mobile to verify the auth model is unified across surfaces.

--- a/docs/roadmap/0-3-auth.md
+++ b/docs/roadmap/0-3-auth.md
@@ -20,7 +20,8 @@ Every feature touching user state needs it. Building those first and retrofittin
 - `auth_required` / `admin_required` axum extractors, mirroring the shape of `StateExtractor`.
 - Unified auth model across web (cookies) and mobile (bearer tokens) — both flow into the same session table.
 - **OIDC/SSO as a day-one extension point, not a v2 bolt-on.** Shape the auth layer so a second `AuthStrategy` (OIDC via the `openidconnect` crate, full PKCE, group→role mapping) slots in without schema rework. ABS's [OidcAuthStrategy.js](https://github.com/advplyr/audiobookshelf/blob/master/server/auth/OidcAuthStrategy.js) is ~560 lines because it was bolted on — designing the trait up front avoids that cost. See [ABS recommendation #11](../audiobookshelf-inspection/7-recommendations.md).
-- **Device rows** for registered clients (`device_id`, `client_name`, `client_version`, `last_seen`, `ip_address`) so admin can see who's connected and revoke a specific phone. ABS pattern: [Device.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Device.js).
+- **Device rows** for registered ereaders / sync destinations (Kobo, Kindle, OPDS clients) — *not* for browser sessions. The [`devices` table](../../db/migrations/0004_auth.sql) carries `name`, `client_kind`, `client_version`, `created_at`, `last_seen_at`, `last_seen_ip` so an admin can see which physical ereader is registered against an account and revoke a specific one. Browser/mobile login state belongs in the `sessions` table, not here. The current login handler ([server/src/auth/handlers.rs:183](../../server/src/auth/handlers.rs)) opportunistically registers a device row when a `device_name` is supplied — fine for mobile, but the canonical writers will be the Kobo registration handshake ([F4.1](4-1-kobo-sync.md)), the Kindle delivery flow ([F4.3](4-3-kindle.md)), and the OPDS client registration ([F4.2](4-2-opds.md)). ABS pattern: [Device.js](https://github.com/advplyr/audiobookshelf/blob/master/server/models/Device.js).
+- **Per-route authorization is its own initiative.** The permission columns above only matter if handlers consult them. Wiring `AuthUser` / `AdminUser` onto every protected handler is scoped under [F0.7 Per-route authorization](0-7-route-authorization.md); F0.3 is responsible for the columns and the extractors, F0.7 is responsible for using them.
 
 ## Dependencies
 
@@ -40,7 +41,7 @@ The "first registered user is admin" rule stays, plus the `OMNIBUS_INITIAL_ADMIN
 
 **What:** When an anonymous user hits `/`, `/settings`, or `/books/:id` on the web client, redirect them to `/login` after hydration the way mobile already does in `ScreenLayout` ([frontend/src/lib.rs:101](../../frontend/src/lib.rs)).
 
-**Why:** Today the web SSR shell renders for anyone; only the `/api/*` calls 401 silently. Users see "No ebooks found" or a blank settings form with no cue that they're unauthenticated. The 2026-04-26 QA pass ([qa-report](../qa/qa-report-2026-04-26.md)) flagged this as the most visible "looks broken" follow-up after the origin_check fix.
+**Why:** Today the web SSR shell renders for anyone; only the `/api/*` calls 401 silently. Worse than just a blank shell — the failed server-function call surfaces the literal string `error running server function: HTTP 401: unauthorized (details: None)` in the page, which looks broken to the user and leaks transport-level error text. The 2026-04-26 QA pass ([qa-report](../qa/qa-report-2026-04-26.md)) flagged this as the most visible "looks broken" follow-up after the origin_check fix; the audit re-pass on the same day confirmed the leaked-error string on `/` and `/settings`.
 
 **Context:** Mirror the mobile pattern. The web `ScreenLayout` pings `/api/auth/me` (already exposed via `data::current_user()`) once on hydrate, drives a `use_signal(authed)`, and `nav.replace(Route::Login {})` if 401. SSR keeps rendering the empty shell — the redirect happens client-side after one RTT, so SSR markup stays deterministic and hydration doesn't break. Auth-shell screens (`Login`/`Register`) already bypass `ScreenLayout` so they stay reachable to anonymous users.
 
@@ -60,9 +61,23 @@ The "first registered user is admin" rule stays, plus the `OMNIBUS_INITIAL_ADMIN
 **Priority:** P2
 **Depends on:** None (independent of the route-guard TODO; either can land first).
 
+### Update `devices.last_seen_at` on session use
+
+**What:** When a request lands with a session/bearer that resolves to a device row, bump that row's `last_seen_at` (and, when the request originates from an ereader/Kobo/Kindle endpoint, write a truncated `last_seen_ip` per the `/24` and `/48` rule from the schema comment in [db/migrations/0004_auth.sql:34](../../db/migrations/0004_auth.sql)). Today the column has a default but no `UPDATE` site, so the value is frozen at registration time.
+
+**Why:** "Last seen" is the audit signal that lets an admin tell a stale Kobo registration apart from one that's actively syncing — without it the admin panel's device list (planned for [F5.4](5-4-admin-panel.md)) is decorative. Rate-limit the touch the same way `sessions.last_used_at` is touched (don't write on every request) so an actively-syncing client doesn't hammer the row.
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** None. The column already exists; this is a writer + a touch threshold.
+
 ## Status
 
-In progress. Auth core landed across multiple PRs: registration, login, logout endpoints, session persistence on web cookies + mobile bearer tokens (PR4), first-user-admin promotion, `OMNIBUS_INITIAL_ADMIN` recovery hook, CSRF `origin_check` middleware, and per-IP rate limiting on `/api/auth/{login,register}`. The 2026-04-26 QA pass ([qa-report](../qa/qa-report-2026-04-26.md), [PR #43](https://github.com/seamus-sloan/omnibus/pull/43)) cleared the cookie-authed-POST regression behind the dx-fullstack proxy and added the missing logout button to TopNav. Outstanding work captured in the TODOs above.
+Auth core landed across multiple PRs: registration, login, logout endpoints, session persistence on web cookies + mobile bearer tokens (PR4), first-user-admin promotion, `OMNIBUS_INITIAL_ADMIN` recovery hook, CSRF `origin_check` middleware (10 req / 60 s per-IP) on `/api/auth/{login,register}`, the `AuthStrategy` trait shaped for OIDC, server-side session revocation on logout, and a DB-backed `registration_enabled` toggle that closes after the first user (boot hook reopens it for the named `OMNIBUS_INITIAL_ADMIN`). The `AuthUser` and `AdminUser` extractors and the `is_admin` / `can_upload` / `can_edit` / `can_download` columns are in place; **wiring them onto every protected handler is tracked separately under [F0.7 Per-route authorization](0-7-route-authorization.md)** so this initiative can close once the TODOs below land.
+
+The 2026-04-26 QA pass ([qa-report](../qa/qa-report-2026-04-26.md), [PR #43](https://github.com/seamus-sloan/omnibus/pull/43)) cleared the cookie-authed-POST regression behind the dx-fullstack proxy and added the missing logout button to TopNav. The same-day audit re-pass spun out F0.7 (per-route authorization), [F5.4](5-4-admin-panel.md) admin-side TODOs for the `registration_enabled` toggle and the device/session list & revoke endpoints, and the `last_seen_at` follow-up captured above.
+
+Out of scope for v1.0 (deliberately): email verification, password reset, account lockout (rate limit only), audit log, session sliding-window expiry. All land later — most under [F5.4](5-4-admin-panel.md).
 
 ---
 

--- a/docs/roadmap/0-7-route-authorization.md
+++ b/docs/roadmap/0-7-route-authorization.md
@@ -1,0 +1,73 @@
+# F0.7 — Per-route authorization
+
+**Phase 0 · Foundations** · **Priority:** P0
+
+Wire the existing `AuthUser` / `AdminUser` extractors onto every `/api/*` and `/api/rpc/*` handler so the permission columns landed in [F0.3](0-3-auth.md) are actually enforced.
+
+## Objective
+
+Today the [`require_auth` gate](../../server/src/auth/gate.rs) middleware admits any logged-in user to every protected route. The `is_admin` / `can_upload` / `can_edit` / `can_download` columns from F0.3 are surfaced via `/api/auth/me` but never consulted. Every handler in [server/src/backend.rs](../../server/src/backend.rs) and [frontend/src/rpc.rs](../../frontend/src/rpc.rs) takes only `State<AppState>` — the typed user is dropped on the floor. Goal: every protected handler declares the strictest extractor it needs (`AuthUser` for read paths, `AdminUser` for state-changing ops on shared config), and the request is rejected before it touches the data layer if the caller lacks the permission.
+
+## User / business value
+
+Closes a real privilege-escalation today: any non-admin who registers (or is added by an admin in F5.4) can `POST /api/settings` and rewrite the library root paths, or `POST /api/rpc/settings` and trigger an arbitrary reindex. Pre-requisite for shipping any feature that reads or writes per-user state — without enforcement, F2.1 progress sync, F3.2 ratings, F3.1 libraries all collapse into a single shared blob the moment more than one user exists.
+
+## Technical considerations
+
+- `AuthUser` extractor at [server/src/auth/extractor.rs:81](../../server/src/auth/extractor.rs:81) and `AdminUser` wrapper at [extractor.rs:111](../../server/src/auth/extractor.rs:111) already exist — the work is wiring, not building.
+- Audit each route and pick the right extractor. First pass:
+  - `GET /api/value`, `GET /api/library`, `GET /api/ebooks`, `GET /api/covers/{id}`, `GET /api/search` → `AuthUser`.
+  - `POST /api/value/increment` → `AuthUser` (placeholder; will go away with the counter app).
+  - `GET/POST /api/settings`, `POST /api/rpc/settings` → `AdminUser` (settings are server-global today).
+- Same pass on the Dioxus server functions in [frontend/src/rpc.rs](../../frontend/src/rpc.rs). Server functions can extract from request parts via `extract::<AuthUser, _>().await` inside the body — server-function ergonomics, not handler args.
+- When the schema gains per-user tables ([F0.1](0-1-schema-refactor.md) follow-ups, [F2.1 progress sync](2-1-progress-sync.md), etc.), the read/write helpers should take `user_id: i64` rather than reading global state — the extractor delivers it. This initiative does the wiring; data-layer per-user scoping rides along with the feature that introduces the table.
+- Tests: every handler integration test in [server/src/backend.rs](../../server/src/backend.rs) currently calls `oneshot` without a session cookie. After this change, the test helpers need a `as_user(pool, &user)` / `as_admin(pool, &user)` shim that issues a session and attaches the cookie, and the existing assertions that rely on "logged-in by default" should split into 200 (authed) + 401 (anonymous) + 403 (wrong role) cases per [03-unit-testing.md](../../.claude/rules/03-unit-testing.md).
+
+## Dependencies
+
+- [F0.3 Auth](0-3-auth.md) — extractors, session table, permission columns. Already shipped.
+
+## Risks
+
+- Touches every protected handler. Diff is mechanical but wide; review burden is real.
+- Tests get noisier — every "happy path" test now needs a session bootstrap. Worth investing in a single `tests::auth_helpers` module rather than copy-pasting per-file.
+
+## TODOs
+
+### Backend route audit
+
+**What:** For every handler under [server/src/backend.rs](../../server/src/backend.rs), declare the appropriate extractor (`AuthUser` or `AdminUser`) and update the integration tests to bootstrap a session.
+
+**Why:** Without this, the per-user permission columns are decorative.
+
+**Effort:** M
+**Priority:** P0
+**Depends on:** None.
+
+### RPC server-function audit
+
+**What:** Same audit for every `#[get]` / `#[post]` in [frontend/src/rpc.rs](../../frontend/src/rpc.rs). Use `extract::<AuthUser, _>()` inside server-function bodies.
+
+**Why:** Web clients reach the same data layer through `/api/rpc/*`; an audit that only covers `/api/*` leaves the web surface wide open.
+
+**Effort:** S
+**Priority:** P0
+**Depends on:** Backend route audit (share the auth-helpers shim).
+
+### Test helper for authed integration tests
+
+**What:** Add a `server::auth::test_support` (or similar) module exposing `as_user(pool, username, password) -> CookieJar` and `as_admin(...)` so handler tests can attach a real session header in one line.
+
+**Why:** Without a shared helper, every test file reinvents the bootstrap and drifts.
+
+**Effort:** S
+**Priority:** P0
+**Depends on:** None.
+
+## Status
+
+Not started. Captured during the [2026-04-26 auth audit](../qa/qa-report-2026-04-26.md) follow-up review, when the F0.3 permission-columns claim was traced through the codebase and found to terminate at `UserSummary` with no enforcement site.
+
+---
+
+[← Back to roadmap summary](0-0-summary.md)

--- a/docs/roadmap/5-4-admin-panel.md
+++ b/docs/roadmap/5-4-admin-panel.md
@@ -29,6 +29,34 @@ v1 #13. The operator surface for the product — the place a self-hoster goes to
 - Absorbs F5.1 and F5.2 as sub-sections rather than freestanding features.
 - SMTP consolidated into one place.
 
+## TODOs
+
+### Admin endpoint to toggle `registration_enabled`
+
+**What:** Expose `POST /api/admin/registration` (`AdminUser`-gated) that flips the `registration_enabled` setting in the [`settings` table](../../db/migrations/0004_auth.sql) via [`db::auth::set_registration_enabled`](../../db/src/auth.rs). Surface it in the admin panel as a toggle on the user-management sub-section.
+
+**Why:** [F0.3 auth](0-3-auth.md) closes registration after the first user lands. Today the only ways to reopen the gate are direct SQL or the `OMNIBUS_INITIAL_ADMIN` boot hook (which only promotes an *existing* user). Until this endpoint exists, an admin literally cannot onboard user #2 through the running app — captured during the [2026-04-26 audit](../qa/qa-report-2026-04-26.md). Pair the toggle with a "create user" admin form so the admin can either (a) flip the gate and let users self-register, or (b) admin-create a user account directly.
+
+**Effort:** S (toggle endpoint + tests). M if paired with the admin user-creation form.
+**Priority:** P2
+**Depends on:** [F0.7 Per-route authorization](0-7-route-authorization.md) for the `AdminUser` enforcement to be real.
+
+### Device & session list / revoke endpoints
+
+**What:** Two admin-gated endpoints plus matching self-service equivalents:
+
+- `GET /api/admin/users/{id}/devices` and `GET /api/admin/users/{id}/sessions` for the admin panel.
+- `DELETE /api/admin/sessions/{id}` (admin-revoke a session) and `DELETE /api/admin/devices/{id}` (admin-revoke an ereader registration).
+- `GET /api/auth/sessions` and `DELETE /api/auth/sessions/{id}` for self-service: a logged-in user can list their own sessions and revoke any except the current one. Same shape for `/api/auth/devices` once Kobo / Kindle write to the `devices` table per [F0.3](0-3-auth.md).
+
+The DB-layer revokers ([`revoke_session`](../../db/src/auth.rs), [`revoke_all_sessions_for_user`](../../db/src/auth.rs), [`list_devices_for_user`](../../db/src/auth.rs)) already exist; the work is HTTP wiring, request authorization (admin-gated vs self-only), and the admin-panel UI.
+
+**Why:** A user with a lost phone has no path to log it out today; an admin investigating a compromise has no surface to see or kill a specific session. Ship the self-service variant in the same change so users don't have to file a support request to revoke their own credentials.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** [F0.7 Per-route authorization](0-7-route-authorization.md) for the role enforcement; partially parallelizable with the registration-toggle TODO above (shares an admin-panel sub-section).
+
 ---
 
 [← Back to roadmap summary](0-0-summary.md)


### PR DESCRIPTION
## Summary

- **New** [F0.7 Per-route authorization](docs/roadmap/0-7-route-authorization.md) — spins out as a P0 follow-up. Audit pass found that `AuthUser`/`AdminUser` extractors are implemented but never wired onto any `/api/*` or `/api/rpc/*` handler, so the F0.3 permission columns (`is_admin`, `can_upload`, `can_edit`, `can_download`) are decorative today and `POST /api/settings` accepts any logged-in user.
- **F0.3** — reframed the device-rows bullet as ereaders/sync destinations (Kobo/Kindle/OPDS), not browser sessions; added a TODO to update `devices.last_seen_at` on use; sharpened the `/login` route-guard TODO with the leaked `HTTP 401` error string the audit observed; rewrote the Status section to enumerate what shipped vs what's deliberately deferred to F5.4 (email verification, password reset, lockout, audit log, sliding-window expiry).
- **F5.4** — added two TODOs: admin endpoint to flip `registration_enabled` (so user #2 can be onboarded without DB surgery), and the device/session list & revoke endpoints (admin + self-service variants).
- **Roadmap summary** — registered F0.7 in the index, the phase table, and the Phase 0 next-steps link.

No code changes — docs only. Captured during the [2026-04-26 auth audit re-pass](docs/qa/qa-report-2026-04-26.md) follow-up review.

## Test plan

- [ ] Roadmap pages render correctly on GitHub (cross-links resolve).
- [ ] F0.7 link from F0.3 Status section and F5.4 TODOs resolves.
- [ ] F0.7 listed in 0-0-summary.md index, phase table, and immediate-next-steps.