### PR TITLE
fix: return 415 instead of panicking on undetectable image upload (#210)

### DIFF
--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -802,17 +802,21 @@ async fn post_ebook_cover(
                                 .into_response();
                         }
                         // Validate magic bytes — don't trust Content-Type alone.
-                        let detected = detect_image_format(&b);
-                        if detected.is_none() {
-                            return (
-                                axum::http::StatusCode::BAD_REQUEST,
-                                "file does not appear to be a valid image",
-                            )
-                                .into_response();
+                        // Bind the detected MIME directly: a `None` here means the
+                        // bytes carry no recognisable image header, so surface a
+                        // 415 rather than `.unwrap()`-panicking the task (#210).
+                        match detect_image_format(&b) {
+                            // Use the detected MIME so the stored extension matches
+                            // actual content, not the (untrusted) client header.
+                            Some(mime) => break (mime, b),
+                            None => {
+                                return (
+                                    axum::http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                                    "Could not detect image format",
+                                )
+                                    .into_response();
+                            }
                         }
-                        // Use the detected MIME so the stored extension matches
-                        // actual content, not the (untrusted) client header.
-                        break (detected.unwrap(), b);
                     }
                     Err(e) => return internal("read cover field", e),
                 }
@@ -967,15 +971,19 @@ async fn put_author_photo(
                             )
                                 .into_response();
                         }
-                        let detected = detect_image_format(&b);
-                        if detected.is_none() {
-                            return (
-                                axum::http::StatusCode::BAD_REQUEST,
-                                "file does not appear to be a valid image",
-                            )
-                                .into_response();
+                        // Bind the detected MIME directly: a `None` here means the
+                        // bytes carry no recognisable image header, so surface a
+                        // 415 rather than `.unwrap()`-panicking the task (#210).
+                        match detect_image_format(&b) {
+                            Some(mime) => break (mime, b),
+                            None => {
+                                return (
+                                    axum::http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                                    "Could not detect image format",
+                                )
+                                    .into_response();
+                            }
                         }
-                        break (detected.unwrap(), b);
                     }
                     Err(e) => return internal("read photo field", e),
                 }
@@ -3242,6 +3250,54 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn api_post_cover_rejects_undetectable_format() {
+        // Content-Type passes the `image/` prefix gate but the bytes carry no
+        // recognisable image magic header, so `detect_image_format` returns
+        // `None`. The handler must surface a 415 (#210) instead of
+        // `.unwrap()`-panicking the task into a bare 500.
+        let _covers = CoversDirGuard::new("undetectable_format");
+        let (app, _state, pool) = fixture().await;
+        let (_id, uuid) = seed_book_with_uuid(&pool, "/lib", "UndetectableBook").await;
+        let admin = test_support::create_admin(&pool, "admin").await;
+        let token = test_support::bearer_token(&pool, admin.id).await;
+
+        // image/png header, but the body is not a real image.
+        let (content_type, body) =
+            build_cover_multipart("image/png", b"definitely not image bytes");
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/ebooks/{uuid}/cover"))
+                    .method("POST")
+                    .header("content-type", content_type)
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+        let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap_or("");
+        assert!(
+            body.contains("Could not detect image format"),
+            "415 body should explain the format detection failure, got {body:?}"
+        );
+
+        // No override row should have been written for the rejected upload.
+        let books = db::list_books(&pool, "/lib").await.unwrap();
+        let uuid = books[0].unique_identifier.clone().unwrap();
+        assert!(
+            db::get_metadata_overrides(&pool, &uuid)
+                .await
+                .unwrap()
+                .is_none(),
+            "rejected undetectable-format upload must not create an override row"
+        );
+    }
+
     // ---------------------------------------------------------------------
     // F1.11 Author profile photos.
     // ---------------------------------------------------------------------
@@ -3416,7 +3472,8 @@ mod tests {
     async fn api_put_author_photo_rejects_bogus_image_bytes() {
         // Content-Type says image/png but the bytes don't carry the PNG magic
         // header — the magic-byte check must catch this even when the
-        // declared MIME passes the `image/` prefix guard.
+        // declared MIME passes the `image/` prefix guard. The handler surfaces
+        // a 415 (#210) since the payload is not a recognisable image format.
         let (app, _state, pool) = fixture().await;
         let id = seed_author(&pool, "Ada Lovelace").await;
         let admin = test_support::create_admin(&pool, "admin").await;
@@ -3435,7 +3492,14 @@ mod tests {
             )
             .await
             .expect("request should succeed");
-        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(res.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+        let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap_or("");
+        assert!(
+            body.contains("Could not detect image format"),
+            "415 body should explain the format detection failure, got {body:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Removes the `detected.unwrap()` call sites in the two live multipart upload handlers (`post_ebook_cover` and `put_author_photo` in `server/src/backend.rs`), the subject of #210.
- Both now bind the detected MIME via a non-panicking `match detect_image_format(&b)`: `Some(mime) => break (mime, b)`, `None => return 415 UNSUPPORTED_MEDIA_TYPE` with the message `Could not detect image format` (the issue's preferred remedy).
- A client uploading bytes that pass the `image/` content-type gate but carry no recognisable image magic header now gets a meaningful 415 instead of a bare 500 (and, per rule 02, no `.unwrap()` remains in these handler paths).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` (project-canonical, default members) — clean
- [x] `cargo test -p omnibus` — 131 passed, 0 failed
- [x] New `api_post_cover_rejects_undetectable_format` asserts 415 + message + that no override row is written for the rejected upload
- [x] Updated `api_put_author_photo_rejects_bogus_image_bytes` to assert 415 + message (was 400)

## Notes
>[!NOTE]
> On the current `main` the panic was already unreachable — both sites had an `if detected.is_none() { return 400 }` guard immediately before the `break (detected.unwrap(), b)`. This PR still removes the `.unwrap()` (rule 02 forbids `unwrap()` in production paths) and, per the issue, upgrades the response from an opaque 400 to a meaningful **415 Unsupported Media Type**.

>[!IMPORTANT]
> **Behaviour change:** the undetectable-format response moves from `400 Bad Request` to `415 Unsupported Media Type` with body `Could not detect image format`. Any client/UI keying off the 400 status or the old `file does not appear to be a valid image` text on this specific path needs to be aware. (The content-type-prefix and 10 MB-cap rejections remain 400.)

>[!NOTE]
> **Out of scope (left untouched):** the URL-fetch photo handler `put_author_photo_url` already used a non-panicking `match` and returns 400 (`file at URL does not appear to be a valid image`); it was never one of the two `.unwrap()` sites in #210, so it is unchanged.

>[!CAUTION]
> **Needs Seamus / environment note:** Nix is not installed in this agent environment (`nix: command not found`), so checks were run with the on-PATH `cargo 1.94.1` directly (the crate uses only runtime string `sqlx::query(...)`, no compile-time macros, so `DATABASE_URL` is not needed to build/test). Separately, `cargo clippy --all-features` fails to compile `omnibus-frontend` (e.g. `CurrentUser not found in this scope`, deprecated `BlobPropertyBag::type_`) because `--all-features` enables the `mobile` feature, which is mutually exclusive with `web` — this is pre-existing and unrelated to this change (CLAUDE.md documents that mobile is excluded from default-members for exactly this reason). The project-canonical `cargo clippy --all-targets` is clean.

Closes #210

---
_Generated by [Claude Code](https://claude.ai/code/session_018DbvP7kDWHSS8Gew1deZCK)_