### PR TITLE
feat(worker): progress channel + indicator on settings page (#69)

### DIFF
--- a/db/src/worker.rs
+++ b/db/src/worker.rs
@@ -7,11 +7,21 @@
 //!   same resource key, so e.g. two scans of the same library path queue
 //!   behind each other while different paths run in parallel.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use omnibus_shared::{ProgressState, TaskKind, TaskProgress, WorkerStatus};
 use sqlx::SqlitePool;
 use tokio::sync::{watch, Mutex, Semaphore};
+
+/// How long a terminal ([`ProgressState::Done`] / [`ProgressState::Failed`])
+/// entry sticks around in [`Worker::progress_snapshot`] after its
+/// `terminal_at` timestamp before lazy eviction drops it. Long enough that
+/// a 1 Hz polling client always observes the transition; short enough that
+/// the in-memory map stays bounded by current concurrency + a handful of
+/// recently-finished tasks.
+const TERMINAL_RETENTION: Duration = Duration::from_secs(10);
 
 /// A unit of background work handed to [`Worker::post`].
 ///
@@ -83,6 +93,20 @@ impl Task {
             } => *route_through_scan_sem,
         }
     }
+
+    /// Wire-protocol discriminant exposed to the UI via
+    /// [`Worker::progress_snapshot`]. Tests deliberately collapse onto an
+    /// existing variant so the [`TaskKind`] enum doesn't grow a `Test` arm
+    /// that downstream UIs would have to render.
+    fn kind(&self) -> TaskKind {
+        match self {
+            Task::Scan { .. } => TaskKind::Scan,
+            Task::GenerateThumbs { .. } => TaskKind::GenerateThumbs,
+            Task::ResolveAuthorPhoto { .. } => TaskKind::ResolveAuthorPhoto,
+            #[cfg(test)]
+            Task::Test { .. } => TaskKind::Scan,
+        }
+    }
 }
 
 /// Process-local handle returned by [`Worker::post`], used to look up a
@@ -141,7 +165,23 @@ pub struct Worker {
     scan_sem: Arc<Semaphore>,
     resource_locks: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
     completions: Arc<StdMutex<HashMap<TaskId, watch::Receiver<Option<TaskOutcome>>>>>,
+    /// Live snapshot of every posted task's lifecycle state. Holds entries
+    /// from `post` until ~[`TERMINAL_RETENTION`] after the task reaches a
+    /// terminal state. Read path is [`Worker::progress_snapshot`]; write
+    /// paths are `post` (initial Running) and `run` (terminal Done/Failed,
+    /// plus the panic-safety guard).
+    progress: Arc<StdMutex<BTreeMap<TaskId, ProgressEntry>>>,
     next_id: std::sync::atomic::AtomicU64,
+}
+
+/// Internal pairing of the wire-facing [`TaskProgress`] with a monotonic
+/// `terminal_at` timestamp used purely for eviction. We intentionally don't
+/// reuse `TaskProgress.last_update_ms` (wall-clock; can jump under NTP) for
+/// expiry decisions — that field exists only so the UI can render elapsed
+/// time.
+struct ProgressEntry {
+    progress: TaskProgress,
+    terminal_at: Option<Instant>,
 }
 
 /// RAII guard that reclaims a `Worker::completions` slot when dropped.
@@ -166,6 +206,45 @@ impl Drop for CompletionsPruneGuard {
     }
 }
 
+/// RAII guard that records a terminal `Failed { "task panicked" }`
+/// progress entry if the spawned future unwinds before [`Worker::run`]
+/// writes one itself. Mirrors [`CompletionsPruneGuard`]'s shape — the
+/// "happy path completed first" check is the `terminal_at.is_some()`
+/// inspection so a clean run leaves the existing terminal alone.
+struct ProgressTerminalGuard {
+    progress: Arc<StdMutex<BTreeMap<TaskId, ProgressEntry>>>,
+    id: TaskId,
+}
+
+impl Drop for ProgressTerminalGuard {
+    fn drop(&mut self) {
+        if let Ok(mut map) = self.progress.lock() {
+            if let Some(entry) = map.get_mut(&self.id) {
+                if entry.terminal_at.is_none() {
+                    let now_ms = wall_clock_ms();
+                    entry.progress.state = ProgressState::Failed {
+                        message: "task panicked".to_string(),
+                    };
+                    entry.progress.last_update_ms = now_ms;
+                    entry.terminal_at = Some(Instant::now());
+                }
+            }
+        }
+    }
+}
+
+/// Current wall-clock time in milliseconds since the UNIX epoch. Used only
+/// for the `started_at_ms` / `last_update_ms` fields on [`TaskProgress`],
+/// which the UI renders as elapsed-time hints. A backward NTP step would
+/// produce a wonky elapsed-time display for one polling tick — well within
+/// the UI's tolerance.
+fn wall_clock_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
 impl Worker {
     /// Build a `Worker` over `pool` with the given `config`, returning it
     /// behind an `Arc` (every method takes `&Arc<Self>` or `&self`, and
@@ -176,6 +255,7 @@ impl Worker {
             scan_sem: Arc::new(Semaphore::new(config.scan_concurrency.max(1))),
             resource_locks: Arc::new(Mutex::new(HashMap::new())),
             completions: Arc::new(StdMutex::new(HashMap::new())),
+            progress: Arc::new(StdMutex::new(BTreeMap::new())),
             next_id: std::sync::atomic::AtomicU64::new(1),
         })
     }
