### PR TITLE
ci: fail on RUSTSEC advisories; add cargo-deny (#214)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,7 @@ on:
       - "flake.lock"
       - "rust-toolchain*"
       - ".github/workflows/rust.yml"
+      - "deny.toml"
   push:
     branches: [main]
 
@@ -129,21 +130,23 @@ jobs:
           purge-primary-key: never
           gc-max-store-size-linux: 5G
 
-      # Run cargo-audit in JSON mode for downstream parsing. We do NOT fail
-      # the job on findings — the next step posts a PR comment instead, so
-      # vulnerabilities are surfaced as a visible report rather than a
-      # blocking gate. `continue-on-error: true` keeps the workflow green
-      # while still letting the report step read `audit.json`.
+      # Run cargo-audit in JSON mode for downstream parsing and also fail the
+      # job on any advisory. `set +e` captures the exit code so we can both
+      # record it for the report step and re-exit with it so CI blocks on
+      # unfixed advisories. To accept a specific advisory (e.g. disputed or
+      # only-affects-unused-feature), pass `--ignore RUSTSEC-XXXX-YYYY` with
+      # a comment explaining the rationale.
       - name: cargo audit
         id: audit
-        continue-on-error: true
         run: |
           set +e
           # Redirect inside the nix-develop subshell so the shellHook's
           # informational echoes (`Nix dev shell ready.`, etc.) don't get
           # mixed into the JSON capture file.
           nix develop --command bash -c 'cargo audit --json > audit.json'
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit $exit_code
 
       # Build a human-readable markdown report from the JSON output. If
       # `audit.json` is missing or not valid JSON (cargo-audit itself failed,
@@ -177,7 +180,7 @@ jobs:
               fi
             fi
             echo
-            echo "<sub>Posted by the Rust workflow's \`security\` job. This gate is informational — see the workflow file for rationale.</sub>"
+            echo "<sub>Posted by the Rust workflow's \`security\` job.</sub>"
           } > audit-report.md
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
@@ -199,3 +202,9 @@ jobs:
           name: cargo-audit-json
           path: audit.json
           retention-days: 14
+
+      # cargo deny checks advisories (overlapping with cargo audit but also
+      # covering git-pinned crates), license compatibility, banned crates, and
+      # duplicate transitive versions. deny.toml in the repo root is the config.
+      - name: cargo deny check
+        run: nix develop --command cargo deny check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,10 +130,11 @@ jobs:
           purge-primary-key: never
           gc-max-store-size-linux: 5G
 
-      # Run cargo-audit in JSON mode for downstream parsing and also fail the
-      # job on any advisory. `set +e` captures the exit code so we can both
-      # record it for the report step and re-exit with it so CI blocks on
-      # unfixed advisories. To accept a specific advisory (e.g. disputed or
+      # Run cargo-audit in JSON mode for downstream parsing. `set +e` captures
+      # the exit code without failing this step, so the report/comment steps
+      # below still run on an advisory; the dedicated "Fail on advisories" gate
+      # at the end re-raises this exit code so CI blocks on unfixed advisories.
+      # To accept a specific advisory (e.g. disputed or
       # only-affects-unused-feature), add `--ignore RUSTSEC-XXXX-YYYY` below
       # with a comment explaining the rationale (keep in sync with deny.toml).
       #
@@ -153,7 +154,9 @@ jobs:
           nix develop --command bash -c 'cargo audit --json --ignore RUSTSEC-2023-0071 > audit.json'
           exit_code=$?
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
-          exit $exit_code
+          # Deliberately succeed here so the report + sticky-comment steps run
+          # even when an advisory is present; the gate step below re-raises it.
+          exit 0
 
       # Build a human-readable markdown report from the JSON output. If
       # `audit.json` is missing or not valid JSON (cargo-audit itself failed,
@@ -161,6 +164,7 @@ jobs:
       # rather than silently claiming "no advisories found".
       - name: Format audit report
         id: report
+        if: always()
         run: |
           set -euo pipefail
           # `jq` is part of the standard ubuntu-latest image.
@@ -196,7 +200,7 @@ jobs:
       # comment instead of stacking new ones. Only runs on pull_request
       # events — pushes to `main` skip this and just leave the artifact.
       - name: Post / update PR comment
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: cargo-audit-report
@@ -209,6 +213,19 @@ jobs:
           name: cargo-audit-json
           path: audit.json
           retention-days: 14
+
+      # Re-raise the captured cargo-audit exit code so the job fails on unfixed
+      # advisories. Kept separate from the audit step so the report + sticky
+      # PR comment above always run first (they lack a hard dependency on this
+      # gate's success).
+      - name: Fail on advisories
+        if: always()
+        run: |
+          code="${{ steps.audit.outputs.exit_code }}"
+          if [ "$code" != "0" ]; then
+            echo "cargo audit reported advisories (exit code $code); failing the job." >&2
+            exit "$code"
+          fi
 
       # cargo deny adds coverage cargo-audit lacks: advisories against the ~31
       # git-pinned Dioxus crates, source allow-listing, and duplicate-version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,8 +134,15 @@ jobs:
       # job on any advisory. `set +e` captures the exit code so we can both
       # record it for the report step and re-exit with it so CI blocks on
       # unfixed advisories. To accept a specific advisory (e.g. disputed or
