### PR TITLE
feat(auth): F1.6 polished login & register pages

### DIFF
--- a/frontend/src/components/auth/shell.rs
+++ b/frontend/src/components/auth/shell.rs
@@ -1,5 +1,62 @@
 use dioxus::prelude::*;
 
+/// One decorative book spine rendered behind the tagline. Pre-login pages
+/// can't query book metadata (the user isn't authenticated), so the spine
+/// row uses a static curated palette.
+struct Spine {
+    title: &'static str,
+    accent: &'static str,
+    ink: &'static str,
+}
+
+const SPINES: &[Spine] = &[
+    Spine {
+        title: "Piranesi",
+        accent: "oklch(0.66 0.13 245)",
+        ink: "#f6f7fb",
+    },
+    Spine {
+        title: "Pachinko",
+        accent: "oklch(0.70 0.13 95)",
+        ink: "#221d10",
+    },
+    Spine {
+        title: "The Overstory",
+        accent: "oklch(0.55 0.11 145)",
+        ink: "#f3f6ee",
+    },
+    Spine {
+        title: "Sea of Tranquility",
+        accent: "oklch(0.74 0.08 220)",
+        ink: "#0e1a22",
+    },
+    Spine {
+        title: "Babel",
+        accent: "oklch(0.55 0.14 35)",
+        ink: "#fbf2eb",
+    },
+    Spine {
+        title: "Hyperion",
+        accent: "oklch(0.45 0.15 295)",
+        ink: "#f0eaf6",
+    },
+    Spine {
+        title: "Klara and the Sun",
+        accent: "oklch(0.78 0.09 75)",
+        ink: "#2a1e0e",
+    },
+    Spine {
+        title: "Tomorrow, and Tomorrow",
+        accent: "oklch(0.55 0.12 165)",
+        ink: "#eaf6f1",
+    },
+    Spine {
+        title: "Demon Copperhead",
+        accent: "oklch(0.60 0.14 30)",
+        ink: "#fbece2",
+    },
+];
+
 /// Split-pane wrapper used by every auth screen. The left pane is the
 /// branded art panel; the right pane hosts the form column.
 ///
