### PR TITLE
ci: make cargo-deny a blocking check (#272)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -244,12 +244,10 @@ jobs:
       # against deny.toml's allow-list locally. The [licenses] config is left in
       # deny.toml so enabling it is a one-line follow-up once verified.
       #
-      # `continue-on-error` (observation mode): this deny.toml was authored
-      # without a runner that has cargo-deny + the advisory DB available, so it
-      # has not yet had a clean run to validate the allow-lists/sources against
-      # the real dependency set. Keep it non-blocking until its first green run,
-      # then drop this line to make it a hard gate. Real enforcement meanwhile
-      # comes from the (blocking) `cargo audit` step above.
+      # Now a hard gate: a violation in advisories, sources, or bans fails the
+      # job. If a deny.toml policy needs to relax (e.g. a new git-pinned source
+      # appears for a Dioxus crate), update deny.toml's `[sources.allow-git]`
+      # or the relevant `ignore`/`skip` list rather than re-introducing
+      # `continue-on-error: true`.
       - name: cargo deny check
-        continue-on-error: true
         run: nix develop --command cargo deny check advisories sources bans

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,31 @@ ignore = [
     # is empty). No fixed `rsa` release exists yet — revisit when one ships.
     # Keep in sync with the `--ignore` flag on the cargo-audit step in rust.yml.
     { id = "RUSTSEC-2023-0071", reason = "rsa is lock-only via the unused sqlx-mysql backend; never compiled (sqlite-only), so not reachable" },
+
+    # ---- Unmaintained (informational) advisories pulled in by the Dioxus
+    # desktop/mobile native shell tree (wry/tao → gtk-rs/webkit2gtk on Linux,
+    # plus a few proc-macro helpers). These are NOT vulnerabilities; they are
+    # "crate is no longer maintained" notices. We accept them because:
+    #   1. They originate exclusively from upstream Dioxus dependencies which
+    #      we git-pin (see [sources.allow-git] below). Removing them requires
+    #      upstream Dioxus to migrate off these crates — not in our control.
+    #   2. cargo-audit (the blocking vulnerability gate in rust.yml's
+    #      `security` job) covers real RUSTSEC vulnerabilities. cargo-deny
+    #      here adds source/ban enforcement; surfacing unmaintained notices
+    #      is informational, not a security gate.
+    # Revisit when Dioxus upgrades the affected sub-trees.
+    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error unmaintained — transitive via Dioxus mobile/desktop crates; awaiting upstream migration" },
+    { id = "RUSTSEC-2024-0411", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0412", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0413", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0414", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0415", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0416", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0418", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0419", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0420", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — transitive via Dioxus mobile/desktop crates; awaiting upstream migration" },
+    { id = "RUSTSEC-2025-0057", reason = "fxhash unmaintained — transitive via Dioxus mobile/desktop crates; awaiting upstream migration" },
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Drops `continue-on-error: true` from the `cargo deny check` step in `.github/workflows/rust.yml` so a violation in `advisories`, `sources`, or `bans` now **fails** the `security` job instead of producing a silently-ignored warning. The original comment ("Keep it non-blocking until its first green run, then drop this line to make it a hard gate.") explicitly called for this once a clean local run was confirmed; per #272 that follow-up was never landed.
- Rewords the inline comment to document the new posture (and how to relax a policy via `deny.toml` rather than re-introducing `continue-on-error`).
- Adds documented `[advisories.ignore]` entries for the 12 unmaintained-crate notices that surface against the current `Cargo.lock` — all transitive via the git-pinned Dioxus desktop/mobile native shell tree (`wry`/`tao` → `gtk-rs`, plus `paste`, `proc-macro-error`, `fxhash`). These are `unmaintained` informational advisories, **not** vulnerabilities; `cargo audit` (already a blocking gate in the same job) continues to be the security-vuln enforcement plane. Revisit when upstream Dioxus migrates off the affected crates.

Stays scoped to `advisories sources bans` — `licenses` remains intentionally off per the existing comment (workspace members are unpublished).

## Test plan
- [x] `cargo fmt --check` — clean (the only changed file is YAML; no Rust touched).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — runs unchanged. Pre-existing failures on `main` (`omnibus-frontend` `CurrentUser`/`web_sys::BlobPropertyBag::type_`) reproduce identically with this branch checked out vs. `origin/main`; not introduced here.
- [x] **Verified `cargo deny check advisories sources bans` locally:** installed `cargo-deny v0.19.8` via `cargo install --locked cargo-deny`, ran the exact CI command. First run failed (12 unmaintained advisories surfaced — exactly the case `continue-on-error` was masking). Added documented ignores; re-ran → `advisories ok, bans ok, sources ok` (exit 0). The branch's own CI run is the production verification.
- [ ] Confirm the `security` job's `cargo deny check` step runs green on this PR's CI.

## Notes
> [!IMPORTANT]
> **The point of this PR.** Before this change, `cargo deny check` could silently fail on a banned crate, a disallowed git source, or a new RUSTSEC advisory and CI would pass anyway — exactly the "policy violations never block PRs" failure mode #272 describes. The blocking `cargo audit` step covers vulnerabilities, but the source allow-list, ban list, and unmaintained-crate notices were getting reported and discarded. They will now fail the job.

> [!NOTE]
> CI `clippy + test` job may show red from the **pre-existing** clippy failures on `main` listed under the test plan (`omnibus-frontend` build errors); unrelated to this change. The relevant gate for this PR is the `security` job's `cargo deny check` step.

Closes #272

<sub>Authored with Claude Code.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr6c66demnTfNf1XYGTtwX)_