### PR TITLE
feat(frontend): user menu dropdown in top nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ components/search_palette.rs — F1.5 command-palette search overlay (⌘K trigg
 components/format_switcher.rs — F1.4 per-format CTA rows on the book detail page (Read/Listen/Send-to-Kindle, all disabled in Phase 1); the UI contract for the F0.1 books/book_files split
 components/author_photo_edit.rs — F1.11 admin photo-edit overlay (web-only): hover-revealed pencil button over the avatar opening a modal with paste-URL / file-upload (→ PUT /api/authors/:id/photo) / re-scan-Open-Library actions. Wraps avatars on the author detail and authors-index pages
 components/auth/{mod,shell,banner,field,strength}.rs — F1.6 auth-UI primitives (purely presentational, SSR/WASM identical for hydration) used by pages/auth.rs: AuthShell split-pane wrapper, Banner callout (err/warn/info/ok), Field label+input+hint/error/success slots, StrengthMeter four-segment password bar
+components/user_menu.rs — avatar trigger + dropdown panel in TopNav; hosts the real Settings link, Sign out action, and Dark/Light theme segmented control (Sepia stubbed). Most rows are forward-looking stubs (disabled <a>) until the underlying features (Profile, Journal, Highlights, Shelves, Goals, Notifications, Switch user) ship. Web-only (not(mobile)).
 ```
 
 ### server/src/

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -155,8 +155,9 @@ body.atrium,
   cursor: default; pointer-events: none;
 }
 
-/* Right cluster: Add books / theme / Settings / Logout. The auto margin
-   pushes the cluster to the far right of the topbar. */
+/* Right cluster: Add books + user menu. The auto margin pushes the
+   cluster to the far right of the topbar. The dropdown panel is anchored
+   to `.um-root` (inside the user-menu component), not here. */
 .atrium-actions {
   display: flex; align-items: center; gap: 6px;
   margin-left: auto;
@@ -1724,3 +1725,149 @@ body.atrium,
 @keyframes worker-status-spin {
   to { transform: rotate(360deg); }
 }
+
+/* ── User menu ──────────────────────────────────────────────────── */
+.um-root { position: relative; display: inline-flex; }
+
+.um-trigger {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px; border-radius: 50%;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--ink-1); cursor: pointer; padding: 0;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.um-trigger:hover { border-color: var(--accent); color: var(--ink-0); }
+.um-trigger .um-initials {
+  font-family: var(--mono); font-size: 10px; font-weight: 600;
+  letter-spacing: .04em; text-transform: uppercase;
+}
+
+.um-scrim {
+  position: fixed; inset: 0; z-index: 60;
+  background: transparent; cursor: default;
+}
+
+.um-panel {
+  position: absolute; top: calc(100% + 8px); right: 0;
+  width: 360px; z-index: 61;
+  background: var(--bg-1); border: 1px solid var(--line-2);
+  border-radius: 14px; padding: 14px;
+  display: flex; flex-direction: column; gap: 14px;
+  box-shadow:
+    0 18px 40px color-mix(in oklch, black 55%, transparent),
+    0 2px 0 color-mix(in oklch, black 25%, transparent);
+}
+
+/* Header */
+.um-header { display: flex; align-items: center; gap: 12px; }
+.um-avatar {
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--ink-1); border-radius: 50%;
+  width: 30px; height: 30px;
+}
+.um-avatar-lg { width: 44px; height: 44px; }
+.um-avatar-lg .um-initials { font-size: 13px; }
+.um-identity { display: flex; flex-direction: column; gap: 2px; flex: 1 1 auto; min-width: 0; }
+.um-name { color: var(--ink-0); font-weight: 600; font-size: 14px; }
+.um-handle { color: var(--ink-2); font-family: var(--mono); font-size: 11px; }
+.um-role { color: var(--accent); }
+.um-edit {
+  color: var(--ink-2); font-size: 12px; text-decoration: none;
+  padding: 4px 6px; border-radius: 6px;
+}
+.um-edit[aria-disabled="true"] { opacity: .55; cursor: not-allowed; pointer-events: none; }
+
+/* Section labels (NOW READING, THEME) */
+.um-section { display: flex; flex-direction: column; gap: 8px; }
+.um-section-label {
+  font-family: var(--mono); font-size: 10px; letter-spacing: .14em;
+  color: var(--ink-3); text-transform: uppercase;
+}
+
+/* Now reading card (stub) */
+.um-now-reading {
+  display: flex; gap: 12px; padding: 12px;
+  background: color-mix(in oklch, var(--accent) 14%, var(--bg-2));
+  border: 1px solid color-mix(in oklch, var(--accent) 30%, var(--line-2));
+  border-radius: 10px; text-decoration: none; color: inherit;
+}
+.um-now-reading[aria-disabled="true"] { cursor: not-allowed; }
+.um-nr-cover {
+  width: 44px; height: 64px; flex: 0 0 44px;
+  background: color-mix(in oklch, var(--accent) 35%, var(--bg-3));
+  border-radius: 3px;
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, black 15%, transparent);
+}
+.um-nr-meta { display: flex; flex-direction: column; gap: 4px; flex: 1 1 auto; min-width: 0; }
+.um-nr-title { font-family: var(--serif); font-style: italic; color: var(--ink-0); font-size: 14px; }
+.um-nr-author { color: var(--ink-2); font-size: 12px; }
+.um-nr-progress { display: flex; flex-direction: column; gap: 4px; margin-top: auto; }
+.um-nr-pbar {
+  height: 2px; background: color-mix(in oklch, var(--accent) 25%, var(--bg-3));
+  border-radius: 999px; overflow: hidden;
+}
+.um-nr-pbar-fill { display: block; height: 100%; width: 68%; background: var(--accent); }
+.um-nr-stats {
+  display: flex; justify-content: space-between; gap: 8px;
+  font-family: var(--mono); font-size: 10px; color: var(--ink-2);
+}
+
+/* Stat grid (stubs) */
+.um-stat-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.um-stat {
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 10px; border-radius: 10px;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  text-decoration: none; color: inherit;
+}
+.um-stat[aria-disabled="true"] { opacity: .85; cursor: not-allowed; }
+.um-stat-label { color: var(--ink-0); font-size: 12px; font-weight: 500; }
+.um-stat-detail { color: var(--ink-3); font-family: var(--mono); font-size: 10px; }
+
+/* Linear rows */
+.um-rows { display: flex; flex-direction: column; }
+.um-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 6px; border-radius: 8px;
+  color: var(--ink-1); text-decoration: none;
+  background: transparent; border: none; cursor: pointer;
+  font: inherit; text-align: left;
+  width: 100%;
+}
+.um-row:hover { background: var(--bg-2); color: var(--ink-0); }
+.um-row[aria-disabled="true"] { opacity: .55; cursor: not-allowed; pointer-events: none; }
+.um-row-icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 18px; color: var(--ink-2); font-size: 13px;
+}
+.um-row-label { flex: 1 1 auto; font-size: 13px; }
+.um-row-aside { color: var(--ink-3); font-family: var(--mono); font-size: 11px; }
+.um-row-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 18px; height: 18px; padding: 0 6px;
+  background: var(--bg-3); color: var(--ink-1);
+  border-radius: 999px; font-family: var(--mono); font-size: 10px;
+}
+.um-row.destructive { color: color-mix(in oklch, red 70%, var(--ink-1)); }
+.um-row.destructive .um-row-icon { color: inherit; }
+.um-row.destructive:hover {
+  background: color-mix(in oklch, red 14%, var(--bg-2));
+  color: color-mix(in oklch, red 80%, white);
+}
+
+/* Theme segmented control */
+.um-theme { display: flex; flex-direction: column; gap: 8px; }
+.um-theme-seg {
+  display: inline-flex; align-self: flex-end;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  border-radius: 8px; padding: 2px;
+}
+.um-theme-btn {
+  background: transparent; border: none; color: var(--ink-2);
+  padding: 4px 12px; border-radius: 6px; cursor: pointer;
+  font: inherit; font-size: 12px;
+}
+.um-theme-btn:hover:not([disabled]) { color: var(--ink-0); }
+.um-theme-btn.on { background: var(--bg-0); color: var(--ink-0); }
+.um-theme-btn[disabled] { opacity: .45; cursor: not-allowed; }

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -221,14 +221,14 @@ pub fn ThemeToggle() -> Element {
 // ── Persistence ───────────────────────────────────────────────────
 
 #[cfg(feature = "web")]
-fn persist_theme(t: Theme) {
+pub(crate) fn persist_theme(t: Theme) {
     if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
         let _ = storage.set_item("omn.theme", t.as_attr());
     }
 }
 
 #[cfg(not(feature = "web"))]
-fn persist_theme(_t: Theme) {
+pub(crate) fn persist_theme(_t: Theme) {
     // TODO(F1.7-mobile): persist to $HOME/.omnibus-theme in debug builds,
     // analogous to data::token_store.
 }

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -50,6 +50,9 @@ pub mod search_palette;
 #[cfg(not(feature = "mobile"))]
 pub mod worker_status;
 
+#[cfg(not(feature = "mobile"))]
+mod user_menu;
+
 // Auth-page primitives — used by the login / register / first-run /
 // recovery screens on every target. Stays platform-agnostic so the same
 // markup ships under web SSR, web WASM, and mobile native.

--- a/frontend/src/components/top_nav.rs
+++ b/frontend/src/components/top_nav.rs
@@ -1,8 +1,8 @@
 use dioxus::prelude::*;
-use dioxus_router::{use_navigator, use_route, Link};
+use dioxus_router::{use_route, Link};
 
-use crate::components::atrium::ThemeToggle;
 use crate::components::search_palette::SearchPaletteHost;
+use crate::components::user_menu::UserMenu;
 use crate::Route;
 
 #[component]
@@ -54,86 +54,8 @@ pub fn TopNav() -> Element {
                     "data-testid": "add-books-button",
                     "Add books"
                 }
-                ThemeToggle {}
-                Link {
-                    to: Route::Settings {},
-                    class: "btn ghost sm",
-                    "Settings"
-                }
-                AuthControl {}
+                UserMenu {}
             }
         }
     }
-}
-
-/// Right-side auth slot. Renders nothing on SSR / first paint, then
-/// reflects the live session: a `Log out` button for an authenticated
-/// user, a `Log in` link otherwise. Logging out POSTs `/api/auth/logout`,
-/// clears the session cookie server-side, and routes back to the login
-/// page. Web-only because mobile uses `BottomNav` and a different auth
-/// flow (bearer token in `data::token_store`).
-#[cfg(any(feature = "web", feature = "server"))]
-#[component]
-fn AuthControl() -> Element {
-    // `mut` is unused on SSR-only builds; the signal is only `.set()` from
-    // the `web`-gated branches below.
-    #[cfg_attr(not(feature = "web"), allow(unused_mut))]
-    let mut authed = use_signal(|| Option::<bool>::None);
-
-    // On the web client only, ping `/api/auth/me` once after hydration so
-    // the nav reflects the actual session. SSR renders with `None`, then
-    // hydration overwrites — keeps the SSR markup deterministic.
-    #[cfg(feature = "web")]
-    use_effect(move || {
-        spawn(async move {
-            match crate::data::current_user().await {
-                Ok(Some(_)) => authed.set(Some(true)),
-                Ok(None) => authed.set(Some(false)),
-                Err(_) => authed.set(Some(false)),
-            }
-        });
-    });
-
-    let nav = use_navigator();
-    let on_logout = move |_| {
-        #[cfg(feature = "web")]
-        {
-            spawn(async move {
-                let _ = crate::data::logout().await;
-                authed.set(Some(false));
-                nav.replace(Route::Login {});
-            });
-        }
-        #[cfg(not(feature = "web"))]
-        {
-            // SSR / server-only build: button is never clicked at runtime.
-            let _ = (nav, authed);
-        }
-    };
-
-    match authed() {
-        Some(true) => rsx! {
-            button {
-                class: "btn ghost sm",
-                "data-testid": "logout-button",
-                r#type: "button",
-                onclick: on_logout,
-                "Log out"
-            }
-        },
-        Some(false) => rsx! {
-            Link {
-                to: Route::Login {},
-                class: "btn ghost sm",
-                "Log in"
-            }
-        },
-        None => rsx! {},
-    }
-}
-
-#[cfg(not(any(feature = "web", feature = "server")))]
-#[component]
-fn AuthControl() -> Element {
-    rsx! {}
 }

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -1,0 +1,395 @@
+//! User-menu dropdown mounted in the top nav. Real wiring: Settings,
+//! Sign out, Dark/Light theme. Everything else is a stubbed `<a>`.
+//!
+//! SSR/hydration: the trigger is always rendered (empty placeholder
+//! initials in the pre-hydration phase) so the topbar markup is stable
+//! and `expectNavVisible` finds it without racing the auth ping. The
+//! post-mount `current_user()` effect then either fills in real initials
+//! (auth'd) or swaps the trigger for a `Log in` link (unauth). The panel
+//! only opens once we have a real user.
+
+use dioxus::prelude::*;
+use dioxus_router::{use_navigator, Link};
+use omnibus_shared::UserSummary;
+
+use crate::components::atrium::{persist_theme, Theme};
+use crate::Route;
+
+/// Derive 1–2 character avatar initials from a username. Empty input falls
+/// back to "?".
+pub(crate) fn initials_for(username: &str) -> String {
+    let trimmed = username.trim();
+    if trimmed.is_empty() {
+        return "?".into();
+    }
+    trimmed.chars().take(2).collect::<String>().to_uppercase()
+}
+
+#[cfg(any(feature = "web", feature = "server"))]
+#[component]
+pub fn UserMenu() -> Element {
+    // `mut` is unused on SSR-only builds; the signal is only `.set()` from
+    // the `web`-gated branches below.
+    #[cfg_attr(not(feature = "web"), allow(unused_mut))]
+    let mut authed = use_signal(|| Option::<Option<UserSummary>>::None);
+    let mut open = use_signal(|| false);
+
+    #[cfg(feature = "web")]
+    use_effect(move || {
+        spawn(async move {
+            // Only an explicit `Ok(None)` (status 401) flips to the
+            // unauth state. Transient errors (429 from the per-IP
+            // `/api/auth/*` rate limit, network blips, etc.) leave
+            // `authed` as `None` so the topbar keeps showing the
+            // placeholder trigger — better than briefly swapping to
+            // "Log in" mid-session and letting parallel Playwright
+            // workers race the 10-req/60s budget on /api/auth/me.
+            match crate::data::current_user().await {
+                Ok(slot) => authed.set(Some(slot)),
+                Err(_) => {}
+            }
+        });
+    });
+
+    let snapshot = authed();
+    // SSR / pre-hydration: render the trigger (empty placeholder initials)
+    // so the topbar markup is stable. WASM hydrates the same DOM, then the
+    // `current_user()` effect resolves: if Some(user), initials fill in
+    // and the dropdown becomes interactive; if None, swap to a Log-in
+    // link. The panel only renders when we have a real user — clicking
+    // the placeholder trigger before auth resolves is a no-op visually.
+    let user = match &snapshot {
+        Some(Some(u)) => Some(u.clone()),
+        _ => None,
+    };
+    let unauth = matches!(snapshot, Some(None));
+
+    if unauth {
+        rsx! {
+            Link {
+                to: Route::Login {},
+                class: "btn ghost sm",
+                "Log in"
+            }
+        }
+    } else {
+        let initials = user
+            .as_ref()
+            .map(|u| initials_for(&u.username))
+            .unwrap_or_default();
+        rsx! {
+            div { class: "um-root",
+                UserMenuTrigger { initials, open }
+                if open() {
+                    if let Some(user) = user {
+                        div {
+                            class: "um-scrim",
+                            "data-testid": "user-menu-scrim",
+                            onclick: move |_| open.set(false),
+                        }
+                        UserMenuPanel { user, open }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(any(feature = "web", feature = "server")))]
+#[component]
+pub fn UserMenu() -> Element {
+    rsx! {}
+}
+
+#[cfg(any(feature = "web", feature = "server"))]
+#[component]
+fn UserMenuTrigger(initials: String, open: Signal<bool>) -> Element {
+    let mut open = open;
+    rsx! {
+        button {
+            class: "um-trigger",
+            "data-testid": "user-menu-trigger",
+            "aria-label": "Open user menu",
+            "aria-haspopup": "dialog",
+            "aria-expanded": "{open()}",
+            r#type: "button",
+            onclick: move |_| {
+                let next = !open();
+                open.set(next);
+            },
+            span { class: "um-initials", "{initials}" }
+        }
+    }
+}
+
+#[cfg(any(feature = "web", feature = "server"))]
+#[component]
+fn UserMenuPanel(user: UserSummary, open: Signal<bool>) -> Element {
+    let mut open = open;
+    let nav = use_navigator();
+    let theme = use_context::<Signal<Theme>>();
+
+    let role = if user.is_admin { "Owner" } else { "Member" };
+    let handle = format!("{}@local", user.username);
+
+    let on_signout = move |_| {
+        // Spawn first; closing the menu unmounts the button mid-handler on
+        // web, which can swallow work queued after `open.set(false)`.
+        #[cfg(feature = "web")]
+        {
+            spawn(async move {
+                let _ = crate::data::logout().await;
+                open.set(false);
+                nav.replace(Route::Login {});
+            });
+        }
+        #[cfg(not(feature = "web"))]
+        {
+            open.set(false);
+            let _ = nav;
+        }
+    };
+
+    let on_keydown = move |evt: Event<KeyboardData>| {
+        if evt.key() == Key::Escape {
+            evt.prevent_default();
+            open.set(false);
+        }
+    };
+
+    rsx! {
+        div {
+            class: "um-panel",
+            "data-testid": "user-menu-panel",
+            role: "dialog",
+            "aria-label": "User menu",
+            tabindex: "-1",
+            onkeydown: on_keydown,
+            onmounted: move |_evt: MountedEvent| {
+                // Focus the panel so the onkeydown listener above receives
+                // ESC presses — opening the menu via the trigger leaves
+                // focus on the (now-unmounted-from-DOM-tab-order) trigger
+                // otherwise. Defer to the next animation frame so the
+                // browser has finished layout before `.focus()` lands.
+                #[cfg(feature = "web")]
+                focus_user_menu_panel(&_evt);
+            },
+
+            // ── Header ────────────────────────────────────────────
+            div { class: "um-header",
+                div { class: "um-avatar um-avatar-lg",
+                    span { class: "um-initials", "{initials_for(&user.username)}" }
+                }
+                div { class: "um-identity",
+                    div { class: "um-name", "{user.username}" }
+                    div { class: "um-handle",
+                        "{handle} · "
+                        span { class: "um-role", "{role}" }
+                    }
+                }
+                a {
+                    class: "um-edit",
+                    href: "#",
+                    "aria-disabled": "true",
+                    tabindex: "-1",
+                    onclick: move |evt| evt.prevent_default(),
+                    "Edit"
+                }
+            }
+
+            // ── Now reading (stub) ───────────────────────────────
+            div { class: "um-section",
+                div { class: "um-section-label", "NOW READING" }
+                a {
+                    class: "um-now-reading",
+                    href: "#",
+                    "aria-disabled": "true",
+                    tabindex: "-1",
+                    onclick: move |evt| evt.prevent_default(),
+                    div { class: "um-nr-cover" }
+                    div { class: "um-nr-meta",
+                        div { class: "um-nr-title", "Piranesi" }
+                        div { class: "um-nr-author", "Susanna Clarke" }
+                        div { class: "um-nr-progress",
+                            div { class: "um-nr-pbar", div { class: "um-nr-pbar-fill" } }
+                            div { class: "um-nr-stats",
+                                span { "68%" }
+                                span { "ch. 22" }
+                                span { "4h 12m left" }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Stat grid (stubs) ────────────────────────────────
+            div { class: "um-stat-grid",
+                UmStat { label: "Journal", detail: "24 entries" }
+                UmStat { label: "Highlights", detail: "412 quotes" }
+                UmStat { label: "Shelves", detail: "3 shared" }
+                UmStat { label: "Goals", detail: "12 / 24 books" }
+            }
+
+            // ── Linear rows (account) ────────────────────────────
+            div { class: "um-rows",
+                Link {
+                    to: Route::Settings {},
+                    class: "um-row",
+                    onclick: move |_| open.set(false),
+                    span { class: "um-row-icon", "⚙" }
+                    span { class: "um-row-label", "Settings" }
+                }
+                a {
+                    class: "um-row",
+                    href: "#",
+                    "aria-disabled": "true",
+                    tabindex: "-1",
+                    onclick: move |evt| evt.prevent_default(),
+                    span { class: "um-row-icon", "▣" }
+                    span { class: "um-row-label", "Admin · server health" }
+                    span { class: "um-row-aside", "all ok" }
+                }
+                a {
+                    class: "um-row",
+                    href: "#",
+                    "aria-disabled": "true",
+                    tabindex: "-1",
+                    onclick: move |evt| evt.prevent_default(),
+                    span { class: "um-row-icon", "◔" }
+                    span { class: "um-row-label", "Notifications" }
+                    span { class: "um-row-badge", "2" }
+                }
+            }
+
+            // ── Linear rows (session) ────────────────────────────
+            div { class: "um-rows",
+                a {
+                    class: "um-row",
+                    href: "#",
+                    "aria-disabled": "true",
+                    tabindex: "-1",
+                    onclick: move |evt| evt.prevent_default(),
+                    span { class: "um-row-icon", "⇄" }
+                    span { class: "um-row-label", "Switch user" }
+                }
+                button {
+                    class: "um-row destructive",
+                    "data-testid": "logout-button",
+                    r#type: "button",
+                    onclick: on_signout,
+                    span { class: "um-row-icon", "⏻" }
+                    span { class: "um-row-label", "Sign out" }
+                }
+            }
+
+            // ── Theme footer ─────────────────────────────────────
+            UmThemeSeg { theme }
+        }
+    }
+}
+
+#[cfg(any(feature = "web", feature = "server"))]
+#[component]
+fn UmStat(label: String, detail: String) -> Element {
+    rsx! {
+        a {
+            class: "um-stat",
+            href: "#",
+            "aria-disabled": "true",
+            tabindex: "-1",
+            onclick: move |evt| evt.prevent_default(),
+            div { class: "um-stat-label", "{label}" }
+            div { class: "um-stat-detail", "{detail}" }
+        }
+    }
+}
+
+#[cfg(any(feature = "web", feature = "server"))]
+#[component]
+fn UmThemeSeg(theme: Signal<Theme>) -> Element {
+    let mut theme = theme;
+    let current = *theme.read();
+    let dark_on = matches!(current, Theme::Dark);
+    let light_on = matches!(current, Theme::Light);
+    rsx! {
+        div { class: "um-theme",
+            div { class: "um-section-label", "THEME" }
+            div { class: "um-theme-seg", role: "group", "aria-label": "Theme",
+                button {
+                    class: if dark_on { "um-theme-btn on" } else { "um-theme-btn" },
+                    r#type: "button",
+                    "data-testid": "theme-dark",
+                    onclick: move |_| {
+                        theme.set(Theme::Dark);
+                        persist_theme(Theme::Dark);
+                    },
+                    "Dark"
+                }
+                button {
+                    class: if light_on { "um-theme-btn on" } else { "um-theme-btn" },
+                    r#type: "button",
+                    "data-testid": "theme-light",
+                    onclick: move |_| {
+                        theme.set(Theme::Light);
+                        persist_theme(Theme::Light);
+                    },
+                    "Light"
+                }
+                button {
+                    class: "um-theme-btn",
+                    r#type: "button",
+                    disabled: true,
+                    "aria-disabled": "true",
+                    "Sepia"
+                }
+            }
+        }
+    }
+}
+
+/// Focus the user-menu panel after the browser has painted it so the
+/// `onkeydown` handler attached to it actually receives ESC. Same
+/// requestAnimationFrame timing pattern as
+/// `search_palette::focus_palette_input`: calling `.focus()` synchronously
+/// inside `onmounted` lands before layout completes and the focus call
+/// no-ops.
+#[cfg(feature = "web")]
+fn focus_user_menu_panel(evt: &MountedEvent) {
+    use dioxus::web::WebEventExt;
+    use wasm_bindgen::prelude::*;
+
+    let Some(element) = evt.try_as_web_event() else {
+        return;
+    };
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let cb = Closure::once_into_js(move || {
+        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
+            let _ = html_el.focus();
+        }
+    });
+    let _ = window.request_animation_frame(cb.unchecked_ref());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initials_uppercases_first_two_chars() {
+        assert_eq!(initials_for("seamus"), "SE");
+        assert_eq!(initials_for("ek"), "EK");
+    }
+
+    #[test]
+    fn initials_handles_short_input() {
+        assert_eq!(initials_for("a"), "A");
+    }
+
+    #[test]
+    fn initials_fallback_for_empty() {
+        assert_eq!(initials_for(""), "?");
+        assert_eq!(initials_for("   "), "?");
+    }
+}

--- a/ui_tests/playwright/tests/flows/theme_toggle.spec.ts
+++ b/ui_tests/playwright/tests/flows/theme_toggle.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "../fixtures/test";
 import { gotoReady } from "../utils/nav";
 
-// F1.6 Atrium theme toggle. Lives on the top-nav (web) and flips the
-// `data-theme` attribute on the `.atrium` wrapper div emitted by
-// `AtriumRoot`. The web build persists the choice under `omn.theme` in
-// localStorage and applies it in a post-hydration `use_effect` so SSR
-// markup stays deterministic.
+// F1.6 Atrium theme toggle. The theme controls now live inside the user-menu
+// dropdown (Dark / Light / Sepia segmented control). Sepia is stubbed —
+// disabled until a Sepia theme variant lands. The web build persists the
+// choice under `omn.theme` in localStorage and applies it in a
+// post-hydration `use_effect` so SSR markup stays deterministic.
 //
 // Notes for future test authors:
 //   - Each Playwright test gets a fresh storage state (only the auth cookie
@@ -16,6 +16,10 @@ import { gotoReady } from "../utils/nav";
 //     specific computed style. The attribute is the contract; the variable
 //     values are an implementation detail tested at the CSS level.
 
+async function openUserMenu(page: import("@playwright/test").Page) {
+  await page.getByTestId("user-menu-trigger").click();
+}
+
 test("renders the dark theme on first paint", async ({ page }) => {
   await gotoReady(page, "/");
 
@@ -23,9 +27,9 @@ test("renders the dark theme on first paint", async ({ page }) => {
   await expect(root).toBeVisible();
   await expect(root).toHaveAttribute("data-theme", "dark");
 
-  const toggle = page.getByTestId("theme-toggle");
-  await expect(toggle).toBeVisible();
-  await expect(toggle).toHaveAttribute("aria-label", "Toggle theme");
+  await openUserMenu(page);
+  await expect(page.getByTestId("theme-dark")).toBeVisible();
+  await expect(page.getByTestId("theme-light")).toBeVisible();
 });
 
 test("toggles dark to light, persists across reload", async ({ page }) => {
@@ -34,7 +38,8 @@ test("toggles dark to light, persists across reload", async ({ page }) => {
   const root = page.locator("div.atrium").first();
   await expect(root).toHaveAttribute("data-theme", "dark");
 
-  await page.getByTestId("theme-toggle").click();
+  await openUserMenu(page);
+  await page.getByTestId("theme-light").click();
   await expect(root).toHaveAttribute("data-theme", "light");
 
   const stored = await page.evaluate(() => window.localStorage.getItem("omn.theme"));
@@ -48,15 +53,18 @@ test("toggles dark to light, persists across reload", async ({ page }) => {
   await expect.poll(async () => root.getAttribute("data-theme")).toBe("light");
 });
 
-test("clicking twice flips back to dark and clears divergence from default", async ({ page }) => {
+test("clicking light then dark flips back and clears divergence from default", async ({ page }) => {
   await gotoReady(page, "/");
 
   const root = page.locator("div.atrium").first();
-  const toggle = page.getByTestId("theme-toggle");
 
-  await toggle.click();
+  // Menu stays open between clicks — selecting a theme does not auto-close
+  // the panel (the user might want to toggle multiple settings in sequence).
+  await openUserMenu(page);
+  await page.getByTestId("theme-light").click();
   await expect(root).toHaveAttribute("data-theme", "light");
-  await toggle.click();
+
+  await page.getByTestId("theme-dark").click();
   await expect(root).toHaveAttribute("data-theme", "dark");
 
   const stored = await page.evaluate(() => window.localStorage.getItem("omn.theme"));

--- a/ui_tests/playwright/tests/flows/user_menu.spec.ts
+++ b/ui_tests/playwright/tests/flows/user_menu.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "../fixtures/test";
+import { expectMutation } from "../utils/api";
+import { gotoReady } from "../utils/nav";
+
+// The user menu replaces the old top-bar cluster (ThemeToggle, Settings
+// link, Log out button) with a single avatar trigger that opens a dropdown.
+// Most rows in the dropdown are forward-looking stubs (disabled <a>); real
+// wiring covers Settings, Sign out, and the Dark/Light theme buttons.
+
+test("renders the user menu trigger after login", async ({ page }) => {
+  await gotoReady(page, "/");
+
+  const trigger = page.getByTestId("user-menu-trigger");
+  await expect(trigger).toBeVisible();
+  await expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+  // The old top-bar Log out button is gone — it now lives inside the menu
+  // and should not be reachable while the menu is closed.
+  await expect(page.getByTestId("logout-button")).toHaveCount(0);
+});
+
+test("opens and closes the user menu", async ({ page }) => {
+  await gotoReady(page, "/");
+
+  const trigger = page.getByTestId("user-menu-trigger");
+  await trigger.click();
+  await expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+  // Real actions are present.
+  await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
+  await expect(page.getByTestId("logout-button")).toBeVisible();
+  await expect(page.getByTestId("theme-dark")).toBeVisible();
+  await expect(page.getByTestId("theme-light")).toBeVisible();
+
+  // Close via the transparent scrim (click outside the panel).
+  await page.getByTestId("user-menu-scrim").click();
+  await expect(page.getByTestId("logout-button")).toHaveCount(0);
+
+  // Re-open and close via ESC. Dispatch the keypress directly to the
+  // panel locator so the test doesn't race the onmounted focus call.
+  await trigger.click();
+  const panel = page.getByTestId("user-menu-panel");
+  await expect(panel).toBeVisible();
+  await panel.press("Escape");
+  await expect(page.getByTestId("logout-button")).toHaveCount(0);
+});
+
+test("Settings link routes to the settings page", async ({ page }) => {
+  await gotoReady(page, "/");
+  await page.getByTestId("user-menu-trigger").click();
+  await page.getByRole("link", { name: "Settings" }).click();
+  await expect(page).toHaveURL(/\/settings$/);
+});
+
+test("Sign out clears the session and routes to /login", async ({ page }) => {
+  // Mock /api/auth/logout instead of letting it hit the real endpoint:
+  //   1. A real logout would invalidate the globalSetup-minted session
+  //      that every parallel test relies on — they'd all redirect to
+  //      /login mid-run with a clobbered cookie.
+  //   2. The realistic alternative (fresh login per test) burns the
+  //      /api/auth/login per-IP rate-limit budget that auth.spec.ts
+  //      already saturates in CI.
+  // The backend logout path is covered by `server::auth` integration
+  // tests; this spec is the UI contract — request fires, UI navigates.
+  await page.route("**/api/auth/logout", async (route) => {
+    await route.fulfill({ status: 200, contentType: "text/plain", body: "" });
+  });
+
+  await gotoReady(page, "/");
+  await page.getByTestId("user-menu-trigger").click();
+
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/auth/logout", expectedStatus: 200 },
+    async () => page.getByTestId("logout-button").click(),
+  );
+
+  await expect(page).toHaveURL(/\/login$/);
+});

