### PR TITLE
fix(frontend): clear clippy field_reassign_with_default in view_prefs

### DIFF
--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -142,15 +142,19 @@ mod tests {
     #[test]
     fn round_trips_and_isolates_per_library() {
         mobile_store::clear();
-        let mut a = ViewPrefs::default();
-        a.view_mode = ViewMode::Grid;
-        a.sort_key = SortKey::Author;
-        a.sort_dir = SortDir::Desc;
+        let a = ViewPrefs {
+            view_mode: ViewMode::Grid,
+            sort_key: SortKey::Author,
+            sort_dir: SortDir::Desc,
+            ..Default::default()
+        };
         save("/library/a", &a);
 
-        let mut b = ViewPrefs::default();
-        b.view_mode = ViewMode::Table;
-        b.sort_key = SortKey::NewestAdded;
+        let b = ViewPrefs {
+            view_mode: ViewMode::Table,
+            sort_key: SortKey::NewestAdded,
+            ..Default::default()
+        };
         save("/library/b", &b);
 
         assert_eq!(load("/library/a"), a);


### PR DESCRIPTION
## Summary
- `cargo clippy --workspace --all-targets -- -D warnings` was failing on `main` with two `field_reassign_with_default` errors in [frontend/src/view_prefs.rs:145-152](frontend/src/view_prefs.rs#L145).
- Rewrites both `let mut x = ViewPrefs::default(); x.field = ...;` blocks as `ViewPrefs { field: ..., ..Default::default() }` per clippy's recommendation.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-frontend --features mobile view_prefs` — 2 passed (the test the lint fired in)

## Notes
- Test-only code; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)