### PR TITLE
chore: scanner two-phase split + book_files.mtime_epoch migration

### DIFF
--- a/db/migrations/0009_book_files_fs_metadata.sql
+++ b/db/migrations/0009_book_files_fs_metadata.sql
@@ -1,0 +1,15 @@
+-- Track filesystem mtime for incremental reindex change detection.
+--
+-- The existing `mtime TEXT` column holds the OPF `dcterms:modified` value
+-- (Dublin Core, not filesystem state) and is preserved as-is. The new
+-- `mtime_epoch INTEGER` column is the filesystem stat in seconds since the
+-- unix epoch, populated by the scanner. `size_bytes` already exists on
+-- `book_files` (previously hardcoded to 0 on insert); the new write path
+-- populates it with the real file size.
+--
+-- The default `0` is a sentinel meaning "never observed". The incremental
+-- reindex diff classifies any row with `mtime_epoch = 0 AND size_bytes = 0`
+-- as Backfill and updates the stat values without re-parsing the OPF, so
+-- the first reindex after this migration is cheap rather than treating
+-- every existing row as Changed.
+ALTER TABLE book_files ADD COLUMN mtime_epoch INTEGER NOT NULL DEFAULT 0;

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -24,10 +24,17 @@ use omnibus_shared::{Contributor, EbookMetadata, Identifier};
 use crate::library_layout;
 
 /// A single scanner output row — metadata plus the raw cover image bytes
-/// (and mime), if the epub included one. Consumed by [`crate::queries::replace_books`].
+/// (and mime), if the epub included one. Consumed by [`crate::queries::sync_books`].
+///
+/// `mtime_epoch` and `size_bytes` are the filesystem stat values captured
+/// during the walk, used by the incremental reindex diff to detect changes
+/// and by the writer to persist on `book_files`.
+#[derive(Default)]
 pub struct IndexedBook {
     pub metadata: EbookMetadata,
     pub cover: Option<(String, Vec<u8>)>,
+    pub mtime_epoch: i64,
+    pub size_bytes: i64,
 }
 
 /// Result of scanning an ebook library directory. Separate from
@@ -37,6 +44,45 @@ pub struct ScanResult {
     pub path: Option<String>,
     pub books: Vec<IndexedBook>,
     pub error: Option<String>,
+}
+
+/// Phase A output: a single filesystem stat row, with no zip open or OPF
+/// parse. The incremental diff compares these against `book_files` to
+/// classify entries as Unchanged / New / Changed / Removed / Backfill.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StatEntry {
+    /// Path relative to the library root — same shape used everywhere else
+    /// as the per-book "filename" string.
+    pub filename: String,
+    /// Stable UUIDv5 of `(library_path, filename)`. Computed here so the
+    /// diff branch never needs to thread `library_path` around again.
+    pub uuid: String,
+    /// Filesystem mtime in seconds since the unix epoch, or `0` if
+    /// `entry.metadata().modified()` failed.
+    pub mtime_epoch: i64,
+    /// Filesystem byte size, or `0` if stat failed.
+    pub size_bytes: i64,
+}
+
+/// Phase A result. Mirrors `ScanResult` for the no-path / unreadable-root
+/// failure modes.
+pub struct StatScanResult {
+    pub path: Option<String>,
+    pub entries: Vec<StatEntry>,
+    pub error: Option<String>,
+}
+
+/// Phase B input: one entry per file the diff says needs a full OPF parse
+/// (the New + Changed buckets). The absolute path lets the parser open the
+/// file directly without re-walking; the stat values carry forward into
+/// the resulting `IndexedBook` so the writer persists the same values the
+/// diff observed.
+#[derive(Debug, Clone)]
+pub struct ParseTarget {
+    pub filename: String,
+    pub absolute: PathBuf,
+    pub mtime_epoch: i64,
+    pub size_bytes: i64,
 }
 
 /// Knobs that change how a scan touches the filesystem. Default keeps the
@@ -56,91 +102,195 @@ pub fn scan_ebook_library(path: Option<&str>) -> ScanResult {
     scan_ebook_library_with(path, ScanOptions::default())
 }
 
+/// Full-walk-and-parse scan, kept for non-indexer callers (server bootstrap
+/// probes, existing tests). Now a thin wrapper over the two phases —
+/// `stat_ebook_library` → build all-entries target list → `parse_ebook_targets`.
+///
+/// The incremental reindex path in [`crate::indexer::reindex`] uses the two
+/// phases directly so it can skip Phase B for unchanged files.
 pub fn scan_ebook_library_with(path: Option<&str>, opts: ScanOptions) -> ScanResult {
-    let Some(path_str) = path else {
+    // For this legacy callpath, the library_path string is the input path
+    // verbatim — same key the indexer uses, so stable_uuid stays consistent
+    // whether you arrive via `scan_ebook_library_with` or the two-phase API.
+    let library_path_key = path.unwrap_or_default();
+    let stat = stat_ebook_library(path, library_path_key);
+    let Some(root) = path else {
         return ScanResult {
-            path: None,
+            path: stat.path,
             books: vec![],
+            error: stat.error,
+        };
+    };
+    let dir = Path::new(root);
+    let targets: Vec<ParseTarget> = stat
+        .entries
+        .iter()
+        .map(|e| ParseTarget {
+            filename: e.filename.clone(),
+            absolute: dir.join(&e.filename),
+            mtime_epoch: e.mtime_epoch,
+            size_bytes: e.size_bytes,
+        })
+        .collect();
+    let mut books = parse_ebook_targets(targets, opts);
+    // Surface unreadable subdirectory placeholders captured during the
+    // stat walk so the legacy contract (one error row per unreadable
+    // subdir) is preserved.
+    for placeholder in stat.entries.into_iter().filter(|e| e.uuid.is_empty()) {
+        books.push(IndexedBook {
+            metadata: EbookMetadata {
+                filename: placeholder.filename.clone(),
+                error: Some("could not read directory".to_string()),
+                ..Default::default()
+            },
+            cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
+        });
+    }
+    books.sort_by(|a, b| a.metadata.filename.cmp(&b.metadata.filename));
+    ScanResult {
+        path: stat.path,
+        books,
+        error: stat.error,
+    }
+}
+
+/// Phase A: walk the library and `stat` every `.epub` without opening the
+/// zip. Returns one `StatEntry` per file plus a synthetic entry (empty
+/// `uuid`) for any unreadable subdirectory — the legacy
+/// `scan_ebook_library_with` shape surfaces these as error rows.
+///
+/// `library_path_key` is what `stable_uuid` hashes; callers pass the same
+/// string they'd use as the `books.library_path` so the uuids line up with
+/// any rows already in the DB.
+pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatScanResult {
+    let Some(path_str) = path else {
+        return StatScanResult {
+            path: None,
+            entries: vec![],
             error: None,
         };
     };
 
     let dir = Path::new(path_str);
     if !dir.exists() {
-        return ScanResult {
+        return StatScanResult {
             path: Some(path_str.to_string()),
-            books: vec![],
+            entries: vec![],
             error: Some(format!("path not found: {path_str}")),
         };
     }
 
-    let mut books: Vec<IndexedBook> = Vec::new();
-    let mut stack: Vec<std::path::PathBuf> = vec![dir.to_path_buf()];
+    let mut entries: Vec<StatEntry> = Vec::new();
+    let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
     while let Some(current) = stack.pop() {
-        let entries = match std::fs::read_dir(&current) {
+        let read = match std::fs::read_dir(&current) {
             Ok(e) => e,
             Err(e) => {
-                // Root failure is fatal (no library to surface at all). A
-                // failure below the root is recorded as a synthetic entry
-                // and we continue — one unreadable subfolder must not hide
-                // the rest of the library, same as a single broken epub.
                 if current == dir {
-                    return ScanResult {
+                    // Root unreadable: fatal — match legacy behavior.
+                    return StatScanResult {
                         path: Some(path_str.to_string()),
-                        books: vec![],
+                        entries: vec![],
                         error: Some(format!("could not read directory: {e}")),
                     };
                 }
+                // Sub-dir unreadable: record a placeholder with an empty
+                // uuid so the legacy wrapper can lift it into an error
+                // row. The incremental indexer ignores empty-uuid entries.
                 let relative = current
                     .strip_prefix(dir)
                     .unwrap_or(&current)
                     .to_string_lossy()
                     .to_string();
-                books.push(IndexedBook {
-                    metadata: EbookMetadata {
-                        filename: relative,
-                        error: Some(format!("could not read directory: {e}")),
-                        ..Default::default()
-                    },
-                    cover: None,
+                entries.push(StatEntry {
+                    filename: relative,
+                    uuid: String::new(),
+                    mtime_epoch: 0,
+                    size_bytes: 0,
                 });
                 continue;
             }
         };
-        for entry in entries.flatten() {
+        for entry in read.flatten() {
             let Ok(file_type) = entry.file_type() else {
                 continue;
             };
             let entry_path = entry.path();
             if file_type.is_dir() {
                 stack.push(entry_path);
-            } else if file_type.is_file()
-                && entry_path
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .map(|s| s.eq_ignore_ascii_case("epub"))
-                    .unwrap_or(false)
-            {
-                // Use the path relative to the library root as the display
-                // identifier so nested files with duplicate names don't
-                // collide as component keys / error tags.
-                let relative = entry_path
-                    .strip_prefix(dir)
-                    .unwrap_or(&entry_path)
-                    .to_string_lossy()
-                    .to_string();
-                books.push(extract_metadata(&entry_path, relative, &opts));
+                continue;
             }
+            if !file_type.is_file() {
+                continue;
+            }
+            let is_epub = entry_path
+                .extension()
+                .and_then(|s| s.to_str())
+                .map(|s| s.eq_ignore_ascii_case("epub"))
+                .unwrap_or(false);
+            if !is_epub {
+                continue;
+            }
+            let relative = entry_path
+                .strip_prefix(dir)
+                .unwrap_or(&entry_path)
+                .to_string_lossy()
+                .to_string();
+            let (mtime_epoch, size_bytes) = stat_file(&entry_path);
+            let uuid = crate::queries::stable_uuid(library_path_key, &relative);
+            entries.push(StatEntry {
+                filename: relative,
+                uuid,
+                mtime_epoch,
+                size_bytes,
+            });
         }
     }
 
-    books.sort_by(|a, b| a.metadata.filename.cmp(&b.metadata.filename));
+    entries.sort_by(|a, b| a.filename.cmp(&b.filename));
 
-    ScanResult {
+    StatScanResult {
         path: Some(path_str.to_string()),
-        books,
+        entries,
         error: None,
     }
+}
+
+/// Phase B: parse the full OPF + cover for the subset of files the diff
+/// said are new or changed. Each target carries the absolute path so we
+/// don't re-walk, and the Phase-A stat values so the resulting
+/// `IndexedBook` ships them straight through to the writer.
+pub fn parse_ebook_targets(targets: Vec<ParseTarget>, opts: ScanOptions) -> Vec<IndexedBook> {
+    targets
+        .into_iter()
+        .map(|t| {
+            let mut book = extract_metadata(&t.absolute, t.filename, &opts);
+            book.mtime_epoch = t.mtime_epoch;
+            book.size_bytes = t.size_bytes;
+            book
+        })
+        .collect()
+}
+
+/// `entry.metadata()` + `modified()` → epoch seconds. Anything we can't
+/// stat returns `(0, 0)`, which the diff treats as the "Backfill" sentinel
+/// — same as a freshly migrated row. That's fine: if we couldn't stat it
+/// now, the next run will either succeed (and the row updates) or keep
+/// failing (and the row stays in the same Backfill-ish state). No data loss.
+fn stat_file(path: &Path) -> (i64, i64) {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return (0, 0);
+    };
+    let size = meta.len() as i64;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    (mtime, size)
 }
 
 fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> IndexedBook {
@@ -154,6 +304,10 @@ fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> Indexe
                     ..Default::default()
                 },
                 cover: None,
+                // Stat values get overwritten by `parse_ebook_targets`
+                // before the writer sees this struct.
+                mtime_epoch: 0,
+                size_bytes: 0,
             };
         }
     };
@@ -208,6 +362,10 @@ fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> Indexe
             has_override: false,
         },
         cover,
+        // Stat values get overwritten by `parse_ebook_targets` before the
+        // writer sees this struct.
+        mtime_epoch: 0,
+        size_bytes: 0,
     }
 }
 

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -49,6 +49,12 @@ pub struct ScanResult {
 /// Phase A output: a single filesystem stat row, with no zip open or OPF
 /// parse. The incremental diff compares these against `book_files` to
 /// classify entries as Unchanged / New / Changed / Removed / Backfill.
+///
+/// An entry with an empty `uuid` is a synthetic placeholder for an
+/// unreadable subdirectory — `error` carries the underlying io message
+/// (e.g. "permission denied" vs. "no such file") so the legacy
+/// [`scan_ebook_library_with`] wrapper can surface it verbatim. The
+/// incremental diff ignores empty-uuid entries.
 #[derive(Debug, Clone, PartialEq)]
 pub struct StatEntry {
     /// Path relative to the library root — same shape used everywhere else
@@ -56,12 +62,17 @@ pub struct StatEntry {
     pub filename: String,
     /// Stable UUIDv5 of `(library_path, filename)`. Computed here so the
     /// diff branch never needs to thread `library_path` around again.
+    /// Empty string for placeholder rows (see struct doc).
     pub uuid: String,
     /// Filesystem mtime in seconds since the unix epoch, or `0` if
     /// `entry.metadata().modified()` failed.
     pub mtime_epoch: i64,
     /// Filesystem byte size, or `0` if stat failed.
     pub size_bytes: i64,
+    /// Only populated for placeholder rows — the original io::Error
+    /// message string from the failed `read_dir`. `None` for real epub
+    /// entries.
+    pub error: Option<String>,
 }
 
 /// Phase A result. Mirrors `ScanResult` for the no-path / unreadable-root
@@ -122,9 +133,15 @@ pub fn scan_ebook_library_with(path: Option<&str>, opts: ScanOptions) -> ScanRes
         };
     };
     let dir = Path::new(root);
+    // Skip the synthetic placeholders the stat walk emits for unreadable
+    // subdirectories — Phase B should only see real `.epub` files.
+    // Without this filter, parse_ebook_targets calls extract_metadata on
+    // the directory path (wasted work + bogus parse-error row), and the
+    // explicit error-row append below produces a duplicate.
     let targets: Vec<ParseTarget> = stat
         .entries
         .iter()
+        .filter(|e| !e.uuid.is_empty())
         .map(|e| ParseTarget {
             filename: e.filename.clone(),
             absolute: dir.join(&e.filename),
@@ -135,12 +152,20 @@ pub fn scan_ebook_library_with(path: Option<&str>, opts: ScanOptions) -> ScanRes
     let mut books = parse_ebook_targets(targets, opts);
     // Surface unreadable subdirectory placeholders captured during the
     // stat walk so the legacy contract (one error row per unreadable
-    // subdir) is preserved.
+    // subdir) is preserved. The placeholder carries the original
+    // io::Error string so callers can distinguish "permission denied"
+    // from "no such file" — same diagnostic detail the pre-split
+    // implementation surfaced.
     for placeholder in stat.entries.into_iter().filter(|e| e.uuid.is_empty()) {
+        let msg = placeholder
+            .error
+            .as_deref()
+            .map(|e| format!("could not read directory: {e}"))
+            .unwrap_or_else(|| "could not read directory".to_string());
         books.push(IndexedBook {
             metadata: EbookMetadata {
                 filename: placeholder.filename.clone(),
-                error: Some("could not read directory".to_string()),
+                error: Some(msg),
                 ..Default::default()
             },
             cover: None,
@@ -198,7 +223,9 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
                 }
                 // Sub-dir unreadable: record a placeholder with an empty
                 // uuid so the legacy wrapper can lift it into an error
-                // row. The incremental indexer ignores empty-uuid entries.
+                // row. Carry the io::Error string so callers can
+                // distinguish "permission denied" from "no such file" —
+                // the incremental indexer ignores empty-uuid entries.
                 let relative = current
                     .strip_prefix(dir)
                     .unwrap_or(&current)
@@ -209,6 +236,7 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
                     uuid: String::new(),
                     mtime_epoch: 0,
                     size_bytes: 0,
+                    error: Some(e.to_string()),
                 });
                 continue;
             }
@@ -245,6 +273,7 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
                 uuid,
                 mtime_epoch,
                 size_bytes,
+                error: None,
             });
         }
     }
