### PR TITLE
docs: rust style guide

### DIFF
--- a/.claude/rules/02-error-handling.md
+++ b/.claude/rules/02-error-handling.md
@@ -1,11 +1,26 @@
 # 02 — Error handling
 
-- **Domain / library errors:** use `thiserror` to define typed error enums per module (e.g. `DbError`, `ScanError`). Each variant gets a meaningful `#[error("...")]` message.
-- **Application-level propagation:** use `anyhow` in handlers and top-level code where the specific error type doesn't need to be matched.
-- Use `#[error(transparent)]` + `#[from]` for wrapping lower-level errors (`sqlx`, `std::io`, etc.) so `?` propagates cleanly.
+The shape rule: **predictable failure space → `thiserror`; unpredictable
+failure space → `anyhow`.** See
+[05-rust-style.md](05-rust-style.md#errors) for the full guidance and
+[docs/style-guide.md](../../docs/style-guide.md#errors) for rationale
+and worked examples.
+
+## When to use `thiserror`
+
+When you can enumerate the ways the function will fail and a caller
+might branch on them. Auth, validation, parsing, API boundary checks —
+anywhere a UI renders a per-case message. Define a typed error enum in
+the module that owns the failure. Use `#[error(transparent)]` + `#[from]`
+to wrap lower-level errors (`sqlx`, `std::io`, etc.) so `?` propagates
+cleanly.
+
+**Coarse variants.** Group by failure mode, let the `#[error("...")]`
+message carry the detail. Don't split `PasswordTooShort` from
+`PasswordTooLong` unless a caller actually branches on them — one
+`Validation(String)` variant is usually enough.
 
 ```rust
-// Domain error — in a library module
 #[derive(Debug, thiserror::Error)]
 pub enum ScanError {
     #[error("file not found: {path}")]
@@ -15,12 +30,45 @@ pub enum ScanError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }
+```
 
-// Handler — anyhow for propagation, no need to enumerate variants
+## When to use `anyhow`
+
+When the failure source is a foreign system that can fail in arbitrary
+ways (filesystem walks, EPUB parsing, network fetches) and the caller
+just propagates. `anyhow::bail!` with a context-rich format string is
+honest about the open-ended failure space:
+
+```rust
+pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
+    let stat = scan(library_path).await?;
+    if let Some(msg) = stat.error {
+        anyhow::bail!("scan of {library_path} failed: {msg}");
+    }
+    Ok(())
+}
+```
+
+Application-level propagation in handlers also uses `anyhow` — the
+handler signature returns `anyhow::Error` and the body upgrades typed
+errors via `?`.
+
+```rust
 async fn trigger_scan(State(s): State<AppState>) -> Result<StatusCode, anyhow::Error> {
     scanner::scan(&s.pool).await?;
     Ok(StatusCode::OK)
 }
 ```
 
-Do **not** use `unwrap()` / `expect()` in production paths — only in tests or truly-infallible setup code.
+## Boundary rule
+
+**Never return raw `sqlx::Error` across a module boundary.** Wrap it
+via `#[error(transparent)] #[from]` on the module's error enum, or
+convert into `anyhow::Error` with `.with_context(...)`. Leaking
+`sqlx::Error` propagates an implementation detail (the DB crate) into
+every downstream caller.
+
+## `unwrap` / `expect`
+
+Banned in production paths — only in tests or truly-infallible setup
+code.

--- a/.claude/rules/03-unit-testing.md
+++ b/.claude/rules/03-unit-testing.md
@@ -1,45 +1,84 @@
 # 03 — Unit & integration testing
 
-Testing is a first-class requirement. Every meaningful behavior should have a test at the **lowest applicable level**.
+Testing is a first-class requirement. Every meaningful behavior should
+have a test at the **lowest applicable level**. See
+[05-rust-style.md](05-rust-style.md#tests) for the broader style
+guidance and [docs/style-guide.md](../../docs/style-guide.md#tests)
+for rationale.
 
 ## Where tests live
 
-- **Unit tests:** inline `#[cfg(test)]` modules in the same file as the code under test. This is the default for all logic in `frontend/src/db.rs`, `frontend/src/scanner.rs`, and the `frontend/src/pages/` components.
-- **Integration tests:** inline `#[cfg(test)]` in `server/src/backend.rs`, driving `rest_router(AppState::new(pool))` via `tower::ServiceExt::oneshot` against an in-memory DB.
+- **Unit tests (non-trivial):** sibling file `<mod>/tests.rs`. Promote
+  a module's tests to a sibling file whenever they cross "trivial" —
+  more than one or two short cases, or any shared helper that would
+  otherwise pad the prod file.
+  [db/src/books/tests.rs](../../db/src/books/tests.rs) is the model.
+- **Unit tests (trivial):** inline `#[cfg(test)] mod tests` at the
+  bottom of the file is fine for 1–2 cases that need no helpers.
+- **Integration tests:** inline `#[cfg(test)]` in
+  `server/src/backend.rs`, driving `rest_router(AppState::new(pool))`
+  via `tower::ServiceExt::oneshot` against an in-memory DB.
 - **E2E tests:** see [04-playwright.md](04-playwright.md).
 
 All tests use `sqlite::memory:` for isolation — never the on-disk DB.
 
+## Shared helpers
+
+Every crate has a `test_support` module
+(`<crate>/src/test_support.rs`, gated
+`#[cfg(any(test, feature = "test-support"))]`) for cross-cutting
+helpers: in-memory pool init, seed factories, fixture builders. No
+duplicated `make_test_dir()` / `seed_minimal_books()` across files.
+
 ## Coverage expectations
 
-- **`frontend::db` functions:** happy path + not-found / missing + constraint violations.
-- **`server::backend` handlers:** 200 success, 4xx client errors, 5xx DB-failure paths.
-- **`frontend::pages` components with logic:** rendered output contains expected content.
-- **`frontend::rpc` server functions:** thin wrappers — covered transitively by db tests; only add a direct test if the wrapper composes multiple db calls non-trivially.
-- **New features** must not ship without tests covering their acceptance criteria from the relevant initiative under [docs/roadmap/](../../docs/roadmap/).
+- **Every `pub` fn:** one happy-path test, plus one test per
+  `thiserror` variant the function can return. For
+  `anyhow`-returning functions, cover happy + one representative
+  failure.
+- **Edge / boundary tests** only for functions doing tricky math,
+  parsing, or arithmetic. Don't multiply for `Some` vs `None`,
+  empty-string vs whitespace, etc. unless the function actually
+  branches on them.
+- **`server::backend` handlers:** 200 success, 4xx client errors,
+  5xx DB-failure paths.
+- **`frontend::pages` components with logic:** rendered output
+  contains expected content.
+- **`frontend::rpc` server functions:** thin wrappers — covered
+  transitively by db tests; only add a direct test if the wrapper
+  composes multiple db calls non-trivially.
+- **New features** must not ship without tests covering their
+  acceptance criteria from the relevant initiative under
+  [docs/roadmap/](../../docs/roadmap/).
+
+## Naming
+
+Long sentence style, `fn_under_test_does_X_when_Y`. The test name is
+the spec; "FAILED `search_books_finds_by_title_and_ranks_by_bm25`"
+tells you what's broken without opening the file.
 
 ## Shape
 
 ```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
+// db/src/books/tests.rs
+use super::*;
+use crate::test_support::{new_in_memory_pool, seed_minimal_books};
 
-    #[tokio::test]
-    async fn get_book_returns_correct_record() { ... }
+#[tokio::test]
+async fn get_book_returns_record_for_known_id() { ... }
 
-    #[tokio::test]
-    async fn get_book_returns_not_found_for_missing_id() { ... }
+#[tokio::test]
+async fn get_book_returns_none_for_missing_id() { ... }
 
-    #[tokio::test]
-    async fn get_book_returns_error_on_db_failure() { ... }
-}
+#[tokio::test]
+async fn get_book_propagates_db_error_when_pool_is_closed() { ... }
 ```
 
 ## Running
 
 ```bash
 cargo test -p omnibus                              # /api/* REST integration tests
-cargo test -p omnibus-frontend --features server   # db + scanner + rpc + page tests
+cargo test -p omnibus-db                           # db + scanner + sync tests
+cargo test -p omnibus-frontend --features server   # rpc + page tests
 cargo test -p <crate> <test_name>                  # single test by name
 ```

--- a/.claude/rules/05-rust-style.md
+++ b/.claude/rules/05-rust-style.md
@@ -1,0 +1,119 @@
+# 05 — Rust style
+
+The normative rules. For rationale, before/after examples, and the *why*
+behind each rule, see [docs/style-guide.md](../../docs/style-guide.md).
+
+This rule applies to all Rust code in the workspace (`db/`, `server/`,
+`frontend/`, `shared/`, `mobile/`). TypeScript / Playwright style is
+covered by [04-playwright.md](04-playwright.md).
+
+## Comments & docs
+
+- **Module `//!`** is required on every file. Keep it to one short
+  paragraph (≤ 5 lines): what this module is for, who calls it. No
+  references to roadmap phases or issue numbers — those belong in commit
+  messages and PR bodies, where they don't rot.
+- **Function `///`** is required on every `pub` item: one-line summary.
+  Add a longer rustdoc block (params, errors, invariants) only when the
+  behaviour is genuinely surprising — locks, retries, side effects, or
+  contracts a caller can break by accident.
+- **Inline `//` inside function bodies** is for explaining **why**, never
+  **what**. A non-obvious invariant, a workaround for a specific bug, a
+  perf trick. If you're narrating the algorithm, the function probably
+  needs to be split (see below). Section-marker comments
+  (`// --- Removed`) are tolerated *only* when a function can't be split
+  further and still needs nav aids.
+
+## Function shape
+
+- **Soft cap: ~80 lines per function.** Once a function crosses it,
+  extract named helpers. Same applies to functions with clear staged
+  sub-steps or stages that are independently testable.
+- Model: [db/src/worker.rs](../../db/src/worker.rs) (small `impl`
+  methods). Anti-pattern: [db/src/sync.rs:60](../../db/src/sync.rs:60)'s
+  ~270-line `sync_books`.
+
+## File shape
+
+- **Soft cap: ~800 lines per file.** When a file crosses it, split by
+  sub-topic using the `books/` subdirectory pattern — e.g.
+  `sync.rs` → `sync/{mod,books,authors,backfill}.rs`.
+- Module-name choice mirrors the responsibilities, not the line count.
+
+## Errors
+
+- **Predictable failure space → `thiserror` enum** in the same module.
+  Anything where callers branch on the failure, or a UI renders a
+  per-case message: auth, validation, parsing, API boundary checks.
+- **Unpredictable failure space → `anyhow`** with a contextual message
+  (`anyhow::bail!("scan of {path} failed: {msg}")`). The right fit when
+  the source is a foreign system (filesystem, parser, network) and the
+  caller just propagates. Example:
+  [db/src/indexer.rs:193](../../db/src/indexer.rs:193).
+- **Coarse variants.** Group by failure mode and let the
+  `#[error("...")]` message carry the detail. One
+  `PasswordInvalid(String)` beats `PasswordTooShort` /
+  `PasswordTooLong` / `PasswordInCommonList` unless the caller actually
+  branches on them.
+- **Never** return raw `sqlx::Error` across a module boundary. Wrap it
+  with `#[error(transparent)] #[from]` on a module-local enum, or
+  convert into `anyhow::Error` with `.with_context(...)`.
+- **Handlers** stay on `anyhow::Error` at the signature; the body
+  upgrades typed errors via `?`.
+
+See [02-error-handling.md](02-error-handling.md) for the underlying rule.
+
+## Tests
+
+- **Placement**: sibling file `<mod>/tests.rs` for anything non-trivial
+  ([db/src/books/tests.rs](../../db/src/books/tests.rs) pattern). Inline
+  `#[cfg(test)] mod tests` is allowed only for tiny modules with 1–2
+  trivial tests.
+- **Shared helpers**: every crate has a `test_support` module
+  (`<crate>/src/test_support.rs`, gated
+  `#[cfg(any(test, feature = "test-support"))]`) for in-memory pool
+  init, seed factories, common fixtures. No duplicated
+  `make_test_dir()` / `seed_minimal_books()` across files.
+- **Coverage rule**: every `pub` fn gets *one happy-path test plus one
+  test per `thiserror` variant it can return*. Skip edge / boundary
+  tests unless the function does tricky math, parsing, or arithmetic.
+  For `anyhow`-returning functions, cover happy + one representative
+  failure.
+- **Naming**: long sentence style,
+  `fn_under_test_does_X_when_Y`. E.g.
+  `search_books_finds_by_title_and_ranks_by_bm25`, not
+  `finds_by_title`.
+
+See [03-unit-testing.md](03-unit-testing.md) for the underlying rule.
+
+## Visibility & types
+
+- **Visibility**: default `pub` is fine. The module structure carries the
+  surface — don't audit-swap to `pub(crate)`, and don't write narrower
+  scopes (`pub(super)`) prophylactically. Use `pub(crate)` only when you
+  have a specific reason a type *must* not leak.
+- **Shared types**: anything used by 2+ crates lives in `shared/`. Hoist
+  when the second consumer appears, not before.
+- **DB row types vs wire DTOs**: when the same record needs to cross the
+  HTTP/RPC boundary, it's fine to have a `db::Foo` and a `shared::Foo`
+  that look similar, with `From`/`Into` at the boundary. Don't try to
+  make one type serve both.
+
+## Mechanics
+
+- **Imports**: three blocks separated by blank lines — `std`, then
+  external crates, then `crate::` — each block alphabetical.
+  Convention-only (we don't depend on nightly rustfmt). Don't add a
+  `rustfmt.toml` group setting that requires nightly.
+- **`unwrap()` / `expect()`** are banned in production paths (see
+  [02-error-handling.md](02-error-handling.md)). Test code can use
+  freely.
+- **`unsafe`**: not used anywhere in the workspace. If you need it,
+  document the invariant in a `// SAFETY:` comment and raise it in the
+  PR description.
+
+## Out of scope
+
+- TypeScript / Playwright — see [04-playwright.md](04-playwright.md).
+- SQL migrations — see the migrations section of
+  [CLAUDE.md](../../CLAUDE.md).

--- a/.claude/rules/05-rust-style.md
+++ b/.claude/rules/05-rust-style.md
@@ -108,9 +108,9 @@ See [03-unit-testing.md](03-unit-testing.md) for the underlying rule.
 - **`unwrap()` / `expect()`** are banned in production paths (see
   [02-error-handling.md](02-error-handling.md)). Test code can use
   freely.
-- **`unsafe`**: not used anywhere in the workspace. If you need it,
-  document the invariant in a `// SAFETY:` comment and raise it in the
-  PR description.
+- **`unsafe`**: avoid it in production code. Any `unsafe` block must
+  document the invariant in a `// SAFETY:` comment, and new production
+  uses must be raised in the PR description.
 
 ## Out of scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,10 @@ Omnibus is a self-hosted ebook/audiobook library (see [docs/roadmap/0-0-summary.
 Numbered rules in [.claude/rules/](.claude/rules/), applied in order. Follow them mechanically.
 
 - [01-dev-environment.md](.claude/rules/01-dev-environment.md) — always work inside `nix develop`; env vars the shellHook sets.
-- [02-error-handling.md](.claude/rules/02-error-handling.md) — `thiserror` for domain errors, `anyhow` for handlers.
-- [03-unit-testing.md](.claude/rules/03-unit-testing.md) — inline `#[cfg(test)]`, `oneshot` for handlers, coverage expectations.
+- [02-error-handling.md](.claude/rules/02-error-handling.md) — `thiserror` for predictable failures, `anyhow` for unpredictable ones and handlers.
+- [03-unit-testing.md](.claude/rules/03-unit-testing.md) — sibling `<mod>/tests.rs`, `test_support` per crate, happy + per-variant coverage.
 - [04-playwright.md](.claude/rules/04-playwright.md) — full E2E conventions (selectors, fixtures, `expectMutation`, error paths).
+- [05-rust-style.md](.claude/rules/05-rust-style.md) — Rust style guide: comments, function/file shape, errors, tests, mechanics. Long-form rationale in [docs/style-guide.md](docs/style-guide.md).
 - [98-keep-skills-fresh.md](.claude/rules/98-keep-skills-fresh.md) — update skills when the code they reference changes.
 - [99-end-of-session.md](.claude/rules/99-end-of-session.md) — end-of-session checklist (docs sync, fmt/clippy, coverage, line-count cap).
 

--- a/docs/style-guide-cleanup.md
+++ b/docs/style-guide-cleanup.md
@@ -1,0 +1,44 @@
+# Style guide cleanup backlog
+
+Files ordered worst-to-least offending against the rules in
+[.claude/rules/05-rust-style.md](../.claude/rules/05-rust-style.md).
+A future agent session should work top-down.
+
+| Rank | File | Score | Top violations | Suggested action |
+|---|---|---|---|---|
+| 1 | db/src/sync.rs | 26 | `sync_books` 210 lines (db/src/sync.rs:60); `insert_author_links` 102 lines; file 1721 lines; 6 section-marker dividers (`// --- Removed`, `// --- Changed`, …); returns raw `sqlx::Error` across module boundary (line 64) | Split into `sync/{mod,books,authors,backfill}.rs`; extract `sync_removed`/`sync_changed`/`sync_new`/`backfill_creator_ids_for_library` from `sync_books`; wrap `sqlx::Error` in module-local `thiserror` enum; move inline tests to `sync/tests.rs` |
+| 2 | db/src/discovery.rs | 24 | Module doc 17 lines with roadmap refs + issue tracker (line 1–16); `get_author` rustdoc 22 lines (line 44–65); file 1443 lines; missing happy-path-only test coverage for pub fns returning sqlx::Error | Trim module doc to ≤5 lines, move roadmap context to PR; consolidate `get_author`/`get_series`/`get_tag_cloud` rustdoc to 3–4 lines; wrap sqlx::Error in module-local enum; add error-path tests for each pub fn |
+| 3 | db/src/palette.rs | 22 | File 1400 lines; single 26-line fn (search_palette); no module doc; missing /// on pub const MAX_DISCOVERY_BOOKS pattern duplication (similar to discovery.rs) | Add brief module doc; split search_palette helpers into subscope fns; check for overlap with discovery.rs const/patterns and consolidate to shared/ if appropriate |
+| 4 | db/src/worker.rs | 21 | File 1296 lines; lack of small focused impl methods per style guide Model reference; error handling sprawl across async task queue | Audit for functions crossing 80 lines; split Worker impl into task_queue, execution, error_handling subscopes |
+| 5 | frontend/src/data.rs | 20 | File 1188 lines; 45+ pub fns with mixed doc coverage; no /// on majority of small fetch wrappers; anyhow-based errors without context | Add one-line /// to every pub fn; consolidate fetch-wrapper helpers into named groups; wrap anyhow errors with contextual messages |
+| 6 | frontend/src/styles.rs | 18 | File 1124 lines; pure CSS constant string (non-Rust); minimal structure; doc comment bloat (3 lines for a const string) | Move or consider: is this the right place? If kept, trim doc to one-liner |
+| 7 | shared/src/lib.rs | 17 | File 881 lines; re-exports + type defs + derives without module structure; missing pub struct/enum doc comments; serde derives without rustdoc | Add /// to each pub struct/enum; consider splitting types into submodules (auth_types.rs, book_types.rs, etc.) if file keeps growing |
+| 8 | db/src/author_photos.rs | 16 | File 990 lines; no module doc; multiple pub async fns with sparse /// coverage; inline test block 479 lines (should move to author_photos/tests.rs) | Add brief module doc; add /// to pub fns; promote tests to sibling file; check error handling (raw sqlx::Error?) |
+| 9 | db/src/metadata_overrides.rs | 15 | File 769 lines; 443 lines (net—tests removed); missing module doc; pub fns without /// on helpers | Add module doc; add /// to all pub fns; audit for >80-line functions |
+| 10 | db/src/auth.rs | 14 | 14 thiserror variants (too granular); 3 password + 4 username variants collapse into Validation(String); module doc 22 lines (excess roadmap); inline test block 9 lines (trivial, ok to keep) | Consolidate to 5–6 coarse variants: InvalidCredentials, Validation(String), SessionNotFound, AccountLocked, RegistrationDisabled, Db, Hash, TokenGeneration; trim module doc |
+| 11 | db/src/scanner.rs | 13 | Missing module doc entirely; pub fn list_files lacks ///; 6 inline happy-path tests, 0 error-path tests for silent fallback cases (missing path, I/O failure); duplicated make_test_dir helper | Add module doc; add one-line ///; add tests for error paths (missing_path_returns_empty, io_error_handled, etc.); move make_test_dir to test_support |
+| 12 | server/src/backend.rs | 12 | File 769 lines; no module doc; handlers lack ///; mixed error handling (some anyhow, some custom); sparse coverage of 4xx/5xx paths | Add brief module doc; add /// to handler pub fns; standardize to anyhow for handlers; audit integration test coverage per 03-unit-testing.md |
+| 13 | frontend/src/pages/metadata_edit.rs | 11 | File 856 lines; component with embedded logic; sparse /// on pub fns; possible refactor candidates (large match/render sections) | Add /// to pub component fn; split large render sections into named sub-components |
+| 14 | server/src/auth/handlers.rs | 10 | File 600 lines; mixed error handling; sparse doc on handler pub fns | Add /// to each pub handler; standardize error wrapping |
+| 15 | db/src/library_layout.rs | 9 | File 661 lines; no module doc; sparse /// coverage; 430-line net (helpers + tests); audit for function-length violations | Add module doc; add /// to pub items; audit for >80-line functions |
+
+## Miscellaneous minor
+
+- **db/src/auth/session.rs** (655 lines): audit module doc + doc coverage
+- **db/src/settings.rs** (622 lines): missing module doc; add /// coverage
+- **db/src/browse.rs** (526 lines): add module doc; audit error handling
+- **db/src/indexer.rs** (508 lines): uses anyhow appropriately; audit doc coverage
+- **server/src/backend/author_photos.rs** (927 lines): add module doc; audit inline tests
+- **server/src/backend/overrides.rs** (594 lines): audit doc + error handling
+- **frontend/src/pages/book_detail.rs** (652 lines): audit component doc + logic extraction
+- **frontend/src/pages/auth.rs** (652 lines): audit component doc
+- **frontend/src/pages/landing/table.rs** (627 lines): audit component doc + extraction candidates
+- **frontend/src/components/search_palette.rs** (765 lines): audit component logic; split if >80-line render
+- **frontend/src/components/chip_editor.rs** (484 lines): audit component doc + extraction
+
+---
+
+**Total files audited:** 104 Rust source files across db/, server/, frontend/, shared/, mobile/ (excluding generated code and tests.rs)
+
+**Key patterns:** Files above 800 lines need subdirectory splits. Functions above 80 lines in high-severity files (top 5) should extract helpers. All files need module-level `//!` and pub items need `///`. Auth enum needs collapsing to coarse variants. Test blocks >150 lines move to sibling `tests.rs`.
+

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,372 @@
+# Rust style guide
+
+Long-form companion to [.claude/rules/05-rust-style.md](../.claude/rules/05-rust-style.md).
+The rule file is the **normative** version — terse, scannable, no
+rationale. This file is for the *why*: each rule, the reasoning, and
+before/after examples drawn from real files in this repo.
+
+If the rule file and this file disagree, the rule file wins.
+
+---
+
+## Comments & docs
+
+### Module-level `//!`
+
+**Rule:** every file gets a `//!` block of about 3–5 lines: what the
+module is for, who calls it.
+
+**Why:** module docs answer the question "do I want to be reading this
+file at all?". A reader scanning crate src/ should be able to skim the
+first paragraph of each file and know which one owns the behaviour they
+care about. Anything longer (multi-section invariants, roadmap context)
+belongs in commit messages and PR bodies — those have an audit trail, a
+review pass, and don't rot when the issue numbers stop being
+meaningful.
+
+**Anti-pattern.** [db/src/discovery.rs:1](../db/src/discovery.rs:1)
+opens with a 17-line `//!` containing a `# Multi-tenancy invariant`
+H2 heading and forward references to "Phase 4 in
+docs/roadmap/0-0-summary.md", issue #232, and an "F4.x" milestone.
+When F4.x ships those references will be wrong; when issue #232 is
+closed nobody updates the file. This belongs in the PR that introduces
+multi-tenancy, not the file itself.
+
+**Pattern.** Something like:
+
+```rust
+//! F1.8 discovery-detail reads: one author or series with their books,
+//! plus the global tag cloud. Returns DB-wide results; per-user ACL
+//! scoping is not implemented.
+```
+
+What the module does, one notable invariant (DB-wide reads), end. No
+roadmap, no issues, no H2 sections.
+
+### Function `///`
+
+**Rule:** every `pub` item gets a one-line `///` summary. Longer
+rustdoc only when behaviour is surprising.
+
+**Why:** when reading a call site, IDE hover or `cargo doc` should show
+*what the function does* without making you open the source. One line
+of useful summary beats five lines of obligatory `# Errors` /
+`# Examples` boilerplate. Reserve longer docs for actual contracts: a
+lock that callers must not hold across `.await`, a function that
+mutates after returning `Err`, a retry budget.
+
+**Anti-pattern.** [db/src/discovery.rs:44](../db/src/discovery.rs:44)
+puts a 22-line rustdoc on `get_author` with three H2 sections
+(`# Bounded reads (issue #150)`, `# Multi-tenancy`) describing what
+the cap *used to be*, what `book_count` means, and what F4.x will
+require. The function is `async fn get_author(pool, author_id) ->
+Result<Option<AuthorDetail>, sqlx::Error>`. Everything beyond "fetch
+an author by ID with their books; `None` if missing" is either
+duplicated in the `MAX_DISCOVERY_BOOKS` const doc above it or belongs
+in a PR description.
+
+**Pattern.** [db/src/scanner.rs:3](../db/src/scanner.rs:3):
+
+```rust
+/// Recursively walk `path` and return total file count plus
+/// per-extension counts for each extension in `extensions` (compared
+/// case-insensitively, without leading dot — e.g. `&["epub", "pdf"]`).
+pub fn list_files(path: Option<&str>, extensions: &[&str]) -> LibrarySection {
+```
+
+Three lines. Tells you what it does and what the inputs look like.
+Done.
+
+### Inline `//` comments
+
+**Rule:** explain *why*, never *what*. If you're narrating the
+algorithm, the function probably needs to be split.
+
+**Why:** the code is the *what*. Reading `// load overrides for the
+visible books` above `let overrides = load_overrides_bulk(&pool,
+&visible).await?;` is noise — the function name already says that.
+Useful comments encode information the reader *can't* derive from the
+code: a known SQLite quirk, a backwards-compat workaround, a
+non-obvious invariant.
+
+**Anti-pattern.** [db/src/sync.rs](../db/src/sync.rs) has section
+markers like `// --- Removed -------------------` and `// --- Backfill
+---------------` scattered through a 270-line function. They're nav
+aids for a function that shouldn't be that long in the first place
+(see [Function shape](#function-shape)).
+
+**Pattern.** A comment that says something the code doesn't:
+
+```rust
+// SQLite returns BLOB columns as Vec<u8>, but the migration that
+// added this column predates the BLOB affinity rule, so older rows
+// can come back as TEXT. Read both cases before treating it as
+// corrupted data.
+```
+
+That's a `// why` comment worth keeping.
+
+---
+
+## Function shape
+
+**Rule:** soft cap ~80 lines per function. Extract named helpers when a
+function exceeds it, when it has clear staged sub-steps, or when a
+stage is independently testable.
+
+**Why:** a function you can read top-to-bottom on one screen is one you
+can hold in your head while modifying. Long functions with section
+comments lie about their structure — the comments suggest discrete
+stages but the locals leak between them, so refactoring one stage
+means re-reading the whole body. Named helpers make the stages
+real: each has a signature, a test, and a name that documents intent.
+
+**Model.** [db/src/worker.rs](../db/src/worker.rs). Each `impl`
+method does one thing and most are short. `resource_key`, `kind`,
+`post`, `await_completion` are all single-purpose.
+
+**Anti-pattern.** [db/src/sync.rs:60](../db/src/sync.rs:60). The
+~270-line `sync_books` does upsert + remove + change + new + backfill
++ FTS-rebuild in one body, marked off with `// --- Removed`,
+`// --- Changed`, `// --- New`, `// --- Backfill` dividers. The fix is
+to extract `sync_removed`, `sync_changed`, `sync_new`,
+`backfill_creator_ids_for_library` as helpers and let the top-level
+function be a 20-line transaction wrapper that calls them in order.
+
+---
+
+## File shape
+
+**Rule:** soft cap ~800 lines per file. When crossed, split by
+sub-topic using the `books/` subdirectory pattern — e.g.
+`sync.rs` → `sync/{mod,books,authors,backfill}.rs`.
+
+**Why:** files this big have stopped being single-responsibility — they
+just collect "things that touch sync". Splitting them forces a naming
+decision (what *is* the sub-topic?) which usually surfaces a
+missing module boundary. The `books/` subdirectory pattern in this
+repo already proves the shape works.
+
+**Candidates today.** `db/src/sync.rs` (~1500 lines),
+`db/src/discovery.rs` (~1440 lines), `db/src/palette.rs`,
+`db/src/worker.rs`, `frontend/src/data.rs`. A prioritized cleanup list lives in
+[`style-guide-cleanup.md`](style-guide-cleanup.md) (created in a
+follow-up commit).
+
+---
+
+## Errors
+
+**Rule:**
+- Predictable failure space → `thiserror` enum in the module.
+- Unpredictable failure space → `anyhow` with a contextual message.
+- Coarse variants — group by failure mode, let the `#[error]` message
+  carry the detail.
+- Never return raw `sqlx::Error` across a module boundary.
+- Handlers stay on `anyhow::Error` at the signature.
+
+**Why predictable vs unpredictable:** when a caller can enumerate the
+ways the call might fail, the typed enum carries useful information
+through the `?` operator and to the UI. When the underlying system can
+fail in arbitrary ways (filesystem walks, EPUB parsing, network
+fetches), an exhaustive enum is a lie that future-you has to keep
+updating — `anyhow` with a `with_context(...)` message is honest.
+
+**Pattern (predictable).** [db/src/auth.rs:58](../db/src/auth.rs:58)
+correctly chooses `thiserror`: login, registration, and session
+validation each have a finite set of outcomes a UI renders
+differently. But the variants are *too* fine-grained — see "Coarse
+variants" below.
+
+**Pattern (unpredictable).**
+[db/src/indexer.rs:193](../db/src/indexer.rs:193):
+
+```rust
+pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
+    // ...
+    if let Some(msg) = stat.error {
+        anyhow::bail!("scan of {library_path} failed: {msg}");
+    }
+```
+
+Good fit: filesystem walks can fail in many ways and the caller just
+propagates. The format string carries the detail.
+
+### Coarse variants
+
+**Rule:** group by failure mode. One `PasswordInvalid(String)` beats
+`PasswordTooShort { min }` / `PasswordTooLong { max }` /
+`PasswordCommon` unless the caller actually branches on them.
+
+**Anti-pattern.** [db/src/auth.rs:58](../db/src/auth.rs:58) has 14
+variants. The login UI renders the same "invalid username or
+password" message for every credential failure regardless of variant,
+and the registration form shows the `#[error]` text directly. The
+three password variants could collapse to one with the message doing
+the work. Same for the four username-validation variants.
+
+**Pattern.** Three to five variants, each genuinely different in how
+the caller handles them:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("invalid credentials")]
+    InvalidCredentials,
+    #[error("account is temporarily locked")]
+    AccountLocked { until_unix: i64 },
+    #[error("{0}")]
+    Validation(String),          // password/username rules, etc.
+    #[error("session not found or expired")]
+    SessionNotFound,
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+```
+
+### Never leak `sqlx::Error`
+
+**Anti-pattern.** [db/src/sync.rs:60](../db/src/sync.rs:60) returns
+`Result<(), sqlx::Error>` from a `pub` function. Callers downstream
+inherit a leaky abstraction: any future migration to a different DB
+crate becomes a workspace-wide rename, and `sqlx::Error` carries
+unrelated variants (`PoolTimedOut`, `Configuration`, …) that the
+caller can't meaningfully handle. Wrap with a module-local
+`#[error(transparent)] #[from]` variant.
+
+---
+
+## Tests
+
+### Placement
+
+**Rule:** sibling file `<mod>/tests.rs` for anything non-trivial.
+Inline `#[cfg(test)] mod tests` only for 1–2 trivial tests.
+
+**Why:** prod files stay readable when the test block isn't padding
+them. A `books/tests.rs` sibling is one file to open when you want
+the tests, and one file to skip when you want the prod code. The
+existing [db/src/books/tests.rs](../db/src/books/tests.rs) is the
+model.
+
+**Migration note.** Existing inline `mod tests` blocks are not in
+violation by themselves; the rule kicks in when a module is being
+touched and its inline tests are large enough that moving them out
+makes the prod file more readable.
+
+### Shared helpers
+
+**Rule:** every crate has a `test_support` module
+(`<crate>/src/test_support.rs`, gated
+`#[cfg(any(test, feature = "test-support"))]`).
+
+**Why:** every db test today recreates the in-memory pool and reseeds
+fixtures with locally-defined helpers. Pulling them into one
+`test_support` per crate gives the tests one canonical
+`new_in_memory_pool()`, one `seed_minimal_books()`, one
+`make_test_dir()`. New tests stop reinventing fixtures and start
+agreeing on what "a seeded library" looks like.
+
+The `feature = "test-support"` gate lets sibling crates depend on the
+helpers in their *own* tests without exporting them in a release
+build.
+
+### Coverage
+
+**Rule:** every `pub` fn gets one happy-path test plus one test per
+`thiserror` variant it can return. Skip edge / boundary tests unless
+the function does tricky math, parsing, or arithmetic. For
+`anyhow`-returning functions, cover happy + one representative
+failure.
+
+**Why:** "exhaustive matrix" sounds rigorous but produces test files
+where 80% of cases test the language, not the function. The variant
+rule scales coverage to the *modeled* failure space — if the error
+space is too big to test, the error enum is probably too granular
+(see Coarse variants).
+
+**Anti-pattern.** [db/src/scanner.rs](../db/src/scanner.rs) has six
+happy-path tests and zero error tests, even though `list_files`
+swallows several distinct error conditions silently (returns empty
+sections on missing path, on I/O failures, etc.). Each silent
+fallback should be a test asserting the contract.
+
+### Naming
+
+**Rule:** long sentence style,
+`fn_under_test_does_X_when_Y`.
+
+**Why:** the test name is the spec. When CI prints "FAILED
+search_books_finds_by_title_and_ranks_by_bm25", you know what the
+function is supposed to do without opening the test. "FAILED
+finds_by_title" doesn't tell you *which* function or *how* it should
+find.
+
+**Pattern.** [db/src/books/tests.rs](../db/src/books/tests.rs) names
+like `search_books_finds_by_title_and_ranks_by_bm25`,
+`list_books_populates_formats_from_book_files`.
+
+**Anti-pattern.** [db/src/scanner.rs](../db/src/scanner.rs) names
+like `list_files_with_no_path_returns_empty` are *close* but elide
+the function-under-test convention; some tests in the file omit it
+entirely.
+
+---
+
+## Visibility & types
+
+**Rule (visibility):** default `pub` is fine. Use `pub(crate)` only
+when you have a specific reason a type *must* not leak.
+
+**Why:** the module structure in this repo (small focused modules,
+re-exported from `lib.rs`) makes `pub` read fine in practice. A
+codebase-wide audit to narrow visibility would touch hundreds of
+items without changing any behaviour. Not worth it.
+
+**Rule (shared types):** anything used by 2+ crates lives in `shared/`.
+Hoist when the second consumer appears.
+
+**Rule (DB rows vs wire DTOs):** when the same record crosses the
+HTTP/RPC boundary, it's fine to have a `db::Foo` and a `shared::Foo`
+that look similar, with `From` / `Into` at the boundary. Don't try to
+make one type serve both — the DB type wants sqlx derives, the wire
+type wants serde, and the two can drift independently
+(`#[serde(rename)]` on the wire side, columns added to the DB row
+without a wire change).
+
+---
+
+## Mechanics
+
+**Imports:** three blocks separated by blank lines — `std`, then
+external crates, then `crate::` — each block alphabetical. This is a
+convention enforced by review; we don't use a nightly-rustfmt
+setting.
+
+```rust
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Context;
+use sqlx::SqlitePool;
+
+use crate::books::row_to_ebook;
+use crate::pool::init_db;
+```
+
+**`unwrap()` / `expect()`:** banned in production paths (see
+[02-error-handling.md](../.claude/rules/02-error-handling.md)). Tests
+use them freely.
+
+**`unsafe`:** not used anywhere in the workspace. If a future change
+needs it, document the invariant in a `// SAFETY:` comment and call
+it out in the PR description.
+
+---
+
+## Out of scope
+
+- TypeScript / Playwright — covered by
+  [04-playwright.md](../.claude/rules/04-playwright.md).
+- SQL migrations — covered by the migrations section of
+  [CLAUDE.md](../CLAUDE.md).

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -358,9 +358,10 @@ use crate::pool::init_db;
 [02-error-handling.md](../.claude/rules/02-error-handling.md)). Tests
 use them freely.
 
-**`unsafe`:** not used anywhere in the workspace. If a future change
-needs it, document the invariant in a `// SAFETY:` comment and call
-it out in the PR description.
+**`unsafe`:** avoid it in production code. The current uses are test-only
+environment guards and must carry `// SAFETY:` comments explaining the
+serialization invariant. If a future production change needs unsafe,
+document the invariant and call it out in the PR description.
 
 ---
 


### PR DESCRIPTION
## Summary
- New normative rule at `.claude/rules/05-rust-style.md` covering comments/docs, function and file shape, errors, tests, visibility, and mechanics.
- New long-form companion at `docs/style-guide.md` with rationale and before/after examples drawn from real files in this repo.
- Updated `02-error-handling.md` and `03-unit-testing.md` so they don't contradict 05 (predictable-vs-unpredictable error rule; sibling `<mod>/tests.rs` default; per-crate `test_support` module; happy + per-variant coverage; long sentence-style test naming).
- Indexed 05 from `CLAUDE.md`.
- Follow-up commit adds `docs/style-guide-cleanup.md` — a prioritized backlog ranking the worst current offenders (top 5: `sync.rs`, `discovery.rs`, `palette.rs`, `worker.rs`, `data.rs`) with `file:line` refs and suggested actions, for a future cleanup session to work through top-down.

## Test plan
- [x] N/A — docs only. Verified line-count cap (CLAUDE.md 179, every `.claude/rules/*.md` ≤ 200), all cross-links resolve to real paths, and rules are consistent across files (test placement / error rule appear identically in the normative rule and the supporting rule files).