### PR TITLE
fix(auth): drop Forgot? link out of the username→password tab path

### DIFF
--- a/frontend/src/components/auth/field.rs
+++ b/frontend/src/components/auth/field.rs
@@ -23,8 +23,12 @@ use dioxus::prelude::*;
 ///   shows the message under the input as `role="alert"`.
 /// - `success` — when true, switches the field to its success visual
 ///   (green accent + check mark).
-/// - `action` — optional right-aligned slot in the label row
-///   (e.g. a "Forgot?" link).
+/// - `action` — optional slot rendered visually at the top-right of the
+///   field (e.g. a "Forgot?" link). Lives **after** the input in DOM order
+///   and is positioned by CSS, so tabbing through the form goes
+///   label → input → action → next field rather than label → action →
+///   input (the latter pulls focus to the action between fields and traps
+///   typed characters that the user thought were going into the input).
 /// - `children` — the input element.
 #[component]
 pub fn Field(
@@ -48,15 +52,15 @@ pub fn Field(
         div { class: "{wrapper_class}", "data-testid": "{field_testid}",
             div { class: "auth-field-label-row",
                 label { class: "auth-field-label", r#for: "{input_id}", "{label}" }
-                if let Some(slot) = action {
-                    span { class: "auth-field-action", {slot} }
-                }
             }
             div { class: "auth-field-input-wrap",
                 {children}
                 if success {
                     span { class: "auth-field-check", "✓" }
                 }
+            }
+            if let Some(slot) = action {
+                span { class: "auth-field-action", {slot} }
             }
             if let Some(msg) = error.as_deref() {
                 div { class: "auth-field-msg auth-field-msg-err", role: "alert", "{msg}" }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -444,7 +444,12 @@ body {
 .auth-shell-body { margin-top: 1.6rem; }
 
 /* Field */
-.auth-field { display: block; margin-bottom: 0.9rem; }
+/* `position: relative` anchors the absolutely-positioned `.auth-field-action`
+   to the field box. The action slot lives after the input in DOM order
+   (see `components/auth/field.rs`) so tab order is label → input → action;
+   absolute positioning pulls it back to the visual top-right next to the
+   label. */
+.auth-field { display: block; margin-bottom: 0.9rem; position: relative; }
 .auth-field-label-row {
   display: flex;
   justify-content: space-between;
@@ -458,7 +463,15 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
-.auth-field-action { font-size: 0.78rem; color: var(--auth-accent); }
+.auth-field-action {
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-size: 0.78rem;
+  color: var(--auth-accent);
+  /* Baseline-align with the label row (0.72rem uppercase). */
+  line-height: 1;
+}
 .auth-field-input-wrap { position: relative; }
 .auth-field input,
 .auth-field textarea,

--- a/ui_tests/playwright/tests/flows/auth.spec.ts
+++ b/ui_tests/playwright/tests/flows/auth.spec.ts
@@ -88,6 +88,38 @@ test("shows an error when submitting an empty form", async ({ page }) => {
   await expect(page.getByRole("alert")).toContainText(/username and password/i);
 });
 
+test("tab from Username focuses Password (skipping the Forgot? link)", async ({ page }) => {
+  // The Forgot? link sits visually beside the Password label. It must
+  // not intercept the tab path between Username and Password — otherwise
+  // a user typing "name <Tab> password <Enter>" lands on the link with
+  // their typed password going nowhere, and Enter activates the link
+  // (re-navigates /login) instead of submitting.
+  await gotoReady(page, "/login");
+
+  await page.getByLabel("Username").focus();
+  await page.keyboard.press("Tab");
+  await expect(page.getByLabel("Password")).toBeFocused();
+});
+
+test("Enter from Password submits the login form", async ({ page }) => {
+  await gotoReady(page, "/login");
+
+  await page.getByLabel("Username").fill(TEST_USERNAME);
+  await page.getByLabel("Password").fill(TEST_PASSWORD);
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/auth/login",
+      expectedStatus: 200,
+    },
+    async () => page.getByLabel("Password").press("Enter"),
+  );
+
+  await expect(page).toHaveURL(/\/$/);
+});
+
 test("register routes a password error to the password Field", async ({ page }) => {
   await gotoReady(page, "/register");
 


### PR DESCRIPTION
## Summary
- The Forgot? action slot lived inside the Field's label row, so it rendered **before** the input in DOM order. Tab from Username landed on the Forgot? link instead of Password — keystrokes the user thought were filling Password went nowhere, and Enter then activated the link (re-navigating to `/login`) instead of submitting.
- Moved the action slot to render after the input wrap in `components/auth/field.rs` and absolute-positioned `.auth-field-action` back into the top-right of the field box, so the visual layout is unchanged.

## Test plan
- [x] `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (Field unit tests still pass)
- [x] `npx playwright test tests/flows/auth.spec.ts` — 8/8 pass, including two new keyboard specs:
  - `tab from Username focuses Password (skipping the Forgot? link)`
  - `Enter from Password submits the login form`
- [x] Eyeballed `/login` in the preview — Forgot? still sits at the top-right beside the PASSWORD label, same as before.

## Notes
- Pure DOM-order + CSS positioning change; the rendered visual is unchanged.