### PR TITLE
perf: wrap blocking FS I/O in spawn_blocking (#106)

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -544,6 +544,11 @@ fn delete_cover_files_for(uuids: &[String]) {
 /// `metadata_overrides` rather than a second `get_metadata_overrides` call.
 /// Covers are fetched per grid tile and per detail page — the hot path
 /// stays at one query regardless of whether overrides exist.
+///
+/// The filesystem probes (`find_override_cover_file` / `find_cover_file`)
+/// are synchronous `std::fs` calls and run on the blocking pool via
+/// [`tokio::task::spawn_blocking`] so a hot cover-fetch loop doesn't pin
+/// tokio worker threads (#106).
 pub async fn get_cover(
     pool: &SqlitePool,
     book_id: i64,
@@ -566,17 +571,43 @@ pub async fn get_cover(
     };
 
     // F5.1: check for override cover first.
-    if has_cover_override != 0 {
-        if let Some(cover) = find_override_cover_file(&uuid) {
-            return Ok(Some(cover));
-        }
-    }
+    let has_cover_override = has_cover_override != 0;
 
-    if has_cover != 0 {
-        Ok(find_cover_file(&uuid))
-    } else {
-        Ok(None)
-    }
+    // Move the sync `std::fs` probes off the runtime. `JoinError` (panic or
+    // cancellation) can't round-trip through `sqlx::Error`, so we fold it
+    // into "no cover" — but log it loudly first so a real panic doesn't get
+    // silently masked into a missing-cover symptom.
+    let uuid_for_blocking = uuid.clone();
+    let result = match tokio::task::spawn_blocking(move || {
+        if has_cover_override {
+            if let Some(cover) = find_override_cover_file(&uuid_for_blocking) {
+                return Some(cover);
+            }
+        }
+        if has_cover != 0 {
+            find_cover_file(&uuid_for_blocking)
+        } else {
+            None
+        }
+    })
+    .await
+    {
+        Ok(cover) => cover,
+        Err(join_err) => {
+            let kind = if join_err.is_panic() {
+                "panicked"
+            } else {
+                "was cancelled"
+            };
+            tracing::error!(
+                book_id,
+                uuid = %uuid,
+                "get_cover spawn_blocking {kind}: {join_err}"
+            );
+            None
+        }
+    };
+    Ok(result)
 }
 
 /// Return `strftime('%s', last_modified)` as epoch seconds for `book_id`,

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -288,8 +288,16 @@ pub async fn rpc_delete_overrides(book_id: i64) -> Result<Option<EbookMetadata>>
         return Ok(None);
     };
     db::delete_metadata_overrides(&pool.0, &uuid).await?;
-    db::delete_override_cover(&uuid);
-    db::thumbs::invalidate_thumbs(book_id);
+    // `delete_override_cover` + `invalidate_thumbs` are sync `std::fs`
+    // operations; run them on the blocking pool so this server function
+    // doesn't pin a tokio worker thread (#106).
+    let uuid_for_blocking = uuid.clone();
+    tokio::task::spawn_blocking(move || {
+        db::delete_override_cover(&uuid_for_blocking);
+        db::thumbs::invalidate_thumbs(book_id);
+    })
+    .await
+    .map_err(|e| ServerFnError::new(format!("spawn_blocking(delete_override_cover): {e}")))?;
     Ok(db::get_book(&pool.0, book_id).await?)
 }
 

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -578,8 +578,18 @@ async fn delete_ebook_overrides(
     if let Err(e) = db::delete_metadata_overrides(&state.pool, &uuid).await {
         return internal("delete_metadata_overrides", e);
     }
-    db::delete_override_cover(&uuid);
-    db::thumbs::invalidate_thumbs(id);
+    // `delete_override_cover` + `invalidate_thumbs` are sync `std::fs`
+    // operations; run them on the blocking pool so the axum runtime stays
+    // responsive under load (#106).
+    let uuid_for_blocking = uuid.clone();
+    if let Err(e) = tokio::task::spawn_blocking(move || {
+        db::delete_override_cover(&uuid_for_blocking);
+        db::thumbs::invalidate_thumbs(id);
+    })
+    .await
+    {
+        return internal("spawn_blocking(delete_override_cover)", e);
+    }
     match db::get_book(&state.pool, id).await {
         Ok(Some(book)) => Json(book).into_response(),
         Ok(None) => (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
@@ -693,9 +703,19 @@ async fn post_ebook_cover(
         }
     };
 
-    // Write the override cover to disk.
-    if let Err(e) = db::write_override_cover(&uuid, &mime, &bytes) {
-        return internal("write_override_cover", e);
+    // Write the override cover to disk. `write_override_cover` is a sync
+    // `std::fs` call — run it on the blocking pool so the axum runtime stays
+    // responsive while we hit disk (#106). `uuid` is needed again below for
+    // the overrides table update, so it's the only value we clone.
+    let uuid_for_write = uuid.clone();
+    let write_result = tokio::task::spawn_blocking(move || {
+        db::write_override_cover(&uuid_for_write, &mime, &bytes)
+    })
+    .await;
+    match write_result {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return internal("write_override_cover", e),
+        Err(e) => return internal("spawn_blocking(write_override_cover)", e),
     }
 
     // Mark the overrides table with has_cover_override = 1. Preserve existing
@@ -712,7 +732,10 @@ async fn post_ebook_cover(
     }
 
     // Invalidate thumb cache so next request regenerates from new cover.
-    db::thumbs::invalidate_thumbs(id);
+    // Also sync `std::fs` — run on the blocking pool (#106).
+    if let Err(e) = tokio::task::spawn_blocking(move || db::thumbs::invalidate_thumbs(id)).await {
+        return internal("spawn_blocking(invalidate_thumbs)", e);
+    }
 
     match db::get_book(&state.pool, id).await {
         Ok(Some(book)) => Json(book).into_response(),


### PR DESCRIPTION
## Summary

Several async axum handlers and Dioxus server functions were calling synchronous `std::fs` operations directly, which can pin tokio worker threads under load (large covers, slow disks, hot `/api/covers/:id` and `/api/thumbs/:id/:size` request paths).

This PR wraps every cited sync-FS-in-async call site with `tokio::task::spawn_blocking`, matching the existing pattern used by `indexer::reindex` (`db/src/indexer.rs:53`) and the worker's thumb generation loop (`db/src/worker.rs:192`).

## Approach: `spawn_blocking` at the call site

Two reasonable options exist: (a) wrap each call in `spawn_blocking` at the handler, or (b) make the helpers async with `tokio::fs`. I chose **(a)** because:

- The rest of the codebase already uses `spawn_blocking` consistently for blocking work (indexer scan, thumb encode loop, eviction loop). Following the established pattern keeps `db::queries` functions ergonomic to call from sync contexts (e.g. tests, future CLI tools) and avoids cascading `.await` through every caller.
- Public function signatures stay unchanged. `write_override_cover` / `delete_override_cover` / `invalidate_thumbs` remain sync helpers, callable from sync contexts.

For `db::get_cover`, which is itself `async`, the internal `std::fs` probes are wrapped in `spawn_blocking` *inside* the function — that fixes all callers (`backend::get_cover`, `backend::get_thumb`, `worker::execute(GenerateThumbs)`) at once without changing the API.

## Files changed

- `db/src/queries.rs` — wrap `find_override_cover_file` + `find_cover_file` inside `db::get_cover` in `spawn_blocking`. A `JoinError` is folded into `Ok(None)` since `sqlx::Error` can't represent join failures and "no cover" is a benign outcome.
- `server/src/backend.rs` — wrap `db::write_override_cover`, `db::delete_override_cover`, `db::thumbs::invalidate_thumbs` calls in `post_ebook_cover` and `delete_ebook_overrides`.
- `frontend/src/rpc.rs` — same pair wrapped in `rpc_delete_overrides`.

## Audit results

| Call site | Before | After |
|---|---|---|
| `post_ebook_cover` -> `write_override_cover` | sync FS on runtime | `spawn_blocking` |
| `post_ebook_cover` -> `invalidate_thumbs` | sync FS on runtime | `spawn_blocking` |
| `delete_ebook_overrides` -> `delete_override_cover` + `invalidate_thumbs` | sync FS on runtime | `spawn_blocking` |
| `rpc_delete_overrides` -> same pair | sync FS on runtime | `spawn_blocking` |
| `get_cover` (axum `get_cover`/`get_thumb` handlers + worker) | sync `std::fs::read`/`read_dir` in async fn | `spawn_blocking` inside `get_cover` |
| `get_thumb` -> `is_stale_async` + `tokio::fs::read` | already async | no change |
| `indexer::reindex` -> `ebook::scan_ebook_library_with` | already `spawn_blocking` | no change |
| `worker::execute(GenerateThumbs)` -> `ensure_thumbnails_sync` + `evict_if_over_cap` | already `spawn_blocking` | no change |

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean; `--all-features` not used because `web` and `mobile` are mutually exclusive — see `frontend/src/components/mod.rs:9` compile_error)
- [x] `cargo test -p omnibus` — 88 passed
- [x] `cargo test -p omnibus-db` — 196 passed
- [x] `cargo test -p omnibus-frontend --features server` — 52 passed

No new tests added: the wrap is internal to existing call paths and behavior is preserved (same `Result` shape, same return values). Existing integration tests for `post_ebook_cover` / `delete_ebook_overrides` / `get_cover` continue to drive these paths via `oneshot` and pass unchanged.

Closes #106


---
_Generated by [Claude Code](https://claude.ai/code/session_015K9CCjLAXmrXHvtC9XbLaN)_