### PR TITLE
refactor: drop async-trait dependency (#218)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,7 +4116,6 @@ dependencies = [
 name = "omnibus"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "axum",
  "axum-extra",
  "dioxus",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = { workspace = true, optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"], optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"], optional = true }
 tracing = { workspace = true, optional = true }
-async-trait = { version = "0.1", optional = true }
 time = { version = "0.3", optional = true }
 
 omnibus-shared = { path = "../shared" }
@@ -58,7 +57,6 @@ server = [
     "dep:sqlx",
     "dep:tokio",
     "dep:tracing",
-    "dep:async-trait",
     "dep:time",
     "dep:omnibus-db",
     "dioxus/server",

--- a/server/src/auth/strategy.rs
+++ b/server/src/auth/strategy.rs
@@ -14,7 +14,6 @@
 //!   only needs to prove it's shaped right; implementations can land in
 //!   their own phases.
 
-use async_trait::async_trait;
 use omnibus_db::auth::AuthError;
 use sqlx::SqlitePool;
 
@@ -31,7 +30,20 @@ pub struct AuthenticatedUser {
 /// Contract for a pluggable auth backend. Implementations do the crypto +
 /// DB lookup; the session-issuing + cookie/bearer plumbing stays in the
 /// handler layer so every strategy lands sessions the same way.
-#[async_trait]
+///
+/// Uses native async-fn-in-traits (stable since Rust 1.75) instead of the
+/// `#[async_trait]` macro, dropping the per-call `Box`-ing it imposed. Sound
+/// here because every consumer holds a *concrete* strategy type — there is no
+/// `dyn AuthStrategy` dispatch anywhere — so the compiler monomorphizes each
+/// call directly.
+///
+/// `authenticate` is written as `fn(..) -> impl Future<..> + Send` rather than
+/// `async fn` so the returned future keeps an explicit `Send` bound (an
+/// `async fn` in a public trait can't carry one — see the `async_fn_in_trait`
+/// lint). The `+ Send` matches the future `#[async_trait]` produced and keeps
+/// the trait usable from `tokio::spawn`-ed axum handlers. If a future strategy
+/// ever needs to be stored behind `dyn`, reintroduce `async-trait` (or
+/// `trait-variant`) for that path.
 pub trait AuthStrategy: Send + Sync {
     /// Short stable tag for logs and admin UI (`"password"`, `"oidc"`, …).
     fn kind(&self) -> &'static str;
@@ -41,12 +53,12 @@ pub trait AuthStrategy: Send + Sync {
     /// implementations will ignore it in favor of their own flow and accept
     /// the trait shape as-is, probably exposing additional methods for the
     /// redirect/assertion dance.
-    async fn authenticate(
+    fn authenticate(
         &self,
         pool: &SqlitePool,
         username: &str,
         secret: &str,
-    ) -> Result<AuthenticatedUser, AuthError>;
+    ) -> impl std::future::Future<Output = Result<AuthenticatedUser, AuthError>> + Send;
 }
 
 /// Username + Argon2id PHC password strategy. Thin wrapper over
@@ -54,7 +66,6 @@ pub trait AuthStrategy: Send + Sync {
 /// logic stays in one place.
 pub struct PasswordStrategy;
 
-#[async_trait]
 impl AuthStrategy for PasswordStrategy {
     fn kind(&self) -> &'static str {
         "password"


### PR DESCRIPTION
## Summary
- Removed the `async-trait = "0.1"` dependency from the `server` crate. Rust 1.75+ supports native `async fn` in traits for the non-`dyn` case, and the toolchain here is 1.94.1.
- Audited every `#[async_trait]` usage in the workspace. The only one is `server/src/auth/strategy.rs`: the `AuthStrategy` trait and its single `PasswordStrategy` impl. Confirmed there is **no** `dyn AuthStrategy` / `Box<dyn AuthStrategy>` / `Arc<dyn AuthStrategy>` anywhere — the trait is used exclusively with the concrete type, so native async-fn-in-traits applies cleanly and `async-trait` is genuinely removable.
- Converted the trait's `authenticate` method from `#[async_trait] async fn` to `fn(..) -> impl Future<..> + Send`, and dropped both `#[async_trait]` attributes plus the `use async_trait::async_trait;` import.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus` — 130 passed, 0 failed (incl. the two `strategy.rs` tests `password_strategy_roundtrip` + `password_strategy_rejects_bad_password`)
- [x] `cargo build -p omnibus --release` — succeeds

## Notes
- **Traits converted:** `AuthStrategy` (in `server/src/auth/strategy.rs`) — its method `authenticate`, and the `PasswordStrategy` impl. No other trait in the workspace used `#[async_trait]`.
- **Confirmed no `dyn` usage:** the only `Box<dyn ...>` / `Arc<dyn ...>` in the tree are unrelated closure types (`Box<dyn FnMut>` in `search_palette.rs`, `Arc<dyn Fn + Send + Sync>` in `db/worker.rs`). None involve `AuthStrategy`.

>[!IMPORTANT]
> **Why `fn(..) -> impl Future<..> + Send` instead of a bare `async fn`:** a plain `async fn` in a public trait can't carry an explicit `Send` bound on its returned future (the `async_fn_in_trait` clippy lint, denied here under `-D warnings`). The explicit `impl Future + Send` return type preserves the `Send` future that `#[async_trait]` used to produce, keeping the trait usable from `tokio::spawn`-ed axum handlers. If a future strategy (OIDC/WebAuthn) ever needs `dyn` dispatch, `async-trait` (or `trait-variant`) should be reintroduced for that path — a comment to that effect is in the trait doc.

>[!NOTE]
> **Dependency / lockfile changes:** `server/Cargo.toml` drops the `async-trait` line and its `dep:async-trait` feature-gate entry. `Cargo.lock` removes the direct `async-trait` edge under the `omnibus` package. The `async-trait` crate **remains in the lockfile** because it's still pulled in transitively by sqlx/dioxus — this PR only removes `server`'s own direct dependency, which is all the issue called for.
> No workspace-root `Cargo.toml` change was needed (the dep was declared per-crate, not in `[workspace.dependencies]`).

Closes #218

---
_Generated by [Claude Code](https://claude.ai/code/session_01SG8Bo7Tbb5wGxqh8GnzisQ)_