### PR TITLE
feat(db): EbookMetadata.formats + get_book query + GET /api/ebooks/{id} (F1.4 PR 1/2)

### DIFF
--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -197,6 +197,7 @@ fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> Indexe
             toc_count: doc.toc.len(),
 
             cover_url: None,
+            formats: vec![],
             error: None,
         },
         cover,

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -795,6 +795,7 @@ pub async fn list_books(
             spine_count: 0,
             toc_count: 0,
             cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+            formats: vec![],
             error: None,
         });
     }
@@ -845,6 +846,86 @@ async fn load_identifiers(pool: &SqlitePool, book_id: i64) -> Result<Vec<Identif
             scheme: Some(r.get("scheme")),
         })
         .collect())
+}
+
+async fn load_formats(pool: &SqlitePool, book_id: i64) -> Result<Vec<String>, sqlx::Error> {
+    sqlx::query_scalar("SELECT format FROM book_files WHERE book_id = ? ORDER BY format")
+        .bind(book_id)
+        .fetch_all(pool)
+        .await
+}
+
+/// Fetch a single book by its stable `books.id`. Returns `None` if not found.
+pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata>, sqlx::Error> {
+    let row = sqlx::query(
+        r#"
+        SELECT b.id, b.uuid, bf.filename AS file_stem, bf.format AS file_format,
+               b.title, b.description, b.series_index, b.has_cover,
+               b.pubdate, b.last_modified, b.isbn,
+               pub.name AS publisher_name, lang.code AS language_code,
+               s.name AS series_name
+        FROM books b
+        LEFT JOIN book_files bf ON bf.book_id = b.id
+        LEFT JOIN books_publishers_link bpl ON bpl.book = b.id
+        LEFT JOIN publishers pub ON pub.id = bpl.publisher
+        LEFT JOIN books_languages_link bll ON bll.book = b.id
+        LEFT JOIN languages lang ON lang.id = bll.language
+        LEFT JOIN books_series_link bsl ON bsl.book = b.id
+        LEFT JOIN series s ON s.id = bsl.series
+        WHERE b.id = ?
+        "#,
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some(r) = row else {
+        return Ok(None);
+    };
+    let book_id: i64 = r.get("id");
+    let has_cover: i64 = r.get("has_cover");
+    let file_stem: Option<String> = r.get("file_stem");
+    let file_format: Option<String> = r.get("file_format");
+    let filename = match (file_stem, file_format) {
+        (Some(stem), Some(fmt)) => format!("{stem}.{}", fmt.to_ascii_lowercase()),
+        _ => String::new(),
+    };
+    let series_index: Option<f64> = r.get("series_index");
+    let creators = load_creators(pool, book_id).await?;
+    let subjects = load_subjects(pool, book_id).await?;
+    let identifiers = load_identifiers(pool, book_id).await?;
+    let formats = load_formats(pool, book_id).await?;
+
+    Ok(Some(EbookMetadata {
+        id: book_id,
+        filename,
+        title: r.get("title"),
+        description: r.get("description"),
+        publisher: r.get("publisher_name"),
+        published: r.get("pubdate"),
+        modified: r.get("last_modified"),
+        language: r.get("language_code"),
+        rights: None,
+        source: None,
+        coverage: None,
+        dc_type: None,
+        dc_format: None,
+        relation: None,
+        creators,
+        contributors: vec![],
+        subjects,
+        identifiers,
+        series: r.get("series_name"),
+        series_index: series_index.map(format_series_index),
+        epub_version: None,
+        unique_identifier: Some(r.get::<String, _>("uuid")),
+        resource_count: 0,
+        spine_count: 0,
+        toc_count: 0,
+        cover_url: (has_cover != 0).then(|| format!("/api/covers/{book_id}")),
+        formats,
+        error: None,
+    }))
 }
 
 /// Full-text search across `books_fts`. Returns hydrated `EbookMetadata`
@@ -937,6 +1018,7 @@ pub async fn search_books(
             spine_count: 0,
             toc_count: 0,
             cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+            formats: vec![],
             error: None,
         });
     }
