### PR TITLE
refactor: use sqlx Transaction API for override merges (#213)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -328,83 +328,77 @@ pub async fn create_user(pool: &SqlitePool, username: &str, password: &str) -> A
     validate_password(password)?;
     let phc = hash_password(password)?;
 
-    let mut conn = pool.acquire().await?;
-    sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+    // `BEGIN IMMEDIATE` is load-bearing here: it takes a RESERVED write lock
+    // at transaction start, so two concurrent first-user registrations can't
+    // both observe an empty `users` table and both become admin. Plain
+    // `pool.begin()` issues a DEFERRED `BEGIN` that acquires the write lock
+    // lazily, which would weaken that guarantee — so we use `begin_with` to
+    // issue the exact statement while still getting a real `sqlx::Transaction`
+    // (structured ROLLBACK on early-return drop, no reliance on
+    // connection-drop implicit cleanup).
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
 
-    // Rollback-on-error guard. We can't use RAII here because async drop
-    // isn't stable; explicit COMMIT/ROLLBACK via match below.
-    let result: AuthResult<User> = async {
-        let user_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
-            .fetch_one(&mut *conn)
-            .await?;
-
-        let is_first = user_count == 0;
-
-        if !is_first {
-            let enabled: String =
-                sqlx::query_scalar("SELECT value FROM settings WHERE key = 'registration_enabled'")
-                    .fetch_optional(&mut *conn)
-                    .await?
-                    .unwrap_or_else(|| "0".to_string());
-            if enabled != "1" {
-                return Err(AuthError::RegistrationDisabled);
-            }
-        }
-
-        let existing: Option<i64> =
-            sqlx::query_scalar("SELECT id FROM users WHERE username = ? COLLATE NOCASE")
-                .bind(username)
-                .fetch_optional(&mut *conn)
-                .await?;
-        if existing.is_some() {
-            return Err(AuthError::UsernameTaken);
-        }
-
-        let is_admin = if is_first { 1i64 } else { 0 };
-        let can_upload = if is_first { 1i64 } else { 0 };
-        let can_edit = if is_first { 1i64 } else { 0 };
-        let can_download = 1i64;
-
-        let id: i64 = sqlx::query_scalar(
-            "INSERT INTO users (username, password_hash, is_admin, can_upload, can_edit, can_download)
-             VALUES (?, ?, ?, ?, ?, ?)
-             RETURNING id",
-        )
-        .bind(username)
-        .bind(&phc)
-        .bind(is_admin)
-        .bind(can_upload)
-        .bind(can_edit)
-        .bind(can_download)
-        .fetch_one(&mut *conn)
+    let user_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
+        .fetch_one(&mut *tx)
         .await?;
 
-        if is_first {
-            sqlx::query("UPDATE settings SET value = '0' WHERE key = 'registration_enabled'")
-                .execute(&mut *conn)
-                .await?;
-        }
+    let is_first = user_count == 0;
 
-        Ok(User {
-            id,
-            username: username.to_string(),
-            is_admin: is_admin != 0,
-            can_upload: can_upload != 0,
-            can_edit: can_edit != 0,
-            can_download: can_download != 0,
-        })
-    }
-    .await;
-
-    match &result {
-        Ok(_) => {
-            sqlx::query("COMMIT").execute(&mut *conn).await?;
-        }
-        Err(_) => {
-            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+    if !is_first {
+        let enabled: String =
+            sqlx::query_scalar("SELECT value FROM settings WHERE key = 'registration_enabled'")
+                .fetch_optional(&mut *tx)
+                .await?
+                .unwrap_or_else(|| "0".to_string());
+        if enabled != "1" {
+            return Err(AuthError::RegistrationDisabled);
         }
     }
-    result
+
+    let existing: Option<i64> =
+        sqlx::query_scalar("SELECT id FROM users WHERE username = ? COLLATE NOCASE")
+            .bind(username)
+            .fetch_optional(&mut *tx)
+            .await?;
+    if existing.is_some() {
+        return Err(AuthError::UsernameTaken);
+    }
+
+    let is_admin = if is_first { 1i64 } else { 0 };
+    let can_upload = if is_first { 1i64 } else { 0 };
+    let can_edit = if is_first { 1i64 } else { 0 };
+    let can_download = 1i64;
+
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO users (username, password_hash, is_admin, can_upload, can_edit, can_download)
+         VALUES (?, ?, ?, ?, ?, ?)
+         RETURNING id",
+    )
+    .bind(username)
+    .bind(&phc)
+    .bind(is_admin)
+    .bind(can_upload)
+    .bind(can_edit)
+    .bind(can_download)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if is_first {
+        sqlx::query("UPDATE settings SET value = '0' WHERE key = 'registration_enabled'")
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    tx.commit().await?;
+
+    Ok(User {
+        id,
+        username: username.to_string(),
+        is_admin: is_admin != 0,
+        can_upload: can_upload != 0,
+        can_edit: can_edit != 0,
+        can_download: can_download != 0,
+    })
 }
 
 pub async fn get_user_by_username(pool: &SqlitePool, username: &str) -> AuthResult<Option<User>> {
@@ -1027,6 +1021,39 @@ mod tests {
         assert!(users >= 1);
         assert!(users <= 2);
         assert!(r1.is_ok() || r2.is_ok());
+    }
+
+    #[tokio::test]
+    async fn create_user_error_path_rolls_back_cleanly() {
+        // A `?` early-return between BEGIN IMMEDIATE and COMMIT (here a
+        // UsernameTaken reject) must drop the transaction without a partial
+        // commit: no extra user row, `registration_enabled` untouched, and a
+        // subsequent valid create still succeeds on the same connection pool.
+        let p = pool().await;
+        create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+        set_registration_enabled(&p, true).await.unwrap();
+
+        // Collide on the existing username — returns inside the transaction.
+        let err = create_user(&p, "alice", "different-long-pass")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AuthError::UsernameTaken));
+
+        // The failed attempt left no trace: still exactly one user, and the
+        // admin's registration toggle wasn't flipped by the rolled-back tx.
+        let users: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
+            .fetch_one(&p)
+            .await
+            .unwrap();
+        assert_eq!(users, 1, "rolled-back create must not insert a row");
+        assert!(
+            registration_enabled(&p).await.unwrap(),
+            "registration toggle must survive the rollback"
+        );
+
+        // The connection is back in a usable, non-stuck state.
+        let bob = create_user(&p, "bob", "bunker9-longer-pass").await.unwrap();
+        assert!(!bob.is_admin);
     }
 
     // ---- login + lockout ------------------------------------------------------

--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -80,44 +80,33 @@ pub async fn merge_metadata_overrides(
     incoming: &MetadataOverrides,
     user_id: i64,
 ) -> Result<(), sqlx::Error> {
-    // Mirror `auth::create_user`'s explicit transaction idiom: async drop
-    // isn't stable, so we acquire one connection, run BEGIN IMMEDIATE, and
-    // COMMIT/ROLLBACK by hand based on the inner result.
-    let mut conn = pool.acquire().await?;
-    sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+    // `begin_with("BEGIN IMMEDIATE")` gives the same RESERVED-lock-at-start
+    // semantics as the old hand-rolled statement (so concurrent edits to the
+    // same book serialize instead of interleaving), but returns a real
+    // `sqlx::Transaction`. Any `?` early-return below drops `tx` without a
+    // commit, and the Drop impl issues a structured ROLLBACK — no reliance on
+    // connection-drop implicit cleanup.
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
 
-    let result: Result<(), sqlx::Error> = async {
-        let existing: Option<(String, i64)> = sqlx::query_as(
-            "SELECT overrides, has_cover_override FROM metadata_overrides WHERE book_uuid = ?",
-        )
-        .bind(book_uuid)
-        .fetch_optional(&mut *conn)
-        .await?;
+    let existing: Option<(String, i64)> = sqlx::query_as(
+        "SELECT overrides, has_cover_override FROM metadata_overrides WHERE book_uuid = ?",
+    )
+    .bind(book_uuid)
+    .fetch_optional(&mut *tx)
+    .await?;
 
-        let (merged, has_cover_override) = match existing {
-            Some((json, has_cover)) => {
-                let prior: MetadataOverrides =
-                    serde_json::from_str(&json).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
-                (prior.merge(incoming), has_cover != 0)
-            }
-            None => (incoming.clone(), false),
-        };
-
-        let json = serde_json::to_string(&merged).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
-        upsert_overrides_row(&mut *conn, book_uuid, &json, has_cover_override, user_id).await?;
-        Ok(())
-    }
-    .await;
-
-    match &result {
-        Ok(()) => {
-            sqlx::query("COMMIT").execute(&mut *conn).await?;
+    let (merged, has_cover_override) = match existing {
+        Some((json, has_cover)) => {
+            let prior: MetadataOverrides =
+                serde_json::from_str(&json).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
+            (prior.merge(incoming), has_cover != 0)
         }
-        Err(_) => {
-            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
-        }
-    }
-    result?;
+        None => (incoming.clone(), false),
+    };
+
+    let json = serde_json::to_string(&merged).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+    upsert_overrides_row(&mut *tx, book_uuid, &json, has_cover_override, user_id).await?;
+    tx.commit().await?;
 
     // Best-effort FTS rebuild — same rationale as `upsert_metadata_overrides`.
     // Kept outside the transaction so the write lock is released first.


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK` query strings in `auth::create_user` and `metadata_overrides::merge_metadata_overrides` with sqlx's first-class `Transaction` API, aligning both with the idiomatic pattern already used in `db/src/sync.rs`. Closes #213.
- A `?` early-return between `BEGIN` and `COMMIT` now drops a real `sqlx::Transaction`, whose `Drop` impl issues a structured `ROLLBACK` — no more reliance on SQLite's connection-drop implicit rollback. The obsolete "async drop isn't stable" comment is gone.
- No observable behavior change; this is auth/locking-sensitive code, so locking semantics are preserved exactly (see the IMMEDIATE note below).

## What changed
- `db/src/auth.rs` — `create_user` now does `let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;` … `tx.commit().await?;`. The inner `async {}` rollback-guard block and the `match &result { COMMIT / ROLLBACK }` tail are removed; the body is now straight-line `?`-propagation against `&mut *tx`.
- `db/src/metadata_overrides.rs` — `merge_metadata_overrides` converted the same way.
- Added `create_user_error_path_rolls_back_cleanly` test: forces a `UsernameTaken` reject mid-transaction and asserts no partial row, the `registration_enabled` toggle untouched, and the pool still usable afterward — directly covering the structured-rollback path the issue flagged.

## The `create_user` IMMEDIATE decision + rationale
> [!IMPORTANT]
> The issue suggested converting to plain `pool.begin()` with `drop(tx)` on error. That would have **silently weakened a security guarantee** for `create_user`, so I did *not* do that.
>
> `BEGIN IMMEDIATE` is load-bearing: it takes a RESERVED write lock at *transaction start*, which is what makes the first-user-becomes-admin path race-free (two concurrent first registrations can't both observe an empty `users` table). `pool.begin()` issues a DEFERRED `BEGIN` that acquires the write lock lazily — that would re-open exactly the race `concurrent_first_user_race_only_one_admin` guards against.
>
> Rather than keep the raw SQL, I used **`Pool::begin_with("BEGIN IMMEDIATE")`** (available in sqlx 0.8.6). At transaction depth 0 sqlx-sqlite executes the exact statement we pass, so the RESERVED-lock-at-start semantics are preserved verbatim, while we still get a real `Transaction` with structured rollback-on-drop. This is strictly better than the issue's literal remedy: idiomatic *and* IMMEDIATE-preserving. The same applies to `merge_metadata_overrides`, whose `BEGIN IMMEDIATE` serializes concurrent edits to the same book (#166) — also preserved via `begin_with`.

## Test plan
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -p omnibus-db --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 315 passed, 0 failed (incl. `concurrent_first_user_race_only_one_admin`, `first_user_is_admin_and_disables_registration`, `merge_metadata_overrides_*`, and the new rollback test)

## Notes
- Verified against sqlx-sqlite 0.8.6 source: `SqliteTransactionManager::begin` runs a `Some(statement)` verbatim at depth 0 and checks the connection actually entered a transaction; `commit`/`rollback` then issue the standard statements. Dropping an un-committed `Transaction` runs a blocking rollback.
- Environment note for the maintainer: this worktree had no `nix` on PATH, so the checks above were run with the toolchain directly (`cargo 1.94.1`) and `DATABASE_URL` exported manually, rather than via `nix develop`.

https://claude.ai/code/session_018DbvP7kDWHSS8Gew1deZCK

---
_Generated by [Claude Code](https://claude.ai/code/session_018DbvP7kDWHSS8Gew1deZCK)_