### PR TITLE
docs: document single-tenant assumption for taxonomy queries (#116)

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -1918,13 +1918,22 @@ fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata, sqlx::Erro
 /// Fetch an author by ID with all their books across every library.
 /// Returns `None` if the author ID doesn't exist.
 ///
-/// TODO(F4.x): scope by `user_id` once per-user ACLs land — today this
-/// query is single-tenant and any authenticated caller can enumerate
-/// authors by ID.
+/// # Multi-tenancy
+///
+/// This function returns all matching rows without filtering by the
+/// requesting user's library access. The app is single-tenant and
+/// single-library today (see Phase 4 in `docs/roadmap/0-0-summary.md`),
+/// so every authenticated caller is implicitly authorised to see every
+/// author. When per-user ACLs land in the F4.x phase this function must
+/// accept a `user_id` parameter and filter both the `authors` row and
+/// the joined `books` via the access-control join. The `TODO(F4.x)`
+/// marker in the body stays in place until that work lands.
 pub async fn get_author(
     pool: &SqlitePool,
     author_id: i64,
 ) -> Result<Option<AuthorDetail>, sqlx::Error> {
+    // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
+    // function-level rustdoc above for the single-tenant rationale.
     let author_row = sqlx::query("SELECT id, name, sort FROM authors WHERE id = ?")
         .bind(author_id)
         .fetch_optional(pool)
@@ -1959,12 +1968,23 @@ pub async fn get_author(
 /// Fetch a series by ID with all its books, ordered by series index.
 /// Returns `None` if the series ID doesn't exist.
 ///
-/// TODO(F4.x): scope by `user_id` once per-user ACLs land — see
-/// [`get_author`] for the same caveat.
+/// # Multi-tenancy
+///
+/// This function returns all matching rows without filtering by the
+/// requesting user's library access. The app is single-tenant and
+/// single-library today (see Phase 4 in `docs/roadmap/0-0-summary.md`),
+/// so every authenticated caller is implicitly authorised to see every
+/// series. When per-user ACLs land in the F4.x phase this function must
+/// accept a `user_id` parameter and filter both the `series` row and the
+/// joined `books` via the access-control join — same caveat as
+/// [`get_author`]. The `TODO(F4.x)` marker in the body stays in place
+/// until that work lands.
 pub async fn get_series(
     pool: &SqlitePool,
     series_id: i64,
 ) -> Result<Option<SeriesDetail>, sqlx::Error> {
+    // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
+    // function-level rustdoc above for the single-tenant rationale.
     let series_row = sqlx::query("SELECT id, name, sort FROM series WHERE id = ?")
         .bind(series_id)
         .fetch_optional(pool)
@@ -2004,9 +2024,19 @@ const TAG_CLOUD_LIMIT: i64 = 500;
 /// Return up to [`TAG_CLOUD_LIMIT`] tags with their book counts, ordered
 /// by count descending then name ascending. Used by the tag cloud page.
 ///
-/// TODO(F4.x): scope by `user_id` once per-user ACLs land — currently
-/// returns the global tag distribution.
+/// # Multi-tenancy
+///
+/// This function returns the global tag distribution without filtering
+/// by the requesting user's library access. The app is single-tenant and
+/// single-library today (see Phase 4 in `docs/roadmap/0-0-summary.md`),
+/// so every authenticated caller sees the same tag cloud. When per-user
+/// ACLs land in the F4.x phase this function must accept a `user_id`
+/// parameter and count only books visible to that user via the
+/// access-control join. The `TODO(F4.x)` marker in the body stays in
+/// place until that work lands.
 pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, sqlx::Error> {
+    // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
+    // function-level rustdoc above for the single-tenant rationale.
     let rows = sqlx::query(
         r#"SELECT t.name, COUNT(btl.book) AS cnt
            FROM tags t


### PR DESCRIPTION
## Summary

- `get_author`, `get_series`, and `get_tag_cloud` in `db/src/queries.rs` return rows without filtering by the requesting user's library access. The app is single-tenant and single-library today, so this is safe in practice — but the gap is real and must be closed before per-user ACLs (F4.x).
- Replaces the one-line `TODO(F4.x)` rustdoc comments on all three functions with a structured `# Multi-tenancy` rustdoc section that states the single-tenant rationale, references Phase 4 of `docs/roadmap/0-0-summary.md`, and spells out the future-shape change (add a `user_id` parameter, filter via the access-control join).
- A short `TODO(F4.x)` marker is kept inside each function body so the existing grep (`grep -rn 'TODO(F4.x)' db/`) still surfaces them.

## Scope

Docs only. No signature changes, no query changes, no behaviour change.

This is the **interim** action prescribed by the issue:

> In the interim, document the single-tenant assumption in the function-level rustdoc.

The actual ACL rewrite (adding `user_id` parameters and joining `user_library_access`) is intentionally deferred to **F4.x**. Issue #116 also serves as the F4.x tracking entry for those three queries, but per the issue's own prescription the interim documentation work is sufficient to close it. When F4.x lands, a new issue/PR will reference the same three functions and convert the rustdoc-documented future-shape into actual code.

## Files changed

- `db/src/queries.rs` — rustdoc on `get_author`, `get_series`, `get_tag_cloud`.

## Test plan

- [x] `cargo fmt --check -p omnibus-db` clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` clean
- [x] `cargo test -p omnibus-db` — 212 passed, 0 failed (no behaviour change expected)
- [x] `cargo doc -p omnibus-db --no-deps` parses without new warnings
- [x] `grep -n 'TODO(F4.x)' db/src/queries.rs` still surfaces all three functions

Closes #116

---
_Generated by [Claude Code](https://claude.ai/code/session_01H54v5vPrZd2xJvR16MokAw)_