### PR TITLE
refactor: make EnvGuard self-locking so ENV_LOCK is type-enforced (#247)

### DIFF
--- a/server/src/auth/boot.rs
+++ b/server/src/auth/boot.rs
@@ -127,61 +127,95 @@ pub async fn seed_dev_user(pool: &SqlitePool) -> Result<(), omnibus_db::auth::Au
 }
 
 #[cfg(test)]
-// Each test in this module holds `ENV_LOCK` across `await` points on
-// purpose — `std::env::{set_var, remove_var}` is process-global and racy,
-// so we serialize via a `std::sync::Mutex` (an async mutex wouldn't help
-// because the lock guards the env var itself, not just coroutine turns).
-#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
     use omnibus_db as db;
 
     // std::env is global so these tests can't be parallelised safely; we
-    // serialize on a static mutex. Also restore the prior value on drop.
-    use std::sync::Mutex;
+    // serialize on a static mutex. `EnvGuard` acquires this lock itself in
+    // its constructor and holds it for its entire lifetime — callers cannot
+    // construct an `EnvGuard` without implicitly holding the lock, so the
+    // safety invariant is enforced by construction rather than by convention.
+    use std::sync::{Mutex, MutexGuard};
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// RAII guard that serializes access to `std::env` and restores the
+    /// prior value on drop.
+    ///
+    /// `EnvGuard::set` / `EnvGuard::unset` acquire `ENV_LOCK` themselves and
+    /// store the `MutexGuard` inside the struct.  The guard is released when
+    /// the `EnvGuard` is dropped (after the env var is restored), so it is
+    /// structurally impossible to mutate the environment without holding the
+    /// lock — no documentation contract for callers to misunderstand.
+    ///
+    /// The `MutexGuard` is held across `.await` points in the tests that use
+    /// this helper, which clippy flags.  The `#[allow]` is on the individual
+    /// tests that do so (rather than the whole module) so it is scoped as
+    /// tightly as possible.  An async mutex is not appropriate here: the lock
+    /// guards the process-global environment, not just a single coroutine
+    /// turn, so we must use a `std::sync::Mutex` and intentionally hold it
+    /// across yield points to prevent other tests from racing on env.
     struct EnvGuard {
         key: &'static str,
         prev: Option<String>,
+        // Held for the lifetime of this guard; released on drop after env is
+        // restored.  Named with a leading underscore to communicate "held for
+        // side-effect" to the compiler (suppresses unused-variable lint).
+        _lock: MutexGuard<'static, ()>,
     }
+
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
+            let lock = ENV_LOCK.lock().unwrap();
             let prev = std::env::var(key).ok();
-            // SAFETY: caller holds `ENV_LOCK` and must keep it held until after
-            // this `EnvGuard` is dropped — i.e. declare `let _lock = ENV_LOCK.lock()`
-            // *before* the `EnvGuard` so reverse-drop order keeps the lock alive
-            // across `Drop` (which also mutates env). No concurrent env mutation
-            // can occur while that contract is upheld.
+            // SAFETY: `_lock` guarantees exclusive access to the process
+            // environment for the duration of this guard's lifetime —
+            // acquired above and held until `Drop` restores the prior value
+            // and then releases the lock.  No concurrent env mutation can
+            // occur while the guard is alive.
             unsafe { std::env::set_var(key, value) };
-            Self { key, prev }
+            Self {
+                key,
+                prev,
+                _lock: lock,
+            }
         }
+
         fn unset(key: &'static str) -> Self {
+            let lock = ENV_LOCK.lock().unwrap();
             let prev = std::env::var(key).ok();
-            // SAFETY: same contract as `EnvGuard::set` — caller must hold `ENV_LOCK`
-            // across this call *and* the eventual `Drop`.
+            // SAFETY: same guarantee as `EnvGuard::set` — `_lock` is held
+            // for the entire guard lifetime, preventing concurrent env access.
             unsafe { std::env::remove_var(key) };
-            Self { key, prev }
+            Self {
+                key,
+                prev,
+                _lock: lock,
+            }
         }
     }
