### PR TITLE
fix: correct missing/generated cover rendering (#92)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -35,6 +35,10 @@
   --accent-soft:   oklch(0.30 0.07 65);
   --accent-ink:    oklch(0.16 0.02 65);
 
+  /* Missing-cover plate ground (issue #92): neutral grey, never the accent. */
+  --cover-fallback-bg:  oklch(0.30 0.004 70);
+  --cover-fallback-ink: oklch(0.92 0.004 70);
+
   --ok:   oklch(0.78 0.13 150);
   --warn: oklch(0.78 0.13 75);
   --bad:  oklch(0.72 0.16 25);
@@ -62,6 +66,8 @@
   --ink-2: oklch(0.52 0.010 70);
   --ink-3: oklch(0.66 0.010 70);
   --accent-ink: oklch(0.99 0 0);
+  --cover-fallback-bg:  oklch(0.86 0.004 70);
+  --cover-fallback-ink: oklch(0.28 0.006 70);
   color-scheme: light;
 }
 
@@ -371,7 +377,10 @@ body.atrium,
 }
 .cover {
   position: absolute; inset: 0;
-  background: var(--accent); color: var(--accent-ink);
+  /* Neutral grey ground (issue #92): the missing-cover plate must never be
+     the accent colour. Real images fill `.cover` via object-fit, so this
+     only shows behind the typographic fallback / before an image paints. */
+  background: var(--cover-fallback-bg); color: var(--cover-fallback-ink);
   border-radius: 2px 4px 4px 2px;
   overflow: hidden; font-family: var(--serif);
   box-shadow:
@@ -414,12 +423,6 @@ body.atrium,
   font-family: var(--sans); font-size: clamp(6.5px, 5.5cqi, 12px);
   letter-spacing: 0.22em; text-transform: uppercase;
   opacity: .82; font-weight: 600;
-}
-.cover .imprint {
-  position: absolute; bottom: 6%; left: 0; right: 0;
-  text-align: center; font-family: var(--sans);
-  font-size: clamp(5.5px, 4cqi, 10px);
-  letter-spacing: 0.32em; opacity: .55; text-transform: uppercase;
 }
 
 /* Cover-as-link: lift on hover */

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -101,7 +101,9 @@ pub fn AtriumRoot(children: Element) -> Element {
 // ── Cover ─────────────────────────────────────────────────────────
 
 /// Book cover. Renders the real image when one exists, otherwise a stylized
-/// "plate" template using the book's title + author + year metadata.
+/// "plate" template using the book's title + author metadata on a neutral
+/// grey ground (the per-book accent only tints real-image theming, never the
+/// missing-cover plate — see issue #92).
 ///
 /// The `--accent` custom property is set inline from the book's extracted
 /// accent color (or left to inherit the page-level default). Consumers who
@@ -129,18 +131,16 @@ pub fn Cover(
         .as_deref()
         .map(|a| format!("--accent: {a};"))
         .unwrap_or_default();
-    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    // Fall back to the filename when the title is absent *or* an empty /
+    // whitespace-only string. Without this, books whose `title` is
+    // `Some("")` rendered a blank plate (issue #92): `unwrap_or_else` only
+    // fires on `None`, so an empty string slipped through as the title.
+    let title = fallback_title(book.title.as_deref(), &book.filename);
     let author = book
         .creators
         .first()
         .map(|c| c.name.clone())
         .unwrap_or_default();
-    let year = book
-        .published
-        .as_deref()
-        .and_then(|p| p.get(0..4))
-        .unwrap_or("")
-        .to_string();
     let author_label = author
         .split(',')
         .next()
@@ -171,12 +171,19 @@ pub fn Cover(
                 } else {
                     div { class: "ca", "{author_label}" }
                     div { class: "ct", "{title}" }
-                    if !year.is_empty() {
-                        div { class: "imprint", "{year} · Omnibus" }
-                    }
                 }
             }
         }
+    }
+}
+
+/// Pick the text for the typographic cover plate: the book's `title` when it
+/// carries non-blank content, otherwise the on-disk `filename`. Guards the
+/// `Some("")` / whitespace-only case that otherwise renders a blank plate.
+fn fallback_title(title: Option<&str>, filename: &str) -> String {
+    match title {
+        Some(t) if !t.trim().is_empty() => t.to_string(),
+        _ => filename.to_string(),
     }
 }
 
