### PR TITLE
docs: trim bloated rustdoc (#303)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -1,25 +1,8 @@
-//! Auth data layer (F0.3).
-//!
-//! Pure SQL + hashing. No axum types, no cookies — those belong to
-//! `server::auth`. This module owns:
-//!
-//! * Argon2id password hashing + verification + PHC rotation on verify.
-//! * Password-policy validation (length + common-password reject-list).
-//! * Race-free first-user-admin creation (BEGIN IMMEDIATE).
-//! * Timing-safe login with per-account lockout + failure counter.
-//! * Session creation: raw 256-bit token returned once, SHA-256 hash stored.
-//! * Session lookup: exact SHA-256 hash match against the stored value
-//!   (the raw token is never persisted), with absolute expiry
-//!   (`expires_at`, set at create time from the caller's TTL — 30 days for
-//!   cookies, 90 days for bearer tokens) and idle expiry
-//!   (`SESSION_IDLE_TIMEOUT_SECS`, 7 days since `last_used_at`).
-//! * Device registration + listing.
-//! * `OMNIBUS_INITIAL_ADMIN` recovery hook (`promote_to_admin`).
-//! * Session-key secret load/create in `secrets`.
-//!
-//! Schema lives in `migrations/0004_auth.sql`. See
-//! `docs/roadmap/0-3-auth.md` for the security rationale behind every
-//! design decision here.
+//! Auth data layer: pure SQL + Argon2id hashing for users, devices, and
+//! sessions. No axum types, no cookies — those belong to `server::auth`.
+//! Covers password hashing/verify with PHC rotation, password-policy
+//! validation, first-user-admin creation, per-account lockout, and
+//! SHA-256-hashed session tokens with absolute + idle expiry.
 
 mod device;
 mod login;

--- a/db/src/author_photos.rs
+++ b/db/src/author_photos.rs
@@ -1,18 +1,9 @@
-//! F1.11 Author profile photo resolver.
-//!
-//! Runs the manual → Open Library → letter cascade for a given author and
-//! persists the result in `author_photos`. Driven by
-//! [`crate::worker::Task::ResolveAuthorPhoto`], which gives us:
-//!   - at most one in-flight resolution per author (per-resource keyed
-//!     mutex),
-//!   - background execution, so the page renders the letter avatar
-//!     immediately and upgrades on the next visit.
-//!
-//! Cache semantics: a `'letter'` row is written on any miss (network
-//! error, Open Library has no match, sub-1KB image, non-image bytes) and
-//! sticks until an admin clears it via `DELETE /api/authors/:id/photo`.
-//! This keeps a single page-view from costing two HTTP round-trips on
-//! every refresh for authors who genuinely have no Open Library entry.
+//! Author profile photo resolver. Runs the manual → Open Library → letter
+//! cascade for a given author and persists the result in `author_photos`.
+//! Driven by [`crate::worker::Task::ResolveAuthorPhoto`] so resolutions
+//! run in the background with at most one in-flight per author. Any miss
+//! writes a sticky `'letter'` row so subsequent page loads don't pay the
+//! network round-trip again until an admin clears it.
 
 use std::net::{IpAddr, SocketAddr};
 use std::sync::OnceLock;
@@ -420,17 +411,11 @@ async fn validated_resolve(url: &str) -> Result<(String, Vec<SocketAddr>), Fetch
 /// the raw bytes and the server-advertised content-type; callers are
 /// expected to run magic-byte sniffing on the bytes before persisting.
 ///
-/// Used by the "paste image URL" branch of the author photo edit modal
-/// (F1.11 follow-up). Lives next to [`fetch_open_library`] because it
-/// reuses the same `reqwest` setup and shares the "we expect an image"
-/// surface area.
-///
-/// **SSRF guard (issue #275).** Production callers go through
-/// [`fetch_remote_image`], which uses the default strict
-/// [`RemoteImageConfig`]: the URL's host is resolved and every resolved IP
-/// is checked against [`is_blocked_address`] *before* any TCP connect, then
-/// the `reqwest` client is built with `.resolve_to_addrs(host, validated)`
-/// so it can't be tricked into re-resolving and hitting a different IP (DNS
+/// Production callers go through the default strict [`RemoteImageConfig`]
+/// SSRF guard: the URL's host is resolved and every resolved IP is checked
+/// against [`is_blocked_address`] *before* any TCP connect, then the
+/// `reqwest` client is built with `.resolve_to_addrs(host, validated)` so
+/// it can't be tricked into re-resolving and hitting a different IP (DNS
 /// rebinding).
 pub async fn fetch_remote_image(url: &str) -> Result<(String, Vec<u8>), FetchRemoteImageError> {
     fetch_remote_image_with(url, &RemoteImageConfig::default()).await

--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -1,19 +1,10 @@
-//! F1.11 author profile photo data layer plus the F5.9-lite admin
-//! `delete_author` primitive.
-//!
-//! `author_photos` holds at most one row per author (PK = author_id). The
-//! `source` column distinguishes:
-//! - `'manual'`     — admin upload via `PUT /api/authors/:id/photo`.
-//! - `'openlibrary'`— resolved by the background worker.
-//! - `'letter'`     — negative-cache marker: no usable image. `bytes` and
-//!   `mime` are NULL; `get_author_photo` returns `None` so the GET handler
-//!   404s and the letter avatar stays in place.
-//!
-//! Admin DELETE clears the row to force re-resolution on next view.
-//!
-//! The OL resolver itself lives in [`crate::author_photos`]; this file
-//! owns just the DB-side row CRUD and the related author-deletion
-//! primitive.
+//! Author profile photo data layer plus the admin `delete_author`
+//! primitive. `author_photos` holds at most one row per author (PK =
+//! author_id) with a `source` of `'manual'`, `'openlibrary'`, or
+//! `'letter'` (negative-cache marker — NULL bytes/mime so `get_author_photo`
+//! returns `None` and the letter avatar stays in place). Admin DELETE
+//! clears the row to force re-resolution. The OL resolver itself lives in
+//! [`crate::author_photos`]; this file owns just the row CRUD.
 
 use sqlx::SqlitePool;
 
@@ -131,10 +122,9 @@ pub async fn delete_author_photo(pool: &SqlitePool, author_id: i64) -> Result<()
 
 /// Delete an author by id and prevent reindex from re-creating the row.
 ///
-/// F5.9-lite durable junk-author removal (issue #159). One transaction:
-/// look up the name (for the blocklist insert) and affected book ids
-/// (for the post-commit FTS refresh), drop the link rows, drop the
-/// `authors` row, then `INSERT OR IGNORE` the name into
+/// One transaction: look up the name (for the blocklist insert) and
+/// affected book ids (for the post-commit FTS refresh), drop the link
+/// rows, drop the `authors` row, then `INSERT OR IGNORE` the name into
 /// `ignored_authors` so the next `indexer::reindex` does not silently
 /// re-create the row via `resolve_or_insert_author`.
 ///

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -227,7 +227,7 @@ pub async fn list_indexed_rows(
 /// `MAX_BOOKS_RETURNED`, so callers that need to surface a truncation
 /// hint (UI banner, `X-Total-Count` header) ask the count separately.
 /// Single scalar query — cheaper than re-running the full SELECT just
-/// to count rows. Issue #81.
+/// to count rows.
 pub async fn count_books(pool: &SqlitePool, library_path: &str) -> Result<i64, sqlx::Error> {
     sqlx::query_scalar::<_, i64>(
         r#"
@@ -246,8 +246,8 @@ pub async fn count_books(pool: &SqlitePool, library_path: &str) -> Result<i64, s
 /// `library_path`. Returns an empty library (no error, no books) if the path
 /// is `None`.
 ///
-/// The returned `books` vec is capped at `MAX_BOOKS_RETURNED` (issue #81);
-/// callers that need to surface a truncation hint should use
+/// The returned `books` vec is capped at `MAX_BOOKS_RETURNED`; callers that
+/// need to surface a truncation hint should use
 /// [`library_from_db_with_total`] instead. This entrypoint deliberately
 /// avoids the extra `count_books` round-trip — non-REST callers (the RPC
 /// path, internal lookups) don't need the total and shouldn't pay for it.
@@ -270,7 +270,7 @@ pub async fn library_from_db(
 /// Same as `library_from_db` but also returns the *true* book count under
 /// `library_path` (before the `MAX_BOOKS_RETURNED` cap). Used by the REST
 /// handler to set `X-Total-Count` and `X-Total-Cap` response headers so
-/// the client can detect a truncated response. Issue #81.
+/// the client can detect a truncated response.
 pub async fn library_from_db_with_total(
     pool: &SqlitePool,
     library_path: Option<&str>,

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -11,15 +11,10 @@ use omnibus_shared::{Contributor, EbookMetadata, Identifier};
 use crate::helpers::format_series_index;
 
 /// Hard server-side cap on the number of books any single list/search
-/// response returns. The F1.3 spec ([docs/roadmap/1-3-library-views.md])
-/// allows client-side sort/filter "for libraries up to ~10k books", but
-/// nothing previously enforced that — `list_books` / `search_books`
-/// streamed the entire library on every request, so a multi-thousand-book
-/// install paid the serialization cost on every poll. Issue #81.
-///
-/// 50k is well above the spec's client-side ceiling (anything beyond
-/// needs server-side pagination anyway) and small enough that JSON-
-/// encoding the response stays in a sensible memory envelope.
+/// response returns. 50k is well above the client-side sort/filter
+/// ceiling (anything beyond needs server-side pagination anyway) and
+/// small enough that JSON-encoding the response stays in a sensible
+/// memory envelope.
 ///
 /// Callers that need the *full* count (for "X books truncated" UI or the
 /// `X-Total-Count` header) should reach for `library_from_db_with_total`

--- a/db/src/books/search.rs
+++ b/db/src/books/search.rs
@@ -42,7 +42,7 @@ pub async fn search_books(
 /// total comes from a scalar `(SELECT COUNT(*) FROM matches)` over it. Used by
 /// the REST search handler and the RPC search server function so neither has
 /// to issue a second `count_search_books` query. Empty/oversized `q` is handled
-/// identically to `search_books` and yields `(vec![], 0)`. Issue #241.
+/// identically to `search_books` and yields `(vec![], 0)`.
 pub async fn search_books_with_total(
     pool: &SqlitePool,
     library_path: &str,
@@ -226,7 +226,7 @@ pub async fn search_books_with_total(
 
 /// Total number of FTS5 hits for `q` under `library_path` (before the
 /// `MAX_BOOKS_RETURNED` cap is applied). Empty/whitespace `q` returns 0
-/// to mirror `search_books`. Issue #81.
+/// to mirror `search_books`.
 pub async fn count_search_books(
     pool: &SqlitePool,
     library_path: &str,

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -1,53 +1,29 @@
-//! F1.12 browse-all index pages: `/authors` and `/series`. Returns every
-//! row (capped at `INDEX_LIMIT`) so the UI's client-side sort/filter has
-//! the full list to work with; per-row counts come back override-aware so
-//! the index surfaces stay consistent with the discovery-detail reads.
-//!
-//! # Multi-tenancy invariant
-//!
-//! Both browse reads are **DB-wide**: they return every author / series in
-//! the configured library without filtering by the requesting user's
-//! access. The app is single-tenant and single-library today (see Phase 4
-//! in `docs/roadmap/0-0-summary.md`), so every authenticated caller sees
-//! the same index. Per-user ACL scoping — a `user_id` parameter plus an
-//! access-control join — is deferred to F4.x and tracked by issue #232;
-//! each function carries a `# Multi-tenancy` rustdoc section and a
-//! `TODO(F4.x)` marker in its body until that work lands.
+//! Browse-all index pages: `/authors` and `/series`. Returns every row
+//! (capped at `INDEX_LIMIT`) so the UI's client-side sort/filter has the
+//! full list to work with; per-row counts come back override-aware so the
+//! index stays consistent with the discovery-detail reads. Single-tenant
+//! today — no per-user ACL filtering.
 
 use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::{AuthorSummary, SeriesSummary};
 
-/// Hard cap on rows returned by [`list_authors`] / [`list_series`]. The
-/// F1.12 roadmap notes a 5k+ author library is the upper bound we want to
-/// keep responsive on a single page; 10k leaves headroom while keeping
-/// the JSON envelope under ~1 MB even with the optional accent string.
+/// Hard cap on rows returned by [`list_authors`] / [`list_series`]. Keeps
+/// the JSON envelope under ~1 MB even with the optional accent string,
+/// while leaving headroom past a 5k+ author library.
 const INDEX_LIMIT: i64 = 10_000;
 
 /// Return every author with their book count and an optional cover-derived
-/// accent, scoped to `library_path`. Empty list when `library_path` does
-/// not match a configured library.
-///
-/// Ordered by name ascending. The UI does its own client-side sort/filter,
-/// so this returns the full list up to [`INDEX_LIMIT`] — see
-/// [docs/roadmap/1-12-browse-authors-series.md] for the per-library size
-/// expectations.
-///
-/// Accent: the `accent_color` of the first book by this author with a
-/// non-null value, by book sort/id order. `NULL` is returned when no book
-/// has one, and the UI falls back to the theme accent.
-///
-/// # Multi-tenancy
-///
-/// Single-tenant today — every authenticated caller sees the same list.
-/// When per-user ACLs land in F4.x this function must accept a `user_id`
-/// and join through the access-control table the same way
-/// [`crate::discovery::get_author`] will.
+/// accent, scoped to `library_path`, ordered by name ascending and capped
+/// at [`INDEX_LIMIT`]. Empty list when `library_path` doesn't match a
+/// configured library. Accent is the `accent_color` of the first book by
+/// this author with a non-null value (book sort/id order); `NULL` falls
+/// back to the theme accent in the UI.
 pub async fn list_authors(
     pool: &SqlitePool,
     library_path: &str,
 ) -> Result<Vec<AuthorSummary>, sqlx::Error> {
-    // TODO(F4.x): scope by `user_id` once per-user ACLs land.
+    // TODO: scope by `user_id` once per-user ACLs land.
     //
     // F5.1: count uses the effective (override-aware) creator set, not
     // the raw `books_authors_link` rows — otherwise an author whose books
@@ -129,24 +105,16 @@ pub async fn list_authors(
 }
 
 /// Return every series with book count, primary author, and an optional
-/// accent, scoped to `library_path`.
-///
-/// `primary_author` is the first creator of the lowest-`series_index`
-/// book in the series (with `book.sort, book.id` as deterministic
-/// tie-breakers). It can be `None` when every book in the series has only
-/// override-supplied creators that haven't been linked to an `authors`
-/// row yet — surface a plain text by-line in that case.
-///
-/// Ordered by name ascending. Capped at [`INDEX_LIMIT`].
-///
-/// # Multi-tenancy
-///
-/// Same single-tenant caveat as [`list_authors`].
+/// accent, scoped to `library_path`, ordered by name ascending and capped
+/// at [`INDEX_LIMIT`]. `primary_author` is the first creator of the
+/// lowest-`series_index` book (with `book.sort, book.id` as tie-breakers);
+/// `None` when every book in the series has only override-supplied
+/// creators not yet linked to an `authors` row.
 pub async fn list_series(
     pool: &SqlitePool,
     library_path: &str,
 ) -> Result<Vec<SeriesSummary>, sqlx::Error> {
-    // TODO(F4.x): scope by `user_id` once per-user ACLs land.
+    // TODO: scope by `user_id` once per-user ACLs land.
     //
     // F5.1: same overlay shape as `list_authors` and the palette series
     // query. `overrides.series` (string) drives membership for `book_count`;

--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -151,22 +151,17 @@ pub(crate) fn find_override_cover_file(uuid: &str) -> Option<(String, Vec<u8>)> 
 /// Load a book's cover image bytes + mime type from disk. The `id` parameter
 /// is the `books.id` primary key — the REST surface is uuid-keyed at
 /// `/api/covers/{uuid}` (`server/src/backend.rs`), where the handler resolves
-/// the uuid to an id via `resolve_book_id_by_uuid` before calling this. Inside,
-/// we look up the book's `uuid` again and read the cover file off disk.
+/// the uuid to an id via `resolve_book_id_by_uuid` before calling this.
 ///
-/// **F5.1:** User-uploaded override covers take precedence. When the
+/// User-uploaded override covers take precedence: when the
 /// `metadata_overrides` table flags `has_cover_override`, the override file
-/// at `covers_dir()/override-<uuid>.<ext>` is returned first.
+/// at `covers_dir()/override-<uuid>.<ext>` is returned first. The override
+/// flag is pulled in via a `LEFT JOIN` so the hot path stays at one query.
 ///
-/// Single round-trip: the override flag is pulled in via a `LEFT JOIN` on
-/// `metadata_overrides` rather than a second `get_metadata_overrides` call.
-/// Covers are fetched per grid tile and per detail page — the hot path
-/// stays at one query regardless of whether overrides exist.
-///
-/// The filesystem probes (`find_override_cover_file` / `find_cover_file`)
-/// are synchronous `std::fs` calls and run on the blocking pool via
+/// Filesystem probes (`find_override_cover_file` / `find_cover_file`) are
+/// synchronous `std::fs` calls and run on the blocking pool via
 /// [`tokio::task::spawn_blocking`] so a hot cover-fetch loop doesn't pin
-/// tokio worker threads (#106).
+/// tokio worker threads.
 pub async fn get_cover(
     pool: &SqlitePool,
     book_id: i64,

--- a/db/src/discovery.rs
+++ b/db/src/discovery.rs
@@ -1,19 +1,8 @@
-//! F1.8 discovery-detail reads: a single author or series with their
-//! books, plus the global tag cloud. Membership and ordering follow the
-//! merged (override-aware) view via the BOOK_COLUMNS template shared
-//! with the book read path.
-//!
-//! # Multi-tenancy invariant
-//!
-//! Every read in this module is **DB-wide**: it returns all matching rows
-//! without filtering by the requesting user's library access. The app is
-//! single-tenant and single-library today (see Phase 4 in
-//! `docs/roadmap/0-0-summary.md`), so every authenticated caller is
-//! implicitly authorised to see every author, series, and tag. Per-user
-//! ACL scoping — a `user_id` parameter on each signature plus an
-//! access-control join in each query — is deferred to F4.x and tracked by
-//! issue #232; each function carries a `# Multi-tenancy` rustdoc section
-//! and a `TODO(F4.x)` marker in its body until that work lands.
+//! Discovery-detail reads: a single author or series with their books,
+//! plus the global tag cloud. Membership and ordering follow the merged
+//! (override-aware) view via the BOOK_COLUMNS template shared with the
+//! book read path. Single-tenant today — every read returns all matching
+//! rows without per-user ACL filtering.
 
 use sqlx::{Row, SqlitePool};
 
@@ -30,52 +19,19 @@ pub enum DiscoveryError {
 }
 
 /// Hard cap on the nested `books` vec returned by the discovery-detail
-/// reads ([`get_author`] / [`get_series`]). Issue #150: these functions
-/// previously serialized *every* book attributed to an author or series
-/// in one payload — a prolific reference author or a giant Calibre series
-/// could nest thousands of `EbookMetadata` structs (each with its own
-/// `Vec<Contributor>` / `Vec` subjects / `Vec<Identifier>`) into a single
-/// response. 1 000 is far above any realistic single-author/series shelf a
-/// client renders in one grid, yet keeps the JSON envelope bounded.
-///
-/// Truncation is surfaced *without* a struct change: `AuthorDetail` /
-/// `SeriesDetail` already carry a `book_count` field. Both reads now set
-/// `book_count` from a dedicated uncapped `COUNT(*)`, so a caller detects
-/// truncation as `book_count > books.len()`. The `X-Total-Count` header
-/// floated in #150 doesn't fit here — these flow through Dioxus server
-/// functions (`frontend/src/rpc.rs`), not raw axum handlers, so there's no
-/// ergonomic place to set a response header. Cursor pagination is the
-/// intended F4.x follow-up; see `docs/roadmap/`.
+/// reads ([`get_author`] / [`get_series`]). Truncation is surfaced via
+/// `book_count` (uncapped `COUNT(*)`) so callers detect it as
+/// `book_count > books.len()`.
 pub const MAX_DISCOVERY_BOOKS: i64 = 1_000;
 
 /// Fetch an author by ID with their books across every library. Returns
-/// `None` if the author ID doesn't exist.
-///
-/// # Bounded reads (issue #150)
-///
-/// The nested `books` vec is hard-capped at [`MAX_DISCOVERY_BOOKS`]; a
-/// prolific reference author no longer serializes thousands of nested
-/// `EbookMetadata` structs in one payload. `book_count` is computed from a
-/// separate uncapped `COUNT(*)`, so it always reports the true shelf size
-/// and callers detect truncation as `book_count > books.len()`. Cursor
-/// pagination is the intended F4.x follow-up.
-///
-/// # Multi-tenancy
-///
-/// This function returns all matching rows without filtering by the
-/// requesting user's library access. The app is single-tenant and
-/// single-library today (see Phase 4 in `docs/roadmap/0-0-summary.md`),
-/// so every authenticated caller is implicitly authorised to see every
-/// author. When per-user ACLs land in the F4.x phase this function must
-/// accept a `user_id` parameter and filter both the `authors` row and
-/// the joined `books` via the access-control join. The `TODO(F4.x)`
-/// marker in the body stays in place until that work lands.
+/// `None` if the author ID doesn't exist. The nested `books` vec is
+/// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
 pub async fn get_author(
     pool: &SqlitePool,
     author_id: i64,
 ) -> Result<Option<AuthorDetail>, DiscoveryError> {
-    // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
-    // function-level rustdoc above for the single-tenant rationale.
+    // TODO: scope by `user_id` once per-user ACLs land (single-tenant today).
     let author_row = sqlx::query("SELECT id, name, sort FROM authors WHERE id = ?")
         .bind(author_id)
         .fetch_optional(pool)
@@ -212,34 +168,13 @@ pub async fn get_author(
 }
 
 /// Fetch a series by ID with its books, ordered by series index. Returns
-/// `None` if the series ID doesn't exist.
-///
-/// # Bounded reads (issue #150)
-///
-/// The nested `books` vec is hard-capped at [`MAX_DISCOVERY_BOOKS`]; a
-/// giant Calibre series no longer serializes its entire shelf in one
-/// payload. `book_count` is computed from a separate uncapped `COUNT(*)`,
-/// so it reports the true series size and truncation is detectable as
-/// `book_count > books.len()`. Cursor pagination is the intended F4.x
-/// follow-up.
-///
-/// # Multi-tenancy
-///
-/// This function returns all matching rows without filtering by the
-/// requesting user's library access. The app is single-tenant and
-/// single-library today (see Phase 4 in `docs/roadmap/0-0-summary.md`),
-/// so every authenticated caller is implicitly authorised to see every
-/// series. When per-user ACLs land in the F4.x phase this function must
-/// accept a `user_id` parameter and filter both the `series` row and the
-/// joined `books` via the access-control join — same caveat as
-/// [`get_author`]. The `TODO(F4.x)` marker in the body stays in place
-/// until that work lands.
+/// `None` if the series ID doesn't exist. The nested `books` vec is
+/// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
 pub async fn get_series(
     pool: &SqlitePool,
     series_id: i64,
 ) -> Result<Option<SeriesDetail>, DiscoveryError> {
-    // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
-    // function-level rustdoc above for the single-tenant rationale.
+    // TODO: scope by `user_id` once per-user ACLs land (single-tenant today).
     let series_row = sqlx::query("SELECT id, name, sort FROM series WHERE id = ?")
         .bind(series_id)
         .fetch_optional(pool)
@@ -400,27 +335,8 @@ const TAG_CLOUD_LIMIT: i64 = 500;
 
 /// Return up to [`TAG_CLOUD_LIMIT`] tags with their book counts, ordered
 /// by count descending then name ascending. Used by the tag cloud page.
-///
-/// # Bounded reads (issue #150)
-///
-/// Unlike [`get_author`] / [`get_series`], this read never nests book
-/// lists — it returns only `TagWeight { name, count }` rows — and the tag
-/// list itself is already capped at [`TAG_CLOUD_LIMIT`]. There is nothing
-/// unbounded to cap here; the #150 work is the discovery-detail reads.
-///
-/// # Multi-tenancy
-///
-/// This function returns the global tag distribution without filtering
-/// by the requesting user's library access. The app is single-tenant and
-/// single-library today (see Phase 4 in `docs/roadmap/0-0-summary.md`),
-/// so every authenticated caller sees the same tag cloud. When per-user
-/// ACLs land in the F4.x phase this function must accept a `user_id`
-/// parameter and count only books visible to that user via the
-/// access-control join. The `TODO(F4.x)` marker in the body stays in
-/// place until that work lands.
 pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, DiscoveryError> {
-    // TODO(F4.x): scope by `user_id` once per-user ACLs land. See the
-    // function-level rustdoc above for the single-tenant rationale.
+    // TODO: scope by `user_id` once per-user ACLs land (single-tenant today).
     //
     // F5.1: counts use the effective (override-aware) subject set, not
     // the raw `books_tags_link` rows — `overrides.subjects` replaces a

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -7,14 +7,13 @@
 //! rest of the library. This output is consumed by [`crate::indexer`],
 //! which writes it to the DB.
 //!
-//! Cover sourcing (F0.6): a `cover.{jpg,jpeg,png}` (or per-stem
+//! Cover sourcing: a `cover.{jpg,jpeg,png}` (or per-stem
 //! `<basename>.{jpg,jpeg,png}`) sidecar next to the epub is preferred over
 //! the embedded cover. With [`ScanOptions::materialize_sidecars`] set, the
 //! scanner extracts the embedded cover into a `<basename>.jpg`/`.png`
 //! sidecar on first encounter so subsequent scans skip the zip altogether.
-//! Materialization is best-effort: a write failure (read-only fs,
-//! permission denied) falls back to the in-memory embedded bytes for the
-//! current scan and retries on the next one.
+//! Materialization is best-effort: a write failure falls back to the
+//! in-memory embedded bytes for the current scan and retries on the next.
 
 use std::path::Path;
 

--- a/db/src/ebook/accent.rs
+++ b/db/src/ebook/accent.rs
@@ -4,11 +4,11 @@
 /// covers while bounding the decode allocation against a crafted EPUB.
 const MAX_EMBEDDED_COVER_BYTES: usize = 20 * 1024 * 1024;
 
-/// F1.7 Atrium: extract a representative accent color from cover bytes.
-/// Returns an `oklch(L C H)` string clamped to a readable band, or `None`
-/// when decoding fails or the cover has no chromatic content. See the
-/// [Atrium design doc](../../../docs/design/atrium-design-system.md) §2b
-/// for the algorithm rationale (hue-bucket → highest-weighted → OKLCH).
+/// Extract a representative accent color from cover bytes. Returns an
+/// `oklch(L C H)` string clamped to a readable band, or `None` when decoding
+/// fails or the cover has no chromatic content. The algorithm hue-buckets
+/// the pixels, picks the highest-weighted bucket, and converts to OKLCH —
+/// see `docs/design/atrium-design-system.md` §2b for the rationale.
 pub fn extract_accent(bytes: &[u8]) -> Option<String> {
     if bytes.is_empty() {
         return None;

--- a/db/src/helpers.rs
+++ b/db/src/helpers.rs
@@ -8,15 +8,14 @@ use std::path::Path;
 /// (`search_books`, `count_search_books`, `search_palette`). Inputs beyond
 /// this are truncated before reaching [`build_fts_match`] / `LIKE` so the
 /// generated MATCH expression and pattern length stay bounded regardless of
-/// caller payload size (issue #189). Module-wide so the limit is tunable in
-/// one place across every search path.
+/// caller payload size. Module-wide so the limit is tunable in one place
+/// across every search path.
 pub(crate) const MAX_QUERY_LEN: usize = 256;
 
 /// Trim surrounding whitespace and cap a user query to [`MAX_QUERY_LEN`]
 /// chars before it reaches [`build_fts_match`] / `LIKE`. Collecting chars
 /// (not bytes) guarantees the truncation never lands mid-codepoint. Shared
-/// by every search entrypoint (`search_books`, `count_search_books`,
-/// `search_palette`) so the cap is applied identically everywhere (#189).
+/// by every search entrypoint so the cap is applied identically everywhere.
 pub(crate) fn cap_query_len(q: &str) -> String {
     q.trim().chars().take(MAX_QUERY_LEN).collect()
 }
@@ -24,15 +23,9 @@ pub(crate) fn cap_query_len(q: &str) -> String {
 /// Deterministic UUIDv5 derived from `(library_path, filename)` so reindexing
 /// the same file produces the same uuid. Keeps `/api/covers/{uuid}` URLs
 /// stable across reindex cycles even as the primary `books.id` renumbers.
-///
-/// Implemented as `Uuid::new_v5(NAMESPACE_URL, "{library_path}\0{filename}")`.
-/// Issue #94: the previous implementation used
-/// `std::collections::hash_map::DefaultHasher`, whose algorithm is documented
-/// as subject to change between Rust toolchain versions. A toolchain bump
-/// would silently rotate every cover UUID on the next reindex and orphan
-/// every cover file on disk. UUIDv5 (SHA-1 over a namespace + name, per
-/// RFC 4122 §4.3) is fixed across toolchains, sets the proper version/variant
-/// bits, and emits the canonical 8-4-4-4-12 hyphenated form.
+/// UUIDv5 (SHA-1 over a namespace + name, per RFC 4122 §4.3) is fixed
+/// across Rust toolchains — a previous `DefaultHasher` derivation rotated
+/// every cover UUID on toolchain bumps and orphaned cover files on disk.
 pub(crate) fn stable_uuid(library_path: &str, filename: &str) -> String {
     // NUL is the one byte that can't appear inside either side, so it's a
     // safe, unambiguous separator — no `(library_path, filename)` collision
@@ -66,7 +59,7 @@ pub(crate) fn parse_series_index(s: &str) -> Option<f64> {
     s.trim().parse::<f64>().ok()
 }
 
-/// Defense-in-depth gate on `books.accent_color` (#125). The indexer's
+/// Defense-in-depth gate on `books.accent_color`. The indexer's
 /// `extract_accent` emits strings of the exact shape `oklch(L C H)` with
 /// three space-separated decimal floats; consumers (Atrium cover tiles,
 /// palette rows, book detail) inline the value into an HTML `style`

--- a/db/src/library_layout.rs
+++ b/db/src/library_layout.rs
@@ -1,24 +1,12 @@
-//! Canonical Omnibus library layout helpers (F0.6).
-//!
-//! Omnibus writes the canonical tree as
-//! `<library_root>/<author-slug>/<title-slug>/<title-slug>.<ext>`. Only the
-//! upload path (F5.3) calls the write helpers today; the read path uses the
-//! tolerant scanner in [`crate::scanner`] / [`crate::ebook`] and the sidecar
-//! cover lookup ([`sidecar_cover_for`]).
-//!
-//! Slug rule: ASCII-fold via `deunicode`, lowercase, non-alphanumerics
-//! collapse into `-`, leading/trailing `-` trimmed, hard-cap at 80 chars on a
-//! codepoint boundary. Empty fold result falls back to `"book"` so we never
-//! produce a zero-length path component. The display name (with case,
-//! punctuation, unicode) lives in the DB — the slug is purely a filesystem
-//! artifact.
-//!
-//! Cover sidecar contract: `cover.jpg` (or per-stem `<basename>.jpg`) sitting
-//! next to an ebook is the *single* source of truth for that book's cover
-//! after the first scan. The scanner materializes the embedded cover into
-//! that file once, then never re-reads the zip. This is opportunistic — a
-//! read-only filesystem is handled by falling back to the in-memory embedded
-//! bytes for the current scan and retrying on the next one.
+//! Canonical Omnibus library layout helpers. The canonical tree is
+//! `<library_root>/<author-slug>/<title-slug>/<title-slug>.<ext>`; slugs
+//! ASCII-fold via `deunicode`, lowercase, collapse non-alphanumerics into
+//! `-`, and cap at 80 chars on a codepoint boundary (empty result falls
+//! back to `"book"`). A `cover.jpg` (or per-stem `<basename>.jpg`) sidecar
+//! next to an ebook is the single source of truth for that book's cover
+//! after the first scan; the scanner materializes the embedded cover once
+//! and never re-reads the zip, falling back to in-memory bytes on a
+//! read-only filesystem.
 
 use std::path::{Path, PathBuf};
 
@@ -96,8 +84,7 @@ pub fn canonical_path(library_root: &Path, author: &str, title: &str, ext: &str)
 /// matters on flat-dump libraries with thousands of files in one folder,
 /// where each `read_dir` is O(files-in-folder). The case-insensitive
 /// `read_dir` scans remain as fallbacks so the matching contract is unchanged
-/// — the only observable difference is fewer syscalls on the common case
-/// (F0.6 / #52).
+/// — the only observable difference is fewer syscalls on the common case.
 ///
 /// Note: "direct-path probe" rather than "exact-case lookup" because
 /// `is_file()` on a case-insensitive filesystem (APFS, NTFS) will match a
@@ -186,9 +173,9 @@ fn find_with_extensions(dir: &Path, base: &str) -> Option<PathBuf> {
 /// the title-slug component until an unused folder is found, and place the
 /// file inside that suffixed folder.
 ///
-/// This is the upload-time helper for F5.3. F0.6 ships it with tests but no
-/// caller. An empty `ext` is rejected with `InvalidInput` — uploads must
-/// know the format they're storing.
+/// Upload-time helper, kept covered by tests even though no caller wires
+/// it in yet. An empty `ext` is rejected with `InvalidInput` — uploads
+/// must know the format they're storing.
 pub fn allocate_canonical_path(
     library_root: &Path,
     author: &str,

--- a/db/src/library_layout.rs
+++ b/db/src/library_layout.rs
@@ -1,12 +1,8 @@
-//! Canonical Omnibus library layout helpers. The canonical tree is
-//! `<library_root>/<author-slug>/<title-slug>/<title-slug>.<ext>`; slugs
-//! ASCII-fold via `deunicode`, lowercase, collapse non-alphanumerics into
-//! `-`, and cap at 80 chars on a codepoint boundary (empty result falls
-//! back to `"book"`). A `cover.jpg` (or per-stem `<basename>.jpg`) sidecar
-//! next to an ebook is the single source of truth for that book's cover
-//! after the first scan; the scanner materializes the embedded cover once
-//! and never re-reads the zip, falling back to in-memory bytes on a
-//! read-only filesystem.
+//! Canonical Omnibus library layout helpers. Writes the tree as
+//! `<library_root>/<author-slug>/<title-slug>/<title-slug>.<ext>` for the
+//! upload path; the read path uses the tolerant scanner in
+//! [`crate::scanner`] / [`crate::ebook`] plus the sidecar cover lookup
+//! ([`sidecar_cover_for`]). Per-helper docs spell out slug + sidecar rules.
 
 use std::path::{Path, PathBuf};
 

--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -1,6 +1,6 @@
-//! F5.1 metadata overrides: the user-editable layer on top of the
-//! canonical scanned metadata. Persists `MetadataOverrides` JSON per
-//! `book_uuid` and merges it on top of the read path.
+//! Metadata overrides: the user-editable layer on top of the canonical
+//! scanned metadata. Persists `MetadataOverrides` JSON per `book_uuid`
+//! and merges it on top of the read path.
 
 use std::collections::HashMap;
 
@@ -70,10 +70,11 @@ pub async fn upsert_metadata_overrides(
 
 /// Merge `incoming` field overrides on top of any existing overrides for
 /// `book_uuid` and persist the result inside one `BEGIN IMMEDIATE`
-/// transaction, so two concurrent edits to the same book can't interleave and
-/// silently drop each other's changes (#166). The existing `has_cover_override`
-/// flag is carried forward — a text-only edit must not clear a cover the user
-/// uploaded earlier. The `books_fts` rebuild runs best-effort after commit.
+/// transaction, so two concurrent edits to the same book can't interleave
+/// and silently drop each other's changes. The existing `has_cover_override`
+/// flag is carried forward — a text-only edit must not clear a cover the
+/// user uploaded earlier. The `books_fts` rebuild runs best-effort after
+/// commit.
 pub async fn merge_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,

--- a/db/src/palette.rs
+++ b/db/src/palette.rs
@@ -1,9 +1,8 @@
-//! F1.5 search palette: grouped command-palette results across books,
-//! authors, series, and tags. Books go through the FTS5 MATCH path
-//! (with override-aware overlays applied after hydration); the taxonomy
-//! categories use scoped `LIKE` substring matches against the name
-//! columns. All results are bounded per category and scoped to
-//! `library_path`.
+//! Search palette: grouped command-palette results across books, authors,
+//! series, and tags. Books go through the FTS5 MATCH path (with
+//! override-aware overlays applied after hydration); taxonomy categories
+//! use scoped `LIKE` substring matches against the name columns. Bounded
+//! per category and scoped to `library_path`.
 
 use sqlx::{Row, SqlitePool};
 
@@ -22,14 +21,10 @@ pub enum PaletteError {
     Db(#[from] sqlx::Error),
 }
 
-/// Search palette — grouped results for the command-palette overlay (F1.5).
-///
-/// Returns up to 5 results per category (books, authors, series, tags),
-/// with server-side timing in `duration_ms`. Books are matched via FTS5
-/// (`build_fts_match`); taxonomy categories use `LIKE '%q%'` against the
-/// name column. All results are scoped to `library_path`.
-///
-/// Returns `PaletteResults::default()` for empty/whitespace queries.
+/// Grouped command-palette results: up to 5 books, authors, series, and
+/// tags scoped to `library_path`, plus server-side timing in `duration_ms`.
+/// Books are matched via FTS5 (`build_fts_match`); taxonomy categories use
+/// `LIKE '%q%'`. Empty/whitespace queries return `PaletteResults::default()`.
 pub async fn search_palette(
     pool: &SqlitePool,
     library_path: &str,

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -1,6 +1,6 @@
 //! SQLite pool initialization for the omnibus data layer. Owns
 //! `init_db` (which runs the embedded migrations, applies per-connection
-//! PRAGMAs, and performs the one-time issue #94 cover-cache cleanup).
+//! PRAGMAs, and performs the one-time legacy cover-cache cleanup).
 
 use std::path::Path;
 
@@ -88,13 +88,14 @@ fn is_memory_url(database_url: &str) -> bool {
 }
 
 /// Sentinel filename written into `covers_dir()` after a one-time cleanup of
-/// pre-issue-#94 cover files. Presence of this file marks the directory as
-/// "already on the UUIDv5 scheme" and short-circuits the purge on subsequent
-/// boots. See `purge_legacy_covers_once`.
+/// legacy `DefaultHasher`-derived cover files. Presence of this file marks
+/// the directory as already on the UUIDv5 scheme and short-circuits the
+/// purge on subsequent boots. See `purge_legacy_covers_once`.
 const COVERS_SCHEME_SENTINEL: &str = ".omnibus-cover-scheme-v5";
 
-/// One-time cleanup for the cover cache when upgrading across the issue #94
-/// fix. The old `stable_uuid` derived ids from `DefaultHasher`, whose output
+/// One-time cleanup for the cover cache when upgrading from the legacy
+/// `DefaultHasher`-derived UUIDs to UUIDv5. The old derivation produced
+/// toolchain-dependent ids, whose output
 /// changes between Rust toolchains; the new derivation uses RFC 4122 UUIDv5,
 /// which produces different ids for the same `(library_path, filename)`
 /// inputs. Any cover files written under the old scheme are now unreachable

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -461,10 +461,9 @@ async fn insert_book_row(
 /// inline by name (NOCASE) — no separate id-resolution `SELECT`. Each batched
 /// statement is chunked to stay under SQLite's bound-parameter limit. This
 /// collapses the old ~4-queries-per-author / 2-queries-per-tag fan-out into a
-/// constant handful per book, which keeps
-/// the SQLite write lock from being held for the whole of a bulk import
-/// (issue #242). Series / publisher / language are single-valued per book,
-/// so they keep the simple resolve-then-link path.
+/// constant handful per book, which keeps the SQLite write lock from being
+/// held for the whole of a bulk import. Series / publisher / language are
+/// single-valued per book, so they keep the simple resolve-then-link path.
 async fn insert_metadata_links(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,

--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -1,4 +1,4 @@
-//! F1.2 thumbnail pipeline — generation, caching, and eviction.
+//! Thumbnail pipeline — generation, caching, and eviction.
 
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -206,8 +206,7 @@ pub fn ensure_thumbnails_sync(
 }
 
 /// Delete all cached thumbnails for a book so the next request regenerates
-/// them. Called after a cover override upload (F5.1) so stale thumbs don't
-/// linger.
+/// them. Called after a cover override upload so stale thumbs don't linger.
 pub fn invalidate_thumbs(book_id: i64) {
     for size in ThumbSize::all() {
         let _ = std::fs::remove_file(thumb_path_for(book_id, size));

--- a/db/src/worker.rs
+++ b/db/src/worker.rs
@@ -1,4 +1,4 @@
-//! Background-worker primitive (F0.5).
+//! Background-worker primitive.
 //!
 //! Single-process queue with two fairness knobs:
 //! - `scan_concurrency` caps how many `Task::Scan` / `Task::ScanAudiobooks`

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -1,4 +1,4 @@
-//! Atrium design-system primitives (F1.7).
+//! Atrium design-system primitives.
 //!
 //! The CSS lives in [`frontend/assets/atrium.css`](../../assets/atrium.css);
 //! this module exposes the Dioxus components that consume those classes.
@@ -102,8 +102,8 @@ pub fn AtriumRoot(children: Element) -> Element {
 
 /// Book cover. Renders the real image when one exists, otherwise a stylized
 /// "plate" template using the book's title + author metadata on a neutral
-/// grey ground (the per-book accent only tints real-image theming, never the
-/// missing-cover plate — see issue #92).
+/// grey ground (the per-book accent only tints real-image theming, never
+/// the missing-cover plate).
 ///
 /// The `--accent` custom property is set inline from the book's extracted
 /// accent color (or left to inherit the page-level default). Consumers who

--- a/frontend/src/components/auth/mod.rs
+++ b/frontend/src/components/auth/mod.rs
@@ -1,14 +1,9 @@
-//! Shared auth-page primitives — the building blocks for [F1.6 Auth UI
-//! polish](../../../../docs/roadmap/1-6-auth-ui.md).
-//!
-//! Each primitive is purely presentational: props in, rsx out. No signals,
-//! no transport, no feature gating inside component bodies — SSR and WASM
-//! must render identical markup so dioxus hydration matches.
-//!
-//! - [`AuthShell`] — split-pane wrapper used by every auth screen.
-//! - [`Field`] — label + input + hint/error/success slots.
-//! - [`Banner`] — top-of-form callout (err / warn / info / ok).
-//! - [`StrengthMeter`] — four-segment presentational password strength bar.
+//! Shared auth-page primitives. Each is purely presentational: props in,
+//! rsx out. No signals, no transport, no feature gating inside component
+//! bodies — SSR and WASM must render identical markup so dioxus hydration
+//! matches. Provides [`AuthShell`] (split-pane wrapper), [`Field`]
+//! (label + input + hint/error/success slots), [`Banner`] (callout), and
+//! [`StrengthMeter`] (four-segment password strength bar).
 
 mod banner;
 mod field;

--- a/frontend/src/components/auth/mod.rs
+++ b/frontend/src/components/auth/mod.rs
@@ -1,9 +1,7 @@
-//! Shared auth-page primitives. Each is purely presentational: props in,
-//! rsx out. No signals, no transport, no feature gating inside component
-//! bodies — SSR and WASM must render identical markup so dioxus hydration
-//! matches. Provides [`AuthShell`] (split-pane wrapper), [`Field`]
-//! (label + input + hint/error/success slots), [`Banner`] (callout), and
-//! [`StrengthMeter`] (four-segment password strength bar).
+//! Shared auth-page primitives used by [`crate::pages::auth`]: [`AuthShell`]
+//! split-pane wrapper, [`Field`] label+input+hint slots, [`Banner`] callout,
+//! and [`StrengthMeter`] password bar. Purely presentational (props in,
+//! rsx out) with no feature-gated bodies so SSR and WASM markup matches.
 
 mod banner;
 mod field;

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -1,30 +1,17 @@
-//! Generic add/remove chip editor with a substring-match suggestion dropdown.
-//!
-//! Used by the F5.1 metadata edit page for authors and tags, and by the
-//! F5.9-lite landing-table inline editor for the Authors column. The
-//! component renders as a sequence of chip elements followed by an
-//! input + optional dropdown — the consumer wraps the output in
-//! whatever flex container fits their layout (`me-chip-row`,
-//! `me-tag-chips`, ...).
-//!
-//! The dropdown surfaces up to [`MAX_SUGGESTIONS`] case-insensitive
-//! substring matches against `suggestions`, excluding values already
-//! present in `values`. Keyboard: ↓/↑ moves the highlight, Enter
-//! commits (highlighted suggestion when present, raw input otherwise),
-//! Escape clears the highlight. Pass an empty signal to disable the
-//! dropdown entirely and fall back to plain free-text entry.
-//!
-//! Suggestions are passed in as a [`ReadSignal`] so the component
-//! reads them by reference each render instead of taking ownership of a
-//! cloned `Vec` on every keystroke. The consumer owns the candidate pool
-//! — usually derived from a fetched list (`data::list_authors`,
-//! `data::get_tag_cloud`) or a flat-uniq of an already-loaded book list.
+//! Generic add/remove chip editor with a substring-match suggestion
+//! dropdown. Renders a sequence of chip elements followed by an
+//! input + optional dropdown so the consumer can wrap the output in
+//! whatever flex container fits their layout. The dropdown surfaces up to
+//! [`MAX_SUGGESTIONS`] case-insensitive substring matches against
+//! `suggestions`, excluding values already present in `values`. Keyboard:
+//! ↓/↑ moves the highlight, Enter commits, Escape clears. Pass an empty
+//! signal to disable the dropdown and fall back to free-text entry.
 
 use dioxus::prelude::*;
 
 /// Cap on suggestion rows. Five fits without scroll on a typical
-/// edit-row layout and matches the explicit "< 5 relevant suggestions"
-/// user requirement from the F5.9-lite plan.
+/// edit-row layout and matches the "< 5 relevant suggestions"
+/// user requirement.
 const MAX_SUGGESTIONS: usize = 5;
 
 /// One entry in the autocomplete pool. Carries the canonical name plus

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -1,11 +1,8 @@
-//! Generic add/remove chip editor with a substring-match suggestion
-//! dropdown. Renders a sequence of chip elements followed by an
-//! input + optional dropdown so the consumer can wrap the output in
-//! whatever flex container fits their layout. The dropdown surfaces up to
-//! [`MAX_SUGGESTIONS`] case-insensitive substring matches against
-//! `suggestions`, excluding values already present in `values`. Keyboard:
-//! ↓/↑ moves the highlight, Enter commits, Escape clears. Pass an empty
-//! signal to disable the dropdown and fall back to free-text entry.
+//! Generic add/remove chip editor with a substring-match suggestion dropdown.
+//! Renders chips, then input, then optional dropdown; the consumer wraps the
+//! output in whatever flex container their layout needs. Up to
+//! [`MAX_SUGGESTIONS`] case-insensitive matches against `suggestions` show,
+//! excluding values already present. Empty `suggestions` → free-text entry.
 
 use dioxus::prelude::*;
 

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -1,13 +1,11 @@
-//! Per-format CTAs on the book detail page (F1.4).
-//!
-//! Renders one row per format the book has, sorted alphabetically, with the
-//! relevant actions wired underneath. The EPUB Read action routes into the
-//! F2.2 immersive reader on web (mobile stays disabled — no JS engine for
-//! epub.js, see F6.2); Listen (F2.3 player) and Send to Kindle (F4.x) ship
-//! later and stay disabled. The rows themselves are the UI contract for the
-//! `books` / `book_files` split from F0.1 — a work with both EPUB and M4B
-//! surfaces both formats here so the future per-format actions slot in
-//! without re-shaping the markup.
+//! Per-format CTAs on the book detail page. Renders one row per format the
+//! book has, sorted alphabetically, with the relevant actions wired
+//! underneath. The EPUB Read action routes into the immersive reader on
+//! web (mobile stays disabled — no JS engine for epub.js); Listen and
+//! Send to Kindle ship later and stay disabled. The rows themselves are
+//! the UI contract for the `books` / `book_files` split — a work with both
+//! EPUB and M4B surfaces both formats so future per-format actions slot
+//! in without re-shaping the markup.
 
 use dioxus::prelude::*;
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -1,11 +1,8 @@
-//! Per-format CTAs on the book detail page. Renders one row per format the
-//! book has, sorted alphabetically, with the relevant actions wired
-//! underneath. The EPUB Read action routes into the immersive reader on
-//! web (mobile stays disabled — no JS engine for epub.js); Listen and
-//! Send to Kindle ship later and stay disabled. The rows themselves are
-//! the UI contract for the `books` / `book_files` split — a work with both
-//! EPUB and M4B surfaces both formats so future per-format actions slot
-//! in without re-shaping the markup.
+//! Per-format CTA rows on the book detail page. Renders one row per format
+//! the book has, sorted alphabetically, with per-format actions wired
+//! underneath. EPUB Read routes into the immersive reader on web (mobile
+//! disabled, no JS engine); Listen and Send-to-Kindle ship later and stay
+//! disabled. The rows are the UI contract for the books / book_files split.
 
 use dioxus::prelude::*;
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -1,4 +1,4 @@
-//! F1.5 Search Palette — command-palette / Spotlight-style search overlay.
+//! Search Palette — command-palette / Spotlight-style search overlay.
 //!
 //! Replaces the inline `NavSearch` text input with a trigger **button** in the
 //! top nav. Clicking the button (or pressing `⌘K` / `Ctrl+K`) opens a floating

--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -1,28 +1,8 @@
-//! Search Palette — command-palette / Spotlight-style search overlay.
-//!
-//! Replaces the inline `NavSearch` text input with a trigger **button** in the
-//! top nav. Clicking the button (or pressing `⌘K` / `Ctrl+K`) opens a floating
-//! palette with its own full-width input, debounced FTS5 search, and grouped
-//! results: Books, Authors, Series, Tags, and a placeholder "Inside text"
-//! section.
-//!
-//! ## Component tree
-//!
-//! ```text
-//! SearchPaletteHost          — mounted in TopNav, replaces NavSearch
-//! ├─ SpTriggerButton         — search button (icon + "Search" + ⌘K kbd hint)
-//! └─ (open) SpOverlay        — portal: scrim + panel
-//!            ├─ SpInput       — autofocused serif italic input
-//!            ├─ SpMeta        — "5 results · 18ms"
-//!            ├─ SpResults     — scrollable grouped results
-//!            └─ SpFooter      — keyboard hints + "fts5 · ranked"
-//! ```
-//!
-//! ## Hydration safety
-//!
-//! The palette starts closed (`PaletteOpen = false`). The overlay only renders
-//! when open, so SSR and WASM agree on initial DOM — no hydration mismatch.
-//! The `⌘K` listener fires only in `#[cfg(feature = "web")]`.
+//! Command-palette / Spotlight-style search overlay. Replaces the inline
+//! nav search input with a trigger button in the top nav; clicking it (or
+//! pressing `⌘K` / `Ctrl+K`) opens a floating palette with debounced FTS5
+//! search and grouped results (Books, Authors, Series, Tags, Inside text).
+//! Mounted by `TopNav`; web-only via `cfg(not(feature = "mobile"))`.
 
 use dioxus::core::Task;
 use dioxus::prelude::*;
@@ -36,11 +16,25 @@ use crate::{data, use_server_url, Route};
 /// Whether the search palette overlay is open. Registered at the App level
 /// via `use_context_provider` so both the trigger button and the global
 /// `⌘K` shortcut can toggle it.
+//
+// Hydration safety: the palette starts closed (`PaletteOpen = false`) and
+// `SpOverlay` only renders when open, so SSR and WASM agree on initial DOM
+// — no hydration mismatch. The `⌘K` listener fires only under
+// `feature = "web"`.
 #[derive(Copy, Clone, PartialEq)]
 pub struct PaletteOpen(pub Signal<bool>);
 
 /// Top-level host: renders the trigger button and (when open) the overlay.
 /// Mount this in `TopNav` in place of the old `NavSearch`.
+//
+// Component tree:
+//   SearchPaletteHost          — mounted in TopNav, replaces NavSearch
+//   ├─ SpTriggerButton         — search button (icon + "Search" + ⌘K kbd hint)
+//   └─ (open) SpOverlay        — portal: scrim + panel
+//              ├─ SpInput       — autofocused serif italic input
+//              ├─ SpMeta        — "5 results · 18ms"
+//              ├─ SpResults     — scrollable grouped results
+//              └─ SpFooter      — keyboard hints + "fts5 · ranked"
 #[component]
 pub fn SearchPaletteHost() -> Element {
     let open = use_context::<PaletteOpen>();

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -1,18 +1,9 @@
 //! Worker progress indicator — polls `/api/rpc/worker_status` at 1 Hz and
 //! renders a per-task row (active scans / thumbnails / author photos)
 //! plus a transient "complete" or red error banner for terminal entries.
-//!
-//! Mounted on `/settings` directly above the Save button for v1. The
-//! component is intentionally agnostic of which page mounts it — future
-//! surfaces (e.g. F5.9 library-cleanup detection trigger) can drop the
-//! same primitive in without changes here, since the data plane already
-//! distinguishes [`TaskKind`] variants.
-//!
-//! Web-only. Mobile UI is out of scope for issue #69 v1; the mobile
-//! `data::worker_status` stub returns an empty status so callers compile.
-//! Wrapping the whole module in `#[cfg(not(feature = "mobile"))]` keeps
-//! it out of the mobile bundle entirely, mirroring how `search_palette`
-//! is gated.
+//! Mounted on `/settings` for v1 but agnostic of its host page — future
+//! surfaces can drop the primitive in without changes here. Web-only;
+//! mobile gets an empty-status stub so callers compile.
 
 #![cfg(not(feature = "mobile"))]
 
@@ -22,9 +13,9 @@ use omnibus_shared::{ProgressState, TaskKind, TaskProgress, WorkerStatus};
 use crate::{data, use_server_url};
 
 /// Polling cadence in milliseconds. Always 1 s while the component is
-/// mounted — the issue spec calls for a 1 s tick, the response is ~1 KB,
-/// and this is a self-hosted single-user app. Idle-throttling adds bug
-/// surface (when does it un-throttle?) for no measurable benefit.
+/// mounted — the response is ~1 KB and this is a self-hosted single-user
+/// app. Idle-throttling adds bug surface (when does it un-throttle?) for
+/// no measurable benefit.
 const POLL_INTERVAL_MS: u32 = 1_000;
 
 /// 1 Hz-polled worker progress strip. Renders nothing when the worker is
@@ -206,8 +197,8 @@ fn FailedRow(kind: TaskKind, message: String, on_dismiss: EventHandler<MouseEven
 /// Map a wire-protocol [`TaskKind`] to a user-facing label. `running` flips
 /// the tense ("Scanning" vs "Library scan") so the indicator reads
 /// naturally in both the in-flight and terminal contexts. New `TaskKind`
-/// variants (e.g. F5.9 cleanup detection) add one match arm here and
-/// inherit the same active/done/failed rendering for free.
+/// variants add one match arm here and inherit the same active/done/failed
+/// rendering for free.
 fn kind_label(kind: TaskKind, running: bool) -> &'static str {
     match (kind, running) {
         (TaskKind::Scan, true) => "Scanning library",

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -1,9 +1,8 @@
 //! Worker progress indicator — polls `/api/rpc/worker_status` at 1 Hz and
-//! renders a per-task row (active scans / thumbnails / author photos)
-//! plus a transient "complete" or red error banner for terminal entries.
-//! Mounted on `/settings` for v1 but agnostic of its host page — future
-//! surfaces can drop the primitive in without changes here. Web-only;
-//! mobile gets an empty-status stub so callers compile.
+//! renders a per-task row (active scans / thumbnails / author photos) plus
+//! a transient "complete" or red error banner for terminal entries.
+//! Mounted on `/settings` but agnostic of host page. Web-only; mobile gets
+//! an empty-status stub so callers compile.
 
 #![cfg(not(feature = "mobile"))]
 

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -495,7 +495,7 @@ pub async fn search_ebooks(server_url: &str, q: &str) -> Result<EbookLibrary, Da
     Ok(response.json::<EbookLibrary>().await?)
 }
 
-/// Search palette — grouped results for the command-palette overlay (F1.5).
+/// Search palette — grouped results for the command-palette overlay.
 #[cfg(feature = "mobile")]
 pub async fn search_palette(server_url: &str, q: &str) -> Result<PaletteResults, DataError> {
     let encoded: String = q
@@ -546,8 +546,8 @@ pub async fn get_author(server_url: &str, id: i64) -> Result<Option<AuthorDetail
     Ok(Some(response.json::<AuthorDetail>().await?))
 }
 
-/// F1.11 follow-up: persist an author photo by URL. Server fetches and
-/// validates the URL — see `db::author_photos::fetch_remote_image`.
+/// Persist an author photo by URL. Server fetches and validates the URL
+/// — see `db::author_photos::fetch_remote_image`.
 #[cfg(feature = "mobile")]
 pub async fn set_author_photo_url(server_url: &str, id: i64, url: String) -> Result<(), DataError> {
     let endpoint = format!("{server_url}/api/authors/{id}/photo/url");
@@ -562,8 +562,8 @@ pub async fn set_author_photo_url(server_url: &str, id: i64, url: String) -> Res
     Ok(())
 }
 
-/// F1.11 follow-up: multipart upload of an author photo. Mobile mirrors the
-/// web FormData path — the same `/api/authors/:id/photo` PUT endpoint.
+/// Multipart upload of an author photo. Mobile mirrors the web FormData
+/// path — the same `/api/authors/:id/photo` PUT endpoint.
 #[cfg(feature = "mobile")]
 pub async fn upload_author_photo(
     server_url: &str,
@@ -588,7 +588,7 @@ pub async fn upload_author_photo(
     Ok(())
 }
 
-/// F1.11: admin "Scan for picture" — synchronously re-runs the Open Library
+/// Admin "Scan for picture" — synchronously re-runs the Open Library
 /// cascade and returns whether a photo was found.
 #[cfg(feature = "mobile")]
 pub async fn scan_author_photo(
@@ -934,8 +934,7 @@ pub async fn get_library(_server_url: &str) -> Result<LibraryContents, DataError
 
 /// Snapshot of the worker progress feed. Web calls the RPC; mobile returns
 /// an empty status because the corresponding REST endpoint doesn't exist
-/// yet (issue #69 keeps the mobile UI out of scope for v1, and the data
-/// stub keeps callers' types lined up across feature gates).
+/// yet (the stub keeps callers' types lined up across feature gates).
 #[cfg(not(feature = "mobile"))]
 pub async fn worker_status(_server_url: &str) -> Result<WorkerStatus, DataError> {
     crate::rpc::rpc_worker_status()
@@ -968,7 +967,7 @@ pub async fn search_ebooks(_server_url: &str, q: &str) -> Result<EbookLibrary, D
         .map_err(note_server_fn_err)
 }
 
-/// Search palette — grouped results for the command-palette overlay (F1.5).
+/// Search palette — grouped results for the command-palette overlay.
 #[cfg(not(feature = "mobile"))]
 pub async fn search_palette(_server_url: &str, q: &str) -> Result<PaletteResults, DataError> {
     crate::rpc::rpc_search_palette(q.to_string())
@@ -1003,13 +1002,12 @@ pub async fn scan_author_photo(
         .map_err(note_server_fn_err)
 }
 
-/// F5.9-lite: admin "Delete author" (issue #159). Removes the author
-/// taxonomy row, drops every `books_authors_link` for it, and adds the
-/// name to `ignored_authors` so the next `indexer::reindex` does not
-/// silently resurrect the row. Returns the number of books that were
-/// un-linked (used by the confirmation modal's "this affects N books"
-/// copy). Web-only — mobile parity is a deliberate follow-up per the
-/// F5.9-lite plan.
+/// Admin "Delete author". Removes the author taxonomy row, drops every
+/// `books_authors_link` for it, and adds the name to `ignored_authors`
+/// so the next `indexer::reindex` does not silently resurrect the row.
+/// Returns the number of books that were un-linked (used by the
+/// confirmation modal's "this affects N books" copy). Web-only — mobile
+/// parity is a deliberate follow-up.
 #[cfg(not(feature = "mobile"))]
 pub async fn delete_author(_server_url: &str, id: i64) -> Result<u64, DataError> {
     crate::rpc::rpc_delete_author(id)
@@ -1017,9 +1015,9 @@ pub async fn delete_author(_server_url: &str, id: i64) -> Result<u64, DataError>
         .map_err(note_server_fn_err)
 }
 
-/// F1.11 follow-up: persist an author photo by URL. Web routes through the
-/// `#[post]` server function in `rpc.rs`, which performs the server-side
-/// fetch + validation and writes a `manual` row.
+/// Persist an author photo by URL. Web routes through the `#[post]` server
+/// function in `rpc.rs`, which performs the server-side fetch + validation
+/// and writes a `manual` row.
 #[cfg(not(feature = "mobile"))]
 pub async fn set_author_photo_url(
     _server_url: &str,
@@ -1031,7 +1029,7 @@ pub async fn set_author_photo_url(
         .map_err(note_server_fn_err)
 }
 
-/// F1.11 follow-up: multipart upload of an author photo on the web client.
+/// Multipart upload of an author photo on the web client.
 ///
 /// Server functions can't carry binary file uploads (they JSON-serialize
 /// their arguments), so this bypasses RPC and POSTs the bytes directly to

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -142,8 +142,8 @@ fn ScreenLayout(children: Element) -> Element {
     }
 }
 
-/// Atrium design-system stylesheet (F1.7). Served as a hashed static asset
-/// via Dioxus's Manganis pipeline so the browser caches it independently of
+/// Atrium design-system stylesheet. Served as a hashed static asset via
+/// Dioxus's Manganis pipeline so the browser caches it independently of
 /// the WASM bundle.
 const ATRIUM_CSS: Asset = asset!("/assets/atrium.css");
 

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -1,30 +1,13 @@
-//! Login and register pages for the web and mobile clients.
-//!
-//! Both pages render the same markup on every target so SSR/WASM hydration
-//! matches. Submit handlers branch on feature:
-//!
-//! * `web` — POST JSON to `/api/auth/{login,register}` via `gloo-net`; the
-//!   server sets the `omnibus_session` cookie via `Set-Cookie` and the
-//!   browser's same-origin fetch keeps it for subsequent requests.
-//! * `mobile` — POST JSON to the same endpoints via `reqwest`, with a
-//!   `client_kind` of `ios` / `android` / `bearer` so the server issues a
-//!   bearer token in the body. The token is stashed in
-//!   `data::token_store` (only present under `feature = "mobile"`, hence
-//!   this is a code-formatted reference rather than an intra-doc link)
-//!   and attached to every subsequent request. Until secure storage
-//!   lands, **debug builds only** persist the token in plaintext to
-//!   `$HOME/.omnibus-token`; release builds keep it in memory and
-//!   require re-login on each cold start. See the TODO at the top of
-//!   that module.
-//! * `server` — SSR never executes the submit closure (no interaction
-//!   happens during SSR), so this path is a compile-only stub returning a
-//!   static error.
-//!
-//! Polish ([F1.6](../../../../docs/roadmap/1-6-auth-ui.md)) wraps both
-//! pages in [`AuthShell`] and replaces the bare `settings-field` divs with
-//! the [`Field`] / [`Banner`] / [`StrengthMeter`] primitives from
-//! [`crate::components::auth`]. The visual layer is presentational only —
-//! server policy still owns password validation and session expiry.
+//! Login and register pages for the web and mobile clients. Both render
+//! the same markup on every target so SSR/WASM hydration matches; submit
+//! handlers branch on feature. Web POSTs to `/api/auth/{login,register}`
+//! and lets the server's `Set-Cookie` carry the session; mobile POSTs the
+//! same endpoints with a `client_kind` of `ios` / `android` / `bearer` so
+//! the server returns a bearer token that's stashed in
+//! `data::token_store`. SSR is a compile-only stub. The visual shell uses
+//! the [`AuthShell`] / [`Field`] / [`Banner`] / [`StrengthMeter`]
+//! primitives from [`crate::components::auth`]; server policy still owns
+//! password validation and session expiry.
 
 use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -1,13 +1,8 @@
-//! Login and register pages for the web and mobile clients. Both render
-//! the same markup on every target so SSR/WASM hydration matches; submit
-//! handlers branch on feature. Web POSTs to `/api/auth/{login,register}`
-//! and lets the server's `Set-Cookie` carry the session; mobile POSTs the
-//! same endpoints with a `client_kind` of `ios` / `android` / `bearer` so
-//! the server returns a bearer token that's stashed in
-//! `data::token_store`. SSR is a compile-only stub. The visual shell uses
-//! the [`AuthShell`] / [`Field`] / [`Banner`] / [`StrengthMeter`]
-//! primitives from [`crate::components::auth`]; server policy still owns
-//! password validation and session expiry.
+//! Login and register pages for the web and mobile clients. Markup is
+//! identical across targets so SSR/WASM hydration matches; submit handlers
+//! branch per feature — `web` POSTs `/api/auth/{login,register}` and lets
+//! the `Set-Cookie` session carry through, `mobile` POSTs the same endpoints
+//! and stashes the returned bearer token in `data::token_store`.
 
 use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -316,18 +316,13 @@ fn render_author(
     }
 }
 
-/// F5.9-lite (issue #159) confirmation modal for the admin "Delete
-/// author" action. On confirm, hits the `rpc_delete_author` server fn
-/// (which un-links every book, inserts the name into
-/// `ignored_authors`, and refreshes FTS) then navigates back to
-/// `/authors`. The blocklist insert is what makes the delete durable
-/// across reindexes — without it the next `Task::Scan` would silently
-/// recreate the row from the OPF metadata.
-///
-/// Web-only — the matching `data::delete_author` is gated
-/// `not(feature = "mobile")` per the F5.9-lite plan's admin-web-only v1
-/// scope. Mobile admins can fall back to the F5.1 detail page for
-/// per-book edits.
+/// Confirmation modal for the admin "Delete author" action. On confirm,
+/// hits the `rpc_delete_author` server fn (which un-links every book,
+/// inserts the name into `ignored_authors`, and refreshes FTS) then
+/// navigates back to `/authors`. The blocklist insert is what makes the
+/// delete durable across reindexes — without it the next `Task::Scan`
+/// would silently recreate the row from the OPF metadata. Web-only;
+/// mobile admins fall back to the per-book metadata edit page.
 #[cfg(not(feature = "mobile"))]
 #[component]
 fn AuthorDeleteModal(

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -1,5 +1,5 @@
-//! Authors index page (F1.12). Lists every author in the library as a
-//! browsable surface, mirroring the `AuthorsIndex` design comp from
+//! Authors index page. Lists every author in the library as a browsable
+//! surface, mirroring the `AuthorsIndex` design comp from
 //! `screens/indices.jsx`.
 
 use dioxus::prelude::*;

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -615,7 +615,7 @@ fn BdFormatBadge(fmt: String) -> Element {
 }
 
 /// Read-only star display. Half-filled stars are rounded down to nearest
-/// integer in the stub; F3.2 replaces this with the interactive widget.
+/// integer in the stub; the interactive widget will replace this later.
 #[component]
 fn BdStars(value: f32) -> Element {
     let full = value.floor().clamp(0.0, 5.0) as u32;

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -22,8 +22,8 @@ use toolbar::Toolbar;
 ///
 /// Hydrates the configured ebook library once, then renders either a dense
 /// table or a cover grid. Sort and filter happen entirely client-side over
-/// the hydrated list (per F1.3 spec for libraries up to ~10k books). View
-/// mode + sort + filters persist per library path via [`view_prefs`].
+/// the hydrated list (for libraries up to ~10k books). View mode + sort +
+/// filters persist per library path via [`view_prefs`].
 #[component]
 pub fn LandingPage() -> Element {
     let server_url = use_server_url();

--- a/frontend/src/pages/landing/table.rs
+++ b/frontend/src/pages/landing/table.rs
@@ -7,18 +7,16 @@ use super::sorting::{contributor_names, row_slug};
 use crate::components::chip_editor::{ChipEditor, SuggestionItem};
 use crate::{data, Route};
 
-/// Inline-editable field on a power-user-table row (F5.9-lite admin
-/// surface). Used by `EbookRow` to track which of its cells (if any) is
-/// in edit mode at any given time — single-cell-at-a-time keeps the
-/// keyboard/blur lifecycle simple and avoids fighting the row's
-/// click-to-navigate handler.
+/// Inline-editable field on a power-user-table row. Used by `EbookRow` to
+/// track which of its cells (if any) is in edit mode at any given time —
+/// single-cell-at-a-time keeps the keyboard/blur lifecycle simple and
+/// avoids fighting the row's click-to-navigate handler.
 ///
-/// `Series` edits the series *name* only — the series index ("#N")
-/// stays in the F5.1 metadata edit page on `/books/:uuid/edit` for v1
-/// to avoid adding a separate Series Index column to the power-user
-/// table. The user's stated cleanup pain (stripping series-prefix
-/// cruft from titles, renaming author/series variants) is satisfied
-/// by Title + Series + Authors.
+/// `Series` edits the series *name* only — the series index ("#N") stays
+/// in the full metadata edit page on `/books/:uuid/edit` to avoid adding a
+/// separate Series Index column to the power-user table. Title + Series +
+/// Authors covers the stated cleanup pain (stripping series-prefix cruft
+/// from titles, renaming author/series variants).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum EditField {
     Title,
@@ -565,7 +563,7 @@ fn EditableCell(
 /// a single-line text input), the Authors cell renders the full
 /// [`ChipEditor`] *inside* the `<td>` when the row's editing signal
 /// matches `EditField::Authors`. The cell grows vertically to fit the
-/// chips + input + dropdown, matching the F5.9-lite design comp.
+/// chips + input + dropdown, matching the design comp.
 ///
 /// Display mode: comma-joined names. Hover: dashed amber outline.
 /// Click: swaps to chip editor (auto-focused) with the library-wide

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -1,15 +1,8 @@
-//! Metadata edit page — F5.1 Screen A (single-book edit form).
-//!
-//! Full-page route at `/books/:uuid/edit`. Two-column layout: a 4-column
-//! form grid (left) and a sticky sidebar with cover preview and
-//! identifiers (right). A sticky save bar at the bottom shows the dirty
-//! field count and provides Save / Discard buttons.
-//!
-//! Edits persist to the `metadata_overrides` table via
-//! [`data::save_overrides`]. The page loads the current merged
-//! [`EbookMetadata`] on mount and initializes per-field signals from it.
-//! The `dirty_count` memo compares each signal to the original value to
-//! drive the save bar state.
+//! Single-book metadata edit form at `/books/:uuid/edit`. Two-column
+//! layout (form grid + sticky cover/identifiers sidebar) with a sticky
+//! save bar showing the dirty field count. Edits persist via
+//! [`data::save_overrides`]; the `dirty_count` memo compares each per-field
+//! signal to the original merged [`EbookMetadata`] loaded on mount.
 
 use dioxus::prelude::*;
 use dioxus_router::{navigator, Link};

--- a/frontend/src/pages/reader.rs
+++ b/frontend/src/pages/reader.rs
@@ -1,11 +1,8 @@
-//! Barebones EPUB reader — an immersive, full-screen reading surface.
-//! Loads epub.js (+ JSZip) as classic sibling scripts and the vendored
-//! `epub-reader-glue.js`, which exposes `window.OmnibusReader`. The Rust
-//! side drives it through `dioxus::document::eval`, streams the EPUB bytes
-//! from the cookie-gated `GET /api/ebooks/:uuid/file` route, and persists
-//! the current position (an opaque EPUB CFI) through
-//! [`crate::reader_progress`]. The chrome compiles on every target; the
-//! JS interop that mounts a book is web-only.
+//! Immersive full-screen EPUB reader. Loads the vendored epub.js + JSZip
+//! glue (`window.OmnibusReader`) via `dioxus::document::eval`, streams
+//! bytes from cookie-gated `GET /api/ebooks/:uuid/file`, and persists
+//! position via [`crate::reader_progress`]. Chrome compiles on every
+//! target; the JS interop that mounts a book is web-only.
 
 use dioxus::prelude::*;
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/pages/reader.rs
+++ b/frontend/src/pages/reader.rs
@@ -1,19 +1,11 @@
-//! F2.2 barebones EPUB reader — immersive, full-screen reading surface.
-//!
+//! Barebones EPUB reader — an immersive, full-screen reading surface.
 //! Loads epub.js (+ JSZip) as classic sibling scripts and the vendored
-//! `epub-reader-glue.js`, which exposes `window.OmnibusReader`. The Rust side
-//! drives it through `dioxus::document::eval`, streams the EPUB bytes from the
-//! cookie-gated `GET /api/ebooks/:uuid/file` route, and persists the current
-//! position (an opaque EPUB CFI) through [`crate::reader_progress`].
-//!
-//! The chrome (back, font −/+, theme buttons, prev/next) renders on every
-//! target so SSR/mobile builds compile; the JS interop that actually mounts a
-//! book is web-only (`#[cfg(feature = "web")]`). Theme changes flow into the
-//! reader via a `use_effect` on the shared `Theme` signal so the in-iframe
-//! content tracks the app theme.
-//!
-//! Position persistence is localStorage-only for now (web) — superseded by the
-//! server-backed F2.1 progress-sync endpoint when that lands.
+//! `epub-reader-glue.js`, which exposes `window.OmnibusReader`. The Rust
+//! side drives it through `dioxus::document::eval`, streams the EPUB bytes
+//! from the cookie-gated `GET /api/ebooks/:uuid/file` route, and persists
+//! the current position (an opaque EPUB CFI) through
+//! [`crate::reader_progress`]. The chrome compiles on every target; the
+//! JS interop that mounts a book is web-only.
 
 use dioxus::prelude::*;
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -1,5 +1,4 @@
-//! Search results page — full-page version of the F1.5 palette.
-//!
+//! Search results page — full-page version of the command palette.
 //! Reached from the palette by pressing Enter on the input (without
 //! arrow-key navigation), or by clicking a Tag result. Reuses the
 //! `data::search_palette` RPC and the same `PaletteResults` shape; each

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -1,5 +1,5 @@
-//! Series index page (F1.12). Lists every series in the library as a
-//! browsable surface, mirroring the `SeriesIndex` design comp from
+//! Series index page. Lists every series in the library as a browsable
+//! surface, mirroring the `SeriesIndex` design comp from
 //! `screens/indices.jsx`.
 
 use dioxus::prelude::*;

--- a/frontend/src/reader_progress.rs
+++ b/frontend/src/reader_progress.rs
@@ -1,15 +1,10 @@
-//! F2.2 reading-position persistence — the saved EPUB CFI for each book.
-//!
-//! Web persists to `localStorage` keyed by book UUID; mobile keeps an
+//! Reading-position persistence — the saved EPUB CFI for each book. Web
+//! persists to `localStorage` keyed by book UUID; mobile keeps an
 //! in-memory map (resets on cold launch); server (SSR) is a no-op so the
-//! rendered markup never depends on a stored position.
-//!
-//! Now the offline / first-paint cache layer for the F2.1 progress-sync
-//! endpoint (`POST /api/progress`, `GET /api/progress/{uuid}`): the reader
-//! reads this synchronously for an instant local CFI, then reconciles
-//! against the server before mounting; saves write here AND fire-and-forget
-//! POST to the server. The stored value is the raw EPUB CFI string (no JSON
-//! envelope) — exactly the opaque locator the reader hands back.
+//! rendered markup never depends on a stored position. Now the offline /
+//! first-paint cache for the progress-sync endpoint — the reader reads
+//! synchronously for an instant local CFI then reconciles against the
+//! server, and saves write here AND fire-and-forget POST.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.reading::";

--- a/frontend/src/reader_progress.rs
+++ b/frontend/src/reader_progress.rs
@@ -1,10 +1,8 @@
-//! Reading-position persistence — the saved EPUB CFI for each book. Web
-//! persists to `localStorage` keyed by book UUID; mobile keeps an
-//! in-memory map (resets on cold launch); server (SSR) is a no-op so the
-//! rendered markup never depends on a stored position. Now the offline /
-//! first-paint cache for the progress-sync endpoint — the reader reads
-//! synchronously for an instant local CFI then reconciles against the
-//! server, and saves write here AND fire-and-forget POST.
+//! Reading-position persistence — saved EPUB CFI per book. Web stores
+//! per-UUID in `localStorage`, mobile keeps an in-memory map, SSR is a
+//! no-op. Now the offline / first-paint cache for the progress-sync
+//! endpoint: reader reads here synchronously then reconciles against
+//! the server; saves write here AND fire-and-forget POST.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.reading::";

--- a/frontend/src/routes.rs
+++ b/frontend/src/routes.rs
@@ -74,7 +74,7 @@ pub fn MetadataEdit(uuid: String) -> Element {
     }
 }
 
-/// Route target for `/read/:uuid` — the F2.2 immersive EPUB reader.
+/// Route target for `/read/:uuid` — the immersive EPUB reader.
 /// Deliberately rendered **without** [`ScreenLayout`]: the reader is a
 /// full-screen surface with its own slim control bar, so the app's top/bottom
 /// nav is suppressed. Same uuid-keyed stability rationale as [`BookDetail`].
@@ -111,7 +111,7 @@ pub fn AuthorDetail(id: i64) -> Element {
     }
 }
 
-/// Route target for `/authors` — browse-all authors index (F1.12).
+/// Route target for `/authors` — browse-all authors index.
 #[component]
 pub fn AuthorsIndex() -> Element {
     rsx! {
@@ -127,7 +127,7 @@ pub fn SeriesDetail(id: i64) -> Element {
     }
 }
 
-/// Route target for `/series` — browse-all series index (F1.12).
+/// Route target for `/series` — browse-all series index.
 #[component]
 pub fn SeriesIndex() -> Element {
     rsx! {

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -168,7 +168,7 @@ pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
 }
 
 /// Snapshot of every in-flight and recently-completed background-worker
-/// task (F0.5). Polled at 1 Hz by the `WorkerStatusIndicator` component to
+/// task. Polled at 1 Hz by the `WorkerStatusIndicator` component to
 /// surface scan / thumbnail / author-photo / (future) cleanup progress
 /// under the Save button on `/settings`.
 ///
@@ -234,11 +234,11 @@ pub async fn rpc_get_ebook(uuid: String) -> Result<Option<EbookMetadata>> {
 /// `#[get]` server functions reject arg bodies because HTTP spec forbids
 /// bodies on GET.
 ///
-/// Issue #81: `search_books` is capped server-side at
-/// `db::MAX_BOOKS_RETURNED` hits. Server functions can't expose response
-/// headers, so — unlike `rpc_get_ebooks` — the search path threads the full
-/// hit count through `EbookLibrary::total` (issue #241), letting the web
-/// client show "N of M results" when the vec is truncated.
+/// `search_books` is capped server-side at `db::MAX_BOOKS_RETURNED` hits.
+/// Server functions can't expose response headers, so — unlike
+/// `rpc_get_ebooks` — the search path threads the full hit count through
+/// `EbookLibrary::total`, letting the web client show "N of M results"
+/// when the vec is truncated.
 #[post("/api/rpc/search", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
     let settings = db::get_settings(&pool.0).await?;
@@ -262,8 +262,8 @@ pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
 /// Fetch a single author and all their books. POST for the same reason as
 /// `rpc_get_ebook` — needs `id` in the body.
 ///
-/// F1.11: queues a background `Task::ResolveAuthorPhoto` when the author has
-/// no `author_photos` row yet so first-time visits trigger Open Library
+/// Queues a background `Task::ResolveAuthorPhoto` when the author has no
+/// `author_photos` row yet so first-time visits trigger Open Library
 /// resolution. A subsequent visit picks up the resolved photo (or the
 /// `letter` negative-cache marker), and the worker's per-author resource
 /// mutex prevents duplicate queueing while resolution is in flight.
@@ -286,16 +286,15 @@ pub async fn rpc_get_series(id: i64) -> Result<Option<SeriesDetail>> {
     Ok(db::get_series(&pool.0, id).await?)
 }
 
-/// F1.11: admin-triggered "Scan for picture" for an author. Clears any
-/// sticky `letter` negative-cache marker and runs the Open Library resolver
+/// Admin-triggered "Scan for picture" for an author. Clears any sticky
+/// `letter` negative-cache marker and runs the Open Library resolver
 /// inline, so the admin gets a definitive "found / not found" answer in a
 /// single round-trip without polling the worker.
 ///
 /// Manual uploads are treated as overrides: a `source = 'manual'` row is
-/// preserved (the F1.11 roadmap explicitly calls this out — "skips if a
-/// manual override exists"). Scan returns `resolved=true` in that case
-/// without touching the row, so admins can't accidentally wipe a manual
-/// upload by clicking the button.
+/// preserved and Scan returns `resolved=true` without touching the row,
+/// so admins can't accidentally wipe a manual upload by clicking the
+/// button.
 #[post("/api/rpc/author/scan-photo", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_scan_author_photo(id: i64) -> Result<AuthorPhotoScanResult> {
     if !user.is_admin {
@@ -311,8 +310,8 @@ pub async fn rpc_scan_author_photo(id: i64) -> Result<AuthorPhotoScanResult> {
     Ok(AuthorPhotoScanResult { resolved })
 }
 
-/// F1.11 follow-up: persist an author photo by URL. Admin-gated server-side
-/// (the `user.is_admin` check below mirrors `rpc_scan_author_photo`). The
+/// Persist an author photo by URL. Admin-gated server-side (the
+/// `user.is_admin` check below mirrors `rpc_scan_author_photo`). The
 /// server fetches the URL via `db::author_photos::fetch_remote_image`,
 /// validates the bytes with the same magic-byte sniff as the multipart
 /// upload path, and stores it as a `manual` row.
@@ -359,7 +358,7 @@ pub async fn rpc_get_tag_cloud() -> Result<Vec<TagWeight>> {
     Ok(db::get_tag_cloud(&pool.0).await?)
 }
 
-/// F1.12 — `/authors` index: every author in the configured library.
+/// `/authors` index: every author in the configured library.
 #[get("/api/rpc/authors", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_list_authors() -> Result<Vec<AuthorSummary>> {
     let settings = db::get_settings(&pool.0).await?;
@@ -369,7 +368,7 @@ pub async fn rpc_list_authors() -> Result<Vec<AuthorSummary>> {
     Ok(db::list_authors(&pool.0, &path).await?)
 }
 
-/// F1.12 — `/series` index: every series in the configured library.
+/// `/series` index: every series in the configured library.
 #[get("/api/rpc/series-list", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_list_series() -> Result<Vec<SeriesSummary>> {
     let settings = db::get_settings(&pool.0).await?;
@@ -379,8 +378,7 @@ pub async fn rpc_list_series() -> Result<Vec<SeriesSummary>> {
     Ok(db::list_series(&pool.0, &path).await?)
 }
 
-/// Save metadata overrides for a book (F5.1). Requires `can_edit` or admin.
-///
+/// Save metadata overrides for a book. Requires `can_edit` or admin.
 /// Returns the merged `EbookMetadata` so the client can update its state
 /// without a second round-trip.
 #[post("/api/rpc/ebook/overrides", pool: PoolExt, user: AuthUser)]
@@ -401,7 +399,7 @@ pub async fn rpc_save_overrides(
     Ok(db::get_book_by_uuid(&pool.0, &uuid).await?)
 }
 
-/// Delete metadata overrides for a book, reverting to scanned values (F5.1).
+/// Delete metadata overrides for a book, reverting to scanned values.
 #[post("/api/rpc/ebook/overrides/delete", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_delete_overrides(uuid: String) -> Result<Option<EbookMetadata>> {
     if !user.is_admin && !user.can_edit {
@@ -426,11 +424,11 @@ pub async fn rpc_delete_overrides(uuid: String) -> Result<Option<EbookMetadata>>
     Ok(db::get_book_by_uuid(&pool.0, &uuid).await?)
 }
 
-/// F5.9-lite: admin "Delete author" (issue #159). Removes the author row,
-/// drops every `books_authors_link` for it, and adds the name to
-/// `ignored_authors` so the next `indexer::reindex` does not silently
-/// resurrect the row. Returns the number of books that were un-linked
-/// (used by the confirmation modal in PR 5).
+/// Admin "Delete author". Removes the author row, drops every
+/// `books_authors_link` for it, and adds the name to `ignored_authors`
+/// so the next `indexer::reindex` does not silently resurrect the row.
+/// Returns the number of books that were un-linked (used by the
+/// confirmation modal).
 #[post("/api/rpc/author/delete", pool: PoolExt, _admin: AdminUser)]
 pub async fn rpc_delete_author(id: i64) -> Result<u64> {
     Ok(db::delete_author(&pool.0, id).await?)
@@ -482,7 +480,7 @@ pub async fn rpc_record_sessions(reports: Vec<SessionReport>) -> Result<u64> {
 }
 
 /// Search palette — grouped results (books, authors, series, tags) for the
-/// command-palette overlay (F1.5).
+/// command-palette overlay.
 #[post("/api/rpc/search-palette", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_search_palette(q: String) -> Result<PaletteResults> {
     let settings = db::get_settings(&pool.0).await?;

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -1,13 +1,10 @@
-//! Per-library view-preference persistence for [`ViewPrefs`].
-//!
-//! Web persists to `localStorage` keyed by library path; mobile keeps an
-//! in-memory map (resets on cold launch — explicit MVP choice in F1.3 plan,
-//! to be replaced when a server-backed `/api/user/view-prefs` lands); server
-//! (SSR) always returns defaults so the rendered markup matches what the
-//! WASM client paints on first hydration.
-//!
-//! Shape lives in `omnibus-shared` so a future server endpoint can reuse the
-//! same JSON contract.
+//! Per-library view-preference persistence for [`ViewPrefs`]. Web persists
+//! to `localStorage` keyed by library path; mobile keeps an in-memory map
+//! (resets on cold launch — MVP choice, to be replaced when a
+//! server-backed `/api/user/view-prefs` lands); server (SSR) always
+//! returns defaults so the rendered markup matches what the WASM client
+//! paints on first hydration. Shape lives in `omnibus-shared` so a future
+//! server endpoint can reuse the same JSON contract.
 
 use omnibus_shared::ViewPrefs;
 

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -1,10 +1,7 @@
-//! Per-library view-preference persistence for [`ViewPrefs`]. Web persists
-//! to `localStorage` keyed by library path; mobile keeps an in-memory map
-//! (resets on cold launch — MVP choice, to be replaced when a
-//! server-backed `/api/user/view-prefs` lands); server (SSR) always
-//! returns defaults so the rendered markup matches what the WASM client
-//! paints on first hydration. Shape lives in `omnibus-shared` so a future
-//! server endpoint can reuse the same JSON contract.
+//! Per-library view-preference persistence for [`ViewPrefs`]. Web stores
+//! per library-path in `localStorage`, mobile keeps an in-memory map, SSR
+//! returns defaults so first-hydration markup matches the WASM client.
+//! Shape lives in `omnibus-shared` so a future server endpoint can reuse it.
 
 use omnibus_shared::ViewPrefs;
 

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -1,9 +1,8 @@
 //! Server-side axum glue on top of [`omnibus_db::auth`]: cookie/bearer
-//! extractors ([`extractor`]), `/api/auth/{register,login,logout,me}` plus
-//! [`auth_router`] ([`handlers`]), CSRF origin check ([`csrf`]), pluggable
-//! auth backends ([`strategy`]), and the `OMNIBUS_INITIAL_ADMIN` recovery
-//! hook ([`boot`]). Per-route extractors (`AuthUser` / `AdminUser`) are
-//! what enforce permissions; [`gate::require_auth`] is just the boundary.
+//! extractors ([`extractor`]), `/api/auth/*` handlers + router ([`handlers`]),
+//! CSRF origin check ([`csrf`]), pluggable auth backends ([`strategy`]),
+//! the initial-admin recovery hook ([`boot`]), and the `/api/*` gate
+//! middleware ([`gate`]). Mounted by [`crate::main`].
 
 pub mod boot;
 pub mod csrf;

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -1,27 +1,9 @@
-//! F0.3 auth — server-side axum glue on top of [`omnibus_db::auth`].
-//!
-//! Layout:
-//!
-//! * [`extractor`] — `AuthUser` / `AdminUser` `FromRequestParts` extractors
-//!   that resolve a live session from either the `omnibus_session` cookie
-//!   or an `Authorization: Bearer` header.
-//! * [`handlers`] — `/api/auth/{register,login,logout,me}` + [`auth_router`].
-//! * [`csrf`] — `origin_check` middleware for cookie-authed state-changing
-//!   requests.
-//! * [`strategy`] — `AuthStrategy` trait + `PasswordStrategy` impl. OIDC
-//!   and WebAuthn fit the same shape.
-//! * [`boot`] — `OMNIBUS_INITIAL_ADMIN` recovery hook.
-//!
-//! Per-IP rate limiting lives in the top-level [`crate::rate_limit`] module
-//! since it is shared by the auth endpoints and the search endpoints. The
-//! auth router mounts it via `rate_limit_by_ip` in `main.rs`.
-//!
-//! Per-route enforcement (F0.7): every protected handler in
-//! [`crate::backend`] and every server function in `omnibus_frontend::rpc`
-//! declares the strictest extractor it needs (`AuthUser` for read paths,
-//! `AdminUser` for state-changing ops on shared config). The middleware
-//! [`gate::require_auth`] is just the boundary; the per-route extractors
-//! are what actually enforce the permission columns.
+//! Server-side axum glue on top of [`omnibus_db::auth`]: cookie/bearer
+//! extractors ([`extractor`]), `/api/auth/{register,login,logout,me}` plus
+//! [`auth_router`] ([`handlers`]), CSRF origin check ([`csrf`]), pluggable
+//! auth backends ([`strategy`]), and the `OMNIBUS_INITIAL_ADMIN` recovery
+//! hook ([`boot`]). Per-route extractors (`AuthUser` / `AdminUser`) are
+//! what enforce permissions; [`gate::require_auth`] is just the boundary.
 
 pub mod boot;
 pub mod csrf;

--- a/server/src/auth/strategy.rs
+++ b/server/src/auth/strategy.rs
@@ -1,9 +1,7 @@
-//! `AuthStrategy` — pluggable authentication back-ends. Ships with
-//! `PasswordStrategy` (username + argon2id PHC); OIDC and WebAuthn fit
-//! the same shape so they can drop in without reshaping the login flow.
-//! The trait returns a `UserId`, not `(username, password)`, which is what
-//! makes credential-agnostic backends fit. `kind()` is a short stable tag
-//! (`"password"`, `"oidc"`, `"webauthn"`) surfaced to the admin UI.
+//! `AuthStrategy` — pluggable authentication back-ends. Ships with the
+//! `PasswordStrategy` (username + argon2id PHC); OIDC and WebAuthn fit the
+//! same shape so they drop in without reshaping the login flow. Consumed
+//! by the handlers in [`super::handlers`].
 
 use omnibus_db::auth::AuthError;
 use sqlx::SqlitePool;

--- a/server/src/auth/strategy.rs
+++ b/server/src/auth/strategy.rs
@@ -1,18 +1,9 @@
-//! `AuthStrategy` — pluggable authentication back-ends.
-//!
-//! v1.0 ships the `PasswordStrategy` (username + argon2id PHC), but F5.x
-//! adds OIDC, and post-v1.0 could bring passkeys/WebAuthn. This trait
-//! exists now so those extensions drop in without reshaping the login flow.
-//!
-//! Design notes:
-//! - The trait returns a `UserId`, not `(username, password)` — keeping it
-//!   credential-agnostic is what makes WebAuthn/OIDC fit later.
-//! - `kind()` is a short stable tag (`"password"`, `"oidc"`, `"webauthn"`)
-//!   surfaced to the admin UI ("how did this user last log in?") and used
-//!   to gate strategy-specific settings.
-//! - Concrete `OidcStrategy` and `WebAuthnStrategy` are deferred. The trait
-//!   only needs to prove it's shaped right; implementations can land in
-//!   their own phases.
+//! `AuthStrategy` — pluggable authentication back-ends. Ships with
+//! `PasswordStrategy` (username + argon2id PHC); OIDC and WebAuthn fit
+//! the same shape so they can drop in without reshaping the login flow.
+//! The trait returns a `UserId`, not `(username, password)`, which is what
+//! makes credential-agnostic backends fit. `kind()` is a short stable tag
+//! (`"password"`, `"oidc"`, `"webauthn"`) surfaced to the admin UI.
 
 use omnibus_db::auth::AuthError;
 use sqlx::SqlitePool;

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -47,8 +47,8 @@ pub const SEARCH_RATE_LIMIT_MAX: u32 = 30;
 /// Per-IP rate-limit budget for the binary-upload endpoints
 /// (`POST /api/ebooks/{id}/cover`, `PUT /api/authors/{id}/photo`,
 /// `PUT /api/authors/{id}/photo/url`). Each accepts a multi-MiB image and
-/// drives disk I/O, WebP transcoding CPU, and SQLite writes, so a tight loop
-/// from a single principal could exhaust resources (#168). 10 uploads per
+/// drives disk I/O, WebP transcoding CPU, and SQLite writes, so a tight
+/// loop from a single principal could exhaust resources. 10 uploads per
 /// 60 seconds per IP is generous for legitimate editing while still
 /// backstopping abuse. Surfaced as constants so callers / tests share a
 /// single source of truth.
@@ -138,7 +138,7 @@ pub fn rest_router(state: AppState) -> Router {
 }
 
 /// Build the `/api/*` REST router, sharing `search_limiter` with the caller so
-/// REST `/api/search/*` and RPC `/api/rpc/search-*` draw from one budget (#249).
+/// REST `/api/search/*` and RPC `/api/rpc/search-*` draw from one budget.
 pub fn rest_router_with_search_limiter(
     state: AppState,
     search_limiter: std::sync::Arc<RateLimiter>,
@@ -230,7 +230,7 @@ pub fn rest_router_with_search_limiter(
 /// `from_fn_with_state`, which doesn't propagate to the route handlers.
 ///
 /// The `limiter` is passed in so the live server can share one `Arc` across both
-/// search families (#249); `rest_router` supplies a fresh dedicated one.
+/// search families; `rest_router` supplies a fresh dedicated one.
 fn search_router(limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> {
     Router::new()
         .route("/api/search", get(search::get_search))
@@ -247,9 +247,9 @@ fn search_router(limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> {
 /// to the handlers), merged into [`rest_router`]. The three routes — cover
 /// `POST`, author-photo `PUT`, author-photo-URL `PUT` — each accept a
 /// multi-MiB payload and drive disk I/O, WebP transcoding, and SQLite
-/// writes, so they share a per-IP budget (#168). The `GET`/`DELETE` author-
-/// photo routes carry no upload body (DELETE mutates but cheaply), so they
-/// stay in `rest_router`, outside this limiter.
+/// writes, so they share a per-IP budget. The `GET`/`DELETE` author-photo
+/// routes carry no upload body (DELETE mutates but cheaply), so they stay
+/// in `rest_router`, outside this limiter.
 fn upload_router() -> Router<AppState> {
     let limiter = std::sync::Arc::new(RateLimiter::with_policy(
         UPLOAD_RATE_LIMIT_WINDOW,
@@ -340,7 +340,7 @@ fn current_dir_string() -> String {
         .unwrap_or_default()
 }
 
-/// Attach the issue-#81 pagination hint headers to a list/search response.
+/// Attach the pagination hint headers to a list/search response.
 ///
 /// * `X-Total-Count` — the true row count of the underlying query, before
 ///   the `MAX_BOOKS_RETURNED` server-side cap is applied.

--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -171,10 +171,9 @@ pub(super) async fn delete_author_photo(
 /// (a `letter` marker is now in place to skip future autoresolution).
 ///
 /// Manual uploads are treated as overrides: a `source = 'manual'` row is
-/// preserved (the F1.11 roadmap explicitly calls this out — "skips if a
-/// manual override exists"). Scan returns `resolved=true` in that case
-/// without touching the row, so admins can't accidentally wipe a manual
-/// upload by clicking the button.
+/// preserved and Scan returns `resolved=true` without touching the row,
+/// so admins can't accidentally wipe a manual upload by clicking the
+/// button.
 pub(super) async fn post_author_photo_scan(
     _admin: AdminUser,
     State(state): State<AppState>,

--- a/server/src/backend/authors.rs
+++ b/server/src/backend/authors.rs
@@ -44,9 +44,9 @@ pub(super) async fn get_author_by_id(
     }
 }
 
-/// F1.12 — `/authors` index. Returns every author in the configured
-/// library with a book count and optional accent. Empty list when no
-/// library is configured.
+/// `/authors` index. Returns every author in the configured library with
+/// a book count and optional accent. Empty list when no library is
+/// configured.
 pub(super) async fn get_authors(_user: AuthUser, State(state): State<AppState>) -> Response {
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,

--- a/server/src/backend/series.rs
+++ b/server/src/backend/series.rs
@@ -8,8 +8,8 @@ use omnibus_db::{self as db};
 use super::{internal, AppState};
 use crate::auth::AuthUser;
 
-/// F1.12 — `/series` index. Returns every series in the configured
-/// library with a book count, primary author, and optional accent.
+/// `/series` index. Returns every series in the configured library with
+/// a book count, primary author, and optional accent.
 pub(super) async fn get_series(_user: AuthUser, State(state): State<AppState>) -> Response {
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,

--- a/server/src/backend/settings.rs
+++ b/server/src/backend/settings.rs
@@ -57,7 +57,7 @@ pub(super) async fn post_settings(
 }
 
 /// Admin-only synchronous reindex: 200 on success, 409 when no library
-/// path is configured, 500 on worker failure. Regression target for #112.
+/// path is configured, 500 on worker failure.
 pub(super) async fn post_reindex(_admin: AdminUser, State(state): State<AppState>) -> Response {
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -51,7 +51,7 @@ const MAX_BUCKETS: usize = 10_000;
 /// `OMNIBUS_TRUST_FORWARDED_FOR={1,true,yes}`). Exposed `pub` so the server
 /// entrypoint can emit a startup warning — enabling this without a trusted
 /// reverse proxy in front of Axum lets any client rotate the header per
-/// request and defeats the per-IP limiter entirely (#278).
+/// request and defeats the per-IP limiter entirely.
 pub fn trust_forwarded_for() -> bool {
     matches!(
         std::env::var("OMNIBUS_TRUST_FORWARDED_FOR").as_deref(),
@@ -169,7 +169,7 @@ pub async fn rate_limit_by_ip(
 ///
 /// Bucket map is shared with whatever limiter is passed in. `main.rs` passes the
 /// *same* `Arc` here and to the REST `/api/search/*` layer so both search
-/// families share one per-IP budget (#249).
+/// families share one per-IP budget.
 pub async fn rate_limit_paths(
     State((limiter, prefixes)): State<(Arc<RateLimiter>, Arc<Vec<&'static str>>)>,
     req: Request,

--- a/server/src/security_headers.rs
+++ b/server/src/security_headers.rs
@@ -1,4 +1,4 @@
-//! Global HTTP security response headers (#277).
+//! Global HTTP security response headers.
 //!
 //! Applies a single conservative set of headers to every response served by
 //! the axum router — covers SSR HTML, the Dioxus WASM bundle, server-function
@@ -37,9 +37,9 @@
 //!   * `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` —
 //!     `'unsafe-inline'` because Dioxus emits inline `style=""` attributes;
 //!     the Google Fonts host because `atrium.css` `@import`s the Geist /
-//!     Instrument Serif stylesheet from it. Self-hosting the fonts (tracked as
-//!     an F1.7 follow-up in `atrium.css`) would let both the CDN host here and
-//!     in `font-src` drop back to `'self'`.
+//!     Instrument Serif stylesheet from it. Self-hosting the fonts (a
+//!     follow-up tracked in `atrium.css`) would let both the CDN host here
+//!     and in `font-src` drop back to `'self'`.
 //!   * `font-src 'self' data: https://fonts.gstatic.com` — Google serves the
 //!     actual WOFF2 files from `fonts.gstatic.com`; without it the `@import`ed
 //!     stylesheet resolves but the glyphs fall back to system fonts.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -70,7 +70,7 @@ pub struct Identifier {
 /// time (creators first, then contributors in source order). The normalized
 /// schema stores them in the same `books_authors_link` table, so they are
 /// indistinguishable on read — a separate wire field would always serialize
-/// as empty. See issue #174.
+/// as empty.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EbookMetadata {
     pub id: i64,
@@ -120,20 +120,19 @@ pub struct EbookMetadata {
 
     pub error: Option<String>,
 
-    /// True when user-supplied metadata overrides (F5.1) are active for this
-    /// book. The detail page uses this to show a "has overrides" indicator and
+    /// True when user-supplied metadata overrides are active for this book.
+    /// The detail page uses this to show a "has overrides" indicator and
     /// offer a revert action.
     #[serde(default)]
     pub has_override: bool,
 }
 
-/// User-supplied metadata overrides (F5.1). JSON-serialized into the
+/// User-supplied metadata overrides. JSON-serialized into the
 /// `metadata_overrides.overrides` column. Each field, when `Some`, replaces
 /// the corresponding scanned value at read time.
 ///
-/// M2M fields (`creators`, `subjects`) replace entirely when present — a tag
-/// list override replaces, not appends (per roadmap: "A tag list override
-/// should replace, not append").
+/// M2M fields (`creators`, `subjects`) replace entirely when present — a
+/// tag list override replaces, not appends.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MetadataOverrides {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -404,7 +403,7 @@ pub struct AuthorDetail {
     pub has_photo: bool,
 }
 
-/// Result of an admin-triggered "Scan for picture" run (F1.11). The endpoint
+/// Result of an admin-triggered "Scan for picture" run. The endpoint
 /// clears any cached row and runs the Open Library cascade inline; a
 /// `false` here means Open Library had nothing to offer for this author
 /// and a sticky `letter` marker has been written to skip future
@@ -432,9 +431,9 @@ pub struct TagWeight {
     pub count: usize,
 }
 
-/// Lightweight author row for the `/authors` index (F1.12). Carries only
-/// what the card needs — no joined book list. The detail page
-/// (`AuthorDetail`) is fetched on click.
+/// Lightweight author row for the `/authors` index. Carries only what the
+/// card needs — no joined book list. The detail page (`AuthorDetail`) is
+/// fetched on click.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuthorSummary {
     pub id: i64,
@@ -446,8 +445,8 @@ pub struct AuthorSummary {
     /// — the UI falls back to the theme accent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub accent: Option<String>,
-    /// F1.11: `true` when a usable profile photo is cached for this author
-    /// (a `manual` or `openlibrary` row in `author_photos`). Same semantics
+    /// `true` when a usable profile photo is cached for this author (a
+    /// `manual` or `openlibrary` row in `author_photos`). Same semantics
     /// as `AuthorDetail::has_photo` — `'letter'` negative-cache rows do
     /// not set this flag. Lets the `/authors` index render a real `<img>`
     /// in one round trip instead of fetching the detail payload per card.
@@ -455,9 +454,9 @@ pub struct AuthorSummary {
     pub has_photo: bool,
 }
 
-/// Lightweight series row for the `/series` index (F1.12). Carries the
-/// primary author of the series (first book's first creator) so the card
-/// can render the by-line without a second fetch.
+/// Lightweight series row for the `/series` index. Carries the primary
+/// author of the series (first book's first creator) so the card can
+/// render the by-line without a second fetch.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SeriesSummary {
     pub id: i64,
@@ -685,11 +684,11 @@ pub struct LoginResponse {
     pub token: Option<String>,
 }
 
-/// Discriminant for [`TaskProgress`] entries (F0.5 worker). Mirrors the
-/// payload-less shape of the server-side `Task` enum so the wire protocol
-/// stays decoupled from the runtime `Task` type's lifetimes and handler
-/// closures. `#[non_exhaustive]` so future worker actions (e.g. F5.9
-/// `DetectCleanup`) can be added without breaking client matches.
+/// Discriminant for [`TaskProgress`] entries. Mirrors the payload-less
+/// shape of the server-side `Task` enum so the wire protocol stays
+/// decoupled from the runtime `Task` type's lifetimes and handler
+/// closures. `#[non_exhaustive]` so future worker actions can be added
+/// without breaking client matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -755,10 +754,10 @@ pub struct TaskProgress {
 
 /// Aggregate progress feed served from `POST /api/rpc/worker_status`.
 ///
-/// Two-vec split mirrors the F0.5 design doc shape: callers can short-circuit
-/// the "do I need a fade timer?" check by inspecting `recent_complete.is_empty()`
-/// without scanning `active`. Both vecs are sorted by `task_id` for stable
-/// list rendering across polls.
+/// Two-vec split lets callers short-circuit the "do I need a fade timer?"
+/// check by inspecting `recent_complete.is_empty()` without scanning
+/// `active`. Both vecs are sorted by `task_id` for stable list rendering
+/// across polls.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkerStatus {
     pub active: Vec<TaskProgress>,


### PR DESCRIPTION
## Summary
- Strip roadmap-phase IDs (F-prefix), GitHub issue numbers, and multi-section `#`-heading H2 blocks out of every `//!` and `///` doc comment per the Comments & docs rules in `.claude/rules/05-rust-style.md`.
- Module docs are back to a single short paragraph; pub-fn rustdoc is back to a one-line summary unless behavior is genuinely surprising (e.g. `db/src/covers.rs::get_cover`, `server/src/security_headers.rs` CSP rationale).
- Biggest restructure is `db/src/discovery.rs` (module + `get_author` + `get_series` + `get_tag_cloud` lost their `# Multi-tenancy` / `# Bounded reads` H2 sections) and `db/src/browse.rs` (same shape). 51 files touched across `db/`, `frontend/`, `server/`, and `shared/`.
- Audit run: `rg -n '^//!|^///' --type rust | rg -i 'F[0-9]\.|issue|#[0-9]{3}'` — the only remaining matches are the English verb ("Issue a session", "issue a token"), not GitHub-issue references. `rg -n '^/// # |^//! # '` returns zero hits.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` on default crates (server / shared / frontend) — clean
- [x] `cargo test` on default crates — 144 + 102 + 20 passed; 0 failed
- [x] No behavior change: only `//!` / `///` comment text edited (plus three inline `TODO(F4.x)` markers in `discovery.rs` / `browse.rs` that pointed at since-removed rustdoc sections, shortened to plain `TODO:` so the breadcrumb keeps working).

## Notes
- Pre-existing `cargo clippy --all-features` errors in `frontend/src/contexts.rs` (mobile/non-mobile feature gating) and `frontend/src/data.rs` (`web_sys::BlobPropertyBag::type_` deprecation) reproduce on `origin/main` and are unrelated to this change.

Closes #303

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cz7NrEjtN3SfEmRLotT3Tz)_