+
     impl Drop for EnvGuard {
         fn drop(&mut self) {
-            // SAFETY: `ENV_LOCK` is still held by the caller — see the contract
-            // documented on `EnvGuard::set`/`unset`. Because callers declare
-            // `_lock` before `_g`, reverse-drop order guarantees the lock
-            // outlives this `Drop`. No concurrent env mutation can occur.
+            // SAFETY: `self._lock` is still live — `MutexGuard` fields are
+            // dropped after other fields in declaration order, but even if
+            // reordering occurred the lock is still held at this point
+            // because `_lock` and the env mutation are part of the same
+            // struct.  Regardless, `_lock` is the last meaningful field, so
+            // we restore the environment while the lock is unambiguously held.
             unsafe {
                 match &self.prev {
                     Some(v) => std::env::set_var(self.key, v),
                     None => std::env::remove_var(self.key),
                 }
             }
+            // `self._lock` is dropped here (end of `drop`), releasing the mutex.
         }
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn unset_env_is_noop() {
-        let _lock = ENV_LOCK.lock().unwrap();
         let _g = EnvGuard::unset("OMNIBUS_INITIAL_ADMIN");
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         db::auth::create_user(&pool, "alice", "correct horse battery staple")
@@ -196,9 +230,9 @@ mod tests {
         assert!(u.is_admin);
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn env_promotes_existing_non_admin() {
-        let _lock = ENV_LOCK.lock().unwrap();
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         // alice becomes admin (first user). bob does not.
         db::auth::create_user(&pool, "alice", "correct horse battery staple")
@@ -226,9 +260,9 @@ mod tests {
         assert!(bob.is_admin);
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn env_for_unknown_user_is_noop_no_error() {
-        let _lock = ENV_LOCK.lock().unwrap();
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         let _g = EnvGuard::set("OMNIBUS_INITIAL_ADMIN", "ghost");
         apply_initial_admin(&pool).await.unwrap();
@@ -236,9 +270,9 @@ mod tests {
 
     // ----- seed_dev_user -----
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn seed_unset_env_is_noop() {
-        let _lock = ENV_LOCK.lock().unwrap();
         let _g = EnvGuard::unset("OMNIBUS_DEV_SEED_USER");
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         seed_dev_user(&pool).await.unwrap();
@@ -248,9 +282,9 @@ mod tests {
             .is_none());
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn seed_creates_admin_when_user_absent() {
-        let _lock = ENV_LOCK.lock().unwrap();
         let _g = EnvGuard::set("OMNIBUS_DEV_SEED_USER", "admin:omnibus-dev");
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         seed_dev_user(&pool).await.unwrap();
@@ -261,9 +295,9 @@ mod tests {
         assert!(u.is_admin, "seeded user should be admin");
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn seed_is_idempotent_when_user_exists() {
-        let _lock = ENV_LOCK.lock().unwrap();
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         // Pre-create admin with a known password.
         db::auth::create_user(&pool, "admin", "preexisting-password")
@@ -280,9 +314,9 @@ mod tests {
             .expect("original password should still authenticate");
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn seed_malformed_env_is_noop_no_error() {
-        let _lock = ENV_LOCK.lock().unwrap();
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         // Missing ':' delimiter.
         let _g = EnvGuard::set("OMNIBUS_DEV_SEED_USER", "no-colon-here");
@@ -293,9 +327,9 @@ mod tests {
             .is_none());
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn seed_works_when_other_users_already_exist() {
-        let _lock = ENV_LOCK.lock().unwrap();
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         // alice is the first user (admin); registration closes afterwards.
         db::auth::create_user(&pool, "alice", "correct horse battery staple")
@@ -312,13 +346,13 @@ mod tests {
         assert!(u.is_admin);
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn seed_restores_prior_registration_enabled_flag() {
         // Reviewer PR #71 / boot.rs:94 — seed_dev_user used to leave
         // registration_enabled=true after running, accidentally re-opening
         // public registration in a half-bootstrapped DB. The fix snapshots
         // the flag before the insert and restores it after.
-        let _lock = ENV_LOCK.lock().unwrap();
         let pool = db::init_db("sqlite::memory:").await.unwrap();
         // First user closes registration as a side effect.
         db::auth::create_user(&pool, "alice", "correct horse battery staple")

--- a/server/src/auth/boot.rs
+++ b/server/src/auth/boot.rs
@@ -166,7 +166,11 @@ mod tests {
 
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
-            let lock = ENV_LOCK.lock().unwrap();
+            // Recover from a poisoned lock (a prior test panicked while
+            // holding it) instead of cascading the panic into every
+            // subsequent env-var test — matches the repo's other ENV_LOCK
+            // / mutex call sites (e.g. db::settings, db::worker).
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
             let prev = std::env::var(key).ok();
             // SAFETY: `_lock` guarantees exclusive access to the process
             // environment for the duration of this guard's lifetime —
@@ -182,7 +186,11 @@ mod tests {
         }
 
         fn unset(key: &'static str) -> Self {
-            let lock = ENV_LOCK.lock().unwrap();
+            // Recover from a poisoned lock (a prior test panicked while
+            // holding it) instead of cascading the panic into every
+            // subsequent env-var test — matches the repo's other ENV_LOCK
+            // / mutex call sites (e.g. db::settings, db::worker).
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
             let prev = std::env::var(key).ok();
             // SAFETY: same guarantee as `EnvGuard::set` — `_lock` is held
             // for the entire guard lifetime, preventing concurrent env access.


### PR DESCRIPTION
## Summary
- `EnvGuard` in `server/src/auth/boot.rs` (test-only helper) previously required every caller to manually `let _lock = ENV_LOCK.lock()` *before* constructing the guard, relying on a documentation contract + reverse drop-order to keep the lock alive across the guard's `Drop` (which mutates `std::env`, `unsafe` since Rust 1.81). A test author copying the pattern without the manual lock would silently introduce a data race.
- `EnvGuard::set`/`unset` now acquire `ENV_LOCK` themselves and store the `MutexGuard<'static, ()>` as a `_lock` field, released on `Drop` after the env var is restored. It is now structurally impossible to mutate the environment without holding the lock — the invariant is enforced by construction, not convention.
- All nine manual `let _lock = ENV_LOCK.lock().unwrap()` call sites are removed. The module-wide `#[allow(clippy::await_holding_lock)]` is demoted to per-test annotations so the suppression is as tight as possible. `SAFETY` comments updated to reflect the self-held guarantee.

Test-helper only — no production code or behavior changes, no new dependencies.

## Test plan
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus -- --test-threads=1` — all 9 `auth::boot::tests::*` env tests pass (independently re-verified by the orchestrator)
- [x] `cargo fmt` — no churn outside `boot.rs`

## Notes
- `MutexGuard` is `!Send`; the `#[tokio::test]`s are single-threaded current-thread runtimes, so holding it across `.await` is sound (the `#[allow]` documents the intent).
- Struct-field drop order: `_lock` is declared last, so it is released after the env restore in `Drop`.

Closes #247

<sub>Authored with Claude Code.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvurhjmAiLqJCg3HwPCB4y)_