### PR TITLE
fix(ci): drop magic-nix-cache (sunset + rate limits break E2E)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Enable Nix store cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,9 +48,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Enable Nix store cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- E2E on `main` has been failing since 2026-05-22; the failure is the magic-nix-cache step, not the Playwright tests.
- `DeterminateSystems/magic-nix-cache-action@main` hits the GitHub Actions cache (FlakeHub auth fails because the workflow doesn't set `id-token: write`), the GHA cache returns `ResourceExhausted: rate limit exceeded` (HTTP 418) on upload, and the local substituter disables itself. After that, Nix can't fetch `rust-src-nightly-latest-2026-04-16` (only ever lived in our magic-nix-cache, not on cache.nixos.org) and the job dies before Playwright starts.
- Determinate is sunsetting magic-nix-cache in favor of FlakeHub Cache (paid). Rather than wire that up, drop the cache step from both `e2e.yml` and `rust.yml`. `Swatinem/rust-cache@v2` still caches the cargo target across runs; Nix store packages pull from cache.nixos.org; fenix's `rust-src` is a fixed-output derivation fetched from static.rust-lang.org and needs no substituter.

## Test plan
- [ ] E2E workflow turns green on this PR (label `run_ui_tests` triggers it).
- [ ] Rust workflow stays green on this PR.

## Notes
- Failing run for reference: https://github.com/seamus-sloan/omnibus/actions/runs/26313848788/job/77468599993
- Expect a one-time CI slowdown on the first run after merge (no warm Nix store cache), then steady-state speed dominated by `Swatinem/rust-cache`.