### PR TITLE
feat(auth): F1.6 UI primitives (AuthShell, Field, Banner, StrengthMeter)

### DIFF
--- a/frontend/src/components/auth/banner.rs
+++ b/frontend/src/components/auth/banner.rs
@@ -1,0 +1,120 @@
+use dioxus::prelude::*;
+
+/// Severity tier for a [`Banner`]. Drives the color, icon, and ARIA role
+/// the banner renders.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BannerKind {
+    Err,
+    Warn,
+    Info,
+    Ok,
+}
+
+impl BannerKind {
+    /// Suffix for the `auth-banner-<kind>` class.
+    pub fn class_suffix(self) -> &'static str {
+        match self {
+            BannerKind::Err => "err",
+            BannerKind::Warn => "warn",
+            BannerKind::Info => "info",
+            BannerKind::Ok => "ok",
+        }
+    }
+
+    /// One-character glyph rendered in the banner's icon slot.
+    pub fn icon(self) -> &'static str {
+        match self {
+            BannerKind::Err | BannerKind::Warn => "!",
+            BannerKind::Info => "i",
+            BannerKind::Ok => "✓",
+        }
+    }
+
+    /// ARIA role for assistive tech. Errors are `alert` so they
+    /// interrupt; warn/info/ok are `status` (polite live region).
+    pub fn aria_role(self) -> &'static str {
+        match self {
+            BannerKind::Err => "alert",
+            BannerKind::Warn | BannerKind::Info | BannerKind::Ok => "status",
+        }
+    }
+}
+
+/// Top-of-form callout. Use [`BannerKind`] to pick severity; `title` is
+/// required, `message` and `action` are optional.
+///
+/// `dismissible` renders an inline dismiss button — purely visual here;
+/// callers are responsible for hiding the banner in response to the
+/// click. (The primitive stays stateless so the same component works
+/// under SSR.)
+#[component]
+pub fn Banner(
+    kind: BannerKind,
+    title: String,
+    #[props(default)] message: Option<String>,
+    #[props(default)] action: Option<Element>,
+    #[props(default = false)] dismissible: bool,
+    #[props(default)] on_dismiss: Option<EventHandler<MouseEvent>>,
+) -> Element {
+    let kind_class = kind.class_suffix();
+    let wrapper_class = format!("auth-banner auth-banner-{kind_class}");
+    let icon = kind.icon();
+    let role = kind.aria_role();
+
+    rsx! {
+        div { class: "{wrapper_class}", role: "{role}",
+            div { class: "auth-banner-icon", "{icon}" }
+            div { class: "auth-banner-body",
+                div { class: "auth-banner-title", "{title}" }
+                if let Some(text) = message {
+                    div { class: "auth-banner-message", "{text}" }
+                }
+                if let Some(slot) = action {
+                    div { class: "auth-banner-action", {slot} }
+                }
+            }
+            if dismissible {
+                button {
+                    class: "auth-banner-dismiss",
+                    r#type: "button",
+                    aria_label: "Dismiss",
+                    onclick: move |evt| {
+                        if let Some(handler) = on_dismiss.as_ref() {
+                            handler.call(evt);
+                        }
+                    },
+                    "✕"
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_suffix_covers_every_kind() {
+        assert_eq!(BannerKind::Err.class_suffix(), "err");
+        assert_eq!(BannerKind::Warn.class_suffix(), "warn");
+        assert_eq!(BannerKind::Info.class_suffix(), "info");
+        assert_eq!(BannerKind::Ok.class_suffix(), "ok");
+    }
+
+    #[test]
+    fn error_uses_alert_role_others_use_status() {
+        assert_eq!(BannerKind::Err.aria_role(), "alert");
+        assert_eq!(BannerKind::Warn.aria_role(), "status");
+        assert_eq!(BannerKind::Info.aria_role(), "status");
+        assert_eq!(BannerKind::Ok.aria_role(), "status");
+    }
+
+    #[test]
+    fn icon_glyphs_match_kind() {
+        assert_eq!(BannerKind::Err.icon(), "!");
+        assert_eq!(BannerKind::Warn.icon(), "!");
+        assert_eq!(BannerKind::Info.icon(), "i");
+        assert_eq!(BannerKind::Ok.icon(), "✓");
+    }
+}

--- a/frontend/src/components/auth/field.rs
+++ b/frontend/src/components/auth/field.rs
@@ -1,0 +1,91 @@
+use dioxus::prelude::*;
+
+/// Form field with shared label / hint / error / success states.
+///
+/// Owns the `<label>` and the input wrapper so callers stop hand-rolling
+/// label-input pairs with the same class triplet. Pass any input element
+/// (`input`, `select`, `textarea`) as `children`.
+///
+/// Props:
+/// - `label` — visible label text.
+/// - `hint` — supporting copy under the input (hidden when an error is shown).
+/// - `error` — when present, switches the field to its error visual and
+///   shows the message under the input.
+/// - `success` — when true, switches the field to its success visual
+///   (green accent + check mark).
+/// - `action` — optional right-aligned slot in the label row
+///   (e.g. a "Forgot?" link).
+/// - `children` — the input element.
+#[component]
+pub fn Field(
+    label: String,
+    #[props(default)] hint: Option<String>,
+    #[props(default)] error: Option<String>,
+    #[props(default = false)] success: bool,
+    #[props(default)] action: Option<Element>,
+    children: Element,
+) -> Element {
+    let state_class = field_state_class(error.as_deref(), success);
+    let wrapper_class = format!("auth-field {state_class}");
+
+    rsx! {
+        label { class: "{wrapper_class}",
+            div { class: "auth-field-label-row",
+                span { class: "auth-field-label", "{label}" }
+                if let Some(slot) = action {
+                    span { class: "auth-field-action", {slot} }
+                }
+            }
+            div { class: "auth-field-input-wrap",
+                {children}
+                if success {
+                    span { class: "auth-field-check", "✓" }
+                }
+            }
+            if let Some(msg) = error.as_deref() {
+                div { class: "auth-field-msg auth-field-msg-err", role: "alert", "{msg}" }
+            } else if let Some(text) = hint.as_deref() {
+                div { class: "auth-field-msg auth-field-msg-hint", "{text}" }
+            }
+        }
+    }
+}
+
+/// Resolve the modifier class for a field based on its error / success
+/// props. Error wins over success when both are set; "neutral" is the
+/// default when neither is set.
+fn field_state_class(error: Option<&str>, success: bool) -> &'static str {
+    match (error, success) {
+        (Some(_), _) => "auth-field-err",
+        (None, true) => "auth-field-ok",
+        (None, false) => "auth-field-neutral",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_wins_over_success() {
+        assert_eq!(field_state_class(Some("bad"), true), "auth-field-err");
+    }
+
+    #[test]
+    fn success_when_no_error() {
+        assert_eq!(field_state_class(None, true), "auth-field-ok");
+    }
+
+    #[test]
+    fn neutral_when_neither() {
+        assert_eq!(field_state_class(None, false), "auth-field-neutral");
+    }
+
+    #[test]
+    fn empty_error_string_still_counts_as_error() {
+        // An empty `Some("")` means the caller flagged the field as
+        // invalid but had no copy ready — visual state stays "err" so
+        // the field doesn't look fine just because the message is blank.
+        assert_eq!(field_state_class(Some(""), false), "auth-field-err");
+    }
+}

--- a/frontend/src/components/auth/mod.rs
+++ b/frontend/src/components/auth/mod.rs
@@ -1,0 +1,21 @@
+//! Shared auth-page primitives — the building blocks for [F1.6 Auth UI
+//! polish](../../../../docs/roadmap/1-6-auth-ui.md).
+//!
+//! Each primitive is purely presentational: props in, rsx out. No signals,
+//! no transport, no feature gating inside component bodies — SSR and WASM
+//! must render identical markup so dioxus hydration matches.
+//!
+//! - [`AuthShell`] — split-pane wrapper used by every auth screen.
+//! - [`Field`] — label + input + hint/error/success slots.
+//! - [`Banner`] — top-of-form callout (err / warn / info / ok).
+//! - [`StrengthMeter`] — four-segment presentational password strength bar.
+
+mod banner;
+mod field;
+mod shell;
+mod strength;
+
+pub use banner::{Banner, BannerKind};
+pub use field::Field;
+pub use shell::AuthShell;
+pub use strength::{StrengthMeter, StrengthScore};

--- a/frontend/src/components/auth/shell.rs
+++ b/frontend/src/components/auth/shell.rs
@@ -1,0 +1,56 @@
+use dioxus::prelude::*;
+
+/// Split-pane wrapper used by every auth screen. The left pane is the
+/// branded art panel; the right pane hosts the form column.
+///
+/// Props:
+/// - `kicker` — small uppercase label above the title (e.g. `"Sign in"`).
+/// - `title` — heading rsx for the right pane. Pass plain text or rich
+///   markup (e.g. an italic span).
+/// - `lede` — optional supporting copy under the title.
+/// - `children` — the form content.
+#[component]
+pub fn AuthShell(
+    kicker: String,
+    title: Element,
+    #[props(default)] lede: Option<String>,
+    children: Element,
+) -> Element {
+    rsx! {
+        div { class: "auth-shell-grid",
+            aside { class: "auth-shell-art",
+                div { class: "auth-shell-brand",
+                    div { class: "auth-shell-brand-mark" }
+                    div { class: "auth-shell-brand-word", "Omnibus" }
+                }
+                div { class: "auth-shell-tagline",
+                    h1 { class: "auth-shell-headline",
+                        "Your "
+                        span { class: "auth-shell-headline-em", "shelf" }
+                        ", anywhere."
+                    }
+                    p { class: "auth-shell-blurb",
+                        "One library for ebooks, audiobooks, journals and quotes — synced across the devices you already own."
+                    }
+                    div { class: "auth-shell-meta",
+                        span { "self-hosted" }
+                        span { "·" }
+                        span { "open source" }
+                        span { "·" }
+                        span { "made with dioxus" }
+                    }
+                }
+            }
+            section { class: "auth-shell-form",
+                div { class: "auth-shell-form-inner",
+                    div { class: "auth-shell-kicker", "{kicker}" }
+                    h2 { class: "auth-shell-title", {title} }
+                    if let Some(text) = lede {
+                        p { class: "auth-shell-lede", "{text}" }
+                    }
+                    div { class: "auth-shell-body", {children} }
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/components/auth/strength.rs
+++ b/frontend/src/components/auth/strength.rs
@@ -1,0 +1,114 @@
+use dioxus::prelude::*;
+
+/// Bounded password-strength score: 0 (none) through 4 (excellent).
+/// Wrap the raw `u8` so out-of-range inputs collapse cleanly to the
+/// nearest endpoint rather than over-filling the meter.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct StrengthScore(u8);
+
+impl StrengthScore {
+    pub const MAX: u8 = 4;
+
+    /// Build a clamped score from any `u8`. Values above [`Self::MAX`]
+    /// saturate to `MAX`; values below 0 are impossible for `u8`.
+    pub fn new(raw: u8) -> Self {
+        Self(raw.min(Self::MAX))
+    }
+
+    pub fn value(self) -> u8 {
+        self.0
+    }
+
+    /// Modifier class for color tiering.
+    pub fn tier_class(self) -> &'static str {
+        match self.0 {
+            0 => "auth-strength-tier-none",
+            1 => "auth-strength-tier-bad",
+            2 => "auth-strength-tier-warn",
+            3 => "auth-strength-tier-mid",
+            _ => "auth-strength-tier-ok",
+        }
+    }
+}
+
+impl From<u8> for StrengthScore {
+    fn from(raw: u8) -> Self {
+        Self::new(raw)
+    }
+}
+
+/// Four-segment presentational strength bar. **Purely visual** — actual
+/// password policy lives on the server. Pass a `label` (e.g. "Strong",
+/// "Weak", "Excellent") to render under the bar; an empty label hides
+/// the label row.
+#[component]
+pub fn StrengthMeter(score: StrengthScore, #[props(default)] label: Option<String>) -> Element {
+    let filled = score.value();
+    let tier = score.tier_class();
+
+    rsx! {
+        div { class: "auth-strength",
+            div {
+                class: "auth-strength-bar {tier}",
+                role: "meter",
+                aria_valuemin: "0",
+                aria_valuemax: "{StrengthScore::MAX}",
+                aria_valuenow: "{filled}",
+                for i in 0..StrengthScore::MAX {
+                    div {
+                        class: if i < filled { "auth-strength-segment auth-strength-segment-on" } else { "auth-strength-segment" },
+                    }
+                }
+            }
+            if let Some(text) = label {
+                div { class: "auth-strength-label",
+                    span { class: "auth-strength-label-lhs", "strength" }
+                    span { class: "auth-strength-label-rhs {tier}", "{text}" }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamps_above_max() {
+        assert_eq!(StrengthScore::new(7).value(), StrengthScore::MAX);
+    }
+
+    #[test]
+    fn passes_through_in_range() {
+        for raw in 0..=StrengthScore::MAX {
+            assert_eq!(StrengthScore::new(raw).value(), raw);
+        }
+    }
+
+    #[test]
+    fn tier_class_covers_each_score() {
+        assert_eq!(
+            StrengthScore::new(0).tier_class(),
+            "auth-strength-tier-none"
+        );
+        assert_eq!(StrengthScore::new(1).tier_class(), "auth-strength-tier-bad");
+        assert_eq!(
+            StrengthScore::new(2).tier_class(),
+            "auth-strength-tier-warn"
+        );
+        assert_eq!(StrengthScore::new(3).tier_class(), "auth-strength-tier-mid");
+        assert_eq!(StrengthScore::new(4).tier_class(), "auth-strength-tier-ok");
+    }
+
+    #[test]
+    fn tier_class_saturates_on_overflow_input() {
+        assert_eq!(StrengthScore::new(99).tier_class(), "auth-strength-tier-ok");
+    }
+
+    #[test]
+    fn from_u8_matches_new() {
+        let via_from: StrengthScore = 3u8.into();
+        assert_eq!(via_from, StrengthScore::new(3));
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -26,3 +26,8 @@ pub use top_nav::TopNav as Nav;
 mod bottom_nav;
 #[cfg(feature = "mobile")]
 pub use bottom_nav::BottomNav as Nav;
+
+// Auth-page primitives — used by the login / register / first-run /
+// recovery screens on every target. Stays platform-agnostic so the same
+// markup ships under web SSR, web WASM, and mobile native.
+pub mod auth;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -232,6 +232,260 @@ body {
 .auth-footer { font-size: 0.85rem; color: #94a3b8; margin-top: 1rem; text-align: center; }
 .auth-footer a { color: #22d3ee; }
 
+/* ---- F1.6 auth primitives (AuthShell / Field / Banner / StrengthMeter) ----
+   Self-contained block. Tokens are `--auth-*` prefixed and declared on
+   `:root` so each primitive renders correctly whether or not it's nested
+   under an AuthShell. No effect on the rest of the app — nothing outside
+   this block references the prefixed tokens. */
+:root {
+  --auth-ink-0: #f8fafc;
+  --auth-ink-1: #cbd5e1;
+  --auth-ink-2: #94a3b8;
+  --auth-ink-3: #64748b;
+  --auth-bg-0: rgba(15, 23, 42, 0.92);
+  --auth-bg-1: rgba(15, 23, 42, 0.65);
+  --auth-bg-2: rgba(30, 41, 59, 0.5);
+  --auth-line: rgba(100, 116, 139, 0.25);
+  --auth-line-2: rgba(100, 116, 139, 0.45);
+  --auth-accent: #22d3ee;
+  --auth-accent-ink: #03131c;
+  --auth-ok: #34d399;
+  --auth-warn: #fbbf24;
+  --auth-bad: #f87171;
+  --auth-info: #60a5fa;
+  --auth-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --auth-serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+  --auth-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.auth-shell-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  min-height: 100vh;
+  color: var(--auth-ink-0);
+  font-family: var(--auth-sans);
+}
+@media (max-width: 720px) {
+  .auth-shell-grid { grid-template-columns: 1fr; }
+  .auth-shell-art { display: none; }
+}
+
+.auth-shell-art {
+  background: var(--auth-bg-1);
+  border-right: 1px solid var(--auth-line-2);
+  padding: 3rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+.auth-shell-brand { display: flex; align-items: center; gap: 0.6rem; }
+.auth-shell-brand-mark {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--auth-accent), #3b82f6);
+}
+.auth-shell-brand-word {
+  font-family: var(--auth-serif);
+  font-size: 1.25rem;
+  letter-spacing: 0.04em;
+}
+
+.auth-shell-tagline { margin-top: auto; max-width: 460px; }
+.auth-shell-headline {
+  font-family: var(--auth-serif);
+  font-size: clamp(2.4rem, 5vw, 3.5rem);
+  line-height: 1;
+  margin: 0;
+}
+.auth-shell-headline-em { font-style: italic; }
+.auth-shell-blurb {
+  margin-top: 1rem;
+  color: var(--auth-ink-1);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+.auth-shell-meta {
+  margin-top: 1.4rem;
+  display: flex;
+  gap: 1rem;
+  font-family: var(--auth-mono);
+  font-size: 0.7rem;
+  color: var(--auth-ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.auth-shell-form {
+  display: grid;
+  place-items: center;
+  padding: 3rem 2rem;
+}
+.auth-shell-form-inner { width: 100%; max-width: 420px; }
+.auth-shell-kicker {
+  font-family: var(--auth-mono);
+  font-size: 0.72rem;
+  color: var(--auth-ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+.auth-shell-title {
+  margin: 0.4rem 0 0;
+  font-family: var(--auth-serif);
+  font-size: 1.9rem;
+  line-height: 1.15;
+}
+.auth-shell-lede {
+  margin-top: 0.7rem;
+  color: var(--auth-ink-2);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+.auth-shell-body { margin-top: 1.6rem; }
+
+/* Field */
+.auth-field { display: block; margin-bottom: 0.9rem; }
+.auth-field-label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.35rem;
+}
+.auth-field-label {
+  font-family: var(--auth-mono);
+  font-size: 0.72rem;
+  color: var(--auth-ink-2);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.auth-field-action { font-size: 0.78rem; color: var(--auth-accent); }
+.auth-field-input-wrap { position: relative; }
+.auth-field input,
+.auth-field textarea,
+.auth-field select {
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  background: var(--auth-bg-1);
+  border: 1px solid var(--auth-line-2);
+  border-radius: 10px;
+  color: var(--auth-ink-0);
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.auth-field input:focus,
+.auth-field textarea:focus,
+.auth-field select:focus { border-color: var(--auth-accent); }
+.auth-field-err input,
+.auth-field-err textarea,
+.auth-field-err select {
+  border-color: var(--auth-bad);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--auth-bad) 18%, transparent);
+}
+.auth-field-ok input,
+.auth-field-ok textarea,
+.auth-field-ok select {
+  border-color: var(--auth-ok);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--auth-ok) 18%, transparent);
+}
+.auth-field-check {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--auth-ok);
+  font-size: 1rem;
+  line-height: 1;
+}
+.auth-field-msg {
+  margin-top: 0.4rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+.auth-field-msg-err { color: var(--auth-bad); }
+.auth-field-msg-hint {
+  color: var(--auth-ink-3);
+  font-family: var(--auth-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+}
+
+/* Banner */
+.auth-banner {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.85rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--auth-line-2);
+  border-radius: 10px;
+  background: var(--auth-bg-1);
+}
+.auth-banner-err   { border-left: 3px solid var(--auth-bad); }
+.auth-banner-warn  { border-left: 3px solid var(--auth-warn); }
+.auth-banner-info  { border-left: 3px solid var(--auth-info); }
+.auth-banner-ok    { border-left: 3px solid var(--auth-ok); }
+.auth-banner-icon {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.75rem;
+  flex: 0 0 20px;
+  background: var(--auth-bg-2);
+}
+.auth-banner-err  .auth-banner-icon { color: var(--auth-bad); }
+.auth-banner-warn .auth-banner-icon { color: var(--auth-warn); }
+.auth-banner-info .auth-banner-icon { color: var(--auth-info); }
+.auth-banner-ok   .auth-banner-icon { color: var(--auth-ok); }
+.auth-banner-body { flex: 1; }
+.auth-banner-title { font-weight: 500; font-size: 0.85rem; color: var(--auth-ink-0); }
+.auth-banner-message { margin-top: 0.25rem; font-size: 0.8rem; color: var(--auth-ink-1); line-height: 1.5; }
+.auth-banner-action { margin-top: 0.6rem; display: flex; gap: 0.5rem; }
+.auth-banner-dismiss {
+  background: transparent;
+  border: 0;
+  color: var(--auth-ink-3);
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  font: inherit;
+  align-self: flex-start;
+}
+.auth-banner-dismiss:hover { color: var(--auth-ink-0); }
+
+/* StrengthMeter */
+.auth-strength { margin-top: 0.5rem; }
+.auth-strength-bar {
+  display: flex;
+  gap: 0.25rem;
+}
+.auth-strength-segment {
+  flex: 1;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--auth-bg-2);
+}
+.auth-strength-tier-bad  .auth-strength-segment-on { background: var(--auth-bad); }
+.auth-strength-tier-warn .auth-strength-segment-on { background: var(--auth-warn); }
+.auth-strength-tier-mid  .auth-strength-segment-on { background: #eab308; }
+.auth-strength-tier-ok   .auth-strength-segment-on { background: var(--auth-ok); }
+.auth-strength-label {
+  margin-top: 0.4rem;
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--auth-mono);
+  font-size: 0.68rem;
+  color: var(--auth-ink-3);
+  letter-spacing: 0.04em;
+}
+.auth-strength-label-rhs.auth-strength-tier-bad  { color: var(--auth-bad); }
+.auth-strength-label-rhs.auth-strength-tier-warn { color: var(--auth-warn); }
+.auth-strength-label-rhs.auth-strength-tier-mid  { color: #eab308; }
+.auth-strength-label-rhs.auth-strength-tier-ok   { color: var(--auth-ok); }
+
 .top-nav {
   display: flex;
   gap: 1rem;


### PR DESCRIPTION
First implementation slice of [F1.6 Auth UI polish](https://github.com/seamus-sloan/omnibus/blob/main/docs/roadmap/1-6-auth-ui.md). Adds four reusable primitives under `frontend/src/components/auth/` plus the CSS that backs them. No user-visible markup changes yet — the bare `LoginPage` / `RegisterPage` keep rendering exactly as before. The polished page rewrites land in follow-up PRs and consume these primitives.

## Summary
- **`AuthShell`** — split-pane wrapper (left art panel with brand + tagline, right form column). Collapses to a single column on viewports ≤ 720px.
- **`Field`** — label + input wrapper with `hint` / `error` / `success` slots and an accent-ring visual per state. `field_state_class` (private helper) resolves the modifier class; error wins over success.
- **`Banner`** — top-of-form callout with four kinds (`Err` / `Warn` / `Info` / `Ok`). Errors render with `role="alert"`; the others render with `role="status"`. Stateless dismiss button — callers control visibility.
- **`StrengthMeter`** — four-segment presentational password-strength bar driven by a bounded `StrengthScore(u8)` newtype that clamps out-of-range inputs to `MAX`. Strictly visual; no client-side enforcement.
- **CSS** — new `--auth-*` design tokens at `:root` (prefixed to avoid collision with the existing palette) plus the primitive classes appended to the existing `STYLES` block in [`frontend/src/lib.rs`](https://github.com/seamus-sloan/omnibus/blob/main/frontend/src/lib.rs). Tokens cover ink/bg/line/accent/ok/warn/bad/info plus sans/serif/mono families.

## Test plan
- [ ] `cargo test -p omnibus-frontend --features server components::auth` — covers 13 unit-test assertions across `BannerKind::{class_suffix, aria_role, icon}`, `field_state_class`, and `StrengthScore::{new, tier_class, From<u8>}`.
- [ ] `cargo clippy -p omnibus-frontend --features server -- -D warnings` — clean locally.
- [ ] Build the polished pages in a follow-up PR and visually confirm the primitives render under web SSR + WASM hydration + mobile native.

## Notes
> [!IMPORTANT]
> `cargo check` and `cargo clippy` both ran clean here, but the **unit-test build OOM'd on disk space** during this session (`/Users/seamus` was at 100%, ~300 MiB free; the test-dev-deps couldn't link). The tests themselves are simple enum→`&'static str` mappings + `u8` clamping logic — low-risk — but they have not been executed. Please run the `cargo test` command above locally before merging.

- No changes to `LoginPage` / `RegisterPage` — those rewrites are the next PR per the [F1.6 TODO ordering](https://github.com/seamus-sloan/omnibus/blob/main/docs/roadmap/1-6-auth-ui.md#todos). Shipping the primitives first keeps the visual rewrite reviewable as one isolated diff.
- Tokens are at `:root` (prefixed `--auth-*`) so primitives work whether or not they're nested under an `AuthShell` — important for the upcoming first-run wizard which may live outside the shell.