@@ -2162,5 +2244,49 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(library_count, 0);
+    }
+
+    #[tokio::test]
+    async fn get_book_returns_none_for_missing_id() {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let result = get_book(&pool, 9999).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_book_returns_metadata_for_indexed_book() {
+        let _covers = CoversTempDir::new("get_book");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "alpha.epub",
+                Some("Alpha Book"),
+                &["Author A"],
+                &["Fiction"],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let id = books[0].id;
+
+        let book = get_book(&pool, id)
+            .await
+            .unwrap()
+            .expect("book should exist");
+        assert_eq!(book.id, id);
+        assert_eq!(book.title.as_deref(), Some("Alpha Book"));
+        assert_eq!(book.creators.len(), 1);
+        assert_eq!(book.creators[0].name, "Author A");
+        assert_eq!(book.subjects, vec!["Fiction"]);
+        assert!(!book.formats.is_empty(), "formats should be populated");
+        assert!(
+            book.formats.iter().any(|f| f.eq_ignore_ascii_case("epub")),
+            "EPUB format should be present"
+        );
     }
 }

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -855,24 +855,79 @@ async fn load_formats(pool: &SqlitePool, book_id: i64) -> Result<Vec<String>, sq
         .await
 }
 
+/// Pick the preferred file row for a book. EPUB wins when present; otherwise
+/// fall back to the first format alphabetically. Returns `(filename_stem,
+/// format)` or `None` when the book has no files.
+async fn load_primary_file(
+    pool: &SqlitePool,
+    book_id: i64,
+) -> Result<Option<(String, String)>, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT filename, format FROM book_files
+         WHERE book_id = ?
+         ORDER BY (format != 'EPUB'), format
+         LIMIT 1",
+    )
+    .bind(book_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|r| (r.get("filename"), r.get("format"))))
+}
+
+async fn load_publisher(pool: &SqlitePool, book_id: i64) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query_scalar(
+        "SELECT pub.name FROM books_publishers_link bpl
+         JOIN publishers pub ON pub.id = bpl.publisher
+         WHERE bpl.book = ?
+         ORDER BY pub.name
+         LIMIT 1",
+    )
+    .bind(book_id)
+    .fetch_optional(pool)
+    .await
+}
+
+async fn load_language(pool: &SqlitePool, book_id: i64) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query_scalar(
+        "SELECT lang.code FROM books_languages_link bll
+         JOIN languages lang ON lang.id = bll.language
+         WHERE bll.book = ?
+         ORDER BY lang.code
+         LIMIT 1",
+    )
+    .bind(book_id)
+    .fetch_optional(pool)
+    .await
+}
+
+async fn load_series_name(pool: &SqlitePool, book_id: i64) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query_scalar(
+        "SELECT s.name FROM books_series_link bsl
+         JOIN series s ON s.id = bsl.series
+         WHERE bsl.book = ?
+         ORDER BY s.name
+         LIMIT 1",
+    )
+    .bind(book_id)
+    .fetch_optional(pool)
+    .await
+}
+
 /// Fetch a single book by its stable `books.id`. Returns `None` if not found.
+///
+/// The main SELECT pulls only `books`-table columns so it remains 1:1 even
+/// when the book has multiple files / publishers / languages / series.
+/// Multi-valued and ambiguous columns are loaded via dedicated helpers that
+/// each apply a deterministic `ORDER BY ... LIMIT 1` (see
+/// `load_primary_file` / `load_publisher` / `load_language` /
+/// `load_series_name`) so the response is stable across calls.
 pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata>, sqlx::Error> {
     let row = sqlx::query(
         r#"
-        SELECT b.id, b.uuid, bf.filename AS file_stem, bf.format AS file_format,
-               b.title, b.description, b.series_index, b.has_cover,
-               b.pubdate, b.last_modified, b.isbn,
-               pub.name AS publisher_name, lang.code AS language_code,
-               s.name AS series_name
-        FROM books b
-        LEFT JOIN book_files bf ON bf.book_id = b.id
-        LEFT JOIN books_publishers_link bpl ON bpl.book = b.id
-        LEFT JOIN publishers pub ON pub.id = bpl.publisher
-        LEFT JOIN books_languages_link bll ON bll.book = b.id
-        LEFT JOIN languages lang ON lang.id = bll.language
-        LEFT JOIN books_series_link bsl ON bsl.book = b.id
-        LEFT JOIN series s ON s.id = bsl.series
-        WHERE b.id = ?
+        SELECT id, uuid, title, description, series_index, has_cover,
+               pubdate, last_modified, isbn
+        FROM books
+        WHERE id = ?
         "#,
     )
     .bind(id)
@@ -884,13 +939,16 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
     };
     let book_id: i64 = r.get("id");
     let has_cover: i64 = r.get("has_cover");
