### PR TITLE
fix(frontend): add key props to search palette + format badge loops (#190)

### DIFF
--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -333,6 +333,7 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             SpGroupHead { label: "Books", count: r.books.len() }
                             for book in r.books.iter() {
                                 SpBookRow {
+                                    key: "{book.id}",
                                     book: book.clone(),
                                     selected: has_nav && is_selected(&items, sel, &FlatItem::Book { uuid: book.uuid.clone(), title: book.title.clone() }),
                                     on_click: {
@@ -351,6 +352,7 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             SpGroupHead { label: "Authors", count: r.authors.len() }
                             for author in r.authors.iter() {
                                 SpAuthorRow {
+                                    key: "{author.id}",
                                     author: author.clone(),
                                     selected: has_nav && is_selected(&items, sel, &FlatItem::Author { id: author.id, name: author.name.clone() }),
                                     on_click: {
@@ -369,6 +371,7 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             SpGroupHead { label: "Series", count: r.series.len() }
                             for s in r.series.iter() {
                                 SpSeriesRow {
+                                    key: "{s.id}",
                                     series: s.clone(),
                                     selected: has_nav && is_selected(&items, sel, &FlatItem::Series { id: s.id, name: s.name.clone() }),
                                     on_click: {
@@ -387,6 +390,7 @@ fn SpOverlay(open: PaletteOpen) -> Element {
                             SpGroupHead { label: "Tags", count: r.tags.len() }
                             for tag in r.tags.iter() {
                                 SpTagRow {
+                                    key: "{tag.id}",
                                     tag: tag.clone(),
                                     selected: has_nav && is_selected(&items, sel, &FlatItem::Tag { id: tag.id, name: tag.name.clone() }),
                                     on_click: {

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -171,7 +171,7 @@ fn render_loaded(b: EbookMetadata) -> Element {
                         if !b.formats.is_empty() {
                             div { class: "bd-format-badges",
                                 for f in b.formats.iter() {
-                                    BdFormatBadge { fmt: f.clone() }
+                                    BdFormatBadge { key: "{f}", fmt: f.clone() }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Add key: props to SpBookRow/SpAuthorRow/SpSeriesRow/SpTagRow loops in search_palette
- Add key: to BdFormatBadge loop in book_detail

## Test plan
- [ ] cargo test -p omnibus-frontend --features server
- [ ] clippy + fmt clean

## Notes
- Closes #190
- Reconciler hints only; no logic or prop-signature changes. No Playwright markup contract changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuS7JA6zK271UvRbimvSrS)_