### PR TITLE
fix(frontend): anchor body gradient with background-attachment: fixed

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -201,6 +201,7 @@ pub const STYLES: &str = r#"
 body {
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   background: radial-gradient(circle at top, #1f2937 0%, #0b1020 50%, #070b16 100%);
+  background-attachment: fixed;
   min-height: 100vh;
   color: #e5e7eb;
 }


### PR DESCRIPTION
## Summary
- Add `background-attachment: fixed` to the `body` rule so the radial gradient stays anchored to the viewport instead of stretching with document height. On long pages (e.g. landing with many books) the unfixed gradient washed out toward the pale top color (`#1f2937`) for nearly the entire scroll, killing the intended dark fade.

## Test plan
- [ ] On `/` with enough books to scroll several viewports, the background looks the same dark tone at the bottom as at the top.
- [ ] No visible "jump" or seam when scrolling — gradient stays put under the content.
- [ ] Short pages (`/settings`, `/login`) look unchanged.
- [ ] iOS / Android mobile shells unaffected (rule is on `body`; native targets don't render the body gradient anyway).

## Notes
- Single-line CSS change in the `STYLES` const in `frontend/src/lib.rs`.