### PR TITLE
fix(db): cap embedded EPUB cover bytes before image decode (#233)

### DIFF
--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -621,7 +621,7 @@ fn all<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>, key: &str) -> Vec<Str
 }
 
 /// Hard cap on embedded cover bytes we'll hand to the `image` decoder.
-/// Higher than the 5 MiB HTTP cap in `author_photos` because these are
+/// Higher than the 10 MiB HTTP cap in `author_photos` because these are
 /// trusted local files; 20 MiB still covers uncompressed print-resolution
 /// covers while bounding the decode allocation against a crafted EPUB.
 const MAX_EMBEDDED_COVER_BYTES: usize = 20 * 1024 * 1024;
@@ -804,13 +804,22 @@ mod tests {
 
     #[test]
     fn extract_accent_returns_none_for_oversized_bytes() {
-        // A slice past the cap must be rejected by the size guard before it
-        // ever reaches the decoder — protecting the indexer from a crafted
-        // EPUB whose stored image expands to gigabytes of pixels on decode.
-        let bytes = vec![0u8; MAX_EMBEDDED_COVER_BYTES + 1];
+        // Start from a *valid* cover that decodes to an accent on its own, so
+        // the only thing keeping the oversized case out of the decoder is the
+        // size guard. (All-zero bytes would fail to decode regardless, which
+        // wouldn't catch a regression that removed the guard.)
+        let mut bytes = solid_color_png(200, 60, 50, 64, 96);
+        assert!(
+            extract_accent(&bytes).is_some(),
+            "sanity: the unpadded cover should decode to an accent"
+        );
+        // Pad past the cap with trailing bytes the PNG decoder ignores (it
+        // stops at IEND). Without the guard these would still decode and
+        // yield Some, so this assertion fails if the cap check is removed.
+        bytes.resize(MAX_EMBEDDED_COVER_BYTES + 1, 0);
         assert!(
             extract_accent(&bytes).is_none(),
-            "oversized cover bytes should be rejected before decoding"
+            "oversized cover bytes should be rejected by the size guard before decoding"
         );
     }
 

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -620,6 +620,12 @@ fn all<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>, key: &str) -> Vec<Str
         .collect()
 }
 
+/// Hard cap on embedded cover bytes we'll hand to the `image` decoder.
+/// Higher than the 5 MiB HTTP cap in `author_photos` because these are
+/// trusted local files; 20 MiB still covers uncompressed print-resolution
+/// covers while bounding the decode allocation against a crafted EPUB.
+const MAX_EMBEDDED_COVER_BYTES: usize = 20 * 1024 * 1024;
+
 /// F1.7 Atrium: extract a representative accent color from cover bytes.
 /// Returns an `oklch(L C H)` string clamped to a readable band, or `None`
 /// when decoding fails or the cover has no chromatic content. See the
@@ -627,6 +633,9 @@ fn all<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>, key: &str) -> Vec<Str
 /// for the algorithm rationale (hue-bucket → highest-weighted → OKLCH).
 pub fn extract_accent(bytes: &[u8]) -> Option<String> {
     if bytes.is_empty() {
+        return None;
+    }
+    if bytes.len() > MAX_EMBEDDED_COVER_BYTES {
         return None;
     }
     let img = image::load_from_memory(bytes).ok()?;
@@ -791,6 +800,18 @@ mod tests {
     #[test]
     fn extract_accent_returns_none_for_corrupt_bytes() {
         assert!(extract_accent(b"not an image, just text").is_none());
+    }
+
+    #[test]
+    fn extract_accent_returns_none_for_oversized_bytes() {
+        // A slice past the cap must be rejected by the size guard before it
+        // ever reaches the decoder — protecting the indexer from a crafted
+        // EPUB whose stored image expands to gigabytes of pixels on decode.
+        let bytes = vec![0u8; MAX_EMBEDDED_COVER_BYTES + 1];
+        assert!(
+            extract_accent(&bytes).is_none(),
+            "oversized cover bytes should be rejected before decoding"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `extract_accent` in `db/src/ebook.rs` decoded raw EPUB cover bytes via `image::load_from_memory` with no size check, so a crafted EPUB containing a huge stored image (e.g. an uncompressed 4K PNG) could force a multi-GB decode allocation and OOM the indexer worker thread on every reindex.
- Mirrors the existing guard in `db/src/author_photos.rs`, adding `const MAX_EMBEDDED_COVER_BYTES: usize = 20 * 1024 * 1024;` and an early `return None;` before the decode. The 20 MiB cap is higher than the 5 MiB HTTP cap since EPUBs are trusted local files, while still covering uncompressed print-resolution covers.
- Added a unit test asserting an oversized slice returns `None` without ever reaching the decoder.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-db --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo test -p omnibus-db` (315 unit + 2 integration tests pass)
- [x] New test `extract_accent_returns_none_for_oversized_bytes` passes

## Notes
>[!NOTE]
> `db/src/ebook.rs` was the only production decode site passing raw zip bytes into the `image` crate (the `thumbs.rs` decode paths are out of scope for this issue). The single guard inside `extract_accent` covers the lone cover-bytes call site at `ebook.rs:352`.

>[!NOTE]
> Verified outside `nix develop` (no `nix`, no `DATABASE_URL` in this environment). This is fine: `omnibus-db` uses runtime `sqlx::query(...)` and `sqlite::memory:` tests, so it builds and tests without a DB URL.

Closes #233

---
_Generated by [Claude Code](https://claude.ai/code/session_014g7y7NE6ydWUi6HfJZeVuU)_