### PR TITLE
refactor: typed DataError for mobile transport (#96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ migrations/         — numbered SQL migrations embedded via sqlx::migrate!
 
 ```
 lib.rs              — Route, App, styles, ScreenLayout (feature-gated)
-data.rs             — Feature-gated data transport (mobile=reqwest, web/server=rpc)
+data.rs             — Feature-gated data transport (mobile=reqwest, web/server=rpc); transport fns return Result<T, DataError> (thiserror enum: Network/Http/Decode/Unauthorized/Other) so the 401 path pattern-matches DataError::Unauthorized instead of re-inspecting raw status codes
 rpc.rs              — #[get]/#[post] server functions (mounted by dioxus::server::router); server bodies call into omnibus_db
 pages/{landing,settings,book_detail,metadata_edit,auth,author,authors_index,series,series_index,tag_cloud,search}.rs  — auth.rs hosts LoginPage + RegisterPage. Landing is the primary Atrium consumer (cover grid + power-user table) and the source of format-faceted filtering (ViewFilters.formats in shared). metadata_edit.rs is the F5.1 single-book edit form at /books/:id/edit. Discovery pages (author, series, tag_cloud) are F1.8. authors_index.rs and series_index.rs are the F1.12 `/authors` and `/series` browse-all index surfaces. search.rs is the full-page /search/:query results view that the F1.5 palette routes into when the user presses Enter without arrow-key navigation, or when a Tag row is selected.
 components/{top_nav,bottom_nav}.rs  — feature = web / mobile respectively

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3886,6 +3886,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wasm-bindgen",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -10,6 +10,11 @@ omnibus-shared = { path = "../shared" }
 omnibus-db = { path = "../db", optional = true }
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
+# Typed transport errors for the feature-gated `data` layer (#96). Always on:
+# `data::DataError` is referenced by callers under every platform feature, so
+# the derive must be available in all builds (including the no-feature
+# default-members check). Version matches `omnibus-db`.
+thiserror = "1"
 reqwest = { workspace = true, optional = true, features = ["multipart"] }
 gloo-net = { version = "0.6", default-features = false, features = ["http", "json"], optional = true }
 gloo-timers = { version = "0.3", features = ["futures"], optional = true }

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -32,8 +32,14 @@ use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
 /// Errors surfaced by the feature-gated data transport.
 #[derive(Debug, thiserror::Error)]
 pub enum DataError {
-    /// Transport-level failure (connect/timeout/TLS). Mobile-only because
-    /// `reqwest` is only linked under `feature = "mobile"`.
+    /// `reqwest`-level failure on the mobile transport: connect / timeout /
+    /// TLS **and** response-body decode errors. The mobile calls deserialize
+    /// via `response.json()`, which surfaces a malformed body as a
+    /// `reqwest::Error` (`reqwest::Error::is_decode()`), not a
+    /// `serde_json::Error` — so a decode failure on mobile lands here rather
+    /// than in [`DataError::Decode`]. That `Decode` variant is produced only
+    /// by the web/SSR path, which deserializes through `serde_json` directly.
+    /// Mobile-only because `reqwest` is only linked under `feature = "mobile"`.
     #[cfg(feature = "mobile")]
     #[error("network error: {0}")]
     Network(#[from] reqwest::Error),
@@ -399,8 +405,10 @@ fn note_status(status: reqwest::StatusCode) -> reqwest::StatusCode {
 /// connection to its pool instead of dropping it mid-stream, and folds the
 /// server's diagnostic text into the structured error.
 ///
-/// Precondition: only call on a non-success status. `note_status` has already
-/// cleared the bearer token by the time we land here on a 401.
+/// Precondition: only call on a non-success status. The authenticated data
+/// calls run `note_status` first, so the bearer token is already cleared by
+/// the time we land here on a 401. The pre-auth `post_mobile_auth` path does
+/// not call `note_status`, but a pre-auth 401 has no stored token to clear.
 #[cfg(feature = "mobile")]
 async fn drain_error(response: reqwest::Response, status: reqwest::StatusCode) -> DataError {
     if status == reqwest::StatusCode::UNAUTHORIZED {

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -18,6 +18,56 @@ use omnibus_shared::{
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
 
+// ===== Typed transport error (#96) =====
+//
+// Replaces the previous `Result<T, String>` everywhere in this module so
+// callers can distinguish failure modes by type — most importantly
+// `Unauthorized`, which the mobile 401 handler and the web router both key
+// on. The variants that carry a foreign error type (`reqwest`, `serde_json`)
+// are feature-gated to match the optional deps that provide them: `reqwest`
+// is mobile-only, `serde_json` is web+mobile. `Unauthorized`, `Http`, and
+// the `Other` catch-all are always present so the enum's public shape is
+// stable across every build that compiles the callers.
+
+/// Errors surfaced by the feature-gated data transport.
+#[derive(Debug, thiserror::Error)]
+pub enum DataError {
+    /// Transport-level failure (connect/timeout/TLS). Mobile-only because
+    /// `reqwest` is only linked under `feature = "mobile"`.
+    #[cfg(feature = "mobile")]
+    #[error("network error: {0}")]
+    Network(#[from] reqwest::Error),
+    /// The server responded with a non-success status (other than 401, which
+    /// maps to [`DataError::Unauthorized`]). `body` carries the server's
+    /// diagnostic text so callers that surface it — e.g. the register-error
+    /// classifier — keep working.
+    #[error("server returned {status}")]
+    Http { status: u16, body: String },
+    /// Response body could not be deserialized into the expected type.
+    #[cfg(any(feature = "mobile", feature = "web"))]
+    #[error("response deserialization failed: {0}")]
+    Decode(#[from] serde_json::Error),
+    /// Authentication failed (HTTP 401). Distinct variant so the 401 →
+    /// clear-token → redirect-to-/login flow can pattern-match instead of
+    /// re-inspecting a raw status code.
+    #[error("unauthorized")]
+    Unauthorized,
+    /// Catch-all for transport paths that don't carry a typed source —
+    /// the web server-function client (whose error is already stringified
+    /// by `note_server_fn_err`), the `gloo-net` web/SSR stubs, and a couple
+    /// of protocol invariants (missing JSON field, absent bearer token).
+    #[error("{0}")]
+    Other(String),
+}
+
+impl DataError {
+    /// `true` when this represents an authentication failure. Lets callers
+    /// branch on auth without depending on a specific HTTP code.
+    pub fn is_unauthorized(&self) -> bool {
+        matches!(self, DataError::Unauthorized)
+    }
+}
+
 // ===== Mobile transport: reqwest =====
 
 #[cfg(feature = "mobile")]
@@ -342,118 +392,103 @@ fn note_status(status: reqwest::StatusCode) -> reqwest::StatusCode {
     status
 }
 
-/// Drain the response body and format an error string. Always reading the
-/// body — even on the error path — lets reqwest return the underlying TCP
+/// Map a non-success response into a typed [`DataError`]. A 401 becomes
+/// [`DataError::Unauthorized`] (so callers can pattern-match the auth path);
+/// everything else drains the body into [`DataError::Http`]. Always reading
+/// the body — even on the error path — lets reqwest return the underlying TCP
 /// connection to its pool instead of dropping it mid-stream, and folds the
-/// server's diagnostic text into the user-visible error.
+/// server's diagnostic text into the structured error.
+///
+/// Precondition: only call on a non-success status. `note_status` has already
+/// cleared the bearer token by the time we land here on a 401.
 #[cfg(feature = "mobile")]
-async fn drain_error(response: reqwest::Response, status: reqwest::StatusCode) -> String {
+async fn drain_error(response: reqwest::Response, status: reqwest::StatusCode) -> DataError {
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return DataError::Unauthorized;
+    }
     let body = response.text().await.unwrap_or_default();
-    if body.is_empty() {
-        format!("Server error: {status}")
-    } else {
-        format!("Server error {status}: {body}")
+    DataError::Http {
+        status: status.as_u16(),
+        body,
     }
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_value(server_url: &str) -> Result<i64, String> {
+pub async fn get_value(server_url: &str) -> Result<i64, DataError> {
     let url = format!("{server_url}/api/value");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    let payload: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+    let payload: serde_json::Value = response.json().await?;
     payload["value"]
         .as_i64()
-        .ok_or_else(|| "missing value field".into())
+        .ok_or_else(|| DataError::Other("missing value field".into()))
 }
 
 #[cfg(feature = "mobile")]
-pub async fn post_increment(server_url: &str) -> Result<i64, String> {
+pub async fn post_increment(server_url: &str) -> Result<i64, DataError> {
     let url = format!("{server_url}/api/value/increment");
-    let response = with_bearer(http_client().post(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().post(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    let payload: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+    let payload: serde_json::Value = response.json().await?;
     payload["value"]
         .as_i64()
-        .ok_or_else(|| "missing value field".into())
+        .ok_or_else(|| DataError::Other("missing value field".into()))
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_settings(server_url: &str) -> Result<Settings, String> {
+pub async fn get_settings(server_url: &str) -> Result<Settings, DataError> {
     let url = format!("{server_url}/api/settings");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response.json::<Settings>().await.map_err(|e| e.to_string())
+    Ok(response.json::<Settings>().await?)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn save_settings(server_url: &str, settings: Settings) -> Result<Settings, String> {
+pub async fn save_settings(server_url: &str, settings: Settings) -> Result<Settings, DataError> {
     let url = format!("{server_url}/api/settings");
     let response = with_bearer(http_client().post(&url).json(&settings))
         .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+        .await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response.json::<Settings>().await.map_err(|e| e.to_string())
+    Ok(response.json::<Settings>().await?)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_library(server_url: &str) -> Result<LibraryContents, String> {
+pub async fn get_library(server_url: &str) -> Result<LibraryContents, DataError> {
     let url = format!("{server_url}/api/library");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<LibraryContents>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<LibraryContents>().await?)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_ebooks(server_url: &str) -> Result<EbookLibrary, String> {
+pub async fn get_ebooks(server_url: &str) -> Result<EbookLibrary, DataError> {
     let url = format!("{server_url}/api/ebooks");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<EbookLibrary>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<EbookLibrary>().await?)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, String> {
+pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, DataError> {
     // Percent-encode the query so FTS5 operators and whitespace survive the
     // URL.
     let encoded: String = q
@@ -466,23 +501,17 @@ pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, St
         })
         .collect();
     let url = format!("{server_url}/api/search?q={encoded}");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<EbookLibrary>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<EbookLibrary>().await?)
 }
 
 /// Search palette — grouped results for the command-palette overlay (F1.5).
 #[cfg(feature = "mobile")]
-pub async fn search_palette(server_url: &str, q: &str) -> Result<PaletteResults, String> {
+pub async fn search_palette(server_url: &str, q: &str) -> Result<PaletteResults, DataError> {
     let encoded: String = q
         .bytes()
         .map(|b| match b {
@@ -493,27 +522,18 @@ pub async fn search_palette(server_url: &str, q: &str) -> Result<PaletteResults,
         })
         .collect();
     let url = format!("{server_url}/api/search/palette?q={encoded}");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<PaletteResults>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<PaletteResults>().await?)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_ebook(server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
+pub async fn get_ebook(server_url: &str, id: i64) -> Result<Option<EbookMetadata>, DataError> {
     let url = format!("{server_url}/api/ebooks/{id}");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if status == reqwest::StatusCode::NOT_FOUND {
         return Ok(None);
@@ -521,20 +541,13 @@ pub async fn get_ebook(server_url: &str, id: i64) -> Result<Option<EbookMetadata
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<EbookMetadata>()
-        .await
-        .map(Some)
-        .map_err(|e| e.to_string())
+    Ok(Some(response.json::<EbookMetadata>().await?))
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_author(server_url: &str, id: i64) -> Result<Option<AuthorDetail>, String> {
+pub async fn get_author(server_url: &str, id: i64) -> Result<Option<AuthorDetail>, DataError> {
     let url = format!("{server_url}/api/authors/{id}");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if status == reqwest::StatusCode::NOT_FOUND {
         return Ok(None);
@@ -542,23 +555,18 @@ pub async fn get_author(server_url: &str, id: i64) -> Result<Option<AuthorDetail
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<AuthorDetail>()
-        .await
-        .map(Some)
-        .map_err(|e| e.to_string())
+    Ok(Some(response.json::<AuthorDetail>().await?))
 }
 
 /// F1.11 follow-up: persist an author photo by URL. Server fetches and
 /// validates the URL — see `db::author_photos::fetch_remote_image`.
 #[cfg(feature = "mobile")]
-pub async fn set_author_photo_url(server_url: &str, id: i64, url: String) -> Result<(), String> {
+pub async fn set_author_photo_url(server_url: &str, id: i64, url: String) -> Result<(), DataError> {
     let endpoint = format!("{server_url}/api/authors/{id}/photo/url");
     let response = with_bearer(http_client().put(&endpoint))
         .json(&serde_json::json!({ "url": url }))
         .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+        .await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
@@ -575,18 +583,16 @@ pub async fn upload_author_photo(
     filename: String,
     mime: String,
     bytes: Vec<u8>,
-) -> Result<(), String> {
+) -> Result<(), DataError> {
     let endpoint = format!("{server_url}/api/authors/{id}/photo");
     let part = reqwest::multipart::Part::bytes(bytes)
         .file_name(filename)
-        .mime_str(&mime)
-        .map_err(|e| format!("{e:#}"))?;
+        .mime_str(&mime)?;
     let form = reqwest::multipart::Form::new().part("photo", part);
     let response = with_bearer(http_client().put(&endpoint))
         .multipart(form)
         .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+        .await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
@@ -597,29 +603,23 @@ pub async fn upload_author_photo(
 /// F1.11: admin "Scan for picture" — synchronously re-runs the Open Library
 /// cascade and returns whether a photo was found.
 #[cfg(feature = "mobile")]
-pub async fn scan_author_photo(server_url: &str, id: i64) -> Result<AuthorPhotoScanResult, String> {
+pub async fn scan_author_photo(
+    server_url: &str,
+    id: i64,
+) -> Result<AuthorPhotoScanResult, DataError> {
     let url = format!("{server_url}/api/authors/{id}/photo/scan");
-    let response = with_bearer(http_client().post(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().post(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<AuthorPhotoScanResult>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<AuthorPhotoScanResult>().await?)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_series(server_url: &str, id: i64) -> Result<Option<SeriesDetail>, String> {
+pub async fn get_series(server_url: &str, id: i64) -> Result<Option<SeriesDetail>, DataError> {
     let url = format!("{server_url}/api/series/{id}");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if status == reqwest::StatusCode::NOT_FOUND {
         return Ok(None);
@@ -627,62 +627,40 @@ pub async fn get_series(server_url: &str, id: i64) -> Result<Option<SeriesDetail
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<SeriesDetail>()
-        .await
-        .map(Some)
-        .map_err(|e| e.to_string())
+    Ok(Some(response.json::<SeriesDetail>().await?))
 }
 
 #[cfg(feature = "mobile")]
-pub async fn list_authors(server_url: &str) -> Result<Vec<AuthorSummary>, String> {
+pub async fn list_authors(server_url: &str) -> Result<Vec<AuthorSummary>, DataError> {
     let url = format!("{server_url}/api/authors");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<Vec<AuthorSummary>>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<Vec<AuthorSummary>>().await?)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn list_series(server_url: &str) -> Result<Vec<SeriesSummary>, String> {
+pub async fn list_series(server_url: &str) -> Result<Vec<SeriesSummary>, DataError> {
     let url = format!("{server_url}/api/series");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<Vec<SeriesSummary>>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<Vec<SeriesSummary>>().await?)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_tag_cloud(server_url: &str) -> Result<Vec<TagWeight>, String> {
+pub async fn get_tag_cloud(server_url: &str) -> Result<Vec<TagWeight>, DataError> {
     let url = format!("{server_url}/api/tags");
-    let response = with_bearer(http_client().get(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<Vec<TagWeight>>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<Vec<TagWeight>>().await?)
 }
 
 #[cfg(feature = "mobile")]
@@ -690,40 +668,31 @@ pub async fn save_overrides(
     server_url: &str,
     id: i64,
     overrides: &MetadataOverrides,
-) -> Result<Option<EbookMetadata>, String> {
+) -> Result<Option<EbookMetadata>, DataError> {
     let url = format!("{server_url}/api/ebooks/{id}/overrides");
     let response = with_bearer(http_client().post(&url))
         .json(overrides)
         .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+        .await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<EbookMetadata>()
-        .await
-        .map(Some)
-        .map_err(|e| e.to_string())
+    Ok(Some(response.json::<EbookMetadata>().await?))
 }
 
 #[cfg(feature = "mobile")]
-pub async fn delete_overrides(server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
+pub async fn delete_overrides(
+    server_url: &str,
+    id: i64,
+) -> Result<Option<EbookMetadata>, DataError> {
     let url = format!("{server_url}/api/ebooks/{id}/overrides/delete");
-    let response = with_bearer(http_client().post(&url))
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = with_bearer(http_client().post(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);
     }
-    response
-        .json::<EbookMetadata>()
-        .await
-        .map(Some)
-        .map_err(|e| e.to_string())
+    Ok(Some(response.json::<EbookMetadata>().await?))
 }
 
 // ===== Mobile auth transport: bearer token =====
@@ -740,7 +709,7 @@ pub async fn mobile_login(
     username: String,
     password: String,
     device_name: Option<String>,
-) -> Result<UserSummary, String> {
+) -> Result<UserSummary, DataError> {
     let req = LoginRequest {
         username,
         password,
@@ -757,7 +726,7 @@ pub async fn mobile_register(
     username: String,
     password: String,
     device_name: Option<String>,
-) -> Result<UserSummary, String> {
+) -> Result<UserSummary, DataError> {
     let req = RegisterRequest {
         username,
         password,
@@ -774,16 +743,18 @@ pub async fn mobile_register(
 /// `client_kind` discriminator was missed server-side, which we want to
 /// fail loudly rather than silently degrade to a no-auth state.
 #[cfg(feature = "mobile")]
-fn finish_bearer_auth(resp: LoginResponse) -> Result<UserSummary, String> {
+fn finish_bearer_auth(resp: LoginResponse) -> Result<UserSummary, DataError> {
     let Some(token) = resp.token else {
-        return Err("server did not issue a bearer token".into());
+        return Err(DataError::Other(
+            "server did not issue a bearer token".into(),
+        ));
     };
     token_store::set(token);
     Ok(resp.user)
 }
 
 #[cfg(feature = "mobile")]
-pub async fn mobile_logout(server_url: &str) -> Result<(), String> {
+pub async fn mobile_logout(server_url: &str) -> Result<(), DataError> {
     // Best-effort server revocation, then always clear the local token so a
     // network failure can't leave the device wedged in a "logged in" state.
     let url = format!("{server_url}/api/auth/logout");
@@ -797,23 +768,19 @@ async fn post_mobile_auth<T: serde::Serialize>(
     server_url: &str,
     path: &str,
     body: &T,
-) -> Result<LoginResponse, String> {
+) -> Result<LoginResponse, DataError> {
     let url = format!("{server_url}{path}");
-    let response = http_client()
-        .post(&url)
-        .json(body)
-        .send()
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    let response = http_client().post(&url).json(body).send().await?;
     let status = response.status();
     if !status.is_success() {
-        let msg = response.text().await.unwrap_or_default();
-        return Err(format!("{status}: {msg}"));
+        // Auth failures arrive here as the server's chosen status (400 bad
+        // credentials, 409 duplicate username, …); 401 maps to the typed
+        // `Unauthorized` variant for symmetry with `drain_error`. The body
+        // is preserved in `Http` so the register-error classifier can still
+        // route "username"/"password" diagnostics to the right field.
+        return Err(drain_error(response, status).await);
     }
-    response
-        .json::<LoginResponse>()
-        .await
-        .map_err(|e| e.to_string())
+    Ok(response.json::<LoginResponse>().await?)
 }
 
 // ===== Web auth state =====
@@ -864,12 +831,13 @@ pub mod web_auth_state {
 /// Inspect a server-function error (Dioxus wraps it in `CapturedError`,
 /// which holds an `Arc<anyhow::Error>`) and — on the web client — ping
 /// `web_auth_state` if the underlying `ServerFnError` carries a 401
-/// status code. Returns the stringified error the previous
-/// `.map_err(|e| e.to_string())` produced so callers don't need to
-/// change their error type. SSR builds (cfg(not(feature = "web"))) just
-/// stringify — there's no client to redirect.
+/// status code. Maps the error into a [`DataError`]: a 401 becomes
+/// [`DataError::Unauthorized`] (so the web side can pattern-match the auth
+/// path the same way mobile does), and any other failure is preserved as a
+/// stringified [`DataError::Other`]. SSR builds (cfg(not(feature = "web")))
+/// skip the redirect ping — there's no client to redirect.
 #[cfg(not(feature = "mobile"))]
-fn note_server_fn_err(e: dioxus::CapturedError) -> String {
+fn note_server_fn_err(e: dioxus::CapturedError) -> DataError {
     if let Some(sfn_err) = e.0.downcast_ref::<dioxus::fullstack::ServerFnError>() {
         let code = match sfn_err {
             dioxus::fullstack::ServerFnError::ServerError { code, .. } => *code,
@@ -878,9 +846,10 @@ fn note_server_fn_err(e: dioxus::CapturedError) -> String {
         if code == 401 {
             #[cfg(feature = "web")]
             web_auth_state::notify_unauthorized();
+            return DataError::Unauthorized;
         }
     }
-    e.to_string()
+    DataError::Other(e.to_string())
 }
 
 // ===== Web / fullstack-SSR transport: dioxus-fullstack server functions =====
@@ -889,7 +858,7 @@ fn note_server_fn_err(e: dioxus::CapturedError) -> String {
 // page origin. We keep the parameter so the call sites stay platform-agnostic.
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_value(_server_url: &str) -> Result<i64, String> {
+pub async fn get_value(_server_url: &str) -> Result<i64, DataError> {
     match crate::rpc::rpc_get_value().await {
         Ok(payload) => Ok(payload.value),
         Err(e) => Err(note_server_fn_err(e)),
@@ -897,7 +866,7 @@ pub async fn get_value(_server_url: &str) -> Result<i64, String> {
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn post_increment(_server_url: &str) -> Result<i64, String> {
+pub async fn post_increment(_server_url: &str) -> Result<i64, DataError> {
     match crate::rpc::rpc_increment_value().await {
         Ok(payload) => Ok(payload.value),
         Err(e) => Err(note_server_fn_err(e)),
@@ -905,35 +874,35 @@ pub async fn post_increment(_server_url: &str) -> Result<i64, String> {
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_settings(_server_url: &str) -> Result<Settings, String> {
+pub async fn get_settings(_server_url: &str) -> Result<Settings, DataError> {
     crate::rpc::rpc_get_settings()
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn save_settings(_server_url: &str, settings: Settings) -> Result<Settings, String> {
+pub async fn save_settings(_server_url: &str, settings: Settings) -> Result<Settings, DataError> {
     crate::rpc::rpc_save_settings(settings)
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_library(_server_url: &str) -> Result<LibraryContents, String> {
+pub async fn get_library(_server_url: &str) -> Result<LibraryContents, DataError> {
     crate::rpc::rpc_get_library()
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_ebooks(_server_url: &str) -> Result<EbookLibrary, String> {
+pub async fn get_ebooks(_server_url: &str) -> Result<EbookLibrary, DataError> {
     crate::rpc::rpc_get_ebooks()
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, String> {
+pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, DataError> {
     crate::rpc::rpc_search(q.to_string())
         .await
         .map_err(note_server_fn_err)
@@ -941,21 +910,21 @@ pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, S
 
 /// Search palette — grouped results for the command-palette overlay (F1.5).
 #[cfg(not(feature = "mobile"))]
-pub async fn search_palette(_server_url: &str, q: &str) -> Result<PaletteResults, String> {
+pub async fn search_palette(_server_url: &str, q: &str) -> Result<PaletteResults, DataError> {
     crate::rpc::rpc_search_palette(q.to_string())
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_ebook(_server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
+pub async fn get_ebook(_server_url: &str, id: i64) -> Result<Option<EbookMetadata>, DataError> {
     crate::rpc::rpc_get_ebook(id)
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_author(_server_url: &str, id: i64) -> Result<Option<AuthorDetail>, String> {
+pub async fn get_author(_server_url: &str, id: i64) -> Result<Option<AuthorDetail>, DataError> {
     crate::rpc::rpc_get_author(id)
         .await
         .map_err(note_server_fn_err)
@@ -965,7 +934,7 @@ pub async fn get_author(_server_url: &str, id: i64) -> Result<Option<AuthorDetai
 pub async fn scan_author_photo(
     _server_url: &str,
     id: i64,
-) -> Result<AuthorPhotoScanResult, String> {
+) -> Result<AuthorPhotoScanResult, DataError> {
     crate::rpc::rpc_scan_author_photo(id)
         .await
         .map_err(note_server_fn_err)
@@ -975,7 +944,11 @@ pub async fn scan_author_photo(
 /// `#[post]` server function in `rpc.rs`, which performs the server-side
 /// fetch + validation and writes a `manual` row.
 #[cfg(not(feature = "mobile"))]
-pub async fn set_author_photo_url(_server_url: &str, id: i64, url: String) -> Result<(), String> {
+pub async fn set_author_photo_url(
+    _server_url: &str,
+    id: i64,
+    url: String,
+) -> Result<(), DataError> {
     crate::rpc::rpc_set_author_photo_url(id, url)
         .await
         .map_err(note_server_fn_err)
@@ -996,12 +969,13 @@ pub async fn upload_author_photo(
     filename: String,
     mime: String,
     bytes: Vec<u8>,
-) -> Result<(), String> {
+) -> Result<(), DataError> {
     use gloo_net::http::Request;
     use wasm_bindgen::JsCast;
 
     let endpoint = format!("/api/authors/{id}/photo");
-    let form = web_sys::FormData::new().map_err(|e| format!("FormData::new: {e:?}"))?;
+    let form =
+        web_sys::FormData::new().map_err(|e| DataError::Other(format!("FormData::new: {e:?}")))?;
     // `Blob` ctor wants a `&Array` of `BufferSource | BlobPart` parts —
     // build a one-element Uint8Array, drop it into a JS Array, then hand
     // that to `Blob::new_with_u8_array_sequence_and_options`.
@@ -1011,27 +985,27 @@ pub async fn upload_author_photo(
     let mut opts = web_sys::BlobPropertyBag::new();
     opts.type_(&mime);
     let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(&parts, &opts)
-        .map_err(|e| format!("Blob::new: {e:?}"))?;
+        .map_err(|e| DataError::Other(format!("Blob::new: {e:?}")))?;
     form.append_with_blob_and_filename("photo", &blob, &filename)
-        .map_err(|e| format!("FormData::append: {e:?}"))?;
+        .map_err(|e| DataError::Other(format!("FormData::append: {e:?}")))?;
 
     let res = Request::put(&endpoint)
         // gloo-net's `body` takes anything `Into<JsValue>` — FormData
         // satisfies that via its JsCast impl. Don't set Content-Type:
         // the browser fills it in with the multipart boundary.
         .body(form.unchecked_into::<wasm_bindgen::JsValue>())
-        .map_err(|e| e.to_string())?
+        .map_err(|e| DataError::Other(e.to_string()))?
         .send()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| DataError::Other(e.to_string()))?;
     if res.status() == 401 {
         web_auth_state::notify_unauthorized();
-        return Err("unauthorized".into());
+        return Err(DataError::Unauthorized);
     }
     if !res.ok() {
         let status = res.status();
-        let msg = res.text().await.unwrap_or_default();
-        return Err(format!("upload failed ({status}): {msg}"));
+        let body = res.text().await.unwrap_or_default();
+        return Err(DataError::Http { status, body });
     }
     Ok(())
 }
@@ -1047,33 +1021,35 @@ pub async fn upload_author_photo(
     _filename: String,
     _mime: String,
     _bytes: Vec<u8>,
-) -> Result<(), String> {
-    Err("upload not available in this build".into())
+) -> Result<(), DataError> {
+    Err(DataError::Other(
+        "upload not available in this build".into(),
+    ))
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_series(_server_url: &str, id: i64) -> Result<Option<SeriesDetail>, String> {
+pub async fn get_series(_server_url: &str, id: i64) -> Result<Option<SeriesDetail>, DataError> {
     crate::rpc::rpc_get_series(id)
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_tag_cloud(_server_url: &str) -> Result<Vec<TagWeight>, String> {
+pub async fn get_tag_cloud(_server_url: &str) -> Result<Vec<TagWeight>, DataError> {
     crate::rpc::rpc_get_tag_cloud()
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn list_authors(_server_url: &str) -> Result<Vec<AuthorSummary>, String> {
+pub async fn list_authors(_server_url: &str) -> Result<Vec<AuthorSummary>, DataError> {
     crate::rpc::rpc_list_authors()
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn list_series(_server_url: &str) -> Result<Vec<SeriesSummary>, String> {
+pub async fn list_series(_server_url: &str) -> Result<Vec<SeriesSummary>, DataError> {
     crate::rpc::rpc_list_series()
         .await
         .map_err(note_server_fn_err)
@@ -1084,14 +1060,17 @@ pub async fn save_overrides(
     _server_url: &str,
     id: i64,
     overrides: &MetadataOverrides,
-) -> Result<Option<EbookMetadata>, String> {
+) -> Result<Option<EbookMetadata>, DataError> {
     crate::rpc::rpc_save_overrides(id, overrides.clone())
         .await
         .map_err(note_server_fn_err)
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn delete_overrides(_server_url: &str, id: i64) -> Result<Option<EbookMetadata>, String> {
+pub async fn delete_overrides(
+    _server_url: &str,
+    id: i64,
+) -> Result<Option<EbookMetadata>, DataError> {
     crate::rpc::rpc_delete_overrides(id)
         .await
         .map_err(note_server_fn_err)
@@ -1179,4 +1158,34 @@ async fn post_auth_json<T: serde::Serialize>(
         return Err(format!("{status}: {msg}"));
     }
     res.json::<LoginResponse>().await.map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unauthorized_reports_is_unauthorized() {
+        assert!(DataError::Unauthorized.is_unauthorized());
+        assert_eq!(DataError::Unauthorized.to_string(), "unauthorized");
+    }
+
+    #[test]
+    fn http_carries_status_and_is_not_unauthorized() {
+        let err = DataError::Http {
+            status: 400,
+            body: "bad request".into(),
+        };
+        assert!(!err.is_unauthorized());
+        // Display intentionally omits the body — callers that need it match
+        // on the `Http { body, .. }` variant directly.
+        assert_eq!(err.to_string(), "server returned 400");
+    }
+
+    #[test]
+    fn other_round_trips_its_message() {
+        let err = DataError::Other("missing value field".into());
+        assert!(!err.is_unauthorized());
+        assert_eq!(err.to_string(), "missing value field");
+    }
 }

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -470,6 +470,7 @@ async fn submit_login(server_url: &str, username: String, password: String) -> R
     crate::data::mobile_login(server_url, username, password, default_device_name())
         .await
         .map(|_| ())
+        .map_err(data_error_message)
 }
 
 #[cfg(feature = "mobile")]
@@ -481,6 +482,23 @@ async fn submit_register(
     crate::data::mobile_register(server_url, username, password, default_device_name())
         .await
         .map(|_| ())
+        .map_err(data_error_message)
+}
+
+/// Flatten a [`crate::data::DataError`] into the user-facing string the auth
+/// pages surface. For an HTTP failure we splice the server's diagnostic body
+/// back in — `DataError`'s own `Display` deliberately omits it, but the
+/// register-error classifier keys on "username"/"password" substrings, so the
+/// mobile path must keep the body to route field errors correctly (mirrors
+/// the pre-#96 `"{status}: {body}"` string).
+#[cfg(feature = "mobile")]
+fn data_error_message(err: crate::data::DataError) -> String {
+    match err {
+        crate::data::DataError::Http { status, body } if !body.is_empty() => {
+            format!("{status}: {body}")
+        }
+        other => other.to_string(),
+    }
 }
 
 /// Best-effort device name for the bearer-login `device_name` field. The
@@ -596,5 +614,39 @@ mod tests {
             RegisterError::Other(m) => assert_eq!(m, "500: internal server error"),
             other => panic!("expected Other variant, got {other:?}"),
         }
+    }
+
+    // `data_error_message` must keep the HTTP body so the register-error
+    // classifier can still route field errors on the mobile path. Without
+    // the body, `DataError`'s own Display ("server returned 400") would
+    // strand every server diagnostic in the `Other` bucket.
+    #[cfg(feature = "mobile")]
+    #[test]
+    fn data_error_message_preserves_http_body_for_classification() {
+        let msg = data_error_message(crate::data::DataError::Http {
+            status: 409,
+            body: "username already exists".into(),
+        });
+        assert_eq!(msg, "409: username already exists");
+        assert!(matches!(
+            classify_register_error(&msg),
+            RegisterError::Username(_)
+        ));
+    }
+
+    #[cfg(feature = "mobile")]
+    #[test]
+    fn data_error_message_falls_back_to_display_without_body() {
+        assert_eq!(
+            data_error_message(crate::data::DataError::Unauthorized),
+            "unauthorized"
+        );
+        assert_eq!(
+            data_error_message(crate::data::DataError::Http {
+                status: 500,
+                body: String::new(),
+            }),
+            "server returned 500"
+        );
     }
 }

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -28,7 +28,7 @@ pub fn AuthorPage(id: i64) -> Element {
                     author.set(a);
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -38,7 +38,7 @@ pub fn AuthorsIndexPage() -> Element {
                     authors.set(a);
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -51,7 +51,7 @@ pub fn BookDetailPage(id: i64) -> Element {
                     book.set(b);
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -43,7 +43,7 @@ pub fn LandingPage() -> Element {
                     library.set(lib);
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -37,7 +37,7 @@ pub fn MetadataEditPage(id: i64) -> Element {
                     book.set(b);
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });
@@ -465,7 +465,7 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
                                                     let nav = navigator();
                                                     nav.push(Route::BookDetail { id });
                                                 }
-                                                Err(e) => save_error.set(Some(e)),
+                                                Err(e) => save_error.set(Some(e.to_string())),
                                             }
                                             saving.set(false);
                                         });
@@ -541,7 +541,7 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
                                             let nav = navigator();
                                             nav.push(Route::BookDetail { id });
                                         }
-                                        Err(e) => save_error.set(Some(e)),
+                                        Err(e) => save_error.set(Some(e.to_string())),
                                     }
                                     saving.set(false);
                                 });

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -31,7 +31,7 @@ pub fn SearchPage(query: String) -> Element {
                     results.set(Some(r));
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -26,7 +26,7 @@ pub fn SeriesPage(id: i64) -> Element {
                     series.set(s);
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -33,7 +33,7 @@ pub fn SeriesIndexPage() -> Element {
                     series.set(s);
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -26,7 +26,7 @@ pub fn SettingsPage() -> Element {
                     audiobook_path.set(settings.audiobook_library_path.unwrap_or_default());
                 }
                 Err(e) => {
-                    status.set(Some(e));
+                    status.set(Some(e.to_string()));
                     status_is_error.set(true);
                 }
             }

--- a/frontend/src/pages/tag_cloud.rs
+++ b/frontend/src/pages/tag_cloud.rs
@@ -24,7 +24,7 @@ pub fn TagCloudPage() -> Element {
                     tags.set(t);
                     error.set(None);
                 }
-                Err(e) => error.set(Some(e)),
+                Err(e) => error.set(Some(e.to_string())),
             }
             loading.set(false);
         });


### PR DESCRIPTION
## Summary
- Replace the `Result<T, String>` error type across the feature-gated `data` transport layer (`frontend/src/data.rs`) with a `thiserror`-derived `DataError` enum (`Network` / `Http { status, body }` / `Decode` / `Unauthorized` / `Other`), aligning the module with rule-02 and letting callers distinguish failure modes by type.
- Make the 401 path produce a typed `DataError::Unauthorized` from both the mobile `drain_error` helper and the web `note_server_fn_err` mapper, so the clear-token / redirect-to-`/login` flow can pattern-match the variant instead of re-inspecting the raw HTTP status after the fact. `note_status` still clears the bearer token on 401, preserving the existing reactive redirect.
- Preserve user-facing behavior: the mobile `Http` variant keeps the server's diagnostic body so the register-error classifier in `auth.rs` still routes username/password field errors correctly (via a small `data_error_message` adapter); page callers now `.to_string()` the typed error at the display boundary.

## What changed
- `frontend/src/data.rs` — new `DataError` enum + `is_unauthorized()`; all mobile (`reqwest`) and web/server (`rpc` / `gloo-net`) transport fns return `Result<T, DataError>`; `drain_error` now returns a structured `DataError` (401 -> `Unauthorized`, else `Http { status, body }`); `note_server_fn_err` maps the web server-fn 401 to `DataError::Unauthorized`. `#[from] reqwest::Error` is mobile-gated and `#[from] serde_json::Error` is web+mobile-gated to match the optional deps; `Unauthorized` / `Http` / `Other` are always present so the enum's shape is stable across every build that compiles the callers.
- `frontend/src/pages/auth.rs` — mobile `submit_login`/`submit_register` map `DataError` to a body-bearing string via the new `data_error_message` so register-error classification is unchanged; added mobile-gated unit tests for it.
- `frontend/src/pages/{landing,settings,book_detail,metadata_edit,author,authors_index,series,series_index,tag_cloud,search}.rs` — one-line `.to_string()` at each `error.set(Some(..))` display boundary (12 sites).
- `frontend/Cargo.toml` — add `thiserror = "1"` (always-on; `DataError` is referenced under every platform feature). `Cargo.lock` updated (no new download — `thiserror 1.0.69` was already in the tree via `omnibus-db`).
- `CLAUDE.md` — note the new `DataError` contract on the `data.rs` line.

## Test plan
- [x] `cargo fmt` / `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` (default members: server/shared/frontend) — clean
- [x] `cargo clippy -p omnibus-frontend --features server` / `--features web` — compile clean (one pre-existing `web_sys::BlobPropertyBag::type_` deprecation under `web`, unrelated to this change)
- [x] `cargo test` (default workspace) — 128 + 63 passing
- [x] `cargo test -p omnibus-frontend --features server` — 63 passing
- [x] `cargo test -p omnibus-frontend --features mobile` — 67 passing, including 5 new `DataError` / `data_error_message` tests
- [x] Mobile-feature build: `cargo build -p omnibus-frontend --features mobile` compiles clean (the `feature = "mobile"` transport code)

## Notes
> [!IMPORTANT]
> Environment did not have `nix` available, so cargo was run directly (toolchain present, `DATABASE_URL` set manually to the shellHook value). Tests use `sqlite::memory:` so this had no effect on results.

> [!WARNING]
> `cargo build -p omnibus-mobile` could not run here: the native Dioxus desktop shell crate needs system `gdk-3.0` (GTK), normally provided by the nix dev shell, which was unavailable. To exercise the mobile-feature code without GTK, the `feature = "mobile"` half of `omnibus-frontend` (where all of this change lives) was built and tested directly and passes clean — please confirm `cargo build -p omnibus-mobile` inside `nix develop`.

- `cargo clippy --all-targets --all-features` is not a valid invocation for this workspace: `--all-features` enables `web` + `mobile` together, which the crate rejects via a `compile_error!` (they're mutually exclusive). Verified per-feature instead, matching the repo convention.
- Out of scope (left as `Result<T, String>`): the web-only cookie/`gloo-net` auth helpers `login` / `register` / `logout` / `current_user` / `post_auth_json` — these are a separate web auth transport, not the mobile `/api/*` data layer the issue targets, and converting them would widen the caller fan-out (top_nav, auth.rs web arm) beyond scope.
- Pre-existing unrelated worktree state from a sibling parallel agent was observed and deliberately excluded; this branch is based directly on `origin/main` and contains only the #96 changes.

Closes #96

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGr166LHKgeg8PtxYRHsBV)_