@@ -188,6 +268,11 @@ impl Worker {
     #[cfg(test)]
     async fn resource_locks_len(&self) -> usize {
         self.resource_locks.lock().await.len()
+    }
+
+    #[cfg(test)]
+    fn progress_len(&self) -> usize {
+        self.progress.lock().unwrap().len()
     }
 
     /// Spawn `task` and return its [`TaskId`] immediately, without waiting
@@ -208,8 +293,34 @@ impl Worker {
         let (tx, rx) = watch::channel(None);
         self.completions.lock().unwrap().insert(id, rx);
 
+        // Seed the progress map *before* spawning so a caller polling
+        // `progress_snapshot()` immediately after `post` returns always
+        // observes the task. The entry stays `Running { 0, None }` while
+        // the task queues behind the resource lock or scan semaphore,
+        // which is exactly the "queued behind another scan" state the UI
+        // wants to surface.
+        {
+            let now_ms = wall_clock_ms();
+            let entry = ProgressEntry {
+                progress: TaskProgress {
+                    task_id: id,
+                    kind: task.kind(),
+                    state: ProgressState::Running {
+                        processed: 0,
+                        total: None,
+                    },
+                    resource_key: task.resource_key(),
+                    started_at_ms: now_ms,
+                    last_update_ms: now_ms,
+                },
+                terminal_at: None,
+            };
+            self.progress.lock().unwrap().insert(id, entry);
+        }
+
         let this = self.clone();
         let completions = self.completions.clone();
+        let progress = self.progress.clone();
         tokio::spawn(async move {
             // RAII guard so the slot is reclaimed on the normal happy path
             // *and* on unwind from a panic inside `run`. Without this, a
@@ -219,8 +330,18 @@ impl Worker {
             // resolutions), which is exactly the unbounded growth this
             // refactor exists to prevent.
             let _prune = CompletionsPruneGuard { completions, id };
+            // Sister guard for the progress map: if `run` unwinds before
+            // recording its own terminal state, this writes a synthetic
+            // `Failed { "task panicked" }` so the UI's red-banner path
+            // fires the same way it does for an `Err(_)` outcome. On the
+            // happy path `run` records the real terminal and this drop is
+            // a no-op (terminal_at is already Some).
+            let _progress_guard = ProgressTerminalGuard {
+                progress: progress.clone(),
+                id,
+            };
 
-            let outcome = this.run(task).await;
+            let outcome = this.run(task, id).await;
             if let TaskOutcome::Err(ref msg) = outcome {
                 tracing::error!(
                     task_id = id,
@@ -266,7 +387,7 @@ impl Worker {
         }
     }
 
-    async fn run(self: &Arc<Self>, task: Task) -> TaskOutcome {
+    async fn run(self: &Arc<Self>, task: Task, id: TaskId) -> TaskOutcome {
         // Resource lock first, then the scan semaphore: holding a permit
         // while blocked on a per-resource mutex would let same-resource
         // queueing starve other resources from running concurrently.
@@ -286,13 +407,44 @@ impl Worker {
         let _scan_permit = if task.uses_scan_sem() {
             match self.scan_sem.clone().acquire_owned().await {
                 Ok(p) => Some(p),
-                Err(_) => return TaskOutcome::Err("scan semaphore closed".into()),
+                Err(_) => {
+                    self.write_terminal_progress(
+                        id,
+                        ProgressState::Failed {
+                            message: "scan semaphore closed".into(),
+                        },
+                    );
+                    return TaskOutcome::Err("scan semaphore closed".into());
+                }
             }
         } else {
             None
         };
 
         let outcome = self.execute(task).await;
+        // Project the outcome into the wire-facing terminal state. We pull
+        // the last reported `processed` count out of the progress map so a
+        // Phase-2 in-flight progress report stays reflected in the final
+        // `Done`. Today there is no in-flight reporter so this is always 0.
+        let terminal = match &outcome {
+            TaskOutcome::Ok => {
+                let processed = self
+                    .progress
+                    .lock()
+                    .unwrap()
+                    .get(&id)
+                    .and_then(|e| match e.progress.state {
+                        ProgressState::Running { processed, .. } => Some(processed),
+                        _ => None,
+                    })
+                    .unwrap_or(0);
+                ProgressState::Done { processed }
+            }
+            TaskOutcome::Err(msg) => ProgressState::Failed {
+                message: msg.clone(),
+            },
+        };
+        self.write_terminal_progress(id, terminal);
 
         // Drop the resource guard before pruning so this task no longer
         // counts as a reference to the keyed mutex when we check it. Without
@@ -306,6 +458,77 @@ impl Worker {
         }
 
         outcome
+    }
+
+    /// Phase-2 seam: write the in-flight progress count for `id`. The
+    /// terminal state is written separately at the end of [`Worker::run`]
+    /// so a mid-task report can't accidentally flip a task to `Done`.
+    /// Currently unused — wired up when `indexer::reindex` learns to
+    /// thread a progress callback through its per-EPUB loop.
+    #[allow(dead_code)]
+    pub(crate) fn report_progress(&self, id: TaskId, processed: u32, total: Option<u32>) {
+        let mut map = self.progress.lock().unwrap();
+        if let Some(entry) = map.get_mut(&id) {
+            if entry.terminal_at.is_some() {
+                return; // race: terminal already recorded
+            }
+            entry.progress.state = ProgressState::Running { processed, total };
+            entry.progress.last_update_ms = wall_clock_ms();
+        }
+    }
+
+    /// Internal terminal write. Called from `run` (Ok/Err) and from the
+    /// `ProgressTerminalGuard` (panic). The `terminal_at` Instant is
+    /// monotonic so eviction is robust to wall-clock drift.
+    fn write_terminal_progress(&self, id: TaskId, state: ProgressState) {
+        let mut map = self.progress.lock().unwrap();
+        if let Some(entry) = map.get_mut(&id) {
+            entry.progress.last_update_ms = wall_clock_ms();
+            entry.progress.state = state;
+            entry.terminal_at = Some(Instant::now());
+        }
+    }
+
+    /// Snapshot of every live worker task — non-terminal entries go in
+    /// `active`, terminal entries (`Done` / `Failed`) less than
+    /// [`TERMINAL_RETENTION`] old go in `recent_complete`. Older terminal
+    /// entries are evicted under the same lock. Both vecs are sorted by
+    /// `task_id` so a polling client renders a stable list across ticks.
+    ///
+    /// Auth-gated at the RPC layer; safe to call from any handler that
+    /// already has an `AuthUser`.
+    pub fn progress_snapshot(&self) -> WorkerStatus {
+        let now = Instant::now();
+        let mut map = self.progress.lock().unwrap();
+
+        // First pass: identify expired terminals so we don't hold the
+        // iterator while mutating the map.
+        let expired: Vec<TaskId> = map
+            .iter()
+            .filter_map(|(id, entry)| match entry.terminal_at {
+                Some(at) if now.saturating_duration_since(at) >= TERMINAL_RETENTION => Some(*id),
+                _ => None,
+            })
+            .collect();
+        for id in expired {
+            map.remove(&id);
+        }
+
+        let mut active = Vec::new();
+        let mut recent_complete = Vec::new();
+        for entry in map.values() {
+            if entry.terminal_at.is_some() {
+                recent_complete.push(entry.progress.clone());
+            } else {
+                active.push(entry.progress.clone());
+            }
+        }
+        // BTreeMap iteration is already key-ordered, so both vecs come out
+        // sorted by `task_id` without an explicit sort.
+        WorkerStatus {
+            active,
+            recent_complete,
+        }
     }
 
     /// Reclaim a keyed resource mutex once no other task references it. Held
@@ -721,5 +944,184 @@ mod tests {
             w.resource_locks_len().await
         );
         assert_eq!(w.completions_len(), 0);
+    }
+
+    /// `progress_snapshot` reports every active entry as `recent_complete`
+    /// terminals are evicted lazily on read. Block the run loop with a
+    /// scan-sem-routed task so the snapshot fires before `execute` returns.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn queued_task_shows_as_running_immediately() {
+        let w = make_worker_default(pool().await);
+        let id = w.post(Task::Test {
+            tag: "queued",
+            latency_ms: 50,
+            resource: Some("queued".into()),
+            route_through_scan_sem: false,
+            on_run: None,
+            on_done: None,
+        });
+        // Snapshot before the task finishes: the entry is the initial Running.
+        let snap = w.progress_snapshot();
+        assert!(snap.recent_complete.is_empty(), "no terminals yet");
+        let entry = snap
+            .active
+            .iter()
+            .find(|p| p.task_id == id)
+            .expect("active entry seeded by post()");
+        assert!(matches!(
+            entry.state,
+            ProgressState::Running {
+                processed: 0,
+                total: None
+            }
+        ));
+        assert_eq!(entry.kind, TaskKind::Scan); // Test variant maps to Scan
+        let _ = w.await_completion(id).await;
+    }
+
+    /// Two concurrent posts both surface in the snapshot. Uses non-overlapping
+    /// resource keys so neither queues behind the other.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_tasks_show_two_active() {
+        let w = make_worker_default(pool().await);
+        let mk = |key: &'static str| {
+            w.post(Task::Test {
+                tag: key,
+                latency_ms: 80,
+                resource: Some(key.into()),
+                route_through_scan_sem: false,
+                on_run: None,
+                on_done: None,
+            })
+        };
+        let id1 = mk("aa");
+        let id2 = mk("bb");
+
+        // Briefly wait for both tasks to start. The map is seeded by `post`
+        // synchronously so this is purely guarding against a stray race where
+        // `await_completion` resolves between `post` and the snapshot below.
+        let snap = w.progress_snapshot();
+        assert_eq!(snap.active.len(), 2, "two queued tasks should be active");
+        assert!(snap.active.iter().any(|p| p.task_id == id1));
+        assert!(snap.active.iter().any(|p| p.task_id == id2));
+
+        let _ = tokio::join!(w.await_completion(id1), w.await_completion(id2));
+    }
+
+    /// A handler that returns `TaskOutcome::Err` (or panics) surfaces in
+    /// `recent_complete` with the `Failed` state and the error message.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn panic_emits_failed_state() {
+        let w = make_worker_default(pool().await);
+        let id = w.post(Task::Test {
+            tag: "panicker",
+            latency_ms: 0,
+            resource: None,
+            route_through_scan_sem: false,
+            on_run: Some(Arc::new(|| panic!("intentional test panic"))),
+            on_done: None,
+        });
+        let _ = w.await_completion(id).await;
+
+        // The spawned future has unwound and our terminal guard wrote the
+        // `Failed` state; the entry now sits in `recent_complete`.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let snap = w.progress_snapshot();
+            if let Some(p) = snap.recent_complete.iter().find(|p| p.task_id == id) {
+                match &p.state {
+                    ProgressState::Failed { message } => {
+                        assert!(
+                            message.contains("panic"),
+                            "expected panic message, got {message:?}"
+                        );
+                        return;
+                    }
+                    other => panic!("expected Failed, got {other:?}"),
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timeout waiting for failed terminal"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    /// Terminal entries get GC'd by `progress_snapshot` after the retention
+    /// window. We can't pause tokio time here because the worker uses real
+    /// `Instant::now()` for `terminal_at`, so the test cheats by sleeping
+    /// for `TERMINAL_RETENTION + a beat`. Keep the constant short in tests
+    /// — 10s is fine; bumping it would slow CI for no value.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn progress_snapshot_evicts_terminals_after_retention() {
+        let w = make_worker_default(pool().await);
+        let id = w.post(Task::Test {
+            tag: "evict",
+            latency_ms: 0,
+            resource: None,
+            route_through_scan_sem: false,
+            on_run: None,
+            on_done: None,
+        });
+        let _ = w.await_completion(id).await;
+
+        // Right after completion: present in recent_complete.
+        let snap = w.progress_snapshot();
+        assert!(snap.recent_complete.iter().any(|p| p.task_id == id));
+
+        // Sleep just past the retention window. 10s + a beat — test takes
+        // ~10s real time, which is the price of monotonic-clock GC; mock
+        // time would require threading a clock through the worker.
+        tokio::time::sleep(TERMINAL_RETENTION + Duration::from_millis(200)).await;
+        let snap2 = w.progress_snapshot();
+        assert!(
+            !snap2.recent_complete.iter().any(|p| p.task_id == id),
+            "terminal entry should be evicted after retention"
+        );
+        assert_eq!(w.progress_len(), 0, "progress map should be empty");
+    }
+
+    /// `report_progress` is the phase-2 seam used to surface per-EPUB
+    /// counts mid-scan. Exercising it here keeps it from being dropped
+    /// as dead code and pins down the "ignored after terminal" invariant.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn report_progress_updates_running_count() {
+        let w = make_worker_default(pool().await);
+        let id = w.post(Task::Test {
+            tag: "report",
+            latency_ms: 50,
+            resource: Some("report".into()),
+            route_through_scan_sem: false,
+            on_run: None,
+            on_done: None,
+        });
+        // Pretend we're mid-scan and have processed 3 of 10.
+        w.report_progress(id, 3, Some(10));
+        let snap = w.progress_snapshot();
+        let entry = snap
+            .active
+            .iter()
+            .find(|p| p.task_id == id)
+            .expect("running entry");
+        assert!(matches!(
+            entry.state,
+            ProgressState::Running {
+                processed: 3,
+                total: Some(10)
+            }
+        ));
+        let _ = w.await_completion(id).await;
+
+        // After completion, the entry is terminal and further reports are
+        // ignored (the run loop's terminal write is authoritative).
+        w.report_progress(id, 99, Some(10));
+        let snap2 = w.progress_snapshot();
+        let entry2 = snap2
+            .recent_complete
+            .iter()
+            .find(|p| p.task_id == id)
+            .expect("terminal entry");
+        assert!(matches!(entry2.state, ProgressState::Done { .. }));
     }
 }

--- a/db/src/worker.rs
+++ b/db/src/worker.rs
@@ -498,6 +498,15 @@ impl Worker {
     /// Auth-gated at the RPC layer; safe to call from any handler that
     /// already has an `AuthUser`.
     pub fn progress_snapshot(&self) -> WorkerStatus {
+        self.progress_snapshot_with_retention(TERMINAL_RETENTION)
+    }
+
+    /// Test-friendly variant of [`Worker::progress_snapshot`] that lets
+    /// callers supply a custom retention window. Production code always
+    /// uses [`TERMINAL_RETENTION`]; the unit-test suite passes a much
+    /// shorter window so the eviction assertion doesn't have to sleep
+    /// for the full 10 s of wall-clock time.
+    fn progress_snapshot_with_retention(&self, retention: Duration) -> WorkerStatus {
         let now = Instant::now();
         let mut map = self.progress.lock().unwrap();
 
@@ -506,7 +515,7 @@ impl Worker {
         let expired: Vec<TaskId> = map
             .iter()
             .filter_map(|(id, entry)| match entry.terminal_at {
-                Some(at) if now.saturating_duration_since(at) >= TERMINAL_RETENTION => Some(*id),
+                Some(at) if now.saturating_duration_since(at) >= retention => Some(*id),
                 _ => None,
             })
             .collect();
@@ -1049,10 +1058,9 @@ mod tests {
     }
 
     /// Terminal entries get GC'd by `progress_snapshot` after the retention
-    /// window. We can't pause tokio time here because the worker uses real
-    /// `Instant::now()` for `terminal_at`, so the test cheats by sleeping
-    /// for `TERMINAL_RETENTION + a beat`. Keep the constant short in tests
-    /// — 10s is fine; bumping it would slow CI for no value.
+    /// window. Uses the test-only `progress_snapshot_with_retention` so we
+    /// can exercise the eviction path with a 100 ms window instead of
+    /// sleeping for the full production 10 s.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn progress_snapshot_evicts_terminals_after_retention() {
         let w = make_worker_default(pool().await);
@@ -1066,15 +1074,15 @@ mod tests {
         });
         let _ = w.await_completion(id).await;
 
-        // Right after completion: present in recent_complete.
-        let snap = w.progress_snapshot();
+        // Right after completion: present in recent_complete with a
+        // generous retention window so eviction is opt-in.
+        let test_retention = Duration::from_millis(100);
+        let snap = w.progress_snapshot_with_retention(Duration::from_secs(60));
         assert!(snap.recent_complete.iter().any(|p| p.task_id == id));
 
-        // Sleep just past the retention window. 10s + a beat — test takes
-        // ~10s real time, which is the price of monotonic-clock GC; mock
-        // time would require threading a clock through the worker.
-        tokio::time::sleep(TERMINAL_RETENTION + Duration::from_millis(200)).await;
-        let snap2 = w.progress_snapshot();
+        // Cross the configured window and re-snapshot.
+        tokio::time::sleep(test_retention + Duration::from_millis(50)).await;
+        let snap2 = w.progress_snapshot_with_retention(test_retention);
         assert!(
             !snap2.recent_complete.iter().any(|p| p.task_id == id),
             "terminal entry should be evicted after retention"

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1643,3 +1643,84 @@ body.atrium,
   padding-top: 4px;
   border-top: 1px solid var(--line-2);
 }
+
+/* ===== Worker progress indicator (issue #69) ===========================
+ * Mounted on the settings form above the Save button. Inline (not sticky)
+ * so the surrounding form layout stays predictable. One row per active /
+ * recently-finished background task. New TaskKind variants (e.g. F5.9
+ * cleanup detection) inherit the same row styling for free.
+ */
+.worker-status {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 12px 0;
+}
+.worker-status-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: var(--bg-1);
+  color: var(--ink-1);
+  font-size: 0.875rem;
+}
+.worker-status-active {
+  border-left: 3px solid var(--accent);
+}
+.worker-status-done {
+  border-left: 3px solid var(--ok);
+  color: var(--ink-0);
+}
+.worker-status-failed {
+  border-left: 3px solid var(--bad);
+  background: color-mix(in oklch, var(--bad) 8%, var(--bg-1));
+  color: var(--ink-0);
+  align-items: flex-start;
+}
+.worker-status-label {
+  flex: 1;
+  font-variant-numeric: tabular-nums;
+}
+.worker-status-icon {
+  font-weight: 700;
+  width: 18px;
+  text-align: center;
+}
+.worker-status-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.worker-status-message {
+  font-size: 0.8125rem;
+  color: var(--ink-2);
+}
+.worker-status-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--ink-2);
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+.worker-status-dismiss:hover {
+  color: var(--ink-0);
+  background: var(--bg-2);
+}
+.worker-status-spinner {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in oklch, var(--accent) 40%, transparent);
+  border-top-color: var(--accent);
+  animation: worker-status-spin 0.9s linear infinite;
+  flex-shrink: 0;
+}
+@keyframes worker-status-spin {
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -43,6 +43,13 @@ pub mod author_photo_edit;
 #[cfg(not(feature = "mobile"))]
 pub mod search_palette;
 
+// F0.5 / issue #69 worker-progress indicator. Mounted on the settings
+// page today; the data plane is generic so future surfaces (e.g. the
+// F5.9 library-cleanup detection trigger) can mount the same primitive
+// without changes here.
+#[cfg(not(feature = "mobile"))]
+pub mod worker_status;
+
 // Auth-page primitives — used by the login / register / first-run /
 // recovery screens on every target. Stays platform-agnostic so the same
 // markup ships under web SSR, web WASM, and mobile native.

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -1,0 +1,256 @@
+//! Worker progress indicator — polls `/api/rpc/worker_status` at 1 Hz and
+//! renders a per-task row (active scans / thumbnails / author photos)
+//! plus a transient "complete" or red error banner for terminal entries.
+//!
+//! Mounted on `/settings` directly above the Save button for v1. The
+//! component is intentionally agnostic of which page mounts it — future
+//! surfaces (e.g. F5.9 library-cleanup detection trigger) can drop the
+//! same primitive in without changes here, since the data plane already
+//! distinguishes [`TaskKind`] variants.
+//!
+//! Web-only. Mobile UI is out of scope for issue #69 v1; the mobile
+//! `data::worker_status` stub returns an empty status so callers compile.
+//! Wrapping the whole module in `#[cfg(not(feature = "mobile"))]` keeps
+//! it out of the mobile bundle entirely, mirroring how `search_palette`
+//! is gated.
+
+#![cfg(not(feature = "mobile"))]
+
+use dioxus::prelude::*;
+use omnibus_shared::{ProgressState, TaskKind, TaskProgress, WorkerStatus};
+
+use crate::{data, use_server_url};
+
+/// Polling cadence in milliseconds. Always 1 s while the component is
+/// mounted — the issue spec calls for a 1 s tick, the response is ~1 KB,
+/// and this is a self-hosted single-user app. Idle-throttling adds bug
+/// surface (when does it un-throttle?) for no measurable benefit.
+const POLL_INTERVAL_MS: u32 = 1_000;
+
+/// How long to keep a dismissed terminal task suppressed client-side. The
+/// server's own eviction (10s — see `TERMINAL_RETENTION` in the worker)
+/// kicks in shortly after, so this only has to outlast a couple of
+/// polling ticks. Longer would risk re-surfacing a still-resident
+/// terminal if the user dismissed it just before the server evicted.
+const DISMISS_GRACE_MS: u32 = 12_000;
+
+/// 1 Hz-polled worker progress strip. Renders nothing when the worker is
+/// idle so consumers can mount it inline without leaving dead space.
+#[component]
+pub fn WorkerStatusIndicator() -> Element {
+    let server_url = use_server_url();
+    let mut status = use_signal(WorkerStatus::default);
+    // Client-suppressed terminal task ids — the user dismissed the
+    // "Library updated" / red banner before the server evicted it.
+    let mut dismissed = use_signal(std::collections::HashSet::<u64>::new);
+
+    let url_for_poll = server_url.clone();
+    use_future(move || {
+        let url = url_for_poll.clone();
+        async move {
+            // The future captures the `status` signal by move; spinning
+            // forever is fine because the component unmount cancels the
+            // associated future. Errors keep the last known snapshot in
+            // place so a transient blip doesn't flash the indicator off.
+            loop {
+                if let Ok(snap) = data::worker_status(&url).await {
+                    status.set(snap);
+                }
+                async_sleep_ms(POLL_INTERVAL_MS).await;
+            }
+        }
+    });
+
+    let snap = status();
+    let visible_terminals: Vec<TaskProgress> = snap
+        .recent_complete
+        .iter()
+        .filter(|p| !dismissed().contains(&p.task_id))
+        .cloned()
+        .collect();
+
+    if snap.active.is_empty() && visible_terminals.is_empty() {
+        return rsx!();
+    }
+
+    rsx! {
+        div {
+            class: "worker-status",
+            role: "status",
+            "aria-live": "polite",
+            "data-testid": "worker-status",
+            // Active tasks first — these have no dismiss affordance since
+            // the user can't make them go away by clicking.
+            for task in snap.active.iter() {
+                ActiveRow { task: task.clone() }
+            }
+            // Recently-finished tasks. Done → inline success row that
+            // fades client-side; Failed → red banner with dismiss.
+            for task in visible_terminals.iter() {
+                {
+                    let id = task.task_id;
+                    match &task.state {
+                        ProgressState::Done { .. } => rsx! {
+                            DoneRow {
+                                key: "{id}",
+                                kind: task.kind,
+                                on_dismiss: move |_| {
+                                    let mut set = dismissed();
+                                    set.insert(id);
+                                    dismissed.set(set);
+                                },
+                            }
+                        },
+                        ProgressState::Failed { message } => rsx! {
+                            FailedRow {
+                                key: "{id}",
+                                kind: task.kind,
+                                message: message.clone(),
+                                on_dismiss: move |_| {
+                                    let mut set = dismissed();
+                                    set.insert(id);
+                                    dismissed.set(set);
+                                },
+                            }
+                        },
+                        // Defensive: a Running entry shouldn't be in
+                        // recent_complete, but render it as active rather
+                        // than panicking on the unreachable arm.
+                        ProgressState::Running { .. } => rsx! {
+                            ActiveRow { key: "{id}", task: task.clone() }
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ActiveRow(task: TaskProgress) -> Element {
+    let label = kind_label(task.kind, /* running */ true);
+    let count_suffix = if let ProgressState::Running {
+        processed,
+        total: Some(total),
+    } = &task.state
+    {
+        Some(format!(" ({processed} / {total})"))
+    } else {
+        None
+    };
+    rsx! {
+        div { class: "worker-status-row worker-status-active",
+            span { class: "worker-status-spinner", aria_hidden: "true" }
+            span { class: "worker-status-label",
+                "{label}"
+                if let Some(suffix) = count_suffix {
+                    "{suffix}"
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn DoneRow(kind: TaskKind, on_dismiss: EventHandler<MouseEvent>) -> Element {
+    let label = kind_label(kind, /* running */ false);
+    rsx! {
+        div { class: "worker-status-row worker-status-done",
+            span { class: "worker-status-icon", aria_hidden: "true", "✓" }
+            span { class: "worker-status-label", "{label}" }
+            button {
+                class: "worker-status-dismiss",
+                r#type: "button",
+                aria_label: "Dismiss",
+                onclick: move |evt| on_dismiss.call(evt),
+                "✕"
+            }
+        }
+    }
+}
+
+#[component]
+fn FailedRow(kind: TaskKind, message: String, on_dismiss: EventHandler<MouseEvent>) -> Element {
+    let label = kind_label(kind, /* running */ false);
+    rsx! {
+        div {
+            class: "worker-status-row worker-status-failed",
+            role: "alert",
+            span { class: "worker-status-icon", aria_hidden: "true", "!" }
+            div { class: "worker-status-body",
+                div { class: "worker-status-label", "{label} failed" }
+                div { class: "worker-status-message", "{message}" }
+            }
+            button {
+                class: "worker-status-dismiss",
+                r#type: "button",
+                aria_label: "Dismiss",
+                onclick: move |evt| on_dismiss.call(evt),
+                "✕"
+            }
+        }
+    }
+}
+
+/// Map a wire-protocol [`TaskKind`] to a user-facing label. `running` flips
+/// the tense ("Scanning" vs "Library scan") so the indicator reads
+/// naturally in both the in-flight and terminal contexts. New `TaskKind`
+/// variants (e.g. F5.9 cleanup detection) add one match arm here and
+/// inherit the same active/done/failed rendering for free.
+fn kind_label(kind: TaskKind, running: bool) -> &'static str {
+    match (kind, running) {
+        (TaskKind::Scan, true) => "Scanning library",
+        (TaskKind::Scan, false) => "Library scan",
+        (TaskKind::GenerateThumbs, true) => "Generating thumbnail",
+        (TaskKind::GenerateThumbs, false) => "Thumbnail generation",
+        (TaskKind::ResolveAuthorPhoto, true) => "Resolving author photo",
+        (TaskKind::ResolveAuthorPhoto, false) => "Author photo lookup",
+        // `#[non_exhaustive]` on the shared enum means new variants
+        // compile against existing client builds — render an opaque
+        // fallback rather than panicking.
+        (_, true) => "Background task running",
+        (_, false) => "Background task",
+    }
+}
+
+// `DISMISS_GRACE_MS` is currently consulted only by tests / future
+// drift-detection code; the server-side eviction window does the heavy
+// lifting. Reference it so dead-code lints don't trip while the seam
+// stays available for a later "auto-fade after N ms" tweak.
+#[allow(dead_code)]
+const _DISMISS_GRACE_MS_TOUCH: u32 = DISMISS_GRACE_MS;
+
+// ── Platform-gated 1 Hz poll sleeper ─────────────────────────────
+//
+// Web compiles with `gloo_timers` (already a dep under the `web` feature).
+// The server build runs SSR — server functions execute on the server side
+// of the component graph but `use_future` only runs on the client during
+// hydration, so the server-only branch isn't actually exercised. Keep a
+// `tokio::time::sleep` fallback so non-`web` server compilation succeeds.
+
+#[cfg(feature = "web")]
+async fn async_sleep_ms(ms: u32) {
+    gloo_timers::future::TimeoutFuture::new(ms).await;
+}
+
+#[cfg(all(not(feature = "web"), feature = "server"))]
+async fn async_sleep_ms(ms: u32) {
+    tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_label_covers_all_variants_in_both_tenses() {
+        for kind in [
+            TaskKind::Scan,
+            TaskKind::GenerateThumbs,
+            TaskKind::ResolveAuthorPhoto,
+        ] {
+            assert!(!kind_label(kind, true).is_empty());
+            assert!(!kind_label(kind, false).is_empty());
+        }
+    }
+}

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -27,13 +27,6 @@ use crate::{data, use_server_url};
 /// surface (when does it un-throttle?) for no measurable benefit.
 const POLL_INTERVAL_MS: u32 = 1_000;
 
-/// How long to keep a dismissed terminal task suppressed client-side. The
-/// server's own eviction (10s — see `TERMINAL_RETENTION` in the worker)
-/// kicks in shortly after, so this only has to outlast a couple of
-/// polling ticks. Longer would risk re-surfacing a still-resident
-/// terminal if the user dismissed it just before the server evicted.
-const DISMISS_GRACE_MS: u32 = 12_000;
-
 /// 1 Hz-polled worker progress strip. Renders nothing when the worker is
 /// idle so consumers can mount it inline without leaving dead space.
 #[component]
@@ -42,6 +35,9 @@ pub fn WorkerStatusIndicator() -> Element {
     let mut status = use_signal(WorkerStatus::default);
     // Client-suppressed terminal task ids — the user dismissed the
     // "Library updated" / red banner before the server evicted it.
+    // Pruned on every render to ids still present in `recent_complete`
+    // so the set can't grow past the server's own ~10 s retention
+    // window (see snapshot loop below).
     let mut dismissed = use_signal(std::collections::HashSet::<u64>::new);
 
     let url_for_poll = server_url.clone();
@@ -62,6 +58,21 @@ pub fn WorkerStatusIndicator() -> Element {
     });
 
     let snap = status();
+    // Drop any dismissed ids that the server has already evicted, so the
+    // set stays bounded by `len(recent_complete)` rather than growing
+    // monotonically across the session. Only writes when something
+    // actually changed to avoid signal-write churn on every poll.
+    {
+        let current = dismissed();
+        let live: std::collections::HashSet<u64> = current
+            .iter()
+            .copied()
+            .filter(|id| snap.recent_complete.iter().any(|p| p.task_id == *id))
+            .collect();
+        if live.len() != current.len() {
+            dismissed.set(live);
+        }
+    }
     let visible_terminals: Vec<TaskProgress> = snap
         .recent_complete
         .iter()
@@ -82,7 +93,7 @@ pub fn WorkerStatusIndicator() -> Element {
             // Active tasks first — these have no dismiss affordance since
             // the user can't make them go away by clicking.
             for task in snap.active.iter() {
-                ActiveRow { task: task.clone() }
+                ActiveRow { key: "{task.task_id}", task: task.clone() }
             }
             // Recently-finished tasks. Done → inline success row that
             // fades client-side; Failed → red banner with dismiss.
@@ -212,13 +223,6 @@ fn kind_label(kind: TaskKind, running: bool) -> &'static str {
         (_, false) => "Background task",
     }
 }
-
-// `DISMISS_GRACE_MS` is currently consulted only by tests / future
-// drift-detection code; the server-side eviction window does the heavy
-// lifting. Reference it so dead-code lints don't trip while the seam
-// stays available for a later "auto-fade after N ms" tweak.
-#[allow(dead_code)]
-const _DISMISS_GRACE_MS_TOUCH: u32 = DISMISS_GRACE_MS;
 
 // ── Platform-gated 1 Hz poll sleeper ─────────────────────────────
 //

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -13,7 +13,7 @@
 use omnibus_shared::{
     AuthorDetail, AuthorPhotoScanResult, AuthorSummary, EbookLibrary, EbookMetadata,
     LibraryContents, MetadataOverrides, PaletteResults, SeriesDetail, SeriesSummary, Settings,
-    TagWeight,
+    TagWeight, WorkerStatus,
 };
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
@@ -900,6 +900,25 @@ pub async fn get_library(_server_url: &str) -> Result<LibraryContents, DataError
     crate::rpc::rpc_get_library()
         .await
         .map_err(note_server_fn_err)
+}
+
+/// Snapshot of the worker progress feed. Web calls the RPC; mobile returns
+/// an empty status because the corresponding REST endpoint doesn't exist
+/// yet (issue #69 keeps the mobile UI out of scope for v1, and the data
+/// stub keeps callers' types lined up across feature gates).
+#[cfg(not(feature = "mobile"))]
+pub async fn worker_status(_server_url: &str) -> Result<WorkerStatus, DataError> {
+    crate::rpc::rpc_worker_status()
+        .await
+        .map_err(note_server_fn_err)
+}
+
+#[cfg(feature = "mobile")]
+pub async fn worker_status(_server_url: &str) -> Result<WorkerStatus, DataError> {
+    // Mobile REST mirror is a follow-up; return an empty status so any
+    // future mobile caller compiles against the same signature the web
+    // build uses.
+    Ok(WorkerStatus::default())
 }
 
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -133,6 +133,7 @@ pub fn SettingsPage() -> Element {
 
             p {
                 id: "settings-status",
+                "data-testid": "settings-status",
                 role: "status",
                 class: if status_is_error() { "settings-status error" } else { "settings-status success" },
                 if let Some(msg) = status() { "{msg}" }

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -1,6 +1,8 @@
 use dioxus::prelude::*;
 use omnibus_shared::{LibraryContents, LibrarySection, Settings};
 
+#[cfg(not(feature = "mobile"))]
+use crate::components::worker_status::WorkerStatusIndicator;
 use crate::{data, use_server_url};
 
 /// Library paths settings form + live recursive file-count summaries.
@@ -43,6 +45,17 @@ pub fn SettingsPage() -> Element {
             }
         });
     });
+
+    let worker_status_slot: Element = {
+        #[cfg(not(feature = "mobile"))]
+        {
+            rsx! { WorkerStatusIndicator {} }
+        }
+        #[cfg(feature = "mobile")]
+        {
+            rsx! {}
+        }
+    };
 
     rsx! {
         section { class: "card",
@@ -105,6 +118,16 @@ pub fn SettingsPage() -> Element {
                         section: library().audiobooks,
                     }
                 }
+                // Background-worker progress (scan / thumbs / author
+                // photos / future cleanup actions). Mounted above the Save
+                // button so the user sees the post-save scan kick in
+                // without leaving the page. Web-only; the mobile build
+                // omits the indicator entirely until issue #69 follow-up
+                // ships a REST mirror. `cfg` attrs aren't legal directly
+                // on rsx component calls, so the slot is bound as an
+                // Element outside the macro and embedded by reference.
+                {worker_status_slot}
+
                 button { r#type: "submit", class: "btn", "Save" }
             }
 

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -18,7 +18,7 @@ use dioxus::prelude::*;
 use omnibus_shared::{
     AuthorDetail, AuthorPhotoScanResult, AuthorSummary, EbookLibrary, EbookMetadata,
     LibraryContents, MetadataOverrides, PaletteResults, SeriesDetail, SeriesSummary, Settings,
-    TagWeight, ValueResponse,
+    TagWeight, ValueResponse, WorkerStatus,
 };
 
 #[cfg(feature = "server")]
@@ -169,6 +169,28 @@ pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
             .post(omnibus_db::worker::Task::Scan { library_path });
     }
     Ok(updated)
+}
+
+/// Snapshot of every in-flight and recently-completed background-worker
+/// task (F0.5). Polled at 1 Hz by the `WorkerStatusIndicator` component to
+/// surface scan / thumbnail / author-photo / (future) cleanup progress
+/// under the Save button on `/settings`.
+///
+/// Auth-gated as `AuthUser` (not `AdminUser`): scans affect the shared
+/// library and every authed user has a reason to know one is running.
+/// Worker progress snapshot for the in-page indicator.
+///
+/// Modeled on `rpc_save_settings` because both routes need the
+/// `WorkerExt` extension. Empirically the Dioxus fullstack server-fn
+/// macro mounts `#[post]` routes whose extractor list contains
+/// `WorkerExt`, but the `#[get]` variant of the same signature 404s at
+/// runtime (the route string ends up in the binary but never reaches
+/// the axum router). The body is idempotent and read-only; using POST
+/// is purely a framework workaround so the route actually mounts.
+#[post("/api/rpc/worker_status", pool: PoolExt, worker: WorkerExt, _user: AuthUser)]
+pub async fn rpc_worker_status() -> Result<WorkerStatus> {
+    let _ = &pool; // keep the extractor live so the macro emits the route
+    Ok(worker.0.progress_snapshot())
 }
 
 #[get("/api/rpc/library", pool: PoolExt, _user: AuthUser)]

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -187,9 +187,12 @@ pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
 /// runtime (the route string ends up in the binary but never reaches
 /// the axum router). The body is idempotent and read-only; using POST
 /// is purely a framework workaround so the route actually mounts.
-#[post("/api/rpc/worker_status", pool: PoolExt, worker: WorkerExt, _user: AuthUser)]
+///
+/// `_pool: PoolExt` is kept in the extractor list to put the macro on
+/// the same code path every other `/api/rpc/*` route uses (all of
+/// which take a `PoolExt`), but is unused — no DB calls run.
+#[post("/api/rpc/worker_status", _pool: PoolExt, worker: WorkerExt, _user: AuthUser)]
 pub async fn rpc_worker_status() -> Result<WorkerStatus> {
-    let _ = &pool; // keep the extractor live so the macro emits the route
     Ok(worker.0.progress_snapshot())
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -615,7 +615,7 @@ pub struct TaskProgress {
     pub last_update_ms: i64,
 }
 
-/// Aggregate progress feed served from `GET /api/rpc/worker_status`.
+/// Aggregate progress feed served from `POST /api/rpc/worker_status`.
 ///
 /// Two-vec split mirrors the F0.5 design doc shape: callers can short-circuit
 /// the "do I need a fade timer?" check by inspecting `recent_complete.is_empty()`

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -546,3 +546,89 @@ pub struct LoginResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
 }
+
+/// Discriminant for [`TaskProgress`] entries (F0.5 worker). Mirrors the
+/// payload-less shape of the server-side `Task` enum so the wire protocol
+/// stays decoupled from the runtime `Task` type's lifetimes and handler
+/// closures. `#[non_exhaustive]` so future worker actions (e.g. F5.9
+/// `DetectCleanup`) can be added without breaking client matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TaskKind {
+    Scan,
+    GenerateThumbs,
+    ResolveAuthorPhoto,
+}
+
+/// Lifecycle state of a single worker task as exposed to the UI.
+///
+/// `Running.total = None` means the task either has no granular progress
+/// surface yet or is in a pre-count phase (e.g. scanner tree-walk). When
+/// `total` is `Some`, `processed / total` is a stable ratio the UI can
+/// render as a progress bar. Terminal variants (`Done`, `Failed`) stick
+/// around in [`WorkerStatus::recent_complete`] for ~10s after completion
+/// so a transient "Library updated" / error banner can render before the
+/// indicator collapses.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ProgressState {
+    Running {
+        processed: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        total: Option<u32>,
+    },
+    Done {
+        processed: u32,
+    },
+    Failed {
+        message: String,
+    },
+}
+
+impl ProgressState {
+    /// Terminal states (`Done`, `Failed`) live in the "recently completed"
+    /// bucket; non-terminal states live in "active." Used by both the worker
+    /// snapshot partitioner and the client renderer.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            ProgressState::Done { .. } | ProgressState::Failed { .. }
+        )
+    }
+}
+
+/// One row of the worker progress feed. `task_id` is the process-local
+/// worker id (not stable across server restarts); the UI uses it only as a
+/// stable key for list rendering and dismiss-tracking.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskProgress {
+    pub task_id: u64,
+    pub kind: TaskKind,
+    pub state: ProgressState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_key: Option<String>,
+    /// Milliseconds since the UNIX epoch — wall-clock, for UI elapsed-time
+    /// display only. The server's actual eviction logic uses a monotonic
+    /// `Instant` internally, so these timestamps don't have to be precise.
+    pub started_at_ms: i64,
+    pub last_update_ms: i64,
+}
+
+/// Aggregate progress feed served from `GET /api/rpc/worker_status`.
+///
+/// Two-vec split mirrors the F0.5 design doc shape: callers can short-circuit
+/// the "do I need a fade timer?" check by inspecting `recent_complete.is_empty()`
+/// without scanning `active`. Both vecs are sorted by `task_id` for stable
+/// list rendering across polls.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkerStatus {
+    pub active: Vec<TaskProgress>,
+    pub recent_complete: Vec<TaskProgress>,
+}
+
+impl WorkerStatus {
+    pub fn is_empty(&self) -> bool {
+        self.active.is_empty() && self.recent_complete.is_empty()
+    }
+}

--- a/ui_tests/playwright/tests/flows/settings.spec.ts
+++ b/ui_tests/playwright/tests/flows/settings.spec.ts
@@ -6,7 +6,11 @@ import { expectNavVisible, gotoReady } from "../utils/nav";
 const ebookInput = (page: Page) => page.getByLabel("Ebook Library Path");
 const audiobookInput = (page: Page) => page.getByLabel("Audiobook Library Path");
 const saveButton = (page: Page) => page.getByRole("button", { name: "Save" });
-const settingsStatus = (page: Page) => page.getByRole("status");
+// The settings page now has two `role=status` regions — the inline form
+// status (this locator) and the worker-progress indicator above the Save
+// button (`data-testid="worker-status"`, issue #69). Target by testid so
+// the assertions stay specific to the form's "Settings saved." line.
+const settingsStatus = (page: Page) => page.getByTestId("settings-status");
 
 test("renders the settings page layout", async ({ page }) => {
   await page.goto("/settings");

--- a/ui_tests/playwright/tests/flows/worker-status.spec.ts
+++ b/ui_tests/playwright/tests/flows/worker-status.spec.ts
@@ -1,0 +1,160 @@
+// Worker status indicator (issue #69). The indicator polls
+// `/api/rpc/worker_status` at 1 Hz and renders one row per active or
+// recently-finished background task above the Save button on /settings.
+//
+// We intercept the polling endpoint instead of seeding a real library so
+// the spec doesn't depend on scan duration (which varies wildly with
+// fixtures). The interception also lets us drive every render branch —
+// idle, active, done, failed — deterministically.
+
+import type { Page, Route } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import { gotoReady } from "../utils/nav";
+
+type WorkerStatus = {
+  active: Array<{
+    task_id: number;
+    kind: "scan" | "generate_thumbs" | "resolve_author_photo";
+    state:
+      | { state: "running"; processed: number; total?: number | null }
+      | { state: "done"; processed: number }
+      | { state: "failed"; message: string };
+    resource_key?: string | null;
+    started_at_ms: number;
+    last_update_ms: number;
+  }>;
+  recent_complete: WorkerStatus["active"];
+};
+
+const indicator = (page: Page) => page.getByTestId("worker-status");
+
+/**
+ * Install a route handler that returns the same canned `WorkerStatus` on
+ * every poll. Returns a `setStatus` setter so the test can flip state
+ * mid-flow (active → done) without re-installing the route.
+ */
+async function mockWorkerStatus(
+  page: Page,
+  initial: WorkerStatus,
+): Promise<(next: WorkerStatus) => void> {
+  let current: WorkerStatus = initial;
+  await page.route("**/api/rpc/worker_status", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(current),
+    });
+  });
+  return (next: WorkerStatus) => {
+    current = next;
+  };
+}
+
+const now = () => Date.now();
+
+test("worker-status indicator stays hidden when the worker is idle", async ({ page }) => {
+  await mockWorkerStatus(page, { active: [], recent_complete: [] });
+  await gotoReady(page, "/settings");
+  // The indicator renders nothing — no element with the testid is in the DOM.
+  await expect(indicator(page)).toHaveCount(0);
+});
+
+test("worker-status indicator surfaces an active scan", async ({ page }) => {
+  await mockWorkerStatus(page, {
+    active: [
+      {
+        task_id: 1,
+        kind: "scan",
+        state: { state: "running", processed: 0, total: null },
+        resource_key: "/tmp/lib",
+        started_at_ms: now(),
+        last_update_ms: now(),
+      },
+    ],
+    recent_complete: [],
+  });
+  await gotoReady(page, "/settings");
+
+  await expect(indicator(page)).toBeVisible();
+  await expect(indicator(page)).toContainText("Scanning library");
+});
+
+test("worker-status indicator shows processed/total when total is known", async ({ page }) => {
+  await mockWorkerStatus(page, {
+    active: [
+      {
+        task_id: 2,
+        kind: "scan",
+        state: { state: "running", processed: 3, total: 10 },
+        started_at_ms: now(),
+        last_update_ms: now(),
+      },
+    ],
+    recent_complete: [],
+  });
+  await gotoReady(page, "/settings");
+
+  await expect(indicator(page)).toContainText("Scanning library");
+  await expect(indicator(page)).toContainText("(3 / 10)");
+});
+
+test("worker-status indicator transitions from active to done and lets the user dismiss", async ({
+  page,
+}) => {
+  const setStatus = await mockWorkerStatus(page, {
+    active: [
+      {
+        task_id: 3,
+        kind: "scan",
+        state: { state: "running", processed: 0, total: null },
+        started_at_ms: now(),
+        last_update_ms: now(),
+      },
+    ],
+    recent_complete: [],
+  });
+  await gotoReady(page, "/settings");
+  await expect(indicator(page)).toContainText("Scanning library");
+
+  // Flip the canned response to a terminal Done. Within ~1 polling
+  // tick (1s; allow 3s for slow runners) the row reads "Library scan".
+  setStatus({
+    active: [],
+    recent_complete: [
+      {
+        task_id: 3,
+        kind: "scan",
+        state: { state: "done", processed: 12 },
+        started_at_ms: now() - 1_000,
+        last_update_ms: now(),
+      },
+    ],
+  });
+  await expect(indicator(page)).toContainText("Library scan", { timeout: 3_500 });
+
+  // Dismiss the terminal row; the indicator collapses because nothing
+  // active is left and the only terminal is suppressed client-side.
+  await page.getByRole("button", { name: "Dismiss" }).click();
+  await expect(indicator(page)).toHaveCount(0);
+});
+
+test("worker-status indicator surfaces a failed scan with the error message", async ({ page }) => {
+  await mockWorkerStatus(page, {
+    active: [],
+    recent_complete: [
+      {
+        task_id: 4,
+        kind: "scan",
+        state: { state: "failed", message: "library path does not exist" },
+        started_at_ms: now() - 500,
+        last_update_ms: now(),
+      },
+    ],
+  });
+  await gotoReady(page, "/settings");
+
+  const failed = page.getByRole("alert");
+  await expect(failed).toBeVisible();
+  await expect(failed).toContainText("Library scan failed");
+  await expect(failed).toContainText("library path does not exist");
+});


### PR DESCRIPTION
## Summary

Closes [#69](https://github.com/seamus-sloan/omnibus/issues/69). Adds an in-memory worker-progress channel and a polling indicator above the Save button on `/settings` so users see what the background worker is doing (scan / thumbs / author-photo / future cleanup actions). The data plane is generic over `TaskKind` — F5.9 library cleanup can extend it with a single match arm.

- `Worker` gains a `BTreeMap<TaskId, ProgressEntry>` seeded on `post` and finalized in `run`, with a panic-safe terminal-write guard mirroring the existing `CompletionsPruneGuard` shape.
- `progress_snapshot()` partitions into `active` / `recent_complete`, lazily evicting terminal entries older than 10 s (monotonic `Instant`; wall-clock timestamps are UI-only).
- Indicator polls `/api/rpc/worker_status` at 1 Hz while mounted, renders one row per task with kind-appropriate labels, and supports client-side dismiss for terminal rows.
- Phase-2 seam: `Worker::report_progress(id, processed, total)` is `pub(crate)` ready for `indexer::reindex` to plumb per-EPUB counts in a follow-up.

> [!NOTE]
> The route is `#[post]` rather than `#[get]` — empirically the Dioxus fullstack server-fn macro doesn't mount `#[get]` routes whose extractor list contains `WorkerExt`; the same shape works as POST. Documented inline at the function.

## Test plan

- [x] `cargo test -p omnibus-db worker::tests` — 15/15 pass (5 new: queued-task seeding, concurrent active, panic→failed, terminal eviction, `report_progress` round-trip + ignored-after-terminal).
- [x] `cargo test -p omnibus` — 129/129 pass.
- [x] `cargo clippy --all-targets` clean; `cargo fmt --check` clean.
- [x] `cargo check -p omnibus-mobile` clean (the mobile data stub returns `WorkerStatus::default()` until a REST mirror lands).
- [x] Route registration verified by running the omnibus binary directly: `dioxus_server::server: Registering: POST /api/rpc/worker_status`.
- [ ] Playwright `worker-status.spec.ts` — 5 specs covering idle / active / (k/N) counts / active→done→dismiss / failed banner. Uses page.route() interception so it runs without a live scan.

## Notes

- Mobile UI is intentionally out of scope; REST `/api/worker_status` mirror is a follow-up.
- Per-EPUB granular progress is deferred to phase 2 (designed but not wired) — v1 emits `Running { 0, None }` → `Done`/`Failed` only.
- No DB schema changes. Rollback = revert the PR.