### PR TITLE
docs(db): document single-tenant invariant on discovery/browse modules (#232)

### DIFF
--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -2,6 +2,17 @@
 //! row (capped at `INDEX_LIMIT`) so the UI's client-side sort/filter has
 //! the full list to work with; per-row counts come back override-aware so
 //! the index surfaces stay consistent with the discovery-detail reads.
+//!
+//! # Multi-tenancy invariant
+//!
+//! Both browse reads are **DB-wide**: they return every author / series in
+//! the configured library without filtering by the requesting user's
+//! access. The app is single-tenant and single-library today (see Phase 4
+//! in `docs/roadmap/0-0-summary.md`), so every authenticated caller sees
+//! the same index. Per-user ACL scoping — a `user_id` parameter plus an
+//! access-control join — is deferred to F4.x and tracked by issue #232;
+//! each function carries a `# Multi-tenancy` rustdoc section and a
+//! `TODO(F4.x)` marker in its body until that work lands.
 
 use sqlx::{Row, SqlitePool};
 

--- a/db/src/discovery.rs
+++ b/db/src/discovery.rs
@@ -2,6 +2,18 @@
 //! books, plus the global tag cloud. Membership and ordering follow the
 //! merged (override-aware) view via the BOOK_COLUMNS template shared
 //! with the book read path.
+//!
+//! # Multi-tenancy invariant
+//!
+//! Every read in this module is **DB-wide**: it returns all matching rows
+//! without filtering by the requesting user's library access. The app is
+//! single-tenant and single-library today (see Phase 4 in
+//! `docs/roadmap/0-0-summary.md`), so every authenticated caller is
+//! implicitly authorised to see every author, series, and tag. Per-user
+//! ACL scoping — a `user_id` parameter on each signature plus an
+//! access-control join in each query — is deferred to F4.x and tracked by
+//! issue #232; each function carries a `# Multi-tenancy` rustdoc section
+//! and a `TODO(F4.x)` marker in its body until that work lands.
 
 use sqlx::{Row, SqlitePool};
 


### PR DESCRIPTION
## Summary
- The five discovery/browse query functions (`get_author`, `get_series`, `get_tag_cloud`, `list_authors`, `list_series`) already carry per-function `# Multi-tenancy` rustdoc notes and `TODO(F4.x)` markers, but neither module header recorded the DB-wide / single-tenant invariant. This adds a module-level `# Multi-tenancy invariant` section to `db/src/discovery.rs` and `db/src/browse.rs`.
- Documentation only: no signatures, queries, or behavior change.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-db --all-targets --all-features -- -D warnings`
- [x] `cargo test -p omnibus-db` (316 tests pass)

## Notes
>[!IMPORTANT]
> **Partial staleness finding.** Issue #232 names `get_author_detail` / `get_series_detail` / `browse_authors` / `browse_series`, but those were renamed to `get_author` / `get_series` / `list_authors` / `list_series` in PR #201 (the `queries.rs` split) — the very PR the issue blames for "inheriting the deferral without documentation." That split also *added* the per-function `# Multi-tenancy` notes the issue assumed were missing. So the issue's literal near-term ask (give the four functions the note `get_author` has) was already satisfied. The only genuine remaining consistency gap was at the module level, which this PR closes.

>[!NOTE]
> The actual per-user ACL implementation (adding a `user_id` parameter and access-control join to each query, plus threading the authenticated user through callers in `frontend/src/rpc.rs` and `server/src/backend.rs`) remains intentionally deferred to Phase 4 (F4.x). This PR only closes the documentation-consistency gap described in the issue's near-term ask.

Closes #232

---
_Generated by [Claude Code](https://claude.ai/code/session_014g7y7NE6ydWUi6HfJZeVuU)_