@@ -888,11 +917,30 @@ mod tests {
         // Good epub still surfaces.
         assert!(out.books.iter().any(|b| b.metadata.filename == "good.epub"));
         // Locked subdir surfaces as a synthetic error entry, not silently
-        // dropped.
-        assert!(out
+        // dropped, and exactly once — Phase B must skip the empty-uuid
+        // placeholder so it doesn't get parsed as a fake epub AND appended
+        // as an error row (which would produce two rows for the same dir).
+        let locked_rows: Vec<_> = out
             .books
             .iter()
-            .any(|b| b.metadata.filename == "locked" && b.metadata.error.is_some()));
+            .filter(|b| b.metadata.filename == "locked")
+            .collect();
+        assert_eq!(
+            locked_rows.len(),
+            1,
+            "exactly one error row per unreadable subdir, got {locked_rows:?}",
+        );
+        let msg = locked_rows[0].metadata.error.as_deref().unwrap_or("");
+        assert!(
+            msg.contains("could not read directory"),
+            "error message should keep the legacy prefix, got {msg:?}",
+        );
+        // Underlying io::Error detail (e.g. "permission denied") must be
+        // carried through so callers can distinguish failure modes.
+        assert!(
+            msg.len() > "could not read directory".len(),
+            "error message should include the io detail, got {msg:?}",
+        );
     }
 
     // ---------- Sidecar cover (F0.6) ----------

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -29,7 +29,7 @@ use crate::library_layout;
 /// `mtime_epoch` and `size_bytes` are the filesystem stat values captured
 /// during the walk, used by the incremental reindex diff to detect changes
 /// and by the writer to persist on `book_files`.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct IndexedBook {
     pub metadata: EbookMetadata,
     pub cover: Option<(String, Vec<u8>)>,

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -2,8 +2,8 @@
 //!
 //! The web and mobile list endpoints read from the `books` table instead of
 //! walking the filesystem on every request. This module owns the write side:
-//! scan the configured library, then atomically replace the DB rows for
-//! that path.
+//! scan the configured library, diff the result against the DB, and apply
+//! only the per-book changes that the on-disk state demands.
 //!
 //! Two triggers fire a reindex (both routed through
 //! [`crate::worker::Worker`] so concurrency and per-path serialization are
@@ -15,6 +15,26 @@
 //!
 //! Scans run on the blocking pool via `spawn_blocking` so the hot axum
 //! runtime stays responsive while the walk + OPF parse + cover reads go.
+//!
+//! ## Diff classification
+//!
+//! [`diff_library`] takes the Phase-A stat output and the DB's current
+//! state and buckets each file:
+//!
+//! - **Unchanged** — on disk, in DB, `(mtime_epoch, size_bytes)` matches.
+//!   No work. `books.id` preserved.
+//! - **New** — on disk, not in DB. Full Phase-B parse + insert.
+//! - **Changed** — on disk, in DB, stat differs. Full Phase-B parse, then
+//!   UPDATE in place (preserves `books.id`).
+//! - **Removed** — in DB, not on disk. DELETE (cascades clean).
+//! - **Backfill** — in DB, in disk, DB has the migration default
+//!   `(mtime_epoch=0, size_bytes=0)`. Treated as the sentinel for "fs
+//!   metadata never observed" (post-migration), so the writer only
+//!   updates the stat columns; the OPF is not re-parsed. Without this,
+//!   the first reindex after the migration would treat every existing
+//!   row as Changed.
+
+use std::path::{Path, PathBuf};
 
 use sqlx::SqlitePool;
 
@@ -38,33 +58,291 @@ pub async fn is_stale(pool: &SqlitePool, library_path: &str) -> Result<bool, sql
     Ok(now - last >= REFRESH_AFTER_SECS)
 }
 
-/// Scan `library_path` and replace the DB index for it. Runs the scan on
-/// the blocking pool so callers can `await` it from a normal async context
-/// without blocking the runtime.
+/// Result of [`diff_library`]. Each bucket is what the writer should do
+/// for the corresponding subset of files.
+#[derive(Debug, Default)]
+pub struct ReindexDiff {
+    /// Already in the DB and the on-disk stat matches. Writer does
+    /// nothing — `books.id` is preserved by definition.
+    pub unchanged: Vec<String>,
+    /// Not in the DB. Writer parses + inserts.
+    pub new: Vec<ebook::ParseTarget>,
+    /// In the DB but the stat differs. Writer parses + UPDATEs in place
+    /// (`books.id` preserved).
+    pub changed: Vec<ebook::ParseTarget>,
+    /// In the DB but not on disk. Writer deletes; cascades clear the link
+    /// tables; cover files on disk get cleaned up post-commit.
+    pub removed: Vec<String>,
+    /// In the DB and on disk, but the DB row carries the post-migration
+    /// `(mtime_epoch=0, size_bytes=0)` sentinel. Writer fills in the stat
+    /// values without re-parsing the OPF — the one-time upgrade fast path.
+    pub backfill: Vec<(String, i64, i64)>,
+}
+
+/// Pure classifier — no I/O. Compares a Phase-A stat output against the
+/// current DB state and routes each file into one of the five buckets.
+/// `library_root` is the absolute path the scanner walked; we join it
+/// with each `filename` to fill `ParseTarget.absolute` so Phase B can
+/// open files directly without re-walking.
+pub fn diff_library(
+    disk: &[ebook::StatEntry],
+    db: &[queries::IndexedRow],
+    library_root: &Path,
+) -> ReindexDiff {
+    use std::collections::HashMap;
+
+    // Skip the synthetic "unreadable subdir" placeholders the stat walk
+    // emits with an empty uuid (`scan_ebook_library_with` lifts those
+    // into error rows for the legacy wrapper, but the diff treats them
+    // as not-present).
+    let disk_by_uuid: HashMap<&str, &ebook::StatEntry> = disk
+        .iter()
+        .filter(|e| !e.uuid.is_empty())
+        .map(|e| (e.uuid.as_str(), e))
+        .collect();
+    let db_by_uuid: HashMap<&str, &queries::IndexedRow> =
+        db.iter().map(|r| (r.uuid.as_str(), r)).collect();
+
+    let mut out = ReindexDiff::default();
+
+    for (uuid, entry) in &disk_by_uuid {
+        match db_by_uuid.get(uuid) {
+            None => out.new.push(ebook::ParseTarget {
+                filename: entry.filename.clone(),
+                absolute: library_root.join(&entry.filename),
+                mtime_epoch: entry.mtime_epoch,
+                size_bytes: entry.size_bytes,
+            }),
+            Some(row) => {
+                let never_observed = row.mtime_epoch == 0 && row.size_bytes == 0;
+                let matches =
+                    row.mtime_epoch == entry.mtime_epoch && row.size_bytes == entry.size_bytes;
+                if never_observed {
+                    out.backfill
+                        .push(((*uuid).to_string(), entry.mtime_epoch, entry.size_bytes));
+                } else if matches {
+                    out.unchanged.push((*uuid).to_string());
+                } else {
+                    out.changed.push(ebook::ParseTarget {
+                        filename: entry.filename.clone(),
+                        absolute: library_root.join(&entry.filename),
+                        mtime_epoch: entry.mtime_epoch,
+                        size_bytes: entry.size_bytes,
+                    });
+                }
+            }
+        }
+    }
+
+    for row in db {
+        if !disk_by_uuid.contains_key(row.uuid.as_str()) {
+            out.removed.push(row.uuid.clone());
+        }
+    }
+
+    // Stable order keeps the writer's behavior predictable across runs
+    // (matters for the cover-file post-commit step, and for tests).
+    out.new.sort_by(|a, b| a.filename.cmp(&b.filename));
+    out.changed.sort_by(|a, b| a.filename.cmp(&b.filename));
+    out.unchanged.sort();
+    out.removed.sort();
+    out.backfill.sort_by(|a, b| a.0.cmp(&b.0));
+
+    out
+}
+
+/// Scan `library_path`, diff against the existing index, and apply only
+/// the per-book changes the diff demands. Runs the scan on the blocking
+/// pool so callers can `await` it from a normal async context without
+/// blocking the runtime.
 ///
-/// A fatal scan error (missing or unreadable root) is returned as `Err` and
-/// the existing index is **not** touched — we'd rather serve stale-but-good
-/// data than wipe the table and mark the index "fresh" (which would also
-/// suppress retries until [`REFRESH_AFTER_SECS`] elapses). Per-book parse
-/// failures are *not* fatal; they land in the DB as rows with `error =
-/// Some(_)`, same as before.
+/// A fatal scan error (missing or unreadable root) is returned as `Err`
+/// and the existing index is **not** touched — we'd rather serve
+/// stale-but-good data than wipe the table and mark the index "fresh"
+/// (which would also suppress retries until [`REFRESH_AFTER_SECS`]
+/// elapses). Per-book parse failures are *not* fatal; they land in the
+/// DB as rows with `error = Some(_)`, same as before.
 pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
     let path_for_scan = library_path.to_owned();
