### PR TITLE
feat(db): delete_author primitive + admin RPC

### DIFF
--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2889,11 +2889,21 @@ pub async fn delete_author(pool: &SqlitePool, author_id: i64) -> Result<u64, sql
         return Ok(0);
     };
 
-    let affected_book_ids: Vec<i64> =
-        sqlx::query_scalar("SELECT book FROM books_authors_link WHERE author = ?")
-            .bind(author_id)
-            .fetch_all(&mut *tx)
-            .await?;
+    // Snapshot the affected book UUIDs *inside* the transaction by
+    // joining link → books. Doing the lookup as a uuid join (one bind
+    // parameter) instead of post-commit `WHERE id IN (?, ?, …)` keeps
+    // the post-commit FTS refresh from hitting SQLite's 999 bind-
+    // parameter cap on authors linked to >999 books — without that
+    // cap a giant-author delete would silently skip its FTS rebuild
+    // and leave the index stale.
+    let affected_uuids: Vec<String> = sqlx::query_scalar(
+        "SELECT b.uuid FROM books b
+         JOIN books_authors_link l ON l.book = b.id
+         WHERE l.author = ?",
+    )
+    .bind(author_id)
+    .fetch_all(&mut *tx)
+    .await?;
 
     sqlx::query("DELETE FROM books_authors_link WHERE author = ?")
         .bind(author_id)
@@ -2912,28 +2922,13 @@ pub async fn delete_author(pool: &SqlitePool, author_id: i64) -> Result<u64, sql
 
     tx.commit().await?;
 
