### PR TITLE
perf: fold has_cover_override into get_cover query (#107)

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -532,8 +532,8 @@ pub async fn get_cover(
     book_id: i64,
 ) -> Result<Option<(String, Vec<u8>)>, sqlx::Error> {
     // `COALESCE(mo.has_cover_override, 0)` keeps the flag at 0 when no
-    // override row exists (the LEFT JOIN yields NULL in that case), so
-    // we don't need a nullable bind in the row tuple.
+    // override row exists (the LEFT JOIN yields NULL in that case), so the
+    // row tuple can decode into `i64` instead of `Option<i64>`.
     let row: Option<(String, i64, i64)> = sqlx::query_as(
         "SELECT b.uuid, b.has_cover, COALESCE(mo.has_cover_override, 0)
            FROM books b

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -522,26 +522,36 @@ fn delete_cover_files_for(uuids: &[String]) {
 /// **F5.1:** User-uploaded override covers take precedence. When the
 /// `metadata_overrides` table flags `has_cover_override`, the override file
 /// at `covers_dir()/override-<uuid>.<ext>` is returned first.
+///
+/// Single round-trip: the override flag is pulled in via a `LEFT JOIN` on
+/// `metadata_overrides` rather than a second `get_metadata_overrides` call.
+/// Covers are fetched per grid tile and per detail page — the hot path
+/// stays at one query regardless of whether overrides exist.
 pub async fn get_cover(
     pool: &SqlitePool,
     book_id: i64,
 ) -> Result<Option<(String, Vec<u8>)>, sqlx::Error> {
-    let row: Option<(String, i64)> =
-        sqlx::query_as("SELECT uuid, has_cover FROM books WHERE id = ?")
-            .bind(book_id)
-            .fetch_optional(pool)
-            .await?;
-    let Some((uuid, has_cover)) = row else {
+    // `COALESCE(mo.has_cover_override, 0)` keeps the flag at 0 when no
+    // override row exists (the LEFT JOIN yields NULL in that case), so
+    // we don't need a nullable bind in the row tuple.
+    let row: Option<(String, i64, i64)> = sqlx::query_as(
+        "SELECT b.uuid, b.has_cover, COALESCE(mo.has_cover_override, 0)
+           FROM books b
+           LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+          WHERE b.id = ?",
+    )
+    .bind(book_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some((uuid, has_cover, has_cover_override)) = row else {
         return Ok(None);
     };
 
     // F5.1: check for override cover first.
-    if let Some((ov, has_cover_ov)) = get_metadata_overrides(pool, &uuid).await? {
-        let _ = ov; // overrides struct not needed here, just the cover flag
-        if has_cover_ov {
-            if let Some(cover) = find_override_cover_file(&uuid) {
-                return Ok(Some(cover));
-            }
+    if has_cover_override != 0 {
+        if let Some(cover) = find_override_cover_file(&uuid) {
+            return Ok(Some(cover));
         }
     }
 
@@ -2919,6 +2929,132 @@ mod tests {
         // None, not error.
         let _ = std::fs::remove_file(cover_path_for(&uuid, "jpg"));
         assert!(get_cover(&pool, books[0].id).await.unwrap().is_none());
+    }
+
+    /// F5.1 / #107: when a `metadata_overrides` row sets
+    /// `has_cover_override = 1` and an `override-<uuid>.<ext>` file exists
+    /// on disk, `get_cover` returns the override bytes — not the scanned
+    /// cover. Single-query form must preserve this precedence.
+    #[tokio::test]
+    async fn cover_returns_override_when_flag_set() {
+        let _covers = CoversTempDir::new("override_set");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("A"),
+                &["A"],
+                &[],
+                None,
+                Some(("image/jpeg", b"ORIGINAL")),
+            )],
+        )
+        .await
+        .unwrap();
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let uuid = books[0].unique_identifier.clone().unwrap();
+
+        // Mark cover-override + drop the override file on disk.
+        write_override_cover(&uuid, "image/png", b"OVERRIDE").unwrap();
+        upsert_metadata_overrides(&pool, &uuid, &MetadataOverrides::default(), true, user_id)
+            .await
+            .unwrap();
+
+        let cover = get_cover(&pool, books[0].id).await.unwrap();
+        assert_eq!(cover, Some(("image/png".into(), b"OVERRIDE".to_vec())));
+    }
+
+    /// F5.1 / #107: with no `metadata_overrides` row, `get_cover` falls
+    /// through to the scanned `<uuid>.<ext>` cover. The LEFT JOIN must
+    /// not filter the book out when no override row exists.
+    #[tokio::test]
+    async fn cover_returns_original_when_no_override_row() {
+        let _covers = CoversTempDir::new("override_absent");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("A"),
+                &["A"],
+                &[],
+                None,
+                Some(("image/jpeg", b"ORIGINAL")),
+            )],
+        )
+        .await
+        .unwrap();
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let cover = get_cover(&pool, books[0].id).await.unwrap();
+        assert_eq!(cover, Some(("image/jpeg".into(), b"ORIGINAL".to_vec())));
+    }
+
+    /// F5.1 / #107: a `metadata_overrides` row with
+    /// `has_cover_override = 0` (text-only edits, no cover swap) must
+    /// resolve to the scanned cover, not the override path.
+    #[tokio::test]
+    async fn cover_returns_original_when_override_flag_unset() {
+        let _covers = CoversTempDir::new("override_flag_off");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("A"),
+                &["A"],
+                &[],
+                None,
+                Some(("image/jpeg", b"ORIGINAL")),
+            )],
+        )
+        .await
+        .unwrap();
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let uuid = books[0].unique_identifier.clone().unwrap();
+
+        // Override row exists with text edits but no cover swap.
+        upsert_metadata_overrides(
+            &pool,
+            &uuid,
+            &MetadataOverrides {
+                title: Some("Edited".into()),
+                ..Default::default()
+            },
+            false,
+            user_id,
+        )
+        .await
+        .unwrap();
+
+        let cover = get_cover(&pool, books[0].id).await.unwrap();
+        assert_eq!(cover, Some(("image/jpeg".into(), b"ORIGINAL".to_vec())));
+    }
+
+    /// #107: `get_cover` for a non-existent book id returns `Ok(None)`
+    /// (not an error). The LEFT JOIN must not change this contract.
+    #[tokio::test]
+    async fn cover_returns_none_for_missing_book_id() {
+        let _covers = CoversTempDir::new("missing_book");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        assert!(get_cover(&pool, 999_999).await.unwrap().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `get_cover` was issuing two DB round-trips per call — one to read `books`, then a second `get_metadata_overrides` lookup purely to read the `has_cover_override` flag. Covers are fetched per grid tile and per detail page, so this hit the hot read path on every request.
- Implements **option 2** from #107: rewrite `get_cover` as a single statement with `LEFT JOIN metadata_overrides ON mo.book_uuid = b.uuid`, pulling `COALESCE(mo.has_cover_override, 0)` alongside the book row. Override-precedence behavior is preserved exactly.
- Before: 2 queries per cover (read `books`, then read `metadata_overrides`, plus a JSON decode that was discarded).
- After: 1 query per cover; no JSON decode on the cover path.
- Public signature unchanged — every caller of `db::get_cover(pool, id)` continues to work.

## Files changed

- `db/src/queries.rs` — `get_cover` rewritten as a single `LEFT JOIN`; four new unit tests covering the resolution matrix.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean (default-members; `--all-features` is unsupported because the frontend crate's `web` / `mobile` features are mutually exclusive)
- [x] `cargo test -p omnibus-db` — 200 passed, 0 failed
- [x] `cargo test -p omnibus` — 88 passed, 0 failed
- [x] New tests cover all four resolution paths:
  - `cover_returns_override_when_flag_set` — override row + on-disk override file resolves to the override bytes
  - `cover_returns_original_when_no_override_row` — no `metadata_overrides` row → falls through to scanned cover (LEFT JOIN doesn't filter the book out)
  - `cover_returns_original_when_override_flag_unset` — override row exists with text edits but `has_cover_override = 0` → scanned cover
  - `cover_returns_none_for_missing_book_id` — non-existent id returns `Ok(None)`, preserving the prior contract

Closes #107

https://claude.ai/code/session_015K9CCjLAXmrXHvtC9XbLaN

---
_Generated by [Claude Code](https://claude.ai/code/session_015K9CCjLAXmrXHvtC9XbLaN)_