### PR TITLE
docs: warn when OMNIBUS_TRUST_FORWARDED_FOR is enabled (#278)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,18 @@ OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
 # oldest-mtime-first order (FIFO by mtime — not true LRU, since reads
 # don't bump mtime). Read by db::thumbs::cap_bytes.
 #OMNIBUS_THUMBS_CAP_BYTES=5368709120
+
+# Whether to trust the client-supplied X-Forwarded-For header as the
+# per-IP rate-limit key. Defaults to false (the TCP peer IP is used).
+#
+# WARNING: OMNIBUS_TRUST_FORWARDED_FOR=1 MUST NOT be set unless a trusted
+# reverse proxy rewrites X-Forwarded-For before requests reach Axum.
+# Setting this on a directly internet-exposed deployment defeats all
+# per-IP rate limiting — any client can rotate the header on every
+# request to spoof a fresh bucket, trivially bypassing the
+# /api/auth/login throttle (10 req/60s) and enabling unbounded
+# credential stuffing. Only enable when a known-good proxy (nginx,
+# Caddy, Traefik, a cloud load balancer, etc.) sits in front of the
+# server and strips inbound X-Forwarded-For from untrusted hops.
+# Read by server::rate_limit::trust_forwarded_for.
+#OMNIBUS_TRUST_FORWARDED_FOR=1

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -34,13 +34,6 @@ fn main() {
             // the rebuild-detection use case.
             backend::init_build_id();
 
-            // #278: warn loudly when the operator has opted in to trusting
-            // client-supplied X-Forwarded-For headers. This is only safe
-            // behind a trusted reverse proxy that rewrites the header from
-            // a known-good source — on a directly internet-exposed
-            // deployment any client can rotate the header per request and
-            // bypass the per-IP rate limiter entirely (e.g. unbounded
-            // /api/auth/login credential stuffing).
             if rate_limit::trust_forwarded_for() {
                 tracing::warn!(
                     target: "omnibus::startup",

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -34,6 +34,20 @@ fn main() {
             // the rebuild-detection use case.
             backend::init_build_id();
 
+            // #278: warn loudly when the operator has opted in to trusting
+            // client-supplied X-Forwarded-For headers. This is only safe
+            // behind a trusted reverse proxy that rewrites the header from
+            // a known-good source — on a directly internet-exposed
+            // deployment any client can rotate the header per request and
+            // bypass the per-IP rate limiter entirely (e.g. unbounded
+            // /api/auth/login credential stuffing).
+            if rate_limit::trust_forwarded_for() {
+                tracing::warn!(
+                    target: "omnibus::startup",
+                    "OMNIBUS_TRUST_FORWARDED_FOR is enabled \u{2014} ensure a trusted reverse proxy is in front."
+                );
+            }
+
             let database_url = std::env::var("DATABASE_URL")
                 .unwrap_or_else(|_| "sqlite://omnibus.db?mode=rwc".to_string());
 

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -46,7 +46,13 @@ pub const MAX_REQUESTS: u32 = 10;
 /// Maximum number of tracked IPs before stale buckets are pruned.
 const MAX_BUCKETS: usize = 10_000;
 
-fn trust_forwarded_for() -> bool {
+/// Returns true when the operator has opted in to consulting the client-supplied
+/// `X-Forwarded-For` header as the rate-limit key (via
+/// `OMNIBUS_TRUST_FORWARDED_FOR={1,true,yes}`). Exposed `pub` so the server
+/// entrypoint can emit a startup warning — enabling this without a trusted
+/// reverse proxy in front of Axum lets any client rotate the header per
+/// request and defeats the per-IP limiter entirely (#278).
+pub fn trust_forwarded_for() -> bool {
     matches!(
         std::env::var("OMNIBUS_TRUST_FORWARDED_FOR").as_deref(),
         Ok("1" | "true" | "yes")


### PR DESCRIPTION
## Summary

- Document in `.env.example` that `OMNIBUS_TRUST_FORWARDED_FOR=1` must NOT be set unless a trusted reverse proxy rewrites `X-Forwarded-For` before requests reach Axum — otherwise any client can rotate the header per request to spoof a fresh rate-limit bucket, trivially bypassing the 10/60s per-IP throttle on `/api/auth/login` and enabling unbounded credential stuffing.
- Emit a `tracing::warn!(target: "omnibus::startup", ...)` at boot in `server/src/main.rs` when the flag is on, prompting operators to verify the proxy assumption holds.
- Expose `rate_limit::trust_forwarded_for` as `pub` so the entrypoint can reuse the existing env reader instead of duplicating it.

No behavior change to the limiter itself — the default (flag unset) is already safe, and this PR does not alter how the IP key is resolved when the flag is on.

## Notes

- Per the Stage-A plan, the long-term "remove the flag and rely on the standard `Forwarded` header from a known-good source" recommendation is intentionally **not** implemented here — it's a follow-up that touches request-resolution semantics and deserves its own issue/PR.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean on default workspace members (`--all-features` has pre-existing failures in `omnibus-frontend` unrelated to this change: `CurrentUser` feature-gate mismatch + deprecated `web_sys::BlobPropertyBag::type_`)
- [x] `cargo test` — full workspace passes (server 128/128, frontend 100/100, db 20/20)
- [x] Existing `rate_limit::tests::*` continue to pass; no new tests added because a startup `tracing::warn!` log line has no observable behavior to assert (matches the project's existing pattern for other one-shot boot logs like `apply_initial_admin` / `seed_dev_user`).
- [ ] Manual sanity: `OMNIBUS_TRUST_FORWARDED_FOR=1 cargo run -p omnibus` and confirm the warn line appears in stderr at boot.

Closes #278

https://claude.ai/code/session_01Jr6c66demnTfNf1XYGTtwX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr6c66demnTfNf1XYGTtwX)_