### PR TITLE
feat(search): F1.1 close-out — facets, nav-hosted box, styling

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -834,29 +834,25 @@ async fn load_identifiers(pool: &SqlitePool, book_id: i64) -> Result<Vec<Identif
 }
 
 /// Full-text search across `books_fts`. Returns hydrated `EbookMetadata`
-/// ordered by bm25 rank (best first). Matching is scoped to
+/// ordered by bm25 rank (best first). Free-text terms are scoped to
 /// `title/authors/series` via a column filter so that short prefix queries
 /// don't surface spurious hits on generic `tags` values (e.g. typing "Dr"
 /// matching books tagged "Drama"). Ranking weights favour title matches:
 /// `bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0)` — unused columns keep
 /// neutral weights since the column filter prevents them from contributing.
 ///
-/// `q` is sanitized via [`sanitize_fts_query`] before reaching `MATCH`, so
-/// arbitrary user input is safe to pass through. Returns an empty vec when
-/// the sanitized query is empty.
+/// `q` is parsed via [`build_fts_match`] (which recognises `author:`,
+/// `series:`, `tag:` facets and sanitises every token) before reaching
+/// `MATCH`, so arbitrary user input is safe to pass through. Returns an
+/// empty vec when the parsed query is empty.
 pub async fn search_books(
     pool: &SqlitePool,
     library_path: &str,
     q: &str,
 ) -> Result<Vec<EbookMetadata>, sqlx::Error> {
-    let Some(sanitized) = sanitize_fts_query(q) else {
+    let Some(match_expr) = build_fts_match(q) else {
         return Ok(Vec::new());
     };
-    // FTS5 column filter. Scoping to title/authors/series keeps short
-    // queries like "Dr" from matching generic `tags` values ("Drama") or
-    // `description` contents. ISBN, tags, description remain in the index
-    // so they can be re-enabled without a migration.
-    let match_expr = format!("{{title authors series}} : ({sanitized})");
 
     let rows = sqlx::query(
         r#"
@@ -1018,6 +1014,79 @@ fn join_names<'a, I: IntoIterator<Item = &'a str>>(iter: I) -> String {
     out
 }
 
+/// Parse a user-typed query into a single FTS5 MATCH expression.
+///
+/// Recognises `author:foo`, `series:foo`, `tag:foo` (case-insensitive on
+/// the prefix) and emits column-scoped clauses. Everything else falls
+/// through to the default `{title authors series}` filter as free-text
+/// terms, preserving the existing scope and prefix-on-last semantics from
+/// [`sanitize_fts_query`].
+///
+/// Returns `None` when nothing usable remains (empty input, or only empty
+/// `author:` / `series:` / `tag:` tokens) so callers can short-circuit
+/// instead of submitting an empty `MATCH`.
+pub fn build_fts_match(raw: &str) -> Option<String> {
+    let mut author_tokens: Vec<&str> = Vec::new();
+    let mut series_tokens: Vec<&str> = Vec::new();
+    let mut tag_tokens: Vec<&str> = Vec::new();
+    let mut free_tokens: Vec<&str> = Vec::new();
+
+    for token in raw.split_whitespace() {
+        if let Some((prefix, value)) = token.split_once(':') {
+            let lower = prefix.to_ascii_lowercase();
+            if value.is_empty() {
+                // `author:` with no value — drop silently rather than
+                // treating it as free-text or erroring.
+                if matches!(lower.as_str(), "author" | "series" | "tag") {
+                    continue;
+                }
+            }
+            match lower.as_str() {
+                "author" => {
+                    author_tokens.push(value);
+                    continue;
+                }
+                "series" => {
+                    series_tokens.push(value);
+                    continue;
+                }
+                "tag" => {
+                    tag_tokens.push(value);
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        free_tokens.push(token);
+    }
+
+    let mut clauses: Vec<String> = Vec::new();
+    if let Some(s) = sanitize_fts_tokens(&author_tokens) {
+        clauses.push(format!("{{authors}} : ({s})"));
+    }
+    if let Some(s) = sanitize_fts_tokens(&series_tokens) {
+        clauses.push(format!("{{series}} : ({s})"));
+    }
+    if let Some(s) = sanitize_fts_tokens(&tag_tokens) {
+        clauses.push(format!("{{tags}} : ({s})"));
+    }
+    if let Some(s) = sanitize_fts_tokens(&free_tokens) {
+        // Default scope: title/authors/series (matches F0.4 design — keeps
+        // short prefix queries from dragging in generic tag/description
+        // values).
+        clauses.push(format!("{{title authors series}} : ({s})"));
+    }
+
+    if clauses.is_empty() {
+        None
+    } else {
+        // Multiple column-filter clauses must be joined with an explicit
+        // FTS5 boolean operator — implicit AND only works *inside* a
+        // single column filter's `( ... )` body.
+        Some(clauses.join(" AND "))
+    }
+}
+
 /// Wrap each whitespace-separated token in double-quotes and append `*` to
 /// the last one for prefix matching. This lets the user type plain words
 /// (including FTS5-reserved tokens like `AND`/`NOT` or hyphenated ISBNs)
@@ -1026,8 +1095,16 @@ fn join_names<'a, I: IntoIterator<Item = &'a str>>(iter: I) -> String {
 /// Returns `None` when the sanitized query is empty — callers should treat
 /// that as "don't run the query" rather than passing an empty MATCH.
 pub fn sanitize_fts_query(raw: &str) -> Option<String> {
+    let tokens: Vec<&str> = raw.split_whitespace().collect();
+    sanitize_fts_tokens(&tokens)
+}
+
+/// Per-token quoting/escaping shared by [`sanitize_fts_query`] and
+/// [`build_fts_match`]. Tokens are assumed to be whitespace-free (the
+/// callers split on whitespace first).
+fn sanitize_fts_tokens(tokens: &[&str]) -> Option<String> {
     let mut parts: Vec<String> = Vec::new();
-    for token in raw.split_whitespace() {
+    for token in tokens {
         // Double quotes inside a token would terminate the quoted phrase.
         // FTS5's quoted phrase escape is `""`, so double every quote.
         let escaped = token.replace('"', "\"\"");
@@ -1542,6 +1619,79 @@ mod tests {
         assert_eq!(out, "\"978-0-123456-78-9\"*");
     }
 
+    #[test]
+    fn build_fts_match_returns_none_for_empty_input() {
+        assert!(build_fts_match("").is_none());
+        assert!(build_fts_match("   \t  ").is_none());
+    }
+
+    #[test]
+    fn build_fts_match_returns_none_when_only_empty_facets() {
+        // `author:` / `series:` / `tag:` with no value are dropped silently.
+        assert!(build_fts_match("author:").is_none());
+        assert!(build_fts_match("series:   tag:").is_none());
+    }
+
+    #[test]
+    fn build_fts_match_emits_default_scope_for_free_text() {
+        // Free-text falls into the same `{title authors series}` filter
+        // that the F0.4 hardcoded filter used to apply directly.
+        assert_eq!(
+            build_fts_match("harry pott").as_deref(),
+            Some("{title authors series} : (\"harry\" \"pott\"*)")
+        );
+    }
+
+    #[test]
+    fn build_fts_match_emits_author_facet() {
+        assert_eq!(
+            build_fts_match("author:austen").as_deref(),
+            Some("{authors} : (\"austen\"*)")
+        );
+    }
+
+    #[test]
+    fn build_fts_match_combines_facet_and_free_text() {
+        // Two clauses joined by an explicit `AND` — FTS5's grammar only
+        // implicit-ANDs *inside* a column-filter body, not between two
+        // top-level column filters.
+        let out = build_fts_match("author:austen pride").expect("non-empty");
+        assert_eq!(
+            out,
+            "{authors} : (\"austen\"*) AND {title authors series} : (\"pride\"*)"
+        );
+    }
+
+    #[test]
+    fn build_fts_match_emits_series_and_tag_facets() {
+        assert_eq!(
+            build_fts_match("series:dune").as_deref(),
+            Some("{series} : (\"dune\"*)")
+        );
+        assert_eq!(
+            build_fts_match("tag:fiction").as_deref(),
+            Some("{tags} : (\"fiction\"*)")
+        );
+    }
+
+    #[test]
+    fn build_fts_match_facet_prefix_is_case_insensitive() {
+        assert_eq!(
+            build_fts_match("Author:Austen").as_deref(),
+            Some("{authors} : (\"Austen\"*)")
+        );
+    }
+
+    #[test]
+    fn build_fts_match_unknown_prefix_falls_through_to_free_text() {
+        // `isbn:` is not a recognised facet — treat the whole token as
+        // free-text rather than erroring.
+        assert_eq!(
+            build_fts_match("isbn:foo").as_deref(),
+            Some("{title authors series} : (\"isbn:foo\"*)")
+        );
+    }
+
     #[tokio::test]
     async fn search_books_finds_by_title_and_ranks_by_bm25() {
         let _covers = CoversTempDir::new("fts_title");
@@ -1663,6 +1813,111 @@ mod tests {
             .await
             .unwrap();
         assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_books_author_facet_filters_to_matching_author() {
+        let _covers = CoversTempDir::new("fts_facet_author");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("Pride and Prejudice"),
+                    &["Austen"],
+                    &[],
+                    None,
+                    None,
+                ),
+                indexed("b.epub", Some("Hamlet"), &["Shakespeare"], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let hits = search_books(&pool, "/lib", "author:austen").await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title.as_deref(), Some("Pride and Prejudice"));
+    }
+
+    #[tokio::test]
+    async fn search_books_series_facet_filters_to_matching_series() {
+        let _covers = CoversTempDir::new("fts_facet_series");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("Dune"),
+                    &["Herbert"],
+                    &[],
+                    Some(("Dune Saga", "1")),
+                    None,
+                ),
+                indexed("b.epub", Some("Standalone"), &["Author"], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let hits = search_books(&pool, "/lib", "series:dune").await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title.as_deref(), Some("Dune"));
+    }
+
+    #[tokio::test]
+    async fn search_books_tag_facet_filters_to_matching_tag() {
+        let _covers = CoversTempDir::new("fts_facet_tag");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed("a.epub", Some("A"), &["X"], &["fiction"], None, None),
+                indexed("b.epub", Some("B"), &["Y"], &["history"], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let hits = search_books(&pool, "/lib", "tag:fiction").await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title.as_deref(), Some("A"));
+    }
+
+    #[tokio::test]
+    async fn search_books_facet_combines_with_free_text_via_explicit_and() {
+        let _covers = CoversTempDir::new("fts_facet_combined");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("Pride and Prejudice"),
+                    &["Austen"],
+                    &[],
+                    None,
+                    None,
+                ),
+                indexed("b.epub", Some("Emma"), &["Austen"], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+
+        // Both clauses must match — only Pride and Prejudice carries the
+        // "pride" token in title/authors/series.
+        let hits = search_books(&pool, "/lib", "author:austen pride")
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title.as_deref(), Some("Pride and Prejudice"));
     }
 
     #[tokio::test]

--- a/docs/roadmap/1-1-search.md
+++ b/docs/roadmap/1-1-search.md
@@ -15,9 +15,9 @@ The feature Calibre-Web users most complain about (see [calibre-inspection §2](
 ## Technical considerations
 
 - `SELECT … FROM books_fts WHERE books_fts MATCH ? ORDER BY bm25(books_fts) LIMIT ?`.
-- Dioxus signal-debounced input (~150ms) so each keystroke doesn't fire a query.
-- Results hydrate the same `BookListItem` DTO used by browse pages — one component, two data sources.
-- Facet syntax parsed client-side before query construction; unknown facets fall through as free-text terms.
+- Results hydrate the same `EbookMetadata` DTO used by browse pages — one component, two data sources.
+- Facet syntax parsed in `build_fts_match` before MATCH construction; unknown facets fall through as free-text terms.
+- No keystroke debounce — FTS5 against the local SQLite index is fast enough that snappy live-update beats batched fetches.
 
 ## Dependencies
 
@@ -26,6 +26,16 @@ The feature Calibre-Web users most complain about (see [calibre-inspection §2](
 ## Risks
 
 None material. FTS5 is the mature, proven path.
+
+## Status
+
+**Shipped.** The search box lives in the top nav (web) and is hidden on `/settings`; results render in the existing landing layout via a shared `SearchQuery` signal context. Off-Landing keystrokes auto-redirect to `/`. Facet parsing supports `author:`, `series:`, `tag:` (case-insensitive prefix); unknown prefixes fall through as free-text. Mobile parity (search box in `BottomNav`) is deferred until the mobile browse story matures.
+
+**Key landmarks:**
+- [db/src/queries.rs](../../db/src/queries.rs) — `build_fts_match` + `search_books`, scoped to `{title authors series}` for free-text and column-filtered for facets, joined by explicit `AND`.
+- [frontend/src/components/top_nav.rs](../../frontend/src/components/top_nav.rs) — site-wide `NavSearch` component, hidden on `Route::Settings`.
+- [frontend/src/lib.rs](../../frontend/src/lib.rs) — `SearchQuery` context provider; `.top-nav .library-search` styling matches the dark Settings input look.
+- [ui_tests/playwright/tests/flows/search.spec.ts](../../ui_tests/playwright/tests/flows/search.spec.ts) — covers title/author/clear, facet `author:` and `tag:`, nav-availability, and settings-absence.
 
 ---
 

--- a/frontend/src/components/top_nav.rs
+++ b/frontend/src/components/top_nav.rs
@@ -1,15 +1,65 @@
 use dioxus::prelude::*;
-use dioxus_router::{use_navigator, Link};
+use dioxus_router::{use_navigator, use_route, Link};
 
-use crate::Route;
+use crate::{use_search_query, Route};
 
 #[component]
 pub fn TopNav() -> Element {
+    // Hide the search box on `/settings` — the page has its own dense form
+    // layout and a search box wedged into the nav above it just clutters
+    // the chrome.
+    let on_settings = matches!(use_route::<Route>(), Route::Settings {});
+
     rsx! {
         nav { class: "top-nav",
             Link { to: Route::Landing {}, "Home" }
             Link { to: Route::Settings {}, "Settings" }
+            if !on_settings {
+                NavSearch {}
+            }
             AuthControl {}
+        }
+    }
+}
+
+/// Site-wide search box. Owns the input wired to the [`crate::SearchQuery`]
+/// context, so typing here updates the same signal the landing page reads
+/// from. When the user types from a non-Landing route, navigate to `/` so
+/// they actually see the matching rows.
+#[component]
+fn NavSearch() -> Element {
+    let mut query = use_search_query().0;
+    let nav = use_navigator();
+    let route = use_route::<Route>();
+
+    rsx! {
+        form {
+            class: "library-search",
+            role: "search",
+            onsubmit: move |evt| evt.prevent_default(),
+            input {
+                id: "library-search-input",
+                "data-testid": "library-search-input",
+                r#type: "search",
+                aria_label: "Search books",
+                placeholder: "Search title, author, series, tag, ISBN…",
+                value: "{query}",
+                oninput: move |evt| {
+                    let v = evt.value();
+                    query.set(v.clone());
+                    // Off-Landing keystrokes redirect to `/` so the
+                    // matching rows render. Once we navigate, the
+                    // component re-renders with `route == Landing` and
+                    // this branch stops firing — so editing a non-empty
+                    // query from a detail route still redirects, but
+                    // typing on Landing doesn't spam `replace`. Empty
+                    // input is excluded so clearing the box doesn't drag
+                    // the user back to `/` mid-edit.
+                    if !v.is_empty() && !matches!(route, Route::Landing {}) {
+                        nav.replace(Route::Landing {});
+                    }
+                },
+            }
         }
     }
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -167,9 +167,22 @@ pub fn use_server_url() -> String {
     }
 }
 
+/// Cross-route search query. Owned by [`App`] via `use_context_provider`
+/// so the [`Nav`]-hosted search box and the [`LandingPage`] read/write the
+/// same signal — typing in the nav from any route updates the landing
+/// results without a route-param round-trip.
+#[derive(Copy, Clone)]
+pub struct SearchQuery(pub Signal<String>);
+
+/// Convenience accessor for the search-query context.
+pub fn use_search_query() -> SearchQuery {
+    use_context::<SearchQuery>()
+}
+
 /// Root app component. Renders global styles and the router.
 #[component]
 pub fn App() -> Element {
+    use_context_provider(|| SearchQuery(Signal::new(String::new())));
     rsx! {
         document::Title { "Omnibus" }
         style { {STYLES} }
@@ -234,6 +247,22 @@ body {
 }
 .top-nav a:hover, .top-nav .top-nav-btn:hover { background: rgba(51, 65, 85, 0.9); }
 .top-nav .top-nav-btn { margin-left: auto; }
+
+.top-nav .library-search { flex: 1; min-width: 0; max-width: 480px; }
+.top-nav .library-search input[type="search"] {
+  width: 100%;
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(100, 116, 139, 0.4);
+  border-radius: 8px;
+  color: #e5e7eb;
+  font: inherit;
+  padding: 0.4rem 0.75rem;
+}
+.top-nav .library-search input[type="search"]::placeholder { color: #94a3b8; }
+.top-nav .library-search input[type="search"]:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
 
 .bottom-nav {
   position: fixed;

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_router::use_navigator;
 use omnibus_shared::{Contributor, EbookLibrary, EbookMetadata};
 
-use crate::{data, use_server_url, Route};
+use crate::{data, use_search_query, use_server_url, Route};
 
 /// Landing page — loads the configured ebook library and renders every book
 /// in a single table with cover thumbnails and the common metadata columns.
@@ -14,7 +14,9 @@ pub fn LandingPage() -> Element {
     let mut library = use_signal(EbookLibrary::default);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
-    let mut query = use_signal(String::new);
+    // Search box lives in the top nav; the query is shared via context so
+    // typing on any route drives the landing results without a route param.
+    let query = use_search_query().0;
 
     let url_for_fetch = server_url.clone();
     use_effect(move || {
@@ -54,20 +56,6 @@ pub fn LandingPage() -> Element {
                     "{path} · {book_count} book(s)"
                 } else {
                     "Configure your ebook library path in Settings."
-                }
-            }
-            form {
-                class: "library-search",
-                role: "search",
-                onsubmit: move |evt| evt.prevent_default(),
-                input {
-                    id: "library-search-input",
-                    "data-testid": "library-search-input",
-                    r#type: "search",
-                    aria_label: "Search books",
-                    placeholder: "Search title, author, series, tag, ISBN…",
-                    value: "{query}",
-                    oninput: move |evt| query.set(evt.value()),
                 }
             }
             if let Some(msg) = page_error.as_ref() {

--- a/ui_tests/playwright/tests/flows/search.spec.ts
+++ b/ui_tests/playwright/tests/flows/search.spec.ts
@@ -45,3 +45,45 @@ test("clearing the search restores the full library", async ({ page }) => {
     .poll(async () => page.getByTestId(/^ebook-row-/).count())
     .toBe(FIXTURE_BOOKS.length);
 });
+
+test("settings page does not render the search box", async ({ page }) => {
+  await gotoReady(page, "/settings");
+  await expect(
+    page.getByRole("searchbox", { name: "Search books" }),
+  ).toHaveCount(0);
+});
+
+test("typing in the nav from a non-Landing route navigates to Landing", async ({
+  page,
+}) => {
+  await gotoReady(page, "/books/1");
+  const search = page.getByRole("searchbox", { name: "Search books" });
+  await expect(search).toBeVisible();
+
+  await search.fill("dracula");
+
+  // Off-Landing keystrokes redirect to `/` so matching rows render.
+  await expect.poll(async () => new URL(page.url()).pathname).toBe("/");
+  await expect.poll(async () => page.getByTestId(/^ebook-row-/).count()).toBe(1);
+  await expect(page.getByTestId("ebook-row-dracula")).toBeVisible();
+});
+
+test("author: facet narrows by author", async ({ page }) => {
+  await gotoReady(page, "/");
+  const search = page.getByRole("searchbox", { name: "Search books" });
+
+  await search.fill("author:shakespeare");
+  await expect.poll(async () => page.getByTestId(/^ebook-row-/).count()).toBe(1);
+  await expect(page.getByTestId("ebook-row-romeo-and-juliet")).toBeVisible();
+});
+
+test("tag: facet narrows by tag", async ({ page }) => {
+  await gotoReady(page, "/");
+  const search = page.getByRole("searchbox", { name: "Search books" });
+
+  // "Vampires" only appears as a dc:subject on Dracula across the fixture
+  // set — Frankenstein/Gatsby/etc. share `Horror tales` etc. but not this.
+  await search.fill("tag:vampires");
+  await expect.poll(async () => page.getByTestId(/^ebook-row-/).count()).toBe(1);
+  await expect(page.getByTestId("ebook-row-dracula")).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Closes the [F1.1 Search](docs/roadmap/1-1-search.md) roadmap initiative. Backend FTS5, RPC/REST, sanitizer, landing input, and Playwright spec already shipped on main; this branch adds the three remaining gaps from the roadmap doc.
- **Facet syntax**: `author:`, `series:`, `tag:` (case-insensitive prefix) parse into FTS5 column-filter clauses joined by explicit `AND`. Unknown prefixes (e.g. `isbn:foo`) fall through as free-text. New `build_fts_match` wraps the existing `sanitize_fts_query`; the hardcoded `{title authors series}` filter at queries.rs:859 now lives inside the builder.
- **Site-wide search box**: a new `NavSearch` component lives in the top nav and reads/writes a shared `SearchQuery` signal context provided in `App`. Hidden on `/settings`. Off-Landing keystrokes auto-redirect to `/` so the user sees matching rows. The duplicate landing-page input is removed — the nav owns the only box.
- **Styling**: input now matches the `.settings-input` dark fill / border / focus-ring look, sized to fill the gap between the Settings link and the Auth control via `flex: 1; max-width: 480px`.
- **Out of scope per direction**: 150ms debounce — kept the snappy live-update UX since FTS5 against a local SQLite index is fast enough.

## Test plan
- [ ] CI Playwright (run_ui_tests label) — new specs cover author/tag facets, nav presence on /books/:id, and absence on /settings.
- [ ] Manual visual: open `/`, confirm dark-themed search box in the nav. Open `/settings`, confirm no box. Type `author:shakespeare` from `/books/1`, confirm redirect to `/` and Romeo & Juliet renders alone.

## Notes
- Backend tests: 84 lib tests pass (`cargo test -p omnibus-db --lib`), including 22 FTS-specific tests across `build_fts_match` unit + `search_books` integration. `cargo clippy --all-targets` and `cargo fmt --check` both clean. Web/server/mobile feature builds all green.
- Local Playwright was blocked by an existing `qa-local` admin user — `playwright` user can't register because registration closes after first user. CI runs against a fresh DB so the `run_ui_tests` label handles it.
- Companion in-flight branches: `yankee` (F0.6 library filesystem) and `zulu` (F0.7 route authorization). No overlap with this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)