### PR TITLE
test: add error-path tests for db/src/scanner.rs (#316)

### DIFF
--- a/db/src/scanner.rs
+++ b/db/src/scanner.rs
@@ -156,6 +156,91 @@ mod tests {
     }
 
     #[test]
+    fn list_files_returns_empty_section_when_path_is_none() {
+        // Silent contract: `path = None` short-circuits to a default-shaped
+        // section (no path, no counts, no error) without touching the FS.
+        let result = list_files(None, EBOOK_EXTENSIONS);
+        assert_eq!(result, LibrarySection::default());
+        assert!(result.path.is_none());
+        assert_eq!(result.total_files, 0);
+        assert!(result.counts_by_ext.is_empty());
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn list_files_returns_section_with_error_when_path_missing() {
+        // Silent contract: a path that doesn't exist on disk still returns
+        // an Ok-shaped `LibrarySection`; the failure is surfaced via
+        // `error: Some("path not found: ...")`, never as a panic or Err.
+        let missing = "/definitely/does/not/exist/omnibus_scanner_missing_dir";
+        let result = list_files(Some(missing), EBOOK_EXTENSIONS);
+        assert_eq!(result.path.as_deref(), Some(missing));
+        assert_eq!(result.total_files, 0);
+        // Counts slot is preallocated for each requested extension, all zero.
+        assert_eq!(
+            result.counts_by_ext,
+            vec![("epub".to_string(), 0), ("pdf".to_string(), 0)],
+        );
+        let err = result.error.expect("missing path should populate error");
+        assert!(
+            err.contains("path not found"),
+            "unexpected error message: {err}",
+        );
+        assert!(
+            err.contains(missing),
+            "error should include the path: {err}"
+        );
+    }
+
+    #[test]
+    fn list_files_surfaces_io_error_on_unreadable_dir() {
+        // Silent contract: when `read_dir` fails mid-walk (e.g. the directory
+        // exists but is not readable), the section is returned with
+        // `error: Some("could not read directory: ...")` instead of panicking
+        // or propagating an `Err`.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let dir = tmp.path();
+        // Seed a file so the walk has something to enumerate if it ever
+        // succeeded; the test only cares about the read_dir failure path.
+        fs::write(dir.join("a.epub"), b"").expect("seed file");
+
+        let original = fs::metadata(dir).expect("stat tempdir").permissions();
+        fs::set_permissions(dir, fs::Permissions::from_mode(0o000)).expect("strip dir perms");
+
+        // Self-skip when the chmod didn't actually deny access (e.g. running
+        // as root in a container — root bypasses DAC perms). Restore perms
+        // before returning so TempDir cleanup can proceed.
+        if fs::read_dir(dir).is_ok() {
+            let _ = fs::set_permissions(dir, original);
+            eprintln!(
+                "skipping list_files_surfaces_io_error_on_unreadable_dir: \
+                 process can still read mode-000 dir (likely running as root)",
+            );
+            return;
+        }
+
+        let result = list_files(Some(dir.to_str().unwrap()), EBOOK_EXTENSIONS);
+
+        // Restore perms *before* assertions so a failed assert can't leak a
+        // mode-000 dir that breaks TempDir's Drop.
+        fs::set_permissions(dir, original).expect("restore dir perms");
+
+        assert_eq!(result.path.as_deref(), dir.to_str());
+        assert_eq!(result.total_files, 0);
+        assert_eq!(
+            result.counts_by_ext,
+            vec![("epub".to_string(), 0), ("pdf".to_string(), 0)],
+        );
+        let err = result.error.expect("unreadable dir should populate error");
+        assert!(
+            err.contains("could not read directory"),
+            "unexpected error message: {err}",
+        );
+    }
+
+    #[test]
     fn scan_libraries_uses_audiobook_extensions() {
         let dir = make_test_dir("audiobooks");
         fs::write(dir.join("chapter1.m4b"), b"").unwrap();


### PR DESCRIPTION
## Summary
- Add three named tests covering the silent fallbacks in `list_files` (`db/src/scanner.rs`):
  - `list_files_returns_empty_section_when_path_is_none` — `path = None` returns `LibrarySection::default()`.
  - `list_files_returns_section_with_error_when_path_missing` — a non-existent path returns a section with `error: Some("path not found: ...")` and the requested extension slots preallocated to zero.
  - `list_files_surfaces_io_error_on_unreadable_dir` — a `tempfile::tempdir()` with mode `0o000` returns a section with `error: Some("could not read directory: ...")`. Restores perms before `TempDir` drop. Self-skips with an `eprintln!` notice when running as root (root bypasses DAC perms, so the chmod can't actually deny access).
- `list_files` itself is unchanged.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` (clean)
- [x] `cargo clippy` (default workspace) clean
- [x] `cargo test -p omnibus-db scanner::` — all 9 scanner tests pass, including the 3 new ones
- [x] Verified the root self-skip path triggers in the sandbox container (`-- --nocapture` shows the skip notice)

## Notes
- Closes #316.
- The unreadable-dir test self-skips when the test process is root. In CI / on developer machines running as a non-root user, the chmod will deny access and the assertions will run for real.
- Two older tests (`list_files_with_no_path_returns_empty`, `list_files_with_nonexistent_path_returns_error`) cover the same two contracts with shorter names; they were left in place to keep this PR scoped to *adding* the spec-named tests. Happy to delete them in a follow-up if preferred.
- Pre-existing flaky test in this workspace: `ebook::accent::tests::extract_accent_completes_within_budget` (timing budget) — passes when run alone, unrelated to this change.

Closes #316

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cz7NrEjtN3SfEmRLotT3Tz)_