### PR TITLE
fix: green the E2E suite — author_delete isolation + chip-editor / row-nav bugs

### DIFF
--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -243,7 +243,15 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
                             {value.chars().filter(|c| c.is_uppercase()).take(2).collect::<String>()}
                         }
                     }
-                    "{value}"
+                    // The label is its own element (not a bare text node) so
+                    // the chip exposes a node whose text is *exactly* the
+                    // value — `getByText(value, { exact: true })` in the E2E
+                    // specs would otherwise match nothing, since the chip
+                    // `div` also contains the avatar initials and the remove
+                    // button's "✕". Visually identical: `.chip` is an
+                    // inline-flex row, so the span is the same flex item the
+                    // bare text already was.
+                    span { class: "me-chip-label", "{value}" }
                     button {
                         class: "me-chip-remove",
                         "aria-label": "{props.aria_remove_prefix} {value}",

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -117,7 +117,20 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
     // by sight, without having to type a character first to "wake up"
     // the autocomplete. `onblur` clears it (and the highlight) so the
     // dropdown collapses when focus leaves.
-    let mut focused = use_signal(|| false);
+    // Seed `focused` from `autofocus`: an autofocused input is focused on
+    // first paint, but the browser's autofocus does not always emit an
+    // `onfocus` event for a freshly-mounted node (e.g. the landing cell's
+    // editor, mounted on click), so relying on the event left `focused`
+    // false and the open-on-focus dropdown never surfaced. Seeding it true
+    // makes the dropdown appear on first paint, as the `autofocus` prop
+    // promises; `onblur` still flips it false when focus leaves.
+    let mut focused = use_signal(|| props.autofocus);
+    // Suppress the open-on-focus pool *after a commit* so committing a chip
+    // (Enter / suggestion pick) collapses the dropdown rather than instantly
+    // re-surfacing the pool against the now-empty input. Any keystroke or a
+    // fresh focus clears it, so the autocomplete still wakes on the next
+    // interaction.
+    let mut suppress_open = use_signal(|| false);
 
     // Filter on every render. Reads the suggestion pool by reference
     // so we never clone the underlying Vec — only the ≤5 matches that
@@ -144,7 +157,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
                 .map(|s| s.to_lowercase())
                 .collect();
             if query_lc.is_empty() {
-                if focused() {
+                if focused() && !suppress_open() {
                     suggestions
                         .iter()
                         .filter(|item| !current.contains(&item.name.to_lowercase()))
@@ -219,6 +232,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
         {
             input.set(String::new());
             highlight.set(None);
+            suppress_open.set(true);
             return;
         }
         let mut new_values = values_sig.read().clone();
@@ -227,6 +241,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
         on_change.call(new_values);
         input.set(String::new());
         highlight.set(None);
+        suppress_open.set(true);
     };
 
     let testid_suggestions = format!("{}-suggestions", props.testid_prefix);
@@ -276,6 +291,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
                     autofocus: props.autofocus,
                     onfocus: move |_| {
                         focused.set(true);
+                        suppress_open.set(false);
                     },
                     onblur: move |_| {
                         focused.set(false);
@@ -284,6 +300,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
                     oninput: move |e| {
                         input.set(e.value());
                         highlight.set(None);
+                        suppress_open.set(false);
                     },
                     onkeydown: move |e| {
                         match e.key() {

--- a/ui_tests/playwright/tests/flows/author_delete.spec.ts
+++ b/ui_tests/playwright/tests/flows/author_delete.spec.ts
@@ -38,24 +38,13 @@ async function fetchAuthorIdByName(
   throw new Error(`no indexed author named ${JSON.stringify(name)}`);
 }
 
-// Undo a confirmed delete so the shared fixture library other specs read
-// stays intact.
-//
-// The E2E server runs against a *persistent* on-disk DB shared by every spec
-// (unlike the per-process `sqlite::memory:` of the unit tests). `delete_author`
-// drops the `books_authors_link` rows and durably blocklists the name in
-// `ignored_authors`, and the indexer is incremental — a re-seed only re-parses
-// files whose mtime changed, so it can't resurrect the author for an unchanged
-// fixture EPUB. Left uncleaned, the un-linked book turns author-less for the
-// rest of the run and breaks every later spec that asserts that author
-// (`landing.spec` renders an empty author cell, etc.).
-//
-// We restore the link the reindex-proof, parallel-safe way: a per-book
-// metadata override that re-asserts the original creator list at read time.
-// Overrides are keyed by uuid and merged on read, so they survive the
-// incremental re-seeds other specs trigger and never touch the shared library
-// path (re-pointing settings would race parallel workers). The fixture table
-// is the source of truth for each book's authors.
+// Undo a confirmed delete so the persistent, shared on-disk DB stays intact
+// for later specs. A plain re-seed can't fix it — `delete_author` durably
+// blocklists the name in `ignored_authors`, and the incremental indexer won't
+// re-parse the unchanged fixture EPUB. So we re-assert the original creators
+// via a per-book metadata override: reindex-proof (keyed by uuid, merged on
+// read) and parallel-safe (never re-points the shared library path). See the
+// PR description for the full rationale.
 async function restoreDeletedAuthor(
   request: APIRequestContext,
   authorName: string,
@@ -145,32 +134,39 @@ test("confirming Delete posts to rpc_delete_author and redirects to /authors", a
   await page.getByTestId("author-delete-btn").click();
   await expect(page.getByTestId("author-delete-modal")).toBeVisible();
 
-  await expectMutation(
-    page,
-    {
-      method: "POST",
-      url: /\/api\/rpc\/author\/delete$/,
-      expectedStatus: 200,
-    },
-    async () => page.getByTestId("author-delete-confirm").click(),
-  );
+  let deleted = false;
+  try {
+    await expectMutation(
+      page,
+      {
+        method: "POST",
+        url: /\/api\/rpc\/author\/delete$/,
+        expectedStatus: 200,
+      },
+      async () => page.getByTestId("author-delete-confirm").click(),
+    );
+    deleted = true;
 
-  // The redirect should land on the /authors index page. Match
-  // trailing slash optional to accept either form.
-  await expect(page).toHaveURL(/\/authors\/?$/);
+    // The redirect should land on the /authors index page. Match
+    // trailing slash optional to accept either form.
+    await expect(page).toHaveURL(/\/authors\/?$/);
 
-  // The deleted author should no longer be linked to any book in the
-  // /api/rpc/ebooks response — confirms the blocklist + link
-  // teardown executed.
-  const after = await request.get("/api/rpc/ebooks");
-  const body = (await after.json()) as {
-    books: { creators: { name: string }[] }[];
-  };
-  for (const book of body.books) {
-    expect(book.creators.find((c) => c.name === targetName)).toBeUndefined();
+    // The deleted author should no longer be linked to any book in the
+    // /api/rpc/ebooks response — confirms the blocklist + link
+    // teardown executed.
+    const after = await request.get("/api/rpc/ebooks");
+    const body = (await after.json()) as {
+      books: { creators: { name: string }[] }[];
+    };
+    for (const book of body.books) {
+      expect(book.creators.find((c) => c.name === targetName)).toBeUndefined();
+    }
+  } finally {
+    // Restore even if an assertion above failed — the delete mutated the
+    // shared, persistent DB, so leaking it would break later specs and
+    // bury the real failure. Skip if the delete itself never landed.
+    if (deleted) await restoreDeletedAuthor(request, targetName);
   }
-
-  await restoreDeletedAuthor(request, targetName);
 });
 
 test("surfaces an error and stays on the page when delete fails", async ({

--- a/ui_tests/playwright/tests/flows/author_delete.spec.ts
+++ b/ui_tests/playwright/tests/flows/author_delete.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../fixtures/test";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expectMutation } from "../utils/api";
+import { fetchBookUuidByTitle } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
 import { fixturesDir, seedLibrary } from "../utils/seed";
 import type { APIRequestContext } from "@playwright/test";
@@ -10,9 +11,10 @@ import type { APIRequestContext } from "@playwright/test";
 // The delete primitive (PR 2) inserts the author name into the
 // `ignored_authors` blocklist, so a re-run of the test suite would
 // keep finding the author missing even if we re-seed. Each test in
-// this file picks a *different* fixture author and cleans up by
-// DELETE-ing the blocklist row at the end, so subsequent runs start
-// from a clean state.
+// this file picks a *different* fixture author; the one test that
+// actually confirms a delete restores that author afterwards (see
+// `restoreDeletedAuthor`) so the shared on-disk fixture library other
+// specs read stays intact.
 
 test.describe.configure({ mode: "serial" });
 
@@ -36,23 +38,68 @@ async function fetchAuthorIdByName(
   throw new Error(`no indexed author named ${JSON.stringify(name)}`);
 }
 
-// Re-seed the library after each delete so the deleted author re-appears
-// on disk (the EPUB is still there) and the ignored_authors guard is the
-// only thing keeping the row absent. Then DELETE the blocklist row so
-// the next reindex re-creates the author cleanly. Without this cleanup
-// every subsequent test run would fail because the seeded fixture's
-// author is permanently blocklisted.
-async function clearBlocklistAndReseed(
+// Undo a confirmed delete so the shared fixture library other specs read
+// stays intact.
+//
+// The E2E server runs against a *persistent* on-disk DB shared by every spec
+// (unlike the per-process `sqlite::memory:` of the unit tests). `delete_author`
+// drops the `books_authors_link` rows and durably blocklists the name in
+// `ignored_authors`, and the indexer is incremental — a re-seed only re-parses
+// files whose mtime changed, so it can't resurrect the author for an unchanged
+// fixture EPUB. Left uncleaned, the un-linked book turns author-less for the
+// rest of the run and breaks every later spec that asserts that author
+// (`landing.spec` renders an empty author cell, etc.).
+//
+// We restore the link the reindex-proof, parallel-safe way: a per-book
+// metadata override that re-asserts the original creator list at read time.
+// Overrides are keyed by uuid and merged on read, so they survive the
+// incremental re-seeds other specs trigger and never touch the shared library
+// path (re-pointing settings would race parallel workers). The fixture table
+// is the source of truth for each book's authors.
+async function restoreDeletedAuthor(
   request: APIRequestContext,
   authorName: string,
 ): Promise<void> {
-  // No public RPC for `DELETE FROM ignored_authors` exists yet — the
-  // F5.9-lite plan defers that to a follow-up admin tool. For now we
-  // rely on the in-memory DB being fresh between full test suite runs;
-  // this helper is a stub so the test file documents the cleanup
-  // intent and can switch to the real call once it exists.
-  void request;
-  void authorName;
+  const affected = FIXTURE_BOOKS.filter((b) => b.authors.includes(authorName));
+  expect(
+    affected.length,
+    `restoreDeletedAuthor: no fixture book lists ${JSON.stringify(authorName)}`,
+  ).toBeGreaterThan(0);
+
+  for (const book of affected) {
+    const uuid = await fetchBookUuidByTitle(request, book.title);
+    const resp = await request.post("/api/rpc/ebook/overrides", {
+      data: {
+        uuid,
+        overrides: {
+          creators: book.authors.map((name) => ({ name, role: null, file_as: null })),
+        },
+      },
+    });
+    expect(
+      resp.status(),
+      `POST /api/rpc/ebook/overrides failed for ${book.title}`,
+    ).toBe(200);
+  }
+
+  // Confirm the author is observable again before releasing the shared DB.
+  await expect
+    .poll(
+      async () => {
+        const r = await request.get("/api/rpc/ebooks");
+        if (r.status() !== 200) return false;
+        const body = (await r.json()) as {
+          books: { creators: { name: string }[] }[];
+        };
+        return body.books.some((b) => b.creators.some((c) => c.name === authorName));
+      },
+      {
+        message: `author ${JSON.stringify(authorName)} should be restored via override`,
+        timeout: 10_000,
+        intervals: [100, 200, 500, 1_000],
+      },
+    )
+    .toBe(true);
 }
 
 test("renders Delete author button for admin viewers", async ({ page, request }) => {
@@ -123,7 +170,7 @@ test("confirming Delete posts to rpc_delete_author and redirects to /authors", a
     expect(book.creators.find((c) => c.name === targetName)).toBeUndefined();
   }
 
-  await clearBlocklistAndReseed(request, targetName);
+  await restoreDeletedAuthor(request, targetName);
 });
 
 test("surfaces an error and stays on the page when delete fails", async ({

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -17,8 +17,13 @@ const TARGET = FIXTURE_BOOKS.find((b) => b.slug === "alpha")!;
 test("navigates from a landing row to the detail page and back", async ({ page }) => {
   await gotoReady(page, "/");
 
-  // Click the row for our target book and follow the SPA navigation.
-  await getRow(page, TARGET.slug).click();
+  // Click the row's cover cell to follow the SPA navigation. We target the
+  // cover specifically because the seeded admin sees inline-editable cells
+  // (title, author, …) that intercept clicks to open their editor instead of
+  // navigating; the cover cell is non-editable, so its click bubbles to the
+  // row's navigate handler — what a user clicking a non-interactive part of
+  // the row gets.
+  await getRow(page, TARGET.slug).getByTestId("ebook-cell-cover").click();
   // `/books/:uuid` — UUIDv5 in canonical 8-4-4-4-12 hyphenated form.
   await expect(page).toHaveURL(/\/books\/[0-9a-fA-F-]{36}$/);
 


### PR DESCRIPTION
## Summary

The `playwright` E2E job has been red on `main` (e.g. PR #290 failed it too). This PR drives it green by fixing the genuine, pre-existing failures behind it.

Reproduced CI locally (`dx bundle` debug + standalone server + Playwright, parallel, `retries=2`). Baseline was **5 failed**; with these fixes the full suite is **green (97 passed, 1 pre-existing flaky that recovers on retry)**.

## Fixes

### 1. `author_delete` corrupts the shared fixture library → `landing:37`
`author_delete.spec.ts` deletes "Joan Clarke" (the sole author of fixture `pioneers-3`), which durably blocklists the name in `ignored_authors`. Its cleanup was a **no-op stub** that assumed a per-process in-memory DB; the E2E server uses a **persistent, shared** DB, so the deletion leaked and broke every later spec reading that author. The incremental indexer can't resurrect it via re-seed, so cleanup now restores the author's link with a per-book **metadata override** (read-time, reindex-proof, parallel-safe), wrapped in `try/finally` so it always runs after a successful delete.

### 2. ChipEditor label not exact-matchable → metadata_edit "+Create" / chip assertions
The chip value rendered as a bare text node beside the avatar and remove button, so `getByText(value, { exact: true })` matched no element even though the chip was present. Wrap the label in its own `<span class="me-chip-label">` (visually identical — `.chip` is inline-flex).

### 3. ChipEditor open-on-focus dropdown → `landing_inline_edit:121`
The `autofocus` prop promises the dropdown "surfaces on first paint", but open-on-focus only keyed off the `onfocus` event, which the browser doesn't reliably emit for a freshly-mounted autofocused input. Seed `focused` from `autofocus`. (Metadata-edit editors use `autofocus=false` and are unaffected.)

### 4. ChipEditor dropdown stays open after commit → `metadata_edit:261`
Committing a chip left the dropdown open because the now-empty input re-triggered the pool. Add a post-commit suppression flag, cleared on the next keystroke / fresh focus.

### 5. `book_detail:17` row-click navigation
For the seeded admin, the row's geometric center is an inline-**editable** cell that intercepts the click (opens the chip editor) instead of navigating. Click the non-editable cover cell, whose click bubbles to the row's navigate handler.

## Not addressed (pre-existing, retry-covered)
`metadata_edit:211` is a flaky parallel race (fails fast, passes on retry #2); it doesn't touch any code here and CI's `retries: 2` absorbs it.

## Validation
- `db`/`server` unit + integration tests pass; `cargo fmt` + `clippy` clean.
- Full Playwright suite green locally under CI-equivalent conditions (parallel, `retries=2`).

https://claude.ai/code/session_01Pna8wuZb3HnHjmkC4JW1oa