### PR TITLE
feat(landing): surface audiobooks alongside ebooks on the library page

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -27,8 +27,9 @@ mod tests;
 
 pub use get::{book_file_path, get_book, get_book_by_uuid, resolve_book_id_by_uuid};
 pub use list::{
-    count_books, library_from_db, library_from_db_with_total, list_books, list_indexed_rows,
-    list_indexed_rows_for_formats, IndexedRow,
+    count_books, count_books_for_paths, library_from_db, library_from_db_combined,
+    library_from_db_with_total, library_from_db_with_total_combined, list_books,
+    list_books_for_paths, list_indexed_rows, list_indexed_rows_for_formats, IndexedRow,
 };
 pub use projection::MAX_BOOKS_RETURNED;
 pub use search::{count_search_books, search_books, search_books_with_total};

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -13,15 +13,40 @@ use super::projection::{
     MAX_BOOKS_RETURNED,
 };
 
-/// Return every book indexed under `library_path`. One round-trip to SQLite:
-/// every multi-valued relation is pulled in a single statement using scalar
-/// subqueries (for single-valued joins) and `json_group_array` over ordered
-/// inner selects (for multi-valued lists), matching the pattern in `get_book`.
+/// Return every book indexed under `library_path`. Thin wrapper around
+/// [`list_books_for_paths`] kept for callers that only consult one library
+/// (ebook-only reindex paths, override tests).
 pub async fn list_books(
     pool: &SqlitePool,
     library_path: &str,
 ) -> Result<Vec<EbookMetadata>, sqlx::Error> {
-    let rows = sqlx::query(
+    list_books_for_paths(pool, &[library_path]).await
+}
+
+/// Return every book indexed under any of `library_paths`. One round-trip
+/// to SQLite: every multi-valued relation is pulled in a single statement
+/// using scalar subqueries (for single-valued joins) and `json_group_array`
+/// over ordered inner selects (for multi-valued lists), matching the
+/// pattern in `get_book`.
+///
+/// Empty `library_paths` returns an empty vec. The library filter uses
+/// `l.path IN (?, …)` so the unified landing path (ebook + audiobook)
+/// stays one query instead of two — `book_files.format` joins through
+/// unchanged, so per-format facet counts on the landing page still work.
+pub async fn list_books_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+) -> Result<Vec<EbookMetadata>, sqlx::Error> {
+    if library_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Inline placeholder list: `library_paths` is owned by the caller (at
+    // most two entries — ebook + audiobook), so there's no injection
+    // surface and a temp table would be heavier than the bind loop below.
+    let placeholders = std::iter::repeat_n("?", library_paths.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
         r#"
         SELECT b.id, b.uuid,
                b.title, b.description, b.series_index, b.has_cover,
@@ -81,15 +106,17 @@ pub async fn list_books(
                          ORDER BY format))                  AS formats_json
         FROM books b
         JOIN libraries l ON l.id = b.library_id
-        WHERE l.path = ?
+        WHERE l.path IN ({placeholders})
         ORDER BY b.sort, b.id
         LIMIT ?
-        "#,
-    )
-    .bind(library_path)
-    .bind(MAX_BOOKS_RETURNED)
-    .fetch_all(pool)
-    .await?;
+        "#
+    );
+    let mut q = sqlx::query(&sql);
+    for path in library_paths {
+        q = q.bind(*path);
+    }
+    q = q.bind(MAX_BOOKS_RETURNED);
+    let rows = q.fetch_all(pool).await?;
 
     let mut out = Vec::with_capacity(rows.len());
     for r in rows {
@@ -279,25 +306,42 @@ pub async fn list_indexed_rows_for_formats(
         .collect())
 }
 
