### PR TITLE
ci: test omnibus-db and omnibus-frontend in addition to omnibus

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,5 +45,14 @@ jobs:
       - name: cargo clippy (server)
         run: nix develop --command cargo clippy -p omnibus --all-targets -- -D warnings
 
+      - name: cargo clippy (db)
+        run: nix develop --command cargo clippy -p omnibus-db --all-targets -- -D warnings
+
       - name: cargo test (server)
         run: nix develop --command cargo test -p omnibus
+
+      - name: cargo test (db)
+        run: nix develop --command cargo test -p omnibus-db
+
+      - name: cargo test (frontend)
+        run: nix develop --command cargo test -p omnibus-frontend --features server

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -626,14 +626,18 @@ mod tests {
         // Real EPUB covers top out around 1500×2250. Test against that size
         // with a generous debug-mode budget — release builds run ~3× faster.
         // The point of the test is to catch a regression to seconds, not to
-        // hold a tight production-grade budget in unoptimized builds.
+        // hold a tight production-grade budget in unoptimized builds. GitHub
+        // Actions ubuntu-latest runners have measurably slower per-core
+        // throughput than developer workstations and can spend 600–700 ms on
+        // this input in debug builds, so the threshold is set to 2 s — any
+        // multi-second regression still trips it.
         let bytes = solid_color_png(80, 140, 200, 1500, 2250);
         let start = std::time::Instant::now();
         let _ = extract_accent(&bytes);
         let elapsed = start.elapsed();
         assert!(
-            elapsed < std::time::Duration::from_millis(500),
-            "extract_accent must stay well under one second on realistic input; took {elapsed:?}"
+            elapsed < std::time::Duration::from_secs(2),
+            "extract_accent must stay well under multiple seconds on realistic input; took {elapsed:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- The `fmt + clippy + test` job in `.github/workflows/rust.yml` only ran `cargo clippy -p omnibus` and `cargo test -p omnibus`. The two crates that hold essentially all of the core domain logic — `omnibus-db` (SQLite query layer, FTS pipeline, ebook metadata extraction, auth data layer, indexer, worker, thumbnail generation) and `omnibus-frontend` (rpc server functions + Dioxus components) — were never tested by the PR gate, even though they already carry inline `#[cfg(test)]` coverage.
- Add three CI steps that mirror the commands already prescribed in [`CLAUDE.md`](CLAUDE.md) and [`.claude/rules/03-unit-testing.md`](.claude/rules/03-unit-testing.md):
  - `cargo clippy -p omnibus-db --all-targets -- -D warnings`
  - `cargo test -p omnibus-db`
  - `cargo test -p omnibus-frontend --features server`

Closes #79

## Stacked follow-up (commit 2)
Turning the gate on immediately surfaced a pre-existing flaky timing test — `extract_accent_completes_within_budget` (`db/src/ebook.rs:625`) — that asserted 500ms wall-clock on a debug build. CI's ubuntu-latest runner clocked 661ms, panicking the assertion. The test's own docstring already calls out its intent ("catch a regression to seconds, not to hold a tight production-grade budget in unoptimized builds"). Raised the threshold to 2s; any real multi-second regression still trips. Stacking the fix here so the gate enabled by the prior commit goes green on the same change.

## Test plan
- [x] Verified each new step green locally against this PR's base commit: `cargo clippy -p omnibus-db --all-targets -- -D warnings`, `cargo test -p omnibus-db` (157 tests pass locally with relaxed budget), `cargo test -p omnibus-frontend --features server` (50/50 tests pass).
- [ ] CI run on this PR exercises the three new steps end-to-end and reports green.

## Notes
- The frontend's `server` feature is required so the rpc.rs server-function bodies + the inline page/rpc tests compile against the real `omnibus-db` layer; the default-feature build is web/mobile-shaped and excludes them.
- No corresponding clippy step for `omnibus-frontend` here — the workspace's `web`/`mobile`/`server` feature triplet is mutually exclusive, and a useful `-p omnibus-frontend` clippy gate would need a deliberate `--features server` (or `--features web`) flag. Out of scope for this PR; opening a follow-up if you want it gated.

https://claude.ai/code/session_01SGPuSyzzcyBq75KN5Mr4Ka