### PR TITLE
fix: add per-field length validation to MetadataOverrides (#294)

### DIFF
--- a/server/src/backend/overrides.rs
+++ b/server/src/backend/overrides.rs
@@ -309,6 +309,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn api_post_overrides_rejects_over_length_title_with_400() {
+        // An admin submitting a title that exceeds TITLE_MAX_LEN must receive a
+        // 400 and no override row must be written. This exercises the
+        // `overrides.validate()` guard in the handler.
+        let (app, _state, pool) = fixture().await;
+        let (_id, uuid) = seed_book_with_uuid(&pool, "/lib", "Original").await;
+        let admin = auth_test_support::create_admin(&pool, "admin").await;
+        let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+        let over_limit_title = "x".repeat(omnibus_shared::MetadataOverrides::TITLE_MAX_LEN + 1);
+        let body = serde_json::json!({ "title": over_limit_title });
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/ebooks/{uuid}/overrides"))
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+        let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap_or("");
+        assert!(
+            body.contains("title"),
+            "400 body should name the offending field, got: {body:?}"
+        );
+
+        // No override row must have been written.
+        assert!(
+            db::get_metadata_overrides(&pool, &uuid)
+                .await
+                .unwrap()
+                .is_none(),
+            "validation failure must not persist any override row"
+        );
+    }
+
+    #[tokio::test]
     async fn api_post_overrides_saves_and_returns_merged_book() {
         // Admin (which carries `can_edit = true` via test_support::create_admin)
         // POSTs an override. The handler must persist it, return the merged

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -158,28 +158,28 @@ pub struct MetadataOverrides {
 }
 
 impl MetadataOverrides {
-    /// Maximum length (in Unicode scalar values, i.e. `chars`) for scalar
-    /// string fields (title, publisher, etc.).
-    const MAX_SCALAR_CHARS: usize = 4096;
-    /// Maximum length (in chars) for the description field.
-    const MAX_DESCRIPTION_CHARS: usize = 256 * 1024;
+    /// Maximum length (in Unicode scalar values, i.e. `chars`) for the `title`
+    /// field.
+    pub const TITLE_MAX_LEN: usize = 500;
+    /// Maximum length (in chars) for the `description` field.
+    pub const DESCRIPTION_MAX_LEN: usize = 50_000;
+    /// Maximum length (in chars) for single-line name fields: `publisher`,
+    /// `published`, `language`, `series`, `series_index`, creator names, and
+    /// tag strings.
+    pub const NAME_MAX_LEN: usize = 250;
     /// Maximum number of tags (subjects).
     const MAX_SUBJECTS: usize = 64;
-    /// Maximum length (in chars) of a single tag.
-    const MAX_SUBJECT_CHARS: usize = 128;
     /// Maximum number of creators.
     const MAX_CREATORS: usize = 32;
-    /// Maximum length (in chars) of a creator name.
-    const MAX_CREATOR_CHARS: usize = 256;
 
     /// Validate field lengths. Returns `Err` with a human-readable message if
-    /// any field exceeds the cap. Call at the handler level before persisting.
+    /// any field exceeds its cap. Call at the handler level before persisting.
     ///
     /// Length caps are measured in Unicode scalar values (`chars`), not UTF-8
     /// bytes, so a multibyte (e.g. CJK or emoji) string is held to the same
     /// visible-character budget as an ASCII one.
     pub fn validate(&self) -> Result<(), String> {
-        let check_scalar = |name: &str, val: &Option<String>, max: usize| -> Result<(), String> {
+        let check = |name: &str, val: &Option<String>, max: usize| -> Result<(), String> {
             if let Some(v) = val {
                 if v.chars().count() > max {
                     return Err(format!("{name} exceeds {max} characters"));
@@ -187,26 +187,22 @@ impl MetadataOverrides {
             }
             Ok(())
         };
-        check_scalar("title", &self.title, Self::MAX_SCALAR_CHARS)?;
-        check_scalar("publisher", &self.publisher, Self::MAX_SCALAR_CHARS)?;
-        check_scalar("published", &self.published, Self::MAX_SCALAR_CHARS)?;
-        check_scalar("language", &self.language, Self::MAX_SCALAR_CHARS)?;
-        check_scalar("series", &self.series, Self::MAX_SCALAR_CHARS)?;
-        check_scalar("series_index", &self.series_index, Self::MAX_SCALAR_CHARS)?;
-        check_scalar(
-            "description",
-            &self.description,
-            Self::MAX_DESCRIPTION_CHARS,
-        )?;
+        check("title", &self.title, Self::TITLE_MAX_LEN)?;
+        check("publisher", &self.publisher, Self::NAME_MAX_LEN)?;
+        check("published", &self.published, Self::NAME_MAX_LEN)?;
+        check("language", &self.language, Self::NAME_MAX_LEN)?;
+        check("series", &self.series, Self::NAME_MAX_LEN)?;
+        check("series_index", &self.series_index, Self::NAME_MAX_LEN)?;
+        check("description", &self.description, Self::DESCRIPTION_MAX_LEN)?;
         if let Some(ref creators) = self.creators {
             if creators.len() > Self::MAX_CREATORS {
                 return Err(format!("too many creators (max {})", Self::MAX_CREATORS));
             }
             for c in creators {
-                if c.name.chars().count() > Self::MAX_CREATOR_CHARS {
+                if c.name.chars().count() > Self::NAME_MAX_LEN {
                     return Err(format!(
                         "creator name exceeds {} characters",
-                        Self::MAX_CREATOR_CHARS
+                        Self::NAME_MAX_LEN
                     ));
                 }
             }
@@ -216,11 +212,8 @@ impl MetadataOverrides {
                 return Err(format!("too many tags (max {})", Self::MAX_SUBJECTS));
             }
             for s in subjects {
-                if s.chars().count() > Self::MAX_SUBJECT_CHARS {
-                    return Err(format!(
-                        "tag exceeds {} characters",
-                        Self::MAX_SUBJECT_CHARS
-                    ));
+                if s.chars().count() > Self::NAME_MAX_LEN {
+                    return Err(format!("tag exceeds {} characters", Self::NAME_MAX_LEN));
                 }
             }
         }
@@ -836,7 +829,7 @@ mod metadata_overrides_tests {
     #[test]
     fn validate_rejects_title_exceeding_length_cap() {
         let ov = MetadataOverrides {
-            title: Some("x".repeat(MetadataOverrides::MAX_SCALAR_CHARS + 1)),
+            title: Some("x".repeat(MetadataOverrides::TITLE_MAX_LEN + 1)),
             ..Default::default()
         };
         let err = ov
@@ -846,26 +839,68 @@ mod metadata_overrides_tests {
             err.contains("title"),
             "message should name the field: {err}"
         );
-        assert!(err.contains("4096"), "message should name the cap: {err}");
+        assert!(err.contains("500"), "message should name the cap: {err}");
     }
 
     #[test]
     fn validate_accepts_title_at_length_cap() {
-        // Boundary: exactly MAX_SCALAR_CHARS is allowed (the check is `> max`).
+        // Boundary: exactly TITLE_MAX_LEN is allowed (the check is `> max`).
         let ov = MetadataOverrides {
-            title: Some("x".repeat(MetadataOverrides::MAX_SCALAR_CHARS)),
+            title: Some("x".repeat(MetadataOverrides::TITLE_MAX_LEN)),
             ..Default::default()
         };
         assert_eq!(ov.validate(), Ok(()));
     }
 
     #[test]
-    fn validate_measures_scalar_cap_in_chars_not_bytes() {
+    fn validate_rejects_description_exceeding_length_cap() {
+        let ov = MetadataOverrides {
+            description: Some("x".repeat(MetadataOverrides::DESCRIPTION_MAX_LEN + 1)),
+            ..Default::default()
+        };
+        let err = ov
+            .validate()
+            .expect_err("over-length description should be rejected");
+        assert!(
+            err.contains("description"),
+            "message should name the field: {err}"
+        );
+        assert!(err.contains("50000"), "message should name the cap: {err}");
+    }
+
+    #[test]
+    fn validate_accepts_description_at_length_cap() {
+        // Boundary: exactly DESCRIPTION_MAX_LEN is allowed.
+        let ov = MetadataOverrides {
+            description: Some("x".repeat(MetadataOverrides::DESCRIPTION_MAX_LEN)),
+            ..Default::default()
+        };
+        assert_eq!(ov.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_rejects_series_name_exceeding_length_cap() {
+        let ov = MetadataOverrides {
+            series: Some("x".repeat(MetadataOverrides::NAME_MAX_LEN + 1)),
+            ..Default::default()
+        };
+        let err = ov
+            .validate()
+            .expect_err("over-length series should be rejected");
+        assert!(
+            err.contains("series"),
+            "message should name the field: {err}"
+        );
+        assert!(err.contains("250"), "message should name the cap: {err}");
+    }
+
+    #[test]
+    fn validate_measures_title_cap_in_chars_not_bytes() {
         // A 4-byte emoji is one Unicode scalar. Exactly the cap in chars must
         // pass even though it is 4× the cap in bytes.
-        let at_cap = "\u{1F600}".repeat(MetadataOverrides::MAX_SCALAR_CHARS);
-        assert_eq!(at_cap.chars().count(), MetadataOverrides::MAX_SCALAR_CHARS);
-        assert!(at_cap.len() > MetadataOverrides::MAX_SCALAR_CHARS);
+        let at_cap = "\u{1F600}".repeat(MetadataOverrides::TITLE_MAX_LEN);
+        assert_eq!(at_cap.chars().count(), MetadataOverrides::TITLE_MAX_LEN);
+        assert!(at_cap.len() > MetadataOverrides::TITLE_MAX_LEN);
         let ov = MetadataOverrides {
             title: Some(at_cap),
             ..Default::default()
@@ -878,7 +913,7 @@ mod metadata_overrides_tests {
 
         // cap + 1 chars must fail even though the same byte count of ASCII
         // would have been accepted.
-        let over_cap = "\u{1F600}".repeat(MetadataOverrides::MAX_SCALAR_CHARS + 1);
+        let over_cap = "\u{1F600}".repeat(MetadataOverrides::TITLE_MAX_LEN + 1);
         let ov = MetadataOverrides {
             title: Some(over_cap),
             ..Default::default()
@@ -893,15 +928,15 @@ mod metadata_overrides_tests {
     fn validate_measures_description_cap_in_chars_not_bytes() {
         // CJK characters are 3 bytes each in UTF-8. Exactly the description cap
         // in chars passes; cap + 1 fails — neither decided by byte length.
-        let at_cap = "\u{4E16}".repeat(MetadataOverrides::MAX_DESCRIPTION_CHARS);
-        assert!(at_cap.len() > MetadataOverrides::MAX_DESCRIPTION_CHARS);
+        let at_cap = "\u{4E16}".repeat(MetadataOverrides::DESCRIPTION_MAX_LEN);
+        assert!(at_cap.len() > MetadataOverrides::DESCRIPTION_MAX_LEN);
         let ov = MetadataOverrides {
             description: Some(at_cap),
             ..Default::default()
         };
         assert_eq!(ov.validate(), Ok(()));
 
-        let over_cap = "\u{4E16}".repeat(MetadataOverrides::MAX_DESCRIPTION_CHARS + 1);
+        let over_cap = "\u{4E16}".repeat(MetadataOverrides::DESCRIPTION_MAX_LEN + 1);
         let ov = MetadataOverrides {
             description: Some(over_cap),
             ..Default::default()
@@ -925,7 +960,7 @@ mod metadata_overrides_tests {
     fn validate_rejects_over_long_creator_name() {
         let ov = MetadataOverrides {
             creators: Some(vec![contributor(
-                &"x".repeat(MetadataOverrides::MAX_CREATOR_CHARS + 1),
+                &"x".repeat(MetadataOverrides::NAME_MAX_LEN + 1),
             )]),
             ..Default::default()
         };
@@ -933,6 +968,18 @@ mod metadata_overrides_tests {
             .validate()
             .expect_err("over-length creator name should be rejected");
         assert!(err.contains("creator name"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_over_long_tag() {
+        let ov = MetadataOverrides {
+            subjects: Some(vec!["x".repeat(MetadataOverrides::NAME_MAX_LEN + 1)]),
+            ..Default::default()
+        };
+        let err = ov
+            .validate()
+            .expect_err("over-length tag should be rejected");
+        assert!(err.contains("tag"), "message should name the field: {err}");
     }
 
     // --- merge() -----------------------------------------------------------

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -158,13 +158,11 @@ pub struct MetadataOverrides {
 }
 
 impl MetadataOverrides {
-    /// Maximum length (in Unicode scalar values, i.e. `chars`) for the `title`
-    /// field.
+    /// Maximum title length in Unicode scalar values (chars).
     pub const TITLE_MAX_LEN: usize = 500;
     /// Maximum length (in chars) for the `description` field.
     pub const DESCRIPTION_MAX_LEN: usize = 50_000;
-    /// Maximum length (in chars) for single-line name fields: `publisher`,
-    /// `published`, `language`, `series`, `series_index`, and creator names.
+    /// Maximum length in chars for single-line name fields: publisher, series, language, and creator names.
     pub const NAME_MAX_LEN: usize = 250;
     /// Maximum length (in chars) for a single tag (subject) string. Preserved
     /// from the pre-existing `MAX_SUBJECT_CHARS = 128` constant — tags are
@@ -209,6 +207,22 @@ impl MetadataOverrides {
                         "creator name exceeds {} characters",
                         Self::NAME_MAX_LEN
                     ));
+                }
+                if let Some(ref role) = c.role {
+                    if role.chars().count() > Self::NAME_MAX_LEN {
+                        return Err(format!(
+                            "creator role exceeds {} characters",
+                            Self::NAME_MAX_LEN
+                        ));
+                    }
+                }
+                if let Some(ref file_as) = c.file_as {
+                    if file_as.chars().count() > Self::NAME_MAX_LEN {
+                        return Err(format!(
+                            "creator file_as exceeds {} characters",
+                            Self::NAME_MAX_LEN
+                        ));
+                    }
                 }
             }
         }
@@ -973,6 +987,38 @@ mod metadata_overrides_tests {
             .validate()
             .expect_err("over-length creator name should be rejected");
         assert!(err.contains("creator name"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_over_long_creator_role() {
+        let ov = MetadataOverrides {
+            creators: Some(vec![Contributor {
+                name: "Ada Lovelace".into(),
+                role: Some("x".repeat(MetadataOverrides::NAME_MAX_LEN + 1)),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let err = ov
+            .validate()
+            .expect_err("over-length creator role should be rejected");
+        assert!(err.contains("creator role"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_over_long_creator_file_as() {
+        let ov = MetadataOverrides {
+            creators: Some(vec![Contributor {
+                name: "Ada Lovelace".into(),
+                file_as: Some("x".repeat(MetadataOverrides::NAME_MAX_LEN + 1)),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let err = ov
+            .validate()
+            .expect_err("over-length creator file_as should be rejected");
+        assert!(err.contains("creator file_as"), "unexpected message: {err}");
     }
 
     #[test]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -164,9 +164,14 @@ impl MetadataOverrides {
     /// Maximum length (in chars) for the `description` field.
     pub const DESCRIPTION_MAX_LEN: usize = 50_000;
     /// Maximum length (in chars) for single-line name fields: `publisher`,
-    /// `published`, `language`, `series`, `series_index`, creator names, and
-    /// tag strings.
+    /// `published`, `language`, `series`, `series_index`, and creator names.
     pub const NAME_MAX_LEN: usize = 250;
+    /// Maximum length (in chars) for a single tag (subject) string. Preserved
+    /// from the pre-existing `MAX_SUBJECT_CHARS = 128` constant — tags are
+    /// typically short controlled-vocabulary terms, so the tighter cap is
+    /// intentional. `NAME_MAX_LEN = 250` applies to author/series/publisher
+    /// names as specified in issue #294.
+    pub const TAG_MAX_LEN: usize = 128;
     /// Maximum number of tags (subjects).
     const MAX_SUBJECTS: usize = 64;
     /// Maximum number of creators.
@@ -212,8 +217,8 @@ impl MetadataOverrides {
                 return Err(format!("too many tags (max {})", Self::MAX_SUBJECTS));
             }
             for s in subjects {
-                if s.chars().count() > Self::NAME_MAX_LEN {
-                    return Err(format!("tag exceeds {} characters", Self::NAME_MAX_LEN));
+                if s.chars().count() > Self::TAG_MAX_LEN {
+                    return Err(format!("tag exceeds {} characters", Self::TAG_MAX_LEN));
                 }
             }
         }
@@ -972,14 +977,27 @@ mod metadata_overrides_tests {
 
     #[test]
     fn validate_rejects_over_long_tag() {
+        // TAG_MAX_LEN = 128 (restored from the pre-existing MAX_SUBJECT_CHARS cap).
+        // Over-limit boundary: 129 chars must be rejected.
         let ov = MetadataOverrides {
-            subjects: Some(vec!["x".repeat(MetadataOverrides::NAME_MAX_LEN + 1)]),
+            subjects: Some(vec!["x".repeat(MetadataOverrides::TAG_MAX_LEN + 1)]),
             ..Default::default()
         };
         let err = ov
             .validate()
             .expect_err("over-length tag should be rejected");
         assert!(err.contains("tag"), "message should name the field: {err}");
+        assert!(err.contains("128"), "message should name the cap: {err}");
+    }
+
+    #[test]
+    fn validate_accepts_tag_at_length_cap() {
+        // Boundary: exactly TAG_MAX_LEN (128) chars is allowed.
+        let ov = MetadataOverrides {
+            subjects: Some(vec!["x".repeat(MetadataOverrides::TAG_MAX_LEN)]),
+            ..Default::default()
+        };
+        assert_eq!(ov.validate(), Ok(()));
     }
 
     // --- merge() -----------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaced the single `MAX_SCALAR_CHARS = 4096` constant with three purpose-scoped public constants that match natural per-field budgets:
  - `MetadataOverrides::TITLE_MAX_LEN = 500` chars
  - `MetadataOverrides::DESCRIPTION_MAX_LEN = 50_000` chars
  - `MetadataOverrides::NAME_MAX_LEN = 250` chars (publisher, series, language, series_index, creator names)
  - `MetadataOverrides::TAG_MAX_LEN = 128` chars (tag/subject strings — see note below)
- Updated `validate()` in `shared/src/lib.rs` to use the new per-field constants
- Added a REST integration test in `server/src/backend/overrides.rs`: `api_post_overrides_rejects_over_length_title_with_400` — verifies that an over-limit title returns 400 and does not write an override row
- Updated all unit tests in `shared/src/lib.rs` to use the new constants and added boundary tests for description and series

## Why

The previous implementation had a single `MAX_SCALAR_CHARS = 4096` cap for every short field (title, publisher, etc.) and `MAX_DESCRIPTION_CHARS = 256 * 1024` for the description. While length validation was present, the limits were too permissive: a 4096-char title uses ~16 KB at 4 bytes/char, and a 262,144-char description uses ~1 MB — well above the safe per-field budgets described in the issue. The new values cap the worst case at ~2 KB for title and ~200 KB for description.

`validate()` is already called at both ingress points:
- `server/src/backend/overrides.rs` — REST endpoint (mobile client)
- `frontend/src/rpc.rs` — server function (web client)

No DB migration needed — SQLite TEXT columns remain unbounded; the cap is enforced purely at the application layer.

## Tag cap: pre-existing `MAX_SUBJECT_CHARS = 128` preserved as `TAG_MAX_LEN = 128`

An adversarial reviewer noted that an earlier revision of this PR silently loosened the tag cap from 128 → 250 by folding tags into `NAME_MAX_LEN`. The pre-existing `MAX_SUBJECT_CHARS = 128` has been preserved as `TAG_MAX_LEN = 128`. `NAME_MAX_LEN = 250` applies only to author/series/publisher names as specified in issue #294. Tags are typically short controlled-vocabulary terms, so the tighter cap is intentional.

## Tests added

- `validate_rejects_title_exceeding_length_cap` — updated to check the 500-char cap (was 4096)
- `validate_accepts_title_at_length_cap` — boundary at exactly 500 chars
- `validate_rejects_description_exceeding_length_cap` — new, checks 50,000-char cap
- `validate_accepts_description_at_length_cap` — new, boundary at exactly 50,000 chars
- `validate_rejects_series_name_exceeding_length_cap` — new, checks 250-char NAME_MAX_LEN
- `validate_measures_title_cap_in_chars_not_bytes` — updated (was `validate_measures_scalar_cap_in_chars_not_bytes`)
- `validate_rejects_over_long_tag` — tag strings checked against TAG_MAX_LEN=128; over-limit boundary is 129 chars
- `validate_accepts_tag_at_length_cap` — new, boundary at exactly 128 chars
- `api_post_overrides_rejects_over_length_title_with_400` — new REST integration test

## Pre-existing notes

None — all checks were green on main before branching. `cargo clippy --all-targets -- -D warnings` and `cargo test -p omnibus-db && cargo test -p omnibus` pass clean.

Closes #294

https://claude.ai/code/session_01PDc9MZzA951sCBXnL7LBF4