### PR TITLE
feat(library): F0.6 library filesystem convention

### DIFF
--- a/.claude/rules/98-keep-skills-fresh.md
+++ b/.claude/rules/98-keep-skills-fresh.md
@@ -6,7 +6,7 @@ When touching any of the following areas, re-read the matching skill and update 
 
 | Code area | Skill to re-check |
 |---|---|
-| `server/src/backend.rs`, `server/src/main.rs`, `frontend/src/rpc.rs`, `frontend/src/data.rs`, `db/src/queries.rs`, `db/src/scanner.rs`, `db/src/ebook.rs`, `db/src/indexer.rs`, `db/src/worker.rs`, `db/migrations/`, `shared/src/lib.rs` | [add-backend-route](../skills/add-backend-route/SKILL.md) |
+| `server/src/backend.rs`, `server/src/main.rs`, `frontend/src/rpc.rs`, `frontend/src/data.rs`, `db/src/queries.rs`, `db/src/scanner.rs`, `db/src/ebook.rs`, `db/src/indexer.rs`, `db/src/library_layout.rs`, `db/src/worker.rs`, `db/migrations/`, `shared/src/lib.rs` | [add-backend-route](../skills/add-backend-route/SKILL.md) |
 | `ui_tests/playwright/tests/fixtures/`, `ui_tests/playwright/tests/utils/`, selector conventions | [add-playwright-flow](../skills/add-playwright-flow/SKILL.md) |
 | jj workflow changes (new commands, new workspace patterns) | [jj-basics](../skills/jj-basics/SKILL.md), [jj-workspaces](../skills/jj-workspaces/SKILL.md), [jj-advanced](../skills/jj-advanced/SKILL.md) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,12 @@ lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection
 ### db/src/
 
 ```
-lib.rs              — re-exports queries::*; pub mod auth/ebook/indexer/queries/scanner/worker
+lib.rs              — re-exports queries::*; pub mod auth/ebook/indexer/library_layout/queries/scanner/worker
 queries.rs          — pool init, schema, query layer (list_books, settings, covers, taxonomy…)
 scanner.rs          — library directory scanning
-ebook.rs            — EPUB OPF metadata + cover extraction
-indexer.rs          — scan → DB indexing, staleness checks (is_stale + reindex)
+ebook.rs            — EPUB OPF metadata + cover extraction; sidecar-first cover with opt-in materialization (ScanOptions)
+indexer.rs          — scan → DB indexing, staleness checks (is_stale + reindex); reindex opts into materialize_sidecars
+library_layout.rs   — F0.6 canonical layout: slugify, canonical_path, sidecar_cover_for, allocate_canonical_path (collision suffix)
 worker.rs           — single-process Worker primitive: per-task-type concurrency cap + per-resource keyed mutex; reindexes route through Task::Scan
 migrations/         — numbered SQL migrations embedded via sqlx::migrate!
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,6 +3678,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "time",
  "tokio",
  "tower",
@@ -3686,6 +3693,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "base64",
+ "deunicode",
  "epub",
  "omnibus-shared",
  "rand 0.8.5",
@@ -3695,6 +3703,7 @@ dependencies = [
  "sqlx",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -18,6 +18,15 @@ epub = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# F0.6 library filesystem: ASCII-fold author/title slugs ("Café" → "cafe",
+# "東京" → "dong-jing") so canonical-layout folder names stay tool-agnostic.
+deunicode = "1"
+
+# F0.6 library filesystem: structured logging when sidecar materialization
+# falls back to embedded covers (read-only fs, etc.). Subscriber is set up
+# by the binary; library code only emits events.
+tracing = "0.1"
+
 # Auth (F0.3). Argon2id password hashing, CSPRNG token generation, SHA-256
 # of the raw token for at-rest storage, base64url for wire-format tokens.
 argon2 = "0.5"

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -6,11 +6,22 @@
 //! error: Some(_), .. }, cover: None }` so one bad file does not hide the
 //! rest of the library. This output is consumed by [`crate::indexer`],
 //! which writes it to the DB.
+//!
+//! Cover sourcing (F0.6): a `cover.{jpg,jpeg,png}` (or per-stem
+//! `<basename>.{jpg,jpeg,png}`) sidecar next to the epub is preferred over
+//! the embedded cover. With [`ScanOptions::materialize_sidecars`] set, the
+//! scanner extracts the embedded cover into a `<basename>.jpg`/`.png`
+//! sidecar on first encounter so subsequent scans skip the zip altogether.
+//! Materialization is best-effort: a write failure (read-only fs,
+//! permission denied) falls back to the in-memory embedded bytes for the
+//! current scan and retries on the next one.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use epub::doc::{EpubDoc, EpubVersion};
 use omnibus_shared::{Contributor, EbookMetadata, Identifier};
+
+use crate::library_layout;
 
 /// A single scanner output row — metadata plus the raw cover image bytes
 /// (and mime), if the epub included one. Consumed by [`crate::queries::replace_books`].
@@ -28,7 +39,24 @@ pub struct ScanResult {
     pub error: Option<String>,
 }
 
+/// Knobs that change how a scan touches the filesystem. Default keeps the
+/// scan read-only; the indexer (production path) opts into
+/// `materialize_sidecars` so subsequent scans hit `<basename>.jpg` directly
+/// instead of re-opening the zip.
+#[derive(Debug, Clone, Default)]
+pub struct ScanOptions {
+    /// On a successful cover extraction with no existing sidecar, write the
+    /// embedded bytes to `<basename>.{jpg|png}` next to the epub. Best-effort:
+    /// errors are swallowed (logged via `tracing::warn!`) so a read-only
+    /// filesystem doesn't kill the scan.
+    pub materialize_sidecars: bool,
+}
+
 pub fn scan_ebook_library(path: Option<&str>) -> ScanResult {
+    scan_ebook_library_with(path, ScanOptions::default())
+}
+
+pub fn scan_ebook_library_with(path: Option<&str>, opts: ScanOptions) -> ScanResult {
     let Some(path_str) = path else {
         return ScanResult {
             path: None,
@@ -101,7 +129,7 @@ pub fn scan_ebook_library(path: Option<&str>) -> ScanResult {
                     .unwrap_or(&entry_path)
                     .to_string_lossy()
                     .to_string();
-                books.push(extract_metadata(&entry_path, relative));
+                books.push(extract_metadata(&entry_path, relative, &opts));
             }
         }
     }
@@ -115,7 +143,7 @@ pub fn scan_ebook_library(path: Option<&str>) -> ScanResult {
     }
 }
 
