### PR TITLE
fix: add request timeout and body-size limit to axum router (#85)

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,7 +16,7 @@ dioxus = "0.7"
 # Server-only deps — all optional and gated behind the `server` feature.
 axum = { version = "0.8", features = ["multipart"], optional = true }
 axum-extra = { version = "0.10", features = ["cookie"], optional = true }
-tower-http = { version = "0.6", features = ["trace"], optional = true }
+tower-http = { version = "0.6", features = ["trace", "timeout"], optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"], optional = true }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -77,6 +77,9 @@ pub fn rest_router(state: AppState) -> Router {
         .merge(
             Router::new()
                 .route("/api/ebooks/{id}/cover", post(post_ebook_cover))
+                // Per-route body-limit override for image uploads. Layered
+                // closer to the handler than the global 1 MiB cap below, so
+                // axum picks this larger value for `/api/ebooks/{id}/cover`.
                 .layer(axum::extract::DefaultBodyLimit::max(11 * 1024 * 1024)),
         )
         .route("/api/search", get(get_search))
@@ -92,6 +95,16 @@ pub fn rest_router(state: AppState) -> Router {
         // tests; in the live server `main.rs` adds the same Extension at
         // the top, which is harmless overlap.
         .layer(Extension(pool))
+        // Global guards against slow / oversized clients. `main.rs` layers
+        // the same protections at the very top so the auth router and
+        // Dioxus server functions are covered too; duplicating them here
+        // means integration tests (which use `rest_router` directly) also
+        // exercise the limits.
+        .layer(tower_http::timeout::TimeoutLayer::with_status_code(
+            axum::http::StatusCode::REQUEST_TIMEOUT,
+            std::time::Duration::from_secs(30),
+        ))
+        .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
 }
 
 /// Process-start build id. Captured once and preserved for the lifetime of
@@ -1705,5 +1718,49 @@ mod tests {
         let (app, _, _) = fixture().await;
         let res = app.oneshot(get_anon("/api/tags")).await.unwrap();
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -------------------------------------------------------------------
+    // Global request guards — protects against slow clients / oversized
+    // bodies holding a tokio worker indefinitely. See #85.
+    // -------------------------------------------------------------------
+
+    /// POSTing a JSON body well over the 1 MiB global cap should be
+    /// rejected with 413 PAYLOAD_TOO_LARGE before the handler ever sees
+    /// it. We pad the JSON with a long throwaway string so the body
+    /// exceeds the cap while staying syntactically valid.
+    #[tokio::test]
+    async fn api_post_settings_rejects_body_over_1mb_with_413() {
+        let (app, _state, pool) = fixture().await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        // 2 MiB of filler — comfortably over the 1 MiB cap, but small
+        // enough that allocating it in-test is cheap.
+        let filler = "a".repeat(2 * 1024 * 1024);
+        let body = serde_json::json!({
+            "ebook_library_path": filler,
+            "audiobook_library_path": "/books/audio"
+        });
+        let bytes = body.to_string();
+        assert!(
+            bytes.len() > 1024 * 1024,
+            "test body must exceed the 1 MiB cap; got {} bytes",
+            bytes.len()
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/settings")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(bytes))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -86,7 +86,24 @@ fn main() {
                 .layer(axum::middleware::from_fn(auth::origin_check))
                 .layer(Extension(pool))
                 .layer(Extension(worker))
-                .layer(tower_http::trace::TraceLayer::new_for_http());
+                .layer(tower_http::trace::TraceLayer::new_for_http())
+                // Global request-handling guards. A slow client or oversized
+                // body can otherwise hold a tokio worker indefinitely.
+                //
+                // - `TimeoutLayer` aborts any request that takes longer than
+                //   30s end-to-end. Long-running scans run on the background
+                //   `Worker` (not the request task), so 30s is safely above
+                //   any synchronous handler.
+                // - `DefaultBodyLimit` caps request bodies to 1 MiB by
+                //   default. Routes that legitimately need larger payloads
+                //   (e.g. `POST /api/ebooks/{id}/cover`) layer their own
+                //   `DefaultBodyLimit::max(...)` closer to the handler,
+                //   which takes precedence over this outer cap.
+                .layer(tower_http::timeout::TimeoutLayer::with_status_code(
+                    axum::http::StatusCode::REQUEST_TIMEOUT,
+                    std::time::Duration::from_secs(30),
+                ))
+                .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024));
 
             Ok(router)
         });

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -86,7 +86,6 @@ fn main() {
                 .layer(axum::middleware::from_fn(auth::origin_check))
                 .layer(Extension(pool))
                 .layer(Extension(worker))
-                .layer(tower_http::trace::TraceLayer::new_for_http())
                 // Global request-handling guards. A slow client or oversized
                 // body can otherwise hold a tokio worker indefinitely.
                 //
@@ -103,7 +102,11 @@ fn main() {
                     axum::http::StatusCode::REQUEST_TIMEOUT,
                     std::time::Duration::from_secs(30),
                 ))
-                .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024));
+                .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
+                // TraceLayer last so it is the outermost layer and observes
+                // every response — including 408/413 short-circuits from the
+                // timeout and body-limit guards above.
+                .layer(tower_http::trace::TraceLayer::new_for_http());
 
             Ok(router)
         });


