### PR TITLE
fix(ci): reduce nix overhead in GitHub Actions workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,24 +45,28 @@ jobs:
           restore-keys: |
             playwright-node-modules-${{ runner.os }}-
 
-      - name: Install Playwright npm deps
-        run: nix develop --command bash -c "cd ui_tests/playwright && npm ci"
-
-      - name: Bundle web app
-        run: nix develop --command dx bundle --platform web --package omnibus --fullstack
-
-      - name: Start server
+      - name: Build, start server, and run Playwright tests
         run: |
-          # Run the pre-bundled server binary directly. dx serve/run both host a
-          # "building your app" / "non-hot-reloadable change" splash page while
-          # they compile on demand, which made Playwright race the build. A
-          # bundled binary has its public/ assets ready alongside it and serves
-          # the real SSR app from the first request.
-          nix develop --command bash -c "PORT=3000 ./target/dx/omnibus/debug/web/server >server.log 2>&1 &"
-          nix develop --command bash -c "npx --yes wait-on -t 60000 http://127.0.0.1:3000"
+          nix develop --command bash -c '
+            set -euo pipefail
 
-      - name: Run Playwright tests
-        run: nix develop --command bash -c "cd ui_tests/playwright && npm test"
+            echo "::group::Install Playwright npm deps"
+            cd ui_tests/playwright && npm ci && cd ../..
+            echo "::endgroup::"
+
+            echo "::group::Bundle web app"
+            dx bundle --platform web --package omnibus --fullstack
+            echo "::endgroup::"
+
+            echo "::group::Start server"
+            PORT=3000 ./target/dx/omnibus/debug/web/server >server.log 2>&1 &
+            npx --yes wait-on -t 60000 http://127.0.0.1:3000
+            echo "::endgroup::"
+
+            echo "::group::Run Playwright tests"
+            cd ui_tests/playwright && npm test
+            echo "::endgroup::"
+          '
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           nix develop --command bash -c '
             set -euo pipefail
+            trap 'echo "::endgroup::"' ERR
 
             echo "::group::Install Playwright npm deps"
             cd ui_tests/playwright && npm ci && cd ../..

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,5 +56,14 @@ jobs:
       - name: cargo clippy (server)
         run: nix develop --command cargo clippy -p omnibus --all-targets -- -D warnings
 
+      - name: cargo clippy (db)
+        run: nix develop --command cargo clippy -p omnibus-db --all-targets -- -D warnings
+
       - name: cargo test (server)
         run: nix develop --command cargo test -p omnibus
+
+      - name: cargo test (db)
+        run: nix develop --command cargo test -p omnibus-db
+
+      - name: cargo test (frontend)
+        run: nix develop --command cargo test -p omnibus-frontend --features server

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,8 +18,22 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable Rust with rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: cargo fmt --check
+        run: cargo fmt --all --check
+
   check:
-    name: fmt + clippy + test
+    name: clippy + test
     runs-on: ubuntu-latest
     env:
       # Match e2e.yml: pin target dir so rust-cache (keyed on `. -> target`)
@@ -39,20 +53,8 @@ jobs:
         with:
           workspaces: ". -> target"
 
-      - name: cargo fmt --check
-        run: nix develop --command cargo fmt --all --check
-
       - name: cargo clippy (server)
         run: nix develop --command cargo clippy -p omnibus --all-targets -- -D warnings
 
-      - name: cargo clippy (db)
-        run: nix develop --command cargo clippy -p omnibus-db --all-targets -- -D warnings
-
       - name: cargo test (server)
         run: nix develop --command cargo test -p omnibus
-
-      - name: cargo test (db)
-        run: nix develop --command cargo test -p omnibus-db
-
-      - name: cargo test (frontend)
-        run: nix develop --command cargo test -p omnibus-frontend --features server


### PR DESCRIPTION
## Summary

Closes #19.

- **rust.yml**: Split `cargo fmt` into its own job that uses `dtolnay/rust-toolchain@stable` instead of `nix develop`. Drops fmt check from ~4m20s to ~30s. Clippy + test remain in the existing Nix-backed job and run in parallel with fmt.
- **e2e.yml**: Combine 5 separate `nix develop --command` invocations into a single shell session with `::group::` annotations for UI readability. Pays the Nix shell setup cost once instead of repeatedly.

## Test plan

- [ ] `rust.yml` `fmt` job completes in <1 minute without Nix
- [ ] `rust.yml` `check` job runs clippy + test normally with Nix
- [ ] `e2e.yml` single `nix develop` session runs all build/test phases
- [ ] Artifact uploads still trigger on failure in e2e