### PR TITLE
fix: serialize metadata override merge in a transaction (#166)

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -796,6 +796,96 @@ pub async fn upsert_metadata_overrides(
     Ok(())
 }
 
+/// Atomically merge `incoming` field overrides on top of any existing
+/// overrides for `book_uuid` and persist the result (#166).
+///
+/// The read-merge-write runs inside a single `BEGIN IMMEDIATE` transaction so
+/// two concurrent edits to the same book cannot interleave (both reading the
+/// same pre-edit row, both merging in Rust, last write wins — silently
+/// dropping one edit). `BEGIN IMMEDIATE` takes the write lock up front rather
+/// than starting deferred and upgrading on first write; that upgrade window is
+/// exactly where two writers collide. Serializing here preserves the
+/// incremental-edit contract that [`MetadataOverrides::merge`] exists for:
+/// saving the title must not clobber a previously saved series or any other
+/// untouched field.
+///
+/// The existing `has_cover_override` flag is carried forward — a text-only
+/// edit must not clear a cover the user uploaded earlier. (The pre-#166
+/// handler passed `has_cover_override = false` to [`upsert_metadata_overrides`]
+/// on every field edit, which reset the flag; folding the read into this
+/// transaction lets us preserve it.)
+///
+/// As with [`upsert_metadata_overrides`], the `books_fts` rebuild runs
+/// best-effort *after* commit so a rebuild failure does not fail the save and
+/// the write lock is released as early as possible.
+pub async fn merge_metadata_overrides(
+    pool: &SqlitePool,
+    book_uuid: &str,
+    incoming: &MetadataOverrides,
+    user_id: i64,
+) -> Result<(), sqlx::Error> {
+    // Mirror `auth::create_user`'s explicit transaction idiom: async drop
+    // isn't stable, so we acquire one connection, run BEGIN IMMEDIATE, and
+    // COMMIT/ROLLBACK by hand based on the inner result.
+    let mut conn = pool.acquire().await?;
+    sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+
+    let result: Result<(), sqlx::Error> = async {
+        let existing: Option<(String, i64)> = sqlx::query_as(
+            "SELECT overrides, has_cover_override FROM metadata_overrides WHERE book_uuid = ?",
+        )
+        .bind(book_uuid)
+        .fetch_optional(&mut *conn)
+        .await?;
+
+        let (merged, has_cover_override) = match existing {
+            Some((json, has_cover)) => {
+                let prior: MetadataOverrides =
+                    serde_json::from_str(&json).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
+                (prior.merge(incoming), has_cover != 0)
+            }
+            None => (incoming.clone(), false),
+        };
+
+        let json =
+            serde_json::to_string(&merged).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+        sqlx::query(
+            "INSERT INTO metadata_overrides (book_uuid, overrides, has_cover_override, updated_by, updated_at)
+             VALUES (?, ?, ?, ?, datetime('now'))
+             ON CONFLICT(book_uuid) DO UPDATE SET
+               overrides = excluded.overrides,
+               has_cover_override = excluded.has_cover_override,
+               updated_by = excluded.updated_by,
+               updated_at = datetime('now')",
+        )
+        .bind(book_uuid)
+        .bind(&json)
+        .bind(i64::from(has_cover_override))
+        .bind(user_id)
+        .execute(&mut *conn)
+        .await?;
+        Ok(())
+    }
+    .await;
+
+    match &result {
+        Ok(()) => {
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
+        }
+        Err(_) => {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+        }
+    }
+    result?;
+
+    // Best-effort FTS rebuild — same rationale as `upsert_metadata_overrides`.
+    // Kept outside the transaction so the write lock is released first.
+    if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
+        tracing::warn!(book_uuid, error = %e, "books_fts rebuild after override merge failed");
+    }
+    Ok(())
+}
+
 /// Load overrides for a single book UUID. Returns `None` if no overrides
 /// exist.
 pub async fn get_metadata_overrides(
@@ -6079,6 +6169,72 @@ mod tests {
         assert_eq!(loaded.description, Some("A new description".into()));
         assert_eq!(loaded.publisher, None);
         assert!(!has_cover);
+    }
+
+    #[tokio::test]
+    async fn merge_metadata_overrides_accumulates_fields_and_preserves_cover_flag() {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        // Seed an existing override carrying a title AND a user-uploaded cover.
+        let initial = MetadataOverrides {
+            title: Some("First Title".into()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, "merge-uuid", &initial, true, user_id)
+            .await
+            .unwrap();
+
+        // A later edit touching only `description` must not clobber the title
+        // (the incremental-edit contract the TOCTOU race nullified) and must
+        // not reset the cover flag (the pre-#166 reset bug).
+        let edit = MetadataOverrides {
+            description: Some("Added later".into()),
+            ..Default::default()
+        };
+        merge_metadata_overrides(&pool, "merge-uuid", &edit, user_id)
+            .await
+            .unwrap();
+
+        let (loaded, has_cover) = get_metadata_overrides(&pool, "merge-uuid")
+            .await
+            .unwrap()
+            .expect("overrides should exist");
+        assert_eq!(
+            loaded.title,
+            Some("First Title".into()),
+            "prior title must survive a description-only merge"
+        );
+        assert_eq!(loaded.description, Some("Added later".into()));
+        assert!(
+            has_cover,
+            "has_cover_override must carry forward across a text-only merge"
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_metadata_overrides_creates_row_when_absent() {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let edit = MetadataOverrides {
+            title: Some("Fresh".into()),
+            ..Default::default()
+        };
+        merge_metadata_overrides(&pool, "fresh-uuid", &edit, user_id)
+            .await
+            .unwrap();
+        let (loaded, has_cover) = get_metadata_overrides(&pool, "fresh-uuid")
+            .await
+            .unwrap()
+            .expect("overrides should exist");
+        assert_eq!(loaded.title, Some("Fresh".into()));
+        assert!(!has_cover, "a brand-new merged row has no cover override");
     }
 
     #[tokio::test]

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -763,14 +763,21 @@ pub async fn get_last_modified_epoch(
 /// with what the UI displays. The FTS rebuild is best-effort: rebuild
 /// failures are logged but do not fail the override save, since the
 /// override write is the user's actual intent.
-pub async fn upsert_metadata_overrides(
-    pool: &SqlitePool,
+/// Execute the `metadata_overrides` INSERT…ON CONFLICT against any executor —
+/// a `&SqlitePool` for the fire-and-forget [`upsert_metadata_overrides`] path,
+/// or a transaction connection for the serialized [`merge_metadata_overrides`]
+/// path — so the upsert statement lives in exactly one place and the two
+/// callers can't drift (e.g. when a column or default changes).
+async fn upsert_overrides_row<'e, E>(
+    executor: E,
     book_uuid: &str,
-    overrides: &MetadataOverrides,
+    overrides_json: &str,
     has_cover_override: bool,
     user_id: i64,
-) -> Result<(), sqlx::Error> {
-    let json = serde_json::to_string(overrides).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+) -> Result<(), sqlx::Error>
+where
+    E: Executor<'e, Database = sqlx::Sqlite>,
+{
     sqlx::query(
         "INSERT INTO metadata_overrides (book_uuid, overrides, has_cover_override, updated_by, updated_at)
          VALUES (?, ?, ?, ?, datetime('now'))
@@ -781,11 +788,23 @@ pub async fn upsert_metadata_overrides(
            updated_at = datetime('now')",
     )
     .bind(book_uuid)
-    .bind(&json)
+    .bind(overrides_json)
     .bind(i64::from(has_cover_override))
     .bind(user_id)
-    .execute(pool)
+    .execute(executor)
     .await?;
+    Ok(())
+}
+
+pub async fn upsert_metadata_overrides(
+    pool: &SqlitePool,
+    book_uuid: &str,
+    overrides: &MetadataOverrides,
+    has_cover_override: bool,
+    user_id: i64,
+) -> Result<(), sqlx::Error> {
+    let json = serde_json::to_string(overrides).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+    upsert_overrides_row(pool, book_uuid, &json, has_cover_override, user_id).await?;
     // Best-effort FTS rebuild: log and continue on failure. The override
     // write is the user's actual intent — a stale FTS row gets fixed on the
     // next reindex, but surfacing a 500 here would make them think their
@@ -796,28 +815,12 @@ pub async fn upsert_metadata_overrides(
     Ok(())
 }
 
-/// Atomically merge `incoming` field overrides on top of any existing
-/// overrides for `book_uuid` and persist the result (#166).
-///
-/// The read-merge-write runs inside a single `BEGIN IMMEDIATE` transaction so
-/// two concurrent edits to the same book cannot interleave (both reading the
-/// same pre-edit row, both merging in Rust, last write wins — silently
-/// dropping one edit). `BEGIN IMMEDIATE` takes the write lock up front rather
-/// than starting deferred and upgrading on first write; that upgrade window is
-/// exactly where two writers collide. Serializing here preserves the
-/// incremental-edit contract that [`MetadataOverrides::merge`] exists for:
-/// saving the title must not clobber a previously saved series or any other
-/// untouched field.
-///
-/// The existing `has_cover_override` flag is carried forward — a text-only
-/// edit must not clear a cover the user uploaded earlier. (The pre-#166
-/// handler passed `has_cover_override = false` to [`upsert_metadata_overrides`]
-/// on every field edit, which reset the flag; folding the read into this
-/// transaction lets us preserve it.)
-///
-/// As with [`upsert_metadata_overrides`], the `books_fts` rebuild runs
-/// best-effort *after* commit so a rebuild failure does not fail the save and
-/// the write lock is released as early as possible.
+/// Merge `incoming` field overrides on top of any existing overrides for
+/// `book_uuid` and persist the result inside one `BEGIN IMMEDIATE`
+/// transaction, so two concurrent edits to the same book can't interleave and
+/// silently drop each other's changes (#166). The existing `has_cover_override`
+/// flag is carried forward — a text-only edit must not clear a cover the user
+/// uploaded earlier. The `books_fts` rebuild runs best-effort after commit.
 pub async fn merge_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
@@ -847,23 +850,8 @@ pub async fn merge_metadata_overrides(
             None => (incoming.clone(), false),
         };
 
-        let json =
-            serde_json::to_string(&merged).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
-        sqlx::query(
-            "INSERT INTO metadata_overrides (book_uuid, overrides, has_cover_override, updated_by, updated_at)
-             VALUES (?, ?, ?, ?, datetime('now'))
-             ON CONFLICT(book_uuid) DO UPDATE SET
-               overrides = excluded.overrides,
-               has_cover_override = excluded.has_cover_override,
-               updated_by = excluded.updated_by,
-               updated_at = datetime('now')",
-        )
-        .bind(book_uuid)
-        .bind(&json)
-        .bind(i64::from(has_cover_override))
-        .bind(user_id)
-        .execute(&mut *conn)
-        .await?;
+        let json = serde_json::to_string(&merged).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+        upsert_overrides_row(&mut *conn, book_uuid, &json, has_cover_override, user_id).await?;
         Ok(())
     }
     .await;

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -611,16 +611,13 @@ async fn post_ebook_overrides(
         Ok(None) => return (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
         Err(e) => return internal("get_book_uuid", e),
     };
-    // Merge incoming overrides with any existing ones so that a second edit
-    // that only touches field B doesn't wipe a prior override on field A.
-    let merged = match db::get_metadata_overrides(&state.pool, &uuid).await {
-        Ok(Some((existing, _))) => existing.merge(&overrides),
-        Ok(None) => overrides,
-        Err(e) => return internal("get_metadata_overrides", e),
-    };
-    if let Err(e) = db::upsert_metadata_overrides(&state.pool, &uuid, &merged, false, user.id).await
-    {
-        return internal("upsert_metadata_overrides", e);
+    // Merge incoming overrides with any existing ones so a second edit that
+    // only touches field B doesn't wipe a prior override on field A. The
+    // read-merge-write is serialized inside a single BEGIN IMMEDIATE
+    // transaction in the db layer so two concurrent edits to the same book
+    // can't interleave and drop each other's changes (#166).
+    if let Err(e) = db::merge_metadata_overrides(&state.pool, &uuid, &overrides, user.id).await {
+        return internal("merge_metadata_overrides", e);
     }
     match db::get_book(&state.pool, id).await {
         Ok(Some(book)) => Json(book).into_response(),


### PR DESCRIPTION
## Summary
- `post_ebook_overrides` did a read-merge-write across three separate db calls (`get_book_uuid` → `get_metadata_overrides` → `upsert_metadata_overrides`) with **no enclosing transaction**. Two concurrent edits to the same book (two tabs / two mobile clients) could interleave: both read the same pre-edit row, both merged independently in Rust, last write won — silently dropping one user's edit and nullifying the incremental-edit contract `MetadataOverrides::merge` exists for.
- Adds `db::merge_metadata_overrides`, which runs the read-merge-write inside a single `BEGIN IMMEDIATE` transaction. `BEGIN IMMEDIATE` takes the write lock up front rather than starting deferred and upgrading on first write — that upgrade window is exactly where two writers collide. `post_ebook_overrides` now calls this one function.

## Test plan
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-db` (264 pass) — incl. new `merge_metadata_overrides_accumulates_fields_and_preserves_cover_flag` and `merge_metadata_overrides_creates_row_when_absent`
- [x] `cargo test -p omnibus` (128 pass) + `cargo fmt --all --check`

## Notes
> [!IMPORTANT]
> **Behavior change (a latent bug fix):** the pre-#166 handler passed `has_cover_override = false` to `upsert_metadata_overrides` on *every* field edit, which reset the flag — so a text-only edit could clear a cover the user had uploaded earlier. Folding the read into the transaction lets `merge_metadata_overrides` carry the existing `has_cover_override` flag forward. A new test asserts a description-only merge preserves both the prior title and the cover flag.

- Transaction is managed by hand (`BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK` on an acquired connection), mirroring the `auth::create_user` idiom already in the codebase, since async `Drop` isn't stable. The best-effort `books_fts` rebuild runs *after* commit so a rebuild failure doesn't fail the save and the write lock releases early.
- Chose the transaction approach over the issue's alternative (a `Task::MergeOverrides` Worker variant) — it's simpler and keeps the fix in the db layer. No `Cargo.lock` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQKsyxkVLZEFd9JpUeFBi9)_