### PR TITLE
docs: convert progress.rs banner to //! module doc (#354)

### DIFF
--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -1,12 +1,8 @@
-// ---------------------------------------------------------------------------
-// F2.1 Progress sync (REST — mobile client).
-//
-// One unified `/api/progress` endpoint accepts a discriminated payload
-// (`{ format: "epub", epub_cfi }` or `{ format: "audio", audio_position_seconds }`)
-// and fans out to per-format write paths inside `db::progress`. The same
-// authenticated handler serves the (future) audiobook player. Web uses the
-// `/api/rpc/progress*` server functions in `omnibus_frontend::rpc`.
-// ---------------------------------------------------------------------------
+//! Progress-sync REST handlers for the mobile client (`/api/progress*`).
+//!
+//! Accepts a discriminated `{ format: "epub" | "audio" }` payload and fans
+//! out to per-format write paths in `omnibus_db::progress`. Web clients use
+//! the `/api/rpc/progress*` server functions in `omnibus_frontend::rpc`.
 
 use axum::{
     extract::{Path, Query, State},


### PR DESCRIPTION
## Summary

Replace the `// ---` banner block at the top of `server/src/backend/progress.rs` with a proper `//!` module-level rustdoc, per the comments-and-docs rule in `.claude/rules/05-rust-style.md`. Same intent (mobile-facing progress sync endpoint, fans out to per-format paths in `omnibus_db::progress`), now in a form `cargo doc` will surface as the module description, and without roadmap-phase references that rot.

## Acceptance criteria

- [x] File opens with a `//!` module-doc block (≤5 lines, no H2 sections, no roadmap-phase references)
- [x] `// ---` banner removed
- [x] `cargo doc -p omnibus` produces a module-level doc string for this module

## Verification

- `cargo fmt --check -p omnibus` — clean
- `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- `cargo test -p omnibus` — 182 passed
- `cargo doc -p omnibus --no-deps` — generated (only pre-existing warnings in unrelated `server/src/auth/` files)

Closes #354

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJYP6ZVeQRY7rTKqrPWN2R)_