### PR TITLE
fix: route rpc_save_overrides through atomic merge (#243)

### DIFF
--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -429,6 +429,65 @@ mod tests {
         assert_eq!(loaded.title, Some("Fresh".into()));
         assert!(!has_cover, "a brand-new merged row has no cover override");
     }
+    /// #243: two concurrent saves to the same book (e.g. the F5.1 edit form
+    /// open in two tabs, or a network retry firing twice) each touch a
+    /// different field. Because the rpc/REST save paths route through
+    /// `merge_metadata_overrides` — whose read-merge-write runs under a single
+    /// `BEGIN IMMEDIATE` — neither write may be silently dropped: both fields
+    /// must survive regardless of interleaving.
+    #[tokio::test]
+    async fn merge_metadata_overrides_concurrent_saves_dont_drop_writes() {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        let pool_a = pool.clone();
+        let pool_b = pool.clone();
+        let save_title = tokio::spawn(async move {
+            merge_metadata_overrides(
+                &pool_a,
+                "race-uuid",
+                &MetadataOverrides {
+                    title: Some("Title From Tab A".into()),
+                    ..Default::default()
+                },
+                user_id,
+            )
+            .await
+        });
+        let save_publisher = tokio::spawn(async move {
+            merge_metadata_overrides(
+                &pool_b,
+                "race-uuid",
+                &MetadataOverrides {
+                    publisher: Some("Publisher From Tab B".into()),
+                    ..Default::default()
+                },
+                user_id,
+            )
+            .await
+        });
+
+        save_title.await.unwrap().unwrap();
+        save_publisher.await.unwrap().unwrap();
+
+        let (loaded, _) = get_metadata_overrides(&pool, "race-uuid")
+            .await
+            .unwrap()
+            .expect("overrides should exist");
+        assert_eq!(
+            loaded.title,
+            Some("Title From Tab A".into()),
+            "tab A's title must not be lost to tab B's concurrent save"
+        );
+        assert_eq!(
+            loaded.publisher,
+            Some("Publisher From Tab B".into()),
+            "tab B's publisher must not be lost to tab A's concurrent save"
+        );
+    }
     #[tokio::test]
     async fn get_metadata_overrides_returns_none_when_absent() {
         let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -434,18 +434,27 @@ mod tests {
     /// different field. Because the rpc/REST save paths route through
     /// `merge_metadata_overrides` — whose read-merge-write runs under a single
     /// `BEGIN IMMEDIATE` — neither write may be silently dropped: both fields
-    /// must survive regardless of interleaving.
+    /// must survive regardless of interleaving. A barrier releases both tasks
+    /// into the merge at the same instant so the test exercises real contention
+    /// rather than letting the first save finish before the second starts.
     #[tokio::test]
     async fn merge_metadata_overrides_concurrent_saves_dont_drop_writes() {
+        use std::sync::Arc;
+        use tokio::sync::Barrier;
+
         let pool = init_db("sqlite::memory:").await.unwrap();
         let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
             .await
             .unwrap()
             .id;
 
+        let barrier = Arc::new(Barrier::new(2));
         let pool_a = pool.clone();
         let pool_b = pool.clone();
+        let barrier_a = barrier.clone();
+        let barrier_b = barrier.clone();
         let save_title = tokio::spawn(async move {
+            barrier_a.wait().await;
             merge_metadata_overrides(
                 &pool_a,
                 "race-uuid",
@@ -458,6 +467,7 @@ mod tests {
             .await
         });
         let save_publisher = tokio::spawn(async move {
+            barrier_b.wait().await;
             merge_metadata_overrides(
                 &pool_b,
                 "race-uuid",

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -397,13 +397,9 @@ pub async fn rpc_save_overrides(
     if let Err(msg) = overrides.validate() {
         return Err(ServerFnError::new(msg).into());
     }
-    // Merge incoming overrides with any existing ones so a second edit that
-    // only touches field B doesn't wipe a prior override on field A. The
-    // read-merge-write is serialized inside a single BEGIN IMMEDIATE
-    // transaction in the db layer so two concurrent edits to the same book
-    // (two tabs, or a network retry) can't interleave and drop each other's
-    // changes, and a text-only edit carries the existing cover flag forward
-    // instead of clearing it (#243, matching the REST path's #166 fix).
+    // Route through the db layer's read-merge-write (one BEGIN IMMEDIATE) so
+    // concurrent edits to the same book can't interleave and drop each other's
+    // changes, and a text-only edit keeps the existing cover flag.
     db::merge_metadata_overrides(&pool.0, &uuid, &overrides, user.id).await?;
     Ok(db::get_book_by_uuid(&pool.0, &uuid).await?)
 }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -397,13 +397,14 @@ pub async fn rpc_save_overrides(
     if let Err(msg) = overrides.validate() {
         return Err(ServerFnError::new(msg).into());
     }
-    // Merge incoming overrides with any existing ones so that a second edit
-    // that only touches field B doesn't wipe a prior override on field A.
-    let merged = match db::get_metadata_overrides(&pool.0, &uuid).await? {
-        Some((existing, _)) => existing.merge(&overrides),
-        None => overrides,
-    };
-    db::upsert_metadata_overrides(&pool.0, &uuid, &merged, false, user.id).await?;
+    // Merge incoming overrides with any existing ones so a second edit that
+    // only touches field B doesn't wipe a prior override on field A. The
+    // read-merge-write is serialized inside a single BEGIN IMMEDIATE
+    // transaction in the db layer so two concurrent edits to the same book
+    // (two tabs, or a network retry) can't interleave and drop each other's
+    // changes, and a text-only edit carries the existing cover flag forward
+    // instead of clearing it (#243, matching the REST path's #166 fix).
+    db::merge_metadata_overrides(&pool.0, &uuid, &overrides, user.id).await?;
     Ok(db::get_book_by_uuid(&pool.0, &uuid).await?)
 }
 


### PR DESCRIPTION
## Summary
- The web RPC save path `rpc_save_overrides` did a non-atomic read-merge-write: `get_metadata_overrides` → merge in memory → `upsert_metadata_overrides`. Two concurrent saves to the same book (the F5.1 edit form open in two tabs, or a network retry) could interleave between the read and the write and silently drop one edit.
- Route it through `db::merge_metadata_overrides`, whose full read-merge-write runs under a single `BEGIN IMMEDIATE` — matching the REST handler (`server/src/backend.rs`), which got this fix in #166. The RPC path was missed there; it's the primary save route for all web clients.

## Test plan
- [x] new `merge_metadata_overrides_concurrent_saves_dont_drop_writes` — two interleaved single-field saves (title vs publisher) to the same UUID both survive (ran 4× + single-threaded, deterministic)
- [x] `cargo test -p omnibus-db --lib -- --test-threads=1` — pass
- [x] `cargo test -p omnibus-frontend --features server` — pass
- [x] `cargo clippy -p omnibus-db` + `-p omnibus-frontend --features server` (`--all-targets -- -D warnings`), `cargo fmt`

## Notes
- The dropped `false` argument to `upsert_metadata_overrides` was the "explicit cover-flag" boolean; `merge_metadata_overrides` already carries the existing cover flag forward, so a text-only edit no longer risks clearing it.
- Touches `frontend/src/rpc.rs` (the overrides save fn) — a different function than #241, which also edits `rpc.rs` (the search fn); no real conflict expected.

> [!NOTE]
> CI `clippy + test` / `playwright` may show red from a **pre-existing** flaky parallel test (`worker::tests::fire_and_forget_panicking_tasks_drain_completions`, passes single-threaded) and an environment-stage Playwright failure — unrelated to this change.

Closes #243

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSAVVBtcykcLMBe4639fra)_