### PR TITLE
feat(authors): add author profile photos (F1.11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,13 +60,14 @@ lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection
 ### db/src/
 
 ```
-lib.rs              — re-exports queries::*; pub mod auth/ebook/indexer/library_layout/queries/scanner/worker
-queries.rs          — pool init, schema, query layer (list_books, settings, covers, taxonomy, metadata_overrides CRUD + merge…)
+lib.rs              — re-exports queries::*; pub mod auth/author_photos/ebook/indexer/library_layout/queries/scanner/worker
+queries.rs          — pool init, schema, query layer (list_books, settings, covers, taxonomy, metadata_overrides CRUD + merge, author_photos CRUD…)
 scanner.rs          — library directory scanning
 ebook.rs            — EPUB OPF metadata + cover extraction; sidecar-first cover with opt-in materialization (ScanOptions)
 indexer.rs          — scan → DB indexing, staleness checks (is_stale + reindex); reindex opts into materialize_sidecars
 library_layout.rs   — F0.6 canonical layout: slugify, canonical_path, sidecar_cover_for, allocate_canonical_path (collision suffix)
-worker.rs           — single-process Worker primitive: per-task-type concurrency cap + per-resource keyed mutex; reindexes route through Task::Scan
+worker.rs           — single-process Worker primitive: per-task-type concurrency cap + per-resource keyed mutex; reindexes route through Task::Scan; F1.11 ResolveAuthorPhoto dispatches into author_photos::resolve
+author_photos.rs    — F1.11 author profile photo cascade (manual → Open Library → letter); injectable `OpenLibraryConfig` for tests (wiremock). First outbound HTTP in the codebase (reqwest, rustls-tls).
 migrations/         — numbered SQL migrations embedded via sqlx::migrate!
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df27b8d5ddb458c5fb1bbc1ce172d4a38c614a97d550b0ac89003897fb01de4"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +909,24 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -2565,6 +2593,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3641,6 +3675,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,6 +3856,7 @@ dependencies = [
  "image",
  "omnibus-shared",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -3820,7 +3865,9 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "urlencoding",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -6186,6 +6233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7082,6 +7135,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -53,5 +53,15 @@ ammonia = "4"
 # is fixed by RFC 4122.
 uuid = { version = "1", features = ["v5"] }
 
+# F1.11 author profile photos: outbound HTTP for the Open Library resolver
+# (`db::author_photos`). `rustls-tls` matches the rest of our async TLS
+# choices (sqlx uses `runtime-tokio-rustls`) so we don't pull in OpenSSL.
+# `json` is needed to deserialize the `/search/authors.json` response.
+# This is the only outbound HTTP in the codebase — keep it scoped to the
+# resolver module.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+urlencoding = "2"
+
 [dev-dependencies]
 tempfile.workspace = true
+wiremock = "0.6"

--- a/db/migrations/0008_author_photos.sql
+++ b/db/migrations/0008_author_photos.sql
@@ -15,5 +15,13 @@ CREATE TABLE author_photos (
     url         TEXT,
     bytes       BLOB,
     mime        TEXT,
-    fetched_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    -- Invariant: a 'letter' marker is a negative-cache hit and carries no
+    -- image bytes; non-letter sources must carry both bytes and mime. Enforced
+    -- at the schema level so `get_author_photo` / `AuthorDetail.has_photo` can
+    -- trust the row shape without special-casing malformed rows.
+    CHECK (
+        (source =  'letter' AND bytes IS NULL     AND mime IS NULL)
+     OR (source <> 'letter' AND bytes IS NOT NULL AND mime IS NOT NULL)
+    )
 );

--- a/db/migrations/0008_author_photos.sql
+++ b/db/migrations/0008_author_photos.sql
@@ -1,0 +1,19 @@
+-- F1.11 Author profile pictures.
+--
+-- Cache for resolved author profile photos. One row per author; rows are
+-- created/replaced by the `Task::ResolveAuthorPhoto` worker or by admin
+-- upload through `PUT /api/authors/:id/photo`.
+--
+-- `source = 'letter'` is a negative-cache marker — `bytes` and `mime` are
+-- NULL and the GET handler 404s, leaving the typographic letter avatar in
+-- place. Admin DELETE removes the row so the next view re-queues
+-- resolution (i.e. cache invalidation is admin-driven only — see the
+-- F1.11 roadmap for the rationale).
+CREATE TABLE author_photos (
+    author_id   INTEGER PRIMARY KEY REFERENCES authors(id) ON DELETE CASCADE,
+    source      TEXT NOT NULL CHECK (source IN ('manual', 'openlibrary', 'letter')),
+    url         TEXT,
+    bytes       BLOB,
+    mime        TEXT,
+    fetched_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/db/src/author_photos.rs
+++ b/db/src/author_photos.rs
@@ -75,8 +75,14 @@ struct AuthorSearchHit {
 ///      previous resolution wins).
 ///   2. If a `letter` row exists, no-op (sticky negative cache).
 ///   3. Look up the author's name and query Open Library.
-///   4. Persist either an `openlibrary` row with bytes, or a `letter`
-///      marker on any miss.
+///   4. On a hit: persist an `openlibrary` row with bytes.
+///      On a clean miss (search returned no docs, cover endpoint 404,
+///      image smaller than [`MIN_IMAGE_BYTES`], non-image MIME): write a
+///      sticky `letter` marker.
+///      On a transient error (network failure, JSON decode error, etc.):
+///      leave the row absent so the next page view can retry. Otherwise a
+///      single Open Library outage would permanently brick resolution for
+///      that author until an admin cleared it.
 pub async fn resolve(pool: &SqlitePool, author_id: i64) -> Result<(), sqlx::Error> {
     resolve_with(pool, author_id, &OpenLibraryConfig::default()).await
 }
@@ -113,17 +119,20 @@ pub async fn resolve_with(
             .await?;
         }
         Ok(None) => {
+            // Clean miss — Open Library has nothing for this name. Record
+            // a sticky `letter` marker so we don't re-query on every view.
             upsert_author_photo(pool, author_id, AuthorPhotoSource::Letter, None, None, None)
                 .await?;
         }
         Err(e) => {
+            // Transient network / decode failure — leave the row absent so a
+            // later page view (or scan) can retry. Logged so an outage is
+            // still visible in the worker log.
             tracing::warn!(
                 author_id,
                 error = %e,
-                "open library resolution failed; writing letter marker"
+                "open library resolution failed (transient); leaving row absent for retry"
             );
-            upsert_author_photo(pool, author_id, AuthorPhotoSource::Letter, None, None, None)
-                .await?;
         }
     }
     Ok(())
@@ -366,5 +375,26 @@ mod tests {
 
         let (src, _) = author_photo_status(&pool, id).await.unwrap().unwrap();
         assert_eq!(src, AuthorPhotoSource::Manual);
+    }
+
+    #[tokio::test]
+    async fn resolve_leaves_row_absent_on_transient_network_error() {
+        // Point the resolver at a TCP port that nothing is listening on so
+        // every request errors at the transport layer. A transient outage
+        // must NOT cache a `letter` marker — the next call should be free
+        // to retry, not stuck for an admin to manually clear.
+        let cfg = OpenLibraryConfig {
+            base_search_url: "http://127.0.0.1:1".into(),
+            base_covers_url: "http://127.0.0.1:1".into(),
+            timeout: Duration::from_millis(500),
+            user_agent: "omnibus-test".into(),
+        };
+        let (pool, id) = pool_with_author("Ada Lovelace").await;
+        resolve_with(&pool, id, &cfg).await.unwrap();
+
+        assert!(
+            author_photo_status(&pool, id).await.unwrap().is_none(),
+            "transient network error must leave the row absent for retry"
+        );
     }
 }

--- a/db/src/author_photos.rs
+++ b/db/src/author_photos.rs
@@ -1,0 +1,370 @@
+//! F1.11 Author profile photo resolver.
+//!
+//! Runs the manual → Open Library → letter cascade for a given author and
+//! persists the result in `author_photos`. Driven by
+//! [`crate::worker::Task::ResolveAuthorPhoto`], which gives us:
+//!   - at most one in-flight resolution per author (per-resource keyed
+//!     mutex),
+//!   - background execution, so the page renders the letter avatar
+//!     immediately and upgrades on the next visit.
+//!
+//! Cache semantics: a `'letter'` row is written on any miss (network
+//! error, Open Library has no match, sub-1KB image, non-image bytes) and
+//! sticks until an admin clears it via `DELETE /api/authors/:id/photo`.
+//! This keeps a single page-view from costing two HTTP round-trips on
+//! every refresh for authors who genuinely have no Open Library entry.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use sqlx::SqlitePool;
+
+use crate::queries::{author_photo_status, upsert_author_photo, AuthorPhotoSource};
+
+/// Injection points for tests. Production builds construct `default()` and
+/// hit the real Open Library endpoints.
+#[derive(Debug, Clone)]
+pub struct OpenLibraryConfig {
+    /// `https://openlibrary.org` in production. Tests point this at a
+    /// `wiremock` server.
+    pub base_search_url: String,
+    /// `https://covers.openlibrary.org` in production. Separate from
+    /// `base_search_url` because Open Library serves search and covers on
+    /// different hostnames.
+    pub base_covers_url: String,
+    pub timeout: Duration,
+    pub user_agent: String,
+}
+
+impl Default for OpenLibraryConfig {
+    fn default() -> Self {
+        Self {
+            base_search_url: "https://openlibrary.org".into(),
+            base_covers_url: "https://covers.openlibrary.org".into(),
+            timeout: Duration::from_secs(5),
+            user_agent: format!(
+                "omnibus/{} (https://github.com/sloansa/omnibus)",
+                env!("CARGO_PKG_VERSION")
+            ),
+        }
+    }
+}
+
+/// Minimum image size in bytes that we'll accept as a real photo. Open
+/// Library returns a tiny placeholder when an OLID has no cover and we
+/// forgot to set `default=false` — guard against the case anyway.
+const MIN_IMAGE_BYTES: usize = 1024;
+
+#[derive(Debug, Deserialize)]
+struct AuthorSearchResponse {
+    #[serde(default)]
+    docs: Vec<AuthorSearchHit>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthorSearchHit {
+    /// e.g. `"OL23919A"` — Open Library author id.
+    #[serde(default)]
+    key: Option<String>,
+}
+
+/// Resolve and persist a profile photo for `author_id`.
+///
+/// Cascade:
+///   1. If a non-letter row already exists, no-op (the admin upload or
+///      previous resolution wins).
+///   2. If a `letter` row exists, no-op (sticky negative cache).
+///   3. Look up the author's name and query Open Library.
+///   4. Persist either an `openlibrary` row with bytes, or a `letter`
+///      marker on any miss.
+pub async fn resolve(pool: &SqlitePool, author_id: i64) -> Result<(), sqlx::Error> {
+    resolve_with(pool, author_id, &OpenLibraryConfig::default()).await
+}
+
+pub async fn resolve_with(
+    pool: &SqlitePool,
+    author_id: i64,
+    config: &OpenLibraryConfig,
+) -> Result<(), sqlx::Error> {
+    // Existing row wins. `'letter'` markers are sticky so we don't re-hit
+    // Open Library for authors with no entry on every page view.
+    if author_photo_status(pool, author_id).await?.is_some() {
+        return Ok(());
+    }
+
+    let name: Option<String> = sqlx::query_scalar("SELECT name FROM authors WHERE id = ?")
+        .bind(author_id)
+        .fetch_optional(pool)
+        .await?;
+    let Some(name) = name else {
+        return Ok(());
+    };
+
+    match fetch_open_library(&name, config).await {
+        Ok(Some((url, mime, bytes))) => {
+            upsert_author_photo(
+                pool,
+                author_id,
+                AuthorPhotoSource::OpenLibrary,
+                Some(&url),
+                Some(&mime),
+                Some(&bytes),
+            )
+            .await?;
+        }
+        Ok(None) => {
+            upsert_author_photo(pool, author_id, AuthorPhotoSource::Letter, None, None, None)
+                .await?;
+        }
+        Err(e) => {
+            tracing::warn!(
+                author_id,
+                error = %e,
+                "open library resolution failed; writing letter marker"
+            );
+            upsert_author_photo(pool, author_id, AuthorPhotoSource::Letter, None, None, None)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+/// Two-step Open Library lookup. Returns `(canonical_url, mime, bytes)` on
+/// a hit, `None` on a clean miss, or `Err` on a network / decode error.
+async fn fetch_open_library(
+    name: &str,
+    config: &OpenLibraryConfig,
+) -> Result<Option<(String, String, Vec<u8>)>, reqwest::Error> {
+    let client = reqwest::Client::builder()
+        .timeout(config.timeout)
+        .user_agent(&config.user_agent)
+        .build()?;
+
+    // Step 1: search for an OLID by name.
+    let search_url = format!(
+        "{}/search/authors.json?q={}",
+        config.base_search_url.trim_end_matches('/'),
+        urlencoding::encode(name)
+    );
+    let resp = client.get(&search_url).send().await?;
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+    let body: AuthorSearchResponse = resp.json().await?;
+    let Some(olid) = body
+        .docs
+        .into_iter()
+        .find_map(|d| d.key.filter(|k| !k.is_empty()))
+    else {
+        return Ok(None);
+    };
+
+    // Step 2: fetch the cover. `default=false` makes Open Library return a
+    // 404 instead of a 1x1 placeholder when the OLID has no photo.
+    let cover_url = format!(
+        "{}/a/olid/{}-L.jpg?default=false",
+        config.base_covers_url.trim_end_matches('/'),
+        olid
+    );
+    let resp = client.get(&cover_url).send().await?;
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "image/jpeg".into());
+    if !content_type.starts_with("image/") {
+        return Ok(None);
+    }
+    let bytes = resp.bytes().await?.to_vec();
+    if bytes.len() < MIN_IMAGE_BYTES {
+        return Ok(None);
+    }
+    Ok(Some((cover_url, content_type, bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::queries::{get_author_photo, init_db};
+    use wiremock::{
+        matchers::{method, path, query_param},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    async fn pool_with_author(name: &str) -> (SqlitePool, i64) {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let id: i64 =
+            sqlx::query_scalar("INSERT INTO authors (name, sort) VALUES (?, ?) RETURNING id")
+                .bind(name)
+                .bind(name)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        (pool, id)
+    }
+
+    fn config_for(server: &MockServer) -> OpenLibraryConfig {
+        OpenLibraryConfig {
+            base_search_url: server.uri(),
+            base_covers_url: server.uri(),
+            timeout: Duration::from_secs(2),
+            user_agent: "omnibus-test".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_writes_open_library_hit() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/authors.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "docs": [ { "key": "OL23919A" } ]
+            })))
+            .mount(&server)
+            .await;
+        // 2 KB of bytes so the MIN_IMAGE_BYTES guard passes.
+        let payload = vec![0xABu8; 2048];
+        Mock::given(method("GET"))
+            .and(path("/a/olid/OL23919A-L.jpg"))
+            .and(query_param("default", "false"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/jpeg")
+                    .set_body_bytes(payload.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let (pool, id) = pool_with_author("Ada Lovelace").await;
+        let cfg = config_for(&server);
+        resolve_with(&pool, id, &cfg).await.unwrap();
+
+        let (mime, bytes) = get_author_photo(&pool, id).await.unwrap().unwrap();
+        assert_eq!(mime, "image/jpeg");
+        assert_eq!(bytes, payload);
+        let (src, _) = author_photo_status(&pool, id).await.unwrap().unwrap();
+        assert_eq!(src, AuthorPhotoSource::OpenLibrary);
+    }
+
+    #[tokio::test]
+    async fn resolve_writes_letter_when_search_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/authors.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "docs": []
+            })))
+            .mount(&server)
+            .await;
+
+        let (pool, id) = pool_with_author("Nobody In Particular").await;
+        let cfg = config_for(&server);
+        resolve_with(&pool, id, &cfg).await.unwrap();
+
+        assert!(get_author_photo(&pool, id).await.unwrap().is_none());
+        let (src, _) = author_photo_status(&pool, id).await.unwrap().unwrap();
+        assert_eq!(src, AuthorPhotoSource::Letter);
+    }
+
+    #[tokio::test]
+    async fn resolve_writes_letter_when_cover_missing() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/authors.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "docs": [ { "key": "OL999A" } ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/a/olid/OL999A-L.jpg"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let (pool, id) = pool_with_author("Ada Lovelace").await;
+        let cfg = config_for(&server);
+        resolve_with(&pool, id, &cfg).await.unwrap();
+
+        let (src, _) = author_photo_status(&pool, id).await.unwrap().unwrap();
+        assert_eq!(src, AuthorPhotoSource::Letter);
+    }
+
+    #[tokio::test]
+    async fn resolve_writes_letter_when_image_too_small() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/authors.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "docs": [ { "key": "OL1A" } ]
+            })))
+            .mount(&server)
+            .await;
+        // Tiny placeholder (well under MIN_IMAGE_BYTES) — should be treated
+        // as a miss.
+        Mock::given(method("GET"))
+            .and(path("/a/olid/OL1A-L.jpg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/gif")
+                    .set_body_bytes(vec![0u8; 42]),
+            )
+            .mount(&server)
+            .await;
+
+        let (pool, id) = pool_with_author("Ada Lovelace").await;
+        let cfg = config_for(&server);
+        resolve_with(&pool, id, &cfg).await.unwrap();
+
+        let (src, _) = author_photo_status(&pool, id).await.unwrap().unwrap();
+        assert_eq!(src, AuthorPhotoSource::Letter);
+    }
+
+    #[tokio::test]
+    async fn resolve_is_noop_when_letter_marker_exists() {
+        // Existing letter marker must prevent any HTTP call. We assert this
+        // by starting a mock server with *no* mounted responses — any
+        // incoming request would 404 and we'd notice via the marker source
+        // not changing.
+        let server = MockServer::start().await;
+        let (pool, id) = pool_with_author("Ada Lovelace").await;
+        upsert_author_photo(&pool, id, AuthorPhotoSource::Letter, None, None, None)
+            .await
+            .unwrap();
+        let cfg = config_for(&server);
+        resolve_with(&pool, id, &cfg).await.unwrap();
+
+        let (src, _) = author_photo_status(&pool, id).await.unwrap().unwrap();
+        assert_eq!(src, AuthorPhotoSource::Letter);
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            0,
+            "letter marker must skip the network entirely"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_is_noop_when_manual_upload_exists() {
+        let server = MockServer::start().await;
+        let (pool, id) = pool_with_author("Ada Lovelace").await;
+        upsert_author_photo(
+            &pool,
+            id,
+            AuthorPhotoSource::Manual,
+            None,
+            Some("image/jpeg"),
+            Some(b"\xFF\xD8\xFFmanual"),
+        )
+        .await
+        .unwrap();
+        let cfg = config_for(&server);
+        resolve_with(&pool, id, &cfg).await.unwrap();
+
+        let (src, _) = author_photo_status(&pool, id).await.unwrap().unwrap();
+        assert_eq!(src, AuthorPhotoSource::Manual);
+    }
+}

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -5,6 +5,7 @@
 //! `feature = "server"`).
 
 pub mod auth;
