### PR TITLE
docs: document cargo audit blind spot for git-pinned Dioxus crates (#219)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,17 @@ tempfile = "3"
 # 0.7.5), so `dx serve` refuses to start with an "incompatible versions" banner.
 # Patching to the matching git tag keeps the lib + CLI in lockstep until the
 # next coordinated crates.io release.
+#
+# SECURITY NOTE — `cargo audit` blind spot: `cargo audit` keys RUSTSEC advisory
+# lookups on crates.io package name + version. These crates resolve by git SHA,
+# not a crates.io version, so any advisory filed against a patched Dioxus crate
+# will NOT surface in `cargo audit` (and therefore not in CI). Severity is low —
+# Dioxus is a UI framework, not a network/crypto dep — but the gap is silent.
+# Mitigation: on every Dioxus bump, manually review the DioxusLabs changelog and
+# GitHub security advisories (https://github.com/DioxusLabs/dioxus/security/advisories)
+# for the new tag. Exit condition: once Dioxus publishes the matching version to
+# crates.io, replace these git patches with plain `version = "..."` entries and
+# delete this whole note (the audited path is then restored automatically).
 [patch.crates-io]
 dioxus = { git = "https://github.com/DioxusLabs/dioxus", tag = "v0.7.9" }
 dioxus-asset-resolver = { git = "https://github.com/DioxusLabs/dioxus", tag = "v0.7.9" }


### PR DESCRIPTION
## Summary
- The workspace root `Cargo.toml` patches all 31 Dioxus ecosystem crates to git tag `v0.7.9` via `[patch.crates-io]`. Because these resolve by git SHA rather than a crates.io version, `cargo audit` silently skips any RUSTSEC advisory filed against them — an invisible CI blind spot.
- Extends the existing patch-block comment (does not duplicate it) with: the audit blind spot, the manual-review mitigation (check the DioxusLabs changelog + GitHub security advisories on each bump), and the exit condition (drop the git patches for plain `version = "..."` entries once Dioxus publishes to crates.io).
- Comment-only change to `Cargo.toml`; no dependency, version, or CI edits.

## Test plan
- [x] `cargo metadata --format-version 1 --no-deps` succeeds (manifest still parses).
- [x] `cargo fmt` clean (does not touch `Cargo.toml`).
- [x] Diff is a single comment block on `Cargo.toml`; no version/dependency changes.

## Notes
>[!IMPORTANT]
> The CI-side enforcement half of the issue's remedy — adding `cargo deny` / a `deny.toml` (which has better coverage for git-patched crates than `cargo audit`) — is deliberately OUT OF SCOPE here. It requires editing `.github/workflows/` (a maintainer-sign-off hard rule) and is tracked separately by #214. This PR delivers only the documentation half.

Closes #219

---
_Generated by [Claude Code](https://claude.ai/code/session_014g7y7NE6ydWUi6HfJZeVuU)_