### PR TITLE
feat(book-detail): redesign to Atrium 'Cinematic' layout

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -350,14 +350,14 @@ body.atrium,
   font-size: 18px;
   color: var(--ink-1);
 }
-.author-link {
+.bd-author-link {
   color: var(--ink-0);
   border-bottom: 1px solid var(--line-2);
   position: relative;
   transition: border-color .15s;
 }
-.author-link:hover { border-bottom-color: var(--accent); }
-.author-link-hint {
+.bd-author-link:hover { border-bottom-color: var(--accent); }
+.bd-author-link-hint {
   font-size: 12px;
   color: var(--ink-3);
   border: 0;
@@ -366,7 +366,7 @@ body.atrium,
   margin-left: 4px;
   font-family: var(--mono);
 }
-.author-link:hover .author-link-hint { opacity: 1; }
+.bd-author-link:hover .bd-author-link-hint { opacity: 1; }
 
 .bd-desc {
   margin-top: 22px;

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -261,3 +261,276 @@ body.atrium,
   font-size: 14px; line-height: 1; padding: 0;
 }
 .theme-toggle:hover { border-color: var(--accent); color: var(--ink-0); }
+
+/* ── Book detail (Atrium "Cinematic" redesign) ─────────────────────
+ *
+ * Two-stage layout:
+ *   1. `.bd-hero`   — accent-tinted radial backdrop, 3-col hero
+ *                     (cover / title+ctas / rating-card).
+ *   2. `.bd-body-grid` — main column + sticky right rail.
+ *
+ * The hero accent picks up `--accent` set inline on `.bd-root` from
+ * `EbookMetadata.accent`. Falls back to the theme default when the
+ * book has no extracted accent.
+ */
+
+.bd-root { width: 100%; }
+
+/* Hero */
+.bd-hero {
+  position: relative;
+  padding: 36px clamp(20px, 4vw, 56px) 40px;
+  background:
+    radial-gradient(60% 100% at 18% 30%,
+      color-mix(in oklch, var(--accent) 28%, transparent),
+      transparent 65%),
+    var(--bg-0);
+}
+
+.bd-hero-grid {
+  display: grid;
+  grid-template-columns: 240px 1fr 280px;
+  gap: 44px;
+  align-items: flex-start;
+}
+@media (max-width: 1100px) {
+  .bd-hero-grid { grid-template-columns: 200px 1fr; }
+  .bd-rating-card { grid-column: 1 / -1; }
+}
+@media (max-width: 700px) {
+  .bd-hero-grid { grid-template-columns: 1fr; gap: 28px; }
+  .bd-cover-col { max-width: 220px; }
+}
+
+/* Breadcrumb */
+.bd-crumb {
+  display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  font-size: 12px; color: var(--ink-2); margin-bottom: 18px;
+}
+.bd-crumb a, .bd-crumb-home {
+  color: var(--ink-2);
+  border-bottom: 1px solid transparent;
+  transition: color .15s, border-color .15s;
+}
+.bd-crumb a:hover, .bd-crumb-home:hover {
+  color: var(--ink-0);
+  border-bottom-color: var(--line);
+}
+.bd-crumb-sep { color: var(--ink-3); }
+.bd-crumb-curr { color: var(--ink-0); }
+.bd-crumb-step { color: var(--ink-2); }
+
+/* Cover column */
+.bd-cover-col { display: block; }
+.bd-format-badges {
+  margin-top: 16px;
+  display: flex; gap: 6px; flex-wrap: wrap;
+}
+.bd-fmt-badge {
+  display: inline-flex; align-items: center;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--ink-1);
+  border: 1px solid var(--line-2); border-radius: 4px;
+  padding: 2px 6px;
+}
+
+/* Title column */
+.bd-title-col { min-width: 0; }
+.atrium .bd-title {
+  font-size: clamp(44px, 7vw, 76px);
+  line-height: 0.95;
+  font-style: italic;
+  margin-top: 10px;
+  font-family: var(--serif);
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+.bd-by {
+  margin-top: 12px;
+  font-size: 18px;
+  color: var(--ink-1);
+}
+.author-link {
+  color: var(--ink-0);
+  border-bottom: 1px solid var(--line-2);
+  position: relative;
+  transition: border-color .15s;
+}
+.author-link:hover { border-bottom-color: var(--accent); }
+.author-link-hint {
+  font-size: 12px;
+  color: var(--ink-3);
+  border: 0;
+  opacity: 0;
+  transition: opacity .15s;
+  margin-left: 4px;
+  font-family: var(--mono);
+}
+.author-link:hover .author-link-hint { opacity: 1; }
+
+.bd-desc {
+  margin-top: 22px;
+  font-size: 16px;
+  color: var(--ink-1);
+  line-height: 1.6;
+  max-width: 640px;
+}
+.bd-desc p + p { margin-top: 12px; }
+.bd-desc ul { margin: 12px 0 12px 18px; }
+.bd-desc em { font-style: italic; color: var(--ink-0); }
+.bd-desc strong { color: var(--ink-0); }
+
+.bd-cta-row {
+  display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+  margin-top: 26px;
+}
+.bd-cta-row .btn[disabled] { opacity: 0.65; cursor: not-allowed; }
+
+.bd-progress-meta { margin-top: 22px; max-width: 460px; }
+.bd-progress-line {
+  display: flex; justify-content: space-between;
+  font-size: 11px; color: var(--ink-2); margin-bottom: 6px;
+}
+
+.bd-tag-list {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  list-style: none; padding: 0; margin: 22px 0 0;
+}
+
+/* Rating + actions card */
+.bd-rating-card {
+  padding: 18px;
+  display: flex; flex-direction: column;
+}
+.bd-rating-card .divider { margin: 14px -18px; }
+.bd-rating-meta { font-size: 11px; color: var(--ink-3); margin-top: 6px; }
+.bd-stars-row { display: inline-flex; gap: 2px; font-size: 26px; line-height: 1; }
+.bd-star { color: var(--bg-3); }
+.bd-star-on { color: var(--accent); }
+.bd-action-head, .bd-shelves-head { margin-bottom: 8px; }
+.bd-actions {
+  display: flex; flex-direction: column; gap: 4px;
+}
+.bd-action-row {
+  display: flex; align-items: center; justify-content: space-between;
+  width: 100%; height: 36px; padding: 0 10px;
+  border-radius: 8px;
+}
+.bd-action-row-arrow { color: var(--ink-3); }
+.bd-shelves { display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* Body grid */
+.bd-body-grid {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 56px;
+  padding: 40px clamp(20px, 4vw, 56px) 80px;
+  align-items: flex-start;
+}
+@media (max-width: 1100px) {
+  .bd-body-grid { grid-template-columns: 1fr; gap: 32px; }
+}
+
+/* Body — main column */
+.bd-body-main { min-width: 0; }
+.bd-section-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  margin-bottom: 16px; gap: 24px;
+}
+.bd-section-kicker { margin-bottom: 6px; }
+.bd-section-title {
+  font-family: var(--serif);
+  font-size: 24px;
+  letter-spacing: -0.015em;
+  color: var(--ink-0);
+  margin: 0;
+}
+
+.bd-journal-empty {
+  padding: 22px 24px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.bd-stub-hint { font-size: 12px; color: var(--ink-3); }
+.bd-stub-strip {
+  padding: 22px 24px;
+  text-align: center;
+}
+
+/* Body — rail */
+.bd-rail {
+  display: flex; flex-direction: column; gap: 24px;
+  position: sticky; top: 80px; align-self: flex-start;
+}
+@media (max-width: 1100px) {
+  .bd-rail { position: static; }
+}
+.bd-rail-head { margin-bottom: 10px; }
+.bd-rail-body { font-size: 13px; color: var(--ink-1); line-height: 1.5; }
+.bd-rail-edit {
+  width: 100%; justify-content: center; margin-top: 12px;
+}
+
+/* File-details table */
+.bd-meta-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11.5px;
+  color: var(--ink-1);
+}
+.bd-meta-table .bd-meta-k {
+  color: var(--ink-3);
+  padding: 4px 8px 4px 0;
+  vertical-align: top;
+  width: 70px;
+}
+.bd-meta-table .bd-meta-v {
+  padding: 4px 0;
+  word-break: break-word;
+}
+
+/* Insights */
+.bd-insights-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+}
+.bd-insights-tag { font-size: 10px; color: var(--ink-3); }
+.bd-insights-grid {
+  margin-top: 10px;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 14px;
+}
+.bd-insight-label { font-size: 10px; color: var(--ink-3); }
+.bd-insight-value {
+  font-family: var(--serif);
+  font-size: 22px; line-height: 1;
+  margin-top: 4px;
+  color: var(--ink-0);
+}
+.bd-activity-bar {
+  display: flex; align-items: flex-end; gap: 3px; height: 36px;
+}
+.bd-activity-tick {
+  flex: 1; height: 6px;
+  background: var(--bg-3);
+  border-radius: 1px;
+  display: block;
+}
+.bd-activity-tick:nth-last-child(-n+4) { background: var(--accent); opacity: 0.55; }
+.bd-activity-axis {
+  display: flex; justify-content: space-between;
+  margin-top: 6px;
+  font-size: 9.5px; color: var(--ink-3); letter-spacing: 0.06em;
+}
+
+/* Footer affordance */
+.bd-footer {
+  padding: 0 clamp(20px, 4vw, 56px) 60px;
+  display: flex;
+}
+.bd-footer .btn {
+  background: transparent;
+  color: var(--ink-1);
+  border: 1px solid var(--line-2);
+  font-weight: 500;
+  font-size: 13px;
+}
+.bd-footer .btn:hover { background: var(--bg-1); color: var(--ink-0); }
+

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -1,8 +1,33 @@
+//! Book detail page — Atrium "Cinematic" redesign.
+//!
+//! Composes Atrium primitives ([`crate::components::atrium::Cover`], buttons,
+//! cards, chips, dividers) into the layout sketched in
+//! `screens/book-detail.jsx#DetailA` from the Omnibus design canvas:
+//!
+//! * **Hero** — accent-tinted radial backdrop, 240-px cover with format
+//!   badges, 76-px italic-serif title, author link, description, primary
+//!   CTAs, in-progress chip bar, tag chips, and a right-side "your rating"
+//!   action card.
+//! * **Body** — two-column grid with journal entries, highlights, and two
+//!   cover-fan rows on the left; a sticky rail on the right holding file
+//!   details (with the relocated [`crate::components::FormatSwitcher`]),
+//!   series/standalone info, and reading insights.
+//!
+//! Backend-supplied fields (title / authors / description / cover / formats
+//! / subjects / identifiers / publisher / language / published) wire through
+//! from `data::get_ebook`. Sections that don't yet have backend support
+//! (rating, journal, highlights, more-by-author, suggestions, reading
+//! activity, shelves) render placeholder content with `aria-hidden` and a
+//! `TODO(F<n>.<m>)` line citing the future roadmap doc that will replace
+//! the stub.
+
 use dioxus::prelude::*;
 use dioxus_router::Link;
 use omnibus_shared::EbookMetadata;
 
-use crate::{components::FormatSwitcher, data, use_server_url, Route};
+use crate::components::atrium::Cover;
+use crate::components::FormatSwitcher;
+use crate::{data, use_server_url, Route};
 
 #[component]
 pub fn BookDetailPage(id: i64) -> Element {
@@ -45,114 +70,442 @@ pub fn BookDetailPage(id: i64) -> Element {
         };
     };
 
+    render_loaded(b)
+}
+
+// ---------------------------------------------------------------------------
+// View — split out so the loaded-book case is the only thing rendered and
+// the data-fetch shell stays small.
+// ---------------------------------------------------------------------------
+
+fn render_loaded(b: EbookMetadata) -> Element {
     let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
-    let authors = b
+    let primary_author = b
+        .creators
+        .first()
+        .map(|c| c.name.clone())
+        .unwrap_or_default();
+    let authors_line = b
         .creators
         .iter()
         .map(|c| c.name.clone())
         .collect::<Vec<_>>()
         .join(", ");
-    let breadcrumb_mid = b
-        .series
-        .clone()
-        .or_else(|| b.creators.first().map(|c| c.name.clone()))
-        .unwrap_or_default();
-    let series_label = match (&b.series, &b.series_index) {
+    let year = b
+        .published
+        .as_deref()
+        .and_then(|p| p.get(0..4))
+        .unwrap_or("")
+        .to_string();
+    let kicker = match (b.dc_type.as_deref(), year.is_empty()) {
+        (Some(t), false) => format!("{t} · {year}"),
+        (Some(t), true) => t.to_string(),
+        (None, false) => format!("Book · {year}"),
+        (None, true) => "Book".to_string(),
+    };
+    let series_label = match (b.series.as_deref(), b.series_index.as_deref()) {
         (Some(s), Some(i)) => Some(format!("{s} #{i}")),
-        (Some(s), None) => Some(s.clone()),
+        (Some(s), None) => Some(s.to_string()),
         _ => None,
     };
-    let cover_src = b.cover_url.as_ref().map(|u| format!("{server_url}{u}"));
+    let accent_style = b
+        .accent
+        .as_deref()
+        .map(|a| format!("--accent: {a};"))
+        .unwrap_or_default();
+
+    let has_audio = b
+        .formats
+        .iter()
+        .any(|f| f.eq_ignore_ascii_case("m4b") || f.eq_ignore_ascii_case("mp3"));
+    let has_ebook = b
+        .formats
+        .iter()
+        .any(|f| f.eq_ignore_ascii_case("epub") || f.eq_ignore_ascii_case("pdf"));
 
     rsx! {
-        nav { class: "breadcrumb", aria_label: "breadcrumb",
-            Link { to: Route::Landing {}, "Home" }
-            if !breadcrumb_mid.is_empty() {
-                span { " \u{203a} " }
-                span { "{breadcrumb_mid}" }
-            }
-            span { " \u{203a} " }
-            span { "{title}" }
-        }
+        div { class: "bd-root", style: "{accent_style}",
 
-        div { class: "book-detail",
-            div { class: "book-detail-cover",
-                if let Some(src) = cover_src {
-                    img {
-                        src: "{src}",
-                        alt: "Cover of {title}",
-                        loading: "lazy",
+            // ── Hero ────────────────────────────────────────────────────
+            section { class: "bd-hero",
+                BdCrumb {
+                    items: vec![
+                        ("Home".to_string(), true),
+                        (primary_author.clone(), false),
+                        (title.clone(), false),
+                    ],
+                }
+
+                div { class: "bd-hero-grid",
+                    // Cover column
+                    div { class: "bd-cover-col cover-link",
+                        Cover { book: b.clone() }
+                        if !b.formats.is_empty() {
+                            div { class: "bd-format-badges",
+                                for f in b.formats.iter() {
+                                    BdFormatBadge { fmt: f.clone() }
+                                }
+                            }
+                        }
                     }
-                } else {
-                    div { class: "book-detail-cover-fallback", "\u{1F4D6}" }
-                }
-            }
 
-            div { class: "book-detail-meta",
-                h1 { "{title}" }
-                if !authors.is_empty() {
-                    p { "data-testid": "book-authors", "{authors}" }
-                }
-                if let Some(s) = series_label {
-                    p { class: "subtitle", "{s}" }
-                }
-                if let Some(desc) = &b.description {
-                    // EPUB OPF descriptions are commonly HTML fragments. The
-                    // server sanitizes the payload in `omnibus_db::get_book`
-                    // via ammonia's default allowlist before it reaches us,
-                    // so `dangerous_inner_html` is safe here. A `<div>`
-                    // wraps the fragment because the sanitized HTML may
-                    // itself contain block-level tags (`<p>`, `<ul>`, …)
-                    // that aren't valid children of `<p>`.
-                    div {
-                        class: "book-detail-description",
-                        "data-testid": "book-description",
-                        dangerous_inner_html: "{desc}",
+                    // Title + CTAs column
+                    div { class: "bd-title-col",
+                        div { class: "label", "{kicker}" }
+                        h1 { class: "bd-title", "{title}" }
+                        if !authors_line.is_empty() {
+                            p {
+                                class: "bd-by",
+                                "data-testid": "book-authors",
+                                "by "
+                                span { class: "author-link",
+                                    "{authors_line}"
+                                    span { class: "author-link-hint", " view author \u{2192}" }
+                                }
+                            }
+                        }
+                        if let Some(desc) = b.description.as_deref() {
+                            // Server-sanitized HTML — preserved from prior implementation.
+                            div {
+                                class: "bd-desc",
+                                "data-testid": "book-description",
+                                dangerous_inner_html: "{desc}",
+                            }
+                        }
+                        div { class: "bd-cta-row",
+                            button {
+                                class: "btn primary lg",
+                                disabled: true,
+                                title: "Reader coming soon",
+                                // TODO(F2.2): open the ebook reader, or "Resume" with progress (F2.1)
+                                if has_ebook { "Start reading" } else { "Start listening" }
+                            }
+                            if has_audio && has_ebook {
+                                button {
+                                    class: "btn lg",
+                                    disabled: true,
+                                    title: "Audio player coming soon",
+                                    // TODO(F2.3): open audiobook player
+                                    "Listen"
+                                }
+                            }
+                            button {
+                                class: "btn lg ghost",
+                                disabled: true,
+                                title: "Send-to-Kindle coming soon",
+                                // TODO(F4.3): send-to-kindle
+                                "Send to Kindle"
+                            }
+                            button {
+                                class: "btn lg ghost",
+                                disabled: true,
+                                title: "Send-to-Kobo coming soon",
+                                // TODO(F4.1): send-to-kobo
+                                "Send to Kobo"
+                            }
+                        }
+                        // TODO(F2.1): replace stub progress with real reading-progress data
+                        div { class: "bd-progress-meta", aria_hidden: "true",
+                            div { class: "bd-progress-line",
+                                span { class: "mono", "Not started" }
+                                span { class: "mono", "0%" }
+                            }
+                            div { class: "pbar", i { style: "width: 0%;" } }
+                        }
+                        if !b.subjects.is_empty() {
+                            ul { class: "bd-tag-list",
+                                for tag in b.subjects.iter() {
+                                    li { class: "chip", "{tag}" }
+                                }
+                            }
+                        }
                     }
-                }
 
-                FormatSwitcher { formats: b.formats.clone() }
+                    // Rating + actions card column
+                    aside { class: "card bd-rating-card",
+                        div { class: "label", "Your rating" }
+                        // TODO(F3.2): wire up interactive rating
+                        div { class: "bd-stars", aria_hidden: "true",
+                            BdStars { value: 0.0 }
+                        }
+                        div { class: "mono bd-rating-meta", "Not rated yet" }
 
-                if !b.subjects.is_empty() {
-                    ul { class: "tag-list",
-                        for tag in &b.subjects {
-                            li { class: "tag", "{tag}" }
+                        div { class: "divider" }
+
+                        div { class: "label bd-action-head", "Actions" }
+                        div { class: "bd-actions",
+                            // TODO(F3.2): journal entry & highlight
+                            button { class: "btn ghost bd-action-row", disabled: true,
+                                span { "Write a journal entry" }
+                                span { class: "bd-action-row-arrow", "\u{2192}" }
+                            }
+                            button { class: "btn ghost bd-action-row", disabled: true,
+                                span { "Add a highlight" }
+                                span { class: "bd-action-row-arrow", "\u{2192}" }
+                            }
+                            button { class: "btn ghost bd-action-row", disabled: true,
+                                span { "Mark as finished" }
+                                span { class: "bd-action-row-arrow", "\u{2192}" }
+                            }
+                            button { class: "btn ghost bd-action-row", disabled: true,
+                                span { "Share or export\u{2026}" }
+                                span { class: "bd-action-row-arrow", "\u{2192}" }
+                            }
+                        }
+
+                        div { class: "divider" }
+
+                        div { class: "label bd-shelves-head", "On your shelves" }
+                        // TODO(F3.x): shelves / collections
+                        div { class: "bd-shelves", aria_hidden: "true",
+                            div { class: "chip", "Not on a shelf" }
                         }
                     }
                 }
+            }
 
-                if !b.identifiers.is_empty() {
-                    dl { class: "identifier-list",
-                        for ident in &b.identifiers {
-                            dt { "{ident.scheme.as_deref().unwrap_or(\"\")}" }
-                            dd { "{ident.value}" }
-                        }
+            // ── Body ────────────────────────────────────────────────────
+            section { class: "bd-body-grid",
+
+                // Main column
+                div { class: "bd-body-main",
+
+                    // Journal — TODO(F3.2)
+                    BdSectionHead { kicker: "Your journal · 0 entries".to_string(), title: "What you've written".to_string() }
+                    div { class: "bd-journal-empty card", aria_hidden: "true",
+                        p { class: "mono", "No journal entries yet." }
+                        p { class: "bd-stub-hint", "Journaling lands in F3.2." }
+                    }
+
+                    div { class: "divider" }
+
+                    // Highlights — TODO(F3.2)
+                    BdSectionHead { kicker: "0 highlights".to_string(), title: "Passages you saved".to_string() }
+                    div { class: "bd-journal-empty card", aria_hidden: "true",
+                        p { class: "mono", "No highlights saved yet." }
+                        p { class: "bd-stub-hint", "Highlights land in F3.2." }
+                    }
+
+                    div { class: "divider" }
+
+                    // More by this author — TODO(F3.3)
+                    BdSectionHead {
+                        kicker: if primary_author.is_empty() { "More to read".to_string() } else { format!("More by {primary_author}") },
+                        title: "From the same hand".to_string(),
+                    }
+                    div { class: "bd-stub-strip card", aria_hidden: "true",
+                        p { class: "bd-stub-hint mono", "Author pages land in F3.3." }
+                    }
+
+                    div { class: "divider" }
+
+                    // Suggested — TODO(F3.3)
+                    BdSectionHead {
+                        kicker: format!("If you liked {title}\u{2026}"),
+                        title: "Suggested for you".to_string(),
+                    }
+                    div { class: "bd-stub-strip card", aria_hidden: "true",
+                        p { class: "bd-stub-hint mono", "Suggestions land in F3.3." }
                     }
                 }
 
-                if let Some(pub_) = &b.publisher {
-                    p { class: "subtitle", "Publisher: {pub_}" }
-                }
-                if let Some(lang) = &b.language {
-                    p { class: "subtitle", "Language: {lang}" }
-                }
-                if let Some(date) = &b.published {
-                    p { class: "subtitle", "Published: {date}" }
-                }
+                // Rail
+                aside { class: "bd-rail",
 
-                div {
-                    class: "ratings-slot",
-                    "data-testid": "ratings-slot",
-                    aria_label: "Ratings \u{2014} coming soon",
-                }
-                div {
-                    class: "suggestions-slot",
-                    "data-testid": "suggestions-slot",
-                    aria_label: "Suggestions \u{2014} coming soon",
-                }
+                    // File details
+                    div { class: "card",
+                        div { class: "label bd-rail-head", "File details" }
+                        table { class: "bd-meta-table mono",
+                            tbody {
+                                BdMetaRow { k: "Title".to_string(), v: title.clone() }
+                                if !authors_line.is_empty() {
+                                    BdMetaRow { k: "Author".to_string(), v: authors_line.clone() }
+                                }
+                                if let Some(p) = b.publisher.clone() {
+                                    BdMetaRow { k: "Pub.".to_string(), v: p }
+                                }
+                                if let Some(d) = b.published.clone() {
+                                    BdMetaRow { k: "Date".to_string(), v: d }
+                                }
+                                if let Some(l) = b.language.clone() {
+                                    BdMetaRow { k: "Language".to_string(), v: l }
+                                }
+                                for ident in b.identifiers.iter() {
+                                    BdMetaRow {
+                                        k: ident.scheme.clone().unwrap_or_else(|| "ID".into()),
+                                        v: ident.value.clone(),
+                                    }
+                                }
+                            }
+                        }
 
+                        div { class: "divider" }
+
+                        div { class: "label bd-rail-head", "Formats" }
+                        // Relocated FormatSwitcher — same testids as before.
+                        FormatSwitcher { formats: b.formats.clone() }
+
+                        // TODO(F5.1): metadata editor
+                        button {
+                            class: "btn ghost sm bd-rail-edit",
+                            disabled: true,
+                            "Edit metadata\u{2026}"
+                        }
+                    }
+
+                    // Series / standalone
+                    div { class: "card",
+                        if let Some(s) = series_label.as_ref() {
+                            div { class: "label bd-rail-head", "Series" }
+                            p { class: "bd-rail-body", "{s}" }
+                        } else {
+                            div { class: "label bd-rail-head", "Standalone" }
+                            p { class: "bd-rail-body", "Not part of a series." }
+                        }
+                    }
+
+                    // Reading insights — TODO(F2.1)
+                    div { class: "card",
+                        div { class: "bd-insights-head",
+                            div { class: "label", "Insights" }
+                            span { class: "mono bd-insights-tag", "this book" }
+                        }
+                        div { class: "bd-insights-grid", aria_hidden: "true",
+                            BdInsightCell { label: "Started".to_string(), value: "—".to_string() }
+                            BdInsightCell { label: "Time read".to_string(), value: "—".to_string() }
+                            BdInsightCell { label: "Sessions".to_string(), value: "—".to_string() }
+                            BdInsightCell { label: "Pace".to_string(), value: "—".to_string() }
+                        }
+                        div { class: "divider" }
+                        div { class: "label bd-rail-head", "Activity · last 22 days" }
+                        // Placeholder sparkline — flat bars until F2.1 lands.
+                        div { class: "bd-activity-bar", aria_hidden: "true",
+                            for _ in 0..22u32 {
+                                i { class: "bd-activity-tick" }
+                            }
+                        }
+                        div { class: "bd-activity-axis mono",
+                            span { "3wk ago" }
+                            span { "minutes read · by day" }
+                            span { "today" }
+                        }
+                    }
+                }
+            }
+
+            // Footer affordance — Back to library link.
+            div { class: "bd-footer",
                 Link { to: Route::Landing {}, class: "btn", "Back to library" }
             }
+
+            // Hidden slots preserved for the F1.4 contract — the hero
+            // rating card and the cover-fan strips are the visible
+            // surfaces; these stay attached so anything keying off the
+            // slot testids still finds them.
+            div {
+                class: "ratings-slot",
+                "data-testid": "ratings-slot",
+                aria_label: "Ratings \u{2014} coming soon",
+                hidden: true,
+            }
+            div {
+                class: "suggestions-slot",
+                "data-testid": "suggestions-slot",
+                aria_label: "Suggestions \u{2014} coming soon",
+                hidden: true,
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Page-local primitives. None of these introduce business logic — they're
+// markup-only adapters so the page reads as a composition of named blocks
+// rather than nested rsx.
+// ---------------------------------------------------------------------------
+
+/// Atrium-styled breadcrumb. The first item is the "Home" link back to the
+/// library; subsequent items are rendered as plain text segments.
+#[component]
+fn BdCrumb(items: Vec<(String, bool)>) -> Element {
+    let last_idx = items.len().saturating_sub(1);
+    rsx! {
+        nav { class: "bd-crumb", "aria-label": "breadcrumb",
+            for (i, (text, is_home)) in items.iter().cloned().enumerate() {
+                if i > 0 {
+                    span { class: "bd-crumb-sep", "\u{203a}" }
+                }
+                if is_home {
+                    Link { to: Route::Landing {}, class: "bd-crumb-home", "{text}" }
+                } else {
+                    span {
+                        class: if i == last_idx { "bd-crumb-curr" } else { "bd-crumb-step" },
+                        "{text}"
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Body section heading row — kicker label + serif title. The kicker stacks
+/// above the title (mirrors `screens/_shared.jsx#SectionHead`); the optional
+/// action slot sits flush right.
+#[component]
+fn BdSectionHead(kicker: String, title: String) -> Element {
+    rsx! {
+        div { class: "bd-section-head",
+            div { class: "bd-section-head-text",
+                if !kicker.is_empty() {
+                    div { class: "label bd-section-kicker", "{kicker}" }
+                }
+                h3 { class: "bd-section-title", "{title}" }
+            }
+        }
+    }
+}
+
+/// Small monospace format pill (matches `screens/_shared.jsx#FormatBadge`).
+#[component]
+fn BdFormatBadge(fmt: String) -> Element {
+    rsx! {
+        div { class: "bd-fmt-badge", "{fmt}" }
+    }
+}
+
+/// Read-only star display. Half-filled stars are rounded down to nearest
+/// integer in the stub; F3.2 replaces this with the interactive widget.
+#[component]
+fn BdStars(value: f32) -> Element {
+    let full = value.floor().clamp(0.0, 5.0) as u32;
+    rsx! {
+        span { class: "bd-stars-row",
+            for i in 0..5u32 {
+                span {
+                    class: if i < full { "bd-star bd-star-on" } else { "bd-star" },
+                    "\u{2605}"
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn BdMetaRow(k: String, v: String) -> Element {
+    rsx! {
+        tr { class: "bd-meta-row",
+            td { class: "bd-meta-k", "{k}" }
+            td { class: "bd-meta-v", "{v}" }
+        }
+    }
+}
+
+#[component]
+fn BdInsightCell(label: String, value: String) -> Element {
+    rsx! {
+        div { class: "bd-insight-cell",
+            div { class: "mono bd-insight-label", "{label}" }
+            div { class: "bd-insight-value", "{value}" }
         }
     }
 }

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -129,16 +129,19 @@ fn render_loaded(b: EbookMetadata) -> Element {
             // ── Hero ────────────────────────────────────────────────────
             section { class: "bd-hero",
                 BdCrumb {
-                    items: vec![
-                        ("Home".to_string(), true),
-                        (primary_author.clone(), false),
-                        (title.clone(), false),
-                    ],
+                    items: {
+                        let mut crumbs = vec![("Home".to_string(), true)];
+                        if !primary_author.is_empty() {
+                            crumbs.push((primary_author.clone(), false));
+                        }
+                        crumbs.push((title.clone(), false));
+                        crumbs
+                    },
                 }
 
                 div { class: "bd-hero-grid",
                     // Cover column
-                    div { class: "bd-cover-col cover-link",
+                    div { class: "bd-cover-col",
                         Cover { book: b.clone() }
                         if !b.formats.is_empty() {
                             div { class: "bd-format-badges",
@@ -158,9 +161,13 @@ fn render_loaded(b: EbookMetadata) -> Element {
                                 class: "bd-by",
                                 "data-testid": "book-authors",
                                 "by "
-                                span { class: "author-link",
+                                span { class: "bd-author-link",
                                     "{authors_line}"
-                                    span { class: "author-link-hint", " view author \u{2192}" }
+                                    span {
+                                        class: "bd-author-link-hint",
+                                        aria_hidden: "true",
+                                        " view author \u{2192}"
+                                    }
                                 }
                             }
                         }
@@ -173,12 +180,22 @@ fn render_loaded(b: EbookMetadata) -> Element {
                             }
                         }
                         div { class: "bd-cta-row",
-                            button {
-                                class: "btn primary lg",
-                                disabled: true,
-                                title: "Reader coming soon",
-                                // TODO(F2.2): open the ebook reader, or "Resume" with progress (F2.1)
-                                if has_ebook { "Start reading" } else { "Start listening" }
+                            if has_ebook {
+                                button {
+                                    class: "btn primary lg",
+                                    disabled: true,
+                                    title: "Reader coming soon",
+                                    // TODO(F2.2): open the ebook reader, or "Resume" with progress (F2.1)
+                                    "Start reading"
+                                }
+                            } else if has_audio {
+                                button {
+                                    class: "btn primary lg",
+                                    disabled: true,
+                                    title: "Audio player coming soon",
+                                    // TODO(F2.3): open audiobook player
+                                    "Start listening"
+                                }
                             }
                             if has_audio && has_ebook {
                                 button {
@@ -449,8 +466,7 @@ fn BdCrumb(items: Vec<(String, bool)>) -> Element {
 }
 
 /// Body section heading row — kicker label + serif title. The kicker stacks
-/// above the title (mirrors `screens/_shared.jsx#SectionHead`); the optional
-/// action slot sits flush right.
+/// above the title (mirrors `screens/_shared.jsx#SectionHead`).
 #[component]
 fn BdSectionHead(kicker: String, title: String) -> Element {
     rsx! {


### PR DESCRIPTION
## Summary
- Rebuilds the book detail page as the `DetailA` "Cinematic" layout from the design canvas: an accent-tinted hero (240-px cover, italic-serif title, primary CTAs, rating + actions card) on top of a two-column body (journal / highlights / "more by author" / suggestions on the left, sticky right rail with file details, series/standalone, and reading insights).
- Backend stays untouched. Backend-supplied fields (title, authors, description, cover, formats, subjects, identifiers, publisher, language, published, series) wire through `data::get_ebook` like before; everything else (rating, journal entries, highlights, cover-fan suggestions, reading-activity sparkline, "on your shelves") is a clearly-marked placeholder with a `TODO(F<n>.<m>)` line citing the future roadmap doc that will replace it (F2.1, F2.2, F2.3, F3.2, F3.3, F4.1, F4.3, F5.1).
- The existing `FormatSwitcher` is relocated into the file-details rail card with its testids intact, so the Playwright contracts (`format-switcher`, `format-row-epub`, `format-badge`, `action-read`, `action-kindle`, `action-listen`) keep working without spec edits.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy -p omnibus-frontend --features server -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` — 50 unit tests pass
- [x] `PORT=3001 just dev-up`, log in as the seeded admin, point the library at `test_data/epubs/generated`, and visit `/books/<id>` in the browser preview at desktop (1440), tablet (900), and mobile (600) widths; the 3-col hero collapses to 2-col then 1-col as designed and no console errors fire
- [x] `PLAYWRIGHT_BASE_URL=http://localhost:3001 npx playwright test book_detail.spec.ts` — both tests pass (`navigates from a landing row…` and `renders the detail contents for the selected book`)

## Notes
- Stubs use `aria-hidden="true"` so screen readers don't announce the placeholder content.
- The `ratings-slot` and `suggestions-slot` divs are kept attached (hidden) so anything keying off those testids still finds them; the visible surfaces are now the hero rating card and the cover-fan section stubs.
- No new dependencies. No backend changes. No roadmap doc — this is a UI refresh of an already-shipped page (F1.4); the new roadmap docs that will replace the stubs are referenced by number in inline `TODO(F<n>.<m>)` comments.