### PR TITLE
fix(e2e): realign Playwright with nixpkgs 1.59 + scoped selectors

### DIFF
--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -158,7 +158,14 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                 evt.prevent_default();
                 let len = items_for_key.read().len();
                 if len > 0 {
-                    selected.set((selected() + 1) % len);
+                    // First arrow press is a "begin navigation" gesture — it
+                    // should highlight the first item, not increment past it.
+                    // Subsequent presses wrap around as usual.
+                    if !has_navigated() {
+                        selected.set(0);
+                    } else {
+                        selected.set((selected() + 1) % len);
+                    }
                     has_navigated.set(true);
                 }
             }
@@ -166,11 +173,17 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                 evt.prevent_default();
                 let len = items_for_key.read().len();
                 if len > 0 {
-                    selected.set(if selected() == 0 {
-                        len - 1
+                    // Symmetric with ArrowDown: first press lands on the
+                    // last item; subsequent presses walk backward.
+                    if !has_navigated() {
+                        selected.set(len - 1);
                     } else {
-                        selected() - 1
-                    });
+                        selected.set(if selected() == 0 {
+                            len - 1
+                        } else {
+                            selected() - 1
+                        });
+                    }
                     has_navigated.set(true);
                 }
             }
@@ -229,6 +242,12 @@ fn SpOverlay(open: PaletteOpen) -> Element {
     let res = results.read();
     let items = flat_items.read();
     let sel = selected();
+    // Only project `selected` into row class names once the user has driven
+    // selection with arrow keys. Otherwise the first row would render with
+    // the "selected" highlight on every fresh query (since `selected`
+    // resets to 0 after each search response), and pressing ArrowDown
+    // would visually jump to index 1 instead of 0.
+    let has_nav = has_navigated();
     let is_loading = loading();
 
     let total = res.as_ref().map(|r| r.total_count()).unwrap_or(0);
@@ -315,7 +334,7 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             for book in r.books.iter() {
                                 SpBookRow {
                                     book: book.clone(),
-                                    selected: is_selected(&items, sel, &FlatItem::Book { uuid: book.uuid.clone(), title: book.title.clone() }),
+                                    selected: has_nav && is_selected(&items, sel, &FlatItem::Book { uuid: book.uuid.clone(), title: book.title.clone() }),
                                     on_click: {
                                         let uuid = book.uuid.clone();
                                         move |_| {
@@ -333,7 +352,7 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             for author in r.authors.iter() {
                                 SpAuthorRow {
                                     author: author.clone(),
-                                    selected: is_selected(&items, sel, &FlatItem::Author { id: author.id, name: author.name.clone() }),
+                                    selected: has_nav && is_selected(&items, sel, &FlatItem::Author { id: author.id, name: author.name.clone() }),
                                     on_click: {
                                         let id = author.id;
                                         move |_| {
@@ -351,7 +370,7 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             for s in r.series.iter() {
                                 SpSeriesRow {
                                     series: s.clone(),
-                                    selected: is_selected(&items, sel, &FlatItem::Series { id: s.id, name: s.name.clone() }),
+                                    selected: has_nav && is_selected(&items, sel, &FlatItem::Series { id: s.id, name: s.name.clone() }),
                                     on_click: {
                                         let id = s.id;
                                         move |_| {
@@ -369,7 +388,7 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             for tag in r.tags.iter() {
                                 SpTagRow {
                                     tag: tag.clone(),
-                                    selected: is_selected(&items, sel, &FlatItem::Tag { id: tag.id, name: tag.name.clone() }),
+                                    selected: has_nav && is_selected(&items, sel, &FlatItem::Tag { id: tag.id, name: tag.name.clone() }),
                                     on_click: {
                                         let name = tag.name.clone();
                                         move |_| {

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -199,7 +199,11 @@ fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
             // ── Page header ────────────────────────────────────────
             div { class: "me-page-header",
                 div {
-                    div { class: "label", "Edit metadata" }
+                    div {
+                        class: "label",
+                        "data-testid": "me-page-title-label",
+                        "Edit metadata"
+                    }
                     h2 { class: "me-page-title",
                         span { class: "me-page-title-book", "{display_title}" }
                         if !primary_author.is_empty() {

--- a/scripts/dev-server-up.sh
+++ b/scripts/dev-server-up.sh
@@ -113,10 +113,15 @@ EOF
 
     # Export overrides for the child server. PORT and OMNIBUS_PUBLIC_ORIGIN
     # need to match the chosen port so origin_check accepts cookie POSTs
-    # from the browser. OMNIBUS_DEV_SEED_USER is inherited from the dev
-    # shell (.env via flake.nix shellHook).
+    # from the browser. Allow both `localhost` (humans typing into a
+    # browser) and `127.0.0.1` (Playwright's PLAYWRIGHT_BASE_URL, which
+    # this same script writes a few lines below) — without the IP form,
+    # the dx serve --fullstack proxy rewrites Host: away from the
+    # Origin: localhost the spec sent, and every cookie-authed POST 403s.
+    # OMNIBUS_DEV_SEED_USER is inherited from the dev shell (.env via
+    # flake.nix shellHook).
     export PORT="$port"
-    export OMNIBUS_PUBLIC_ORIGIN="http://localhost:$port"
+    export OMNIBUS_PUBLIC_ORIGIN="http://localhost:$port,http://127.0.0.1:$port"
 
     echo "dev-up: starting dx serve on port $port (log: $RUNTIME_DIR/server.log)" >&2
     # nohup detaches from this script's process group so `just dev-up` can

--- a/ui_tests/playwright/package-lock.json
+++ b/ui_tests/playwright/package-lock.json
@@ -8,7 +8,7 @@
       "name": "omnibus-ui-tests-playwright",
       "version": "0.0.0",
       "devDependencies": {
-        "@playwright/test": "~1.58.0",
+        "@playwright/test": "~1.59.0",
         "@types/node": "^22.10.0",
         "jszip": "^3.10.1",
         "tsx": "^4.21.0",
@@ -458,13 +458,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -612,13 +612,13 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -631,9 +631,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/ui_tests/playwright/package.json
+++ b/ui_tests/playwright/package.json
@@ -8,7 +8,7 @@
     "test:ui": "playwright test --ui"
   },
   "devDependencies": {
-    "@playwright/test": "~1.58.0",
+    "@playwright/test": "~1.59.0",
     "@types/node": "^22.10.0",
     "jszip": "^3.10.1",
     "tsx": "^4.21.0",

--- a/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
@@ -21,8 +21,14 @@ test("renders the metadata edit form with pre-populated fields", async ({ page, 
   await gotoReady(page, `/books/${id}/edit`);
 
   // Page header renders with the book title and "Edit metadata" label.
-  await expect(page.getByText("Edit metadata")).toBeVisible();
-  await expect(page.getByText(TARGET.title)).toBeVisible();
+  // Disambiguated by testid: "Edit metadata" also appears in the breadcrumb tail.
+  await expect(page.getByTestId("me-page-title-label")).toBeVisible();
+  // Title text appears in the breadcrumb link, the page heading, and the
+  // identifier "urn:omnibus-test:alpha" — substring-match it under the h2 so
+  // strict mode resolves to a single element.
+  await expect(
+    page.getByRole("heading", { level: 2 }).getByText(TARGET.title),
+  ).toBeVisible();
 
   // Breadcrumb navigation is present with "Home" link.
   await expect(
@@ -34,8 +40,11 @@ test("renders the metadata edit form with pre-populated fields", async ({ page, 
   await expect(titleInput).toBeVisible();
   await expect(titleInput).toHaveValue(TARGET.title);
 
-  // Author chip is visible.
-  await expect(page.getByText(TARGET.authors[0])).toBeVisible();
+  // Author chip is visible. "Ada Lovelace" appears in the breadcrumb,
+  // page heading, and chip — scope to the chip via its enclosing class.
+  await expect(
+    page.locator(".me-chip-item").getByText(TARGET.authors[0]),
+  ).toBeVisible();
 
   // Save bar is present.
   await expect(page.getByTestId("me-save")).toBeVisible();
@@ -186,7 +195,7 @@ test("book detail page has a working edit metadata link", async ({ page, request
   // Clicking it should navigate to the edit page.
   await editLink.click();
   await expect(page).toHaveURL(new RegExp(`/books/${id}/edit$`));
-  await expect(page.getByText("Edit metadata")).toBeVisible();
+  await expect(page.getByTestId("me-page-title-label")).toBeVisible();
 });
 
 // ---------------------------------------------------------------------------

--- a/ui_tests/playwright/tests/flows/thumbnails.spec.ts
+++ b/ui_tests/playwright/tests/flows/thumbnails.spec.ts
@@ -60,7 +60,9 @@ test("thumb endpoint serves an image", async ({ page, request }) => {
   const bookUuid = match![1];
 
   // On first request the endpoint may return the original cover (image/jpeg);
-  // poll until the background WebP generation has finished (up to 10 s).
+  // poll until the background WebP generation has finished. The CI worker
+  // competes with index/scan jobs on a cold runner, so 10 s was empirically
+  // too tight; allow up to 30 s.
   await expect
     .poll(
       async () => {
@@ -70,8 +72,8 @@ test("thumb endpoint serves an image", async ({ page, request }) => {
       },
       {
         message: "expected /api/thumbs/{uuid}/md to return image/webp",
-        timeout: 10_000,
-        intervals: [200, 500, 1_000],
+        timeout: 30_000,
+        intervals: [200, 500, 1_000, 2_000, 3_000],
       },
     )
     .toContain("image/webp");


### PR DESCRIPTION
## Summary

- Bump `@playwright/test` to `~1.59.0` so the npm-pinned Chromium build matches the `playwright-driver 1.59.1` that nixpkgs-unstable started shipping after the [`b5049c272374`](https://github.com/seamus-sloan/omnibus/commit/b5049c272374) `nixpkgs-unstable` bump on May 23. Since May 25 every CI E2E run has died at `browserType.launch: Executable doesn't exist at .../chromium_headless_shell-1208/chrome-headless-shell-linux64/...` — the build path moved to `1215` on 1.59 and the 1.58 client never finds it. Contract is documented in [`.claude/rules/04-playwright.md:13`](.claude/rules/04-playwright.md#L13).
- Fix the six product/spec failures the last clean CI glimpse (run [26366703626](https://github.com/seamus-sloan/omnibus/actions/runs/26366703626) on 2026-05-24) exposed before the version mismatch hid them. Once Chromium launches, these would surface again, so they ride along:
  - **metadata_edit:19 / :178** — disambiguate the `Edit metadata` text that appears in both the breadcrumb tail and page-header label with `data-testid="me-page-title-label"`; scope the `Alpha` and `Ada Lovelace` strict-mode matches to the heading and chip respectively.
  - **search-palette:142 / :223** — gate the `sp-row selected` class on `has_navigated()` so no row carries the highlight before the user navigates, and make the first `ArrowDown` / `ArrowUp` land on index 0 / len-1 instead of incrementing past the starting position. Matches the test contract and the intent already encoded by `has_navigated`.
  - **thumbnails:37** — bump the WebP-poll budget from 10s to 30s with longer back-off intervals; on a cold CI worker the background thumb pipeline was racing the test.
- Bonus dev-server fix: `scripts/dev-server-up.sh` was exporting `OMNIBUS_PUBLIC_ORIGIN=http://localhost:$port` while writing `PLAYWRIGHT_BASE_URL=http://127.0.0.1:$port` to `.claude/runtime/env.sh`. Under `dx serve --fullstack` (which proxies `Host:`), every cookie-authed POST 403'd against `origin_check`. Allow both forms in the allowlist.

## Test plan

- [x] Re-bundled web app on `nix develop` with new lockfile; `cargo check -p omnibus-frontend --features server` clean.
- [x] Local E2E against bundled binary on `:3002` (`workers=2 retries=2` mimicking CI): 83 passed, 2 flaky-passed-on-retry, 1 hard fail confined to `theme_toggle:23` — that test was passing-on-retry in PR #181's CI run with the same code, so it should clear on CI.
- [ ] **CI Playwright job goes green on this PR** ← the actual bar.
- [ ] Smoke that `gh run watch` is still green on `main` after merge.

## Notes

- No flake.lock / flake.nix change — both are already on `nixpkgs-unstable` rev `29916453…` (playwright-driver 1.59.1). The bump direction matches the rule's recommendation ("update both together when bumping the version").
- Search-palette behavior change is observable to a user: first arrow press now highlights the first item rather than visually doing nothing (no `selected` class) until the second press. Lines up with what the existing `has_navigated` signal was always trying to express.
- The local-only `metadata_edit:208` parallel-state race (one test renames Alpha, another looks up Alpha) is a latent issue unrelated to this CI breakage and is left untouched — flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)