### PR TITLE
test(ebooks): add 5xx coverage for /api/ebooks/{uuid}/file (#329)

### DIFF
--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -523,14 +523,20 @@ mod tests {
         // it, so disable FK enforcement before dropping to keep the
         // single DROP statement minimal. We don't touch `users` /
         // `sessions`, so the auth gate's `lookup_session` still works.
+        // `PRAGMA foreign_keys` is per-connection in SQLite, so acquire
+        // one connection and pin both statements to it — `execute(&pool)`
+        // would let the PRAGMA and the DROP land on different pool
+        // connections and the DROP could then trip an FK error.
+        let mut conn = pool.acquire().await.unwrap();
         sqlx::query("PRAGMA foreign_keys = OFF")
-            .execute(&pool)
+            .execute(&mut *conn)
             .await
             .unwrap();
         sqlx::query("DROP TABLE books")
-            .execute(&pool)
+            .execute(&mut *conn)
             .await
             .unwrap();
+        drop(conn);
 
         let app = crate::backend::rest_router(AppState::new(pool));
         let res = app
@@ -568,14 +574,18 @@ mod tests {
 
         // FKs off because `book_file_parts` references `book_files`;
         // we want the single DROP to succeed without cascading further.
+        // PRAGMA + DROP pinned to a single connection — see the sibling
+        // test above for the rationale.
+        let mut conn = pool.acquire().await.unwrap();
         sqlx::query("PRAGMA foreign_keys = OFF")
-            .execute(&pool)
+            .execute(&mut *conn)
             .await
             .unwrap();
         sqlx::query("DROP TABLE book_files")
-            .execute(&pool)
+            .execute(&mut *conn)
             .await
             .unwrap();
+        drop(conn);
 
         let app = crate::backend::rest_router(AppState::new(pool));
         let res = app

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -503,4 +503,85 @@ mod tests {
 
         std::fs::remove_dir_all(&tmp).ok();
     }
+
+    /// Drives the first `internal(...)` arm of `get_ebook_file`: when
+    /// `db::resolve_book_id_by_uuid` returns `Err`, the handler must
+    /// surface 500 (not 404). The induce-sqlx-error idiom is to drop
+    /// the `books` table out from under the live pool after seeding the
+    /// auth gate's `users`/`sessions` tables — the gate keeps passing,
+    /// the handler's first query hits "no such table: books" and the
+    /// response collapses into the shared `internal()` envelope. Same
+    /// pattern is reusable for any future 5xx test that needs to
+    /// isolate a single db call without a mock layer.
+    #[tokio::test]
+    async fn api_get_ebook_file_returns_500_when_resolve_book_id_by_uuid_fails() {
+        let (_, _, pool) = fixture().await;
+        let user = auth_test_support::create_user(&pool, "alice").await;
+        let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+        // FK cascade: dependents of `books` (book_files, etc.) reference
+        // it, so disable FK enforcement before dropping to keep the
+        // single DROP statement minimal. We don't touch `users` /
+        // `sessions`, so the auth gate's `lookup_session` still works.
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DROP TABLE books")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let app = crate::backend::rest_router(AppState::new(pool));
+        let res = app
+            .oneshot(get_with_bearer("/api/ebooks/any-uuid/file", &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    /// Drives the second `internal(...)` arm of `get_ebook_file`: when
+    /// `db::resolve_book_id_by_uuid` returns `Ok(Some(_))` but
+    /// `db::book_file_path` returns `Err`, the handler must surface 500.
+    /// Seed a book row so the first call succeeds, then drop the
+    /// `book_files` table so the second call's JOIN errors out.
+    #[tokio::test]
+    async fn api_get_ebook_file_returns_500_when_book_file_path_fails() {
+        let (_, _, pool) = fixture().await;
+        let user = auth_test_support::create_user(&pool, "alice").await;
+        let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+        let lib_id = sqlx::query("INSERT INTO libraries (path, display_name) VALUES (?, 'lib')")
+            .bind("/lib")
+            .execute(&pool)
+            .await
+            .unwrap()
+            .last_insert_rowid();
+        let uuid = "22222222-2222-2222-2222-222222222222";
+        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, 'B')")
+            .bind(uuid)
+            .bind(lib_id)
+            .bind("/lib")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // FKs off because `book_file_parts` references `book_files`;
+        // we want the single DROP to succeed without cascading further.
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DROP TABLE book_files")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let app = crate::backend::rest_router(AppState::new(pool));
+        let res = app
+            .oneshot(get_with_bearer(&format!("/api/ebooks/{uuid}/file"), &token))
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
 }


### PR DESCRIPTION
## Summary

`.claude/rules/03-unit-testing.md` requires every `/api/*` handler to cover 200, 4xx, and 5xx/DB-failure paths via `rest_router(...)` + `oneshot`. The cited handler (`get_ebook_file` in `server/src/backend/ebooks.rs`, the function with `internal("resolve_book_id_by_uuid", e)` and `internal("book_file_path", e)` arms) had 401/404/200 coverage but no 5xx tests.

This PR adds two integration tests that exercise each `internal(...)` arm in isolation:

- `api_get_ebook_file_returns_500_when_resolve_book_id_by_uuid_fails` — drops the `books` table after seeding auth, so the first db call inside the handler errors out with "no such table".
- `api_get_ebook_file_returns_500_when_book_file_path_fails` — seeds a book row (first db call succeeds), then drops `book_files` so the second db call's JOIN errors out.

### Induce-sqlx-error idiom

The simplest reproducible way to make a real sqlx query against an in-memory pool fail is to disable FKs and `DROP TABLE` the table the call under test touches, while leaving `users` / `sessions` intact so the auth gate keeps passing. No mock layer, no closing the pool (which would also trip the auth gate's `lookup_session` and short-circuit the test before the handler ever ran). The same pattern is reusable for any future 5xx test that needs to isolate a single db call.

Tests only — no production code changes.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default features; `--all-features` errors are pre-existing on main because `web` + `mobile` are mutually exclusive)
- [x] `cargo test -p omnibus` — 172 passed, 0 failed
- [x] Both new tests pass and exercise the intended `internal(...)` arms independently (full both-branch isolation, not the pool-close-covers-both fallback).

Closes #329

https://claude.ai/code/session_01UjCnJFY8vxN6i6FQJKthnp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjCnJFY8vxN6i6FQJKthnp)_