### PR TITLE
fix(ci): install prebuilt wasm-bindgen-cli instead of building from source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,9 @@
               url = "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/${version}/wasm-bindgen-${version}-${plat.triple}.tar.gz";
               inherit (plat) hash;
             };
+            # The tarball is already-built binaries — only unpack + install.
+            dontConfigure = true;
+            dontBuild = true;
             installPhase = ''
               runHook preInstall
               mkdir -p $out/bin

--- a/flake.nix
+++ b/flake.nix
@@ -36,21 +36,58 @@
         # `dioxus-cli` from nixpkgs-unstable bundles its own `wasm-bindgen-cli`
         # (appended to PATH via `--suffix`), but the `dioxus` git pin in
         # Cargo.toml (v0.7.9 monorepo tag) pulls in `wasm-bindgen 0.2.122`
-        # transitively. Build the matching CLI ourselves and put it earlier
-        # in PATH so dx picks it up first.
-        wasm-bindgen-cli-0_2_122 = pkgs-unstable.wasm-bindgen-cli.overrideAttrs (old: rec {
-          version = "0.2.122";
-          src = pkgs.fetchCrate {
+        # transitively, and nixpkgs-unstable only ships 0.2.121. `dx` requires
+        # the CLI version to match the locked crate, so we supply 0.2.122 and
+        # put it earlier in PATH.
+        #
+        # We install the upstream *prebuilt* CLI binary from the GitHub release
+        # rather than building it from source. Building from source (via
+        # `fetchCrate` + `fetchCargoVendor`) downloads the crate and every one
+        # of its dependencies from the crates.io app endpoint
+        # (https://crates.io/api/v1/crates/.../download), which enforces
+        # User-Agent policy + rate limits and intermittently 403s the Nix
+        # fetcher on cold-cache CI runs — that failure aborts the whole
+        # `nix develop` shell before any cargo command runs. GitHub release
+        # assets are a plain CDN with no such gating and touch crates.io zero
+        # times. Linux uses the static musl build so no dynamic-linker patching
+        # is needed inside the Nix sandbox.
+        wasm-bindgen-cli-0_2_122 =
+          let
+            version = "0.2.122";
+            plat = {
+              x86_64-linux = {
+                triple = "x86_64-unknown-linux-musl";
+                hash = "sha256-Eio/4uqcbj6JtQ5C3Ro0bkmfP2WlSq4LTq62WBOdHg4=";
+              };
+              aarch64-linux = {
+                triple = "aarch64-unknown-linux-musl";
+                hash = "sha256-sd/kcq8O4SzaCHoLKJhd87UXQV2a5GfLz4USMbzoVts=";
+              };
+              x86_64-darwin = {
+                triple = "x86_64-apple-darwin";
+                hash = "sha256-y1AKayScIEdLvdhtTY1ZP6Zcnl29Vquxrn7kjAg5ChE=";
+              };
+              aarch64-darwin = {
+                triple = "aarch64-apple-darwin";
+                hash = "sha256-Nr6tyGxcAsURoVLo/CxjhQZGiH6X3JSuBFU2QPg56Ag=";
+              };
+            }.${system} or (throw "wasm-bindgen-cli ${version}: unsupported system ${system}");
+          in
+          pkgs.stdenvNoCC.mkDerivation {
             pname = "wasm-bindgen-cli";
             inherit version;
-            hash = "sha256-vO4RSxi/sMWxmsEs3GuljdMfIRSu75A+Q+c5wgYToRU=";
+            src = pkgs.fetchurl {
+              url = "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/${version}/wasm-bindgen-${version}-${plat.triple}.tar.gz";
+              inherit (plat) hash;
+            };
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/bin
+              cp wasm-bindgen wasm2es6js wasm-bindgen-test-runner $out/bin/
+              chmod +x $out/bin/*
+              runHook postInstall
+            '';
           };
-          cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
-            inherit src;
-            name = "wasm-bindgen-cli-${version}-vendor";
-            hash = "sha256-Inup6vvJSG5ghNyeDPyZbfZo4d0LsMG2OJfStoaeDBs=";
-          };
-        });
       in {
         devShells.default = pkgs.mkShell {
           packages = [


### PR DESCRIPTION
## Summary
- The `clippy + test` (and `e2e`) jobs run inside `nix develop`. The dev shell needs `wasm-bindgen-cli 0.2.122` because `dioxus 0.7.9` pulls `wasm-bindgen 0.2.122` transitively and `dx` requires the CLI version to match, but `nixpkgs-unstable` only ships `0.2.121`.
- That CLI was **built from source** via `fetchCrate` + `fetchCargoVendor`, which downloads the crate *and every one of its dependencies* from the crates.io app endpoint (`https://crates.io/api/v1/crates/.../download`). That endpoint enforces User-Agent policy + rate limits and intermittently returns **HTTP 403** to the Nix fetcher on cold-cache CI runs — aborting the entire dev shell before any cargo command runs. (This is why the failure surfaced as a "clippy" failure that never actually reached clippy.)
- Fix: install the upstream **prebuilt CLI binary from the GitHub release** instead, selected per-system (static **musl** on Linux so no dynamic-linker patching is needed in the Nix sandbox). This touches crates.io **zero** times.

>[!NOTE]
> This is a flaky-infrastructure fix, not specific to any one PR — the 403 can fail any PR whose CI run hits a cold Nix cache. It was observed on [#253](https://github.com/seamus-sloan/omnibus/pull/253).

## Test plan
- [x] `nix build .#devShells.aarch64-darwin.default` succeeds and `wasm-bindgen --version` reports `0.2.122`
- [x] Reproduced the original 403 locally (cold vendor build hit `crates.io/api/v1/.../download` 403), then confirmed the new path builds clean
- [x] Verified the `x86_64-unknown-linux-musl` (CI platform) release asset hash by forced fresh fetch — matches the pinned SRI
- [ ] CI green on this branch

## Notes
- Hashes for all four platforms come from upstream's published `.sha256sum` files; the darwin + linux-x86_64 conversions were independently confirmed against live downloads.
- A longer-term alternative is bumping the `nixpkgs-unstable` pin once it ships `0.2.122` (then drop the override entirely), but that risks dragging `dioxus-cli` / `playwright-driver` versions and was deliberately avoided here.