### PR TITLE
fix(db): cap search_books query length to match search_palette (#189)

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -7,7 +7,7 @@ use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::{Contributor, EbookLibrary, EbookMetadata, Identifier};
 
-use crate::helpers::{build_fts_match, format_series_index, MAX_QUERY_LEN};
+use crate::helpers::{build_fts_match, cap_query_len, format_series_index};
 use crate::metadata_overrides::{apply_overrides, get_metadata_overrides, load_overrides_bulk};
 
 /// Hard server-side cap on the number of books any single list/search
@@ -743,9 +743,9 @@ pub async fn search_books(
     q: &str,
 ) -> Result<Vec<EbookMetadata>, sqlx::Error> {
     // Cap query length before parsing to bound the FTS5 MATCH expression size,
-    // matching `search_palette` (issue #189). Collect chars (not bytes) to
-    // avoid slicing mid-codepoint. Normal/short queries are unaffected.
-    let capped: String = q.trim().chars().take(MAX_QUERY_LEN).collect();
+    // matching `search_palette` (issue #189). Normal/short queries are
+    // unaffected; see `cap_query_len`.
+    let capped = cap_query_len(q);
     let Some(match_expr) = build_fts_match(&capped) else {
         return Ok(Vec::new());
     };
@@ -921,9 +921,9 @@ pub async fn count_search_books(
     q: &str,
 ) -> Result<i64, sqlx::Error> {
     // Cap query length before parsing to mirror `search_books` /
-    // `search_palette` (issue #189). Collect chars to avoid mid-codepoint
-    // slicing; normal/short queries are unaffected.
-    let capped: String = q.trim().chars().take(MAX_QUERY_LEN).collect();
+    // `search_palette` (issue #189). Normal/short queries are unaffected;
+    // see `cap_query_len`.
+    let capped = cap_query_len(q);
     let Some(match_expr) = build_fts_match(&capped) else {
         return Ok(0);
     };
@@ -997,6 +997,7 @@ mod tests {
         author_id_by_name, seed_discovery_fixture, series_id_by_name,
     };
     use crate::ebook::IndexedBook;
+    use crate::helpers::MAX_QUERY_LEN;
     use crate::metadata_overrides::upsert_metadata_overrides;
     use crate::pool::init_db;
     use crate::sync::replace_books;

--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -7,7 +7,7 @@ use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::{Contributor, EbookLibrary, EbookMetadata, Identifier};
 
-use crate::helpers::{build_fts_match, format_series_index};
+use crate::helpers::{build_fts_match, format_series_index, MAX_QUERY_LEN};
 use crate::metadata_overrides::{apply_overrides, get_metadata_overrides, load_overrides_bulk};
 
 /// Hard server-side cap on the number of books any single list/search
@@ -742,7 +742,11 @@ pub async fn search_books(
     library_path: &str,
     q: &str,
 ) -> Result<Vec<EbookMetadata>, sqlx::Error> {
-    let Some(match_expr) = build_fts_match(q) else {
+    // Cap query length before parsing to bound the FTS5 MATCH expression size,
+    // matching `search_palette` (issue #189). Collect chars (not bytes) to
+    // avoid slicing mid-codepoint. Normal/short queries are unaffected.
+    let capped: String = q.trim().chars().take(MAX_QUERY_LEN).collect();
+    let Some(match_expr) = build_fts_match(&capped) else {
         return Ok(Vec::new());
     };
 
@@ -916,7 +920,11 @@ pub async fn count_search_books(
     library_path: &str,
     q: &str,
 ) -> Result<i64, sqlx::Error> {
-    let Some(match_expr) = build_fts_match(q) else {
+    // Cap query length before parsing to mirror `search_books` /
+    // `search_palette` (issue #189). Collect chars to avoid mid-codepoint
+    // slicing; normal/short queries are unaffected.
+    let capped: String = q.trim().chars().take(MAX_QUERY_LEN).collect();
+    let Some(match_expr) = build_fts_match(&capped) else {
         return Ok(0);
     };
     sqlx::query_scalar::<_, i64>(
@@ -1150,6 +1158,40 @@ mod tests {
         let hits = search_books(&pool, "/lib-a", "tolkien").await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].title.as_deref(), Some("A"));
+    }
+    #[tokio::test]
+    async fn search_books_truncates_oversized_query() {
+        // Issue #189: a query longer than MAX_QUERY_LEN chars must be capped
+        // before reaching build_fts_match, not panic or pass an unbounded
+        // expression to FTS5. The exact rows don't matter — this documents
+        // the contract that oversized input is bounded and returns Ok.
+        let _covers = CoversTempDir::new("fts_oversized");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        replace_books(
+            &pool,
+            "/lib",
+            vec![indexed(
+                "a.epub",
+                Some("Harry Potter"),
+                &["J.K. Rowling"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        // A single token far longer than the cap (no whitespace) is the
+        // worst case the issue describes.
+        let oversized = "a".repeat(MAX_QUERY_LEN * 10);
+        assert!(oversized.chars().count() > MAX_QUERY_LEN);
+
+        let hits = search_books(&pool, "/lib", &oversized).await;
+        assert!(hits.is_ok(), "oversized query should not error");
+
+        let total = count_search_books(&pool, "/lib", &oversized).await;
+        assert!(total.is_ok(), "oversized count query should not error");
     }
     #[tokio::test]
     async fn search_books_empty_query_returns_empty_vec() {

--- a/db/src/helpers.rs
+++ b/db/src/helpers.rs
@@ -12,6 +12,15 @@ use std::path::Path;
 /// one place across every search path.
 pub(crate) const MAX_QUERY_LEN: usize = 256;
 
+/// Trim surrounding whitespace and cap a user query to [`MAX_QUERY_LEN`]
+/// chars before it reaches [`build_fts_match`] / `LIKE`. Collecting chars
+/// (not bytes) guarantees the truncation never lands mid-codepoint. Shared
+/// by every search entrypoint (`search_books`, `count_search_books`,
+/// `search_palette`) so the cap is applied identically everywhere (#189).
+pub(crate) fn cap_query_len(q: &str) -> String {
+    q.trim().chars().take(MAX_QUERY_LEN).collect()
+}
+
 /// Deterministic UUIDv5 derived from `(library_path, filename)` so reindexing
 /// the same file produces the same uuid. Keeps `/api/covers/{uuid}` URLs
 /// stable across reindex cycles even as the primary `books.id` renumbers.
@@ -267,6 +276,34 @@ mod tests {
             );
         }
         assert_eq!(sanitize_accent_color(None), None);
+    }
+
+    // ---------- query-length cap (#189) ----------
+
+    #[test]
+    fn cap_query_len_passes_short_input_through_trimmed() {
+        // Under the cap: only surrounding whitespace is stripped.
+        assert_eq!(cap_query_len("  harry potter  "), "harry potter");
+    }
+
+    #[test]
+    fn cap_query_len_truncates_oversized_input_to_the_cap() {
+        let oversized = "a".repeat(MAX_QUERY_LEN * 10);
+        let capped = cap_query_len(&oversized);
+        // Observable effect: the tail is dropped, leaving exactly the cap.
+        assert_eq!(capped.chars().count(), MAX_QUERY_LEN);
+        assert!(capped.chars().all(|c| c == 'a'));
+        assert!(capped.len() < oversized.len());
+    }
+
+    #[test]
+    fn cap_query_len_truncates_on_a_char_boundary() {
+        // A multibyte char repeated past the cap must slice cleanly — never
+        // panic and never split a codepoint.
+        let multibyte = "é".repeat(MAX_QUERY_LEN * 2);
+        let capped = cap_query_len(&multibyte);
+        assert_eq!(capped.chars().count(), MAX_QUERY_LEN);
+        assert!(capped.chars().all(|c| c == 'é'));
     }
 
     // ---------- FTS5 (F0.4) ----------

--- a/db/src/helpers.rs
+++ b/db/src/helpers.rs
@@ -4,6 +4,14 @@
 
 use std::path::Path;
 
+/// Maximum query length (in chars) accepted by the FTS5 search entrypoints
+/// (`search_books`, `count_search_books`, `search_palette`). Inputs beyond
+/// this are truncated before reaching [`build_fts_match`] / `LIKE` so the
+/// generated MATCH expression and pattern length stay bounded regardless of
+/// caller payload size (issue #189). Module-wide so the limit is tunable in
+/// one place across every search path.
+pub(crate) const MAX_QUERY_LEN: usize = 256;
+
 /// Deterministic UUIDv5 derived from `(library_path, filename)` so reindexing
 /// the same file produces the same uuid. Keeps `/api/covers/{uuid}` URLs
 /// stable across reindex cycles even as the primary `books.id` renumbers.

--- a/db/src/palette.rs
+++ b/db/src/palette.rs
@@ -12,13 +12,8 @@ use omnibus_shared::{
 };
 
 use crate::books::parse_json_array;
-use crate::helpers::build_fts_match;
+use crate::helpers::{build_fts_match, MAX_QUERY_LEN};
 use crate::metadata_overrides::load_overrides_bulk;
-
-/// Maximum query length (in chars) accepted by `search_palette`. Inputs
-/// beyond this are truncated to bound FTS5 expression size and LIKE
-/// pattern length.
-const MAX_QUERY_LEN: usize = 256;
 
 /// Search palette — grouped results for the command-palette overlay (F1.5).
 ///

--- a/db/src/palette.rs
+++ b/db/src/palette.rs
@@ -12,7 +12,7 @@ use omnibus_shared::{
 };
 
 use crate::books::parse_json_array;
-use crate::helpers::{build_fts_match, MAX_QUERY_LEN};
+use crate::helpers::{build_fts_match, cap_query_len};
 use crate::metadata_overrides::load_overrides_bulk;
 
 /// Search palette — grouped results for the command-palette overlay (F1.5).
@@ -32,9 +32,8 @@ pub async fn search_palette(
     if trimmed.is_empty() {
         return Ok(PaletteResults::default());
     }
-    // Truncate to cap FTS5 + LIKE expression size. Collect chars to
-    // avoid slicing mid-codepoint.
-    let trimmed: String = trimmed.chars().take(MAX_QUERY_LEN).collect();
+    // Truncate to cap FTS5 + LIKE expression size; see `cap_query_len`.
+    let trimmed: String = cap_query_len(trimmed);
     let trimmed = trimmed.as_str();
 
     let start = std::time::Instant::now();


### PR DESCRIPTION
## Summary
- Hoist MAX_QUERY_LEN to helpers.rs as module-wide policy
- Apply 256-char cap in search_books + count_search_books
- Add oversized-query contract test

## Test plan
- [x] cargo test -p omnibus-db (incl. new test)
- [x] clippy + fmt clean

## Notes
- Closes #189
- Nix is not installed on this build host, so the verification used the system cargo toolchain (1.94.1) with the per-worktree `CARGO_TARGET_DIR` and `DATABASE_URL` the shellHook would otherwise set. The crate uses runtime `sqlx::query(...)` (no compile-time macros), so the dev-shell absence did not affect the build. fmt-check clean, clippy `-D warnings` clean, 304 lib + 2 integration tests pass including `search_books_truncates_oversized_query`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuS7JA6zK271UvRbimvSrS)_