### PR TITLE
fix(frontend): style password and email inputs on auth pages

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -323,7 +323,10 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   font-weight: 500;
   color: #cbd5e1;
 }
-.settings-field input[type="text"], .settings-input {
+.settings-field input[type="text"],
+.settings-field input[type="password"],
+.settings-field input[type="email"],
+.settings-input {
   background: rgba(30, 41, 59, 0.8);
   border: 1px solid rgba(100, 116, 139, 0.4);
   border-radius: 8px;
@@ -332,7 +335,10 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   padding: 0.55rem 0.75rem;
   width: 100%;
 }
-.settings-field input[type="text"]:focus, .settings-input:focus {
+.settings-field input[type="text"]:focus,
+.settings-field input[type="password"]:focus,
+.settings-field input[type="email"]:focus,
+.settings-input:focus {
   outline: none;
   border-color: #3b82f6;
 }


### PR DESCRIPTION
## Summary
- Extend `.settings-field` input selector to cover `input[type="password"]` and `input[type="email"]` so the login and register password (and register email) fields pick up the same dark-themed background, border, and focus ring as the settings page text inputs. Previously they fell through to browser defaults and rendered as bare white boxes.

## Test plan
- [ ] Visit `/login` — password field has dark background, subtle border, matches settings page styling.
- [ ] Visit `/register` — both email and password fields are styled.
- [ ] Focus state on each: outline removed, border switches to `#3b82f6`.
- [ ] Settings page text inputs unchanged (regression check).

## Notes
- CSS-only change inside the `STYLES` const in `frontend/src/lib.rs`. No markup changes; auth.rs already wraps inputs in `.settings-field`.