### PR TITLE
chore(nix): split devShells into slim default + opt-in shells

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -7,13 +7,40 @@ nix develop --command zsh   # preferred — keeps your shell prompt intact
 nix develop                 # also works; spawns a bash subshell
 ```
 
-The shell hook sets:
+## Shells
+
+The flake exposes five purpose-built shells so daily cargo work doesn't pay for Playwright + mobile + audit tooling. Pick the smallest one that has what you need:
+
+| Shell | Headline tools | When to use |
+|---|---|---|
+| `default` (slim) | rust core + sqlite + openssl + just + zellij + process-compose | Daily `cargo test`/`clippy`/`fmt`, editor, rust-analyzer — this is what direnv auto-loads via `.envrc` |
+| `web` | default + dioxus-cli + matched `wasm-bindgen` + node | `dx serve --platform web`, `just dev-up`, anything that bundles the WASM client |
+| `e2e` | web + Playwright Chromium bundle | `npx playwright test`, the `playwright` pane in the multiplexer, CI's E2E job |
+| `mobile` | default + Android + iOS rust-std targets + JDK 21 + Xcode/Android SDK auto-detect | `dx serve --platform ios`/`android`, `cargo build -p omnibus-mobile` |
+| `audit` | default + cargo-audit + cargo-deny | Local `cargo audit` / `cargo deny`, mirrors CI's security job |
+
+One-shot pattern for any non-default shell:
+
+```bash
+nix develop .#web    --command dx serve --platform web -p omnibus
+nix develop .#audit  --command cargo deny check advisories sources bans
+nix develop .#mobile                  # interactive shell with Android NDK + iOS targets
+```
+
+`.envrc` resolves `use flake` to `default`, so the editor stays on the slim shell at all times. `just serve` works from default because zellij + process-compose live there; each multiplexer pane internally wraps its command in the right `.#shell` (server → `.#web`, mobile → `.#mobile`, playwright → `.#e2e`), so only the panes you actually start realize their extras. `just dev-up` and `just dev-bounce` self-wrap in `.#web`, so they work straight from default too.
+
+## Common environment
+
+Every shell sets:
 
 - `DATABASE_URL=sqlite://omnibus.db?mode=rwc`
 - `CARGO_TARGET_DIR=$HOME/.cache/cargo-target/<worktree-root-name>` — keeps `target/` outside the repo so flake evaluations don't snapshot multi-GB build artifacts into `/nix/store` on every direnv reload. The worktree root is resolved via `git rev-parse --show-toplevel` (so `nix develop` from a subdir picks the same dir), and the basename keeps it per-worktree to avoid races between parallel worktrees.
