### PR TITLE
refactor: collapse AuthError variants from 14 to coarse set (#315)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -55,24 +55,12 @@ use sqlx::Row;
 // Errors
 // -----------------------------------------------------------------------------
 
-/// Auth-layer error space. Coarse variants by design (per
-/// `.claude/rules/05-rust-style.md#errors`): every input-rule rejection
-/// — password policy, username policy, and device-field bounds — folds
-/// into [`AuthError::Validation`] carrying the user-facing message
-/// verbatim. The remaining variants stay distinct because callers
-/// branch on them: [`AuthError::UsernameTaken`] maps to `409 Conflict`
-/// (a state collision, not a malformed input) while every other input
-/// rejection is `400 Bad Request`, and `InvalidCredentials` /
-/// `AccountLocked` / `SessionNotFound` / `RegistrationDisabled` each
-/// carry distinct HTTP semantics and/or structured data.
+/// Auth-layer error space.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthError {
     #[error("invalid credentials")]
     InvalidCredentials,
-    /// Input-rule rejection — password policy, username policy, or
-    /// device-field bounds. The wrapped string is the user-facing
-    /// message that the HTTP layer hands back verbatim (always
-    /// `400 Bad Request`).
+    /// Input-rule rejection; wrapped string is the user-facing 400 body.
     #[error("{0}")]
     Validation(String),
     #[error("username is already taken")]
@@ -85,11 +73,7 @@ pub enum AuthError {
     RegistrationDisabled,
     #[error(transparent)]
     Db(#[from] sqlx::Error),
-    /// Crypto-layer failure: Argon2 hash/verify or CSPRNG byte
-    /// generation. The wrapped string carries the disambiguating
-    /// prefix (`"password hashing failed: …"` /
-    /// `"CSPRNG byte generation failed: …"`) so logs keep the original
-    /// wording. All callers map this to `500 Internal Server Error`.
+    /// Argon2 hash/verify or CSPRNG byte-generation failure (maps to 500).
     #[error("{0}")]
     Crypto(String),
 }

--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -55,50 +55,48 @@ use sqlx::Row;
 // Errors
 // -----------------------------------------------------------------------------
 
+/// Auth-layer error space. Coarse variants by design (per
+/// `.claude/rules/05-rust-style.md#errors`): every input-rule rejection
+/// — password policy, username policy, and device-field bounds — folds
+/// into [`AuthError::Validation`] carrying the user-facing message
+/// verbatim. The remaining variants stay distinct because callers
+/// branch on them: [`AuthError::UsernameTaken`] maps to `409 Conflict`
+/// (a state collision, not a malformed input) while every other input
+/// rejection is `400 Bad Request`, and `InvalidCredentials` /
+/// `AccountLocked` / `SessionNotFound` / `RegistrationDisabled` each
+/// carry distinct HTTP semantics and/or structured data.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthError {
     #[error("invalid credentials")]
     InvalidCredentials,
-    #[error("account is temporarily locked")]
-    AccountLocked { until_unix: i64 },
+    /// Input-rule rejection — password policy, username policy, or
+    /// device-field bounds. The wrapped string is the user-facing
+    /// message that the HTTP layer hands back verbatim (always
+    /// `400 Bad Request`).
+    #[error("{0}")]
+    Validation(String),
     #[error("username is already taken")]
     UsernameTaken,
-    #[error("username must not be empty")]
-    UsernameEmpty,
-    #[error("username is too long (max {max} chars)")]
-    UsernameTooLong { max: usize },
-    #[error("username must not have leading or trailing whitespace")]
-    UsernameWhitespace,
-    #[error("username contains an invalid control character")]
-    UsernameInvalidChar,
-    #[error("password is too short (min {min} chars)")]
-    PasswordTooShort { min: usize },
-    #[error("password is too long (max {max} chars)")]
-    PasswordTooLong { max: usize },
-    #[error("password is on the common-passwords reject list")]
-    PasswordCommon,
-    #[error("registration is disabled")]
-    RegistrationDisabled,
     #[error("session not found or expired")]
     SessionNotFound,
-    #[error("invalid {field}: {reason}")]
-    DeviceFieldInvalid {
-        field: &'static str,
-        reason: &'static str,
-    },
+    #[error("account is temporarily locked")]
+    AccountLocked { until_unix: i64 },
+    #[error("registration is disabled")]
+    RegistrationDisabled,
     #[error(transparent)]
     Db(#[from] sqlx::Error),
-    #[error("password hashing failed: {0}")]
-    Hash(String),
-    // Covers both session-token and signing-key generation, so the message
-    // is phrased generically rather than naming "token".
-    #[error("CSPRNG byte generation failed: {0}")]
-    TokenGeneration(String),
+    /// Crypto-layer failure: Argon2 hash/verify or CSPRNG byte
+    /// generation. The wrapped string carries the disambiguating
+    /// prefix (`"password hashing failed: …"` /
+    /// `"CSPRNG byte generation failed: …"`) so logs keep the original
+    /// wording. All callers map this to `500 Internal Server Error`.
+    #[error("{0}")]
+    Crypto(String),
 }
 
 impl From<argon2::password_hash::Error> for AuthError {
     fn from(e: argon2::password_hash::Error) -> Self {
-        AuthError::Hash(e.to_string())
+        AuthError::Crypto(format!("password hashing failed: {e}"))
     }
 }
 

--- a/db/src/auth/device.rs
+++ b/db/src/auth/device.rs
@@ -37,16 +37,12 @@ fn validate_device_field(
         return Ok(());
     };
     if v.chars().count() > max_chars {
-        return Err(AuthError::DeviceFieldInvalid {
-            field: label,
-            reason: "too long",
-        });
+        return Err(AuthError::Validation(format!("invalid {label}: too long")));
     }
     if v.chars().any(|c| c.is_control()) {
-        return Err(AuthError::DeviceFieldInvalid {
-            field: label,
-            reason: "contains control characters",
-        });
+        return Err(AuthError::Validation(format!(
+            "invalid {label}: contains control characters"
+        )));
     }
     Ok(())
 }
@@ -146,8 +142,11 @@ mod tests {
         let too_long: String = "a".repeat(MAX_DEVICE_NAME_CHARS + 1);
         let err = validate_device_name(Some(&too_long)).unwrap_err();
         match err {
-            AuthError::DeviceFieldInvalid { field, .. } => assert_eq!(field, "device_name"),
-            other => panic!("expected DeviceFieldInvalid, got {other:?}"),
+            AuthError::Validation(msg) => assert!(
+                msg.contains("invalid device_name") && msg.contains("too long"),
+                "expected Validation about device_name being too long, got {msg:?}",
+            ),
+            other => panic!("expected Validation, got {other:?}"),
         }
     }
 
@@ -164,7 +163,8 @@ mod tests {
         for raw in ["benign\nlog", "tab\there", "null\0byte", "bell\x07"] {
             let err = validate_device_name(Some(raw)).unwrap_err();
             assert!(
-                matches!(err, AuthError::DeviceFieldInvalid { .. }),
+                matches!(&err, AuthError::Validation(m)
+                    if m.contains("invalid device_name") && m.contains("control characters")),
                 "expected control-char rejection for {raw:?}, got {err:?}",
             );
         }
@@ -176,7 +176,9 @@ mod tests {
         let too_long: String = "1".repeat(MAX_CLIENT_VERSION_CHARS + 1);
         let err = validate_client_version(Some(&too_long)).unwrap_err();
         assert!(
-            matches!(err, AuthError::DeviceFieldInvalid { field, .. } if field == "client_version")
+            matches!(&err, AuthError::Validation(m)
+                if m.contains("invalid client_version") && m.contains("too long")),
+            "expected Validation about client_version being too long, got {err:?}",
         );
     }
 
@@ -190,7 +192,10 @@ mod tests {
         let err = register_device(&p, u.id, &too_long, "ios", None)
             .await
             .unwrap_err();
-        assert!(matches!(err, AuthError::DeviceFieldInvalid { .. }));
+        assert!(
+            matches!(&err, AuthError::Validation(m) if m.contains("invalid device_name")),
+            "expected Validation about device_name, got {err:?}",
+        );
         let list = list_devices_for_user(&p, u.id).await.unwrap();
         assert!(list.is_empty(), "rejection must not leave a partial row");
     }
@@ -202,9 +207,10 @@ mod tests {
         let err = register_device(&p, u.id, "Phone", "ios", Some("1.0\n0"))
             .await
             .unwrap_err();
-        assert!(matches!(
-            err,
-            AuthError::DeviceFieldInvalid { field, .. } if field == "client_version"
-        ));
+        assert!(
+            matches!(&err, AuthError::Validation(m)
+                if m.contains("invalid client_version") && m.contains("control characters")),
+            "expected Validation about client_version control chars, got {err:?}",
+        );
     }
 }

--- a/db/src/auth/password.rs
+++ b/db/src/auth/password.rs
@@ -94,18 +94,18 @@ pub fn validate_password(password: &str) -> AuthResult<()> {
     // separate limit; MAX_PASSWORD_LEN guards against unbounded CPU work.
     let char_count = password.chars().count();
     if char_count < MIN_PASSWORD_LEN {
-        return Err(AuthError::PasswordTooShort {
-            min: MIN_PASSWORD_LEN,
-        });
+        return Err(AuthError::Validation(format!(
+            "password too short (min {MIN_PASSWORD_LEN})"
+        )));
     }
     if char_count > MAX_PASSWORD_LEN {
-        return Err(AuthError::PasswordTooLong {
-            max: MAX_PASSWORD_LEN,
-        });
+        return Err(AuthError::Validation(format!(
+            "password too long (max {MAX_PASSWORD_LEN})"
+        )));
     }
     let lower = password.to_lowercase();
     if COMMON_PASSWORDS.iter().any(|c| *c == lower) {
-        return Err(AuthError::PasswordCommon);
+        return Err(AuthError::Validation("password is too common".to_string()));
     }
     Ok(())
 }
@@ -130,27 +130,35 @@ pub fn validate_password(password: &str) -> AuthResult<()> {
 /// this layer makes.
 pub fn validate_username(username: &str) -> AuthResult<()> {
     if username.is_empty() {
-        return Err(AuthError::UsernameEmpty);
+        return Err(AuthError::Validation(
+            "username must not be empty".to_string(),
+        ));
     }
     if username.trim() != username {
-        return Err(AuthError::UsernameWhitespace);
+        return Err(AuthError::Validation(
+            "username must not have leading or trailing whitespace".to_string(),
+        ));
     }
     // Re-check after trim in case the input was entirely whitespace —
     // `trim() != self` would have already caught that, but the empty check
     // here makes the intent explicit if the rules above ever reorder.
     if username.trim().is_empty() {
-        return Err(AuthError::UsernameEmpty);
+        return Err(AuthError::Validation(
+            "username must not be empty".to_string(),
+        ));
     }
     if username.chars().count() > MAX_USERNAME_LEN {
-        return Err(AuthError::UsernameTooLong {
-            max: MAX_USERNAME_LEN,
-        });
+        return Err(AuthError::Validation(format!(
+            "username too long (max {MAX_USERNAME_LEN})"
+        )));
     }
     if username
         .chars()
         .any(|c| (c as u32) <= 0x1F || c as u32 == 0x7F)
     {
-        return Err(AuthError::UsernameInvalidChar);
+        return Err(AuthError::Validation(
+            "username contains an invalid control character".to_string(),
+        ));
     }
     Ok(())
 }
@@ -188,18 +196,20 @@ mod tests {
 
     #[test]
     fn password_policy_rejects_short() {
-        assert!(matches!(
-            validate_password("short"),
-            Err(AuthError::PasswordTooShort { .. })
-        ));
+        let err = validate_password("short").unwrap_err();
+        assert!(
+            matches!(&err, AuthError::Validation(m) if m.contains("password too short")),
+            "expected validation `password too short …`, got {err:?}",
+        );
     }
 
     #[test]
     fn password_policy_rejects_common() {
-        assert!(matches!(
-            validate_password("password123"),
-            Err(AuthError::PasswordCommon)
-        ));
+        let err = validate_password("password123").unwrap_err();
+        assert!(
+            matches!(&err, AuthError::Validation(m) if m == "password is too common"),
+            "expected validation `password is too common`, got {err:?}",
+        );
     }
 
     #[test]
@@ -209,12 +219,20 @@ mod tests {
 
     // ---- username policy ----------------------------------------------------
 
+    /// Assert the validator rejects `input` with a `Validation` whose message
+    /// contains `needle` — keeps test failures debuggable by surfacing the
+    /// actual message when the substring drifts.
+    fn assert_validation_contains(input: &str, needle: &str) {
+        let err = validate_username(input).unwrap_err();
+        assert!(
+            matches!(&err, AuthError::Validation(m) if m.contains(needle)),
+            "input {input:?}: expected Validation containing {needle:?}, got {err:?}",
+        );
+    }
+
     #[test]
     fn username_policy_rejects_empty() {
-        assert!(matches!(
-            validate_username(""),
-            Err(AuthError::UsernameEmpty)
-        ));
+        assert_validation_contains("", "username must not be empty");
     }
 
     #[test]
@@ -231,77 +249,50 @@ mod tests {
     #[test]
     fn username_policy_rejects_over_max_length() {
         let name: String = "a".repeat(MAX_USERNAME_LEN + 1);
-        assert!(matches!(
-            validate_username(&name),
-            Err(AuthError::UsernameTooLong { .. })
-        ));
+        assert_validation_contains(&name, "username too long");
     }
 
     #[test]
     fn username_policy_rejects_leading_whitespace() {
-        assert!(matches!(
-            validate_username(" alice"),
-            Err(AuthError::UsernameWhitespace)
-        ));
+        assert_validation_contains(" alice", "leading or trailing whitespace");
     }
 
     #[test]
     fn username_policy_rejects_trailing_whitespace() {
-        assert!(matches!(
-            validate_username("alice "),
-            Err(AuthError::UsernameWhitespace)
-        ));
+        assert_validation_contains("alice ", "leading or trailing whitespace");
     }
 
     #[test]
     fn username_policy_rejects_only_whitespace() {
         // All-whitespace input has trim() != self, so it surfaces as the
-        // whitespace error rather than the empty error — either is a
-        // reject, but lock the variant to keep callers' error UX stable.
-        assert!(matches!(
-            validate_username("   "),
-            Err(AuthError::UsernameWhitespace)
-        ));
+        // whitespace message rather than the empty message — either is a
+        // reject, but lock the wording to keep callers' error UX stable.
+        assert_validation_contains("   ", "leading or trailing whitespace");
     }
 
     #[test]
     fn username_policy_rejects_embedded_tab() {
-        assert!(matches!(
-            validate_username("ali\tce"),
-            Err(AuthError::UsernameInvalidChar)
-        ));
+        assert_validation_contains("ali\tce", "invalid control character");
     }
 
     #[test]
     fn username_policy_rejects_embedded_newline() {
-        assert!(matches!(
-            validate_username("ali\nce"),
-            Err(AuthError::UsernameInvalidChar)
-        ));
+        assert_validation_contains("ali\nce", "invalid control character");
     }
 
     #[test]
     fn username_policy_rejects_embedded_null() {
-        assert!(matches!(
-            validate_username("ali\0ce"),
-            Err(AuthError::UsernameInvalidChar)
-        ));
+        assert_validation_contains("ali\0ce", "invalid control character");
     }
 
     #[test]
     fn username_policy_rejects_low_control_char() {
-        assert!(matches!(
-            validate_username("ali\x1fce"),
-            Err(AuthError::UsernameInvalidChar)
-        ));
+        assert_validation_contains("ali\x1fce", "invalid control character");
     }
 
     #[test]
     fn username_policy_rejects_delete_char() {
-        assert!(matches!(
-            validate_username("ali\x7fce"),
-            Err(AuthError::UsernameInvalidChar)
-        ));
+        assert_validation_contains("ali\x7fce", "invalid control character");
     }
 
     #[test]

--- a/db/src/auth/session_key.rs
+++ b/db/src/auth/session_key.rs
@@ -16,7 +16,8 @@ pub async fn load_or_create_session_key(pool: &SqlitePool) -> AuthResult<Vec<u8>
         return Ok(bytes);
     }
     let mut key = vec![0u8; SESSION_KEY_LEN];
-    getrandom::getrandom(&mut key).map_err(|e| AuthError::TokenGeneration(e.to_string()))?;
+    getrandom::getrandom(&mut key)
+        .map_err(|e| AuthError::Crypto(format!("CSPRNG byte generation failed: {e}")))?;
     put_session_key(pool, &key).await?;
     Ok(key)
 }

--- a/db/src/auth/token.rs
+++ b/db/src/auth/token.rs
@@ -9,7 +9,8 @@ use super::{AuthError, AuthResult, SessionKind};
 /// padding). ~43 chars, 256-bit entropy. Returned to the client exactly once.
 pub fn generate_token() -> AuthResult<String> {
     let mut bytes = [0u8; 32];
-    getrandom::getrandom(&mut bytes).map_err(|e| AuthError::TokenGeneration(e.to_string()))?;
+    getrandom::getrandom(&mut bytes)
+        .map_err(|e| AuthError::Crypto(format!("CSPRNG byte generation failed: {e}")))?;
     Ok(URL_SAFE_NO_PAD.encode(bytes))
 }
 

--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -273,18 +273,20 @@ mod tests {
         // consuming the first-user-admin slot.
         let p = pool().await;
 
-        assert!(matches!(
-            create_user(&p, "", "hunter2-real-long").await,
-            Err(AuthError::UsernameEmpty)
-        ));
-        assert!(matches!(
-            create_user(&p, "ali\0ce", "hunter2-real-long").await,
-            Err(AuthError::UsernameInvalidChar)
-        ));
-        assert!(matches!(
-            create_user(&p, " alice", "hunter2-real-long").await,
-            Err(AuthError::UsernameWhitespace)
-        ));
+        let cases: &[(&str, &str)] = &[
+            ("", "username must not be empty"),
+            ("ali\0ce", "invalid control character"),
+            (" alice", "leading or trailing whitespace"),
+        ];
+        for (input, needle) in cases {
+            let err = create_user(&p, input, "hunter2-real-long")
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(&err, AuthError::Validation(m) if m.contains(needle)),
+                "input {input:?}: expected Validation containing {needle:?}, got {err:?}",
+            );
+        }
 
         // None of the rejected attempts created a row, so the first valid
         // create still gets the admin slot.

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -78,49 +78,17 @@ fn auth_error_to_response(e: AuthError) -> Response {
                 .into_response()
         }
         AuthError::UsernameTaken => (StatusCode::CONFLICT, "username taken").into_response(),
-        AuthError::UsernameEmpty => {
-            (StatusCode::BAD_REQUEST, "username must not be empty").into_response()
-        }
-        AuthError::UsernameTooLong { max } => (
-            StatusCode::BAD_REQUEST,
-            format!("username too long (max {max})"),
-        )
-            .into_response(),
-        AuthError::UsernameWhitespace => (
-            StatusCode::BAD_REQUEST,
-            "username must not have leading or trailing whitespace",
-        )
-            .into_response(),
-        AuthError::UsernameInvalidChar => (
-            StatusCode::BAD_REQUEST,
-            "username contains an invalid control character",
-        )
-            .into_response(),
-        AuthError::PasswordTooShort { min } => (
-            StatusCode::BAD_REQUEST,
-            format!("password too short (min {min})"),
-        )
-            .into_response(),
-        AuthError::PasswordTooLong { max } => (
-            StatusCode::BAD_REQUEST,
-            format!("password too long (max {max})"),
-        )
-            .into_response(),
-        AuthError::PasswordCommon => {
-            (StatusCode::BAD_REQUEST, "password is too common").into_response()
-        }
+        // All input-rule rejections (password policy, username policy,
+        // device-field bounds) carry their user-facing message verbatim
+        // on the wrapped string — hand it back as the 400 body so the
+        // pre-collapse copy stays byte-identical for the UI.
+        AuthError::Validation(msg) => (StatusCode::BAD_REQUEST, msg).into_response(),
         AuthError::RegistrationDisabled => {
             (StatusCode::FORBIDDEN, "registration disabled").into_response()
         }
         AuthError::SessionNotFound => (StatusCode::UNAUTHORIZED, "unauthorized").into_response(),
-        AuthError::DeviceFieldInvalid { field, reason } => (
-            StatusCode::BAD_REQUEST,
-            format!("invalid {field}: {reason}"),
-        )
-            .into_response(),
         AuthError::Db(e) => internal(e),
-        AuthError::Hash(e) => internal(e),
-        AuthError::TokenGeneration(e) => internal(e),
+        AuthError::Crypto(e) => internal(e),
     }
 }
 
@@ -437,7 +405,7 @@ mod tests {
 
     #[tokio::test]
     async fn register_invalid_username_returns_400() {
-        // Cover each AuthError::Username* validation rejection at the HTTP
+        // Cover each AuthError::Validation username rejection at the HTTP
         // boundary (#276). Each case is a fresh app so the
         // first-registration / registration-disabled gate doesn't latch
         // between iterations.

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -78,10 +78,6 @@ fn auth_error_to_response(e: AuthError) -> Response {
                 .into_response()
         }
         AuthError::UsernameTaken => (StatusCode::CONFLICT, "username taken").into_response(),
-        // All input-rule rejections (password policy, username policy,
-        // device-field bounds) carry their user-facing message verbatim
-        // on the wrapped string — hand it back as the 400 body so the
-        // pre-collapse copy stays byte-identical for the UI.
         AuthError::Validation(msg) => (StatusCode::BAD_REQUEST, msg).into_response(),
         AuthError::RegistrationDisabled => {
             (StatusCode::FORBIDDEN, "registration disabled").into_response()


### PR DESCRIPTION
## Summary

Folds `AuthError` from 14 variants to 8 per the coarse-variants rule (`.claude/rules/05-rust-style.md#errors`). Every input-rule rejection — password policy, username policy, and device-field bounds — now uses a single `Validation(String)` carrying the user-facing message verbatim. The two crypto-failure variants (`Hash` + `TokenGeneration`) also fold into one `Crypto(String)` since they mapped to identical HTTP status (500).

### Before -> after

| Before (14) | After (8) | Notes |
|---|---|---|
| `InvalidCredentials` | `InvalidCredentials` | unchanged |
| `AccountLocked { until_unix }` | `AccountLocked { until_unix }` | unchanged — structured field, 429 + Retry-After |
| `UsernameTaken` | `UsernameTaken` | **kept distinct** — 409 Conflict (state collision, not a malformed input); the Playwright `tests/utils/auth.ts` setup branches on this status |
| `UsernameEmpty` | `Validation(String)` | message: `"username must not be empty"` |
| `UsernameTooLong { max }` | `Validation(String)` | message: `"username too long (max {max})"` |
| `UsernameWhitespace` | `Validation(String)` | message: `"username must not have leading or trailing whitespace"` |
| `UsernameInvalidChar` | `Validation(String)` | message: `"username contains an invalid control character"` |
| `PasswordTooShort { min }` | `Validation(String)` | message: `"password too short (min {min})"` |
| `PasswordTooLong { max }` | `Validation(String)` | message: `"password too long (max {max})"` |
| `PasswordCommon` | `Validation(String)` | message: `"password is too common"` |
| `RegistrationDisabled` | `RegistrationDisabled` | unchanged — 403 |
| `SessionNotFound` | `SessionNotFound` | unchanged — 401 |
| `DeviceFieldInvalid { field, reason }` | `Validation(String)` | message: `"invalid {field}: {reason}"` |
| `Db(#[from] sqlx::Error)` | `Db(#[from] sqlx::Error)` | unchanged |
| `Hash(String)` | `Crypto(String)` | wrapped string keeps the `"password hashing failed: …"` prefix |
| `TokenGeneration(String)` | `Crypto(String)` | wrapped string keeps the `"CSPRNG byte generation failed: …"` prefix |

### Deviations from the issue's target shape

The issue's target sketch lists 8 variants but omits `UsernameTaken` and `DeviceFieldInvalid`. Two judgment calls:

- **`UsernameTaken` stays distinct.** It maps to `409 Conflict`, not `400 Bad Request` — the input is well-formed, it's a state collision. Collapsing it into `Validation` would regress the HTTP status code that `ui_tests/playwright/tests/utils/auth.ts:25` branches on. Per the worker runbook, surfaced here instead of silently changing the contract.
- **`Hash` + `TokenGeneration` merge into `Crypto(String)`.** Both mapped to `500` via the same `internal(e)` arm; the wrapped string carries the disambiguating prefix, so logs and `Display` retain the original wording. Picking this merge over keeping `UsernameTaken` collapsed lands the final count at exactly 8.

### HTTP status mapping (unchanged for callers)

`auth_error_to_response` in `server/src/auth/handlers.rs`:

- `InvalidCredentials` -> 401 `"invalid credentials"`
- `AccountLocked` -> 429 `"invalid credentials"` + `Retry-After`
- `UsernameTaken` -> 409 `"username taken"`
- `Validation(msg)` -> 400 `msg` (hands the wrapped string back verbatim — `username taken` aside, this is every former 400 arm)
- `RegistrationDisabled` -> 403 `"registration disabled"`
- `SessionNotFound` -> 401 `"unauthorized"`
- `Db` / `Crypto` -> 500 (logged via `internal()`)

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-db auth::` — 63 passed
- [x] `cargo test -p omnibus-db` — 395 passed
- [x] `cargo test -p omnibus` — 156 passed
- [x] grep-verified user-facing copy strings still appear in source (every former handler arm's exact text is now constructed in the validator before being handed to the 400 body)
- [ ] Playwright `auth.spec.ts` — **not run locally** (no `nix develop` available in this isolated worktree); added `run_ui_tests` label so CI runs the suite. Affected contracts: 409 for `username taken` (preserved), 400 + body containing `password` / `username` substrings (preserved — `frontend/src/pages/auth.rs::classify_register_error` only keys on those substrings).

## Notes — user-facing copy preserved

Every pre-collapse `auth_error_to_response` body string is now constructed verbatim in the validator and handed back unchanged. Spot-check:

- `"username taken"` — still emitted by the `UsernameTaken` arm
- `"username must not be empty"` — `validate_username("")` builds this exact string
- `"username too long (max {max})"` — same `format!` shape
- `"username must not have leading or trailing whitespace"` — exact
- `"username contains an invalid control character"` — exact
- `"password too short (min {min})"` — same `format!` shape
- `"password too long (max {max})"` — same `format!` shape
- `"password is too common"` — exact
- `"registration disabled"` — still emitted by the `RegistrationDisabled` arm
- `"invalid {field}: {reason}"` — `validate_device_field` builds `"invalid device_name: too long"` etc.

Closes #315

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvK3HEBBL8CysXnCykUnNQ)_