### PR TITLE
feat(authors): add author photo edit modal (URL / upload / scan)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,7 @@ dependencies = [
  "dioxus-router",
  "gloo-net",
  "gloo-timers",
+ "js-sys",
  "omnibus-db",
  "omnibus-shared",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,6 +3841,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/db/src/author_photos.rs
+++ b/db/src/author_photos.rs
@@ -195,6 +195,82 @@ async fn fetch_open_library(
     Ok(Some((cover_url, content_type, bytes)))
 }
 
+/// Hard cap on the bytes we'll read from a user-supplied URL. Same 10 MiB
+/// budget as the multipart upload route — callers should pre-check
+/// Content-Length when available, but this cap is what actually bounds
+/// memory consumption mid-download.
+pub const REMOTE_IMAGE_MAX_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Errors surfaced by [`fetch_remote_image`]. The variants are deliberately
+/// user-facing — the handler maps each to a 4xx/5xx response without further
+/// rephrasing.
+#[derive(Debug, thiserror::Error)]
+pub enum FetchRemoteImageError {
+    #[error("URL must start with http:// or https://")]
+    BadScheme,
+    #[error("remote server returned {0}")]
+    BadStatus(u16),
+    #[error("remote response content-type is not an image ({0})")]
+    NotImage(String),
+    #[error("SVG photos are not accepted")]
+    SvgRejected,
+    #[error("image exceeds {} byte cap", REMOTE_IMAGE_MAX_BYTES)]
+    TooLarge,
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+/// Fetch an image from a user-supplied URL with the same validation gates as
+/// the multipart upload route — image content-type, no SVG, size cap. Returns
+/// the raw bytes and the server-advertised content-type; callers are
+/// expected to run magic-byte sniffing on the bytes before persisting.
+///
+/// Used by the "paste image URL" branch of the author photo edit modal
+/// (F1.11 follow-up). Lives next to [`fetch_open_library`] because it
+/// reuses the same `reqwest` setup and shares the "we expect an image"
+/// surface area.
+pub async fn fetch_remote_image(url: &str) -> Result<(String, Vec<u8>), FetchRemoteImageError> {
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return Err(FetchRemoteImageError::BadScheme);
+    }
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .user_agent(format!(
+            "omnibus/{} (https://github.com/sloansa/omnibus)",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()?;
+    let resp = client.get(url).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(FetchRemoteImageError::BadStatus(status.as_u16()));
+    }
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "application/octet-stream".into());
+    if !content_type.starts_with("image/") {
+        return Err(FetchRemoteImageError::NotImage(content_type));
+    }
+    if content_type.contains("svg") {
+        return Err(FetchRemoteImageError::SvgRejected);
+    }
+    // Pre-check Content-Length when the server advertises it so an
+    // obviously-oversized download bails before allocating.
+    if let Some(len) = resp.content_length() {
+        if len > REMOTE_IMAGE_MAX_BYTES {
+            return Err(FetchRemoteImageError::TooLarge);
+        }
+    }
+    let bytes = resp.bytes().await?.to_vec();
+    if bytes.len() as u64 > REMOTE_IMAGE_MAX_BYTES {
+        return Err(FetchRemoteImageError::TooLarge);
+    }
+    Ok((content_type, bytes))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/db/src/author_photos.rs
+++ b/db/src/author_photos.rs
@@ -264,11 +264,21 @@ pub async fn fetch_remote_image(url: &str) -> Result<(String, Vec<u8>), FetchRem
             return Err(FetchRemoteImageError::TooLarge);
         }
     }
-    let bytes = resp.bytes().await?.to_vec();
-    if bytes.len() as u64 > REMOTE_IMAGE_MAX_BYTES {
-        return Err(FetchRemoteImageError::TooLarge);
+    // Stream the body and abort the moment we'd cross the cap. A hostile
+    // (or buggy) server may advertise no `Content-Length`, or chunk past
+    // the cap, or lie about its size — `resp.bytes()` would have
+    // happily allocated whatever it sent. Cap memory at
+    // `REMOTE_IMAGE_MAX_BYTES + 1` bytes worst case (one chunk overshoot
+    // before the check fires).
+    let mut buf: Vec<u8> = Vec::new();
+    let mut stream = resp;
+    while let Some(chunk) = stream.chunk().await? {
+        if buf.len() as u64 + chunk.len() as u64 > REMOTE_IMAGE_MAX_BYTES {
+            return Err(FetchRemoteImageError::TooLarge);
+        }
+        buf.extend_from_slice(&chunk);
     }
-    Ok((content_type, bytes))
+    Ok((content_type, buf))
 }
 
 #[cfg(test)]

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2608,7 +2608,13 @@ pub async fn list_authors(
                    AND l2.path = ?1
                    AND b2.accent_color IS NOT NULL
                  ORDER BY b2.sort, b2.id
-                 LIMIT 1) AS accent
+                 LIMIT 1) AS accent,
+               EXISTS(
+                 SELECT 1 FROM author_photos ap
+                  WHERE ap.author_id = a.id
+                    AND ap.source IN ('manual', 'openlibrary')
+                    AND ap.bytes IS NOT NULL
+               ) AS has_photo
         FROM authors a
         WHERE EXISTS (
             SELECT 1 FROM books_authors_link bal
@@ -2633,6 +2639,7 @@ pub async fn list_authors(
             sort: r.get("sort"),
             book_count: r.get::<i64, _>("book_count") as usize,
             accent: r.get("accent"),
+            has_photo: r.get::<i64, _>("has_photo") != 0,
         })
         .collect())
 }
