### PR TITLE
fix: bundle small tech-debt fixes (#125, #128, #126, #57)

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -4831,6 +4831,131 @@ mod tests {
         assert_eq!(results.tags[0].book_count, 1);
     }
 
+    // #128: lock the wiring between the palette and `build_fts_match`'s
+    // facet prefixes. A regression in the facet parser could otherwise
+    // silently break palette tag:/author:/series: queries without any
+    // palette test failing.
+
+    #[tokio::test]
+    async fn palette_book_matches_tag_facet() {
+        let _covers = CoversTempDir::new("palette_tag_facet");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("Dracula"),
+                    &["Bram Stoker"],
+                    &["vampires"],
+                    None,
+                    None,
+                ),
+                indexed(
+                    "b.epub",
+                    Some("Frankenstein"),
+                    &["Mary Shelley"],
+                    &["monsters"],
+                    None,
+                    None,
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "tag:vampires").await.unwrap();
+        let titles: Vec<&str> = results.books.iter().map(|b| b.title.as_str()).collect();
+        assert!(
+            titles.contains(&"Dracula"),
+            "tag:vampires should match Dracula, got {titles:?}"
+        );
+        assert!(
+            !titles.contains(&"Frankenstein"),
+            "tag:vampires should not match Frankenstein"
+        );
+    }
+
+    #[tokio::test]
+    async fn palette_book_matches_author_facet() {
+        let _covers = CoversTempDir::new("palette_author_facet");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("Dracula"),
+                    &["Bram Stoker"],
+                    &["horror"],
+                    None,
+                    None,
+                ),
+                indexed(
+                    "b.epub",
+                    Some("Frankenstein"),
+                    &["Mary Shelley"],
+                    &["horror"],
+                    None,
+                    None,
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "author:stoker")
+            .await
+            .unwrap();
+        let titles: Vec<&str> = results.books.iter().map(|b| b.title.as_str()).collect();
+        assert!(
+            titles.contains(&"Dracula"),
+            "author:stoker should match Dracula, got {titles:?}"
+        );
+        assert!(
+            !titles.contains(&"Frankenstein"),
+            "author:stoker should not match Frankenstein"
+        );
+    }
+
+    #[tokio::test]
+    async fn palette_book_matches_series_facet() {
+        let _covers = CoversTempDir::new("palette_series_facet");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("Book One"),
+                    &["Author A"],
+                    &[],
+                    Some(("Dracula Chronicles", "1")),
+                    None,
+                ),
+                indexed("b.epub", Some("Unrelated"), &["Author B"], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let results = search_palette(&pool, "/lib", "series:dracula")
+            .await
+            .unwrap();
+        let titles: Vec<&str> = results.books.iter().map(|b| b.title.as_str()).collect();
+        assert!(
+            titles.contains(&"Book One"),
+            "series:dracula should match Book One, got {titles:?}"
+        );
+        assert!(
+            !titles.contains(&"Unrelated"),
+            "series:dracula should not match Unrelated"
+        );
+    }
+
     #[tokio::test]
     async fn palette_empty_query_returns_empty() {
         let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -902,7 +902,7 @@ async fn insert_book_row(
     .bind(has_cover)
     .bind(&m.description)
     .bind(&first_isbn)
-    .bind(m.accent.as_deref())
+    .bind(sanitize_accent_color(m.accent.as_deref()))
     .fetch_one(&mut **tx)
     .await?;
 
@@ -2165,6 +2165,42 @@ fn parse_series_index(s: &str) -> Option<f64> {
     s.trim().parse::<f64>().ok()
 }
 
+/// Defense-in-depth gate on `books.accent_color` (#125). The indexer's
+/// `extract_accent` emits strings of the exact shape `oklch(L C H)` with
+/// three space-separated decimal floats; consumers (Atrium cover tiles,
+/// palette rows, book detail) inline the value into an HTML `style`
+/// attribute. Reject anything that doesn't match that strict shape so a
+/// future override path or imported value can't smuggle CSS / break out
+/// of the attribute, regardless of consumer escaping.
+fn sanitize_accent_color(raw: Option<&str>) -> Option<String> {
+    let s = raw?.trim();
+    let inner = s.strip_prefix("oklch(")?.strip_suffix(')')?;
+    let parts: Vec<&str> = inner.split(' ').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    for part in &parts {
+        if part.is_empty() || part.matches('.').count() > 1 {
+            return None;
+        }
+        let mut has_digit = false;
+        for c in part.chars() {
+            match c {
+                '0'..='9' => has_digit = true,
+                '.' => {}
+                _ => return None,
+            }
+        }
+        // Reject parts with no digits at all (a bare "." or ".." stripped of
+        // characters). The `extract_accent` formatter always emits at least
+        // one digit on each side per `{l:.3}` / `{c:.3}` / `{h:.1}`.
+        if !has_digit {
+            return None;
+        }
+    }
+    Some(s.to_string())
+}
+
 /// Join an iterator of names into a single whitespace-separated string for
 /// the FTS `authors` / `tags` columns. Empty inputs collapse to "".
 fn join_names<'a, I: IntoIterator<Item = &'a str>>(iter: I) -> String {
@@ -2670,6 +2706,80 @@ mod tests {
         assert_eq!(detail.accent.as_deref(), Some("oklch(0.660 0.130 245.0)"));
         let detail_plain = get_book(&pool, plain.id).await.unwrap().unwrap();
         assert_eq!(detail_plain.accent, None);
+    }
+
+    /// #125: the write-boundary gate must accept the exact `oklch(L C H)`
+    /// shape the indexer emits, and reject anything else — including raw
+    /// hex, CSS keywords, and injection payloads that try to break out of
+    /// the `style="background: {bg}"` attribute used by Atrium consumers.
+    #[test]
+    fn sanitize_accent_color_accepts_indexer_shape() {
+        assert_eq!(
+            sanitize_accent_color(Some("oklch(0.660 0.130 245.0)")).as_deref(),
+            Some("oklch(0.660 0.130 245.0)")
+        );
+        assert_eq!(
+            sanitize_accent_color(Some("oklch(0.780 0.060 12.5)")).as_deref(),
+            Some("oklch(0.780 0.060 12.5)")
+        );
+    }
+
+    #[test]
+    fn sanitize_accent_color_rejects_bad_shapes() {
+        for bad in [
+            "",
+            "red",
+            "#aabbcc",
+            "rgb(1,2,3)",
+            "oklch(0.66, 0.13, 245)",                   // commas, not spaces
+            "oklch(0.66 0.13)",                         // wrong arity
+            "oklch(0.66 0.13 245 extra)",               // wrong arity
+            "oklch(0.66 0.13 245",                      // missing close paren
+            "0.66 0.13 245",                            // missing wrapper
+            "oklch(0.66 0.13 abc)",                     // non-numeric
+            "oklch(0.66 0.13 24.5.0)",                  // multiple dots
+            "oklch(0.66 0.13 245); background: url(x)", // injection
+            "oklch(0.66 0.13 245)\" onload=\"alert(1)", // attribute breakout
+            "oklch(. . .)",                             // dot-only parts (no digits)
+            "oklch(0.66 . 245.0)",                      // one part has no digits
+        ] {
+            assert!(
+                sanitize_accent_color(Some(bad)).is_none(),
+                "expected None for {bad:?}"
+            );
+        }
+        assert_eq!(sanitize_accent_color(None), None);
+    }
+
+    /// End-to-end gate: writing an `IndexedBook` whose `accent` carries an
+    /// injection payload must result in `accent_color = NULL` in the DB,
+    /// not the unsanitized string.
+    #[tokio::test]
+    async fn replace_books_drops_unsafe_accent_color() {
+        let _covers = CoversTempDir::new("accent_unsafe");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let unsafe_book = IndexedBook {
+            metadata: EbookMetadata {
+                filename: "shady.epub".into(),
+                title: Some("Shady".into()),
+                creators: vec![Contributor {
+                    name: "Anon".into(),
+                    ..Default::default()
+                }],
+                accent: Some("red; background: url(x)".into()),
+                ..Default::default()
+            },
+            cover: None,
+        };
+        replace_books(&pool, "/lib", vec![unsafe_book])
+            .await
+            .expect("replace should succeed");
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let shady = books
+            .iter()
+            .find(|b| b.title.as_deref() == Some("Shady"))
+            .unwrap();
+        assert_eq!(shady.accent, None);
     }
 
     #[tokio::test]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -33,7 +33,19 @@ tracing = { workspace = true, optional = true }
 [features]
 default = []
 # Web client (WASM): uses dioxus-fullstack server-function client stubs.
-web = ["dioxus/web", "dep:gloo-net", "dep:gloo-timers", "dep:serde_json", "dep:web-sys", "dep:wasm-bindgen"]
+# tokio/sync (sync-only, WASM-safe) backs `data::web_auth_state` — a watch
+# channel that lets data-layer 401s notify the router to redirect to /login
+# (#57), mirroring the mobile token_store pattern.
+web = [
+    "dioxus/web",
+    "dep:gloo-net",
+    "dep:gloo-timers",
+    "dep:serde_json",
+    "dep:web-sys",
+    "dep:wasm-bindgen",
+    "dep:tokio",
+    "tokio/sync",
+]
 # Native mobile client: talks to `/api/*` REST routes via reqwest.
 # tokio is enabled for `sync::watch` — used by `data::token_store` to
 # notify the UI when auth state changes so screens redirect to /login

--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -24,6 +24,7 @@
 //! when open, so SSR and WASM agree on initial DOM — no hydration mismatch.
 //! The `⌘K` listener fires only in `#[cfg(feature = "web")]`.
 
+use dioxus::core::Task;
 use dioxus::prelude::*;
 use dioxus_router::use_navigator;
 use omnibus_shared::{
@@ -100,12 +101,14 @@ fn SpOverlay(open: PaletteOpen) -> Element {
     let mut results = use_signal(|| Option::<PaletteResults>::None);
     let mut selected = use_signal(|| 0_usize);
     let mut loading = use_signal(|| false);
-    // Generation counter for debounce — stale responses are discarded.
-    let mut generation = use_signal(|| 0_u64);
     // Tracks whether the user has driven selection with arrow keys this
     // session. When false, pressing Enter navigates to the full-page
     // search results instead of drilling into `selected`.
     let mut has_navigated = use_signal(|| false);
+    // #126: handle of the in-flight debounce+RPC task so the next keystroke
+    // can `.cancel()` it before spawning a new one (instead of leaving N
+    // sleeping spawns to race past the debounce and burn pool connections).
+    let mut current_task = use_signal(|| Option::<Task>::None);
     let nav = use_navigator();
 
     // Build a flat list of selectable items for keyboard navigation.
@@ -190,21 +193,19 @@ fn SpOverlay(open: PaletteOpen) -> Element {
         }
     };
 
-    // Debounced search effect. Uses gloo_timers on web, tokio::time on
-    // server. The generation counter ensures stale responses are discarded.
+    // Debounced search. Uses gloo_timers on web, tokio::time on server.
+    // Each keystroke cancels the prior task (debounce sleep + RPC) before
+    // spawning a new one — only one task is in flight at a time, so stale
+    // requests don't race past the debounce or hit SQLite.
     let url = server_url.clone();
-    use_effect(move || {
-        let q = query();
-        let gen = generation();
+    let mut spawn_search = move |v: String| {
+        if let Some(prev) = current_task.write().take() {
+            prev.cancel();
+        }
         let url = url.clone();
-        spawn(async move {
-            // 150ms debounce.
+        let task = spawn(async move {
             async_sleep_ms(150).await;
-            // Stale? Skip.
-            if gen != generation() {
-                return;
-            }
-            let trimmed = q.trim().to_string();
+            let trimmed = v.trim().to_string();
             if trimmed.is_empty() {
                 results.set(None);
                 loading.set(false);
@@ -213,23 +214,17 @@ fn SpOverlay(open: PaletteOpen) -> Element {
             loading.set(true);
             match data::search_palette(&url, &trimmed).await {
                 Ok(r) => {
-                    // Only apply if still current generation.
-                    if gen == generation() {
-                        selected.set(0);
-                        results.set(Some(r));
-                    }
+                    selected.set(0);
+                    results.set(Some(r));
                 }
                 Err(_) => {
-                    if gen == generation() {
-                        results.set(None);
-                    }
+                    results.set(None);
                 }
             }
-            if gen == generation() {
-                loading.set(false);
-            }
+            loading.set(false);
         });
-    });
+        current_task.set(Some(task));
+    };
 
     let res = results.read();
     let items = flat_items.read();
@@ -292,8 +287,8 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                         value: "{query}",
                         oninput: move |evt| {
                             let v = evt.value();
-                            query.set(v);
-                            generation += 1;
+                            query.set(v.clone());
+                            spawn_search(v);
                             // Typing reverts to "Enter goes to /search" until
                             // the user re-engages arrow-key navigation.
                             has_navigated.set(false);

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -717,6 +717,73 @@ async fn post_mobile_auth<T: serde::Serialize>(
         .map_err(|e| e.to_string())
 }
 
+// ===== Web auth state =====
+//
+// #57: web counterpart to `token_store::subscribe()`. The web client uses
+// session cookies (round-tripped automatically by the browser), so there's
+// no client-side token to clear — but we still need a reactive signal so
+// the router can redirect to /login when any data-layer call returns 401
+// (session expired, server restarted, admin revoked). All web data
+// wrappers route their errors through [`note_server_fn_err`] below, which
+// pushes `false` onto this channel on a 401 response; `ScreenLayout`
+// subscribes and `nav.replace`s.
+
+#[cfg(feature = "web")]
+pub mod web_auth_state {
+    use std::sync::OnceLock;
+    use tokio::sync::watch;
+
+    fn channel() -> &'static (watch::Sender<bool>, watch::Receiver<bool>) {
+        static CH: OnceLock<(watch::Sender<bool>, watch::Receiver<bool>)> = OnceLock::new();
+        CH.get_or_init(|| watch::channel(true))
+    }
+
+    /// Returns a receiver that observes auth state. `true` = currently
+    /// believed-authenticated, `false` = a recent request returned 401.
+    pub fn subscribe() -> watch::Receiver<bool> {
+        channel().0.subscribe()
+    }
+
+    /// Signal that the most recent data call returned 401. `send_replace`
+    /// doesn't require active receivers and never errors, so this is safe
+    /// to call from any async context.
+    pub fn notify_unauthorized() {
+        channel().0.send_replace(false);
+    }
+
+    /// Signal that we've just observed an authenticated state — a fresh
+    /// login/register succeeded, or `/api/auth/me` confirmed an existing
+    /// session. Without this, the channel would latch at `false` after
+    /// the first 401 and stay there for the WASM instance's lifetime, so
+    /// a re-login from the redirected-to /login page couldn't reactively
+    /// re-mount protected screens.
+    pub fn notify_authorized() {
+        channel().0.send_replace(true);
+    }
+}
+
+/// Inspect a server-function error (Dioxus wraps it in `CapturedError`,
+/// which holds an `Arc<anyhow::Error>`) and — on the web client — ping
+/// `web_auth_state` if the underlying `ServerFnError` carries a 401
+/// status code. Returns the stringified error the previous
+/// `.map_err(|e| e.to_string())` produced so callers don't need to
+/// change their error type. SSR builds (cfg(not(feature = "web"))) just
+/// stringify — there's no client to redirect.
+#[cfg(not(feature = "mobile"))]
+fn note_server_fn_err(e: dioxus::CapturedError) -> String {
+    if let Some(sfn_err) = e.0.downcast_ref::<dioxus::fullstack::ServerFnError>() {
+        let code = match sfn_err {
+            dioxus::fullstack::ServerFnError::ServerError { code, .. } => *code,
+            _ => 0,
+        };
+        if code == 401 {
+            #[cfg(feature = "web")]
+            web_auth_state::notify_unauthorized();
+        }
+    }
+    e.to_string()
+}
+
 // ===== Web / fullstack-SSR transport: dioxus-fullstack server functions =====
 //
 // `server_url` is unused here — server functions always resolve against the
@@ -726,7 +793,7 @@ async fn post_mobile_auth<T: serde::Serialize>(
 pub async fn get_value(_server_url: &str) -> Result<i64, String> {
     match crate::rpc::rpc_get_value().await {
         Ok(payload) => Ok(payload.value),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(note_server_fn_err(e)),
     }
 }
 
@@ -734,7 +801,7 @@ pub async fn get_value(_server_url: &str) -> Result<i64, String> {
 pub async fn post_increment(_server_url: &str) -> Result<i64, String> {
     match crate::rpc::rpc_increment_value().await {
         Ok(payload) => Ok(payload.value),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(note_server_fn_err(e)),
     }
 }
 
@@ -742,35 +809,35 @@ pub async fn post_increment(_server_url: &str) -> Result<i64, String> {
 pub async fn get_settings(_server_url: &str) -> Result<Settings, String> {
     crate::rpc::rpc_get_settings()
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn save_settings(_server_url: &str, settings: Settings) -> Result<Settings, String> {
     crate::rpc::rpc_save_settings(settings)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn get_library(_server_url: &str) -> Result<LibraryContents, String> {
     crate::rpc::rpc_get_library()
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn get_ebooks(_server_url: &str) -> Result<EbookLibrary, String> {
     crate::rpc::rpc_get_ebooks()
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, String> {
     crate::rpc::rpc_search(q.to_string())
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 /// Search palette — grouped results for the command-palette overlay (F1.5).
@@ -778,35 +845,35 @@ pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, S
 pub async fn search_palette(_server_url: &str, q: &str) -> Result<PaletteResults, String> {
     crate::rpc::rpc_search_palette(q.to_string())
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn get_ebook(_server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
     crate::rpc::rpc_get_ebook(id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn get_author(_server_url: &str, id: i64) -> Result<Option<AuthorDetail>, String> {
     crate::rpc::rpc_get_author(id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn get_series(_server_url: &str, id: i64) -> Result<Option<SeriesDetail>, String> {
     crate::rpc::rpc_get_series(id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn get_tag_cloud(_server_url: &str) -> Result<Vec<TagWeight>, String> {
     crate::rpc::rpc_get_tag_cloud()
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
@@ -817,14 +884,14 @@ pub async fn save_overrides(
 ) -> Result<Option<EbookMetadata>, String> {
     crate::rpc::rpc_save_overrides(id, overrides.clone())
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
 pub async fn delete_overrides(_server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
     crate::rpc::rpc_delete_overrides(id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(note_server_fn_err)
 }
 
 // ===== Auth transport (web only) =====
@@ -842,12 +909,18 @@ pub async fn delete_overrides(_server_url: &str, id: i64) -> Result<Option<Ebook
 
 #[cfg(feature = "web")]
 pub async fn login(req: LoginRequest) -> Result<LoginResponse, String> {
-    post_auth_json("/api/auth/login", &req).await
+    let resp = post_auth_json("/api/auth/login", &req).await?;
+    // Reset the auth-state channel so a prior 401 doesn't keep
+    // ScreenLayout in redirect mode after a successful re-login.
+    web_auth_state::notify_authorized();
+    Ok(resp)
 }
 
 #[cfg(feature = "web")]
 pub async fn register(req: RegisterRequest) -> Result<LoginResponse, String> {
-    post_auth_json("/api/auth/register", &req).await
+    let resp = post_auth_json("/api/auth/register", &req).await?;
+    web_auth_state::notify_authorized();
+    Ok(resp)
 }
 
 #[cfg(feature = "web")]
@@ -860,6 +933,9 @@ pub async fn logout() -> Result<(), String> {
     if !res.ok() && res.status() != 204 {
         return Err(format!("logout failed: {}", res.status()));
     }
+    // A successful logout is the unauth path — same signal as a 401, so
+    // ScreenLayout redirects to /login without each caller having to nav.
+    web_auth_state::notify_unauthorized();
     Ok(())
 }
 
@@ -871,15 +947,15 @@ pub async fn current_user() -> Result<Option<UserSummary>, String> {
         .await
         .map_err(|e| e.to_string())?;
     if res.status() == 401 {
+        web_auth_state::notify_unauthorized();
         return Ok(None);
     }
     if !res.ok() {
         return Err(format!("me failed: {}", res.status()));
     }
-    res.json::<UserSummary>()
-        .await
-        .map(Some)
-        .map_err(|e| e.to_string())
+    let user = res.json::<UserSummary>().await.map_err(|e| e.to_string())?;
+    web_auth_state::notify_authorized();
+    Ok(Some(user))
 }
 
 #[cfg(feature = "web")]

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -137,6 +137,44 @@ pub fn Register() -> Element {
 #[cfg(not(feature = "mobile"))]
 #[component]
 fn ScreenLayout(children: Element) -> Element {
+    // #57: web-side reactive redirect to /login on 401. Mirrors the
+    // mobile ScreenLayout's `token_store::subscribe()` loop, but driven
+    // by `data::web_auth_state` since web auth lives in a session cookie
+    // (no client-side token to clear). Render path stays unconditional
+    // so SSR and WASM produce identical markup — only the effect runs
+    // on the WASM client. `Login` / `Register` routes don't go through
+    // `ScreenLayout`, so they stay reachable for unauthenticated users
+    // and the redirect can't loop.
+    #[cfg(feature = "web")]
+    {
+        let nav = dioxus_router::use_navigator();
+        let mut unauthorized = use_signal(|| false);
+        use_future(move || async move {
+            let mut rx = data::web_auth_state::subscribe();
+            // Sync the initial value once before awaiting changes. The
+            // signal's initial closure ran at scope-creation time, which
+            // can race with a 401 that fired (e.g. during SSR-to-WASM
+            // hydration) between channel creation and this future
+            // starting — without this borrow_and_update the first 401
+            // is lost. Mirrors the mobile ScreenLayout pattern.
+            if !*rx.borrow_and_update() {
+                unauthorized.set(true);
+                return;
+            }
+            while rx.changed().await.is_ok() {
+                if !*rx.borrow_and_update() {
+                    unauthorized.set(true);
+                    break;
+                }
+            }
+        });
+        use_effect(move || {
+            if unauthorized() {
+                nav.replace(Route::Login {});
+            }
+        });
+    }
+
     rsx! {
         div { class: "app-shell",
             Nav {}


### PR DESCRIPTION
## Summary
Four small, mostly-orthogonal tech-debt fixes bundled into one PR. Each is its own commit so reviewers can read commit-by-commit.

- **fix(db): validate accent_color shape at write boundary** ([#125](https://github.com/seamus-sloan/omnibus/issues/125)) — defense-in-depth gate on `books.accent_color`. The indexer's `extract_accent` emits strict `oklch(L C H)` strings, but consumers inline the value into a `style: "background: {bg}"` attribute. A future override / import path supplying an attacker-controlled string can't smuggle CSS or break out of the attribute now — invalid shapes coerce to `NULL`.
- **test(db): palette FTS5 facet tests** ([#128](https://github.com/seamus-sloan/omnibus/issues/128)) — three new unit tests (`palette_book_matches_{tag,author,series}_facet`) that lock the wiring between `search_palette` and `build_fts_match`'s facet-prefix parser. The parser is tested against `search_books` but not against the palette path, so a regression could silently break palette `tag:` / `author:` / `series:` queries without any palette test failing.
- **fix(frontend): cancel in-flight palette RPC on each keystroke** ([#126](https://github.com/seamus-sloan/omnibus/issues/126)) — replace the spawn-and-discard pattern (N tasks per N keystrokes, each sleeping 150ms then firing an RPC, deduped by a generation counter) with a `Signal<Option<Task>>` whose previous handle is `.cancel()`ed before each new spawn. Only one debounce + RPC task is alive at a time; SQLite pool burn under fast typing is gone.
- **fix(auth): redirect to /login on 401 in web data layer** ([#57](https://github.com/seamus-sloan/omnibus/issues/57)) — mobile already has this via `token_store::subscribe()`; web (cookie-based auth, no client token) had no equivalent. Adds a `data::web_auth_state` watch channel; server-function wrappers downcast `CapturedError` to `ServerFnError`, detect `code == 401`, and ping the channel. The web `ScreenLayout` subscribes and `nav.replace`s to `/login`. Login/Register routes don't go through `ScreenLayout` so the redirect can't loop. SSR/WASM render paths stay identical.

Closes #125, #128, #126, #57.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -p omnibus-db` — 188 passed (includes 3 new sanitize tests + 3 new palette facet tests)
- [x] `cargo test -p omnibus-frontend --features server --no-default-features` — 50 passed
- [x] `cargo test -p omnibus` — 88 passed
- [x] `cargo check -p omnibus-frontend --features web` clean
- [x] `cargo check -p omnibus-mobile` clean
- [ ] Manual UI smoke (palette keystroke spam; clear cookie + nav → /login)

## Notes
- #125: regex-free validator — strict `oklch(L C H)` parser with three space-separated decimal floats. No new dep.
- #126: `dioxus::core::Task::cancel(self)` is a no-op if the task already completed, so the cancel-then-spawn loop is safe.
- #57: web auth state lives behind `cfg(feature = "web")`; SSR builds still go through `note_server_fn_err` but the `notify_unauthorized()` call is compiled out.