-- `PLAYWRIGHT_BROWSERS_PATH` → Nix-provided Chromium (don't run `npx playwright install`)
 - `OMNIBUS_PUBLIC_ORIGIN=http://localhost:$PORT` — comma-separated allowlist consumed by `auth::origin_check`. Required for `dx serve --fullstack`: its HTTP proxy rewrites `Host` to the upstream backend's loopback address without setting `X-Forwarded-Host`, so without an allowlist every cookie-authed POST 403s. Override in production deployments behind a reverse proxy.
-- `ANDROID_HOME` and `ANDROID_NDK_HOME` (auto-detected from standard Android Studio install paths)
+
+Shell-specific additions:
+
+- `e2e` only — `PLAYWRIGHT_BROWSERS_PATH` → Nix-provided Chromium (don't run `npx playwright install`)
+- `mobile` only — `ANDROID_HOME`, `ANDROID_NDK_HOME` (auto-detected from standard Android Studio install paths), plus the Xcode `DEVELOPER_DIR`/`SDKROOT`/`PATH` shim on macOS
 
 Override `PORT` (default `3000`) if you need a different port. Playwright targets `$PLAYWRIGHT_BASE_URL` (set by `scripts/dev-server-up.sh`); it falls back to `http://127.0.0.1:3000` when unset.
 
@@ -34,7 +61,7 @@ Optional storage overrides:
 - `OMNIBUS_THUMBS_DIR` — where WebP thumbnails are cached (default `./thumbs`)
 - `OMNIBUS_THUMBS_CAP_BYTES` — eviction cap in bytes (default 5 GiB)
 
-If `ANDROID_HOME` / `ANDROID_NDK_HOME` come back empty, set them manually:
+If `ANDROID_HOME` / `ANDROID_NDK_HOME` come back empty inside `nix develop .#mobile`, set them manually:
 
 ```bash
 export ANDROID_HOME=$HOME/Library/Android/sdk

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Bundle web app
         if: steps.bundle-cache.outputs.cache-hit != 'true'
-        run: nix develop --command bash -c 'set -euo pipefail; dx bundle --platform web --package omnibus --fullstack'
+        run: nix develop .#e2e --command bash -c 'set -euo pipefail; dx bundle --platform web --package omnibus --fullstack'
 
       # Explicit save (not the combined cache action's post-step) so it runs
       # while `target/dx/omnibus/debug/web` still exists. See the restore step
@@ -164,13 +164,13 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Install Playwright npm deps
-        run: nix develop --command bash -c 'set -euo pipefail; cd ui_tests/playwright && npm ci'
+        run: nix develop .#e2e --command bash -c 'set -euo pipefail; cd ui_tests/playwright && npm ci'
 
       # Backgrounded with `nohup ... &` + `disown` so the server survives the
       # step's shell exit and the next step can poll it.
       - name: Start server
         run: |
-          nix develop --command bash -c '
+          nix develop .#e2e --command bash -c '
             set -euo pipefail
             chmod +x ./target/dx/omnibus/debug/web/server
             nohup env PORT=3000 ./target/dx/omnibus/debug/web/server >server.log 2>&1 &
@@ -180,7 +180,7 @@ jobs:
 
       - name: Run Playwright tests
         run: |
-          nix develop --command bash -c '
+          nix develop .#e2e --command bash -c '
             set -euo pipefail
             cd ui_tests/playwright
             npx playwright test --shard=${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -161,7 +161,7 @@ jobs:
           # Redirect inside the nix-develop subshell so the shellHook's
           # informational echoes (`Nix dev shell ready.`, etc.) don't get
           # mixed into the JSON capture file.
-          nix develop --command bash -c 'cargo audit --json --ignore RUSTSEC-2023-0071 > audit.json'
+          nix develop .#audit --command bash -c 'cargo audit --json --ignore RUSTSEC-2023-0071 > audit.json'
           exit_code=$?
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           # Deliberately succeed here so the report + sticky-comment steps run
@@ -254,4 +254,4 @@ jobs:
       # or the relevant `ignore`/`skip` list rather than re-introducing
       # `continue-on-error: true`.
       - name: cargo deny check
-        run: nix develop --command cargo deny check advisories sources bans
+        run: nix develop .#audit --command cargo deny check advisories sources bans

--- a/.zellij/layout.kdl
+++ b/.zellij/layout.kdl
@@ -26,7 +26,7 @@ layout {
     }
     tab name="playwright" {
         pane cwd="ui_tests/playwright" command="nix" start_suspended=true {
-            args "develop" ".#e2e" "--command" "npx" "playwright" "test" "--ui"
+            args "develop" "../..#e2e" "--command" "npx" "playwright" "test" "--ui"
         }
     }
 }

--- a/.zellij/layout.kdl
+++ b/.zellij/layout.kdl
@@ -10,23 +10,23 @@ layout {
     }
 
     tab name="server" focus=true {
-        pane command="dx" {
-            args "serve" "--platform" "web" "--fullstack" "--port" "3000" "--package" "omnibus"
+        pane command="nix" {
+            args "develop" ".#web" "--command" "dx" "serve" "--platform" "web" "--fullstack" "--port" "3000" "--package" "omnibus"
         }
     }
     tab name="android" {
-        pane command="dx" start_suspended=true {
-            args "serve" "--platform" "android" "--package" "omnibus-mobile"
+        pane command="nix" start_suspended=true {
+            args "develop" ".#mobile" "--command" "dx" "serve" "--platform" "android" "--package" "omnibus-mobile"
         }
     }
     tab name="ios" {
-        pane command="dx" start_suspended=true {
-            args "serve" "--platform" "ios" "--package" "omnibus-mobile"
+        pane command="nix" start_suspended=true {
+            args "develop" ".#mobile" "--command" "dx" "serve" "--platform" "ios" "--package" "omnibus-mobile"
         }
     }
     tab name="playwright" {
-        pane cwd="ui_tests/playwright" command="npx" start_suspended=true {
-            args "playwright" "test" "--ui"
+        pane cwd="ui_tests/playwright" command="nix" start_suspended=true {
+            args "develop" ".#e2e" "--command" "npx" "playwright" "test" "--ui"
         }
     }
 }

--- a/Justfile
+++ b/Justfile
@@ -17,7 +17,7 @@ serve-pc:
 # Use `source .claude/runtime/env.sh` afterwards to pick up OMNIBUS_PORT
 # and PLAYWRIGHT_BASE_URL for follow-on commands (Playwright, preview).
 dev-up:
-    scripts/dev-server-up.sh
+    nix develop .#web --command scripts/dev-server-up.sh
 
 # Peek at THIS workspace's dev server without mutating anything.
 # Exit 0 + emit OMNIBUS_DEV_READY when healthy; exit 1 if no server is
@@ -36,4 +36,4 @@ dev-down:
 # migration (the running server boots its migrations at startup) or when
 # `dx serve` has wedged on a compile error and `dev-up` exits 2.
 dev-bounce:
-    scripts/dev-server-bounce.sh
+    nix develop .#web --command scripts/dev-server-bounce.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Self-hosted ebook and audiobook library — the Plex/Jellyfin for your book coll
 ## Running
 This project utilizes [Nix](https://wiki.nixos.org/wiki/NixOS_Wiki) to save all dependencies.
 ```bash
-# Launch the nix shell
+# Launch the nix shell (slim default — daily cargo/clippy/test)
 nix develop
 
 # Launch the nix shell manually (and keep your shell)
@@ -16,6 +16,18 @@ nix develop --command zsh
 # Auto-load the nix shell with direnv
 direnv allow # Only necessary once
 ```
+
+The flake exposes purpose-built shells so daily work doesn't pull Playwright + mobile + audit tooling. The default direnv-loaded shell is `default` (slim); opt in to a heavier shell only when you need it:
+
+| Shell | When to use |
+|---|---|
+| `default` | Daily `cargo` / editor — what direnv auto-loads |
+| `.#web` | `dx serve --platform web`, `just dev-up`, anything that bundles WASM |
+| `.#e2e` | `npx playwright test` (Chromium bundle is here) |
+| `.#mobile` | Android / iOS builds (rust cross-targets + JDK + Android NDK detect) |
+| `.#audit` | `cargo audit` / `cargo deny` |
+
+`just serve`, `just serve-pc`, `just dev-up`, and `just dev-bounce` self-wrap in the right shell, so they work from `default`.
 
 Multiplexers with ZelliJ and Process-Compose both leverage the same `.justfile` to launch all of the different platforms here (frontend, mobile, server, playwright).
 ```bash
@@ -50,10 +62,10 @@ The iOS pane in the multiplexer will be able to launch the simulator and install
 
 3. **Create an emulator** — in Android Studio: **Tools → Device Manager → Create Virtual Device**, pick a device with a recent API level (API 33+ recommended), then start it.
 
-4. **Enter the Nix dev shell** — the shellHook auto-detects `ANDROID_HOME` and `ANDROID_NDK_HOME` from the standard Android Studio install paths:
+4. **Enter the Nix mobile dev shell** — the `mobile` shellHook auto-detects `ANDROID_HOME` and `ANDROID_NDK_HOME` from the standard Android Studio install paths:
 
    ```bash
-   nix develop --command zsh
+   nix develop .#mobile --command zsh
    ```
 
    Verify the vars are set:

--- a/flake.nix
+++ b/flake.nix
@@ -122,9 +122,12 @@
           pkgs.openssl
           rustCore
           pkgs.zellij
-          # process-compose comes from unstable: stable (25.05) ships v1.64.1,
-          # but `is_interactive: true` was added in v1.85.0 and our
-          # process-compose.yaml uses it to give `dx` panes a real TTY.
+          # process-compose pinned to unstable for a fresher build than the
+          # v1.64.1 that nixpkgs-stable (25.05) ships. The original driver
+          # (`is_interactive: true`) was reverted from process-compose.yaml
+          # because it pinned `dx` panes to a PTY that detached from the TUI
+          # log pane, but we keep the newer build for general quality-of-life
+          # fixes and to leave room for future config keys.
           pkgs-unstable.process-compose
           pkgs.just
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,10 @@
           pkgs.openssl
           rustCore
           pkgs.zellij
-          pkgs.process-compose
+          # process-compose comes from unstable: stable (25.05) ships v1.64.1,
+          # but `is_interactive: true` was added in v1.85.0 and our
+          # process-compose.yaml uses it to give `dx` panes a real TTY.
+          pkgs-unstable.process-compose
           pkgs.just
         ];
 
@@ -305,7 +308,7 @@
               pkgs.openssl
               rustMobile
               pkgs.zellij
-              pkgs.process-compose
+              pkgs-unstable.process-compose
               pkgs.just
             ] ++ mobileExtras;
             DATABASE_URL = "sqlite://omnibus.db?mode=rwc";

--- a/flake.nix
+++ b/flake.nix
@@ -17,21 +17,39 @@
         pkgs = import nixpkgs { inherit system; };
         pkgs-unstable = import nixpkgs-unstable { inherit system; };
 
-        # Rust toolchain with mobile cross-compilation targets pre-installed.
-        # fenix packages are read-only Nix store paths, so dx can't call rustup
-        # to install them at runtime — they must be declared here instead.
-        rust = fenix.packages.${system}.combine ([
+        # Slim core Rust toolchain. wasm32 rust-std is kept here because it's
+        # small (single-digit MB) and lets rust-analyzer / `cargo check` exercise
+        # the frontend's WASM target without flipping into the `web` shell.
+        rustCore = fenix.packages.${system}.combine [
           fenix.packages.${system}.latest.cargo
           fenix.packages.${system}.latest.rustc
           fenix.packages.${system}.latest.rustfmt
           fenix.packages.${system}.latest.clippy
           fenix.packages.${system}.latest.rust-src
-          fenix.packages.${system}.targets.aarch64-linux-android.latest.rust-std
           fenix.packages.${system}.targets.wasm32-unknown-unknown.latest.rust-std
+        ];
+
+        # Mobile-only Rust cross-compilation targets. Pulled into the `mobile`
+        # shell only — daily cargo work doesn't pay for them.
+        # fenix packages are read-only Nix store paths, so dx can't call rustup
+        # to install them at runtime — they must be declared here instead.
+        rustMobileTargets = [
+          fenix.packages.${system}.targets.aarch64-linux-android.latest.rust-std
         ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
           fenix.packages.${system}.targets.aarch64-apple-ios.latest.rust-std
           fenix.packages.${system}.targets.aarch64-apple-ios-sim.latest.rust-std
-        ]);
+        ];
+
+        # Slim core + mobile targets, combined into a single fenix toolchain so
+        # `dx` and `cargo` see one rustc with every needed --target.
+        rustMobile = fenix.packages.${system}.combine ([
+          fenix.packages.${system}.latest.cargo
+          fenix.packages.${system}.latest.rustc
+          fenix.packages.${system}.latest.rustfmt
+          fenix.packages.${system}.latest.clippy
+          fenix.packages.${system}.latest.rust-src
+          fenix.packages.${system}.targets.wasm32-unknown-unknown.latest.rust-std
+        ] ++ rustMobileTargets);
 
         # `dioxus-cli` from nixpkgs-unstable bundles its own `wasm-bindgen-cli`
         # (appended to PATH via `--suffix`), but the `dioxus` git pin in
@@ -91,129 +109,197 @@
               runHook postInstall
             '';
           };
+
+        # Package buckets per shell. The slim default carries only what
+        # everyday cargo/rust-analyzer work needs; opt-in shells layer their
+        # extras on top. zellij + process-compose live in `default` so
+        # `just serve` / `just serve-pc` work from a fresh checkout without
+        # an extra bootstrap step — they're ~10 MB each and harmless.
+        slimPackages = [
+          pkgs-unstable.git
+          pkgs.sqlite
+          pkgs.pkg-config
+          pkgs.openssl
+          rustCore
+          pkgs.zellij
+          pkgs.process-compose
+          pkgs.just
+        ];
+
+        # Web-build extras: dioxus-cli + matched wasm-bindgen + node.
+        # Node is here (not in `e2e`) because some web-only workflows shell
+        # out to `npm`/`npx` (e.g. tooling under `ui_tests/playwright/tools/`).
+        webExtras = [
+          wasm-bindgen-cli-0_2_122
+          pkgs-unstable.dioxus-cli
+          pkgs-unstable.nodejs_22
+        ];
+
+        # E2E extras layer on top of webExtras: Playwright's Nix-provided
+        # Chromium bundle. The PLAYWRIGHT_BROWSERS_PATH export below pins it.
+        e2eExtras = [
+          pkgs-unstable.playwright-driver.browsers
+        ];
+
+        # Mobile extras: JDK for the Android NDK toolchain. Mobile rust
+        # targets are bundled into rustMobile (used in place of rustCore).
+        mobileExtras = [
+          pkgs.jdk21
+        ];
+
+        # CI / occasional-local audit tooling. Not needed for daily work.
+        auditExtras = [
+          pkgs-unstable.cargo-audit
+          pkgs-unstable.cargo-deny
+        ];
+
+        # Common shellHook fragment shared by every shell: parks
+        # CARGO_TARGET_DIR outside the repo so flake evals don't snapshot
+        # ~12 GB of build artifacts into /nix/store, exports the CSRF
+        # origin allowlist used by `dx serve --fullstack`, and sources a
+        # per-repo `.env` last so it can override any default above.
+        commonShellHook = ''
+          # Keep target/ out of the repo so flake evaluations don't snapshot
+          # ~12GB of build artifacts into /nix/store on every direnv reload.
+          # Resolve the repo root so `nix develop` from a subdir lands in the
+          # same target dir; basename keeps it per-worktree so parallel
+          # worktrees don't race.
+          # Skip if the caller already pinned CARGO_TARGET_DIR (CI sets it
+          # to ./target so workflow paths and rust-cache stay valid).
+          if [ -z "''${CARGO_TARGET_DIR:-}" ]; then
+            _cargo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+            export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/$(basename "$_cargo_root")"
+          fi
+
+          # `dx serve --fullstack` runs an HTTP proxy on $PORT that
+          # rewrites Host: to the upstream backend's loopback address,
+          # without setting X-Forwarded-Host. The CSRF origin_check
+          # middleware then sees Origin=http://localhost:3000 vs
+          # Host=127.0.0.1:<random>, calls it a mismatch, and 403s every
+          # cookie-authed POST. Declare an allowlist so origin_check can
+          # match the browser's Origin directly. Override or extend in
+          # production deployments.
+          export OMNIBUS_PUBLIC_ORIGIN="http://localhost:''${PORT:-3000}"
+
+          # Source per-repo .env last so it can override any default set
+          # above. Look in the worktree root (resolved via git so
+          # `nix develop` from a subdir still picks it up); fall back to
+          # the current dir. `.env` is gitignored and is meant for
+          # secret-bearing or per-developer values only — non-secret
+          # defaults live in this shellHook. `.env.example` is the
+          # checked-in template.
+          _env_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+          if [ -f "$_env_root/.env" ]; then
+            set -a
+            # shellcheck disable=SC1090
+            source "$_env_root/.env"
+            set +a
+          fi
+        '';
+
+        # `e2e` shell pins Playwright's Chromium to the Nix store. The npm
+        # @playwright/test version must match this bundle's version.
+        playwrightHook = ''
+          export PLAYWRIGHT_BROWSERS_PATH="${pkgs-unstable.playwright-driver.browsers}"
+          export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+        '';
+
+        # `mobile` shell auto-detects Xcode + Android SDK/NDK on the host.
+        # These detections only make sense when actually building mobile
+        # targets, so they live outside the common hook.
+        mobileHook = ''
+          # Nix injects xcbuild's fake xcrun and its own cc wrapper, both of which
+          # break iOS builds. Fix: prepend /usr/bin so the real Xcode xcrun and
+          # Apple clang shadow Nix's stubs. Set DEVELOPER_DIR so the real xcrun
+          # can locate all platform SDKs (including iphonesimulator). Set SDKROOT
+          # to the Xcode macOS SDK so Apple clang and xcrun agree on the sysroot.
+          # Rust (fenix) uses absolute store paths and is unaffected by PATH order.
+          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+            export PATH="/usr/bin:$PATH"
+            export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+            export SDKROOT="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+            echo "DEVELOPER_DIR=$DEVELOPER_DIR"
+          fi
+
+          # Auto-detect Android SDK + NDK on macOS.
+          if [ -z "$ANDROID_HOME" ]; then
+            for sdk_base in \
+              "$HOME/Library/Android/sdk" \
+              "$HOME/Android/Sdk"; do
+              if [ -d "$sdk_base" ]; then
+                export ANDROID_HOME="$sdk_base"
+                echo "ANDROID_HOME=$ANDROID_HOME"
+                break
+              fi
+            done
+          fi
+          if [ -z "$ANDROID_NDK_HOME" ] && [ -n "$ANDROID_HOME" ] && [ -d "$ANDROID_HOME/ndk" ]; then
+            _ndk=$(ls -d "$ANDROID_HOME/ndk/"* 2>/dev/null | sort -V | tail -1)
+            [ -n "$_ndk" ] && export ANDROID_NDK_HOME="$_ndk" && echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME"
+          fi
+        '';
+
+        mkShell = { name, packages, extraHook ? "" }:
+          pkgs.mkShell {
+            inherit packages;
+            DATABASE_URL = "sqlite://omnibus.db?mode=rwc";
+            shellHook = ''
+              echo "Nix dev shell ready (${name})."
+            '' + commonShellHook + extraHook;
+          };
       in {
-        devShells.default = pkgs.mkShell {
-          packages = [
-            pkgs-unstable.git
-            pkgs.sqlite
-            pkgs.pkg-config
-            pkgs.openssl
-            rust
-            pkgs-unstable.cargo-audit
-            pkgs-unstable.cargo-deny
-            pkgs.jdk21
-            wasm-bindgen-cli-0_2_122
-            pkgs-unstable.dioxus-cli
-            pkgs-unstable.nodejs_22
-            pkgs-unstable.playwright-driver.browsers
-            pkgs.zellij
-            pkgs.process-compose
-            pkgs.just
+        devShells = {
+          # Slim default — covers daily cargo/clippy/fmt/test and the
+          # `rust.yml/check` CI job. Anything WASM-, mobile-, or
+          # Playwright-shaped lives in an opt-in shell below.
+          default = mkShell {
+            name = "default";
+            packages = slimPackages;
+          };
 
-            # F2.3 audiobook HLS pipeline: transcodes source mp3/m4b into
-            # AAC-in-MPEG-TS segments + serves them via tower-http's
-            # ServeFile. Bundled with the dev shell so cold-start contributors
-            # can play any audiobook end-to-end; production deploys must ship
-            # the same binary in the runtime image (see docs/design/f2-3-audiobook-hls.md).
-            pkgs.ffmpeg-headless
-          ];
+          # WASM dev: dioxus-cli, matched wasm-bindgen, node. Used by
+          # `just dev-up`, ad-hoc `dx serve --platform web`, and the
+          # server pane in the multiplexer.
+          web = mkShell {
+            name = "web";
+            packages = slimPackages ++ webExtras;
+          };
 
-          DATABASE_URL = "sqlite://omnibus.db?mode=rwc";
+          # End-to-end browser tests: web extras + Playwright's Chromium
+          # bundle, with PLAYWRIGHT_BROWSERS_PATH pinned to the Nix store.
+          # Used by `e2e.yml` and the playwright pane in the multiplexer.
+          e2e = mkShell {
+            name = "e2e";
+            packages = slimPackages ++ webExtras ++ e2eExtras;
+            extraHook = playwrightHook;
+          };
 
-          shellHook = ''
-            echo "Nix dev shell ready."
-            echo "Run: cargo test -p omnibus"
-            echo "Run: cargo run -p omnibus"
+          # Mobile builds: Android + iOS rust-std targets, JDK 21, and
+          # the Xcode/Android SDK auto-detection hook. Used by the
+          # mobile panes in the multiplexer and `cargo build -p omnibus-mobile`.
+          mobile = pkgs.mkShell {
+            packages = [
+              pkgs-unstable.git
+              pkgs.sqlite
+              pkgs.pkg-config
+              pkgs.openssl
+              rustMobile
+              pkgs.zellij
+              pkgs.process-compose
+              pkgs.just
+            ] ++ mobileExtras;
+            DATABASE_URL = "sqlite://omnibus.db?mode=rwc";
+            shellHook = ''
+              echo "Nix dev shell ready (mobile)."
+            '' + commonShellHook + mobileHook;
+          };
 
-            # Keep target/ out of the repo so flake evaluations don't snapshot
-            # ~12GB of build artifacts into /nix/store on every direnv reload.
-            # Resolve the repo root so `nix develop` from a subdir lands in the
-            # same target dir; basename keeps it per-worktree so parallel
-            # worktrees don't race.
-            # Skip if the caller already pinned CARGO_TARGET_DIR (CI sets it
-            # to ./target so workflow paths and rust-cache stay valid).
-            if [ -z "''${CARGO_TARGET_DIR:-}" ]; then
-              _cargo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-              export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/$(basename "$_cargo_root")"
-            fi
-
-            # Per-workspace stable PORT — each known `jj workspace` gets its
-            # own base port so three agents in three workspaces don't compete
-            # for the same port. scripts/dev-server-up.sh port-walks within
-            # $PORT..$PORT+9 as a fallback for foreign-process / sibling
-            # collisions. Override by exporting PORT before `nix develop`.
-            if [ -z "''${PORT:-}" ]; then
-              _ws_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-              case "$(basename "$_ws_root")" in
-                omnibus)        export PORT=3000 ;;
-                omnibus-xray)   export PORT=3010 ;;
-                omnibus-yankee) export PORT=3020 ;;
-                omnibus-zulu)   export PORT=3030 ;;
-                *)              export PORT=3000 ;;  # fallback for any other checkout
-              esac
-            fi
-
-            # Pin Playwright's Chromium to the Nix store so no per-user
-            # download lands in ~/Library/Caches/ms-playwright/. The npm
-            # @playwright/test version must match this bundle's version.
-            export PLAYWRIGHT_BROWSERS_PATH="${pkgs-unstable.playwright-driver.browsers}"
-            export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-
-            # `dx serve --fullstack` runs an HTTP proxy on $PORT that
-            # rewrites Host: to the upstream backend's loopback address,
-            # without setting X-Forwarded-Host. The CSRF origin_check
-            # middleware then sees Origin=http://localhost:3000 vs
-            # Host=127.0.0.1:<random>, calls it a mismatch, and 403s every
-            # cookie-authed POST. Declare an allowlist so origin_check can
-            # match the browser's Origin directly. Override or extend in
-            # production deployments.
-            export OMNIBUS_PUBLIC_ORIGIN="http://localhost:''${PORT:-3000}"
-
-            # Nix injects xcbuild's fake xcrun and its own cc wrapper, both of which
-            # break iOS builds. Fix: prepend /usr/bin so the real Xcode xcrun and
-            # Apple clang shadow Nix's stubs. Set DEVELOPER_DIR so the real xcrun
-            # can locate all platform SDKs (including iphonesimulator). Set SDKROOT
-            # to the Xcode macOS SDK so Apple clang and xcrun agree on the sysroot.
-            # Rust (fenix) uses absolute store paths and is unaffected by PATH order.
-            if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-              export PATH="/usr/bin:$PATH"
-              export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
-              export SDKROOT="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
-              echo "DEVELOPER_DIR=$DEVELOPER_DIR"
-            fi
-
-            # Auto-detect Android SDK + NDK on macOS.
-            if [ -z "$ANDROID_HOME" ]; then
-              for sdk_base in \
-                "$HOME/Library/Android/sdk" \
-                "$HOME/Android/Sdk"; do
-                if [ -d "$sdk_base" ]; then
-                  export ANDROID_HOME="$sdk_base"
-                  echo "ANDROID_HOME=$ANDROID_HOME"
-                  break
-                fi
-              done
-            fi
-            if [ -z "$ANDROID_NDK_HOME" ] && [ -n "$ANDROID_HOME" ] && [ -d "$ANDROID_HOME/ndk" ]; then
-              _ndk=$(ls -d "$ANDROID_HOME/ndk/"* 2>/dev/null | sort -V | tail -1)
-              [ -n "$_ndk" ] && export ANDROID_NDK_HOME="$_ndk" && echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME"
-            fi
-
-            # Source per-repo .env last so it can override any default set
-            # above. Look in the worktree root (resolved via git so
-            # `nix develop` from a subdir still picks it up); fall back to
-            # the current dir. `.env` is gitignored and is meant for
-            # secret-bearing or per-developer values only — non-secret
-            # defaults live in this shellHook. `.env.example` is the
-            # checked-in template.
-            _env_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-            if [ -f "$_env_root/.env" ]; then
-              set -a
-              # shellcheck disable=SC1090
-              source "$_env_root/.env"
-              set +a
-            fi
-          '';
+          # Security tooling: cargo-audit + cargo-deny. Used by
+          # `rust.yml/security` and the occasional local audit.
+          audit = mkShell {
+            name = "audit";
+            packages = slimPackages ++ auditExtras;
+          };
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -126,13 +126,17 @@
           pkgs.just
         ];
 
-        # Web-build extras: dioxus-cli + matched wasm-bindgen + node.
+        # Web-build extras: dioxus-cli + matched wasm-bindgen + node + ffmpeg.
         # Node is here (not in `e2e`) because some web-only workflows shell
         # out to `npm`/`npx` (e.g. tooling under `ui_tests/playwright/tools/`).
+        # ffmpeg is the runtime backend for the F2.3 audiobook HLS pipeline
+        # (`db::hls` shells out via OMNIBUS_FFMPEG_PATH); kept out of slim
+        # `default` since daily cargo work doesn't need it.
         webExtras = [
           wasm-bindgen-cli-0_2_122
           pkgs-unstable.dioxus-cli
           pkgs-unstable.nodejs_22
+          pkgs.ffmpeg-headless
         ];
 
         # E2E extras layer on top of webExtras: Playwright's Nix-provided
@@ -171,6 +175,22 @@
             export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/$(basename "$_cargo_root")"
           fi
 
+          # Per-workspace stable PORT — each known `jj workspace` gets its
+          # own base port so three agents in three workspaces don't compete
+          # for the same port. scripts/dev-server-up.sh port-walks within
+          # $PORT..$PORT+9 as a fallback for foreign-process / sibling
+          # collisions. Override by exporting PORT before `nix develop`.
+          if [ -z "''${PORT:-}" ]; then
+            _ws_name="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+            case "$_ws_name" in
+              omnibus)        export PORT=3000 ;;
+              omnibus-xray)   export PORT=3010 ;;
+              omnibus-yankee) export PORT=3020 ;;
+              omnibus-zulu)   export PORT=3030 ;;
+              *)              export PORT=3000 ;;
+            esac
+          fi
+
           # `dx serve --fullstack` runs an HTTP proxy on $PORT that
           # rewrites Host: to the upstream backend's loopback address,
           # without setting X-Forwarded-Host. The CSRF origin_check
@@ -179,7 +199,7 @@
           # cookie-authed POST. Declare an allowlist so origin_check can
           # match the browser's Origin directly. Override or extend in
           # production deployments.
-          export OMNIBUS_PUBLIC_ORIGIN="http://localhost:''${PORT:-3000}"
+          export OMNIBUS_PUBLIC_ORIGIN="http://localhost:''${PORT}"
 
           # Source per-repo .env last so it can override any default set
           # above. Look in the worktree root (resolved via git so

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -13,6 +13,6 @@ processes:
     disabled: true
 
   playwright:
-    command: nix develop .#e2e --command npx playwright test --ui
+    command: nix develop ../..#e2e --command npx playwright test --ui
     working_dir: ui_tests/playwright
     disabled: true

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -3,16 +3,13 @@ version: "0.5"
 processes:
   server:
     command: nix develop .#web --command dx serve --platform web --fullstack --port 3000 --package omnibus
-    is_interactive: true
 
   android:
     command: nix develop .#mobile --command dx serve --platform android --package omnibus-mobile
-    is_interactive: true
     disabled: true
 
   ios:
     command: nix develop .#mobile --command dx serve --platform ios --package omnibus-mobile
-    is_interactive: true
     disabled: true
 
   playwright:

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -2,17 +2,20 @@ version: "0.5"
 
 processes:
   server:
-    command: dx serve --platform web --fullstack --port 3000 --package omnibus
+    command: nix develop .#web --command dx serve --platform web --fullstack --port 3000 --package omnibus
+    is_interactive: true
 
   android:
-    command: dx serve --platform android --package omnibus-mobile
+    command: nix develop .#mobile --command dx serve --platform android --package omnibus-mobile
+    is_interactive: true
     disabled: true
 
   ios:
-    command: dx serve --platform ios --package omnibus-mobile
+    command: nix develop .#mobile --command dx serve --platform ios --package omnibus-mobile
+    is_interactive: true
     disabled: true
 
   playwright:
-    command: npx playwright test --ui
+    command: nix develop .#e2e --command npx playwright test --ui
     working_dir: ui_tests/playwright
     disabled: true


### PR DESCRIPTION
> [!NOTE]
> Re-opened after a force-push mishap closed [#336](https://github.com/seamus-sloan/omnibus/pull/336). Identical contents; commits cleaned up to 3 instead of 4.

## Summary

- Split monolithic `devShells.default` into five purpose-built shells (`default`, `web`, `e2e`, `mobile`, `audit`) so daily cargo work no longer pays for Playwright Chromium, mobile cross-targets, JDK, dioxus-cli, wasm-bindgen, or audit tooling.
- Daily direnv-loaded `default` shrinks to **3.6 GiB** closure; opt-in shells layer extras on top (`web` 3.9, `e2e` 4.9, `mobile` 4.3, `audit` 3.6).
- Multiplexer panes (`.zellij/layout.kdl`, `process-compose.yaml`) self-wrap in the right `nix develop .#<shell> --command …` so `just serve` / `just serve-pc` work from `default`.
- CI wired up: `rust.yml/security` uses `.#audit`, `e2e.yml` (bundle + playwright shards) uses `.#e2e`. `rust.yml/check` stays on `default`.

## Commits

1. `chore(nix): split devShells into slim default + opt-in shells` — the split itself.
2. `fix(nix): restore ffmpeg + per-workspace PORT lost in shell split` — Copilot-review follow-ups: `pkgs.ffmpeg-headless` added to `webExtras` for the F2.3 HLS pipeline; per-workspace PORT case statement (`omnibus`=3000, `omnibus-xray`=3010, …) restored to `commonShellHook`.
3. `fix(pc): drop is_interactive; logs were detaching from the TUI's standard pane` — bumps `process-compose` to nixpkgs-unstable (v1.110.0) since stable's v1.64.1 predates `is_interactive`, but then drops the key from `process-compose.yaml` because `is_interactive` attaches the process to a PTY (vim/REPL semantic) and `dx serve`'s stdout never reaches the standard log pane that way.

## Test plan

- [x] `nix flake check --no-build` — all five shells evaluate
- [x] Closure size measured for each shell: default 3.6 GiB, web 3.9, e2e 4.9, mobile 4.3, audit 3.6
- [x] `nix develop --command cargo test -p omnibus-db --lib` → 409 passed on slim default
- [x] `nix develop --command cargo clippy -p omnibus-db --all-targets -- -D warnings` → clean on slim default
- [x] `nix develop .#web --command dx --version` → dioxus 0.7.9, wasm-bindgen 0.2.122, node v22, ffmpeg 7.1.1 all present
- [x] `nix develop .#e2e` → `PLAYWRIGHT_BROWSERS_PATH` pinned, Chromium present
- [x] `nix develop .#audit --command cargo deny check advisories sources bans` → `advisories ok, bans ok, sources ok`
- [x] `nix develop .#mobile` → JDK 21, aarch64-(linux-android|apple-ios|apple-ios-sim) targets, Android NDK + Xcode DEVELOPER_DIR auto-detected
- [x] `process-compose up --dry-run` → `Validated 4 configured processes from 2 files.`
- [x] `process-compose up` → `server` process reaches Running, binds port 3000 via `dx serve` inside `.#web`
- [ ] CI green: `rust.yml/check`, `rust.yml/security`, `e2e.yml`

>[!IMPORTANT]
> After merging, anyone with an existing `nix develop` shell open should re-enter; `.envrc` will auto-load the new slim `default`.

>[!TIP]
> One-shot pattern for anything non-default: `nix develop .#<shell> --command <cmd>`. The `just` recipes (`serve`, `serve-pc`, `dev-up`, `dev-bounce`) already self-wrap, so `default` is the right daily shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)