### PR TITLE
fix(indexer): scope reindex format-filtered to avoid cross-library deletes (#328)

### DIFF
--- a/db/src/audiobook.rs
+++ b/db/src/audiobook.rs
@@ -39,6 +39,14 @@ pub use stat::{stat_audiobook_library, AudiobookStatEntry, AudiobookStatScanResu
 /// indexer would surface files the count display ignores, or vice versa.
 pub const AUDIOBOOK_EXTENSIONS: &[&str] = &["m4b", "m4a", "mp3"];
 
+/// `book_files.format` values produced by the audiobook indexer. Used by
+/// [`crate::indexer::reindex_audiobooks`] to scope the diff's "currently
+/// indexed" view to audiobook rows — prevents `sync_audiobooks` from
+/// classifying foreign (ebook) rows under a shared `library_path` as
+/// Removed and deleting them. Uppercased to match the values written
+/// in [`crate::sync::sync_audiobooks`].
+pub const AUDIOBOOK_FORMATS: &[&str] = &["M4B", "M4A", "MP3"];
+
 /// Re-export of [`crate::ebook::IndexedBook`] so callers using
 /// `audiobook::IndexedBook` and `ebook::IndexedBook` stay in sync. The
 /// sync writer is format-agnostic — it inspects the file extension via

--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -28,7 +28,7 @@ mod tests;
 pub use get::{book_file_path, get_book, get_book_by_uuid, resolve_book_id_by_uuid};
 pub use list::{
     count_books, library_from_db, library_from_db_with_total, list_books, list_indexed_rows,
-    IndexedRow,
+    list_indexed_rows_for_formats, IndexedRow,
 };
 pub use projection::MAX_BOOKS_RETURNED;
 pub use search::{count_search_books, search_books, search_books_with_total};

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -221,6 +221,64 @@ pub async fn list_indexed_rows(
         .collect())
 }
 
+/// Format-scoped variant of [`list_indexed_rows`]: returns only books
+/// that have **at least one** `book_files` row whose `format` is in
+/// `formats` (matched case-insensitively via the `COLLATE NOCASE`
+/// `book_files.format` column).
+///
+/// Used by the per-format reindex paths (ebook / audiobook) so that
+/// when the user configures the ebook and audiobook libraries to the
+/// same on-disk directory, an audiobook reindex does not classify the
+/// EPUB rows as Removed (and vice versa). With this filter the diff
+/// only sees the rows the current scan can legitimately account for.
+///
+/// `formats` is an allow-list of uppercase `book_files.format` values
+/// — see [`crate::ebook::EBOOK_FORMATS`] and
+/// [`crate::audiobook::AUDIOBOOK_FORMATS`]. An empty slice returns an
+/// empty vec (no formats to match against).
+pub async fn list_indexed_rows_for_formats(
+    pool: &SqlitePool,
+    library_path: &str,
+    formats: &[&str],
+) -> Result<Vec<IndexedRow>, sqlx::Error> {
+    if formats.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Inline placeholder list — formats is a small static slice owned by
+    // the caller, so there's no injection surface here and we avoid the
+    // overhead of a temp table or sqlx `Arguments` round-trip.
+    let placeholders = std::iter::repeat_n("?", formats.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        r#"
+        SELECT b.uuid                                  AS uuid,
+               COALESCE(MAX(bf.mtime_epoch), 0)        AS mtime_epoch,
+               COALESCE(MAX(bf.size_bytes), 0)         AS size_bytes
+          FROM books b
+          JOIN libraries l   ON l.id = b.library_id
+          JOIN book_files bf ON bf.book_id = b.id
+         WHERE l.path = ?
+           AND bf.format IN ({placeholders})
+         GROUP BY b.id, b.uuid
+        "#
+    );
+    let mut q = sqlx::query(&sql).bind(library_path);
+    for fmt in formats {
+        q = q.bind(*fmt);
+    }
+    let rows = q.fetch_all(pool).await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| IndexedRow {
+            uuid: r.get("uuid"),
+            mtime_epoch: r.get("mtime_epoch"),
+            size_bytes: r.get("size_bytes"),
+        })
+        .collect())
+}
+
 /// Total number of books currently indexed under `library_path`.
 ///
 /// Companion to `list_books`: `list_books` caps the returned vec at

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -1538,3 +1538,98 @@ async fn book_file_path_returns_none_when_no_file_row_for_format() {
     let path = book_file_path(&pool, book_id, "EPUB").await.unwrap();
     assert!(path.is_none());
 }
