### PR TITLE
refactor: auth hardening batch — __Host- cookies, device name caps, gate test, password_changed_at invariant (#279, #280, #281, #282)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -29,7 +29,10 @@ mod session_key;
 mod token;
 mod users;
 
-pub use device::{list_devices_for_user, register_device};
+pub use device::{
+    list_devices_for_user, register_device, validate_client_version, validate_device_name,
+    MAX_CLIENT_VERSION_CHARS, MAX_DEVICE_NAME_CHARS,
+};
 pub use login::verify_login;
 pub use password::{hash_password, validate_password, verify_password};
 pub use session::{
@@ -37,7 +40,10 @@ pub use session::{
     revoke_session, validate_session, SessionAuthError,
 };
 pub use session_key::{get_session_key, load_or_create_session_key, put_session_key};
-pub use token::{generate_token, hash_token, parse_session_token, SESSION_COOKIE_NAME};
+pub use token::{
+    generate_token, hash_token, is_session_cookie_name, parse_session_token, SESSION_COOKIE_NAME,
+    SESSION_COOKIE_NAME_HOST_PREFIXED,
+};
 pub use users::{
     create_user, get_user_by_id, get_user_by_username, promote_to_admin, registration_enabled,
     set_registration_enabled,
@@ -67,6 +73,11 @@ pub enum AuthError {
     RegistrationDisabled,
     #[error("session not found or expired")]
     SessionNotFound,
+    #[error("invalid {field}: {reason}")]
+    DeviceFieldInvalid {
+        field: &'static str,
+        reason: &'static str,
+    },
     #[error(transparent)]
     Db(#[from] sqlx::Error),
     #[error("password hashing failed: {0}")]

--- a/db/src/auth/device.rs
+++ b/db/src/auth/device.rs
@@ -2,7 +2,62 @@
 
 use sqlx::{Row, SqlitePool};
 
-use super::{AuthResult, Device};
+use super::{AuthError, AuthResult, Device};
+
+/// Maximum accepted length of a `LoginRequest.device_name` /
+/// `RegisterRequest.device_name`. The column is `TEXT NOT NULL`, so the
+/// only natural upper bound is the global 1 MiB body limit — small per
+/// request but unbounded across many calls, so an unauthenticated caller
+/// could spray oversized device names at `/api/auth/register` /
+/// `/login`. 255 chars matches the historical convention for "human
+/// label" columns and keeps the row small for `list_devices_for_user`
+/// pagination.
+pub const MAX_DEVICE_NAME_CHARS: usize = 255;
+
+/// Maximum accepted length of a `client_version`. App version strings
+/// don't legitimately exceed semver + a few build-meta segments; 64
+/// chars covers `1.2.3-rc.10+build.20251205abcdef` with headroom.
+pub const MAX_CLIENT_VERSION_CHARS: usize = 64;
+
+/// Reject ASCII control characters (incl. CR/LF) and oversize strings
+/// before INSERT. We *reject* rather than truncate so a buggy or
+/// malicious client gets a deterministic error instead of silently
+/// shipping mangled data into the `devices` table — log-injection (CR
+/// + crafted `tracing` line) is the specific risk this guards against.
+///
+/// Returns `Ok(())` for `None`: both fields are `#[serde(default)]
+/// Option<String>` on the wire and absence is the legitimate path
+/// (anonymous web login).
+fn validate_device_field(
+    value: Option<&str>,
+    max_chars: usize,
+    label: &'static str,
+) -> AuthResult<()> {
+    let Some(v) = value else {
+        return Ok(());
+    };
+    if v.chars().count() > max_chars {
+        return Err(AuthError::DeviceFieldInvalid {
+            field: label,
+            reason: "too long",
+        });
+    }
+    if v.chars().any(|c| c.is_control()) {
+        return Err(AuthError::DeviceFieldInvalid {
+            field: label,
+            reason: "contains control characters",
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_device_name(name: Option<&str>) -> AuthResult<()> {
+    validate_device_field(name, MAX_DEVICE_NAME_CHARS, "device_name")
+}
+
+pub fn validate_client_version(version: Option<&str>) -> AuthResult<()> {
+    validate_device_field(version, MAX_CLIENT_VERSION_CHARS, "client_version")
+}
 
 pub async fn register_device(
     pool: &SqlitePool,
@@ -11,6 +66,10 @@ pub async fn register_device(
     client_kind: &str,
     client_version: Option<&str>,
 ) -> AuthResult<Device> {
+    // Guards run *before* the INSERT so a rejected field never reaches
+    // SQLite. Mirrors the placement of `validate_password` in `users`.
+    validate_device_name(Some(name))?;
+    validate_client_version(client_version)?;
     let row = sqlx::query(
         "INSERT INTO devices (user_id, name, client_kind, client_version)
          VALUES (?, ?, ?, ?)
@@ -72,5 +131,80 @@ mod tests {
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].id, d.id);
         assert_eq!(list[0].client_kind, "ios");
+    }
+
+    #[test]
+    fn validate_device_name_accepts_short_unicode_label() {
+        // Char count, not byte count: a 4-byte emoji is one character.
+        let s = "📱 Phone — Alice";
+        assert!(validate_device_name(Some(s)).is_ok());
+        assert!(validate_device_name(None).is_ok());
+    }
+
+    #[test]
+    fn validate_device_name_rejects_overlength() {
+        let too_long: String = "a".repeat(MAX_DEVICE_NAME_CHARS + 1);
+        let err = validate_device_name(Some(&too_long)).unwrap_err();
+        match err {
+            AuthError::DeviceFieldInvalid { field, .. } => assert_eq!(field, "device_name"),
+            other => panic!("expected DeviceFieldInvalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_device_name_at_exact_cap_passes() {
+        let exact: String = "a".repeat(MAX_DEVICE_NAME_CHARS);
+        assert!(validate_device_name(Some(&exact)).is_ok());
+    }
+
+    #[test]
+    fn validate_device_name_rejects_control_characters() {
+        // CR/LF guard the log-injection vector — without it a `device_name`
+        // of `"benign\nFAKE LOG LINE"` would split a tracing event into two.
+        for raw in ["benign\nlog", "tab\there", "null\0byte", "bell\x07"] {
+            let err = validate_device_name(Some(raw)).unwrap_err();
+            assert!(
+                matches!(err, AuthError::DeviceFieldInvalid { .. }),
+                "expected control-char rejection for {raw:?}, got {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_client_version_caps_at_64_chars() {
+        assert!(validate_client_version(Some("1.2.3-rc.10+build.abc")).is_ok());
+        let too_long: String = "1".repeat(MAX_CLIENT_VERSION_CHARS + 1);
+        let err = validate_client_version(Some(&too_long)).unwrap_err();
+        assert!(
+            matches!(err, AuthError::DeviceFieldInvalid { field, .. } if field == "client_version")
+        );
+    }
+
+    #[tokio::test]
+    async fn register_device_rejects_overlong_name_before_insert() {
+        // No row is inserted on rejection — the validator runs before the
+        // SQL roundtrip, so list_devices_for_user stays empty.
+        let p = pool().await;
+        let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+        let too_long: String = "x".repeat(MAX_DEVICE_NAME_CHARS + 1);
+        let err = register_device(&p, u.id, &too_long, "ios", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AuthError::DeviceFieldInvalid { .. }));
+        let list = list_devices_for_user(&p, u.id).await.unwrap();
+        assert!(list.is_empty(), "rejection must not leave a partial row");
+    }
+
+    #[tokio::test]
+    async fn register_device_rejects_control_char_in_client_version() {
+        let p = pool().await;
+        let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+        let err = register_device(&p, u.id, "Phone", "ios", Some("1.0\n0"))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            AuthError::DeviceFieldInvalid { field, .. } if field == "client_version"
+        ));
     }
 }

--- a/db/src/auth/token.rs
+++ b/db/src/auth/token.rs
@@ -20,14 +20,37 @@ pub fn hash_token(raw: &str) -> Vec<u8> {
     hasher.finalize().to_vec()
 }
 
-/// Cookie name for cookie-mode sessions. Centralized here so HTTP-side
+/// Plain cookie name for cookie-mode sessions on plain-HTTP dev origins
+/// (loopback / LAN IPs without TLS). Centralized here so HTTP-side
 /// callers (server's `AuthUser` extractor + the rpc.rs body-side
 /// equivalent) don't drift apart.
 pub const SESSION_COOKIE_NAME: &str = "omnibus_session";
 
+/// `__Host-` prefixed cookie name used on HTTPS deployments (RFC 6265bis).
+/// The prefix is a browser-enforced contract: the cookie MUST be
+/// `Secure`, MUST NOT have a `Domain` attribute, and MUST have `Path=/`
+/// — together this prevents subdomain-based cookie injection from a
+/// sibling `evil.example.com` against `omnibus.example.com`. The
+/// write-side guarantees those attributes in `server::auth::handlers`.
+pub const SESSION_COOKIE_NAME_HOST_PREFIXED: &str = "__Host-omnibus_session";
+
+/// Returns true if `name` is either of the recognized session cookie
+/// names. Used so the same parser accepts both the plain dev name and
+/// the `__Host-` prefixed production name without the read side having
+/// to know which the server is currently writing.
+pub fn is_session_cookie_name(name: &str) -> bool {
+    name == SESSION_COOKIE_NAME || name == SESSION_COOKIE_NAME_HOST_PREFIXED
+}
+
 /// Pull a session token out of HTTP request headers, preferring an
-/// `Authorization: Bearer …` value over the `omnibus_session` cookie.
-/// Returns `None` when neither source has a non-empty token.
+/// `Authorization: Bearer …` value over the session cookie. Returns
+/// `None` when neither source has a non-empty token.
+///
+/// Recognizes both the plain `omnibus_session` cookie and the
+/// `__Host-omnibus_session` production form — the server picks one to
+/// write based on `OMNIBUS_SECURE_COOKIES`, but the parser stays
+/// permissive so a deploy that flips the flag mid-rollout doesn't
+/// invalidate in-flight cookies on the wrong path.
 ///
 /// Pure-string API by design — keeps `omnibus-db` free of an axum/http
 /// type dependency. Callers pass the relevant header values through.
@@ -45,17 +68,30 @@ pub fn parse_session_token(
     }
     if let Some(cookies) = cookie_header {
         // Cookie header is `name1=value1; name2=value2`. Walk it manually
-        // rather than pulling in axum-extra's CookieJar.
+        // rather than pulling in axum-extra's CookieJar. If both the
+        // `__Host-`-prefixed and plain names are present, the
+        // `__Host-`-prefixed value wins because that's the stronger
+        // attestation; only fall back to the plain name if no prefixed
+        // form had a non-empty value.
+        let mut fallback: Option<String> = None;
         for pair in cookies.split(';') {
             let pair = pair.trim();
             if let Some((name, value)) = pair.split_once('=') {
-                if name.trim() == SESSION_COOKIE_NAME {
-                    let token = value.trim();
-                    if !token.is_empty() {
-                        return Some((token.to_string(), SessionKind::Cookie));
-                    }
+                let name = name.trim();
+                let token = value.trim();
+                if token.is_empty() {
+                    continue;
+                }
+                if name == SESSION_COOKIE_NAME_HOST_PREFIXED {
+                    return Some((token.to_string(), SessionKind::Cookie));
+                }
+                if name == SESSION_COOKIE_NAME && fallback.is_none() {
+                    fallback = Some(token.to_string());
                 }
             }
+        }
+        if let Some(token) = fallback {
+            return Some((token, SessionKind::Cookie));
         }
     }
     None
@@ -81,5 +117,46 @@ mod tests {
         let t = "abc123";
         assert_eq!(hash_token(t), hash_token(t));
         assert_eq!(hash_token(t).len(), 32);
+    }
+
+    #[test]
+    fn parse_token_accepts_plain_session_cookie() {
+        let got = parse_session_token(None, Some("omnibus_session=raw-token"));
+        assert_eq!(got, Some(("raw-token".to_string(), SessionKind::Cookie)));
+    }
+
+    #[test]
+    fn parse_token_accepts_host_prefixed_session_cookie() {
+        let got = parse_session_token(None, Some("__Host-omnibus_session=raw-token"));
+        assert_eq!(got, Some(("raw-token".to_string(), SessionKind::Cookie)));
+    }
+
+    #[test]
+    fn parse_token_prefers_host_prefixed_when_both_present() {
+        // A deployment that just flipped OMNIBUS_SECURE_COOKIES on may have
+        // an in-flight client carrying both names; the prefixed form is
+        // the stronger attestation and must win.
+        let got = parse_session_token(
+            None,
+            Some("omnibus_session=legacy; __Host-omnibus_session=prefixed"),
+        );
+        assert_eq!(got, Some(("prefixed".to_string(), SessionKind::Cookie)));
+    }
+
+    #[test]
+    fn parse_token_bearer_beats_cookie() {
+        let got = parse_session_token(
+            Some("Bearer bear-token"),
+            Some("__Host-omnibus_session=cookie-token"),
+        );
+        assert_eq!(got, Some(("bear-token".to_string(), SessionKind::Bearer)));
+    }
+
+    #[test]
+    fn is_session_cookie_name_matches_both_forms() {
+        assert!(is_session_cookie_name("omnibus_session"));
+        assert!(is_session_cookie_name("__Host-omnibus_session"));
+        assert!(!is_session_cookie_name("__Secure-omnibus_session"));
+        assert!(!is_session_cookie_name("session"));
     }
 }

--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -55,6 +55,14 @@ pub async fn create_user(pool: &SqlitePool, username: &str, password: &str) -> A
     let can_edit = if is_first { 1i64 } else { 0 };
     let can_download = 1i64;
 
+    // INVARIANT: update `password_changed_at` here when password changes.
+    // The column defaults to `strftime('%s','now')` on INSERT (see
+    // `migrations/0004_auth.sql`), which is correct for first creation —
+    // but any future password-change endpoint MUST issue
+    // `UPDATE users SET password_changed_at = strftime('%s','now')
+    //  WHERE id = ?` in the same transaction as the new `password_hash`,
+    // otherwise downstream "invalidate sessions older than last password
+    // change" logic will silently read the account-creation timestamp.
     let id: i64 = sqlx::query_scalar(
         "INSERT INTO users (username, password_hash, is_admin, can_upload, can_edit, can_download)
          VALUES (?, ?, ?, ?, ?, ?)

--- a/server/src/auth/csrf.rs
+++ b/server/src/auth/csrf.rs
@@ -26,7 +26,16 @@ use axum::{
 };
 use axum_extra::extract::cookie::CookieJar;
 
-use super::SESSION_COOKIE;
+use super::{SESSION_COOKIE, SESSION_COOKIE_HOST_PREFIXED};
+
+/// Look up either form of the session cookie in `jar`. The CSRF gate
+/// triggers off the *presence* of a session cookie regardless of which
+/// name the server is currently writing, so a mid-rollout
+/// `OMNIBUS_SECURE_COOKIES` toggle doesn't drop CSRF protection for
+/// cookies issued under the previous name.
+fn has_session_cookie(jar: &CookieJar) -> bool {
+    jar.get(SESSION_COOKIE_HOST_PREFIXED).is_some() || jar.get(SESSION_COOKIE).is_some()
+}
 
 pub async fn origin_check(req: Request, next: Next) -> Response {
     let method = req.method();
@@ -50,7 +59,7 @@ pub async fn origin_check(req: Request, next: Next) -> Response {
     // the header so unrelated cookies that merely contain our name don't
     // trigger the origin check.
     let jar = CookieJar::from_headers(req.headers());
-    if jar.get(SESSION_COOKIE).is_none() {
+    if !has_session_cookie(&jar) {
         return next.run(req).await;
     }
 
@@ -244,7 +253,7 @@ mod tests {
                 }
             }
             let jar = CookieJar::from_headers(req.headers());
-            if jar.get(SESSION_COOKIE).is_none() {
+            if !has_session_cookie(&jar) {
                 return (StatusCode::OK, "ok").into_response();
             }
             let origin = req
@@ -290,6 +299,43 @@ mod tests {
         )
         .await;
         assert_eq!(blocked.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn host_prefixed_cookie_also_triggers_origin_check() {
+        // A cookie under the `__Host-` prefixed name must arm the origin
+        // check the same as the legacy plain name, otherwise a deploy that
+        // flips OMNIBUS_SECURE_COOKIES on would silently drop CSRF
+        // protection for cookies the server is now issuing.
+        let res = guarded_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/mut")
+                    .method("POST")
+                    .header(header::HOST, "localhost:3000")
+                    .header(header::ORIGIN, "http://evil.example")
+                    .header(
+                        header::COOKIE,
+                        format!("{SESSION_COOKIE_HOST_PREFIXED}=fake"),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn has_session_cookie_matches_either_name() {
+        let make = |raw: &str| {
+            let mut h = axum::http::HeaderMap::new();
+            h.insert(header::COOKIE, raw.parse().unwrap());
+            CookieJar::from_headers(&h)
+        };
+        assert!(has_session_cookie(&make("omnibus_session=tok")));
+        assert!(has_session_cookie(&make("__Host-omnibus_session=tok")));
+        assert!(!has_session_cookie(&make("other=tok")));
     }
 
     #[tokio::test]

--- a/server/src/auth/gate.rs
+++ b/server/src/auth/gate.rs
@@ -106,6 +106,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bare_api_auth_path_passes_gate_then_404s() {
+        // Locks in issue #279: the `path == "/api/auth"` allow-list entry
+        // is intentional (some HTTP clients normalize trailing slashes
+        // during redirect following), but no real handler is mounted at
+        // the bare `/api/auth` root. If a future change accidentally
+        // mounts one — e.g. a status endpoint on the auth sub-router —
+        // that handler would be unauthenticated. This test catches that
+        // class of change by asserting the bare path still 404s and never
+        // 200s, so the gate's pass-through stays free of routable
+        // surface area.
+        let (app, _pool) = app().await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
     async fn api_auth_passes_through_without_auth() {
         let (app, _pool) = app().await;
         let res = app

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -17,7 +17,7 @@ use omnibus_db::auth::{self as auth_db, AuthError, SessionKind};
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
 
 use super::extractor::{extract_token, AuthUser};
-use super::{BEARER_TTL_SECS, COOKIE_TTL_SECS, SESSION_COOKIE};
+use super::{session_cookie_name, BEARER_TTL_SECS, COOKIE_TTL_SECS};
 use crate::backend::AppState;
 
 pub fn auth_router(state: AppState) -> Router {
@@ -94,6 +94,11 @@ fn auth_error_to_response(e: AuthError) -> Response {
             (StatusCode::FORBIDDEN, "registration disabled").into_response()
         }
         AuthError::SessionNotFound => (StatusCode::UNAUTHORIZED, "unauthorized").into_response(),
+        AuthError::DeviceFieldInvalid { field, reason } => (
+            StatusCode::BAD_REQUEST,
+            format!("invalid {field}: {reason}"),
+        )
+            .into_response(),
         AuthError::Db(e) => internal(e),
         AuthError::Hash(e) => internal(e),
         AuthError::TokenGeneration(e) => internal(e),
@@ -118,22 +123,34 @@ fn secure_cookies() -> bool {
     parse_secure_cookies(std::env::var("OMNIBUS_SECURE_COOKIES").ok().as_deref())
 }
 
+/// Build a session cookie. When `OMNIBUS_SECURE_COOKIES` is on (the
+/// default) this emits a `__Host-omnibus_session` cookie; the
+/// `__Host-` prefix is browser-enforced to require `Secure` + no
+/// `Domain` + `Path=/`, all of which this helper already sets. On dev
+/// origins with the flag flipped off it falls back to the plain
+/// `omnibus_session` name (no `Secure`, same `Path=/`, still no
+/// `Domain`) so loopback/LAN HTTP keeps working.
 fn session_cookie(value: String, max_age_secs: i64) -> Cookie<'static> {
-    let mut c = Cookie::new(SESSION_COOKIE, value);
+    let secure = secure_cookies();
+    // Invariants required by the `__Host-` prefix when `secure` is true:
+    // no Domain attribute, Path=/, Secure. We set all three unconditionally
+    // here so a future edit can't break the prefix contract by accident.
+    let mut c = Cookie::new(session_cookie_name(secure), value);
     c.set_http_only(true);
     c.set_same_site(SameSite::Lax);
     c.set_path("/");
-    c.set_secure(secure_cookies());
+    c.set_secure(secure);
     c.set_max_age(time::Duration::seconds(max_age_secs));
     c
 }
 
 fn cleared_cookie() -> Cookie<'static> {
-    let mut c = Cookie::new(SESSION_COOKIE, "");
+    let secure = secure_cookies();
+    let mut c = Cookie::new(session_cookie_name(secure), "");
     c.set_http_only(true);
     c.set_same_site(SameSite::Lax);
     c.set_path("/");
-    c.set_secure(secure_cookies());
+    c.set_secure(secure);
     c.set_max_age(time::Duration::seconds(0));
     c
 }
@@ -306,6 +323,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn session_cookie_uses_host_prefix_when_secure() {
+        // `__Host-` is required for the subdomain-injection guarantee;
+        // verify both the chosen name and the attributes that the prefix
+        // contract demands (Secure, Path=/, no Domain).
+        let c = session_cookie("tok".to_string(), 60);
+        // secure_cookies() defaults to true (no env override in test).
+        assert_eq!(c.name(), crate::auth::SESSION_COOKIE_HOST_PREFIXED);
+        assert_eq!(c.path(), Some("/"));
+        assert!(c.secure().unwrap_or(false));
+        assert!(c.domain().is_none());
+    }
+
+    #[test]
+    fn session_cookie_name_helper_branches_on_secure_flag() {
+        assert_eq!(super::session_cookie_name(true), "__Host-omnibus_session");
+        assert_eq!(super::session_cookie_name(false), "omnibus_session");
+    }
+
     #[tokio::test]
     async fn register_first_user_becomes_admin_and_sets_cookie() {
         let (app, _pool) = app().await;
@@ -324,7 +360,14 @@ mod tests {
             .iter()
             .map(|v| v.to_str().unwrap().to_string())
             .collect();
-        assert!(set_cookie.iter().any(|c| c.starts_with("omnibus_session=")));
+        // Default is secure_cookies() == true, so the cookie ships under the
+        // `__Host-` prefixed name. The plain name is used only when
+        // OMNIBUS_SECURE_COOKIES is explicitly disabled for plain-HTTP LAN dev.
+        let expected_name = format!("{}=", super::session_cookie_name(true));
+        assert!(
+            set_cookie.iter().any(|c| c.starts_with(&expected_name)),
+            "expected Set-Cookie starting with {expected_name:?}, got {set_cookie:?}",
+        );
         let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
             .await
             .unwrap();

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -38,13 +38,34 @@ pub use extractor::{AdminUser, AuthUser};
 pub use gate::require_auth;
 pub use handlers::auth_router;
 
-/// Name of the session cookie issued to web clients. Re-exported from
-/// `omnibus_db::auth::SESSION_COOKIE_NAME` so cookie issuance
+/// Plain session-cookie name used on plain-HTTP dev origins. Re-exported
+/// from `omnibus_db::auth::SESSION_COOKIE_NAME` so cookie issuance
 /// (`Set-Cookie`), CSRF cookie checks, and token parsing all share a
-/// single source of truth. Not using the `__Host-` prefix so the dev
-/// server on plain HTTP still works; production deployments behind HTTPS
-/// should set `OMNIBUS_SECURE_COOKIES=1` to toggle the `Secure` attribute.
+/// single source of truth.
 pub use omnibus_db::auth::SESSION_COOKIE_NAME as SESSION_COOKIE;
+
+/// `__Host-` prefixed session-cookie name (RFC 6265bis) used when
+/// `OMNIBUS_SECURE_COOKIES` is on (the default). The prefix is a
+/// browser-enforced contract — `Secure` + no `Domain` + `Path=/` — and
+/// blocks subdomain cookie injection from a sibling host. The write side
+/// in [`handlers::session_cookie`] is the single place that picks between
+/// this and the plain form via [`session_cookie_name`]; the read side
+/// (token parser, CSRF jar lookup) accepts either so a deploy that
+/// toggles `OMNIBUS_SECURE_COOKIES` mid-rollout doesn't invalidate
+/// in-flight cookies.
+pub use omnibus_db::auth::SESSION_COOKIE_NAME_HOST_PREFIXED as SESSION_COOKIE_HOST_PREFIXED;
+
+/// Pure selector used by the cookie write path: returns the `__Host-`
+/// prefixed name when `secure` is true (production HTTPS), the plain
+/// name otherwise. Kept pure so it can be unit-tested without env or
+/// `OnceLock` state.
+pub fn session_cookie_name(secure: bool) -> &'static str {
+    if secure {
+        SESSION_COOKIE_HOST_PREFIXED
+    } else {
+        SESSION_COOKIE
+    }
+}
 
 /// 30 days for cookie sessions; matches the plan's absolute expiry.
 pub const COOKIE_TTL_SECS: i64 = 30 * 24 * 60 * 60;

--- a/server/src/auth/test_support.rs
+++ b/server/src/auth/test_support.rs
@@ -14,6 +14,10 @@ use omnibus_db::{
 use sqlx::SqlitePool;
 
 use super::{BEARER_TTL_SECS, COOKIE_TTL_SECS, SESSION_COOKIE};
+// `SESSION_COOKIE` (plain name) is intentionally used here even on a
+// production-shaped deploy: the read side `parse_session_token` accepts
+// either form, so integration-test cookies don't need to negotiate the
+// `OMNIBUS_SECURE_COOKIES` env var to hit the same code path.
 
 /// Insert a user with the given `is_admin` flag, bypassing the registration
 /// gate and first-user auto-promote logic. The password hash is a sentinel


### PR DESCRIPTION
## Summary

Sanctioned Low-tier batch covering four related auth-subsystem refinements. All four touch `db/src/auth/` or `server/src/auth/`, so they ship together per the batch rule.

- **#280** — session cookie now picks the `__Host-omnibus_session` name when `OMNIBUS_SECURE_COOKIES` is on (the default). New pure helper `session_cookie_name(secure: bool)` in `server::auth` returns the prefixed name on HTTPS, the plain `omnibus_session` on plain-HTTP dev. The cookie attributes the `__Host-` prefix demands (Secure, Path=/, no Domain) are all already set unconditionally and now have a guard test confirming it. The read side — `parse_session_token` in `omnibus_db` and the `CookieJar` lookup in `csrf.rs` — accepts either form so a deploy that flips `OMNIBUS_SECURE_COOKIES` mid-rollout does not strand in-flight cookies.
- **#281** — `device_name` capped at 255 chars and `client_version` at 64 chars before the `devices` INSERT in `db::auth::register_device`. ASCII control characters are rejected (log-injection guard). New `AuthError::DeviceFieldInvalid { field, reason }` variant surfaces as `400 BAD_REQUEST` through the auth handler. Pure validators `validate_device_name` / `validate_client_version` are exported for direct callers.
- **#282** — INVARIANT comment added at the `users` INSERT site in `db/src/auth/users.rs` noting that any future password-change endpoint MUST update `password_changed_at` in the same transaction as the new `password_hash`. Migration `0004_auth.sql` is intentionally left untouched (it is applied).
- **#279** — new gate test asserts `GET /api/auth` returns `404 NOT_FOUND` after passing the gate's allow-list. Locks in the invariant that the bare-path allow-list entry exists only because some HTTP clients normalize trailing slashes — no real handler may be mounted at the bare `/api/auth` root, otherwise it would be unauthenticated.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 340 lib + 2 integration tests pass (covers new device-name validator tests, host-prefixed cookie parser tests, and the existing session/cookie roundtrip)
- [x] `cargo test -p omnibus` — 133 tests pass (covers the new gate test for `GET /api/auth → 404`, the `session_cookie` `__Host-` prefix attribute guard, and the existing handlers/csrf/extractor tests)
- [x] `cargo test -p omnibus-frontend --features server` — 100 tests pass (no regressions in the rpc.rs / data.rs surface that consumes the auth types)
- [x] Manual reasoning: `parse_session_token` correctly prefers the `__Host-` prefixed cookie when both names are present (covered by `parse_token_prefers_host_prefixed_when_both_present`), keeping the upgrade path safe.

## Notes

- Sanctioned Low batch per worker plan: four issues, all same theme (auth hardening), each with its own `Closes #` line so GitHub auto-closes them on merge.
- No `run_ui_tests` label — all four changes are server-only with zero UI markup deltas.
- `db/migrations/0004_auth.sql` is intentionally not edited (it is an applied migration). The `password_changed_at` reminder lives in the Rust code per the issue's explicit instruction.

Closes #279
Closes #280
Closes #281
Closes #282

https://claude.ai/code/session_01Jr6c66demnTfNf1XYGTtwX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr6c66demnTfNf1XYGTtwX)_