### PR TITLE
refactor: wrap raw sqlx::Error at module boundaries (#305)

### DIFF
--- a/db/src/discovery.rs
+++ b/db/src/discovery.rs
@@ -22,12 +22,7 @@ use omnibus_shared::{AuthorDetail, SeriesDetail, TagWeight};
 use crate::books::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
 use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};
 
-/// Error returned by the discovery-detail reads. Wraps `sqlx::Error` so
-/// the module boundary doesn't leak SQLite implementation details — per
-/// the "never return raw `sqlx::Error` across a module boundary" rule
-/// in `.claude/rules/02-error-handling.md`. `Option<T>` is preserved for
-/// missing-id semantics (callers branch on `Ok(None)`), so there is no
-/// `NotFound` variant.
+/// Errors returned by the discovery-detail reads.
 #[derive(Debug, thiserror::Error)]
 pub enum DiscoveryError {
     #[error(transparent)]

--- a/db/src/discovery.rs
+++ b/db/src/discovery.rs
@@ -22,6 +22,18 @@ use omnibus_shared::{AuthorDetail, SeriesDetail, TagWeight};
 use crate::books::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
 use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};
 
+/// Error returned by the discovery-detail reads. Wraps `sqlx::Error` so
+/// the module boundary doesn't leak SQLite implementation details — per
+/// the "never return raw `sqlx::Error` across a module boundary" rule
+/// in `.claude/rules/02-error-handling.md`. `Option<T>` is preserved for
+/// missing-id semantics (callers branch on `Ok(None)`), so there is no
+/// `NotFound` variant.
+#[derive(Debug, thiserror::Error)]
+pub enum DiscoveryError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Hard cap on the nested `books` vec returned by the discovery-detail
 /// reads ([`get_author`] / [`get_series`]). Issue #150: these functions
 /// previously serialized *every* book attributed to an author or series
