### PR TITLE
feat: add Author, Series, and Tag Cloud discovery pages (F1.8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Default `cargo build` / `clippy` covers `server`, `shared`, `frontend` only. Mob
 ### shared/src/
 
 ```
-lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection, EbookMetadata, EbookLibrary
+lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection, EbookMetadata, EbookLibrary, AuthorDetail, SeriesDetail, TagWeight, ViewPrefs, ViewFilters
 ```
 
 ### db/src/
@@ -76,7 +76,7 @@ migrations/         — numbered SQL migrations embedded via sqlx::migrate!
 lib.rs              — Route, App, styles, ScreenLayout (feature-gated)
 data.rs             — Feature-gated data transport (mobile=reqwest, web/server=rpc)
 rpc.rs              — #[get]/#[post] server functions (mounted by dioxus::server::router); server bodies call into omnibus_db
-pages/{landing,settings,book_detail,auth}.rs  — auth.rs hosts LoginPage + RegisterPage. Landing is the primary Atrium consumer (cover grid + power-user table) and the source of format-faceted filtering (ViewFilters.formats in shared)
+pages/{landing,settings,book_detail,auth,author,series,tag_cloud}.rs  — auth.rs hosts LoginPage + RegisterPage. Landing is the primary Atrium consumer (cover grid + power-user table) and the source of format-faceted filtering (ViewFilters.formats in shared). Discovery pages (author, series, tag_cloud) are F1.8.
 components/{top_nav,bottom_nav}.rs  — feature = web / mobile respectively
 components/atrium.rs  — F1.7 design-system primitives (AtriumRoot, Cover, ThemeToggle); CSS at frontend/assets/atrium.css
 ```

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -192,6 +192,7 @@ fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> Indexe
 
             series,
             series_index,
+            series_id: None,
 
             epub_version: Some(format_version(doc.version)),
             unique_identifier: doc.unique_identifier.clone(),
@@ -357,6 +358,7 @@ fn collect_contributors<R: std::io::Read + std::io::Seek>(
                 name,
                 role,
                 file_as,
+                id: None,
             })
         })
         .collect()

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -17,7 +17,9 @@ use std::path::{Path, PathBuf};
 use sqlx::{sqlite::SqlitePoolOptions, Row, SqlitePool, Transaction};
 
 pub use omnibus_shared::Settings;
-use omnibus_shared::{Contributor, EbookLibrary, EbookMetadata, Identifier};
+use omnibus_shared::{
+    AuthorDetail, Contributor, EbookLibrary, EbookMetadata, Identifier, SeriesDetail, TagWeight,
+};
 
 /// Schema migrations embedded at compile time from `db/migrations/`.
 /// Every schema change ships as a new numbered `.sql` file there; applied
@@ -852,8 +854,13 @@ pub async fn list_books(
                  WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
                                                             AS series_name,
 
-               (SELECT json_group_array(json_object('name', name, 'sort', sort))
-                  FROM (SELECT a.name AS name, a.sort AS sort
+               (SELECT s.id FROM books_series_link bsl
+                  JOIN series s ON s.id = bsl.series
+                 WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
+                                                            AS series_link_id,
+
+               (SELECT json_group_array(json_object('id', a_id, 'name', name, 'sort', sort))
+                  FROM (SELECT a.id AS a_id, a.name AS name, a.sort AS sort
                           FROM books_authors_link bal
                           JOIN authors a ON a.id = bal.author
                          WHERE bal.book = b.id
@@ -902,6 +909,7 @@ pub async fn list_books(
                 name: c.name,
                 role: None,
                 file_as: c.sort.filter(|s| !s.is_empty()),
+                id: c.id,
             })
             .collect();
         let subjects: Vec<String> = parse_json_array(r.get("subjects_json"))?;
@@ -935,6 +943,7 @@ pub async fn list_books(
             identifiers,
             series: r.get("series_name"),
             series_index: series_index.map(format_series_index),
+            series_id: r.get("series_link_id"),
             epub_version: None,
             unique_identifier: Some(r.get::<String, _>("uuid")),
             resource_count: 0,
@@ -997,8 +1006,13 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
              WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
                                                            AS series_name,
 
-            (SELECT json_group_array(json_object('name', name, 'sort', sort))
-               FROM (SELECT a.name AS name, a.sort AS sort
+            (SELECT s.id FROM books_series_link bsl
+              JOIN series s ON s.id = bsl.series
+             WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
+                                                           AS series_link_id,
+
+            (SELECT json_group_array(json_object('id', a_id, 'name', name, 'sort', sort))
+               FROM (SELECT a.id AS a_id, a.name AS name, a.sort AS sort
                        FROM books_authors_link bal
                        JOIN authors a ON a.id = bal.author
                       WHERE bal.book = b.id
@@ -1051,6 +1065,7 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
             name: c.name,
             role: None,
             file_as: c.sort.filter(|s| !s.is_empty()),
+            id: c.id,
         })
         .collect();
 
@@ -1088,6 +1103,7 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
         identifiers,
         series: r.get("series_name"),
         series_index: series_index.map(format_series_index),
+        series_id: r.get("series_link_id"),
         epub_version: None,
         unique_identifier: Some(uuid),
         resource_count: 0,
@@ -1103,6 +1119,8 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
 
 #[derive(serde::Deserialize)]
 struct CreatorRow {
+    #[serde(default)]
+    id: Option<i64>,
     name: String,
     #[serde(default)]
     sort: Option<String>,
@@ -1198,8 +1216,13 @@ pub async fn search_books(
                  WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
                                                             AS series_name,
 
-               (SELECT json_group_array(json_object('name', name, 'sort', sort))
-                  FROM (SELECT a.name AS name, a.sort AS sort
+               (SELECT s.id FROM books_series_link bsl
+                  JOIN series s ON s.id = bsl.series
+                 WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
+                                                            AS series_link_id,
+
+               (SELECT json_group_array(json_object('id', a_id, 'name', name, 'sort', sort))
+                  FROM (SELECT a.id AS a_id, a.name AS name, a.sort AS sort
                           FROM books_authors_link bal
                           JOIN authors a ON a.id = bal.author
                          WHERE bal.book = b.id
@@ -1250,6 +1273,7 @@ pub async fn search_books(
                 name: c.name,
                 role: None,
                 file_as: c.sort.filter(|s| !s.is_empty()),
+                id: c.id,
             })
             .collect();
         let subjects: Vec<String> = parse_json_array(r.get("subjects_json"))?;
@@ -1283,6 +1307,7 @@ pub async fn search_books(
             identifiers,
             series: r.get("series_name"),
             series_index: series_index.map(format_series_index),
+            series_id: r.get("series_link_id"),
             epub_version: None,
             unique_identifier: Some(r.get::<String, _>("uuid")),
             resource_count: 0,
@@ -1296,6 +1321,235 @@ pub async fn search_books(
         });
     }
     Ok(out)
+}
+
+// -----------------------------------------------------------------------------
+// Discovery pages (F1.8)
+// -----------------------------------------------------------------------------
+
+/// The shared book-column SELECT for discovery queries. Same scalar-subquery
+/// pattern as `list_books` / `search_books` — one row per `books.id` with
+/// all m2m relations inlined as JSON aggregates.
+const BOOK_COLUMNS: &str = r#"
+    b.id, b.uuid,
+    b.title, b.description, b.series_index, b.has_cover,
+    b.pubdate, b.last_modified, b.timestamp, b.isbn, b.accent_color,
+
+    (SELECT bf.filename FROM book_files bf
+      WHERE bf.book_id = b.id
+      ORDER BY (bf.format != 'EPUB'), bf.format
+      LIMIT 1)                                   AS primary_filename,
+
+    (SELECT bf.format FROM book_files bf
+      WHERE bf.book_id = b.id
+      ORDER BY (bf.format != 'EPUB'), bf.format
+      LIMIT 1)                                   AS primary_format,
+
+    (SELECT pub.name FROM books_publishers_link bpl
+       JOIN publishers pub ON pub.id = bpl.publisher
+      WHERE bpl.book = b.id ORDER BY pub.name LIMIT 1)
+                                                  AS publisher_name,
+
+    (SELECT lang.code FROM books_languages_link bll
+       JOIN languages lang ON lang.id = bll.language
+      WHERE bll.book = b.id ORDER BY lang.code LIMIT 1)
+                                                  AS language_code,
+
+    (SELECT s.name FROM books_series_link bsl
+       JOIN series s ON s.id = bsl.series
+      WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
+                                                  AS series_name,
+
+    (SELECT s.id FROM books_series_link bsl
+       JOIN series s ON s.id = bsl.series
+      WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
+                                                  AS series_link_id,
+
+    (SELECT json_group_array(json_object('id', a_id, 'name', name, 'sort', sort))
+       FROM (SELECT a.id AS a_id, a.name AS name, a.sort AS sort
+               FROM books_authors_link bal
+               JOIN authors a ON a.id = bal.author
+              WHERE bal.book = b.id
+              ORDER BY bal.position))             AS creators_json,
+
+    (SELECT json_group_array(name)
+       FROM (SELECT t.name AS name FROM books_tags_link btl
+               JOIN tags t ON t.id = btl.tag
+              WHERE btl.book = b.id
+              ORDER BY t.name))                   AS subjects_json,
+
+    (SELECT json_group_array(json_object('scheme', scheme, 'value', value))
+       FROM (SELECT scheme, value FROM book_identifiers
+              WHERE book_id = b.id
+              ORDER BY scheme, value))            AS identifiers_json,
+
+    (SELECT json_group_array(format)
+       FROM (SELECT format FROM book_files
+              WHERE book_id = b.id
+              ORDER BY format))                   AS formats_json
+"#;
+
+/// Convert a SQLite row (selected with [`BOOK_COLUMNS`]) into an
+/// [`EbookMetadata`]. Shared across the discovery query functions.
+fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata, sqlx::Error> {
+    let id: i64 = r.get("id");
+    let has_cover: i64 = r.get("has_cover");
+    let primary_filename: Option<String> = r.get("primary_filename");
+    let primary_format: Option<String> = r.get("primary_format");
+    let filename = match (primary_filename, primary_format) {
+        (Some(stem), Some(fmt)) => format!("{stem}.{}", fmt.to_ascii_lowercase()),
+        _ => String::new(),
+    };
+    let series_index: Option<f64> = r.get("series_index");
+
+    let creators: Vec<Contributor> = parse_json_array::<CreatorRow>(r.get("creators_json"))?
+        .into_iter()
+        .map(|c| Contributor {
+            name: c.name,
+            role: None,
+            file_as: c.sort.filter(|s| !s.is_empty()),
+            id: c.id,
+        })
+        .collect();
+    let subjects: Vec<String> = parse_json_array(r.get("subjects_json"))?;
+    let identifiers: Vec<Identifier> =
+        parse_json_array::<IdentifierRow>(r.get("identifiers_json"))?
+            .into_iter()
+            .map(|i| Identifier {
+                value: i.value,
+                scheme: Some(i.scheme),
+            })
+            .collect();
+
+    Ok(EbookMetadata {
+        id,
+        filename,
+        title: r.get("title"),
+        description: sanitize_description(r.get("description")),
+        publisher: r.get("publisher_name"),
+        published: r.get("pubdate"),
+        modified: r.get("last_modified"),
+        language: r.get("language_code"),
+        rights: None,
+        source: None,
+        coverage: None,
+        dc_type: None,
+        dc_format: None,
+        relation: None,
+        creators,
+        contributors: vec![],
+        subjects,
+        identifiers,
+        series: r.get("series_name"),
+        series_index: series_index.map(format_series_index),
+        series_id: r.get("series_link_id"),
+        epub_version: None,
+        unique_identifier: Some(r.get::<String, _>("uuid")),
+        resource_count: 0,
+        spine_count: 0,
+        toc_count: 0,
+        cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+        accent: r.get("accent_color"),
+        formats: parse_json_array(r.get("formats_json"))?,
+        added_at: r.get("timestamp"),
+        error: None,
+    })
+}
+
+/// Fetch an author by ID with all their books across every library.
+/// Returns `None` if the author ID doesn't exist.
+pub async fn get_author(
+    pool: &SqlitePool,
+    author_id: i64,
+) -> Result<Option<AuthorDetail>, sqlx::Error> {
+    let author_row = sqlx::query("SELECT id, name, sort FROM authors WHERE id = ?")
+        .bind(author_id)
+        .fetch_optional(pool)
+        .await?;
+    let Some(a) = author_row else {
+        return Ok(None);
+    };
+
+    let sql = format!(
+        r#"SELECT {BOOK_COLUMNS}
+           FROM books b
+           JOIN books_authors_link bal ON bal.book = b.id
+           WHERE bal.author = ?
+           ORDER BY b.series_index NULLS LAST, b.sort, b.id"#
+    );
+    let rows = sqlx::query(&sql).bind(author_id).fetch_all(pool).await?;
+
+    let mut books = Vec::with_capacity(rows.len());
+    for r in &rows {
+        books.push(row_to_ebook(r)?);
+    }
+
+    Ok(Some(AuthorDetail {
+        id: a.get("id"),
+        name: a.get("name"),
+        sort: a.get("sort"),
+        book_count: books.len(),
+        books,
+    }))
+}
+
+/// Fetch a series by ID with all its books, ordered by series index.
+/// Returns `None` if the series ID doesn't exist.
+pub async fn get_series(
+    pool: &SqlitePool,
+    series_id: i64,
+) -> Result<Option<SeriesDetail>, sqlx::Error> {
+    let series_row = sqlx::query("SELECT id, name, sort FROM series WHERE id = ?")
+        .bind(series_id)
+        .fetch_optional(pool)
+        .await?;
+    let Some(s) = series_row else {
+        return Ok(None);
+    };
+
+    let sql = format!(
+        r#"SELECT {BOOK_COLUMNS}
+           FROM books b
+           JOIN books_series_link bsl ON bsl.book = b.id
+           WHERE bsl.series = ?
+           ORDER BY b.series_index, b.sort, b.id"#
+    );
+    let rows = sqlx::query(&sql).bind(series_id).fetch_all(pool).await?;
+
+    let mut books = Vec::with_capacity(rows.len());
+    for r in &rows {
+        books.push(row_to_ebook(r)?);
+    }
+
+    Ok(Some(SeriesDetail {
+        id: s.get("id"),
+        name: s.get("name"),
+        sort: s.get("sort"),
+        book_count: books.len(),
+        books,
+    }))
+}
+
+/// Return all tags with their book counts, ordered by count descending
+/// then name ascending. Used by the tag cloud page.
+pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, sqlx::Error> {
+    let rows = sqlx::query(
+        r#"SELECT t.name, COUNT(btl.book) AS cnt
+           FROM tags t
+           JOIN books_tags_link btl ON btl.tag = t.id
+           GROUP BY t.id
+           ORDER BY cnt DESC, t.name ASC"#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|r| TagWeight {
+            name: r.get("name"),
+            count: r.get::<i64, _>("cnt") as usize,
+        })
+        .collect())
 }
 
 /// Build an `EbookLibrary` from whatever is currently in the DB for

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -1458,6 +1458,10 @@ fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata, sqlx::Erro
 
 /// Fetch an author by ID with all their books across every library.
 /// Returns `None` if the author ID doesn't exist.
+///
+/// TODO(F4.x): scope by `user_id` once per-user ACLs land — today this
+/// query is single-tenant and any authenticated caller can enumerate
+/// authors by ID.
 pub async fn get_author(
     pool: &SqlitePool,
     author_id: i64,
@@ -1495,6 +1499,9 @@ pub async fn get_author(
 
 /// Fetch a series by ID with all its books, ordered by series index.
 /// Returns `None` if the series ID doesn't exist.
+///
+/// TODO(F4.x): scope by `user_id` once per-user ACLs land — see
+/// [`get_author`] for the same caveat.
 pub async fn get_series(
     pool: &SqlitePool,
     series_id: i64,
@@ -1530,16 +1537,26 @@ pub async fn get_series(
     }))
 }
 
-/// Return all tags with their book counts, ordered by count descending
-/// then name ascending. Used by the tag cloud page.
+/// Maximum number of tags returned from [`get_tag_cloud`]. Caps the
+/// payload so a Calibre dump with 10k+ unique subjects can't blow up
+/// the client or stall the SQLite pool on serialization.
+const TAG_CLOUD_LIMIT: i64 = 500;
+
+/// Return up to [`TAG_CLOUD_LIMIT`] tags with their book counts, ordered
+/// by count descending then name ascending. Used by the tag cloud page.
+///
+/// TODO(F4.x): scope by `user_id` once per-user ACLs land — currently
+/// returns the global tag distribution.
 pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, sqlx::Error> {
     let rows = sqlx::query(
         r#"SELECT t.name, COUNT(btl.book) AS cnt
            FROM tags t
            JOIN books_tags_link btl ON btl.tag = t.id
            GROUP BY t.id
-           ORDER BY cnt DESC, t.name ASC"#,
+           ORDER BY cnt DESC, t.name ASC
+           LIMIT ?"#,
     )
+    .bind(TAG_CLOUD_LIMIT)
     .fetch_all(pool)
     .await?;
 
@@ -3316,5 +3333,197 @@ mod tests {
         assert!(desc.contains("<p>Brief.</p>"));
         assert!(desc.contains("<b>detail</b>"));
         assert!(!desc.contains("<script"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Discovery query tests (F1.8)
+    // -------------------------------------------------------------------------
+
+    /// Seed a small multi-author, multi-series, multi-tag fixture for the
+    /// discovery query tests below. Returns the pool and a `CoversTempDir`
+    /// guard the caller must keep alive for the lifetime of the test.
+    async fn seed_discovery_fixture() -> (SqlitePool, CoversTempDir) {
+        let guard = CoversTempDir::new("discovery");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                // Two-author book in Saga #1 with tag "fiction"
+                indexed(
+                    "saga1.epub",
+                    Some("Saga: Book One"),
+                    &["Ada Lovelace", "Grace Hopper"],
+                    &["fiction", "classic"],
+                    Some(("Saga", "1")),
+                    None,
+                ),
+                // Sequel in Saga #2, same primary author + new tag
+                indexed(
+                    "saga2.epub",
+                    Some("Saga: Book Two"),
+                    &["Ada Lovelace"],
+                    &["fiction"],
+                    Some(("Saga", "2")),
+                    None,
+                ),
+                // Standalone by Ada — no series
+                indexed(
+                    "standalone.epub",
+                    Some("Standalone"),
+                    &["Ada Lovelace"],
+                    &["essay"],
+                    None,
+                    None,
+                ),
+                // Different-author, different-series book
+                indexed(
+                    "other.epub",
+                    Some("Other Story"),
+                    &["Niklaus Wirth"],
+                    &["nonfiction"],
+                    Some(("Pioneers", "1")),
+                    None,
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+        (pool, guard)
+    }
+
+    async fn author_id_by_name(pool: &SqlitePool, name: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT id FROM authors WHERE name = ?")
+            .bind(name)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    async fn series_id_by_name(pool: &SqlitePool, name: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE name = ?")
+            .bind(name)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn get_author_returns_author_with_all_books_ordered_by_series_index() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        let author = get_author(&pool, id).await.unwrap().expect("author exists");
+
+        assert_eq!(author.name, "Ada Lovelace");
+        assert_eq!(author.book_count, 3);
+        assert_eq!(author.books.len(), 3);
+
+        // Series books come first, ordered by series_index ASC (NULLS LAST
+        // means the standalone trails).
+        let titles: Vec<_> = author
+            .books
+            .iter()
+            .filter_map(|b| b.title.clone())
+            .collect();
+        assert_eq!(
+            titles,
+            vec![
+                "Saga: Book One".to_string(),
+                "Saga: Book Two".to_string(),
+                "Standalone".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_author_populates_series_id_on_books() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let id = author_id_by_name(&pool, "Ada Lovelace").await;
+        let expected_sid = series_id_by_name(&pool, "Saga").await;
+
+        let author = get_author(&pool, id).await.unwrap().unwrap();
+        for book in author.books.iter().filter(|b| b.series.is_some()) {
+            assert_eq!(
+                book.series_id,
+                Some(expected_sid),
+                "series book should carry series_id"
+            );
+        }
+        let standalone = author
+            .books
+            .iter()
+            .find(|b| b.series.is_none())
+            .expect("standalone present");
+        assert_eq!(standalone.series_id, None);
+    }
+
+    #[tokio::test]
+    async fn get_author_returns_none_for_missing_id() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let missing = get_author(&pool, 999_999).await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_series_returns_books_ordered_by_series_index() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let id = series_id_by_name(&pool, "Saga").await;
+
+        let series = get_series(&pool, id).await.unwrap().expect("series exists");
+        assert_eq!(series.name, "Saga");
+        assert_eq!(series.book_count, 2);
+
+        let titles: Vec<_> = series
+            .books
+            .iter()
+            .filter_map(|b| b.title.clone())
+            .collect();
+        assert_eq!(
+            titles,
+            vec!["Saga: Book One".to_string(), "Saga: Book Two".to_string()]
+        );
+        // Each book should carry the parent series id back out so the
+        // frontend can navigate cross-references without an extra lookup.
+        for book in &series.books {
+            assert_eq!(book.series_id, Some(id));
+        }
+    }
+
+    #[tokio::test]
+    async fn get_series_returns_none_for_missing_id() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let missing = get_series(&pool, 999_999).await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_tag_cloud_returns_counts_ordered_by_count_then_name() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let tags = get_tag_cloud(&pool).await.unwrap();
+
+        // Fixture has: fiction × 2, classic × 1, essay × 1, nonfiction × 1.
+        // Order: cnt DESC, then name ASC.
+        let names: Vec<_> = tags.iter().map(|t| t.name.clone()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "fiction".to_string(),
+                "classic".to_string(),
+                "essay".to_string(),
+                "nonfiction".to_string(),
+            ]
+        );
+        assert_eq!(tags[0].count, 2);
+        assert!(tags[1..].iter().all(|t| t.count == 1));
+    }
+
+    #[tokio::test]
+    async fn get_tag_cloud_returns_empty_vec_when_no_tags() {
+        let _guard = CoversTempDir::new("empty_tags");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        // No books, no tags.
+        let tags = get_tag_cloud(&pool).await.unwrap();
+        assert!(tags.is_empty());
     }
 }

--- a/docs/roadmap/0-0-summary.md
+++ b/docs/roadmap/0-0-summary.md
@@ -111,6 +111,8 @@ Phase 6  Mobile                   (feature parity on native)
 - [F1.7 Atrium design system](1-7-atrium-design-system.md)
 - [F1.8 Discovery pages](1-8-discovery-pages.md)
 - [F1.9 Themes & density](1-9-themes-and-density.md)
+- [F1.11 Author profiles](1-11-author-profiles.md)
+- [F1.12 Browse authors & series](1-12-browse-authors-series.md)
 
 ### Phase 2 — Reading & listening
 

--- a/docs/roadmap/1-11-author-profiles.md
+++ b/docs/roadmap/1-11-author-profiles.md
@@ -1,0 +1,101 @@
+# F1.11 — Author profile pictures
+
+**Phase 1 · Browse & discovery** · **Priority:** P3
+
+Cascading author photo resolution so author pages show a real profile picture instead of a typographic initial-letter avatar.
+
+## Objective
+
+Add a multi-source cascading resolver for author profile photos. When an author page loads, the system checks (in order): manual admin upload → Open Library API → Wikidata/Wikipedia → letter avatar fallback. Resolved images are cached locally so subsequent page loads are instant.
+
+## User / business value
+
+Unblocks:
+- **Author page visual identity** — the F1.8 author page currently shows a serif-initial circle avatar. A real photo makes the page feel polished and recognizable, especially for well-known authors.
+
+## Technical considerations
+
+- **Resolution cascade:** `manual upload` → `Open Library covers API` → `Wikidata/Wikipedia Commons` → `letter avatar` (current fallback).
+- **Schema:** new `author_photos` table: `author_id INTEGER PRIMARY KEY, source TEXT, url TEXT, blob BLOB, mime TEXT, fetched_at TEXT`.
+- **Resolver worker task:** `Task::ResolveAuthorPhoto { author_id }` — runs the cascade, stores the first hit, skips if a manual override exists.
+- **API:** `GET /api/authors/:id/photo` → serves the cached photo (or 404 if none resolved). `PUT /api/authors/:id/photo` (admin) → manual upload override.
+- **Frontend:** `AuthorPage` hero section checks for a photo URL before falling back to the letter avatar.
+- **Observability:** log resolver hits/misses per source. Track average resolution time.
+
+## Dependencies
+
+- [F1.8 Discovery pages](1-8-discovery-pages.md) — author page must exist for the photo to render on.
+
+## Risks
+
+- **External API reliability** — Open Library and Wikidata may be slow or return low-quality images. Mitigation: timeout + fallback chain.
+- **Name matching** — author name in the EPUB may not match the canonical name in external APIs. Mitigation: try `file_as` (surname-first) as a secondary lookup.
+
+## Open questions
+
+**Resolved:**
+
+- **Cascade order** — Manual → Open Library → Wikidata → Letter. Decided by user preference.
+
+**Unresolved:**
+
+- **Cache invalidation** — how long before we re-check external sources for an author whose photo resolved to "letter"? Weekly? Never until admin action?
+- **Image sizing** — should we store a single size or generate thumbnails (sm/md/lg) like book covers?
+
+## TODOs
+
+### Schema and migration
+
+**What:** Add `author_photos` table with `author_id`, `source`, `url`, `blob`, `mime`, `fetched_at` columns.
+
+**Why:** Persistent cache for resolved photos so the cascade doesn't re-run on every page load.
+
+**Context:** FK to `authors.id`. `source` is one of `manual`, `openlibrary`, `wikidata`, `letter`.
+
+**Effort:** S
+**Priority:** P0
+**Depends on:** None.
+
+### Resolver worker task
+
+**What:** `Task::ResolveAuthorPhoto` that runs the cascade for a given author.
+
+**Why:** Background resolution keeps the author page fast — it shows the letter avatar immediately and upgrades to the real photo once resolved.
+
+**Context:** Runs on first view of an author page (if no photo cached) or on admin trigger. Cascade order: check `author_photos` for manual → try Open Library → try Wikidata → store "letter" as negative cache.
+
+**Effort:** M
+**Priority:** P1
+**Depends on:** Schema and migration.
+
+### API endpoints
+
+**What:** `GET /api/authors/:id/photo` and `PUT /api/authors/:id/photo` (admin upload).
+
+**Why:** Frontend needs a URL to fetch the photo; admin needs an upload path for manual overrides.
+
+**Context:** GET returns the cached blob with appropriate `Content-Type`. PUT accepts multipart upload and sets `source = 'manual'`.
+
+**Effort:** S
+**Priority:** P1
+**Depends on:** Schema and migration.
+
+### Frontend integration
+
+**What:** Update `AuthorPage` hero to show the photo when available.
+
+**Why:** Visual upgrade from the letter avatar.
+
+**Context:** Check `/api/authors/:id/photo` — on 200 render `<img>`, on 404 fall back to the existing `.disc-avatar` letter circle.
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** API endpoints.
+
+## Status
+
+Queued. Blocked on [F1.8 Discovery pages](1-8-discovery-pages.md).
+
+---
+
+[← Back to roadmap summary](0-0-summary.md)

--- a/docs/roadmap/1-12-browse-authors-series.md
+++ b/docs/roadmap/1-12-browse-authors-series.md
@@ -1,0 +1,116 @@
+# F1.12 — Browse authors & series
+
+**Phase 1 · Browse & discovery** · **Priority:** P3
+
+Dedicated `/authors` and `/series` index pages that list every author and every series in the library as browsable, sortable surfaces.
+
+## Objective
+
+Two new routes — `/authors` and `/series` — that serve as entry points into the taxonomy. The Authors index lists every author with their book count, sortable by name or book count, with search/filter. The Series index lists every series with book count and completion status. Both link through to the per-author and per-series detail pages from [F1.8](1-8-discovery-pages.md).
+
+Today, the only way to reach an author page is from a book detail breadcrumb or a search result. These index pages make "browse all authors" and "browse all series" first-class navigation destinations, reachable from the top nav or sidebar.
+
+## User / business value
+
+Unblocks:
+- **Navigation completeness** — without index pages, the author/series detail pages from F1.8 are dead ends reachable only via deep links. The index pages close the navigation loop.
+
+## Technical considerations
+
+- **Authors index (`/authors`):** grid or list of author cards. Each card shows: author name, book count, optional photo ([F1.11](1-11-author-profiles.md) if landed, else initial-letter avatar), accent color from their most-read book. Sortable by name (A–Z) or book count (desc). Filterable via a search input (client-side filter for libraries under 1k authors).
+- **Series index (`/series`):** grid or list of series cards. Each card shows: series name, book count, completion fraction (e.g. "3 of 5"), fan-stack of covers (first 3–4 books), primary author name. Sortable by name or book count.
+- **New query functions:** `list_authors(pool) -> Vec<AuthorSummary>` and `list_series(pool) -> Vec<SeriesSummary>`. Lightweight — just name + count + optional accent, no full book metadata.
+- **New shared types:** `AuthorSummary { id, name, sort, book_count, accent }` and `SeriesSummary { id, name, sort, book_count, primary_author }`.
+- **New RPC + REST endpoints:** `GET /api/rpc/authors`, `GET /api/rpc/series-list`, plus matching `/api/authors` and `/api/series` REST routes for mobile.
+- **Nav integration:** add "Authors" and "Series" links to the top nav or as sub-items under a "Browse" dropdown. Exact placement is a design question.
+- **Observability:** page-load timing for the index queries. Should be <50ms for libraries under 10k books.
+
+## Dependencies
+
+- [F1.8 Discovery pages](1-8-discovery-pages.md) — the per-author and per-series detail pages must exist for the index to link into.
+
+## Risks
+
+- **Large libraries** — a library with 5k+ unique authors could make the authors index slow to render if we load all cards at once. Mitigation: virtual scrolling or pagination. For v1, a simple full list is fine — revisit if performance data says otherwise.
+
+## Open questions
+
+**Resolved:**
+
+(None yet.)
+
+**Unresolved:**
+
+- **Card vs list layout** — should the index pages use a card grid (like the library cover grid) or a dense list (like the library table view)? Probably both, togglable via the existing ViewMode preference.
+- **Nav placement** — top-level nav items ("Authors", "Series") or nested under a "Browse" menu? Depends on nav redesign timeline.
+- **Series completion** — "3 of 5" requires knowing the total planned book count for a series, which isn't in our metadata. Options: derive from max series_index, allow admin override, or just show "3 books" without a denominator.
+
+## TODOs
+
+### Shared types for summaries
+
+**What:** Add `AuthorSummary` and `SeriesSummary` to `shared/src/lib.rs`.
+
+**Why:** Lightweight types for the index pages — no full book metadata, just name + count + accent.
+
+**Context:** Distinct from `AuthorDetail` / `SeriesDetail` (which carry full book lists). These are for the index view only.
+
+**Effort:** S
+**Priority:** P0
+**Depends on:** None.
+
+### Query functions for index pages
+
+**What:** `list_authors(pool)` and `list_series(pool)` in `db/src/queries.rs`.
+
+**Why:** Aggregated queries returning name + count + optional accent for all authors/series.
+
+**Context:** Simple GROUP BY queries with COUNT. Author accent derived from the most-covered book's accent_color. Series primary_author from the first book's first author.
+
+**Effort:** S
+**Priority:** P0
+**Depends on:** Shared types for summaries.
+
+### Authors index page
+
+**What:** `/authors` route + `AuthorsIndexPage` component.
+
+**Why:** Browse-all entry point for author discovery.
+
+**Context:** Reuses Atrium card/grid primitives. Shows author name, book count, avatar (letter or photo if F1.11 landed). Sortable, filterable. Links to `/authors/:id`.
+
+**Effort:** M
+**Priority:** P1
+**Depends on:** Query functions for index pages.
+
+### Series index page
+
+**What:** `/series` route + `SeriesIndexPage` component.
+
+**Why:** Browse-all entry point for series discovery.
+
+**Context:** Reuses Atrium card/grid primitives. Shows series name, book count, cover fan (first 3–4 covers stacked), primary author. Links to `/series/:id`.
+
+**Effort:** M
+**Priority:** P1
+**Depends on:** Query functions for index pages.
+
+### Playwright coverage
+
+**What:** E2E specs for both index pages.
+
+**Why:** Verify navigation loop: index → detail → back.
+
+**Context:** Use existing fixture data. Assert page renders, sort toggles work, clicking a card navigates to the detail page.
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** Authors index page, Series index page.
+
+## Status
+
+Queued. Blocked on [F1.8 Discovery pages](1-8-discovery-pages.md).
+
+---
+
+[← Back to roadmap summary](0-0-summary.md)

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -534,3 +534,188 @@ body.atrium,
 }
 .bd-footer .btn:hover { background: var(--bg-1); color: var(--ink-0); }
 
+/* ===== Discovery pages (F1.8) ===== */
+
+.disc-page { padding-bottom: 60px; }
+
+/* Hero — accent-gradient backdrop, avatar + name + stat */
+.disc-hero {
+  padding: 48px clamp(20px, 4vw, 56px) 24px;
+}
+.disc-hero-grid {
+  display: grid;
+  grid-template-columns: 120px 1fr auto;
+  gap: 32px;
+  align-items: flex-end;
+  margin-top: 24px;
+}
+@media (max-width: 720px) {
+  .disc-hero-grid { grid-template-columns: 80px 1fr; gap: 16px; }
+  .disc-stat-block { display: none; }
+}
+.disc-hero-title {
+  font-family: var(--serif);
+  font-size: clamp(48px, 6vw, 84px);
+  line-height: 0.92;
+  letter-spacing: -0.02em;
+  margin: 8px 0 0;
+  color: var(--ink-0);
+}
+.disc-hero-title em { font-style: italic; }
+.disc-hero-info { min-width: 0; }
+
+/* Avatar — 120px circle, serif initial */
+.disc-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 999px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  display: grid;
+  place-items: center;
+  font-family: var(--serif);
+  font-size: 56px;
+  font-style: italic;
+  color: var(--ink-1);
+}
+@media (max-width: 720px) {
+  .disc-avatar { width: 80px; height: 80px; font-size: 36px; }
+}
+
+/* Stat block */
+.disc-stat-block { text-align: right; }
+.disc-stat-label { display: block; margin-bottom: 6px; }
+.disc-stat {
+  font-family: var(--serif);
+  font-size: 56px;
+  line-height: 1;
+  color: var(--ink-0);
+}
+
+/* Body and sections */
+.disc-body {
+  padding: 32px clamp(20px, 4vw, 56px) 0;
+}
+.disc-section { margin-bottom: 40px; }
+.disc-section-head {
+  margin-bottom: 16px;
+}
+.disc-section-title {
+  font-family: var(--serif);
+  font-size: 24px;
+  margin-top: 4px;
+  color: var(--ink-0);
+}
+
+/* Responsive cover grid (reused across author/series) */
+.disc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 20px 16px;
+}
+
+/* Series header (no avatar, simpler layout) */
+.disc-series-header {
+  padding: 48px clamp(20px, 4vw, 56px) 32px;
+}
+.disc-series-head-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-top: 12px;
+}
+
+/* Series card grid */
+.series-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: 20px;
+}
+@media (max-width: 800px) {
+  .series-cards { grid-template-columns: 1fr; }
+}
+.series-card {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 20px;
+  align-items: flex-start;
+  padding: 22px;
+}
+@media (max-width: 480px) {
+  .series-card { grid-template-columns: 80px 1fr; gap: 12px; padding: 14px; }
+}
+.series-card-cover { width: 120px; }
+@media (max-width: 480px) { .series-card-cover { width: 80px; } }
+.series-card-info { min-width: 0; }
+.series-card-title {
+  font-size: 24px;
+  margin-top: 8px;
+  color: var(--ink-0);
+  line-height: 1.2;
+}
+.series-card-title a {
+  color: inherit;
+  text-decoration: none;
+}
+.series-card-title a:hover { text-decoration: underline; }
+.series-card-desc {
+  margin-top: 12px;
+  font-size: 13.5px;
+  color: var(--ink-1);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Tag cloud page */
+.disc-tag-header {
+  padding: 48px clamp(20px, 4vw, 56px) 24px;
+}
+.disc-tag-subtitle {
+  margin-top: 8px;
+  color: var(--ink-2);
+  font-size: 14px;
+}
+
+/* Two-column layout for tag cloud + sidebar */
+.disc-two-col {
+  padding: 12px clamp(20px, 4vw, 56px) 48px;
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 40px;
+  align-items: flex-start;
+}
+@media (max-width: 900px) {
+  .disc-two-col { grid-template-columns: 1fr; }
+  .disc-two-col > aside { display: none; }
+}
+
+/* Tag cloud container */
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px 22px;
+  font-family: var(--serif);
+  line-height: 1;
+  padding: 20px 0;
+}
+.tag-cloud-item {
+  color: var(--ink-0);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.15s, transform 0.15s;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.tag-cloud-item:hover { color: var(--accent); }
+.tag-cloud-item--hi { color: var(--accent); }
+.tag-cloud-count {
+  font-size: 10px;
+  opacity: 0.55;
+  color: var(--ink-2);
+}
+

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -10,7 +10,9 @@
 //! - Server-only compiles (`feature = "server"` without `"web"`) reuse the
 //!   web stubs so SSR-during-fullstack-render still returns sensible data.
 
-use omnibus_shared::{EbookLibrary, EbookMetadata, LibraryContents, Settings};
+use omnibus_shared::{
+    AuthorDetail, EbookLibrary, EbookMetadata, LibraryContents, SeriesDetail, Settings, TagWeight,
+};
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
 
@@ -489,6 +491,65 @@ pub async fn get_ebook(server_url: &str, id: i64) -> Result<Option<EbookMetadata
         .map_err(|e| e.to_string())
 }
 
+#[cfg(feature = "mobile")]
+pub async fn get_author(server_url: &str, id: i64) -> Result<Option<AuthorDetail>, String> {
+    let url = format!("{server_url}/api/authors/{id}");
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    response
+        .json::<AuthorDetail>()
+        .await
+        .map(Some)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(feature = "mobile")]
+pub async fn get_series(server_url: &str, id: i64) -> Result<Option<SeriesDetail>, String> {
+    let url = format!("{server_url}/api/series/{id}");
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    response
+        .json::<SeriesDetail>()
+        .await
+        .map(Some)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(feature = "mobile")]
+pub async fn get_tag_cloud(server_url: &str) -> Result<Vec<TagWeight>, String> {
+    let url = format!("{server_url}/api/tags");
+    let response = with_bearer(http_client().get(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    response
+        .json::<Vec<TagWeight>>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
 // ===== Mobile auth transport: bearer token =====
 //
 // Mobile cannot use cookies (Dioxus Native is not a webview), so login
@@ -638,6 +699,27 @@ pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, S
 #[cfg(not(feature = "mobile"))]
 pub async fn get_ebook(_server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
     crate::rpc::rpc_get_ebook(id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn get_author(_server_url: &str, id: i64) -> Result<Option<AuthorDetail>, String> {
+    crate::rpc::rpc_get_author(id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn get_series(_server_url: &str, id: i64) -> Result<Option<SeriesDetail>, String> {
+    crate::rpc::rpc_get_series(id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn get_tag_cloud(_server_url: &str) -> Result<Vec<TagWeight>, String> {
+    crate::rpc::rpc_get_tag_cloud()
         .await
         .map_err(|e| e.to_string())
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -15,7 +15,10 @@ pub mod rpc;
 pub mod view_prefs;
 
 pub use components::Nav;
-pub use pages::{BookDetailPage, LandingPage, LoginPage, RegisterPage, SettingsPage};
+pub use pages::{
+    AuthorPage, BookDetailPage, LandingPage, LoginPage, RegisterPage, SeriesPage, SettingsPage,
+    TagCloudPage,
+};
 
 #[cfg(feature = "mobile")]
 pub use data::ServerUrl;
@@ -29,6 +32,12 @@ pub enum Route {
     Settings {},
     #[route("/books/:id")]
     BookDetail { id: i64 },
+    #[route("/authors/:id")]
+    AuthorDetail { id: i64 },
+    #[route("/series/:id")]
+    SeriesDetail { id: i64 },
+    #[route("/tags")]
+    TagCloud {},
     #[route("/login")]
     Login {},
     #[route("/register")]
@@ -66,6 +75,30 @@ pub fn BookDetail(id: i64) -> Element {
 #[component]
 pub fn Login() -> Element {
     rsx! { LoginPage {} }
+}
+
+/// Route target for `/authors/:id` — single author discovery page.
+#[component]
+pub fn AuthorDetail(id: i64) -> Element {
+    rsx! {
+        ScreenLayout { AuthorPage { id } }
+    }
+}
+
+/// Route target for `/series/:id` — single series discovery page.
+#[component]
+pub fn SeriesDetail(id: i64) -> Element {
+    rsx! {
+        ScreenLayout { SeriesPage { id } }
+    }
+}
+
+/// Route target for `/tags` — tag cloud discovery page.
+#[component]
+pub fn TagCloud() -> Element {
+    rsx! {
+        ScreenLayout { TagCloudPage {} }
+    }
 }
 
 /// Route target for `/register` — account-creation form. Same chrome as

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -1,0 +1,193 @@
+//! Author discovery page — shows author details and their books grouped by
+//! series, mirroring the `AuthorScreen` design comp from
+//! `screens/discovery.jsx`.
+
+use dioxus::prelude::*;
+use dioxus_router::Link;
+use omnibus_shared::AuthorDetail;
+
+use crate::components::atrium::Cover;
+use crate::{data, use_server_url, Route};
+
+#[component]
+pub fn AuthorPage(id: i64) -> Element {
+    let server_url = use_server_url();
+    let mut author: Signal<Option<AuthorDetail>> = use_signal(|| None);
+    let mut loading = use_signal(|| true);
+    let mut error: Signal<Option<String>> = use_signal(|| None);
+
+    let url = server_url.clone();
+    use_effect(move || {
+        let url = url.clone();
+        spawn(async move {
+            loading.set(true);
+            match data::get_author(&url, id).await {
+                Ok(a) => {
+                    author.set(a);
+                    error.set(None);
+                }
+                Err(e) => error.set(Some(e)),
+            }
+            loading.set(false);
+        });
+    });
+
+    if loading() {
+        return rsx! {
+            p { class: "subtitle", "Loading\u{2026}" }
+        };
+    }
+    if let Some(msg) = error() {
+        return rsx! {
+            p { role: "alert", class: "subtitle", "{msg}" }
+            Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        };
+    }
+    let Some(a) = author() else {
+        return rsx! {
+            p { class: "subtitle", "Author not found." }
+            Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        };
+    };
+
+    render_author(a)
+}
+
+// ---------------------------------------------------------------------------
+// View
+// ---------------------------------------------------------------------------
+
+fn render_author(a: AuthorDetail) -> Element {
+    // Derive accent from the first book that has one, or fall back to theme.
+    let accent = a
+        .books
+        .iter()
+        .find_map(|b| b.accent.as_deref())
+        .unwrap_or("var(--accent)");
+
+    // Split first / last name for italic styling.
+    let parts: Vec<&str> = a.name.splitn(2, ' ').collect();
+    let first = parts.first().copied().unwrap_or("");
+    let last = if parts.len() > 1 { parts[1] } else { "" };
+
+    // Initial letter for the avatar.
+    let initial = a
+        .name
+        .chars()
+        .next()
+        .unwrap_or('?')
+        .to_uppercase()
+        .to_string();
+
+    // Group books by series — series books first, standalone after.
+    let mut series_groups: Vec<(String, i64, Vec<&omnibus_shared::EbookMetadata>)> = Vec::new();
+    let mut standalone: Vec<&omnibus_shared::EbookMetadata> = Vec::new();
+
+    for book in &a.books {
+        if let Some(ref series_name) = book.series {
+            if let Some(group) = series_groups
+                .iter_mut()
+                .find(|(name, _, _)| name == series_name)
+            {
+                group.2.push(book);
+            } else {
+                let sid = book.series_id.unwrap_or(0);
+                series_groups.push((series_name.clone(), sid, vec![book]));
+            }
+        } else {
+            standalone.push(book);
+        }
+    }
+
+    let bg_style = format!(
+        "radial-gradient(50% 80% at 80% 20%, color-mix(in oklch, {accent} 14%, transparent), transparent 70%)"
+    );
+
+    rsx! {
+        div { class: "disc-page", style: "--accent: {accent}",
+            // Hero header
+            div { class: "disc-hero", style: "background: {bg_style}",
+                // Breadcrumb
+                nav { class: "breadcrumb",
+                    Link { to: Route::Landing {}, "Library" }
+                    span { " › " }
+                    span { "{a.name}" }
+                }
+                div { class: "disc-hero-grid",
+                    // Avatar
+                    div { class: "disc-avatar", "{initial}" }
+                    // Name + metadata
+                    div { class: "disc-hero-info",
+                        h1 { class: "disc-hero-title",
+                            "{first} "
+                            if !last.is_empty() {
+                                em { "{last}" }
+                            }
+                        }
+                    }
+                    // Book count stat
+                    div { class: "disc-stat-block",
+                        span { class: "disc-stat-label label", "In your library" }
+                        span { class: "disc-stat", "{a.book_count}" }
+                    }
+                }
+            }
+
+            // Body: books grouped by series
+            div { class: "disc-body",
+                for (series_name, series_id, books) in series_groups.iter() {
+                    div { class: "disc-section",
+                        div { class: "disc-section-head",
+                            span { class: "label", "Series" }
+                            if *series_id > 0 {
+                                Link {
+                                    to: Route::SeriesDetail { id: *series_id },
+                                    class: "disc-section-title",
+                                    h2 { "{series_name}" }
+                                }
+                            } else {
+                                h2 { class: "disc-section-title", "{series_name}" }
+                            }
+                        }
+                        div { class: "disc-grid",
+                            for book in books.iter() {
+                                Link {
+                                    to: Route::BookDetail { id: book.id },
+                                    class: "lib-tile",
+                                    Cover { book: (*book).clone() }
+                                    div { class: "lib-tile-title",
+                                        if let Some(ref idx) = book.series_index {
+                                            "#{idx} · "
+                                        }
+                                        "{book.title.as_deref().unwrap_or(&book.filename)}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if !standalone.is_empty() {
+                    div { class: "disc-section",
+                        div { class: "disc-section-head",
+                            span { class: "label", "Other works" }
+                            h2 { class: "disc-section-title", "Standalone & novellas" }
+                        }
+                        div { class: "disc-grid",
+                            for book in standalone.iter() {
+                                Link {
+                                    to: Route::BookDetail { id: book.id },
+                                    class: "lib-tile",
+                                    Cover { book: (*book).clone() }
+                                    div { class: "lib-tile-title",
+                                        "{book.title.as_deref().unwrap_or(&book.filename)}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -156,17 +156,23 @@ fn render_loaded(b: EbookMetadata) -> Element {
                     div { class: "bd-title-col",
                         div { class: "label", "{kicker}" }
                         h1 { class: "bd-title", "{title}" }
-                        if !authors_line.is_empty() {
+                        if !b.creators.is_empty() {
                             p {
                                 class: "bd-by",
                                 "data-testid": "book-authors",
                                 "by "
-                                span { class: "bd-author-link",
-                                    "{authors_line}"
-                                    span {
-                                        class: "bd-author-link-hint",
-                                        aria_hidden: "true",
-                                        " view author \u{2192}"
+                                for (i, creator) in b.creators.iter().enumerate() {
+                                    if i > 0 {
+                                        ", "
+                                    }
+                                    if let Some(author_id) = creator.id {
+                                        Link {
+                                            to: Route::AuthorDetail { id: author_id },
+                                            class: "bd-author-link",
+                                            "{creator.name}"
+                                        }
+                                    } else {
+                                        span { class: "bd-author-link", "{creator.name}" }
                                     }
                                 }
                             }
@@ -374,7 +380,15 @@ fn render_loaded(b: EbookMetadata) -> Element {
                     div { class: "card",
                         if let Some(s) = series_label.as_ref() {
                             div { class: "label bd-rail-head", "Series" }
-                            p { class: "bd-rail-body", "{s}" }
+                            if let Some(sid) = b.series_id {
+                                Link {
+                                    to: Route::SeriesDetail { id: sid },
+                                    class: "bd-rail-body bd-series-link",
+                                    "{s}"
+                                }
+                            } else {
+                                p { class: "bd-rail-body", "{s}" }
+                            }
                         } else {
                             div { class: "label bd-rail-head", "Standalone" }
                             p { class: "bd-rail-body", "Not part of a series." }

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -376,7 +376,13 @@ fn FilterSidebar(
                 "authors" => &mut next.authors,
                 "series" => &mut next.series,
                 "tags" => &mut next.tags,
-                _ => &mut next.authors,
+                other => {
+                    debug_assert!(
+                        false,
+                        "FilterSidebar::toggle: unknown facet group {other:?}"
+                    );
+                    return;
+                }
             };
             if let Some(pos) = bucket.iter().position(|v| v == &value) {
                 bucket.remove(pos);

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -355,6 +355,7 @@ struct FacetCounts {
     /// counts. The display label is derived at render time via
     /// [`format_display_label`] so the keys stay canonical.
     formats: Vec<(String, usize)>,
+    tags: Vec<(String, usize)>,
 }
 
 #[component]
@@ -371,10 +372,11 @@ fn FilterSidebar(
         let filters = filters.clone();
         move |group: &'static str, value: String| {
             let mut next = filters.clone();
-            let bucket = if group == "authors" {
-                &mut next.authors
-            } else {
-                &mut next.series
+            let bucket = match group {
+                "authors" => &mut next.authors,
+                "series" => &mut next.series,
+                "tags" => &mut next.tags,
+                _ => &mut next.authors,
             };
             if let Some(pos) = bucket.iter().position(|v| v == &value) {
                 bucket.remove(pos);
@@ -414,6 +416,16 @@ fn FilterSidebar(
                 on_toggle: {
                     let toggle = toggle.clone();
                     move |v: String| toggle("series", v)
+                },
+            }
+            FacetSection {
+                title: "Tags",
+                testid: "lib-facet-tags",
+                items: facets.tags.clone(),
+                selected: filters.tags.clone(),
+                on_toggle: {
+                    let toggle = toggle.clone();
+                    move |v: String| toggle("tags", v)
                 },
             }
         }
@@ -942,6 +954,14 @@ fn matches_filters(book: &EbookMetadata, filters: &ViewFilters) -> bool {
     {
         return false;
     }
+    if !filters.tags.is_empty()
+        && !filters
+            .tags
+            .iter()
+            .any(|t| book.subjects.iter().any(|s| s == t))
+    {
+        return false;
+    }
     true
 }
 
@@ -960,6 +980,7 @@ fn facet_counts(books: &[EbookMetadata]) -> FacetCounts {
     let mut authors: BTreeMap<String, usize> = BTreeMap::new();
     let mut series: BTreeMap<String, usize> = BTreeMap::new();
     let mut formats: BTreeMap<String, usize> = BTreeMap::new();
+    let mut tags: BTreeMap<String, usize> = BTreeMap::new();
     for book in books {
         for c in &book.creators {
             *authors.entry(c.name.clone()).or_default() += 1;
@@ -975,11 +996,17 @@ fn facet_counts(books: &[EbookMetadata]) -> FacetCounts {
                 *formats.entry(key).or_default() += 1;
             }
         }
+        for tag in &book.subjects {
+            if !tag.is_empty() {
+                *tags.entry(tag.clone()).or_default() += 1;
+            }
+        }
     }
     FacetCounts {
         authors: sorted_facet(authors),
         series: sorted_facet(series),
         formats: sorted_facet(formats),
+        tags: sorted_facet(tags),
     }
 }
 
@@ -1117,6 +1144,7 @@ mod tests {
                     name: (*name).into(),
                     role: None,
                     file_as: file_as.map(Into::into),
+                    id: None,
                 })
                 .collect(),
             series: series.map(|(s, _)| s.into()),

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,9 +1,15 @@
 mod auth;
+mod author;
 mod book_detail;
 mod landing;
+mod series;
 mod settings;
+mod tag_cloud;
 
 pub use auth::{LoginPage, RegisterPage};
+pub use author::AuthorPage;
 pub use book_detail::BookDetailPage;
 pub use landing::LandingPage;
+pub use series::SeriesPage;
 pub use settings::SettingsPage;
+pub use tag_cloud::TagCloudPage;

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -134,7 +134,7 @@ fn render_series(s: SeriesDetail) -> Element {
                                     }
                                 }
                                 if let Some(ref desc) = book.description {
-                                    p { class: "series-card-desc",
+                                    div { class: "series-card-desc",
                                         dangerous_inner_html: "{desc}"
                                     }
                                 }

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -1,0 +1,148 @@
+//! Series discovery page — shows series details and ordered books, mirroring
+//! the `SeriesScreen` design comp from `screens/discovery.jsx`.
+
+use dioxus::prelude::*;
+use dioxus_router::Link;
+use omnibus_shared::SeriesDetail;
+
+use crate::components::atrium::Cover;
+use crate::{data, use_server_url, Route};
+
+#[component]
+pub fn SeriesPage(id: i64) -> Element {
+    let server_url = use_server_url();
+    let mut series: Signal<Option<SeriesDetail>> = use_signal(|| None);
+    let mut loading = use_signal(|| true);
+    let mut error: Signal<Option<String>> = use_signal(|| None);
+
+    let url = server_url.clone();
+    use_effect(move || {
+        let url = url.clone();
+        spawn(async move {
+            loading.set(true);
+            match data::get_series(&url, id).await {
+                Ok(s) => {
+                    series.set(s);
+                    error.set(None);
+                }
+                Err(e) => error.set(Some(e)),
+            }
+            loading.set(false);
+        });
+    });
+
+    if loading() {
+        return rsx! {
+            p { class: "subtitle", "Loading\u{2026}" }
+        };
+    }
+    if let Some(msg) = error() {
+        return rsx! {
+            p { role: "alert", class: "subtitle", "{msg}" }
+            Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        };
+    }
+    let Some(s) = series() else {
+        return rsx! {
+            p { class: "subtitle", "Series not found." }
+            Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        };
+    };
+
+    render_series(s)
+}
+
+// ---------------------------------------------------------------------------
+// View
+// ---------------------------------------------------------------------------
+
+fn render_series(s: SeriesDetail) -> Element {
+    // Derive accent from the first book that has one.
+    let accent = s
+        .books
+        .iter()
+        .find_map(|b| b.accent.as_deref())
+        .unwrap_or("var(--accent)");
+
+    // Primary author from the first book's first creator.
+    let primary_author = s
+        .books
+        .iter()
+        .find_map(|b| b.creators.first().map(|c| c.name.clone()))
+        .unwrap_or_default();
+
+    // Split series name for italic styling on key word.
+    let title_parts: Vec<&str> = s.name.splitn(2, ' ').collect();
+    let title_first = title_parts.first().copied().unwrap_or("");
+    let title_rest = if title_parts.len() > 1 {
+        title_parts[1]
+    } else {
+        ""
+    };
+
+    rsx! {
+        div { class: "disc-page", style: "--accent: {accent}",
+            // Header
+            div { class: "disc-series-header",
+                nav { class: "breadcrumb",
+                    Link { to: Route::Landing {}, "Library" }
+                    span { " › " }
+                    if !primary_author.is_empty() {
+                        span { "{primary_author}" }
+                        span { " › " }
+                    }
+                    span { "{s.name}" }
+                }
+                div { class: "disc-series-head-row",
+                    div {
+                        span { class: "label", "Series · {s.book_count} in library" }
+                        h1 { class: "disc-hero-title",
+                            "The "
+                            em { "{title_first}" }
+                            if !title_rest.is_empty() {
+                                " {title_rest}"
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Body: card grid of books
+            div { class: "disc-body",
+                div { class: "series-cards",
+                    for book in s.books.iter() {
+                        article { class: "card series-card",
+                            div { class: "series-card-cover",
+                                Link {
+                                    to: Route::BookDetail { id: book.id },
+                                    Cover { book: book.clone() }
+                                }
+                            }
+                            div { class: "series-card-info",
+                                span { class: "label",
+                                    if let Some(ref idx) = book.series_index {
+                                        "Book #{idx}"
+                                    }
+                                    if let Some(ref year) = book.published {
+                                        " · {year}"
+                                    }
+                                }
+                                h3 { class: "series-card-title",
+                                    Link {
+                                        to: Route::BookDetail { id: book.id },
+                                        "{book.title.as_deref().unwrap_or(&book.filename)}"
+                                    }
+                                }
+                                if let Some(ref desc) = book.description {
+                                    p { class: "series-card-desc",
+                                        dangerous_inner_html: "{desc}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -97,7 +97,6 @@ fn render_series(s: SeriesDetail) -> Element {
                     div {
                         span { class: "label", "Series · {s.book_count} in library" }
                         h1 { class: "disc-hero-title",
-                            "The "
                             em { "{title_first}" }
                             if !title_rest.is_empty() {
                                 " {title_rest}"

--- a/frontend/src/pages/tag_cloud.rs
+++ b/frontend/src/pages/tag_cloud.rs
@@ -1,0 +1,117 @@
+//! Tag cloud discovery page — renders all tags scaled by book count, mirroring
+//! the `TagCloudScreen` design comp from `screens/discovery.jsx`.
+
+use dioxus::prelude::*;
+use dioxus_router::Link;
+use omnibus_shared::TagWeight;
+
+use crate::{data, use_server_url, Route};
+
+#[component]
+pub fn TagCloudPage() -> Element {
+    let server_url = use_server_url();
+    let mut tags: Signal<Vec<TagWeight>> = use_signal(Vec::new);
+    let mut loading = use_signal(|| true);
+    let mut error: Signal<Option<String>> = use_signal(|| None);
+
+    let url = server_url.clone();
+    use_effect(move || {
+        let url = url.clone();
+        spawn(async move {
+            loading.set(true);
+            match data::get_tag_cloud(&url).await {
+                Ok(t) => {
+                    tags.set(t);
+                    error.set(None);
+                }
+                Err(e) => error.set(Some(e)),
+            }
+            loading.set(false);
+        });
+    });
+
+    if loading() {
+        return rsx! {
+            p { class: "subtitle", "Loading\u{2026}" }
+        };
+    }
+    if let Some(msg) = error() {
+        return rsx! {
+            p { role: "alert", class: "subtitle", "{msg}" }
+            Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        };
+    }
+
+    let tag_list = tags();
+    let total_tags = tag_list.len();
+    let max_count = tag_list.iter().map(|t| t.count).max().unwrap_or(1);
+
+    rsx! {
+        div { class: "disc-page",
+            // Header
+            div { class: "disc-tag-header",
+                span { class: "label", "Library lens" }
+                h1 { class: "disc-hero-title",
+                    "By "
+                    em { "tag" }
+                }
+                p { class: "disc-tag-subtitle",
+                    "{total_tags} unique tags \u{b7} click to filter"
+                }
+            }
+
+            // Two-column: cloud + sidebar stub
+            div { class: "disc-two-col",
+                // The cloud
+                div { class: "tag-cloud",
+                    for tag in tag_list.iter() {
+                        { render_tag_item(tag, max_count) }
+                    }
+                }
+                // Overlap sidebar — placeholder for future tag analysis
+                aside { class: "card", aria_hidden: "true",
+                    // TODO(F1.13): Tag overlap matrix — show related tags when
+                    // one is selected. Stubbed out until the backend supports
+                    // co-occurrence queries.
+                }
+            }
+        }
+    }
+}
+
+/// Render a single tag in the cloud with size/opacity scaled by weight.
+fn render_tag_item(tag: &TagWeight, max_count: usize) -> Element {
+    let weight = tag.count as f64 / max_count as f64;
+    let size = 16.0 + (weight * 56.0);
+    let opacity = 0.55 + (weight * 0.45);
+    let is_high = weight > 0.7;
+    let is_italic = weight > 0.5;
+
+    let class = if is_high {
+        "tag-cloud-item tag-cloud-item--hi"
+    } else {
+        "tag-cloud-item"
+    };
+
+    let style = format!(
+        "font-size: {size:.0}px; opacity: {opacity:.2};{}",
+        if is_italic {
+            " font-style: italic;"
+        } else {
+            ""
+        }
+    );
+
+    let name = tag.name.clone();
+    let count = tag.count;
+
+    rsx! {
+        Link {
+            to: Route::Landing {},
+            class: "{class}",
+            style: "{style}",
+            "{name}"
+            span { class: "tag-cloud-count mono", "{count}" }
+        }
+    }
+}

--- a/frontend/src/pages/tag_cloud.rs
+++ b/frontend/src/pages/tag_cloud.rs
@@ -100,12 +100,20 @@ fn render_tag_item(tag: &TagWeight, max_count: usize) -> Element {
 
     let name = tag.name.clone();
     let count = tag.count;
+    // Font-size + opacity are the visual weight signal. Screen readers
+    // get the same weight info via an explicit aria-label since neither
+    // styling property is exposed to assistive tech.
+    let aria = format!(
+        "{name} — {count} {}",
+        if count == 1 { "book" } else { "books" }
+    );
 
     rsx! {
         Link {
             to: Route::Landing {},
             class: "{class}",
             style: "{style}",
+            aria_label: "{aria}",
             "{name}"
             span { class: "tag-cloud-count mono", "{count}" }
         }

--- a/frontend/src/pages/tag_cloud.rs
+++ b/frontend/src/pages/tag_cloud.rs
@@ -68,12 +68,8 @@ pub fn TagCloudPage() -> Element {
                         { render_tag_item(tag, max_count) }
                     }
                 }
-                // Overlap sidebar — placeholder for future tag analysis
-                aside { class: "card", aria_hidden: "true",
-                    // TODO(F1.13): Tag overlap matrix — show related tags when
-                    // one is selected. Stubbed out until the backend supports
-                    // co-occurrence queries.
-                }
+                // TODO(F1.13): Tag overlap matrix — related-tag panel.
+                aside { class: "card", aria_hidden: "true" }
             }
         }
     }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -15,7 +15,10 @@
 
 use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
-use omnibus_shared::{EbookLibrary, EbookMetadata, LibraryContents, Settings, ValueResponse};
+use omnibus_shared::{
+    AuthorDetail, EbookLibrary, EbookMetadata, LibraryContents, SeriesDetail, Settings, TagWeight,
+    ValueResponse,
+};
 
 #[cfg(feature = "server")]
 use omnibus_db::{self as db, scanner};
@@ -206,4 +209,27 @@ pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
         books,
         error: None,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Discovery pages (F1.8)
+// ---------------------------------------------------------------------------
+
+/// Fetch a single author and all their books. POST for the same reason as
+/// `rpc_get_ebook` — needs `id` in the body.
+#[post("/api/rpc/author", pool: PoolExt, _user: AuthUser)]
+pub async fn rpc_get_author(id: i64) -> Result<Option<AuthorDetail>> {
+    Ok(db::get_author(&pool.0, id).await?)
+}
+
+/// Fetch a single series and all its books (ordered by series index).
+#[post("/api/rpc/series", pool: PoolExt, _user: AuthUser)]
+pub async fn rpc_get_series(id: i64) -> Result<Option<SeriesDetail>> {
+    Ok(db::get_series(&pool.0, id).await?)
+}
+
+/// Return all tags with book counts for the tag cloud.
+#[get("/api/rpc/tags", pool: PoolExt, _user: AuthUser)]
+pub async fn rpc_get_tag_cloud() -> Result<Vec<TagWeight>> {
+    Ok(db::get_tag_cloud(&pool.0).await?)
 }

--- a/scripts/dev-server-up.sh
+++ b/scripts/dev-server-up.sh
@@ -30,7 +30,7 @@ cd "$REPO_ROOT"
 RUNTIME_DIR=".claude/runtime"
 mkdir -p "$RUNTIME_DIR"
 
-START_PORT="${PORT:-3000}"
+START_PORT="${PORT:-3010}"
 END_PORT=$((START_PORT + 20))
 
 # Tighter timeouts than curl defaults so a misbehaving foreign process

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -71,6 +71,9 @@ pub fn rest_router(state: AppState) -> Router {
         .route("/api/search", get(get_search))
         .route("/api/covers/{id}", get(get_cover))
         .route("/api/thumbs/{id}/{size}", get(get_thumb))
+        .route("/api/authors/{id}", get(get_author_by_id))
+        .route("/api/series/{id}", get(get_series_by_id))
+        .route("/api/tags", get(get_tags))
         .with_state(state)
         // `AuthUser`/`AdminUser` read the pool from `Extension<SqlitePool>`.
         // Layer it here so the router is self-contained for integration
@@ -316,6 +319,37 @@ async fn get_thumb(
         }
         Ok(None) => axum::http::StatusCode::ACCEPTED.into_response(),
         Err(e) => internal("cover fetch for thumb", e),
+    }
+}
+
+async fn get_author_by_id(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
+    match db::get_author(&state.pool, id).await {
+        Ok(Some(author)) => Json(author).into_response(),
+        Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
+        Err(error) => internal("read author", error),
+    }
+}
+
+async fn get_series_by_id(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
+    match db::get_series(&state.pool, id).await {
+        Ok(Some(series)) => Json(series).into_response(),
+        Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
+        Err(error) => internal("read series", error),
+    }
+}
+
+async fn get_tags(_user: AuthUser, State(state): State<AppState>) -> Response {
+    match db::get_tag_cloud(&state.pool).await {
+        Ok(tags) => Json(tags).into_response(),
+        Err(error) => internal("read tags", error),
     }
 }
 
@@ -1039,5 +1073,192 @@ mod tests {
             !body.contains("app_state") && !body.contains("sqlx") && !body.contains("SQL"),
             "500 body must not leak internal error details, got {body:?}"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // Discovery endpoints: /api/authors/:id, /api/series/:id, /api/tags
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn api_get_author_returns_200_with_detail() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        // Seed a book with an author via replace_books.
+        db::replace_books(
+            &pool,
+            "/lib",
+            vec![db::ebook::IndexedBook {
+                metadata: omnibus_shared::EbookMetadata {
+                    filename: "test.epub".into(),
+                    title: Some("Test Book".into()),
+                    creators: vec![omnibus_shared::Contributor {
+                        name: "Jane Austen".into(),
+                        role: Some("aut".into()),
+                        file_as: Some("Austen, Jane".into()),
+                        id: None,
+                    }],
+                    ..Default::default()
+                },
+                cover: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        // Look up the author id from the DB.
+        let author_id: i64 =
+            sqlx::query_scalar("SELECT id FROM authors WHERE name = 'Jane Austen'")
+                .fetch_one(&pool)
+                .await
+                .expect("author should exist");
+
+        let response = app
+            .oneshot(get_with_bearer(
+                &format!("/api/authors/{author_id}"),
+                &token,
+            ))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let detail: omnibus_shared::AuthorDetail = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(detail.name, "Jane Austen");
+        assert_eq!(detail.book_count, 1);
+        assert_eq!(detail.books.len(), 1);
+        assert_eq!(detail.books[0].title.as_deref(), Some("Test Book"));
+    }
+
+    #[tokio::test]
+    async fn api_get_author_returns_404_for_unknown_id() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        let response = app
+            .oneshot(get_with_bearer("/api/authors/9999", &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_get_author_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/authors/1")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_get_series_returns_200_with_detail() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        // Seed a book with a series.
+        db::replace_books(
+            &pool,
+            "/lib",
+            vec![db::ebook::IndexedBook {
+                metadata: omnibus_shared::EbookMetadata {
+                    filename: "series-book.epub".into(),
+                    title: Some("Dune".into()),
+                    series: Some("Dune Chronicles".into()),
+                    series_index: Some("1".into()),
+                    ..Default::default()
+                },
+                cover: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let series_id: i64 =
+            sqlx::query_scalar("SELECT id FROM series WHERE name = 'Dune Chronicles'")
+                .fetch_one(&pool)
+                .await
+                .expect("series should exist");
+
+        let response = app
+            .oneshot(get_with_bearer(&format!("/api/series/{series_id}"), &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let detail: omnibus_shared::SeriesDetail = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(detail.name, "Dune Chronicles");
+        assert_eq!(detail.book_count, 1);
+        assert_eq!(detail.books.len(), 1);
+        assert_eq!(detail.books[0].title.as_deref(), Some("Dune"));
+    }
+
+    #[tokio::test]
+    async fn api_get_series_returns_404_for_unknown_id() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        let response = app
+            .oneshot(get_with_bearer("/api/series/9999", &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_get_series_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/series/1")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_get_tags_returns_200_with_tag_weights() {
+        let (app, _state, pool) = fixture().await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        // Seed a book with subjects (tags).
+        db::replace_books(
+            &pool,
+            "/lib",
+            vec![db::ebook::IndexedBook {
+                metadata: omnibus_shared::EbookMetadata {
+                    filename: "tagged.epub".into(),
+                    title: Some("Tagged Book".into()),
+                    subjects: vec!["Fiction".into(), "Science".into()],
+                    ..Default::default()
+                },
+                cover: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let response = app
+            .oneshot(get_with_bearer("/api/tags", &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let tags: Vec<omnibus_shared::TagWeight> = serde_json::from_slice(&bytes).unwrap();
+        assert!(!tags.is_empty());
+        assert!(tags.iter().any(|t| t.name == "Fiction"));
+        assert!(tags.iter().any(|t| t.name == "Science"));
+        // Each tag should have count = 1 since we seeded one book.
+        for tag in &tags {
+            assert_eq!(tag.count, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn api_get_tags_returns_401_when_anonymous() {
+        let (app, _, _) = fixture().await;
+        let res = app.oneshot(get_anon("/api/tags")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -43,11 +43,17 @@ pub struct LibraryContents {
 
 /// A contributor (or creator) with the optional OPF refinements — the MARC
 /// role code (`aut`, `ill`, `edt`, `bkp`, `trl`, …) and the sort-key name.
+///
+/// `id` is the stable `authors.id` primary key from the normalized DB. Set
+/// when the contributor was loaded from a m2m join; `None` for contributors
+/// created by the EPUB parser before indexing.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Contributor {
     pub name: String,
     pub role: Option<String>,
     pub file_as: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<i64>,
 }
 
 /// A typed identifier from the OPF, e.g. `{ scheme: "ISBN", value: "…" }`.
@@ -90,6 +96,10 @@ pub struct EbookMetadata {
     // Series / collection (Calibre + EPUB3 belongs-to-collection).
     pub series: Option<String>,
     pub series_index: Option<String>,
+    /// Stable `series.id` primary key from the normalized DB. Set when the
+    /// book was loaded from a join; `None` for books not in any series.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub series_id: Option<i64>,
 
     // Structural / document-level info.
     pub epub_version: Option<String>,
@@ -125,6 +135,39 @@ pub struct EbookLibrary {
     pub path: Option<String>,
     pub books: Vec<EbookMetadata>,
     pub error: Option<String>,
+}
+
+// -----------------------------------------------------------------------------
+// Discovery pages (F1.8)
+// -----------------------------------------------------------------------------
+
+/// Author detail payload for `GET /api/authors/:id` and `rpc_get_author`.
+/// Contains the author row plus every book by that author.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthorDetail {
+    pub id: i64,
+    pub name: String,
+    pub sort: Option<String>,
+    pub book_count: usize,
+    pub books: Vec<EbookMetadata>,
+}
+
+/// Series detail payload for `GET /api/series/:id` and `rpc_get_series`.
+/// Books are ordered by `series_index`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SeriesDetail {
+    pub id: i64,
+    pub name: String,
+    pub sort: Option<String>,
+    pub book_count: usize,
+    pub books: Vec<EbookMetadata>,
+}
+
+/// Single tag with its book count, for the tag cloud.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TagWeight {
+    pub name: String,
+    pub count: usize,
 }
 
 // -----------------------------------------------------------------------------
@@ -176,12 +219,17 @@ pub struct ViewFilters {
     pub series: Vec<String>,
     #[serde(default)]
     pub formats: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 impl ViewFilters {
     /// `true` when no facet has any selected value.
     pub fn is_empty(&self) -> bool {
-        self.authors.is_empty() && self.series.is_empty() && self.formats.is_empty()
+        self.authors.is_empty()
+            && self.series.is_empty()
+            && self.formats.is_empty()
+            && self.tags.is_empty()
     }
 }
 

--- a/ui_tests/playwright/tests/flows/discovery.spec.ts
+++ b/ui_tests/playwright/tests/flows/discovery.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "../fixtures/test";
+import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { gotoReady } from "../utils/nav";
+import { fixturesDir, seedLibrary } from "../utils/seed";
+import type { APIRequestContext } from "@playwright/test";
+
+// Seed before all tests so the indexer has populated authors/series/tags.
+test.beforeAll(async ({ request }) => {
+  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — resolve IDs via the RPC layer so tests don't hardcode DB ids.
+// ---------------------------------------------------------------------------
+
+async function fetchAuthorIdByName(
+  request: APIRequestContext,
+  name: string,
+): Promise<number> {
+  // POST to /api/rpc/ebooks (same as the landing page) and scan creators.
+  const resp = await request.get("/api/rpc/ebooks");
+  expect(resp.status(), "GET /api/rpc/ebooks failed").toBe(200);
+  const body = (await resp.json()) as {
+    books: { creators: { name: string; id: number | null }[] }[];
+  };
+  for (const book of body.books) {
+    const match = book.creators.find((c) => c.name === name);
+    if (match?.id) return match.id;
+  }
+  throw new Error(`no indexed author named ${JSON.stringify(name)}`);
+}
+
+async function fetchSeriesIdByName(
+  request: APIRequestContext,
+  name: string,
+): Promise<number> {
+  // The ebooks list doesn't carry series IDs directly. Instead query the
+  // dedicated tag cloud endpoint which doesn't help either. Use the books
+  // list to find a book in the series, then query the /api/rpc/search for
+  // the series name and use that result's series field to locate the id
+  // via a direct SQL approach — or simpler: just POST to the rpc/series
+  // endpoint after finding via the DB. But we don't have an index endpoint
+  // yet. Instead, use the REST API /api/series/:id by probing.
+  //
+  // Simplest approach: POST to /api/rpc/ebooks to get a book in the series,
+  // then use the books_series_link table. Since we can't do raw SQL from
+  // Playwright, we'll search for the series name in the ebooks response and
+  // then iterate candidate IDs via the REST endpoint.
+  const ebooksResp = await request.get("/api/rpc/ebooks");
+  expect(ebooksResp.status()).toBe(200);
+  const ebooksBody = (await ebooksResp.json()) as {
+    books: { series: string | null; id: number }[];
+  };
+  const bookInSeries = ebooksBody.books.find((b) => b.series === name);
+  if (!bookInSeries) {
+    throw new Error(`no book in series ${JSON.stringify(name)}`);
+  }
+
+  // Try IDs 1..100 via the REST endpoint until we find the matching series.
+  for (let id = 1; id <= 100; id++) {
+    const resp = await request.post("/api/rpc/series", {
+      data: { id },
+    });
+    if (resp.status() === 200) {
+      const body = (await resp.json()) as { name: string; id: number } | null;
+      if (body && body.name === name) return body.id;
+    }
+  }
+  throw new Error(`could not resolve series id for ${JSON.stringify(name)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Author page
+// ---------------------------------------------------------------------------
+
+test("renders the author page layout", async ({ page, request }) => {
+  const authorName = "Ada Lovelace";
+  const authorId = await fetchAuthorIdByName(request, authorName);
+
+  await gotoReady(page, `/authors/${authorId}`);
+
+  // H1 contains the author's name (split first/last with italic)
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Ada");
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Lovelace");
+
+  // Book count stat is visible
+  await expect(page.getByText("In your library")).toBeVisible();
+
+  // Breadcrumb has "Library" link
+  const breadcrumb = page.locator("nav.breadcrumb");
+  await expect(breadcrumb.getByRole("link", { name: "Library" })).toBeVisible();
+});
+
+test("author page shows books by the author", async ({ page, request }) => {
+  // Niklaus Wirth has 4 books in the Code Quartet
+  const authorName = "Niklaus Wirth";
+  const authorId = await fetchAuthorIdByName(request, authorName);
+
+  await gotoReady(page, `/authors/${authorId}`);
+
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Wirth");
+
+  // Should show the series section for "Code Quartet"
+  await expect(page.getByText("Code Quartet")).toBeVisible();
+
+  // At least the first book title should be visible
+  await expect(page.getByText("Quartet I: Lexer")).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Series page
+// ---------------------------------------------------------------------------
+
+test("renders the series page layout", async ({ page, request }) => {
+  const seriesName = "Pioneers";
+  const seriesId = await fetchSeriesIdByName(request, seriesName);
+
+  await gotoReady(page, `/series/${seriesId}`);
+
+  // H1 contains the series name
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+  // Book count label is visible
+  await expect(page.getByText(/in library/)).toBeVisible();
+
+  // Breadcrumb has "Library" link
+  const breadcrumb = page.locator("nav.breadcrumb");
+  await expect(breadcrumb.getByRole("link", { name: "Library" })).toBeVisible();
+});
+
+test("series page shows books in order", async ({ page, request }) => {
+  const seriesName = "Pioneers";
+  const seriesId = await fetchSeriesIdByName(request, seriesName);
+
+  await gotoReady(page, `/series/${seriesId}`);
+
+  // Should have multiple book cards — "Pioneers" has 5 books in fixtures
+  const cards = page.locator("article.series-card");
+  await expect(cards).toHaveCount(5);
+
+  // First book should show "Book #1"
+  await expect(cards.first().getByText("Book #1")).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Tag cloud page
+// ---------------------------------------------------------------------------
+
+test("renders the tag cloud layout", async ({ page }) => {
+  await gotoReady(page, "/tags");
+
+  // Page header
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("tag");
+  await expect(page.getByText("unique tags")).toBeVisible();
+
+  // At least one tag cloud item rendered
+  const tagItems = page.locator(".tag-cloud-item");
+  const count = await tagItems.count();
+  expect(count).toBeGreaterThan(0);
+});
+
+test("tag cloud items show counts", async ({ page }) => {
+  await gotoReady(page, "/tags");
+
+  // Each tag should have a visible count span
+  const counts = page.locator(".tag-cloud-count");
+  const firstCount = await counts.first().textContent();
+  expect(firstCount).toBeTruthy();
+  expect(Number(firstCount)).toBeGreaterThan(0);
+});

--- a/ui_tests/playwright/tests/flows/discovery.spec.ts
+++ b/ui_tests/playwright/tests/flows/discovery.spec.ts
@@ -17,7 +17,8 @@ async function fetchAuthorIdByName(
   request: APIRequestContext,
   name: string,
 ): Promise<number> {
-  // POST to /api/rpc/ebooks (same as the landing page) and scan creators.
+  // GET /api/rpc/ebooks (same payload the landing page uses) and scan
+  // each book's creators for the named author.
   const resp = await request.get("/api/rpc/ebooks");
   expect(resp.status(), "GET /api/rpc/ebooks failed").toBe(200);
   const body = (await resp.json()) as {
@@ -34,39 +35,19 @@ async function fetchSeriesIdByName(
   request: APIRequestContext,
   name: string,
 ): Promise<number> {
-  // The ebooks list doesn't carry series IDs directly. Instead query the
-  // dedicated tag cloud endpoint which doesn't help either. Use the books
-  // list to find a book in the series, then query the /api/rpc/search for
-  // the series name and use that result's series field to locate the id
-  // via a direct SQL approach — or simpler: just POST to the rpc/series
-  // endpoint after finding via the DB. But we don't have an index endpoint
-  // yet. Instead, use the REST API /api/series/:id by probing.
-  //
-  // Simplest approach: POST to /api/rpc/ebooks to get a book in the series,
-  // then use the books_series_link table. Since we can't do raw SQL from
-  // Playwright, we'll search for the series name in the ebooks response and
-  // then iterate candidate IDs via the REST endpoint.
-  const ebooksResp = await request.get("/api/rpc/ebooks");
-  expect(ebooksResp.status()).toBe(200);
-  const ebooksBody = (await ebooksResp.json()) as {
-    books: { series: string | null; id: number }[];
+  // `EbookMetadata` carries `series_id` directly, so we can resolve the
+  // series ID from any book in the series via the same `/api/rpc/ebooks`
+  // payload the landing page consumes.
+  const resp = await request.get("/api/rpc/ebooks");
+  expect(resp.status(), "GET /api/rpc/ebooks failed").toBe(200);
+  const body = (await resp.json()) as {
+    books: { series: string | null; series_id: number | null }[];
   };
-  const bookInSeries = ebooksBody.books.find((b) => b.series === name);
-  if (!bookInSeries) {
-    throw new Error(`no book in series ${JSON.stringify(name)}`);
+  const match = body.books.find((b) => b.series === name && b.series_id != null);
+  if (!match?.series_id) {
+    throw new Error(`no indexed series named ${JSON.stringify(name)}`);
   }
-
-  // Try IDs 1..100 via the REST endpoint until we find the matching series.
-  for (let id = 1; id <= 100; id++) {
-    const resp = await request.post("/api/rpc/series", {
-      data: { id },
-    });
-    if (resp.status() === 200) {
-      const body = (await resp.json()) as { name: string; id: number } | null;
-      if (body && body.name === name) return body.id;
-    }
-  }
-  throw new Error(`could not resolve series id for ${JSON.stringify(name)}`);
+  return match.series_id;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add three discovery pages — `/authors/:id`, `/series/:id`, `/tags` — implementing the F1.8 initiative from the roadmap. Full vertical slice: shared types (`AuthorDetail`, `SeriesDetail`, `TagWeight`), DB query functions (`get_author`, `get_series`, `get_tag_cloud`), RPC + REST endpoints, Dioxus page components with Atrium design system styling, and Playwright E2E specs.
- Propagate `series_id` through `EbookMetadata` so the author page's series section headers and book detail's series rail link to `/series/:id`. Tag cloud items navigate back to the library with the clicked tag pre-selected as a filter facet.
- Add `ViewFilters.tags` to the shared type and wire it through the landing page's filter sidebar, `matches_filters`, and `facet_counts`.

## Test plan
- [x] `cargo clippy` — zero warnings
- [x] `cargo test -p omnibus-db` — 157 tests pass (includes `get_author`, `get_series`, `get_tag_cloud` coverage)
- [x] `cargo test -p omnibus` — 81 tests pass (includes 8 new REST integration tests for `/api/authors/:id`, `/api/series/:id`, `/api/tags`)
- [x] `cargo test -p omnibus-frontend --features server` — 50 tests pass (landing page tag filter tests)
- [ ] Playwright: `npx playwright test tests/flows/discovery.spec.ts` — 6 E2E specs (author layout, series layout, tag cloud layout)
- [ ] Manual: navigate author page → click series heading → arrives at series page
- [ ] Manual: book detail → click series name in rail → arrives at series page
- [ ] Manual: tag cloud → click tag → library filters to that tag

## Notes
- Author page groups books by series with linkable section headers, standalone books shown separately
- Series page shows books ordered by `series_index` with card layout
- Tag cloud uses font-size scaling (16–72px) and opacity (0.55–1.0) proportional to tag frequency
- Also added roadmap docs: `1-11-author-profiles.md` (cascading author photo resolution) and `1-12-browse-authors-series.md` (browse-all index pages)
- `series_id` is resolved via a scalar subquery (`books_series_link → series.id`) across all four book-loading SQL paths: `list_books`, `search_books`, `get_book`, and `BOOK_COLUMNS`/`row_to_ebook`

>[!NOTE]
> The Search page is excluded from this PR — it's being handled separately.