### PR TITLE
feat(book-detail): single-query load + format switcher (F1.4)

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -855,33 +855,33 @@ async fn load_identifiers(pool: &SqlitePool, book_id: i64) -> Result<Vec<Identif
 ///
 /// One round-trip to SQLite: the main `books` row plus every m2m relation are
 /// pulled in a single statement using scalar subqueries (for single-valued
-/// joins) and `GROUP_CONCAT` over ordered inner selects (for multi-valued
+/// joins) and `json_group_array` over ordered inner selects (for multi-valued
 /// lists). Determinism is preserved by always ordering the inner selects —
 /// EPUB-preferred for the primary file, alphabetical for publisher/language/
 /// series/tags/formats/identifiers, and `books_authors_link.position` for
 /// authors.
 ///
-/// Multi-valued lists are encoded with two private separators that can't
-/// appear in user content: `0x1F` (unit separator) between records and `0x1E`
-/// (record separator) between fields within a record. The two-level encoding
-/// lets `creators` and `identifiers` carry pairs (name+sort, scheme+value)
-/// through `GROUP_CONCAT` without colliding with commas or other punctuation
-/// in real titles, names, or ISBNs.
+/// Multi-valued lists are returned as JSON via SQLite's `json_group_array` +
+/// `json_object`, which round-trips any UTF-8 — including control chars and
+/// punctuation that a delimiter-based encoding would corrupt. The Rust side
+/// parses each blob with `serde_json`. Empty aggregates come back as `"[]"`,
+/// so the `Option<String>` path only fires when the column itself was NULL.
 pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata>, sqlx::Error> {
-    const FS: char = '\x1F';
-    const RS: char = '\x1E';
-
     let row = sqlx::query(
         r#"
         SELECT
             b.id, b.uuid, b.title, b.description, b.series_index, b.has_cover,
             b.pubdate, b.last_modified, b.timestamp, b.accent_color,
 
-            (SELECT bf.filename || char(0x1E) || bf.format
-               FROM book_files bf
+            (SELECT bf.filename FROM book_files bf
               WHERE bf.book_id = b.id
               ORDER BY (bf.format != 'EPUB'), bf.format
-              LIMIT 1)                                     AS primary_file,
+              LIMIT 1)                                     AS primary_filename,
+
+            (SELECT bf.format FROM book_files bf
+              WHERE bf.book_id = b.id
+              ORDER BY (bf.format != 'EPUB'), bf.format
+              LIMIT 1)                                     AS primary_format,
 
             (SELECT pub.name FROM books_publishers_link bpl
               JOIN publishers pub ON pub.id = bpl.publisher
@@ -898,29 +898,28 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
              WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
                                                            AS series_name,
 
-            (SELECT GROUP_CONCAT(record, char(0x1F))
-               FROM (SELECT a.name || char(0x1E) || COALESCE(a.sort, '') AS record
+            (SELECT json_group_array(json_object('name', name, 'sort', sort))
+               FROM (SELECT a.name AS name, a.sort AS sort
                        FROM books_authors_link bal
                        JOIN authors a ON a.id = bal.author
                       WHERE bal.book = b.id
-                      ORDER BY bal.position))              AS creators_blob,
+                      ORDER BY bal.position))              AS creators_json,
 
-            (SELECT GROUP_CONCAT(name, char(0x1F))
-               FROM (SELECT t.name FROM books_tags_link btl
+            (SELECT json_group_array(name)
+               FROM (SELECT t.name AS name FROM books_tags_link btl
                        JOIN tags t ON t.id = btl.tag
                       WHERE btl.book = b.id
-                      ORDER BY t.name))                    AS subjects_blob,
+                      ORDER BY t.name))                    AS subjects_json,
 
-            (SELECT GROUP_CONCAT(record, char(0x1F))
-               FROM (SELECT scheme || char(0x1E) || value AS record
-                       FROM book_identifiers
+            (SELECT json_group_array(json_object('scheme', scheme, 'value', value))
+               FROM (SELECT scheme, value FROM book_identifiers
                       WHERE book_id = b.id
-                      ORDER BY scheme, value))             AS identifiers_blob,
+                      ORDER BY scheme, value))             AS identifiers_json,
 
-            (SELECT GROUP_CONCAT(format, char(0x1F))
+            (SELECT json_group_array(format)
                FROM (SELECT format FROM book_files
                       WHERE book_id = b.id
-                      ORDER BY format))                    AS formats_blob
+                      ORDER BY format))                    AS formats_json
 
         FROM books b
         WHERE b.id = ?
@@ -939,46 +938,48 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
     let series_index: Option<f64> = r.get("series_index");
     let uuid: String = r.get("uuid");
 
-    let filename = r
-        .get::<Option<String>, _>("primary_file")
-        .map(|blob| {
-            let mut parts = blob.splitn(2, RS);
-            let stem = parts.next().unwrap_or("");
-            let fmt = parts.next().unwrap_or("");
-            format!("{stem}.{}", fmt.to_ascii_lowercase())
-        })
-        .unwrap_or_default();
+    let filename = match (
+        r.get::<Option<String>, _>("primary_filename"),
+        r.get::<Option<String>, _>("primary_format"),
+    ) {
+        (Some(stem), Some(fmt)) => format!("{stem}.{}", fmt.to_ascii_lowercase()),
+        _ => String::new(),
+    };
 
-    let creators = split_concat(r.get::<Option<String>, _>("creators_blob"), FS)
+    #[derive(serde::Deserialize)]
+    struct CreatorRow {
+        name: String,
+        #[serde(default)]
+        sort: Option<String>,
+    }
+
+    let creators: Vec<Contributor> = parse_json_array::<CreatorRow>(r.get("creators_json"))?
         .into_iter()
-        .map(|rec| {
-            let mut parts = rec.splitn(2, RS);
-            let name = parts.next().unwrap_or("").to_string();
-            let sort = parts.next().unwrap_or("");
-            Contributor {
-                name,
-                role: None,
-                file_as: (!sort.is_empty()).then(|| sort.to_string()),
-            }
+        .map(|c| Contributor {
+            name: c.name,
+            role: None,
+            file_as: c.sort.filter(|s| !s.is_empty()),
         })
         .collect();
 
-    let subjects = split_concat(r.get::<Option<String>, _>("subjects_blob"), FS);
+    let subjects: Vec<String> = parse_json_array(r.get("subjects_json"))?;
 
-    let identifiers = split_concat(r.get::<Option<String>, _>("identifiers_blob"), FS)
-        .into_iter()
-        .map(|rec| {
-            let mut parts = rec.splitn(2, RS);
-            let scheme = parts.next().unwrap_or("").to_string();
-            let value = parts.next().unwrap_or("").to_string();
-            Identifier {
-                value,
-                scheme: Some(scheme),
-            }
-        })
-        .collect();
+    #[derive(serde::Deserialize)]
+    struct IdentifierRow {
+        scheme: String,
+        value: String,
+    }
 
-    let formats = split_concat(r.get::<Option<String>, _>("formats_blob"), FS);
+    let identifiers: Vec<Identifier> =
+        parse_json_array::<IdentifierRow>(r.get("identifiers_json"))?
+            .into_iter()
+            .map(|i| Identifier {
+                value: i.value,
+                scheme: Some(i.scheme),
+            })
+            .collect();
+
+    let formats: Vec<String> = parse_json_array(r.get("formats_json"))?;
 
     Ok(Some(EbookMetadata {
         id: book_id,
@@ -1014,12 +1015,16 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
     }))
 }
 
-/// Decode a `GROUP_CONCAT` blob produced by `get_book`. A `None` or empty
-/// payload yields an empty vec; otherwise the blob is split on `sep`.
-fn split_concat(blob: Option<String>, sep: char) -> Vec<String> {
+/// Decode a `json_group_array` blob produced by `get_book`. SQLite returns
+/// `"[]"` for an aggregate over zero rows, so a `None` here only means the
+/// column itself was NULL (which the get_book subqueries never produce, but
+/// we tolerate it defensively).
+fn parse_json_array<T: serde::de::DeserializeOwned>(
+    blob: Option<String>,
+) -> Result<Vec<T>, sqlx::Error> {
     match blob {
-        Some(s) if !s.is_empty() => s.split(sep).map(str::to_string).collect(),
-        _ => Vec::new(),
+        Some(s) => serde_json::from_str(&s).map_err(|e| sqlx::Error::Decode(Box::new(e))),
+        None => Ok(Vec::new()),
     }
 }
 
@@ -2550,7 +2555,7 @@ mod tests {
     #[tokio::test]
     async fn get_book_handles_book_with_no_relations() {
         // A `books` row that has zero m2m link rows and zero files: every
-        // GROUP_CONCAT subquery in the single-query rewrite returns NULL, and
+        // `json_group_array` subquery returns "[]" (over zero inner rows) and
         // every scalar subquery returns NULL. The function must still return
         // a populated `EbookMetadata` with empty vecs and an empty filename
         // rather than erroring out on the missing data.
@@ -2586,5 +2591,48 @@ mod tests {
         assert!(book.language.is_none());
         assert!(book.series.is_none());
         assert!(book.cover_url.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_book_round_trips_values_containing_control_chars_and_quotes() {
+        // Regression for PR #65 review: prior delimiter-based encoding
+        // (`GROUP_CONCAT` with 0x1F/0x1E separators) would have silently
+        // corrupted any value containing those control chars. The JSON
+        // encoding must survive arbitrary UTF-8 — control chars, quotes,
+        // backslashes, commas — without altering the round-tripped value.
+        let _covers = CoversTempDir::new("get_book_collide");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let nasty_name = "Smith\u{001F}, John \"O'Reilly\" \\back\u{001E}/";
+        let nasty_tag = "Sci-Fi\u{001F}Drama";
+        let nasty_value = "9780\u{001E}123\"456\\";
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "alpha.epub",
+                Some("Alpha"),
+                &[nasty_name],
+                &[nasty_tag],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        let id = list_books(&pool, "/lib").await.unwrap()[0].id;
+        sqlx::query("INSERT INTO book_identifiers (book_id, scheme, value) VALUES (?, 'ISBN', ?)")
+            .bind(id)
+            .bind(nasty_value)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let book = get_book(&pool, id).await.unwrap().expect("book");
+        assert_eq!(book.creators.len(), 1);
+        assert_eq!(book.creators[0].name, nasty_name);
+        assert_eq!(book.subjects, vec![nasty_tag.to_string()]);
+        assert_eq!(book.identifiers.len(), 1);
+        assert_eq!(book.identifiers[0].value, nasty_value);
+        assert_eq!(book.identifiers[0].scheme.as_deref(), Some("ISBN"));
     }
 }

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -851,86 +851,79 @@ async fn load_identifiers(pool: &SqlitePool, book_id: i64) -> Result<Vec<Identif
         .collect())
 }
 
-async fn load_formats(pool: &SqlitePool, book_id: i64) -> Result<Vec<String>, sqlx::Error> {
-    sqlx::query_scalar("SELECT format FROM book_files WHERE book_id = ? ORDER BY format")
-        .bind(book_id)
-        .fetch_all(pool)
-        .await
-}
-
-/// Pick the preferred file row for a book. EPUB wins when present; otherwise
-/// fall back to the first format alphabetically. Returns `(filename_stem,
-/// format)` or `None` when the book has no files.
-async fn load_primary_file(
-    pool: &SqlitePool,
-    book_id: i64,
-) -> Result<Option<(String, String)>, sqlx::Error> {
-    let row = sqlx::query(
-        "SELECT filename, format FROM book_files
-         WHERE book_id = ?
-         ORDER BY (format != 'EPUB'), format
-         LIMIT 1",
-    )
-    .bind(book_id)
-    .fetch_optional(pool)
-    .await?;
-    Ok(row.map(|r| (r.get("filename"), r.get("format"))))
-}
-
-async fn load_publisher(pool: &SqlitePool, book_id: i64) -> Result<Option<String>, sqlx::Error> {
-    sqlx::query_scalar(
-        "SELECT pub.name FROM books_publishers_link bpl
-         JOIN publishers pub ON pub.id = bpl.publisher
-         WHERE bpl.book = ?
-         ORDER BY pub.name
-         LIMIT 1",
-    )
-    .bind(book_id)
-    .fetch_optional(pool)
-    .await
-}
-
-async fn load_language(pool: &SqlitePool, book_id: i64) -> Result<Option<String>, sqlx::Error> {
-    sqlx::query_scalar(
-        "SELECT lang.code FROM books_languages_link bll
-         JOIN languages lang ON lang.id = bll.language
-         WHERE bll.book = ?
-         ORDER BY lang.code
-         LIMIT 1",
-    )
-    .bind(book_id)
-    .fetch_optional(pool)
-    .await
-}
-
-async fn load_series_name(pool: &SqlitePool, book_id: i64) -> Result<Option<String>, sqlx::Error> {
-    sqlx::query_scalar(
-        "SELECT s.name FROM books_series_link bsl
-         JOIN series s ON s.id = bsl.series
-         WHERE bsl.book = ?
-         ORDER BY s.name
-         LIMIT 1",
-    )
-    .bind(book_id)
-    .fetch_optional(pool)
-    .await
-}
-
 /// Fetch a single book by its stable `books.id`. Returns `None` if not found.
 ///
-/// The main SELECT pulls only `books`-table columns so it remains 1:1 even
-/// when the book has multiple files / publishers / languages / series.
-/// Multi-valued and ambiguous columns are loaded via dedicated helpers that
-/// each apply a deterministic `ORDER BY ... LIMIT 1` (see
-/// `load_primary_file` / `load_publisher` / `load_language` /
-/// `load_series_name`) so the response is stable across calls.
+/// One round-trip to SQLite: the main `books` row plus every m2m relation are
+/// pulled in a single statement using scalar subqueries (for single-valued
+/// joins) and `GROUP_CONCAT` over ordered inner selects (for multi-valued
+/// lists). Determinism is preserved by always ordering the inner selects —
+/// EPUB-preferred for the primary file, alphabetical for publisher/language/
+/// series/tags/formats/identifiers, and `books_authors_link.position` for
+/// authors.
+///
+/// Multi-valued lists are encoded with two private separators that can't
+/// appear in user content: `0x1F` (unit separator) between records and `0x1E`
+/// (record separator) between fields within a record. The two-level encoding
+/// lets `creators` and `identifiers` carry pairs (name+sort, scheme+value)
+/// through `GROUP_CONCAT` without colliding with commas or other punctuation
+/// in real titles, names, or ISBNs.
 pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata>, sqlx::Error> {
+    const FS: char = '\x1F';
+    const RS: char = '\x1E';
+
     let row = sqlx::query(
         r#"
-        SELECT id, uuid, title, description, series_index, has_cover,
-               pubdate, last_modified, timestamp, isbn, accent_color
-        FROM books
-        WHERE id = ?
+        SELECT
+            b.id, b.uuid, b.title, b.description, b.series_index, b.has_cover,
+            b.pubdate, b.last_modified, b.timestamp, b.accent_color,
+
+            (SELECT bf.filename || char(0x1E) || bf.format
+               FROM book_files bf
+              WHERE bf.book_id = b.id
+              ORDER BY (bf.format != 'EPUB'), bf.format
+              LIMIT 1)                                     AS primary_file,
+
+            (SELECT pub.name FROM books_publishers_link bpl
+              JOIN publishers pub ON pub.id = bpl.publisher
+             WHERE bpl.book = b.id ORDER BY pub.name LIMIT 1)
+                                                           AS publisher,
+
+            (SELECT lang.code FROM books_languages_link bll
+              JOIN languages lang ON lang.id = bll.language
+             WHERE bll.book = b.id ORDER BY lang.code LIMIT 1)
+                                                           AS language,
+
+            (SELECT s.name FROM books_series_link bsl
+              JOIN series s ON s.id = bsl.series
+             WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
+                                                           AS series_name,
+
+            (SELECT GROUP_CONCAT(record, char(0x1F))
+               FROM (SELECT a.name || char(0x1E) || COALESCE(a.sort, '') AS record
+                       FROM books_authors_link bal
+                       JOIN authors a ON a.id = bal.author
+                      WHERE bal.book = b.id
+                      ORDER BY bal.position))              AS creators_blob,
+
+            (SELECT GROUP_CONCAT(name, char(0x1F))
+               FROM (SELECT t.name FROM books_tags_link btl
+                       JOIN tags t ON t.id = btl.tag
+                      WHERE btl.book = b.id
+                      ORDER BY t.name))                    AS subjects_blob,
+
+            (SELECT GROUP_CONCAT(record, char(0x1F))
+               FROM (SELECT scheme || char(0x1E) || value AS record
+                       FROM book_identifiers
+                      WHERE book_id = b.id
+                      ORDER BY scheme, value))             AS identifiers_blob,
+
+            (SELECT GROUP_CONCAT(format, char(0x1F))
+               FROM (SELECT format FROM book_files
+                      WHERE book_id = b.id
+                      ORDER BY format))                    AS formats_blob
+
+        FROM books b
+        WHERE b.id = ?
         "#,
     )
     .bind(id)
@@ -940,32 +933,62 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
     let Some(r) = row else {
         return Ok(None);
     };
+
     let book_id: i64 = r.get("id");
     let has_cover: i64 = r.get("has_cover");
     let series_index: Option<f64> = r.get("series_index");
+    let uuid: String = r.get("uuid");
 
-    let primary_file = load_primary_file(pool, book_id).await?;
-    let filename = primary_file
-        .map(|(stem, fmt)| format!("{stem}.{}", fmt.to_ascii_lowercase()))
+    let filename = r
+        .get::<Option<String>, _>("primary_file")
+        .map(|blob| {
+            let mut parts = blob.splitn(2, RS);
+            let stem = parts.next().unwrap_or("");
+            let fmt = parts.next().unwrap_or("");
+            format!("{stem}.{}", fmt.to_ascii_lowercase())
+        })
         .unwrap_or_default();
 
-    let publisher = load_publisher(pool, book_id).await?;
-    let language = load_language(pool, book_id).await?;
-    let series = load_series_name(pool, book_id).await?;
-    let creators = load_creators(pool, book_id).await?;
-    let subjects = load_subjects(pool, book_id).await?;
-    let identifiers = load_identifiers(pool, book_id).await?;
-    let formats = load_formats(pool, book_id).await?;
+    let creators = split_concat(r.get::<Option<String>, _>("creators_blob"), FS)
+        .into_iter()
+        .map(|rec| {
+            let mut parts = rec.splitn(2, RS);
+            let name = parts.next().unwrap_or("").to_string();
+            let sort = parts.next().unwrap_or("");
+            Contributor {
+                name,
+                role: None,
+                file_as: (!sort.is_empty()).then(|| sort.to_string()),
+            }
+        })
+        .collect();
+
+    let subjects = split_concat(r.get::<Option<String>, _>("subjects_blob"), FS);
+
+    let identifiers = split_concat(r.get::<Option<String>, _>("identifiers_blob"), FS)
+        .into_iter()
+        .map(|rec| {
+            let mut parts = rec.splitn(2, RS);
+            let scheme = parts.next().unwrap_or("").to_string();
+            let value = parts.next().unwrap_or("").to_string();
+            Identifier {
+                value,
+                scheme: Some(scheme),
+            }
+        })
+        .collect();
+
+    let formats = split_concat(r.get::<Option<String>, _>("formats_blob"), FS);
 
     Ok(Some(EbookMetadata {
         id: book_id,
         filename,
         title: r.get("title"),
         description: r.get("description"),
-        publisher,
+        publisher: r.get("publisher"),
         published: r.get("pubdate"),
         modified: r.get("last_modified"),
-        language,
+        language: r.get("language"),
         rights: None,
         source: None,
         coverage: None,
@@ -976,10 +999,10 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
         contributors: vec![],
         subjects,
         identifiers,
-        series,
+        series: r.get("series_name"),
         series_index: series_index.map(format_series_index),
         epub_version: None,
-        unique_identifier: Some(r.get::<String, _>("uuid")),
+        unique_identifier: Some(uuid),
         resource_count: 0,
         spine_count: 0,
         toc_count: 0,
@@ -989,6 +1012,15 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
         added_at: r.get("timestamp"),
         error: None,
     }))
+}
+
+/// Decode a `GROUP_CONCAT` blob produced by `get_book`. A `None` or empty
+/// payload yields an empty vec; otherwise the blob is split on `sep`.
+fn split_concat(blob: Option<String>, sep: char) -> Vec<String> {
+    match blob {
+        Some(s) if !s.is_empty() => s.split(sep).map(str::to_string).collect(),
+        _ => Vec::new(),
+    }
 }
 
 /// Full-text search across `books_fts`. Returns hydrated `EbookMetadata`
@@ -2513,5 +2545,46 @@ mod tests {
             book.formats.iter().any(|f| f.eq_ignore_ascii_case("epub")),
             "EPUB format should be present"
         );
+    }
+
+    #[tokio::test]
+    async fn get_book_handles_book_with_no_relations() {
+        // A `books` row that has zero m2m link rows and zero files: every
+        // GROUP_CONCAT subquery in the single-query rewrite returns NULL, and
+        // every scalar subquery returns NULL. The function must still return
+        // a populated `EbookMetadata` with empty vecs and an empty filename
+        // rather than erroring out on the missing data.
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let lib_res =
+            sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+                .execute(&pool)
+                .await
+                .unwrap();
+        let lib_id = lib_res.last_insert_rowid();
+        let res = sqlx::query(
+            "INSERT INTO books (uuid, library_id, path, title) \
+             VALUES ('lonely-uuid', ?, '/lib/lonely', 'Lonely')",
+        )
+        .bind(lib_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let id = res.last_insert_rowid();
+
+        let book = get_book(&pool, id)
+            .await
+            .unwrap()
+            .expect("book should exist");
+        assert_eq!(book.id, id);
+        assert_eq!(book.title.as_deref(), Some("Lonely"));
+        assert_eq!(book.filename, "");
+        assert!(book.creators.is_empty());
+        assert!(book.subjects.is_empty());
+        assert!(book.identifiers.is_empty());
+        assert!(book.formats.is_empty());
+        assert!(book.publisher.is_none());
+        assert!(book.language.is_none());
+        assert!(book.series.is_none());
+        assert!(book.cover_url.is_none());
     }
 }

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -33,11 +33,13 @@ pub fn FormatSwitcher(formats: Vec<String>) -> Element {
 #[component]
 fn FormatRow(kind: FormatKind) -> Element {
     let label = kind.label();
+    let testid = format!("format-row-{}", label.to_ascii_lowercase());
     rsx! {
         div {
             class: "format-row",
             "data-format": "{label}",
-            span { class: "format-badge", "{label}" }
+            "data-testid": "{testid}",
+            span { class: "format-badge", "data-testid": "format-badge", "{label}" }
             div { class: "format-actions",
                 match kind {
                     FormatKind::Epub => rsx! {
@@ -104,11 +106,18 @@ impl FormatKind {
     }
 }
 
-/// Dedupe (case-insensitive), sort alphabetical by label, and map raw format
-/// strings to the typed rows the switcher renders.
+/// Dedupe (case-insensitive), sort alphabetical by label (also case-
+/// insensitive — otherwise unknown-cased rows like `"cbz"` would sort after
+/// the upper-cased known ones, which doesn't match the "alphabetical"
+/// contract or the dedupe logic), and map raw format strings to the typed
+/// rows the switcher renders.
 fn prepare_rows(formats: &[String]) -> Vec<FormatKind> {
     let mut rows: Vec<FormatKind> = formats.iter().map(|s| FormatKind::from_raw(s)).collect();
-    rows.sort_by(|a, b| a.label().cmp(b.label()));
+    rows.sort_by(|a, b| {
+        a.label()
+            .to_ascii_lowercase()
+            .cmp(&b.label().to_ascii_lowercase())
+    });
     rows.dedup_by(|a, b| a.label().eq_ignore_ascii_case(b.label()));
     rows
 }
@@ -131,6 +140,19 @@ mod tests {
         let rows = prepare_rows(&["epub".into(), "EPUB".into()]);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].label(), "EPUB");
+    }
+
+    #[test]
+    fn prepare_rows_sorts_case_insensitively() {
+        // Regression for PR #65 review: mixed-case input must produce a
+        // consistent alphabetical order regardless of casing — otherwise
+        // upper-cased known formats (EPUB, M4B) would always sort before
+        // lower-cased unknown ones (cbz), which surprises users.
+        let rows = prepare_rows(&["PDF".into(), "cbz".into(), "EPUB".into()]);
+        assert_eq!(
+            rows.iter().map(|r| r.label()).collect::<Vec<_>>(),
+            vec!["cbz", "EPUB", "PDF"],
+        );
     }
 
     #[test]

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -1,0 +1,151 @@
+//! Per-format CTAs on the book detail page (F1.4).
+//!
+//! Renders one row per format the book has, sorted alphabetically, with the
+//! relevant actions wired underneath. All actions stay disabled in Phase 1:
+//! Read (F2.2 reader), Listen (F2.3 player), and Send to Kindle (F4.x) ship
+//! later. The rows themselves are the UI contract for the `books` /
+//! `book_files` split from F0.1 — a work with both EPUB and M4B surfaces both
+//! formats here so the future per-format actions slot in without re-shaping
+//! the markup.
+
+use dioxus::prelude::*;
+
+#[component]
+pub fn FormatSwitcher(formats: Vec<String>) -> Element {
+    let rows = prepare_rows(&formats);
+    if rows.is_empty() {
+        return rsx! {};
+    }
+
+    rsx! {
+        div {
+            class: "format-switcher",
+            role: "group",
+            aria_label: "Available formats",
+            "data-testid": "format-switcher",
+            for row in rows {
+                FormatRow { kind: row }
+            }
+        }
+    }
+}
+
+#[component]
+fn FormatRow(kind: FormatKind) -> Element {
+    let label = kind.label();
+    rsx! {
+        div {
+            class: "format-row",
+            "data-format": "{label}",
+            span { class: "format-badge", "{label}" }
+            div { class: "format-actions",
+                match kind {
+                    FormatKind::Epub => rsx! {
+                        button {
+                            class: "btn",
+                            disabled: true,
+                            title: "Reader coming soon",
+                            "data-testid": "action-read",
+                            "Read"
+                        }
+                        button {
+                            class: "btn",
+                            disabled: true,
+                            title: "Send-to-Kindle coming soon",
+                            "data-testid": "action-kindle",
+                            "Send to Kindle"
+                        }
+                    },
+                    FormatKind::M4b => rsx! {
+                        button {
+                            class: "btn",
+                            disabled: true,
+                            title: "Audio player coming soon",
+                            "data-testid": "action-listen",
+                            "Listen"
+                        }
+                    },
+                    FormatKind::Other(_) => rsx! {
+                        span { class: "format-actions-empty", "No actions yet" }
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// One row in the switcher. `Other(String)` keeps the original casing of the
+/// raw `book_files.format` value so the badge displays whatever the schema
+/// stored (e.g. "PDF", "CBZ") without invoking a giant match.
+#[derive(Clone, PartialEq, Eq)]
+enum FormatKind {
+    Epub,
+    M4b,
+    Other(String),
+}
+
+impl FormatKind {
+    fn from_raw(raw: &str) -> Self {
+        if raw.eq_ignore_ascii_case("EPUB") {
+            FormatKind::Epub
+        } else if raw.eq_ignore_ascii_case("M4B") {
+            FormatKind::M4b
+        } else {
+            FormatKind::Other(raw.to_string())
+        }
+    }
+
+    fn label(&self) -> &str {
+        match self {
+            FormatKind::Epub => "EPUB",
+            FormatKind::M4b => "M4B",
+            FormatKind::Other(s) => s.as_str(),
+        }
+    }
+}
+
+/// Dedupe (case-insensitive), sort alphabetical by label, and map raw format
+/// strings to the typed rows the switcher renders.
+fn prepare_rows(formats: &[String]) -> Vec<FormatKind> {
+    let mut rows: Vec<FormatKind> = formats.iter().map(|s| FormatKind::from_raw(s)).collect();
+    rows.sort_by(|a, b| a.label().cmp(b.label()));
+    rows.dedup_by(|a, b| a.label().eq_ignore_ascii_case(b.label()));
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepare_rows_sorts_alphabetical() {
+        let rows = prepare_rows(&["M4B".into(), "EPUB".into(), "PDF".into()]);
+        assert_eq!(
+            rows.iter().map(|r| r.label()).collect::<Vec<_>>(),
+            vec!["EPUB", "M4B", "PDF"],
+        );
+    }
+
+    #[test]
+    fn prepare_rows_dedupes_case_insensitively() {
+        let rows = prepare_rows(&["epub".into(), "EPUB".into()]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].label(), "EPUB");
+    }
+
+    #[test]
+    fn prepare_rows_preserves_unknown_format_casing() {
+        let rows = prepare_rows(&["CbZ".into()]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].label(), "CbZ");
+        assert!(matches!(rows[0], FormatKind::Other(_)));
+    }
+
+    #[test]
+    fn empty_input_renders_nothing_meaningful() {
+        // We don't exercise the actual rsx! macro (no SSR dep in this crate),
+        // but the prepare_rows path is what gates the FormatSwitcher's
+        // `rows.is_empty() → return rsx!{}` branch.
+        assert!(prepare_rows(&[]).is_empty());
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -27,6 +27,9 @@ mod bottom_nav;
 #[cfg(feature = "mobile")]
 pub use bottom_nav::BottomNav as Nav;
 
+mod format_switcher;
+pub use format_switcher::FormatSwitcher;
+
 pub mod atrium;
 
 // Auth-page primitives — used by the login / register / first-run /

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -763,7 +763,30 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .breadcrumb a { color: #22d3ee; text-decoration: none; }
 .breadcrumb a:hover { text-decoration: underline; }
 .book-detail-description { line-height: 1.6; color: rgba(255,255,255,.8); margin: .5rem 0 1rem; }
-.format-actions { display: flex; gap: .75rem; flex-wrap: wrap; margin: .75rem 0; }
+.format-switcher {
+  display: flex; flex-direction: column; gap: .4rem;
+  margin: .75rem 0; padding: .5rem .75rem;
+  background: rgba(255,255,255,.03);
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 6px;
+}
+.format-row {
+  display: flex; align-items: center; gap: .75rem; flex-wrap: wrap;
+}
+.format-row + .format-row {
+  padding-top: .4rem; border-top: 1px solid rgba(255,255,255,.05);
+}
+.format-badge {
+  font-family: monospace; font-size: .75rem; font-weight: 600;
+  letter-spacing: .05em; padding: .15rem .5rem;
+  background: rgba(34,211,238,.12); color: #22d3ee;
+  border: 1px solid rgba(34,211,238,.3); border-radius: 4px;
+  min-width: 3.5rem; text-align: center;
+}
+.format-actions { display: flex; gap: .5rem; flex-wrap: wrap; }
+.format-actions-empty {
+  font-size: .8rem; color: rgba(255,255,255,.4); font-style: italic;
+}
 .tag-list { display: flex; flex-wrap: wrap; gap: .4rem; list-style: none; padding: 0; margin: .4rem 0; }
 .tag {
   background: rgba(34,211,238,.12); border: 1px solid rgba(34,211,238,.3);

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_router::Link;
 use omnibus_shared::EbookMetadata;
 
-use crate::{data, use_server_url, Route};
+use crate::{components::FormatSwitcher, data, use_server_url, Route};
 
 #[component]
 pub fn BookDetailPage(id: i64) -> Element {
@@ -63,8 +63,6 @@ pub fn BookDetailPage(id: i64) -> Element {
         _ => None,
     };
     let cover_src = b.cover_url.as_ref().map(|u| format!("{server_url}{u}"));
-    let has_epub = b.formats.iter().any(|f| f.eq_ignore_ascii_case("epub"));
-    let has_m4b = b.formats.iter().any(|f| f.eq_ignore_ascii_case("m4b"));
 
     rsx! {
         nav { class: "breadcrumb", aria_label: "breadcrumb",
@@ -102,35 +100,7 @@ pub fn BookDetailPage(id: i64) -> Element {
                     p { class: "book-detail-description", "{desc}" }
                 }
 
-                if has_epub || has_m4b {
-                    div { class: "format-actions",
-                        if has_epub {
-                            button {
-                                class: "btn",
-                                disabled: true,
-                                title: "Reader coming soon",
-                                "data-testid": "action-read",
-                                "Read"
-                            }
-                            button {
-                                class: "btn",
-                                disabled: true,
-                                title: "Send-to-Kindle coming soon",
-                                "data-testid": "action-kindle",
-                                "Send to Kindle"
-                            }
-                        }
-                        if has_m4b {
-                            button {
-                                class: "btn",
-                                disabled: true,
-                                title: "Audio player coming soon",
-                                "data-testid": "action-listen",
-                                "Listen"
-                            }
-                        }
-                    }
-                }
+                FormatSwitcher { formats: b.formats.clone() }
 
                 if !b.subjects.is_empty() {
                     ul { class: "tag-list",

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -59,10 +59,11 @@ test("renders the detail contents for the selected book", async ({ page, request
   await expect(switcher).toBeVisible();
 
   // All fixture books are EPUB; the EPUB row must exist with its badge and
-  // the per-format CTAs grouped underneath.
-  const epubRow = switcher.locator('[data-format="EPUB"]');
+  // the per-format CTAs grouped underneath. Use getByTestId rather than CSS
+  // attribute/class locators per `04-playwright.md` ("semantic first").
+  const epubRow = switcher.getByTestId("format-row-epub");
   await expect(epubRow).toBeVisible();
-  await expect(epubRow.locator(".format-badge")).toHaveText("EPUB");
+  await expect(epubRow.getByTestId("format-badge")).toHaveText("EPUB");
 
   // Read + Send-to-Kindle are scoped inside the EPUB row and stay disabled
   // until F2.2 (reader) and F4.x (kindle) ship.

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -54,8 +54,27 @@ test("renders the detail contents for the selected book", async ({ page, request
     page.getByRole("navigation", { name: "breadcrumb" }).getByRole("link", { name: "Home" }),
   ).toBeVisible();
 
-  // All fixture books are EPUB — "Read" CTA must be rendered
-  await expect(page.getByTestId("action-read")).toBeVisible();
+  // Format switcher renders one row per available format (F1.4).
+  const switcher = page.getByTestId("format-switcher");
+  await expect(switcher).toBeVisible();
+
+  // All fixture books are EPUB; the EPUB row must exist with its badge and
+  // the per-format CTAs grouped underneath.
+  const epubRow = switcher.locator('[data-format="EPUB"]');
+  await expect(epubRow).toBeVisible();
+  await expect(epubRow.locator(".format-badge")).toHaveText("EPUB");
+
+  // Read + Send-to-Kindle are scoped inside the EPUB row and stay disabled
+  // until F2.2 (reader) and F4.x (kindle) ship.
+  const readBtn = epubRow.getByTestId("action-read");
+  await expect(readBtn).toBeVisible();
+  await expect(readBtn).toBeDisabled();
+  const kindleBtn = epubRow.getByTestId("action-kindle");
+  await expect(kindleBtn).toBeVisible();
+  await expect(kindleBtn).toBeDisabled();
+
+  // No M4B fixture in the seed — the Listen CTA must NOT render.
+  await expect(page.getByTestId("action-listen")).toHaveCount(0);
 
   // F3.2 / F3.3 placeholder slots must be in the DOM (may be invisible)
   await expect(page.getByTestId("ratings-slot")).toBeAttached();


### PR DESCRIPTION
## Summary

Knocks out the two open technical considerations from [docs/roadmap/1-4-book-detail.md](docs/roadmap/1-4-book-detail.md):

- **One query per book load.** [`db::queries::get_book`](db/src/queries.rs) was doing 1 main SELECT + 7 helper loads. Rewritten to a single statement that uses scalar subqueries for the single-valued joins (publisher / language / series / primary file) and `GROUP_CONCAT` over ordered inner selects for the multi-valued lists (creators, subjects, identifiers, formats). A two-level separator scheme (`0x1F` between records, `0x1E` between fields in a record) lets pairs like `(name, sort)` and `(scheme, value)` round-trip without colliding with punctuation in real titles.
- **Format switcher as the UI for the `books` / `book_files` split.** Pulled the inline per-format CTAs out of `book_detail.rs` into a new `FormatSwitcher` component at [frontend/src/components/format_switcher.rs](frontend/src/components/format_switcher.rs). It renders one row per available format (alphabetical, dedup'd case-insensitively), each with its own badge and the relevant actions grouped underneath — so a work with both EPUB and M4B surfaces both rows. Read / Listen / Send-to-Kindle stay disabled (their dependencies — F2.2 reader, F2.3 player, F4.x kindle — haven't shipped).

Ratings (F3.2) and Suggestions (F3.3) placeholder slots stay as-is; the breadcrumb already uses author/series relations.

## Test plan

- [x] `cargo test -p omnibus-db` — 139 pass, includes new `get_book_handles_book_with_no_relations` regression test for the empty-aggregates path
- [x] `cargo test -p omnibus-frontend --features server` — 26 pass, includes 4 new tests covering `FormatSwitcher` row prep (alphabetical sort, case-insensitive dedup, unknown-format preservation, empty input)
- [x] `cargo test -p omnibus` — 61 pass
- [x] `cargo clippy` clean, `cargo fmt --check` clean
- [ ] Playwright `flows/book_detail.spec.ts` — extended with format-switcher assertions; not run locally this round due to a port-routing conflict on my dev machine. Spec change is small + additive (asserts the new `data-testid="format-switcher"` and the EPUB row contents); CI will run it on the PR.

## Notes

- `load_creators` / `load_subjects` / `load_identifiers` helpers are kept — they still have other callers in `list_books` / `search`.
- No new fixtures: the single-format EPUB fixtures already cover the happy path. Multi-format coverage would need an audiobook generator analogous to `make_epub.ts` — out of scope here.
- No reader / player / kindle wiring; those land with their own initiatives.