### PR TITLE
feat(search): F1.5 search palette with grouped FTS5 results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Default `cargo build` / `clippy` covers `server`, `shared`, `frontend` only. Mob
 ### shared/src/
 
 ```
-lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection, EbookMetadata, EbookLibrary, AuthorDetail, SeriesDetail, TagWeight, ViewPrefs, ViewFilters, MetadataOverrides, Contributor, Identifier
+lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection, EbookMetadata, EbookLibrary, AuthorDetail, SeriesDetail, TagWeight, ViewPrefs, ViewFilters, MetadataOverrides, Contributor, Identifier, PaletteResults + palette hit types (F1.5)
 ```
 
 ### db/src/
@@ -79,6 +79,7 @@ rpc.rs              — #[get]/#[post] server functions (mounted by dioxus::serv
 pages/{landing,settings,book_detail,metadata_edit,auth,author,series,tag_cloud}.rs  — auth.rs hosts LoginPage + RegisterPage. Landing is the primary Atrium consumer (cover grid + power-user table) and the source of format-faceted filtering (ViewFilters.formats in shared). metadata_edit.rs is the F5.1 single-book edit form at /books/:id/edit. Discovery pages (author, series, tag_cloud) are F1.8.
 components/{top_nav,bottom_nav}.rs  — feature = web / mobile respectively
 components/atrium.rs  — F1.7 design-system primitives (AtriumRoot, Cover, ThemeToggle); CSS at frontend/assets/atrium.css
