### PR TITLE
refactor: dedup detect_image_format into shared crate (#211)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ Default `cargo build` / `clippy` covers `server`, `shared`, `frontend` only. Mob
 ### shared/src/
 
 ```
-lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection, EbookMetadata, EbookLibrary, AuthorDetail, SeriesDetail, TagWeight, ViewPrefs, ViewFilters, MetadataOverrides, Contributor, Identifier, PaletteResults + palette hit types (F1.5)
+lib.rs              — Settings, ValueResponse, LibraryContents, LibrarySection, EbookMetadata, EbookLibrary, AuthorDetail, SeriesDetail, TagWeight, ViewPrefs, ViewFilters, MetadataOverrides, Contributor, Identifier, PaletteResults + palette hit types (F1.5); re-exports image_format::detect_image_format
+image_format.rs     — magic-byte image-format sniff (detect_image_format); pure &[u8] inspection, single source of truth for both server::backend and frontend::rpc upload paths
 ```
 
 ### db/src/

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -24,6 +24,11 @@ use omnibus_shared::{
 #[cfg(feature = "server")]
 use omnibus_db::{self as db, scanner};
 
+// Magic-byte image-format sniff lives in `omnibus-shared` (single source of
+// truth shared with `server::backend`). Only the server-side bodies call it.
+#[cfg(feature = "server")]
+use omnibus_shared::detect_image_format;
+
 /// Server-only extractor alias used by each server function. Only referenced
 /// by the server-side body; the `#[cfg(feature = "server")]` stops the
 /// web build from importing axum/sqlx types.
@@ -351,28 +356,6 @@ pub async fn rpc_set_author_photo_url(id: i64, url: String) -> Result<()> {
     .await
     .map_err(|e| ServerFnError::new(format!("upsert_author_photo: {e}")))?;
     Ok(())
-}
-
-/// Magic-byte image format sniff. Duplicates `server::backend::detect_image_format`
-/// because the `frontend` crate can't depend on `server` (cycle) and the
-/// function is four lines of pattern matching. Keep the two implementations
-/// in sync — both must recognise the same formats.
-#[cfg(feature = "server")]
-fn detect_image_format(bytes: &[u8]) -> Option<String> {
-    if bytes.len() < 4 {
-        return None;
-    }
-    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
-        Some("image/jpeg".into())
-    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
-        Some("image/png".into())
-    } else if bytes.starts_with(b"GIF8") {
-        Some("image/gif".into())
-    } else if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
-        Some("image/webp".into())
-    } else {
-        None
-    }
 }
 
 /// Return all tags with book counts for the tag cloud.

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -18,7 +18,7 @@ use omnibus_db::{
     self as db, scanner,
     worker::{Task, TaskOutcome, Worker, WorkerConfig},
 };
-use omnibus_shared::{MetadataOverrides, Settings, ValueResponse};
+use omnibus_shared::{detect_image_format, MetadataOverrides, Settings, ValueResponse};
 use serde::Deserialize;
 use sqlx::SqlitePool;
 
@@ -716,26 +716,6 @@ async fn delete_ebook_overrides(
         Ok(Some(book)) => Json(book).into_response(),
         Ok(None) => (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
         Err(e) => internal("get_book", e),
-    }
-}
-
-/// Detect image format from magic bytes. Returns the canonical MIME type for
-/// accepted raster formats (JPEG, PNG, GIF, WebP). Returns `None` for
-/// unrecognised or dangerous formats (SVG, arbitrary binaries).
-fn detect_image_format(bytes: &[u8]) -> Option<String> {
-    if bytes.len() < 4 {
-        return None;
-    }
-    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
-        Some("image/jpeg".into())
-    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
-        Some("image/png".into())
-    } else if bytes.starts_with(b"GIF8") {
-        Some("image/gif".into())
-    } else if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
-        Some("image/webp".into())
-    } else {
-        None
     }
 }
 