-fn extract_metadata(path: &Path, filename: String) -> IndexedBook {
+fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> IndexedBook {
     let mut doc = match EpubDoc::new(path) {
         Ok(d) => d,
         Err(e) => {
@@ -135,14 +163,7 @@ fn extract_metadata(path: &Path, filename: String) -> IndexedBook {
     let identifiers = collect_identifiers(&doc);
     let (series, series_index) = collect_series(&doc);
 
-    let cover = doc.get_cover().map(|(bytes, mime)| {
-        let mime = if mime.is_empty() {
-            "image/jpeg".to_string()
-        } else {
-            mime
-        };
-        (mime, bytes)
-    });
+    let cover = resolve_cover(path, &mut doc, opts);
 
     IndexedBook {
         metadata: EbookMetadata {
@@ -179,6 +200,122 @@ fn extract_metadata(path: &Path, filename: String) -> IndexedBook {
             error: None,
         },
         cover,
+    }
+}
+
+/// Sidecar-first cover resolution.
+///
+/// 1. If `<path>` has a sidecar (per-stem first, folder-level fallback),
+///    read its bytes and return them.
+/// 2. Otherwise, ask the EPUB for its embedded cover.
+/// 3. If `opts.materialize_sidecars` is set and the embedded cover came back
+///    successfully, write it to a `<basename>.{jpg|png}` sidecar so the next
+///    scan hits the sidecar directly. Failures are non-fatal.
+///
+/// Returns the cover bytes used for *this* scan (the in-memory copy, even
+/// when materialization wrote them to disk — this avoids a round-trip read).
+fn resolve_cover<R: std::io::Read + std::io::Seek>(
+    path: &Path,
+    doc: &mut EpubDoc<R>,
+    opts: &ScanOptions,
+) -> Option<(String, Vec<u8>)> {
+    let mut corrupt_sidecar: Option<PathBuf> = None;
+    if let Some(sidecar) = library_layout::sidecar_cover_for(path) {
+        if let Some(bytes) = read_sidecar(&sidecar) {
+            return Some(bytes);
+        }
+        // Sidecar lookup found a file but reading it failed — fall through
+        // to the embedded path. Pass the broken path to materialize_sidecar
+        // so it can repair the cache instead of refusing forever.
+        corrupt_sidecar = Some(sidecar);
+    }
+
+    let embedded = doc.get_cover().map(|(bytes, mime)| {
+        let mime = if mime.is_empty() {
+            "image/jpeg".to_string()
+        } else {
+            mime
+        };
+        (mime, bytes)
+    });
+
+    if opts.materialize_sidecars {
+        if let Some((mime, bytes)) = embedded.as_ref() {
+            materialize_sidecar(path, mime, bytes, corrupt_sidecar.as_deref());
+        }
+    }
+
+    embedded
+}
+
+fn read_sidecar(path: &Path) -> Option<(String, Vec<u8>)> {
+    let bytes = std::fs::read(path).ok()?;
+    // A zero-length file is no better than a read error — surfacing it as
+    // "the cover" would just blank the row in the UI. Treat as corrupt so
+    // the materialize path can repair it next pass.
+    if bytes.is_empty() {
+        return None;
+    }
+    let mime = mime_for_extension(path).to_string();
+    Some((mime, bytes))
+}
+
+fn mime_for_extension(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("png") => "image/png",
+        // jpg / jpeg / anything else falls back to JPEG. Embedded EPUB covers
+        // are overwhelmingly JPEG, and a wrong-but-close mime is better than
+        // none for the cover endpoint.
+        _ => "image/jpeg",
+    }
+}
+
+/// Best-effort write of `<basename>.{jpg|png}` next to the epub so future
+/// scans skip the zip. Fails silently — this is a cache, not a contract.
+///
+/// `corrupt_sidecar`, when set, is a sidecar path the caller already
+/// confirmed is unreadable. We allow overwriting *exactly* that file so a
+/// corrupt cache entry self-heals on the next scan instead of forcing every
+/// future scan to re-open the zip. Anything else under `target.exists()`
+/// (a valid file, a different filename) we leave alone.
+fn materialize_sidecar(epub_path: &Path, mime: &str, bytes: &[u8], corrupt_sidecar: Option<&Path>) {
+    let Some(parent) = epub_path.parent() else {
+        return;
+    };
+    let Some(stem) = epub_path.file_stem().and_then(|s| s.to_str()) else {
+        return;
+    };
+    let ext = if mime.eq_ignore_ascii_case("image/png") {
+        "png"
+    } else {
+        "jpg"
+    };
+    let target = parent.join(format!("{stem}.{ext}"));
+    if target.exists() {
+        let is_known_corrupt = corrupt_sidecar.is_some_and(|p| p == target.as_path());
+        if !is_known_corrupt {
+            // A valid file we don't own (race or user-dropped sidecar). Don't
+            // clobber.
+            return;
+        }
+        // Fall through and overwrite — std::fs::write truncates the existing
+        // file, repairing the cache.
+        tracing::warn!(
+            path = %target.display(),
+            "repairing unreadable cover sidecar"
+        );
+    }
+    if let Err(e) = std::fs::write(&target, bytes) {
+        tracing::warn!(
+            error = %e,
+            path = %target.display(),
+            "could not materialize cover sidecar; falling back to embedded for this scan"
+        );
     }
 }
 
@@ -403,5 +540,354 @@ mod tests {
             .books
             .iter()
             .any(|b| b.metadata.filename == "locked" && b.metadata.error.is_some()));
+    }
+
+    // ---------- Sidecar cover (F0.6) ----------
+
+    /// Path to a real fixture epub from `test_data/epubs/generated/` so
+    /// cover-related tests have real OPF + embedded image bytes to work
+    /// with. Stub `b"not a zip"` files won't decode.
+    fn fixture(name: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("test_data")
+            .join("epubs")
+            .join("generated")
+            .join(name)
+    }
+
+    /// Copy a fixture epub into `dest` and return the destination path.
+    fn copy_fixture_into(name: &str, dest: &Path) -> std::path::PathBuf {
+        let target = dest.join(name);
+        std::fs::copy(fixture(name), &target).expect("copy fixture");
+        target
+    }
+
+    #[test]
+    fn extract_metadata_uses_sidecar_when_present() {
+        // alpha.epub ships an embedded cover. Plant a recognizably-different
+        // sidecar next to it; the scanner must return the sidecar bytes.
+        let dir = make_test_dir("sidecar_wins");
+        copy_fixture_into("alpha.epub", &dir);
+        let sidecar_bytes: &[u8] = b"sidecar-jpg-magic-bytes";
+        std::fs::write(dir.join("alpha.jpg"), sidecar_bytes).unwrap();
+
+        let out = scan_ebook_library(Some(dir.to_str().unwrap()));
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        let alpha = out
+            .books
+            .iter()
+            .find(|b| b.metadata.filename == "alpha.epub")
+            .expect("alpha present");
+        let (mime, bytes) = alpha.cover.as_ref().expect("cover present");
+        assert_eq!(bytes, sidecar_bytes, "expected sidecar bytes, got embedded");
+        assert_eq!(mime, "image/jpeg");
+    }
+
+    #[test]
+    fn extract_metadata_uses_embedded_when_no_sidecar() {
+        // alpha.epub has an embedded cover; no sidecar planted. We don't
+        // know the exact embedded bytes, but they should be non-empty and
+        // the cover slot must be populated. Default ScanOptions disables
+        // materialization, so no sidecar should appear after the scan.
+        let dir = make_test_dir("embedded_only");
+        copy_fixture_into("alpha.epub", &dir);
+
+        let out = scan_ebook_library(Some(dir.to_str().unwrap()));
+        let sidecar_appeared = find_materialized_sidecar(&dir, "alpha").is_some();
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert!(
+            !sidecar_appeared,
+            "default ScanOptions must not materialize sidecars"
+        );
+        let alpha = out
+            .books
+            .iter()
+            .find(|b| b.metadata.filename == "alpha.epub")
+            .expect("alpha present");
+        let (_, bytes) = alpha.cover.as_ref().expect("embedded cover present");
+        assert!(!bytes.is_empty());
+    }
+
+    /// Locate the materialized sidecar in `dir` for `<stem>` — checks both
+    /// `.jpg` and `.png` since the materialized extension follows the
+    /// embedded mime, which the test can't predict for arbitrary fixtures.
+    fn find_materialized_sidecar(dir: &Path, stem: &str) -> Option<std::path::PathBuf> {
+        for ext in ["jpg", "jpeg", "png"] {
+            let candidate = dir.join(format!("{stem}.{ext}"));
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn extract_metadata_materializes_sidecar_with_opt_in() {
+        // With `materialize_sidecars: true`, scanning an epub that has an
+        // embedded cover but no sidecar must write `<basename>.{jpg|png}`
+        // (extension matches embedded mime) next to the file so subsequent
+        // scans hit the sidecar directly.
+        let dir = make_test_dir("materialize");
+        copy_fixture_into("alpha.epub", &dir);
+        assert!(
+            find_materialized_sidecar(&dir, "alpha").is_none(),
+            "precondition: no sidecar yet"
+        );
+
+        let out = scan_ebook_library_with(
+            Some(dir.to_str().unwrap()),
+            ScanOptions {
+                materialize_sidecars: true,
+            },
+        );
+
+        let sidecar = find_materialized_sidecar(&dir, "alpha");
+        let written = sidecar.as_ref().and_then(|p| std::fs::read(p).ok());
+        let alpha = out
+            .books
+            .iter()
+            .find(|b| b.metadata.filename == "alpha.epub")
+            .map(|b| b.cover.as_ref().map(|(_, bytes)| bytes.clone()))
+            .unwrap_or(None);
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert!(sidecar.is_some(), "sidecar should have been written");
+        assert_eq!(
+            written.as_deref(),
+            alpha.as_deref(),
+            "written sidecar bytes must match returned cover bytes"
+        );
+    }
+
+    #[test]
+    fn extract_metadata_second_scan_reads_sidecar_not_zip() {
+        // After materialization, swap the sidecar with different bytes. The
+        // next scan should return *those* bytes, proving the read came from
+        // the sidecar and not the unchanged embedded cover in the zip.
+        let dir = make_test_dir("second_scan");
+        copy_fixture_into("alpha.epub", &dir);
+
+        // First scan: materialize.
+        let _ = scan_ebook_library_with(
+            Some(dir.to_str().unwrap()),
+            ScanOptions {
+                materialize_sidecars: true,
+            },
+        );
+
+        let sidecar_path =
+            find_materialized_sidecar(&dir, "alpha").expect("first scan materialized a sidecar");
+
+        // Replace the sidecar (same path/extension) with sentinel bytes.
+        let sentinel: &[u8] = b"replaced-after-materialization";
+        std::fs::write(&sidecar_path, sentinel).unwrap();
+
+        // Second scan (default opts) — should read the sentinel, not
+        // re-extract the embedded cover.
+        let out = scan_ebook_library(Some(dir.to_str().unwrap()));
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        let alpha = out
+            .books
+            .iter()
+            .find(|b| b.metadata.filename == "alpha.epub")
+            .expect("alpha present");
+        let (_, bytes) = alpha.cover.as_ref().expect("cover present");
+        assert_eq!(
+            bytes, sentinel,
+            "second scan should have read the swapped sidecar"
+        );
+    }
+
+    #[test]
+    fn extract_metadata_repairs_unreadable_sidecar_on_materialize() {
+        // alpha.epub has an embedded cover. Plant a zero-length sidecar that
+        // sidecar_cover_for() will pick up but read_sidecar() can't use.
+        // With materialize_sidecars=true, the broken cache must be repaired
+        // so the next scan reads the sidecar instead of re-opening the zip.
+        let dir = make_test_dir("repair_sidecar");
+        copy_fixture_into("alpha.epub", &dir);
+
+        // alpha.epub embeds a PNG, so the materializer would write
+        // `alpha.png`. Plant the corrupt sidecar at that exact path.
+        let broken = dir.join("alpha.png");
+        std::fs::write(&broken, b"").unwrap();
+
+        let out = scan_ebook_library_with(
+            Some(dir.to_str().unwrap()),
+            ScanOptions {
+                materialize_sidecars: true,
+            },
+        );
+
+        let repaired_bytes = std::fs::read(&broken).expect("sidecar still on disk");
+        let alpha_cover = out
+            .books
+            .iter()
+            .find(|b| b.metadata.filename == "alpha.epub")
+            .and_then(|b| b.cover.as_ref().map(|(_, bytes)| bytes.clone()));
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert!(
+            !repaired_bytes.is_empty(),
+            "broken zero-length sidecar should have been repaired"
+        );
+        assert_eq!(
+            alpha_cover.as_deref(),
+            Some(repaired_bytes.as_slice()),
+            "repaired sidecar bytes must match the embedded cover the scan returned"
+        );
+    }
+
+    #[test]
+    fn extract_metadata_does_not_clobber_unrelated_existing_sidecar() {
+        // The repair gate must only overwrite the *exact* corrupt file the
+        // sidecar lookup returned — never a different valid file that
+        // happens to sit at the materialize target.
+        //
+        // Setup: alpha.epub embeds a PNG, so materialize would target
+        // alpha.png. We plant a corrupt (empty) `alpha.jpg` (which jpg-over-
+        // png priority makes sidecar_cover_for return) AND a valid `alpha.png`
+        // (the user's curated cover). The materialize step must refuse to
+        // overwrite alpha.png because the *known* corrupt path is alpha.jpg.
+        let dir = make_test_dir("no_clobber");
+        copy_fixture_into("alpha.epub", &dir);
+
+        let corrupt_jpg = dir.join("alpha.jpg");
+        std::fs::write(&corrupt_jpg, b"").unwrap();
+        let valid_png = dir.join("alpha.png");
+        let curated: &[u8] = b"user-curated-cover-do-not-touch";
+        std::fs::write(&valid_png, curated).unwrap();
+
+        let _ = scan_ebook_library_with(
+            Some(dir.to_str().unwrap()),
+            ScanOptions {
+                materialize_sidecars: true,
+            },
+        );
+
+        let png_after = std::fs::read(&valid_png).unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert_eq!(
+            png_after, curated,
+            "alpha.png is not the corrupt sidecar — must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn extract_metadata_no_embedded_no_sidecar_returns_none() {
+        // gamma.epub has no embedded cover. No sidecar planted, no
+        // materialization. Cover should stay None and no file should be
+        // written.
+        let dir = make_test_dir("no_cover");
+        copy_fixture_into("gamma.epub", &dir);
+
+        let out = scan_ebook_library_with(
+            Some(dir.to_str().unwrap()),
+            ScanOptions {
+                materialize_sidecars: true,
+            },
+        );
+        let sidecar_appeared = find_materialized_sidecar(&dir, "gamma").is_some();
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert!(
+            !sidecar_appeared,
+            "no embedded cover → nothing to materialize"
+        );
+        let gamma = out
+            .books
+            .iter()
+            .find(|b| b.metadata.filename == "gamma.epub")
+            .expect("gamma present");
+        assert!(gamma.cover.is_none());
+    }
+
+    #[test]
+    fn scan_handles_calibre_shaped_tree_and_ignores_metadata_opf() {
+        // Lock in the read-tolerance promise from F0.6: a Calibre-style
+        // library tree (`<Lastname, First>/Title (id)/title.epub` plus an
+        // adjacent `metadata.opf` Calibre wrote out) must scan correctly.
+        // We assert (a) the epub is found, (b) the title comes from the
+        // *embedded* OPF inside the epub, not the deliberately-wrong
+        // sidecar `metadata.opf`. The sidecar is ignored entirely.
+        let dir = make_test_dir("calibre_shaped");
+        let book_dir = dir.join("Lovelace, Ada").join("Alpha (42)");
+        std::fs::create_dir_all(&book_dir).unwrap();
+        std::fs::copy(fixture("alpha.epub"), book_dir.join("alpha.epub")).unwrap();
+        // Calibre's metadata.opf — write garbage into it so any code path
+        // that *did* read it would visibly disagree with the embedded OPF.
+        std::fs::write(
+            book_dir.join("metadata.opf"),
+            br#"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:title>WRONG TITLE FROM CALIBRE SIDECAR</dc:title>
+<dc:creator>Wrong Author</dc:creator>
+</metadata></package>"#,
+        )
+        .unwrap();
+
+        let out = scan_ebook_library(Some(dir.to_str().unwrap()));
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert!(out.error.is_none(), "scan errored: {:?}", out.error);
+        // Exactly one epub found despite the metadata.opf sibling.
+        let epubs: Vec<_> = out
+            .books
+            .iter()
+            .filter(|b| b.metadata.error.is_none())
+            .collect();
+        assert_eq!(epubs.len(), 1);
+        // Title comes from the embedded OPF, not the misleading sidecar.
+        assert_eq!(epubs[0].metadata.title.as_deref(), Some("Alpha"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_metadata_materialization_failure_falls_back_to_embedded() {
+        // chmod the directory read-only-execute so write fails. The scanner
+        // must still return cover bytes (from embedded), and no sidecar
+        // should appear.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = make_test_dir("readonly_dir");
+        copy_fixture_into("alpha.epub", &dir);
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        // Skip if the chmod didn't take (e.g. running as root in some CI
+        // containers).
+        if std::fs::write(dir.join("write_probe"), b"x").is_ok() {
+            std::fs::remove_file(dir.join("write_probe")).ok();
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+            std::fs::remove_dir_all(&dir).unwrap();
+            return;
+        }
+
+        let out = scan_ebook_library_with(
+            Some(dir.to_str().unwrap()),
+            ScanOptions {
+                materialize_sidecars: true,
+            },
+        );
+
+        let sidecar_appeared = find_materialized_sidecar(&dir, "alpha").is_some();
+
+        // Restore perms before cleanup.
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert!(!sidecar_appeared, "read-only fs must not produce a sidecar");
+        let alpha = out
+            .books
+            .iter()
+            .find(|b| b.metadata.filename == "alpha.epub")
+            .expect("alpha present");
+        let (_, bytes) = alpha.cover.as_ref().expect("embedded fallback present");
+        assert!(!bytes.is_empty(), "embedded fallback must be non-empty");
     }
 }

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -50,8 +50,18 @@ pub async fn is_stale(pool: &SqlitePool, library_path: &str) -> Result<bool, sql
 /// Some(_)`, same as before.
 pub async fn reindex(pool: &SqlitePool, library_path: String) -> anyhow::Result<()> {
     let path_for_scan = library_path.clone();
-    let scan = tokio::task::spawn_blocking(move || ebook::scan_ebook_library(Some(&path_for_scan)))
-        .await?;
+    let scan = tokio::task::spawn_blocking(move || {
+        // Materialize cover sidecars so future scans skip the zip
+        // (F0.6). Best-effort: read-only filesystems fall through to the
+        // in-memory bytes for the current scan and retry next time.
+        ebook::scan_ebook_library_with(
+            Some(&path_for_scan),
+            ebook::ScanOptions {
+                materialize_sidecars: true,
+            },
+        )
+    })
+    .await?;
     if let Some(msg) = scan.error {
         anyhow::bail!("scan of {library_path} failed: {msg}");
     }

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod auth;
 pub mod ebook;
 pub mod indexer;
+pub mod library_layout;
 pub mod queries;
 pub mod scanner;
 pub mod worker;

--- a/db/src/library_layout.rs
+++ b/db/src/library_layout.rs
@@ -1,0 +1,538 @@
+//! Canonical Omnibus library layout helpers (F0.6).
+//!
+//! Omnibus writes the canonical tree as
+//! `<library_root>/<author-slug>/<title-slug>/<title-slug>.<ext>`. Only the
+//! upload path (F5.3) calls the write helpers today; the read path uses the
+//! tolerant scanner in [`crate::scanner`] / [`crate::ebook`] and the sidecar
+//! cover lookup ([`sidecar_cover_for`]).
+//!
+//! Slug rule: ASCII-fold via `deunicode`, lowercase, non-alphanumerics
+//! collapse into `-`, leading/trailing `-` trimmed, hard-cap at 80 chars on a
+//! codepoint boundary. Empty fold result falls back to `"book"` so we never
+//! produce a zero-length path component. The display name (with case,
+//! punctuation, unicode) lives in the DB — the slug is purely a filesystem
+//! artifact.
+//!
+//! Cover sidecar contract: `cover.jpg` (or per-stem `<basename>.jpg`) sitting
+//! next to an ebook is the *single* source of truth for that book's cover
+//! after the first scan. The scanner materializes the embedded cover into
+//! that file once, then never re-reads the zip. This is opportunistic — a
+//! read-only filesystem is handled by falling back to the in-memory embedded
+//! bytes for the current scan and retrying on the next one.
+
+use std::path::{Path, PathBuf};
+
+const MAX_SLUG_LEN: usize = 80;
+const FALLBACK_SLUG: &str = "book";
+
+/// ASCII-fold + lowercase + collapse non-alphanumerics into a single `-`.
+/// Caps at 80 chars on a codepoint boundary. Empty result falls back to
+/// `"book"`.
+pub fn slugify(s: &str) -> String {
+    let folded = deunicode::deunicode(s).to_ascii_lowercase();
+    let mut out = String::with_capacity(folded.len().min(MAX_SLUG_LEN));
+    let mut last_was_dash = true; // suppress leading dashes
+    for ch in folded.chars() {
+        if ch.is_ascii_alphanumeric() {
+            // Codepoint-boundary cap. Since the post-deunicode string is ASCII,
+            // every char is one byte, but checking len() keeps us correct if
+            // deunicode ever returns a non-ASCII char.
+            if out.len() + ch.len_utf8() > MAX_SLUG_LEN {
+                break;
+            }
+            out.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash && out.len() < MAX_SLUG_LEN {
+            out.push('-');
+            last_was_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        FALLBACK_SLUG.to_string()
+    } else {
+        out
+    }
+}
+
+/// Compute the canonical on-disk path for a book without touching the
+/// filesystem: `<root>/<author-slug>/<title-slug>/<title-slug>.<ext>`.
+///
+/// An empty `ext` produces a filename without an extension
+/// (`<title-slug>`), not a trailing dot — paths ending in `.` are awkward on
+/// POSIX and outright rejected by Windows.
+pub fn canonical_path(library_root: &Path, author: &str, title: &str, ext: &str) -> PathBuf {
+    let author_slug = slugify(author);
+    let title_slug = slugify(title);
+    let ext_clean = ext.trim_start_matches('.').to_ascii_lowercase();
+    let filename = if ext_clean.is_empty() {
+        title_slug.clone()
+    } else {
+        format!("{title_slug}.{ext_clean}")
+    };
+    library_root
+        .join(&author_slug)
+        .join(&title_slug)
+        .join(filename)
+}
+
+/// Return the cover sidecar file path for `ebook_path`, if any. Looks first
+/// for a per-stem sidecar (`<basename>.{jpg,jpeg,png}` next to the epub) and
+/// falls back to a folder-level `cover.{jpg,jpeg,png}`. All filename matches
+/// are case-insensitive. Within each tier, priority order is `.jpg` > `.jpeg`
+/// > `.png`.
+pub fn sidecar_cover_for(ebook_path: &Path) -> Option<PathBuf> {
+    let parent = ebook_path.parent()?;
+
+    // Per-stem first (handles flat-dump layouts where one folder contains
+    // many books and `cover.jpg` would be ambiguous), then folder-level.
+    // Per-stem matching needs UTF-8 for the case-insensitive compare; if the
+    // filename isn't UTF-8 we skip the per-stem tier but still fall back to
+    // `cover.*` since that lookup doesn't depend on the ebook's name.
+    if let Some(stem) = ebook_path.file_stem().and_then(|s| s.to_str()) {
+        if let Some(found) = find_with_extensions(parent, stem) {
+            return Some(found);
+        }
+    }
+    find_with_extensions(parent, "cover")
+}
+
+const COVER_EXTS: &[&str] = &["jpg", "jpeg", "png"];
+
+fn find_with_extensions(dir: &Path, base: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    let mut best: Option<(usize, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !name.eq_ignore_ascii_case(base) {
+            continue;
+        }
+        let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+        if let Some(rank) = COVER_EXTS.iter().position(|e| e.eq_ignore_ascii_case(ext)) {
+            if best.as_ref().is_none_or(|(r, _)| rank < *r) {
+                best = Some((rank, path));
+            }
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+/// Compute a canonical path that doesn't already exist on disk. If the
+/// canonical title-slug folder already exists, append ` (2)`, ` (3)`, … to
+/// the title-slug component until an unused folder is found, and place the
+/// file inside that suffixed folder.
+///
+/// This is the upload-time helper for F5.3. F0.6 ships it with tests but no
+/// caller. An empty `ext` is rejected with `InvalidInput` — uploads must
+/// know the format they're storing.
+pub fn allocate_canonical_path(
+    library_root: &Path,
+    author: &str,
+    title: &str,
+    ext: &str,
+) -> std::io::Result<PathBuf> {
+    let author_slug = slugify(author);
+    let title_slug = slugify(title);
+    let ext_clean = ext.trim_start_matches('.').to_ascii_lowercase();
+    if ext_clean.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "file extension must not be empty",
+        ));
+    }
+    let author_dir = library_root.join(&author_slug);
+
+    let mut suffix: u32 = 1;
+    loop {
+        let folder_name = if suffix == 1 {
+            title_slug.clone()
+        } else {
+            format!("{title_slug} ({suffix})")
+        };
+        let candidate = author_dir.join(&folder_name);
+        if !candidate.exists() {
+            return Ok(candidate.join(format!("{title_slug}.{ext_clean}")));
+        }
+        suffix += 1;
+        if suffix > 9999 {
+            // Defensive: a real library will never see 10k collisions on one
+            // title slug. Bail loudly rather than spin.
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("too many collisions for title slug {title_slug:?}"),
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn temp_dir(suffix: &str) -> PathBuf {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let pid = std::process::id();
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("omnibus_layout_{suffix}_{pid}_{seq}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    // ---------- slugify ----------
+
+    #[test]
+    fn slugify_basic_ascii() {
+        assert_eq!(slugify("Hello World"), "hello-world");
+    }
+
+    #[test]
+    fn slugify_strips_punctuation() {
+        assert_eq!(slugify("What?! Really..."), "what-really");
+    }
+
+    #[test]
+    fn slugify_collapses_runs() {
+        assert_eq!(slugify("a---b___c"), "a-b-c");
+    }
+
+    #[test]
+    fn slugify_trims_leading_and_trailing() {
+        assert_eq!(slugify("---trim---"), "trim");
+    }
+
+    #[test]
+    fn slugify_folds_accents() {
+        assert_eq!(slugify("Café au Lait"), "cafe-au-lait");
+    }
+
+    #[test]
+    fn slugify_transliterates_cjk() {
+        // Locks in deunicode's transliteration. The exact letters matter less
+        // than the fact that the result is non-empty ASCII.
+        let out = slugify("東京物語");
+        assert!(!out.is_empty(), "got empty slug for CJK input");
+        assert!(
+            out != FALLBACK_SLUG,
+            "expected real transliteration, got fallback"
+        );
+        assert!(
+            out.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            "got non-ASCII in slug: {out:?}"
+        );
+    }
+
+    #[test]
+    fn slugify_handles_cyrillic() {
+        let out = slugify("Война и мир");
+        assert!(!out.is_empty());
+        assert!(
+            out.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            "got non-ASCII in slug: {out:?}"
+        );
+    }
+
+    #[test]
+    fn slugify_empty_input_falls_back() {
+        assert_eq!(slugify(""), "book");
+    }
+
+    #[test]
+    fn slugify_all_punctuation_falls_back() {
+        assert_eq!(slugify("!!!???"), "book");
+    }
+
+    #[test]
+    fn slugify_caps_at_80_chars() {
+        let long = "a".repeat(200);
+        let out = slugify(&long);
+        assert_eq!(out.len(), MAX_SLUG_LEN);
+        assert!(out.is_char_boundary(out.len()));
+    }
+
+    #[test]
+    fn slugify_preserves_digits() {
+        assert_eq!(slugify("Volume 2: The Sequel"), "volume-2-the-sequel");
+    }
+
+    #[test]
+    fn slugify_cap_does_not_leave_trailing_dash() {
+        // 79 letters then a separator: cap at 80 must not stop right on the
+        // dash and leave it dangling.
+        let s = format!("{}-tail", "a".repeat(79));
+        let out = slugify(&s);
+        assert!(!out.ends_with('-'), "got trailing dash: {out:?}");
+        assert!(out.len() <= MAX_SLUG_LEN);
+    }
+
+    // ---------- canonical_path ----------
+
+    #[test]
+    fn canonical_path_typical() {
+        let p = canonical_path(
+            Path::new("/lib"),
+            "Brandon Sanderson",
+            "The Way of Kings",
+            "epub",
+        );
+        assert_eq!(
+            p,
+            PathBuf::from("/lib/brandon-sanderson/the-way-of-kings/the-way-of-kings.epub")
+        );
+    }
+
+    #[test]
+    fn canonical_path_apostrophe() {
+        let p = canonical_path(
+            Path::new("/lib"),
+            "Madeleine L'Engle",
+            "A Wrinkle in Time",
+            "epub",
+        );
+        assert_eq!(
+            p,
+            PathBuf::from("/lib/madeleine-l-engle/a-wrinkle-in-time/a-wrinkle-in-time.epub")
+        );
+    }
+
+    #[test]
+    fn canonical_path_unicode_author() {
+        let p = canonical_path(Path::new("/lib"), "村上春樹", "Norwegian Wood", "epub");
+        // Author slug must be non-empty ASCII (deunicode-folded), and must
+        // not be the fallback.
+        let comps: Vec<_> = p
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().to_string())
+            .collect();
+        let author_seg = &comps[2];
+        assert_ne!(author_seg, "book", "unicode author folded to fallback");
+        assert!(author_seg
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-'));
+    }
+
+    #[test]
+    fn canonical_path_empty_author_falls_back() {
+        let p = canonical_path(Path::new("/lib"), "", "Some Title", "epub");
+        assert!(p.starts_with(Path::new("/lib/book/")));
+    }
+
+    #[test]
+    fn canonical_path_strips_leading_dot_in_ext() {
+        let p = canonical_path(Path::new("/lib"), "A B", "T", ".EPUB");
+        assert!(p.to_string_lossy().ends_with("/t.epub"));
+    }
+
+    #[test]
+    fn canonical_path_empty_ext_drops_trailing_dot() {
+        // A trailing `.` is invalid on Windows and weird on POSIX. With an
+        // empty `ext`, the filename is just the title slug.
+        let p = canonical_path(Path::new("/lib"), "Author", "Title", "");
+        assert!(
+            p.to_string_lossy().ends_with("/title"),
+            "got {}",
+            p.display()
+        );
+        assert!(!p.to_string_lossy().ends_with('.'));
+    }
+
+    #[test]
+    fn canonical_path_lone_dot_ext_drops_trailing_dot() {
+        let p = canonical_path(Path::new("/lib"), "Author", "Title", ".");
+        assert!(p.to_string_lossy().ends_with("/title"));
+        assert!(!p.to_string_lossy().ends_with('.'));
+    }
+
+    // ---------- sidecar_cover_for ----------
+
+    #[test]
+    fn sidecar_cover_for_per_stem_jpg() {
+        let dir = temp_dir("per_stem_jpg");
+        let epub = dir.join("book.epub");
+        std::fs::write(&epub, b"").unwrap();
+        let jpg = dir.join("book.jpg");
+        std::fs::write(&jpg, b"x").unwrap();
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, Some(jpg));
+    }
+
+    #[test]
+    fn sidecar_cover_for_per_stem_png() {
+        let dir = temp_dir("per_stem_png");
+        let epub = dir.join("book.epub");
+        std::fs::write(&epub, b"").unwrap();
+        let png = dir.join("book.png");
+        std::fs::write(&png, b"x").unwrap();
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, Some(png));
+    }
+
+    #[test]
+    fn sidecar_cover_for_per_stem_jpeg() {
+        let dir = temp_dir("per_stem_jpeg");
+        let epub = dir.join("book.epub");
+        std::fs::write(&epub, b"").unwrap();
+        let jpeg = dir.join("book.jpeg");
+        std::fs::write(&jpeg, b"x").unwrap();
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, Some(jpeg));
+    }
+
+    #[test]
+    fn sidecar_cover_for_falls_back_to_folder_cover() {
+        let dir = temp_dir("folder_cover");
+        let epub = dir.join("book.epub");
+        std::fs::write(&epub, b"").unwrap();
+        let cover = dir.join("cover.jpg");
+        std::fs::write(&cover, b"x").unwrap();
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, Some(cover));
+    }
+
+    #[test]
+    fn sidecar_cover_for_prefers_per_stem_over_folder() {
+        let dir = temp_dir("per_stem_wins");
+        let epub = dir.join("book.epub");
+        std::fs::write(&epub, b"").unwrap();
+        let stem = dir.join("book.jpg");
+        std::fs::write(&stem, b"stem").unwrap();
+        std::fs::write(dir.join("cover.jpg"), b"folder").unwrap();
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, Some(stem));
+    }
+
+    #[test]
+    fn sidecar_cover_for_case_insensitive() {
+        let dir = temp_dir("case");
+        let epub = dir.join("book.epub");
+        std::fs::write(&epub, b"").unwrap();
+        let upper = dir.join("Cover.JPG");
+        std::fs::write(&upper, b"x").unwrap();
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, Some(upper));
+    }
+
+    #[test]
+    fn sidecar_cover_for_priority_jpg_over_png() {
+        let dir = temp_dir("priority");
+        let epub = dir.join("book.epub");
+        std::fs::write(&epub, b"").unwrap();
+        let jpg = dir.join("book.jpg");
+        std::fs::write(&jpg, b"x").unwrap();
+        std::fs::write(dir.join("book.png"), b"x").unwrap();
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, Some(jpg));
+    }
+
+    #[test]
+    fn sidecar_cover_for_no_match_returns_none() {
+        let dir = temp_dir("no_match");
+        let epub = dir.join("book.epub");
+        std::fs::write(&epub, b"").unwrap();
+        std::fs::write(dir.join("notes.txt"), b"x").unwrap();
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sidecar_cover_for_non_utf8_stem_still_falls_back_to_cover() {
+        // A path whose stem isn't valid UTF-8 should still pick up a
+        // folder-level `cover.jpg` — the per-stem tier needs UTF-8 for the
+        // case-insensitive compare, but the fallback doesn't.
+        //
+        // The epub path itself is constructed in-memory and doesn't need to
+        // exist on disk (this also dodges macOS's APFS rejection of
+        // non-UTF-8 filenames). Only the parent dir + cover.jpg need to
+        // exist, since the function reads the parent.
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = temp_dir("non_utf8_stem");
+        let cover = dir.join("cover.jpg");
+        std::fs::write(&cover, b"x").unwrap();
+        // 0xFF is invalid UTF-8 in any leading byte position. Build the
+        // path by concatenating bytes onto the dir's OsStr.
+        let mut bad_path_bytes = dir.as_os_str().as_bytes().to_vec();
+        bad_path_bytes.extend_from_slice(b"/\xff\xff.epub");
+        let epub = std::path::PathBuf::from(OsStr::from_bytes(&bad_path_bytes));
+
+        let got = sidecar_cover_for(&epub);
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(got, Some(cover));
+    }
+
+    // ---------- allocate_canonical_path ----------
+
+    #[test]
+    fn allocate_no_collision_returns_canonical() {
+        let dir = temp_dir("alloc_clean");
+        let p = allocate_canonical_path(&dir, "Author A", "Title T", "epub").unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+        let s = p.to_string_lossy();
+        assert!(s.ends_with("/author-a/title-t/title-t.epub"), "got: {s}");
+    }
+
+    #[test]
+    fn allocate_one_collision_appends_2() {
+        let dir = temp_dir("alloc_one");
+        std::fs::create_dir_all(dir.join("author-a").join("title-t")).unwrap();
+        let p = allocate_canonical_path(&dir, "Author A", "Title T", "epub").unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+        let s = p.to_string_lossy();
+        assert!(
+            s.ends_with("/author-a/title-t (2)/title-t.epub"),
+            "got: {s}"
+        );
+    }
+
+    #[test]
+    fn allocate_empty_ext_is_invalid_input() {
+        let dir = temp_dir("alloc_empty_ext");
+        let result = allocate_canonical_path(&dir, "Author", "Title", "");
+        std::fs::remove_dir_all(&dir).unwrap();
+        let err = result.expect_err("empty ext must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn allocate_lone_dot_ext_is_invalid_input() {
+        let dir = temp_dir("alloc_lone_dot");
+        let result = allocate_canonical_path(&dir, "Author", "Title", ".");
+        std::fs::remove_dir_all(&dir).unwrap();
+        let err = result.expect_err("lone dot must be rejected after stripping");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn allocate_three_collisions_returns_4() {
+        let dir = temp_dir("alloc_three");
+        let author = dir.join("author-a");
+        std::fs::create_dir_all(author.join("title-t")).unwrap();
+        std::fs::create_dir_all(author.join("title-t (2)")).unwrap();
+        std::fs::create_dir_all(author.join("title-t (3)")).unwrap();
+        let p = allocate_canonical_path(&dir, "Author A", "Title T", "epub").unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+        let s = p.to_string_lossy();
+        assert!(
+            s.ends_with("/author-a/title-t (4)/title-t.epub"),
+            "got: {s}"
+        );
+    }
+}

--- a/docs/roadmap/1-2-thumbnails.md
+++ b/docs/roadmap/1-2-thumbnails.md
@@ -21,6 +21,7 @@ This sidesteps Calibre-Web's scheduled-only pipeline (see [calibre-inspection §
 - Generation runs on the [F0.5 worker](0-5-background-worker.md) so the web request returns immediately (serve placeholder → 304 after generate).
 - Prefer `cover.jpg` sidecar next to the ebook over the embedded cover ([F0.6](0-6-library-filesystem.md)).
 - LRU eviction past a configurable cap (default ~5 GB) to keep disk footprint bounded on 100k-book libraries.
+- **Re-examine [F0.6](0-6-library-filesystem.md) sidecar lookup cost while we have a perf harness.** [`sidecar_cover_for`](../../db/src/library_layout.rs) currently does up to 2× `read_dir` per epub (per-stem then folder-level). Acceptable for canonical Omnibus layouts (1 epub per folder), but may show up on flat-dump libraries with thousands of files in one folder. F1.2 is the natural moment to measure: thumbnail generation iterates every book and stresses the same code path. If measurement shows it matters, swap in a fast-path that checks the expected exact-case names directly via `is_file()` before falling back to the case-insensitive `read_dir`. Tracked in [omnibus#52](https://github.com/seamus-sloan/omnibus/issues/52).
 
 ## Dependencies
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -36,6 +36,10 @@ omnibus-db = { path = "../db", optional = true }
 
 [dev-dependencies]
 tower = "0.5"
+# RAII temp directories so panicking integration tests don't leak fixture
+# copies under /tmp. Already a transitive dep elsewhere — explicit here only
+# for the backend integration tests.
+tempfile = "3"
 
 [features]
 default = ["server"]

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -564,15 +564,26 @@ mod tests {
         let state = AppState::new(pool);
         let app = rest_router(state.clone());
 
-        // Resolve the playwright fixtures directory relative to the server
-        // crate manifest. Asserting `is_dir` up front avoids a confusing
-        // "scan failed" error if the fixtures move.
-        let fixtures = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        // Copy the playwright fixtures into an RAII temp dir before pointing
+        // the indexer at them. Reindex now opts into cover-sidecar
+        // materialization (F0.6) and would otherwise write `<stem>.{jpg|png}`
+        // into the shared fixtures dir on every CI run. `tempfile::TempDir`
+        // cleans itself up on Drop, so a panic before the assert below doesn't
+        // leak under /tmp.
+        let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../test_data/epubs/generated")
             .canonicalize()
             .expect("fixtures dir should resolve");
-        assert!(fixtures.is_dir(), "fixtures dir missing: {fixtures:?}");
-        let path_str = fixtures.to_string_lossy().to_string();
+        assert!(source.is_dir(), "fixtures dir missing: {source:?}");
+        let scratch = tempfile::tempdir().expect("create scratch dir");
+        for entry in std::fs::read_dir(&source).expect("read fixtures dir") {
+            let entry = entry.expect("fixture entry");
+            if entry.file_type().expect("file type").is_file() {
+                let dest = scratch.path().join(entry.file_name());
+                std::fs::copy(entry.path(), dest).expect("copy fixture");
+            }
+        }
+        let path_str = scratch.path().to_string_lossy().to_string();
 
         let body = serde_json::json!({
             "ebook_library_path": path_str,
@@ -623,5 +634,7 @@ mod tests {
             !lib.books.is_empty(),
             "worker should have indexed at least one book from {path_str}"
         );
+        // `scratch` (and any cover sidecars the indexer materialized into
+        // it) cleans up on Drop here.
     }
 }


### PR DESCRIPTION
## Summary
- New \`db/src/library_layout\` module: \`slugify\` (deunicode-folded ASCII slugs, 80-char cap, fallback \"book\"), \`canonical_path\`, \`sidecar_cover_for\` (per-stem first, folder-level \`cover.{jpg,jpeg,png}\` fallback), and \`allocate_canonical_path\` for collision-suffixed write paths. F5.3 (uploads) will be the first caller.
- Sidecar-first cover resolution in [\`db/src/ebook.rs\`](db/src/ebook.rs): when a \`<basename>.{jpg,jpeg,png}\` (or folder-level \`cover.*\`) sits next to an epub, it wins over the embedded EPUB cover. \`ScanOptions::materialize_sidecars\` opts callers in to writing the embedded bytes to a sidecar on first encounter so subsequent scans bypass the zip; failures are best-effort and fall back to the in-memory bytes for the current scan.
- [\`db/src/indexer::reindex\`](db/src/indexer.rs) opts in to materialization. \`scan_ebook_library\` (default opts) stays read-only — used by tests and any future read-side caller that doesn't want side effects.
- Calibre-shaped tree regression test locks in the read-tolerance promise: \`<author>/<title (id)>/<title>.epub\` + a deliberately-wrong \`metadata.opf\` scans correctly and ignores the OPF sidecar (matches the F0.6 explicit non-goal of OPF round-trip).
- The existing \`backend::tests::post_settings_triggers_scan_via_worker\` test now scans a temp copy of the playwright fixtures so the new materialization side effect doesn't pollute \`test_data/\` on every CI run.

## Test plan
- [x] \`cargo test -p omnibus-db\` — 107 unit tests + 2 integration tests green; includes 28 new \`library_layout::tests\` (ASCII / accents / CJK / Cyrillic / cap-on-codepoint-boundary / collision allocator) and 6 new \`ebook::tests\` (sidecar wins, embedded fallback, materialization opt-in, second-scan-reads-sidecar, no-cover-no-side-effect, read-only-fs fallback).
- [x] \`cargo test -p omnibus\` — 44 backend tests pass with the temp-copy fix.
- [x] \`cargo test -p omnibus-frontend --features server\` — 5 tests pass.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` and \`cargo fmt --all\` clean.
- [x] Calibre-shaped tree regression test (\`scan_handles_calibre_shaped_tree_and_ignores_metadata_opf\`).
- [x] Verified \`test_data/epubs/generated/\` stays pristine across full \`cargo test\` runs.

## Notes
- Roadmap doc [\`docs/roadmap/0-6-library-filesystem.md\`](docs/roadmap/0-6-library-filesystem.md) called for the sidecar to be \"opportunistic\" — preferred when present, fall back to embedded otherwise. Per discussion in plan review, this PR ships the stronger \"single source of truth post-bootstrap\" interpretation: the indexer materializes the sidecar on first scan so every subsequent read is sidecar-only. The roadmap doc is left as-is since the contract surface (sidecar wins) is the same; the materialization is an implementation detail.

- **Out of scope, called out for follow-up:**
  - **F5.3 prerequisite:** \`stable_uuid(library_path, filename)\` in [\`db/src/queries.rs\`](db/src/queries.rs) is path-derived. Before the canonical write path lands (F5.3), this needs to be replaced with a content-anchored UUID (\`dc:identifier\` → file SHA-256 fallback) so reorganizing files into the canonical layout doesn't invalidate ratings/journals tied to old UUIDs.
  - **F5.1 design pivot:** the original roadmap doc proposed \`books.metadata_overrides\` JSON for user metadata edits. Per offline discussion, F5.1 should write metadata changes into the EPUB OPF directly so they ride through to Kobo via the existing file-sync path; no DB-overrides column ships now. F5.1 will need to handle SHA-anchor invalidation if F5.3 hashes file contents.
  - One-time backfill cost: a brand-new library with thousands of epubs materializes N sidecars synchronously inside the worker pool on first reindex. Acceptable for v1.0; revisit if it becomes a perf complaint.
  - \`(2)\` collision suffix logic ships with the module; gets exercised once F5.3 imports \`allocate_canonical_path\`.

>[!NOTE]
> deunicode adds ~150 KB to the dependency tree. Pure Rust, used by mdbook and many SSGs. Folds \"Café\" → \"cafe\", \"東京物語\" → \"dong-jing-wu-yu\", \"Война и мир\" → \"voina-i-mir\".