### PR TITLE
feat(book-detail): render HTML in description with sanitization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ammonia"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+dependencies = [
+ "cssparser 0.35.0",
+ "html5ever 0.35.0",
+ "maplit",
+ "tendril",
+ "url",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +821,19 @@ dependencies = [
  "quote",
  "smallvec",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
 ]
 
 [[package]]
@@ -2579,8 +2605,19 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
- "match_token",
+ "markup5ever 0.14.1",
+ "match_token 0.1.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever 0.35.0",
+ "match_token 0.35.0",
 ]
 
 [[package]]
@@ -3041,8 +3078,8 @@ version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
  "indexmap",
  "selectors",
 ]
@@ -3291,6 +3328,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,10 +3348,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3738,6 +3803,7 @@ dependencies = [
 name = "omnibus-db"
 version = "0.1.0"
 dependencies = [
+ "ammonia",
  "anyhow",
  "argon2",
  "base64",
@@ -3943,7 +4009,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
  "proc-macro-hack",
 ]
@@ -3954,6 +4020,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -4019,6 +4086,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4780,7 +4860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
+ "cssparser 0.29.6",
  "derive_more 0.99.20",
  "fxhash",
  "log",
@@ -6335,6 +6415,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "webbrowser"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7089,7 +7181,7 @@ dependencies = [
  "dpi",
  "dunce",
  "gtk",
- "html5ever",
+ "html5ever 0.29.1",
  "http",
  "javascriptcore-rs",
  "jni 0.21.1",

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -39,5 +39,12 @@ base64 = "0.22"
 # compile times and binary size down.
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 
+# HTML sanitization for EPUB description fields (issue #62). OPF
+# `<dc:description>` is often HTML; we sanitize server-side with a strict
+# allowlist so the `book_detail` page can render it via `dangerous_inner_html`
+# without exposing XSS. Done at read time in `get_book` so existing rows in
+# the DB are sanitized without a reindex.
+ammonia = "4"
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -1104,7 +1104,7 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
         id: book_id,
         filename,
         title: r.get("title"),
-        description: r.get("description"),
+        description: sanitize_description(r.get("description")),
         publisher: r.get("publisher"),
         published: r.get("pubdate"),
         modified: r.get("last_modified"),
@@ -1144,6 +1144,26 @@ fn parse_json_array<T: serde::de::DeserializeOwned>(
     match blob {
         Some(s) => serde_json::from_str(&s).map_err(|e| sqlx::Error::Decode(Box::new(e))),
         None => Ok(Vec::new()),
+    }
+}
+
+/// Sanitize an EPUB `<dc:description>` payload for safe rendering via
+/// `dangerous_inner_html`. OPF descriptions are commonly HTML fragments
+/// (`<p>`, `<b>`, `<em>`, lists, links). We rely on ammonia's default
+/// allowlist: it strips `<script>`, event handlers, `javascript:` URLs,
+/// `<style>`, `<iframe>`, etc., while preserving inline formatting.
+///
+/// Applied at read time in `get_book` so existing DB rows benefit without a
+/// reindex. Empty/whitespace-only output collapses to `None` so the book
+/// detail page hides the description block entirely.
+fn sanitize_description(raw: Option<String>) -> Option<String> {
+    let raw = raw?;
+    let cleaned = ammonia::clean(&raw);
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
     }
 }
 
@@ -2883,5 +2903,77 @@ mod tests {
         assert_eq!(book.identifiers.len(), 1);
         assert_eq!(book.identifiers[0].value, nasty_value);
         assert_eq!(book.identifiers[0].scheme.as_deref(), Some("ISBN"));
+    }
+
+    #[test]
+    fn sanitize_description_preserves_safe_html() {
+        let cleaned = sanitize_description(Some(
+            "<p>Hello <strong>world</strong>!</p><p>Second <em>line</em>.</p>".into(),
+        ))
+        .unwrap();
+        assert!(cleaned.contains("<p>"));
+        assert!(cleaned.contains("<strong>world</strong>"));
+        assert!(cleaned.contains("<em>line</em>"));
+    }
+
+    #[test]
+    fn sanitize_description_strips_scripts_and_event_handlers() {
+        // ammonia's defaults must drop <script>, inline `onerror`, and
+        // `javascript:` URLs. Anything that could execute on the detail page
+        // when rendered via dangerous_inner_html is the threat model here.
+        let cleaned = sanitize_description(Some(
+            "<p>Safe</p><script>alert('xss')</script>\
+             <img src=x onerror=\"alert(1)\"/>\
+             <a href=\"javascript:alert(1)\">click</a>"
+                .into(),
+        ))
+        .unwrap();
+        assert!(!cleaned.contains("<script"));
+        assert!(!cleaned.to_ascii_lowercase().contains("onerror"));
+        assert!(!cleaned.to_ascii_lowercase().contains("javascript:"));
+        assert!(cleaned.contains("<p>Safe</p>"));
+    }
+
+    #[test]
+    fn sanitize_description_collapses_empty_input_to_none() {
+        assert_eq!(sanitize_description(None), None);
+        assert_eq!(sanitize_description(Some(String::new())), None);
+        assert_eq!(sanitize_description(Some("   \n\t".into())), None);
+        // A bare <script> with no other content sanitizes to "" and must
+        // collapse to None so the UI hides the description block entirely.
+        assert_eq!(
+            sanitize_description(Some("<script>alert(1)</script>".into())),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn get_book_returns_sanitized_html_description() {
+        let _covers = CoversTempDir::new("sanitize_desc");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let raw =
+            "<p>Brief.</p><script>alert('xss')</script><p>More <b>detail</b>.</p>".to_string();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![IndexedBook {
+                metadata: EbookMetadata {
+                    filename: "alpha.epub".into(),
+                    title: Some("Alpha".into()),
+                    description: Some(raw),
+                    ..Default::default()
+                },
+                cover: None,
+            }],
+        )
+        .await
+        .unwrap();
+        let id = list_books(&pool, "/lib").await.unwrap()[0].id;
+
+        let desc = get_book(&pool, id).await.unwrap().unwrap().description;
+        let desc = desc.expect("description should be present");
+        assert!(desc.contains("<p>Brief.</p>"));
+        assert!(desc.contains("<b>detail</b>"));
+        assert!(!desc.contains("<script"));
     }
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -951,6 +951,11 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .breadcrumb a { color: #22d3ee; text-decoration: none; }
 .breadcrumb a:hover { text-decoration: underline; }
 .book-detail-description { line-height: 1.6; color: rgba(255,255,255,.8); margin: .5rem 0 1rem; }
+.book-detail-description > :first-child { margin-top: 0; }
+.book-detail-description > :last-child { margin-bottom: 0; }
+.book-detail-description p { margin: 0 0 .75rem; }
+.book-detail-description ul, .book-detail-description ol { margin: 0 0 .75rem; padding-left: 1.25rem; }
+.book-detail-description a { color: #22d3ee; }
 .format-switcher {
   display: flex; flex-direction: column; gap: .4rem;
   margin: .75rem 0; padding: .5rem .75rem;

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -97,7 +97,18 @@ pub fn BookDetailPage(id: i64) -> Element {
                     p { class: "subtitle", "{s}" }
                 }
                 if let Some(desc) = &b.description {
-                    p { class: "book-detail-description", "{desc}" }
+                    // EPUB OPF descriptions are commonly HTML fragments. The
+                    // server sanitizes the payload in `omnibus_db::get_book`
+                    // via ammonia's default allowlist before it reaches us,
+                    // so `dangerous_inner_html` is safe here. A `<div>`
+                    // wraps the fragment because the sanitized HTML may
+                    // itself contain block-level tags (`<p>`, `<ul>`, …)
+                    // that aren't valid children of `<p>`.
+                    div {
+                        class: "book-detail-description",
+                        "data-testid": "book-description",
+                        dangerous_inner_html: "{desc}",
+                    }
                 }
 
                 FormatSwitcher { formats: b.formats.clone() }


### PR DESCRIPTION
## Summary

Closes #62.

EPUB OPF `<dc:description>` payloads are commonly HTML fragments (`<p>`, `<b>`, `<em>`, lists, links). Today the book detail page renders the description via plain-text interpolation, so users see the raw tags as text (`<p>` shown literally) instead of formatted prose. This PR renders the description as HTML while keeping it safe to display.

## Changes

- **`db/`**: new `ammonia` dep + `sanitize_description` helper in `queries.rs`. Sanitization runs at read time inside `get_book` using ammonia's default allowlist — strips `<script>`, inline event handlers, `javascript:` URLs, `<style>`, `<iframe>`, etc., while preserving inline-formatting tags. Doing it at read time means existing DB rows benefit without a reindex. Empty / whitespace-only output collapses to `None` so the description block hides entirely.
- **`frontend/`**: book detail page now renders the sanitized description via `dangerous_inner_html` inside a `<div>` (was a `<p>`, which can't legally contain block children like `<p>`/`<ul>`). The element exposes `data-testid="book-description"` for future Playwright coverage. Added scoped CSS so nested `<p>`, `<ul>`, `<a>` render with sensible margins and the existing link accent.

## Why server-side sanitization

The sanitizer lives in the DB layer rather than the rpc/REST boundary so it covers both transports (`/api/rpc/ebooks/:id` for web and `/api/ebooks/:id` for mobile) in one place, and doesn't bloat the WASM bundle (ammonia → html5ever). `dangerous_inner_html` is safe here because the client only ever receives already-sanitized HTML.

## Test plan

- [x] `cargo test -p omnibus-db` — 154 passing (4 new: safe HTML preserved, scripts/event-handlers/`javascript:` stripped, empty input → `None`, end-to-end `get_book_returns_sanitized_html_description`)
- [x] `cargo test -p omnibus` — 69 passing
- [x] `cargo test -p omnibus-frontend --features server` — 50 passing
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: visit a book whose EPUB has an HTML description (none of the committed Playwright fixtures carry one — `make_epub.ts` doesn't emit `<dc:description>` yet — so visual verification needs a real EPUB)

Playwright coverage for the new `data-testid="book-description"` selector is deferred to a follow-up that also extends `make_epub.ts` with a description field.


---
_Generated by [Claude Code](https://claude.ai/code/session_015CqgiMRWwUE2EAcG88Myki)_