### PR TITLE
refactor: hoist db/ test helpers into test_support (#306)

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -68,6 +68,13 @@ uuid = { version = "1", features = ["v5"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 urlencoding = "2"
 
+[features]
+# Re-exports `test_support` helpers (in-memory pool seeders, `IndexedBook`
+# factories, `CoversTempDir`) so external test crates can depend on them
+# without re-implementing fixtures. Internal `#[cfg(test)]` builds get the
+# module automatically via the `any(test, feature = "test-support")` gate.
+test-support = []
+
 [dev-dependencies]
 tempfile.workspace = true
 wiremock = "0.6"

--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -205,11 +205,9 @@ pub async fn delete_author(pool: &SqlitePool, author_id: i64) -> Result<u64, sql
 mod tests {
     use super::*;
     use crate::books::list_books;
-    use crate::covers::test_helpers::CoversTempDir;
-    use crate::discovery::test_helpers::*;
     use crate::pool::init_db;
     use crate::sync::replace_books;
-    use crate::sync::test_helpers::indexed;
+    use crate::test_support::*;
 
     // -------------------------------------------------------------------------
     // F1.11 author profile photo tests

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -3,18 +3,16 @@
 //! drive `list_books` + `search_books` + `get_book` together stay co-located.
 
 use super::*;
-use crate::covers::test_helpers::CoversTempDir;
-use crate::discovery::test_helpers::{
-    author_id_by_name, seed_discovery_fixture, series_id_by_name,
-};
 use crate::ebook::IndexedBook;
 use crate::helpers::MAX_QUERY_LEN;
 use crate::metadata_overrides::upsert_metadata_overrides;
 use crate::pool::init_db;
 use crate::sync::replace_books;
-use crate::sync::test_helpers::indexed;
+use crate::test_support::{
+    author_id_by_name, indexed, seed_discovery_fixture, seed_minimal_books, series_id_by_name,
+    CoversTempDir,
+};
 use omnibus_shared::{Contributor, EbookMetadata, Identifier, MetadataOverrides};
-use sqlx::SqlitePool;
 
 // ---------- Server-side cap (issue #81) ----------
 //
@@ -22,39 +20,6 @@ use sqlx::SqlitePool;
 // `/api/ebooks` poll on a multi-thousand-book library serialized the
 // whole table. The fix is a hard `LIMIT MAX_BOOKS_RETURNED`, plus a
 // companion count helper so callers can detect truncation.
-
-/// Seed `count` minimal `books` rows under `/lib` using a recursive CTE.
-/// Bypasses `replace_books` / the indexer entirely — the cap behavior
-/// only depends on rows existing, not on full m2m relations being set
-/// up. Keeps the test runtime down to milliseconds even for 50k+ rows.
-async fn seed_minimal_books(pool: &SqlitePool, count: i64) {
-    sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
-        .execute(pool)
-        .await
-        .unwrap();
-    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM libraries WHERE path = '/lib'")
-        .fetch_one(pool)
-        .await
-        .unwrap();
-    sqlx::query(
-        r#"
-        WITH RECURSIVE n(i) AS (
-            SELECT 1
-            UNION ALL
-            SELECT i + 1 FROM n WHERE i < ?
-        )
-        INSERT INTO books (uuid, library_id, path, title, sort)
-        SELECT 'uuid-' || i, ?, '/lib/b' || i, 'Title ' || i,
-               'Title ' || printf('%010d', i)
-          FROM n
-        "#,
-    )
-    .bind(count)
-    .bind(lib_id)
-    .execute(pool)
-    .await
-    .unwrap();
-}
 
 #[tokio::test]
 async fn library_from_db_returns_empty_for_none_path() {

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -236,10 +236,9 @@ mod tests {
     use super::*;
     use crate::author_photos_data::{upsert_author_photo, AuthorPhotoSource};
     use crate::books::list_books;
-    use crate::covers::test_helpers::CoversTempDir;
-    use crate::discovery::test_helpers::*;
     use crate::metadata_overrides::upsert_metadata_overrides;
     use crate::pool::init_db;
+    use crate::test_support::*;
     use omnibus_shared::{Contributor, MetadataOverrides};
 
     // -----------------------------------------------------------------

--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -3,11 +3,6 @@
 //! small and covers can be regenerated independently by reindexing.
 //! `books.has_cover` tracks whether a file should exist; a missing file on
 //! disk is treated as "no cover" (404), not an error.
-//!
-//! Also hosts the `CoversTempDir` test guard used throughout the db tests
-//! — `pub(crate)` so siblings can `use crate::covers::test_helpers::*`
-//! without each test module needing its own copy of the OMNIBUS_COVERS_DIR
-//! mutex.
 
 use std::path::PathBuf;
 
@@ -248,65 +243,13 @@ pub async fn get_last_modified_epoch(
 }
 
 #[cfg(test)]
-pub(crate) mod test_helpers {
-    //! Shared test guards used by every db test module that touches the
-    //! covers directory. `OMNIBUS_COVERS_DIR` is a process-global env var,
-    //! so tests that touch it must serialize. A single Mutex held for the
-    //! duration of each test keeps parallel `cargo test` runs from stomping
-    //! on each other's covers dir.
-
-    use std::path::PathBuf;
-
-    pub(crate) static COVERS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    pub(crate) struct CoversTempDir {
-        pub(crate) path: PathBuf,
-        prev: Option<String>,
-        _guard: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl CoversTempDir {
-        pub(crate) fn new(tag: &str) -> Self {
-            let guard = COVERS_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let pid = std::process::id();
-            let seq = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0);
-            let path = std::env::temp_dir().join(format!("omnibus_covers_{tag}_{pid}_{seq}"));
-            let _ = std::fs::remove_dir_all(&path);
-            let prev = std::env::var("OMNIBUS_COVERS_DIR").ok();
-            std::env::set_var("OMNIBUS_COVERS_DIR", &path);
-            Self {
-                path,
-                prev,
-                _guard: guard,
-            }
-        }
-    }
-
-    impl Drop for CoversTempDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.path);
-            match self.prev.take() {
-                Some(v) => std::env::set_var("OMNIBUS_COVERS_DIR", v),
-                None => std::env::remove_var("OMNIBUS_COVERS_DIR"),
-            }
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::books::list_books;
-    use crate::covers::test_helpers::CoversTempDir;
     use crate::metadata_overrides::{upsert_metadata_overrides, write_override_cover};
     use crate::pool::init_db;
     use crate::sync::replace_books;
-    use crate::sync::test_helpers::indexed;
+    use crate::test_support::{indexed, CoversTempDir};
     use omnibus_shared::MetadataOverrides;
 
     #[tokio::test]

--- a/db/src/discovery.rs
+++ b/db/src/discovery.rs
@@ -480,173 +480,17 @@ pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, sqlx::Er
 }
 
 #[cfg(test)]
-pub(crate) mod test_helpers {
-    //! Discovery fixture seeders shared with `browse`, `books`, and
-    //! `author_photos_data` tests. `pub(crate)` so siblings can call e.g.
-    //! `use crate::discovery::test_helpers::seed_discovery_fixture;`.
-
-    use crate::covers::test_helpers::CoversTempDir;
-    use crate::pool::init_db;
-    use crate::sync::replace_books;
-    use crate::sync::test_helpers::indexed;
-    use sqlx::SqlitePool;
-
-    // -------------------------------------------------------------------------
-    // Discovery query tests (F1.8)
-    // -------------------------------------------------------------------------
-
-    /// Seed a small multi-author, multi-series, multi-tag fixture for the
-    /// discovery query tests below. Returns the pool and a `CoversTempDir`
-    /// guard the caller must keep alive for the lifetime of the test.
-    pub(crate) async fn seed_discovery_fixture() -> (SqlitePool, CoversTempDir) {
-        let guard = CoversTempDir::new("discovery");
-        let pool = init_db("sqlite::memory:").await.unwrap();
-        replace_books(
-            &pool,
-            "/lib",
-            vec![
-                // Two-author book in Saga #1 with tag "fiction"
-                indexed(
-                    "saga1.epub",
-                    Some("Saga: Book One"),
-                    &["Ada Lovelace", "Grace Hopper"],
-                    &["fiction", "classic"],
-                    Some(("Saga", "1")),
-                    None,
-                ),
-                // Sequel in Saga #2, same primary author + new tag
-                indexed(
-                    "saga2.epub",
-                    Some("Saga: Book Two"),
-                    &["Ada Lovelace"],
-                    &["fiction"],
-                    Some(("Saga", "2")),
-                    None,
-                ),
-                // Standalone by Ada — no series
-                indexed(
-                    "standalone.epub",
-                    Some("Standalone"),
-                    &["Ada Lovelace"],
-                    &["essay"],
-                    None,
-                    None,
-                ),
-                // Different-author, different-series book
-                indexed(
-                    "other.epub",
-                    Some("Other Story"),
-                    &["Niklaus Wirth"],
-                    &["nonfiction"],
-                    Some(("Pioneers", "1")),
-                    None,
-                ),
-            ],
-        )
-        .await
-        .unwrap();
-        (pool, guard)
-    }
-    pub(crate) async fn author_id_by_name(pool: &SqlitePool, name: &str) -> i64 {
-        sqlx::query_scalar::<_, i64>("SELECT id FROM authors WHERE name = ?")
-            .bind(name)
-            .fetch_one(pool)
-            .await
-            .unwrap()
-    }
-    pub(crate) async fn series_id_by_name(pool: &SqlitePool, name: &str) -> i64 {
-        sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE name = ?")
-            .bind(name)
-            .fetch_one(pool)
-            .await
-            .unwrap()
-    }
-    // -------------------------------------------------------------------------
-    // Discovery read caps (issue #150)
-    //
-    // `get_author` / `get_series` previously serialized every attributed book
-    // in one payload. The fix is a hard `LIMIT MAX_DISCOVERY_BOOKS` on the
-    // nested `books` vec plus an uncapped `book_count` so callers can detect
-    // truncation as `book_count > books.len()`.
-    // -------------------------------------------------------------------------
-
-    /// Seed `count` minimal `books` rows under `/lib`, all linked to one
-    /// author ("Prolific") and one series ("Mega"), via recursive CTEs.
-    /// Bypasses `replace_books`/the indexer — the cap only depends on link
-    /// rows existing — keeping the test fast even past the 1k cap. Returns
-    /// `(author_id, series_id)`.
-    pub(crate) async fn seed_books_for_one_author_and_series(
-        pool: &SqlitePool,
-        count: i64,
-    ) -> (i64, i64) {
-        sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
-            .execute(pool)
-            .await
-            .unwrap();
-        let lib_id: i64 = sqlx::query_scalar("SELECT id FROM libraries WHERE path = '/lib'")
-            .fetch_one(pool)
-            .await
-            .unwrap();
-        let author_id: i64 = sqlx::query_scalar(
-            "INSERT INTO authors (name, sort) VALUES ('Prolific', 'Prolific') RETURNING id",
-        )
-        .fetch_one(pool)
-        .await
-        .unwrap();
-        let series_id: i64 = sqlx::query_scalar(
-            "INSERT INTO series (name, sort) VALUES ('Mega', 'Mega') RETURNING id",
-        )
-        .fetch_one(pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            r#"
-            WITH RECURSIVE n(i) AS (
-                SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
-            )
-            INSERT INTO books (uuid, library_id, path, title, sort, series_index)
-            SELECT 'uuid-' || i, ?, '/lib/b' || i, 'Title ' || i,
-                   'Title ' || printf('%010d', i), i
-              FROM n
-            "#,
-        )
-        .bind(count)
-        .bind(lib_id)
-        .execute(pool)
-        .await
-        .unwrap();
-        // Link every seeded book to the author and the series.
-        sqlx::query(
-            "INSERT INTO books_authors_link (book, author, position)
-             SELECT id, ?, 0 FROM books",
-        )
-        .bind(author_id)
-        .execute(pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            "INSERT INTO books_series_link (book, series)
-             SELECT id, ? FROM books",
-        )
-        .bind(series_id)
-        .execute(pool)
-        .await
-        .unwrap();
-        (author_id, series_id)
-    }
-}
-
-#[cfg(test)]
 mod tests {
-    use super::test_helpers::*;
     use super::*;
     use crate::author_photos_data::{upsert_author_photo, AuthorPhotoSource};
     use crate::books::list_books;
-    use crate::covers::test_helpers::CoversTempDir;
     use crate::metadata_overrides::upsert_metadata_overrides;
     use crate::pool::init_db;
     use crate::sync::replace_books;
-    use crate::sync::test_helpers::indexed;
+    use crate::test_support::{
+        author_id_by_name, indexed, seed_books_for_one_author_and_series, seed_discovery_fixture,
+        series_id_by_name, CoversTempDir,
+    };
     use omnibus_shared::{Contributor, MetadataOverrides};
 
     #[tokio::test]

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -140,20 +140,12 @@ pub fn scan_ebook_library_with(path: Option<&str>, opts: ScanOptions) -> ScanRes
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::path::Path;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// Build a unique temp directory per test invocation. Rust runs unit
-    /// tests in parallel by default, so a fixed path under `temp_dir()`
-    /// would collide between tests (and between repeated runs).
-    pub(crate) fn make_test_dir(suffix: &str) -> std::path::PathBuf {
-        static COUNTER: AtomicUsize = AtomicUsize::new(0);
-        let pid = std::process::id();
-        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!("omnibus_ebook_{suffix}_{pid}_{seq}"));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("should create test dir");
-        dir
-    }
+    // `make_test_dir` lives in the crate-level `test_support` module so
+    // every db test reaches for the same unique-per-invocation builder.
+    // Re-export here so existing `use crate::ebook::test_support::*;`
+    // globs keep resolving without touching every callsite.
+    pub(crate) use crate::test_support::make_test_dir;
 
     /// Build an in-memory PNG of a single solid color. Used to drive
     /// `extract_accent` without baking a fixture cover into the repo.

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -235,11 +235,10 @@ pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()
 mod tests {
     use super::*;
     use crate::books::{list_books, IndexedRow};
-    use crate::covers::test_helpers::CoversTempDir;
     use crate::ebook::StatEntry;
     use crate::pool::init_db;
     use crate::sync::replace_books;
-    use crate::sync::test_helpers::indexed;
+    use crate::test_support::{indexed, CoversTempDir};
 
     /// Seed a `libraries` row for `path` with an explicit `last_indexed`
     /// epoch-seconds value. There's no public writer for `last_indexed`

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -22,6 +22,8 @@ pub mod scanner;
 pub mod settings;
 pub mod sync;
 mod taxonomy;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 pub mod thumbs;
 pub mod worker;
 

--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -328,11 +328,10 @@ pub fn delete_override_cover(uuid: &str) {
 mod tests {
     use super::*;
     use crate::books::{get_book, list_books, search_books};
-    use crate::covers::test_helpers::CoversTempDir;
     use crate::palette::search_palette;
     use crate::pool::init_db;
     use crate::sync::replace_books;
-    use crate::sync::test_helpers::indexed;
+    use crate::test_support::{indexed, CoversTempDir};
     use omnibus_shared::MetadataOverrides;
 
     // -----------------------------------------------------------------

--- a/db/src/palette.rs
+++ b/db/src/palette.rs
@@ -381,11 +381,10 @@ pub async fn search_palette(
 mod tests {
     use super::*;
     use crate::books::list_books;
-    use crate::covers::test_helpers::CoversTempDir;
     use crate::metadata_overrides::upsert_metadata_overrides;
     use crate::pool::init_db;
     use crate::sync::replace_books;
-    use crate::sync::test_helpers::indexed;
+    use crate::test_support::{indexed, CoversTempDir};
     use omnibus_shared::{Contributor, MetadataOverrides};
     use sqlx::SqlitePool;
 

--- a/db/src/scanner.rs
+++ b/db/src/scanner.rs
@@ -80,14 +80,8 @@ pub fn scan_libraries(ebook_path: Option<&str>, audiobook_path: Option<&str>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::make_test_dir;
     use std::fs;
-
-    fn make_test_dir(suffix: &str) -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!("omnibus_scanner_test_{suffix}"));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).expect("should create test dir");
-        dir
-    }
 
     #[test]
     fn list_files_with_no_path_returns_empty() {

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -245,7 +245,7 @@ pub(crate) mod test_helpers {
     //! tests. They mutate `EBOOK_LIBRARY_PATH` / `AUDIOBOOK_LIBRARY_PATH`,
     //! which is process-global; under `cargo test`'s default parallel
     //! execution two tests racing those vars can observe a torn state.
-    //! Mirrors `covers::test_helpers::CoversTempDir`: acquiring the guard
+    //! Mirrors `test_support::CoversTempDir`: acquiring the guard
     //! locks `ENV_LOCK` and snapshots both vars, and dropping it restores
     //! their prior values (so the rest of the test run — and local dev — sees
     //! them unchanged) before releasing the lock. Keeping the `MutexGuard` in
@@ -395,10 +395,9 @@ mod tests {
     }
 
     use crate::books::list_books;
-    use crate::covers::test_helpers::CoversTempDir;
     use crate::covers::{cover_path_for, delete_cover_files_for, write_cover_file};
     use crate::sync::replace_books;
-    use crate::sync::test_helpers::indexed;
+    use crate::test_support::{indexed, CoversTempDir};
 
     #[tokio::test]
     async fn set_settings_prunes_library_when_ebook_path_changes() {

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -732,84 +732,16 @@ fn materialize_new_covers(new_covers: Vec<(String, String, Vec<u8>)>) {
 }
 
 #[cfg(test)]
-pub(crate) mod test_helpers {
-    //! Shared `IndexedBook` builders used by db tests across modules.
-    //! `pub(crate)` so siblings can call e.g.
-    //! `use crate::sync::test_helpers::indexed;`.
-
-    use crate::ebook::IndexedBook;
-    use omnibus_shared::{Contributor, EbookMetadata};
-
-    pub(crate) fn indexed(
-        filename: &str,
-        title: Option<&str>,
-        authors: &[&str],
-        subjects: &[&str],
-        series: Option<(&str, &str)>,
-        cover: Option<(&str, &[u8])>,
-    ) -> IndexedBook {
-        IndexedBook {
-            metadata: EbookMetadata {
-                filename: filename.into(),
-                title: title.map(Into::into),
-                creators: authors
-                    .iter()
-                    .map(|a| Contributor {
-                        name: (*a).into(),
-                        ..Default::default()
-                    })
-                    .collect(),
-                subjects: subjects.iter().map(|s| (*s).to_string()).collect(),
-                series: series.map(|(n, _)| n.into()),
-                series_index: series.map(|(_, i)| i.into()),
-                ..Default::default()
-            },
-            cover: cover.map(|(m, b)| (m.into(), b.to_vec())),
-            mtime_epoch: 0,
-            size_bytes: 0,
-        }
-    }
-    // ------------------------------------------------------------------
-    // sync_books — incremental write path. Each test seeds an initial
-    // state via `replace_books` (the legacy nuke-and-pave wrapper), then
-    // applies a hand-built `SyncPlan` to exercise one or more diff
-    // buckets and asserts the post-state.
-    // ------------------------------------------------------------------
-
-    /// Build an `IndexedBook` matching `indexed(...)` but with the
-    /// supplied (mtime_epoch, size_bytes). Used to drive the New +
-    /// Changed branches of sync_books with realistic fs metadata.
-    pub(crate) fn indexed_with_stat(
-        filename: &str,
-        title: Option<&str>,
-        mtime_epoch: i64,
-        size_bytes: i64,
-    ) -> IndexedBook {
-        IndexedBook {
-            metadata: EbookMetadata {
-                filename: filename.into(),
-                title: title.map(Into::into),
-                ..Default::default()
-            },
-            cover: None,
-            mtime_epoch,
-            size_bytes,
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
-    use super::test_helpers::{indexed, indexed_with_stat};
     use super::*;
     use crate::books::{get_book, list_books, list_indexed_rows, search_books};
     use crate::covers::get_cover;
-    use crate::covers::test_helpers::CoversTempDir;
     use crate::ebook::IndexedBook;
     use crate::helpers::stable_uuid;
     use crate::metadata_overrides::upsert_metadata_overrides;
     use crate::pool::init_db;
     use crate::settings::last_indexed_at;
+    use crate::test_support::{indexed, indexed_with_stat, CoversTempDir};
     use omnibus_shared::{Contributor, EbookMetadata, MetadataOverrides};
 
     #[tokio::test]

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -1,0 +1,313 @@
+//! Shared test-only helpers for the `omnibus-db` crate.
+//!
+//! Gated behind `#[cfg(any(test, feature = "test-support"))]` so non-test
+//! consumers don't pay the compile cost. This is the single source of
+//! truth for cross-cutting helpers — temp-dir builders, in-memory pool
+//! seeders, env-var guards, and the `IndexedBook` factories. Module-local
+//! ones (e.g. ebook fixture loaders) stay next to their callers.
+
+#![cfg(any(test, feature = "test-support"))]
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use sqlx::SqlitePool;
+
+use crate::ebook::IndexedBook;
+use omnibus_shared::{Contributor, EbookMetadata};
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+/// Build a unique temp directory per test invocation. Rust runs unit
+/// tests in parallel by default, so a fixed path under `temp_dir()`
+/// would collide between tests (and between repeated runs).
+pub fn make_test_dir(suffix: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let pid = std::process::id();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("omnibus_test_{suffix}_{pid}_{seq}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("should create test dir");
+    dir
+}
+
+// ---------------------------------------------------------------------------
+// Covers env guard
+// ---------------------------------------------------------------------------
+
+/// Process-wide lock for `OMNIBUS_COVERS_DIR`. Tests that touch the
+/// covers directory must serialize, since the env var is global.
+pub static COVERS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// RAII guard that points `OMNIBUS_COVERS_DIR` at a unique temp dir for
+/// the lifetime of the test, then restores the previous value (and
+/// removes the temp dir) on drop. Holds `COVERS_ENV_LOCK` so parallel
+/// `cargo test` runs don't stomp on each other.
+pub struct CoversTempDir {
+    pub path: PathBuf,
+    prev: Option<String>,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl CoversTempDir {
+    pub fn new(tag: &str) -> Self {
+        let guard = COVERS_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let pid = std::process::id();
+        let seq = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!("omnibus_covers_{tag}_{pid}_{seq}"));
+        let _ = std::fs::remove_dir_all(&path);
+        let prev = std::env::var("OMNIBUS_COVERS_DIR").ok();
+        std::env::set_var("OMNIBUS_COVERS_DIR", &path);
+        Self {
+            path,
+            prev,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for CoversTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+        match self.prev.take() {
+            Some(v) => std::env::set_var("OMNIBUS_COVERS_DIR", v),
+            None => std::env::remove_var("OMNIBUS_COVERS_DIR"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal book row seeder (bypasses the indexer)
+// ---------------------------------------------------------------------------
+
+/// Seed `count` minimal `books` rows under `/lib` using a recursive CTE.
+/// Bypasses `replace_books` / the indexer entirely — callers that only
+/// need rows to exist (e.g. response-cap tests) avoid the multi-second
+/// cost of running the full pipeline.
+pub async fn seed_minimal_books(pool: &SqlitePool, count: i64) {
+    sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+        .execute(pool)
+        .await
+        .unwrap();
+    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM libraries WHERE path = '/lib'")
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        WITH RECURSIVE n(i) AS (
+            SELECT 1
+            UNION ALL
+            SELECT i + 1 FROM n WHERE i < ?
+        )
+        INSERT INTO books (uuid, library_id, path, title, sort)
+        SELECT 'uuid-' || i, ?, '/lib/b' || i, 'Title ' || i,
+               'Title ' || printf('%010d', i)
+          FROM n
+        "#,
+    )
+    .bind(count)
+    .bind(lib_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// IndexedBook factories (formerly `sync::test_helpers`)
+// ---------------------------------------------------------------------------
+
+/// Shared `IndexedBook` builder used by db tests across modules.
+pub fn indexed(
+    filename: &str,
+    title: Option<&str>,
+    authors: &[&str],
+    subjects: &[&str],
+    series: Option<(&str, &str)>,
+    cover: Option<(&str, &[u8])>,
+) -> IndexedBook {
+    IndexedBook {
+        metadata: EbookMetadata {
+            filename: filename.into(),
+            title: title.map(Into::into),
+            creators: authors
+                .iter()
+                .map(|a| Contributor {
+                    name: (*a).into(),
+                    ..Default::default()
+                })
+                .collect(),
+            subjects: subjects.iter().map(|s| (*s).to_string()).collect(),
+            series: series.map(|(n, _)| n.into()),
+            series_index: series.map(|(_, i)| i.into()),
+            ..Default::default()
+        },
+        cover: cover.map(|(m, b)| (m.into(), b.to_vec())),
+        mtime_epoch: 0,
+        size_bytes: 0,
+    }
+}
+
+/// Build an `IndexedBook` matching `indexed(...)` but with the supplied
+/// (mtime_epoch, size_bytes). Used to drive the New + Changed branches
+/// of `sync_books` with realistic fs metadata.
+pub fn indexed_with_stat(
+    filename: &str,
+    title: Option<&str>,
+    mtime_epoch: i64,
+    size_bytes: i64,
+) -> IndexedBook {
+    IndexedBook {
+        metadata: EbookMetadata {
+            filename: filename.into(),
+            title: title.map(Into::into),
+            ..Default::default()
+        },
+        cover: None,
+        mtime_epoch,
+        size_bytes,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Discovery fixture seeders (formerly `discovery::test_helpers`)
+// ---------------------------------------------------------------------------
+
+/// Seed a small multi-author, multi-series, multi-tag fixture for the
+/// discovery query tests. Returns the pool and a `CoversTempDir` guard
+/// the caller must keep alive for the lifetime of the test.
+pub async fn seed_discovery_fixture() -> (SqlitePool, CoversTempDir) {
+    let guard = CoversTempDir::new("discovery");
+    let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
+    crate::sync::replace_books(
+        &pool,
+        "/lib",
+        vec![
+            // Two-author book in Saga #1 with tag "fiction"
+            indexed(
+                "saga1.epub",
+                Some("Saga: Book One"),
+                &["Ada Lovelace", "Grace Hopper"],
+                &["fiction", "classic"],
+                Some(("Saga", "1")),
+                None,
+            ),
+            // Sequel in Saga #2, same primary author + new tag
+            indexed(
+                "saga2.epub",
+                Some("Saga: Book Two"),
+                &["Ada Lovelace"],
+                &["fiction"],
+                Some(("Saga", "2")),
+                None,
+            ),
+            // Standalone by Ada — no series
+            indexed(
+                "standalone.epub",
+                Some("Standalone"),
+                &["Ada Lovelace"],
+                &["essay"],
+                None,
+                None,
+            ),
+            // Different-author, different-series book
+            indexed(
+                "other.epub",
+                Some("Other Story"),
+                &["Niklaus Wirth"],
+                &["nonfiction"],
+                Some(("Pioneers", "1")),
+                None,
+            ),
+        ],
+    )
+    .await
+    .unwrap();
+    (pool, guard)
+}
+
+/// Look up an `authors.id` by name. Panics on miss — test helper only.
+pub async fn author_id_by_name(pool: &SqlitePool, name: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT id FROM authors WHERE name = ?")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// Look up a `series.id` by name. Panics on miss — test helper only.
+pub async fn series_id_by_name(pool: &SqlitePool, name: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE name = ?")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// Seed `count` minimal `books` rows under `/lib`, all linked to one
+/// author ("Prolific") and one series ("Mega"), via recursive CTEs.
+/// Bypasses `replace_books`/the indexer — the discovery read caps only
+/// depend on link rows existing — keeping the test fast even past the
+/// 1k cap. Returns `(author_id, series_id)`.
+pub async fn seed_books_for_one_author_and_series(pool: &SqlitePool, count: i64) -> (i64, i64) {
+    sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+        .execute(pool)
+        .await
+        .unwrap();
+    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM libraries WHERE path = '/lib'")
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    let author_id: i64 = sqlx::query_scalar(
+        "INSERT INTO authors (name, sort) VALUES ('Prolific', 'Prolific') RETURNING id",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let series_id: i64 =
+        sqlx::query_scalar("INSERT INTO series (name, sort) VALUES ('Mega', 'Mega') RETURNING id")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    sqlx::query(
+        r#"
+        WITH RECURSIVE n(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
+        )
+        INSERT INTO books (uuid, library_id, path, title, sort, series_index)
+        SELECT 'uuid-' || i, ?, '/lib/b' || i, 'Title ' || i,
+               'Title ' || printf('%010d', i), i
+          FROM n
+        "#,
+    )
+    .bind(count)
+    .bind(lib_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    // Link every seeded book to the author and the series.
+    sqlx::query(
+        "INSERT INTO books_authors_link (book, author, position)
+         SELECT id, ?, 0 FROM books",
+    )
+    .bind(author_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO books_series_link (book, series)
+         SELECT id, ? FROM books",
+    )
+    .bind(series_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    (author_id, series_id)
+}


### PR DESCRIPTION
## Summary
- Create `db/src/test_support.rs` as the single source of truth for cross-cutting db test helpers, gated behind `#[cfg(any(test, feature = "test-support"))]` per the **Shared helpers** rule in `.claude/rules/03-unit-testing.md`.
- Relocate `make_test_dir` (was duplicated in `scanner.rs` and `ebook::test_support`), `seed_minimal_books` (from `books/tests.rs`), the `sync::test_helpers::indexed` / `indexed_with_stat` family, `discovery::test_helpers::*` (`seed_discovery_fixture`, `author_id_by_name`, `series_id_by_name`, `seed_books_for_one_author_and_series`), and `covers::test_helpers::CoversTempDir` + `COVERS_ENV_LOCK`.
- Update every `*/tests.rs` consumer (`author_photos_data`, `books`, `browse`, `covers`, `discovery`, `indexer`, `metadata_overrides`, `palette`, `scanner`, `settings`, `sync`) to import from `crate::test_support::*`. `ebook.rs` re-exports `make_test_dir` so existing `use crate::ebook::test_support::*;` globs in `ebook/{stat,parse,cover,accent}.rs` keep resolving without churn.

## Test plan
- [x] `cargo test -p omnibus-db` passes (378 tests; the two flaky tests under heavy parallelism — `worker::tests::poisoned_completions_lock_recovers_instead_of_panicking` and `ebook::accent::tests::extract_accent_completes_within_budget` — reproduce on `main` too and pass with `--test-threads=2`).
- [x] `cargo test -p omnibus` passes (144 tests).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean on `omnibus-db` and the workspace default members.
- [x] `cargo fmt` applied.

## Notes
- Adds a `test-support` feature to `db/Cargo.toml` so the cfg gate compiles for external consumers; no extra dev-deps.
- Out of scope per the issue: `settings::test_helpers::LibraryEnvGuard` (single-module use) and ebook-internal fixture loaders (`solid_color_png`, `fixture`, `copy_fixture_into`, `find_materialized_sidecar`) stay where they are.
- `server/` and `frontend/` `test_support` modules are explicitly deferred — to be done when those crates accumulate enough cross-cutting helpers.

Closes #306

https://claude.ai/code/session_01Cz7NrEjtN3SfEmRLotT3Tz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cz7NrEjtN3SfEmRLotT3Tz)_