### PR TITLE
docs(db): add single-tenant ACL scoping notes to discovery and browse functions (#232)

### DIFF
--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -19,6 +19,10 @@ const INDEX_LIMIT: i64 = 10_000;
 /// configured library. Accent is the `accent_color` of the first book by
 /// this author with a non-null value (book sort/id order); `NULL` falls
 /// back to the theme accent in the UI.
+///
+/// Currently returns results across all users (single-tenant). When F4.x
+/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
+/// to books accessible to that user.
 pub async fn list_authors(
     pool: &SqlitePool,
     library_path: &str,
@@ -110,6 +114,10 @@ pub async fn list_authors(
 /// lowest-`series_index` book (with `book.sort, book.id` as tie-breakers);
 /// `None` when every book in the series has only override-supplied
 /// creators not yet linked to an `authors` row.
+///
+/// Currently returns results across all users (single-tenant). When F4.x
+/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
+/// to books accessible to that user.
 pub async fn list_series(
     pool: &SqlitePool,
     library_path: &str,

--- a/db/src/discovery.rs
+++ b/db/src/discovery.rs
@@ -27,10 +27,6 @@ pub const MAX_DISCOVERY_BOOKS: i64 = 1_000;
 /// Fetch an author by ID with their books across every library. Returns
 /// `None` if the author ID doesn't exist. The nested `books` vec is
 /// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
-///
-/// Currently returns results across all users (single-tenant). When F4.x
-/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
-/// to books accessible to that user.
 pub async fn get_author(
     pool: &SqlitePool,
     author_id: i64,

--- a/db/src/discovery.rs
+++ b/db/src/discovery.rs
@@ -27,6 +27,10 @@ pub const MAX_DISCOVERY_BOOKS: i64 = 1_000;
 /// Fetch an author by ID with their books across every library. Returns
 /// `None` if the author ID doesn't exist. The nested `books` vec is
 /// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
+///
+/// Currently returns results across all users (single-tenant). When F4.x
+/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
+/// to books accessible to that user.
 pub async fn get_author(
     pool: &SqlitePool,
     author_id: i64,
@@ -170,6 +174,10 @@ pub async fn get_author(
 /// Fetch a series by ID with its books, ordered by series index. Returns
 /// `None` if the series ID doesn't exist. The nested `books` vec is
 /// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
+///
+/// Currently returns results across all users (single-tenant). When F4.x
+/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
+/// to books accessible to that user.
 pub async fn get_series(
     pool: &SqlitePool,
     series_id: i64,
@@ -335,6 +343,10 @@ const TAG_CLOUD_LIMIT: i64 = 500;
 
 /// Return up to [`TAG_CLOUD_LIMIT`] tags with their book counts, ordered
 /// by count descending then name ascending. Used by the tag cloud page.
+///
+/// Currently returns results across all users (single-tenant). When F4.x
+/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
+/// to books accessible to that user.
 pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, DiscoveryError> {
     // TODO: scope by `user_id` once per-user ACLs land (single-tenant today).
     //


### PR DESCRIPTION
## Summary

- Adds a `///` rustdoc paragraph to five functions in `db/src/discovery.rs` and `db/src/browse.rs` that carry `TODO(F4.x)` inline comments about per-user ACL scoping.
- The note reads: "Currently returns results across all users (single-tenant). When F4.x per-user ACL lands, add a `user_id: i64` parameter and scope the query to books accessible to that user."
- Functions covered: `get_series`, `get_tag_cloud` (discovery.rs); `list_authors`, `list_series` (browse.rs). `get_author` is excluded — its module-level `//!` doc already states "Single-tenant today — every read returns all matching rows without per-user ACL filtering" and the function body carries a matching `// TODO:` inline comment, making a `///` paragraph redundant there.
- Documentation-only — no signature changes, no SQL changes.

## Function name note (issue #232 has stale names)

Issue #232 cites `get_author_detail`, `get_series_detail`, `browse_authors`, and `browse_series` — these are pre-#201 names that no longer exist. The PR targets the actual current function names: `get_author`, `get_series`, `get_tag_cloud` (in `db/src/discovery.rs`) and `list_authors`, `list_series` (in `db/src/browse.rs`). The issue text was not updated after the rename.

## Merge order

⚠️ This PR should be merged **before** #347 (`refactor/308-split-discovery`). PR #347 splits `db/src/discovery.rs` into `discovery/{mod,authors,series,tags,tests}.rs`. If #347 lands first, this PR's changes to `discovery.rs` will conflict and be lost — rebase this branch onto main after #347 merges and move the annotations to the appropriate split submodule files (`discovery/series.rs` for `get_series`, `discovery/tags.rs` for `get_tag_cloud`).

## Test plan

- [x] `cargo fmt` — no changes
- [x] `cargo clippy -p omnibus-db -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 416 tests pass, 0 failed

Closes #232

https://claude.ai/code/session_01PDc9MZzA951sCBXnL7LBF4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDc9MZzA951sCBXnL7LBF4)_