-/// Total number of books currently indexed under `library_path`.
-///
-/// Companion to `list_books`: `list_books` caps the returned vec at
-/// `MAX_BOOKS_RETURNED`, so callers that need to surface a truncation
-/// hint (UI banner, `X-Total-Count` header) ask the count separately.
-/// Single scalar query — cheaper than re-running the full SELECT just
-/// to count rows.
+/// Total number of books currently indexed under `library_path`. Thin
+/// wrapper around [`count_books_for_paths`] for single-library callers.
 pub async fn count_books(pool: &SqlitePool, library_path: &str) -> Result<i64, sqlx::Error> {
-    sqlx::query_scalar::<_, i64>(
+    count_books_for_paths(pool, &[library_path]).await
+}
+
+/// Total number of books currently indexed under any of `library_paths`.
+///
+/// Companion to `list_books_for_paths`: `list_books_for_paths` caps the
+/// returned vec at `MAX_BOOKS_RETURNED`, so callers that need to surface a
+/// truncation hint (UI banner, `X-Total-Count` header) ask the count
+/// separately. Single scalar query — cheaper than re-running the full
+/// SELECT just to count rows.
+pub async fn count_books_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+) -> Result<i64, sqlx::Error> {
+    if library_paths.is_empty() {
+        return Ok(0);
+    }
+    let placeholders = std::iter::repeat_n("?", library_paths.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
         r#"
         SELECT COUNT(*)
           FROM books b
           JOIN libraries l ON l.id = b.library_id
-         WHERE l.path = ?
-        "#,
-    )
-    .bind(library_path)
-    .fetch_one(pool)
-    .await
+         WHERE l.path IN ({placeholders})
+        "#
+    );
+    let mut q = sqlx::query_scalar::<_, i64>(&sql);
+    for path in library_paths {
+        q = q.bind(*path);
+    }
+    q.fetch_one(pool).await
 }
 
 /// Build an `EbookLibrary` from whatever is currently in the DB for
@@ -313,16 +357,7 @@ pub async fn library_from_db(
     pool: &SqlitePool,
     library_path: Option<&str>,
 ) -> Result<EbookLibrary, sqlx::Error> {
-    let Some(path) = library_path else {
-        return Ok(EbookLibrary::default());
-    };
-    let books = list_books(pool, path).await?;
-    Ok(EbookLibrary {
-        path: Some(path.to_string()),
-        books,
-        error: None,
-        total: None,
-    })
+    library_from_db_combined(pool, library_path, None).await
 }
 
 /// Same as `library_from_db` but also returns the *true* book count under
@@ -333,18 +368,83 @@ pub async fn library_from_db_with_total(
     pool: &SqlitePool,
     library_path: Option<&str>,
 ) -> Result<(EbookLibrary, i64), sqlx::Error> {
-    let Some(path) = library_path else {
+    library_from_db_with_total_combined(pool, library_path, None).await
+}
+
+/// Build an `EbookLibrary` spanning the ebook and audiobook libraries
+/// together — both rows live in the same `books` table under different
+/// `library_id`s, so the unified landing grid is one query over the union.
+/// Either path may be `None` (no library configured for that format).
+///
+/// `EbookLibrary.path` reports the ebook path when set, otherwise the
+/// audiobook path; the landing page uses it to key per-library
+/// `view_prefs` and to render the subtitle, and treating ebooks as the
+/// "primary" key preserves prefs across an audiobook-path edit.
+pub async fn library_from_db_combined(
+    pool: &SqlitePool,
+    ebook_path: Option<&str>,
+    audiobook_path: Option<&str>,
+) -> Result<EbookLibrary, sqlx::Error> {
+    let paths = collect_paths(ebook_path, audiobook_path);
+    if paths.is_empty() {
+        return Ok(EbookLibrary::default());
+    }
+    let books = list_books_for_paths(pool, &paths).await?;
+    Ok(EbookLibrary {
+        path: Some(
+            ebook_path
+                .or(audiobook_path)
+                .unwrap_or_default()
+                .to_string(),
+        ),
+        books,
+        error: None,
+        total: None,
+    })
+}
+
+/// `library_from_db_combined` + the true total under the union (before the
+/// `MAX_BOOKS_RETURNED` cap), for the REST handler's `X-Total-Count` /
+/// `X-Total-Cap` headers.
+pub async fn library_from_db_with_total_combined(
+    pool: &SqlitePool,
+    ebook_path: Option<&str>,
+    audiobook_path: Option<&str>,
+) -> Result<(EbookLibrary, i64), sqlx::Error> {
+    let paths = collect_paths(ebook_path, audiobook_path);
+    if paths.is_empty() {
         return Ok((EbookLibrary::default(), 0));
-    };
-    let books = list_books(pool, path).await?;
-    let total = count_books(pool, path).await?;
+    }
+    let books = list_books_for_paths(pool, &paths).await?;
+    let total = count_books_for_paths(pool, &paths).await?;
     Ok((
         EbookLibrary {
-            path: Some(path.to_string()),
+            path: Some(
+                ebook_path
+                    .or(audiobook_path)
+                    .unwrap_or_default()
+                    .to_string(),
+            ),
             books,
             error: None,
             total: None,
         },
         total,
     ))
+}
+
+fn collect_paths<'a>(ebook: Option<&'a str>, audiobook: Option<&'a str>) -> Vec<&'a str> {
+    // De-dup when the user points both at the same on-disk root — the
+    // `IN` filter would still return one row per book, but the input
+    // shape stays consistent with the single-library calls.
+    let mut paths: Vec<&str> = Vec::with_capacity(2);
+    if let Some(p) = ebook {
+        paths.push(p);
+    }
+    if let Some(p) = audiobook {
+        if !paths.contains(&p) {
+            paths.push(p);
+        }
+    }
+    paths
 }

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -78,6 +78,121 @@ async fn library_from_db_with_total_reports_zero_for_none_path() {
     assert!(lib.books.is_empty());
     assert_eq!(total, 0);
 }
