### PR TITLE
fix: enforce 7-day session idle expiry (#95)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -9,7 +9,10 @@
 //! * Timing-safe login with per-account lockout + failure counter.
 //! * Session creation: raw 256-bit token returned once, SHA-256 hash stored.
 //! * Session lookup: exact SHA-256 hash match against the stored value
-//!   (the raw token is never persisted), with absolute + idle expiry.
+//!   (the raw token is never persisted), with absolute expiry
+//!   (`expires_at`, set at create time from the caller's TTL — 30 days for
+//!   cookies, 90 days for bearer tokens) and idle expiry
+//!   (`SESSION_IDLE_TIMEOUT_SECS`, 7 days since `last_used_at`).
 //! * Device registration + listing.
 //! * `OMNIBUS_INITIAL_ADMIN` recovery hook (`promote_to_admin`).
 //! * Session-key secret load/create in `secrets`.
@@ -560,6 +563,12 @@ pub async fn verify_login(pool: &SqlitePool, username: &str, password: &str) -> 
 /// seconds. Avoids write-amplification on every authenticated request.
 const SESSION_TOUCH_THRESHOLD_SECS: i64 = 5 * 60;
 
+/// Idle-expiry threshold. A session whose `last_used_at` is older than this
+/// is treated as expired by `lookup_session`, even if `expires_at` is still
+/// in the future. Caps the blast radius of a stolen or forgotten session
+/// (cookie absolute TTL is 30 days; bearer is 90).
+pub(crate) const SESSION_IDLE_TIMEOUT_SECS: i64 = 7 * 24 * 60 * 60;
+
 pub async fn create_session(
     pool: &SqlitePool,
     user_id: i64,
@@ -631,6 +640,15 @@ pub async fn lookup_session(pool: &SqlitePool, raw_token: &str) -> AuthResult<(U
 
     let session_id: i64 = row.get("s_id");
     let last_used_at: i64 = row.get("last_used_at");
+
+    // Idle expiry: a session that hasn't been touched in
+    // `SESSION_IDLE_TIMEOUT_SECS` is treated as expired regardless of its
+    // absolute `expires_at`. `last_used_at` is updated opportunistically
+    // below (rate-limited by `SESSION_TOUCH_THRESHOLD_SECS`), so this
+    // genuinely tracks user inactivity.
+    if now - last_used_at > SESSION_IDLE_TIMEOUT_SECS {
+        return Err(AuthError::SessionNotFound);
+    }
 
     let user = User {
         id: row.get("u_id"),
@@ -1058,6 +1076,45 @@ mod tests {
             .unwrap();
         let err = lookup_session(&p, &ns.raw_token).await.unwrap_err();
         assert!(matches!(err, AuthError::SessionNotFound));
+    }
+
+    #[tokio::test]
+    async fn session_idle_expired_after_threshold() {
+        // Absolute expiry is still in the future, but `last_used_at` is
+        // older than `SESSION_IDLE_TIMEOUT_SECS` — must be rejected.
+        let p = pool().await;
+        let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+        let ns = create_session(&p, u.id, None, SessionKind::Cookie, 30 * 24 * 60 * 60)
+            .await
+            .unwrap();
+        let stale = now_unix() - SESSION_IDLE_TIMEOUT_SECS - 1;
+        sqlx::query("UPDATE sessions SET last_used_at = ? WHERE id = ?")
+            .bind(stale)
+            .bind(ns.session.id)
+            .execute(&p)
+            .await
+            .unwrap();
+        let err = lookup_session(&p, &ns.raw_token).await.unwrap_err();
+        assert!(matches!(err, AuthError::SessionNotFound));
+    }
+
+    #[tokio::test]
+    async fn session_idle_just_below_threshold_is_accepted() {
+        // A session touched right before the idle cutoff stays valid.
+        let p = pool().await;
+        let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+        let ns = create_session(&p, u.id, None, SessionKind::Cookie, 30 * 24 * 60 * 60)
+            .await
+            .unwrap();
+        let fresh = now_unix() - SESSION_IDLE_TIMEOUT_SECS + 60;
+        sqlx::query("UPDATE sessions SET last_used_at = ? WHERE id = ?")
+            .bind(fresh)
+            .bind(ns.session.id)
+            .execute(&p)
+            .await
+            .unwrap();
+        let (user2, _) = lookup_session(&p, &ns.raw_token).await.unwrap();
+        assert_eq!(user2.id, u.id);
     }
 
     #[tokio::test]

--- a/docs/roadmap/0-3-auth.md
+++ b/docs/roadmap/0-3-auth.md
@@ -77,7 +77,9 @@ Auth core landed across multiple PRs: registration, login, logout endpoints, ses
 
 The 2026-04-26 QA pass ([qa-report](../qa/qa-report-2026-04-26.md), [PR #43](https://github.com/seamus-sloan/omnibus/pull/43)) cleared the cookie-authed-POST regression behind the dx-fullstack proxy and added the missing logout button to TopNav. The same-day audit re-pass spun out F0.7 (per-route authorization), [F5.4](5-4-admin-panel.md) admin-side TODOs for the `registration_enabled` toggle and the device/session list & revoke endpoints, and the `last_seen_at` follow-up captured above.
 
-Out of scope for v1.0 (deliberately): email verification, password reset, account lockout (rate limit only), audit log, session sliding-window expiry. All land later — most under [F5.4](5-4-admin-panel.md).
+Sessions enforce both absolute expiry (30 days cookie / 90 days bearer, set on `expires_at` at create time) and idle expiry (7 days since `last_used_at`, via `SESSION_IDLE_TIMEOUT_SECS` in `db::auth`). `last_used_at` is touched opportunistically on every `lookup_session` (rate-limited to one write per 5 minutes per session).
+
+Out of scope for v1.0 (deliberately): email verification, password reset, account lockout (rate limit only), audit log, sliding-window renewal of the absolute expiry. All land later — most under [F5.4](5-4-admin-panel.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- Closes #95.
- `db/src/auth.rs` and the `0004_auth.sql` migration both documented "absolute + idle" expiry, but `lookup_session` only ever checked `revoked_at` and `expires_at`. `last_used_at` was kept up to date (rate-limited to one write per 5 minutes per session) but no threshold consulted it, so a stolen/forgotten session lived the full absolute TTL (30 days cookie / 90 days bearer).
- Add `pub(crate) const SESSION_IDLE_TIMEOUT_SECS: i64 = 7 * 24 * 60 * 60;` next to `SESSION_TOUCH_THRESHOLD_SECS` in `db/src/auth.rs`, and reject sessions in `lookup_session` whose `last_used_at` is older than the threshold — even when `expires_at` is still in the future.
- Update the `db::auth` module doc to describe both constants accurately. Update `docs/roadmap/0-3-auth.md` to record the actual enforcement (absolute + idle, with the 5-minute touch debounce) and narrow the explicit "out of scope" line from "sliding-window expiry" to "sliding-window renewal of the absolute expiry", which is still intentionally unimplemented.

## Files changed
- `db/src/auth.rs` — module doc, new `SESSION_IDLE_TIMEOUT_SECS` constant, idle check in `lookup_session`, two new inline tests (`session_idle_expired_after_threshold`, `session_idle_just_below_threshold_is_accepted`).
- `docs/roadmap/0-3-auth.md` — describe enforced absolute + idle expiry; narrow the out-of-scope line.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default-members; the workspace-wide `--all-features` is broken on `main` because `omnibus-frontend`'s `web` and `mobile` features are mutually exclusive, unrelated to this change)
- [x] `cargo test -p omnibus-db` — 24 auth tests pass, including the two new idle-expiry cases
- [x] `cargo test -p omnibus` — 88 tests pass

## Notes
- The threshold (7 days) is shorter than both absolute TTLs and gives users a full week of inactivity before re-auth is required.
- The SQL comment on the `sessions` table in `db/migrations/0004_auth.sql:50-51` already describes idle expiry as the intended behavior. It is now accurate by construction, but the migration file is intentionally left untouched per the project's "never edit an applied migration" rule.
- No new dependencies, env vars, or migrations. No changes to public REST/RPC contracts. No markup changes — Playwright suite unaffected.

https://claude.ai/code/session_016VxzNdf5VYtV8mAKNDLDNc

---
_Generated by [Claude Code](https://claude.ai/code/session_016VxzNdf5VYtV8mAKNDLDNc)_