### PR TITLE
test: add error-path Playwright coverage for metadata edit (#108)

### DIFF
--- a/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
@@ -188,3 +188,118 @@ test("book detail page has a working edit metadata link", async ({ page, request
   await expect(page).toHaveURL(new RegExp(`/books/${id}/edit$`));
   await expect(page.getByText("Edit metadata")).toBeVisible();
 });
+
+// ---------------------------------------------------------------------------
+// Error paths — force 500 on the save / delete RPC and assert the UI does
+// not navigate away from the edit form. The metadata edit page renders the
+// `save_error` as visible text near the save bar (no `role=status` /
+// `role=alert` today — see PR body for the missing-error-UX finding), so
+// the most concrete observable state is that the URL still matches
+// `/books/:id/edit` and the save button has come out of its "Saving…"
+// state (re-enabled, label restored).
+// ---------------------------------------------------------------------------
+
+test("surfaces error and stays on edit form when save mutation fails", async ({ page, request }) => {
+  const id = await fetchBookIdByTitle(request, TARGET.title);
+  await gotoReady(page, `/books/${id}/edit`);
+
+  // Dirty a field so Save is enabled and a POST will fire.
+  const titleInput = page.getByLabel("Title");
+  await titleInput.clear();
+  await titleInput.fill("Alpha Should Not Persist");
+  await expect(page.getByTestId("me-save")).toBeEnabled();
+
+  // Force-fail the override-save RPC. Match the trailing path explicitly so
+  // we don't accidentally intercept the `/delete` sibling.
+  await page.route("**/api/rpc/ebook/overrides", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ status: 500, contentType: "text/plain", body: "forced failure" });
+    }
+    return route.continue();
+  });
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: /\/api\/rpc\/ebook\/overrides$/,
+      expectedStatus: 500,
+    },
+    async () => page.getByTestId("me-save").click(),
+  );
+
+  // URL must not have navigated away from the edit form.
+  await expect(page).toHaveURL(new RegExp(`/books/${id}/edit$`));
+
+  // Edited title is still in the input (state preserved).
+  await expect(titleInput).toHaveValue("Alpha Should Not Persist");
+
+  // Save button has come out of its "Saving…" state and is re-enabled so
+  // the user can retry. `toBeEnabled` auto-retries until the signal settles.
+  await expect(page.getByTestId("me-save")).toBeEnabled();
+});
+
+test("surfaces error and stays on edit form when revert mutation fails", async ({ page, request }) => {
+  // First, create an override on the fixture so the revert button shows up.
+  const id = await fetchBookIdByTitle(request, TARGET.title);
+  await gotoReady(page, `/books/${id}/edit`);
+
+  const titleInput = page.getByLabel("Title");
+  await titleInput.clear();
+  await titleInput.fill("Alpha Revert Setup");
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: /\/api\/rpc\/ebook\/overrides$/,
+      expectedStatus: 200,
+    },
+    async () => page.getByTestId("me-save").click(),
+  );
+  await expect(page).toHaveURL(new RegExp(`/books/${id}$`));
+
+  // Re-open the edit form — the revert button should now be visible.
+  const editId = await fetchBookIdByTitle(request, "Alpha Revert Setup");
+  await gotoReady(page, `/books/${editId}/edit`);
+  const revertBtn = page.getByTestId("revert-overrides");
+  await expect(revertBtn).toBeVisible();
+
+  // Force-fail the delete RPC.
+  await page.route("**/api/rpc/ebook/overrides/delete", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ status: 500, contentType: "text/plain", body: "forced failure" });
+    }
+    return route.continue();
+  });
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: /\/api\/rpc\/ebook\/overrides\/delete$/,
+      expectedStatus: 500,
+    },
+    async () => revertBtn.click(),
+  );
+
+  // URL must not have navigated away from the edit form.
+  await expect(page).toHaveURL(new RegExp(`/books/${editId}/edit$`));
+
+  // Revert button is still visible (override still active) and re-enabled.
+  await expect(revertBtn).toBeVisible();
+  await expect(revertBtn).toBeEnabled();
+
+  // Clean up: stop intercepting and revert successfully so subsequent runs
+  // start from a clean fixture state. `page.unroute` removes our handler.
+  await page.unroute("**/api/rpc/ebook/overrides/delete");
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: /\/api\/rpc\/ebook\/overrides\/delete$/,
+      expectedStatus: 200,
+    },
+    async () => revertBtn.click(),
+  );
+  await expect(page).toHaveURL(new RegExp(`/books/${editId}$`));
+});