-    let file_stem: Option<String> = r.get("file_stem");
-    let file_format: Option<String> = r.get("file_format");
-    let filename = match (file_stem, file_format) {
-        (Some(stem), Some(fmt)) => format!("{stem}.{}", fmt.to_ascii_lowercase()),
-        _ => String::new(),
-    };
     let series_index: Option<f64> = r.get("series_index");
+
+    let primary_file = load_primary_file(pool, book_id).await?;
+    let filename = primary_file
+        .map(|(stem, fmt)| format!("{stem}.{}", fmt.to_ascii_lowercase()))
+        .unwrap_or_default();
+
+    let publisher = load_publisher(pool, book_id).await?;
+    let language = load_language(pool, book_id).await?;
+    let series = load_series_name(pool, book_id).await?;
     let creators = load_creators(pool, book_id).await?;
     let subjects = load_subjects(pool, book_id).await?;
     let identifiers = load_identifiers(pool, book_id).await?;
@@ -901,10 +959,10 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
         filename,
         title: r.get("title"),
         description: r.get("description"),
-        publisher: r.get("publisher_name"),
+        publisher,
         published: r.get("pubdate"),
         modified: r.get("last_modified"),
-        language: r.get("language_code"),
+        language,
         rights: None,
         source: None,
         coverage: None,
@@ -915,7 +973,7 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
         contributors: vec![],
         subjects,
         identifiers,
-        series: r.get("series_name"),
+        series,
         series_index: series_index.map(format_series_index),
         epub_version: None,
         unique_identifier: Some(r.get::<String, _>("uuid")),
