### PR TITLE
test: add discovery nav action tests (#110)

### DIFF
--- a/ui_tests/playwright/tests/flows/discovery.spec.ts
+++ b/ui_tests/playwright/tests/flows/discovery.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../fixtures/test";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { fetchBookIdByTitle } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
 import { fixturesDir, seedLibrary } from "../utils/seed";
 import type { APIRequestContext } from "@playwright/test";
@@ -86,6 +87,47 @@ test("author page shows books by the author", async ({ page, request }) => {
 
   // At least the first book title should be visible
   await expect(page.getByText("Quartet I: Lexer")).toBeVisible();
+});
+
+test("author series section heading links to the series page", async ({ page, request }) => {
+  // Niklaus Wirth's four books all belong to "Code Quartet", so the author
+  // page renders a single series section whose heading is a router Link to
+  // /series/:id. The author-page breadcrumb only carries a "Library" link, so
+  // the "Code Quartet" link role is unambiguous on this page.
+  const authorId = await fetchAuthorIdByName(request, "Niklaus Wirth");
+  await gotoReady(page, `/authors/${authorId}`);
+
+  const seriesLink = page.getByRole("link", { name: "Code Quartet" });
+  await expect(seriesLink).toBeVisible();
+  await seriesLink.click();
+
+  await expect(page).toHaveURL(/\/series\/\d+$/);
+  // Destination renders: series page H1 + book-count label.
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Code Quartet");
+  await expect(page.getByText(/in library/)).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Book detail → series
+// ---------------------------------------------------------------------------
+
+test("book detail series rail link navigates to the series page", async ({ page, request }) => {
+  // `beta` ("Beta in the Series") is Pioneers #1, so the book detail rail
+  // renders a Series card whose body is a Link to /series/:id. Both the rail
+  // link and the breadcrumb series segment share the "Pioneers #1" text, so
+  // scope to the rail link's dedicated `.bd-series-link` class to target the
+  // rail specifically (the contract this test covers).
+  const beta = FIXTURE_BOOKS.find((b) => b.slug === "beta")!;
+  const id = await fetchBookIdByTitle(request, beta.title);
+  await gotoReady(page, `/books/${id}`);
+
+  const railLink = page.locator(".bd-series-link");
+  await expect(railLink).toHaveText("Pioneers #1");
+  await railLink.click();
+
+  await expect(page).toHaveURL(/\/series\/\d+$/);
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Pioneers");
+  await expect(page.getByText(/in library/)).toBeVisible();
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #109. The discovery spec (`ui_tests/playwright/tests/flows/discovery.spec.ts`) previously asserted layout/static content only. This adds two navigation **action** tests:

- **Author series section heading → `/series/:id`** — on the Niklaus Wirth author page, clicks the "Code Quartet" series-section heading link (rendered by `render_author` as a `Link` to `Route::SeriesDetail`) and asserts the URL is `/series/:id` and the series page renders (H1 contains "Code Quartet", "in library" count label visible).
- **Book detail series rail link → `/series/:id`** — on the `beta` book detail page (Pioneers #1), clicks the rail's `.bd-series-link` (rendered by `render_loaded` in `book_detail.rs`) and asserts the URL is `/series/:id` and the destination series page renders.

Both are GET navigations, so no `expectMutation` is needed; each asserts the resulting URL plus that the destination page renders, per the one-file-per-flow + layout-test-plus-action-tests structure in `.claude/rules/04-playwright.md`. IDs are resolved via the existing `/api/rpc/ebooks` helpers (`fetchAuthorIdByName`, `fetchBookIdByTitle`) so nothing hardcodes DB ids. No production code or markup changed — selectors map onto existing roles/text/classes.

## Test plan

- [x] `tsc --noEmit` on the Playwright project — `discovery.spec.ts` typechecks clean (the 3 pre-existing errors are in untouched specs and don't affect the runtime, which uses esbuild).
- [ ] CI `run_ui_tests` job exercises the two new specs against a live `dx serve` + Chromium (see Notes — couldn't run E2E locally).

## Notes

- **Third checklist item deferred / blocked.** The issue's third box (tag cloud → click a tag → return to library with that tag pre-selected as a `ViewFilters.tags` filter) is **not** implemented here. It's blocked: `render_tag_item` in `frontend/src/pages/tag_cloud.rs` currently navigates to `Route::Landing {}` **without** passing the tag, so there's no filter state to assert against. Wiring tag→filter is out of scope for this test-only PR and needs its own change first. `Closes #110` will auto-close the issue on merge even with that box unchecked — flagging so you can decide whether to open a follow-up to track the tag-filter wiring + its test.
- **E2E not run locally.** The sandbox this was prepared in has no Nix toolchain, so `dx serve` (WASM build) + the Nix-provided Chromium couldn't be brought up — local Playwright execution wasn't possible. Confidence rests on: (a) `discovery.spec.ts` typechecking clean, and (b) re-reading each selector against the actual rsx markup (`author.rs` series-section `Link`, `book_detail.rs` `.bd-series-link`, `series.rs` H1 + "Series · N in library" label). The `run_ui_tests` label is applied so CI runs the full suite.

https://claude.ai/code/session_01UvoQ8RDugg1XJbfRdmKJYD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvoQ8RDugg1XJbfRdmKJYD)_