### PR TITLE
refactor: make worker report_progress dead-code suppression traceable (#220)

### DIFF
--- a/db/src/worker.rs
+++ b/db/src/worker.rs
@@ -479,9 +479,12 @@ impl Worker {
     /// Phase-2 seam: write the in-flight progress count for `id`. The
     /// terminal state is written separately at the end of [`Worker::run`]
     /// so a mid-task report can't accidentally flip a task to `Done`.
-    /// Currently unused — wired up when `indexer::reindex` learns to
-    /// thread a progress callback through its per-EPUB loop.
-    #[allow(dead_code)]
+    /// Only exercised by tests today (see `report_progress_updates_running_count`),
+    /// so it lives behind `#[cfg(test)]` rather than an untraceable
+    /// `#[allow(dead_code)]`. Un-gate it — and drop this cfg — when
+    /// `indexer::reindex` learns to thread a progress callback through its
+    /// per-EPUB loop (#220).
+    #[cfg(test)]
     pub(crate) fn report_progress(&self, id: TaskId, processed: u32, total: Option<u32>) {
         let mut map = lock_unpoison(&self.progress);
         if let Some(entry) = map.get_mut(&id) {


### PR DESCRIPTION
## Summary
- Resolves #220. `Worker::report_progress` in `db/src/worker.rs` was suppressed with a bare `#[allow(dead_code)]` and a comment that never referenced a tracking issue, making the known Phase-2 progress-reporting seam invisible to triage.
- Chose **Option 2** (gate behind `#[cfg(test)]`) over Option 1 (just add a `#220` reference to the `#[allow]`). Every call site of `report_progress` lives inside the `#[cfg(test)] mod tests` block (lines 1106 and 1126 on `main`); the production path `indexer::reindex` does **not** call it yet. Gating the method behind `#[cfg(test)]` means production builds never compile it, so there is no dead-code lint to suppress at all — strictly cleaner than keeping the allow. The doc comment still references #220 and spells out the un-gate plan for when `indexer::reindex` learns to thread a progress callback through its per-EPUB loop.

## Test plan
- [x] `cargo fmt -p omnibus-db -- --check` — clean
- [x] `cargo clippy -p omnibus-db --all-targets --all-features -- -D warnings` — passed (the `--all-targets` test build still resolves the `#[cfg(test)]` method via its test callers; the non-test build no longer compiles it, so no dead-code warning)
- [x] `cargo test -p omnibus-db` — 314 + 1 + 1 passed, 0 failed (incl. `worker::tests::report_progress_updates_running_count`)

## Notes
- Single-file diff (`db/src/worker.rs`, +6/-3). No `Cargo.lock`, migration, or CI-workflow changes. Kept deliberately minimal to avoid conflicting with PR #222, which also edits `db/src/worker.rs` (mutex-poison fix) but in a different region.

>[!NOTE]
> `nix` was unavailable in the environment, so checks were run with `cargo` directly. Worker tests use `sqlite::memory:`, so no on-disk DB was involved.

Closes #220

https://claude.ai/code/session_01SG8Bo7Tbb5wGxqh8GnzisQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SG8Bo7Tbb5wGxqh8GnzisQ)_