--- a/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
@@ -302,4 +302,11 @@ test("surfaces error and stays on edit form when revert mutation fails", async (
     async () => revertBtn.click(),
   );
   await expect(page).toHaveURL(new RegExp(`/books/${editId}$`));
+
+  // Verify the override was actually removed, not just that the delete
+  // returned 200 — the detail page should now show the original scanned
+  // title, and re-opening /edit should hide the revert button.
+  await expect(page.getByRole("heading", { level: 1, name: TARGET.title })).toBeVisible();
+  await gotoReady(page, `/books/${editId}/edit`);
+  await expect(page.getByTestId("revert-overrides")).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

Per `.claude/rules/04-playwright.md`, every mutation flow should have forced-failure tests using `page.route(...)` + `expectMutation`. The metadata edit spec previously only covered happy paths — this PR adds the two missing error-path tests requested in #108.

## Tests added (in `ui_tests/playwright/tests/flows/metadata_edit.spec.ts`)

- `surfaces error and stays on edit form when save mutation fails` — dirties the title, intercepts `POST /api/rpc/ebook/overrides` with a 500, asserts via `expectMutation` that the request fired and observed status 500, then asserts the URL still matches `/books/:id/edit`, the edited title value is preserved in the input, and the save button is re-enabled (out of its "Saving…" state) so the user can retry.
- `surfaces error and stays on edit form when revert mutation fails` — first creates an override via a happy-path save so the revert button is visible, re-opens the edit form, intercepts `POST /api/rpc/ebook/overrides/delete` with a 500, asserts URL stability and that the revert button is still visible + enabled. Then unroutes and reverts cleanly so subsequent runs start from a clean fixture state.

Both tests follow the existing pattern from `settings.spec.ts` (`shows an error status when saving settings fails`).

## Finding: metadata edit lacks semantic error UX

While writing the assertions, I noticed the metadata edit page renders its `save_error` as plain visible text in `.me-save-bar` (a `<span class="mono">` styled with `color: var(--bad)`) — no `role="status"` or `role="alert"` anchor, unlike the settings page which uses a `getByRole("status")` locator. This makes the error invisible to screen readers and hard for tests to anchor against semantically.

I chose to keep this PR strictly test-coverage-only (test addition, no SSR markup change) and asserted on URL stability + button re-enabled state instead, which are the most concrete observable signals today. **Recommend a follow-up issue to add `role="alert"` to the `save_error` span in `frontend/src/pages/metadata_edit.rs:484` so future tests can use `getByRole("alert")` and screen readers announce the failure.**

## Files changed

- `ui_tests/playwright/tests/flows/metadata_edit.spec.ts` — +115 lines, two new `test()` blocks at the end of the file.

## Test plan

- [x] `npx playwright test --list metadata_edit.spec.ts` lists 8 tests (was 6) including the two new error-path entries
- [ ] Live `npx playwright test metadata_edit.spec.ts` not run from this environment — no `nix` / `dx` toolchain available outside the dev shell, so the fullstack server (`just dev-up` / `dx serve --platform web --fullstack`) couldn't be brought up. Verification deferred to CI via the `run_ui_tests` label.
- [x] No XPath; semantic-first selectors (`getByLabel`, `getByTestId` matching existing markup contracts, `toHaveURL`).
- [x] No `waitForTimeout`; `expectMutation` + Playwright auto-waiting only.
- [x] No SSR markup changes (no new testids added).

Closes #108

https://claude.ai/code/session_015K9CCjLAXmrXHvtC9XbLaN

---
_Generated by [Claude Code](https://claude.ai/code/session_015K9CCjLAXmrXHvtC9XbLaN)_