--- a/shared/src/image_format.rs
+++ b/shared/src/image_format.rs
@@ -1,0 +1,77 @@
+//! Magic-byte image format detection shared by the REST upload handler
+//! (`server::backend`) and the server-function bodies (`frontend::rpc`).
+//!
+//! Lives here in `omnibus-shared` — which both `server` and `frontend`
+//! already depend on — so the sniff has a single source of truth. It is
+//! pure byte inspection (no `image`-crate dependency), so it stays free of
+//! transport/platform deps and compiles on every target.
+
+/// Detect image format from magic bytes. Returns the canonical MIME type for
+/// accepted raster formats (JPEG, PNG, GIF, WebP). Returns `None` for
+/// unrecognised or dangerous formats (SVG, arbitrary binaries).
+pub fn detect_image_format(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg".into())
+    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+        Some("image/png".into())
+    } else if bytes.starts_with(b"GIF8") {
+        Some("image/gif".into())
+    } else if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        Some("image/webp".into())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_jpeg() {
+        assert_eq!(
+            detect_image_format(&[0xFF, 0xD8, 0xFF, 0xE0]),
+            Some("image/jpeg".into())
+        );
+    }
+
+    #[test]
+    fn detects_png() {
+        let png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        assert_eq!(detect_image_format(&png), Some("image/png".into()));
+    }
+
+    #[test]
+    fn detects_gif() {
+        assert_eq!(detect_image_format(b"GIF89a..."), Some("image/gif".into()));
+    }
+
+    #[test]
+    fn detects_webp() {
+        // "RIFF" + 4-byte length + "WEBP".
+        let webp = b"RIFF\x00\x00\x00\x00WEBPVP8 ";
+        assert_eq!(detect_image_format(webp), Some("image/webp".into()));
+    }
+
+    #[test]
+    fn rejects_too_short_input() {
+        assert_eq!(detect_image_format(&[0xFF, 0xD8]), None);
+    }
+
+    #[test]
+    fn rejects_unrecognised_bytes() {
+        // SVG / arbitrary text must not be accepted.
+        assert_eq!(detect_image_format(b"<svg xmlns=..."), None);
+        assert_eq!(detect_image_format(&[0x00, 0x01, 0x02, 0x03]), None);
+    }
+
+    #[test]
+    fn rejects_riff_without_webp_marker() {
+        // A RIFF container that isn't WebP (e.g. WAV/AVI) is not an image.
+        let riff_wav = b"RIFF\x00\x00\x00\x00WAVEfmt ";
+        assert_eq!(detect_image_format(riff_wav), None);
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -6,6 +6,9 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod image_format;
+pub use image_format::detect_image_format;
+
 /// User-configurable paths for the ebook and audiobook libraries.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Settings {


### PR DESCRIPTION
## Summary
- Removed the two byte-identical copies of `detect_image_format` (the ~15-line magic-byte sniff) and the "keep the two implementations in sync" comment, replacing them with a single shared definition. Closes #211.
- **Chosen home: `omnibus-shared`** (new `shared/src/image_format.rs`, re-exported from `lib.rs`). The function is pure `&[u8]` inspection with no `image`-crate dependency, so it carries no transport/platform deps. Both `server/` and `frontend/` already depend on `omnibus-shared` (and so does `mobile/`), so no feature gate is needed on the definition and no new crate dependency was introduced. This is the cleaner of the issue's two suggested homes (`omnibus-shared` vs `omnibus-db` behind a `server` gate).
- Call sites updated:
  - `server/src/backend.rs` — added `detect_image_format` to the existing `omnibus_shared` import; the three handler call sites (cover upload, author-photo upload, remote-image fetch) are unchanged.
  - `frontend/src/rpc.rs` — deleted the local `#[cfg(feature = "server")]` copy and import the shared fn under the same `#[cfg(feature = "server")]` gate so non-server (web/mobile) builds don't pick up an unused import.
- Behavior/return type unchanged (`fn(&[u8]) -> Option<String>`, same JPEG/PNG/GIF/WebP detection and `None` cases).
- Consolidated unit tests next to the new home (positives for JPEG/PNG/GIF/WebP + negatives: too-short input, unrecognised bytes/SVG, RIFF-without-WEBP).
- Doc sync: noted the new `shared/src/image_format.rs` module in `CLAUDE.md` (per end-of-session rule 99).

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default members: server/shared/frontend) — clean
- [x] `cargo test -p omnibus-shared` — 7 passed (the new sniff tests)
- [x] `cargo test -p omnibus` — 130 passed (REST upload integration tests)
- [x] `cargo test -p omnibus-db` — passed
- [x] `cargo test -p omnibus-frontend --features server` — 73 passed
- [x] `cargo check -p omnibus-frontend --no-default-features --features mobile` — clean (confirms the shared import compiles under the `mobile` feature with no unused-import warning)

## Notes
> [!NOTE]
> This environment has no Nix and no GTK system libs, so `cargo build -p omnibus-mobile` could not be run to completion — it fails at link time on the missing `gdk-3.0` system dependency that the Nix dev shell normally provides. To confirm my change is mobile-safe I instead ran `cargo check -p omnibus-frontend --features mobile` (the crate I actually edited), which passes. The mobile link failure is purely the missing system lib, unrelated to this change. **Needs Seamus:** a quick `cargo build -p omnibus-mobile` inside `nix develop` to fully confirm the mobile target links.

> [!NOTE]
> `cargo clippy --all-features` is not usable on this workspace (pre-existing): `--all-features` enables the mutually-exclusive `mobile` + `web` features together, which fails to compile `omnibus-frontend` regardless of this change. I followed the project's documented lint path (plain `cargo clippy` over default members + an explicit per-feature check) instead.

> [!NOTE]
> PR #210 also touches `server/src/backend.rs`. This change only removes the standalone `detect_image_format` fn and tweaks one `use` line there, so conflicts should be minimal.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DbvP7kDWHSS8Gew1deZCK)_