@@ -236,4 +243,30 @@ fn read_persisted_theme() -> Option<Theme> {
     let storage = web_sys::window().and_then(|w| w.local_storage().ok().flatten())?;
     let value = storage.get_item("omn.theme").ok().flatten()?;
     Theme::from_attr(&value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_title_prefers_a_present_title() {
+        assert_eq!(fallback_title(Some("Dune"), "dune.epub"), "Dune");
+    }
+
+    #[test]
+    fn fallback_title_uses_filename_when_title_is_none() {
+        assert_eq!(fallback_title(None, "dune.epub"), "dune.epub");
+    }
+
+    #[test]
+    fn fallback_title_uses_filename_for_empty_title() {
+        // Regression for issue #92: a `Some("")` title rendered a blank plate.
+        assert_eq!(fallback_title(Some(""), "dune.epub"), "dune.epub");
+    }
+
+    #[test]
+    fn fallback_title_uses_filename_for_whitespace_only_title() {
+        assert_eq!(fallback_title(Some("   "), "dune.epub"), "dune.epub");
+    }
 }


### PR DESCRIPTION
## Summary
- Missing-cover plates now render on a neutral **grey** ground instead of the per-book accent colour.
- Books whose title is an empty/whitespace string (`Some("")`) no longer render a blank plate — they fall back to the filename.
- Removed the `{year} · Omnibus` imprint footer that overlapped the title on generated covers.

Fixes all three problems reported in #92:
1. **Blank accent rectangle for missing covers** — two root causes. The `.cover` plate used `background: var(--accent)`, and the `Cover` component's `unwrap_or_else` only filled in the filename on `None`, so a `Some("")` title produced an empty `.ct` div over the accent fill. Now the plate uses grey tokens, and `fallback_title` treats blank/whitespace titles as missing.
2. **Imprint overlapping the title** — the `.imprint` div was `position: absolute; bottom: 6%` while the title flowed in normal layout, so long titles collided with it. The imprint (markup + CSS) is removed.
3. **All missing covers should be grey** — done via a single source of truth.

## What changed
- `frontend/assets/atrium.css`
  - New `--cover-fallback-bg` / `--cover-fallback-ink` grey tokens (dark + light theme blocks) — the single source of truth for the plate ground.
  - `.cover` ground switched from `var(--accent)` → the grey tokens. The per-book accent still drives real-image theming via `--accent` on `.cover-wrap`.
  - Removed the `.cover .imprint` rule.
- `frontend/src/components/atrium.rs`
  - Added `fallback_title(title, filename)` helper: uses the title only when it has non-blank content, else the filename. Replaces the `unwrap_or_else` that let empty strings through.
  - Removed the `year`/imprint markup from the `Cover` rsx.
  - Added four `#[cfg(test)]` unit tests for `fallback_title` (present / none / empty / whitespace).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` (default-members: server/shared/frontend) — clean. Note: `--all-features` is not applicable here — the frontend's `web`/`mobile` features are mutually exclusive by design (`compile_error!`), so the repo lints per-crate.
- [x] `cargo test -p omnibus-frontend --features server` — 64 passed (incl. 4 new `fallback_title` tests)
- [x] `cargo test -p omnibus` — 128 passed

## Notes
> [!IMPORTANT]
> **Visual verification was not performed.** A browser preview could not be driven from this isolated worktree (`nix` is not on PATH here, so `just dev-up` / the `ui-validate` flow was unavailable). The change is a CSS-token + markup fix verified by unit/integration tests and diff review, not by observing the rendered page. A reviewer should eyeball a missing-cover grid tile and a long-title generated cover to confirm the grey ground and the absence of the imprint.

> [!NOTE]
> Out of scope: the `book_detail.rs` cover fallback uses a separate `.book-detail-cover-fallback` (book emoji on a translucent ground) and was not part of this issue — left untouched. No Cargo.lock / dependency changes. No Playwright specs were modified (none assert on the typographic plate's `.ct`/`.ca`/imprint content), so `run_ui_tests` is not applied.

Closes #92

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGr166LHKgeg8PtxYRHsBV)_