### PR TITLE
fix: metadata-edit, palette, breadcrumb and route-param bugs

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -572,6 +572,12 @@ pub async fn get_last_modified_epoch(
 
 /// Upsert user metadata overrides for a book identified by its stable UUID.
 /// The `overrides` are JSON-serialized into the `metadata_overrides` table.
+///
+/// After the upsert, the book's `books_fts` row is rebuilt from the merged
+/// (canonical + override) metadata so that search results stay consistent
+/// with what the UI displays. The FTS rebuild is best-effort: rebuild
+/// failures are logged but do not fail the override save, since the
+/// override write is the user's actual intent.
 pub async fn upsert_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
@@ -595,6 +601,7 @@ pub async fn upsert_metadata_overrides(
     .bind(user_id)
     .execute(pool)
     .await?;
+    rebuild_fts_for_book(pool, book_uuid).await?;
     Ok(())
 }
 
@@ -622,6 +629,10 @@ pub async fn get_metadata_overrides(
 }
 
 /// Delete overrides for a book UUID (revert to scanned values).
+///
+/// Also rebuilds the book's `books_fts` row so that search reverts to
+/// matching the canonical scanned metadata, mirroring
+/// [`upsert_metadata_overrides`].
 pub async fn delete_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
@@ -630,6 +641,7 @@ pub async fn delete_metadata_overrides(
         .bind(book_uuid)
         .execute(pool)
         .await?;
+    rebuild_fts_for_book(pool, book_uuid).await?;
     Ok(())
 }
 
@@ -724,6 +736,47 @@ fn apply_overrides(book: &mut EbookMetadata, ov: &MetadataOverrides, has_cover_o
         book.cover_url = Some(format!("/api/covers/{}", book.id));
     }
     book.has_override = true;
+}
+
+/// Rebuild the `books_fts` row for the book identified by `book_uuid` using
+/// the merged metadata returned from [`get_book`] (canonical taxonomy with
+/// overrides applied). Called from the override write paths so search
+/// matches what the UI displays.
+///
+/// Silently returns `Ok(())` if the UUID has no matching book — overrides
+/// for an unknown UUID would only happen if a book row was deleted out from
+/// under us, in which case there is no FTS row to maintain.
+async fn rebuild_fts_for_book(pool: &SqlitePool, book_uuid: &str) -> Result<(), sqlx::Error> {
+    let Some(book_id) = sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
+        .bind(book_uuid)
+        .fetch_optional(pool)
+        .await?
+    else {
+        return Ok(());
+    };
+
+    let Some(merged) = get_book(pool, book_id).await? else {
+        return Ok(());
+    };
+    let title = merged.title.clone().unwrap_or_default();
+    let first_isbn = merged
+        .identifiers
+        .iter()
+        .find(|i| {
+            i.scheme
+                .as_deref()
+                .is_some_and(|s| s.eq_ignore_ascii_case("ISBN"))
+        })
+        .map(|i| i.value.clone());
+
+    let mut tx = pool.begin().await?;
+    sqlx::query("DELETE FROM books_fts WHERE rowid = ?")
+        .bind(book_id)
+        .execute(&mut *tx)
+        .await?;
+    insert_fts_row(&mut tx, book_id, &title, first_isbn.as_deref(), &merged).await?;
+    tx.commit().await?;
+    Ok(())
 }
 
 /// Probe for a user-uploaded override cover file for the given UUID.