+
+#[tokio::test]
+async fn library_from_db_combined_returns_books_from_both_paths() {
+    let _covers = CoversTempDir::new("combined_landing");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/ebooks",
+        vec![indexed("a.epub", Some("Ebook A"), &[], &[], None, None)],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/audiobooks",
+        vec![
+            indexed("b.m4b", Some("Audio B"), &[], &[], None, None),
+            indexed("c.m4b", Some("Audio C"), &[], &[], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let lib = library_from_db_combined(&pool, Some("/ebooks"), Some("/audiobooks"))
+        .await
+        .unwrap();
+    let titles: Vec<_> = lib.books.iter().filter_map(|b| b.title.clone()).collect();
+    assert!(titles.contains(&"Ebook A".to_string()));
+    assert!(titles.contains(&"Audio B".to_string()));
+    assert!(titles.contains(&"Audio C".to_string()));
+    assert_eq!(lib.books.len(), 3);
+    assert_eq!(lib.path.as_deref(), Some("/ebooks"));
+}
+
+#[tokio::test]
+async fn library_from_db_combined_falls_back_to_audiobook_path_for_subtitle() {
+    let _covers = CoversTempDir::new("combined_audio_only");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/audiobooks",
+        vec![indexed("a.m4b", Some("Audio Only"), &[], &[], None, None)],
+    )
+    .await
+    .unwrap();
+
+    let lib = library_from_db_combined(&pool, None, Some("/audiobooks"))
+        .await
+        .unwrap();
+    assert_eq!(lib.books.len(), 1);
+    assert_eq!(lib.path.as_deref(), Some("/audiobooks"));
+}
+
+#[tokio::test]
+async fn library_from_db_combined_returns_empty_when_both_paths_none() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = library_from_db_combined(&pool, None, None).await.unwrap();
+    assert!(lib.path.is_none());
+    assert!(lib.books.is_empty());
+}
+
+#[tokio::test]
+async fn library_from_db_with_total_combined_counts_books_across_paths() {
+    let _covers = CoversTempDir::new("combined_total");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/ebooks",
+        vec![indexed("a.epub", Some("E1"), &[], &[], None, None)],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/audiobooks",
+        vec![
+            indexed("b.m4b", Some("A1"), &[], &[], None, None),
+            indexed("c.m4b", Some("A2"), &[], &[], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let (lib, total) =
+        library_from_db_with_total_combined(&pool, Some("/ebooks"), Some("/audiobooks"))
+            .await
+            .unwrap();
+    assert_eq!(lib.books.len(), 3);
+    assert_eq!(total, 3);
+}
+
+#[tokio::test]
+async fn library_from_db_combined_dedupes_shared_path() {
+    let _covers = CoversTempDir::new("combined_shared");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/shared",
+        vec![
+            indexed("a.epub", Some("Ebook"), &[], &[], None, None),
+            indexed("b.m4b", Some("Audio"), &[], &[], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Both paths point at the same on-disk root — `IN (?, ?)` with a
+    // duplicate would still return one row per book, but the helper
+    // dedupes so the input shape stays consistent with single-library
+    // callsites that rely on `library_paths.len()`.
+    let lib = library_from_db_combined(&pool, Some("/shared"), Some("/shared"))
+        .await
+        .unwrap();
+    assert_eq!(lib.books.len(), 2);
+}
 #[tokio::test]
 async fn search_books_finds_by_title_and_ranks_by_bm25() {
     let _covers = CoversTempDir::new("fts_title");

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -35,9 +35,11 @@ pub mod worker;
 // and mirrors how `db.rs` looked before the extraction.
 pub use author_photos_data::*;
 pub use books::{
-    book_file_path, count_books, count_search_books, get_book, get_book_by_uuid, library_from_db,
-    library_from_db_with_total, list_books, list_indexed_rows, list_indexed_rows_for_formats,
-    resolve_book_id_by_uuid, search_books, search_books_with_total, IndexedRow, MAX_BOOKS_RETURNED,
+    book_file_path, count_books, count_books_for_paths, count_search_books, get_book,
+    get_book_by_uuid, library_from_db, library_from_db_combined, library_from_db_with_total,
+    library_from_db_with_total_combined, list_books, list_books_for_paths, list_indexed_rows,
+    list_indexed_rows_for_formats, resolve_book_id_by_uuid, search_books, search_books_with_total,
+    IndexedRow, MAX_BOOKS_RETURNED,
 };
 pub use browse::*;
 pub use covers::{covers_dir, get_cover, get_last_modified_epoch};

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -207,6 +207,11 @@ pub async fn rpc_get_ebooks() -> Result<EbookLibrary> {
     // Served straight from the DB — the indexer is responsible for keeping
     // it up to date (startup + settings save triggers).
     //
+    // Unified landing: ebooks + audiobooks live in the same `books` table
+    // under different `library_id`s, so the unified grid is one query
+    // over the union. The format facet in `ViewFilters` does the per-format
+    // splitting on the client.
+    //
     // Issue #81: the underlying `list_books` query is capped at
     // `db::MAX_BOOKS_RETURNED` rows so a multi-thousand-book install
     // can't bandwidth-DoS itself on every poll. Dioxus server functions
@@ -214,7 +219,12 @@ pub async fn rpc_get_ebooks() -> Result<EbookLibrary> {
     // surface a "truncated" hint to the web client — the F1.3 spec
     // constrains the client-side sort/filter UX to ~10k books anyway,
     // which is well under the cap. Cursor pagination is the next step.
-    Ok(db::library_from_db(&pool.0, settings.ebook_library_path.as_deref()).await?)
+    Ok(db::library_from_db_combined(
+        &pool.0,
+        settings.ebook_library_path.as_deref(),
+        settings.audiobook_library_path.as_deref(),
+    )
+    .await?)
 }
 
 /// POST (not GET) for the same reason as `rpc_search`: Dioxus `#[get]`

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -20,7 +20,12 @@ pub(super) async fn get_ebooks(_user: AuthUser, State(state): State<AppState>) -
         Ok(s) => s,
         Err(error) => return internal("read settings", error),
     };
-    match db::library_from_db_with_total(&state.pool, settings.ebook_library_path.as_deref()).await
+    match db::library_from_db_with_total_combined(
+        &state.pool,
+        settings.ebook_library_path.as_deref(),
+        settings.audiobook_library_path.as_deref(),
+    )
+    .await
     {
         Ok((library, total)) => with_pagination_headers(Json(library).into_response(), total),
         Err(error) => internal("read books", error),


### PR DESCRIPTION
## Summary
- The landing page only ever queried `settings.ebook_library_path`, so books indexed under `audiobook_library_path` (correctly stored in the same `books` table under a different `library_id`) were invisible despite the indexer doing its job.
- Add `library_from_db_combined` / `library_from_db_with_total_combined`, which union both library paths in a single `WHERE l.path IN (?, ?)` query, and route `rpc_get_ebooks` (web) and `get_ebooks` (mobile REST) through them.
- `book_files.format` joins through unchanged, so the existing `ViewFilters.formats` facet on the landing page splits the unified grid back into ebooks / audiobooks on demand.
- `EbookLibrary.path` keeps reporting the ebook path when set (falls back to audiobook path otherwise) so the per-library `view_prefs` key and the header subtitle stay stable.

## Test plan
- [x] `cargo test -p omnibus-db -p omnibus` — full suite passes, including 5 new tests covering both-paths, audiobook-only fallback, both-None, total/count, and shared-path dedupe.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Live check against running dev server: `/api/rpc/ebooks` now returns 34 books (3 EPUB + 24 M4B + 7 MP3) where it previously returned 3.