### PR TITLE
fix: validate username on create_user (#276)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -31,7 +31,7 @@ mod users;
 
 pub use device::{list_devices_for_user, register_device};
 pub use login::verify_login;
-pub use password::{hash_password, validate_password, verify_password};
+pub use password::{hash_password, validate_password, validate_username, verify_password};
 pub use session::{
     create_session, lookup_session, prune_expired_sessions, revoke_all_sessions_for_user,
     revoke_session, validate_session, SessionAuthError,
@@ -57,6 +57,14 @@ pub enum AuthError {
     AccountLocked { until_unix: i64 },
     #[error("username is already taken")]
     UsernameTaken,
+    #[error("username must not be empty")]
+    UsernameEmpty,
+    #[error("username is too long (max {max} chars)")]
+    UsernameTooLong { max: usize },
+    #[error("username must not have leading or trailing whitespace")]
+    UsernameWhitespace,
+    #[error("username contains an invalid control character")]
+    UsernameInvalidChar,
     #[error("password is too short (min {min} chars)")]
     PasswordTooShort { min: usize },
     #[error("password is too long (max {max} chars)")]

--- a/db/src/auth/password.rs
+++ b/db/src/auth/password.rs
@@ -17,6 +17,12 @@ const ARGON2_PARALLELISM: u32 = 1;
 const MIN_PASSWORD_LEN: usize = 10;
 const MAX_PASSWORD_LEN: usize = 128;
 
+/// Username length ceiling, measured in Unicode scalar values. Sized to
+/// comfortably cover real names, role-style handles, and email-derived
+/// usernames while keeping the value short enough to render in any UI
+/// column and to bound storage/log overhead per row.
+const MAX_USERNAME_LEN: usize = 64;
+
 /// Tiny embedded reject-list. Deliberately small (top ~50) — this is a
 /// "don't be stupid" check, not a HIBP replacement. Self-hosted deployments
 /// are offline-tolerant, so a runtime breach check is out of scope.
@@ -104,6 +110,51 @@ pub fn validate_password(password: &str) -> AuthResult<()> {
     Ok(())
 }
 
+/// Validate a username before insert. Rules:
+///
+/// * Non-empty after rejecting leading/trailing whitespace.
+/// * Maximum `MAX_USERNAME_LEN` Unicode scalar values (not bytes), so a
+///   handful of multi-byte characters can't cheaply blow past the cap.
+/// * No leading or trailing whitespace — those are almost always a paste
+///   accident and the lack of normalization would let "alice" and
+///   " alice" coexist as distinct rows under `COLLATE NOCASE`.
+/// * No ASCII control characters (U+0000..=U+001F, U+007F). Null bytes
+///   break C-string-shaped consumers; other controls corrupt log output
+///   and terminal/UI rendering.
+///
+/// Deliberately *not* handled here: Unicode homoglyph confusables
+/// (e.g. Cyrillic `а` vs Latin `a`). That's a normalization/display
+/// concern that belongs alongside the admin UI surfaces that render
+/// user-supplied usernames; case-collision dedup via the existing
+/// `users.username COLLATE NOCASE` index is the only collision guarantee
+/// this layer makes.
+pub fn validate_username(username: &str) -> AuthResult<()> {
+    if username.is_empty() {
+        return Err(AuthError::UsernameEmpty);
+    }
+    if username.trim() != username {
+        return Err(AuthError::UsernameWhitespace);
+    }
+    // Re-check after trim in case the input was entirely whitespace —
+    // `trim() != self` would have already caught that, but the empty check
+    // here makes the intent explicit if the rules above ever reorder.
+    if username.trim().is_empty() {
+        return Err(AuthError::UsernameEmpty);
+    }
+    if username.chars().count() > MAX_USERNAME_LEN {
+        return Err(AuthError::UsernameTooLong {
+            max: MAX_USERNAME_LEN,
+        });
+    }
+    if username
+        .chars()
+        .any(|c| (c as u32) <= 0x1F || c as u32 == 0x7F)
+    {
+        return Err(AuthError::UsernameInvalidChar);
+    }
+    Ok(())
+}
+
 pub fn hash_password(password: &str) -> AuthResult<String> {
     let salt = SaltString::generate(&mut PhcOsRng);
     let phc = argon2_hasher()
@@ -154,5 +205,109 @@ mod tests {
     #[test]
     fn password_policy_accepts_reasonable() {
         assert!(validate_password("xk7-banana-frog-42").is_ok());
+    }
+
+    // ---- username policy ----------------------------------------------------
+
+    #[test]
+    fn username_policy_rejects_empty() {
+        assert!(matches!(
+            validate_username(""),
+            Err(AuthError::UsernameEmpty)
+        ));
+    }
+
+    #[test]
+    fn username_policy_accepts_single_char() {
+        assert!(validate_username("a").is_ok());
+    }
+
+    #[test]
+    fn username_policy_accepts_max_length() {
+        let name: String = "a".repeat(MAX_USERNAME_LEN);
+        assert!(validate_username(&name).is_ok());
+    }
+
+    #[test]
+    fn username_policy_rejects_over_max_length() {
+        let name: String = "a".repeat(MAX_USERNAME_LEN + 1);
+        assert!(matches!(
+            validate_username(&name),
+            Err(AuthError::UsernameTooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn username_policy_rejects_leading_whitespace() {
+        assert!(matches!(
+            validate_username(" alice"),
+            Err(AuthError::UsernameWhitespace)
+        ));
+    }
+
+    #[test]
+    fn username_policy_rejects_trailing_whitespace() {
+        assert!(matches!(
+            validate_username("alice "),
+            Err(AuthError::UsernameWhitespace)
+        ));
+    }
+
+    #[test]
+    fn username_policy_rejects_only_whitespace() {
+        // All-whitespace input has trim() != self, so it surfaces as the
+        // whitespace error rather than the empty error — either is a
+        // reject, but lock the variant to keep callers' error UX stable.
+        assert!(matches!(
+            validate_username("   "),
+            Err(AuthError::UsernameWhitespace)
+        ));
+    }
+
+    #[test]
+    fn username_policy_rejects_embedded_tab() {
+        assert!(matches!(
+            validate_username("ali\tce"),
+            Err(AuthError::UsernameInvalidChar)
+        ));
+    }
+
+    #[test]
+    fn username_policy_rejects_embedded_newline() {
+        assert!(matches!(
+            validate_username("ali\nce"),
+            Err(AuthError::UsernameInvalidChar)
+        ));
+    }
+
+    #[test]
+    fn username_policy_rejects_embedded_null() {
+        assert!(matches!(
+            validate_username("ali\0ce"),
+            Err(AuthError::UsernameInvalidChar)
+        ));
+    }
+
+    #[test]
+    fn username_policy_rejects_low_control_char() {
+        assert!(matches!(
+            validate_username("ali\x1fce"),
+            Err(AuthError::UsernameInvalidChar)
+        ));
+    }
+
+    #[test]
+    fn username_policy_rejects_delete_char() {
+        assert!(matches!(
+            validate_username("ali\x7fce"),
+            Err(AuthError::UsernameInvalidChar)
+        ));
+    }
+
+    #[test]
+    fn username_policy_accepts_reasonable() {
+        assert!(validate_username("alice").is_ok());
+        assert!(validate_username("Alice.Smith-42_").is_ok());
+        assert!(validate_username("user@example.com").is_ok());
     }
 }

--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -2,7 +2,7 @@
 
 use sqlx::SqlitePool;
 
-use super::password::{hash_password, validate_password};
+use super::password::{hash_password, validate_password, validate_username};
 use super::{row_to_user, AuthError, AuthResult, User};
 
 /// Atomically create a user. The first user created becomes admin; the
@@ -11,6 +11,7 @@ use super::{row_to_user, AuthError, AuthResult, User};
 /// if disabled. Uses BEGIN IMMEDIATE so two concurrent callers cannot both
 /// observe an empty users table.
 pub async fn create_user(pool: &SqlitePool, username: &str, password: &str) -> AuthResult<User> {
+    validate_username(username)?;
     validate_password(password)?;
     let phc = hash_password(password)?;
 
@@ -255,6 +256,32 @@ mod tests {
         // The connection is back in a usable, non-stuck state.
         let bob = create_user(&p, "bob", "bunker9-longer-pass").await.unwrap();
         assert!(!bob.is_admin);
+    }
+
+    #[tokio::test]
+    async fn create_user_rejects_invalid_username() {
+        // create_user runs validate_username before touching the DB, so an
+        // empty/control-char/oversize username should error out without
+        // consuming the first-user-admin slot.
+        let p = pool().await;
+
+        assert!(matches!(
+            create_user(&p, "", "hunter2-real-long").await,
+            Err(AuthError::UsernameEmpty)
+        ));
+        assert!(matches!(
+            create_user(&p, "ali\0ce", "hunter2-real-long").await,
+            Err(AuthError::UsernameInvalidChar)
+        ));
+        assert!(matches!(
+            create_user(&p, " alice", "hunter2-real-long").await,
+            Err(AuthError::UsernameWhitespace)
+        ));
+
+        // None of the rejected attempts created a row, so the first valid
+        // create still gets the admin slot.
+        let alice = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+        assert!(alice.is_admin);
     }
 
     #[tokio::test]

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -391,6 +391,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn register_invalid_username_returns_400() {
+        // Cover each AuthError::Username* validation rejection at the HTTP
+        // boundary (#276). Each case is a fresh app so the
+        // first-registration / registration-disabled gate doesn't latch
+        // between iterations.
+        // `too_long` deliberately uses 256 chars — well over the 64-scalar
+        // MAX_USERNAME_LEN policy without depending on the (private) const.
+        let too_long = "x".repeat(256);
+        let cases: &[(&str, &str)] = &[
+            ("empty", ""),
+            ("too_long", &too_long),
+            ("leading_space", " alice"),
+            ("trailing_space", "alice "),
+            ("control_char", "ali\x01ce"),
+            ("null_byte", "ali\0ce"),
+        ];
+        for (label, username) in cases {
+            let (app, _pool) = app().await;
+            let res = app
+                .oneshot(json_req(
+                    "/api/auth/register",
+                    "POST",
+                    json!({"username": username, "password": "correct horse battery staple"}),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(
+                res.status(),
+                StatusCode::BAD_REQUEST,
+                "username case {label} must reject with 400, got {}",
+                res.status()
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn register_second_same_username_returns_409() {
         let (app, pool) = app().await;
         // First registration closes the gate; reopen it so the second attempt

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -77,6 +77,24 @@ fn auth_error_to_response(e: AuthError) -> Response {
                 .into_response()
         }
         AuthError::UsernameTaken => (StatusCode::CONFLICT, "username taken").into_response(),
+        AuthError::UsernameEmpty => {
+            (StatusCode::BAD_REQUEST, "username must not be empty").into_response()
+        }
+        AuthError::UsernameTooLong { max } => (
+            StatusCode::BAD_REQUEST,
+            format!("username too long (max {max})"),
+        )
+            .into_response(),
+        AuthError::UsernameWhitespace => (
+            StatusCode::BAD_REQUEST,
+            "username must not have leading or trailing whitespace",
+        )
+            .into_response(),
+        AuthError::UsernameInvalidChar => (
+            StatusCode::BAD_REQUEST,
+            "username contains an invalid control character",
+        )
+            .into_response(),
         AuthError::PasswordTooShort { min } => (
             StatusCode::BAD_REQUEST,
             format!("password too short (min {min})"),


### PR DESCRIPTION
## Summary

- `create_user` previously called `validate_password` but had no equivalent guard for usernames — any string (including empty, megabyte-sized, leading/trailing whitespace, or ASCII control characters like NUL/`\t`/`\n`/`\x1f`/`\x7f`) was accepted and stored verbatim in `users.username TEXT NOT NULL COLLATE NOCASE`.
- Adds `validate_username` in `db/src/auth/password.rs` (next to `validate_password` for proximity) enforcing: non-empty, max 64 Unicode scalar values, no leading/trailing whitespace, no ASCII controls (`U+0000..=U+001F`, `U+007F`). Called at the top of `create_user`, matching the `validate_password` pattern.
- Extends `AuthError` with four new variants (`UsernameEmpty`, `UsernameTooLong`, `UsernameWhitespace`, `UsernameInvalidChar`) and maps each to a 400 in `server/src/auth/handlers.rs::auth_error_to_response` so registration surfaces the failure cleanly. The handler match was already exhaustive, so the variants are covered explicitly rather than via a wildcard.

Closes #276

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` clean (default features). `--all-features` surfaces pre-existing `omnibus-frontend` failures on `main` (deprecated `web_sys::BlobPropertyBag::type_`, missing `CurrentUser` under the `mobile` feature) that are unrelated to this change.
- [x] `cargo test -p omnibus-db` — 342 passed (15 new username tests: empty, single char, 64-char boundary, 65-char over, leading/trailing/only-whitespace, embedded `\t` / `\n` / `\0` / `\x1f` / `\x7f`, three happy-path cases, plus a `create_user_rejects_invalid_username` integration test confirming the guard runs before any DB work)
- [x] `cargo test -p omnibus` — 128 passed (handler match still exhaustive, no behavior regression)

## Notes

- Unicode homoglyph confusables (e.g. Cyrillic `а` vs Latin `a` impersonating `admin`) are deliberately out of scope here — that's a normalization concern that belongs alongside whichever admin UI surfaces start rendering user-supplied usernames in security-sensitive contexts. The existing `COLLATE NOCASE` dedup only guards exact case-collisions; a confusables pass would need to land in the same change as a display-side normalization to be coherent. Filed as a follow-up consideration in the `validate_username` doc-comment.
- The whitespace check intentionally rejects all-whitespace input under `UsernameWhitespace` (since `trim() != self`) rather than `UsernameEmpty`. Locked in a test so the rejection variant doesn't silently change if the rule order is reshuffled.

https://claude.ai/code/session_01Jr6c66demnTfNf1XYGTtwX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr6c66demnTfNf1XYGTtwX)_