### PR TITLE
ci: lint omnibus-frontend and omnibus-shared in CI clippy (#251)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,6 +84,12 @@ jobs:
       - name: cargo clippy (db)
         run: nix develop --command cargo clippy -p omnibus-db --all-targets -- -D warnings
 
+      - name: Clippy frontend
+        run: nix develop --command cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings
+
+      - name: Clippy shared
+        run: nix develop --command cargo clippy -p omnibus-shared --all-targets -- -D warnings
+
       - name: cargo test (server)
         run: nix develop --command cargo test -p omnibus
 


### PR DESCRIPTION
## Summary
- `omnibus-frontend` and `omnibus-shared` had no dedicated clippy step in the `check` job, so lint warnings in these two high-traffic crates (the largest Dioxus-RSX consumer and the shared wire-type layer) were never surfaced or blocked in CI.
- Adds two steps to `.github/workflows/rust.yml`, right after `cargo clippy (db)`, mirroring the exact style of the existing per-crate clippy steps.
- `--features server` is required on the frontend step so the non-WASM, server-feature-gated code paths are included in the lint pass.

Both crates are already clippy-clean on `main`, so the new steps are green from the first run.

## Test plan
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean locally
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — clean locally
- [x] YAML validated (`yq` + `python yaml.safe_load`)
- [ ] Confirm the `check` job runs all four clippy steps green in CI

## Notes
- `rust.yml` is also edited by the #214 PR (cargo-audit gate, in the separate `security` job ~L139). Different sections — no real conflict; whichever merges second may just need a trivial branch update.

Closes #251

<sub>Authored with Claude Code.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvurhjmAiLqJCg3HwPCB4y)_