### PR TITLE
fix: replace eprintln! with structured tracing calls (#84)

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -804,7 +804,11 @@ async fn insert_fts_row(
 fn materialize_new_covers(new_covers: Vec<(String, String, Vec<u8>)>) {
     for (uuid, mime, bytes) in new_covers {
         if let Err(e) = write_cover_file(&uuid, &mime, &bytes) {
-            eprintln!("replace_books: failed to write cover for {uuid}: {e}");
+            tracing::error!(
+                error = %e,
+                uuid = %uuid,
+                "replace_books: failed to write cover"
+            );
         }
     }
 }

--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -247,7 +247,11 @@ pub fn evict_if_over_cap(cap_bytes: u64) -> Result<(), std::io::Error> {
         // freeing the rest.
         match std::fs::remove_file(path) {
             Ok(()) => total = total.saturating_sub(*size),
-            Err(e) => eprintln!("thumbs: evict {path:?} failed: {e}"),
+            Err(e) => tracing::warn!(
+                error = %e,
+                path = ?path,
+                "thumbs: evict failed"
+            ),
         }
     }
 

--- a/db/src/worker.rs
+++ b/db/src/worker.rs
@@ -110,7 +110,11 @@ impl Worker {
         tokio::spawn(async move {
             let outcome = this.run(task).await;
             if let TaskOutcome::Err(ref msg) = outcome {
-                eprintln!("worker: task {id} failed: {msg}");
+                tracing::error!(
+                    task_id = id,
+                    error = %msg,
+                    "worker: task failed"
+                );
             }
             let _ = tx.send(Some(outcome));
         });

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -37,7 +37,7 @@ web = ["dioxus/web", "dep:gloo-net", "dep:serde_json", "dep:web-sys"]
 # notify the UI when auth state changes so screens redirect to /login
 # without a polling loop. No runtime/macro features are pulled in here:
 # reqwest's own runtime is sufficient and `watch` is sync-only.
-mobile = ["dep:reqwest", "dep:serde_json", "dep:tokio", "tokio/sync"]
+mobile = ["dep:reqwest", "dep:serde_json", "dep:tokio", "tokio/sync", "dep:tracing"]
 # Server-function bodies: compiles the server-side halves of the #[get]/#[post]
 # functions in rpc.rs against the real DB layer. Used by `server/` when
 # building the fullstack native binary. The DB work lives in `omnibus-db`;

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -229,12 +229,20 @@ pub mod token_store {
             match op {
                 Op::Write(token) => {
                     if let Err(e) = write_token_file(&path, token.as_bytes()) {
-                        eprintln!("warning: could not persist bearer token: {e}");
+                        tracing::warn!(
+                            error = %e,
+                            path = %path.display(),
+                            "could not persist bearer token"
+                        );
                     }
                 }
                 Op::Delete => {
                     if let Err(e) = delete_token_file(&path) {
-                        eprintln!("warning: could not delete bearer token: {e}");
+                        tracing::warn!(
+                            error = %e,
+                            path = %path.display(),
+                            "could not delete bearer token"
+                        );
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Replace `eprintln!` with `tracing::error!`/`tracing::warn!` at five production-code sites so failure logs route through the structured logging pipeline the rest of the server already uses (see `db/src/ebook.rs:315,321` as the established model).
- Each call gains structured fields (`error = %e`, plus contextual keys like `uuid`, `task_id`, `path`) so logs are machine-readable instead of formatted strings.
- Enable the optional `tracing` dep on the `mobile` feature in `frontend/Cargo.toml` so `frontend/src/data.rs::token_store` (mobile-only) can emit warnings without bloating the WASM bundle (where it stays unenabled).

### Files changed (issue cites six sites; `frontend/src/rpc.rs:76` was already migrated on `main`, leaving five)
- `db/src/queries.rs:807` — cover write failure during indexing -> `tracing::error!` with `error`, `uuid`
- `db/src/worker.rs:113` — worker task failure -> `tracing::error!` with `task_id`, `error`
- `db/src/thumbs.rs:250` — thumbnail eviction failure -> `tracing::warn!` with `error`, `path`
- `frontend/src/data.rs:232` — bearer token persist warning -> `tracing::warn!` with `error`, `path`
- `frontend/src/data.rs:237` — bearer token delete warning -> `tracing::warn!` with `error`, `path`
- `frontend/Cargo.toml` — add `dep:tracing` to the `mobile` feature

### Why tracing matters
`eprintln!` writes plaintext to stderr, bypassing the `tracing` subscriber the server installs at startup. That means these failures don't get the request-scoped span context, structured field rendering, log-level filtering, or any future exporter (file, JSON, OTLP) the rest of the codebase opts into through `tracing`. Routing every production log site through `tracing` makes failures observable the same way as everything else.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean on default members
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` clean (verifies tracing usage compiles under the server feature)
- [x] `cargo check -p omnibus-frontend --features mobile --no-default-features` clean (verifies the mobile feature picks up the new `dep:tracing`)
- [x] `cargo test -p omnibus-db -p omnibus -p omnibus-frontend --features server` — 245+ tests pass, no regressions

## Notes
- Pure log-call refactor — no behavior changes, no public API changes, no new dependencies (tracing was already in the workspace and on `omnibus-db`).
- Mobile clippy emits two unrelated `field_reassign_with_default` errors in `frontend/src/view_prefs.rs` that exist on `main` and are out of scope for this PR.

Closes #84

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3A4thhmjpWpdjnQdXxd53)_