### PR TITLE
test: add unit tests for landing sort/filter/facet logic (#215)

### DIFF
--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -1982,4 +1982,80 @@ mod tests {
         assert_eq!(short_path("/Users/ek/books/"), "books");
         assert_eq!(short_path("relative"), "relative");
     }
+
+    // --- additional filter / facet / sort edge cases (#215) ---
+
+    #[test]
+    fn tag_filter_or_within_bucket() {
+        // tags is OR within the bucket: a book matches if it carries *any* of
+        // the selected subjects. alpha=Fantasy, beta=Sci-Fi, gamma=both.
+        let s = sample();
+        let f = ViewFilters {
+            tags: vec!["Fantasy".into()],
+            ..Default::default()
+        };
+        let out = apply_filters(&s, &f);
+        // alpha (Fantasy) and gamma (Fantasy + Sci-Fi) carry the tag; beta does not.
+        assert_eq!(ids(&out), vec![1, 3]);
+    }
+
+    #[test]
+    fn multi_format_filter_is_or_within_bucket_not_and() {
+        // Guards against the bug called out in #215: selecting two formats must
+        // include books matching *either* (OR within the formats bucket), never
+        // require a book to carry *both* (AND would wrongly exclude single-format
+        // books). Each book here has exactly one format.
+        let books = vec![
+            with_formats(sample()[0].clone(), &["epub"]),
+            with_formats(sample()[1].clone(), &["m4b"]),
+            with_formats(sample()[2].clone(), &["pdf"]),
+        ];
+        let f = ViewFilters {
+            formats: vec!["epub".into(), "m4b".into()],
+            ..Default::default()
+        };
+        let out = apply_filters(&books, &f);
+        // OR semantics keep both single-format epub and m4b books; AND would
+        // have dropped both and returned an empty list.
+        assert_eq!(ids(&out), vec![1, 2]);
+    }
+
+    #[test]
+    fn format_facet_counts_tally_across_full_unfiltered_list() {
+        // facet_counts must accumulate over every book it is given (the full,
+        // unfiltered list) — duplicates across books increment the same key.
+        let books = vec![
+            with_formats(sample()[0].clone(), &["epub"]),
+            with_formats(sample()[1].clone(), &["epub", "m4b"]),
+            with_formats(sample()[2].clone(), &["m4b"]),
+        ];
+        let f = facet_counts(&books);
+        let formats: std::collections::HashMap<_, _> = f.formats.into_iter().collect();
+        assert_eq!(formats.get("epub").copied(), Some(2));
+        assert_eq!(formats.get("m4b").copied(), Some(2));
+        assert_eq!(formats.len(), 2);
+    }
+
+    #[test]
+    fn sort_by_title_is_stable_on_equal_keys_via_id_tiebreak() {
+        // Two books share the same title; the id tiebreak keeps a deterministic
+        // order regardless of input order or sort direction.
+        let mut a = book(5, "a.epub", Some("Same"), &[], None, None, None, &[]);
+        let mut b = book(2, "b.epub", Some("Same"), &[], None, None, None, &[]);
+        a.title = Some("Same".into());
+        b.title = Some("Same".into());
+        let asc = sort_books(vec![a.clone(), b.clone()], SortKey::Title, SortDir::Asc);
+        assert_eq!(ids(&asc), vec![2, 5]);
+        // Reversed direction does not reverse the tiebreak: ids stay ascending.
+        let desc = sort_books(vec![a, b], SortKey::Title, SortDir::Desc);
+        assert_eq!(ids(&desc), vec![2, 5]);
+    }
+
+    #[test]
+    fn empty_filters_returns_full_list_unchanged_in_original_order() {
+        // Acceptance (4): an empty ViewFilters yields the input list verbatim.
+        let s = sample();
+        let out = apply_filters(&s, &ViewFilters::default());
+        assert_eq!(ids(&out), ids(&s));
+    }
 }

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -1986,17 +1986,24 @@ mod tests {
     // --- additional filter / facet / sort edge cases (#215) ---
 
     #[test]
-    fn tag_filter_or_within_bucket() {
-        // tags is OR within the bucket: a book matches if it carries *any* of
-        // the selected subjects. alpha=Fantasy, beta=Sci-Fi, gamma=both.
+    fn tag_filter_is_or_within_bucket_not_and() {
+        // tags is OR within the bucket: selecting two subjects must keep books
+        // carrying *either* one, never require *both* (AND would wrongly drop
+        // the single-tag books). alpha=Fantasy, beta=Sci-Fi, gamma=both.
         let s = sample();
-        let f = ViewFilters {
+        let both = ViewFilters {
+            tags: vec!["Fantasy".into(), "Sci-Fi".into()],
+            ..Default::default()
+        };
+        // OR keeps all three; AND would have returned only gamma (id 3).
+        assert_eq!(ids(&apply_filters(&s, &both)), vec![1, 2, 3]);
+
+        // A single selected tag still matches every book carrying it.
+        let one = ViewFilters {
             tags: vec!["Fantasy".into()],
             ..Default::default()
         };
-        let out = apply_filters(&s, &f);
-        // alpha (Fantasy) and gamma (Fantasy + Sci-Fi) carry the tag; beta does not.
-        assert_eq!(ids(&out), vec![1, 3]);
+        assert_eq!(ids(&apply_filters(&s, &one)), vec![1, 3]);
     }
 
     #[test]

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -162,3 +162,51 @@ mod tests {
         assert_eq!(load("/library/missing"), ViewPrefs::default());
     }
 }
+
+// -----------------------------------------------------------------------------
+// SSR / server-only tests — exercise the no-persistence path that compiles
+// under the `server` feature (the default `cargo test -p omnibus-frontend
+// --features server`). The `web`/`mobile` impls live behind their own cfgs and
+// are unreachable here, so these assertions pin the documented SSR contract:
+// every call returns defaults and `save` is an inert no-op.
+// -----------------------------------------------------------------------------
+#[cfg(all(test, not(any(feature = "web", feature = "mobile"))))]
+mod ssr_tests {
+    use super::*;
+    use omnibus_shared::{SortDir, SortKey, ViewFilters, ViewMode};
+
+    #[test]
+    fn load_always_returns_defaults() {
+        assert_eq!(load("/library/a"), ViewPrefs::default());
+        assert_eq!(load(""), ViewPrefs::default());
+    }
+
+    #[test]
+    fn save_is_a_noop_and_does_not_affect_subsequent_loads() {
+        let prefs = ViewPrefs {
+            view_mode: ViewMode::Grid,
+            sort_key: SortKey::Author,
+            sort_dir: SortDir::Desc,
+            filters: ViewFilters {
+                formats: vec!["epub".into()],
+                ..Default::default()
+            },
+            filters_open: true,
+        };
+        // Persisting must not change what a later load returns under SSR.
+        save("/library/a", &prefs);
+        assert_eq!(load("/library/a"), ViewPrefs::default());
+    }
+
+    #[test]
+    fn default_prefs_match_documented_shape() {
+        // First-hydration markup depends on these defaults: Table view, sorted
+        // by Title ascending, no active filters, sidebar closed.
+        let d = ViewPrefs::default();
+        assert_eq!(d.view_mode, ViewMode::Table);
+        assert_eq!(d.sort_key, SortKey::Title);
+        assert_eq!(d.sort_dir, SortDir::Asc);
+        assert!(d.filters.is_empty());
+        assert!(!d.filters_open);
+    }
+}


### PR DESCRIPTION
## Summary
- Strengthens unit coverage of the landing page's pure sort/filter/facet helpers in `frontend/src/pages/landing.rs` and adds an SSR-runnable test module for `frontend/src/view_prefs.rs`.
- Landing additions (5 tests): tag-bucket OR membership, multi-format OR-not-AND (guards the exact bug #215 calls out), `facet_counts` tally across the full unfiltered list, sort stability via id tiebreak on equal keys, and empty-`ViewFilters` passthrough preserving order.
- `view_prefs.rs` additions (3 tests): a new `#[cfg(all(test, not(any(feature = "web", feature = "mobile"))))]` module pinning the SSR contract — `load` always returns defaults, `save` is an inert no-op, and the default `ViewPrefs` shape (Table / Title / Asc / no filters / sidebar closed).

>[!NOTE]
> **The issue was partially stale.** `frontend/src/pages/landing.rs` already shipped an inline `#[cfg(test)] mod tests` (commit `b17b0d6`, 2026-05-24 — two days *before* this issue was filed) that already satisfies all four stated acceptance criteria: (1) `sort_books` stable order by title and author, (2) format-facet filter inclusion, (3) `facet_counts` format tally, (4) empty-`ViewFilters` passthrough. Rather than duplicate that, this PR adds the higher-value edge cases the existing suite did not assert directly.

>[!IMPORTANT]
> Two divergences from the issue prose, written against actual code behavior:
> - There is **no `ViewPrefs::merge`** function anywhere in the codebase (only `MetadataOverrides::merge` in `shared`). `view_prefs.rs` exposes `load`/`save` over a per-target store, not a merge/apply API — the new tests cover what actually exists.
> - `view_prefs.rs` *did* have tests, but they were gated behind `#[cfg(all(test, feature = "mobile"))]`, so they never ran under the crate's standard `cargo test -p omnibus-frontend --features server`. The new SSR module closes that real gap.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` (clean, exit 0)
- [x] `cargo test -p omnibus-frontend --features server` (81 passed, 0 failed; was 73 before this change)

## Notes
- Test-only change. No production logic touched; no new dependencies; **no `Cargo.lock` change**.
- No Playwright specs changed, so `run_ui_tests` is intentionally not requested.
- `nix` is unavailable in the resolving environment; `cargo` was run directly per repo fallback guidance. All checks were run inside the standard toolchain.

Closes #215

---
_Generated by [Claude Code](https://claude.ai/code/session_01SG8Bo7Tbb5wGxqh8GnzisQ)_