-      # only-affects-unused-feature), pass `--ignore RUSTSEC-XXXX-YYYY` with
-      # a comment explaining the rationale.
+      # only-affects-unused-feature), add `--ignore RUSTSEC-XXXX-YYYY` below
+      # with a comment explaining the rationale (keep in sync with deny.toml).
+      #
+      # Ignored advisories:
+      #   RUSTSEC-2023-0071 (rsa "Marvin Attack") — `rsa` is pulled into
+      #   Cargo.lock only by `sqlx-mysql`. We use sqlx with the sqlite backend
+      #   only, so `rsa` is never compiled into any target (`cargo tree -i rsa
+      #   --target all` is empty). No fixed `rsa` release exists yet; revisit
+      #   when one does. Lock-file-only, not reachable — not exploitable here.
       - name: cargo audit
         id: audit
         run: |
@@ -143,7 +150,7 @@ jobs:
           # Redirect inside the nix-develop subshell so the shellHook's
           # informational echoes (`Nix dev shell ready.`, etc.) don't get
           # mixed into the JSON capture file.
-          nix develop --command bash -c 'cargo audit --json > audit.json'
+          nix develop --command bash -c 'cargo audit --json --ignore RUSTSEC-2023-0071 > audit.json'
           exit_code=$?
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           exit $exit_code
@@ -203,8 +210,23 @@ jobs:
           path: audit.json
           retention-days: 14
 
-      # cargo deny checks advisories (overlapping with cargo audit but also
-      # covering git-pinned crates), license compatibility, banned crates, and
-      # duplicate transitive versions. deny.toml in the repo root is the config.
+      # cargo deny adds coverage cargo-audit lacks: advisories against the ~31
+      # git-pinned Dioxus crates, source allow-listing, and duplicate-version
+      # bans. deny.toml in the repo root is the config.
+      #
+      # Scoped to `advisories sources bans` for now — the `licenses` check is
+      # intentionally NOT run here yet: the workspace member crates carry no
+      # `license` field (they're unpublished), which cargo-deny reports as
+      # "unlicensed", and the full transitive license set hasn't been validated
+      # against deny.toml's allow-list locally. The [licenses] config is left in
+      # deny.toml so enabling it is a one-line follow-up once verified.
+      #
+      # `continue-on-error` (observation mode): this deny.toml was authored
+      # without a runner that has cargo-deny + the advisory DB available, so it
+      # has not yet had a clean run to validate the allow-lists/sources against
+      # the real dependency set. Keep it non-blocking until its first green run,
+      # then drop this line to make it a hard gate. Real enforcement meanwhile
+      # comes from the (blocking) `cargo audit` step above.
       - name: cargo deny check
-        run: nix develop --command cargo deny check
+        continue-on-error: true
+        run: nix develop --command cargo deny check advisories sources bans

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,76 @@
+# cargo-deny configuration — https://embarkstudios.github.io/cargo-deny/
+# Schema version 2 (required for cargo-deny >= 0.14).
+#
+# Run locally:  cargo deny check
+# CI:           rust.yml `security` job, `cargo deny check` step.
+
+# ---------------------------------------------------------------------------
+# Advisories
+# ---------------------------------------------------------------------------
+# Deny known vulnerabilities and unmaintained crates. Advisories that are
+# accepted (e.g. disputed, only affects an unused feature) can be silenced
+# with an `ignore` entry below alongside a comment explaining the rationale.
+[advisories]
+version = 2
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# "sound" = no known exploitable vulnerability; "best-effort" also pulls in
+# unmaintained / notice advisories.
+ignore = [
+    # Example — add RUSTSEC IDs here when accepting a specific advisory:
+    # { id = "RUSTSEC-0000-0000", reason = "..." }
+]
+
+# ---------------------------------------------------------------------------
+# Licenses
+# ---------------------------------------------------------------------------
+# Permissive set covering everything currently in the dependency tree.
+# Add entries here (never remove) when `cargo deny check licenses` reports
+# an unlicensed or denied crate after a dependency bump.
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "Zlib",
+    "MPL-2.0",
+    "CC0-1.0",
+]
+# Treat crates whose license cannot be determined as an error.
+unlicensed = "deny"
+# Copyleft licenses that are not in the allow-list are denied by default.
+copyleft = "deny"
+
+# ---------------------------------------------------------------------------
+# Bans
+# ---------------------------------------------------------------------------
+# Using "warn" for duplicate versions because this workspace has ~31
+# git-pinned Dioxus crates that pull in multiple transitive versions of
+# several common crates. Promoting to "deny" after the Dioxus patches are
+# replaced with plain crates.io versions.
+[bans]
+multiple-versions = "warn"
+# Deny crates that should never appear in the dependency tree.
+deny = []
+skip = []
+skip-tree = []
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+# Allow crates.io plus the DioxusLabs monorepo git source that the workspace
+# patches all dioxus-* crates from (see [patch.crates-io] in root Cargo.toml).
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+    # All dioxus-* crates are git-patched to this repo until they publish
+    # the matching version to crates.io — see root Cargo.toml for rationale.
+    "https://github.com/DioxusLabs/dioxus",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -16,8 +16,12 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # "sound" = no known exploitable vulnerability; "best-effort" also pulls in
 # unmaintained / notice advisories.
 ignore = [
-    # Example — add RUSTSEC IDs here when accepting a specific advisory:
-    # { id = "RUSTSEC-0000-0000", reason = "..." }
+    # rsa "Marvin Attack" timing sidechannel. `rsa` enters Cargo.lock only via
+    # `sqlx-mysql`; this project uses sqlx with the sqlite backend only, so
+    # `rsa` is never compiled into any target (`cargo tree -i rsa --target all`
+    # is empty). No fixed `rsa` release exists yet — revisit when one ships.
+    # Keep in sync with the `--ignore` flag on the cargo-audit step in rust.yml.
+    { id = "RUSTSEC-2023-0071", reason = "rsa is lock-only via the unused sqlx-mysql backend; never compiled (sqlite-only), so not reachable" },
 ]
 
 # ---------------------------------------------------------------------------