+pub mod author_photos;
 pub mod ebook;
 pub mod indexer;
 pub mod library_layout;

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2272,11 +2272,18 @@ pub async fn get_author_photo(
     pool: &SqlitePool,
     author_id: i64,
 ) -> Result<Option<(String, Vec<u8>)>, sqlx::Error> {
-    let row: Option<(String, Option<String>, Option<Vec<u8>>)> =
-        sqlx::query_as("SELECT source, mime, bytes FROM author_photos WHERE author_id = ?")
-            .bind(author_id)
-            .fetch_optional(pool)
-            .await?;
+    // Filter `letter` rows in SQL as well as via the schema CHECK constraint
+    // so a malformed row (e.g. left over from a future migration drift)
+    // can never accidentally serve `letter` bytes as a real image. Belt +
+    // suspenders alongside the table-level invariant.
+    let row: Option<(String, Option<String>, Option<Vec<u8>>)> = sqlx::query_as(
+        "SELECT source, mime, bytes
+           FROM author_photos
+          WHERE author_id = ? AND source <> 'letter'",
+    )
+    .bind(author_id)
+    .fetch_optional(pool)
+    .await?;
     match row {
         Some((_, Some(mime), Some(bytes))) if !bytes.is_empty() => Ok(Some((mime, bytes))),
         _ => Ok(None),

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2197,13 +2197,147 @@ pub async fn get_author(
     }
     backfill_creator_ids(pool, &mut books).await?;
 
+    // F1.11: surface whether a usable profile photo is cached so the
+    // frontend can render <img> vs the typographic letter avatar in one
+    // round trip. `'letter'` rows are the negative-cache marker and do
+    // not count as a usable photo.
+    let has_photo: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+             SELECT 1 FROM author_photos
+              WHERE author_id = ?
+                AND source IN ('manual', 'openlibrary')
+                AND bytes IS NOT NULL
+         )",
+    )
+    .bind(author_id)
+    .fetch_one(pool)
+    .await?;
+
     Ok(Some(AuthorDetail {
         id: a.get("id"),
         name: a.get("name"),
         sort: a.get("sort"),
         book_count: books.len(),
         books,
+        has_photo,
     }))
