### PR TITLE
test(playwright): switch undici `request` fixture to bearer auth

### DIFF
--- a/ui_tests/playwright/globalSetup.ts
+++ b/ui_tests/playwright/globalSetup.ts
@@ -1,10 +1,11 @@
 import { request as apiRequest, type FullConfig } from "@playwright/test";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
-import { ensureLoggedIn } from "./tests/utils/auth";
+import { ensureLoggedIn, loginBearer } from "./tests/utils/auth";
 
 export const STORAGE_STATE_PATH = resolve(__dirname, ".auth", "storage.json");
+export const BEARER_TOKEN_PATH = resolve(__dirname, ".auth", "bearer.txt");
 
 export default async function globalSetup(config: FullConfig): Promise<void> {
   // Pull `baseURL`, `extraHTTPHeaders`, and `storageState` from the merged
@@ -23,6 +24,16 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
     await ensureLoggedIn(ctx);
     mkdirSync(dirname(storageStatePath), { recursive: true });
     await ctx.storageState({ path: storageStatePath });
+
+    // Mint a bearer session for the same user. The browser fixture (`page`)
+    // rides the cookie persisted to storageState above; the undici-backed
+    // `request` fixture rides the bearer below (see fixtures/test.ts) so
+    // Secure-by-default cookies don't drop session state on non-browser HTTP
+    // calls — Playwright's undici client doesn't honor Chromium's
+    // localhost-secure-context exception.
+    const token = await loginBearer(ctx);
+    mkdirSync(dirname(BEARER_TOKEN_PATH), { recursive: true });
+    writeFileSync(BEARER_TOKEN_PATH, token, { mode: 0o600 });
   } finally {
     await ctx.dispose();
   }

--- a/ui_tests/playwright/tests/fixtures/test.ts
+++ b/ui_tests/playwright/tests/fixtures/test.ts
@@ -1,10 +1,35 @@
 // Extended `test` / `expect` for the omnibus Playwright suite.
 //
-// Today this just re-exports Playwright's base test runner. It exists so every
-// spec imports from a single place — when we need shared state (seeded DB,
-// mocked library responses, pre-filled settings), we add a `test.extend(...)`
-// here and every spec picks it up automatically.
+// Overrides the default `request` fixture so the undici-backed
+// `APIRequestContext` rides bearer auth on protected `/api/*` routes.
+// Browsers (`page` fixture) keep cookie auth via storageState. This split
+// matches production: web uses Secure cookies, mobile/CLI uses bearer —
+// Playwright's undici client is in the mobile/CLI bucket since it doesn't
+// honor Chromium's `http://localhost` secure-context exception for Secure
+// cookies. The bearer is provisioned by globalSetup.
 import { test as base, expect } from "@playwright/test";
+import { existsSync, readFileSync } from "node:fs";
 
