### PR TITLE
fix: replace panic!() with unreachable!() in auth validation (#113)

### DIFF
--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -544,7 +544,9 @@ mod tests {
     fn classify_register_error_routes_username() {
         match classify_register_error("username already exists") {
             RegisterError::Username(m) => assert_eq!(m, "username already exists"),
-            other => panic!("expected Username variant, got {other:?}"),
+            other => unreachable!(
+                "input contains \"username\", so classify_register_error must return Username, got {other:?}"
+            ),
         }
     }
 
@@ -552,7 +554,9 @@ mod tests {
     fn classify_register_error_routes_password() {
         match classify_register_error("password is too short") {
             RegisterError::Password(m) => assert_eq!(m, "password is too short"),
-            other => panic!("expected Password variant, got {other:?}"),
+            other => unreachable!(
+                "input contains \"password\" and not \"username\", so classify_register_error must return Password, got {other:?}"
+            ),
         }
     }
 
@@ -560,7 +564,9 @@ mod tests {
     fn classify_register_error_falls_back_to_other() {
         match classify_register_error("500: internal server error") {
             RegisterError::Other(m) => assert_eq!(m, "500: internal server error"),
-            other => panic!("expected Other variant, got {other:?}"),
+            other => unreachable!(
+                "input matches neither \"username\" nor \"password\" substrings, so classify_register_error must fall back to Other, got {other:?}"
+            ),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace three bare `panic!()` calls in `frontend/src/pages/auth.rs` (lines 547, 555, 563) with `unreachable!("…")` carrying descriptive messages.
- `panic!` in a Dioxus WASM event handler aborts the event loop with an `unreachable` trap and breaks the whole app; `unreachable!()` is semantically correct and produces a better diagnostic. (See issue #113.)

Closes #113.

## What each site was changed to

All three sites are the wildcard arm of a `match` over `RegisterError` (defined just above `classify_register_error` in the same file) where a specific variant has already been asserted by the surrounding test/handler logic. In each case the variant truly cannot be reached by construction, so the fix is `unreachable!("…why this variant cannot occur here…")`, not a `tracing::warn!` + `return`.

- **Line 547 — `classify_register_error_routes_username`**
  Input is `"username already exists"`. `classify_register_error` lowercases the input and checks `contains("username")` first, so this input deterministically routes to `RegisterError::Username`. The wildcard arm is unreachable.
  - Before: `other => panic!("expected Username variant, got {other:?}")`
  - After: `other => unreachable!("input contains \"username\", so classify_register_error must return Username, got {other:?}")`

- **Line 555 — `classify_register_error_routes_password`**
  Input is `"password is too short"`. It does not contain `"username"` but does contain `"password"`, so it deterministically routes to `RegisterError::Password`. The wildcard arm is unreachable.
  - Before: `other => panic!("expected Password variant, got {other:?}")`
  - After: `other => unreachable!("input contains \"password\" and not \"username\", so classify_register_error must return Password, got {other:?}")`

- **Line 563 — `classify_register_error_falls_back_to_other`**
  Input is `"500: internal server error"`. It contains neither `"username"` nor `"password"`, so `classify_register_error` falls through to `RegisterError::Other`. The wildcard arm is unreachable.
  - Before: `other => panic!("expected Other variant, got {other:?}")`
  - After: `other => unreachable!("input matches neither \"username\" nor \"password\" substrings, so classify_register_error must fall back to Other, got {other:?}")`

## Justification — why each site is truly unreachable

`classify_register_error` is a deterministic pure function over `&str` with no I/O, no randomness, and no shared state:

```rust
fn classify_register_error(raw: &str) -> RegisterError {
    let lower = raw.to_lowercase();
    if lower.contains("username") || lower.contains("user already") {
        RegisterError::Username(raw.to_string())
    } else if lower.contains("password") {
        RegisterError::Password(raw.to_string())
    } else {
        RegisterError::Other(raw.to_string())
    }
}
```

Each call site passes a hard-coded string literal whose substring composition uniquely determines which `if`/`else if`/`else` branch is taken, and therefore which `RegisterError` variant is returned. The wildcard arm in each match can only ever be reached if `classify_register_error` itself were changed to either return a different variant for the same input or to grow a new variant — both of which would be intentional changes that should re-visit these tests anyway. `unreachable!` (vs. `tracing::warn!` + `return`) is correct because (a) these are `#[cfg(test)]` unit tests, not user-facing event handlers, and (b) silently skipping the assertion would mask a regression in `classify_register_error`.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (default workspace members)
- [x] `cargo test` — all 131 tests pass, including the three modified tests (`classify_register_error_routes_username`, `classify_register_error_routes_password`, `classify_register_error_falls_back_to_other`)

## Notes
- No behavior change: `unreachable!()` expands to a panic at runtime, so if the underlying assumption is ever violated the test will still fail loudly — but with a message that explains the invariant rather than just naming the expected variant.
- No other files touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3A4thhmjpWpdjnQdXxd53)_