+components/search_palette.rs — F1.5 command-palette search overlay (⌘K trigger, grouped FTS5 results, keyboard nav); web-only (not(mobile))
 ```
 
 ### server/src/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,6 +3829,7 @@ dependencies = [
  "dioxus",
  "dioxus-router",
  "gloo-net",
+ "gloo-timers",
  "omnibus-db",
  "omnibus-shared",
  "reqwest",
@@ -3837,6 +3838,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tracing",
+ "wasm-bindgen",
  "web-sys",
 ]
 

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -19,6 +19,7 @@ use sqlx::{sqlite::SqlitePoolOptions, Row, SqlitePool, Transaction};
 pub use omnibus_shared::Settings;
 use omnibus_shared::{
     AuthorDetail, Contributor, EbookLibrary, EbookMetadata, Identifier, MetadataOverrides,
+    PaletteAuthorHit, PaletteBookHit, PaletteResults, PaletteSeriesHit, PaletteTagHit,
     SeriesDetail, TagWeight,
 };
 
@@ -1827,6 +1828,214 @@ pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, sqlx::Er
             count: r.get::<i64, _>("cnt") as usize,
         })
         .collect())
+}
+
+// -----------------------------------------------------------------------------
+// Search palette (F1.5)
+// -----------------------------------------------------------------------------
+
+/// Maximum query length (in chars) accepted by `search_palette`. Inputs
+/// beyond this are truncated to bound FTS5 expression size and LIKE
+/// pattern length.
+const MAX_QUERY_LEN: usize = 256;
+
+/// Search palette — grouped results for the command-palette overlay (F1.5).
+///
+/// Returns up to 5 results per category (books, authors, series, tags),
+/// with server-side timing in `duration_ms`. Books are matched via FTS5
+/// (`build_fts_match`); taxonomy categories use `LIKE '%q%'` against the
+/// name column. All results are scoped to `library_path`.
+///
+/// Returns `PaletteResults::default()` for empty/whitespace queries.
+pub async fn search_palette(
+    pool: &SqlitePool,
+    library_path: &str,
+    q: &str,
+) -> Result<PaletteResults, sqlx::Error> {
+    let trimmed = q.trim();
+    if trimmed.is_empty() {
+        return Ok(PaletteResults::default());
+    }
+    // Truncate to cap FTS5 + LIKE expression size. Collect chars to
+    // avoid slicing mid-codepoint.
+    let trimmed: String = trimmed.chars().take(MAX_QUERY_LEN).collect();
+    let trimmed = trimmed.as_str();
+
+    let start = std::time::Instant::now();
+    const LIMIT: i32 = 5;
+
+    // A. Books — FTS5 MATCH with BM25 ranking, slim projection.
+    let books = if let Some(match_expr) = build_fts_match(trimmed) {
+        let rows = sqlx::query(
+            r#"
+            SELECT b.id, b.title, b.has_cover, b.accent_color,
+                   SUBSTR(b.pubdate, 1, 4) AS year,
+
+                   (SELECT GROUP_CONCAT(a.name, ', ')
+                      FROM (SELECT a2.name FROM books_authors_link bal
+                              JOIN authors a2 ON a2.id = bal.author
+                             WHERE bal.book = b.id
+                             ORDER BY bal.position) a)          AS author_display,
+
+                   (SELECT json_group_array(format)
+                      FROM (SELECT format FROM book_files
+                             WHERE book_id = b.id
+                             ORDER BY format))                  AS formats_json
+
+            FROM books_fts
+            JOIN books b ON b.id = books_fts.rowid
+            JOIN libraries l ON l.id = b.library_id
+            WHERE books_fts MATCH ?1 AND l.path = ?2
+            ORDER BY bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0), b.sort, b.id
+            LIMIT ?3
+            "#,
+        )
+        .bind(&match_expr)
+        .bind(library_path)
+        .bind(LIMIT)
+        .fetch_all(pool)
+        .await?;
+
+        rows.iter()
+            .map(|r| {
+                let id: i64 = r.get("id");
+                let has_cover: i64 = r.get("has_cover");
+                Ok(PaletteBookHit {
+                    id,
+                    title: r.get::<Option<String>, _>("title").unwrap_or_default(),
+                    author_display: r
+                        .get::<Option<String>, _>("author_display")
+                        .unwrap_or_default(),
+                    year: r.get("year"),
+                    formats: parse_json_array(r.get("formats_json"))?,
+                    cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+                    accent: r.get("accent_color"),
+                })
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?
+    } else {
+        Vec::new()
+    };
+
+    // Escape the query for LIKE pattern: backslash first (it's the ESCAPE char),
+    // then the LIKE wildcards percent and underscore.
+    let like_q = trimmed
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    let like_pattern = format!("%{like_q}%");
+
+    // B. Authors — substring match, scoped to library, ordered by book count.
+    let authors: Vec<PaletteAuthorHit> = sqlx::query(
+        r#"
+        SELECT a.id, a.name,
+               (SELECT COUNT(*) FROM books_authors_link bal
+                  JOIN books b ON b.id = bal.book
+                  JOIN libraries l ON l.id = b.library_id
+                 WHERE bal.author = a.id AND l.path = ?1) AS book_count
+        FROM authors a
+        WHERE a.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (SELECT 1 FROM books_authors_link bal
+                        JOIN books b ON b.id = bal.book
+                        JOIN libraries l ON l.id = b.library_id
+                       WHERE bal.author = a.id AND l.path = ?1)
+        ORDER BY book_count DESC, a.name
+        LIMIT ?3
+        "#,
+    )
+    .bind(library_path)
+    .bind(&like_pattern)
+    .bind(LIMIT)
+    .fetch_all(pool)
+    .await?
+    .iter()
+    .map(|r| PaletteAuthorHit {
+        id: r.get("id"),
+        name: r.get("name"),
+        book_count: r.get::<i32, _>("book_count") as u32,
+    })
+    .collect();
+
+    // C. Series — substring match with primary author from first book.
+    let series: Vec<PaletteSeriesHit> = sqlx::query(
+        r#"
+        SELECT s.id, s.name,
+               (SELECT COUNT(*) FROM books_series_link bsl
+                  JOIN books b ON b.id = bsl.book
+                  JOIN libraries l ON l.id = b.library_id
+                 WHERE bsl.series = s.id AND l.path = ?1) AS book_count,
+               (SELECT a.name FROM books_series_link bsl2
+                  JOIN books b2 ON b2.id = bsl2.book
+                  JOIN libraries l2 ON l2.id = b2.library_id
+                  JOIN books_authors_link bal ON bal.book = bsl2.book
+                  JOIN authors a ON a.id = bal.author
+                 WHERE bsl2.series = s.id AND l2.path = ?1
+                 ORDER BY b2.sort, b2.id, bal.position LIMIT 1) AS author_display
+        FROM series s
+        WHERE s.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (SELECT 1 FROM books_series_link bsl
+                        JOIN books b ON b.id = bsl.book
+                        JOIN libraries l ON l.id = b.library_id
+                       WHERE bsl.series = s.id AND l.path = ?1)
+        ORDER BY book_count DESC, s.name
+        LIMIT ?3
+        "#,
+    )
+    .bind(library_path)
+    .bind(&like_pattern)
+    .bind(LIMIT)
+    .fetch_all(pool)
+    .await?
+    .iter()
+    .map(|r| PaletteSeriesHit {
+        id: r.get("id"),
+        name: r.get("name"),
+        book_count: r.get::<i32, _>("book_count") as u32,
+        author_display: r.get("author_display"),
+    })
+    .collect();
+
+    // D. Tags — substring match, scoped to library.
+    let tags: Vec<PaletteTagHit> = sqlx::query(
+        r#"
+        SELECT t.id, t.name,
+               (SELECT COUNT(*) FROM books_tags_link btl
+                  JOIN books b ON b.id = btl.book
+                  JOIN libraries l ON l.id = b.library_id
+                 WHERE btl.tag = t.id AND l.path = ?1) AS book_count
+        FROM tags t
+        WHERE t.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (SELECT 1 FROM books_tags_link btl
+                        JOIN books b ON b.id = btl.book
+                        JOIN libraries l ON l.id = b.library_id
+                       WHERE btl.tag = t.id AND l.path = ?1)
+        ORDER BY book_count DESC, t.name
+        LIMIT ?3
+        "#,
+    )
+    .bind(library_path)
+    .bind(&like_pattern)
+    .bind(LIMIT)
+    .fetch_all(pool)
+    .await?
+    .iter()
+    .map(|r| PaletteTagHit {
+        id: r.get("id"),
+        name: r.get("name"),
+        book_count: r.get::<i32, _>("book_count") as u32,
+    })
+    .collect();
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    Ok(PaletteResults {
+        query: trimmed.to_string(),
+        books,
+        authors,
+        series,
+        tags,
+        duration_ms,
+    })
 }
 
 /// Build an `EbookLibrary` from whatever is currently in the DB for
@@ -4217,5 +4426,218 @@ mod tests {
         assert_eq!(merged.publisher.as_deref(), Some("Edited Publisher"));
         // unset in both stays None
         assert_eq!(merged.language, None);
+    }
+
+    // ── search_palette ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn palette_books_match_title() {
+        let _covers = CoversTempDir::new("palette_books");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("Dracula"),
+                    &["Bram Stoker"],
+                    &["Horror"],
+                    None,
+                    None,
+                ),
+                indexed(
+                    "b.epub",
+                    Some("Frankenstein"),
+                    &["Mary Shelley"],
+                    &["Horror"],
+                    None,
+                    None,
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "dracula").await.unwrap();
+        assert_eq!(results.books.len(), 1);
+        assert_eq!(results.books[0].title, "Dracula");
+        assert_eq!(results.books[0].author_display, "Bram Stoker");
+        assert!(results.books[0].formats.contains(&"EPUB".to_string()));
+    }
+
+    #[tokio::test]
+    async fn palette_authors_match_substring() {
+        let _covers = CoversTempDir::new("palette_authors");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("Babel"),
+                &["R. F. Kuang"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "kuang").await.unwrap();
+        assert!(!results.authors.is_empty(), "should match author substring");
+        assert_eq!(results.authors[0].name, "R. F. Kuang");
+        assert_eq!(results.authors[0].book_count, 1);
+    }
+
+    #[tokio::test]
+    async fn palette_series_match() {
+        let _covers = CoversTempDir::new("palette_series");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("Book One"),
+                    &["Author"],
+                    &[],
+                    Some(("Poppy War", "1")),
+                    None,
+                ),
+                indexed(
+                    "b.epub",
+                    Some("Book Two"),
+                    &["Author"],
+                    &[],
+                    Some(("Poppy War", "2")),
+                    None,
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "poppy").await.unwrap();
+        assert!(!results.series.is_empty(), "should match series substring");
+        assert_eq!(results.series[0].name, "Poppy War");
+        assert_eq!(results.series[0].book_count, 2);
+    }
+
+    #[tokio::test]
+    async fn palette_tags_match() {
+        let _covers = CoversTempDir::new("palette_tags");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("A"),
+                &["Author"],
+                &["Dark academia"],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "academia").await.unwrap();
+        assert!(!results.tags.is_empty(), "should match tag substring");
+        assert_eq!(results.tags[0].name, "Dark academia");
+        assert_eq!(results.tags[0].book_count, 1);
+    }
+
+    #[tokio::test]
+    async fn palette_empty_query_returns_empty() {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let results = search_palette(&pool, "/lib", "   ").await.unwrap();
+        assert!(results.books.is_empty());
+        assert!(results.authors.is_empty());
+        assert!(results.series.is_empty());
+        assert!(results.tags.is_empty());
+        assert_eq!(results.query, "");
+    }
+
+    #[tokio::test]
+    async fn palette_no_results() {
+        let _covers = CoversTempDir::new("palette_no_results");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed("a.epub", Some("A"), &["Author"], &[], None, None)],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "zzzznonexistent")
+            .await
+            .unwrap();
+        assert!(results.books.is_empty());
+        assert!(results.authors.is_empty());
+        assert!(results.series.is_empty());
+        assert!(results.tags.is_empty());
+    }
+
+    #[tokio::test]
+    async fn palette_scoped_to_library() {
+        let _covers = CoversTempDir::new("palette_scoped");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib-a",
+            vec![indexed(
+                "a.epub",
+                Some("Alpha"),
+                &["Tolkien"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        replace_books(
+            &pool,
+            "/lib-b",
+            vec![indexed(
+                "b.epub",
+                Some("Beta"),
+                &["Tolkien"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib-a", "tolkien").await.unwrap();
+        // Books should only include lib-a
+        assert_eq!(results.books.len(), 1);
+        assert_eq!(results.books[0].title, "Alpha");
+        // Author book_count should be 1 (scoped to lib-a), not 2
+        assert_eq!(results.authors[0].book_count, 1);
+    }
+
+    #[tokio::test]
+    async fn palette_duration_populated() {
+        let _covers = CoversTempDir::new("palette_duration");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed("a.epub", Some("A"), &["Author"], &[], None, None)],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "author").await.unwrap();
+        // duration_ms should be populated (at least 0 — we just check it's set)
+        assert!(results.duration_ms < 10000, "duration should be reasonable");
     }
 }

--- a/docs/roadmap/1-10-palette-discovery-link.md
+++ b/docs/roadmap/1-10-palette-discovery-link.md
@@ -1,0 +1,29 @@
+# F1.10 — Palette ↔ Discovery page links
+
+**Phase 1 · Browse & discovery** · **Priority:** P3
+
+Link search-palette entity results directly to F1.8 discovery pages once those routes exist.
+
+## Objective
+
+The F1.5 search palette currently navigates author/series/tag results to the landing page with a `SearchQuery` filter applied (e.g. `author:kuang`). This is a stopgap. Once the F1.8 discovery pages ship (`/authors/:slug`, `/series/:slug`, `/tags/:name`), the palette should route to those pages instead — giving the user a dedicated page for the entity they selected, not just a filtered book list.
+
+## Dependencies
+
+- **F1.5 Search palette** (this branch) — provides the palette component and `PaletteAuthorHit` / `PaletteSeriesHit` / `PaletteTagHit` result types.
+- **F1.8 Discovery pages** — provides the routes to link to.
+
+## Scope
+
+1. Update `search_palette.rs` `navigate_to_item` so `FlatItem::Author` pushes `Route::AuthorDetail { slug }` instead of setting `SearchQuery`.
+2. Same for `FlatItem::Series` → `Route::SeriesDetail { slug }` and `FlatItem::Tag` → `Route::TagDetail { name }`.
+3. The palette hit types may need a `slug` field added (currently carry `id` + `name`). Coordinate with F1.8's slug strategy — if F1.8 uses `id`-based routes the change is trivial; if slug-based, `search_palette` in `db/src/queries.rs` needs to join `authors.slug`.
+4. Update `search-palette.spec.ts` navigation tests to assert the new routes.
+
+## Effort
+
+Low — a few lines of route-push logic and a slug join. The majority of the work is in F1.8 itself.
+
+## Status
+
+Queued — blocked on F1.8.

--- a/docs/roadmap/1-5-advanced-search.md
+++ b/docs/roadmap/1-5-advanced-search.md
@@ -318,7 +318,9 @@ log line stable so a future Loki/Tempo query can parse it.
 
 ## Status
 
-Queued.
+In progress — the **search palette** (command-palette / Spotlight pattern) shipped as the first deliverable, replacing the inline nav search input with a floating ⌘K-triggered overlay showing grouped FTS5 results (books, authors, series, tags). This is a lighter, faster surface than the facet-picker modal originally described above. The facet modal's slice-and-dice use case (multi-select facet pickers, structured `AdvancedSearchQuery`, saved filters) moves to [F3.1](3-1-libraries.md).
+
+The palette lives in `frontend/src/components/search_palette.rs` with backing query `db::search_palette` and both RPC (`/api/rpc/search-palette`) and REST (`/api/search/palette`) endpoints. Entity results (author/series/tag) currently navigate to the landing page with a filter; [F1.10](1-10-palette-discovery-link.md) will link them to F1.8 discovery pages once those ship.
 
 ---
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -12,9 +12,11 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 gloo-net = { version = "0.6", default-features = false, features = ["http", "json"], optional = true }
+gloo-timers = { version = "0.3", features = ["futures"], optional = true }
 # `web-sys` is enabled only on the WASM client for `Window::local_storage()`.
 # F1.3 view-mode / sort / filter prefs are persisted there per library path.
-web-sys = { version = "0.3", features = ["Window", "Storage"], optional = true }
+web-sys = { version = "0.3", features = ["Window", "Storage", "KeyboardEvent"], optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 # sqlx + tokio are needed at the type level by rpc.rs when building server
 # functions (PoolExt = Extension<SqlitePool>, #[tokio::spawn] for reindex).
 # Kept as optional deps enabled only by the `server` feature. Tokio is
@@ -31,7 +33,7 @@ tracing = { workspace = true, optional = true }
 [features]
 default = []
 # Web client (WASM): uses dioxus-fullstack server-function client stubs.
-web = ["dioxus/web", "dep:gloo-net", "dep:serde_json", "dep:web-sys"]
+web = ["dioxus/web", "dep:gloo-net", "dep:gloo-timers", "dep:serde_json", "dep:web-sys", "dep:wasm-bindgen"]
 # Native mobile client: talks to `/api/*` REST routes via reqwest.
 # tokio is enabled for `sync::watch` — used by `data::token_store` to
 # notify the UI when auth state changes so screens redirect to /login

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -131,6 +131,150 @@ body.atrium,
 .atrium-nav a:hover { color: var(--ink-0); background: var(--bg-1); }
 .atrium-nav a.on    { color: var(--ink-0); background: var(--bg-2); }
 
+/* ── Search palette (F1.5) ──────────────────────────────────────── */
+.sp-trigger {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 0 14px; height: 36px; border-radius: 999px;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--ink-2); font-size: 13px; cursor: pointer;
+  transition: color .15s, border-color .15s, background .15s;
+  margin-left: auto;
+}
+.sp-trigger:hover { color: var(--ink-0); border-color: var(--line); background: var(--bg-3); }
+.sp-trigger .sp-trigger-icon {
+  width: 14px; height: 14px; position: relative;
+}
+.sp-trigger .sp-trigger-icon::before {
+  content: ''; position: absolute; left: 0; top: 0;
+  width: 10px; height: 10px; border: 1.5px solid currentColor;
+  border-radius: 50%;
+}
+.sp-trigger .sp-trigger-icon::after {
+  content: ''; position: absolute; right: 0; bottom: 0;
+  width: 5px; height: 1.5px; background: currentColor;
+  transform: rotate(45deg); transform-origin: right center;
+}
+.sp-trigger-kbd {
+  font-family: var(--mono); font-size: 10px; color: var(--ink-3);
+  padding: 1px 5px; border-radius: 4px;
+  border: 1px solid var(--line-2); background: var(--bg-1);
+}
+
+.sp-scrim {
+  position: fixed; inset: 0;
+  background: color-mix(in oklch, var(--bg-0) 70%, transparent);
+  backdrop-filter: blur(6px);
+  z-index: 50;
+  animation: sp-fade-in .12s ease-out;
+}
+.sp-panel {
+  position: fixed;
+  top: 60px; left: 50%; transform: translateX(-50%);
+  width: min(680px, calc(100vw - 48px));
+  max-height: calc(100vh - 120px);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: 0 24px 48px color-mix(in oklch, black 40%, transparent),
+              0 0 0 1px var(--line-2);
+  z-index: 51;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  animation: sp-slide-in .15s ease-out;
+}
+.sp-input-wrap {
+  display: flex; align-items: center; gap: 12px;
+  padding: 16px 22px 14px;
+  border-bottom: 1px solid var(--line-2);
+}
+.sp-input-icon {
+  width: 18px; height: 18px; position: relative; flex-shrink: 0;
+  color: var(--ink-2);
+}
+.sp-input-icon::before {
+  content: ''; position: absolute; left: 0; top: 0;
+  width: 12px; height: 12px; border: 1.5px solid currentColor;
+  border-radius: 50%;
+}
+.sp-input-icon::after {
+  content: ''; position: absolute; right: 0; bottom: 1px;
+  width: 6px; height: 1.5px; background: currentColor;
+  transform: rotate(45deg); transform-origin: right center;
+}
+.sp-input {
+  flex: 1; min-width: 0;
+  background: transparent; border: none; outline: none;
+  font-family: var(--serif); font-size: 22px; font-style: italic;
+  color: var(--ink-0); letter-spacing: -0.02em;
+}
+.sp-input::placeholder { color: var(--ink-3); font-style: italic; }
+.sp-meta {
+  font-family: var(--mono); font-size: 11px; color: var(--ink-3);
+  white-space: nowrap; flex-shrink: 0;
+}
+.sp-results {
+  overflow-y: auto; flex: 1; padding: 6px 0;
+}
+.sp-group-head {
+  padding: 12px 22px 6px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--ink-2); font-weight: 500;
+}
+.sp-row {
+  display: flex; align-items: center; gap: 14px;
+  padding: 8px 22px; cursor: pointer; border-radius: 0;
+  transition: background .08s;
+}
+.sp-row:hover, .sp-row.selected { background: var(--bg-2); }
+.sp-row-cover {
+  width: 36px; height: 54px; border-radius: 2px;
+  overflow: hidden; flex-shrink: 0; background: var(--bg-3);
+}
+.sp-row-cover img { width: 100%; height: 100%; object-fit: cover; }
+.sp-row-body { flex: 1; min-width: 0; }
+.sp-row-title {
+  font-size: 14px; color: var(--ink-0); line-height: 1.3;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.sp-row-title em { font-style: italic; font-family: var(--serif); }
+.sp-row-sub {
+  font-size: 12px; color: var(--ink-2); margin-top: 2px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.sp-row-meta {
+  font-family: var(--mono); font-size: 10.5px; color: var(--ink-3);
+  white-space: nowrap; flex-shrink: 0;
+}
+.sp-avatar {
+  width: 36px; height: 36px; border-radius: 50%;
+  background: var(--bg-3); display: flex;
+  align-items: center; justify-content: center;
+  font-family: var(--serif); font-size: 16px;
+  font-style: italic; color: var(--ink-1); flex-shrink: 0;
+}
+.sp-tag-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px; border-radius: 999px; font-size: 12px;
+  background: var(--bg-2); color: var(--ink-1);
+  border: 1px solid var(--line-2);
+}
+.sp-coming-soon {
+  padding: 10px 22px; font-size: 12px; color: var(--ink-3);
+  font-style: italic;
+}
+.sp-footer {
+  padding: 10px 22px;
+  border-top: 1px solid var(--line-2);
+  display: flex; justify-content: space-between;
+  font-family: var(--mono); font-size: 10.5px; color: var(--ink-3);
+}
+@keyframes sp-fade-in { from { opacity: 0 } to { opacity: 1 } }
+@keyframes sp-slide-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(-8px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
 /* ── Buttons ────────────────────────────────────────────────────── */
 .btn {
   display: inline-flex; align-items: center; gap: 8px;

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -32,6 +32,9 @@ pub use format_switcher::FormatSwitcher;
 
 pub mod atrium;
 
+#[cfg(not(feature = "mobile"))]
+pub mod search_palette;
+
 // Auth-page primitives — used by the login / register / first-run /
 // recovery screens on every target. Stays platform-agnostic so the same
 // markup ships under web SSR, web WASM, and mobile native.

--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -1,0 +1,692 @@
+//! F1.5 Search Palette — command-palette / Spotlight-style search overlay.
+//!
+//! Replaces the inline `NavSearch` text input with a trigger **button** in the
+//! top nav. Clicking the button (or pressing `⌘K` / `Ctrl+K`) opens a floating
+//! palette with its own full-width input, debounced FTS5 search, and grouped
+//! results: Books, Authors, Series, Tags, and a placeholder "Inside text"
+//! section.
+//!
+//! ## Component tree
+//!
+//! ```text
+//! SearchPaletteHost          — mounted in TopNav, replaces NavSearch
+//! ├─ SpTriggerButton         — search button (icon + "Search" + ⌘K kbd hint)
+//! └─ (open) SpOverlay        — portal: scrim + panel
+//!            ├─ SpInput       — autofocused serif italic input
+//!            ├─ SpMeta        — "5 results · 18ms"
+//!            ├─ SpResults     — scrollable grouped results
+//!            └─ SpFooter      — keyboard hints + "fts5 · ranked"
+//! ```
+//!
+//! ## Hydration safety
+//!
+//! The palette starts closed (`PaletteOpen = false`). The overlay only renders
+//! when open, so SSR and WASM agree on initial DOM — no hydration mismatch.
+//! The `⌘K` listener fires only in `#[cfg(feature = "web")]`.
+
+use dioxus::prelude::*;
+use dioxus_router::use_navigator;
+use omnibus_shared::{
+    PaletteAuthorHit, PaletteBookHit, PaletteResults, PaletteSeriesHit, PaletteTagHit,
+};
+
+use crate::{data, use_search_query, use_server_url, Route};
+
+/// Whether the search palette overlay is open. Registered at the App level
+/// via `use_context_provider` so both the trigger button and the global
+/// `⌘K` shortcut can toggle it.
+#[derive(Copy, Clone, PartialEq)]
+pub struct PaletteOpen(pub Signal<bool>);
+
+/// Top-level host: renders the trigger button and (when open) the overlay.
+/// Mount this in `TopNav` in place of the old `NavSearch`.
+#[component]
+pub fn SearchPaletteHost() -> Element {
+    let open = use_context::<PaletteOpen>();
+
+    // Register global ⌘K / Ctrl+K listener here (always-mounted) so the
+    // shortcut can open the palette from the closed state.
+    #[cfg(feature = "web")]
+    use_global_shortcut(open);
+
+    rsx! {
+        SpTriggerButton { open }
+        if open.0() {
+            SpOverlay { open }
+        }
+    }
+}
+
+// ── Trigger button ───────────────────────────────────────────────
+
+/// Pill-shaped search button in the nav: search icon + "Search" + ⌘K hint.
+#[component]
+fn SpTriggerButton(open: PaletteOpen) -> Element {
+    let mut open = open;
+    rsx! {
+        button {
+            class: "sp-trigger",
+            "data-testid": "search-trigger",
+            r#type: "button",
+            onclick: move |_| open.0.set(true),
+            // Search icon (SVG magnifying glass)
+            svg {
+                class: "sp-trigger-icon",
+                width: "15",
+                height: "15",
+                view_box: "0 0 24 24",
+                fill: "none",
+                stroke: "currentColor",
+                stroke_width: "2",
+                stroke_linecap: "round",
+                stroke_linejoin: "round",
+                circle { cx: "11", cy: "11", r: "8" }
+                line { x1: "21", y1: "21", x2: "16.65", y2: "16.65" }
+            }
+            span { "Search" }
+            kbd { class: "sp-trigger-kbd", "⌘K" }
+        }
+    }
+}
+
+// ── Overlay (scrim + panel) ──────────────────────────────────────
+
+/// Floating overlay: dark scrim + centered panel with input, results, footer.
+#[component]
+fn SpOverlay(open: PaletteOpen) -> Element {
+    let mut open = open;
+    let server_url = use_server_url();
+    let mut query = use_signal(String::new);
+    let mut results = use_signal(|| Option::<PaletteResults>::None);
+    let mut selected = use_signal(|| 0_usize);
+    let mut loading = use_signal(|| false);
+    // Generation counter for debounce — stale responses are discarded.
+    let mut generation = use_signal(|| 0_u64);
+    let nav = use_navigator();
+    let mut search_query = use_search_query();
+
+    // Build a flat list of selectable items for keyboard navigation.
+    let flat_items = use_memo(move || build_flat_items(&results.read()));
+
+    // Close the palette.
+    let mut close = move || {
+        open.0.set(false);
+    };
+
+    // Navigate to the selected result.
+    let navigate_to_item = {
+        move |item: &FlatItem| {
+            match item {
+                FlatItem::Book { id, .. } => {
+                    nav.push(Route::BookDetail { id: *id });
+                }
+                FlatItem::Author { name, .. } => {
+                    search_query.0.set(facet_query("author", name));
+                    nav.push(Route::Landing {});
+                }
+                FlatItem::Series { name, .. } => {
+                    search_query.0.set(facet_query("series", name));
+                    nav.push(Route::Landing {});
+                }
+                FlatItem::Tag { name, .. } => {
+                    search_query.0.set(facet_query("tag", name));
+                    nav.push(Route::Landing {});
+                }
+            }
+            open.0.set(false);
+        }
+    };
+
+    // Handle keyboard events on the panel.
+    let items_for_key = flat_items;
+    let mut nav_for_key = navigate_to_item;
+    let on_keydown = move |evt: Event<KeyboardData>| {
+        let key = evt.key();
+        match key {
+            Key::Escape => {
+                evt.prevent_default();
+                open.0.set(false);
+            }
+            Key::ArrowDown => {
+                evt.prevent_default();
+                let len = items_for_key.read().len();
+                if len > 0 {
+                    selected.set((selected() + 1) % len);
+                }
+            }
+            Key::ArrowUp => {
+                evt.prevent_default();
+                let len = items_for_key.read().len();
+                if len > 0 {
+                    selected.set(if selected() == 0 {
+                        len - 1
+                    } else {
+                        selected() - 1
+                    });
+                }
+            }
+            Key::Enter => {
+                evt.prevent_default();
+                let items = items_for_key.read();
+                if let Some(item) = items.get(selected()) {
+                    nav_for_key(item);
+                }
+            }
+            _ => {}
+        }
+    };
+
+    // Debounced search effect. Uses gloo_timers on web, tokio::time on
+    // server. The generation counter ensures stale responses are discarded.
+    let url = server_url.clone();
+    use_effect(move || {
+        let q = query();
+        let gen = generation();
+        let url = url.clone();
+        spawn(async move {
+            // 150ms debounce.
+            async_sleep_ms(150).await;
+            // Stale? Skip.
+            if gen != generation() {
+                return;
+            }
+            let trimmed = q.trim().to_string();
+            if trimmed.is_empty() {
+                results.set(None);
+                loading.set(false);
+                return;
+            }
+            loading.set(true);
+            match data::search_palette(&url, &trimmed).await {
+                Ok(r) => {
+                    // Only apply if still current generation.
+                    if gen == generation() {
+                        selected.set(0);
+                        results.set(Some(r));
+                    }
+                }
+                Err(_) => {
+                    if gen == generation() {
+                        results.set(None);
+                    }
+                }
+            }
+            if gen == generation() {
+                loading.set(false);
+            }
+        });
+    });
+
+    let res = results.read();
+    let items = flat_items.read();
+    let sel = selected();
+    let is_loading = loading();
+
+    let total = res.as_ref().map(|r| r.total_count()).unwrap_or(0);
+    let duration = res.as_ref().map(|r| r.duration_ms).unwrap_or(0);
+
+    rsx! {
+        div {
+            class: "sp-scrim",
+            "data-testid": "sp-scrim",
+            onclick: move |_| close(),
+            tabindex: "-1",
+            div {
+                class: "sp-panel",
+                "data-testid": "sp-panel",
+                role: "dialog",
+                aria_label: "Search palette",
+                aria_modal: "true",
+                // Stop clicks inside the panel from closing the scrim.
+                onclick: move |evt| evt.stop_propagation(),
+                onkeydown: on_keydown,
+
+                // Input row
+                div { class: "sp-input-wrap",
+                    svg {
+                        class: "sp-input-icon",
+                        width: "18",
+                        height: "18",
+                        view_box: "0 0 24 24",
+                        fill: "none",
+                        stroke: "currentColor",
+                        stroke_width: "2",
+                        stroke_linecap: "round",
+                        stroke_linejoin: "round",
+                        circle { cx: "11", cy: "11", r: "8" }
+                        line { x1: "21", y1: "21", x2: "16.65", y2: "16.65" }
+                    }
+                    input {
+                        class: "sp-input",
+                        "data-testid": "sp-input",
+                        r#type: "text",
+                        placeholder: "Search books, authors, series, tags…",
+                        autofocus: true,
+                        // `autofocus` only fires on initial page load.
+                        // `onmounted` programmatically focuses the input
+                        // when the overlay is dynamically rendered (⌘K).
+                        // Uses `requestAnimationFrame` so the browser has
+                        // finished layout before we `.focus()`.
+                        onmounted: move |_evt: MountedEvent| {
+                            document::eval(r#"
+                                requestAnimationFrame(() => {
+                                    const el = document.querySelector('[data-testid="sp-input"]');
+                                    if (el) el.focus();
+                                });
+                            "#);
+                        },
+                        value: "{query}",
+                        oninput: move |evt| {
+                            let v = evt.value();
+                            query.set(v);
+                            generation += 1;
+                        },
+                    }
+                    if is_loading {
+                        span { class: "sp-spinner", "…" }
+                    }
+                }
+
+                // Meta line
+                if res.is_some() {
+                    div { class: "sp-meta", "data-testid": "sp-result-count",
+                        "{total} result{plural(total)} · {duration}ms"
+                    }
+                }
+
+                // Results
+                div { class: "sp-results",
+                    if let Some(ref r) = *res {
+                        // Books
+                        if !r.books.is_empty() {
+                            SpGroupHead { label: "Books", count: r.books.len() }
+                            for book in r.books.iter() {
+                                SpBookRow {
+                                    book: book.clone(),
+                                    selected: is_selected(&items, sel, &FlatItem::Book { id: book.id, title: book.title.clone() }),
+                                    on_click: {
+                                        let id = book.id;
+                                        move |_| {
+                                            nav.push(Route::BookDetail { id });
+                                            open.0.set(false);
+                                        }
+                                    },
+                                }
+                            }
+                        }
+
+                        // Authors
+                        if !r.authors.is_empty() {
+                            SpGroupHead { label: "Authors", count: r.authors.len() }
+                            for author in r.authors.iter() {
+                                SpAuthorRow {
+                                    author: author.clone(),
+                                    selected: is_selected(&items, sel, &FlatItem::Author { id: author.id, name: author.name.clone() }),
+                                    on_click: {
+                                        let name = author.name.clone();
+                                        let mut sq = search_query;
+                                        move |_| {
+                                            sq.0.set(format!("author:{name}"));
+                                            nav.push(Route::Landing {});
+                                            open.0.set(false);
+                                        }
+                                    },
+                                }
+                            }
+                        }
+
+                        // Series
+                        if !r.series.is_empty() {
+                            SpGroupHead { label: "Series", count: r.series.len() }
+                            for s in r.series.iter() {
+                                SpSeriesRow {
+                                    series: s.clone(),
+                                    selected: is_selected(&items, sel, &FlatItem::Series { id: s.id, name: s.name.clone() }),
+                                    on_click: {
+                                        let name = s.name.clone();
+                                        let mut sq = search_query;
+                                        move |_| {
+                                            sq.0.set(format!("series:{name}"));
+                                            nav.push(Route::Landing {});
+                                            open.0.set(false);
+                                        }
+                                    },
+                                }
+                            }
+                        }
+
+                        // Tags
+                        if !r.tags.is_empty() {
+                            SpGroupHead { label: "Tags", count: r.tags.len() }
+                            for tag in r.tags.iter() {
+                                SpTagRow {
+                                    tag: tag.clone(),
+                                    selected: is_selected(&items, sel, &FlatItem::Tag { id: tag.id, name: tag.name.clone() }),
+                                    on_click: {
+                                        let name = tag.name.clone();
+                                        let mut sq = search_query;
+                                        move |_| {
+                                            sq.0.set(format!("tag:{name}"));
+                                            nav.push(Route::Landing {});
+                                            open.0.set(false);
+                                        }
+                                    },
+                                }
+                            }
+                        }
+
+                        // Inside text — placeholder
+                        SpGroupHead { label: "Inside text", count: 0 }
+                        div { class: "sp-coming-soon", "data-testid": "sp-coming-soon",
+                            "Coming soon"
+                        }
+                    }
+                }
+
+                // Footer
+                SpFooter {}
+            }
+        }
+    }
+}
+
+// ── Result rows ──────────────────────────────────────────────────
+
+#[component]
+fn SpGroupHead(label: &'static str, count: usize) -> Element {
+    rsx! {
+        div { class: "sp-group-head label",
+            if count > 0 {
+                "{label} · {count}"
+            } else {
+                "{label}"
+            }
+        }
+    }
+}
+
+#[component]
+fn SpBookRow(book: PaletteBookHit, selected: bool, on_click: EventHandler<MouseEvent>) -> Element {
+    let sel_class = if selected {
+        "sp-row selected"
+    } else {
+        "sp-row"
+    };
+    let server_url = use_server_url();
+    let cover = if book.cover_url.is_some() {
+        let url = format!("{server_url}/api/thumbs/{}/sm", book.id);
+        rsx! {
+            img {
+                class: "sp-row-cover",
+                src: "{url}",
+                alt: "",
+                loading: "lazy",
+            }
+        }
+    } else {
+        // Accent-backed fallback with first letter
+        let initial = book
+            .title
+            .chars()
+            .next()
+            .unwrap_or('?')
+            .to_uppercase()
+            .to_string();
+        let bg = book.accent.as_deref().unwrap_or("var(--bg-2)");
+        rsx! {
+            div {
+                class: "sp-row-cover sp-row-cover-fallback",
+                style: "background: {bg};",
+                "{initial}"
+            }
+        }
+    };
+
+    let year = book.year.as_deref().unwrap_or("");
+    let formats: String = book.formats.join(" · ");
+
+    rsx! {
+        div {
+            class: "{sel_class}",
+            "data-testid": "sp-book-row",
+            onclick: move |evt| on_click.call(evt),
+            {cover}
+            div { class: "sp-row-body",
+                div { class: "sp-row-title", "{book.title}" }
+                div { class: "sp-row-sub", "{book.author_display}" }
+            }
+            if !year.is_empty() || !formats.is_empty() {
+                div { class: "sp-row-meta",
+                    if !year.is_empty() { span { "{year}" } }
+                    if !formats.is_empty() { span { "{formats}" } }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn SpAuthorRow(
+    author: PaletteAuthorHit,
+    selected: bool,
+    on_click: EventHandler<MouseEvent>,
+) -> Element {
+    let sel_class = if selected {
+        "sp-row selected"
+    } else {
+        "sp-row"
+    };
+    let initial = author
+        .name
+        .chars()
+        .next()
+        .unwrap_or('?')
+        .to_uppercase()
+        .to_string();
+
+    rsx! {
+        div {
+            class: "{sel_class}",
+            "data-testid": "sp-author-row",
+            onclick: move |evt| on_click.call(evt),
+            div { class: "sp-avatar", "{initial}" }
+            div { class: "sp-row-body",
+                div { class: "sp-row-title", "{author.name}" }
+                div { class: "sp-row-sub",
+                    "{author.book_count} book{plural(author.book_count as usize)}"
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn SpSeriesRow(
+    series: PaletteSeriesHit,
+    selected: bool,
+    on_click: EventHandler<MouseEvent>,
+) -> Element {
+    let sel_class = if selected {
+        "sp-row selected"
+    } else {
+        "sp-row"
+    };
+
+    rsx! {
+        div {
+            class: "{sel_class}",
+            "data-testid": "sp-series-row",
+            onclick: move |evt| on_click.call(evt),
+            div { class: "sp-avatar", "S" }
+            div { class: "sp-row-body",
+                div { class: "sp-row-title", "{series.name}" }
+                div { class: "sp-row-sub",
+                    "{series.book_count} book{plural(series.book_count as usize)}"
+                    if let Some(ref author) = series.author_display {
+                        " · {author}"
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn SpTagRow(tag: PaletteTagHit, selected: bool, on_click: EventHandler<MouseEvent>) -> Element {
+    let sel_class = if selected {
+        "sp-row selected"
+    } else {
+        "sp-row"
+    };
+
+    rsx! {
+        div {
+            class: "{sel_class}",
+            "data-testid": "sp-tag-row",
+            onclick: move |evt| on_click.call(evt),
+            span { class: "sp-tag-chip", "# {tag.name}" }
+            div { class: "sp-row-body",
+                div { class: "sp-row-sub",
+                    "{tag.book_count} book{plural(tag.book_count as usize)}"
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn SpFooter() -> Element {
+    rsx! {
+        div { class: "sp-footer",
+            div { class: "sp-footer-keys",
+                kbd { "↑↓" }
+                span { " navigate" }
+                kbd { "⏎" }
+                span { " open" }
+                kbd { "esc" }
+                span { " close" }
+            }
+            div { class: "sp-footer-engine",
+                "fts5 · ranked by relevance"
+            }
+        }
+    }
+}
+
+// ── Flat item model for keyboard nav ─────────────────────────────
+
+/// A single selectable item in the flat list used for arrow-key navigation.
+#[derive(Clone, Debug, PartialEq)]
+enum FlatItem {
+    Book { id: i64, title: String },
+    Author { id: i64, name: String },
+    Series { id: i64, name: String },
+    Tag { id: i64, name: String },
+}
+
+/// Build a flat ordered list of all selectable items from the results.
+fn build_flat_items(results: &Option<PaletteResults>) -> Vec<FlatItem> {
+    let Some(r) = results else {
+        return Vec::new();
+    };
+    let mut items = Vec::new();
+    for b in &r.books {
+        items.push(FlatItem::Book {
+            id: b.id,
+            title: b.title.clone(),
+        });
+    }
+    for a in &r.authors {
+        items.push(FlatItem::Author {
+            id: a.id,
+            name: a.name.clone(),
+        });
+    }
+    for s in &r.series {
+        items.push(FlatItem::Series {
+            id: s.id,
+            name: s.name.clone(),
+        });
+    }
+    for t in &r.tags {
+        items.push(FlatItem::Tag {
+            id: t.id,
+            name: t.name.clone(),
+        });
+    }
+    items
+}
+
+/// Check if a given flat item matches the currently selected index.
+fn is_selected(items: &[FlatItem], selected_idx: usize, candidate: &FlatItem) -> bool {
+    items.get(selected_idx) == Some(candidate)
+}
+
+/// Simple English plural suffix.
+fn plural(n: usize) -> &'static str {
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+/// Build a facet query string where every whitespace-separated word in
+/// `value` is prefixed with `prefix:`. This ensures `build_fts_match`
+/// routes each token to the correct FTS5 column filter instead of
+/// treating trailing words as free-text (e.g. `tag:Dark tag:academia`
+/// rather than `tag:Dark academia`).
+fn facet_query(prefix: &str, value: &str) -> String {
+    value
+        .split_whitespace()
+        .map(|w| format!("{prefix}:{w}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ── Async sleep (platform-gated) ─────────────────────────────────
+
+/// Platform-gated async sleep. Web uses `gloo_timers`, server uses `tokio`.
+#[cfg(feature = "web")]
+async fn async_sleep_ms(ms: u32) {
+    gloo_timers::future::TimeoutFuture::new(ms).await;
+}
+
+#[cfg(all(not(feature = "web"), feature = "server"))]
+async fn async_sleep_ms(ms: u32) {
+    tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
+}
+
+// ── Global ⌘K shortcut (web only) ───────────────────────────────
+
+/// Register a global `keydown` listener that toggles the palette on `⌘K`
+/// (Mac) or `Ctrl+K` (other platforms). Only compiled for the web target
+/// so SSR builds don't pull in `web_sys`.
+#[cfg(feature = "web")]
+fn use_global_shortcut(open: PaletteOpen) {
+    let mut open = open;
+    // use_hook runs exactly once per component instance (not on re-renders),
+    // so the closure is registered once and leaked once — no duplicate listeners.
+    use_hook(move || {
+        use wasm_bindgen::prelude::*;
+
+        let closure = Closure::wrap(Box::new(move |evt: web_sys::KeyboardEvent| {
+            let is_cmd_k = (evt.meta_key() || evt.ctrl_key()) && evt.key() == "k";
+            if is_cmd_k {
+                evt.prevent_default();
+                let current = open.0();
+                open.0.set(!current);
+            }
+        }) as Box<dyn FnMut(_)>);
+
+        if let Some(window) = web_sys::window() {
+            let _ = window
+                .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref());
+        }
+
+        // Leak the closure so it lives for the app lifetime. The shortcut
+        // is registered once (use_hook guarantees this) and never removed —
+        // acceptable for a single-page app.
+        closure.forget();
+    });
+}

--- a/frontend/src/components/top_nav.rs
+++ b/frontend/src/components/top_nav.rs
@@ -2,13 +2,14 @@ use dioxus::prelude::*;
 use dioxus_router::{use_navigator, use_route, Link};
 
 use crate::components::atrium::ThemeToggle;
-use crate::{use_search_query, Route};
+use crate::components::search_palette::SearchPaletteHost;
+use crate::Route;
 
 #[component]
 pub fn TopNav() -> Element {
-    // Hide the search box on `/settings` — the page has its own dense form
-    // layout and a search box wedged into the nav above it just clutters
-    // the chrome.
+    // Hide the search trigger on `/settings` — the page has its own dense
+    // form layout and a search button wedged into the nav above it just
+    // clutters the chrome.
     let on_settings = matches!(use_route::<Route>(), Route::Settings {});
 
     rsx! {
@@ -16,52 +17,10 @@ pub fn TopNav() -> Element {
             Link { to: Route::Landing {}, "Home" }
             Link { to: Route::Settings {}, "Settings" }
             if !on_settings {
-                NavSearch {}
+                SearchPaletteHost {}
             }
             ThemeToggle {}
             AuthControl {}
-        }
-    }
-}
-
-/// Site-wide search box. Owns the input wired to the [`crate::SearchQuery`]
-/// context, so typing here updates the same signal the landing page reads
-/// from. When the user types from a non-Landing route, navigate to `/` so
-/// they actually see the matching rows.
-#[component]
-fn NavSearch() -> Element {
-    let mut query = use_search_query().0;
-    let nav = use_navigator();
-    let route = use_route::<Route>();
-
-    rsx! {
-        form {
-            class: "library-search",
-            role: "search",
-            onsubmit: move |evt| evt.prevent_default(),
-            input {
-                id: "library-search-input",
-                "data-testid": "library-search-input",
-                r#type: "search",
-                aria_label: "Search books",
-                placeholder: "Search title, author, series, tag, ISBN…",
-                value: "{query}",
-                oninput: move |evt| {
-                    let v = evt.value();
-                    query.set(v.clone());
-                    // Off-Landing keystrokes redirect to `/` so the
-                    // matching rows render. Once we navigate, the
-                    // component re-renders with `route == Landing` and
-                    // this branch stops firing — so editing a non-empty
-                    // query from a detail route still redirects, but
-                    // typing on Landing doesn't spam `replace`. Empty
-                    // input is excluded so clearing the box doesn't drag
-                    // the user back to `/` mid-edit.
-                    if !v.is_empty() && !matches!(route, Route::Landing {}) {
-                        nav.replace(Route::Landing {});
-                    }
-                },
-            }
         }
     }
 }

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -11,8 +11,8 @@
 //!   web stubs so SSR-during-fullstack-render still returns sensible data.
 
 use omnibus_shared::{
-    AuthorDetail, EbookLibrary, EbookMetadata, LibraryContents, MetadataOverrides, SeriesDetail,
-    Settings, TagWeight,
+    AuthorDetail, EbookLibrary, EbookMetadata, LibraryContents, MetadataOverrides, PaletteResults,
+    SeriesDetail, Settings, TagWeight,
 };
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
@@ -479,6 +479,33 @@ pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, St
         .map_err(|e| e.to_string())
 }
 
+/// Search palette — grouped results for the command-palette overlay (F1.5).
+#[cfg(feature = "mobile")]
+pub async fn search_palette(server_url: &str, q: &str) -> Result<PaletteResults, String> {
+    let encoded: String = q
+        .bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                (b as char).to_string()
+            }
+            _ => format!("%{b:02X}"),
+        })
+        .collect();
+    let url = format!("{server_url}/api/search/palette?q={encoded}");
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    response
+        .json::<PaletteResults>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
 #[cfg(feature = "mobile")]
 pub async fn get_ebook(server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
     let url = format!("{server_url}/api/ebooks/{id}");
@@ -742,6 +769,14 @@ pub async fn get_ebooks(_server_url: &str) -> Result<EbookLibrary, String> {
 #[cfg(not(feature = "mobile"))]
 pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, String> {
     crate::rpc::rpc_search(q.to_string())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Search palette — grouped results for the command-palette overlay (F1.5).
+#[cfg(not(feature = "mobile"))]
+pub async fn search_palette(_server_url: &str, q: &str) -> Result<PaletteResults, String> {
+    crate::rpc::rpc_search_palette(q.to_string())
         .await
         .map_err(|e| e.to_string())
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -225,6 +225,8 @@ const ATRIUM_CSS: Asset = asset!("/assets/atrium.css");
 #[component]
 pub fn App() -> Element {
     use_context_provider(|| SearchQuery(Signal::new(String::new())));
+    #[cfg(not(feature = "mobile"))]
+    use_context_provider(|| components::search_palette::PaletteOpen(Signal::new(false)));
     components::atrium::init_theme();
     rsx! {
         document::Title { "Omnibus" }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -16,8 +16,8 @@
 use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
 use omnibus_shared::{
-    AuthorDetail, EbookLibrary, EbookMetadata, LibraryContents, MetadataOverrides, SeriesDetail,
-    Settings, TagWeight, ValueResponse,
+    AuthorDetail, EbookLibrary, EbookMetadata, LibraryContents, MetadataOverrides, PaletteResults,
+    SeriesDetail, Settings, TagWeight, ValueResponse,
 };
 
 #[cfg(feature = "server")]
@@ -279,4 +279,15 @@ pub async fn rpc_delete_overrides(book_id: i64) -> Result<Option<EbookMetadata>>
     db::delete_override_cover(&uuid);
     db::thumbs::invalidate_thumbs(book_id);
     Ok(db::get_book(&pool.0, book_id).await?)
+}
+
+/// Search palette — grouped results (books, authors, series, tags) for the
+/// command-palette overlay (F1.5).
+#[post("/api/rpc/search-palette", pool: PoolExt, _user: AuthUser)]
+pub async fn rpc_search_palette(q: String) -> Result<PaletteResults> {
+    let settings = db::get_settings(&pool.0).await?;
+    let Some(path) = settings.ebook_library_path else {
+        return Ok(PaletteResults::default());
+    };
+    Ok(db::search_palette(&pool.0, &path, &q).await?)
 }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -79,6 +79,7 @@ pub fn rest_router(state: AppState) -> Router {
                 .layer(axum::extract::DefaultBodyLimit::max(11 * 1024 * 1024)),
         )
         .route("/api/search", get(get_search))
+        .route("/api/search/palette", get(get_search_palette))
         .route("/api/covers/{id}", get(get_cover))
         .route("/api/thumbs/{id}/{size}", get(get_thumb))
         .route("/api/authors/{id}", get(get_author_by_id))
@@ -240,6 +241,24 @@ async fn get_search(
         })
         .into_response(),
         Err(error) => internal("search books", error),
+    }
+}
+
+async fn get_search_palette(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Query(params): Query<SearchQuery>,
+) -> Response {
+    let settings = match db::get_settings(&state.pool).await {
+        Ok(s) => s,
+        Err(error) => return internal("read settings", error),
+    };
+    let Some(path) = settings.ebook_library_path else {
+        return Json(omnibus_shared::PaletteResults::default()).into_response();
+    };
+    match db::search_palette(&state.pool, &path, &params.q).await {
+        Ok(results) => Json(results).into_response(),
+        Err(error) => internal("search palette", error),
     }
 }
 
@@ -1132,6 +1151,36 @@ mod tests {
     async fn api_search_returns_401_when_anonymous() {
         let (app, _, _) = fixture().await;
         let res = app.oneshot(get_anon("/api/search?q=hello")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -------------------------------------------------------------------
+    // /api/search/palette — search palette (F1.5)
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn api_search_palette_returns_empty_when_path_not_configured() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+        let response = app
+            .oneshot(get_with_bearer("/api/search/palette?q=hello", &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let results: omnibus_shared::PaletteResults = serde_json::from_slice(&bytes).unwrap();
+        assert!(results.books.is_empty());
+        assert!(results.authors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn api_search_palette_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app
+            .oneshot(get_anon("/api/search/palette?q=hello"))
+            .await
+            .unwrap();
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -285,6 +285,74 @@ pub struct TagWeight {
 }
 
 // -----------------------------------------------------------------------------
+// Search palette (F1.5)
+//
+// Grouped results for the command-palette overlay. Slim types — the palette
+// needs display data only, not the full `EbookMetadata` with its N+1 queries.
+// Each category is capped at 5 results server-side.
+// -----------------------------------------------------------------------------
+
+/// Search-palette response — grouped results with server-side timing.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PaletteResults {
+    pub query: String,
+    pub books: Vec<PaletteBookHit>,
+    pub authors: Vec<PaletteAuthorHit>,
+    pub series: Vec<PaletteSeriesHit>,
+    pub tags: Vec<PaletteTagHit>,
+    pub duration_ms: u64,
+}
+
+impl PaletteResults {
+    pub fn total_count(&self) -> usize {
+        self.books.len() + self.authors.len() + self.series.len() + self.tags.len()
+    }
+}
+
+/// Slim book hit for the search palette. No description, no identifiers,
+/// no subjects — just what the result row needs to render.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PaletteBookHit {
+    pub id: i64,
+    pub title: String,
+    /// Pre-joined author names (e.g. "Grace Hopper, Margaret Hamilton").
+    pub author_display: String,
+    /// Four-digit year extracted from `pubdate`, if present.
+    pub year: Option<String>,
+    pub formats: Vec<String>,
+    pub cover_url: Option<String>,
+    pub accent: Option<String>,
+}
+
+/// Author hit for the search palette.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PaletteAuthorHit {
+    pub id: i64,
+    pub name: String,
+    /// Number of books by this author in the active library.
+    pub book_count: u32,
+}
+
+/// Series hit for the search palette.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PaletteSeriesHit {
+    pub id: i64,
+    pub name: String,
+    pub book_count: u32,
+    /// Primary author of the first book in the series, if any.
+    pub author_display: Option<String>,
+}
+
+/// Tag hit for the search palette.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PaletteTagHit {
+    pub id: i64,
+    pub name: String,
+    /// Number of books with this tag in the active library.
+    pub book_count: u32,
+}
+
+// -----------------------------------------------------------------------------
 // Library view preferences (F1.3)
 //
 // These types live here — and not in `frontend/` — so a future server-backed

--- a/ui_tests/playwright/tests/flows/search-palette.spec.ts
+++ b/ui_tests/playwright/tests/flows/search-palette.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test } from "../fixtures/test";
+import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { expectNavVisible, gotoReady } from "../utils/nav";
+import { fixturesDir, seedLibrary } from "../utils/seed";
+
+// ── Layout & interaction (no seeded data needed) ──────────────────────
+
+test("renders search trigger button in nav", async ({ page }) => {
+  await gotoReady(page, "/");
+  await expectNavVisible(page);
+
+  const trigger = page.getByTestId("search-trigger");
+  await expect(trigger).toBeVisible();
+  await expect(trigger).toHaveText(/Search/);
+});
+
+test("palette opens on clicking search button", async ({ page }) => {
+  await gotoReady(page, "/");
+  await page.getByTestId("search-trigger").click();
+
+  const panel = page.getByTestId("sp-panel");
+  await expect(panel).toBeVisible();
+});
+
+test("palette opens on Cmd+K", async ({ page }) => {
+  await gotoReady(page, "/");
+  await page.keyboard.press("Meta+k");
+
+  const panel = page.getByTestId("sp-panel");
+  await expect(panel).toBeVisible();
+});
+
+test("palette closes on Escape", async ({ page }) => {
+  await gotoReady(page, "/");
+  await page.getByTestId("search-trigger").click();
+  await expect(page.getByTestId("sp-panel")).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("sp-panel")).toHaveCount(0);
+});
+
+test("palette closes on scrim click", async ({ page }) => {
+  await gotoReady(page, "/");
+  await page.getByTestId("search-trigger").click();
+  await expect(page.getByTestId("sp-panel")).toBeVisible();
+
+  // Click the scrim (outside the panel). The scrim fills the viewport.
+  await page.getByTestId("sp-scrim").click({ position: { x: 10, y: 10 } });
+  await expect(page.getByTestId("sp-panel")).toHaveCount(0);
+});
+
+// ── Autofocus ─────────────────────────────────────────────────────────
+
+test("input is focused after clicking trigger so typing works immediately", async ({
+  page,
+}) => {
+  await gotoReady(page, "/");
+  await page.getByTestId("search-trigger").click();
+  await expect(page.getByTestId("sp-panel")).toBeVisible();
+
+  // Type on the keyboard without clicking the input first.
+  await page.keyboard.type("dracula");
+
+  // The characters should have gone into the search input.
+  await expect(page.getByTestId("sp-input")).toHaveValue("dracula");
+});
+
+test("input is focused after Cmd+K so typing works immediately", async ({
+  page,
+}) => {
+  await gotoReady(page, "/");
+  await page.keyboard.press("Meta+k");
+  await expect(page.getByTestId("sp-panel")).toBeVisible();
+
+  // Type on the keyboard without clicking the input first.
+  await page.keyboard.type("hello");
+
+  // The characters should have gone into the search input.
+  await expect(page.getByTestId("sp-input")).toHaveValue("hello");
+});
+
+// ── Seeded-data tests (books, authors, series, tags) ──────────────────
+
+test.describe("with seeded library", () => {
+  test.beforeAll(async ({ request }) => {
+    await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
+  });
+
+  test("palette shows book results", async ({ page }) => {
+    await gotoReady(page, "/");
+    await page.getByTestId("search-trigger").click();
+    const input = page.getByTestId("sp-input");
+    await input.fill("dracula");
+
+    await expect
+      .poll(async () => page.getByTestId("sp-book-row").count())
+      .toBeGreaterThanOrEqual(1);
+  });
+
+  test("palette shows author results", async ({ page }) => {
+    await gotoReady(page, "/");
+    await page.getByTestId("search-trigger").click();
+    const input = page.getByTestId("sp-input");
+    await input.fill("stoker");
+
+    await expect
+      .poll(async () => page.getByTestId("sp-author-row").count())
+      .toBeGreaterThanOrEqual(1);
+  });
+
+  test("palette shows result count and timing", async ({ page }) => {
+    await gotoReady(page, "/");
+    await page.getByTestId("search-trigger").click();
+    const input = page.getByTestId("sp-input");
+    await input.fill("dracula");
+
+    await expect
+      .poll(async () => page.getByTestId("sp-result-count").count())
+      .toBe(1);
+    await expect(page.getByTestId("sp-result-count")).toContainText(/result/);
+    await expect(page.getByTestId("sp-result-count")).toContainText(/ms/);
+  });
+
+  test("clicking book result navigates to detail", async ({ page }) => {
+    await gotoReady(page, "/");
+    await page.getByTestId("search-trigger").click();
+    const input = page.getByTestId("sp-input");
+    await input.fill("dracula");
+
+    await expect
+      .poll(async () => page.getByTestId("sp-book-row").count())
+      .toBeGreaterThanOrEqual(1);
+
+    await page.getByTestId("sp-book-row").first().click();
+
+    // Should navigate to /books/:id
+    await expect.poll(async () => new URL(page.url()).pathname).toMatch(
+      /^\/books\/\d+$/,
+    );
+  });
+
+  test("keyboard navigation highlights results", async ({ page }) => {
+    await gotoReady(page, "/");
+    await page.getByTestId("search-trigger").click();
+    const input = page.getByTestId("sp-input");
+    await input.fill("dracula");
+
+    // Wait for results to appear.
+    await expect
+      .poll(async () => page.getByTestId("sp-book-row").count())
+      .toBeGreaterThanOrEqual(1);
+
+    // Arrow down should select the first book row.
+    await page.keyboard.press("ArrowDown");
+    await expect(page.getByTestId("sp-book-row").first()).toHaveClass(/selected/);
+  });
+
+  test("inside text shows coming soon", async ({ page }) => {
+    await gotoReady(page, "/");
+    await page.getByTestId("search-trigger").click();
+    const input = page.getByTestId("sp-input");
+    await input.fill("dracula");
+
+    // Wait for results, then check the placeholder.
+    await expect
+      .poll(async () => page.getByTestId("sp-book-row").count())
+      .toBeGreaterThanOrEqual(1);
+
+    await expect(page.getByTestId("sp-coming-soon")).toBeVisible();
+    await expect(page.getByTestId("sp-coming-soon")).toHaveText("Coming soon");
+  });
+});

--- a/ui_tests/playwright/tests/flows/search.spec.ts
+++ b/ui_tests/playwright/tests/flows/search.spec.ts
@@ -7,83 +7,84 @@ test.beforeAll(async ({ request }) => {
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
 });
 
-test("search input narrows the library to matching rows", async ({ page }) => {
+// ── Helper: open the search palette and type a query ──────────────────
+// The old inline search input is replaced by the F1.5 palette. These
+// helpers open the palette and type into its input. The palette shows
+// grouped results (books, authors, series, tags) inline — no form
+// submission is needed.
+
+async function openPaletteAndType(
+  page: import("@playwright/test").Page,
+  query: string,
+) {
+  await page.getByTestId("search-trigger").click();
+  const input = page.getByTestId("sp-input");
+  await expect(input).toBeVisible();
+  await input.fill(query);
+}
+
+test("search input shows matching book results in palette", async ({ page }) => {
   await gotoReady(page, "/");
 
-  const search = page.getByRole("searchbox", { name: "Search books" });
-  await expect(search).toBeVisible();
+  await openPaletteAndType(page, "dracula");
 
-  await search.fill("dracula");
-
-  // Poll until the table updates — the search kicks off an async fetch that
-  // races the input event. `expect.poll` respects Playwright's auto-retry.
-  await expect.poll(async () => page.getByTestId(/^ebook-row-/).count()).toBe(1);
-
-  await expect(page.getByTestId("ebook-row-dracula")).toBeVisible();
-});
-
-test("search by author pulls matching books across the library", async ({ page }) => {
-  await gotoReady(page, "/");
-  const search = page.getByRole("searchbox", { name: "Search books" });
-
-  await search.fill("shakespeare");
-  await expect.poll(async () => page.getByTestId(/^ebook-row-/).count()).toBe(1);
-  await expect(page.getByTestId("ebook-row-romeo-and-juliet")).toBeVisible();
-});
-
-test("clearing the search restores the full library", async ({ page }) => {
-  await gotoReady(page, "/");
-  const search = page.getByRole("searchbox", { name: "Search books" });
-
-  await search.fill("dracula");
+  // Poll until the palette shows a book result matching "dracula".
   await expect
-    .poll(async () => page.getByTestId(/^ebook-row-/).count())
-    .toBe(1);
-
-  await search.fill("");
-  await expect
-    .poll(async () => page.getByTestId(/^ebook-row-/).count())
-    .toBe(FIXTURE_BOOKS.length);
+    .poll(async () => page.getByTestId("sp-book-row").count())
+    .toBeGreaterThanOrEqual(1);
 });
 
-test("settings page does not render the search box", async ({ page }) => {
+test("search by author shows author results", async ({ page }) => {
+  await gotoReady(page, "/");
+  await openPaletteAndType(page, "shakespeare");
+
+  // Poll until the palette shows author results.
+  await expect
+    .poll(async () => page.getByTestId("sp-author-row").count())
+    .toBeGreaterThanOrEqual(1);
+});
+
+test("clearing the search clears results", async ({ page }) => {
+  await gotoReady(page, "/");
+  await openPaletteAndType(page, "dracula");
+  await expect
+    .poll(async () => page.getByTestId("sp-book-row").count())
+    .toBeGreaterThanOrEqual(1);
+
+  // Clear the input.
+  const input = page.getByTestId("sp-input");
+  await input.fill("");
+
+  // Results should disappear.
+  await expect
+    .poll(async () => page.getByTestId("sp-book-row").count())
+    .toBe(0);
+});
+
+test("settings page does not render the search trigger", async ({ page }) => {
   await gotoReady(page, "/settings");
-  await expect(
-    page.getByRole("searchbox", { name: "Search books" }),
-  ).toHaveCount(0);
+  await expect(page.getByTestId("search-trigger")).toHaveCount(0);
 });
 
-test("typing in the nav from a non-Landing route navigates to Landing", async ({
-  page,
-}) => {
-  await gotoReady(page, "/books/1");
-  const search = page.getByRole("searchbox", { name: "Search books" });
-  await expect(search).toBeVisible();
-
-  await search.fill("dracula");
-
-  // Off-Landing keystrokes redirect to `/` so matching rows render.
-  await expect.poll(async () => new URL(page.url()).pathname).toBe("/");
-  await expect.poll(async () => page.getByTestId(/^ebook-row-/).count()).toBe(1);
-  await expect(page.getByTestId("ebook-row-dracula")).toBeVisible();
-});
-
-test("author: facet narrows by author", async ({ page }) => {
+test("author substring shows author results", async ({ page }) => {
   await gotoReady(page, "/");
-  const search = page.getByRole("searchbox", { name: "Search books" });
+  await openPaletteAndType(page, "shakespeare");
 
-  await search.fill("author:shakespeare");
-  await expect.poll(async () => page.getByTestId(/^ebook-row-/).count()).toBe(1);
-  await expect(page.getByTestId("ebook-row-romeo-and-juliet")).toBeVisible();
+  await expect
+    .poll(async () => page.getByTestId("sp-author-row").count())
+    .toBeGreaterThanOrEqual(1);
 });
 
-test("tag: facet narrows by tag", async ({ page }) => {
+test("tag substring shows tag or book results", async ({ page }) => {
   await gotoReady(page, "/");
-  const search = page.getByRole("searchbox", { name: "Search books" });
+  await openPaletteAndType(page, "vampires");
 
-  // "Vampires" only appears as a dc:subject on Dracula across the fixture
-  // set — Frankenstein/Gatsby/etc. share `Horror tales` etc. but not this.
-  await search.fill("tag:vampires");
-  await expect.poll(async () => page.getByTestId(/^ebook-row-/).count()).toBe(1);
-  await expect(page.getByTestId("ebook-row-dracula")).toBeVisible();
+  // "Vampires" is a tag on Dracula — should appear in tag results or book results.
+  await expect
+    .poll(async () => {
+      const tags = await page.getByTestId("sp-tag-row").count();
+      const books = await page.getByTestId("sp-book-row").count();
+      return tags + books;
+    })
+    .toBeGreaterThanOrEqual(1);
 });


### PR DESCRIPTION
## Summary

- Replace the inline nav search input with a **command-palette overlay** (⌘K / Ctrl+K) showing grouped FTS5 results: Books, Authors, Series, Tags, and a "Coming soon" placeholder for Inside Text
- New `search_palette()` DB query runs four sequential queries (FTS5 books + LIKE taxonomy, 5 per category) with timing metadata
- Both RPC (`POST /api/rpc/search-palette`) and REST (`GET /api/search/palette`) endpoints for web + mobile parity
- Trigger button replaces inline search input in the top nav; floating panel has autofocused input, 150ms debounced search, keyboard navigation (↑↓ ⏎ Esc), and result-type-aware navigation (book → detail page, author/series/tag → filtered landing)

## Test plan

- [x] 8 DB unit tests for `search_palette` (books, authors, series, tags, empty query, no results, library scoping, timing)
- [x] 2 REST integration tests (401 for anonymous, empty results when no library configured)
- [x] `cargo clippy` and `cargo fmt` clean
- [x] 11 new Playwright E2E specs in `search-palette.spec.ts` (trigger button, open/close, ⌘K, results, navigation, keyboard nav, coming soon)
- [x] Updated existing `search.spec.ts` to work with palette instead of old inline search
- [x] Manual smoke test: `just dev-up` → ⌘K → type "dracula" → see grouped results → click book → navigates to detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)