+
+// ---------- list_indexed_rows_for_formats (#328) ----------
+
+#[tokio::test]
+async fn list_indexed_rows_for_formats_returns_only_matching_format_rows() {
+    // Regression for #328: when ebook and audiobook libraries share a
+    // path, the format-scoped read must return only the rows whose
+    // `book_files.format` is in the allow-list.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    // Seed one EPUB and one M4B row under the same library_path. Use
+    // separate library rows to keep the seed helper simple — they share
+    // the same `libraries.path` string only via the second seed adding
+    // its own row, so we instead insert both books under the same id.
+    let lib_id: i64 = sqlx::query_scalar(
+        "INSERT INTO libraries (path, display_name) VALUES ('/shared', '/shared') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let epub_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, library_id, path, title, sort) \
+         VALUES ('uuid-epub', ?, '/shared/epub', 'EpubTitle', 'EpubTitle') RETURNING id",
+    )
+    .bind(lib_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let m4b_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, library_id, path, title, sort) \
+         VALUES ('uuid-m4b', ?, '/shared/audio', 'AudioTitle', 'AudioTitle') RETURNING id",
+    )
+    .bind(lib_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch) \
+         VALUES (?, 'EPUB', 'EpubTitle', 100, '', 100), \
+                (?, 'M4B',  'AudioTitle', 200, '', 200)",
+    )
+    .bind(epub_id)
+    .bind(m4b_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let ebooks = list_indexed_rows_for_formats(&pool, "/shared", &["EPUB"])
+        .await
+        .unwrap();
+    assert_eq!(ebooks.len(), 1);
+    assert_eq!(ebooks[0].uuid, "uuid-epub");
+    assert_eq!(ebooks[0].mtime_epoch, 100);
+    assert_eq!(ebooks[0].size_bytes, 100);
+
+    let audiobooks = list_indexed_rows_for_formats(&pool, "/shared", &["M4B", "M4A", "MP3"])
+        .await
+        .unwrap();
+    assert_eq!(audiobooks.len(), 1);
+    assert_eq!(audiobooks[0].uuid, "uuid-m4b");
+}
+
+#[tokio::test]
+async fn list_indexed_rows_for_formats_returns_empty_for_empty_allow_list() {
+    // Defensive contract: callers passing an empty allow-list mean
+    // "no formats to match against" and must get an empty result, not
+    // every row (which would re-introduce the #328 bug).
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib_id: i64 = sqlx::query_scalar(
+        "INSERT INTO libraries (path, display_name) VALUES ('/lib', '/lib') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, library_id, path, title, sort) \
+         VALUES ('uuid-a', ?, '/lib/a', 'A', 'A') RETURNING id",
+    )
+    .bind(lib_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch) \
+         VALUES (?, 'EPUB', 'a', 0, '', 0)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let rows = list_indexed_rows_for_formats(&pool, "/lib", &[])
+        .await
+        .unwrap();
+    assert!(rows.is_empty());
+}

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -28,6 +28,14 @@ pub use accent::extract_accent;
 pub use parse::{parse_ebook_targets, ParseTarget};
 pub use stat::{stat_ebook_library, StatEntry, StatScanResult};
 
+/// `book_files.format` values produced by the ebook indexer. Used by
+/// [`crate::indexer::reindex`] to scope the diff's "currently indexed"
+/// view to ebook rows — prevents `sync_books` from classifying foreign
+/// (audiobook) rows under a shared `library_path` as Removed and
+/// deleting them. Uppercased to match
+/// [`crate::helpers::split_filename`]'s output.
+pub const EBOOK_FORMATS: &[&str] = &["EPUB"];
+
 /// A single scanner output row — metadata plus the raw cover image bytes
 /// (and mime), if the epub included one. Consumed by [`crate::sync::sync_books`].
 ///

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -201,7 +201,10 @@ pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()
         anyhow::bail!("scan of {library_path} failed: {msg}");
     }
 
-    let db_rows = books::list_indexed_rows(pool, library_path).await?;
+    // Scope to ebook formats so a shared ebook + audiobook library_path
+    // does not classify audiobook rows here as Removed (#328 inverse).
+    let db_rows =
+        books::list_indexed_rows_for_formats(pool, library_path, ebook::EBOOK_FORMATS).await?;
     let library_root: PathBuf = PathBuf::from(library_path);
     let diff = diff_library(&stat.entries, &db_rows, &library_root);
 
@@ -254,8 +257,12 @@ pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow
             .await?;
 
     // Diff groups against DB rows (project groups to the ebook StatEntry shape