@@ -8402,6 +8409,44 @@ mod tests {
         .await
         .unwrap();
         let ada = get_author(&pool, ada_id).await.unwrap().unwrap();
+        assert!(ada.has_photo, "manual upload should yield has_photo = true");
+    }
+
+    /// `list_authors` mirrors the `get_author` has_photo semantics so the
+    /// /authors index can pick the right avatar without a per-card detail
+    /// fetch. Same three-state matrix: no row → false, `letter` marker →
+    /// false, `manual` upload → true.
+    #[tokio::test]
+    async fn list_authors_populates_has_photo() {
+        let (pool, _guard) = seed_discovery_fixture().await;
+        let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+        let initial = list_authors(&pool, "/lib").await.unwrap();
+        let ada = initial.iter().find(|a| a.id == ada_id).unwrap();
+        assert!(!ada.has_photo, "no row should yield has_photo = false");
+
+        upsert_author_photo(&pool, ada_id, AuthorPhotoSource::Letter, None, None, None)
+            .await
+            .unwrap();
+        let after_letter = list_authors(&pool, "/lib").await.unwrap();
+        let ada = after_letter.iter().find(|a| a.id == ada_id).unwrap();
+        assert!(
+            !ada.has_photo,
+            "letter marker should yield has_photo = false"
+        );
+
+        upsert_author_photo(
+            &pool,
+            ada_id,
+            AuthorPhotoSource::Manual,
+            None,
+            Some("image/jpeg"),
+            Some(b"\xFF\xD8\xFFfake"),
+        )
+        .await
+        .unwrap();
+        let after_upload = list_authors(&pool, "/lib").await.unwrap();
+        let ada = after_upload.iter().find(|a| a.id == ada_id).unwrap();
         assert!(ada.has_photo, "manual upload should yield has_photo = true");
     }
 }

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -10,13 +10,17 @@ omnibus-shared = { path = "../shared" }
 omnibus-db = { path = "../db", optional = true }
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
-reqwest = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true, features = ["multipart"] }
 gloo-net = { version = "0.6", default-features = false, features = ["http", "json"], optional = true }
 gloo-timers = { version = "0.3", features = ["futures"], optional = true }
 # `web-sys` is enabled only on the WASM client for `Window::local_storage()`.
 # F1.3 view-mode / sort / filter prefs are persisted there per library path.
-web-sys = { version = "0.3", features = ["Window", "Storage", "KeyboardEvent"], optional = true }
+# F1.11: FormData/Blob/BlobPropertyBag are used by `data::upload_author_photo`
+# to build a multipart body for the author profile photo upload — the only
+# path that needs to ship raw bytes from the web client.
+web-sys = { version = "0.3", features = ["Window", "Storage", "KeyboardEvent", "FormData", "Blob", "BlobPropertyBag"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true }
 # sqlx + tokio are needed at the type level by rpc.rs when building server
 # functions (PoolExt = Extension<SqlitePool>, #[tokio::spawn] for reindex).
 # Kept as optional deps enabled only by the `server` feature. Tokio is
@@ -43,6 +47,7 @@ web = [
     "dep:serde_json",
     "dep:web-sys",
     "dep:wasm-bindgen",
+    "dep:js-sys",
     "dep:tokio",
     "tokio/sync",
 ]

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -754,7 +754,11 @@ body.atrium,
   display: grid;
   grid-template-columns: 120px 1fr auto;
   gap: 32px;
-  align-items: flex-end;
+  /* `center` keeps the heading visually on the same line as the avatar
+     after the inline Scan button row moved into the edit modal. Bottom
+     alignment looked correct when the info column carried both the
+     title and the actions row, but with just the title it sat low. */
+  align-items: center;
   margin-top: 24px;
 }
 @media (max-width: 720px) {
@@ -1122,6 +1126,14 @@ body.atrium,
   color: var(--ink-1);
 }
 
+/* F1.11 — When the index card avatar is the cached profile photo
+   (`<img>` instead of letter `<div>`), clip the image to the circle and
+   drop the typographic styling. */
+.idx-card-avatar--photo {
+  object-fit: cover;
+  display: block;
+}
+
 .idx-card-body { min-width: 0; }
 .idx-card-title {
   font-family: var(--serif);
@@ -1484,3 +1496,114 @@ body.atrium,
   gap: 8px;
 }
 
+
+/* ============================================================================
+   F1.11 follow-up — Author photo edit overlay + modal.
+
+   Wraps the existing letter / photo avatar; the pencil overlay sits on top
+   and only fades in on hover or keyboard focus inside the wrapper. The
+   modal is a centered card with a darkened backdrop and three sections
+   (URL, file upload, scan).
+   ============================================================================ */
+
+.author-photo-edit {
+  position: relative;
+  display: inline-block;
+  line-height: 0;
+}
+
+.author-photo-edit__overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: color-mix(in oklch, var(--bg-0) 60%, transparent);
+  color: var(--ink-0);
+  border: none;
+  border-radius: inherit;
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+/* The avatar inside is a circle (border-radius: 999px on .idx-card-avatar
+   and .disc-avatar). Match that so the overlay tint clips correctly. */
+.author-photo-edit .idx-card-avatar,
+.author-photo-edit .disc-avatar,
+.author-photo-edit__overlay {
+  border-radius: 999px;
+}
+.author-photo-edit:hover .author-photo-edit__overlay,
+.author-photo-edit:focus-within .author-photo-edit__overlay {
+  opacity: 1;
+}
+
+.author-photo-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in oklch, #000 55%, transparent);
+  display: grid;
+  place-items: center;
+  z-index: 100;
+  padding: 20px;
+}
+.author-photo-modal {
+  background: var(--bg-0);
+  border: 1px solid var(--line-2);
+  border-radius: 14px;
+  padding: 24px;
+  width: min(440px, 100%);
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: 0 24px 48px color-mix(in oklch, #000 35%, transparent);
+}
+.author-photo-modal__head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.author-photo-modal__title {
+  font-family: var(--serif);
+  font-size: 22px;
+  margin: 0;
+}
+.author-photo-modal__sub {
+  margin: 0;
+  font-size: 13px;
+}
+.author-photo-modal__section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.author-photo-modal__url-row {
+  display: flex;
+  gap: 8px;
+}
+.author-photo-modal__url-row input {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: var(--bg-1);
+  color: var(--ink-0);
+  font-size: 14px;
+}
+.author-photo-modal__status {
+  margin: 0;
+  font-size: 13px;
+  color: var(--ink-1);
+}
+.author-photo-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1551,59 +1551,92 @@ body.atrium,
   z-index: 100;
   padding: 20px;
 }
+/* Match the `.card` / `.me-input` rhythm used by the metadata edit form
+   so the modal feels like an inline editor rather than a tight popover.
+   `--r-lg` (14px) for the shell, 28px outer padding, 22px between
+   sections, 10px between label and field — mirrors the page-level
+   spacing tokens. */
 .author-photo-modal {
-  background: var(--bg-0);
+  background: var(--bg-1);
   border: 1px solid var(--line-2);
-  border-radius: 14px;
-  padding: 24px;
-  width: min(440px, 100%);
+  border-radius: var(--r-lg);
+  padding: 28px;
+  width: min(460px, 100%);
   max-height: calc(100vh - 40px);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 22px;
   box-shadow: 0 24px 48px color-mix(in oklch, #000 35%, transparent);
 }
 .author-photo-modal__head {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--line-2);
 }
 .author-photo-modal__title {
   font-family: var(--serif);
-  font-size: 22px;
+  font-size: 26px;
+  line-height: 1.1;
   margin: 0;
 }
 .author-photo-modal__sub {
   margin: 0;
   font-size: 13px;
+  color: var(--ink-2);
 }
 .author-photo-modal__section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 .author-photo-modal__url-row {
   display: flex;
-  gap: 8px;
+  gap: 10px;
+  align-items: stretch;
 }
