### PR TITLE
feat: cache current user in App context; exempt /me from auth limiter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ migrations/         — numbered SQL migrations embedded via sqlx::migrate!
 ### frontend/src/
 
 ```
-lib.rs              — Route, App, styles, ScreenLayout (feature-gated)
+lib.rs              — Route, App, styles, ScreenLayout (feature-gated); also owns the App-wide `CurrentUser` context (`use_current_user`) — a single `/api/auth/me` fetch on boot fills it, components gate `is_admin` off the cached signal instead of refetching per mount, and a `web_auth_state` subscription refills on login / clears on 401. Web/SSR only — mobile uses bearer tokens.
 data.rs             — Feature-gated data transport (mobile=reqwest, web/server=rpc); transport fns return Result<T, DataError> (thiserror enum: Network/Http/Decode/Unauthorized/Other) so the 401 path pattern-matches DataError::Unauthorized instead of re-inspecting raw status codes
 view_prefs.rs       — F1.3 per-library ViewPrefs/ViewFilters persistence for the landing page (sort/filter/facet state); web → localStorage keyed by library path, mobile → in-memory map (resets on cold launch), server (SSR) → defaults so first-hydration markup matches. Shape lives in omnibus-shared for a future server-backed endpoint
 rpc.rs              — #[get]/#[post] server functions (mounted by dioxus::server::router); server bodies call into omnibus_db
@@ -94,7 +94,7 @@ components/user_menu.rs — avatar trigger + dropdown panel in TopNav; hosts the
 main.rs             — dioxus::launch (WASM) / dioxus::serve (native); mounts auth_router + rate-limit + origin-check
 lib.rs              — re-exports backend + auth + rate_limit under `server` feature for tests
 backend.rs          — /api/* REST router (mobile-facing) + integration tests; `/api/search/*` sub-router carries its own per-IP rate-limit layer
-rate_limit.rs       — reusable in-memory per-IP fixed-window counter + `rate_limit_by_ip` axum middleware (login/register + search endpoints); `rate_limit_paths` is a path-prefix wrapper used for `/api/rpc/search-palette`
+rate_limit.rs       — reusable in-memory per-IP fixed-window counter + `rate_limit_by_ip` axum middleware; `rate_limit_paths` is a path-prefix wrapper used for both `/api/rpc/search-palette` and the auth router (allow-list = login/register/logout, so `/api/auth/me` is deliberately exempt from the 10/60s bucket)
 auth/mod.rs         — /api/auth/{register,login,logout,me} + AuthUser/AdminUser extractors + CSRF origin-check
 auth/gate.rs        — top-level middleware gating /api/* (pass-through for /api/auth/*)
 auth/strategy.rs    — AuthStrategy trait + PasswordStrategy (OIDC/WebAuthn fit the same shape)

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -4,7 +4,8 @@
 //! SSR/hydration: the trigger is always rendered (empty placeholder
 //! initials in the pre-hydration phase) so the topbar markup is stable
 //! and `expectNavVisible` finds it without racing the auth ping. The
-//! post-mount `current_user()` effect then either fills in real initials
+//! App-wide [`crate::CurrentUser`] context — populated once by the boot
+//! effect in [`crate::App`] — then either fills in real initials
 //! (auth'd) or swaps the trigger for a `Log in` link (unauth). The panel
 //! only opens once we have a real user.
 
@@ -13,7 +14,7 @@ use dioxus_router::{use_navigator, Link};
 use omnibus_shared::UserSummary;
 
 use crate::components::atrium::{persist_theme, Theme};
-use crate::Route;
+use crate::{use_current_user, Route};
 
 /// Derive 1–2 character avatar initials from a username. Empty input falls
 /// back to "?".
@@ -28,36 +29,23 @@ pub(crate) fn initials_for(username: &str) -> String {
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
 pub fn UserMenu() -> Element {
-    // `mut` is unused on SSR-only builds; the signal is only `.set()` from
-    // the `web`-gated branches below.
-    #[cfg_attr(not(feature = "web"), allow(unused_mut))]
-    let mut authed = use_signal(|| Option::<Option<UserSummary>>::None);
     let mut open = use_signal(|| false);
 
-    #[cfg(feature = "web")]
-    use_effect(move || {
-        spawn(async move {
-            // Only an explicit `Ok(None)` (status 401) flips to the
-            // unauth state. Transient errors (429 from the per-IP
-            // `/api/auth/*` rate limit, network blips, etc.) leave
-            // `authed` as `None` so the topbar keeps showing the
-            // placeholder trigger — better than briefly swapping to
-            // "Log in" mid-session and letting parallel Playwright
-            // workers race the 10-req/60s budget on /api/auth/me.
-            match crate::data::current_user().await {
-                Ok(slot) => authed.set(Some(slot)),
-                Err(_) => {}
-            }
-        });
-    });
-
-    let snapshot = authed();
+    // Read the App-wide cached `/api/auth/me` result instead of firing our
+    // own fetch on every mount. The boot effect in `App` fills this in
+    // once; we just re-render reactively when it changes.
+    //
+    // Outer `None` = not yet resolved (pre-hydration on SSR, or a
+    // transient error left the cache empty). Inner `None` = explicit 401.
+    // Inner `Some(u)` = authenticated.
+    let snapshot = use_current_user().0();
     // SSR / pre-hydration: render the trigger (empty placeholder initials)
     // so the topbar markup is stable. WASM hydrates the same DOM, then the
-    // `current_user()` effect resolves: if Some(user), initials fill in
-    // and the dropdown becomes interactive; if None, swap to a Log-in
-    // link. The panel only renders when we have a real user — clicking
-    // the placeholder trigger before auth resolves is a no-op visually.
+    // App-level boot effect resolves the cached user: if Some(user),
+    // initials fill in and the dropdown becomes interactive; if None,
+    // swap to a Log-in link. The panel only renders when we have a real
+    // user — clicking the placeholder trigger before auth resolves is a
+    // no-op visually.
     let user = match &snapshot {
         Some(Some(u)) => Some(u.clone()),
         _ => None,

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -288,6 +288,33 @@ pub fn use_search_query() -> SearchQuery {
     use_context::<SearchQuery>()
 }
 
+/// App-wide cached `/api/auth/me` result. Owned by [`App`] via
+/// `use_context_provider` so every component that needs to gate on
+/// `is_admin` (top nav avatar, landing inline edits, author Delete) reads
+/// from one signal instead of each firing its own `current_user()` round
+/// trip on mount. Without this every navigation would re-fetch `/me`
+/// from N components and race the `/api/auth/*` rate-limit budget.
+///
+/// The outer `Option` is "not yet resolved since boot" (pre-hydration on
+/// SSR, or the very first tick before the boot effect lands). The inner
+/// `Option` is "resolved": `None` means an explicit 401 (unauthenticated),
+/// `Some(u)` means authenticated. Transient errors (network blip, 429)
+/// leave the outer `None` in place so the UI keeps showing the
+/// placeholder rather than briefly swapping to "Log in".
+///
+/// Web-only: mobile uses bearer tokens via `token_store` and never hits
+/// `/api/auth/me`. The context isn't provided on mobile and
+/// [`use_current_user`] is not callable there.
+#[cfg(not(feature = "mobile"))]
+#[derive(Copy, Clone)]
+pub struct CurrentUser(pub Signal<Option<Option<omnibus_shared::UserSummary>>>);
+
+/// Convenience accessor for the cached-user context. Web/SSR only.
+#[cfg(not(feature = "mobile"))]
+pub fn use_current_user() -> CurrentUser {
+    use_context::<CurrentUser>()
+}
+
 /// Atrium design-system stylesheet (F1.7). Served as a hashed static asset
 /// via Dioxus's Manganis pipeline so the browser caches it independently of
 /// the WASM bundle.
@@ -299,6 +326,62 @@ pub fn App() -> Element {
     use_context_provider(|| SearchQuery(Signal::new(String::new())));
     #[cfg(not(feature = "mobile"))]
     use_context_provider(|| components::search_palette::PaletteOpen(Signal::new(false)));
+
+    // Cached `/api/auth/me`. Provided unconditionally on non-mobile builds
+    // so SSR can render the placeholder topbar without resolving anything;
+    // the WASM hydration phase then runs the boot effect below to fill it
+    // in once for the lifetime of the App instance.
+    #[cfg(not(feature = "mobile"))]
+    {
+        use_context_provider(|| CurrentUser(Signal::new(None)));
+    }
+
+    // Single boot-time `/me` fetch (replaces the per-component effects in
+    // user_menu / landing / author). Also subscribes to `web_auth_state`
+    // so a fresh login refills the cache and a 401 clears it without
+    // requiring a hard reload.
+    #[cfg(feature = "web")]
+    {
+        let mut slot = use_context::<CurrentUser>().0;
+        use_future(move || async move {
+            // Initial fetch on mount. Only an explicit `Ok(_)` updates
+            // state — transient errors (network blip, rate-limit 429)
+            // leave the signal at `None` so callers keep showing the
+            // pre-resolve placeholder.
+            if let Ok(resolved) = data::current_user().await {
+                slot.set(Some(resolved));
+            }
+
+            // React to subsequent auth-state transitions. `current_user`
+            // itself pings `web_auth_state` on every call (true on 200,
+            // false on 401), so the very first transition we observe
+            // here is usually `true -> true` from the initial fetch
+            // above — skip same-value updates to avoid a redundant
+            // refetch loop.
+            let mut rx = data::web_auth_state::subscribe();
+            let mut last = *rx.borrow_and_update();
+            while rx.changed().await.is_ok() {
+                let now = *rx.borrow_and_update();
+                if now == last {
+                    continue;
+                }
+                last = now;
+                if now {
+                    // Fresh login (channel flipped false -> true): refetch
+                    // so the avatar / admin gates update without a reload.
+                    if let Ok(resolved) = data::current_user().await {
+                        slot.set(Some(resolved));
+                    }
+                } else {
+                    // 401 observed elsewhere: flip to unauthenticated
+                    // immediately. ScreenLayout already drives the
+                    // /login redirect off the same channel.
+                    slot.set(Some(None));
+                }
+            }
+        });
+    }
+
     components::atrium::init_theme();
     rsx! {
         document::Title { "Omnibus" }

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -50,22 +50,24 @@ pub fn LandingPage() -> Element {
     let query = use_search_query().0;
 
     // F5.9-lite: admin-only inline-edit affordances on the power-user
-    // table. Non-admins see the existing read-only cells; the
-    // `current_user` effect resolves async and gates the click handlers
-    // server-side anyway via `rpc_save_overrides`, but hiding the
-    // affordance is the UX contract. Web-only (mobile keeps the
-    // read-only landing for now per the F5.9-lite plan; admin can edit
-    // via the per-book detail page).
+    // table. Non-admins see the existing read-only cells; hiding the
+    // affordance is the UX contract — `rpc_save_overrides` enforces the
+    // real boundary server-side. Web-only (mobile keeps the read-only
+    // landing for now per the F5.9-lite plan; admin can edit via the
+    // per-book detail page).
+    //
+    // Reads from the App-wide `CurrentUser` context — no per-mount
+    // `/api/auth/me` round-trip. Reactive: re-runs on boot resolve,
+    // fresh login, or observed 401.
     #[cfg_attr(not(feature = "web"), allow(unused_mut))]
     let mut is_admin = use_signal(|| false);
     #[cfg(feature = "web")]
-    use_effect(move || {
-        spawn(async move {
-            if let Ok(Some(user)) = data::current_user().await {
-                is_admin.set(user.is_admin);
-            }
+    {
+        let user_ctx = crate::use_current_user().0;
+        use_effect(move || {
+            is_admin.set(matches!(user_ctx(), Some(Some(ref u)) if u.is_admin));
         });
-    });
+    }
 
     // Suggestion pools for the inline Authors chip editor and the
     // (currently future-reserved) Tags pool. Each item carries the

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -93,6 +93,20 @@ fn main() {
             }
 
             let auth_limiter = Arc::new(rate_limit::RateLimiter::new());
+            // Prefix-scope the auth limiter to credential-handling endpoints
+            // only. `/api/auth/me` is an authenticated read of the caller's
+            // own row — it's hit on every web App boot (and historically
+            // on every page mount) but presents no brute-force surface, so
+            // sharing the same 10-req/60s bucket as `/login`/`/register`
+            // just throttled legitimate UI rendering (and parallel
+            // Playwright workers from the same loopback IP). Logout stays
+            // limited because a stolen token could otherwise be used to
+            // DoS revoke endpoints.
+            let auth_limiter_prefixes: Arc<Vec<&'static str>> = Arc::new(vec![
+                "/api/auth/login",
+                "/api/auth/register",
+                "/api/auth/logout",
+            ]);
             // Search RPC limiter. Mirrors the REST-side limiter's policy
             // (`backend::search_router`, 30 req / 10s) but is a SEPARATE
             // instance with its own bucket map — the two routers are built
@@ -118,8 +132,8 @@ fn main() {
                 .merge(backend::rest_router(state.clone()))
                 .merge(auth::auth_router(state.clone()).layer(
                     axum::middleware::from_fn_with_state(
-                        auth_limiter,
-                        rate_limit::rate_limit_by_ip,
+                        (auth_limiter, auth_limiter_prefixes),
+                        rate_limit::rate_limit_paths,
                     ),
                 ))
                 // Apply require_auth and origin_check at the top level so

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -19,6 +19,13 @@
 //! Default policy (`RateLimiter::new`) is tuned for the auth endpoints:
 //! 10 requests / 60s / IP. Search uses a separate limiter built via
 //! [`RateLimiter::with_policy`] with a tighter budget (30 / 10s).
+//!
+//! The auth limiter is mounted via [`rate_limit_paths`] with a prefix
+//! allow-list of `/api/auth/{login,register,logout}` — `/api/auth/me` is
+//! deliberately exempt. `/me` is an authenticated read of the caller's
+//! own row and presents no brute-force surface, so sharing the 10/60s
+//! bucket with credential endpoints just throttled legitimate UI boots
+//! (and parallel Playwright workers from the loopback IP).
 
 use axum::{
     extract::{ConnectInfo, Request, State},
@@ -264,6 +271,89 @@ mod tests {
                 "non-matching /api/rpc/* path must bypass the limiter"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn auth_limiter_throttles_login_but_not_me() {
+        // Mirrors the `main.rs` auth-router wiring: a default RateLimiter
+        // mounted on the auth router via `rate_limit_paths` with a prefix
+        // allow-list that *excludes* `/api/auth/me`. Verifies that bursting
+        // /me past the 10/60s default budget never trips the limiter, while
+        // /login on the same IP still does. Guards against future regression
+        // where someone re-mounts the auth router with `rate_limit_by_ip`
+        // (which would re-include /me in the bucket).
+        use axum::middleware::from_fn_with_state;
+        use axum::{body::Body, routing::get, routing::post, Router};
+        use tower::ServiceExt;
+
+        let limiter = Arc::new(RateLimiter::new()); // default 10/60s
+        let prefixes: Arc<Vec<&'static str>> = Arc::new(vec![
+            "/api/auth/login",
+            "/api/auth/register",
+            "/api/auth/logout",
+        ]);
+        let app = Router::new()
+            .route("/api/auth/me", get(|| async { "ok" }))
+            .route("/api/auth/login", post(|| async { "ok" }))
+            .layer(from_fn_with_state((limiter, prefixes), rate_limit_paths));
+
+        // Burst /me far past the 10/60s budget — every request must pass.
+        for i in 0..(MAX_REQUESTS as usize * 3) {
+            let res = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/auth/me")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                res.status(),
+                StatusCode::OK,
+                "/api/auth/me must bypass the auth limiter (request #{i})"
+            );
+        }
+
+        // /login on the same shared bucket (oneshot has no ConnectInfo so
+        // everything resolves to the 0.0.0.0 fallback) must still throttle
+        // after MAX_REQUESTS hits. The /me burst above did NOT consume from
+        // the bucket, so the first MAX_REQUESTS logins all succeed.
+        for i in 0..MAX_REQUESTS {
+            let res = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/auth/login")
+                        .method("POST")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                res.status(),
+                StatusCode::OK,
+                "/api/auth/login within budget (request #{i})"
+            );
+        }
+        let over = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/login")
+                    .method("POST")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            over.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "/api/auth/login must still be limited"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Hoist `/api/auth/me` into an App-wide `CurrentUser` context — one boot fetch in `frontend/src/lib.rs::App` plus a `web_auth_state` subscription that refills on login and clears on 401. `user_menu` and the landing admin gate now read the cached signal instead of firing their own per-mount round-trips.
- Narrow the auth limiter to credential endpoints. `main.rs` swaps `rate_limit_by_ip` for `rate_limit_paths` with an allow-list of `/api/auth/{login,register,logout}`, so `/me` no longer competes with login attempts for the 10/60s bucket.
- Mobile path unchanged: bearer-token flow doesn't go through `/me` or the cached context.

## Test plan
- [x] `cargo test -p omnibus` — 130 passed (incl. new `auth_limiter_throttles_login_but_not_me` in `server/src/rate_limit.rs`).
- [x] `cargo test -p omnibus-frontend --features server` — 73 passed.
- [x] `cargo test -p omnibus-db` — 1 passed.
- [x] `cargo clippy --features omnibus-frontend/server -- -D warnings` — clean.
- [x] `cargo fmt --all` — no diff.
- [ ] Manual: load the web app, navigate Landing → Author → back; confirm Network tab shows a single `/api/auth/me` call per session and no 429s under parallel Playwright runs.