--- a/ui_tests/playwright/tests/utils/nav.ts
+++ b/ui_tests/playwright/tests/utils/nav.ts
@@ -13,10 +13,12 @@ export async function gotoReady(page: Page, path: string): Promise<void> {
 }
 
 // Asserts the shared top-nav is present with the expected links. Used by every
-// flow's layout test so we catch nav regressions in one place.
+// flow's layout test so we catch nav regressions in one place. Settings now
+// lives inside the user-menu dropdown, so we assert the user-menu trigger is
+// present instead of a top-level Settings link.
 export async function expectNavVisible(page: Page): Promise<void> {
   const nav = page.getByRole("navigation", { name: "Primary" });
   await expect(nav).toBeVisible();
   await expect(nav.getByRole("link", { name: "Library" })).toBeVisible();
-  await expect(nav.getByRole("link", { name: "Settings" })).toBeVisible();
+  await expect(nav.getByTestId("user-menu-trigger")).toBeVisible();
 }


### PR DESCRIPTION
## Summary

Replaces the three-button top-nav cluster (ThemeToggle / Settings link / Logout button) with a single avatar trigger that opens a dropdown panel matching the new design. Most rows are forward-looking stubs (disabled `<a>`) — only Settings, Sign out, and the Dark/Light theme controls are wired up today.

- New `UserMenu` component with avatar trigger (user initials), dropdown panel, scrim-click + ESC to close.
- Stubbed surfaces (disabled): Edit, NOW READING card, Journal / Highlights / Shelves / Goals, Admin · server health, Notifications, Switch user, Sepia theme.
- `expectNavVisible` updated to assert `user-menu-trigger` instead of a top-bar Settings link; `theme_toggle.spec.ts` rewritten to open the menu before toggling.

## Test plan

- [x] `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -p omnibus-frontend --features server --lib` — 70 passed (3 new `initials_for` tests)
- [x] `cargo test -p omnibus` — 129 passed
- [x] `npx playwright test flows/user_menu.spec.ts` — trigger renders, open/close + scrim + ESC, Settings routes
- [x] Live preview screenshot confirms avatar trigger replaces the old cluster and panel renders per the design