-export const test = base;
+import { BEARER_TOKEN_PATH } from "../../globalSetup";
+
+function loadBearerToken(): string | null {
+  if (!existsSync(BEARER_TOKEN_PATH)) return null;
+  const token = readFileSync(BEARER_TOKEN_PATH, "utf8").trim();
+  return token.length > 0 ? token : null;
+}
+
+export const test = base.extend({
+  request: async ({ playwright, baseURL, extraHTTPHeaders }, use) => {
+    const token = loadBearerToken();
+    const ctx = await playwright.request.newContext({
+      baseURL,
+      extraHTTPHeaders: {
+        ...extraHTTPHeaders,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    await use(ctx);
+    await ctx.dispose();
+  },
+});
 export { expect };

--- a/ui_tests/playwright/tests/utils/auth.ts
+++ b/ui_tests/playwright/tests/utils/auth.ts
@@ -1,5 +1,4 @@
-import { type APIRequestContext } from "@playwright/test";
-import { expect } from "../fixtures/test";
+import { expect, type APIRequestContext } from "@playwright/test";
 
 // A single shared test user. The server gates all `/api/*` routes behind
 // authentication and disables registration after the first user is created,
@@ -38,4 +37,32 @@ export async function ensureLoggedIn(request: APIRequestContext): Promise<void> 
     loginResp.status(),
     `auth setup: /api/auth/login returned ${loginResp.status()} — wipe omnibus.db and rerun if the existing ${TEST_USERNAME} row has a different password`,
   ).toBe(200);
+}
+
+/**
+ * Mint a bearer session for the shared test user and return the raw token.
+ * Used by `globalSetup` to provision a token for the undici-backed `request`
+ * fixture — Playwright's `APIRequestContext` does not honor Chromium's
+ * `http://localhost` secure-context exception, so the Secure cookie from
+ * `ensureLoggedIn` is dropped on every undici-side call. Bearer tokens ride
+ * in `Authorization: Bearer` and are not subject to Secure, matching the
+ * mobile-client auth path the server already supports in production.
+ *
+ * Assumes the shared test user already exists (`ensureLoggedIn` runs first
+ * in `globalSetup`).
+ */
+export async function loginBearer(request: APIRequestContext): Promise<string> {
+  const resp = await request.post("/api/auth/login", {
+    data: {
+      username: TEST_USERNAME,
+      password: TEST_PASSWORD,
+      client_kind: "bearer",
+    },
+  });
+  expect(resp.status(), "bearer login failed").toBe(200);
+  const body = (await resp.json()) as { token?: string };
+  if (!body.token) {
+    throw new Error("bearer login: response missing `token` — server did not honor client_kind");
+  }
+  return body.token;
 }


### PR DESCRIPTION
## Summary
- `ca86f1a` ("default session cookies to Secure=true") regressed the Playwright E2E suite on main. Every spec that calls `seedLibrary` 401s on `POST /api/rpc/settings` (`tests/utils/seed.ts:35`), and `fetchBookIdByTitle` / thumbnails-spec API polls inherit the same break.
- Root cause: Chromium honors a `http://localhost` secure-context exception and replays Secure cookies over HTTP, so the browser-side suite (`page` fixture) keeps working. Playwright's undici-backed `APIRequestContext` does **not** honor that exception, so the cookie persisted by `globalSetup`'s storageState is dropped on every spec-side `request` call.
- Rather than disable Secure cookies on the CI runner (which makes the runtime diverge from production), use the auth split production already runs: web uses Secure cookies, mobile/CLI uses bearer. Playwright's undici client is in the mobile/CLI bucket. The server already supports this — `LoginRequest.client_kind = "bearer"` returns a bearer token in the JSON body.

## What changed
- `globalSetup`: after the existing cookie register/login, mint a bearer session via the new `loginBearer()` helper and persist the raw token to `.auth/bearer.txt` (mode 0600).
- `tests/fixtures/test.ts`: override the default `request` fixture to attach `Authorization: Bearer <token>` from the persisted file. Browser `page` fixture is unchanged and still rides the cookie via storageState — so cookie-based session flow stays exercised end-to-end.
- `tests/utils/auth.ts`: add `loginBearer()`. Switch its `expect` import to come from `@playwright/test` directly to break the new `fixtures/test.ts` → `globalSetup.ts` → `tests/utils/auth.ts` import cycle.

Closes the regression introduced by ca86f1a for E2E; server stays Secure-by-default in CI and prod alike.

## Test plan
- [x] `npx tsc --noEmit` clean against the diff (the two pre-existing errors in `book_detail.spec.ts:51` and `landing.spec.ts:82` are present on `main` too — unrelated, surfaced only because `noUncheckedIndexedAccess` is on).
- [ ] CI playwright run on this PR (would need `run_ui_tests` label).
- [ ] Confirms PR #98's previously-red specs (`book_detail`, `landing`, `search`, `thumbnails`) go green after re-trigger.

## Notes
- The browser `page` fixture continues to use the Secure cookie via storageState — so cookie-session behavior remains under E2E coverage, including the `Secure` attribute on the wire. We're not removing cookie auth from the test surface, we're just routing the non-browser HTTP path through the bearer surface that exists for non-browser clients.
- No server-side change; `OMNIBUS_SECURE_COOKIES` is not touched in CI or anywhere else.

https://claude.ai/code/session_01SGPuSyzzcyBq75KN5Mr4Ka