@@ -4229,6 +4282,164 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    /// Bug #1: saving a title override must rebuild `books_fts` so search
+    /// finds the new title and stops matching the original one.
+    #[tokio::test]
+    async fn upsert_metadata_overrides_rebuilds_fts_for_title() {
+        let _covers = CoversTempDir::new("fts_override_title");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("Original Title"),
+                &["Author A"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        // Sanity: search finds the original title.
+        let hits = search_books(&pool, "/lib", "Original").await.unwrap();
+        assert_eq!(hits.len(), 1);
+
+        // Save an override that changes the title.
+        let uuid = list_books(&pool, "/lib").await.unwrap()[0]
+            .unique_identifier
+            .clone()
+            .unwrap();
+        let ov = MetadataOverrides {
+            title: Some("Brand New Title".into()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        // Search now matches the overridden title and no longer the original.
+        let new_hits = search_books(&pool, "/lib", "Brand").await.unwrap();
+        assert_eq!(new_hits.len(), 1);
+        assert_eq!(new_hits[0].title.as_deref(), Some("Brand New Title"));
+        let old_hits = search_books(&pool, "/lib", "Original").await.unwrap();
+        assert!(
+            old_hits.is_empty(),
+            "FTS still matches the pre-override title"
+        );
+    }
+
+    /// Bug #1: the palette uses the same `books_fts` table, so the override
+    /// rebuild must also surface there.
+    #[tokio::test]
+    async fn upsert_metadata_overrides_rebuilds_fts_for_palette() {
+        let _covers = CoversTempDir::new("fts_override_palette");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "p.epub",
+                Some("Scanned Title"),
+                &["Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let uuid = list_books(&pool, "/lib").await.unwrap()[0]
+            .unique_identifier
+            .clone()
+            .unwrap();
+        let ov = MetadataOverrides {
+            title: Some("Edited Palette Title".into()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let palette = search_palette(&pool, "/lib", "Edited").await.unwrap();
+        assert_eq!(palette.books.len(), 1);
+    }
+
+    /// Bug #1 follow-on: deleting the override should restore the FTS row
+    /// to the canonical scanned values.
+    #[tokio::test]
+    async fn delete_metadata_overrides_restores_fts() {
+        let _covers = CoversTempDir::new("fts_override_revert");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "r.epub",
+                Some("Canonical Title"),
+                &["Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let uuid = list_books(&pool, "/lib").await.unwrap()[0]
+            .unique_identifier
+            .clone()
+            .unwrap();
+
+        upsert_metadata_overrides(
+            &pool,
+            &uuid,
+            &MetadataOverrides {
+                title: Some("Temporary Override".into()),
+                ..Default::default()
+            },
+            false,
+            user_id,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            search_books(&pool, "/lib", "Temporary").await.unwrap().len(),
+            1
+        );
+
+        delete_metadata_overrides(&pool, &uuid).await.unwrap();
+
+        // FTS is back to the canonical title; the override token no longer
+        // matches.
+        assert_eq!(
+            search_books(&pool, "/lib", "Canonical").await.unwrap().len(),
+            1
+        );
+        assert!(search_books(&pool, "/lib", "Temporary")
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -1975,11 +1975,15 @@ pub async fn search_palette(
     let start = std::time::Instant::now();
     const LIMIT: i32 = 5;
 
-    // A. Books — FTS5 MATCH with BM25 ranking, slim projection.
+    // A. Books — FTS5 MATCH with BM25 ranking, slim projection. After
+    // hydration we overlay metadata_overrides so the title and author line
+    // shown in the palette match the merged values the rest of the app
+    // displays (FTS already matches on the merged text — see
+    // `rebuild_fts_for_book` in the override write path).
     let books = if let Some(match_expr) = build_fts_match(trimmed) {
         let rows = sqlx::query(
             r#"
-            SELECT b.id, b.title, b.has_cover, b.accent_color,
+            SELECT b.id, b.uuid, b.title, b.has_cover, b.accent_color,
                    SUBSTR(b.pubdate, 1, 4) AS year,
 
                    (SELECT GROUP_CONCAT(a.name, ', ')
@@ -2007,23 +2011,43 @@ pub async fn search_palette(
         .fetch_all(pool)
         .await?;
 
-        rows.iter()
-            .map(|r| {
-                let id: i64 = r.get("id");
-                let has_cover: i64 = r.get("has_cover");
-                Ok(PaletteBookHit {
-                    id,
-                    title: r.get::<Option<String>, _>("title").unwrap_or_default(),
-                    author_display: r
-                        .get::<Option<String>, _>("author_display")
-                        .unwrap_or_default(),
-                    year: r.get("year"),
-                    formats: parse_json_array(r.get("formats_json"))?,
-                    cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
-                    accent: r.get("accent_color"),
-                })
-            })
-            .collect::<Result<Vec<_>, sqlx::Error>>()?
+        let mut uuids: Vec<String> = Vec::with_capacity(rows.len());
+        let mut hits: Vec<PaletteBookHit> = Vec::with_capacity(rows.len());
+        for r in rows.iter() {
+            let id: i64 = r.get("id");
+            let uuid: String = r.get("uuid");
+            let has_cover: i64 = r.get("has_cover");
+            uuids.push(uuid);
+            hits.push(PaletteBookHit {
+                id,
+                title: r.get::<Option<String>, _>("title").unwrap_or_default(),
+                author_display: r
+                    .get::<Option<String>, _>("author_display")
+                    .unwrap_or_default(),
+                year: r.get("year"),
+                formats: parse_json_array(r.get("formats_json"))?,
+                cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+                accent: r.get("accent_color"),
+            });
+        }
+
+        let overrides_map = load_overrides_bulk(pool, &uuids).await?;
+        for (hit, uuid) in hits.iter_mut().zip(uuids.iter()) {
+            if let Some((ov, _)) = overrides_map.get(uuid) {
+                if let Some(ref t) = ov.title {
+                    hit.title = t.clone();
+                }
+                if let Some(ref creators) = ov.creators {
+                    hit.author_display = creators
+                        .iter()
+                        .map(|c| c.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                }
+            }
+        }
+
+        hits
     } else {
         Vec::new()
     };
@@ -5040,6 +5064,114 @@ mod tests {
         assert!(!results.tags.is_empty(), "should match tag substring");
         assert_eq!(results.tags[0].name, "Dark academia");
         assert_eq!(results.tags[0].book_count, 1);
+    }
+
+    /// Bug #1 (display side): the palette must show the overridden title,
+    /// not the canonical scanned `b.title`, so what the user clicks matches
+    /// what they searched for.
+    #[tokio::test]
+    async fn palette_book_hit_uses_overridden_title() {
+        let _covers = CoversTempDir::new("palette_override_title");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "p.epub",
+                Some("Scanned Title"),
+                &["Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        let uuid = list_books(&pool, "/lib").await.unwrap()[0]
+            .unique_identifier
+            .clone()
+            .unwrap();
+        upsert_metadata_overrides(
+            &pool,
+            &uuid,
+            &MetadataOverrides {
+                title: Some("Edited Title".into()),
+                ..Default::default()
+            },
+            false,
+            user_id,
+        )
+        .await
+        .unwrap();
+
+        let palette = search_palette(&pool, "/lib", "Edited").await.unwrap();
+        assert_eq!(palette.books.len(), 1);
+        assert_eq!(palette.books[0].title, "Edited Title");
+    }
+
+    /// Bug #1 (display side): overriding the creators list rebuilds the
+    /// comma-joined `author_display` so the palette subtitle matches the
+    /// detail page.
+    #[tokio::test]
+    async fn palette_book_hit_uses_overridden_author_display() {
+        let _covers = CoversTempDir::new("palette_override_authors");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "p.epub",
+                Some("Searchable"),
+                &["Original Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        let uuid = list_books(&pool, "/lib").await.unwrap()[0]
+            .unique_identifier
+            .clone()
+            .unwrap();
+        upsert_metadata_overrides(
+            &pool,
+            &uuid,
+            &MetadataOverrides {
+                creators: Some(vec![
+                    Contributor {
+                        name: "First Override".into(),
+                        ..Default::default()
+                    },
+                    Contributor {
+                        name: "Second Override".into(),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            },
+            false,
+            user_id,
+        )
+        .await
+        .unwrap();
+
+        let palette = search_palette(&pool, "/lib", "Searchable").await.unwrap();
+        assert_eq!(palette.books.len(), 1);
+        assert_eq!(
+            palette.books[0].author_display,
+            "First Override, Second Override"
+        );
     }
 
     // #128: lock the wiring between the palette and `build_fts_match`'s

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -601,7 +601,13 @@ pub async fn upsert_metadata_overrides(
     .bind(user_id)
     .execute(pool)
     .await?;
-    rebuild_fts_for_book(pool, book_uuid).await?;
+    // Best-effort FTS rebuild: log and continue on failure. The override
+    // write is the user's actual intent — a stale FTS row gets fixed on the
+    // next reindex, but surfacing a 500 here would make them think their
+    // save was lost. Matches the docstring contract above.
+    if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
+        tracing::warn!(book_uuid, error = %e, "books_fts rebuild after override upsert failed");
+    }
     Ok(())
 }
 
@@ -641,7 +647,10 @@ pub async fn delete_metadata_overrides(
         .bind(book_uuid)
         .execute(pool)
         .await?;
-    rebuild_fts_for_book(pool, book_uuid).await?;
+    // Best-effort FTS rebuild — same rationale as `upsert_metadata_overrides`.
+    if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
+        tracing::warn!(book_uuid, error = %e, "books_fts rebuild after override delete failed");
+    }
     Ok(())
 }
 
@@ -2033,7 +2042,7 @@ pub async fn search_palette(
 
         let overrides_map = load_overrides_bulk(pool, &uuids).await?;
         for (hit, uuid) in hits.iter_mut().zip(uuids.iter()) {
-            if let Some((ov, _)) = overrides_map.get(uuid) {
+            if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
                 if let Some(ref t) = ov.title {
                     hit.title = t.clone();
                 }
@@ -2043,6 +2052,11 @@ pub async fn search_palette(
                         .map(|c| c.name.as_str())
                         .collect::<Vec<_>>()
                         .join(", ");
+                }
+                // Mirror `apply_overrides`: surface user-uploaded covers even
+                // when the scanned book had `has_cover = 0`.
+                if *has_cover_ov {
+                    hit.cover_url = Some(format!("/api/covers/{}", hit.id));
                 }
             }
         }
@@ -5177,6 +5191,49 @@ mod tests {
         assert_eq!(
             palette.books[0].author_display,
             "First Override, Second Override"
+        );
+    }
+
+    /// Palette book hits should surface a user-uploaded cover even when the
+    /// scanned book had no cover. Mirrors `apply_overrides` so the palette
+    /// row doesn't go cover-less for an override-only cover.
+    #[tokio::test]
+    async fn palette_book_hit_uses_overridden_cover() {
+        let _covers = CoversTempDir::new("palette_override_cover");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        // Indexed book with no scanned cover.
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "p.epub",
+                Some("Coverless Searchable"),
+                &["Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        let book = list_books(&pool, "/lib").await.unwrap().remove(0);
+        let uuid = book.unique_identifier.clone().unwrap();
+
+        // Set has_cover_override = true with no text edits.
+        upsert_metadata_overrides(&pool, &uuid, &MetadataOverrides::default(), true, user_id)
+            .await
+            .unwrap();
+
+        let palette = search_palette(&pool, "/lib", "Coverless").await.unwrap();
+        assert_eq!(palette.books.len(), 1);
+        assert_eq!(
+            palette.books[0].cover_url,
+            Some(format!("/api/covers/{}", book.id))
         );
     }
 

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -4448,7 +4448,10 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            search_books(&pool, "/lib", "Temporary").await.unwrap().len(),
+            search_books(&pool, "/lib", "Temporary")
+                .await
+                .unwrap()
+                .len(),
             1
         );
 
@@ -4457,7 +4460,10 @@ mod tests {
         // FTS is back to the canonical title; the override token no longer
         // matches.
         assert_eq!(
-            search_books(&pool, "/lib", "Canonical").await.unwrap().len(),
+            search_books(&pool, "/lib", "Canonical")
+                .await
+                .unwrap()
+                .len(),
             1
         );
         assert!(search_books(&pool, "/lib", "Temporary")

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1148,10 +1148,20 @@ body.atrium,
   display: flex;
   gap: 8px;
   align-items: center;
+  /* Flex items default to `min-width: auto`, which lets a long unbroken
+     value force the row wider than its parent card. Pin to 0 so the value
+     box below can shrink and trigger overflow-wrap. */
+  min-width: 0;
 }
 .me-ident-key { min-width: 78px; }
 .me-ident-val {
   flex: 1;
+  /* Same `min-width: auto` problem as the parent row — without this, a
+     URL-shaped identifier (no whitespace, no hyphens) would push the value
+     box past the card's right edge. `overflow-wrap: anywhere` lets the
+     string break mid-word once the box is shrinkable. */
+  min-width: 0;
+  overflow-wrap: anywhere;
   padding: 6px 10px;
   background: var(--bg-2);
   border: 1px solid var(--line-2);

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -16,8 +16,9 @@ pub fn AuthorPage(id: i64) -> Element {
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
+    // See `BookDetailPage` for why `id` needs `use_reactive!`.
     let url = server_url.clone();
-    use_effect(move || {
+    use_effect(use_reactive!(|id| {
         let url = url.clone();
         spawn(async move {
             loading.set(true);
@@ -30,7 +31,7 @@ pub fn AuthorPage(id: i64) -> Element {
             }
             loading.set(false);
         });
-    });
+    }));
 
     if loading() {
         return rsx! {

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -36,8 +36,13 @@ pub fn BookDetailPage(id: i64) -> Element {
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
+    // `use_reactive!` declares `id` as an explicit dependency so the effect
+    // re-runs when the router swaps the route param in place. Without this,
+    // navigating `/books/A` → `/books/B` reuses the same component instance
+    // and leaves the page rendering the stale book — Dioxus' implicit
+    // subscription tracking only covers signals, not plain props.
     let url = server_url.clone();
-    use_effect(move || {
+    use_effect(use_reactive!(|id| {
         let url = url.clone();
         spawn(async move {
             loading.set(true);
@@ -50,7 +55,7 @@ pub fn BookDetailPage(id: i64) -> Element {
             }
             loading.set(false);
         });
-    });
+    }));
 
     if loading() {
         return rsx! {

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -26,8 +26,9 @@ pub fn MetadataEditPage(id: i64) -> Element {
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
+    // See `BookDetailPage` for why `id` needs `use_reactive!`.
     let url = server_url.clone();
-    use_effect(move || {
+    use_effect(use_reactive!(|id| {
         let url = url.clone();
         spawn(async move {
             loading.set(true);
@@ -40,7 +41,7 @@ pub fn MetadataEditPage(id: i64) -> Element {
             }
             loading.set(false);
         });
-    });
+    }));
 
     if loading() {
         return rsx! {

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -153,10 +153,10 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
     let dirty_count = use_memo(move || dirty_fields().len());
 
     let display_title = book.title.clone().unwrap_or_else(|| book.filename.clone());
-    let primary_author = book
+    let (primary_author, primary_author_id) = book
         .creators
         .first()
-        .map(|c| c.name.clone())
+        .map(|c| (c.name.clone(), c.id))
         .unwrap_or_default();
 
     let accent_style = book
@@ -173,7 +173,20 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
                 Link { to: Route::Landing {}, class: "bd-crumb-home", "Home" }
                 span { class: "bd-crumb-sep", "\u{203a}" }
                 if !primary_author.is_empty() {
-                    span { class: "bd-crumb-step", "{primary_author}" }
+                    if let Some(author_id) = primary_author_id {
+                        Link {
+                            to: Route::AuthorDetail { id: author_id },
+                            class: "bd-crumb-step",
+                            "data-testid": "me-crumb-author",
+                            "{primary_author}"
+                        }
+                    } else {
+                        span {
+                            class: "bd-crumb-step",
+                            "data-testid": "me-crumb-author",
+                            "{primary_author}"
+                        }
+                    }
                     span { class: "bd-crumb-sep", "\u{203a}" }
                 }
                 Link { to: Route::BookDetail { id }, class: "bd-crumb-step", "{display_title}" }

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -19,14 +19,14 @@ pub fn SearchPage(query: String) -> Element {
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
+    // See `BookDetailPage` for why `query` needs `use_reactive!`.
     let url = server_url.clone();
-    let q = query.clone();
-    use_effect(move || {
+    let query_dep = query.clone();
+    use_effect(use_reactive!(|query_dep| {
         let url = url.clone();
-        let q = q.clone();
         spawn(async move {
             loading.set(true);
-            match data::search_palette(&url, &q).await {
+            match data::search_palette(&url, &query_dep).await {
                 Ok(r) => {
                     results.set(Some(r));
                     error.set(None);
@@ -35,7 +35,7 @@ pub fn SearchPage(query: String) -> Element {
             }
             loading.set(false);
         });
-    });
+    }));
 
     let header = rsx! {
         div { class: "search-page-header",

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -15,8 +15,9 @@ pub fn SeriesPage(id: i64) -> Element {
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
+    // See `BookDetailPage` for why `id` needs `use_reactive!`.
     let url = server_url.clone();
-    use_effect(move || {
+    use_effect(use_reactive!(|id| {
         let url = url.clone();
         spawn(async move {
             loading.set(true);
@@ -29,7 +30,7 @@ pub fn SeriesPage(id: i64) -> Element {
             }
             loading.set(false);
         });
-    });
+    }));
 
     if loading() {
         return rsx! {

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -64,11 +64,14 @@ fn render_series(s: SeriesDetail) -> Element {
         .find_map(|b| b.accent.as_deref())
         .unwrap_or("var(--accent)");
 
-    // Primary author from the first book's first creator.
-    let primary_author = s
+    // Primary author from the first book's first creator. Capture the
+    // author id alongside the name so the breadcrumb can render a Link
+    // when the row is resolvable; books whose first creator is an
+    // override-only string (no `authors` row) fall back to a plain span.
+    let (primary_author, primary_author_id) = s
         .books
         .iter()
-        .find_map(|b| b.creators.first().map(|c| c.name.clone()))
+        .find_map(|b| b.creators.first().map(|c| (c.name.clone(), c.id)))
         .unwrap_or_default();
 
     // Split series name for italic styling on key word.
@@ -84,12 +87,20 @@ fn render_series(s: SeriesDetail) -> Element {
         div { class: "disc-page", style: "--accent: {accent}",
             // Header
             div { class: "disc-series-header",
-                nav { class: "breadcrumb",
+                nav { class: "breadcrumb", aria_label: "breadcrumb",
                     Link { to: Route::Landing {}, "Library" }
-                    span { " › " }
+                    span { class: "breadcrumb-sep", " › " }
                     if !primary_author.is_empty() {
-                        span { "{primary_author}" }
-                        span { " › " }
+                        if let Some(author_id) = primary_author_id {
+                            Link {
+                                to: Route::AuthorDetail { id: author_id },
+                                "data-testid": "series-crumb-author",
+                                "{primary_author}"
+                            }
+                        } else {
+                            span { "data-testid": "series-crumb-author", "{primary_author}" }
+                        }
+                        span { class: "breadcrumb-sep", " › " }
                     }
                     span { "{s.name}" }
                 }


### PR DESCRIPTION
## Summary

Fixes the four bugs reported against the metadata editor / palette flow on the current main, scoped to one branch so each fix is independently reviewable. Full investigation lives at [docs/qa/qa-report-2026-05-22-edit-bugs.md](docs/qa/qa-report-2026-05-22-edit-bugs.md).

| Commit | Fix |
|---|---|
| 1 — `fix(db): rebuild books_fts on metadata override save and delete` | `metadata_overrides` writes never touched `books_fts`, so the palette and `/search/*` couldn't match an edited title. Rebuild the FTS row from the merged metadata on every override upsert/delete. |
| 2 — `fix(db): apply metadata overrides to search_palette book hits` | The palette projection read `b.title` and the canonical authors join raw, so the displayed row would still show the pre-override title/authors even when FTS matched. Overlay overrides on the slim hit shape via the existing `load_overrides_bulk` helper. |
| 3 — `fix(frontend): link the author segment in series and edit-metadata breadcrumbs` | The series page (and the edit-metadata breadcrumb) rendered the author as a plain `<span>` even when `creators[0].id` was available. Make it a `Link to Route::AuthorDetail` when resolvable, falling back to the span for override-only authors. |
| 4 — `fix(frontend): wrap long identifier values inside the metadata edit rail` | A URL-shaped identifier (e.g. _A Dance With Dragons_' ePubBud URL) pushed the value box past the right edge of the Identifiers card. Add `min-width: 0` and `overflow-wrap: anywhere` so the flex item can shrink and break mid-word. |
| 5 — `fix(frontend): re-fetch detail and search pages when their route param changes` | `BookDetailPage` / `MetadataEditPage` / `SeriesPage` / `AuthorPage` / `SearchPage` all loaded data inside a bare `use_effect` whose only captures were plain props. Same-component-type navigation (e.g. clicking a different book in the palette while already on `/books/:id`) updated the URL but left the page rendering stale data. Wrap each body in `use_reactive!(|id| ...)` so the route param becomes an explicit dependency. |

## Test plan

- [x] `cargo test --workspace` → 345 passed, 0 failed (the three new override→FTS tests and two new palette→overrides tests live alongside the existing query tests).
- [x] `cargo check` clean on the full workspace.
- [ ] Manual repro from the QA report still red on `main`, green here:
  - [ ] Edit a book's title → palette/`/search/*` find and display the new title; revert restores the original.
  - [ ] Open a series page → "Library › Author › Series" breadcrumb has the author segment as a link.
  - [ ] `/books/1650/edit` (A Dance With Dragons) → the ePubBud URL row stays inside the Identifiers card.
  - [ ] On a `/books/:id` page, open palette → click a different book → page body re-renders with the new book.
- [ ] CSS change (commit 4) should be eyeballed in the running preview — verified via reasoning in the worktree, but the user's `dx serve` is bound to the main worktree so I couldn't drive it from the xray branch.

## Notes

> [!NOTE]
> Pre-existing clippy errors on `main` in `db/src/worker.rs:301,345` and `frontend/src/view_prefs.rs:145,151` were not introduced by this branch — `cargo clippy -D warnings` was already red. Out of scope here.

> [!IMPORTANT]
> Follow-ups intentionally left out of this branch (see `docs/qa/qa-report-2026-05-22-edit-bugs.md` § Follow-ups):
> 1. Author / series / tag **name** overrides still don't reach the canonical taxonomy tables, so the canonical pages and the palette's Authors/Series/Tags rows keep showing pre-override names. Needs its own design doc.
> 2. The read-only book-detail rail also displays identifiers (`BdMetaRow`) and may have its own overflow story — not reproduced specifically.
> 3. No Playwright spec covers the override → search round-trip yet; the regression tests in this PR are at the query layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)