### PR TITLE
fix: legible Light-theme contrast on book-detail rails (#289)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -64,7 +64,16 @@
   --ink-0: oklch(0.17 0.006 70);
   --ink-1: oklch(0.36 0.008 70);
   --ink-2: oklch(0.52 0.010 70);
-  --ink-3: oklch(0.66 0.010 70);
+  /* `--ink-3` is the muted-label tier — meta-table keys, hints, axis labels,
+     disabled-action arrows. The dark theme runs it at 0.48 L against a
+     0.175 L ground (≈3.9:1). The original light value of 0.66 L against a
+     0.965 L card ground only reached ≈2.2:1, which is the rails-mismatch
+     issue (#289): on the book-detail / metadata-edit rails the identifier
+     keys, "Mark as finished" action row, and axis labels wash out in Light
+     mode. Pulling it down to 0.50 L mirrors the dark side of the token and
+     lands the contrast ratio near 3.5:1 — still reads as muted, but legible
+     for the small UI text these rails carry. */
+  --ink-3: oklch(0.50 0.010 70);
   --accent-ink: oklch(0.99 0 0);
   --cover-fallback-bg:  oklch(0.86 0.004 70);
   --cover-fallback-ink: oklch(0.28 0.006 70);
@@ -627,6 +636,19 @@ body.atrium,
   display: flex; align-items: center; justify-content: space-between;
   width: 100%; height: 36px; padding: 0 10px;
   border-radius: 8px;
+}
+/* The action rows ship disabled until F3.x wires the real handlers, and the
+   browser's default `button[disabled]` styling drops their opacity, which
+   tanks contrast on Light theme (was the second half of #289 — "Mark as
+   finished" reading as a washed-out grey). Pin our own disabled style so
+   the row reads as muted-but-legible in every theme. The non-disabled state
+   intentionally inherits `.btn.ghost` so the row is ready for the wired
+   future without extra rules. */
+.bd-action-row[disabled],
+.bd-action-row:disabled {
+  opacity: 1;
+  color: var(--ink-2);
+  cursor: not-allowed;
 }
 .bd-action-row-arrow { color: var(--ink-3); }
 .bd-shelves { display: flex; gap: 6px; flex-wrap: wrap; }


### PR DESCRIPTION
## Summary
- Pull `[data-theme="light"] --ink-3` from `oklch(0.66)` → `oklch(0.50)` so the muted-label tier (meta-table identifier keys, hints, axis labels, action-row arrows) actually reads on the book-detail rails in Light mode — was ≈2.2:1 against the card ground, now ≈3.5:1. Dark theme's `--ink-3` already sits at 0.48 against its 0.175 ground, so this just symmetrizes the design intent across both themes.
- Pin an explicit disabled style on `.bd-action-row` (`opacity: 1` + `color: var(--ink-2)`) so the rating-card "Actions" buttons ("Mark as finished", "Write a journal entry", …) don't pick up the browser's default disabled-button opacity dim — which is what made "Mark as finished" wash out into the card ground in Light mode. The non-disabled state still inherits `.btn.ghost` so the row is ready for F3.x to wire up real handlers without further CSS.

>[!NOTE]
> The issue title also calls out Sepia, but the `Theme` enum (`frontend/src/components/atrium.rs`) is still Dark/Light only — the Sepia button in the user-menu is a disabled stub. When the Sepia palette lands (deferred per `docs/design/atrium-design-system.md` §1), the same `--ink-3` retune will apply to its block.

## Test plan
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean on default-members (`server`, `shared`, `frontend`).
- [x] `cargo test -p omnibus` — 128 passed.
- [x] `cargo test -p omnibus-frontend --features server` — 100 passed.
- [x] `cargo test -p omnibus-db` — 328 passed (one initial flake on `worker::tests::poisoned_completions_lock_recovers_instead_of_panicking` cleared on rerun; same flake reproduces on `main` and is unrelated to a CSS change).
- [ ] Visual verification in a real browser — **not done**. This worktree doesn't have `nix develop` or the `dx` CLI available, so `just dev-up` / the `ui-validate` skill couldn't bring up a preview. The fix is by code inspection only; please eyeball Light mode on `/books/:uuid` after merge to confirm the rails read as muted-but-legible (especially the file-details identifier rows and the rating-card "Actions" buttons).

## Notes
- CSS-only change; no Rust / markup / testid / role / label touched, so no Playwright spec needs updating.
- No `Cargo.lock` change.
- `--ink-3` is referenced 35× across the stylesheet. Most call sites already passed contrast in Light mode against `--bg-0` or were on already-bright accents; the rails-on-card combination was the regressing case. The token bump improves the few remaining marginal cases too — none of them regress because we're moving away from the background, not toward it.

Closes #289

https://claude.ai/code/session_01V1khPHj86bq18g4aVfbeuC

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1khPHj86bq18g4aVfbeuC)_