### PR TITLE
fix(auth): default session cookies to Secure=true (#80)

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -27,7 +27,7 @@ Non-secret defaults stay in the shellHook above. Anything with a secret — pass
 Currently documented:
 
 - `OMNIBUS_DEV_SEED_USER=username:password` — creates a named admin user on server boot if absent. Dev convenience for `ui-validate` and parallel agents; never set in production. Password must satisfy `db::auth` validation (≥10 chars, not in `COMMON_PASSWORDS`).
-- `OMNIBUS_SECURE_COOKIES=0` — disables the `Secure` flag on session cookies. The default is `true` (secure-by-default). Set to `0` only for local http:// dev where browsers would otherwise drop the cookie. Never set in production.
+- `OMNIBUS_SECURE_COOKIES=0` — disables the `Secure` flag on session cookies. The default is `true` (secure-by-default). Browsers treat `http://localhost` as a secure context, so the Nix dev shell does not need this override; only set `0` when serving plain `http://` from a non-localhost origin (e.g. an IP-based dev server on a LAN). Never set in production.
 
 Optional thumbnail cache overrides (F1.2):
 - `OMNIBUS_THUMBS_DIR` — where WebP thumbnails are cached (default `./thumbs`)

--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -27,6 +27,7 @@ Non-secret defaults stay in the shellHook above. Anything with a secret — pass
 Currently documented:
 
 - `OMNIBUS_DEV_SEED_USER=username:password` — creates a named admin user on server boot if absent. Dev convenience for `ui-validate` and parallel agents; never set in production. Password must satisfy `db::auth` validation (≥10 chars, not in `COMMON_PASSWORDS`).
+- `OMNIBUS_SECURE_COOKIES=0` — disables the `Secure` flag on session cookies. The default is `true` (secure-by-default). Set to `0` only for local http:// dev where browsers would otherwise drop the cookie. Never set in production.
 
 Optional thumbnail cache overrides (F1.2):
 - `OMNIBUS_THUMBS_DIR` — where WebP thumbnails are cached (default `./thumbs`)

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@
 OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
 
 # Session cookie Secure flag. Defaults to true (cookies sent over HTTPS only).
-# Set to 0 when running the dev server over plain http://localhost so browsers
-# don't silently drop the session cookie. Never disable in production.
+# Browsers treat http://localhost as a secure context, so the Nix dev shell
+# does NOT need this override. Set to 0 only when serving plain http:// from a
+# non-localhost origin (e.g. an IP-based dev server on a LAN). Never disable
+# in production.
 #OMNIBUS_SECURE_COOKIES=0

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,8 @@
 # The dev-up script and the ui-validate skill assume this exact value;
 # change it only if you understand both will follow you.
 OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
+
+# Session cookie Secure flag. Defaults to true (cookies sent over HTTPS only).
+# Set to 0 when running the dev server over plain http://localhost so browsers
+# don't silently drop the session cookie. Never disable in production.
+#OMNIBUS_SECURE_COOKIES=0

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -103,14 +103,18 @@ fn want_bearer(kind: Option<&str>) -> bool {
     matches!(kind, Some("ios") | Some("android") | Some("bearer"))
 }
 
-fn secure_cookies() -> bool {
-    match std::env::var("OMNIBUS_SECURE_COOKIES") {
-        Ok(v) => {
+fn parse_secure_cookies(raw: Option<&str>) -> bool {
+    match raw {
+        Some(v) => {
             let v = v.trim().to_ascii_lowercase();
             !matches!(v.as_str(), "0" | "false" | "no" | "")
         }
-        Err(_) => true, // default on; set OMNIBUS_SECURE_COOKIES=0 only for non-localhost HTTP origins (e.g. LAN IPs)
+        None => true, // default on; set OMNIBUS_SECURE_COOKIES=0 only for non-localhost HTTP origins (e.g. LAN IPs)
     }
+}
+
+fn secure_cookies() -> bool {
+    parse_secure_cookies(std::env::var("OMNIBUS_SECURE_COOKIES").ok().as_deref())
 }
 
 fn session_cookie(value: String, max_age_secs: i64) -> Cookie<'static> {
@@ -274,6 +278,31 @@ mod tests {
             .header("content-type", "application/json")
             .body(Body::from(body.to_string()))
             .unwrap()
+    }
+
+    #[test]
+    fn parse_secure_cookies_defaults_on_when_unset() {
+        assert!(parse_secure_cookies(None));
+    }
+
+    #[test]
+    fn parse_secure_cookies_off_for_falsey_values() {
+        for raw in ["0", "false", "FALSE", "no", " 0 ", ""] {
+            assert!(
+                !parse_secure_cookies(Some(raw)),
+                "expected {raw:?} to disable Secure"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_secure_cookies_on_for_anything_else() {
+        for raw in ["1", "true", "yes", "anything"] {
+            assert!(
+                parse_secure_cookies(Some(raw)),
+                "expected {raw:?} to keep Secure on"
+            );
+        }
     }
 
     #[tokio::test]

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -109,7 +109,7 @@ fn secure_cookies() -> bool {
             let v = v.trim().to_ascii_lowercase();
             !matches!(v.as_str(), "0" | "false" | "no" | "")
         }
-        Err(_) => false, // default off so the dev shell on http://localhost works
+        Err(_) => true, // default on; set OMNIBUS_SECURE_COOKIES=0 in .env for http://localhost dev
     }
 }
 

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -109,7 +109,7 @@ fn secure_cookies() -> bool {
             let v = v.trim().to_ascii_lowercase();
             !matches!(v.as_str(), "0" | "false" | "no" | "")
         }
-        Err(_) => true, // default on; set OMNIBUS_SECURE_COOKIES=0 in .env for http://localhost dev
+        Err(_) => true, // default on; set OMNIBUS_SECURE_COOKIES=0 only for non-localhost HTTP origins (e.g. LAN IPs)
     }
 }
 


### PR DESCRIPTION
## Summary

- Inverts the `secure_cookies()` default in `server/src/auth/handlers.rs` from `false` to `true` — session cookies now carry the `Secure` attribute by default, ensuring they are only sent over HTTPS.
- Adds `OMNIBUS_SECURE_COOKIES=0` (commented out) to `.env.example` as the developer escape hatch for plain-`http://` origins that aren't `localhost`.
- Documents the variable in `.claude/rules/01-dev-environment.md`.

## Why the default is safe for localhost dev

Modern browsers (Chrome, Firefox, Safari) treat `localhost` as a secure context per the Fetch spec, so `Secure` cookies are accepted and sent on `localhost` even over plain HTTP. The Nix dev shell (`http://localhost:3000`) is unaffected without any config change.

The escape hatch (`OMNIBUS_SECURE_COOKIES=0`) is only needed for non-localhost HTTP origins, e.g. an IP-based dev server on a LAN.

## Sniffer remedy vs. this implementation

The issue suggested either inverting the default with a new `OMNIBUS_INSECURE_COOKIES` variable, or auto-detecting via `OMNIBUS_PUBLIC_ORIGIN`. I kept the existing `OMNIBUS_SECURE_COOKIES` variable name (backward-compatible — `=1` still means secure) and just flipped the `Err(_)` fallback to `true`. This is simpler and avoids introducing a second env var for the same toggle.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus -- -D warnings` — clean
- [x] `cargo test -p omnibus` — 69 tests pass (no test asserts on `Secure` flag presence; cookie tests check name prefix only)

## Files changed (3)

- `server/src/auth/handlers.rs` — flip `Err(_) => false` → `Err(_) => true`; update comment
- `.env.example` — document `OMNIBUS_SECURE_COOKIES=0` escape hatch
- `.claude/rules/01-dev-environment.md` — add variable to documented list

Closes #80

https://claude.ai/code/session_01XypC1ayuYX1drsBFbTxj69

---
_Generated by [Claude Code](https://claude.ai/code/session_01XypC1ayuYX1drsBFbTxj69)_