### PR TITLE
refactor: use DELETE for /api/ebooks/:uuid/overrides (#217)

### DIFF
--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -694,8 +694,8 @@ pub async fn delete_overrides(
     server_url: &str,
     uuid: &str,
 ) -> Result<Option<EbookMetadata>, DataError> {
-    let url = format!("{server_url}/api/ebooks/{uuid}/overrides/delete");
-    let response = with_bearer(http_client().post(&url)).send().await?;
+    let url = format!("{server_url}/api/ebooks/{uuid}/overrides");
+    let response = with_bearer(http_client().delete(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {
         return Err(drain_error(response, status).await);

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -91,10 +91,9 @@ pub fn rest_router(state: AppState) -> Router {
         .route("/api/library", get(get_library))
         .route("/api/ebooks", get(get_ebooks))
         .route("/api/ebooks/{uuid}", get(get_ebook_by_uuid))
-        .route("/api/ebooks/{uuid}/overrides", post(post_ebook_overrides))
         .route(
-            "/api/ebooks/{uuid}/overrides/delete",
-            post(delete_ebook_overrides),
+            "/api/ebooks/{uuid}/overrides",
+            post(post_ebook_overrides).delete(delete_ebook_overrides),
         )
         // GET/DELETE for author photos carry no upload body (DELETE mutates,
         // but cheaply — it clears photo state, it doesn't ingest one), so
@@ -3067,8 +3066,8 @@ mod tests {
         let res = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/ebooks/{uuid}/overrides/delete"))
-                    .method("POST")
+                    .uri(format!("/api/ebooks/{uuid}/overrides"))
+                    .method("DELETE")
                     .header(AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .unwrap(),


### PR DESCRIPTION
## Summary
- Register the metadata-overrides delete handler at `DELETE /api/ebooks/{uuid}/overrides` instead of `POST /api/ebooks/{uuid}/overrides/delete`, so the REST verb matches the operation's idempotent, semantically-DELETE nature (mirrors the neighboring `/api/authors/{id}/photo` `get(...).delete(...)` style). Handler body unchanged.
- Update the mobile `reqwest` client (`frontend/src/data.rs::delete_overrides`) to issue HTTP `DELETE` against the suffix-free path.
- Update the backend integration test to drive the new verb + path.

>[!WARNING]
> **Breaking REST API change.** The old `POST /api/ebooks/{uuid}/overrides/delete` route is removed; clients must now call `DELETE /api/ebooks/{uuid}/overrides`. The only in-repo REST caller is the mobile client (updated here). The web client uses the Dioxus server-function path `/api/rpc/ebook/overrides/delete`, which is a separate convention (server functions are POST-only by the macro) and is intentionally left unchanged — it is out of scope for this issue.

## Test plan
- [x] `cargo fmt` (no changes)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` (clean)
- [x] `cargo test -p omnibus` — 130 passed, including `api_delete_overrides_reverts`
- [x] `cargo test -p omnibus-frontend --features server` — 73 passed
- [ ] No Playwright spec changed (the only override-delete spec hits the unchanged `/api/rpc/...` path), so no E2E update was required.

## Notes
- No `Cargo.lock` change.
- No migrations or CI workflows touched.

Closes #217

---
_Generated by [Claude Code](https://claude.ai/code/session_01SG8Bo7Tbb5wGxqh8GnzisQ)_