### PR TITLE
docs: add // SAFETY comments to unsafe blocks in boot.rs (#114)

### DIFF
--- a/server/src/auth/boot.rs
+++ b/server/src/auth/boot.rs
@@ -148,20 +148,28 @@ mod tests {
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let prev = std::env::var(key).ok();
-            // SAFETY: ENV_LOCK is held exclusively by the caller; no concurrent env mutation can occur.
+            // SAFETY: caller holds `ENV_LOCK` and must keep it held until after
+            // this `EnvGuard` is dropped — i.e. declare `let _lock = ENV_LOCK.lock()`
+            // *before* the `EnvGuard` so reverse-drop order keeps the lock alive
+            // across `Drop` (which also mutates env). No concurrent env mutation
+            // can occur while that contract is upheld.
             unsafe { std::env::set_var(key, value) };
             Self { key, prev }
         }
         fn unset(key: &'static str) -> Self {
             let prev = std::env::var(key).ok();
-            // SAFETY: ENV_LOCK is held exclusively by the caller; no concurrent env mutation can occur.
+            // SAFETY: same contract as `EnvGuard::set` — caller must hold `ENV_LOCK`
+            // across this call *and* the eventual `Drop`.
             unsafe { std::env::remove_var(key) };
             Self { key, prev }
         }
     }
     impl Drop for EnvGuard {
         fn drop(&mut self) {
-            // SAFETY: ENV_LOCK is held exclusively by the caller; no concurrent env mutation can occur.
+            // SAFETY: `ENV_LOCK` is still held by the caller — see the contract
+            // documented on `EnvGuard::set`/`unset`. Because callers declare
+            // `_lock` before `_g`, reverse-drop order guarantees the lock
+            // outlives this `Drop`. No concurrent env mutation can occur.
             unsafe {
                 match &self.prev {
                     Some(v) => std::env::set_var(self.key, v),

--- a/server/src/auth/boot.rs
+++ b/server/src/auth/boot.rs
@@ -148,18 +148,20 @@ mod tests {
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let prev = std::env::var(key).ok();
-            // Safety: we hold ENV_LOCK for the duration of any test using this.
+            // SAFETY: ENV_LOCK is held exclusively by the caller; no concurrent env mutation can occur.
             unsafe { std::env::set_var(key, value) };
             Self { key, prev }
         }
         fn unset(key: &'static str) -> Self {
             let prev = std::env::var(key).ok();
+            // SAFETY: ENV_LOCK is held exclusively by the caller; no concurrent env mutation can occur.
             unsafe { std::env::remove_var(key) };
             Self { key, prev }
         }
     }
     impl Drop for EnvGuard {
         fn drop(&mut self) {
+            // SAFETY: ENV_LOCK is held exclusively by the caller; no concurrent env mutation can occur.
             unsafe {
                 match &self.prev {
                     Some(v) => std::env::set_var(self.key, v),


### PR DESCRIPTION
## Summary
- Add a `// SAFETY:` comment directly above each of the three `unsafe { std::env::set_var(...) }` / `unsafe { std::env::remove_var(...) }` blocks in `server/src/auth/boot.rs` (the `EnvGuard::set`, `EnvGuard::unset`, and `Drop for EnvGuard` callsites).
- Each comment explains the invariant at the callsite: `ENV_LOCK is held exclusively by the caller; no concurrent env mutation can occur.`
- The module-level comment that documents the `ENV_LOCK` serialization invariant is left intact — both can coexist. Rust convention is to put a `// SAFETY:` note at *each* `unsafe` site (not just one module-level explanation), and clippy / common review tools key off that exact pattern.

This is a documentation-only change with zero runtime impact — the bytes inside the `unsafe { ... }` blocks are unchanged.

Closes #114

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` clean
- [x] `cargo test -p omnibus` — 81 passed, 0 failed (including the `auth::boot::tests::*` suite that exercises the affected `EnvGuard`)

## Notes
- No new dependencies, env vars, modules, or conventions introduced; CLAUDE.md / `.claude/rules` are unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E3A4thhmjpWpdjnQdXxd53)_