### PR TITLE
fix(overrides): apply F5.1 overlay to discovery + palette read paths

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2326,11 +2326,37 @@ const TAG_CLOUD_LIMIT: i64 = 500;
 pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, sqlx::Error> {
     // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
     // function-level rustdoc above for the single-tenant rationale.
+    //
+    // F5.1: counts use the effective (override-aware) subject set, not
+    // the raw `books_tags_link` rows — `overrides.subjects` replaces a
+    // book's canonical tag list wholesale when Some. Visibility still
+    // requires at least one canonical link so tags that exist only as a
+    // string inside override JSON don't surface (no `tags` row to point
+    // at). The single-library, single-tenant scope means the cloud is
+    // global; if/when per-library scoping lands this picks up a path
+    // filter alongside the existing `WHERE EXISTS`.
     let rows = sqlx::query(
-        r#"SELECT t.name, COUNT(btl.book) AS cnt
+        r#"SELECT t.name,
+             (SELECT COUNT(*)
+                FROM books b
+                LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+               WHERE CASE
+                       WHEN mo.book_uuid IS NOT NULL
+                            AND json_type(mo.overrides, '$.subjects') IS NOT NULL
+                         THEN EXISTS (
+                           SELECT 1 FROM json_each(mo.overrides, '$.subjects') je
+                            WHERE je.value = t.name
+                         )
+                       ELSE EXISTS (
+                         SELECT 1 FROM books_tags_link btl
+                          WHERE btl.book = b.id AND btl.tag = t.id
+                       )
+                     END
+             ) AS cnt
            FROM tags t
-           JOIN books_tags_link btl ON btl.tag = t.id
-           GROUP BY t.id
+           WHERE EXISTS (
+             SELECT 1 FROM books_tags_link btl WHERE btl.tag = t.id
+           )
            ORDER BY cnt DESC, t.name ASC
            LIMIT ?"#,
     )
@@ -4981,6 +5007,71 @@ mod tests {
         // No books, no tags.
         let tags = get_tag_cloud(&pool).await.unwrap();
         assert!(tags.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_tag_cloud_counts_reflect_overrides() {
+        // F5.1: per-tag counts in the cloud must follow the merged view.
+        // Without the override-aware count, the cloud kept showing the
+        // canonical totals — over-reporting tags the user had removed
+        // from books and missing books whose tags were reassigned via
+        // override.
+        let _guard = CoversTempDir::new("tag_cloud_overrides");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed("a.epub", Some("A"), &["X"], &["fiction"], None, None),
+                indexed("b.epub", Some("B"), &["X"], &["fiction"], None, None),
+                indexed("c.epub", Some("C"), &["X"], &["essay"], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+
+        // Sanity: canonical counts before any overrides.
+        let pre = get_tag_cloud(&pool).await.unwrap();
+        let fiction_pre = pre
+            .iter()
+            .find(|t| t.name == "fiction")
+            .expect("fiction present pre-override");
+        assert_eq!(fiction_pre.count, 2);
+
+        // Reassign a.epub: drop "fiction", add "essay".
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let a = books.iter().find(|b| b.filename == "a.epub").unwrap();
+        let uuid = a.unique_identifier.clone().unwrap();
+        let ov = MetadataOverrides {
+            subjects: Some(vec!["essay".into()]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let post = get_tag_cloud(&pool).await.unwrap();
+        let fiction = post
+            .iter()
+            .find(|t| t.name == "fiction")
+            .expect("fiction still visible (canonical anchor remains on b.epub)");
+        assert_eq!(
+            fiction.count, 1,
+            "fiction should drop a.epub after override, got {post:?}",
+        );
+        let essay = post
+            .iter()
+            .find(|t| t.name == "essay")
+            .expect("essay present");
+        assert_eq!(
+            essay.count, 2,
+            "essay should pick up override-tagged a.epub, got {post:?}",
+        );
     }
 
     // -----------------------------------------------------------------

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2260,7 +2260,12 @@ pub async fn get_series(
                     CASE
                       WHEN mo.book_uuid IS NOT NULL
                            AND json_type(mo.overrides, '$.series_index') IS NOT NULL
-                        THEN CAST(json_extract(mo.overrides, '$.series_index') AS REAL)
+                        -- NULLIF: an override that explicitly clears the
+                        -- index (`Some("")` from the edit form) would
+                        -- otherwise CAST to 0.0 and sort to the front of
+                        -- the series. Treat empty-string as "no index"
+                        -- and let ORDER BY's NULLS LAST trail it.
+                        THEN CAST(NULLIF(json_extract(mo.overrides, '$.series_index'), '') AS REAL)
                       ELSE b.series_index
                     END AS series_index
                FROM books b
@@ -2270,7 +2275,7 @@ pub async fn get_series(
            FROM books b
            JOIN effective e ON e.book_id = b.id
            WHERE e.series_name = ? COLLATE NOCASE
-           ORDER BY e.series_index, b.sort, b.id"#
+           ORDER BY e.series_index NULLS LAST, b.sort, b.id"#
     );
     let rows = sqlx::query(&sql).bind(&series_name).fetch_all(pool).await?;
 
@@ -2293,13 +2298,17 @@ pub async fn get_series(
                 apply_overrides(book, ov, *has_cover_ov);
             }
         }
-        // Books matched purely via override have no `books_series_link`
-        // row, so the canonical subquery left `series_id` unset. Pin it
-        // to the parent series so the rendered card carries the link.
-        if book.series_id.is_none() {
-            book.series_id = Some(series_id);
-            book.series = Some(series_name.clone());
-        }
+        // Pin `series_id` / `series` to the parent series for every
+        // returned row, not just the override-only ones. A book that was
+        // canonically in series A but overridden into series B would
+        // otherwise come back here with `series_id = Some(A)` (from the
+        // BOOK_COLUMNS subquery, which only reads `books_series_link`)
+        // — so the card on B's page would link back to /series/A. We're
+        // already on B's page by construction (the WHERE filter matched
+        // the effective series name), so unconditionally pinning to the
+        // requested series is correct.
+        book.series_id = Some(series_id);
+        book.series = Some(series_name.clone());
     }
     backfill_creator_ids(pool, &mut books).await?;
 
@@ -5972,6 +5981,117 @@ mod tests {
         assert!(
             titles.contains(&"Standalone".to_string()),
             "lowercase override should still match NOCASE series row, got {titles:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_series_empty_string_series_index_sorts_last() {
+        // `Some("")` from the edit form (user cleared the position
+        // field) was sorting to the front because `CAST('' AS REAL)`
+        // returns 0.0. NULLIF on the override value drops it to NULL,
+        // and ORDER BY ... NULLS LAST trails it after positioned books.
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let saga_id = series_id_by_name(&pool, "Saga").await;
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let standalone = books
+            .iter()
+            .find(|b| b.filename == "standalone.epub")
+            .unwrap();
+        let uuid = standalone.unique_identifier.clone().unwrap();
+
+        // Add Standalone to Saga but clear its position.
+        let ov = MetadataOverrides {
+            series: Some("Saga".into()),
+            series_index: Some(String::new()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let series = get_series(&pool, saga_id)
+            .await
+            .unwrap()
+            .expect("series exists");
+        let titles: Vec<_> = series
+            .books
+            .iter()
+            .map(|b| b.title.clone().unwrap_or_default())
+            .collect();
+        assert_eq!(
+            titles,
+            vec![
+                "Saga: Book One".to_string(),
+                "Saga: Book Two".to_string(),
+                "Standalone".to_string(),
+            ],
+            "empty-string series_index should trail positioned books, not lead them",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_series_pins_series_id_for_books_moved_between_series() {
+        // A book canonically in Series A overridden into Series B used
+        // to come back from get_series(B) with `series_id = Some(A)`
+        // (BOOK_COLUMNS reads only books_series_link), so the card on
+        // B's page would link back to /series/A. The fix pins
+        // series_id/series unconditionally to the requested parent.
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let pioneers_id = series_id_by_name(&pool, "Pioneers").await;
+
+        // "Other Story" is canonically in Pioneers; override moves it
+        // into Saga. Verify that opening Saga's page returns the book
+        // pinned to Saga's id, not Pioneers'.
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let other = books.iter().find(|b| b.filename == "other.epub").unwrap();
+        let uuid = other.unique_identifier.clone().unwrap();
+
+        let saga_id = series_id_by_name(&pool, "Saga").await;
+        let ov = MetadataOverrides {
+            series: Some("Saga".into()),
+            series_index: Some("5".into()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let saga = get_series(&pool, saga_id)
+            .await
+            .unwrap()
+            .expect("Saga exists");
+        let moved = saga
+            .books
+            .iter()
+            .find(|b| b.title.as_deref() == Some("Other Story"))
+            .expect("override moved Other Story into Saga");
+        assert_eq!(
+            moved.series_id,
+            Some(saga_id),
+            "card on Saga's page must link back to Saga, not the canonical Pioneers",
+        );
+        assert_eq!(moved.series.as_deref(), Some("Saga"));
+
+        // And it should be gone from Pioneers' page.
+        let pioneers = get_series(&pool, pioneers_id)
+            .await
+            .unwrap()
+            .expect("Pioneers exists");
+        assert!(
+            !pioneers
+                .books
+                .iter()
+                .any(|b| b.title.as_deref() == Some("Other Story")),
+            "override moved Other Story off Pioneers",
         );
     }
 

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2061,19 +2061,71 @@ pub async fn get_author(
     let Some(a) = author_row else {
         return Ok(None);
     };
+    let author_name: String = a.get("name");
 
+    // F5.1: membership and ordering follow the merged (override-aware)
+    // view, not the raw `books_authors_link` table. `apply_overrides`
+    // replaces creators wholesale when the override JSON has the
+    // `creators` key, so the effective creator set for a book is:
+    //   - `overrides.creators` if the JSON has that key (including the
+    //     empty array, which clears all authors), else
+    //   - the canonical names from `books_authors_link`.
+    // Override creators carry only `name`, so we match by name against
+    // the target author. `series_index` overrides drive ordering the same
+    // way as in `get_series`.
     let sql = format!(
         r#"SELECT {BOOK_COLUMNS}
            FROM books b
-           JOIN books_authors_link bal ON bal.book = b.id
-           WHERE bal.author = ?
-           ORDER BY b.series_index NULLS LAST, b.sort, b.id"#
+           LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+           WHERE
+             CASE
+               WHEN mo.book_uuid IS NOT NULL
+                    AND json_type(mo.overrides, '$.creators') IS NOT NULL
+                 THEN EXISTS (
+                   SELECT 1 FROM json_each(mo.overrides, '$.creators') je
+                    WHERE json_extract(je.value, '$.name') = ?
+                 )
+               ELSE EXISTS (
+                 SELECT 1 FROM books_authors_link bal
+                  WHERE bal.book = b.id AND bal.author = ?
+               )
+             END
+           ORDER BY
+             COALESCE(
+               CASE
+                 WHEN mo.book_uuid IS NOT NULL
+                      AND json_type(mo.overrides, '$.series_index') IS NOT NULL
+                   THEN CAST(json_extract(mo.overrides, '$.series_index') AS REAL)
+                 ELSE NULL
+               END,
+               b.series_index
+             ) NULLS LAST,
+             b.sort, b.id"#
     );
-    let rows = sqlx::query(&sql).bind(author_id).fetch_all(pool).await?;
+    let rows = sqlx::query(&sql)
+        .bind(&author_name)
+        .bind(author_id)
+        .fetch_all(pool)
+        .await?;
 
     let mut books = Vec::with_capacity(rows.len());
     for r in &rows {
         books.push(row_to_ebook(r)?);
+    }
+
+    // Bulk-apply overrides so card titles / descriptions / covers reflect
+    // user edits, matching what `list_books` does for the landing grid.
+    let uuids: Vec<String> = books
+        .iter()
+        .filter_map(|b| b.unique_identifier.clone())
+        .collect();
+    let overrides_map = load_overrides_bulk(pool, &uuids).await?;
+    for book in &mut books {
+        if let Some(uuid) = book.unique_identifier.as_deref() {
+            if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
+                apply_overrides(book, ov, *has_cover_ov);
+            }
+        }
     }
 
     Ok(Some(AuthorDetail {
@@ -5216,6 +5268,147 @@ mod tests {
             merged.series_id,
             Some(saga_id),
             "override-only series must still resolve series_id so the detail rail can link"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_author_includes_books_whose_override_names_this_author() {
+        // Repro of the bug where renaming a book's author via the
+        // metadata form (e.g. "Sanderson, Brandon" → "Brandon Sanderson")
+        // left the book invisible on the new author's `/author/:id` page.
+        // The override path writes JSON only — `books_authors_link` keeps
+        // pointing at the canonical author row — so `get_author` must
+        // layer overrides on top of the relational link at read time.
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        // Set up the "Brandon Sanderson" vs "Sanderson, Brandon" shape:
+        // one canonical author and a second name the user prefers, then
+        // override one book to use the preferred name.
+        let canonical_id = author_id_by_name(&pool, "Ada Lovelace").await;
+        let preferred_id = sqlx::query_scalar::<_, i64>(
+            "INSERT INTO authors (name, sort) VALUES (?, ?) RETURNING id",
+        )
+        .bind("Lovelace, Ada")
+        .bind("Lovelace, Ada")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let saga_one = books.iter().find(|b| b.filename == "saga1.epub").unwrap();
+        let uuid = saga_one.unique_identifier.clone().unwrap();
+        let saga_one_id = saga_one.id;
+
+        // saga1.epub canonically lists ["Ada Lovelace", "Grace Hopper"];
+        // the override renames the primary author to "Lovelace, Ada".
+        let ov = MetadataOverrides {
+            creators: Some(vec![
+                Contributor {
+                    name: "Lovelace, Ada".into(),
+                    role: Some("aut".into()),
+                    file_as: None,
+                    id: None,
+                },
+                Contributor {
+                    name: "Grace Hopper".into(),
+                    role: Some("aut".into()),
+                    file_as: None,
+                    id: None,
+                },
+            ]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        // Visiting the preferred-name author page must now include the
+        // overridden book, even though `books_authors_link` for that book
+        // still points at the canonical "Ada Lovelace" row.
+        let preferred = get_author(&pool, preferred_id)
+            .await
+            .unwrap()
+            .expect("author exists");
+        let titles: Vec<_> = preferred
+            .books
+            .iter()
+            .map(|b| b.title.clone().unwrap_or_default())
+            .collect();
+        assert_eq!(
+            titles,
+            vec!["Saga: Book One".to_string()],
+            "override-named author must surface the book on /author/:id",
+        );
+
+        // And the canonical-name author page must drop it, because the
+        // override replaced the creator list wholesale.
+        let canonical = get_author(&pool, canonical_id)
+            .await
+            .unwrap()
+            .expect("author exists");
+        let canonical_titles: Vec<_> = canonical
+            .books
+            .iter()
+            .map(|b| b.title.clone().unwrap_or_default())
+            .collect();
+        assert!(
+            !canonical_titles.contains(&"Saga: Book One".to_string()),
+            "override moved the book off the canonical author, got {canonical_titles:?}",
+        );
+
+        // The card on the preferred-name page should show the override
+        // creator name, not the canonical one.
+        let card = &preferred.books[0];
+        assert_eq!(card.id, saga_one_id);
+        assert_eq!(
+            card.creators.first().map(|c| c.name.as_str()),
+            Some("Lovelace, Ada")
+        );
+    }
+
+    #[tokio::test]
+    async fn get_author_excludes_books_whose_override_clears_authors() {
+        // A book whose override sets creators to the empty array should
+        // disappear from every author's page, matching what the book
+        // detail page already shows (no breadcrumb author).
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let standalone = books
+            .iter()
+            .find(|b| b.filename == "standalone.epub")
+            .unwrap();
+        let uuid = standalone.unique_identifier.clone().unwrap();
+
+        let ov = MetadataOverrides {
+            creators: Some(vec![]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let ada = get_author(&pool, ada_id)
+            .await
+            .unwrap()
+            .expect("author exists");
+        let titles: Vec<_> = ada
+            .books
+            .iter()
+            .map(|b| b.title.clone().unwrap_or_default())
+            .collect();
+        assert!(
+            !titles.contains(&"Standalone".to_string()),
+            "override-cleared creators must drop the book from /author/:id, got {titles:?}",
         );
     }
 

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2112,19 +2112,73 @@ pub async fn get_series(
     let Some(s) = series_row else {
         return Ok(None);
     };
+    let series_name: String = s.get("name");
 
+    // F5.1: membership and ordering follow the merged (override-aware)
+    // view, not the raw `books_series_link` table. `upsert_metadata_overrides`
+    // never writes to the relational link tables, so a book added to a
+    // series purely through the edit form would otherwise be invisible
+    // here even though `apply_overrides` shows it in that series everywhere
+    // else (book detail, landing grid). The effective series for a book is:
+    //   - `overrides.series` if the JSON has that key (including the empty
+    //     string, which means "clear the series"), else
+    //   - the canonical name from `books_series_link`.
+    // Same fallback for `series_index` so the override-set position drives
+    // ordering when present.
     let sql = format!(
-        r#"SELECT {BOOK_COLUMNS}
+        r#"WITH effective AS (
+             SELECT b.id AS book_id,
+                    CASE
+                      WHEN mo.book_uuid IS NOT NULL
+                           AND json_type(mo.overrides, '$.series') IS NOT NULL
+                        THEN json_extract(mo.overrides, '$.series')
+                      ELSE (SELECT s2.name FROM books_series_link bsl
+                              JOIN series s2 ON s2.id = bsl.series
+                             WHERE bsl.book = b.id LIMIT 1)
+                    END AS series_name,
+                    CASE
+                      WHEN mo.book_uuid IS NOT NULL
+                           AND json_type(mo.overrides, '$.series_index') IS NOT NULL
+                        THEN CAST(json_extract(mo.overrides, '$.series_index') AS REAL)
+                      ELSE b.series_index
+                    END AS series_index
+               FROM books b
+               LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+           )
+           SELECT {BOOK_COLUMNS}
            FROM books b
-           JOIN books_series_link bsl ON bsl.book = b.id
-           WHERE bsl.series = ?
-           ORDER BY b.series_index, b.sort, b.id"#
+           JOIN effective e ON e.book_id = b.id
+           WHERE e.series_name = ?
+           ORDER BY e.series_index, b.sort, b.id"#
     );
-    let rows = sqlx::query(&sql).bind(series_id).fetch_all(pool).await?;
+    let rows = sqlx::query(&sql).bind(&series_name).fetch_all(pool).await?;
 
     let mut books = Vec::with_capacity(rows.len());
     for r in &rows {
         books.push(row_to_ebook(r)?);
+    }
+
+    // Merge overrides into each book so the series-card title/description
+    // /cover reflect user edits, matching what `list_books` does for the
+    // landing grid.
+    let uuids: Vec<String> = books
+        .iter()
+        .filter_map(|b| b.unique_identifier.clone())
+        .collect();
+    let overrides_map = load_overrides_bulk(pool, &uuids).await?;
+    for book in &mut books {
+        if let Some(uuid) = book.unique_identifier.as_deref() {
+            if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
+                apply_overrides(book, ov, *has_cover_ov);
+            }
+        }
+        // Books matched purely via override have no `books_series_link`
+        // row, so the canonical subquery left `series_id` unset. Pin it
+        // to the parent series so the rendered card carries the link.
+        if book.series_id.is_none() {
+            book.series_id = Some(series_id);
+            book.series = Some(series_name.clone());
+        }
     }
 
     Ok(Some(SeriesDetail {
@@ -5162,6 +5216,103 @@ mod tests {
             merged.series_id,
             Some(saga_id),
             "override-only series must still resolve series_id so the detail rail can link"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_series_includes_books_added_via_override() {
+        // Repro of the bug where editing a book to set its series via the
+        // metadata form left the book invisible on `/series/:id`. The
+        // override path only writes JSON into `metadata_overrides` and
+        // never touches `books_series_link`, so `get_series` must layer
+        // overrides on top of the relational link at read time.
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let saga_id = series_id_by_name(&pool, "Saga").await;
+
+        // Loner has no canonical series at all. After the override it
+        // should show up as #3 in Saga, after the two indexed books.
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let standalone = books
+            .iter()
+            .find(|b| b.filename == "standalone.epub")
+            .unwrap();
+        let standalone_uuid = standalone.unique_identifier.clone().unwrap();
+        let standalone_id = standalone.id;
+
+        let ov = MetadataOverrides {
+            series: Some("Saga".into()),
+            series_index: Some("3".into()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &standalone_uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let series = get_series(&pool, saga_id)
+            .await
+            .unwrap()
+            .expect("series exists");
+        assert_eq!(series.book_count, 3);
+
+        let titles: Vec<_> = series
+            .books
+            .iter()
+            .map(|b| b.title.clone().unwrap_or_default())
+            .collect();
+        assert_eq!(
+            titles,
+            vec![
+                "Saga: Book One".to_string(),
+                "Saga: Book Two".to_string(),
+                "Standalone".to_string(),
+            ],
+            "override-set series_index=3 should sort the overridden book last",
+        );
+
+        // The overridden book must carry the parent series id so the card
+        // links back to /series/:id.
+        let overridden = series.books.iter().find(|b| b.id == standalone_id).unwrap();
+        assert_eq!(overridden.series_id, Some(saga_id));
+        assert_eq!(overridden.series.as_deref(), Some("Saga"));
+    }
+
+    #[tokio::test]
+    async fn get_series_excludes_books_whose_override_clears_series() {
+        // A book canonically in Saga whose override clears the series (sets
+        // series to an empty string) should disappear from /series/:id,
+        // matching what the book detail page already shows.
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let saga_id = series_id_by_name(&pool, "Saga").await;
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let book_two = books.iter().find(|b| b.filename == "saga2.epub").unwrap();
+        let uuid = book_two.unique_identifier.clone().unwrap();
+
+        let ov = MetadataOverrides {
+            series: Some(String::new()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let series = get_series(&pool, saga_id)
+            .await
+            .unwrap()
+            .expect("series exists");
+        assert_eq!(series.book_count, 1);
+        assert_eq!(
+            series.books[0].title.as_deref(),
+            Some("Saga: Book One"),
+            "the unaffected book stays; the cleared one drops out",
         );
     }
 

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -1446,6 +1446,7 @@ pub async fn list_books(
             }
         }
     }
+    backfill_creator_ids(pool, &mut out).await?;
 
     Ok(out)
 }
@@ -1648,7 +1649,66 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
         }
     }
 
+    // Override Contributors are stored by name only — apply_overrides
+    // therefore leaves `id` unset, which renders the breadcrumb /
+    // "More by …" author link as an unclickable span even when an
+    // `authors` row with that name exists. Backfill the id from the
+    // authors table by name. Mirrors the series_id backfill above.
+    backfill_creator_ids(pool, std::slice::from_mut(&mut book)).await?;
+
     Ok(Some(book))
+}
+
+/// Fill in `Contributor::id` for every creator whose `id` is `None` by
+/// looking up the `authors` table by exact name. Used after the override
+/// merge in `get_book`, `list_books`, `get_author`, and `get_series` so
+/// the UI's `Route::AuthorDetail { id }` link resolves for books whose
+/// authors were renamed (or replaced) through `metadata_overrides`.
+async fn backfill_creator_ids(
+    pool: &SqlitePool,
+    books: &mut [EbookMetadata],
+) -> Result<(), sqlx::Error> {
+    use std::collections::HashMap;
+
+    // Collect every distinct name that still needs an id.
+    let names: Vec<String> = {
+        let mut set = std::collections::HashSet::new();
+        for b in books.iter() {
+            for c in &b.creators {
+                if c.id.is_none() && !c.name.is_empty() {
+                    set.insert(c.name.clone());
+                }
+            }
+        }
+        set.into_iter().collect()
+    };
+    if names.is_empty() {
+        return Ok(());
+    }
+
+    // Bulk lookup in chunks to stay under SQLite's bound-parameter limit.
+    let mut name_to_id: HashMap<String, i64> = HashMap::with_capacity(names.len());
+    for chunk in names.chunks(500) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!("SELECT id, name FROM authors WHERE name IN ({placeholders})");
+        let mut q = sqlx::query(&sql);
+        for n in chunk {
+            q = q.bind(n);
+        }
+        let rows = q.fetch_all(pool).await?;
+        for r in rows {
+            name_to_id.insert(r.get("name"), r.get("id"));
+        }
+    }
+
+    for b in books.iter_mut() {
+        for c in &mut b.creators {
+            if c.id.is_none() {
+                c.id = name_to_id.get(&c.name).copied();
+            }
+        }
+    }
+    Ok(())
 }
 
 #[derive(serde::Deserialize)]
@@ -1871,6 +1931,7 @@ pub async fn search_books(
             }
         }
     }
+    backfill_creator_ids(pool, &mut out).await?;
 
     Ok(out)
 }
@@ -2127,6 +2188,7 @@ pub async fn get_author(
             }
         }
     }
+    backfill_creator_ids(pool, &mut books).await?;
 
     Ok(Some(AuthorDetail {
         id: a.get("id"),
@@ -2232,6 +2294,7 @@ pub async fn get_series(
             book.series = Some(series_name.clone());
         }
     }
+    backfill_creator_ids(pool, &mut books).await?;
 
     Ok(Some(SeriesDetail {
         id: s.get("id"),
@@ -5205,6 +5268,89 @@ mod tests {
 
         let merged = get_book(&pool, id).await.unwrap().unwrap();
         assert_eq!(merged.subjects, vec!["sci-fi", "adventure"]);
+    }
+
+    #[tokio::test]
+    async fn get_book_backfills_creator_ids_after_override_replaces_authors() {
+        // Override Contributors carry only a name, so a book whose author
+        // list was edited through the metadata form would otherwise come
+        // back with `creators[*].id == None`, rendering the breadcrumb's
+        // author link as an unclickable span even when the `authors` row
+        // exists. Verify get_book backfills the id by name. Mirrors the
+        // user's report against book 268 (multi-author book where the
+        // user removed all but one canonical author).
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        // saga1.epub canonically has ["Ada Lovelace", "Grace Hopper"];
+        // simulate the user dropping the second author through the edit
+        // form. apply_overrides replaces creators wholesale, so the
+        // override Contributor has id = None.
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let saga_one = books.iter().find(|b| b.filename == "saga1.epub").unwrap();
+        let uuid = saga_one.unique_identifier.clone().unwrap();
+        let book_id = saga_one.id;
+
+        let ov = MetadataOverrides {
+            creators: Some(vec![Contributor {
+                name: "Ada Lovelace".into(),
+                role: Some("aut".into()),
+                file_as: None,
+                id: None,
+            }]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let merged = get_book(&pool, book_id).await.unwrap().unwrap();
+        assert_eq!(merged.creators.len(), 1);
+        assert_eq!(merged.creators[0].name, "Ada Lovelace");
+        assert_eq!(
+            merged.creators[0].id,
+            Some(ada_id),
+            "creator id must be backfilled so the breadcrumb renders as a Link",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_book_leaves_creator_id_none_when_override_author_unknown() {
+        // If the override sets an author name that doesn't exist in the
+        // `authors` table, backfill must leave the id None — same shape
+        // as get_book_leaves_series_id_none_when_override_series_unknown.
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let saga_one = books.iter().find(|b| b.filename == "saga1.epub").unwrap();
+        let uuid = saga_one.unique_identifier.clone().unwrap();
+        let book_id = saga_one.id;
+
+        let ov = MetadataOverrides {
+            creators: Some(vec![Contributor {
+                name: "Nobody Indexed".into(),
+                role: Some("aut".into()),
+                file_as: None,
+                id: None,
+            }]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let merged = get_book(&pool, book_id).await.unwrap().unwrap();
+        assert_eq!(merged.creators.len(), 1);
+        assert_eq!(merged.creators[0].name, "Nobody Indexed");
+        assert_eq!(merged.creators[0].id, None);
     }
 
     #[tokio::test]

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -1687,6 +1687,12 @@ async fn backfill_creator_ids(
     }
 
     // Bulk lookup in chunks to stay under SQLite's bound-parameter limit.
+    //
+    // `authors.name` is `UNIQUE COLLATE NOCASE`, so the SQL `WHERE name IN (...)`
+    // matches case-insensitively — but the returned row carries the DB casing,
+    // and an override's `Contributor::name` carries the user-supplied casing.
+    // Key the map by `to_lowercase()` on both sides so an override like
+    // "ada lovelace" still resolves to the canonical "Ada Lovelace" row's id.
     let mut name_to_id: HashMap<String, i64> = HashMap::with_capacity(names.len());
     for chunk in names.chunks(500) {
         let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
@@ -1697,14 +1703,15 @@ async fn backfill_creator_ids(
         }
         let rows = q.fetch_all(pool).await?;
         for r in rows {
-            name_to_id.insert(r.get("name"), r.get("id"));
+            let db_name: String = r.get("name");
+            name_to_id.insert(db_name.to_lowercase(), r.get("id"));
         }
     }
 
     for b in books.iter_mut() {
         for c in &mut b.creators {
             if c.id.is_none() {
-                c.id = name_to_id.get(&c.name).copied();
+                c.id = name_to_id.get(&c.name.to_lowercase()).copied();
             }
         }
     }
@@ -2144,7 +2151,7 @@ pub async fn get_author(
                     AND json_type(mo.overrides, '$.creators') IS NOT NULL
                  THEN EXISTS (
                    SELECT 1 FROM json_each(mo.overrides, '$.creators') je
-                    WHERE json_extract(je.value, '$.name') = ?
+                    WHERE json_extract(je.value, '$.name') = ? COLLATE NOCASE
                  )
                ELSE EXISTS (
                  SELECT 1 FROM books_authors_link bal
@@ -2262,7 +2269,7 @@ pub async fn get_series(
            SELECT {BOOK_COLUMNS}
            FROM books b
            JOIN effective e ON e.book_id = b.id
-           WHERE e.series_name = ?
+           WHERE e.series_name = ? COLLATE NOCASE
            ORDER BY e.series_index, b.sort, b.id"#
     );
     let rows = sqlx::query(&sql).bind(&series_name).fetch_all(pool).await?;
@@ -5493,6 +5500,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_book_backfills_creator_ids_case_insensitively() {
+        // `authors.name` is `UNIQUE COLLATE NOCASE`, so a SQL `IN (...)`
+        // lookup matches case-insensitively — but the returned row carries
+        // the DB casing while the override carries the user-supplied
+        // casing. The HashMap must normalise both sides to lowercase so
+        // an override like "ada lovelace" still resolves to the canonical
+        // "Ada Lovelace" id.
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let saga_one = books.iter().find(|b| b.filename == "saga1.epub").unwrap();
+        let uuid = saga_one.unique_identifier.clone().unwrap();
+        let book_id = saga_one.id;
+
+        let ov = MetadataOverrides {
+            creators: Some(vec![Contributor {
+                name: "ADA LOVELACE".into(),
+                role: Some("aut".into()),
+                file_as: None,
+                id: None,
+            }]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let merged = get_book(&pool, book_id).await.unwrap().unwrap();
+        assert_eq!(merged.creators.len(), 1);
+        assert_eq!(merged.creators[0].name, "ADA LOVELACE");
+        assert_eq!(
+            merged.creators[0].id,
+            Some(ada_id),
+            "case-mismatched override should still resolve to the canonical author id",
+        );
+    }
+
+    #[tokio::test]
     async fn get_book_leaves_creator_id_none_when_override_author_unknown() {
         // If the override sets an author name that doesn't exist in the
         // `authors` table, backfill must leave the id None — same shape
@@ -5733,6 +5783,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_author_override_creator_match_is_case_insensitive() {
+        // `authors.name` is `UNIQUE COLLATE NOCASE`, so an override that
+        // differs only by case from the target author's row must still
+        // surface the book on `/author/:id`. The override comparison
+        // gets an explicit `COLLATE NOCASE` because the LHS is a
+        // `json_extract(...)` expression (BINARY by default) and the RHS
+        // is a bound parameter (also no collation).
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let standalone = books
+            .iter()
+            .find(|b| b.filename == "standalone.epub")
+            .unwrap();
+        let uuid = standalone.unique_identifier.clone().unwrap();
+
+        // Override uses lowercase casing; canonical row is "Ada Lovelace".
+        let ov = MetadataOverrides {
+            creators: Some(vec![Contributor {
+                name: "ada lovelace".into(),
+                role: Some("aut".into()),
+                file_as: None,
+                id: None,
+            }]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let ada = get_author(&pool, ada_id)
+            .await
+            .unwrap()
+            .expect("author exists");
+        let titles: Vec<_> = ada
+            .books
+            .iter()
+            .map(|b| b.title.clone().unwrap_or_default())
+            .collect();
+        assert!(
+            titles.contains(&"Standalone".to_string()),
+            "lowercase override should still match NOCASE author row, got {titles:?}",
+        );
+    }
+
+    #[tokio::test]
     async fn get_series_includes_books_added_via_override() {
         // Repro of the bug where editing a book to set its series via the
         // metadata form left the book invisible on `/series/:id`. The
@@ -5826,6 +5927,51 @@ mod tests {
             series.books[0].title.as_deref(),
             Some("Saga: Book One"),
             "the unaffected book stays; the cleared one drops out",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_series_override_match_is_case_insensitive() {
+        // The CTE's `series_name` column is BINARY by default — without
+        // `COLLATE NOCASE` on the filter, an override that differs only
+        // by case from the canonical series row fails to match, even
+        // though `series.name` is `UNIQUE COLLATE NOCASE`.
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let saga_id = series_id_by_name(&pool, "Saga").await;
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let standalone = books
+            .iter()
+            .find(|b| b.filename == "standalone.epub")
+            .unwrap();
+        let uuid = standalone.unique_identifier.clone().unwrap();
+
+        // Override uses lowercase casing; canonical row is "Saga".
+        let ov = MetadataOverrides {
+            series: Some("saga".into()),
+            series_index: Some("3".into()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let series = get_series(&pool, saga_id)
+            .await
+            .unwrap()
+            .expect("series exists");
+        let titles: Vec<_> = series
+            .books
+            .iter()
+            .map(|b| b.title.clone().unwrap_or_default())
+            .collect();
+        assert!(
+            titles.contains(&"Standalone".to_string()),
+            "lowercase override should still match NOCASE series row, got {titles:?}",
         );
     }
 

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2604,17 +2604,42 @@ pub async fn search_palette(
 
     // D. Tags — substring match, scoped to library.
     //
-    // Same single-pass shape as authors: drives from libraries → books →
-    // books_tags_link by PK → tags. See the locked-in plan test.
+    // F5.1: the count uses the effective (override-aware) subject set,
+    // not the raw `books_tags_link` rows. `MetadataOverrides.subjects`
+    // (Option<Vec<String>>) replaces the canonical tag list wholesale
+    // when Some — including the empty array, which clears all tags.
+    // Visibility still requires at least one canonical link in this
+    // library so we don't list tags that exist only inside override
+    // JSON (no navigable id).
     let tags: Vec<PaletteTagHit> = sqlx::query(
         r#"
-        SELECT t.id, t.name, COUNT(*) AS book_count
+        SELECT t.id, t.name,
+          (SELECT COUNT(*)
+             FROM books b
+             JOIN libraries l2 ON l2.id = b.library_id
+             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+            WHERE l2.path = ?1
+              AND CASE
+                    WHEN mo.book_uuid IS NOT NULL
+                         AND json_type(mo.overrides, '$.subjects') IS NOT NULL
+                      THEN EXISTS (
+                        SELECT 1 FROM json_each(mo.overrides, '$.subjects') je
+                         WHERE je.value = t.name
+                      )
+                    ELSE EXISTS (
+                      SELECT 1 FROM books_tags_link btl
+                       WHERE btl.book = b.id AND btl.tag = t.id
+                    )
+                  END
+          ) AS book_count
         FROM tags t
-        JOIN books_tags_link btl ON btl.tag = t.id
-        JOIN books b ON b.id = btl.book
-        JOIN libraries l ON l.id = b.library_id
-        WHERE t.name LIKE ?2 ESCAPE '\' AND l.path = ?1
-        GROUP BY t.id, t.name
+        WHERE t.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (
+            SELECT 1 FROM books_tags_link btl
+              JOIN books b ON b.id = btl.book
+              JOIN libraries l ON l.id = b.library_id
+             WHERE btl.tag = t.id AND l.path = ?1
+          )
         ORDER BY book_count DESC, t.name
         LIMIT ?3
         "#,
@@ -6682,6 +6707,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn palette_tag_count_reflects_overrides() {
+        // F5.1: same shape for tags. `overrides.subjects` replaces the
+        // canonical tag list wholesale, so a book moved between tags
+        // must shift both counts.
+        let _covers = CoversTempDir::new("palette_tag_count_overrides");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed("a.epub", Some("A"), &["X"], &["tag-source"], None, None),
+                indexed("b.epub", Some("B"), &["X"], &["tag-source"], None, None),
+                indexed("c.epub", Some("C"), &["X"], &["tag-dest"], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+
+        // Move a.epub off tag-source and onto tag-dest via override.
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let a = books.iter().find(|b| b.filename == "a.epub").unwrap();
+        let uuid = a.unique_identifier.clone().unwrap();
+        let ov = MetadataOverrides {
+            subjects: Some(vec!["tag-dest".into()]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let results = search_palette(&pool, "/lib", "tag-").await.unwrap();
+        let source = results
+            .tags
+            .iter()
+            .find(|t| t.name == "tag-source")
+            .expect("tag-source still visible (canonical anchor remains)");
+        assert_eq!(
+            source.book_count, 1,
+            "tag-source should drop a.epub after override, got {results:?}",
+        );
+        let dest = results
+            .tags
+            .iter()
+            .find(|t| t.name == "tag-dest")
+            .expect("tag-dest present");
+        assert_eq!(
+            dest.book_count, 2,
+            "tag-dest should add the override-tagged a.epub, got {results:?}",
+        );
+    }
+
+    #[tokio::test]
     async fn palette_series_count_reflects_overrides() {
         // F5.1: same shape as palette_author_count_reflects_overrides
         // but for the series tile. Books moved into a series via
@@ -6909,16 +6991,31 @@ mod tests {
             "series plan should not full-scan the link table:\n{plan}"
         );
 
-        // Tags
+        // Tags — override-aware count, must still drive through the
+        // `books_tags_link` index for visibility and the no-override
+        // branch of the CASE.
         let plan = plan_text(
             &pool,
-            "SELECT t.id, t.name, COUNT(*) AS book_count \
+            "SELECT t.id, t.name, \
+              (SELECT COUNT(*) FROM books b \
+                 JOIN libraries l2 ON l2.id = b.library_id \
+                 LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
+                WHERE l2.path = ?1 \
+                  AND CASE \
+                        WHEN mo.book_uuid IS NOT NULL \
+                             AND json_type(mo.overrides, '$.subjects') IS NOT NULL \
+                          THEN EXISTS (SELECT 1 FROM json_each(mo.overrides, '$.subjects') je \
+                                        WHERE je.value = t.name) \
+                        ELSE EXISTS (SELECT 1 FROM books_tags_link btl \
+                                      WHERE btl.book = b.id AND btl.tag = t.id) \
+                      END \
+              ) AS book_count \
              FROM tags t \
-             JOIN books_tags_link btl ON btl.tag = t.id \
-             JOIN books b ON b.id = btl.book \
-             JOIN libraries l ON l.id = b.library_id \
-             WHERE t.name LIKE ?2 ESCAPE '\\' AND l.path = ?1 \
-             GROUP BY t.id, t.name \
+             WHERE t.name LIKE ?2 ESCAPE '\\' \
+               AND EXISTS (SELECT 1 FROM books_tags_link btl \
+                             JOIN books b ON b.id = btl.book \
+                             JOIN libraries l ON l.id = b.library_id \
+                            WHERE btl.tag = t.id AND l.path = ?1) \
              ORDER BY book_count DESC, t.name \
              LIMIT ?3",
         )

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2477,15 +2477,44 @@ pub async fn search_palette(
     // book_count stays library-correct (covered by `palette_scoped_to_library`
     // and `palette_taxonomy_counts_scoped_per_library`). The join plan is
     // locked in by `palette_taxonomy_query_plans_use_indexes`.
+    //
+    // F5.1: the count uses the effective (override-aware) creator set, not
+    // the raw `books_authors_link` rows — otherwise an author whose books
+    // were all reassigned through the metadata edit form (e.g. "Sanderson,
+    // Brandon" → "Brandon Sanderson") keeps reporting the canonical count
+    // even though `/author/:id` shows zero. Visibility still requires at
+    // least one canonical link row in this library so we don't list
+    // authors that exist only as a string inside override JSON (no
+    // navigable id), matching the rest of the palette's behavior.
     let authors: Vec<PaletteAuthorHit> = sqlx::query(
         r#"
-        SELECT a.id, a.name, COUNT(*) AS book_count
+        SELECT a.id, a.name,
+          (SELECT COUNT(*)
+             FROM books b
+             JOIN libraries l2 ON l2.id = b.library_id
+             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+            WHERE l2.path = ?1
+              AND CASE
+                    WHEN mo.book_uuid IS NOT NULL
+                         AND json_type(mo.overrides, '$.creators') IS NOT NULL
+                      THEN EXISTS (
+                        SELECT 1 FROM json_each(mo.overrides, '$.creators') je
+                         WHERE json_extract(je.value, '$.name') = a.name
+                      )
+                    ELSE EXISTS (
+                      SELECT 1 FROM books_authors_link bal
+                       WHERE bal.book = b.id AND bal.author = a.id
+                    )
+                  END
+          ) AS book_count
         FROM authors a
-        JOIN books_authors_link bal ON bal.author = a.id
-        JOIN books b ON b.id = bal.book
-        JOIN libraries l ON l.id = b.library_id
-        WHERE a.name LIKE ?2 ESCAPE '\' AND l.path = ?1
-        GROUP BY a.id, a.name
+        WHERE a.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (
+            SELECT 1 FROM books_authors_link bal
+              JOIN books b ON b.id = bal.book
+              JOIN libraries l ON l.id = b.library_id
+             WHERE bal.author = a.id AND l.path = ?1
+          )
         ORDER BY book_count DESC, a.name
         LIMIT ?3
         "#,
@@ -6544,6 +6573,85 @@ mod tests {
         assert_eq!(tag_b.book_count, 2);
     }
 
+    #[tokio::test]
+    async fn palette_author_count_reflects_overrides() {
+        // F5.1: the palette author count must match the merged
+        // (override-aware) view, not the raw `books_authors_link` count.
+        // Repro of the "Sanderson, Brandon still says 4 books" report:
+        // every canonical book for an author was reassigned to a
+        // differently-named author through the metadata edit form, so the
+        // palette must report 0 books for the source name and the full
+        // count for the destination name.
+        let _covers = CoversTempDir::new("palette_author_count_overrides");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        // Two books canonically by "Last, First", plus one book by the
+        // already-correct "First Last" so the destination author has a
+        // canonical anchor (palette visibility requires ≥1 canonical link).
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed("a.epub", Some("A"), &["Last, First"], &[], None, None),
+                indexed("b.epub", Some("B"), &["Last, First"], &[], None, None),
+                indexed("c.epub", Some("C"), &["First Last"], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+
+        // User edits a.epub and b.epub through the metadata form to
+        // rename their author to "First Last" — overrides only, no
+        // change to the relational link table.
+        let books = list_books(&pool, "/lib").await.unwrap();
+        for filename in ["a.epub", "b.epub"] {
+            let book = books.iter().find(|b| b.filename == filename).unwrap();
+            let uuid = book.unique_identifier.clone().unwrap();
+            let ov = MetadataOverrides {
+                creators: Some(vec![Contributor {
+                    name: "First Last".into(),
+                    role: Some("aut".into()),
+                    file_as: None,
+                    id: None,
+                }]),
+                ..Default::default()
+            };
+            upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+                .await
+                .unwrap();
+        }
+
+        let results = search_palette(&pool, "/lib", "Last").await.unwrap();
+
+        // Source author still visible (canonical anchor remains), but
+        // count must reflect the effective view: 0 books.
+        let source = results
+            .authors
+            .iter()
+            .find(|a| a.name == "Last, First")
+            .expect("source author still appears in palette");
+        assert_eq!(
+            source.book_count, 0,
+            "renamed-away author must report effective count 0, got {results:?}",
+        );
+
+        // Destination author picks up the override-renamed books on top
+        // of its own canonical anchor: 1 + 2 = 3.
+        let dest = results
+            .authors
+            .iter()
+            .find(|a| a.name == "First Last")
+            .expect("destination author present");
+        assert_eq!(
+            dest.book_count, 3,
+            "destination author must include override-renamed books, got {results:?}",
+        );
+    }
+
     /// #127: capture `EXPLAIN QUERY PLAN` for each of the three rewritten
     /// taxonomy queries and assert the planner uses the link-table indexes.
     /// This is a structural check — it doesn't pin the literal plan string
@@ -6568,16 +6676,31 @@ mod tests {
                 .join("\n")
         }
 
-        // Authors
+        // Authors — override-aware count, must still drive through the
+        // covering `books_authors_link` index when checking visibility
+        // and when the no-override branch of the CASE runs.
         let plan = plan_text(
             &pool,
-            "SELECT a.id, a.name, COUNT(*) AS book_count \
+            "SELECT a.id, a.name, \
+              (SELECT COUNT(*) FROM books b \
+                 JOIN libraries l2 ON l2.id = b.library_id \
+                 LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
+                WHERE l2.path = ?1 \
+                  AND CASE \
+                        WHEN mo.book_uuid IS NOT NULL \
+                             AND json_type(mo.overrides, '$.creators') IS NOT NULL \
+                          THEN EXISTS (SELECT 1 FROM json_each(mo.overrides, '$.creators') je \
+                                        WHERE json_extract(je.value, '$.name') = a.name) \
+                        ELSE EXISTS (SELECT 1 FROM books_authors_link bal \
+                                      WHERE bal.book = b.id AND bal.author = a.id) \
+                      END \
+              ) AS book_count \
              FROM authors a \
-             JOIN books_authors_link bal ON bal.author = a.id \
-             JOIN books b ON b.id = bal.book \
-             JOIN libraries l ON l.id = b.library_id \
-             WHERE a.name LIKE ?2 ESCAPE '\\' AND l.path = ?1 \
-             GROUP BY a.id, a.name \
+             WHERE a.name LIKE ?2 ESCAPE '\\' \
+               AND EXISTS (SELECT 1 FROM books_authors_link bal \
+                             JOIN books b ON b.id = bal.book \
+                             JOIN libraries l ON l.id = b.library_id \
+                            WHERE bal.author = a.id AND l.path = ?1) \
              ORDER BY book_count DESC, a.name \
              LIMIT ?3",
         )

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2534,27 +2534,56 @@ pub async fn search_palette(
 
     // C. Series — substring match with primary author from first book.
     //
-    // Same single-pass shape as authors. The `author_display` correlated
-    // subquery is intentionally retained: it needs ORDER BY ... LIMIT 1 over
-    // a separate join chain (`books_authors_link` + position) that doesn't
-    // fold cleanly into the grouped row. It only runs for the up-to-LIMIT
-    // outer rows, so its cost is bounded.
+    // F5.1: both the count and the `author_display` line use the effective
+    // (override-aware) view, mirroring `get_series` and the palette author
+    // count. `overrides.series` (string) drives membership; if a book's
+    // first creator was renamed through the metadata edit form,
+    // `overrides.creators[0].name` drives the displayed author. Visibility
+    // still requires at least one canonical link in this library so we
+    // don't list series that exist only inside override JSON (no
+    // navigable id).
     let series: Vec<PaletteSeriesHit> = sqlx::query(
         r#"
-        SELECT s.id, s.name, COUNT(*) AS book_count,
-               (SELECT a.name FROM books_series_link bsl2
-                  JOIN books b2 ON b2.id = bsl2.book
-                  JOIN libraries l2 ON l2.id = b2.library_id
-                  JOIN books_authors_link bal ON bal.book = bsl2.book
-                  JOIN authors a ON a.id = bal.author
-                 WHERE bsl2.series = s.id AND l2.path = ?1
-                 ORDER BY b2.sort, b2.id, bal.position LIMIT 1) AS author_display
+        SELECT s.id, s.name,
+          (SELECT COUNT(*)
+             FROM books b
+             JOIN libraries l2 ON l2.id = b.library_id
+             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+            WHERE l2.path = ?1
+              AND CASE
+                    WHEN mo.book_uuid IS NOT NULL
+                         AND json_type(mo.overrides, '$.series') IS NOT NULL
+                      THEN json_extract(mo.overrides, '$.series') = s.name
+                    ELSE EXISTS (
+                      SELECT 1 FROM books_series_link bsl
+                       WHERE bsl.book = b.id AND bsl.series = s.id
+                    )
+                  END
+          ) AS book_count,
+          (SELECT
+             CASE
+               WHEN mo2.book_uuid IS NOT NULL
+                    AND json_type(mo2.overrides, '$.creators') IS NOT NULL
+                 THEN json_extract(mo2.overrides, '$.creators[0].name')
+               ELSE (SELECT a.name FROM books_authors_link bal
+                       JOIN authors a ON a.id = bal.author
+                      WHERE bal.book = b2.id
+                      ORDER BY bal.position LIMIT 1)
+             END
+           FROM books_series_link bsl2
+             JOIN books b2 ON b2.id = bsl2.book
+             JOIN libraries l2 ON l2.id = b2.library_id
+             LEFT JOIN metadata_overrides mo2 ON mo2.book_uuid = b2.uuid
+            WHERE bsl2.series = s.id AND l2.path = ?1
+            ORDER BY b2.sort, b2.id LIMIT 1) AS author_display
         FROM series s
-        JOIN books_series_link bsl ON bsl.series = s.id
-        JOIN books b ON b.id = bsl.book
-        JOIN libraries l ON l.id = b.library_id
-        WHERE s.name LIKE ?2 ESCAPE '\' AND l.path = ?1
-        GROUP BY s.id, s.name
+        WHERE s.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (
+            SELECT 1 FROM books_series_link bsl
+              JOIN books b ON b.id = bsl.book
+              JOIN libraries l ON l.id = b.library_id
+             WHERE bsl.series = s.id AND l.path = ?1
+          )
         ORDER BY book_count DESC, s.name
         LIMIT ?3
         "#,
@@ -6652,6 +6681,143 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn palette_series_count_reflects_overrides() {
+        // F5.1: same shape as palette_author_count_reflects_overrides
+        // but for the series tile. Books moved into a series via
+        // `overrides.series` must add to the destination count; books
+        // moved out drop from the source count.
+        let _covers = CoversTempDir::new("palette_series_count_overrides");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "a.epub",
+                    Some("A"),
+                    &["X"],
+                    &[],
+                    Some(("Series Source", "1")),
+                    None,
+                ),
+                indexed(
+                    "b.epub",
+                    Some("B"),
+                    &["X"],
+                    &[],
+                    Some(("Series Source", "2")),
+                    None,
+                ),
+                indexed(
+                    "c.epub",
+                    Some("C"),
+                    &["X"],
+                    &[],
+                    Some(("Series Dest", "1")),
+                    None,
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+
+        // Move a.epub from Series Source to Series Dest via override.
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let a = books.iter().find(|b| b.filename == "a.epub").unwrap();
+        let uuid = a.unique_identifier.clone().unwrap();
+        let ov = MetadataOverrides {
+            series: Some("Series Dest".into()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        // "Series" matches both names.
+        let results = search_palette(&pool, "/lib", "Series").await.unwrap();
+        let source = results
+            .series
+            .iter()
+            .find(|s| s.name == "Series Source")
+            .expect("Series Source still visible (canonical anchor remains)");
+        assert_eq!(
+            source.book_count, 1,
+            "Series Source should count only b.epub after a.epub is overridden away, got {results:?}",
+        );
+        let dest = results
+            .series
+            .iter()
+            .find(|s| s.name == "Series Dest")
+            .expect("Series Dest present");
+        assert_eq!(
+            dest.book_count, 2,
+            "Series Dest should count its canonical c.epub plus the override-moved a.epub, got {results:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn palette_series_author_display_reflects_override() {
+        // F5.1: the "by X" line on a series tile must follow the first
+        // book's effective creator, not the canonical one — otherwise
+        // renaming the author through the metadata edit form leaves the
+        // palette showing the old name.
+        let _covers = CoversTempDir::new("palette_series_author_display");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "k1.epub",
+                Some("K1"),
+                &["Old Name"],
+                &[],
+                Some(("Kingsway", "1")),
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let uuid = books[0].unique_identifier.clone().unwrap();
+
+        let ov = MetadataOverrides {
+            creators: Some(vec![Contributor {
+                name: "New Name".into(),
+                role: Some("aut".into()),
+                file_as: None,
+                id: None,
+            }]),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+            .await
+            .unwrap();
+
+        let results = search_palette(&pool, "/lib", "Kingsway").await.unwrap();
+        let kingsway = results
+            .series
+            .iter()
+            .find(|s| s.name == "Kingsway")
+            .expect("Kingsway present");
+        assert_eq!(
+            kingsway.author_display.as_deref(),
+            Some("New Name"),
+            "palette author line must follow override.creators, got {results:?}",
+        );
+    }
+
     /// #127: capture `EXPLAIN QUERY PLAN` for each of the three rewritten
     /// taxonomy queries and assert the planner uses the link-table indexes.
     /// This is a structural check — it doesn't pin the literal plan string
@@ -6710,16 +6876,30 @@ mod tests {
             "authors plan should not full-scan the link table:\n{plan}"
         );
 
-        // Series
+        // Series — override-aware count + author_display, must still drive
+        // through the `books_series_link` index for visibility and the
+        // no-override branch of the CASE.
         let plan = plan_text(
             &pool,
-            "SELECT s.id, s.name, COUNT(*) AS book_count \
+            "SELECT s.id, s.name, \
+              (SELECT COUNT(*) FROM books b \
+                 JOIN libraries l2 ON l2.id = b.library_id \
+                 LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
+                WHERE l2.path = ?1 \
+                  AND CASE \
+                        WHEN mo.book_uuid IS NOT NULL \
+                             AND json_type(mo.overrides, '$.series') IS NOT NULL \
+                          THEN json_extract(mo.overrides, '$.series') = s.name \
+                        ELSE EXISTS (SELECT 1 FROM books_series_link bsl \
+                                      WHERE bsl.book = b.id AND bsl.series = s.id) \
+                      END \
+              ) AS book_count \
              FROM series s \
-             JOIN books_series_link bsl ON bsl.series = s.id \
-             JOIN books b ON b.id = bsl.book \
-             JOIN libraries l ON l.id = b.library_id \
-             WHERE s.name LIKE ?2 ESCAPE '\\' AND l.path = ?1 \
-             GROUP BY s.id, s.name \
+             WHERE s.name LIKE ?2 ESCAPE '\\' \
+               AND EXISTS (SELECT 1 FROM books_series_link bsl \
+                             JOIN books b ON b.id = bsl.book \
+                             JOIN libraries l ON l.id = b.library_id \
+                            WHERE bsl.series = s.id AND l.path = ?1) \
              ORDER BY book_count DESC, s.name \
              LIMIT ?3",
         )


### PR DESCRIPTION
## Summary
F5.1 overrides only write JSON into `metadata_overrides`, never the relational link tables. Read paths that joined canonical link tables directly missed overridden books. Applies the same overlay pattern (`LEFT JOIN metadata_overrides` + `CASE` on `json_type`) to:

- `get_series` / `get_author` — book lists.
- `get_book` + bulk callers — backfill missing creator `id` from `authors.name` so author links render.
- Search palette author/series/tag counts, series byline, and the `/tags` cloud counts.

Link tables stay untouched — revert via `delete_metadata_overrides` still restores cleanly.

## Test plan
- [x] `cargo test -p omnibus-db` — 229 passing (12 new tests).
- [x] `cargo fmt` + `cargo clippy` clean.
- [x] Verified against live DB.