### PR TITLE
fix(ci): switch to cache-nix-action with auto-purge to avoid GHA cache quota

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,11 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'run_ui_tests')
+    permissions:
+      contents: read
+      # Required by nix-community/cache-nix-action `purge: true` so it can
+      # delete its own expired cache entries via the Actions cache API.
+      actions: write
     env:
       CI: "1"
       # Pin target dir so the bundled binary lands at the path "Start server"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,8 +29,20 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Enable Nix store cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      # Cache the Nix store across runs. Auto-purges caches with the same
+      # prefix that haven't been touched in 7 days so we stay under the 10 GB
+      # per-repo GHA cache quota. Replaces DeterminateSystems/magic-nix-cache-action
+      # (sunset; was uploading unbounded and exceeding the quota).
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-e2e-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-e2e-${{ runner.os }}-
+          purge: true
+          purge-prefixes: nix-e2e-${{ runner.os }}-
+          purge-last-accessed: 604800
+          purge-primary-key: never
+          gc-max-store-size-linux: 5G
 
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,8 +48,20 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Enable Nix store cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      # Cache the Nix store across runs. Auto-purges caches with the same
+      # prefix that haven't been touched in 7 days so we stay under the 10 GB
+      # per-repo GHA cache quota. Replaces DeterminateSystems/magic-nix-cache-action
+      # (sunset; was uploading unbounded and exceeding the quota).
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-rust-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-rust-${{ runner.os }}-
+          purge: true
+          purge-prefixes: nix-rust-${{ runner.os }}-
+          purge-last-accessed: 604800
+          purge-primary-key: never
+          gc-max-store-size-linux: 5G
 
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,11 @@ jobs:
   check:
     name: clippy + test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required by nix-community/cache-nix-action `purge: true` so it can
+      # delete its own expired cache entries via the Actions cache API.
+      actions: write
     env:
       # Match e2e.yml: pin target dir so rust-cache (keyed on `. -> target`)
       # actually caches anything across runs.


### PR DESCRIPTION
## Summary
- E2E on `main` has been failing since 2026-05-22 because the repo's GHA cache hit the 10 GB per-repo quota (4,827 entries, 10.18 GB). `DeterminateSystems/magic-nix-cache-action@main` then got `ResourceExhausted: rate limit exceeded` on every upload, disabled its substituter, and Nix couldn't fetch `rust-src-nightly-latest-2026-04-16` (which only ever lived in our magic-nix-cache, not on cache.nixos.org).
- Switch the Nix store cache from `DeterminateSystems/magic-nix-cache-action@main` to [`nix-community/cache-nix-action@v7`](https://github.com/nix-community/cache-nix-action) in both `e2e.yml` and `rust.yml`. The new action has *built-in* automatic purging: `purge: true` + `purge-last-accessed: 604800` deletes its own cache entries that haven't been touched in 7 days after every CI run, keeping us permanently under the 10 GB quota with no separate cleanup workflow.
- Each workflow gets its own key prefix (`nix-e2e-` / `nix-rust-`) so they prune independently. `purge-primary-key: never` protects the just-saved entry. `gc-max-store-size-linux: 5G` caps the per-job store snapshot.
- Manually purged the existing overflow as a one-time cleanup: repo cache is now **3.19 GB / 1,564 entries** (down from 10.18 GB / 4,827). The leftover unprefixed `.nar.zstd-*` entries from magic-nix-cache won't be reused by the new action's keyed scheme but will age out via GitHub's 7-day LRU.

## Test plan
- [ ] E2E workflow runs on this PR (label `run_ui_tests` triggers it) and turns green.
- [ ] Rust workflow stays green on this PR.
- [ ] After a few runs, confirm via `gh api repos/seamus-sloan/omnibus/actions/cache/usage` that total cache size stays bounded.

## Notes
- Failing run for reference: https://github.com/seamus-sloan/omnibus/actions/runs/26313848788/job/77468599993
- `cache-nix-action@v7` was released 2026-01-08 and is the actively maintained community successor to magic-nix-cache. It uses `actions/cache` under the hood, so no FlakeHub auth (or `id-token: write` permissions) is required.
- First run after merge will be slow (cold cache); subsequent runs should match or beat prior magic-nix-cache performance.