-    let scan = tokio::task::spawn_blocking(move || {
+    let library_key_for_scan = library_path.to_owned();
+    let stat = tokio::task::spawn_blocking(move || {
+        ebook::stat_ebook_library(Some(&path_for_scan), &library_key_for_scan)
+    })
+    .await?;
+    if let Some(msg) = stat.error {
+        anyhow::bail!("scan of {library_path} failed: {msg}");
+    }
+
+    let db_rows = queries::list_indexed_rows(pool, library_path).await?;
+    let library_root: PathBuf = PathBuf::from(library_path);
+    let diff = diff_library(&stat.entries, &db_rows, &library_root);
+
+    // Parse Phase B only for the buckets that need it.
+    let new_targets = diff.new.clone();
+    let changed_targets = diff.changed.clone();
+    let parsed = tokio::task::spawn_blocking(move || {
         // Materialize cover sidecars so future scans skip the zip
         // (F0.6). Best-effort: read-only filesystems fall through to the
         // in-memory bytes for the current scan and retry next time.
-        ebook::scan_ebook_library_with(
-            Some(&path_for_scan),
-            ebook::ScanOptions {
-                materialize_sidecars: true,
-            },
-        )
+        let opts = ebook::ScanOptions {
+            materialize_sidecars: true,
+        };
+        let new_books = ebook::parse_ebook_targets(new_targets, opts.clone());
+        let changed_books = ebook::parse_ebook_targets(changed_targets, opts);
+        (new_books, changed_books)
     })
     .await?;
-    if let Some(msg) = scan.error {
-        anyhow::bail!("scan of {library_path} failed: {msg}");
-    }
-    queries::replace_books(pool, library_path, scan.books).await?;
+
+    let plan = queries::SyncPlan {
+        new_books: parsed.0,
+        changed_books: parsed.1,
+        removed_uuids: diff.removed,
+        backfill: diff.backfill,
+    };
+    queries::sync_books(pool, library_path, plan).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ebook::StatEntry;
+    use crate::queries::IndexedRow;
+
+    fn entry(name: &str, uuid: &str, mtime: i64, size: i64) -> StatEntry {
+        StatEntry {
+            filename: name.into(),
+            uuid: uuid.into(),
+            mtime_epoch: mtime,
+            size_bytes: size,
+        }
+    }
+    fn row(uuid: &str, mtime: i64, size: i64) -> IndexedRow {
+        IndexedRow {
+            uuid: uuid.into(),
+            mtime_epoch: mtime,
+            size_bytes: size,
+        }
+    }
+
+    #[test]
+    fn diff_classifies_new_file_as_new() {
+        let disk = vec![entry("a.epub", "uuid-a", 100, 1000)];
+        let db: Vec<IndexedRow> = vec![];
+        let d = diff_library(&disk, &db, Path::new("/lib"));
+        assert_eq!(d.new.len(), 1);
+        assert_eq!(d.new[0].filename, "a.epub");
+        assert_eq!(d.new[0].mtime_epoch, 100);
+        assert_eq!(d.new[0].size_bytes, 1000);
+        assert!(d.changed.is_empty());
+        assert!(d.unchanged.is_empty());
+        assert!(d.removed.is_empty());
+        assert!(d.backfill.is_empty());
+    }
+
+    #[test]
+    fn diff_classifies_missing_file_as_removed() {
+        let disk: Vec<StatEntry> = vec![];
+        let db = vec![row("uuid-a", 100, 1000)];
+        let d = diff_library(&disk, &db, Path::new("/lib"));
+        assert_eq!(d.removed, vec!["uuid-a".to_string()]);
+        assert!(d.new.is_empty());
+        assert!(d.changed.is_empty());
+        assert!(d.unchanged.is_empty());
+    }
+
+    #[test]
+    fn diff_classifies_matching_stat_as_unchanged() {
+        let disk = vec![entry("a.epub", "uuid-a", 100, 1000)];
+        let db = vec![row("uuid-a", 100, 1000)];
+        let d = diff_library(&disk, &db, Path::new("/lib"));
+        assert_eq!(d.unchanged, vec!["uuid-a".to_string()]);
+        assert!(d.new.is_empty());
+        assert!(d.changed.is_empty());
+        assert!(d.removed.is_empty());
+        assert!(d.backfill.is_empty());
+    }
+
+    #[test]
+    fn diff_classifies_mtime_drift_as_changed() {
+        let disk = vec![entry("a.epub", "uuid-a", 200, 1000)];
+        let db = vec![row("uuid-a", 100, 1000)];
+        let d = diff_library(&disk, &db, Path::new("/lib"));
+        assert_eq!(d.changed.len(), 1);
+        assert_eq!(d.changed[0].mtime_epoch, 200);
+        assert!(d.unchanged.is_empty());
+    }
+
+    #[test]
+    fn diff_classifies_size_drift_as_changed() {
+        let disk = vec![entry("a.epub", "uuid-a", 100, 2000)];
+        let db = vec![row("uuid-a", 100, 1000)];
+        let d = diff_library(&disk, &db, Path::new("/lib"));
+        assert_eq!(d.changed.len(), 1);
+        assert_eq!(d.changed[0].size_bytes, 2000);
+    }
+
+    #[test]
+    fn diff_routes_zero_zero_sentinel_to_backfill_not_changed() {
+        // Migration default: existing rows look like (0, 0). The disk
+        // has real values — that combination must NOT trigger a full
+        // re-parse on the first post-migration reindex.
+        let disk = vec![entry("a.epub", "uuid-a", 100, 1000)];
+        let db = vec![row("uuid-a", 0, 0)];
+        let d = diff_library(&disk, &db, Path::new("/lib"));
+        assert_eq!(d.backfill, vec![("uuid-a".into(), 100, 1000)]);
+        assert!(d.changed.is_empty());
+        assert!(d.new.is_empty());
+        assert!(d.unchanged.is_empty());
+    }
+
+    #[test]
+    fn diff_handles_mixed_buckets_in_one_call() {
+        let disk = vec![
+            entry("keep.epub", "uuid-keep", 100, 1000),
+            entry("edit.epub", "uuid-edit", 250, 1100),
+            entry("add.epub", "uuid-add", 300, 500),
+            entry("backfill.epub", "uuid-bf", 400, 600),
+        ];
+        let db = vec![
+            row("uuid-keep", 100, 1000),
+            row("uuid-edit", 200, 1000),
+            row("uuid-bf", 0, 0),
+            row("uuid-gone", 50, 200),
+        ];
+        let d = diff_library(&disk, &db, Path::new("/lib"));
+        assert_eq!(d.unchanged, vec!["uuid-keep".to_string()]);
+        assert_eq!(d.changed.len(), 1);
+        assert_eq!(d.changed[0].filename, "edit.epub");
+        assert_eq!(d.new.len(), 1);
+        assert_eq!(d.new[0].filename, "add.epub");
+        assert_eq!(d.removed, vec!["uuid-gone".to_string()]);
+        assert_eq!(d.backfill, vec![("uuid-bf".into(), 400, 600)]);
+    }
+
+    #[test]
+    fn diff_ignores_empty_uuid_placeholders_from_stat_walk() {
+        // `stat_ebook_library` emits a synthetic empty-uuid entry for
+        // unreadable subdirs. The diff must not treat those as books.
+        let disk = vec![
+            entry("good.epub", "uuid-good", 100, 1000),
+            StatEntry {
+                filename: "bad/".into(),
+                uuid: String::new(),
+                mtime_epoch: 0,
+                size_bytes: 0,
+            },
+        ];
+        let db: Vec<IndexedRow> = vec![];
+        let d = diff_library(&disk, &db, Path::new("/lib"));
+        assert_eq!(d.new.len(), 1);
+        assert_eq!(d.new[0].filename, "good.epub");
+    }
+
+    #[test]
+    fn diff_builds_absolute_paths_for_parse_targets() {
+        let disk = vec![entry("sub/a.epub", "uuid-a", 100, 1000)];
+        let d = diff_library(&disk, &[], Path::new("/srv/library"));
+        assert_eq!(d.new[0].absolute, Path::new("/srv/library/sub/a.epub"));
+    }
 }

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -215,6 +215,7 @@ mod tests {
             uuid: uuid.into(),
             mtime_epoch: mtime,
             size_bytes: size,
+            error: None,
         }
     }
     fn row(uuid: &str, mtime: i64, size: i64) -> IndexedRow {
@@ -331,6 +332,7 @@ mod tests {
                 uuid: String::new(),
                 mtime_epoch: 0,
                 size_bytes: 0,
+                error: Some("permission denied".into()),
             },
         ];
         let db: Vec<IndexedRow> = vec![];

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -1141,8 +1141,7 @@ pub async fn sync_books(
 
     // --- Removed ---------------------------------------------------------
     if !plan.removed_uuids.is_empty() {
-        let placeholders = std::iter::repeat("?")
-            .take(plan.removed_uuids.len())
+        let placeholders = std::iter::repeat_n("?", plan.removed_uuids.len())
             .collect::<Vec<_>>()
             .join(", ");
 

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -3338,7 +3338,7 @@ pub async fn library_from_db_with_total(
 /// every cover file on disk. UUIDv5 (SHA-1 over a namespace + name, per
 /// RFC 4122 §4.3) is fixed across toolchains, sets the proper version/variant
 /// bits, and emits the canonical 8-4-4-4-12 hyphenated form.
-fn stable_uuid(library_path: &str, filename: &str) -> String {
+pub(crate) fn stable_uuid(library_path: &str, filename: &str) -> String {
     // NUL is the one byte that can't appear inside either side, so it's a
     // safe, unambiguous separator — no `(library_path, filename)` collision
     // is reachable from a different split.
@@ -3782,6 +3782,8 @@ mod tests {
                 ..Default::default()
             },
             cover: cover.map(|(m, b)| (m.into(), b.to_vec())),
+            mtime_epoch: 0,
+            size_bytes: 0,
         }
     }
 
@@ -3876,6 +3878,8 @@ mod tests {
                 ..Default::default()
             },
             cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
         };
         let no_accent = IndexedBook {
             metadata: EbookMetadata {
@@ -3889,6 +3893,8 @@ mod tests {
                 ..Default::default()
             },
             cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
         };
         replace_books(&pool, "/lib", vec![with_accent, no_accent])
             .await
@@ -3976,6 +3982,8 @@ mod tests {
                 ..Default::default()
             },
             cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
         };
         replace_books(&pool, "/lib", vec![unsafe_book])
             .await
@@ -4580,6 +4588,8 @@ mod tests {
             vec![IndexedBook {
                 metadata: meta,
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await
@@ -4942,6 +4952,8 @@ mod tests {
                     ..Default::default()
                 },
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await
@@ -5478,6 +5490,8 @@ mod tests {
                     ..Default::default()
                 },
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -1090,52 +1090,189 @@ pub fn delete_override_cover(uuid: &str) {
 // Indexer write path.
 // -----------------------------------------------------------------------------
 
-/// Atomically replace every book under `library_path` with `books` and stamp
-/// the last-indexed time. Upserts a matching `libraries` row if one doesn't
-/// exist yet. The cascade from `books` → link tables + `book_files` runs
-/// automatically thanks to the `PRAGMA foreign_keys = ON` set in `init_db`.
-pub async fn replace_books(
+/// Per-bucket payload for [`sync_books`]. Built by
+/// `crate::indexer::diff_library` (plus the Phase-B parse for new + changed).
+///
+/// The four buckets are mutually exclusive — a given uuid appears in at
+/// most one of them per sync — and the diff already ordered them
+/// deterministically.
+#[derive(Debug, Default)]
+pub struct SyncPlan {
+    pub new_books: Vec<crate::ebook::IndexedBook>,
+    pub changed_books: Vec<crate::ebook::IndexedBook>,
+    pub removed_uuids: Vec<String>,
+    /// `(uuid, mtime_epoch, size_bytes)` — see the Backfill section of
+    /// the [`crate::indexer`] module doc for why this exists.
+    pub backfill: Vec<(String, i64, i64)>,
+}
+
+/// Apply a per-bucket sync plan atomically. Unchanged books are not in
+/// the plan, so their `books.id` is preserved by definition; Changed
+/// books are UPDATEd in place so their `books.id` is preserved too.
+///
+/// Inside a single transaction, in this order:
+/// 1. Upsert the `libraries` row.
+/// 2. Delete Removed: explicit FTS clear + cascade DELETE from `books`.
+/// 3. Update Changed in place (preserves `books.id`); wipe-and-rewrite
+///    link rows + FTS row for each.
+/// 4. Insert New (autoincrement assigns a fresh id).
+/// 5. Backfill: UPDATE `book_files.(mtime_epoch, size_bytes)` only — no
+///    OPF re-parse, no link writes, no FTS write. See the Backfill rule
+///    in the [`crate::indexer`] module doc.
+/// 6. Stamp `libraries.last_indexed`.
+///
+/// Post-commit (best-effort, logged on failure — covers are a
+/// rebuildable cache):
+/// - Delete cover files for Removed uuids only.
+/// - Write cover files for New + Changed (overwrites the old file in
+///   place; mime change sweeps the stale-extension orphan).
+///
+/// `metadata_overrides` is intentionally not touched — keyed by
+/// `book_uuid` with no FK to `books.id` (see `0007_metadata_overrides.sql`).
+/// User edits survive Changed UPDATEs and even Removed→New cycles for
+/// the same filename.
+pub async fn sync_books(
     pool: &SqlitePool,
     library_path: &str,
-    books: Vec<crate::ebook::IndexedBook>,
+    plan: SyncPlan,
 ) -> Result<(), sqlx::Error> {
-    // Collect uuids of books we're about to delete so we can clean up their
-    // cover files on disk. Happens before the transaction so a mid-txn
-    // failure doesn't leave orphaned files, at the cost of a tiny window
-    // where disk + DB disagree on rollback (acceptable; covers are a
-    // rebuildable cache).
-    let old_uuids: Vec<String> = sqlx::query_scalar(
-        "SELECT b.uuid FROM books b
-         JOIN libraries l ON l.id = b.library_id
-         WHERE l.path = ?",
-    )
-    .bind(library_path)
-    .fetch_all(pool)
-    .await?;
-
     let mut tx = pool.begin().await?;
     let library_id = upsert_library(&mut tx, library_path).await?;
 
-    // `books_fts` is a standalone FTS5 table with no FK/cascade to `books`,
-    // so we must clear its rows explicitly before the cascade delete below.
-    // Scoped to this library via the books.id → books_fts.rowid mapping.
-    sqlx::query(
-        "DELETE FROM books_fts WHERE rowid IN
-            (SELECT id FROM books WHERE library_id = ?)",
-    )
-    .bind(library_id)
-    .execute(&mut *tx)
-    .await?;
+    // --- Removed ---------------------------------------------------------
+    if !plan.removed_uuids.is_empty() {
+        let placeholders = std::iter::repeat("?")
+            .take(plan.removed_uuids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
 
-    sqlx::query("DELETE FROM books WHERE library_id = ?")
-        .bind(library_id)
+        // FTS5 is standalone (no FK to `books`), so we must clear it
+        // explicitly before the cascade DELETE on `books` runs.
+        let fts_sql = format!(
+            "DELETE FROM books_fts WHERE rowid IN
+                (SELECT id FROM books WHERE library_id = ? AND uuid IN ({placeholders}))"
+        );
+        let mut q = sqlx::query(&fts_sql).bind(library_id);
+        for uuid in &plan.removed_uuids {
+            q = q.bind(uuid);
+        }
+        q.execute(&mut *tx).await?;
+
+        let books_sql =
+            format!("DELETE FROM books WHERE library_id = ? AND uuid IN ({placeholders})");
+        let mut q = sqlx::query(&books_sql).bind(library_id);
+        for uuid in &plan.removed_uuids {
+            q = q.bind(uuid);
+        }
+        q.execute(&mut *tx).await?;
+    }
+
+    // --- Changed ---------------------------------------------------------
+    //
+    // Wipe-and-rewrite the per-book link rows for each Changed entry,
+    // then UPDATE the `books` row and re-insert FTS. This trades two
+    // small per-book deletes for the much simpler "compute the link
+    // diff" alternative, while preserving `books.id` — which is the
+    // only invariant any external caller depends on.
+    let mut changed_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
+    for b in &plan.changed_books {
+        let uuid = stable_uuid(library_path, &b.metadata.filename);
+        let Some(book_id) =
+            sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE library_id = ? AND uuid = ?")
+                .bind(library_id)
+                .bind(&uuid)
+                .fetch_optional(&mut *tx)
+                .await?
+        else {
+            // The diff said this uuid existed in the DB, but a concurrent
+            // process removed it between Phase A and the write. Promote
+            // to a New insert so the file still gets indexed; cleaner
+            // than failing the whole sync over a TOCTOU.
+            let inserted = insert_book_row(&mut tx, library_id, library_path, b).await?;
+            insert_metadata_links(&mut tx, inserted.book_id, &b.metadata).await?;
+            insert_fts_row(
+                &mut tx,
+                inserted.book_id,
+                &inserted.title,
+                inserted.first_isbn.as_deref(),
+                &b.metadata,
+            )
+            .await?;
+            if let Some((mime, bytes)) = &b.cover {
+                changed_covers.push((inserted.uuid, mime.clone(), bytes.clone()));
+            }
+            continue;
+        };
+
+        update_book_row(&mut tx, book_id, b).await?;
+        // Cascade delete on FK isn't an option here (the `books` row
+        // stays), so wipe the per-book join rows explicitly. All these
+        // tables have UNIQUE(book, ...) constraints, so a re-insert
+        // without the wipe would fail.
+        for table in &[
+            "book_files",
+            "book_identifiers",
+            "books_authors_link",
+            "books_tags_link",
+            "books_publishers_link",
+            "books_series_link",
+            "books_languages_link",
+        ] {
+            // Note: the link tables use `book` (not `book_id`) as the
+            // FK column, but `book_files` and `book_identifiers` use
+            // `book_id`. Switch on the table name.
+            let col = if *table == "book_files" || *table == "book_identifiers" {
+                "book_id"
+            } else {
+                "book"
+            };
+            let sql = format!("DELETE FROM {table} WHERE {col} = ?");
+            sqlx::query(&sql).bind(book_id).execute(&mut *tx).await?;
+        }
+        // Re-insert the book_files row with the fresh fs metadata. The
+        // INSERT body matches `insert_book_row` exactly.
+        let m = &b.metadata;
+        let (_, file_stem, file_ext) = split_filename(&m.filename);
+        let mtime = m.modified.clone().unwrap_or_default();
+        sqlx::query(
+            "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(book_id)
+        .bind(&file_ext)
+        .bind(&file_stem)
+        .bind(b.size_bytes)
+        .bind(&mtime)
+        .bind(b.mtime_epoch)
         .execute(&mut *tx)
         .await?;
+        insert_metadata_links(&mut tx, book_id, &b.metadata).await?;
+        // FTS5 row is keyed by rowid = book_id; delete + re-insert.
+        sqlx::query("DELETE FROM books_fts WHERE rowid = ?")
+            .bind(book_id)
+            .execute(&mut *tx)
+            .await?;
+        let title = m.title.clone().unwrap_or_else(|| m.filename.clone());
+        let first_isbn = m
+            .identifiers
+            .iter()
+            .find(|id| {
+                id.scheme
+                    .as_deref()
+                    .is_some_and(|s| s.eq_ignore_ascii_case("isbn"))
+            })
+            .map(|id| id.value.clone());
+        insert_fts_row(&mut tx, book_id, &title, first_isbn.as_deref(), &b.metadata).await?;
 
+        if let Some((mime, bytes)) = &b.cover {
+            changed_covers.push((uuid, mime.clone(), bytes.clone()));
+        }
+    }
+
+    // --- New -------------------------------------------------------------
     let mut new_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
-
-    for b in books {
-        let inserted = insert_book_row(&mut tx, library_id, library_path, &b).await?;
+    for b in &plan.new_books {
+        let inserted = insert_book_row(&mut tx, library_id, library_path, b).await?;
         insert_metadata_links(&mut tx, inserted.book_id, &b.metadata).await?;
         insert_fts_row(
             &mut tx,
@@ -1145,10 +1282,23 @@ pub async fn replace_books(
             &b.metadata,
         )
         .await?;
-
-        if let Some((mime, bytes)) = b.cover {
-            new_covers.push((inserted.uuid, mime, bytes));
+        if let Some((mime, bytes)) = &b.cover {
+            new_covers.push((inserted.uuid, mime.clone(), bytes.clone()));
         }
+    }
+
+    // --- Backfill --------------------------------------------------------
+    for (uuid, mtime_epoch, size_bytes) in &plan.backfill {
+        sqlx::query(
+            "UPDATE book_files SET mtime_epoch = ?, size_bytes = ?
+             WHERE book_id = (SELECT id FROM books WHERE library_id = ? AND uuid = ?)",
+        )
+        .bind(mtime_epoch)
+        .bind(size_bytes)
+        .bind(library_id)
+        .bind(uuid)
+        .execute(&mut *tx)
+        .await?;
     }
 
     let now = std::time::SystemTime::now()
@@ -1163,12 +1313,98 @@ pub async fn replace_books(
 
     tx.commit().await?;
 
-    // DB commit succeeded — now reconcile the covers directory. Delete the
-    // files for every book that was replaced, then write out the new covers.
-    delete_cover_files_for(&old_uuids);
+    // DB commit succeeded — reconcile the covers directory.
+    delete_cover_files_for(&plan.removed_uuids);
     materialize_new_covers(new_covers);
+    materialize_new_covers(changed_covers);
 
     Ok(())
+}
+
+/// UPDATE the `books` row for a Changed entry in place (preserving id).
+/// All scalar columns that `insert_book_row` writes get refreshed; the
+/// link tables and FTS row are handled by the caller.
+async fn update_book_row(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    b: &crate::ebook::IndexedBook,
+) -> Result<(), sqlx::Error> {
+    let m = &b.metadata;
+    let (book_path, _, _) = split_filename(&m.filename);
+    let title = m.title.clone().unwrap_or_else(|| m.filename.clone());
+    let series_index_num = m.series_index.as_deref().and_then(parse_series_index);
+    let author_sort = m
+        .creators
+        .first()
+        .and_then(|c| c.file_as.clone())
+        .or_else(|| m.creators.first().map(|c| c.name.clone()));
+    let first_isbn = m
+        .identifiers
+        .iter()
+        .find(|id| {
+            id.scheme
+                .as_deref()
+                .is_some_and(|s| s.eq_ignore_ascii_case("isbn"))
+        })
+        .map(|id| id.value.clone());
+    let has_cover = i64::from(b.cover.is_some());
+
+    sqlx::query(
+        "UPDATE books SET
+            path = ?, title = ?, sort = ?, author_sort = ?, series_index = ?,
+            pubdate = ?, has_cover = ?, description = ?, isbn = ?, accent_color = ?,
+            last_modified = datetime('now')
+         WHERE id = ?",
+    )
+    .bind(&book_path)
+    .bind(&title)
+    .bind(&title)
+    .bind(&author_sort)
+    .bind(series_index_num)
+    .bind(&m.published)
+    .bind(has_cover)
+    .bind(&m.description)
+    .bind(&first_isbn)
+    .bind(sanitize_accent_color(m.accent.as_deref()))
+    .bind(book_id)
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+/// Atomically replace every book under `library_path` with `books` and stamp
+/// the last-indexed time. Thin compatibility shim over [`sync_books`]: it
+/// computes the diff implicitly by treating every existing book as
+/// Removed and every passed-in book as New. Kept for tests and any
+/// caller that still wants the nuke-and-pave semantics; production
+/// reindex goes through [`sync_books`] directly via
+/// `crate::indexer::reindex`.
+pub async fn replace_books(
+    pool: &SqlitePool,
+    library_path: &str,
+    books: Vec<crate::ebook::IndexedBook>,
+) -> Result<(), sqlx::Error> {
+    let removed_uuids: Vec<String> = sqlx::query_scalar(
+        "SELECT b.uuid FROM books b
+         JOIN libraries l ON l.id = b.library_id
+         WHERE l.path = ?",
+    )
+    .bind(library_path)
+    .fetch_all(pool)
+    .await?;
+
+    sync_books(
+        pool,
+        library_path,
+        SyncPlan {
+            new_books: books,
+            changed_books: vec![],
+            removed_uuids,
+            backfill: vec![],
+        },
+    )
+    .await
 }
 
 /// Fields the per-book outer loop needs after the canonical `books` /
@@ -1231,17 +1467,21 @@ async fn insert_book_row(
     .fetch_one(&mut **tx)
     .await?;
 
-    let size_bytes = 0i64;
+    // The legacy `mtime TEXT` column holds the OPF `dcterms:modified` value
+    // (Dublin Core, not filesystem state) — kept for backward compat. The
+    // new `mtime_epoch INTEGER` column holds the filesystem stat the
+    // incremental diff compares against (migration 0009).
     let mtime = m.modified.clone().unwrap_or_default();
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime)
-         VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch)
+         VALUES (?, ?, ?, ?, ?, ?)",
     )
     .bind(book_id)
     .bind(&file_ext)
     .bind(&file_stem)
-    .bind(size_bytes)
+    .bind(b.size_bytes)
     .bind(&mtime)
+    .bind(b.mtime_epoch)
     .execute(&mut **tx)
     .await?;
 
@@ -1513,6 +1753,7 @@ pub async fn list_books(
                 })
                 .collect();
 
+        let uuid: String = r.get("uuid");
         out.push(EbookMetadata {
             id,
             filename,
@@ -1536,11 +1777,11 @@ pub async fn list_books(
             series_index: series_index.map(format_series_index),
             series_id: r.get("series_link_id"),
             epub_version: None,
-            unique_identifier: Some(r.get::<String, _>("uuid")),
+            unique_identifier: Some(uuid.clone()),
             resource_count: 0,
             spine_count: 0,
             toc_count: 0,
-            cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+            cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
             accent: r.get("accent_color"),
             formats: parse_json_array(r.get("formats_json"))?,
             added_at: r.get("timestamp"),
@@ -1565,6 +1806,57 @@ pub async fn list_books(
     backfill_creator_ids(pool, &mut out).await?;
 
     Ok(out)
+}
+
+/// One row per book under `library_path`, carrying just the bits the
+/// incremental reindex diff needs to classify a filesystem stat against
+/// the existing index.
+///
+/// `mtime_epoch` / `size_bytes` come from the matching `book_files` row.
+/// Today the scanner only writes `.epub` files, so there's one
+/// `book_files` row per book; the `MAX(...)` aggregation is defensive in
+/// case a future audiobook scanner adds a sibling format row for the
+/// same `books.id`. The diff treats `(mtime_epoch=0, size_bytes=0)` as a
+/// "never observed" sentinel (the migration default) and routes those
+/// rows through the Backfill branch — no OPF re-parse on first run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IndexedRow {
+    pub uuid: String,
+    pub mtime_epoch: i64,
+    pub size_bytes: i64,
+}
+
+/// Read every indexed book under `library_path`, projecting just the
+/// columns the incremental diff needs. Single query; the diff itself is
+/// pure CPU on the returned `Vec`.
+pub async fn list_indexed_rows(
+    pool: &SqlitePool,
+    library_path: &str,
+) -> Result<Vec<IndexedRow>, sqlx::Error> {
+    let rows = sqlx::query(
+        r#"
+        SELECT b.uuid                                  AS uuid,
+               COALESCE(MAX(bf.mtime_epoch), 0)        AS mtime_epoch,
+               COALESCE(MAX(bf.size_bytes), 0)         AS size_bytes
+          FROM books b
+          JOIN libraries l   ON l.id = b.library_id
+          LEFT JOIN book_files bf ON bf.book_id = b.id
+         WHERE l.path = ?
+         GROUP BY b.id, b.uuid
+        "#,
+    )
+    .bind(library_path)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| IndexedRow {
+            uuid: r.get("uuid"),
+            mtime_epoch: r.get("mtime_epoch"),
+            size_bytes: r.get("size_bytes"),
+        })
+        .collect())
 }
 
 /// Total number of books currently indexed under `library_path`.
@@ -1738,7 +2030,7 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
         resource_count: 0,
         spine_count: 0,
         toc_count: 0,
-        cover_url: (has_cover != 0).then(|| format!("/api/covers/{book_id}")),
+        cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
         accent: r.get("accent_color"),
         formats,
         added_at: r.get("timestamp"),
@@ -1773,6 +2065,39 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
     backfill_creator_ids(pool, std::slice::from_mut(&mut book)).await?;
 
     Ok(Some(book))
+}
+
+/// Look up a book by its stable `books.uuid` and return the same merged
+/// metadata `get_book` produces. Delegates to `get_book` after resolving
+/// the uuid to an id so the body stays a single source of truth.
+///
+/// This is the read path for `/books/:uuid` and `/api/ebooks/:uuid` —
+/// the URL-stable counterparts to the renumbering `:id` routes.
+pub async fn get_book_by_uuid(
+    pool: &SqlitePool,
+    uuid: &str,
+) -> Result<Option<EbookMetadata>, sqlx::Error> {
+    let Some(id) = resolve_book_id_by_uuid(pool, uuid).await? else {
+        return Ok(None);
+    };
+    get_book(pool, id).await
+}
+
+/// Map a `books.uuid` to its current `books.id`. `books.uuid` is
+/// `UNIQUE`, so this is one indexed lookup. Returns `None` if the uuid
+/// is unknown — handlers translate to a 404.
+///
+/// The covers / thumbs / mobile-ebooks routes use this to keep their
+/// URLs uuid-keyed externally while reusing the existing id-keyed
+/// internal helpers (`get_cover`, the thumbnail pipeline) unchanged.
+pub async fn resolve_book_id_by_uuid(
+    pool: &SqlitePool,
+    uuid: &str,
+) -> Result<Option<i64>, sqlx::Error> {
+    sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
+        .bind(uuid)
+        .fetch_optional(pool)
+        .await
 }
 
 /// Fill in `Contributor::id` for every creator whose `id` is `None` by
@@ -2005,6 +2330,7 @@ pub async fn search_books(
                 })
                 .collect();
 
+        let uuid: String = r.get("uuid");
         out.push(EbookMetadata {
             id,
             filename,
@@ -2028,11 +2354,11 @@ pub async fn search_books(
             series_index: series_index.map(format_series_index),
             series_id: r.get("series_link_id"),
             epub_version: None,
-            unique_identifier: Some(r.get::<String, _>("uuid")),
+            unique_identifier: Some(uuid.clone()),
             resource_count: 0,
             spine_count: 0,
             toc_count: 0,
-            cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+            cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
             accent: r.get("accent_color"),
             formats: parse_json_array(r.get("formats_json"))?,
             added_at: r.get("timestamp"),
@@ -2155,6 +2481,7 @@ const BOOK_COLUMNS: &str = r#"
 /// [`EbookMetadata`]. Shared across the discovery query functions.
 fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata, sqlx::Error> {
     let id: i64 = r.get("id");
+    let uuid: String = r.get("uuid");
     let has_cover: i64 = r.get("has_cover");
     let primary_filename: Option<String> = r.get("primary_filename");
     let primary_format: Option<String> = r.get("primary_format");
@@ -2206,11 +2533,11 @@ fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata, sqlx::Erro
         series_index: series_index.map(format_series_index),
         series_id: r.get("series_link_id"),
         epub_version: None,
-        unique_identifier: Some(r.get::<String, _>("uuid")),
+        unique_identifier: Some(uuid.clone()),
         resource_count: 0,
         spine_count: 0,
         toc_count: 0,
-        cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+        cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
         accent: r.get("accent_color"),
         formats: parse_json_array(r.get("formats_json"))?,
         added_at: r.get("timestamp"),
@@ -3029,16 +3356,17 @@ pub async fn search_palette(
             let id: i64 = r.get("id");
             let uuid: String = r.get("uuid");
             let has_cover: i64 = r.get("has_cover");
-            uuids.push(uuid);
+            uuids.push(uuid.clone());
             hits.push(PaletteBookHit {
                 id,
+                uuid: uuid.clone(),
                 title: r.get::<Option<String>, _>("title").unwrap_or_default(),
                 author_display: r
                     .get::<Option<String>, _>("author_display")
                     .unwrap_or_default(),
                 year: r.get("year"),
                 formats: parse_json_array(r.get("formats_json"))?,
-                cover_url: (has_cover != 0).then(|| format!("/api/covers/{id}")),
+                cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
                 accent: r.get("accent_color"),
             });
         }
@@ -3059,7 +3387,7 @@ pub async fn search_palette(
                 // Mirror `apply_overrides`: surface user-uploaded covers even
                 // when the scanned book had `has_cover = 0`.
                 if *has_cover_ov {
-                    hit.cover_url = Some(format!("/api/covers/{}", hit.id));
+                    hit.cover_url = Some(format!("/api/covers/{}", hit.uuid));
                 }
             }
         }
@@ -3829,9 +4157,10 @@ mod tests {
         assert_eq!(a.series.as_deref(), Some("Saga"));
         assert_eq!(a.series_index.as_deref(), Some("1"));
 
+        let a_uuid = a.unique_identifier.clone().unwrap();
         assert_eq!(
             a.cover_url.as_deref(),
-            Some(format!("/api/covers/{}", a.id).as_str())
+            Some(format!("/api/covers/{a_uuid}").as_str())
         );
         assert_eq!(b.cover_url, None);
 
@@ -3994,6 +4323,439 @@ mod tests {
             .find(|b| b.title.as_deref() == Some("Shady"))
             .unwrap();
         assert_eq!(shady.accent, None);
+    }
+
+    // ------------------------------------------------------------------
+    // sync_books — incremental write path. Each test seeds an initial
+    // state via `replace_books` (the legacy nuke-and-pave wrapper), then
+    // applies a hand-built `SyncPlan` to exercise one or more diff
+    // buckets and asserts the post-state.
+    // ------------------------------------------------------------------
+
+    /// Build an `IndexedBook` matching `indexed(...)` but with the
+    /// supplied (mtime_epoch, size_bytes). Used to drive the New +
+    /// Changed branches of sync_books with realistic fs metadata.
+    fn indexed_with_stat(
+        filename: &str,
+        title: Option<&str>,
+        mtime_epoch: i64,
+        size_bytes: i64,
+    ) -> IndexedBook {
+        IndexedBook {
+            metadata: EbookMetadata {
+                filename: filename.into(),
+                title: title.map(Into::into),
+                ..Default::default()
+            },
+            cover: None,
+            mtime_epoch,
+            size_bytes,
+        }
+    }
+
+    /// Seed two books via `replace_books`, then `sync_books` with no
+    /// diff buckets at all. Both ids must survive — that's the whole
+    /// point of the refactor.
+    #[tokio::test]
+    async fn sync_preserves_book_id_for_unchanged() {
+        let _covers = CoversTempDir::new("sync_unchanged");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed("a.epub", Some("A"), &[], &[], None, None),
+                indexed("b.epub", Some("B"), &[], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+        let before: Vec<_> = list_books(&pool, "/lib")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|b| (b.filename.clone(), b.id))
+            .collect();
+
+        sync_books(&pool, "/lib", SyncPlan::default())
+            .await
+            .unwrap();
+
+        let after: Vec<_> = list_books(&pool, "/lib")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|b| (b.filename.clone(), b.id))
+            .collect();
+        assert_eq!(before, after, "ids must be preserved across a no-op sync");
+    }
+
+    #[tokio::test]
+    async fn sync_preserves_book_id_for_changed() {
+        let _covers = CoversTempDir::new("sync_changed");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("Old Title"),
+                &["Old Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        let original_id = list_books(&pool, "/lib").await.unwrap()[0].id;
+
+        // One Changed entry — same filename so same uuid, new title + author.
+        let plan = SyncPlan {
+            changed_books: vec![IndexedBook {
+                metadata: EbookMetadata {
+                    filename: "a.epub".into(),
+                    title: Some("New Title".into()),
+                    creators: vec![Contributor {
+                        name: "New Author".into(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                cover: None,
+                mtime_epoch: 999,
+                size_bytes: 42,
+            }],
+            ..Default::default()
+        };
+        sync_books(&pool, "/lib", plan).await.unwrap();
+
+        let after = list_books(&pool, "/lib").await.unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].id, original_id, "books.id must be preserved");
+        assert_eq!(after[0].title.as_deref(), Some("New Title"));
+        assert_eq!(after[0].creators.len(), 1);
+        assert_eq!(after[0].creators[0].name, "New Author");
+    }
+
+    /// A user-supplied metadata override (keyed by `book_uuid`, no FK to
+    /// `books.id`) must still apply after a Changed UPDATE — proving
+    /// that the in-place UPDATE doesn't accidentally rotate the uuid
+    /// and that the overrides table isn't touched by sync_books.
+    #[tokio::test]
+    async fn sync_overrides_survive_changed() {
+        let _covers = CoversTempDir::new("sync_overrides");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed("a.epub", Some("Scanned"), &[], &[], None, None)],
+        )
+        .await
+        .unwrap();
+        let book_uuid = list_indexed_rows(&pool, "/lib").await.unwrap()[0]
+            .uuid
+            .clone();
+
+        // Write a user override that renames the title.
+        let overrides = MetadataOverrides {
+            title: Some("User Title".into()),
+            ..Default::default()
+        };
+        upsert_metadata_overrides(&pool, &book_uuid, &overrides, false, user_id)
+            .await
+            .unwrap();
+
+        // Now Change the book — the scan would happily say "Scanned"
+        // again, but the override should still surface "User Title".
+        let plan = SyncPlan {
+            changed_books: vec![indexed_with_stat("a.epub", Some("Scanned v2"), 100, 100)],
+            ..Default::default()
+        };
+        sync_books(&pool, "/lib", plan).await.unwrap();
+
+        let after = list_books(&pool, "/lib").await.unwrap();
+        assert_eq!(after[0].title.as_deref(), Some("User Title"));
+    }
+
+    /// A Removed uuid must wipe books_fts, book_files,
+    /// books_authors_link, etc. — the cascade plus our explicit FTS
+    /// clear should leave no orphans.
+    #[tokio::test]
+    async fn sync_removes_book_cascades_links_and_fts() {
+        let _covers = CoversTempDir::new("sync_removed_cascade");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "doomed.epub",
+                Some("Doomed"),
+                &["Anon"],
+                &["fic"],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        let book_id = list_books(&pool, "/lib").await.unwrap()[0].id;
+        let uuid = list_indexed_rows(&pool, "/lib").await.unwrap()[0]
+            .uuid
+            .clone();
+
+        let plan = SyncPlan {
+            removed_uuids: vec![uuid],
+            ..Default::default()
+        };
+        sync_books(&pool, "/lib", plan).await.unwrap();
+
+        let books_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books WHERE id = ?")
+            .bind(book_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let files_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM book_files WHERE book_id = ?")
+                .bind(book_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let link_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM books_authors_link WHERE book = ?")
+                .bind(book_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let fts_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books_fts WHERE rowid = ?")
+            .bind(book_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(books_count, 0);
+        assert_eq!(files_count, 0);
+        assert_eq!(link_count, 0);
+        assert_eq!(fts_count, 0);
+    }
+
+    /// One sync covering all four mutating branches at once. Unchanged
+    /// ids stay put; Changed id stays put; New gets a fresh id;
+    /// Removed disappears.
+    #[tokio::test]
+    async fn sync_mixed_diff_in_one_transaction() {
+        let _covers = CoversTempDir::new("sync_mixed");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed("keep.epub", Some("Keep"), &[], &[], None, None),
+                indexed("edit.epub", Some("Old Edit"), &[], &[], None, None),
+                indexed("gone.epub", Some("Gone"), &[], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+        let before: std::collections::HashMap<String, i64> = list_books(&pool, "/lib")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|b| (b.filename.clone(), b.id))
+            .collect();
+        let gone_uuid = stable_uuid("/lib", "gone.epub");
+
+        let plan = SyncPlan {
+            new_books: vec![indexed_with_stat("add.epub", Some("Added"), 100, 100)],
+            changed_books: vec![indexed_with_stat("edit.epub", Some("New Edit"), 200, 200)],
+            removed_uuids: vec![gone_uuid],
+            backfill: vec![],
+        };
+        sync_books(&pool, "/lib", plan).await.unwrap();
+
+        let after: std::collections::HashMap<String, i64> = list_books(&pool, "/lib")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|b| (b.filename.clone(), b.id))
+            .collect();
+
+        assert_eq!(after.len(), 3);
+        assert_eq!(after.get("keep.epub"), before.get("keep.epub"));
+        assert_eq!(after.get("edit.epub"), before.get("edit.epub"));
+        assert!(after.contains_key("add.epub"));
+        assert!(!after.contains_key("gone.epub"));
+    }
+
+    /// Removed books should lose their cover files; survivors' covers
+    /// must stay intact. Catches "delete every cover on every sync"
+    /// regressions if anyone ever short-circuits the bucket logic.
+    #[tokio::test]
+    async fn sync_cover_sidecar_lifecycle_on_remove() {
+        let covers = CoversTempDir::new("sync_cover_remove");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed(
+                    "keep.epub",
+                    Some("Keep"),
+                    &[],
+                    &[],
+                    None,
+                    Some(("image/jpeg", b"KEEP_BYTES")),
+                ),
+                indexed(
+                    "gone.epub",
+                    Some("Gone"),
+                    &[],
+                    &[],
+                    None,
+                    Some(("image/jpeg", b"GONE_BYTES")),
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+        let keep_uuid = stable_uuid("/lib", "keep.epub");
+        let gone_uuid = stable_uuid("/lib", "gone.epub");
+        let keep_path = covers.path.join(format!("{keep_uuid}.jpg"));
+        let gone_path = covers.path.join(format!("{gone_uuid}.jpg"));
+        assert!(keep_path.exists(), "cover for keep should exist");
+        assert!(gone_path.exists(), "cover for gone should exist");
+
+        sync_books(
+            &pool,
+            "/lib",
+            SyncPlan {
+                removed_uuids: vec![gone_uuid],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(keep_path.exists(), "survivor cover must remain");
+        assert!(!gone_path.exists(), "removed cover must be deleted");
+    }
+
+    /// FTS5 row carries `rowid = books.id`. After a Changed UPDATE the
+    /// rowid must still equal the preserved id, and the index content
+    /// must reflect the new title.
+    #[tokio::test]
+    async fn sync_fts_row_consistent_after_changed() {
+        let _covers = CoversTempDir::new("sync_fts");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed("a.epub", Some("Antarctica"), &[], &[], None, None)],
+        )
+        .await
+        .unwrap();
+        let original_id = list_books(&pool, "/lib").await.unwrap()[0].id;
+
+        sync_books(
+            &pool,
+            "/lib",
+            SyncPlan {
+                changed_books: vec![indexed_with_stat("a.epub", Some("Borealis"), 200, 200)],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let stale = search_books(&pool, "/lib", "Antarctica").await.unwrap();
+        let fresh = search_books(&pool, "/lib", "Borealis").await.unwrap();
+        assert!(stale.is_empty(), "old title must not match after change");
+        assert_eq!(fresh.len(), 1);
+        assert_eq!(fresh[0].id, original_id, "FTS rowid stable across change");
+    }
+
+    /// The Backfill bucket fills in the post-migration sentinel stat
+    /// values without touching any metadata columns. Confirm both
+    /// invariants: stat populated, OPF-derived fields untouched.
+    #[tokio::test]
+    async fn sync_backfill_writes_stat_without_touching_metadata() {
+        let _covers = CoversTempDir::new("sync_backfill");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed("a.epub", Some("Original"), &[], &[], None, None)],
+        )
+        .await
+        .unwrap();
+        let uuid = list_indexed_rows(&pool, "/lib").await.unwrap()[0]
+            .uuid
+            .clone();
+        // Confirm the row started at the (0, 0) sentinel — replace_books
+        // wrote the IndexedBook stats (which the test fixture defaults
+        // to 0).
+        let pre = list_indexed_rows(&pool, "/lib").await.unwrap();
+        assert_eq!(pre[0].mtime_epoch, 0);
+        assert_eq!(pre[0].size_bytes, 0);
+
+        sync_books(
+            &pool,
+            "/lib",
+            SyncPlan {
+                backfill: vec![(uuid, 1234, 5678)],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let post = list_indexed_rows(&pool, "/lib").await.unwrap();
+        assert_eq!(post[0].mtime_epoch, 1234);
+        assert_eq!(post[0].size_bytes, 5678);
+        // Title is untouched — backfill must not have triggered any
+        // metadata writes.
+        let books = list_books(&pool, "/lib").await.unwrap();
+        assert_eq!(books[0].title.as_deref(), Some("Original"));
+    }
+
+    /// Empty disk → diff says "remove all" → sync_books wipes the
+    /// library cleanly. Stress test for the Removed branch.
+    #[tokio::test]
+    async fn sync_empty_plan_with_full_removed_clears_library() {
+        let _covers = CoversTempDir::new("sync_empty");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed("a.epub", Some("A"), &[], &[], None, None),
+                indexed("b.epub", Some("B"), &[], &[], None, None),
+            ],
+        )
+        .await
+        .unwrap();
+        let all_uuids: Vec<String> = list_indexed_rows(&pool, "/lib")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.uuid)
+            .collect();
+
+        sync_books(
+            &pool,
+            "/lib",
+            SyncPlan {
+                removed_uuids: all_uuids,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(list_books(&pool, "/lib").await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -7804,7 +8566,7 @@ mod tests {
         assert_eq!(palette.books.len(), 1);
         assert_eq!(
             palette.books[0].cover_url,
-            Some(format!("/api/covers/{}", book.id))
+            Some(format!("/api/covers/{uuid}"))
         );
     }
 

--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -125,8 +125,8 @@ fn SpOverlay(open: PaletteOpen) -> Element {
     let navigate_to_item = {
         move |item: &FlatItem| {
             match item {
-                FlatItem::Book { id, .. } => {
-                    nav.push(Route::BookDetail { id: *id });
+                FlatItem::Book { uuid, .. } => {
+                    nav.push(Route::BookDetail { uuid: uuid.clone() });
                 }
                 FlatItem::Author { id, .. } => {
                     nav.push(Route::AuthorDetail { id: *id });
@@ -315,11 +315,11 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             for book in r.books.iter() {
                                 SpBookRow {
                                     book: book.clone(),
-                                    selected: is_selected(&items, sel, &FlatItem::Book { id: book.id, title: book.title.clone() }),
+                                    selected: is_selected(&items, sel, &FlatItem::Book { uuid: book.uuid.clone(), title: book.title.clone() }),
                                     on_click: {
-                                        let id = book.id;
+                                        let uuid = book.uuid.clone();
                                         move |_| {
-                                            nav.push(Route::BookDetail { id });
+                                            nav.push(Route::BookDetail { uuid: uuid.clone() });
                                             open.0.set(false);
                                         }
                                     },
@@ -584,9 +584,12 @@ fn SpFooter() -> Element {
 // ── Flat item model for keyboard nav ─────────────────────────────
 
 /// A single selectable item in the flat list used for arrow-key navigation.
+/// Books carry the stable `uuid` so the palette can build `/books/:uuid`
+/// URLs without a second round-trip — [`PaletteBookHit`] now includes
+/// the uuid alongside `id`.
 #[derive(Clone, Debug, PartialEq)]
 enum FlatItem {
-    Book { id: i64, title: String },
+    Book { uuid: String, title: String },
     Author { id: i64, name: String },
     Series { id: i64, name: String },
     Tag { id: i64, name: String },
@@ -600,7 +603,7 @@ fn build_flat_items(results: &Option<PaletteResults>) -> Vec<FlatItem> {
     let mut items = Vec::new();
     for b in &r.books {
         items.push(FlatItem::Book {
-            id: b.id,
+            uuid: b.uuid.clone(),
             title: b.title.clone(),
         });
     }

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -539,8 +539,8 @@ pub async fn search_palette(server_url: &str, q: &str) -> Result<PaletteResults,
 }
 
 #[cfg(feature = "mobile")]
-pub async fn get_ebook(server_url: &str, id: i64) -> Result<Option<EbookMetadata>, DataError> {
-    let url = format!("{server_url}/api/ebooks/{id}");
+pub async fn get_ebook(server_url: &str, uuid: &str) -> Result<Option<EbookMetadata>, DataError> {
+    let url = format!("{server_url}/api/ebooks/{uuid}");
     let response = with_bearer(http_client().get(&url)).send().await?;
     let status = note_status(response.status());
     if status == reqwest::StatusCode::NOT_FOUND {
@@ -674,10 +674,10 @@ pub async fn get_tag_cloud(server_url: &str) -> Result<Vec<TagWeight>, DataError
 #[cfg(feature = "mobile")]
 pub async fn save_overrides(
     server_url: &str,
-    id: i64,
+    uuid: &str,
     overrides: &MetadataOverrides,
 ) -> Result<Option<EbookMetadata>, DataError> {
-    let url = format!("{server_url}/api/ebooks/{id}/overrides");
+    let url = format!("{server_url}/api/ebooks/{uuid}/overrides");
     let response = with_bearer(http_client().post(&url))
         .json(overrides)
         .send()
@@ -692,9 +692,9 @@ pub async fn save_overrides(
 #[cfg(feature = "mobile")]
 pub async fn delete_overrides(
     server_url: &str,
-    id: i64,
+    uuid: &str,
 ) -> Result<Option<EbookMetadata>, DataError> {
-    let url = format!("{server_url}/api/ebooks/{id}/overrides/delete");
+    let url = format!("{server_url}/api/ebooks/{uuid}/overrides/delete");
     let response = with_bearer(http_client().post(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
@@ -925,8 +925,8 @@ pub async fn search_palette(_server_url: &str, q: &str) -> Result<PaletteResults
 }
 
 #[cfg(not(feature = "mobile"))]
-pub async fn get_ebook(_server_url: &str, id: i64) -> Result<Option<EbookMetadata>, DataError> {
-    crate::rpc::rpc_get_ebook(id)
+pub async fn get_ebook(_server_url: &str, uuid: &str) -> Result<Option<EbookMetadata>, DataError> {
+    crate::rpc::rpc_get_ebook(uuid.to_string())
         .await
         .map_err(note_server_fn_err)
 }
@@ -1066,10 +1066,10 @@ pub async fn list_series(_server_url: &str) -> Result<Vec<SeriesSummary>, DataEr
 #[cfg(not(feature = "mobile"))]
 pub async fn save_overrides(
     _server_url: &str,
-    id: i64,
+    uuid: &str,
     overrides: &MetadataOverrides,
 ) -> Result<Option<EbookMetadata>, DataError> {
-    crate::rpc::rpc_save_overrides(id, overrides.clone())
+    crate::rpc::rpc_save_overrides(uuid.to_string(), overrides.clone())
         .await
         .map_err(note_server_fn_err)
 }
@@ -1077,9 +1077,9 @@ pub async fn save_overrides(
 #[cfg(not(feature = "mobile"))]
 pub async fn delete_overrides(
     _server_url: &str,
-    id: i64,
+    uuid: &str,
 ) -> Result<Option<EbookMetadata>, DataError> {
-    crate::rpc::rpc_delete_overrides(id)
+    crate::rpc::rpc_delete_overrides(uuid.to_string())
         .await
         .map_err(note_server_fn_err)
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -30,10 +30,10 @@ pub enum Route {
     Landing {},
     #[route("/settings")]
     Settings {},
-    #[route("/books/:id")]
-    BookDetail { id: i64 },
-    #[route("/books/:id/edit")]
-    MetadataEdit { id: i64 },
+    #[route("/books/:uuid")]
+    BookDetail { uuid: String },
+    #[route("/books/:uuid/edit")]
+    MetadataEdit { uuid: String },
     #[route("/authors")]
     AuthorsIndex {},
     #[route("/authors/:id")]
@@ -68,20 +68,24 @@ pub fn Settings() -> Element {
     }
 }
 
-/// Route target for `/books/:id` — stub detail page. Replace the id shape
-/// once the backend exposes stable book ids.
+/// Route target for `/books/:uuid` — the detail page is uuid-keyed so
+/// bookmarked URLs survive reindexes (`books.id` is `AUTOINCREMENT` and
+/// the indexer's DELETE+INSERT path renumbers it on every run;
+/// `books.uuid` is a deterministic UUIDv5 of `(library_path, filename)`
+/// that stays stable across reindexes and re-installs).
 #[component]
-pub fn BookDetail(id: i64) -> Element {
+pub fn BookDetail(uuid: String) -> Element {
     rsx! {
-        ScreenLayout { BookDetailPage { id } }
+        ScreenLayout { BookDetailPage { uuid } }
     }
 }
 
-/// Route target for `/books/:id/edit` — metadata edit form.
+/// Route target for `/books/:uuid/edit` — metadata edit form. Same
+/// stability rationale as [`BookDetail`].
 #[component]
-pub fn MetadataEdit(id: i64) -> Element {
+pub fn MetadataEdit(uuid: String) -> Element {
     rsx! {
-        ScreenLayout { MetadataEditPage { id } }
+        ScreenLayout { MetadataEditPage { uuid } }
     }
 }
 

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -195,7 +195,7 @@ fn render_author(
                         div { class: "disc-grid",
                             for book in books.iter() {
                                 Link {
-                                    to: Route::BookDetail { id: book.id },
+                                    to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
                                     class: "lib-tile",
                                     Cover { book: (*book).clone() }
                                     div { class: "lib-tile-title",
@@ -219,7 +219,7 @@ fn render_author(
                         div { class: "disc-grid",
                             for book in standalone.iter() {
                                 Link {
-                                    to: Route::BookDetail { id: book.id },
+                                    to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
                                     class: "lib-tile",
                                     Cover { book: (*book).clone() }
                                     div { class: "lib-tile-title",

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -30,23 +30,25 @@ use crate::components::FormatSwitcher;
 use crate::{data, use_server_url, Route};
 
 #[component]
-pub fn BookDetailPage(id: i64) -> Element {
+pub fn BookDetailPage(uuid: String) -> Element {
     let server_url = use_server_url();
     let mut book: Signal<Option<EbookMetadata>> = use_signal(|| None);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
-    // `use_reactive!` declares `id` as an explicit dependency so the effect
-    // re-runs when the router swaps the route param in place. Without this,
-    // navigating `/books/A` → `/books/B` reuses the same component instance
-    // and leaves the page rendering the stale book — Dioxus' implicit
-    // subscription tracking only covers signals, not plain props.
+    // `use_reactive!` declares `uuid` as an explicit dependency so the
+    // effect re-runs when the router swaps the route param in place.
+    // Without this, navigating `/books/A` → `/books/B` reuses the same
+    // component instance and leaves the page rendering the stale book —
+    // Dioxus' implicit subscription tracking only covers signals, not
+    // plain props.
     let url = server_url.clone();
-    use_effect(use_reactive!(|id| {
+    use_effect(use_reactive!(|uuid| {
         let url = url.clone();
+        let uuid = uuid.clone();
         spawn(async move {
             loading.set(true);
-            match data::get_ebook(&url, id).await {
+            match data::get_ebook(&url, &uuid).await {
                 Ok(b) => {
                     book.set(b);
                     error.set(None);
@@ -181,7 +183,7 @@ fn render_loaded(b: EbookMetadata) -> Element {
                         div { class: "bd-title-row",
                             h1 { class: "bd-title", "{title}" }
                             Link {
-                                to: Route::MetadataEdit { id: b.id },
+                                to: Route::MetadataEdit { uuid: b.unique_identifier.clone().unwrap_or_default() },
                                 class: "btn ghost sm bd-edit-hero",
                                 "data-testid": "edit-metadata-hero",
                                 title: "Edit metadata\u{2026}",
@@ -405,7 +407,7 @@ fn render_loaded(b: EbookMetadata) -> Element {
 
                         // F5.1: metadata editor
                         Link {
-                            to: Route::MetadataEdit { id: b.id },
+                            to: Route::MetadataEdit { uuid: b.unique_identifier.clone().unwrap_or_default() },
                             class: "btn ghost sm bd-rail-edit",
                             "data-testid": "edit-metadata",
                             "Edit metadata\u{2026}"

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -677,11 +677,14 @@ fn SortableHeader(
 
 #[component]
 fn EbookRow(book: EbookMetadata, server_url: String) -> Element {
-    let id = book.id;
+    // Stable per-book uuid drives both the detail-route URL and the
+    // thumbnail URL — see `Route::BookDetail` for why it's keyed on the
+    // uuid instead of `books.id`.
+    let uuid = book.unique_identifier.clone().unwrap_or_default();
     let display_title = book.title.as_deref().unwrap_or(&book.filename).to_string();
     let row_testid = format!("ebook-row-{}", row_slug(&book.filename));
     let has_cover = book.cover_url.is_some();
-    let thumb_base = format!("{server_url}/api/thumbs/{}", book.id);
+    let thumb_base = format!("{server_url}/api/thumbs/{uuid}");
     let series_line = match (book.series.as_deref(), book.series_index.as_deref()) {
         (Some(s), Some(i)) => format!("{s} #{i}"),
         (Some(s), None) => s.to_string(),
@@ -692,6 +695,8 @@ fn EbookRow(book: EbookMetadata, server_url: String) -> Element {
     let added = book.added_at.as_deref().unwrap_or("").to_string();
 
     let nav = use_navigator();
+    let uuid_click = uuid.clone();
+    let uuid_key = uuid.clone();
 
     rsx! {
         tr {
@@ -702,13 +707,13 @@ fn EbookRow(book: EbookMetadata, server_url: String) -> Element {
             tabindex: "0",
             aria_label: "Open details for {display_title}",
             onclick: move |_| {
-                nav.push(Route::BookDetail { id });
+                nav.push(Route::BookDetail { uuid: uuid_click.clone() });
             },
             onkeydown: move |evt: Event<KeyboardData>| {
                 let key = evt.key();
                 if key == Key::Enter || key == Key::Character(" ".to_string()) {
                     evt.prevent_default();
-                    nav.push(Route::BookDetail { id });
+                    nav.push(Route::BookDetail { uuid: uuid_key.clone() });
                 }
             },
             td { class: "ebook-col-cover", "data-testid": "ebook-cell-cover",
@@ -774,19 +779,22 @@ fn BookGrid(books: Vec<EbookMetadata>, server_url: String) -> Element {
 
 #[component]
 fn GridTile(book: EbookMetadata, server_url: String) -> Element {
-    let id = book.id;
+    // Stable per-book uuid drives both detail-route URL and thumb URL
+    // (see `Route::BookDetail`).
+    let uuid = book.unique_identifier.clone().unwrap_or_default();
     let display_title = book.title.as_deref().unwrap_or(&book.filename).to_string();
     let tile_testid = format!("ebook-tile-{}", row_slug(&book.filename));
     let authors = contributor_names(&book.creators);
     let book_for_cover = book.clone();
     let nav = use_navigator();
 
-    // Prefer the responsive `/api/thumbs/:id/{sm,md,lg}` endpoint over the
-    // raw `/api/covers/:id`: smaller payload (WebP, resized per slot) and
-    // the URL is server-prefixed so mobile picks up the right origin.
-    // Books with no cover fall back to the Atrium plate template.
+    // Prefer the responsive `/api/thumbs/:uuid/{sm,md,lg}` endpoint over
+    // the raw `/api/covers/:uuid`: smaller payload (WebP, resized per
+    // slot) and the URL is server-prefixed so mobile picks up the right
+    // origin. Books with no cover fall back to the Atrium plate
+    // template.
     let (thumb_src, thumb_srcset) = if book.cover_url.is_some() {
-        let base = format!("{server_url}/api/thumbs/{id}");
+        let base = format!("{server_url}/api/thumbs/{uuid}");
         (
             Some(format!("{base}/md")),
             Some(format!("{base}/sm 160w, {base}/md 320w, {base}/lg 640w")),
@@ -795,6 +803,9 @@ fn GridTile(book: EbookMetadata, server_url: String) -> Element {
         (None, None)
     };
 
+    let uuid_click = uuid.clone();
+    let uuid_key = uuid.clone();
+
     rsx! {
         a {
             class: "cover-link lib-tile",
@@ -802,12 +813,12 @@ fn GridTile(book: EbookMetadata, server_url: String) -> Element {
             role: "listitem",
             tabindex: "0",
             aria_label: "Open details for {display_title}",
-            onclick: move |_| { nav.push(Route::BookDetail { id }); },
+            onclick: move |_| { nav.push(Route::BookDetail { uuid: uuid_click.clone() }); },
             onkeydown: move |evt: Event<KeyboardData>| {
                 let key = evt.key();
                 if key == Key::Enter || key == Key::Character(" ".to_string()) {
                     evt.prevent_default();
-                    nav.push(Route::BookDetail { id });
+                    nav.push(Route::BookDetail { uuid: uuid_key.clone() });
                 }
             },
             crate::components::atrium::Cover {

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -1,6 +1,6 @@
 //! Metadata edit page — F5.1 Screen A (single-book edit form).
 //!
-//! Full-page route at `/books/:id/edit`. Two-column layout: a 4-column
+//! Full-page route at `/books/:uuid/edit`. Two-column layout: a 4-column
 //! form grid (left) and a sticky sidebar with cover preview and
 //! identifiers (right). A sticky save bar at the bottom shows the dirty
 //! field count and provides Save / Discard buttons.
@@ -18,21 +18,22 @@ use omnibus_shared::{Contributor, EbookMetadata, MetadataOverrides};
 use crate::components::atrium::Cover;
 use crate::{data, use_server_url, Route};
 
-/// Top-level metadata edit page component, mounted at `/books/:id/edit`.
+/// Top-level metadata edit page component, mounted at `/books/:uuid/edit`.
 #[component]
-pub fn MetadataEditPage(id: i64) -> Element {
+pub fn MetadataEditPage(uuid: String) -> Element {
     let server_url = use_server_url();
     let mut book: Signal<Option<EbookMetadata>> = use_signal(|| None);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
-    // See `BookDetailPage` for why `id` needs `use_reactive!`.
+    // See `BookDetailPage` for why `uuid` needs `use_reactive!`.
     let url = server_url.clone();
-    use_effect(use_reactive!(|id| {
+    use_effect(use_reactive!(|uuid| {
         let url = url.clone();
+        let uuid = uuid.clone();
         spawn(async move {
             loading.set(true);
-            match data::get_ebook(&url, id).await {
+            match data::get_ebook(&url, &uuid).await {
                 Ok(b) => {
                     book.set(b);
                     error.set(None);
@@ -51,7 +52,7 @@ pub fn MetadataEditPage(id: i64) -> Element {
     if let Some(msg) = error() {
         return rsx! {
             p { role: "alert", class: "subtitle", "{msg}" }
-            Link { to: Route::BookDetail { id }, class: "btn", "Back to book" }
+            Link { to: Route::BookDetail { uuid: uuid.clone() }, class: "btn", "Back to book" }
         };
     }
     let Some(b) = book() else {
@@ -62,7 +63,7 @@ pub fn MetadataEditPage(id: i64) -> Element {
     };
 
     rsx! {
-        MetadataEditForm { book: b, id }
+        MetadataEditForm { book: b, uuid }
     }
 }
 
@@ -72,7 +73,7 @@ pub fn MetadataEditPage(id: i64) -> Element {
 // ---------------------------------------------------------------------------
 
 #[component]
-fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
+fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
     let server_url = use_server_url();
 
     // Original values — frozen snapshot for dirty comparison.
@@ -190,7 +191,7 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
                     }
                     span { class: "bd-crumb-sep", "\u{203a}" }
                 }
-                Link { to: Route::BookDetail { id }, class: "bd-crumb-step", "{display_title}" }
+                Link { to: Route::BookDetail { uuid: uuid.clone() }, class: "bd-crumb-step", "{display_title}" }
                 span { class: "bd-crumb-sep", "\u{203a}" }
                 span { class: "bd-crumb-curr", "Edit metadata" }
             }
@@ -454,16 +455,18 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
                                 disabled: saving(),
                                 onclick: {
                                     let url = server_url.clone();
+                                    let uuid = uuid.clone();
                                     move |_| {
                                         let url = url.clone();
+                                        let uuid = uuid.clone();
                                         spawn(async move {
                                             saving.set(true);
                                             save_error.set(None);
-                                            match data::delete_overrides(&url, id).await {
+                                            match data::delete_overrides(&url, &uuid).await {
                                                 Ok(_) => {
                                                     // Navigate back to the detail page
                                                     let nav = navigator();
-                                                    nav.push(Route::BookDetail { id });
+                                                    nav.push(Route::BookDetail { uuid: uuid.clone() });
                                                 }
                                                 Err(e) => save_error.set(Some(e.to_string())),
                                             }
@@ -503,7 +506,7 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
                 div { class: "me-save-actions",
                     // Discard — navigates back without saving
                     Link {
-                        to: Route::BookDetail { id },
+                        to: Route::BookDetail { uuid: uuid.clone() },
                         class: "btn ghost",
                         "data-testid": "me-discard",
                         "Discard"
@@ -516,8 +519,10 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
                         disabled: dirty_count() == 0 || saving(),
                         onclick: {
                             let url = server_url.clone();
+                            let uuid = uuid.clone();
                             move |_| {
                                 let url = url.clone();
+                                let uuid = uuid.clone();
                                 spawn(async move {
                                     saving.set(true);
                                     save_error.set(None);
@@ -536,10 +541,10 @@ fn MetadataEditForm(book: EbookMetadata, id: i64) -> Element {
                                         &tags(),
                                     );
 
-                                    match data::save_overrides(&url, id, &overrides).await {
+                                    match data::save_overrides(&url, &uuid, &overrides).await {
                                         Ok(_) => {
                                             let nav = navigator();
-                                            nav.push(Route::BookDetail { id });
+                                            nav.push(Route::BookDetail { uuid: uuid.clone() });
                                         }
                                         Err(e) => save_error.set(Some(e.to_string())),
                                     }

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -95,7 +95,7 @@ pub fn SearchPage(query: String) -> Element {
                     for book in r.books.iter().cloned() {
                         li {
                             Link {
-                                to: Route::BookDetail { id: book.id },
+                                to: Route::BookDetail { uuid: book.uuid.clone() },
                                 class: "search-result-row",
                                 "data-testid": "search-book-row",
                                 div { class: "search-row-title", "{book.title}" }

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -125,7 +125,7 @@ fn render_series(s: SeriesDetail) -> Element {
                         article { class: "card series-card",
                             div { class: "series-card-cover",
                                 Link {
-                                    to: Route::BookDetail { id: book.id },
+                                    to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
                                     Cover { book: book.clone() }
                                 }
                             }
@@ -140,7 +140,7 @@ fn render_series(s: SeriesDetail) -> Element {
                                 }
                                 h3 { class: "series-card-title",
                                     Link {
-                                        to: Route::BookDetail { id: book.id },
+                                        to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
                                         "{book.title.as_deref().unwrap_or(&book.filename)}"
                                     }
                                 }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -198,10 +198,12 @@ pub async fn rpc_get_ebooks() -> Result<EbookLibrary> {
 
 /// POST (not GET) for the same reason as `rpc_search`: Dioxus `#[get]`
 /// server functions can't carry an argument body, so anything that needs
-/// `id` rides as a JSON-bodied POST.
+/// `uuid` rides as a JSON-bodied POST. The argument is the stable
+/// `books.uuid` rather than the renumbering `books.id` so bookmarked
+/// `/books/:uuid` URLs survive reindexes.
 #[post("/api/rpc/ebook", pool: PoolExt, _user: AuthUser)]
-pub async fn rpc_get_ebook(id: i64) -> Result<Option<EbookMetadata>> {
-    Ok(db::get_book(&pool.0, id).await?)
+pub async fn rpc_get_ebook(uuid: String) -> Result<Option<EbookMetadata>> {
+    Ok(db::get_book_by_uuid(&pool.0, &uuid).await?)
 }
 
 /// FTS5-backed search across the configured ebook library. Empty or
@@ -380,7 +382,7 @@ pub async fn rpc_list_series() -> Result<Vec<SeriesSummary>> {
 /// without a second round-trip.
 #[post("/api/rpc/ebook/overrides", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_save_overrides(
-    book_id: i64,
+    uuid: String,
     overrides: MetadataOverrides,
 ) -> Result<Option<EbookMetadata>> {
     if !user.is_admin && !user.can_edit {
@@ -389,9 +391,6 @@ pub async fn rpc_save_overrides(
     if let Err(msg) = overrides.validate() {
         return Err(ServerFnError::new(msg).into());
     }
-    let Some(uuid) = db::get_book_uuid(&pool.0, book_id).await? else {
-        return Ok(None);
-    };
     // Merge incoming overrides with any existing ones so that a second edit
     // that only touches field B doesn't wipe a prior override on field A.
     let merged = match db::get_metadata_overrides(&pool.0, &uuid).await? {
@@ -399,16 +398,18 @@ pub async fn rpc_save_overrides(
         None => overrides,
     };
     db::upsert_metadata_overrides(&pool.0, &uuid, &merged, false, user.id).await?;
-    Ok(db::get_book(&pool.0, book_id).await?)
+    Ok(db::get_book_by_uuid(&pool.0, &uuid).await?)
 }
 
 /// Delete metadata overrides for a book, reverting to scanned values (F5.1).
 #[post("/api/rpc/ebook/overrides/delete", pool: PoolExt, user: AuthUser)]
-pub async fn rpc_delete_overrides(book_id: i64) -> Result<Option<EbookMetadata>> {
+pub async fn rpc_delete_overrides(uuid: String) -> Result<Option<EbookMetadata>> {
     if !user.is_admin && !user.can_edit {
         return Err(ServerFnError::new("forbidden: edit permission required").into());
     }
-    let Some(uuid) = db::get_book_uuid(&pool.0, book_id).await? else {
+    // Resolve uuid → id once so the `invalidate_thumbs` call (id-keyed by
+    // the thumbnail pipeline's file layout) stays accurate.
+    let Some(book_id) = db::resolve_book_id_by_uuid(&pool.0, &uuid).await? else {
         return Ok(None);
     };
     db::delete_metadata_overrides(&pool.0, &uuid).await?;
@@ -422,7 +423,7 @@ pub async fn rpc_delete_overrides(book_id: i64) -> Result<Option<EbookMetadata>>
     })
     .await
     .map_err(|e| ServerFnError::new(format!("spawn_blocking(delete_override_cover): {e}")))?;
-    Ok(db::get_book(&pool.0, book_id).await?)
+    Ok(db::get_book_by_uuid(&pool.0, &uuid).await?)
 }
 
 /// Search palette — grouped results (books, authors, series, tags) for the

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -1446,6 +1446,8 @@ mod tests {
                         ..Default::default()
                     },
                     cover: None,
+                    mtime_epoch: 0,
+                    size_bytes: 0,
                 },
                 db::ebook::IndexedBook {
                     metadata: omnibus_shared::EbookMetadata {
@@ -1454,6 +1456,8 @@ mod tests {
                         ..Default::default()
                     },
                     cover: None,
+                    mtime_epoch: 0,
+                    size_bytes: 0,
                 },
             ],
         )
@@ -1580,6 +1584,8 @@ mod tests {
                         ..Default::default()
                     },
                     cover: None,
+                    mtime_epoch: 0,
+                    size_bytes: 0,
                 },
                 db::ebook::IndexedBook {
                     metadata: omnibus_shared::EbookMetadata {
@@ -1588,6 +1594,8 @@ mod tests {
                         ..Default::default()
                     },
                     cover: None,
+                    mtime_epoch: 0,
+                    size_bytes: 0,
                 },
             ],
         )
@@ -1657,6 +1665,8 @@ mod tests {
                     ..Default::default()
                 },
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await
@@ -2415,6 +2425,8 @@ mod tests {
                     ..Default::default()
                 },
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await
@@ -2483,6 +2495,8 @@ mod tests {
                     ..Default::default()
                 },
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await
@@ -2546,6 +2560,8 @@ mod tests {
                     ..Default::default()
                 },
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await
@@ -2610,6 +2626,8 @@ mod tests {
                         ..Default::default()
                     },
                     cover: None,
+                    mtime_epoch: 0,
+                    size_bytes: 0,
                 },
                 db::ebook::IndexedBook {
                     metadata: omnibus_shared::EbookMetadata {
@@ -2622,6 +2640,8 @@ mod tests {
                         ..Default::default()
                     },
                     cover: None,
+                    mtime_epoch: 0,
+                    size_bytes: 0,
                 },
             ],
         )
@@ -2702,6 +2722,8 @@ mod tests {
                     ..Default::default()
                 },
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await
@@ -2795,6 +2817,8 @@ mod tests {
                     ..Default::default()
                 },
                 cover: None,
+                mtime_epoch: 0,
+                size_bytes: 0,
             }],
         )
         .await

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -90,10 +90,10 @@ pub fn rest_router(state: AppState) -> Router {
         .route("/api/reindex", post(post_reindex))
         .route("/api/library", get(get_library))
         .route("/api/ebooks", get(get_ebooks))
-        .route("/api/ebooks/{id}", get(get_ebook_by_id))
-        .route("/api/ebooks/{id}/overrides", post(post_ebook_overrides))
+        .route("/api/ebooks/{uuid}", get(get_ebook_by_uuid))
+        .route("/api/ebooks/{uuid}/overrides", post(post_ebook_overrides))
         .route(
-            "/api/ebooks/{id}/overrides/delete",
+            "/api/ebooks/{uuid}/overrides/delete",
             post(delete_ebook_overrides),
         )
         // GET/DELETE for author photos carry no upload body (DELETE mutates,
@@ -107,8 +107,8 @@ pub fn rest_router(state: AppState) -> Router {
         )
         .merge(upload_router())
         .merge(search_router())
-        .route("/api/covers/{id}", get(get_cover))
-        .route("/api/thumbs/{id}/{size}", get(get_thumb))
+        .route("/api/covers/{uuid}", get(get_cover))
+        .route("/api/thumbs/{uuid}/{size}", get(get_thumb))
         .route("/api/authors", get(get_authors))
         .route("/api/authors/{id}/photo/scan", post(post_author_photo_scan))
         .route("/api/authors/{id}", get(get_author_by_id))
@@ -176,7 +176,7 @@ fn upload_router() -> Router<AppState> {
         UPLOAD_RATE_LIMIT_MAX,
     ));
     Router::new()
-        .route("/api/ebooks/{id}/cover", post(post_ebook_cover))
+        .route("/api/ebooks/{uuid}/cover", post(post_ebook_cover))
         .route("/api/authors/{id}/photo", put(put_author_photo))
         .route("/api/authors/{id}/photo/url", put(put_author_photo_url))
         // Image uploads need more than the global 1 MiB cap; layered closer
@@ -349,12 +349,12 @@ fn with_pagination_headers(mut resp: Response, total: i64) -> Response {
     resp
 }
 
-async fn get_ebook_by_id(
+async fn get_ebook_by_uuid(
     _user: AuthUser,
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path(uuid): Path<String>,
 ) -> Response {
-    match db::get_book(&state.pool, id).await {
+    match db::get_book_by_uuid(&state.pool, &uuid).await {
         Ok(Some(book)) => Json(book).into_response(),
         Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
         Err(error) => internal("read book", error),
@@ -425,8 +425,18 @@ async fn get_search_palette(
 async fn get_cover(
     _user: AuthUser,
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path(uuid): Path<String>,
 ) -> Response {
+    // Resolve uuid → id so the existing id-keyed `db::get_cover` (which
+    // reads cover bytes from `<covers_dir>/<uuid>.<ext>` by way of the
+    // books row) stays unchanged. The route surface is uuid-keyed so
+    // bookmarked URLs survive reindexes; the storage layer keeps using
+    // the autoincrement id internally for join performance.
+    let id = match db::resolve_book_id_by_uuid(&state.pool, &uuid).await {
+        Ok(Some(id)) => id,
+        Ok(None) => return axum::http::StatusCode::NOT_FOUND.into_response(),
+        Err(e) => return internal("resolve_book_id_by_uuid", e),
+    };
     match db::get_cover(&state.pool, id).await {
         Ok(Some((mime, bytes))) => (
             [
@@ -452,7 +462,7 @@ async fn get_cover(
 async fn get_thumb(
     _user: AuthUser,
     State(state): State<AppState>,
-    Path((id, size_str)): Path<(i64, String)>,
+    Path((uuid, size_str)): Path<(String, String)>,
 ) -> Response {
     let size: db::ThumbSize = match size_str.parse() {
         Ok(s) => s,
@@ -463,6 +473,14 @@ async fn get_thumb(
             )
                 .into_response();
         }
+    };
+    // uuid → id translation: see the comment in `get_cover` for why we
+    // resolve at the edge rather than rewriting the thumbnail pipeline
+    // to be uuid-keyed end-to-end.
+    let id = match db::resolve_book_id_by_uuid(&state.pool, &uuid).await {
+        Ok(Some(id)) => id,
+        Ok(None) => return axum::http::StatusCode::NOT_FOUND.into_response(),
+        Err(e) => return internal("resolve_book_id_by_uuid", e),
     };
 
     let last_modified_epoch = match db::get_last_modified_epoch(&state.pool, id).await {
@@ -625,7 +643,7 @@ async fn get_library(_user: AuthUser, State(state): State<AppState>) -> Response
 async fn post_ebook_overrides(
     user: AuthUser,
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path(uuid): Path<String>,
     Json(overrides): Json<MetadataOverrides>,
 ) -> Response {
     if !user.is_admin && !user.can_edit {
@@ -638,10 +656,13 @@ async fn post_ebook_overrides(
     if let Err(msg) = overrides.validate() {
         return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
     }
-    let uuid = match db::get_book_uuid(&state.pool, id).await {
-        Ok(Some(u)) => u,
+    // Resolve uuid → id so the thumbnail/cover invalidate calls stay
+    // id-keyed. Returns 404 for unknown uuids — same behavior the old
+    // `get_book_uuid(id)` -> 404 had for unknown ids.
+    let id = match db::resolve_book_id_by_uuid(&state.pool, &uuid).await {
+        Ok(Some(id)) => id,
         Ok(None) => return (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
-        Err(e) => return internal("get_book_uuid", e),
+        Err(e) => return internal("resolve_book_id_by_uuid", e),
     };
     // Merge incoming overrides with any existing ones so a second edit that
     // only touches field B doesn't wipe a prior override on field A. The
@@ -662,7 +683,7 @@ async fn post_ebook_overrides(
 async fn delete_ebook_overrides(
     user: AuthUser,
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path(uuid): Path<String>,
 ) -> Response {
     if !user.is_admin && !user.can_edit {
         return (
@@ -671,10 +692,10 @@ async fn delete_ebook_overrides(
         )
             .into_response();
     }
-    let uuid = match db::get_book_uuid(&state.pool, id).await {
-        Ok(Some(u)) => u,
+    let id = match db::resolve_book_id_by_uuid(&state.pool, &uuid).await {
+        Ok(Some(id)) => id,
         Ok(None) => return (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
-        Err(e) => return internal("get_book_uuid", e),
+        Err(e) => return internal("resolve_book_id_by_uuid", e),
     };
     if let Err(e) = db::delete_metadata_overrides(&state.pool, &uuid).await {
         return internal("delete_metadata_overrides", e);
@@ -723,7 +744,7 @@ fn detect_image_format(bytes: &[u8]) -> Option<String> {
 async fn post_ebook_cover(
     user: AuthUser,
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path(uuid): Path<String>,
     mut multipart: axum::extract::Multipart,
 ) -> Response {
     if !user.is_admin && !user.can_edit {
@@ -734,10 +755,13 @@ async fn post_ebook_cover(
             .into_response();
     }
 
-    let uuid = match db::get_book_uuid(&state.pool, id).await {
-        Ok(Some(u)) => u,
+    // uuid → id for the thumb-invalidate + `get_book` calls that still
+    // use the internal autoincrement key. Returns 404 for unknown uuids,
+    // matching the prior `get_book_uuid(id)` → 404 behavior.
+    let id = match db::resolve_book_id_by_uuid(&state.pool, &uuid).await {
+        Ok(Some(id)) => id,
         Ok(None) => return (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
-        Err(e) => return internal("get_book_uuid", e),
+        Err(e) => return internal("resolve_book_id_by_uuid", e),
     };
 
     // Extract the cover field from the multipart body.
@@ -1674,9 +1698,10 @@ mod tests {
 
         let books = db::list_books(&pool, "/lib").await.unwrap();
         let id = books[0].id;
+        let uuid = books[0].unique_identifier.clone().unwrap();
 
         let response = app
-            .oneshot(get_with_bearer(&format!("/api/ebooks/{id}"), &token))
+            .oneshot(get_with_bearer(&format!("/api/ebooks/{uuid}"), &token))
             .await
             .expect("request should succeed");
         assert_eq!(response.status(), StatusCode::OK);
@@ -2302,15 +2327,14 @@ mod tests {
     #[tokio::test]
     async fn api_thumbs_returns_202_for_book_without_cover() {
         let (_, _, pool) = fixture().await;
-        let book_id = seed_book_no_cover(&pool).await;
+        // seed_book_no_cover uses this fixed uuid; route is uuid-keyed now.
+        let _ = seed_book_no_cover(&pool).await;
+        let uuid = "00000000-0000-0000-0000-000000000001";
         let user = test_support::create_user(&pool, "alice").await;
         let token = test_support::bearer_token(&pool, user.id).await;
         let app = rest_router(AppState::new(pool));
         let res = app
-            .oneshot(get_with_bearer(
-                &format!("/api/thumbs/{book_id}/md"),
-                &token,
-            ))
+            .oneshot(get_with_bearer(&format!("/api/thumbs/{uuid}/md"), &token))
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::ACCEPTED);
@@ -2807,6 +2831,16 @@ mod tests {
     /// `list_books` if a test needs to assert against the overrides row
     /// directly.
     async fn seed_book(pool: &sqlx::SqlitePool, library: &str, title: &str) -> i64 {
+        seed_book_with_uuid(pool, library, title).await.0
+    }
+
+    /// Same as `seed_book` but returns `(id, uuid)`. New tests that build
+    /// uuid-keyed URLs (covers, thumbs, ebooks, overrides) use this.
+    async fn seed_book_with_uuid(
+        pool: &sqlx::SqlitePool,
+        library: &str,
+        title: &str,
+    ) -> (i64, String) {
         db::replace_books(
             pool,
             library,
@@ -2824,11 +2858,11 @@ mod tests {
         .await
         .expect("seed_book should succeed");
         let books = db::list_books(pool, library).await.expect("list_books");
-        books
+        let book = books
             .into_iter()
             .find(|b| b.title.as_deref() == Some(title))
-            .map(|b| b.id)
-            .expect("seeded book should be present")
+            .expect("seeded book should be present");
+        (book.id, book.unique_identifier.clone().unwrap())
     }
 
     /// Build a `multipart/form-data` body with a single `cover` field
@@ -2972,7 +3006,7 @@ mod tests {
         // POSTs an override. The handler must persist it, return the merged
         // book, and flip `has_override` on the response.
         let (app, _state, pool) = fixture().await;
-        let id = seed_book(&pool, "/lib", "Original").await;
+        let (id, uuid) = seed_book_with_uuid(&pool, "/lib", "Original").await;
         let admin = test_support::create_admin(&pool, "admin").await;
         let token = test_support::bearer_token(&pool, admin.id).await;
 
@@ -2983,7 +3017,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/ebooks/{id}/overrides"))
+                    .uri(format!("/api/ebooks/{uuid}/overrides"))
                     .method("POST")
                     .header("content-type", "application/json")
                     .header(AUTHORIZATION, format!("Bearer {token}"))
@@ -3022,7 +3056,7 @@ mod tests {
         // delete it and assert the response reflects the canonical scanned
         // values (no `Option` overrides applied).
         let (app, _state, pool) = fixture().await;
-        let id = seed_book(&pool, "/lib", "Original").await;
+        let (id, uuid) = seed_book_with_uuid(&pool, "/lib", "Original").await;
         let admin = test_support::create_admin(&pool, "admin").await;
         let token = test_support::bearer_token(&pool, admin.id).await;
 
@@ -3031,7 +3065,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/ebooks/{id}/overrides"))
+                    .uri(format!("/api/ebooks/{uuid}/overrides"))
                     .method("POST")
                     .header("content-type", "application/json")
                     .header(AUTHORIZATION, format!("Bearer {token}"))
@@ -3045,7 +3079,7 @@ mod tests {
         let res = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/ebooks/{id}/overrides/delete"))
+                    .uri(format!("/api/ebooks/{uuid}/overrides/delete"))
                     .method("POST")
                     .header(AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
@@ -3088,7 +3122,7 @@ mod tests {
         // `has_override = true`.
         let _covers = CoversDirGuard::new("upload_replaces");
         let (app, _state, pool) = fixture().await;
-        let id = seed_book(&pool, "/lib", "CoverBook").await;
+        let (id, uuid) = seed_book_with_uuid(&pool, "/lib", "CoverBook").await;
         let admin = test_support::create_admin(&pool, "admin").await;
         let token = test_support::bearer_token(&pool, admin.id).await;
 
@@ -3096,7 +3130,7 @@ mod tests {
         let res = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/ebooks/{id}/cover"))
+                    .uri(format!("/api/ebooks/{uuid}/cover"))
                     .method("POST")
                     .header("content-type", content_type)
                     .header(AUTHORIZATION, format!("Bearer {token}"))
@@ -3138,7 +3172,7 @@ mod tests {
         // be rejected at the `starts_with("image/")` guard with 400.
         let _covers = CoversDirGuard::new("non_image");
         let (app, _state, pool) = fixture().await;
-        let id = seed_book(&pool, "/lib", "NonImageBook").await;
+        let (_id, uuid) = seed_book_with_uuid(&pool, "/lib", "NonImageBook").await;
         let admin = test_support::create_admin(&pool, "admin").await;
         let token = test_support::bearer_token(&pool, admin.id).await;
 
@@ -3146,7 +3180,7 @@ mod tests {
         let res = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/ebooks/{id}/cover"))
+                    .uri(format!("/api/ebooks/{uuid}/cover"))
                     .method("POST")
                     .header("content-type", content_type)
                     .header(AUTHORIZATION, format!("Bearer {token}"))
@@ -3177,7 +3211,7 @@ mod tests {
         // handler-level check.
         let _covers = CoversDirGuard::new("oversized");
         let (app, _state, pool) = fixture().await;
-        let id = seed_book(&pool, "/lib", "OversizedBook").await;
+        let (_id, uuid) = seed_book_with_uuid(&pool, "/lib", "OversizedBook").await;
         let admin = test_support::create_admin(&pool, "admin").await;
         let token = test_support::bearer_token(&pool, admin.id).await;
 
@@ -3189,7 +3223,7 @@ mod tests {
         let res = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/ebooks/{id}/cover"))
+                    .uri(format!("/api/ebooks/{uuid}/cover"))
                     .method("POST")
                     .header("content-type", content_type)
                     .header(AUTHORIZATION, format!("Bearer {token}"))

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -371,6 +371,10 @@ impl PaletteResults {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct PaletteBookHit {
     pub id: i64,
+    /// Stable UUID — what the frontend should use to construct
+    /// `/books/:uuid` and `/api/covers/:uuid` URLs.
+    #[serde(default)]
+    pub uuid: String,
     pub title: String,
     /// Pre-joined author names (e.g. "Grace Hopper, Margaret Hamilton").
     pub author_display: String,

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -19,7 +19,8 @@ test("navigates from a landing row to the detail page and back", async ({ page }
 
   // Click the row for our target book and follow the SPA navigation.
   await getRow(page, TARGET.slug).click();
-  await expect(page).toHaveURL(/\/books\/\d+$/);
+  // `/books/:uuid` — UUIDv5 in canonical 8-4-4-4-12 hyphenated form.
+  await expect(page).toHaveURL(/\/books\/[0-9a-fA-F-]{36}$/);
 
   // The detail page should render the standard "Book #<id>" heading and the
   // shared back-to-library affordance.

--- a/ui_tests/playwright/tests/flows/book_url_stability.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_url_stability.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "../fixtures/test";
+import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { fetchBookUuidByTitle } from "../utils/ebooks";
+import { gotoReady } from "../utils/nav";
+import { fixturesDir, seedLibrary } from "../utils/seed";
+
+/**
+ * Regression coverage for the "bookmarked `/books/:id` URL goes 404 after
+ * the next reindex" failure mode that motivated the uuid-URL switch.
+ *
+ * `books.id` is `AUTOINCREMENT` and renumbers on every `DELETE+INSERT`
+ * pass through the indexer, so a URL captured before a reindex used to
+ * resolve to a different (or no) book afterward. The route now keys on
+ * `books.uuid` — a deterministic UUIDv5 of `(library_path, filename)` —
+ * which survives reindexes, re-installs, and any other churn.
+ *
+ * The spec captures a uuid URL, kicks a reindex via the same settings
+ * POST the seed flow uses (which the indexer's incremental sync handles
+ * via the Backfill bucket on the first post-migration pass), and
+ * re-fetches the same URL. The detail heading must still match.
+ */
+test.beforeAll(async ({ request }) => {
+  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
+});
+
+const TARGET = FIXTURE_BOOKS.find((b) => b.slug === "alpha")!;
+
+test("bookmarked /books/:uuid still resolves after a reindex", async ({
+  page,
+  request,
+}) => {
+  // Capture the uuid before the reindex. This is the URL a user would
+  // have bookmarked.
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+
+  // First visit — pre-reindex. Detail heading matches the fixture.
+  await gotoReady(page, `/books/${uuid}`);
+  await expect(
+    page.getByRole("heading", { level: 1, name: TARGET.title }),
+  ).toBeVisible();
+
+  // Kick a fresh reindex by re-seeding against the same library path.
+  // The indexer's diff/sync path treats every book as either Backfill
+  // (first run after the fs-metadata migration) or Unchanged, and `id`
+  // is preserved either way. UUID is deterministic from path+filename,
+  // so the captured URL stays valid.
+  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
+
+  // Second visit — same URL, post-reindex. Must still render the same
+  // book; "Book not found" failure means the route lookup is no longer
+  // stable across reindexes.
+  await gotoReady(page, `/books/${uuid}`);
+  await expect(
+    page.getByRole("heading", { level: 1, name: TARGET.title }),
+  ).toBeVisible();
+  await expect(page.getByText("Book not found.")).toHaveCount(0);
+});

--- a/ui_tests/playwright/tests/flows/search-palette.spec.ts
+++ b/ui_tests/playwright/tests/flows/search-palette.spec.ts
@@ -133,9 +133,9 @@ test.describe("with seeded library", () => {
 
     await page.getByTestId("sp-book-row").first().click();
 
-    // Should navigate to /books/:id
+    // Should navigate to /books/:uuid
     await expect.poll(async () => new URL(page.url()).pathname).toMatch(
-      /^\/books\/\d+$/,
+      /^\/books\/[0-9a-fA-F-]{36}$/,
     );
   });
 
@@ -235,7 +235,7 @@ test.describe("with seeded library", () => {
     await page.keyboard.press("Enter");
 
     await expect.poll(async () => new URL(page.url()).pathname).toMatch(
-      /^\/books\/\d+$/,
+      /^\/books\/[0-9a-fA-F-]{36}$/,
     );
   });
 });

--- a/ui_tests/playwright/tests/flows/thumbnails.spec.ts
+++ b/ui_tests/playwright/tests/flows/thumbnails.spec.ts
@@ -28,7 +28,9 @@ test("renders book grid with srcset cover images", async ({ page }) => {
 
   const srcset = await coverImg.getAttribute("srcset");
   expect(srcset, "srcset attribute must be present").not.toBeNull();
-  expect(srcset).toMatch(/\/api\/thumbs\/\d+\/sm/);
+  // Thumb URLs are uuid-keyed (UUIDv5, 8-4-4-4-12 hyphenated form) —
+  // see `/api/thumbs/:uuid/:size` in the router.
+  expect(srcset).toMatch(/\/api\/thumbs\/[0-9a-fA-F-]{36}\/sm/);
   expect(srcset).toContain("160w");
   expect(srcset).toContain("320w");
   expect(srcset).toContain("640w");
@@ -49,22 +51,25 @@ test("thumb endpoint serves an image", async ({ page, request }) => {
   const srcset = await coverImg.getAttribute("srcset");
   expect(srcset).not.toBeNull();
 
-  // Parse the book ID out of the srcset (e.g. "/api/thumbs/3/sm 160w, ...").
-  const match = srcset!.match(/\/api\/thumbs\/(\d+)\/sm/);
-  expect(match, "could not parse book id from srcset").not.toBeNull();
-  const bookId = match![1];
+  // Parse the book UUID out of the srcset
+  // (e.g. "/api/thumbs/ad8d591f-546b-59d0-bfff-0a4de6fc7e55/sm 160w, ...").
+  // The route is uuid-keyed (not id-keyed) for the same URL-stability
+  // reason `/books/:uuid` uses — see `db::queries::stable_uuid`.
+  const match = srcset!.match(/\/api\/thumbs\/([0-9a-fA-F-]{36})\/sm/);
+  expect(match, "could not parse book uuid from srcset").not.toBeNull();
+  const bookUuid = match![1];
 
   // On first request the endpoint may return the original cover (image/jpeg);
   // poll until the background WebP generation has finished (up to 10 s).
   await expect
     .poll(
       async () => {
-        const resp = await request.get(`/api/thumbs/${bookId}/md`);
+        const resp = await request.get(`/api/thumbs/${bookUuid}/md`);
         if (resp.status() !== 200) return `status:${resp.status()}`;
         return resp.headers()["content-type"] ?? "missing";
       },
       {
-        message: "expected /api/thumbs/{id}/md to return image/webp",
+        message: "expected /api/thumbs/{uuid}/md to return image/webp",
         timeout: 10_000,
         intervals: [200, 500, 1_000],
       },

--- a/ui_tests/playwright/tests/utils/ebooks.ts
+++ b/ui_tests/playwright/tests/utils/ebooks.ts
@@ -3,26 +3,44 @@ import { expect } from "../fixtures/test";
 import type { ExpectedBook } from "../fixtures/epubs";
 
 /**
- * Look up the backend `id` for a fixture book by exact title. Hits the same
- * RPC the landing page reads, so the id matches what `/books/:id` would
- * receive on a real click. Throws if the seeded library does not contain a
- * book with that title.
+ * Look up the backend `uuid` for a fixture book by exact title. Hits the
+ * same RPC the landing page reads, so the uuid matches what
+ * `/books/:uuid` would receive on a real click. Throws if the seeded
+ * library does not contain a book with that title.
+ *
+ * The route is uuid-keyed (not id-keyed) so bookmarked URLs survive
+ * reindexes — `books.id` is `AUTOINCREMENT` and renumbers on every
+ * `replace_books` run, while `books.uuid` is deterministic UUIDv5 of
+ * `(library_path, filename)` and stays stable across reindexes and
+ * re-installs. See `db::queries::stable_uuid`.
  */
-export async function fetchBookIdByTitle(
+export async function fetchBookUuidByTitle(
   request: APIRequestContext,
   title: string,
-): Promise<number> {
+): Promise<string> {
   const resp = await request.get("/api/rpc/ebooks");
   expect(resp.status(), "GET /api/rpc/ebooks failed").toBe(200);
-  const body = (await resp.json()) as { books: { id: number; title: string | null }[] };
+  const body = (await resp.json()) as {
+    books: { unique_identifier: string | null; title: string | null }[];
+  };
   const match = body.books.find((b) => b.title === title);
   if (!match) {
     throw new Error(
       `no seeded book with title ${JSON.stringify(title)} (got ${body.books.length} books)`,
     );
   }
-  return match.id;
+  if (!match.unique_identifier) {
+    throw new Error(`book ${JSON.stringify(title)} is missing its uuid`);
+  }
+  return match.unique_identifier;
 }
+
+/**
+ * @deprecated — kept as a compatibility shim for older specs. New tests
+ * should use {@link fetchBookUuidByTitle}, since `/books/:id` was
+ * replaced by `/books/:uuid` for URL stability across reindexes.
+ */
+export const fetchBookIdByTitle = fetchBookUuidByTitle;
 
 /** Locate the row for a fixture by its slug — matches `data-testid="ebook-row-${slug}"`. */
 export function getRow(page: Page, slug: string): Locator {


### PR DESCRIPTION
## Summary

Foundations for incremental reindex (Part A of the larger incremental-reindex + uuid-URLs plan). No behavior change yet — `sync_books`, the diff function, and the `reindex` rewire land in follow-up commits.

- Migration `0009_book_files_fs_metadata.sql` adds `mtime_epoch INTEGER DEFAULT 0` to `book_files`. The `0` default is the sentinel the upcoming diff classifies as Backfill (no OPF re-parse on first run after upgrade).
- `db::ebook` split into Phase A (`stat_ebook_library` — stat-only walk, computes stable UUID per file without opening the zip) and Phase B (`parse_ebook_targets` — parses only the subset the diff requests).
- `IndexedBook` gains `mtime_epoch` + `size_bytes`; `scan_ebook_library_with` becomes a thin wrapper over the two phases so non-indexer callers are unaffected.
- `stable_uuid` exposed `pub(crate)` for the scanner.

## Test plan
- [x] `cargo test -p omnibus-db` — 270 passed
- [x] `cargo test -p omnibus --lib` — 129 passed
- [x] `cargo clippy --workspace --all-targets` — no new warnings
- [x] `cargo fmt --check` — clean

## Notes
- This PR is intentionally a no-op at runtime — landing it small lets the heavier `sync_books` write path go up as its own reviewable diff.