### PR TITLE
feat: enforce per-route authorization (F0.7)

### DIFF
--- a/.claude/skills/add-backend-route/SKILL.md
+++ b/.claude/skills/add-backend-route/SKILL.md
@@ -31,14 +31,14 @@ In [shared/src/lib.rs](../../../shared/src/lib.rs):
 In [frontend/src/rpc.rs](../../../frontend/src/rpc.rs):
 
 ```rust
-#[post("/api/rpc/my_action", pool: PoolExt)]
+#[post("/api/rpc/my_action", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_my_action(input: MyInput) -> Result<MyOutput> {
     let result = db::do_work(&pool.0, &input).await?;
     Ok(result)
 }
 ```
 
-- The server-only extractor `pool: PoolExt` is declared after the path in the macro. It's extracted by axum on the server and elided from the client-side fetch stub.
+- The server-only extractors are declared after the path in the macro. `pool: PoolExt` gives the SQLite pool. `_user: AuthUser` (or `_admin: AdminUser` for state-changing ops on shared config) enforces per-route authorization (F0.7) — both extractors live in `mod server_auth` at the top of `rpc.rs`. The leading `_` is intentional until the route actually consumes the user (per-user data lands with F2.1+).
 - `Result<T>` is the anyhow-backed alias from `dioxus::prelude::Result`. Domain errors use `thiserror` per [02-error-handling.md](../../rules/02-error-handling.md).
 - The function body is only compiled when `feature = "server"` is active — guard any other imports with `#[cfg(feature = "server")]`. At the top of `rpc.rs`, import the DB layer as `use omnibus_db::{self as db, scanner};` (gated on `feature = "server"`). Background reindex work goes through the shared `Worker` extension (`worker: WorkerExt` on the macro, then `worker.0.post(omnibus_db::worker::Task::Scan { library_path })`) — never `tokio::spawn(indexer::reindex(...))` from a handler.
 - Dioxus auto-registers the route via `dioxus::server::router(App)` in [server/src/main.rs](../../../server/src/main.rs) — no manual registration.