@@ -2251,6 +2309,92 @@ mod tests {
         let pool = init_db("sqlite::memory:").await.unwrap();
         let result = get_book(&pool, 9999).await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_book_is_deterministic_with_multiple_files_and_links() {
+        // Regression for PR #55 review: when a book has multiple `book_files`
+        // rows (and incidental duplicate publisher/language/series links),
+        // get_book() must return the EPUB-preferred filename and stable
+        // publisher/language/series values rather than whichever joined row
+        // SQLite happens to return first.
+        let _covers = CoversTempDir::new("get_book_multi");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "alpha.epub",
+                Some("Alpha Book"),
+                &["Author A"],
+                &["Fiction"],
+                Some(("Saga", "1")),
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let id = books[0].id;
+
+        // Add a second physical file in another format.
+        sqlx::query(
+            "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime)
+             VALUES (?, 'M4B', 'alpha', 0, '')",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Add a second publisher and a second language to exercise the
+        // multi-row JOIN path on those link tables. Series already has one
+        // row from `replace_books`.
+        sqlx::query("INSERT INTO publishers (name) VALUES ('Acme'), ('Zenith')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO books_publishers_link (book, publisher)
+             SELECT ?, id FROM publishers WHERE name IN ('Acme', 'Zenith')",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO languages (code) VALUES ('eng'), ('fra')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO books_languages_link (book, language)
+             SELECT ?, id FROM languages WHERE code IN ('eng', 'fra')",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Run get_book repeatedly — every call must return identical values.
+        let first = get_book(&pool, id).await.unwrap().expect("book");
+        for _ in 0..3 {
+            let again = get_book(&pool, id).await.unwrap().expect("book");
+            assert_eq!(again.filename, first.filename);
+            assert_eq!(again.publisher, first.publisher);
+            assert_eq!(again.language, first.language);
+            assert_eq!(again.series, first.series);
+            assert_eq!(again.formats, first.formats);
+        }
+
+        // EPUB should win the tiebreak for filename.
+        assert_eq!(first.filename, "alpha.epub");
+        // Both formats surface in the formats list, sorted by format code.
+        assert_eq!(first.formats, vec!["EPUB".to_string(), "M4B".to_string()]);
+        // Publisher/language pick alphabetical winners deterministically.
+        assert_eq!(first.publisher.as_deref(), Some("Acme"));
+        assert_eq!(first.language.as_deref(), Some("eng"));
+        assert_eq!(first.series.as_deref(), Some("Saga"));
+        assert_eq!(first.series_index.as_deref(), Some("1"));
     }
 
     #[tokio::test]

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -54,6 +54,7 @@ pub fn rest_router(state: AppState) -> Router {
         .route("/api/settings", post(post_settings))
         .route("/api/library", get(get_library))
         .route("/api/ebooks", get(get_ebooks))
+        .route("/api/ebooks/{id}", get(get_ebook_by_id))
         .route("/api/search", get(get_search))
         .route("/api/covers/{id}", get(get_cover))
         .route("/api/thumbs/{id}/{size}", get(get_thumb))
@@ -159,6 +160,22 @@ async fn get_ebooks(_user: AuthUser, State(state): State<AppState>) -> Response 
         Err(error) => (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to read books: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn get_ebook_by_id(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
+    match db::get_book(&state.pool, id).await {
+        Ok(Some(book)) => Json(book).into_response(),
+        Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
+        Err(error) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to read book: {error}"),
         )
             .into_response(),
     }
@@ -584,6 +601,65 @@ mod tests {
         assert_eq!(lib.path.as_deref(), Some(path));
         assert!(lib.books.is_empty());
         assert!(lib.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn api_get_ebook_returns_200_with_metadata() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        db::replace_books(
+            &pool,
+            "/lib",
+            vec![db::ebook::IndexedBook {
+                metadata: omnibus_shared::EbookMetadata {
+                    filename: "alpha.epub".into(),
+                    title: Some("Alpha Book".into()),
+                    ..Default::default()
+                },
+                cover: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let books = db::list_books(&pool, "/lib").await.unwrap();
+        let id = books[0].id;
+
+        let response = app
+            .oneshot(get_with_bearer(&format!("/api/ebooks/{id}"), &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let book: omnibus_shared::EbookMetadata = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(book.title.as_deref(), Some("Alpha Book"));
+        assert_eq!(book.id, id);
+    }
+
+    #[tokio::test]
+    async fn api_get_ebook_returns_404_for_unknown_id() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        let response = app
+            .oneshot(get_with_bearer("/api/ebooks/9999", &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_get_ebook_returns_401_when_anonymous() {
+        let (app, _state, _pool) = fixture().await;
+        let response = app
+            .oneshot(get_anon("/api/ebooks/1"))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -100,6 +100,9 @@ pub struct EbookMetadata {
 
     pub cover_url: Option<String>,
 
+    #[serde(default)]
+    pub formats: Vec<String>,
+
     pub error: Option<String>,
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -100,7 +100,7 @@ pub struct EbookMetadata {
 
     pub cover_url: Option<String>,
 
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub formats: Vec<String>,
 
     pub error: Option<String>,


### PR DESCRIPTION
## Summary

- Adds `formats: Vec<String>` (with `#[serde(default)]`) to `EbookMetadata` in `shared/src/lib.rs` — enables the detail page format switcher
- Adds `load_formats` + `pub async fn get_book(pool, id)` to `db/src/queries.rs` — single-book fetch by stable id with all m2m relations joined
- Adds `GET /api/ebooks/{id}` REST handler to `server/src/backend.rs` — returns 200+JSON, 404, or 500; requires `AuthUser`

Existing `list_books` and `search_books` callers get `formats: vec![]` (no behaviour change).

## Test plan

- [x] `cargo test -p omnibus-db` — 137 tests pass (includes `get_book_returns_none_for_missing_id` + `get_book_returns_metadata_for_indexed_book`)
- [x] `cargo test -p omnibus` — 61 tests pass (includes `api_get_ebook_returns_200_with_metadata`, `_404_for_unknown_id`, `_401_when_anonymous`)
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean

**PR 2/2** (frontend — `BookDetailPage` component + CSS + Playwright) stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)