@@ -22,6 +79,15 @@ pub fn AuthShell(
                 div { class: "auth-shell-brand",
                     div { class: "auth-shell-brand-mark" }
                     div { class: "auth-shell-brand-word", "Omnibus" }
+                }
+                div { class: "auth-shell-spines", aria_hidden: "true",
+                    for (i, spine) in SPINES.iter().enumerate() {
+                        div {
+                            class: "auth-shell-spine auth-shell-spine-{i}",
+                            style: "background: {spine.accent}; color: {spine.ink};",
+                            div { class: "auth-shell-spine-title", "{spine.title}" }
+                        }
+                    }
                 }
                 div { class: "auth-shell-tagline",
                     h1 { class: "auth-shell-headline",

--- a/frontend/src/components/auth/shell.rs
+++ b/frontend/src/components/auth/shell.rs
@@ -1,59 +1,40 @@
 use dioxus::prelude::*;
 
-/// One decorative book spine rendered behind the tagline. Pre-login pages
-/// can't query book metadata (the user isn't authenticated), so the spine
-/// row uses a static curated palette.
+/// One decorative book rendered on the shelf above the tagline. Pre-login
+/// pages can't query book metadata (the user isn't authenticated), so the
+/// shelf uses a static curated palette of accent colors. Heights / widths
+/// vary per slot in CSS for the staggered shelf look.
 struct Spine {
-    title: &'static str,
     accent: &'static str,
-    ink: &'static str,
 }
 
 const SPINES: &[Spine] = &[
     Spine {
-        title: "Piranesi",
         accent: "oklch(0.66 0.13 245)",
-        ink: "#f6f7fb",
     },
     Spine {
-        title: "Pachinko",
         accent: "oklch(0.70 0.13 95)",
-        ink: "#221d10",
     },
     Spine {
-        title: "The Overstory",
         accent: "oklch(0.55 0.11 145)",
-        ink: "#f3f6ee",
     },
     Spine {
-        title: "Sea of Tranquility",
         accent: "oklch(0.74 0.08 220)",
-        ink: "#0e1a22",
     },
     Spine {
-        title: "Babel",
         accent: "oklch(0.55 0.14 35)",
-        ink: "#fbf2eb",
     },
     Spine {
-        title: "Hyperion",
         accent: "oklch(0.45 0.15 295)",
-        ink: "#f0eaf6",
     },
     Spine {
-        title: "Klara and the Sun",
         accent: "oklch(0.78 0.09 75)",
-        ink: "#2a1e0e",
     },
     Spine {
-        title: "Tomorrow, and Tomorrow",
         accent: "oklch(0.55 0.12 165)",
-        ink: "#eaf6f1",
     },
     Spine {
-        title: "Demon Copperhead",
         accent: "oklch(0.60 0.14 30)",
-        ink: "#fbece2",
     },
 ];
 
@@ -80,14 +61,17 @@ pub fn AuthShell(
                     div { class: "auth-shell-brand-mark" }
                     div { class: "auth-shell-brand-word", "Omnibus" }
                 }
-                div { class: "auth-shell-spines", aria_hidden: "true",
-                    for (i, spine) in SPINES.iter().enumerate() {
-                        div {
-                            class: "auth-shell-spine auth-shell-spine-{i}",
-                            style: "background: {spine.accent}; color: {spine.ink};",
-                            div { class: "auth-shell-spine-title", "{spine.title}" }
+                div { class: "auth-shell-shelf", aria_hidden: "true",
+                    div { class: "auth-shell-spines",
+                        for (i, spine) in SPINES.iter().enumerate() {
+                            div {
+                                class: "auth-shell-spine auth-shell-spine-{i}",
+                                style: "background: {spine.accent};",
+                                span { class: "auth-shell-spine-dot" }
+                            }
                         }
                     }
+                    div { class: "auth-shell-shelf-plank" }
                 }
                 div { class: "auth-shell-tagline",
                     h1 { class: "auth-shell-headline",

--- a/frontend/src/components/auth/strength.rs
+++ b/frontend/src/components/auth/strength.rs
@@ -51,6 +51,7 @@ pub fn StrengthMeter(score: StrengthScore, #[props(default)] label: Option<Strin
             div {
                 class: "auth-strength-bar {tier}",
                 role: "meter",
+                aria_label: "Password strength",
                 aria_valuemin: "0",
                 aria_valuemax: "{StrengthScore::MAX}",
                 aria_valuenow: "{filled}",

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -61,25 +61,18 @@ pub fn BookDetail(id: i64) -> Element {
 }
 
 /// Route target for `/login` — credential entry form. Rendered without the
-/// main screen chrome so the login flow stands alone.
+/// main screen chrome so the login flow stands alone. `LoginPage` owns its
+/// own full-page chrome via [`crate::components::auth::AuthShell`].
 #[component]
 pub fn Login() -> Element {
-    rsx! {
-        div { class: "auth-shell",
-            LoginPage {}
-        }
-    }
+    rsx! { LoginPage {} }
 }
 
 /// Route target for `/register` — account-creation form. Same chrome as
 /// [`Login`] so the two pages feel like one flow.
 #[component]
 pub fn Register() -> Element {
-    rsx! {
-        div { class: "auth-shell",
-            RegisterPage {}
-        }
-    }
+    rsx! { RegisterPage {} }
 }
 
 /// Platform-specific page chrome. Web puts nav at the top of the flow;
@@ -274,10 +267,6 @@ body {
   color: var(--auth-ink-0);
   font-family: var(--auth-sans);
 }
-@media (max-width: 720px) {
-  .auth-shell-grid { grid-template-columns: 1fr; }
-  .auth-shell-art { display: none; }
-}
 
 .auth-shell-art {
   background: var(--auth-bg-1);
@@ -287,6 +276,14 @@ body {
   flex-direction: column;
   position: relative;
   overflow: hidden;
+}
+
+/* Mobile collapse: hides the art panel below 720px. Placed *after* the
+   base .auth-shell-art rule so the cascade-by-source-order picks
+   `display: none` instead of the base `display: flex`. */
+@media (max-width: 720px) {
+  .auth-shell-grid { grid-template-columns: 1fr; }
+  .auth-shell-art { display: none; }
 }
 .auth-shell-brand { display: flex; align-items: center; gap: 0.6rem; }
 .auth-shell-brand-mark {
@@ -494,6 +491,83 @@ body {
 .auth-strength-label-rhs.auth-strength-tier-warn { color: var(--auth-warn); }
 .auth-strength-label-rhs.auth-strength-tier-mid  { color: #eab308; }
 .auth-strength-label-rhs.auth-strength-tier-ok   { color: var(--auth-ok); }
+
+/* Page-level adornments consumed by LoginPage / RegisterPage on top of the
+   F1.6 primitives. Stays in the auth-* namespace so a future move to a
+   dedicated stylesheet is grep-friendly. */
+.auth-form-inner { display: block; }
+.auth-submit {
+  width: 100%;
+  justify-content: center;
+  margin-top: 0.4rem;
+}
+.auth-field-action-link {
+  color: var(--auth-accent);
+  font-size: 0.78rem;
+  text-decoration: none;
+}
+.auth-field-action-link:hover { text-decoration: underline; }
+
+.auth-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0.4rem 0 0.8rem;
+  font-size: 0.85rem;
+  color: var(--auth-ink-1);
+  cursor: pointer;
+}
+.auth-checkbox-block { align-items: flex-start; line-height: 1.5; }
+.auth-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  accent-color: var(--auth-accent);
+  margin-top: 1px;
+}
+
+.auth-requirements {
+  margin-top: 0.9rem;
+  padding: 0.7rem 0.85rem;
+  background: var(--auth-bg-2);
+  border: 1px solid var(--auth-line-2);
+  border-radius: 10px;
+}
+.auth-requirements-title {
+  font-family: var(--auth-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--auth-ink-2);
+  margin-bottom: 0.5rem;
+}
+.auth-req {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--auth-ink-2);
+  padding: 0.15rem 0;
+}
+.auth-req-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--auth-ink-3);
+  flex: 0 0 6px;
+}
+.auth-req.ok { color: var(--auth-ink-0); }
+.auth-req.ok .auth-req-dot { background: var(--auth-ok); }
+.auth-req.bad .auth-req-dot { background: var(--auth-bad); }
+
+.auth-footer-note {
+  margin-top: 1.1rem;
+  text-align: center;
+  font-family: var(--auth-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  color: var(--auth-ink-3);
+}
 
 .top-nav {
   display: flex;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -314,8 +314,8 @@ body {
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  gap: 0.4rem;
-  min-height: 320px;
+  gap: 0.55rem;
+  min-height: 360px;
 }
 .auth-shell-spine {
   position: relative;
@@ -323,6 +323,7 @@ body {
   align-items: center;
   justify-content: center;
   border-radius: 2px 2px 0 0;
+  transform-origin: bottom center;
   /* board edge: subtle spine highlight + shadow + drop shadow on the shelf */
   box-shadow:
     inset 1px 0 0 rgba(255, 255, 255, 0.14),
@@ -330,26 +331,49 @@ body {
     inset 0 -8px 12px -8px rgba(0, 0, 0, 0.45),
     0 6px 8px -4px rgba(0, 0, 0, 0.55);
 }
-/* Varied widths (28–52px) and heights (250–340px) — gives the random
-   library look while staying deterministic across SSR/WASM/native. */
+/* Two horizontal binding bands per spine — the dark strips that wrap
+   around the spine of a real bound book. Positioned near top and
+   bottom so the centerfield stays clean for the optional dot motif. */
+.auth-shell-spine::before,
+.auth-shell-spine::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: rgba(0, 0, 0, 0.32);
+  pointer-events: none;
+}
+.auth-shell-spine::before { top: 10%; }
+.auth-shell-spine::after  { bottom: 10%; }
+/* Varied widths (28–52px) and heights (250–340px). A few spines tilt
+   slightly so the shelf reads "casual library" rather than "soldiers
+   on parade." Tilts stay subtle (≤2°) so the binding bands stay
+   readable. */
 .auth-shell-spine-0 { width: 36px; height: 280px; }
 .auth-shell-spine-1 { width: 44px; height: 320px; }
-.auth-shell-spine-2 { width: 28px; height: 240px; }
+.auth-shell-spine-2 { width: 28px; height: 240px; transform: rotate(-1.8deg); }
 .auth-shell-spine-3 { width: 50px; height: 340px; }
 .auth-shell-spine-4 { width: 40px; height: 300px; }
-.auth-shell-spine-5 { width: 32px; height: 260px; }
+.auth-shell-spine-5 { width: 32px; height: 260px; transform: rotate(1.5deg); }
 .auth-shell-spine-6 { width: 46px; height: 310px; }
-.auth-shell-spine-7 { width: 36px; height: 280px; }
+.auth-shell-spine-7 { width: 36px; height: 280px; transform: rotate(-1.1deg); }
 .auth-shell-spine-8 { width: 42px; height: 290px; }
-/* Small motif circle on each spine — outlined dot using currentColor
-   with reduced opacity so it picks up the book's accent ink subtly. */
+/* Small motif circle — only on a curated subset (spines 1, 3, 6) so
+   the shelf doesn't read as "every book has the same sticker." */
 .auth-shell-spine-dot {
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  border: 1.5px solid rgba(0, 0, 0, 0.35);
+  border: 1.5px solid rgba(0, 0, 0, 0.4);
   background: transparent;
-  opacity: 0.7;
+  opacity: 0.75;
+  display: none;
+}
+.auth-shell-spine-1 .auth-shell-spine-dot,
+.auth-shell-spine-3 .auth-shell-spine-dot,
+.auth-shell-spine-6 .auth-shell-spine-dot {
+  display: block;
 }
 /* Wooden plank under the books — warm brown gradient with a darker
    shadow line below to suggest a real shelf. */

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -299,7 +299,55 @@ body {
   letter-spacing: 0.04em;
 }
 
-.auth-shell-tagline { margin-top: auto; max-width: 460px; }
+/* Decorative book-spine row. Absolutely positioned so the tagline below
+   can stack on top via z-index. Inline `background`/`color` set per
+   spine; height/rotation patterns live here so the markup stays clean. */
+.auth-shell-spines {
+  position: absolute;
+  left: 3.5rem; right: 3.5rem; bottom: 3.5rem; top: 6rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-end;
+  pointer-events: none;
+  opacity: 0.92;
+  z-index: 1;
+}
+.auth-shell-spine {
+  flex: 1 1 0;
+  min-width: 0;
+  border-radius: 2px;
+  box-shadow:
+    inset 1px 0 0 rgba(255, 255, 255, 0.12),
+    inset -1px 0 0 rgba(0, 0, 0, 0.25),
+    0 16px 30px -20px rgba(0, 0, 0, 0.7);
+  overflow: hidden;
+}
+/* Heights cycle every 4, rotations every 5, vertical offset every 3 —
+   gives the "casually leaned against each other" look without random
+   per-render churn. */
+.auth-shell-spine-0 { height: 230px; transform: rotate(-4deg)   translateY(0); }
+.auth-shell-spine-1 { height: 274px; transform: rotate(-2.3deg) translateY(8px); }
+.auth-shell-spine-2 { height: 318px; transform: rotate(-0.6deg) translateY(16px); }
+.auth-shell-spine-3 { height: 362px; transform: rotate(1.1deg)  translateY(0); }
+.auth-shell-spine-4 { height: 230px; transform: rotate(2.8deg)  translateY(8px); }
+.auth-shell-spine-5 { height: 274px; transform: rotate(-4deg)   translateY(16px); }
+.auth-shell-spine-6 { height: 318px; transform: rotate(-2.3deg) translateY(0); }
+.auth-shell-spine-7 { height: 362px; transform: rotate(-0.6deg) translateY(8px); }
+.auth-shell-spine-8 { height: 230px; transform: rotate(1.1deg)  translateY(16px); }
+.auth-shell-spine-title {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  padding: 0.9rem 0;
+  font-family: var(--auth-serif);
+  font-size: 0.8rem;
+  font-style: italic;
+  text-align: center;
+  height: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.auth-shell-tagline { margin-top: auto; max-width: 460px; position: relative; z-index: 2; }
 .auth-shell-headline {
   font-family: var(--auth-serif);
   font-size: clamp(2.4rem, 5vw, 3.5rem);

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -222,17 +222,18 @@ body {
   padding: 1.5rem 1rem 5rem;
 }
 
-.auth-shell {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 1rem;
-}
-.auth-card { width: 100%; max-width: 380px; }
-.auth-form { display: flex; flex-direction: column; gap: 1rem; margin-top: 1rem; }
 .auth-footer { font-size: 0.85rem; color: #94a3b8; margin-top: 1rem; text-align: center; }
 .auth-footer a { color: #22d3ee; }
+
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 
 /* ---- F1.6 auth primitives (AuthShell / Field / Banner / StrengthMeter) ----
    Self-contained block. Tokens are `--auth-*` prefixed and declared on
@@ -558,7 +559,6 @@ body {
 }
 .auth-req.ok { color: var(--auth-ink-0); }
 .auth-req.ok .auth-req-dot { background: var(--auth-ok); }
-.auth-req.bad .auth-req-dot { background: var(--auth-bad); }
 
 .auth-footer-note {
   margin-top: 1.1rem;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -299,52 +299,72 @@ body {
   letter-spacing: 0.04em;
 }
 
-/* Decorative book-spine row. Absolutely positioned so the tagline below
-   can stack on top via z-index. Inline `background`/`color` set per
-   spine; height/rotation patterns live here so the markup stays clean. */
-.auth-shell-spines {
+/* Decorative bookshelf: a row of upright books standing on a wooden
+   plank. Anchored to the top of the art panel so the tagline below sits
+   on its own ground line. Books are pure block elements (no rotation)
+   with varied widths/heights to mimic the casual library look. Each
+   spine has a small decorative dot rendered via a child span. */
+.auth-shell-shelf {
   position: absolute;
-  left: 3.5rem; right: 3.5rem; bottom: 3.5rem; top: 6rem;
-  display: flex;
-  gap: 0.5rem;
-  align-items: flex-end;
+  left: 3.5rem; right: 3.5rem; top: 6rem;
   pointer-events: none;
-  opacity: 0.92;
   z-index: 1;
 }
-.auth-shell-spine {
-  flex: 1 1 0;
-  min-width: 0;
-  border-radius: 2px;
-  box-shadow:
-    inset 1px 0 0 rgba(255, 255, 255, 0.12),
-    inset -1px 0 0 rgba(0, 0, 0, 0.25),
-    0 16px 30px -20px rgba(0, 0, 0, 0.7);
-  overflow: hidden;
+.auth-shell-spines {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 0.4rem;
+  min-height: 320px;
 }
-/* Heights cycle every 4, rotations every 5, vertical offset every 3 —
-   gives the "casually leaned against each other" look without random
-   per-render churn. */
-.auth-shell-spine-0 { height: 230px; transform: rotate(-4deg)   translateY(0); }
-.auth-shell-spine-1 { height: 274px; transform: rotate(-2.3deg) translateY(8px); }
-.auth-shell-spine-2 { height: 318px; transform: rotate(-0.6deg) translateY(16px); }
-.auth-shell-spine-3 { height: 362px; transform: rotate(1.1deg)  translateY(0); }
-.auth-shell-spine-4 { height: 230px; transform: rotate(2.8deg)  translateY(8px); }
-.auth-shell-spine-5 { height: 274px; transform: rotate(-4deg)   translateY(16px); }
-.auth-shell-spine-6 { height: 318px; transform: rotate(-2.3deg) translateY(0); }
-.auth-shell-spine-7 { height: 362px; transform: rotate(-0.6deg) translateY(8px); }
-.auth-shell-spine-8 { height: 230px; transform: rotate(1.1deg)  translateY(16px); }
-.auth-shell-spine-title {
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
-  padding: 0.9rem 0;
-  font-family: var(--auth-serif);
-  font-size: 0.8rem;
-  font-style: italic;
-  text-align: center;
-  height: 100%;
-  white-space: nowrap;
-  overflow: hidden;
+.auth-shell-spine {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px 2px 0 0;
+  /* board edge: subtle spine highlight + shadow + drop shadow on the shelf */
+  box-shadow:
+    inset 1px 0 0 rgba(255, 255, 255, 0.14),
+    inset -1px 0 0 rgba(0, 0, 0, 0.28),
+    inset 0 -8px 12px -8px rgba(0, 0, 0, 0.45),
+    0 6px 8px -4px rgba(0, 0, 0, 0.55);
+}
+/* Varied widths (28–52px) and heights (250–340px) — gives the random
+   library look while staying deterministic across SSR/WASM/native. */
+.auth-shell-spine-0 { width: 36px; height: 280px; }
+.auth-shell-spine-1 { width: 44px; height: 320px; }
+.auth-shell-spine-2 { width: 28px; height: 240px; }
+.auth-shell-spine-3 { width: 50px; height: 340px; }
+.auth-shell-spine-4 { width: 40px; height: 300px; }
+.auth-shell-spine-5 { width: 32px; height: 260px; }
+.auth-shell-spine-6 { width: 46px; height: 310px; }
+.auth-shell-spine-7 { width: 36px; height: 280px; }
+.auth-shell-spine-8 { width: 42px; height: 290px; }
+/* Small motif circle on each spine — outlined dot using currentColor
+   with reduced opacity so it picks up the book's accent ink subtly. */
+.auth-shell-spine-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0, 0, 0, 0.35);
+  background: transparent;
+  opacity: 0.7;
+}
+/* Wooden plank under the books — warm brown gradient with a darker
+   shadow line below to suggest a real shelf. */
+.auth-shell-shelf-plank {
+  height: 14px;
+  margin-top: -2px;
+  border-radius: 2px;
+  background:
+    linear-gradient(180deg,
+      oklch(0.42 0.04 55) 0%,
+      oklch(0.34 0.04 55) 55%,
+      oklch(0.26 0.03 55) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 10px 16px -8px rgba(0, 0, 0, 0.7);
 }
 
 .auth-shell-tagline { margin-top: auto; max-width: 460px; position: relative; z-index: 2; }

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -38,8 +38,6 @@ pub fn LoginPage() -> Element {
     let mut password = use_signal(String::new);
     let mut error = use_signal(|| Option::<String>::None);
     let mut submitting = use_signal(|| false);
-    // Presentational only this PR; LoginRequest.session_ttl wiring is the
-    // documented follow-up (F1.6 roadmap, "Keep me signed in" bullet).
     let mut keep_signed_in = use_signal(|| false);
     let nav = use_navigator();
 
@@ -198,6 +196,8 @@ pub fn RegisterPage() -> Element {
         _ => None,
     });
     let has_error = err.is_some();
+    let username_invalid = username_err.is_some();
+    let password_invalid = password_err.is_some();
     let submit_label = if submitting() {
         "Creating…"
     } else if has_error {
@@ -232,6 +232,7 @@ pub fn RegisterPage() -> Element {
                         r#type: "text",
                         autocomplete: "username",
                         value: "{username}",
+                        aria_invalid: "{username_invalid}",
                         oninput: move |e| username.set(e.value()),
                     }
                 }
@@ -242,6 +243,7 @@ pub fn RegisterPage() -> Element {
                         r#type: "password",
                         autocomplete: "new-password",
                         value: "{password}",
+                        aria_invalid: "{password_invalid}",
                         oninput: move |e| password.set(e.value()),
                     }
                 }
@@ -283,10 +285,14 @@ pub fn RegisterPage() -> Element {
 #[component]
 fn PasswordRequirementRow(ok: bool, text: String) -> Element {
     let cls = if ok { "auth-req ok" } else { "auth-req" };
+    let status = if ok { "met" } else { "not met" };
     rsx! {
         div { class: "{cls}",
-            span { class: "auth-req-dot" }
+            span { class: "auth-req-dot", aria_hidden: "true" }
             span { "{text}" }
+            // Screen-reader-only status — the dot color alone isn't
+            // perceivable to assistive tech, so announce met/unmet.
+            span { class: "sr-only", ": {status}" }
         }
     }
 }

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -19,10 +19,17 @@
 //! * `server` — SSR never executes the submit closure (no interaction
 //!   happens during SSR), so this path is a compile-only stub returning a
 //!   static error.
+//!
+//! Polish ([F1.6](../../../../docs/roadmap/1-6-auth-ui.md)) wraps both
+//! pages in [`AuthShell`] and replaces the bare `settings-field` divs with
+//! the [`Field`] / [`Banner`] / [`StrengthMeter`] primitives from
+//! [`crate::components::auth`]. The visual layer is presentational only —
+//! server policy still owns password validation and session expiry.
 
 use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};
 
+use crate::components::auth::{AuthShell, Banner, BannerKind, Field, StrengthMeter, StrengthScore};
 use crate::{use_server_url, Route};
 
 #[component]
@@ -31,6 +38,9 @@ pub fn LoginPage() -> Element {
     let mut password = use_signal(String::new);
     let mut error = use_signal(|| Option::<String>::None);
     let mut submitting = use_signal(|| false);
+    // Presentational only this PR; LoginRequest.session_ttl wiring is the
+    // documented follow-up (F1.6 roadmap, "Keep me signed in" bullet).
+    let mut keep_signed_in = use_signal(|| false);
     let nav = use_navigator();
 
     // `use_server_url()` is feature-aware: empty string on web/server (where
@@ -61,14 +71,24 @@ pub fn LoginPage() -> Element {
     };
 
     rsx! {
-        div { class: "auth-card card",
-            h1 { "Log in" }
-            p { class: "subtitle", "Welcome back to Omnibus." }
-            form { class: "auth-form",
+        AuthShell {
+            kicker: "Sign in".to_string(),
+            title: rsx! {
+                "Welcome "
+                span { class: "auth-shell-headline-em", "back" }
+            },
+            lede: Some("Continue to your library.".to_string()),
+            form { class: "auth-form-inner",
                 onsubmit: on_submit,
                 "data-testid": "login-form",
-                div { class: "settings-field",
-                    label { r#for: "login-username", "Username" }
+                if let Some(msg) = error() {
+                    Banner {
+                        kind: BannerKind::Err,
+                        title: msg,
+                        dismissible: false,
+                    }
+                }
+                Field { label: "Username".to_string(),
                     input {
                         id: "login-username",
                         name: "username",
@@ -78,8 +98,18 @@ pub fn LoginPage() -> Element {
                         oninput: move |e| username.set(e.value()),
                     }
                 }
-                div { class: "settings-field",
-                    label { r#for: "login-password", "Password" }
+                Field {
+                    label: "Password".to_string(),
+                    // Stub: forgot-password page is P3-deferred (F5.4).
+                    // Routing it back to /login keeps the affordance
+                    // without dead routes.
+                    action: rsx! {
+                        Link {
+                            to: Route::Login {},
+                            class: "auth-field-action-link",
+                            "Forgot?"
+                        }
+                    },
                     input {
                         id: "login-password",
                         name: "password",
@@ -89,19 +119,28 @@ pub fn LoginPage() -> Element {
                         oninput: move |e| password.set(e.value()),
                     }
                 }
-                if let Some(msg) = error() {
-                    div { class: "error", role: "alert", "{msg}" }
+                label { class: "auth-checkbox",
+                    input {
+                        r#type: "checkbox",
+                        checked: keep_signed_in(),
+                        oninput: move |e| keep_signed_in.set(e.value() == "true"),
+                    }
+                    span { "Keep me signed in for 30 days" }
                 }
                 button {
-                    class: "btn",
+                    class: "btn primary lg auth-submit",
                     r#type: "submit",
                     disabled: submitting(),
                     if submitting() { "Logging in…" } else { "Log in" }
                 }
-            }
-            p { class: "auth-footer",
-                "No account? "
-                Link { to: Route::Register {}, "Register" }
+                p { class: "auth-footer",
+                    "No account? "
+                    Link { to: Route::Register {}, "Register" }
+                }
+                div { class: "auth-footer-note",
+                    "omnibus · v"
+                    {env!("CARGO_PKG_VERSION")}
+                }
             }
         }
     }
@@ -111,12 +150,11 @@ pub fn LoginPage() -> Element {
 pub fn RegisterPage() -> Element {
     let mut username = use_signal(String::new);
     let mut password = use_signal(String::new);
-    let mut error = use_signal(|| Option::<String>::None);
+    let mut error = use_signal(|| Option::<RegisterError>::None);
     let mut submitting = use_signal(|| false);
+    let mut terms_ack = use_signal(|| false);
     let nav = use_navigator();
 
-    // `use_server_url()` is feature-aware: empty string on web/server (where
-    // requests are same-origin) and the `ServerUrl` context value on mobile.
     let server_url = use_server_url();
 
     let on_submit = move |evt: FormEvent| {
@@ -124,7 +162,9 @@ pub fn RegisterPage() -> Element {
         let u = username();
         let p = password();
         if u.is_empty() || p.is_empty() {
-            error.set(Some("enter a username and password".into()));
+            error.set(Some(RegisterError::Other(
+                "enter a username and password".into(),
+            )));
             return;
         }
         error.set(None);
@@ -137,20 +177,55 @@ pub fn RegisterPage() -> Element {
                 Ok(()) => {
                     nav.replace(Route::Landing {});
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(classify_register_error(&e))),
             }
         });
     };
 
+    let pw = password();
+    let (score, score_label, rules) = score_password(&pw);
+    let err = error();
+    let username_err = err.as_ref().and_then(|e| match e {
+        RegisterError::Username(m) => Some(m.clone()),
+        _ => None,
+    });
+    let password_err = err.as_ref().and_then(|e| match e {
+        RegisterError::Password(m) => Some(m.clone()),
+        _ => None,
+    });
+    let other_err = err.as_ref().and_then(|e| match e {
+        RegisterError::Other(m) => Some(m.clone()),
+        _ => None,
+    });
+    let has_error = err.is_some();
+    let submit_label = if submitting() {
+        "Creating…"
+    } else if has_error {
+        "Fix to continue"
+    } else {
+        "Create account"
+    };
+
     rsx! {
-        div { class: "auth-card card",
-            h1 { "Create an account" }
-            p { class: "subtitle", "Register to start using Omnibus." }
-            form { class: "auth-form",
+        AuthShell {
+            kicker: "Create account".to_string(),
+            title: rsx! {
+                "Make "
+                span { class: "auth-shell-headline-em", "yourself" }
+                " at home"
+            },
+            lede: Some("Set up your account to start using Omnibus.".to_string()),
+            form { class: "auth-form-inner",
                 onsubmit: on_submit,
                 "data-testid": "register-form",
-                div { class: "settings-field",
-                    label { r#for: "register-username", "Username" }
+                if let Some(msg) = other_err {
+                    Banner {
+                        kind: BannerKind::Err,
+                        title: msg,
+                        dismissible: false,
+                    }
+                }
+                Field { label: "Username".to_string(), error: username_err,
                     input {
                         id: "register-username",
                         name: "username",
@@ -160,8 +235,7 @@ pub fn RegisterPage() -> Element {
                         oninput: move |e| username.set(e.value()),
                     }
                 }
-                div { class: "settings-field",
-                    label { r#for: "register-password", "Password" }
+                Field { label: "Password".to_string(), error: password_err,
                     input {
                         id: "register-password",
                         name: "password",
@@ -171,22 +245,115 @@ pub fn RegisterPage() -> Element {
                         oninput: move |e| password.set(e.value()),
                     }
                 }
-                if let Some(msg) = error() {
-                    div { class: "error", role: "alert", "{msg}" }
+                StrengthMeter {
+                    score: score,
+                    label: Some(score_label.to_string()),
+                }
+                div { class: "auth-requirements",
+                    div { class: "auth-requirements-title", "Password needs" }
+                    PasswordRequirementRow { ok: rules[0], text: "At least 12 characters" }
+                    PasswordRequirementRow { ok: rules[1], text: "Mixed case" }
+                    PasswordRequirementRow { ok: rules[2], text: "One number or symbol" }
+                }
+                label { class: "auth-checkbox auth-checkbox-block",
+                    input {
+                        r#type: "checkbox",
+                        checked: terms_ack(),
+                        oninput: move |e| terms_ack.set(e.value() == "true"),
+                    }
+                    span {
+                        "I understand that the server admin can see my reading list, ratings, journals on shared shelves, and audiobook play position."
+                    }
                 }
                 button {
-                    class: "btn",
+                    class: "btn primary lg auth-submit",
                     r#type: "submit",
                     disabled: submitting(),
-                    if submitting() { "Creating…" } else { "Create account" }
+                    "{submit_label}"
                 }
-            }
-            p { class: "auth-footer",
-                "Already have an account? "
-                Link { to: Route::Login {}, "Log in" }
+                p { class: "auth-footer",
+                    "Already have an account? "
+                    Link { to: Route::Login {}, "Log in" }
+                }
             }
         }
     }
+}
+
+#[component]
+fn PasswordRequirementRow(ok: bool, text: String) -> Element {
+    let cls = if ok { "auth-req ok" } else { "auth-req" };
+    rsx! {
+        div { class: "{cls}",
+            span { class: "auth-req-dot" }
+            span { "{text}" }
+        }
+    }
+}
+
+// ---- presentational helpers ---------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+enum RegisterError {
+    Username(String),
+    Password(String),
+    Other(String),
+}
+
+/// Classify a flat error string into a field bucket. Heuristic — keys on
+/// lowercase substring matches so trivial server-message wording changes
+/// don't strand the UI. New variants ride the `Other` fallback (renders as
+/// a top banner) rather than breaking field rendering.
+fn classify_register_error(raw: &str) -> RegisterError {
+    let lower = raw.to_lowercase();
+    if lower.contains("username") || lower.contains("user already") {
+        RegisterError::Username(raw.to_string())
+    } else if lower.contains("password") {
+        RegisterError::Password(raw.to_string())
+    } else {
+        RegisterError::Other(raw.to_string())
+    }
+}
+
+/// Presentational password scoring — server still enforces policy. Returns
+/// the meter score (0..=4), a short label, and the three checklist booleans
+/// (length≥12, mixed case, number-or-symbol) so the page renders both the
+/// meter and the requirements list from one pass.
+fn score_password(pw: &str) -> (StrengthScore, &'static str, [bool; 3]) {
+    let len = pw.chars().count();
+    let has_lower = pw.chars().any(|c| c.is_ascii_lowercase());
+    let has_upper = pw.chars().any(|c| c.is_ascii_uppercase());
+    let mixed_case = has_lower && has_upper;
+    let has_number_or_symbol = pw
+        .chars()
+        .any(|c| c.is_ascii_digit() || !c.is_alphanumeric());
+    let len_ok = len >= 12;
+
+    let mut raw: u8 = 0;
+    if len >= 4 {
+        raw = raw.saturating_add(1);
+    }
+    if len >= 8 {
+        raw = raw.saturating_add(1);
+    }
+    if mixed_case {
+        raw = raw.saturating_add(1);
+    }
+    if has_number_or_symbol {
+        raw = raw.saturating_add(1);
+    }
+    if len_ok {
+        raw = raw.saturating_add(1);
+    }
+    let score = StrengthScore::new(raw.min(StrengthScore::MAX));
+    let label = match score.value() {
+        0 => "empty",
+        1 => "weak",
+        2 => "fair",
+        3 => "good",
+        _ => "strong",
+    };
+    (score, label, [len_ok, mixed_case, has_number_or_symbol])
 }
 
 // ---- submit helpers ------------------------------------------------------
@@ -286,4 +453,61 @@ async fn submit_register(
     _password: String,
 ) -> Result<(), String> {
     Err("registration is only available in the web or mobile client".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn score_password_empty_is_zero() {
+        let (score, label, rules) = score_password("");
+        assert_eq!(score.value(), 0);
+        assert_eq!(label, "empty");
+        assert_eq!(rules, [false, false, false]);
+    }
+
+    #[test]
+    fn score_password_grows_with_length_and_classes() {
+        let (s, _, _) = score_password("abcd");
+        assert_eq!(s.value(), 1);
+        let (s, _, _) = score_password("AbCdEfGh");
+        assert_eq!(s.value(), 3);
+        let (s, label, rules) = score_password("AbCdEfGh1!2x");
+        assert_eq!(s.value(), 4);
+        assert_eq!(label, "strong");
+        assert_eq!(rules, [true, true, true]);
+    }
+
+    #[test]
+    fn score_password_rules_track_thresholds() {
+        let (_, _, rules) = score_password("Ab1");
+        assert_eq!(rules, [false, true, true]);
+        let (_, _, rules) = score_password("abcdefghijk1");
+        assert_eq!(rules, [true, false, true]);
+    }
+
+    #[test]
+    fn classify_register_error_routes_username() {
+        match classify_register_error("username already exists") {
+            RegisterError::Username(m) => assert_eq!(m, "username already exists"),
+            other => panic!("expected Username variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_register_error_routes_password() {
+        match classify_register_error("password is too short") {
+            RegisterError::Password(m) => assert_eq!(m, "password is too short"),
+            other => panic!("expected Password variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_register_error_falls_back_to_other() {
+        match classify_register_error("500: internal server error") {
+            RegisterError::Other(m) => assert_eq!(m, "500: internal server error"),
+            other => panic!("expected Other variant, got {other:?}"),
+        }
+    }
 }

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -233,7 +233,10 @@ pub fn RegisterPage() -> Element {
                         autocomplete: "username",
                         value: "{username}",
                         aria_invalid: "{username_invalid}",
-                        oninput: move |e| username.set(e.value()),
+                        oninput: move |e| {
+                            username.set(e.value());
+                            error.set(None);
+                        },
                     }
                 }
                 Field { label: "Password".to_string(), error: password_err,
@@ -244,7 +247,10 @@ pub fn RegisterPage() -> Element {
                         autocomplete: "new-password",
                         value: "{password}",
                         aria_invalid: "{password_invalid}",
-                        oninput: move |e| password.set(e.value()),
+                        oninput: move |e| {
+                            password.set(e.value());
+                            error.set(None);
+                        },
                     }
                 }
                 StrengthMeter {
@@ -270,7 +276,11 @@ pub fn RegisterPage() -> Element {
                 button {
                     class: "btn primary lg auth-submit",
                     r#type: "submit",
-                    disabled: submitting(),
+                    // Disable while submitting AND while a routed error is
+                    // shown — keeps users from immediately re-submitting
+                    // the same invalid form. Each input's `oninput` clears
+                    // the error signal so editing re-enables the button.
+                    disabled: submitting() || has_error,
                     "{submit_label}"
                 }
                 p { class: "auth-footer",
@@ -352,12 +362,17 @@ fn score_password(pw: &str) -> (StrengthScore, &'static str, [bool; 3]) {
         raw = raw.saturating_add(1);
     }
     let score = StrengthScore::new(raw.min(StrengthScore::MAX));
-    let label = match score.value() {
-        0 => "empty",
-        1 => "weak",
-        2 => "fair",
-        3 => "good",
-        _ => "strong",
+    // "empty" only when nothing was typed; a non-empty score-0 input
+    // (1–3 chars, no special chars) is still weak, not empty.
+    let label = if pw.is_empty() {
+        "empty"
+    } else {
+        match score.value() {
+            0 | 1 => "weak",
+            2 => "fair",
+            3 => "good",
+            _ => "strong",
+        }
     };
     (score, label, [len_ok, mixed_case, has_number_or_symbol])
 }
@@ -491,6 +506,31 @@ mod tests {
         assert_eq!(rules, [false, true, true]);
         let (_, _, rules) = score_password("abcdefghijk1");
         assert_eq!(rules, [true, false, true]);
+    }
+
+    #[test]
+    fn score_password_length_rule_boundary() {
+        // Right at the server-policy boundary (10 chars). 9-char inputs
+        // must report length-not-met; 10-char inputs must report met.
+        let (_, _, rules) = score_password("abcdefgh1");
+        assert!(!rules[0], "9-char input must not satisfy len_ok");
+        let (_, _, rules) = score_password("abcdefghi1");
+        assert!(rules[0], "10-char input must satisfy len_ok");
+        let (_, _, rules) = score_password("abcdefghij1");
+        assert!(rules[0], "11-char input must satisfy len_ok");
+    }
+
+    #[test]
+    fn score_password_label_distinguishes_empty_from_short() {
+        // Empty -> "empty"; any non-empty input -> at least "weak"
+        // (covers the 1–3 char range where score=0 but typed content
+        // exists, so the meter shouldn't lie about being empty).
+        let (_, label, _) = score_password("");
+        assert_eq!(label, "empty");
+        let (_, label, _) = score_password("a");
+        assert_eq!(label, "weak");
+        let (_, label, _) = score_password("ab");
+        assert_eq!(label, "weak");
     }
 
     #[test]

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -251,7 +251,7 @@ pub fn RegisterPage() -> Element {
                 }
                 div { class: "auth-requirements",
                     div { class: "auth-requirements-title", "Password needs" }
-                    PasswordRequirementRow { ok: rules[0], text: "At least 12 characters" }
+                    PasswordRequirementRow { ok: rules[0], text: "At least 10 characters" }
                     PasswordRequirementRow { ok: rules[1], text: "Mixed case" }
                     PasswordRequirementRow { ok: rules[2], text: "One number or symbol" }
                 }
@@ -315,10 +315,10 @@ fn classify_register_error(raw: &str) -> RegisterError {
     }
 }
 
-/// Presentational password scoring — server still enforces policy. Returns
-/// the meter score (0..=4), a short label, and the three checklist booleans
-/// (length≥12, mixed case, number-or-symbol) so the page renders both the
-/// meter and the requirements list from one pass.
+/// Presentational password scoring — server still enforces policy (10-char
+/// minimum). Returns the meter score (0..=4), a short label, and the three
+/// checklist booleans (length≥10, mixed case, number-or-symbol) so the
+/// page renders both the meter and the requirements list from one pass.
 fn score_password(pw: &str) -> (StrengthScore, &'static str, [bool; 3]) {
     let len = pw.chars().count();
     let has_lower = pw.chars().any(|c| c.is_ascii_lowercase());
@@ -327,7 +327,7 @@ fn score_password(pw: &str) -> (StrengthScore, &'static str, [bool; 3]) {
     let has_number_or_symbol = pw
         .chars()
         .any(|c| c.is_ascii_digit() || !c.is_alphanumeric());
-    let len_ok = len >= 12;
+    let len_ok = len >= 10;
 
     let mut raw: u8 = 0;
     if len >= 4 {

--- a/ui_tests/playwright/tests/flows/auth.spec.ts
+++ b/ui_tests/playwright/tests/flows/auth.spec.ts
@@ -29,7 +29,9 @@ test("renders the register page layout", async ({ page }) => {
     page.getByRole("heading", { level: 2, name: /Make yourself at home/i }),
   ).toBeVisible();
   await expect(page.getByLabel("Username")).toBeVisible();
-  await expect(page.getByLabel("Password")).toBeVisible();
+  // `exact: true` scopes to the input — the StrengthMeter carries
+  // `aria-label="Password strength"` which would otherwise also match.
+  await expect(page.getByLabel("Password", { exact: true })).toBeVisible();
   await expect(page.getByRole("meter")).toBeVisible();
   await expect(page.getByText("At least 10 characters")).toBeVisible();
   await expect(
@@ -97,8 +99,11 @@ test("register routes a password error to the password Field", async ({ page }) 
     });
   });
 
+  // `exact: true` scopes the password label to the input; the
+  // StrengthMeter's `aria-label="Password strength"` would otherwise
+  // make this a strict-mode violation.
   await page.getByLabel("Username").fill("new-user");
-  await page.getByLabel("Password").fill("short");
+  await page.getByLabel("Password", { exact: true }).fill("short");
 
   await expectMutation(
     page,
@@ -114,7 +119,7 @@ test("register routes a password error to the password Field", async ({ page }) 
   // Prove the routing: the password input flips to aria-invalid, and
   // the error message renders inside the password Field (not the
   // top-level Banner, which would also carry role=alert).
-  const passwordInput = page.getByLabel("Password");
+  const passwordInput = page.getByLabel("Password", { exact: true });
   await expect(passwordInput).toHaveAttribute("aria-invalid", "true");
   await expect(page.getByLabel("Username")).toHaveAttribute("aria-invalid", "false");
   const passwordField = passwordInput.locator("xpath=ancestor::label[contains(@class,'auth-field')]");

--- a/ui_tests/playwright/tests/flows/auth.spec.ts
+++ b/ui_tests/playwright/tests/flows/auth.spec.ts
@@ -10,7 +10,6 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test("renders the login page layout", async ({ page }) => {
   await gotoReady(page, "/login");
 
-  // F1.6 wraps the form in AuthShell — the form title is now an h2.
   await expect(
     page.getByRole("heading", { level: 2, name: /Welcome back/i }),
   ).toBeVisible();
@@ -31,9 +30,7 @@ test("renders the register page layout", async ({ page }) => {
   ).toBeVisible();
   await expect(page.getByLabel("Username")).toBeVisible();
   await expect(page.getByLabel("Password")).toBeVisible();
-  // StrengthMeter renders role=meter.
   await expect(page.getByRole("meter")).toBeVisible();
-  // One checklist row is enough — full coverage is overkill.
   await expect(page.getByText("At least 10 characters")).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Create account" }),
@@ -76,8 +73,6 @@ test("shows an error when login credentials are wrong", async ({ page }) => {
     async () => page.getByRole("button", { name: "Log in" }).click(),
   );
 
-  // F1.6 routes errors through the Banner primitive; BannerKind::Err
-  // renders role=alert and inherits the server's flat error string.
   await expect(page.getByRole("alert")).toContainText("invalid credentials");
   await expect(page).toHaveURL(/\/login$/);
 });
@@ -89,4 +84,35 @@ test("shows an error when submitting an empty form", async ({ page }) => {
   await page.getByRole("button", { name: "Log in" }).click();
 
   await expect(page.getByRole("alert")).toContainText(/username and password/i);
+});
+
+test("register routes a password error to the password Field", async ({ page }) => {
+  await page.goto("/register");
+
+  await page.route("**/api/auth/register", async (route) => {
+    await route.fulfill({
+      status: 400,
+      contentType: "text/plain",
+      body: "password is too short",
+    });
+  });
+
+  await page.getByLabel("Username").fill("new-user");
+  await page.getByLabel("Password").fill("short");
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/auth/register",
+      expectedStatus: 400,
+    },
+    async () =>
+      page.getByRole("button", { name: "Create account" }).click(),
+  );
+
+  await expect(page.getByRole("alert")).toContainText("password is too short");
+  await expect(
+    page.getByRole("button", { name: /fix to continue/i }),
+  ).toBeDisabled();
 });

--- a/ui_tests/playwright/tests/flows/auth.spec.ts
+++ b/ui_tests/playwright/tests/flows/auth.spec.ts
@@ -10,9 +10,15 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test("renders the login page layout", async ({ page }) => {
   await gotoReady(page, "/login");
 
-  await expect(page.getByRole("heading", { level: 1, name: "Log in" })).toBeVisible();
+  // F1.6 wraps the form in AuthShell — the form title is now an h2.
+  await expect(
+    page.getByRole("heading", { level: 2, name: /Welcome back/i }),
+  ).toBeVisible();
   await expect(page.getByLabel("Username")).toBeVisible();
   await expect(page.getByLabel("Password")).toBeVisible();
+  await expect(
+    page.getByLabel("Keep me signed in for 30 days"),
+  ).toBeVisible();
   await expect(page.getByRole("button", { name: "Log in" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Register" })).toBeVisible();
 });
@@ -21,11 +27,17 @@ test("renders the register page layout", async ({ page }) => {
   await page.goto("/register");
 
   await expect(
-    page.getByRole("heading", { level: 1, name: "Create an account" }),
+    page.getByRole("heading", { level: 2, name: /Make yourself at home/i }),
   ).toBeVisible();
   await expect(page.getByLabel("Username")).toBeVisible();
   await expect(page.getByLabel("Password")).toBeVisible();
-  await expect(page.getByRole("button", { name: "Create account" })).toBeVisible();
+  // StrengthMeter renders role=meter.
+  await expect(page.getByRole("meter")).toBeVisible();
+  // One checklist row is enough — full coverage is overkill.
+  await expect(page.getByText("At least 12 characters")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Create account" }),
+  ).toBeVisible();
   await expect(page.getByRole("link", { name: "Log in" })).toBeVisible();
 });
 
@@ -64,6 +76,8 @@ test("shows an error when login credentials are wrong", async ({ page }) => {
     async () => page.getByRole("button", { name: "Log in" }).click(),
   );
 
+  // F1.6 routes errors through the Banner primitive; BannerKind::Err
+  // renders role=alert and inherits the server's flat error string.
   await expect(page.getByRole("alert")).toContainText("invalid credentials");
   await expect(page).toHaveURL(/\/login$/);
 });

--- a/ui_tests/playwright/tests/flows/auth.spec.ts
+++ b/ui_tests/playwright/tests/flows/auth.spec.ts
@@ -87,7 +87,7 @@ test("shows an error when submitting an empty form", async ({ page }) => {
 });
 
 test("register routes a password error to the password Field", async ({ page }) => {
-  await page.goto("/register");
+  await gotoReady(page, "/register");
 
   await page.route("**/api/auth/register", async (route) => {
     await route.fulfill({
@@ -111,7 +111,14 @@ test("register routes a password error to the password Field", async ({ page }) 
       page.getByRole("button", { name: "Create account" }).click(),
   );
 
-  await expect(page.getByRole("alert")).toContainText("password is too short");
+  // Prove the routing: the password input flips to aria-invalid, and
+  // the error message renders inside the password Field (not the
+  // top-level Banner, which would also carry role=alert).
+  const passwordInput = page.getByLabel("Password");
+  await expect(passwordInput).toHaveAttribute("aria-invalid", "true");
+  await expect(page.getByLabel("Username")).toHaveAttribute("aria-invalid", "false");
+  const passwordField = passwordInput.locator("xpath=ancestor::label[contains(@class,'auth-field')]");
+  await expect(passwordField.getByRole("alert")).toContainText("password is too short");
   await expect(
     page.getByRole("button", { name: /fix to continue/i }),
   ).toBeDisabled();

--- a/ui_tests/playwright/tests/flows/auth.spec.ts
+++ b/ui_tests/playwright/tests/flows/auth.spec.ts
@@ -34,7 +34,7 @@ test("renders the register page layout", async ({ page }) => {
   // StrengthMeter renders role=meter.
   await expect(page.getByRole("meter")).toBeVisible();
   // One checklist row is enough — full coverage is overkill.
-  await expect(page.getByText("At least 12 characters")).toBeVisible();
+  await expect(page.getByText("At least 10 characters")).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Create account" }),
   ).toBeVisible();


### PR DESCRIPTION
Implements the polished login and register screens from [F1.6 Auth UI polish](https://github.com/seamus-sloan/omnibus/blob/main/docs/roadmap/1-6-auth-ui.md), consuming the primitives shipped in #67 and the design from #66.

## Summary
- **LoginPage** rewritten on `AuthShell` + `Field` + `Banner` — split-pane layout, kicker + serif title ("Welcome _back_"), `Forgot?` stub link (P3-deferred page), presentational **Keep me signed in for 30 days** checkbox, mono version footer. Existing semantic selectors (`getByLabel("Username"/"Password")`, `getByRole("button", { name: "Log in" })`, `getByRole("link", { name: "Register" })`, `getByRole("alert")`) all preserved; the form-level `data-testid="login-form"` stays.
- **RegisterPage** rewritten on the same shell + `StrengthMeter` + a 3-row password-needs checklist (length ≥ 10 — aligned with the server policy in `db/src/auth.rs` — mixed case, number-or-symbol; _no HIBP_, per roadmap) + a terms-acknowledgement checkbox (not gating submit, per design).
- **Per-field register errors** — new `RegisterError { Username, Password, Other }` classifier routes the flat server string to the right `Field.error` (or to a top `Banner` if it doesn't pattern-match). Submit-button label flips to "Fix to continue" and the button disables while an error is shown; each input's `oninput` clears the error so editing re-enables submit.
- **AuthShell art panel** — split-pane wrapper with the brand mark + 9 decorative upright books standing on a wooden shelf + tagline. Shelf uses a static curated palette (pre-login pages can't query book metadata); per-spine widths/heights vary deterministically via per-index CSS classes.
- **Accessibility** — `aria-invalid` on register Field inputs reflects the per-field error state; `StrengthMeter` carries `aria-label="Password strength"`; password-needs rows append an sr-only `: met` / `: not met` so the color dots aren't the sole signal; spine row marked `aria-hidden`.
- **Responsive collapse fix** — moved the `@media (max-width: 720px)` block *after* the base `.auth-shell-art` rule so the cascade actually picks `display: none` below 720px. Pre-existing source-order bug from #67 that stopped the art panel from hiding on narrow viewports.

## Test plan
- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test -p omnibus-frontend --features server pages::auth` — 8 / 8 pass (length-rule boundary at 9/10/11 chars + empty-vs-short label distinction included).
- [x] `cargo build -p omnibus-mobile` — clean (no `cfg(feature = "web")` leaked into the rewritten component bodies).
- [x] `npx playwright test auth.spec.ts` — passes against `dx serve --fullstack`.
- [x] Visual verification at desktop and ≤720px: login + register match the design canvas; art panel hides on narrow; strength meter + checklist update live; empty-form submit disables and surfaces the `Banner`; editing re-enables.

## Notes
- **Out of scope (deliberate, all per the F1.6 roadmap):**
  - `session_ttl` backend plumbing for the keep-signed-in checkbox — checkbox is presentational only this PR.
  - Structured `RegisterError` enum on the wire — the client-side classifier is a substring heuristic over the existing flat error string.
  - Server-unreachable banner (P2), first-run wizard (P2), forgot/reset/lockout/passkey/HIBP (P3 / deferred to F5.4).
- The `Forgot?` link routes back to `/login` until the recovery page lands (F5.4). Stub flagged in the code with a short comment.