@@ -48,7 +48,7 @@ pub async fn rpc_my_action(input: MyInput) -> Result<MyOutput> {
 In [server/src/backend.rs](../../../server/src/backend.rs):
 
 - Register on `rest_router()` with `.route(...)`.
-- Use `State<AppState>` for the pool, `Json<T>` for bodies.
+- **First argument is the auth extractor** (`_user: AuthUser` for read paths and per-user mutations, `_admin: AdminUser` for shared-config writes). Then `State<AppState>` for the pool, `Json<T>` / `Path<…>` / `Query<…>` for the rest. F0.7 makes this mandatory — without an extractor the route would default to "any logged-in user" which defeats the per-user permission columns.
 - Pick a URL under `/api/<resource>` that does **not** collide with the `/api/rpc/*` namespace used by server functions.
 - Return `Response` with explicit status + error string on failure so mobile's error UI can surface it.
 
@@ -74,7 +74,7 @@ The page component then calls a single `data::my_action(...)` and works on both 
 Per [03-unit-testing.md](../../rules/03-unit-testing.md):
 
 - **DB:** inline `#[cfg(test)]` in `db/src/queries.rs` (or the relevant module). Happy path + not-found + constraint violation. Run with `cargo test -p omnibus-db`.
-- **REST handler:** inline `#[cfg(test)]` in `server/src/backend.rs`. Drive with `tower::ServiceExt::oneshot` against `rest_router(AppState::new(in-memory pool))`. Cover 200 + 4xx + 5xx. Run with `cargo test -p omnibus`.
+- **REST handler:** inline `#[cfg(test)]` in `server/src/backend.rs`. Drive with `tower::ServiceExt::oneshot` against `rest_router(AppState::new(in-memory pool))`. Bootstrap a session via the helpers in [server/src/auth/test_support.rs](../../../server/src/auth/test_support.rs) (`create_user` / `create_admin` / `bearer_token`) and attach the bearer header. Cover the full matrix per [03-unit-testing.md](../../rules/03-unit-testing.md): 200 (authed) + 401 (anon) + 403 (wrong role, for admin-gated routes) + relevant 4xx/5xx. Run with `cargo test -p omnibus`.
 - **Server function:** covered indirectly by the DB tests (the function body is a thin wrapper). Add an integration test only if the wrapper does non-trivial composition.
 
 ## 8. Add Playwright coverage (user-facing changes)

--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -260,6 +260,47 @@ pub fn hash_token(raw: &str) -> Vec<u8> {
     hasher.finalize().to_vec()
 }
 
+/// Cookie name for cookie-mode sessions. Centralized here so HTTP-side
+/// callers (server's `AuthUser` extractor + the rpc.rs body-side
+/// equivalent) don't drift apart.
+pub const SESSION_COOKIE_NAME: &str = "omnibus_session";
+
+/// Pull a session token out of HTTP request headers, preferring an
+/// `Authorization: Bearer …` value over the `omnibus_session` cookie.
+/// Returns `None` when neither source has a non-empty token.
+///
+/// Pure-string API by design — keeps `omnibus-db` free of an axum/http
+/// type dependency. Callers pass the relevant header values through.
+pub fn parse_session_token(
+    authorization: Option<&str>,
+    cookie_header: Option<&str>,
+) -> Option<(String, SessionKind)> {
+    if let Some(value) = authorization {
+        if let Some(rest) = value.strip_prefix("Bearer ") {
+            let token = rest.trim();
+            if !token.is_empty() {
+                return Some((token.to_string(), SessionKind::Bearer));
+            }
+        }
+    }
+    if let Some(cookies) = cookie_header {
+        // Cookie header is `name1=value1; name2=value2`. Walk it manually
+        // rather than pulling in axum-extra's CookieJar.
+        for pair in cookies.split(';') {
+            let pair = pair.trim();
+            if let Some((name, value)) = pair.split_once('=') {
+                if name.trim() == SESSION_COOKIE_NAME {
+                    let token = value.trim();
+                    if !token.is_empty() {
+                        return Some((token.to_string(), SessionKind::Cookie));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 // -----------------------------------------------------------------------------
 // User CRUD
 // -----------------------------------------------------------------------------

--- a/docs/roadmap/0-7-route-authorization.md
+++ b/docs/roadmap/0-7-route-authorization.md
@@ -66,7 +66,7 @@ Closes a real privilege-escalation today: any non-admin who registers (or is add
 
 ## Status
 
-Not started. Captured during the [2026-04-26 auth audit](../qa/qa-report-2026-04-26.md) follow-up review, when the F0.3 permission-columns claim was traced through the codebase and found to terminate at `UserSummary` with no enforcement site.
+Shipped 2026-04-26. Every protected handler in [server/src/backend.rs](../../server/src/backend.rs) now declares `AuthUser` (read paths + the placeholder counter mutation) or `AdminUser` (`/api/settings` GET/POST), and every Dioxus server function in [frontend/src/rpc.rs](../../frontend/src/rpc.rs) does the same. The `AuthUser` / `AdminUser` `FromRequestParts` impls were decoupled from `AppState` and now read the pool from `Extension<SqlitePool>` so the same logic backs both routers; the wire-format token resolution lives in [`omnibus_db::auth::parse_session_token`](../../db/src/auth.rs) so the `frontend` crate can reuse it without taking a dep on the `server` crate. Integration-test bootstrap is consolidated in [`server/src/auth/test_support.rs`](../../server/src/auth/test_support.rs); each protected route gained an anon-401 sibling test, and admin-only routes additionally gained a non-admin-403 sibling test per [03-unit-testing.md](../../.claude/rules/03-unit-testing.md). Playwright already seeds an admin session via `globalSetup` (F0.3) so the `seedLibrary` helper kept working without modification.
 
 ---
 

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -33,24 +33,119 @@ type PoolExt = dioxus::fullstack::axum::Extension<sqlx::SqlitePool>;
 #[cfg(feature = "server")]
 type WorkerExt = dioxus::fullstack::axum::Extension<std::sync::Arc<omnibus_db::worker::Worker>>;
 
-#[get("/api/rpc/value", pool: PoolExt)]
+#[cfg(feature = "server")]
+pub use server_auth::{AdminUser, AuthUser};
+
+/// Server-side per-route authorization extractors used by the `#[get]` /
+/// `#[post]` macros below. These are deliberately scoped to this module
+/// instead of imported from `crate::omnibus::auth` — the `frontend` crate
+/// can't depend on the `server` crate (cycle), and dioxus already
+/// re-exports axum/axum-extra under `dioxus::fullstack::*`, so duplicating
+/// ~50 lines is cheaper than restructuring the workspace.
+///
+/// Behaviour mirrors `server::auth::extractor::AuthUser` /
+/// `AdminUser`. Both call `omnibus_db::auth::parse_session_token` and
+/// `lookup_session` so the wire-level token format stays in lockstep with
+/// the REST side.
+#[cfg(feature = "server")]
+mod server_auth {
+    use dioxus::fullstack::axum::extract::FromRequestParts;
+    use dioxus::fullstack::axum::http::{header, request::Parts, StatusCode};
+    use dioxus::fullstack::axum::response::{IntoResponse, Response};
+    use omnibus_db::auth::{self as auth_db, AuthError};
+    use sqlx::SqlitePool;
+
+    /// Authenticated user. Extractor returns 401 when no live session is
+    /// attached to the request.
+    #[derive(Debug, Clone)]
+    pub struct AuthUser {
+        pub id: i64,
+        pub is_admin: bool,
+    }
+
+    /// Admin-only wrapper. Extracting this returns 403 for non-admin users
+    /// (after a successful `AuthUser` resolution).
+    #[derive(Debug, Clone)]
+    pub struct AdminUser(pub AuthUser);
+
+    fn unauthorized() -> Response {
+        (StatusCode::UNAUTHORIZED, "unauthorized").into_response()
+    }
+
+    fn internal<E: std::fmt::Display>(e: E) -> Response {
+        eprintln!("rpc auth extractor error: {e}");
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+    }
+
+    impl<S> FromRequestParts<S> for AuthUser
+    where
+        S: Send + Sync,
+    {
+        type Rejection = Response;
+
+        async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+            let pool = parts
+                .extensions
+                .get::<SqlitePool>()
+                .cloned()
+                .ok_or_else(|| internal("missing SqlitePool extension"))?;
+            let authorization = parts
+                .headers
+                .get(header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok());
+            let cookie_header = parts
+                .headers
+                .get(header::COOKIE)
+                .and_then(|v| v.to_str().ok());
+            let Some((token, _kind)) = auth_db::parse_session_token(authorization, cookie_header)
+            else {
+                return Err(unauthorized());
+            };
+            match auth_db::lookup_session(&pool, &token).await {
+                Ok((user, _session)) => Ok(AuthUser {
+                    id: user.id,
+                    is_admin: user.is_admin,
+                }),
+                Err(AuthError::SessionNotFound) => Err(unauthorized()),
+                Err(e) => Err(internal(e)),
+            }
+        }
+    }
+
+    impl<S> FromRequestParts<S> for AdminUser
+    where
+        S: Send + Sync,
+    {
+        type Rejection = Response;
+
+        async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+            let user = AuthUser::from_request_parts(parts, state).await?;
+            if !user.is_admin {
+                return Err((StatusCode::FORBIDDEN, "admin required").into_response());
+            }
+            Ok(AdminUser(user))
+        }
+    }
+}
+
+#[get("/api/rpc/value", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_value() -> Result<ValueResponse> {
     let value = db::get_value(&pool.0).await?;
     Ok(ValueResponse { value })
 }
 
-#[post("/api/rpc/value/increment", pool: PoolExt)]
+#[post("/api/rpc/value/increment", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_increment_value() -> Result<ValueResponse> {
     let value = db::increment_value(&pool.0).await?;
     Ok(ValueResponse { value })
 }
 
-#[get("/api/rpc/settings", pool: PoolExt)]
+#[get("/api/rpc/settings", pool: PoolExt, _admin: AdminUser)]
 pub async fn rpc_get_settings() -> Result<Settings> {
     Ok(db::get_settings(&pool.0).await?)
 }
 
-#[post("/api/rpc/settings", pool: PoolExt, worker: WorkerExt)]
+#[post("/api/rpc/settings", pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
 pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
     db::set_settings(&pool.0, &settings).await?;
     let updated = db::get_settings(&pool.0).await?;
@@ -65,7 +160,7 @@ pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
     Ok(updated)
 }
 
-#[get("/api/rpc/library", pool: PoolExt)]
+#[get("/api/rpc/library", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_library() -> Result<LibraryContents> {
     let settings = db::get_settings(&pool.0).await?;
     Ok(scanner::scan_libraries(
@@ -74,7 +169,7 @@ pub async fn rpc_get_library() -> Result<LibraryContents> {
     ))
 }
 
-#[get("/api/rpc/ebooks", pool: PoolExt)]
+#[get("/api/rpc/ebooks", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_ebooks() -> Result<EbookLibrary> {
     let settings = db::get_settings(&pool.0).await?;
     // Served straight from the DB — the indexer is responsible for keeping
@@ -88,7 +183,7 @@ pub async fn rpc_get_ebooks() -> Result<EbookLibrary> {
 /// POST (not GET) so the query string can ride in the JSON body — Dioxus
 /// `#[get]` server functions reject arg bodies because HTTP spec forbids
 /// bodies on GET.
-#[post("/api/rpc/search", pool: PoolExt)]
+#[post("/api/rpc/search", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
     let settings = db::get_settings(&pool.0).await?;
     let Some(path) = settings.ebook_library_path else {

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -83,7 +83,10 @@ mod server_auth {
     {
         type Rejection = Response;
 
-        async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        async fn from_request_parts(
+            parts: &mut Parts,
+            _state: &S,
+        ) -> Result<Self, Self::Rejection> {
             let pool = parts
                 .extensions
                 .get::<SqlitePool>()

--- a/server/src/auth/extractor.rs
+++ b/server/src/auth/extractor.rs
@@ -13,8 +13,6 @@ use omnibus_db::auth::{self as auth_db, AuthError, SessionKind};
 use omnibus_shared::UserSummary;
 use sqlx::SqlitePool;
 
-use super::SESSION_COOKIE;
-
 /// Authenticated user resolved from either a session cookie or a bearer
 /// token. Extractor returns `401 Unauthorized` on anything that isn't a
 /// live session.
@@ -48,25 +46,20 @@ impl AuthUser {
 pub struct AdminUser(pub AuthUser);
 
 /// Pull a session token out of the request, preferring a `Bearer` header
-/// over a cookie. Returns `None` when neither source has a non-empty token.
-pub(super) fn extract_token(headers: &HeaderMap, jar: &CookieJar) -> Option<(String, SessionKind)> {
-    if let Some(value) = headers.get(header::AUTHORIZATION) {
-        if let Ok(s) = value.to_str() {
-            if let Some(rest) = s.strip_prefix("Bearer ") {
-                let token = rest.trim().to_string();
-                if !token.is_empty() {
-                    return Some((token, SessionKind::Bearer));
-                }
-            }
-        }
-    }
-    if let Some(cookie) = jar.get(SESSION_COOKIE) {
-        let token = cookie.value().to_string();
-        if !token.is_empty() {
-            return Some((token, SessionKind::Cookie));
-        }
-    }
-    None
+/// over a cookie. Thin wrapper around [`auth_db::parse_session_token`] —
+/// the pure-string parsing lives in `omnibus-db` so the rpc.rs server
+/// functions can call the same logic without pulling axum-extra in.
+///
+/// `_jar` is retained for backward compatibility with callers (the gate
+/// middleware) that already have a `CookieJar` parsed from the request;
+/// the cookie value is read from the raw `Cookie` header inside the db
+/// helper.
+pub(super) fn extract_token(headers: &HeaderMap, _jar: &CookieJar) -> Option<(String, SessionKind)> {
+    let authorization = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+    let cookie_header = headers.get(header::COOKIE).and_then(|v| v.to_str().ok());
+    auth_db::parse_session_token(authorization, cookie_header)
 }
 
 fn unauthorized() -> Response {
@@ -215,7 +208,7 @@ mod tests {
                     .uri("/api/auth/me")
                     .header(
                         header::COOKIE,
-                        format!("{}={}", SESSION_COOKIE, issued.raw_token),
+                        format!("{}={}", crate::auth::SESSION_COOKIE, issued.raw_token),
                     )
                     .body(Body::empty())
                     .unwrap(),

--- a/server/src/auth/extractor.rs
+++ b/server/src/auth/extractor.rs
@@ -4,16 +4,16 @@
 //! a typed view of the authenticated user.
 
 use axum::{
-    extract::{FromRef, FromRequestParts},
+    extract::FromRequestParts,
     http::{header, request::Parts, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 use axum_extra::extract::cookie::CookieJar;
 use omnibus_db::auth::{self as auth_db, AuthError, SessionKind};
 use omnibus_shared::UserSummary;
+use sqlx::SqlitePool;
 
 use super::SESSION_COOKIE;
-use crate::backend::AppState;
 
 /// Authenticated user resolved from either a session cookie or a bearer
 /// token. Extractor returns `401 Unauthorized` on anything that isn't a
@@ -81,17 +81,26 @@ fn internal<E: std::fmt::Display>(e: E) -> Response {
 impl<S> FromRequestParts<S> for AuthUser
 where
     S: Send + Sync,
-    AppState: FromRef<S>,
 {
     type Rejection = Response;
 
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let state = AppState::from_ref(state);
+    // The pool is read from `Extension<SqlitePool>` rather than from router
+    // state so the same extractor works on the hand-written `/api/*` REST
+    // router (which uses `with_state(AppState)`) and on the auto-mounted
+    // Dioxus server-function router for `/api/rpc/*` (whose state type is
+    // private). The top-level fullstack router in `server/src/main.rs`
+    // installs `Extension(pool)` on every request.
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let pool = parts
+            .extensions
+            .get::<SqlitePool>()
+            .cloned()
+            .ok_or_else(|| internal("missing SqlitePool extension"))?;
         let jar = CookieJar::from_headers(&parts.headers);
         let Some((token, _kind)) = extract_token(&parts.headers, &jar) else {
             return Err(unauthorized());
         };
-        match auth_db::lookup_session(state.pool(), &token).await {
+        match auth_db::lookup_session(&pool, &token).await {
             Ok((user, session)) => Ok(AuthUser {
                 id: user.id,
                 username: user.username,
@@ -111,7 +120,6 @@ where
 impl<S> FromRequestParts<S> for AdminUser
 where
     S: Send + Sync,
-    AppState: FromRef<S>,
 {
     type Rejection = Response;
 
@@ -128,6 +136,7 @@ where
 mod tests {
     use super::*;
     use crate::auth::handlers::auth_router;
+    use crate::backend::AppState;
     use axum::{body::Body, http::Request};
     use omnibus_db as db;
     use tower::ServiceExt;

--- a/server/src/auth/extractor.rs
+++ b/server/src/auth/extractor.rs
@@ -8,7 +8,6 @@ use axum::{
     http::{header, request::Parts, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
-use axum_extra::extract::cookie::CookieJar;
 use omnibus_db::auth::{self as auth_db, AuthError, SessionKind};
 use omnibus_shared::UserSummary;
 use sqlx::SqlitePool;
@@ -49,12 +48,7 @@ pub struct AdminUser(pub AuthUser);
 /// over a cookie. Thin wrapper around [`auth_db::parse_session_token`] —
 /// the pure-string parsing lives in `omnibus-db` so the rpc.rs server
 /// functions can call the same logic without pulling axum-extra in.
-///
-/// `_jar` is retained for backward compatibility with callers (the gate
-/// middleware) that already have a `CookieJar` parsed from the request;
-/// the cookie value is read from the raw `Cookie` header inside the db
-/// helper.
-pub(super) fn extract_token(headers: &HeaderMap, _jar: &CookieJar) -> Option<(String, SessionKind)> {
+pub(super) fn extract_token(headers: &HeaderMap) -> Option<(String, SessionKind)> {
     let authorization = headers
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok());
@@ -89,8 +83,7 @@ where
             .get::<SqlitePool>()
             .cloned()
             .ok_or_else(|| internal("missing SqlitePool extension"))?;
-        let jar = CookieJar::from_headers(&parts.headers);
-        let Some((token, _kind)) = extract_token(&parts.headers, &jar) else {
+        let Some((token, _kind)) = extract_token(&parts.headers) else {
             return Err(unauthorized());
         };
         match auth_db::lookup_session(&pool, &token).await {

--- a/server/src/auth/gate.rs
+++ b/server/src/auth/gate.rs
@@ -27,7 +27,6 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use axum_extra::extract::cookie::CookieJar;
 use omnibus_db::auth as auth_db;
 
 use super::extractor::extract_token;
@@ -38,8 +37,7 @@ pub async fn require_auth(State(state): State<AppState>, req: Request, next: Nex
     if !path.starts_with("/api/") || path == "/api/auth" || path.starts_with("/api/auth/") {
         return next.run(req).await;
     }
-    let jar = CookieJar::from_headers(req.headers());
-    let Some((token, _kind)) = extract_token(req.headers(), &jar) else {
+    let Some((token, _kind)) = extract_token(req.headers()) else {
         return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
     };
     match auth_db::lookup_session(state.pool(), &token).await {

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -231,7 +231,7 @@ async fn logout_handler(
 ) -> Response {
     // Resolve the session from either cookie or bearer, revoke it, and
     // clear the cookie. Idempotent: unknown tokens still return 204.
-    if let Some((token, _)) = extract_token(&headers, &jar) {
+    if let Some((token, _)) = extract_token(&headers) {
         match auth_db::lookup_session(state.pool(), &token).await {
             Ok((_user, session)) => {
                 if let Err(e) = auth_db::revoke_session(state.pool(), session.id).await {

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -10,7 +10,7 @@ use axum::{
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
-    Json, Router,
+    Extension, Json, Router,
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use omnibus_db::auth::{self as auth_db, AuthError, SessionKind};
@@ -21,12 +21,18 @@ use super::{BEARER_TTL_SECS, COOKIE_TTL_SECS, SESSION_COOKIE};
 use crate::backend::AppState;
 
 pub fn auth_router(state: AppState) -> Router {
+    let pool = state.pool().clone();
     Router::new()
         .route("/api/auth/register", post(register_handler))
         .route("/api/auth/login", post(login_handler))
         .route("/api/auth/logout", post(logout_handler))
         .route("/api/auth/me", get(me_handler))
         .with_state(state)
+        // `AuthUser` reads the pool from `Extension<SqlitePool>` so it stays
+        // state-agnostic. Keep this layer here so the router is usable
+        // standalone (in integration tests) without relying on the
+        // top-level Extension layer in `main.rs`.
+        .layer(Extension(pool))
 }
 
 fn user_summary(u: &auth_db::User) -> UserSummary {

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -14,7 +14,12 @@
 //!   and WebAuthn fit the same shape.
 //! * [`boot`] — `OMNIBUS_INITIAL_ADMIN` recovery hook.
 //!
-//! No existing `/api/*` routes are gated yet — PR3 flips that switch.
+//! Per-route enforcement (F0.7): every protected handler in
+//! [`crate::backend`] and every server function in `omnibus_frontend::rpc`
+//! declares the strictest extractor it needs (`AuthUser` for read paths,
+//! `AdminUser` for state-changing ops on shared config). The middleware
+//! [`gate::require_auth`] is just the boundary; the per-route extractors
+//! are what actually enforce the permission columns.
 
 pub mod boot;
 pub mod csrf;
@@ -23,6 +28,9 @@ pub mod gate;
 pub mod handlers;
 pub mod rate_limit;
 pub mod strategy;
+
+#[cfg(test)]
+pub mod test_support;
 
 pub use csrf::origin_check;
 pub use extractor::{AdminUser, AuthUser};

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -38,11 +38,13 @@ pub use gate::require_auth;
 pub use handlers::auth_router;
 pub use rate_limit::{rate_limit_auth, RateLimiter};
 
-/// Name of the session cookie issued to web clients. Not using the
-/// `__Host-` prefix so the dev server on plain HTTP still works; production
-/// deployments behind HTTPS should set `OMNIBUS_SECURE_COOKIES=1` to toggle
-/// the `Secure` attribute.
-pub const SESSION_COOKIE: &str = "omnibus_session";
+/// Name of the session cookie issued to web clients. Re-exported from
+/// `omnibus_db::auth::SESSION_COOKIE_NAME` so cookie issuance
+/// (`Set-Cookie`), CSRF cookie checks, and token parsing all share a
+/// single source of truth. Not using the `__Host-` prefix so the dev
+/// server on plain HTTP still works; production deployments behind HTTPS
+/// should set `OMNIBUS_SECURE_COOKIES=1` to toggle the `Secure` attribute.
+pub use omnibus_db::auth::SESSION_COOKIE_NAME as SESSION_COOKIE;
 
 /// 30 days for cookie sessions; matches the plan's absolute expiry.
 pub const COOKIE_TTL_SECS: i64 = 30 * 24 * 60 * 60;

--- a/server/src/auth/test_support.rs
+++ b/server/src/auth/test_support.rs
@@ -1,0 +1,74 @@
+//! Helpers for bootstrapping authenticated sessions in handler integration
+//! tests. Lets each test attach a real bearer token (or cookie) in one line
+//! instead of repeating the create-user → create-session dance.
+//!
+//! User creation goes through raw SQL rather than [`db::auth::create_user`]
+//! because the production helper auto-promotes the first user to admin and
+//! flips `registration_enabled` off afterward. Tests want explicit role
+//! assignment, not the registration policy.
+
+use omnibus_db::{
+    self as db,
+    auth::{NewSession, SessionKind, User},
+};
+use sqlx::SqlitePool;
+
+use super::{BEARER_TTL_SECS, COOKIE_TTL_SECS, SESSION_COOKIE};
+
+/// Insert a user with the given `is_admin` flag, bypassing the registration
+/// gate and first-user auto-promote logic. The password hash is a sentinel
+/// that no `verify_password` call will accept — these test users only log
+/// in via direct session minting.
+async fn insert_user(pool: &SqlitePool, username: &str, is_admin: bool) -> User {
+    let admin_flag = if is_admin { 1i64 } else { 0 };
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO users (username, password_hash, is_admin, can_upload, can_edit, can_download)
+         VALUES (?, '!test-no-password', ?, ?, ?, 1)
+         RETURNING id",
+    )
+    .bind(username)
+    .bind(admin_flag)
+    .bind(admin_flag)
+    .bind(admin_flag)
+    .fetch_one(pool)
+    .await
+    .expect("insert user");
+    User {
+        id,
+        username: username.to_string(),
+        is_admin,
+        can_upload: is_admin,
+        can_edit: is_admin,
+        can_download: true,
+    }
+}
+
+/// Create a non-admin user.
+pub async fn create_user(pool: &SqlitePool, username: &str) -> User {
+    insert_user(pool, username, false).await
+}
+
+/// Create an admin user.
+pub async fn create_admin(pool: &SqlitePool, username: &str) -> User {
+    insert_user(pool, username, true).await
+}
+
+/// Issue a bearer session for `user_id`. Returns the raw token (no `Bearer `
+/// prefix) — call sites format it as `format!("Bearer {token}")`.
+pub async fn bearer_token(pool: &SqlitePool, user_id: i64) -> String {
+    let issued: NewSession =
+        db::auth::create_session(pool, user_id, None, SessionKind::Bearer, BEARER_TTL_SECS)
+            .await
+            .expect("create_session should succeed");
+    issued.raw_token
+}
+
+/// Issue a cookie session for `user_id`. Returns the full `name=value` pair
+/// suitable for the `Cookie` request header.
+pub async fn cookie_value(pool: &SqlitePool, user_id: i64) -> String {
+    let issued: NewSession =
+        db::auth::create_session(pool, user_id, None, SessionKind::Cookie, COOKIE_TTL_SECS)
+            .await
+            .expect("create_session should succeed");
+    format!("{}={}", SESSION_COOKIE, issued.raw_token)
+}

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -201,7 +201,11 @@ async fn get_search(
     }
 }
 
-async fn get_cover(_user: AuthUser, State(state): State<AppState>, Path(id): Path<i64>) -> Response {
+async fn get_cover(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
     match db::get_cover(&state.pool, id).await {
         Ok(Some((mime, bytes))) => (
             [
@@ -274,10 +278,7 @@ mod tests {
 
     /// Convenience: anonymous GET (no auth header).
     fn get_anon(uri: &str) -> Request<Body> {
-        Request::builder()
-            .uri(uri)
-            .body(Body::empty())
-            .unwrap()
+        Request::builder().uri(uri).body(Body::empty()).unwrap()
     }
 
     // -------------------------------------------------------------------

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -12,7 +12,7 @@ use axum::{
     http::header,
     response::{IntoResponse, Response},
     routing::{get, post},
-    Json, Router,
+    Extension, Json, Router,
 };
 use omnibus_db::{
     self as db, scanner,
@@ -21,6 +21,8 @@ use omnibus_db::{
 use omnibus_shared::{Settings, ValueResponse};
 use serde::Deserialize;
 use sqlx::SqlitePool;
+
+use crate::auth::{AdminUser, AuthUser};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -44,6 +46,7 @@ impl AppState {
 }
 
 pub fn rest_router(state: AppState) -> Router {
+    let pool = state.pool().clone();
     Router::new()
         .route("/api/value", get(get_value))
         .route("/api/value/increment", post(increment_value))
@@ -54,9 +57,14 @@ pub fn rest_router(state: AppState) -> Router {
         .route("/api/search", get(get_search))
         .route("/api/covers/{id}", get(get_cover))
         .with_state(state)
+        // `AuthUser`/`AdminUser` read the pool from `Extension<SqlitePool>`.
+        // Layer it here so the router is self-contained for integration
+        // tests; in the live server `main.rs` adds the same Extension at
+        // the top, which is harmless overlap.
+        .layer(Extension(pool))
 }
 
-async fn get_value(State(state): State<AppState>) -> Response {
+async fn get_value(_user: AuthUser, State(state): State<AppState>) -> Response {
     match db::get_value(&state.pool).await {
         Ok(value) => Json(ValueResponse { value }).into_response(),
         Err(error) => (
@@ -67,7 +75,7 @@ async fn get_value(State(state): State<AppState>) -> Response {
     }
 }
 
-async fn increment_value(State(state): State<AppState>) -> Response {
+async fn increment_value(_user: AuthUser, State(state): State<AppState>) -> Response {
     match db::increment_value(&state.pool).await {
         Ok(value) => Json(ValueResponse { value }).into_response(),
         Err(error) => (
@@ -78,7 +86,7 @@ async fn increment_value(State(state): State<AppState>) -> Response {
     }
 }
 
-async fn get_settings(State(state): State<AppState>) -> Response {
+async fn get_settings(_admin: AdminUser, State(state): State<AppState>) -> Response {
     match db::get_settings(&state.pool).await {
         Ok(settings) => Json(settings).into_response(),
         Err(error) => (
@@ -89,7 +97,11 @@ async fn get_settings(State(state): State<AppState>) -> Response {
     }
 }
 
-async fn post_settings(State(state): State<AppState>, Json(settings): Json<Settings>) -> Response {
+async fn post_settings(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Json(settings): Json<Settings>,
+) -> Response {
     match db::set_settings(&state.pool, &settings).await {
         Ok(()) => match db::get_settings(&state.pool).await {
             Ok(updated) => {
@@ -130,7 +142,7 @@ async fn post_settings(State(state): State<AppState>, Json(settings): Json<Setti
     }
 }
 
-async fn get_ebooks(State(state): State<AppState>) -> Response {
+async fn get_ebooks(_user: AuthUser, State(state): State<AppState>) -> Response {
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,
         Err(error) => {
@@ -156,7 +168,11 @@ struct SearchQuery {
     q: String,
 }
 
-async fn get_search(State(state): State<AppState>, Query(params): Query<SearchQuery>) -> Response {
+async fn get_search(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Query(params): Query<SearchQuery>,
+) -> Response {
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,
         Err(error) => {
@@ -185,7 +201,7 @@ async fn get_search(State(state): State<AppState>, Query(params): Query<SearchQu
     }
 }
 
-async fn get_cover(State(state): State<AppState>, Path(id): Path<i64>) -> Response {
+async fn get_cover(_user: AuthUser, State(state): State<AppState>, Path(id): Path<i64>) -> Response {
     match db::get_cover(&state.pool, id).await {
         Ok(Some((mime, bytes))) => (
             [
@@ -209,7 +225,7 @@ async fn get_cover(State(state): State<AppState>, Path(id): Path<i64>) -> Respon
     }
 }
 
-async fn get_library(State(state): State<AppState>) -> Response {
+async fn get_library(_user: AuthUser, State(state): State<AppState>) -> Response {
     match db::get_settings(&state.pool).await {
         Ok(settings) => {
             let contents = scanner::scan_libraries(
@@ -228,46 +244,75 @@ async fn get_library(State(state): State<AppState>) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use axum::{body::to_bytes, http::Request};
+    use axum::{
+        body::{to_bytes, Body},
+        http::{header::AUTHORIZATION, Request, StatusCode},
+    };
     use tower::ServiceExt;
 
     use super::*;
+    use crate::auth::test_support;
 
-    #[tokio::test]
-    async fn api_reads_and_increments_value() {
+    /// Build a router + AppState wired against a fresh in-memory DB.
+    async fn fixture() -> (Router, AppState, sqlx::SqlitePool) {
         let pool = db::init_db("sqlite::memory:")
             .await
             .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let state = AppState::new(pool.clone());
+        let app = rest_router(state.clone());
+        (app, state, pool)
+    }
+
+    /// Convenience: GET request with a bearer auth header.
+    fn get_with_bearer(uri: &str, token: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    /// Convenience: anonymous GET (no auth header).
+    fn get_anon(uri: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    // -------------------------------------------------------------------
+    // Happy paths — every protected route bootstraps the appropriate user.
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn api_reads_and_increments_value() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
 
         let response = app
             .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/api/value")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/value", &token))
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let payload: ValueResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(payload.value, 0);
 
         let response = app
-            .clone()
             .oneshot(
                 Request::builder()
                     .uri("/api/value/increment")
                     .method("POST")
-                    .body(axum::body::Body::empty())
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
                     .unwrap(),
             )
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let payload: ValueResponse = serde_json::from_slice(&body).unwrap();
@@ -276,21 +321,15 @@ mod tests {
 
     #[tokio::test]
     async fn api_get_settings_returns_null_defaults() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let (app, _state, pool) = fixture().await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
 
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/settings")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/settings", &token))
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let settings: Settings = serde_json::from_slice(&body).unwrap();
@@ -300,10 +339,9 @@ mod tests {
 
     #[tokio::test]
     async fn api_post_settings_persists_and_returns_saved_values() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let (app, _state, pool) = fixture().await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
 
         let body = serde_json::json!({
             "ebook_library_path": "/books/ebooks",
@@ -315,12 +353,13 @@ mod tests {
                     .uri("/api/settings")
                     .method("POST")
                     .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body.to_string()))
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body.to_string()))
                     .unwrap(),
             )
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let settings: Settings = serde_json::from_slice(&bytes).unwrap();
@@ -336,10 +375,9 @@ mod tests {
 
     #[tokio::test]
     async fn api_get_settings_after_post_reflects_saved_values() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let (app, _state, pool) = fixture().await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
 
         let body = serde_json::json!({
             "ebook_library_path": "/my/ebooks",
@@ -351,22 +389,18 @@ mod tests {
                     .uri("/api/settings")
                     .method("POST")
                     .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body.to_string()))
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body.to_string()))
                     .unwrap(),
             )
             .await
             .expect("POST should succeed");
 
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/settings")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/settings", &token))
             .await
             .expect("GET should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let settings: Settings = serde_json::from_slice(&bytes).unwrap();
@@ -376,21 +410,15 @@ mod tests {
 
     #[tokio::test]
     async fn api_get_library_returns_empty_sections_when_paths_not_configured() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
 
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/library")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/library", &token))
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let contents: omnibus_shared::LibraryContents = serde_json::from_slice(&bytes).unwrap();
@@ -402,9 +430,7 @@ mod tests {
 
     #[tokio::test]
     async fn api_get_library_reports_error_for_nonexistent_path() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
+        let (_, _, pool) = fixture().await;
         db::set_settings(
             &pool,
             &Settings {
@@ -414,18 +440,15 @@ mod tests {
         )
         .await
         .expect("set should succeed");
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
         let app = rest_router(AppState::new(pool));
 
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/library")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/library", &token))
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let contents: omnibus_shared::LibraryContents = serde_json::from_slice(&bytes).unwrap();
@@ -435,21 +458,15 @@ mod tests {
 
     #[tokio::test]
     async fn api_get_ebooks_returns_empty_when_path_not_configured() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
 
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/ebooks")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/ebooks", &token))
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let lib: omnibus_shared::EbookLibrary = serde_json::from_slice(&bytes).unwrap();
@@ -475,18 +492,15 @@ mod tests {
         )
         .await
         .expect("set should succeed");
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
         let app = rest_router(AppState::new(pool));
 
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/ebooks")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/ebooks", &token))
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let lib: omnibus_shared::EbookLibrary = serde_json::from_slice(&bytes).unwrap();
@@ -497,20 +511,14 @@ mod tests {
 
     #[tokio::test]
     async fn api_search_returns_empty_when_path_not_configured() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/search?q=hello")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/search?q=hello", &token))
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let lib: omnibus_shared::EbookLibrary = serde_json::from_slice(&bytes).unwrap();
         assert!(lib.path.is_none());
@@ -519,50 +527,36 @@ mod tests {
 
     #[tokio::test]
     async fn api_search_rejects_missing_q_param() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/search")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/search", &token))
             .await
             .expect("request should succeed");
         // axum's Query extractor returns 400 for missing required fields.
-        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
     async fn api_get_covers_returns_not_found_for_missing_id() {
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let app = rest_router(AppState::new(pool));
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/covers/9999")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/covers/9999", &token))
             .await
             .expect("request should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
     async fn post_settings_triggers_scan_via_worker() {
         use db::worker::TaskOutcome;
 
-        let pool = db::init_db("sqlite::memory:")
-            .await
-            .expect("db should initialize");
-        let state = AppState::new(pool);
-        let app = rest_router(state.clone());
+        let (app, state, pool) = fixture().await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
 
         // Resolve the playwright fixtures directory relative to the server
         // crate manifest. Asserting `is_dir` up front avoids a confusing
@@ -585,12 +579,13 @@ mod tests {
                     .uri("/api/settings")
                     .method("POST")
                     .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body.to_string()))
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body.to_string()))
                     .unwrap(),
             )
             .await
             .expect("POST should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let task_id: db::worker::TaskId = response
             .headers()
@@ -607,15 +602,10 @@ mod tests {
         }
 
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/ebooks")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(get_with_bearer("/api/ebooks", &token))
             .await
             .expect("GET /api/ebooks should succeed");
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let lib: omnibus_shared::EbookLibrary = serde_json::from_slice(&bytes).unwrap();
@@ -623,5 +613,130 @@ mod tests {
             !lib.books.is_empty(),
             "worker should have indexed at least one book from {path_str}"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // 401 — anonymous request rejected by the per-route extractor (the
+    // top-level `require_auth` middleware is not in this test stack;
+    // these assertions confirm the extractor itself enforces the gate).
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn api_value_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/value")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_value_increment_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/value/increment")
+                    .method("POST")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_get_settings_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/settings")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_post_settings_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let body = serde_json::json!({
+            "ebook_library_path": null,
+            "audiobook_library_path": null,
+        });
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/settings")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_library_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/library")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_ebooks_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/ebooks")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_search_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/search?q=hello")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_covers_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/covers/1")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -------------------------------------------------------------------
+    // 403 — non-admin authenticated user hits an admin-only route.
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn api_get_settings_returns_403_when_not_admin() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "reader").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+        let res = app
+            .oneshot(get_with_bearer("/api/settings", &token))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn api_post_settings_returns_403_when_not_admin() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "reader").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+        let body = serde_json::json!({
+            "ebook_library_path": "/evil/path",
+            "audiobook_library_path": null,
+        });
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/settings")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 }


### PR DESCRIPTION
## Summary
- Wire `AuthUser` / `AdminUser` extractors onto every protected handler in `server/src/backend.rs` and every Dioxus server function in `frontend/src/rpc.rs`. Closes the privilege-escalation gap where any logged-in user could `POST /api/settings` or trigger an arbitrary reindex via `/api/rpc/settings` — the per-user permission columns from F0.3 are now actually enforced ([0-7-route-authorization.md](docs/roadmap/0-7-route-authorization.md)).
- Refactor the extractors to read the pool from `Extension<SqlitePool>` instead of `State<AppState>`, dropping the `AppState: FromRef<S>` bound so the same impls work on both the REST router and the auto-mounted Dioxus server-function router. Wire-format token resolution moves down to `omnibus_db::auth::parse_session_token` so the `frontend` crate can mirror the extractor locally without depending on the `server` crate (cycle).
- Add `server::auth::test_support` (`create_user` / `create_admin` / `bearer_token` / `cookie_value`) and refactor `backend.rs` integration tests to bootstrap a session per case. Adds the full anon-401 + non-admin-403 sibling-test matrix per [03-unit-testing.md](.claude/rules/03-unit-testing.md): 12 new tests, all green.

## Test plan
- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test -p omnibus` — 54 passed (was 42; +12 sibling tests).
- [x] `cargo test -p omnibus-frontend --features server` — 5 passed.
- [x] `cargo test -p omnibus-db` — 74 passed.
- [ ] Manual sanity against `dx serve`: `curl -i /api/settings` → 401; register first user, `curl -b cookie /api/settings` → 200; register a second user, retry → 403.
- [ ] `cd ui_tests/playwright && npx playwright test` — `globalSetup` already registers `playwright` as first-user-admin (F0.3), so `seedLibrary` keeps working without modification.

## Notes
- The `frontend` crate can't depend on `server` (cycle), so the extractor types are duplicated in `frontend/src/rpc.rs` under `mod server_auth` (~50 lines). Both sides delegate to the same `omnibus_db::auth::parse_session_token` helper to keep the wire format from drifting.
- No `CanUploadUser` / `CanEditUser` / `CanDownloadUser` extractors yet — those land alongside the upload/edit/download routes that need them. The columns are already on `AuthUser`, so future PRs add the wrappers without rework.
- Refreshes the [add-backend-route](.claude/skills/add-backend-route/SKILL.md) skill so future routes start with the auth extractor on the first arg.