### PR DESCRIPTION
Closes #85

## Summary
- Added a 30s `TimeoutLayer` and a 1 MiB global `DefaultBodyLimit` to the axum router so a slow client or oversized JSON payload can no longer hold a tokio worker indefinitely.
- Layered the new guards in both `server/src/main.rs` (production stack, top of the middleware chain) and inside `rest_router()` in `server/src/backend.rs`, so the existing integration-test harness — which exercises `rest_router` directly — actually validates the limits.
- The existing `POST /api/ebooks/{id}/cover` route already had a per-route `DefaultBodyLimit::max(11 MiB)` override; that wins over the new global 1 MiB cap because per-route layers sit closer to the handler. Added a comment to make that precedence explicit.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets` (workspace default members) — clean
- [x] `cargo test -p omnibus` — 89 passed, including the new `api_post_settings_rejects_body_over_1mb_with_413` (POSTs a 2 MiB body, expects `413 PAYLOAD_TOO_LARGE`).

## Files changed (3)
- `server/Cargo.toml` — added the `timeout` feature to the existing `tower-http` dependency.
- `server/src/main.rs` — top-level `TimeoutLayer::with_status_code(REQUEST_TIMEOUT, 30s)` and `DefaultBodyLimit::max(1 MiB)` layers applied after the existing middleware stack.
- `server/src/backend.rs` — same two layers applied at the bottom of `rest_router`, plus an inline integration test asserting the body cap is enforced before the handler executes.

## Values chosen
- **Timeout:** `Duration::from_secs(30)`. Long-running scans run on the background `Worker` (not the request task), so 30s is well above any synchronous handler latency.
- **Global body limit:** `1024 * 1024` (1 MiB).
- **Per-route override:** unchanged — `POST /api/ebooks/{id}/cover` keeps its existing 11 MiB cap.

## Cargo.toml / Cargo.lock
- `server/Cargo.toml`: `tower-http`'s feature list goes from `["trace"]` to `["trace", "timeout"]`.
- `Cargo.lock`: unchanged — `tower-http` 0.6.8 was already in the lockfile and adding a feature didn't bring in any new versions.

## Notes
- `TimeoutLayer::new` is deprecated as of tower-http 0.6.7 (`note = "Use TimeoutLayer::with_status_code instead"`), so the PR uses `with_status_code(StatusCode::REQUEST_TIMEOUT, 30s)`.
- Timeout test skipped — exercising the 30s path deterministically requires a custom always-sleeping handler wired only for tests, which felt out of scope for a router-config fix. The 413 path is covered.

https://claude.ai/code/session_016VxzNdf5VYtV8mAKNDLDNc

---
_Generated by [Claude Code](https://claude.ai/code/session_016VxzNdf5VYtV8mAKNDLDNc)_