### PR TITLE
test: add unit tests for pure-logic helpers across frontend pages (#244)

### DIFF
--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -85,9 +85,6 @@ pub fn BookDetailPage(uuid: String) -> Element {
 // the data-fetch shell stays small.
 // ---------------------------------------------------------------------------
 
-/// Build the "kicker" line above the title — "<type> · <year>", falling back
-/// to "Book" when the Dublin Core type is absent and dropping the year when
-/// it's empty. Pure derivation, unit-tested below.
 fn kicker_label(dc_type: Option<&str>, year: &str) -> String {
     match (dc_type, year.is_empty()) {
         (Some(t), false) => format!("{t} · {year}"),
@@ -97,8 +94,6 @@ fn kicker_label(dc_type: Option<&str>, year: &str) -> String {
     }
 }
 
-/// Format the series label under the title — "<series> #<index>", just the
-/// series name when there's no index, or `None` when there's no series.
 fn series_label(series: Option<&str>, index: Option<&str>) -> Option<String> {
     match (series, index) {
         (Some(s), Some(i)) => Some(format!("{s} #{i}")),

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -85,6 +85,63 @@ pub fn BookDetailPage(uuid: String) -> Element {
 // the data-fetch shell stays small.
 // ---------------------------------------------------------------------------
 
+/// Build the "kicker" line above the title — "<type> · <year>", falling back
+/// to "Book" when the Dublin Core type is absent and dropping the year when
+/// it's empty. Pure derivation, unit-tested below.
+fn kicker_label(dc_type: Option<&str>, year: &str) -> String {
+    match (dc_type, year.is_empty()) {
+        (Some(t), false) => format!("{t} · {year}"),
+        (Some(t), true) => t.to_string(),
+        (None, false) => format!("Book · {year}"),
+        (None, true) => "Book".to_string(),
+    }
+}
+
+/// Format the series label under the title — "<series> #<index>", just the
+/// series name when there's no index, or `None` when there's no series.
+fn series_label(series: Option<&str>, index: Option<&str>) -> Option<String> {
+    match (series, index) {
+        (Some(s), Some(i)) => Some(format!("{s} #{i}")),
+        (Some(s), None) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kicker_label_combines_type_and_year() {
+        assert_eq!(kicker_label(Some("Novel"), "2021"), "Novel · 2021");
+    }
+    #[test]
+    fn kicker_label_drops_empty_year() {
+        assert_eq!(kicker_label(Some("Novel"), ""), "Novel");
+    }
+    #[test]
+    fn kicker_label_defaults_type_to_book() {
+        assert_eq!(kicker_label(None, "2021"), "Book · 2021");
+        assert_eq!(kicker_label(None, ""), "Book");
+    }
+    #[test]
+    fn series_label_formats_name_and_index() {
+        assert_eq!(
+            series_label(Some("Dune"), Some("2")),
+            Some("Dune #2".into())
+        );
+    }
+    #[test]
+    fn series_label_without_index_is_just_name() {
+        assert_eq!(series_label(Some("Dune"), None), Some("Dune".into()));
+    }
+    #[test]
+    fn series_label_absent_series_is_none() {
+        assert_eq!(series_label(None, Some("2")), None);
+        assert_eq!(series_label(None, None), None);
+    }
+}
+
 fn render_loaded(b: EbookMetadata) -> Element {
     let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
     let primary_author = b
@@ -104,17 +161,8 @@ fn render_loaded(b: EbookMetadata) -> Element {
         .and_then(|p| p.get(0..4))
         .unwrap_or("")
         .to_string();
-    let kicker = match (b.dc_type.as_deref(), year.is_empty()) {
-        (Some(t), false) => format!("{t} · {year}"),
-        (Some(t), true) => t.to_string(),
-        (None, false) => format!("Book · {year}"),
-        (None, true) => "Book".to_string(),
-    };
-    let series_label = match (b.series.as_deref(), b.series_index.as_deref()) {
-        (Some(s), Some(i)) => Some(format!("{s} #{i}")),
-        (Some(s), None) => Some(s.to_string()),
-        _ => None,
-    };
+    let kicker = kicker_label(b.dc_type.as_deref(), &year);
+    let series_label = series_label(b.series.as_deref(), b.series_index.as_deref());
     let accent_style = b
         .accent
         .as_deref()

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -727,3 +727,130 @@ fn MeArea(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn book_with(title: Option<&str>, creators: &[&str], subjects: &[&str]) -> EbookMetadata {
+        EbookMetadata {
+            title: title.map(String::from),
+            creators: creators
+                .iter()
+                .map(|n| Contributor {
+                    name: (*n).to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            subjects: subjects.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn label_to_id_slugifies_spaces_and_case() {
+        assert_eq!(label_to_id("Title"), "me-title");
+        assert_eq!(label_to_id("Book #"), "me-book--");
+        assert_eq!(label_to_id("Published Date"), "me-published-date");
+    }
+
+    #[test]
+    fn label_to_id_replaces_all_non_alphanumeric() {
+        assert_eq!(label_to_id("A/B:C"), "me-a-b-c");
+        assert_eq!(label_to_id(""), "me-");
+    }
+
+    #[test]
+    fn build_overrides_no_changes_yields_all_none() {
+        let orig = book_with(Some("Dune"), &["Frank Herbert"], &["scifi"]);
+        let ov = build_overrides(
+            &orig,
+            "Dune",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            &["Frank Herbert".to_string()],
+            &["scifi".to_string()],
+        );
+        assert_eq!(ov, MetadataOverrides::default());
+    }
+
+    #[test]
+    fn build_overrides_sets_only_changed_scalar_fields() {
+        let orig = book_with(Some("Dune"), &["Frank Herbert"], &[]);
+        let ov = build_overrides(
+            &orig,
+            "Dune: Messiah",
+            "",
+            "Ace",
+            "",
+            "",
+            "",
+            "",
+            &["Frank Herbert".to_string()],
+            &[],
+        );
+        assert_eq!(ov.title.as_deref(), Some("Dune: Messiah"));
+        assert_eq!(ov.publisher.as_deref(), Some("Ace"));
+        assert!(ov.description.is_none());
+        assert!(ov.creators.is_none());
+        assert!(ov.subjects.is_none());
+    }
+
+    #[test]
+    fn build_overrides_clearing_a_populated_field_emits_empty_string() {
+        // orig.title = "Dune", edited to "" -> the override must carry the
+        // empty string so the merge clears it rather than leaving it untouched.
+        let orig = book_with(Some("Dune"), &[], &[]);
+        let ov = build_overrides(&orig, "", "", "", "", "", "", "", &[], &[]);
+        assert_eq!(ov.title.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn build_overrides_replaces_full_creator_and_subject_lists() {
+        let orig = book_with(Some("Dune"), &["Frank Herbert"], &["scifi"]);
+        let ov = build_overrides(
+            &orig,
+            "Dune",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            &["Frank Herbert".to_string(), "Brian Herbert".to_string()],
+            &["scifi".to_string(), "classic".to_string()],
+        );
+        let creators = ov.creators.expect("creators should be set");
+        assert_eq!(creators.len(), 2);
+        assert_eq!(creators[0].name, "Frank Herbert");
+        assert_eq!(creators[1].name, "Brian Herbert");
+        assert_eq!(creators[0].role.as_deref(), Some("aut"));
+        assert_eq!(
+            ov.subjects,
+            Some(vec!["scifi".to_string(), "classic".to_string()])
+        );
+    }
+
+    #[test]
+    fn build_overrides_unchanged_lists_stay_none() {
+        let orig = book_with(Some("Dune"), &["Frank Herbert"], &["scifi"]);
+        let ov = build_overrides(
+            &orig,
+            "Dune",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            &["Frank Herbert".to_string()],
+            &["scifi".to_string()],
+        );
+        assert!(ov.creators.is_none());
+        assert!(ov.subjects.is_none());
+    }
+}

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -209,3 +209,41 @@ fn sort_key(s: &SeriesSummary) -> String {
     let stripped = n.strip_prefix("The ").or_else(|| n.strip_prefix("the "));
     stripped.unwrap_or(n).to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(name: &str, sort: Option<&str>) -> SeriesSummary {
+        SeriesSummary {
+            name: name.to_string(),
+            sort: sort.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sort_key_prefers_explicit_sort_field() {
+        let s = summary("The Expanse", Some("Expanse"));
+        assert_eq!(sort_key(&s), "Expanse");
+    }
+
+    #[test]
+    fn sort_key_ignores_empty_sort_field() {
+        let s = summary("Foundation", Some(""));
+        assert_eq!(sort_key(&s), "Foundation");
+    }
+
+    #[test]
+    fn sort_key_strips_leading_the_in_both_cases() {
+        assert_eq!(sort_key(&summary("The Foo Bar", None)), "Foo Bar");
+        assert_eq!(sort_key(&summary("the foo bar", None)), "foo bar");
+    }
+
+    #[test]
+    fn sort_key_leaves_non_the_prefix_intact() {
+        // "Theology" must not have "The" stripped — only the "The " word.
+        assert_eq!(sort_key(&summary("Theology", None)), "Theology");
+        assert_eq!(sort_key(&summary("Dune", None)), "Dune");
+    }
+}

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -142,6 +142,44 @@ pub fn SettingsPage() -> Element {
     }
 }
 
+/// Build the human-readable summary line for a configured library section:
+/// "<n> file(s) found." plus a " <count> .<ext> found." clause per extension.
+/// Pure derivation, unit-tested below.
+fn library_summary_line(section: &LibrarySection) -> String {
+    let mut line = format!("{} file(s) found.", section.total_files);
+    for (ext, count) in &section.counts_by_ext {
+        line.push_str(&format!(" {count} .{ext} found."));
+    }
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn section(total: usize, counts: &[(&str, usize)]) -> LibrarySection {
+        LibrarySection {
+            path: Some("/lib".into()),
+            total_files: total,
+            counts_by_ext: counts.iter().map(|(e, c)| (e.to_string(), *c)).collect(),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn summary_line_reports_total_only_when_no_ext_breakdown() {
+        assert_eq!(library_summary_line(&section(3, &[])), "3 file(s) found.");
+    }
+
+    #[test]
+    fn summary_line_appends_a_clause_per_extension() {
+        let line = library_summary_line(&section(5, &[("epub", 4), ("pdf", 1)]));
+        assert!(line.starts_with("5 file(s) found."));
+        assert!(line.contains("4 .epub found."));
+        assert!(line.contains("1 .pdf found."));
+    }
+}
+
 #[component]
 fn LibrarySummary(testid: String, section: LibrarySection) -> Element {
     if section.path.is_none() {
@@ -165,10 +203,7 @@ fn LibrarySummary(testid: String, section: LibrarySection) -> Element {
         };
     }
 
-    let mut line = format!("{} file(s) found.", section.total_files);
-    for (ext, count) in &section.counts_by_ext {
-        line.push_str(&format!(" {count} .{ext} found."));
-    }
+    let line = library_summary_line(&section);
 
     rsx! {
         p {

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -142,9 +142,6 @@ pub fn SettingsPage() -> Element {
     }
 }
 
-/// Build the human-readable summary line for a configured library section:
-/// "<n> file(s) found." plus a " <count> .<ext> found." clause per extension.
-/// Pure derivation, unit-tested below.
 fn library_summary_line(section: &LibrarySection) -> String {
     let mut line = format!("{} file(s) found.", section.total_files);
     for (ext, count) in &section.counts_by_ext {


### PR DESCRIPTION
## Summary
Per rule 03 and #244, page modules with logic should carry inline tests. This adds unit tests to the four pages whose logic is extractable as pure functions:
- **metadata_edit** — form-state / validation / chip helpers (7 tests)
- **series_index** — `sort_key` (leading-"The" stripping, explicit-sort precedence) (4 tests)
- **book_detail** — `kicker_label` (type · year fallbacks) and `series_label` (name + index), extracted from the inline `render_loaded` derivation (6 tests)
- **settings** — `library_summary_line` ("N file(s) found." + per-extension clauses), extracted from `LibrarySummary` (2 tests)

For book_detail and settings the derivation logic lived inside the `-> Element` render functions, so it's lifted into small pure helpers and unit-tested — **no behavior change** (the render fns just call the helpers).

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 100 pass, 0 fail
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo fmt`

## Notes
- The remaining listed pages — **author, series, tag_cloud** — expose only `-> Element` render helpers whose logic is display markup using Router `Link`s. Per the issue ("component render tests require `dioxus::ssr::render_element` and can be deferred; pure-logic tests require no Dioxus"), those are deferred: testing them needs an SSR + Router-context harness this crate doesn't yet have. Recommend a follow-up to add that harness if render-level coverage is wanted.
- No production behavior changed; helpers are pure and the render fns produce identical output.

Closes #244

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSAVVBtcykcLMBe4639fra)_