### PR TITLE
test: add unit tests for core book query functions (#115)

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -4811,11 +4811,7 @@ mod tests {
         assert!(results.duration_ms < 10000, "duration should be reasonable");
     }
 
-    // -----------------------------------------------------------------
-    // Issue #115 — additional coverage for core book query functions.
-    // The library-path filter on list_books and the raw-operator path
-    // through search_books were previously untested end-to-end.
-    // -----------------------------------------------------------------
+    // Additional coverage for core book query functions.
 
     #[tokio::test]
     async fn list_books_filters_by_library_path() {

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -4810,4 +4810,172 @@ mod tests {
         // duration_ms should be populated (at least 0 — we just check it's set)
         assert!(results.duration_ms < 10000, "duration should be reasonable");
     }
+
+    // -----------------------------------------------------------------
+    // Issue #115 — additional coverage for core book query functions.
+    // The library-path filter on list_books and the raw-operator path
+    // through search_books were previously untested end-to-end.
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_books_filters_by_library_path() {
+        let _covers = CoversTempDir::new("list_books_filter_lib");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+
+        replace_books(
+            &pool,
+            "/lib-a",
+            vec![
+                indexed("a1.epub", Some("Alpha One"), &["Author A"], &[], None, None),
+                indexed("a2.epub", Some("Alpha Two"), &["Author A"], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+        replace_books(
+            &pool,
+            "/lib-b",
+            vec![indexed(
+                "b1.epub",
+                Some("Beta One"),
+                &["Author B"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let lib_a = list_books(&pool, "/lib-a").await.unwrap();
+        let lib_b = list_books(&pool, "/lib-b").await.unwrap();
+
+        assert_eq!(lib_a.len(), 2, "lib-a should return only its two books");
+        let mut titles_a: Vec<String> = lib_a.iter().filter_map(|b| b.title.clone()).collect();
+        titles_a.sort();
+        assert_eq!(titles_a, vec!["Alpha One", "Alpha Two"]);
+
+        assert_eq!(lib_b.len(), 1, "lib-b should return only its one book");
+        assert_eq!(lib_b[0].title.as_deref(), Some("Beta One"));
+    }
+
+    #[tokio::test]
+    async fn list_books_returns_empty_for_unknown_path() {
+        let _covers = CoversTempDir::new("list_books_unknown");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("Title"),
+                &["Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let hits = list_books(&pool, "/does-not-exist").await.unwrap();
+        assert!(
+            hits.is_empty(),
+            "unknown library path should yield an empty vec (no error)"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_books_returns_empty_for_empty_db() {
+        let _covers = CoversTempDir::new("list_books_empty_db");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let hits = list_books(&pool, "/lib").await.unwrap();
+        assert!(hits.is_empty(), "empty DB should yield an empty vec");
+    }
+
+    #[tokio::test]
+    async fn search_books_handles_bare_asterisk_without_error() {
+        // A raw `*` is an FTS5 operator; the sanitizer must quote it so MATCH
+        // doesn't reject the expression as a syntax error. We assert the call
+        // succeeds — not a particular hit shape — because the goal is "no panic
+        // / no sqlx parse error".
+        let _covers = CoversTempDir::new("fts_asterisk");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("Anything"),
+                &["Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let hits = search_books(&pool, "/lib", "*")
+            .await
+            .expect("sanitizer should guard MATCH against the bare `*` operator");
+        // `*` alone has no literal token to match; an empty result is fine.
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_books_handles_bare_double_quote_without_error() {
+        // A raw `"` is the FTS5 phrase delimiter. Without sanitization, MATCH
+        // would reject this with a parse error and the call would `Err`.
+        let _covers = CoversTempDir::new("fts_dquote");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("Anything"),
+                &["Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let hits = search_books(&pool, "/lib", "\"")
+            .await
+            .expect("sanitizer should guard MATCH against a bare `\"` operator");
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_books_returns_empty_for_unknown_library() {
+        // Even with a real match in another library, the WHERE l.path = ?
+        // clause must scope results to the requested library.
+        let _covers = CoversTempDir::new("search_books_unknown_lib");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib-a",
+            vec![indexed(
+                "a.epub",
+                Some("Findable"),
+                &["Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let hits = search_books(&pool, "/lib-b", "Findable").await.unwrap();
+        assert!(
+            hits.is_empty(),
+            "query against a non-existent library must not leak rows from another library"
+        );
+    }
 }


### PR DESCRIPTION
Closes #115

## Summary

The issue described the core book query layer (`list_books`, `search_books`, `get_book`, `get_author`, `get_series`, `get_tag_cloud`) as having zero inline tests. In practice the test module in `db/src/queries.rs` already covers most of the bullets in the issue (the file has ~180 tests passing on `main`). Audit of the existing tests vs. the issue's specific bullets surfaced two gaps that were genuinely uncovered end-to-end — this PR fills exactly those gaps, nothing more.

New inline `#[tokio::test]`s in `db/src/queries.rs`:

**`list_books`**
- `list_books_filters_by_library_path` — seeds two libraries and asserts each call only returns the matching library's books (exercises the `WHERE l.path = ?` clause that previously had no direct test).
- `list_books_returns_empty_for_unknown_path` — books present in one library, query a different path, expect empty vec (no error).
- `list_books_returns_empty_for_empty_db` — fresh DB, no books, expect empty vec.

**`search_books`**
- `search_books_handles_bare_asterisk_without_error` — raw `*` (FTS5 operator) flows through `build_fts_match` / sanitizer without surfacing as a MATCH parse error.
- `search_books_handles_bare_double_quote_without_error` — raw `"` (FTS5 phrase delimiter) likewise sanitized.
- `search_books_returns_empty_for_unknown_library` — confirms the library-path scope clause prevents cross-library leakage even when the FTS row exists.

## Files changed
- `db/src/queries.rs` — +168 lines (test module only; no production code changed).

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean; `--all-features` is intentionally rejected by the `omnibus-frontend` crate per its `compile_error!` — out of scope here)
- [x] `cargo test -p omnibus-db` — 188 unit tests + 2 integration tests pass (was 182 before; +6 from this PR)

## Notes
- The issue's premise that these functions have "ZERO inline unit tests" overstated the gap — `list_books_*`, `search_books_*`, `get_book_*`, `get_author_*`, `get_series_*`, and `get_tag_cloud_*` tests already existed. This PR addresses the specific cases the issue called out that weren't already covered (library-path filter, unknown path, raw `*` / `"` through `search_books`). Worth a follow-up read of the existing coverage before filing similar issues.
- No surprises in the functions under test — their behavior matches the rustdoc.

https://claude.ai/code/session_016VxzNdf5VYtV8mAKNDLDNc

---
_Generated by [Claude Code](https://claude.ai/code/session_016VxzNdf5VYtV8mAKNDLDNc)_