-    if !affected_book_ids.is_empty() {
-        let placeholders = vec!["?"; affected_book_ids.len()].join(",");
-        let query = format!("SELECT uuid FROM books WHERE id IN ({placeholders})");
-        let mut q = sqlx::query_scalar::<_, String>(&query);
-        for id in &affected_book_ids {
-            q = q.bind(id);
-        }
-        match q.fetch_all(pool).await {
-            Ok(uuids) => {
-                for uuid in uuids {
-                    if let Err(e) = rebuild_fts_for_book(pool, &uuid).await {
-                        tracing::warn!(uuid, error = %e, "books_fts rebuild after delete_author failed");
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "uuid lookup for FTS refresh after delete_author failed");
-            }
+    for uuid in &affected_uuids {
+        if let Err(e) = rebuild_fts_for_book(pool, uuid).await {
+            tracing::warn!(uuid = uuid.as_str(), error = %e, "books_fts rebuild after delete_author failed");
         }
     }
 
-    Ok(affected_book_ids.len() as u64)
+    Ok(affected_uuids.len() as u64)
 }
 
 /// Fetch a series by ID with its books, ordered by series index. Returns

--- a/db/src/queries.rs
+++ b/db/src/queries.rs
@@ -2860,6 +2860,82 @@ pub async fn delete_author_photo(pool: &SqlitePool, author_id: i64) -> Result<()
     Ok(())
 }
 
+/// Delete an author by id and prevent reindex from re-creating the row.
+///
+/// F5.9-lite durable junk-author removal (issue #159). One transaction:
+/// look up the name (for the blocklist insert) and affected book ids
+/// (for the post-commit FTS refresh), drop the link rows, drop the
+/// `authors` row, then `INSERT OR IGNORE` the name into
+/// `ignored_authors` so the next `indexer::reindex` does not silently
+/// re-create the row via `resolve_or_insert_author`.
+///
+/// Returns the number of books that were un-linked (used by the admin
+/// confirmation modal to show "this affects N books"). Returns `Ok(0)`
+/// without touching the blocklist if `author_id` does not exist — a
+/// stale tab firing a second Delete must not leak a ghost row into
+/// `ignored_authors`.
+///
+/// FTS refresh runs best-effort *after* commit, mirroring
+/// [`upsert_metadata_overrides`]: a stale FTS row is fixed on the next
+/// reindex, but a refresh failure must not undo the admin's intent.
+pub async fn delete_author(pool: &SqlitePool, author_id: i64) -> Result<u64, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let Some(name): Option<String> = sqlx::query_scalar("SELECT name FROM authors WHERE id = ?")
+        .bind(author_id)
+        .fetch_optional(&mut *tx)
+        .await?
+    else {
+        return Ok(0);
+    };
+
+    let affected_book_ids: Vec<i64> =
+        sqlx::query_scalar("SELECT book FROM books_authors_link WHERE author = ?")
+            .bind(author_id)
+            .fetch_all(&mut *tx)
+            .await?;
+
+    sqlx::query("DELETE FROM books_authors_link WHERE author = ?")
+        .bind(author_id)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("DELETE FROM authors WHERE id = ?")
+        .bind(author_id)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("INSERT OR IGNORE INTO ignored_authors(name) VALUES (?)")
+        .bind(&name)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    if !affected_book_ids.is_empty() {
+        let placeholders = vec!["?"; affected_book_ids.len()].join(",");
+        let query = format!("SELECT uuid FROM books WHERE id IN ({placeholders})");
+        let mut q = sqlx::query_scalar::<_, String>(&query);
+        for id in &affected_book_ids {
+            q = q.bind(id);
+        }
+        match q.fetch_all(pool).await {
+            Ok(uuids) => {
+                for uuid in uuids {
+                    if let Err(e) = rebuild_fts_for_book(pool, &uuid).await {
+                        tracing::warn!(uuid, error = %e, "books_fts rebuild after delete_author failed");
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "uuid lookup for FTS refresh after delete_author failed");
+            }
+        }
+    }
+
+    Ok(affected_book_ids.len() as u64)
+}
+
 /// Fetch a series by ID with its books, ordered by series index. Returns
 /// `None` if the series ID doesn't exist.
 ///
@@ -9855,6 +9931,158 @@ mod tests {
         tx.commit().await.unwrap();
 
         assert!(id.is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // delete_author (F5.9-lite admin "Delete author" primitive)
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn delete_author_removes_links_and_inserts_blocklist_row() {
+        let _covers = CoversTempDir::new("delete_author_basic");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![
+                indexed("a.epub", Some("A"), &["Junk Author"], &[], None, None),
+                indexed(
+                    "b.epub",
+                    Some("B"),
+                    &["Junk Author", "Real Author"],
+                    &[],
+                    None,
+                    None,
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let junk_id: i64 = sqlx::query_scalar("SELECT id FROM authors WHERE name = ?")
+            .bind("Junk Author")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let unlinked = delete_author(&pool, junk_id).await.unwrap();
+        assert_eq!(unlinked, 2, "both books should report as un-linked");
+
+        let junk_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM authors WHERE id = ?")
+            .bind(junk_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(junk_count, 0, "authors row should be gone");
+
+        let link_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM books_authors_link WHERE author = ?")
+                .bind(junk_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            link_count, 0,
+            "no link rows should remain for deleted author"
+        );
+
+        let blocklist_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM ignored_authors WHERE name = ?")
+                .bind("Junk Author")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(blocklist_count, 1, "name must be added to ignored_authors");
+
+        // Real Author on book B should still be linked.
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let b = books
+            .iter()
+            .find(|x| x.title.as_deref() == Some("B"))
+            .unwrap();
+        let creators: Vec<&str> = b.creators.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(creators, vec!["Real Author"]);
+    }
+
+    #[tokio::test]
+    async fn delete_author_is_no_op_for_missing_id() {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let unlinked = delete_author(&pool, 99_999).await.unwrap();
+        assert_eq!(unlinked, 0);
+        let blocklist_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ignored_authors")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            blocklist_count, 0,
+            "missing id must not leak a ghost blocklist row"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_author_survives_reindex() {
+        // Full durability check: delete the junk author, then run the
+        // reindex pipeline against a fixture that *still* lists the junk
+        // contributor in its OPF (simulated via replace_books with the
+        // same input). The blocklist row inserted by delete_author must
+        // keep resolve_or_insert_author from re-creating the author.
+        let _covers = CoversTempDir::new("delete_author_reindex");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+
+        let junk_name = "calibre (8.0.0) [https://calibre-ebook.com]";
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("A"),
+                &["Real Author", junk_name],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let junk_id: i64 = sqlx::query_scalar("SELECT id FROM authors WHERE name = ?")
+            .bind(junk_name)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        delete_author(&pool, junk_id).await.unwrap();
+
+        // Simulated reindex: same OPF contents, run through the
+        // indexing pipeline again. Without the blocklist guard this
+        // would re-create the junk author and relink it.
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("A"),
+                &["Real Author", junk_name],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        let junk_after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM authors WHERE name = ?")
+            .bind(junk_name)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            junk_after, 0,
+            "second reindex must not resurrect a deleted author"
+        );
+
+        let books = list_books(&pool, "/lib").await.unwrap();
+        let creators: Vec<&str> = books[0].creators.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(creators, vec!["Real Author"]);
     }
 
     #[tokio::test]

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -451,6 +451,16 @@ pub async fn rpc_delete_overrides(uuid: String) -> Result<Option<EbookMetadata>>
     Ok(db::get_book_by_uuid(&pool.0, &uuid).await?)
 }
 
+/// F5.9-lite: admin "Delete author" (issue #159). Removes the author row,
+/// drops every `books_authors_link` for it, and adds the name to
+/// `ignored_authors` so the next `indexer::reindex` does not silently
+/// resurrect the row. Returns the number of books that were un-linked
+/// (used by the confirmation modal in PR 5).
+#[post("/api/rpc/author/delete", pool: PoolExt, _admin: AdminUser)]
+pub async fn rpc_delete_author(id: i64) -> Result<u64> {
+    Ok(db::delete_author(&pool.0, id).await?)
+}
+
 /// Search palette — grouped results (books, authors, series, tags) for the
 /// command-palette overlay (F1.5).
 #[post("/api/rpc/search-palette", pool: PoolExt, _user: AuthUser)]


### PR DESCRIPTION
## Summary
- New `db::delete_author` transactional primitive: snapshots affected book ids, drops every `books_authors_link` row for the author, deletes the `authors` row, inserts the name into `ignored_authors` (PR #194's blocklist), and runs a best-effort `books_fts` refresh.
- New admin-gated server function `rpc_delete_author` (POST `/api/rpc/author/delete`) in `frontend/src/rpc.rs`; reuses the existing `AdminUser` extractor pattern.
- Returns the count of un-linked books so the upcoming admin confirmation modal (PR 5) can render "this affects N books".

## Test plan
- [x] `cargo test -p omnibus-db` — 305 passing total; 3 new tests in this PR:
  - `delete_author_removes_links_and_inserts_blocklist_row` (multi-book + multi-author scenario)
  - `delete_author_is_no_op_for_missing_id` (no ghost blocklist row on stale double-delete)
  - `delete_author_survives_reindex` (delete → `replace_books` again with the same OPF → asserts author is not re-created)
- [x] `cargo clippy -p omnibus-db -p omnibus-frontend --features server -- -D warnings` clean.

## Notes
- Part 2 of the F5.9-lite stack. Depends on #194 (the `ignored_authors` blocklist + guard).
- Web admin only — no `/api/*` REST route was added since mobile parity is deliberately deferred to a follow-up per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)