@@ -66,7 +78,7 @@ pub const MAX_DISCOVERY_BOOKS: i64 = 1_000;
 pub async fn get_author(
     pool: &SqlitePool,
     author_id: i64,
-) -> Result<Option<AuthorDetail>, sqlx::Error> {
+) -> Result<Option<AuthorDetail>, DiscoveryError> {
     // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
     // function-level rustdoc above for the single-tenant rationale.
     let author_row = sqlx::query("SELECT id, name, sort FROM authors WHERE id = ?")
@@ -230,7 +242,7 @@ pub async fn get_author(
 pub async fn get_series(
     pool: &SqlitePool,
     series_id: i64,
-) -> Result<Option<SeriesDetail>, sqlx::Error> {
+) -> Result<Option<SeriesDetail>, DiscoveryError> {
     // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
     // function-level rustdoc above for the single-tenant rationale.
     let series_row = sqlx::query("SELECT id, name, sort FROM series WHERE id = ?")
@@ -411,7 +423,7 @@ const TAG_CLOUD_LIMIT: i64 = 500;
 /// parameter and count only books visible to that user via the
 /// access-control join. The `TODO(F4.x)` marker in the body stays in
 /// place until that work lands.
-pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, sqlx::Error> {
+pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, DiscoveryError> {
     // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
     // function-level rustdoc above for the single-tenant rationale.
     //

--- a/db/src/palette.rs
+++ b/db/src/palette.rs
@@ -15,10 +15,7 @@ use crate::books::parse_json_array;
 use crate::helpers::{build_fts_match, cap_query_len};
 use crate::metadata_overrides::load_overrides_bulk;
 
-/// Error returned by the search palette. Wraps `sqlx::Error` so the
-/// module boundary doesn't leak SQLite implementation details — per the
-/// "never return raw `sqlx::Error` across a module boundary" rule in
-/// `.claude/rules/02-error-handling.md`.
+/// Errors returned by the search palette.
 #[derive(Debug, thiserror::Error)]
 pub enum PaletteError {
     #[error(transparent)]

--- a/db/src/palette.rs
+++ b/db/src/palette.rs
@@ -15,6 +15,16 @@ use crate::books::parse_json_array;
 use crate::helpers::{build_fts_match, cap_query_len};
 use crate::metadata_overrides::load_overrides_bulk;
 
+/// Error returned by the search palette. Wraps `sqlx::Error` so the
+/// module boundary doesn't leak SQLite implementation details — per the
+/// "never return raw `sqlx::Error` across a module boundary" rule in
+/// `.claude/rules/02-error-handling.md`.
+#[derive(Debug, thiserror::Error)]
+pub enum PaletteError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Search palette — grouped results for the command-palette overlay (F1.5).
 ///
 /// Returns up to 5 results per category (books, authors, series, tags),
@@ -27,7 +37,7 @@ pub async fn search_palette(
     pool: &SqlitePool,
     library_path: &str,
     q: &str,
-) -> Result<PaletteResults, sqlx::Error> {
+) -> Result<PaletteResults, PaletteError> {
     let trimmed = q.trim();
     if trimmed.is_empty() {
         return Ok(PaletteResults::default());

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -16,11 +16,7 @@ use crate::taxonomy::{
     resolve_or_insert_language, resolve_or_insert_publisher, resolve_or_insert_series,
 };
 
-/// Error returned by the sync write path. Wraps `sqlx::Error` so the
-/// module boundary doesn't leak SQLite implementation details — per the
-/// "never return raw `sqlx::Error` across a module boundary" rule in
-/// `.claude/rules/02-error-handling.md`. Internal `pub(crate)` helpers
-/// stay on `sqlx::Error` and are promoted at the `pub` boundary via `?`.
+/// Errors returned by the public sync write path.
 #[derive(Debug, thiserror::Error)]
 pub enum SyncError {
     #[error(transparent)]

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -16,6 +16,17 @@ use crate::taxonomy::{
     resolve_or_insert_language, resolve_or_insert_publisher, resolve_or_insert_series,
 };
 
+/// Error returned by the sync write path. Wraps `sqlx::Error` so the
+/// module boundary doesn't leak SQLite implementation details — per the
+/// "never return raw `sqlx::Error` across a module boundary" rule in
+/// `.claude/rules/02-error-handling.md`. Internal `pub(crate)` helpers
+/// stay on `sqlx::Error` and are promoted at the `pub` boundary via `?`.
+#[derive(Debug, thiserror::Error)]
+pub enum SyncError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Per-bucket payload for [`sync_books`]. Built by
 /// `crate::indexer::diff_library` (plus the Phase-B parse for new + changed).
 ///
@@ -61,7 +72,7 @@ pub async fn sync_books(
     pool: &SqlitePool,
     library_path: &str,
     plan: SyncPlan,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), SyncError> {
     let mut tx = pool.begin().await?;
     let library_id = upsert_library(&mut tx, library_path).await?;
 
@@ -331,7 +342,7 @@ pub async fn replace_books(
     pool: &SqlitePool,
     library_path: &str,
     books: Vec<crate::ebook::IndexedBook>,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), SyncError> {
     let removed_uuids: Vec<String> = sqlx::query_scalar(
         "SELECT b.uuid FROM books b
          JOIN libraries l ON l.id = b.library_id


### PR DESCRIPTION
## Summary
- Three db modules were leaking raw `sqlx::Error` across their public surface, violating the boundary rule in `.claude/rules/02-error-handling.md`. This PR introduces a small module-local `thiserror` enum in each — `SyncError`, `DiscoveryError`, `PaletteError` — and rewrites the affected `pub fn` signatures to return the new enum. Each enum has a single `#[error(transparent)] Db(#[from] sqlx::Error)` variant so existing `?` chains inside the module body keep working with zero call-site churn.
- Affected `pub fn`s:
  - `db/src/sync.rs`: `sync_books`, `replace_books`
  - `db/src/discovery.rs`: `get_author`, `get_series`, `get_tag_cloud`
  - `db/src/palette.rs`: `search_palette`
- `Option<T>` semantics on the discovery reads are preserved (callers still branch on `Ok(None)` for missing ids); no `NotFound` variant added — keeping the shape stable was specced.
- `pub(crate)` helpers like `sync::insert_fts_row` deliberately keep `sqlx::Error` since they're internal and the caller (`metadata_overrides::rebuild_fts_for_book`) is on the same crate-private boundary. The boundary rule is about *public* surfaces.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets` clean (the `--all-features` flavor doesn't apply here because `omnibus-frontend`'s `web` and `mobile` features are mutually exclusive at the workspace level — a pre-existing constraint)
- [x] `cargo build -p omnibus-db` clean
- [x] `cargo test -p omnibus-db` — 378 / 378 passed (one unrelated flaky perf test, `ebook::accent::tests::extract_accent_completes_within_budget`, tripped its 2 s wall-time guard under heavy parallel CPU load from sibling agents but passes in isolation)
- [x] `cargo test -p omnibus` — 144 / 144 passed
- [x] Audit `rg -n 'pub.*async fn.*Result.*sqlx::Error|^pub fn.*Result.*sqlx::Error' db/src/sync.rs db/src/discovery.rs db/src/palette.rs` returns empty

## Notes
- No source changes needed in `server/` or `frontend/`. Existing callers either go through `internal(context, e)` (which only requires `E: Display`) or propagate via `?` into an `anyhow::Result` handler — both work transparently with any `std::error::Error` type, and `thiserror` derives that for free.
- Closes #305.

https://claude.ai/code/session_01Cz7NrEjtN3SfEmRLotT3Tz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cz7NrEjtN3SfEmRLotT3Tz)_