-.author-photo-modal__url-row input {
+.author-photo-modal__url-row .me-input {
   flex: 1;
-  padding: 8px 10px;
-  border: 1px solid var(--line-2);
-  border-radius: 8px;
+  min-width: 0;
+}
+/* Lift the native file input to roughly match `.me-input` so the upload
+   field aligns with the URL field's height and rounded outline. The
+   browser-rendered "Choose File" button stays native but sits inside a
+   themed container. */
+.author-photo-modal__file {
+  width: 100%;
+  padding: 10px 14px;
   background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
   color: var(--ink-0);
-  font-size: 14px;
+  font-family: var(--sans);
+  font-size: 13px;
+  cursor: pointer;
+}
+.author-photo-modal__file:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.author-photo-modal__file:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 .author-photo-modal__status {
   margin: 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
   font-size: 13px;
   color: var(--ink-1);
 }
 .author-photo-modal__actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 4px;
+  gap: 10px;
+  padding-top: 4px;
+  border-top: 1px solid var(--line-2);
 }

--- a/frontend/src/components/author_photo_edit.rs
+++ b/frontend/src/components/author_photo_edit.rs
@@ -121,6 +121,7 @@ fn AuthorPhotoEditModal(
                     div { class: "author-photo-modal__url-row",
                         input {
                             id: "author-photo-url",
+                            class: "me-input",
                             r#type: "url",
                             placeholder: "https://example.com/photo.jpg",
                             "data-testid": "author-photo-url-input",
@@ -167,6 +168,7 @@ fn AuthorPhotoEditModal(
                     }
                     input {
                         id: "author-photo-file",
+                        class: "author-photo-modal__file",
                         r#type: "file",
                         accept: "image/jpeg,image/png,image/webp,image/gif",
                         "data-testid": "author-photo-file-input",
@@ -219,7 +221,7 @@ fn AuthorPhotoEditModal(
                     label { class: "label", "Or fetch automatically" }
                     button {
                         r#type: "button",
-                        class: "btn btn-ghost",
+                        class: "btn ghost",
                         disabled: busy(),
                         "data-testid": "author-photo-scan",
                         onclick: {
@@ -259,7 +261,7 @@ fn AuthorPhotoEditModal(
                 div { class: "author-photo-modal__actions",
                     button {
                         r#type: "button",
-                        class: "btn btn-ghost",
+                        class: "btn ghost",
                         onclick: move |_| on_close.call(()),
                         "Close"
                     }

--- a/frontend/src/components/author_photo_edit.rs
+++ b/frontend/src/components/author_photo_edit.rs
@@ -1,0 +1,270 @@
+//! Author photo edit affordance: a hover-revealed pencil button overlaid on
+//! the existing avatar that opens a modal with three actions —
+//!
+//! 1. **Paste image URL** — server fetches and validates the URL, persists
+//!    as a `manual` photo.
+//! 2. **Upload file** — multipart body to the same `PUT /api/authors/:id/photo`
+//!    endpoint used by the original admin upload path.
+//! 3. **Scan for picture** — re-runs the Open Library cascade.
+//!
+//! Used by `pages::author::AuthorPage` (hero avatar) and
+//! `pages::authors_index::AuthorsIndexPage` (per-card avatar). Both wrap
+//! their `<img>`/`<div>` inside `<AuthorPhotoEditOverlay>` so the same hover
+//! affordance shows up wherever the photo is rendered.
+//!
+//! The modal is web-only. SSR renders the wrapper but no overlay, and the
+//! mobile shell doesn't mount this component — mobile uses the discovery
+//! screens read-only for now.
+
+use dioxus::prelude::*;
+
+use crate::data;
+
+/// Wrapper that renders an "edit" pencil button positioned over its child.
+/// The button is hidden by default and revealed on hover/focus (via the
+/// `author-photo-edit__overlay` CSS rule). Clicking opens the modal.
+///
+/// `on_change` fires after a successful URL/upload/scan so the parent can
+/// re-fetch the author payload and swap in the new photo.
+#[component]
+pub fn AuthorPhotoEditOverlay(
+    author_id: i64,
+    author_name: String,
+    server_url: String,
+    on_change: EventHandler<()>,
+    children: Element,
+) -> Element {
+    let mut open = use_signal(|| false);
+
+    rsx! {
+        div { class: "author-photo-edit",
+            {children}
+            button {
+                r#type: "button",
+                class: "author-photo-edit__overlay",
+                aria_label: "Edit photo for {author_name}",
+                "data-testid": "author-photo-edit",
+                // The overlay sits on top of the avatar — which on the
+                // index card is wrapped in a `Link`. Stop propagation
+                // AND prevent the browser's default click-on-anchor
+                // navigation so clicking the pencil doesn't also navigate
+                // to the author detail page. `stop_propagation` alone
+                // wouldn't be enough — dioxus_router's Link intercepts
+                // the click in the capture phase, and the browser still
+                // honours the `<a href>` default action when a click is
+                // dispatched inside the link's subtree.
+                onclick: move |evt| {
+                    evt.stop_propagation();
+                    evt.prevent_default();
+                    open.set(true);
+                },
+                "Edit"
+            }
+            if open() {
+                AuthorPhotoEditModal {
+                    author_id,
+                    author_name: author_name.clone(),
+                    server_url: server_url.clone(),
+                    on_close: move |_| open.set(false),
+                    on_change: move |_| {
+                        on_change.call(());
+                        open.set(false);
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn AuthorPhotoEditModal(
+    author_id: i64,
+    author_name: String,
+    server_url: String,
+    on_close: EventHandler<()>,
+    on_change: EventHandler<()>,
+) -> Element {
+    let mut url_input = use_signal(String::new);
+    let mut status: Signal<Option<String>> = use_signal(|| None);
+    let mut busy = use_signal(|| false);
+
+    rsx! {
+        div {
+            class: "author-photo-modal-backdrop",
+            role: "dialog",
+            aria_modal: "true",
+            aria_label: "Edit photo for {author_name}",
+            // The overlay is rendered as a child of the author card's
+            // `<Link>`, so any unstopped click would also navigate to the
+            // detail page. Stop propagation on every modal-level click.
+            onclick: move |evt| {
+                evt.stop_propagation();
+                on_close.call(());
+            },
+            div {
+                class: "author-photo-modal",
+                // Clicks inside the modal body don't close it (they don't
+                // reach the backdrop) and don't navigate (propagation
+                // stops here).
+                onclick: move |evt| evt.stop_propagation(),
+
+                div { class: "author-photo-modal__head",
+                    h2 { class: "author-photo-modal__title", "Edit photo" }
+                    p { class: "subtitle author-photo-modal__sub", "{author_name}" }
+                }
+
+                // ===== Option 1: paste image URL =====
+                section { class: "author-photo-modal__section",
+                    label { class: "label", r#for: "author-photo-url",
+                        "Paste image URL"
+                    }
+                    div { class: "author-photo-modal__url-row",
+                        input {
+                            id: "author-photo-url",
+                            r#type: "url",
+                            placeholder: "https://example.com/photo.jpg",
+                            "data-testid": "author-photo-url-input",
+                            disabled: busy(),
+                            value: "{url_input}",
+                            oninput: move |e| url_input.set(e.value()),
+                        }
+                        button {
+                            r#type: "button",
+                            class: "btn",
+                            disabled: busy() || url_input.read().trim().is_empty(),
+                            "data-testid": "author-photo-url-submit",
+                            onclick: {
+                                let server_url = server_url.clone();
+                                move |_| {
+                                    let server_url = server_url.clone();
+                                    let url = url_input.read().trim().to_string();
+                                    if url.is_empty() {
+                                        return;
+                                    }
+                                    busy.set(true);
+                                    status.set(Some("Fetching\u{2026}".into()));
+                                    spawn(async move {
+                                        match data::set_author_photo_url(&server_url, author_id, url).await {
+                                            Ok(()) => {
+                                                status.set(Some("Photo updated.".into()));
+                                                on_change.call(());
+                                            }
+                                            Err(e) => status.set(Some(format!("URL failed: {e}"))),
+                                        }
+                                        busy.set(false);
+                                    });
+                                }
+                            },
+                            "Use URL"
+                        }
+                    }
+                }
+
+                // ===== Option 2: upload file =====
+                section { class: "author-photo-modal__section",
+                    label { class: "label", r#for: "author-photo-file",
+                        "Upload from this device"
+                    }
+                    input {
+                        id: "author-photo-file",
+                        r#type: "file",
+                        accept: "image/jpeg,image/png,image/webp,image/gif",
+                        "data-testid": "author-photo-file-input",
+                        disabled: busy(),
+                        onchange: {
+                            let server_url = server_url.clone();
+                            move |evt: Event<FormData>| {
+                                let server_url = server_url.clone();
+                                let Some(file) = evt.files().into_iter().next() else { return };
+                                let filename = file.name();
+                                let mime = file
+                                    .content_type()
+                                    .unwrap_or_else(|| "application/octet-stream".into());
+                                busy.set(true);
+                                status.set(Some(format!("Uploading {filename}\u{2026}")));
+                                spawn(async move {
+                                    match file.read_bytes().await {
+                                        Ok(bytes) => {
+                                            match data::upload_author_photo(
+                                                &server_url,
+                                                author_id,
+                                                filename,
+                                                mime,
+                                                bytes.to_vec(),
+                                            )
+                                            .await
+                                            {
+                                                Ok(()) => {
+                                                    status.set(Some("Photo uploaded.".into()));
+                                                    on_change.call(());
+                                                }
+                                                Err(e) => {
+                                                    status.set(Some(format!("Upload failed: {e}")))
+                                                }
+                                            }
+                                        }
+                                        Err(e) => {
+                                            status.set(Some(format!("Read file failed: {e}")))
+                                        }
+                                    }
+                                    busy.set(false);
+                                });
+                            }
+                        },
+                    }
+                }
+
+                // ===== Option 3: scan Open Library =====
+                section { class: "author-photo-modal__section",
+                    label { class: "label", "Or fetch automatically" }
+                    button {
+                        r#type: "button",
+                        class: "btn btn-ghost",
+                        disabled: busy(),
+                        "data-testid": "author-photo-scan",
+                        onclick: {
+                            let server_url = server_url.clone();
+                            move |_| {
+                                let server_url = server_url.clone();
+                                busy.set(true);
+                                status.set(Some("Scanning Open Library\u{2026}".into()));
+                                spawn(async move {
+                                    match data::scan_author_photo(&server_url, author_id).await {
+                                        Ok(r) if r.resolved => {
+                                            status.set(Some("Photo found.".into()));
+                                            on_change.call(());
+                                        }
+                                        Ok(_) => status.set(Some(
+                                            "No photo on Open Library for this author.".into(),
+                                        )),
+                                        Err(e) => status.set(Some(format!("Scan failed: {e}"))),
+                                    }
+                                    busy.set(false);
+                                });
+                            }
+                        },
+                        "Scan for picture"
+                    }
+                }
+
+                if let Some(msg) = status() {
+                    p {
+                        class: "author-photo-modal__status",
+                        role: "status",
+                        "data-testid": "author-photo-status",
+                        "{msg}"
+                    }
+                }
+
+                div { class: "author-photo-modal__actions",
+                    button {
+                        r#type: "button",
+                        class: "btn btn-ghost",
+                        onclick: move |_| on_close.call(()),
+                        "Close"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -32,6 +32,13 @@ pub use format_switcher::FormatSwitcher;
 
 pub mod atrium;
 
+// F1.11 follow-up: hover-overlay "edit photo" affordance + modal with
+// three actions (paste URL, upload file, scan Open Library). Reused by
+// the author detail hero and the /authors index cards. Lives in
+// components/ rather than pages/ so both surfaces share the same
+// component instance and styling.
+pub mod author_photo_edit;
+
 #[cfg(not(feature = "mobile"))]
 pub mod search_palette;
 

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -33,10 +33,11 @@ pub use format_switcher::FormatSwitcher;
 pub mod atrium;
 
 // F1.11 follow-up: hover-overlay "edit photo" affordance + modal with
-// three actions (paste URL, upload file, scan Open Library). Reused by
-// the author detail hero and the /authors index cards. Lives in
-// components/ rather than pages/ so both surfaces share the same
-// component instance and styling.
+// three actions (paste URL, upload file, scan Open Library). Mounted by
+// the author detail hero only — the `/authors` index renders cached
+// photos read-only. Lives in components/ rather than pages/ so the
+// modal can be lifted to other surfaces (e.g. an admin bulk-edit view)
+// without duplicating the form.
 pub mod author_photo_edit;
 
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -549,6 +549,51 @@ pub async fn get_author(server_url: &str, id: i64) -> Result<Option<AuthorDetail
         .map_err(|e| e.to_string())
 }
 
+/// F1.11 follow-up: persist an author photo by URL. Server fetches and
+/// validates the URL — see `db::author_photos::fetch_remote_image`.
+#[cfg(feature = "mobile")]
+pub async fn set_author_photo_url(server_url: &str, id: i64, url: String) -> Result<(), String> {
+    let endpoint = format!("{server_url}/api/authors/{id}/photo/url");
+    let response = with_bearer(http_client().put(&endpoint))
+        .json(&serde_json::json!({ "url": url }))
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(())
+}
+
+/// F1.11 follow-up: multipart upload of an author photo. Mobile mirrors the
+/// web FormData path — the same `/api/authors/:id/photo` PUT endpoint.
+#[cfg(feature = "mobile")]
+pub async fn upload_author_photo(
+    server_url: &str,
+    id: i64,
+    filename: String,
+    mime: String,
+    bytes: Vec<u8>,
+) -> Result<(), String> {
+    let endpoint = format!("{server_url}/api/authors/{id}/photo");
+    let part = reqwest::multipart::Part::bytes(bytes)
+        .file_name(filename)
+        .mime_str(&mime)
+        .map_err(|e| format!("{e:#}"))?;
+    let form = reqwest::multipart::Form::new().part("photo", part);
+    let response = with_bearer(http_client().put(&endpoint))
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(())
+}
+
 /// F1.11: admin "Scan for picture" — synchronously re-runs the Open Library
 /// cascade and returns whether a photo was found.
 #[cfg(feature = "mobile")]
@@ -924,6 +969,86 @@ pub async fn scan_author_photo(
     crate::rpc::rpc_scan_author_photo(id)
         .await
         .map_err(note_server_fn_err)
+}
+
+/// F1.11 follow-up: persist an author photo by URL. Web routes through the
+/// `#[post]` server function in `rpc.rs`, which performs the server-side
+/// fetch + validation and writes a `manual` row.
+#[cfg(not(feature = "mobile"))]
+pub async fn set_author_photo_url(_server_url: &str, id: i64, url: String) -> Result<(), String> {
+    crate::rpc::rpc_set_author_photo_url(id, url)
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// F1.11 follow-up: multipart upload of an author photo on the web client.
+///
+/// Server functions can't carry binary file uploads (they JSON-serialize
+/// their arguments), so this bypasses RPC and POSTs the bytes directly to
+/// the REST endpoint via `gloo-net`. The browser auto-attaches the
+/// `omnibus_session` cookie on a same-origin request, so no manual auth
+/// plumbing is needed. SSR doesn't call this — it only fires from a user
+/// `onchange` handler after hydration.
+#[cfg(feature = "web")]
+pub async fn upload_author_photo(
+    _server_url: &str,
+    id: i64,
+    filename: String,
+    mime: String,
+    bytes: Vec<u8>,
+) -> Result<(), String> {
+    use gloo_net::http::Request;
+    use wasm_bindgen::JsCast;
+
+    let endpoint = format!("/api/authors/{id}/photo");
+    let form = web_sys::FormData::new().map_err(|e| format!("FormData::new: {e:?}"))?;
+    // `Blob` ctor wants a `&Array` of `BufferSource | BlobPart` parts —
+    // build a one-element Uint8Array, drop it into a JS Array, then hand
+    // that to `Blob::new_with_u8_array_sequence_and_options`.
+    let u8 = js_sys::Uint8Array::from(bytes.as_slice());
+    let parts = js_sys::Array::new();
+    parts.push(&u8);
+    let mut opts = web_sys::BlobPropertyBag::new();
+    opts.type_(&mime);
+    let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(&parts, &opts)
+        .map_err(|e| format!("Blob::new: {e:?}"))?;
+    form.append_with_blob_and_filename("photo", &blob, &filename)
+        .map_err(|e| format!("FormData::append: {e:?}"))?;
+
+    let res = Request::put(&endpoint)
+        // gloo-net's `body` takes anything `Into<JsValue>` — FormData
+        // satisfies that via its JsCast impl. Don't set Content-Type:
+        // the browser fills it in with the multipart boundary.
+        .body(form.unchecked_into::<wasm_bindgen::JsValue>())
+        .map_err(|e| e.to_string())?
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if res.status() == 401 {
+        web_auth_state::notify_unauthorized();
+        return Err("unauthorized".into());
+    }
+    if !res.ok() {
+        let status = res.status();
+        let msg = res.text().await.unwrap_or_default();
+        return Err(format!("upload failed ({status}): {msg}"));
+    }
+    Ok(())
+}
+
+/// Fallback stub for the non-web, non-mobile build (cargo check on the
+/// default workspace members compiles the frontend with no platform
+/// feature so type-checking still passes). The author detail page only
+/// invokes upload after a user `onchange`, which never fires under SSR.
+#[cfg(not(any(feature = "web", feature = "mobile")))]
+pub async fn upload_author_photo(
+    _server_url: &str,
+    _id: i64,
+    _filename: String,
+    _mime: String,
+    _bytes: Vec<u8>,
+) -> Result<(), String> {
+    Err("upload not available in this build".into())
 }
 
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -7,6 +7,7 @@ use dioxus_router::Link;
 use omnibus_shared::AuthorDetail;
 
 use crate::components::atrium::Cover;
+use crate::components::author_photo_edit::AuthorPhotoEditOverlay;
 use crate::{data, use_server_url, Route};
 
 #[component]
@@ -15,25 +16,6 @@ pub fn AuthorPage(id: i64) -> Element {
     let mut author: Signal<Option<AuthorDetail>> = use_signal(|| None);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
-    // F1.11: gate the "Scan for picture" button on admin. SSR renders with
-    // `false` and the web client overwrites after `/api/auth/me` returns —
-    // matches the pattern in `top_nav::AuthControl`.
-    let is_admin = use_signal(|| false);
-    // Scan-button state: idle / scanning / a one-shot status message.
-    let scanning = use_signal(|| false);
-    let scan_status: Signal<Option<String>> = use_signal(|| None);
-
-    #[cfg(feature = "web")]
-    {
-        let mut admin_setter = is_admin;
-        use_effect(move || {
-            spawn(async move {
-                if let Ok(Some(u)) = crate::data::current_user().await {
-                    admin_setter.set(u.is_admin);
-                }
-            });
-        });
-    }
 
     // See `BookDetailPage` for why `id` needs `use_reactive!`.
     let url = server_url.clone();
@@ -70,7 +52,7 @@ pub fn AuthorPage(id: i64) -> Element {
         };
     };
 
-    render_author(a, server_url, is_admin, scanning, scan_status, author)
+    render_author(a, server_url, author)
 }
 
 // ---------------------------------------------------------------------------
@@ -80,9 +62,6 @@ pub fn AuthorPage(id: i64) -> Element {
 fn render_author(
     a: AuthorDetail,
     server_url: String,
-    is_admin: Signal<bool>,
-    mut scanning: Signal<bool>,
-    mut scan_status: Signal<Option<String>>,
     mut author: Signal<Option<AuthorDetail>>,
 ) -> Element {
     // Derive accent from the first book that has one, or fall back to theme.
@@ -143,18 +122,42 @@ fn render_author(
                 div { class: "disc-hero-grid",
                     // Avatar — letter fallback by default; F1.11 swaps in
                     // the cached profile photo when `has_photo` is set.
-                    if a.has_photo {
-                        img {
-                            class: "disc-avatar disc-avatar--photo",
-                            // Prefix with `server_url` so mobile WebViews
-                            // hit the configured backend origin instead of
-                            // the in-app document origin. `server_url` is
-                            // empty on web, so this is a no-op there.
-                            src: "{server_url}/api/authors/{a.id}/photo",
-                            alt: "{a.name}",
+                    // Wrapped in `AuthorPhotoEditOverlay` so a hover-revealed
+                    // pencil opens the URL/upload/scan modal. The on_change
+                    // callback re-fetches the author payload so the new
+                    // photo (or restored letter, after a scan miss) replaces
+                    // the hero in place.
+                    AuthorPhotoEditOverlay {
+                        author_id: a.id,
+                        author_name: a.name.clone(),
+                        server_url: server_url.clone(),
+                        on_change: {
+                            let server_url = server_url.clone();
+                            let author_id = a.id;
+                            move |_| {
+                                let server_url = server_url.clone();
+                                spawn(async move {
+                                    if let Ok(a2) =
+                                        data::get_author(&server_url, author_id).await
+                                    {
+                                        author.set(a2);
+                                    }
+                                });
+                            }
+                        },
+                        if a.has_photo {
+                            img {
+                                class: "disc-avatar disc-avatar--photo",
+                                // Prefix with `server_url` so mobile WebViews
+                                // hit the configured backend origin instead of
+                                // the in-app document origin. `server_url` is
+                                // empty on web, so this is a no-op there.
+                                src: "{server_url}/api/authors/{a.id}/photo",
+                                alt: "{a.name}",
+                            }
+                        } else {
+                            div { class: "disc-avatar", "{initial}" }
                         }
-                    } else {
-                        div { class: "disc-avatar", "{initial}" }
                     }
                     // Name + metadata
                     div { class: "disc-hero-info",
@@ -162,58 +165,6 @@ fn render_author(
                             "{first} "
                             if !last.is_empty() {
                                 em { "{last}" }
-                            }
-                        }
-                        // F1.11 admin action: re-run the Open Library
-                        // resolver on demand. Hidden on SSR + for non-admins;
-                        // the signal flips after `/api/auth/me` returns.
-                        if is_admin() {
-                            div { class: "disc-hero-actions",
-                                button {
-                                    r#type: "button",
-                                    class: "btn btn-ghost disc-scan-btn",
-                                    disabled: scanning(),
-                                    onclick: {
-                                        let server_url = server_url.clone();
-                                        let author_id = a.id;
-                                        move |_| {
-                                            let server_url = server_url.clone();
-                                            scanning.set(true);
-                                            scan_status.set(None);
-                                            spawn(async move {
-                                                let result = data::scan_author_photo(&server_url, author_id).await;
-                                                match result {
-                                                    Ok(r) => scan_status.set(Some(if r.resolved {
-                                                        "Photo found.".into()
-                                                    } else {
-                                                        "No photo on Open Library for this author.".into()
-                                                    })),
-                                                    Err(e) => scan_status.set(Some(format!("Scan failed: {e}"))),
-                                                }
-                                                // Re-fetch on every outcome so the hero
-                                                // matches server state. Scan deletes the
-                                                // existing row before resolving, so a miss
-                                                // (or even a transient error) means the
-                                                // photo we used to show may no longer
-                                                // exist and the letter needs to come
-                                                // back.
-                                                if let Ok(a2) = data::get_author(&server_url, author_id).await {
-                                                    author.set(a2);
-                                                }
-                                                scanning.set(false);
-                                            });
-                                        }
-                                    },
-                                    if scanning() { "Scanning\u{2026}" } else { "Scan for picture" }
-                                }
-                                if let Some(msg) = scan_status() {
-                                    span {
-                                        class: "disc-scan-status",
-                                        role: "status",
-                                        "data-testid": "scan-status",
-                                        "{msg}"
-                                    }
-                                }
                             }
                         }
                     }

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -21,6 +21,7 @@ enum Sort {
 #[component]
 pub fn AuthorsIndexPage() -> Element {
     let server_url = use_server_url();
+    let server_url_for_cards = server_url.clone();
     let mut authors: Signal<Vec<AuthorSummary>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
@@ -211,7 +212,7 @@ pub fn AuthorsIndexPage() -> Element {
                             }
                             div { class: "idx-card-grid",
                                 for a in group.iter() {
-                                    {render_author_card(a)}
+                                    {render_author_card(a, &server_url_for_cards)}
                                 }
                             }
                         }
@@ -219,7 +220,7 @@ pub fn AuthorsIndexPage() -> Element {
                 } else {
                     div { class: "idx-card-grid idx-card-grid--flat",
                         for a in filtered.iter() {
-                            {render_author_card(a)}
+                            {render_author_card(a, &server_url_for_cards)}
                         }
                     }
                 }
@@ -228,7 +229,7 @@ pub fn AuthorsIndexPage() -> Element {
     }
 }
 
-fn render_author_card(a: &AuthorSummary) -> Element {
+fn render_author_card(a: &AuthorSummary, server_url: &str) -> Element {
     let accent = a.accent.clone().unwrap_or_else(|| "var(--accent)".into());
     let name = a.name.clone();
     let id = a.id;
@@ -254,7 +255,20 @@ fn render_author_card(a: &AuthorSummary) -> Element {
             class: "idx-card idx-card-author",
             style: "--accent: {accent}",
             "data-testid": "author-card",
-            div { class: "idx-card-avatar", "{initial}" }
+            // F1.11: swap the letter glyph for the cached profile photo
+            // when one exists. `server_url` is empty on web (same-origin
+            // fetch) and the configured backend URL on mobile so the
+            // markup is portable. Editing the photo lives on the author
+            // detail page — the index is read-only.
+            if a.has_photo {
+                img {
+                    class: "idx-card-avatar idx-card-avatar--photo",
+                    src: "{server_url}/api/authors/{id}/photo",
+                    alt: "{name}",
+                }
+            } else {
+                div { class: "idx-card-avatar", "{initial}" }
+            }
             div { class: "idx-card-body",
                 div { class: "idx-card-title",
                     if !rest.is_empty() {
@@ -347,6 +361,7 @@ mod tests {
             sort: sort.map(Into::into),
             book_count: 0,
             accent: None,
+            has_photo: false,
         }
     }
 

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -284,6 +284,70 @@ pub async fn rpc_scan_author_photo(id: i64) -> Result<AuthorPhotoScanResult> {
     Ok(AuthorPhotoScanResult { resolved })
 }
 
+/// F1.11 follow-up: persist an author photo by URL. Admin-gated server-side
+/// (the `user.is_admin` check below mirrors `rpc_scan_author_photo`). The
+/// server fetches the URL via `db::author_photos::fetch_remote_image`,
+/// validates the bytes with the same magic-byte sniff as the multipart
+/// upload path, and stores it as a `manual` row.
+#[post("/api/rpc/author/photo-url", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_set_author_photo_url(id: i64, url: String) -> Result<()> {
+    if !user.is_admin {
+        return Err(ServerFnError::new("forbidden: admin required").into());
+    }
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return Err(ServerFnError::new("url is required").into());
+    }
+    let author_exists: bool =
+        sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
+            .bind(id)
+            .fetch_one(&pool.0)
+            .await
+            .map_err(|e| ServerFnError::new(format!("author exists check: {e}")))?
+            != 0;
+    if !author_exists {
+        return Err(ServerFnError::new("author not found").into());
+    }
+    let (_mime_hint, bytes) = db::author_photos::fetch_remote_image(trimmed)
+        .await
+        .map_err(|e| ServerFnError::new(e.to_string()))?;
+    let mime = detect_image_format(&bytes)
+        .ok_or_else(|| ServerFnError::new("file at URL does not appear to be a valid image"))?;
+    db::upsert_author_photo(
+        &pool.0,
+        id,
+        db::AuthorPhotoSource::Manual,
+        Some(trimmed),
+        Some(&mime),
+        Some(&bytes),
+    )
+    .await
+    .map_err(|e| ServerFnError::new(format!("upsert_author_photo: {e}")))?;
+    Ok(())
+}
+
+/// Magic-byte image format sniff. Duplicates `server::backend::detect_image_format`
+/// because the `frontend` crate can't depend on `server` (cycle) and the
+/// function is four lines of pattern matching. Keep the two implementations
+/// in sync — both must recognise the same formats.
+#[cfg(feature = "server")]
+fn detect_image_format(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg".into())
+    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+        Some("image/png".into())
+    } else if bytes.starts_with(b"GIF8") {
+        Some("image/gif".into())
+    } else if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        Some("image/webp".into())
+    } else {
+        None
+    }
+}
+
 /// Return all tags with book counts for the tag cloud.
 #[get("/api/rpc/tags", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_tag_cloud() -> Result<Vec<TagWeight>> {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -40,6 +40,10 @@ tower = "0.5"
 # copies under /tmp. Already a transitive dep elsewhere — explicit here only
 # for the backend integration tests.
 tempfile.workspace = true
+# Mock HTTP server for tests that exercise the remote-image fetcher in
+# `db::author_photos::fetch_remote_image`. Already pinned at this version
+# in `db`'s dev-deps so cargo unifies on one build.
+wiremock = "0.6"
 
 [features]
 default = ["server"]

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -3302,6 +3302,214 @@ mod tests {
         assert!(db::author_photo_status(&pool, id).await.unwrap().is_none());
     }
 
+    // --- Set-by-URL admin handler. The remote fetch is exercised via a
+    // local `wiremock` server, never the public internet. Covers the
+    // admin gate, the validation paths (404 missing author, 400 empty /
+    // bad-scheme URL, non-image content-type, bogus magic bytes), and the
+    // happy path (204 then GET returns the bytes).
+
+    /// JSON PUT helper for the `/api/authors/:id/photo/url` route.
+    fn put_photo_url(uri: &str, token: &str, url: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .method("PUT")
+            .header("content-type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::from(serde_json::json!({ "url": url }).to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_url_requires_admin() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let user = test_support::create_user(&pool, "alice").await;
+        let token = test_support::bearer_token(&pool, user.id).await;
+
+        let res = app
+            .oneshot(put_photo_url(
+                &format!("/api/authors/{id}/photo/url"),
+                &token,
+                "http://127.0.0.1:1/never-reached",
+            ))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_url_404_for_missing_author() {
+        let (app, _state, pool) = fixture().await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let res = app
+            .oneshot(put_photo_url(
+                "/api/authors/9999/photo/url",
+                &token,
+                "http://127.0.0.1:1/never-reached",
+            ))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_url_rejects_empty_url() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let res = app
+            .oneshot(put_photo_url(
+                &format!("/api/authors/{id}/photo/url"),
+                &token,
+                "   ",
+            ))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_url_rejects_bad_scheme() {
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        // ftp:// trips the `fetch_remote_image` scheme guard before any
+        // outbound request fires.
+        let res = app
+            .oneshot(put_photo_url(
+                &format!("/api/authors/{id}/photo/url"),
+                &token,
+                "ftp://example.com/photo.jpg",
+            ))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_url_uploads_and_get_serves() {
+        use wiremock::{
+            matchers::{method, path},
+            Mock, MockServer, ResponseTemplate,
+        };
+
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/portrait.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(TINY_PNG),
+            )
+            .mount(&mock)
+            .await;
+
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let url = format!("{}/portrait.png", mock.uri());
+        let res = app
+            .clone()
+            .oneshot(put_photo_url(
+                &format!("/api/authors/{id}/photo/url"),
+                &token,
+                &url,
+            ))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        let res = app
+            .oneshot(get_with_bearer(&format!("/api/authors/{id}/photo"), &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(bytes.as_ref(), TINY_PNG);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_url_rejects_non_image_content_type() {
+        use wiremock::{
+            matchers::{method, path},
+            Mock, MockServer, ResponseTemplate,
+        };
+
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/not-a-photo.html"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string("<html>nope</html>"),
+            )
+            .mount(&mock)
+            .await;
+
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let url = format!("{}/not-a-photo.html", mock.uri());
+        let res = app
+            .oneshot(put_photo_url(
+                &format!("/api/authors/{id}/photo/url"),
+                &token,
+                &url,
+            ))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn api_put_author_photo_url_rejects_bogus_image_bytes() {
+        // Server lies — declares image/png but the bytes don't carry the
+        // PNG magic header. The handler-side `detect_image_format` sniff
+        // must catch this even though the content-type passes the
+        // `image/` prefix gate.
+        use wiremock::{
+            matchers::{method, path},
+            Mock, MockServer, ResponseTemplate,
+        };
+
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/fake.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(b"definitely not png bytes" as &[u8]),
+            )
+            .mount(&mock)
+            .await;
+
+        let (app, _state, pool) = fixture().await;
+        let id = seed_author(&pool, "Ada Lovelace").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        let url = format!("{}/fake.png", mock.uri());
+        let res = app
+            .oneshot(put_photo_url(
+                &format!("/api/authors/{id}/photo/url"),
+                &token,
+                &url,
+            ))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
     // --- Scan-for-picture admin gate / not-found contract. The resolver
     // itself is exercised by the wiremock-backed tests in
     // `omnibus_db::author_photos::tests`; these only cover the wiring so

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -106,6 +106,10 @@ pub fn rest_router(state: AppState) -> Router {
         .route("/api/thumbs/{id}/{size}", get(get_thumb))
         .route("/api/authors", get(get_authors))
         .route("/api/authors/{id}/photo/scan", post(post_author_photo_scan))
+        // F1.11 follow-up: "Paste image URL" branch of the photo edit
+        // modal. Server-side fetches the URL, validates it, persists as
+        // a `manual` row (same as a multipart upload).
+        .route("/api/authors/{id}/photo/url", put(put_author_photo_url))
         .route("/api/authors/{id}", get(get_author_by_id))
         .route("/api/series", get(get_series))
         .route("/api/series/{id}", get(get_series_by_id))
@@ -1011,6 +1015,86 @@ async fn post_author_photo_scan(
         Err(e) => return internal("get_author_photo (post-scan)", e),
     };
     Json(omnibus_shared::AuthorPhotoScanResult { resolved }).into_response()
+}
+
+/// JSON body for [`put_author_photo_url`]. Kept inline because the shape is
+/// trivial and not shared with any other call site (the RPC server function
+/// passes the URL as a positional arg).
+#[derive(Debug, Deserialize)]
+struct AuthorPhotoUrlBody {
+    url: String,
+}
+
+/// Admin: persist an author photo by URL. Server-side fetches the URL,
+/// validates content-type/size/magic-bytes, and stores it as a `manual`
+/// row — the same source as a multipart upload, so it wins over Open
+/// Library resolution and survives a "Scan for picture" click.
+async fn put_author_photo_url(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(body): Json<AuthorPhotoUrlBody>,
+) -> Response {
+    let author_exists: bool =
+        match sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
+            .bind(id)
+            .fetch_one(&state.pool)
+            .await
+        {
+            Ok(v) => v != 0,
+            Err(e) => return internal("author exists check", e),
+        };
+    if !author_exists {
+        return (axum::http::StatusCode::NOT_FOUND, "author not found").into_response();
+    }
+
+    let url = body.url.trim();
+    if url.is_empty() {
+        return (axum::http::StatusCode::BAD_REQUEST, "url is required").into_response();
+    }
+
+    let (advertised_mime, bytes) = match db::author_photos::fetch_remote_image(url).await {
+        Ok(pair) => pair,
+        Err(db::author_photos::FetchRemoteImageError::Http(e)) => {
+            return internal("fetch remote image", e);
+        }
+        Err(e) => {
+            // All other variants are validation errors (bad scheme, non-image
+            // content-type, too-large, …) — map to 400 with the user-facing
+            // message from `#[error]`.
+            return (axum::http::StatusCode::BAD_REQUEST, e.to_string()).into_response();
+        }
+    };
+
+    // Magic-byte sniff — don't trust the remote Content-Type header.
+    let mime = match detect_image_format(&bytes) {
+        Some(m) => m,
+        None => {
+            tracing::warn!(
+                advertised_mime,
+                "remote URL returned image content-type but bytes are not a recognized image"
+            );
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                "file at URL does not appear to be a valid image",
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(e) = db::upsert_author_photo(
+        &state.pool,
+        id,
+        db::AuthorPhotoSource::Manual,
+        Some(url),
+        Some(&mime),
+        Some(&bytes),
+    )
+    .await
+    {
+        return internal("upsert_author_photo (url)", e);
+    }
+    axum::http::StatusCode::NO_CONTENT.into_response()
 }
 
 #[cfg(test)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -314,6 +314,13 @@ pub struct AuthorSummary {
     /// — the UI falls back to the theme accent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub accent: Option<String>,
+    /// F1.11: `true` when a usable profile photo is cached for this author
+    /// (a `manual` or `openlibrary` row in `author_photos`). Same semantics
+    /// as `AuthorDetail::has_photo` — `'letter'` negative-cache rows do
+    /// not set this flag. Lets the `/authors` index render a real `<img>`
+    /// in one round trip instead of fetching the detail payload per card.
+    #[serde(default)]
+    pub has_photo: bool,
 }
 
 /// Lightweight series row for the `/series` index (F1.12). Carries the


### PR DESCRIPTION
## Summary
Adds a hover-revealed pencil overlay on the author detail hero that opens a modal with three actions: paste image URL, upload file, or re-run the Open Library scan. Replaces the inline admin-only "Scan for picture" button. The `/authors` index now shows cached photos but is read-only — editing lives only on `/authors/:id`.

- `AuthorSummary` gains `has_photo` (mirrors `AuthorDetail`) so the index renders real photos in one round trip.
- New `PUT /api/authors/:id/photo/url` + `rpc_set_author_photo_url`: server fetches the URL, runs the same magic-byte sniff as the multipart upload path, persists as `manual`.
- Hero grid switches to `align-items: center` so the avatar and the heading line up after the inline actions row moved into the modal.

## Test plan
- [x] `cargo test -p omnibus-db` — new `list_authors_populates_has_photo` covers the same no-row / `letter` / `manual` matrix as the `get_author` regression.
- [x] `cargo test -p omnibus -p omnibus-db -p omnibus-frontend --features omnibus-frontend/server` — full suite green.
- [x] `cargo clippy --workspace --no-deps` clean.
- [x] Manual: `/authors` shows photos, no edit affordance, clicking a card navigates. `/authors/:id` hover reveals pencil; modal opens without navigating; URL / upload / scan all round-trip; modal auto-closes on success and the hero refetches.

## Notes
- URL fetcher caps at 10 MiB and rejects SVG (same gates as the multipart route). Manual uploads still win the cascade — `Scan for picture` is a no-op when a `manual` row exists.