@@ -41,10 +45,9 @@ allow = [
     "MPL-2.0",
     "CC0-1.0",
 ]
-# Treat crates whose license cannot be determined as an error.
-unlicensed = "deny"
-# Copyleft licenses that are not in the allow-list are denied by default.
-copyleft = "deny"
+# With version = 2 the allow-list above is authoritative: any license not
+# listed is denied, and a crate whose license cannot be determined is an
+# error. (The pre-v2 `unlicensed` / `copyleft` keys were removed in v2.)
 
 # ---------------------------------------------------------------------------
 # Bans

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,7 @@
             pkgs.openssl
             rust
             pkgs-unstable.cargo-audit
+            pkgs-unstable.cargo-deny
             pkgs.jdk21
             wasm-bindgen-cli-0_2_122
             pkgs-unstable.dioxus-cli


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from the **`cargo audit`** step in `.github/workflows/rust.yml` so RUSTSEC advisories now **block** merges. The exit code is captured (so the report/PR-comment step still runs) and then re-raised. This is the issue's primary ask and is **proven green on this PR** (CI's first run went red on a real advisory, then green once it was explicitly accepted — see below).
- Accepts **RUSTSEC-2023-0071** (`rsa` "Marvin Attack") via a documented `--ignore` (audit) + `ignore` (deny.toml): `rsa 0.9.10` enters `Cargo.lock` **only** through `sqlx-mysql`; this project uses `sqlx` with the **sqlite backend only**, so `rsa` is never compiled into any target (`cargo tree -i rsa --target all` is empty). No fixed `rsa` release exists yet. Lock-only + unreachable → not exploitable.
- Adds a root `deny.toml` (cargo-deny schema v2) + a `cargo deny check` step (and provisions `cargo-deny` in `flake.nix`), covering what cargo-audit can't: advisories against the ~31 git-pinned Dioxus crates, source allow-listing, and duplicate-version bans.

## ⚠️ cargo-deny ships in observation mode (`continue-on-error`)
> [!IMPORTANT]
> The `cargo deny check` step is intentionally **non-blocking for now**. This `deny.toml` was authored in an environment without `cargo-deny` + the advisory DB, so its allow-lists/sources have **not** had a clean validating run. The step is scoped to `advisories sources bans` (the `licenses` check is left configured but not run — workspace members are unpublished/unlicensed). **Action for the maintainer:** once it has one green run on a real runner, drop the `continue-on-error: true` line to promote it to a hard gate (and optionally add `licenses`). Real enforcement in the meantime comes from the blocking `cargo audit` step.

## deny.toml posture (conservative)
- `[advisories] version = 2` — vulnerabilities/unmaintained denied; `ignore` carries only the documented rsa entry.
- `[licenses] version = 2` — permissive allow-list (MIT/Apache-2.0/BSD/ISC/Unicode/Zlib/MPL-2.0/CC0); deprecated `unlicensed`/`copyleft` keys omitted (v2 rejects them).
- `[bans] multiple-versions = "warn"` — the git-pinned Dioxus tree legitimately duplicates transitive versions.
- `[sources]` — crates.io + the DioxusLabs git source (the only non-crates.io source in the lock).

## Test plan
- [x] cargo-audit now **fails CI on advisories** — proven: first run red on RUSTSEC-2023-0071, green after the documented ignore.
- [ ] First real `cargo deny check` run on a runner; then remove `continue-on-error` to make it blocking.

## Notes
- `rust.yml` is also edited by #268 (clippy steps in the separate `check` job). Different sections — no real conflict.

Closes #214

<sub>Authored with Claude Code.</sub>