+}
+
+// -----------------------------------------------------------------------------
+// F1.11 Author profile photos.
+//
+// `author_photos` holds at most one row per author (PK = author_id). The
+// `source` column distinguishes:
+//   - `'manual'`     — admin upload via `PUT /api/authors/:id/photo`.
+//   - `'openlibrary'`— resolved by the background worker.
+//   - `'letter'`     — negative-cache marker: no usable image. `bytes` and
+//                       `mime` are NULL; `get_author_photo` returns `None`
+//                       so the GET handler 404s and the letter avatar
+//                       stays in place.
+// Admin DELETE clears the row to force re-resolution on next view.
+// -----------------------------------------------------------------------------
+
+/// Source-of-truth marker for a cached author photo row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorPhotoSource {
+    Manual,
+    OpenLibrary,
+    Letter,
+}
+
+impl AuthorPhotoSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AuthorPhotoSource::Manual => "manual",
+            AuthorPhotoSource::OpenLibrary => "openlibrary",
+            AuthorPhotoSource::Letter => "letter",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "manual" => Some(Self::Manual),
+            "openlibrary" => Some(Self::OpenLibrary),
+            "letter" => Some(Self::Letter),
+            _ => None,
+        }
+    }
+}
+
+/// Fetch a cached profile photo for the given author. Returns `None` when no
+/// row exists or the row is a `'letter'` negative-cache marker — both cases
+/// should produce a 404 from the GET handler so the frontend keeps rendering
+/// the letter avatar.
+pub async fn get_author_photo(
+    pool: &SqlitePool,
+    author_id: i64,
+) -> Result<Option<(String, Vec<u8>)>, sqlx::Error> {
+    let row: Option<(String, Option<String>, Option<Vec<u8>>)> =
+        sqlx::query_as("SELECT source, mime, bytes FROM author_photos WHERE author_id = ?")
+            .bind(author_id)
+            .fetch_optional(pool)
+            .await?;
+    match row {
+        Some((_, Some(mime), Some(bytes))) if !bytes.is_empty() => Ok(Some((mime, bytes))),
+        _ => Ok(None),
+    }
+}
+
+/// Look up just the cascade-state metadata (source + fetched_at) for an
+/// author. Used by the resolver to decide whether to skip resolution — a
+/// `'letter'` row prevents re-querying Open Library until an admin clears it
+/// via `delete_author_photo`.
+pub async fn author_photo_status(
+    pool: &SqlitePool,
+    author_id: i64,
+) -> Result<Option<(AuthorPhotoSource, String)>, sqlx::Error> {
+    let row: Option<(String, String)> =
+        sqlx::query_as("SELECT source, fetched_at FROM author_photos WHERE author_id = ?")
+            .bind(author_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.and_then(|(s, t)| AuthorPhotoSource::parse(&s).map(|src| (src, t))))
+}
+
+/// Upsert a photo row. Replaces any existing row (PRIMARY KEY conflict on
+/// `author_id`). `bytes` / `mime` are `None` for `'letter'` negative-cache
+/// markers; `url` is `None` for manual uploads.
+pub async fn upsert_author_photo(
+    pool: &SqlitePool,
+    author_id: i64,
+    source: AuthorPhotoSource,
+    url: Option<&str>,
+    mime: Option<&str>,
+    bytes: Option<&[u8]>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO author_photos (author_id, source, url, mime, bytes, fetched_at)
+              VALUES (?, ?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(author_id) DO UPDATE SET
+              source     = excluded.source,
+              url        = excluded.url,
+              mime       = excluded.mime,
+              bytes      = excluded.bytes,
+              fetched_at = excluded.fetched_at",
+    )
+    .bind(author_id)
+    .bind(source.as_str())
+    .bind(url)
+    .bind(mime)
+    .bind(bytes)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Drop the cache row for an author so the next page view re-queues
+/// resolution. Used by admin DELETE.
+pub async fn delete_author_photo(pool: &SqlitePool, author_id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM author_photos WHERE author_id = ?")
+        .bind(author_id)
+        .execute(pool)
+        .await?;
+    Ok(())
 }
 
 /// Fetch a series by ID with all its books, ordered by series index.
@@ -8133,5 +8267,134 @@ mod tests {
             !dir.exists(),
             "purge must not create the covers dir as a side effect",
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // F1.11 author profile photo tests
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn author_photo_roundtrips_manual_upload() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        let bytes = b"\xFF\xD8\xFFfake-jpeg".to_vec();
+        upsert_author_photo(
+            &pool,
+            ada_id,
+            AuthorPhotoSource::Manual,
+            None,
+            Some("image/jpeg"),
+            Some(&bytes),
+        )
+        .await
+        .unwrap();
+
+        let (mime, fetched) = get_author_photo(&pool, ada_id).await.unwrap().unwrap();
+        assert_eq!(mime, "image/jpeg");
+        assert_eq!(fetched, bytes);
+    }
+
+    #[tokio::test]
+    async fn author_photo_letter_marker_returns_none() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        upsert_author_photo(&pool, ada_id, AuthorPhotoSource::Letter, None, None, None)
+            .await
+            .unwrap();
+
+        assert!(get_author_photo(&pool, ada_id).await.unwrap().is_none());
+
+        let (src, _) = author_photo_status(&pool, ada_id).await.unwrap().unwrap();
+        assert_eq!(src, AuthorPhotoSource::Letter);
+    }
+
+    #[tokio::test]
+    async fn author_photo_status_none_when_unset() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+        assert!(author_photo_status(&pool, ada_id).await.unwrap().is_none());
+        assert!(get_author_photo(&pool, ada_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn author_photo_upsert_replaces_existing_row() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        // Letter marker first, then a manual upload replaces it.
+        upsert_author_photo(&pool, ada_id, AuthorPhotoSource::Letter, None, None, None)
+            .await
+            .unwrap();
+        upsert_author_photo(
+            &pool,
+            ada_id,
+            AuthorPhotoSource::Manual,
+            None,
+            Some("image/png"),
+            Some(b"\x89PNG\r\n\x1a\nfake"),
+        )
+        .await
+        .unwrap();
+
+        let (src, _) = author_photo_status(&pool, ada_id).await.unwrap().unwrap();
+        assert_eq!(src, AuthorPhotoSource::Manual);
+        let (mime, _) = get_author_photo(&pool, ada_id).await.unwrap().unwrap();
+        assert_eq!(mime, "image/png");
+    }
+
+    #[tokio::test]
+    async fn author_photo_delete_clears_row() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        upsert_author_photo(
+            &pool,
+            ada_id,
+            AuthorPhotoSource::Manual,
+            None,
+            Some("image/jpeg"),
+            Some(b"\xFF\xD8\xFFfoo"),
+        )
+        .await
+        .unwrap();
+        delete_author_photo(&pool, ada_id).await.unwrap();
+
+        assert!(author_photo_status(&pool, ada_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn get_author_populates_has_photo() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        // No row → false.
+        let ada = get_author(&pool, ada_id).await.unwrap().unwrap();
+        assert!(!ada.has_photo, "no row should yield has_photo = false");
+
+        // Letter marker → still false (negative-cache shouldn't render an img).
+        upsert_author_photo(&pool, ada_id, AuthorPhotoSource::Letter, None, None, None)
+            .await
+            .unwrap();
+        let ada = get_author(&pool, ada_id).await.unwrap().unwrap();
+        assert!(
+            !ada.has_photo,
+            "letter marker should yield has_photo = false"
+        );
+
+        // Manual upload → true.
+        upsert_author_photo(
+            &pool,
+            ada_id,
+            AuthorPhotoSource::Manual,
+            None,
+            Some("image/jpeg"),
+            Some(b"\xFF\xD8\xFFfake"),
+        )
+        .await
+        .unwrap();
+        let ada = get_author(&pool, ada_id).await.unwrap().unwrap();
+        assert!(ada.has_photo, "manual upload should yield has_photo = true");
     }
 }

--- a/db/src/worker.rs
+++ b/db/src/worker.rs
@@ -22,6 +22,13 @@ pub enum Task {
         book_id: i64,
         last_modified_epoch: i64,
     },
+    /// F1.11: resolve and cache an author's profile photo. The resolver
+    /// hits Open Library at most once per author per (admin-DELETE-able)
+    /// cache window; a `'letter'` marker is written on any miss so future
+    /// page views skip the network entirely.
+    ResolveAuthorPhoto {
+        author_id: i64,
+    },
     #[cfg(test)]
     Test {
         tag: &'static str,
@@ -38,6 +45,7 @@ impl Task {
         match self {
             Task::Scan { library_path } => Some(library_path.clone()),
             Task::GenerateThumbs { book_id, .. } => Some(format!("thumb:{book_id}")),
+            Task::ResolveAuthorPhoto { author_id } => Some(format!("author-photo:{author_id}")),
             #[cfg(test)]
             Task::Test { resource, .. } => resource.clone(),
         }
@@ -47,6 +55,7 @@ impl Task {
         match self {
             Task::Scan { .. } => true,
             Task::GenerateThumbs { .. } => false,
+            Task::ResolveAuthorPhoto { .. } => false,
             #[cfg(test)]
             Task::Test {
                 route_through_scan_sem,
@@ -172,6 +181,12 @@ impl Worker {
         match task {
             Task::Scan { library_path } => {
                 match crate::indexer::reindex(&self.pool, &library_path).await {
+                    Ok(()) => TaskOutcome::Ok,
+                    Err(e) => TaskOutcome::Err(e.to_string()),
+                }
+            }
+            Task::ResolveAuthorPhoto { author_id } => {
+                match crate::author_photos::resolve(&self.pool, author_id).await {
                     Ok(()) => TaskOutcome::Ok,
                     Err(e) => TaskOutcome::Err(e.to_string()),
                 }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -766,6 +766,32 @@ body.atrium,
   .disc-avatar { width: 80px; height: 80px; font-size: 36px; }
 }
 
+/* F1.11 — When the avatar is the resolved profile photo, drop the
+   typographic styling and clip the image to the circle. The `img` element
+   shares the `.disc-avatar` class so the size/border tokens stay in sync
+   with the letter variant. */
+.disc-avatar--photo {
+  object-fit: cover;
+  background: var(--bg-2);
+}
+
+/* F1.11 admin "Scan for picture" action row in the author hero. */
+.disc-hero-actions {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+.disc-scan-btn[disabled] {
+  opacity: 0.6;
+  cursor: progress;
+}
+.disc-scan-status {
+  font-size: 0.875rem;
+  color: var(--ink-2);
+}
+
 /* Stat block */
 .disc-stat-block { text-align: right; }
 .disc-stat-label { display: block; margin-bottom: 6px; }

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -11,8 +11,9 @@
 //!   web stubs so SSR-during-fullstack-render still returns sensible data.
 
 use omnibus_shared::{
-    AuthorDetail, AuthorSummary, EbookLibrary, EbookMetadata, LibraryContents, MetadataOverrides,
-    PaletteResults, SeriesDetail, SeriesSummary, Settings, TagWeight,
+    AuthorDetail, AuthorPhotoScanResult, AuthorSummary, EbookLibrary, EbookMetadata,
+    LibraryContents, MetadataOverrides, PaletteResults, SeriesDetail, SeriesSummary, Settings,
+    TagWeight,
 };
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
@@ -548,6 +549,25 @@ pub async fn get_author(server_url: &str, id: i64) -> Result<Option<AuthorDetail
         .map_err(|e| e.to_string())
 }
 
+/// F1.11: admin "Scan for picture" — synchronously re-runs the Open Library
+/// cascade and returns whether a photo was found.
+#[cfg(feature = "mobile")]
+pub async fn scan_author_photo(server_url: &str, id: i64) -> Result<AuthorPhotoScanResult, String> {
+    let url = format!("{server_url}/api/authors/{id}/photo/scan");
+    let response = with_bearer(http_client().post(&url))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    response
+        .json::<AuthorPhotoScanResult>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
 #[cfg(feature = "mobile")]
 pub async fn get_series(server_url: &str, id: i64) -> Result<Option<SeriesDetail>, String> {
     let url = format!("{server_url}/api/series/{id}");
@@ -892,6 +912,16 @@ pub async fn get_ebook(_server_url: &str, id: i64) -> Result<Option<EbookMetadat
 #[cfg(not(feature = "mobile"))]
 pub async fn get_author(_server_url: &str, id: i64) -> Result<Option<AuthorDetail>, String> {
     crate::rpc::rpc_get_author(id)
+        .await
+        .map_err(note_server_fn_err)
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn scan_author_photo(
+    _server_url: &str,
+    id: i64,
+) -> Result<AuthorPhotoScanResult, String> {
+    crate::rpc::rpc_scan_author_photo(id)
         .await
         .map_err(note_server_fn_err)
 }

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -15,6 +15,25 @@ pub fn AuthorPage(id: i64) -> Element {
     let mut author: Signal<Option<AuthorDetail>> = use_signal(|| None);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
+    // F1.11: gate the "Scan for picture" button on admin. SSR renders with
+    // `false` and the web client overwrites after `/api/auth/me` returns —
+    // matches the pattern in `top_nav::AuthControl`.
+    let is_admin = use_signal(|| false);
+    // Scan-button state: idle / scanning / a one-shot status message.
+    let scanning = use_signal(|| false);
+    let scan_status: Signal<Option<String>> = use_signal(|| None);
+
+    #[cfg(feature = "web")]
+    {
+        let mut admin_setter = is_admin;
+        use_effect(move || {
+            spawn(async move {
+                if let Ok(Some(u)) = crate::data::current_user().await {
+                    admin_setter.set(u.is_admin);
+                }
+            });
+        });
+    }
 
     // See `BookDetailPage` for why `id` needs `use_reactive!`.
     let url = server_url.clone();
@@ -51,14 +70,21 @@ pub fn AuthorPage(id: i64) -> Element {
         };
     };
 
-    render_author(a)
+    render_author(a, server_url, is_admin, scanning, scan_status, author)
 }
 
 // ---------------------------------------------------------------------------
 // View
 // ---------------------------------------------------------------------------
 
-fn render_author(a: AuthorDetail) -> Element {
+fn render_author(
+    a: AuthorDetail,
+    server_url: String,
+    is_admin: Signal<bool>,
+    mut scanning: Signal<bool>,
+    mut scan_status: Signal<Option<String>>,
+    mut author: Signal<Option<AuthorDetail>>,
+) -> Element {
     // Derive accent from the first book that has one, or fall back to theme.
     let accent = a
         .books
@@ -115,14 +141,72 @@ fn render_author(a: AuthorDetail) -> Element {
                     span { "{a.name}" }
                 }
                 div { class: "disc-hero-grid",
-                    // Avatar
-                    div { class: "disc-avatar", "{initial}" }
+                    // Avatar — letter fallback by default; F1.11 swaps in
+                    // the cached profile photo when `has_photo` is set.
+                    if a.has_photo {
+                        img {
+                            class: "disc-avatar disc-avatar--photo",
+                            src: "/api/authors/{a.id}/photo",
+                            alt: "{a.name}",
+                        }
+                    } else {
+                        div { class: "disc-avatar", "{initial}" }
+                    }
                     // Name + metadata
                     div { class: "disc-hero-info",
                         h1 { class: "disc-hero-title",
                             "{first} "
                             if !last.is_empty() {
                                 em { "{last}" }
+                            }
+                        }
+                        // F1.11 admin action: re-run the Open Library
+                        // resolver on demand. Hidden on SSR + for non-admins;
+                        // the signal flips after `/api/auth/me` returns.
+                        if is_admin() {
+                            div { class: "disc-hero-actions",
+                                button {
+                                    r#type: "button",
+                                    class: "btn btn-ghost disc-scan-btn",
+                                    disabled: scanning(),
+                                    onclick: {
+                                        let server_url = server_url.clone();
+                                        let author_id = a.id;
+                                        move |_| {
+                                            let server_url = server_url.clone();
+                                            scanning.set(true);
+                                            scan_status.set(None);
+                                            spawn(async move {
+                                                let result = data::scan_author_photo(&server_url, author_id).await;
+                                                match result {
+                                                    Ok(r) if r.resolved => {
+                                                        scan_status.set(Some("Photo found.".into()));
+                                                        // Re-fetch so `has_photo`
+                                                        // flips and the <img>
+                                                        // renders on this view.
+                                                        if let Ok(a2) = data::get_author(&server_url, author_id).await {
+                                                            author.set(a2);
+                                                        }
+                                                    }
+                                                    Ok(_) => scan_status.set(Some(
+                                                        "No photo on Open Library for this author.".into(),
+                                                    )),
+                                                    Err(e) => scan_status.set(Some(format!("Scan failed: {e}"))),
+                                                }
+                                                scanning.set(false);
+                                            });
+                                        }
+                                    },
+                                    if scanning() { "Scanning\u{2026}" } else { "Scan for picture" }
+                                }
+                                if let Some(msg) = scan_status() {
+                                    span {
+                                        class: "disc-scan-status",
+                                        role: "status",
+                                        "data-testid": "scan-status",
+                                        "{msg}"
+                                    }
+                                }
                             }
                         }
                     }

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -146,7 +146,11 @@ fn render_author(
                     if a.has_photo {
                         img {
                             class: "disc-avatar disc-avatar--photo",
-                            src: "/api/authors/{a.id}/photo",
+                            // Prefix with `server_url` so mobile WebViews
+                            // hit the configured backend origin instead of
+                            // the in-app document origin. `server_url` is
+                            // empty on web, so this is a no-op there.
+                            src: "{server_url}/api/authors/{a.id}/photo",
                             alt: "{a.name}",
                         }
                     } else {
@@ -179,19 +183,22 @@ fn render_author(
                                             spawn(async move {
                                                 let result = data::scan_author_photo(&server_url, author_id).await;
                                                 match result {
-                                                    Ok(r) if r.resolved => {
-                                                        scan_status.set(Some("Photo found.".into()));
-                                                        // Re-fetch so `has_photo`
-                                                        // flips and the <img>
-                                                        // renders on this view.
-                                                        if let Ok(a2) = data::get_author(&server_url, author_id).await {
-                                                            author.set(a2);
-                                                        }
-                                                    }
-                                                    Ok(_) => scan_status.set(Some(
-                                                        "No photo on Open Library for this author.".into(),
-                                                    )),
+                                                    Ok(r) => scan_status.set(Some(if r.resolved {
+                                                        "Photo found.".into()
+                                                    } else {
+                                                        "No photo on Open Library for this author.".into()
+                                                    })),
                                                     Err(e) => scan_status.set(Some(format!("Scan failed: {e}"))),
+                                                }
+                                                // Re-fetch on every outcome so the hero
+                                                // matches server state. Scan deletes the
+                                                // existing row before resolving, so a miss
+                                                // (or even a transient error) means the
+                                                // photo we used to show may no longer
+                                                // exist and the letter needs to come
+                                                // back.
+                                                if let Ok(a2) = data::get_author(&server_url, author_id).await {
+                                                    author.set(a2);
                                                 }
                                                 scanning.set(false);
                                             });

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -275,9 +275,7 @@ pub async fn rpc_scan_author_photo(id: i64) -> Result<AuthorPhotoScanResult> {
         return Err(ServerFnError::new("forbidden: admin required").into());
     }
     // Manual uploads win — don't delete or overwrite.
-    if let Some((db::AuthorPhotoSource::Manual, _)) =
-        db::author_photo_status(&pool.0, id).await?
-    {
+    if let Some((db::AuthorPhotoSource::Manual, _)) = db::author_photo_status(&pool.0, id).await? {
         return Ok(AuthorPhotoScanResult { resolved: true });
     }
     db::delete_author_photo(&pool.0, id).await?;

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -234,9 +234,23 @@ pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
 
 /// Fetch a single author and all their books. POST for the same reason as
 /// `rpc_get_ebook` — needs `id` in the body.
-#[post("/api/rpc/author", pool: PoolExt, _user: AuthUser)]
+///
+/// F1.11: queues a background `Task::ResolveAuthorPhoto` when the author has
+/// no `author_photos` row yet so first-time visits trigger Open Library
+/// resolution. A subsequent visit picks up the resolved photo (or the
+/// `letter` negative-cache marker), and the worker's per-author resource
+/// mutex prevents duplicate queueing while resolution is in flight.
+#[post("/api/rpc/author", pool: PoolExt, worker: WorkerExt, _user: AuthUser)]
 pub async fn rpc_get_author(id: i64) -> Result<Option<AuthorDetail>> {
-    Ok(db::get_author(&pool.0, id).await?)
+    let author = db::get_author(&pool.0, id).await?;
+    if let Some(ref a) = author {
+        if !a.has_photo && db::author_photo_status(&pool.0, id).await?.is_none() {
+            worker
+                .0
+                .post(db::worker::Task::ResolveAuthorPhoto { author_id: id });
+        }
+    }
+    Ok(author)
 }
 
 /// Fetch a single series and all its books (ordered by series index).
@@ -246,13 +260,25 @@ pub async fn rpc_get_series(id: i64) -> Result<Option<SeriesDetail>> {
 }
 
 /// F1.11: admin-triggered "Scan for picture" for an author. Clears any
-/// cached row (including sticky `letter` markers) and runs the Open Library
-/// resolver inline, so the admin gets a definitive "found / not found"
-/// answer in a single round-trip without polling the worker.
+/// sticky `letter` negative-cache marker and runs the Open Library resolver
+/// inline, so the admin gets a definitive "found / not found" answer in a
+/// single round-trip without polling the worker.
+///
+/// Manual uploads are treated as overrides: a `source = 'manual'` row is
+/// preserved (the F1.11 roadmap explicitly calls this out — "skips if a
+/// manual override exists"). Scan returns `resolved=true` in that case
+/// without touching the row, so admins can't accidentally wipe a manual
+/// upload by clicking the button.
 #[post("/api/rpc/author/scan-photo", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_scan_author_photo(id: i64) -> Result<AuthorPhotoScanResult> {
     if !user.is_admin {
         return Err(ServerFnError::new("forbidden: admin required").into());
+    }
+    // Manual uploads win — don't delete or overwrite.
+    if let Some((db::AuthorPhotoSource::Manual, _)) =
+        db::author_photo_status(&pool.0, id).await?
+    {
+        return Ok(AuthorPhotoScanResult { resolved: true });
     }
     db::delete_author_photo(&pool.0, id).await?;
     db::author_photos::resolve(&pool.0, id).await?;

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -16,8 +16,9 @@
 use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
 use omnibus_shared::{
-    AuthorDetail, AuthorSummary, EbookLibrary, EbookMetadata, LibraryContents, MetadataOverrides,
-    PaletteResults, SeriesDetail, SeriesSummary, Settings, TagWeight, ValueResponse,
+    AuthorDetail, AuthorPhotoScanResult, AuthorSummary, EbookLibrary, EbookMetadata,
+    LibraryContents, MetadataOverrides, PaletteResults, SeriesDetail, SeriesSummary, Settings,
+    TagWeight, ValueResponse,
 };
 
 #[cfg(feature = "server")]
@@ -242,6 +243,21 @@ pub async fn rpc_get_author(id: i64) -> Result<Option<AuthorDetail>> {
 #[post("/api/rpc/series", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_series(id: i64) -> Result<Option<SeriesDetail>> {
     Ok(db::get_series(&pool.0, id).await?)
+}
+
+/// F1.11: admin-triggered "Scan for picture" for an author. Clears any
+/// cached row (including sticky `letter` markers) and runs the Open Library
+/// resolver inline, so the admin gets a definitive "found / not found"
+/// answer in a single round-trip without polling the worker.
+#[post("/api/rpc/author/scan-photo", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_scan_author_photo(id: i64) -> Result<AuthorPhotoScanResult> {
+    if !user.is_admin {
+        return Err(ServerFnError::new("forbidden: admin required").into());
+    }
+    db::delete_author_photo(&pool.0, id).await?;
+    db::author_photos::resolve(&pool.0, id).await?;
+    let resolved = db::get_author_photo(&pool.0, id).await?.is_some();
+    Ok(AuthorPhotoScanResult { resolved })
 }
 
 /// Return all tags with book counts for the tag cloud.

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -11,7 +11,7 @@ use axum::{
     extract::{Path, Query, State},
     http::header,
     response::{IntoResponse, Response},
-    routing::{get, post},
+    routing::{get, post, put},
     Extension, Json, Router,
 };
 use omnibus_db::{
@@ -88,6 +88,14 @@ pub fn rest_router(state: AppState) -> Router {
         .merge(
             Router::new()
                 .route("/api/ebooks/{id}/cover", post(post_ebook_cover))
+                // F1.11: same 10 MiB cap rationale as the book-cover route —
+                // larger than the global 1 MiB so multipart uploads succeed.
+                .route(
+                    "/api/authors/{id}/photo",
+                    put(put_author_photo)
+                        .get(get_author_photo)
+                        .delete(delete_author_photo),
+                )
                 // Per-route body-limit override for image uploads. Layered
                 // closer to the handler than the global 1 MiB cap below, so
                 // axum picks this larger value for `/api/ebooks/{id}/cover`.
@@ -97,6 +105,7 @@ pub fn rest_router(state: AppState) -> Router {
         .route("/api/covers/{id}", get(get_cover))
         .route("/api/thumbs/{id}/{size}", get(get_thumb))
         .route("/api/authors", get(get_authors))
+        .route("/api/authors/{id}/photo/scan", post(post_author_photo_scan))
         .route("/api/authors/{id}", get(get_author_by_id))
         .route("/api/series", get(get_series))
         .route("/api/series/{id}", get(get_series_by_id))
@@ -777,6 +786,192 @@ async fn post_ebook_cover(
         Ok(None) => (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
         Err(e) => internal("get_book", e),
     }
+}
+
+// ---------------------------------------------------------------------------
+// F1.11 Author profile photos.
+// ---------------------------------------------------------------------------
+
+/// Serve a cached author profile photo. Returns 404 when no photo is cached
+/// (including `'letter'` negative-cache markers) — the frontend keeps the
+/// letter avatar in that case. On a miss, enqueues a background resolution
+/// task so a subsequent page view can render the resolved photo.
+async fn get_author_photo(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
+    match db::get_author_photo(&state.pool, id).await {
+        Ok(Some((mime, bytes))) => (
+            [
+                (header::CONTENT_TYPE, mime.as_str()),
+                // Match `/api/covers/:id` cache semantics.
+                (header::CACHE_CONTROL, "private, max-age=86400"),
+                (header::VARY, "Cookie"),
+                (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+            ],
+            bytes,
+        )
+            .into_response(),
+        Ok(None) => {
+            // Only queue resolution if no row exists yet — a `letter` marker
+            // is a sticky miss until an admin DELETEs it. `author_photo_status`
+            // returns the row regardless of source.
+            if let Ok(None) = db::author_photo_status(&state.pool, id).await {
+                state
+                    .worker
+                    .post(Task::ResolveAuthorPhoto { author_id: id });
+            }
+            axum::http::StatusCode::NOT_FOUND.into_response()
+        }
+        Err(error) => internal("read author photo", error),
+    }
+}
+
+/// Admin upload of a manual author profile photo. Multipart with one
+/// `photo` field. Mirrors the `/api/ebooks/{id}/cover` validation
+/// pipeline: 10 MiB cap, magic-byte sniff, SVG rejection.
+async fn put_author_photo(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    mut multipart: axum::extract::Multipart,
+) -> Response {
+    // Confirm the author exists before reading multipart so a malformed
+    // upload to a missing id fails fast with 404 (not 400).
+    let author_exists: bool =
+        match sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
+            .bind(id)
+            .fetch_one(&state.pool)
+            .await
+        {
+            Ok(v) => v != 0,
+            Err(e) => return internal("author exists check", e),
+        };
+    if !author_exists {
+        return (axum::http::StatusCode::NOT_FOUND, "author not found").into_response();
+    }
+
+    let (mime, bytes) = loop {
+        match multipart.next_field().await {
+            Ok(Some(field)) => {
+                let name = field.name().unwrap_or("").to_string();
+                if name != "photo" {
+                    continue;
+                }
+                let content_type = field
+                    .content_type()
+                    .unwrap_or("application/octet-stream")
+                    .to_string();
+                if !content_type.starts_with("image/") {
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        "photo must be an image",
+                    )
+                        .into_response();
+                }
+                if content_type.contains("svg") {
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        "SVG photos are not accepted",
+                    )
+                        .into_response();
+                }
+                match field.bytes().await {
+                    Ok(b) => {
+                        if b.len() > 10 * 1024 * 1024 {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                "photo must be under 10 MB",
+                            )
+                                .into_response();
+                        }
+                        let detected = detect_image_format(&b);
+                        if detected.is_none() {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                "file does not appear to be a valid image",
+                            )
+                                .into_response();
+                        }
+                        break (detected.unwrap(), b);
+                    }
+                    Err(e) => return internal("read photo field", e),
+                }
+            }
+            Ok(None) => {
+                return (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "missing 'photo' field in multipart body",
+                )
+                    .into_response()
+            }
+            Err(e) => return internal("parse multipart", e),
+        }
+    };
+
+    if let Err(e) = db::upsert_author_photo(
+        &state.pool,
+        id,
+        db::AuthorPhotoSource::Manual,
+        None,
+        Some(&mime),
+        Some(&bytes),
+    )
+    .await
+    {
+        return internal("upsert_author_photo", e);
+    }
+    axum::http::StatusCode::NO_CONTENT.into_response()
+}
+
+/// Admin: drop the cached photo so the next page view re-queues resolution.
+async fn delete_author_photo(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
+    match db::delete_author_photo(&state.pool, id).await {
+        Ok(()) => axum::http::StatusCode::NO_CONTENT.into_response(),
+        Err(e) => internal("delete_author_photo", e),
+    }
+}
+
+/// Admin: synchronously run the Open Library cascade for an author. Clears
+/// any existing row (including sticky `letter` markers) so the resolver
+/// re-queries Open Library, then awaits the resolver inline and returns
+/// `{ "resolved": bool }`. `resolved=false` means Open Library had nothing
+/// (a `letter` marker is now in place to skip future autoresolution).
+async fn post_author_photo_scan(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
+    // Verify the author exists first so a typo on the id gets a 404 instead
+    // of a successful no-op scan.
+    let author_exists: bool =
+        match sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
+            .bind(id)
+            .fetch_one(&state.pool)
+            .await
+        {
+            Ok(v) => v != 0,
+            Err(e) => return internal("author exists check", e),
+        };
+    if !author_exists {
+        return (axum::http::StatusCode::NOT_FOUND, "author not found").into_response();
+    }
+    if let Err(e) = db::delete_author_photo(&state.pool, id).await {
+        return internal("delete_author_photo (pre-scan)", e);
+    }
+    if let Err(e) = db::author_photos::resolve(&state.pool, id).await {
+        return internal("author_photos::resolve", e);
+    }
+    let resolved = match db::get_author_photo(&state.pool, id).await {
+        Ok(opt) => opt.is_some(),
+        Err(e) => return internal("get_author_photo (post-scan)", e),
+    };
+    Json(omnibus_shared::AuthorPhotoScanResult { resolved }).into_response()
 }
 
 #[cfg(test)]
@@ -2731,5 +2926,318 @@ mod tests {
             body.contains("10 MB"),
             "400 body should explain the size cap, got {body:?}"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // F1.11 Author profile photos.
+    // ---------------------------------------------------------------------
+
+    async fn seed_author(pool: &sqlx::SqlitePool, name: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>("INSERT INTO authors (name, sort) VALUES (?, ?) RETURNING id")
+            .bind(name)
+            .bind(name)
+            .fetch_one(pool)
+            .await
+            .expect("seed author")
+    }
+
+    /// Multipart body with one `photo` field, matching `build_cover_multipart`
+    /// but using the field name the author-photo handler expects.
+    fn build_photo_multipart(content_type: &str, bytes: &[u8]) -> (String, Vec<u8>) {
+        let boundary = "----omnibus-test-photo-boundary";
+        let mut body: Vec<u8> = Vec::with_capacity(bytes.len() + 256);
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"photo\"; filename=\"photo.png\"\r\n",
+        );
+        body.extend_from_slice(format!("Content-Type: {content_type}\r\n\r\n").as_bytes());
+        body.extend_from_slice(bytes);
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        (format!("multipart/form-data; boundary={boundary}"), body)
+    }
+
+    #[tokio::test]
+    async fn api_get_author_photo_requires_auth() {
+        let (app, _state, _pool) = fixture().await;
+        let res = app
+            .oneshot(get_anon("/api/authors/1/photo"))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_get_author_photo_404_when_unset() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+        let res = app
+            .oneshot(get_with_bearer(&format!("/api/authors/{id}/photo"), &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_requires_admin() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        let (content_type, body) = build_photo_multipart("image/png", TINY_PNG);
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/authors/{id}/photo"))
+                    .method("PUT")
+                    .header("content-type", content_type)
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_uploads_and_get_serves() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let (content_type, body) = build_photo_multipart("image/png", TINY_PNG);
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/authors/{id}/photo"))
+                    .method("PUT")
+                    .header("content-type", content_type)
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        // GET should now return the uploaded bytes with the detected mime.
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(&format!("/api/authors/{id}/photo"), &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::OK);
+        let ct = res
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert_eq!(ct, "image/png");
+        let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(bytes.as_ref(), TINY_PNG);
+
+        // The author detail payload must now flag has_photo = true.
+        let res = app
+            .oneshot(get_with_bearer(&format!("/api/authors/{id}"), &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let author: omnibus_shared::AuthorDetail = serde_json::from_slice(&bytes).unwrap();
+        assert!(author.has_photo, "has_photo should flip after upload");
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_404_for_missing_author() {
+        let (app, _state, pool) = fixture().await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let (content_type, body) = build_photo_multipart("image/png", TINY_PNG);
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/authors/9999/photo")
+                    .method("PUT")
+                    .header("content-type", content_type)
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_rejects_non_image() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let (content_type, body) = build_photo_multipart("text/plain", b"not an image");
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/authors/{id}/photo"))
+                    .method("PUT")
+                    .header("content-type", content_type)
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_rejects_bogus_image_bytes() {
+        // Content-Type says image/png but the bytes don't carry the PNG magic
+        // header — the magic-byte check must catch this even when the
+        // declared MIME passes the `image/` prefix guard.
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let (content_type, body) = build_photo_multipart("image/png", b"not really a png");
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/authors/{id}/photo"))
+                    .method("PUT")
+                    .header("content-type", content_type)
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn api_delete_author_photo_requires_admin() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/authors/{id}/photo"))
+                    .method("DELETE")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn api_delete_author_photo_clears_row() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        db::upsert_author_photo(
+            &pool,
+            id,
+            db::AuthorPhotoSource::Manual,
+            None,
+            Some("image/png"),
+            Some(TINY_PNG),
+        )
+        .await
+        .unwrap();
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/authors/{id}/photo"))
+                    .method("DELETE")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        assert!(db::author_photo_status(&pool, id).await.unwrap().is_none());
+    }
+
+    // --- Scan-for-picture admin gate / not-found contract. The resolver
+    // itself is exercised by the wiremock-backed tests in
+    // `omnibus_db::author_photos::tests`; these only cover the wiring so
+    // they don't reach the real Open Library service.
+
+    #[tokio::test]
+    async fn api_scan_author_photo_requires_admin() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/authors/{id}/photo/scan"))
+                    .method("POST")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn api_scan_author_photo_404_for_missing_author() {
+        let (app, _state, pool) = fixture().await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/authors/9999/photo/scan")
+                    .method("POST")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_scan_author_photo_requires_auth() {
+        let (app, _state, _pool) = fixture().await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/authors/1/photo/scan")
+                    .method("POST")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -494,7 +494,9 @@ async fn get_author_by_id(
             if !author.has_photo {
                 match db::author_photo_status(&state.pool, id).await {
                     Ok(None) => {
-                        state.worker.post(Task::ResolveAuthorPhoto { author_id: id });
+                        state
+                            .worker
+                            .post(Task::ResolveAuthorPhoto { author_id: id });
                     }
                     Ok(Some(_)) => {}
                     Err(e) => {
@@ -993,8 +995,7 @@ async fn post_author_photo_scan(
     // and report resolved=true so the UI keeps the existing photo.
     match db::author_photo_status(&state.pool, id).await {
         Ok(Some((db::AuthorPhotoSource::Manual, _))) => {
-            return Json(omnibus_shared::AuthorPhotoScanResult { resolved: true })
-                .into_response();
+            return Json(omnibus_shared::AuthorPhotoScanResult { resolved: true }).into_response();
         }
         Ok(_) => {}
         Err(e) => return internal("author_photo_status (pre-scan)", e),
@@ -3313,9 +3314,11 @@ mod tests {
             .expect("request should succeed");
         assert_eq!(res.status(), StatusCode::OK);
         let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
-        let body: omnibus_shared::AuthorPhotoScanResult =
-            serde_json::from_slice(&bytes).unwrap();
-        assert!(body.resolved, "scan on manual upload should report resolved=true");
+        let body: omnibus_shared::AuthorPhotoScanResult = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            body.resolved,
+            "scan on manual upload should report resolved=true"
+        );
 
         // Manual row must still be intact (same source, same bytes).
         let (src, _) = db::author_photo_status(&pool, id).await.unwrap().unwrap();

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -486,7 +486,29 @@ async fn get_author_by_id(
     Path(id): Path<i64>,
 ) -> Response {
     match db::get_author(&state.pool, id).await {
-        Ok(Some(author)) => Json(author).into_response(),
+        Ok(Some(author)) => {
+            // F1.11: queue a background resolution when the author has no
+            // `author_photos` row yet so first-time visits trigger Open
+            // Library resolution. A subsequent visit picks up the resolved
+            // photo (or the `letter` negative-cache marker).
+            if !author.has_photo {
+                match db::author_photo_status(&state.pool, id).await {
+                    Ok(None) => {
+                        state.worker.post(Task::ResolveAuthorPhoto { author_id: id });
+                    }
+                    Ok(Some(_)) => {}
+                    Err(e) => {
+                        // Don't fail the read — just skip the queue and log.
+                        tracing::warn!(
+                            author_id = id,
+                            error = %e,
+                            "author_photo_status check failed; skipping autoresolution"
+                        );
+                    }
+                }
+            }
+            Json(author).into_response()
+        }
         Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
         Err(error) => internal("read author", error),
     }
@@ -938,10 +960,16 @@ async fn delete_author_photo(
 }
 
 /// Admin: synchronously run the Open Library cascade for an author. Clears
-/// any existing row (including sticky `letter` markers) so the resolver
-/// re-queries Open Library, then awaits the resolver inline and returns
+/// any sticky `letter` negative-cache marker so the resolver re-queries Open
+/// Library, then awaits the resolver inline and returns
 /// `{ "resolved": bool }`. `resolved=false` means Open Library had nothing
 /// (a `letter` marker is now in place to skip future autoresolution).
+///
+/// Manual uploads are treated as overrides: a `source = 'manual'` row is
+/// preserved (the F1.11 roadmap explicitly calls this out — "skips if a
+/// manual override exists"). Scan returns `resolved=true` in that case
+/// without touching the row, so admins can't accidentally wipe a manual
+/// upload by clicking the button.
 async fn post_author_photo_scan(
     _admin: AdminUser,
     State(state): State<AppState>,
@@ -960,6 +988,16 @@ async fn post_author_photo_scan(
         };
     if !author_exists {
         return (axum::http::StatusCode::NOT_FOUND, "author not found").into_response();
+    }
+    // Manual uploads win — don't delete or overwrite. Treat scan as a no-op
+    // and report resolved=true so the UI keeps the existing photo.
+    match db::author_photo_status(&state.pool, id).await {
+        Ok(Some((db::AuthorPhotoSource::Manual, _))) => {
+            return Json(omnibus_shared::AuthorPhotoScanResult { resolved: true })
+                .into_response();
+        }
+        Ok(_) => {}
+        Err(e) => return internal("author_photo_status (pre-scan)", e),
     }
     if let Err(e) = db::delete_author_photo(&state.pool, id).await {
         return internal("delete_author_photo (pre-scan)", e);
@@ -3239,5 +3277,75 @@ mod tests {
             .await
             .expect("request should succeed");
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_scan_author_photo_preserves_manual_upload() {
+        // Roadmap: manual override wins over the resolver. An admin clicking
+        // "Scan for picture" on an author who already has a manual upload
+        // must not wipe that upload — the scan handler treats the row as a
+        // sticky override and returns resolved=true without deleting.
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+        db::upsert_author_photo(
+            &pool,
+            id,
+            db::AuthorPhotoSource::Manual,
+            None,
+            Some("image/png"),
+            Some(TINY_PNG),
+        )
+        .await
+        .unwrap();
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/authors/{id}/photo/scan"))
+                    .method("POST")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let body: omnibus_shared::AuthorPhotoScanResult =
+            serde_json::from_slice(&bytes).unwrap();
+        assert!(body.resolved, "scan on manual upload should report resolved=true");
+
+        // Manual row must still be intact (same source, same bytes).
+        let (src, _) = db::author_photo_status(&pool, id).await.unwrap().unwrap();
+        assert_eq!(src, db::AuthorPhotoSource::Manual);
+        let (_, served) = db::get_author_photo(&pool, id).await.unwrap().unwrap();
+        assert_eq!(served, TINY_PNG, "manual photo bytes must be preserved");
+    }
+
+    #[tokio::test]
+    async fn api_get_author_response_carries_has_photo_flag() {
+        // F1.11 autoresolution wiring lives behind the GET handler — the
+        // worker call itself is fire-and-forget so we can't deterministically
+        // observe it from a test without a network. What we can verify is
+        // that the handler still returns the expected `AuthorDetail` shape
+        // with `has_photo = false` when no row exists, and `true` after a
+        // manual upload (covered by `api_put_author_photo_uploads_and_get_serves`
+        // for the positive case).
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Brandon Sanderson").await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        let res = app
+            .oneshot(get_with_bearer(&format!("/api/authors/{id}"), &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let author: omnibus_shared::AuthorDetail = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(author.id, id);
+        assert!(!author.has_photo, "no row yet means has_photo = false");
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -264,6 +264,22 @@ pub struct AuthorDetail {
     pub sort: Option<String>,
     pub book_count: usize,
     pub books: Vec<EbookMetadata>,
+    /// F1.11: `true` when a usable profile photo is cached for this author
+    /// (a `manual` or `openlibrary` row in `author_photos`). The frontend
+    /// hero swaps the letter avatar for `<img src="/api/authors/:id/photo">`
+    /// when set. `'letter'` negative-cache rows do not set this flag.
+    #[serde(default)]
+    pub has_photo: bool,
+}
+
+/// Result of an admin-triggered "Scan for picture" run (F1.11). The endpoint
+/// clears any cached row and runs the Open Library cascade inline; a
+/// `false` here means Open Library had nothing to offer for this author
+/// and a sticky `letter` marker has been written to skip future
+/// autoresolution.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthorPhotoScanResult {
+    pub resolved: bool,
 }
 
 /// Series detail payload for `GET /api/series/:id` and `rpc_get_series`.

--- a/ui_tests/playwright/tests/flows/author_photo.spec.ts
+++ b/ui_tests/playwright/tests/flows/author_photo.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "../fixtures/test";
+import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { gotoReady } from "../utils/nav";
+import { fixturesDir, seedLibrary } from "../utils/seed";
+import type { APIRequestContext } from "@playwright/test";
+
+// Minimal valid 1x1 PNG. detect_image_format only inspects magic bytes,
+// so the body can be tiny — duplicates the constant from the Rust tests.
+const TINY_PNG = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06,
+  0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44,
+  0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d,
+  0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
+// All tests in this file mutate the cached photo for the same author
+// ("Ada Lovelace") — run them serially so the afterEach DELETE on one test
+// doesn't race the assertions of another.
+test.describe.configure({ mode: "serial" });
+
+test.beforeAll(async ({ request }) => {
+  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
+});
+
+async function fetchAuthorIdByName(
+  request: APIRequestContext,
+  name: string,
+): Promise<number> {
+  const resp = await request.get("/api/rpc/ebooks");
+  expect(resp.status(), "GET /api/rpc/ebooks failed").toBe(200);
+  const body = (await resp.json()) as {
+    books: { creators: { name: string; id: number | null }[] }[];
+  };
+  for (const book of body.books) {
+    const match = book.creators.find((c) => c.name === name);
+    if (match?.id) return match.id;
+  }
+  throw new Error(`no indexed author named ${JSON.stringify(name)}`);
+}
+
+test.afterEach(async ({ request }) => {
+  // Clean up any uploaded photo so reruns start from a known-empty state.
+  // Discovery tests rely on the same authors being present, so we must not
+  // touch the author row itself — only the cached photo.
+  const ada = await fetchAuthorIdByName(request, "Ada Lovelace").catch(() => null);
+  if (ada !== null) {
+    await request.delete(`/api/authors/${ada}/photo`);
+  }
+});
+
+test("author page shows letter avatar when no photo is uploaded", async ({
+  page,
+  request,
+}) => {
+  const id = await fetchAuthorIdByName(request, "Ada Lovelace");
+  await gotoReady(page, `/authors/${id}`);
+
+  // Avatar div with the initial visible; no <img.disc-avatar--photo>.
+  const letter = page.locator("div.disc-avatar");
+  await expect(letter).toBeVisible();
+  await expect(letter).toHaveText("A");
+  await expect(page.locator("img.disc-avatar--photo")).toHaveCount(0);
+});
+
+test("admin upload swaps the letter avatar for the photo", async ({
+  page,
+  request,
+}) => {
+  const id = await fetchAuthorIdByName(request, "Ada Lovelace");
+
+  // PUT the photo through the REST endpoint. The seeded test user is the
+  // first user registered, so it has is_admin = true.
+  const putResp = await request.put(`/api/authors/${id}/photo`, {
+    multipart: {
+      photo: {
+        name: "ada.png",
+        mimeType: "image/png",
+        buffer: TINY_PNG,
+      },
+    },
+  });
+  expect(putResp.status(), "PUT photo should succeed").toBe(204);
+
+  await gotoReady(page, `/authors/${id}`);
+
+  const img = page.locator("img.disc-avatar--photo");
+  await expect(img).toBeVisible();
+  await expect(img).toHaveAttribute("src", `/api/authors/${id}/photo`);
+  // Letter variant should no longer render in the hero.
+  await expect(page.locator("div.disc-avatar")).toHaveCount(0);
+
+  // Sanity-check the image bytes load — fetch directly from the page
+  // context so cookies ride along. We can't rely on `waitForResponse` here
+  // because the <img> request may complete before we register the listener.
+  const status = await page.evaluate(
+    async (url: string) => (await fetch(url)).status,
+    `/api/authors/${id}/photo`,
+  );
+  expect(status).toBe(200);
+});
+
+test("admin DELETE clears the photo and the letter returns", async ({
+  page,
+  request,
+}) => {
+  const id = await fetchAuthorIdByName(request, "Ada Lovelace");
+
+  // Upload, confirm photo, then DELETE and confirm letter is back.
+  const putResp = await request.put(`/api/authors/${id}/photo`, {
+    multipart: {
+      photo: {
+        name: "ada.png",
+        mimeType: "image/png",
+        buffer: TINY_PNG,
+      },
+    },
+  });
+  expect(putResp.status()).toBe(204);
+
+  const delResp = await request.delete(`/api/authors/${id}/photo`);
+  expect(delResp.status(), "DELETE photo should succeed").toBe(204);
+
+  await gotoReady(page, `/authors/${id}`);
+  await expect(page.locator("div.disc-avatar")).toBeVisible();
+  await expect(page.locator("img.disc-avatar--photo")).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

Closes the F1.11 [Author profile pictures](docs/roadmap/1-11-author-profiles.md) initiative. Per discussion, the roadmap's 4-step cascade was narrowed to **manual upload → Open Library → letter fallback** — Wikidata is deferred to keep the scope tight and avoid a second outbound provider in this PR.

- New `author_photos` table (BLOB-in-DB, mirrors `book_covers`)
- `db::author_photos::resolve` runs the Open Library cascade against an injectable `OpenLibraryConfig` so the wiremock-backed tests cover every branch without ever hitting the real `openlibrary.org`
- `Task::ResolveAuthorPhoto` with a per-author `resource_key` so background resolutions for the same author serialize
- REST + RPC: `GET / PUT (admin) / DELETE (admin) /api/authors/:id/photo` and `POST /api/authors/:id/photo/scan` (admin, synchronous)
- `AuthorDetail.has_photo` flips the hero from the typographic letter to `<img src="/api/authors/:id/photo">`
- Admin-only **Scan for picture** button on the author hero that clears any cached row (including sticky `letter` markers) and re-runs the resolver inline so the admin sees a "found / not found" answer in one round-trip

>[!NOTE]
> `'letter'` rows are a sticky negative cache so we don't re-query Open Library on every page view. An admin can clear them via DELETE or by hitting the Scan button.

>[!NOTE]
> First outbound HTTP in the codebase. `reqwest` is added with `rustls-tls` + `json` only (no OpenSSL) and is scoped to the resolver module.

## Test plan

- [x] `cargo test --workspace --exclude omnibus-mobile` — 11 new resolver/query tests + 12 new REST integration tests pass; full suite 414 / 414
- [x] `cargo clippy --workspace --exclude omnibus-mobile --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-mobile` — clean
- [x] `cargo fmt --check`
- [x] New Playwright spec `flows/author_photo.spec.ts` — 3/3 pass (letter avatar, admin upload swaps to photo, DELETE returns letter)
- [x] Live browser verification: logged in as the seeded admin, visited `/authors/37` (Brandon Sanderson), saw the Open Library photo render; visited `/authors/1` (Ada Lovelace), clicked **Scan for picture**, saw the "No photo on Open Library for this author." status; Brandon Sanderson **Scan** round-trip returned `{resolved:true}` and the avatar refreshed in place

## Notes

- Open Library coverage for the seeded fixture authors is poor — Ada Lovelace, Grace Hopper, etc. all return a ~13-byte placeholder, which the resolver correctly treats as a miss (>= 1 KiB threshold) and writes a `letter` marker for. Brandon Sanderson is the easiest positive smoke since Open Library has a 44 KB JPEG for him.
- The "Scan for picture" button runs the resolver **inline** (not via the worker). The worker mutex isn't needed since the handler itself is the only writer in this code path; this keeps the admin UX synchronous ("Found / Not found" in ~3-5s) without polling.
- Admin upload UI is intentionally out of scope here — `PUT /api/authors/:id/photo` is wired and tested so it can be driven from a future metadata-edit-style surface, but no form ships in this PR.