### PR TITLE
feat(ui): F1.4 BookDetailPage component + CSS + Playwright (F1.4 PR 2/2)

### DIFF
--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -469,15 +469,15 @@ pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, St
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_ebook(server_url: &str, id: i64) -> Result<EbookMetadata, String> {
+pub async fn get_ebook(server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
     let url = format!("{server_url}/api/ebooks/{id}");
     let response = with_bearer(http_client().get(&url))
         .send()
         .await
         .map_err(|e| format!("{e:#}"))?;
     let status = note_status(response.status());
-    if status.as_u16() == 404 {
-        return Err(format!("Book {id} not found"));
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
     }
     if !status.is_success() {
         return Err(drain_error(response, status).await);
@@ -485,6 +485,7 @@ pub async fn get_ebook(server_url: &str, id: i64) -> Result<EbookMetadata, Strin
     response
         .json::<EbookMetadata>()
         .await
+        .map(Some)
         .map_err(|e| e.to_string())
 }
 
@@ -635,11 +636,10 @@ pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, S
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_ebook(_server_url: &str, id: i64) -> Result<EbookMetadata, String> {
+pub async fn get_ebook(_server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
     crate::rpc::rpc_get_ebook(id)
         .await
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Book {id} not found"))
+        .map_err(|e| e.to_string())
 }
 
 // ===== Auth transport (web only) =====

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -10,7 +10,7 @@
 //! - Server-only compiles (`feature = "server"` without `"web"`) reuse the
 //!   web stubs so SSR-during-fullstack-render still returns sensible data.
 
-use omnibus_shared::{EbookLibrary, LibraryContents, Settings};
+use omnibus_shared::{EbookLibrary, EbookMetadata, LibraryContents, Settings};
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
 
@@ -468,6 +468,26 @@ pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, St
         .map_err(|e| e.to_string())
 }
 
+#[cfg(feature = "mobile")]
+pub async fn get_ebook(server_url: &str, id: i64) -> Result<EbookMetadata, String> {
+    let url = format!("{server_url}/api/ebooks/{id}");
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if status.as_u16() == 404 {
+        return Err(format!("Book {id} not found"));
+    }
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    response
+        .json::<EbookMetadata>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
 // ===== Mobile auth transport: bearer token =====
 //
 // Mobile cannot use cookies (Dioxus Native is not a webview), so login
@@ -612,6 +632,14 @@ pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, S
     crate::rpc::rpc_search(q.to_string())
         .await
         .map_err(|e| e.to_string())
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn get_ebook(_server_url: &str, id: i64) -> Result<EbookMetadata, String> {
+    crate::rpc::rpc_get_ebook(id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Book {id} not found"))
 }
 
 // ===== Auth transport (web only) =====

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -463,4 +463,46 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   .ebook-table tbody td { padding: 0.5rem 0.6rem; }
   .ebook-thumb { width: 32px; height: 48px; }
 }
+
+/* ===== Book detail page ===== */
+.book-detail {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+@media (max-width: 600px) {
+  .book-detail { grid-template-columns: 1fr; }
+}
+.book-detail-cover { width: 220px; max-width: 100%; }
+.book-detail-cover img {
+  width: 100%; height: auto; display: block;
+  border-radius: 6px; box-shadow: 0 4px 20px rgba(0,0,0,.5);
+}
+.book-detail-cover-fallback {
+  width: 220px; height: 300px; background: rgba(255,255,255,.05);
+  border-radius: 6px; display: flex; align-items: center;
+  justify-content: center; font-size: 3rem; color: rgba(255,255,255,.2);
+}
+.book-detail-meta { display: flex; flex-direction: column; gap: .5rem; min-width: 0; }
+.breadcrumb {
+  display: flex; gap: .5rem; align-items: center;
+  font-size: .85rem; color: rgba(255,255,255,.5); margin-bottom: .5rem;
+}
+.breadcrumb a { color: #22d3ee; text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+.book-detail-description { line-height: 1.6; color: rgba(255,255,255,.8); margin: .5rem 0 1rem; }
+.format-actions { display: flex; gap: .75rem; flex-wrap: wrap; margin: .75rem 0; }
+.tag-list { display: flex; flex-wrap: wrap; gap: .4rem; list-style: none; padding: 0; margin: .4rem 0; }
+.tag {
+  background: rgba(34,211,238,.12); border: 1px solid rgba(34,211,238,.3);
+  border-radius: 9999px; padding: .2rem .65rem; font-size: .8rem; color: #22d3ee;
+}
+.identifier-list {
+  display: grid; grid-template-columns: auto 1fr;
+  gap: .2rem .75rem; font-size: .85rem; margin: .5rem 0;
+}
+.identifier-list dt { color: rgba(255,255,255,.5); font-family: monospace; }
+.identifier-list dd { margin: 0; font-family: monospace; }
+.ratings-slot, .suggestions-slot { min-height: 1px; }
 "#;

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -93,7 +93,7 @@ pub fn BookDetailPage(id: i64) -> Element {
             div { class: "book-detail-meta",
                 h1 { "{title}" }
                 if !authors.is_empty() {
-                    p { "{authors}" }
+                    p { "data-testid": "book-authors", "{authors}" }
                 }
                 if let Some(s) = series_label {
                     p { class: "subtitle", "{s}" }

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -18,7 +18,7 @@ pub fn BookDetailPage(id: i64) -> Element {
             loading.set(true);
             match data::get_ebook(&url, id).await {
                 Ok(b) => {
-                    book.set(Some(b));
+                    book.set(b);
                     error.set(None);
                 }
                 Err(e) => error.set(Some(e)),
@@ -160,10 +160,12 @@ pub fn BookDetailPage(id: i64) -> Element {
                 }
 
                 div {
+                    class: "ratings-slot",
                     "data-testid": "ratings-slot",
                     aria_label: "Ratings \u{2014} coming soon",
                 }
                 div {
+                    class: "suggestions-slot",
                     "data-testid": "suggestions-slot",
                     aria_label: "Suggestions \u{2014} coming soon",
                 }

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -1,19 +1,175 @@
 use dioxus::prelude::*;
 use dioxus_router::Link;
+use omnibus_shared::EbookMetadata;
 
-use crate::Route;
+use crate::{data, use_server_url, Route};
 
-/// Stub detail page for a single book. `id` is the stable backend id from
-/// the `books` table (`EbookMetadata.id`), so deep links survive re-indexes
-/// and the detail page can later fetch by id without depending on
-/// landing-page row ordering.
 #[component]
 pub fn BookDetailPage(id: i64) -> Element {
-    rsx! {
-        section { class: "card",
-            h1 { "Book #{id}" }
-            p { class: "subtitle", "Book detail page — TODO." }
+    let server_url = use_server_url();
+    let mut book: Signal<Option<EbookMetadata>> = use_signal(|| None);
+    let mut loading = use_signal(|| true);
+    let mut error: Signal<Option<String>> = use_signal(|| None);
+
+    let url = server_url.clone();
+    use_effect(move || {
+        let url = url.clone();
+        spawn(async move {
+            loading.set(true);
+            match data::get_ebook(&url, id).await {
+                Ok(b) => {
+                    book.set(Some(b));
+                    error.set(None);
+                }
+                Err(e) => error.set(Some(e)),
+            }
+            loading.set(false);
+        });
+    });
+
+    if loading() {
+        return rsx! {
+            p { class: "subtitle", "Loading\u{2026}" }
+        };
+    }
+    if let Some(msg) = error() {
+        return rsx! {
+            p { role: "alert", class: "subtitle", "{msg}" }
             Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        };
+    }
+    let Some(b) = book() else {
+        return rsx! {
+            p { class: "subtitle", "Book not found." }
+            Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        };
+    };
+
+    let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
+    let authors = b
+        .creators
+        .iter()
+        .map(|c| c.name.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let breadcrumb_mid = b
+        .series
+        .clone()
+        .or_else(|| b.creators.first().map(|c| c.name.clone()))
+        .unwrap_or_default();
+    let series_label = match (&b.series, &b.series_index) {
+        (Some(s), Some(i)) => Some(format!("{s} #{i}")),
+        (Some(s), None) => Some(s.clone()),
+        _ => None,
+    };
+    let cover_src = b.cover_url.as_ref().map(|u| format!("{server_url}{u}"));
+    let has_epub = b.formats.iter().any(|f| f.eq_ignore_ascii_case("epub"));
+    let has_m4b = b.formats.iter().any(|f| f.eq_ignore_ascii_case("m4b"));
+
+    rsx! {
+        nav { class: "breadcrumb", aria_label: "breadcrumb",
+            Link { to: Route::Landing {}, "Home" }
+            if !breadcrumb_mid.is_empty() {
+                span { " \u{203a} " }
+                span { "{breadcrumb_mid}" }
+            }
+            span { " \u{203a} " }
+            span { "{title}" }
+        }
+
+        div { class: "book-detail",
+            div { class: "book-detail-cover",
+                if let Some(src) = cover_src {
+                    img {
+                        src: "{src}",
+                        alt: "Cover of {title}",
+                        loading: "lazy",
+                    }
+                } else {
+                    div { class: "book-detail-cover-fallback", "\u{1F4D6}" }
+                }
+            }
+
+            div { class: "book-detail-meta",
+                h1 { "{title}" }
+                if !authors.is_empty() {
+                    p { "{authors}" }
+                }
+                if let Some(s) = series_label {
+                    p { class: "subtitle", "{s}" }
+                }
+                if let Some(desc) = &b.description {
+                    p { class: "book-detail-description", "{desc}" }
+                }
+
+                if has_epub || has_m4b {
+                    div { class: "format-actions",
+                        if has_epub {
+                            button {
+                                class: "btn",
+                                disabled: true,
+                                title: "Reader coming soon",
+                                "data-testid": "action-read",
+                                "Read"
+                            }
+                            button {
+                                class: "btn",
+                                disabled: true,
+                                title: "Send-to-Kindle coming soon",
+                                "data-testid": "action-kindle",
+                                "Send to Kindle"
+                            }
+                        }
+                        if has_m4b {
+                            button {
+                                class: "btn",
+                                disabled: true,
+                                title: "Audio player coming soon",
+                                "data-testid": "action-listen",
+                                "Listen"
+                            }
+                        }
+                    }
+                }
+
+                if !b.subjects.is_empty() {
+                    ul { class: "tag-list",
+                        for tag in &b.subjects {
+                            li { class: "tag", "{tag}" }
+                        }
+                    }
+                }
+
+                if !b.identifiers.is_empty() {
+                    dl { class: "identifier-list",
+                        for ident in &b.identifiers {
+                            dt { "{ident.scheme.as_deref().unwrap_or(\"\")}" }
+                            dd { "{ident.value}" }
+                        }
+                    }
+                }
+
+                if let Some(pub_) = &b.publisher {
+                    p { class: "subtitle", "Publisher: {pub_}" }
+                }
+                if let Some(lang) = &b.language {
+                    p { class: "subtitle", "Language: {lang}" }
+                }
+                if let Some(date) = &b.published {
+                    p { class: "subtitle", "Published: {date}" }
+                }
+
+                div {
+                    "data-testid": "ratings-slot",
+                    aria_label: "Ratings \u{2014} coming soon",
+                }
+                div {
+                    "data-testid": "suggestions-slot",
+                    aria_label: "Suggestions \u{2014} coming soon",
+                }
+
+                Link { to: Route::Landing {}, class: "btn", "Back to library" }
+            }
         }
     }
 }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -15,7 +15,7 @@
 
 use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
-use omnibus_shared::{EbookLibrary, LibraryContents, Settings, ValueResponse};
+use omnibus_shared::{EbookLibrary, EbookMetadata, LibraryContents, Settings, ValueResponse};
 
 #[cfg(feature = "server")]
 use omnibus_db::{self as db, scanner};
@@ -178,6 +178,14 @@ pub async fn rpc_get_ebooks() -> Result<EbookLibrary> {
     // Served straight from the DB — the indexer is responsible for keeping
     // it up to date (startup + settings save triggers).
     Ok(db::library_from_db(&pool.0, settings.ebook_library_path.as_deref()).await?)
+}
+
+/// POST (not GET) for the same reason as `rpc_search`: Dioxus `#[get]`
+/// server functions can't carry an argument body, so anything that needs
+/// `id` rides as a JSON-bodied POST.
+#[post("/api/rpc/ebook", pool: PoolExt, _user: AuthUser)]
+pub async fn rpc_get_ebook(id: i64) -> Result<Option<EbookMetadata>> {
+    Ok(db::get_book(&pool.0, id).await?)
 }
 
 /// FTS5-backed search across the configured ebook library. Empty or

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -44,8 +44,10 @@ test("renders the detail contents for the selected book", async ({ page, request
   // Title heading matches the fixture
   await expect(page.getByRole("heading", { level: 1, name: TARGET.title })).toBeVisible();
 
-  // At least the first author is visible
-  await expect(page.getByText(TARGET.authors[0])).toBeVisible();
+  // At least the first author is visible. Scoped to the dedicated authors
+  // line because the breadcrumb falls back to the first author when the book
+  // has no series, so a bare getByText(...) matches twice.
+  await expect(page.getByTestId("book-authors")).toContainText(TARGET.authors[0]);
 
   // Breadcrumb navigation: "Home" link must be present inside the breadcrumb nav
   await expect(

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -41,10 +41,28 @@ test("renders the detail contents for the selected book", async ({ page, request
 
   await gotoReady(page, `/books/${id}`);
 
-  await expect(page.getByRole("heading", { level: 1, name: `Book #${id}` })).toBeVisible();
-  // Today the detail page is a stub. Pin the placeholder copy so when the
-  // real metadata view lands, this test fails loudly and forces us to
-  // rewrite it against the new contract instead of silently passing.
-  await expect(page.getByText("Book detail page — TODO.")).toBeVisible();
-  await expect(page.getByRole("link", { name: "Back to library" })).toBeVisible();
+  // Title heading matches the fixture
+  await expect(page.getByRole("heading", { level: 1, name: TARGET.title })).toBeVisible();
+
+  // At least the first author is visible
+  await expect(page.getByText(TARGET.authors[0])).toBeVisible();
+
+  // Breadcrumb navigation: "Home" link must be present inside the breadcrumb nav
+  await expect(
+    page.getByRole("navigation", { name: "breadcrumb" }).getByRole("link", { name: "Home" }),
+  ).toBeVisible();
+
+  // All fixture books are EPUB — "Read" CTA must be rendered
+  await expect(page.getByTestId("action-read")).toBeVisible();
+
+  // F3.2 / F3.3 placeholder slots must be in the DOM (may be invisible)
+  await expect(page.getByTestId("ratings-slot")).toBeAttached();
+  await expect(page.getByTestId("suggestions-slot")).toBeAttached();
+
+  // Back link still navigates to landing
+  const backLink = page.getByRole("link", { name: "Back to library" });
+  await expect(backLink).toBeVisible();
+  await backLink.click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByTestId("ebook-table")).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- Replaces the `BookDetailPage` stub with a full metadata view in `frontend/src/pages/book_detail.rs`: cover, title/authors/series, description, tags, identifiers, publisher/language/published, breadcrumb, and per-format action buttons (Read / Listen / Send to Kindle — disabled stubs for now). Ratings + Suggestions placeholder slots are in the DOM (F3.2 / F3.3 fill them later).
- Adds `data::get_ebook(server_url, id) -> Result<Option<EbookMetadata>, String>` in `frontend/src/data.rs` with both feature-gated transports (`reqwest` for `mobile`, `rpc_get_ebook` server function for `web`/`server`). 404 / `None` is distinct from a real transport error.
- Adds `#[post("/api/rpc/ebook")] rpc_get_ebook(id)` server function in `frontend/src/rpc.rs` that calls `db::get_book` (now on main from PR #55). POST (not GET) because Dioxus `#[get]` server functions can't carry argument bodies — same reason `rpc_search` is POST.
- Adds `.book-detail*`, `.breadcrumb`, `.format-actions`, `.tag-list`, `.identifier-list`, `.ratings-slot`, `.suggestions-slot` styles in `frontend/src/lib.rs`.
- Updates `ui_tests/playwright/tests/flows/book_detail.spec.ts` to assert the real metadata contract: title heading, author, breadcrumb nav, action-read testid, ratings/suggestions slots attached, back-link.

## Test plan

- [x] `cargo test -p omnibus-frontend --features server` — passes
- [x] `cargo test -p omnibus` — passes
- [x] `cargo test -p omnibus-db` — passes (incl. `get_book_*` tests merged in PR #55)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [ ] Playwright E2E (book_detail.spec.ts) — gated by run_ui_tests label, runs in CI

Stacks on top of [#55](https://github.com/seamus-sloan/seamus-sloan/omnibus/pull/55) (now merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)