### PR TITLE
docs: add /// one-liners to undocumented pub items (#304)

### DIFF
--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -76,6 +76,7 @@ impl DataError {
 
 // ===== Mobile transport: reqwest =====
 
+/// Dioxus context wrapper holding the backend base URL for mobile clients.
 #[cfg(feature = "mobile")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ServerUrl(pub String);
@@ -421,6 +422,7 @@ async fn drain_error(response: reqwest::Response, status: reqwest::StatusCode) -
     }
 }
 
+/// GET `/api/settings` — fetch library paths and indexer config.
 #[cfg(feature = "mobile")]
 pub async fn get_settings(server_url: &str) -> Result<Settings, DataError> {
     let url = format!("{server_url}/api/settings");
@@ -432,6 +434,7 @@ pub async fn get_settings(server_url: &str) -> Result<Settings, DataError> {
     Ok(response.json::<Settings>().await?)
 }
 
+/// POST `/api/settings` — persist updated library paths; server kicks a reindex.
 #[cfg(feature = "mobile")]
 pub async fn save_settings(server_url: &str, settings: Settings) -> Result<Settings, DataError> {
     let url = format!("{server_url}/api/settings");
@@ -445,6 +448,7 @@ pub async fn save_settings(server_url: &str, settings: Settings) -> Result<Setti
     Ok(response.json::<Settings>().await?)
 }
 
+/// GET `/api/library` — fetch the high-level library section listing.
 #[cfg(feature = "mobile")]
 pub async fn get_library(server_url: &str) -> Result<LibraryContents, DataError> {
     let url = format!("{server_url}/api/library");
@@ -456,6 +460,7 @@ pub async fn get_library(server_url: &str) -> Result<LibraryContents, DataError>
     Ok(response.json::<LibraryContents>().await?)
 }
 
+/// GET `/api/ebooks` — fetch the full ebook library payload.
 #[cfg(feature = "mobile")]
 pub async fn get_ebooks(server_url: &str) -> Result<EbookLibrary, DataError> {
     let url = format!("{server_url}/api/ebooks");
@@ -467,6 +472,7 @@ pub async fn get_ebooks(server_url: &str) -> Result<EbookLibrary, DataError> {
     Ok(response.json::<EbookLibrary>().await?)
 }
 
+/// GET `/api/search?q=` — full-text search across the ebook library.
 #[cfg(feature = "mobile")]
 pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, DataError> {
     // Percent-encode the query so FTS5 operators and whitespace survive the
@@ -510,6 +516,7 @@ pub async fn search_palette(server_url: &str, q: &str) -> Result<PaletteResults,
     Ok(response.json::<PaletteResults>().await?)
 }
 
+/// GET `/api/ebooks/{uuid}` — fetch one ebook by uuid, `Ok(None)` on 404.
 #[cfg(feature = "mobile")]
 pub async fn get_ebook(server_url: &str, uuid: &str) -> Result<Option<EbookMetadata>, DataError> {
     let url = format!("{server_url}/api/ebooks/{uuid}");
@@ -524,6 +531,7 @@ pub async fn get_ebook(server_url: &str, uuid: &str) -> Result<Option<EbookMetad
     Ok(Some(response.json::<EbookMetadata>().await?))
 }
 
+/// GET `/api/authors/{id}` — fetch one author detail, `Ok(None)` on 404.
 #[cfg(feature = "mobile")]
 pub async fn get_author(server_url: &str, id: i64) -> Result<Option<AuthorDetail>, DataError> {
     let url = format!("{server_url}/api/authors/{id}");
@@ -596,6 +604,7 @@ pub async fn scan_author_photo(
     Ok(response.json::<AuthorPhotoScanResult>().await?)
 }
 
+/// GET `/api/series/{id}` — fetch one series detail, `Ok(None)` on 404.
 #[cfg(feature = "mobile")]
 pub async fn get_series(server_url: &str, id: i64) -> Result<Option<SeriesDetail>, DataError> {
     let url = format!("{server_url}/api/series/{id}");
@@ -610,6 +619,7 @@ pub async fn get_series(server_url: &str, id: i64) -> Result<Option<SeriesDetail
     Ok(Some(response.json::<SeriesDetail>().await?))
 }
 
+/// GET `/api/authors` — fetch the full authors index for browse / autocomplete.
 #[cfg(feature = "mobile")]
 pub async fn list_authors(server_url: &str) -> Result<Vec<AuthorSummary>, DataError> {
     let url = format!("{server_url}/api/authors");
@@ -621,6 +631,7 @@ pub async fn list_authors(server_url: &str) -> Result<Vec<AuthorSummary>, DataEr
     Ok(response.json::<Vec<AuthorSummary>>().await?)
 }
 
+/// GET `/api/series` — fetch the full series index for browse / autocomplete.
 #[cfg(feature = "mobile")]
 pub async fn list_series(server_url: &str) -> Result<Vec<SeriesSummary>, DataError> {
     let url = format!("{server_url}/api/series");
@@ -632,6 +643,7 @@ pub async fn list_series(server_url: &str) -> Result<Vec<SeriesSummary>, DataErr
     Ok(response.json::<Vec<SeriesSummary>>().await?)
 }
 
+/// GET `/api/tags` — fetch the weighted tag cloud for the discovery page.
 #[cfg(feature = "mobile")]
 pub async fn get_tag_cloud(server_url: &str) -> Result<Vec<TagWeight>, DataError> {
     let url = format!("{server_url}/api/tags");
@@ -643,6 +655,7 @@ pub async fn get_tag_cloud(server_url: &str) -> Result<Vec<TagWeight>, DataError
     Ok(response.json::<Vec<TagWeight>>().await?)
 }
 
+/// POST `/api/ebooks/{uuid}/overrides` — persist user metadata overrides.
 #[cfg(feature = "mobile")]
 pub async fn save_overrides(
     server_url: &str,
@@ -661,6 +674,7 @@ pub async fn save_overrides(
     Ok(Some(response.json::<EbookMetadata>().await?))
 }
 
+/// DELETE `/api/ebooks/{uuid}/overrides` — revert to original metadata.
 #[cfg(feature = "mobile")]
 pub async fn delete_overrides(
     server_url: &str,
@@ -683,6 +697,7 @@ pub async fn delete_overrides(
 // of a `Set-Cookie` header. The token is stashed in [`token_store`] and
 // attached to every subsequent request via `with_bearer`.
 
+/// POST `/api/auth/login` (mobile) — bearer-token login, stashes the token.
 #[cfg(feature = "mobile")]
 pub async fn mobile_login(
     server_url: &str,
@@ -700,6 +715,7 @@ pub async fn mobile_login(
     finish_bearer_auth(post_mobile_auth(server_url, "/api/auth/login", &req).await?)
 }
 
+/// POST `/api/auth/register` (mobile) — bearer-token signup, stashes the token.
 #[cfg(feature = "mobile")]
 pub async fn mobile_register(
     server_url: &str,
@@ -733,6 +749,7 @@ fn finish_bearer_auth(resp: LoginResponse) -> Result<UserSummary, DataError> {
     Ok(resp.user)
 }
 
+/// POST `/api/auth/logout` (mobile) — best-effort revoke, then clear local token.
 #[cfg(feature = "mobile")]
 pub async fn mobile_logout(server_url: &str) -> Result<(), DataError> {
     // Best-effort server revocation, then always clear the local token so a
@@ -837,6 +854,7 @@ fn note_server_fn_err(e: dioxus::CapturedError) -> DataError {
 // `server_url` is unused here — server functions always resolve against the
 // page origin. We keep the parameter so the call sites stay platform-agnostic.
 
+/// Web/SSR `get_settings` — server-function wrapper that proxies to `rpc_get_settings`.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_settings(_server_url: &str) -> Result<Settings, DataError> {
     crate::rpc::rpc_get_settings()
@@ -844,6 +862,7 @@ pub async fn get_settings(_server_url: &str) -> Result<Settings, DataError> {
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `save_settings` — server-function wrapper that proxies to `rpc_save_settings`.
 #[cfg(not(feature = "mobile"))]
 pub async fn save_settings(_server_url: &str, settings: Settings) -> Result<Settings, DataError> {
     crate::rpc::rpc_save_settings(settings)
@@ -851,6 +870,7 @@ pub async fn save_settings(_server_url: &str, settings: Settings) -> Result<Sett
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `get_library` — server-function wrapper that proxies to `rpc_get_library`.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_library(_server_url: &str) -> Result<LibraryContents, DataError> {
     crate::rpc::rpc_get_library()
@@ -869,6 +889,7 @@ pub async fn worker_status(_server_url: &str) -> Result<WorkerStatus, DataError>
         .map_err(note_server_fn_err)
 }
 
+/// Mobile stub for `worker_status` — returns an empty snapshot until the REST mirror lands.
 #[cfg(feature = "mobile")]
 pub async fn worker_status(_server_url: &str) -> Result<WorkerStatus, DataError> {
     // Mobile REST mirror is a follow-up; return an empty status so any
@@ -877,6 +898,7 @@ pub async fn worker_status(_server_url: &str) -> Result<WorkerStatus, DataError>
     Ok(WorkerStatus::default())
 }
 
+/// Web/SSR `get_ebooks` — server-function wrapper that proxies to `rpc_get_ebooks`.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_ebooks(_server_url: &str) -> Result<EbookLibrary, DataError> {
     crate::rpc::rpc_get_ebooks()
@@ -884,6 +906,7 @@ pub async fn get_ebooks(_server_url: &str) -> Result<EbookLibrary, DataError> {
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `search_ebooks` — server-function wrapper that proxies to `rpc_search`.
 #[cfg(not(feature = "mobile"))]
 pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, DataError> {
     crate::rpc::rpc_search(q.to_string())
@@ -899,6 +922,7 @@ pub async fn search_palette(_server_url: &str, q: &str) -> Result<PaletteResults
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `get_ebook` — server-function wrapper that proxies to `rpc_get_ebook`.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_ebook(_server_url: &str, uuid: &str) -> Result<Option<EbookMetadata>, DataError> {
     crate::rpc::rpc_get_ebook(uuid.to_string())
@@ -906,6 +930,7 @@ pub async fn get_ebook(_server_url: &str, uuid: &str) -> Result<Option<EbookMeta
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `get_author` — server-function wrapper that proxies to `rpc_get_author`.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_author(_server_url: &str, id: i64) -> Result<Option<AuthorDetail>, DataError> {
     crate::rpc::rpc_get_author(id)
@@ -913,6 +938,7 @@ pub async fn get_author(_server_url: &str, id: i64) -> Result<Option<AuthorDetai
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `scan_author_photo` — server-function wrapper that proxies to `rpc_scan_author_photo`.
 #[cfg(not(feature = "mobile"))]
 pub async fn scan_author_photo(
     _server_url: &str,
@@ -1024,6 +1050,7 @@ pub async fn upload_author_photo(
     ))
 }
 
+/// Web/SSR `get_series` — server-function wrapper that proxies to `rpc_get_series`.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_series(_server_url: &str, id: i64) -> Result<Option<SeriesDetail>, DataError> {
     crate::rpc::rpc_get_series(id)
@@ -1031,6 +1058,7 @@ pub async fn get_series(_server_url: &str, id: i64) -> Result<Option<SeriesDetai
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `get_tag_cloud` — server-function wrapper that proxies to `rpc_get_tag_cloud`.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_tag_cloud(_server_url: &str) -> Result<Vec<TagWeight>, DataError> {
     crate::rpc::rpc_get_tag_cloud()
@@ -1038,6 +1066,7 @@ pub async fn get_tag_cloud(_server_url: &str) -> Result<Vec<TagWeight>, DataErro
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `list_authors` — server-function wrapper that proxies to `rpc_list_authors`.
 #[cfg(not(feature = "mobile"))]
 pub async fn list_authors(_server_url: &str) -> Result<Vec<AuthorSummary>, DataError> {
     crate::rpc::rpc_list_authors()
@@ -1045,6 +1074,7 @@ pub async fn list_authors(_server_url: &str) -> Result<Vec<AuthorSummary>, DataE
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `list_series` — server-function wrapper that proxies to `rpc_list_series`.
 #[cfg(not(feature = "mobile"))]
 pub async fn list_series(_server_url: &str) -> Result<Vec<SeriesSummary>, DataError> {
     crate::rpc::rpc_list_series()
@@ -1052,6 +1082,7 @@ pub async fn list_series(_server_url: &str) -> Result<Vec<SeriesSummary>, DataEr
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `save_overrides` — server-function wrapper that proxies to `rpc_save_overrides`.
 #[cfg(not(feature = "mobile"))]
 pub async fn save_overrides(
     _server_url: &str,
@@ -1063,6 +1094,7 @@ pub async fn save_overrides(
         .map_err(note_server_fn_err)
 }
 
+/// Web/SSR `delete_overrides` — server-function wrapper that proxies to `rpc_delete_overrides`.
 #[cfg(not(feature = "mobile"))]
 pub async fn delete_overrides(
     _server_url: &str,
@@ -1086,6 +1118,7 @@ pub async fn delete_overrides(
 // pages render the same markup on the server (no auth calls issued during
 // SSR), and the actions only fire on user interaction after hydration.
 
+/// POST `/api/auth/login` (web) — cookie-session login; pings `web_auth_state` on success.
 #[cfg(feature = "web")]
 pub async fn login(req: LoginRequest) -> Result<LoginResponse, String> {
     let resp = post_auth_json("/api/auth/login", &req).await?;
@@ -1095,6 +1128,7 @@ pub async fn login(req: LoginRequest) -> Result<LoginResponse, String> {
     Ok(resp)
 }
 
+/// POST `/api/auth/register` (web) — cookie-session signup; pings `web_auth_state` on success.
 #[cfg(feature = "web")]
 pub async fn register(req: RegisterRequest) -> Result<LoginResponse, String> {
     let resp = post_auth_json("/api/auth/register", &req).await?;
@@ -1102,6 +1136,7 @@ pub async fn register(req: RegisterRequest) -> Result<LoginResponse, String> {
     Ok(resp)
 }
 
+/// POST `/api/auth/logout` (web) — clears the session cookie and notifies subscribers.
 #[cfg(feature = "web")]
 pub async fn logout() -> Result<(), String> {
     use gloo_net::http::Request;
@@ -1118,6 +1153,7 @@ pub async fn logout() -> Result<(), String> {
     Ok(())
 }
 
+/// GET `/api/auth/me` (web) — resolve the currently-authenticated user, if any.
 #[cfg(feature = "web")]
 pub async fn current_user() -> Result<Option<UserSummary>, String> {
     use gloo_net::http::Request;

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -20,6 +20,7 @@ use super::extractor::{extract_token, AuthUser};
 use super::{session_cookie_name, BEARER_TTL_SECS, COOKIE_TTL_SECS};
 use crate::backend::AppState;
 
+/// Build the `/api/auth/{register,login,logout,me}` router.
 pub fn auth_router(state: AppState) -> Router {
     let pool = state.pool().clone();
     Router::new()
@@ -127,6 +128,7 @@ fn want_bearer(kind: Option<&str>) -> bool {
     matches!(kind, Some("ios") | Some("android") | Some("bearer"))
 }
 
+/// Parse the `OMNIBUS_SECURE_COOKIES` env value (defaults to `true` when unset).
 pub fn parse_secure_cookies(raw: Option<&str>) -> bool {
     match raw {
         Some(v) => {

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -39,6 +39,7 @@ mod tags;
 /// client. Surfaced as a constant so callers / tests share a single source
 /// of truth.
 pub const SEARCH_RATE_LIMIT_WINDOW: std::time::Duration = std::time::Duration::from_secs(10);
+/// Max search requests per [`SEARCH_RATE_LIMIT_WINDOW`] per IP.
 pub const SEARCH_RATE_LIMIT_MAX: u32 = 30;
 
 /// Per-IP rate-limit budget for the binary-upload endpoints
@@ -50,6 +51,7 @@ pub const SEARCH_RATE_LIMIT_MAX: u32 = 30;
 /// backstopping abuse. Surfaced as constants so callers / tests share a
 /// single source of truth.
 pub const UPLOAD_RATE_LIMIT_WINDOW: std::time::Duration = std::time::Duration::from_secs(60);
+/// Max upload requests per [`UPLOAD_RATE_LIMIT_WINDOW`] per IP.
 pub const UPLOAD_RATE_LIMIT_MAX: u32 = 10;
 
 /// Generic 500 response that never leaks internal error details to the wire.
@@ -64,6 +66,7 @@ fn internal<E: std::fmt::Display>(context: &'static str, e: E) -> Response {
         .into_response()
 }
 
+/// Shared axum router state — SQLite pool, worker handle, SSRF guard config.
 #[derive(Clone)]
 pub struct AppState {
     pool: SqlitePool,
@@ -77,6 +80,7 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Build an `AppState` with the default (strict) SSRF guard.
     pub fn new(pool: SqlitePool) -> Self {
         let worker = Worker::new(pool.clone(), WorkerConfig::default());
         Self {
@@ -102,19 +106,23 @@ impl AppState {
         }
     }
 
+    /// SQLite connection pool used by every handler.
     pub fn pool(&self) -> &SqlitePool {
         &self.pool
     }
 
+    /// Shared single-process background worker handle.
     pub fn worker(&self) -> &Arc<Worker> {
         &self.worker
     }
 
+    /// SSRF guard config consulted before fetching admin-supplied URLs.
     pub fn remote_image_config(&self) -> &db::author_photos::RemoteImageConfig {
         &self.remote_image_config
     }
 }
 
+/// Build the `/api/*` REST router with a fresh per-call search rate-limiter.
 pub fn rest_router(state: AppState) -> Router {
     // Standalone/test entrypoint: a fresh, dedicated search limiter per call.
     // The live server uses `rest_router_with_search_limiter` to share one (#249).

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -372,6 +372,7 @@ pub struct PaletteResults {
 }
 
 impl PaletteResults {
+    /// Total number of hits across every result category.
     pub fn total_count(&self) -> usize {
         self.books.len() + self.authors.len() + self.series.len() + self.tags.len()
     }
@@ -453,6 +454,7 @@ pub enum SortKey {
     NewestAdded,
 }
 
+/// Ascending or descending sort direction for a [`SortKey`].
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum SortDir {
@@ -643,6 +645,7 @@ pub struct WorkerStatus {
 }
 
 impl WorkerStatus {
+    /// `true` when no tasks are active or recently completed.
     pub fn is_empty(&self) -> bool {
         self.active.is_empty() && self.recent_complete.is_empty()
     }


### PR DESCRIPTION
## Summary
- Per the rustdoc rule in `.claude/rules/05-rust-style.md` ("every `pub` item gets a one-line `///` summary"), add behavior-describing one-liners to every previously-undocumented `pub fn` / `struct` / `enum` / `const` in the files cited by issue #304.
- 49 new `///` lines total. No signatures, bodies, or other code changed. No `# Errors` / `# Examples` boilerplate.

Per-file count of new `///` lines:

| File | New `///` lines |
|---|---|
| `frontend/src/data.rs` | 36 (mobile `reqwest` + web/SSR server-fn wrappers, `ServerUrl`, web auth helpers) |
| `server/src/backend.rs` | 8 (rate-limit `*_MAX` consts, `AppState` + accessors, `rest_router`) |
| `server/src/auth/handlers.rs` | 2 (`auth_router`, `parse_secure_cookies`) |
| `shared/src/lib.rs` | 3 (`PaletteResults::total_count`, `SortDir`, `WorkerStatus::is_empty`) |

`db/src/library_layout.rs` and `db/src/metadata_overrides.rs` were already fully documented — no changes needed there.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets` clean on default-members
- [x] `cargo test` — 266 tests pass across server / frontend / shared / db; 0 failures
- [x] Re-ran an "undocumented `pub` items" audit script across the in-scope files post-edit — empty output

## Notes
- `cargo clippy --all-features` fails because `omnibus-frontend`'s `web` and `mobile` features are mutually exclusive (the crate emits a `compile_error!` when both are enabled). Per `CLAUDE.md`, the supported lints are `cargo clippy` (default-members) and per-crate builds — both clean.
- The audit was scoped exactly to the files cited in #304. `pub(crate)` items and `pub mod` declarations were left alone per the issue spec.

Closes #304

https://claude.ai/code/session_01Cz7NrEjtN3SfEmRLotT3Tz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cz7NrEjtN3SfEmRLotT3Tz)_