-    // so diff_library can be reused verbatim).
-    let db_rows = books::list_indexed_rows(pool, library_path).await?;
+    // so diff_library can be reused verbatim). Scope to audiobook formats so a
+    // shared ebook + audiobook library_path does not classify EPUB rows here
+    // as Removed (#328).
+    let db_rows =
+        books::list_indexed_rows_for_formats(pool, library_path, audiobook::AUDIOBOOK_FORMATS)
+            .await?;
     let library_root: PathBuf = PathBuf::from(library_path);
     let groups_as_stat: Vec<ebook::StatEntry> = groups
         .iter()
@@ -578,5 +585,145 @@ mod tests {
             "a failed scan must preserve the existing index"
         );
         assert_eq!(after[0].title.as_deref(), Some("Dracula"));
+    }
+
+    // ---------- #328: shared-path cross-format deletion guard ----------
+
+    /// Seed one `IndexedAudiobook` row into the DB at `library_path`.
+    /// Bypasses the full audiobook indexer (no real .m4b file needed) so
+    /// the cross-format-deletion regression tests can focus on the
+    /// reindex read-side filter, not on parsing real audio files.
+    async fn seed_audiobook_row(pool: &SqlitePool, library_path: &str, group_path: &str) {
+        let plan = crate::sync::AudiobookSyncPlan {
+            new_books: vec![crate::audiobook::IndexedAudiobook {
+                uuid: "uuid-m4b".to_string(),
+                group_path: group_path.to_string(),
+                format: "M4B".to_string(),
+                title: "AudioTitle".to_string(),
+                creator_name: None,
+                cover: None,
+                parts: vec![],
+                total_size_bytes: 100,
+                max_mtime_epoch: 100,
+                description: None,
+                error: None,
+            }],
+            changed_books: vec![],
+            removed_uuids: vec![],
+            backfill: vec![],
+        };
+        crate::sync::sync_audiobooks(pool, library_path, plan)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn reindex_audiobooks_does_not_delete_ebook_rows_when_libraries_share_a_path() {
+        // #328: when ebook_library_path == audiobook_library_path, an
+        // audiobook reindex must not classify every EPUB row as Removed
+        // and delete it. The fix scopes the diff's "currently indexed"
+        // view to the audiobook formats only.
+        let _covers = CoversTempDir::new("reindex-audio-shared");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+
+        // The audiobook reindex needs a real (but empty) directory to
+        // scan — `stat_audiobook_library` returns an error otherwise.
+        let shared = crate::test_support::make_test_dir("reindex-audio-shared-lib");
+        let shared_path = shared.to_string_lossy().into_owned();
+
+        // Pre-seed one EPUB row and one audiobook row at the same
+        // library_path — the exact configuration the bug reproduces on.
+        replace_books(
+            &pool,
+            &shared_path,
+            vec![indexed(
+                "dracula.epub",
+                Some("Dracula"),
+                &["Stoker"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        seed_audiobook_row(&pool, &shared_path, "audio/AudioTitle.m4b").await;
+        assert_eq!(
+            list_books(&pool, &shared_path).await.unwrap().len(),
+            2,
+            "test precondition: two books (EPUB + M4B) seeded at the shared path"
+        );
+
+        // Run the audiobook reindex against the empty directory. The
+        // audiobook row should be classified as Removed (and deleted);
+        // the EPUB row must survive because its format is outside the
+        // audiobook allow-list.
+        reindex_audiobooks(&pool, &shared_path).await.unwrap();
+
+        let after = list_books(&pool, &shared_path).await.unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "EPUB row must survive an audiobook-only reindex"
+        );
+        assert_eq!(after[0].title.as_deref(), Some("Dracula"));
+        assert!(
+            after[0].formats.iter().any(|f| f == "EPUB"),
+            "the surviving row must be the EPUB, not a stray audiobook"
+        );
+
+        let _ = std::fs::remove_dir_all(&shared);
+    }
+
+    #[tokio::test]
+    async fn reindex_ebooks_does_not_delete_audiobook_rows_when_libraries_share_a_path() {
+        // #328 inverse: an ebook reindex against a shared path must not
+        // delete audiobook rows for the same symmetric reason.
+        let _covers = CoversTempDir::new("reindex-ebook-shared");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+
+        let shared = crate::test_support::make_test_dir("reindex-ebook-shared-lib");
+        let shared_path = shared.to_string_lossy().into_owned();
+
+        replace_books(
+            &pool,
+            &shared_path,
+            vec![indexed(
+                "dracula.epub",
+                Some("Dracula"),
+                &["Stoker"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+        seed_audiobook_row(&pool, &shared_path, "audio/AudioTitle.m4b").await;
+        assert_eq!(
+            list_books(&pool, &shared_path).await.unwrap().len(),
+            2,
+            "test precondition: two books (EPUB + M4B) seeded at the shared path"
+        );
+
+        // Run the ebook reindex against the empty directory. The EPUB
+        // row should be classified as Removed (and deleted); the M4B
+        // row must survive because its format is outside the ebook
+        // allow-list.
+        reindex(&pool, &shared_path).await.unwrap();
+
+        let after = list_books(&pool, &shared_path).await.unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "audiobook row must survive an ebook-only reindex"
+        );
+        assert_eq!(after[0].title.as_deref(), Some("AudioTitle"));
+        assert!(
+            after[0].formats.iter().any(|f| f == "M4B"),
+            "the surviving row must be the audiobook, not a stray ebook"
+        );
+
+        let _ = std::fs::remove_dir_all(&shared);
     }
 }

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -36,8 +36,8 @@ pub mod worker;
 pub use author_photos_data::*;
 pub use books::{
     book_file_path, count_books, count_search_books, get_book, get_book_by_uuid, library_from_db,
-    library_from_db_with_total, list_books, list_indexed_rows, resolve_book_id_by_uuid,
-    search_books, search_books_with_total, IndexedRow, MAX_BOOKS_RETURNED,
+    library_from_db_with_total, list_books, list_indexed_rows, list_indexed_rows_for_formats,
+    resolve_book_id_by_uuid, search_books, search_books_with_total, IndexedRow, MAX_BOOKS_RETURNED,
 };
 pub use browse::*;
 pub use covers::{covers_dir, get_cover, get_last_modified_epoch};


### PR DESCRIPTION
## Root cause

`reindex_audiobooks` (at `db/src/indexer.rs:251` on `main`) read the DB's
"currently indexed" set via `books::list_indexed_rows(pool, library_path)`,
which returns **every** book row at that `library_path` regardless of
`book_files.format`. When `ebook_library_path == audiobook_library_path`,
the audiobook stat only enumerated M4B/M4A/MP3 uuids, so `diff_library`
classified every EPUB row as Removed and `sync_audiobooks` then deleted
them. The inverse bug existed on `reindex` too.

Repro: configure both library paths to the same directory containing a
mix of `.epub` and `.m4b`, then trigger an audiobook reindex. EPUB rows
disappear from the DB.

## Fix

Fix direction (a) from the issue — read-side format scope.

- Add a sibling `books::list_indexed_rows_for_formats(pool, library_path, formats)`
  that joins `book_files` and filters by an explicit allow-list. Existing
  `list_indexed_rows` keeps its current shape so all of its other callers
  (mostly tests) stay unchanged.
- Add `ebook::EBOOK_FORMATS` (`["EPUB"]`) and `audiobook::AUDIOBOOK_FORMATS`
  (`["M4B","M4A","MP3"]`) constants next to the existing
  `AUDIOBOOK_EXTENSIONS` / scanner constants.
- Wire both reindex paths through the format-scoped reader. **Symmetric fix
  on the ebook path** — `reindex` now also passes `EBOOK_FORMATS`, so an
  ebook reindex against a shared path no longer deletes audiobook rows.

No schema change. No library-type column. No new env vars or migrations.

## Tests

- `list_indexed_rows_for_formats_returns_only_matching_format_rows` — pins
  the new fn's allow-list semantics (EPUB vs M4B/M4A/MP3) on a single
  library path.
- `list_indexed_rows_for_formats_returns_empty_for_empty_allow_list` —
  defensive: empty slice must NOT degrade to "return everything" (which
  would re-introduce the bug).
- `reindex_audiobooks_does_not_delete_ebook_rows_when_libraries_share_a_path` —
  end-to-end regression. Seeds one EPUB + one M4B at the same path, runs
  `reindex_audiobooks` against an empty directory, asserts the EPUB row
  survives while the M4B row is correctly removed.
- `reindex_ebooks_does_not_delete_audiobook_rows_when_libraries_share_a_path` —
  symmetric regression on the ebook side.

`cargo test -p omnibus-db` → 420 passed.
`cargo test -p omnibus` → 170 passed.
`cargo clippy --all-targets -p omnibus-db -- -D warnings` → clean.
`cargo clippy --all-targets -p omnibus -- -D warnings` → clean.

(Workspace-wide `cargo clippy --all-features` surfaces pre-existing
`omnibus-frontend` build errors on `main` unrelated to this change —
`CurrentUser` symbol resolution under non-mobile features and a
deprecated `BlobPropertyBag::type_` call. Left untouched per the
"document, don't fix pre-existing failures" rule.)

Closes #328

https://claude.ai/code/session_01UjCnJFY8vxN6i6FQJKthnp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjCnJFY8vxN6i6FQJKthnp)_