### PR TITLE
fix(frontend): add key props to rsx for-loops on search/author/metadata pages (#231)

### DIFF
--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -274,6 +274,7 @@ fn render_author(
                         div { class: "disc-grid",
                             for book in books.iter() {
                                 Link {
+                                    key: "{book.id}",
                                     to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
                                     class: "lib-tile",
                                     Cover { book: (*book).clone() }
@@ -298,6 +299,7 @@ fn render_author(
                         div { class: "disc-grid",
                             for book in standalone.iter() {
                                 Link {
+                                    key: "{book.id}",
                                     to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
                                     class: "lib-tile",
                                     Cover { book: (*book).clone() }

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -205,7 +205,9 @@ pub fn AuthorsIndexPage() -> Element {
                     }
                 } else if show_letters {
                     for (letter, group) in letters.iter() {
-                        section { class: "idx-letter-section",
+                        section {
+                            key: "{letter}",
+                            class: "idx-letter-section",
                             div { class: "idx-letter-rail",
                                 div { class: "idx-letter-rail-glyph", "{letter}" }
                                 div { class: "idx-letter-rail-count mono", "{group.len()}" }

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -406,7 +406,9 @@ fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
                             div { class: "label", style: "margin-bottom: 12px;", "Identifiers" }
                             div { class: "me-ident-list",
                                 for ident in book.identifiers.iter() {
-                                    div { class: "me-ident-row",
+                                    div {
+                                        key: "{ident.scheme:?}-{ident.value}",
+                                        class: "me-ident-row",
                                         span { class: "label me-ident-key",
                                             {ident.scheme.clone().unwrap_or_else(|| "ID".into())}
                                         }

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -152,7 +152,7 @@ pub fn SearchPage(query: String) -> Element {
                 ul { class: "search-results",
                     for tag in r.tags.iter().cloned() {
                         li {
-                            key: "{tag.name}",
+                            key: "{tag.id}",
                             Link {
                                 to: Route::Search { query: format!("tag:{}", tag.name) },
                                 class: "search-result-row",

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -94,6 +94,7 @@ pub fn SearchPage(query: String) -> Element {
                 ul { class: "search-results",
                     for book in r.books.iter().cloned() {
                         li {
+                            key: "{book.uuid}",
                             Link {
                                 to: Route::BookDetail { uuid: book.uuid.clone() },
                                 class: "search-result-row",
@@ -110,6 +111,7 @@ pub fn SearchPage(query: String) -> Element {
                 ul { class: "search-results",
                     for author in r.authors.iter().cloned() {
                         li {
+                            key: "{author.id}",
                             Link {
                                 to: Route::AuthorDetail { id: author.id },
                                 class: "search-result-row",
@@ -128,6 +130,7 @@ pub fn SearchPage(query: String) -> Element {
                 ul { class: "search-results",
                     for s in r.series.iter().cloned() {
                         li {
+                            key: "{s.id}",
                             Link {
                                 to: Route::SeriesDetail { id: s.id },
                                 class: "search-result-row",
@@ -149,6 +152,7 @@ pub fn SearchPage(query: String) -> Element {
                 ul { class: "search-results",
                     for tag in r.tags.iter().cloned() {
                         li {
+                            key: "{tag.name}",
                             Link {
                                 to: Route::Search { query: format!("tag:{}", tag.name) },
                                 class: "search-result-row",


### PR DESCRIPTION
## Summary
- Add `key:` attributes to 8 keyless `for` loops inside `rsx!` blocks across four pages (`search.rs`, `author.rs`, `authors_index.rs`, `metadata_edit.rs`), carrying the existing `search_palette.rs` convention forward so Dioxus diffs lists by stable identity instead of falling back to positional matching.
- Keys: books `{book.uuid}` / authors `{author.id}` / series `{s.id}` / tags `{tag.name}` on the search page; `{book.id}` on the author detail grids; `{letter}` on the authors-index letter sections; `{ident.scheme:?}-{ident.value}` on the metadata-edit identifiers list.
- Net change is 12 insertions of virtual-DOM hints — no prop signatures, markup contracts (roles/labels/testids), or component logic touched.

## Test plan
- [x] `cargo fmt` (no changes)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` (zero warnings)
- [x] `cargo test -p omnibus-frontend --features server` (73 passed)
- [x] `cargo check -p omnibus-frontend --no-default-features --features mobile` (type-checks)

## Notes
>[!NOTE]
> Two substitutions vs. the issue's recommended keys, dictated by the actual struct shapes:
> - author detail books use `{book.id}` — `EbookMetadata` has no `uuid` (only `unique_identifier`); `id` is the stable primary key.
> - metadata-edit identifiers use `{ident.scheme:?}-{ident.value}` — `Identifier.scheme` is `Option<String>`, so it's Debug-formatted.
>
> `key:` is not rendered to the DOM, so no Playwright spec needs updating.

>[!NOTE]
> `cargo build -p omnibus-mobile` is not part of verification — it cannot link in this environment (missing GTK system libs), which is expected and documented in the repo. The mobile feature was confirmed via `cargo check ... --features mobile` instead.

Closes #231

---
_Generated by [Claude Code](https://claude.ai/code/session_014g7y7NE6ydWUi6HfJZeVuU)_