### PR TITLE
fix: make /authors alphabet strip clickable for letter jump (#361)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1087,6 +1087,12 @@ body.atrium,
   opacity: 0.35;
 }
 .idx-letter-on { color: var(--ink-0); opacity: 1; font-weight: 500; }
+a.idx-letter-on { cursor: pointer; }
+a.idx-letter-on:hover { background: var(--bg-2); }
+a.idx-letter-on:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .idx-letters-spacer { flex: 1; }
 .idx-letters-count { font-size: 11px; color: var(--ink-3); }
 

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -184,12 +184,15 @@ pub fn AuthorsIndexPage() -> Element {
                         for l in alphabet.iter() {
                             {
                                 let has = present_letters.contains(l);
+                                // `#` is not valid inside a URL fragment, so the
+                                // non-alpha bucket gets a textual slug instead.
+                                let frag = letter_frag(*l);
                                 if has {
                                     rsx! {
                                         a {
                                             class: "idx-letter idx-letter-on",
-                                            href: "#letter-{l}",
-                                            "data-testid": "authors-letter-{l}",
+                                            href: "#letter-{frag}",
+                                            "data-testid": "authors-letter-{frag}",
                                             "{l}"
                                         }
                                     }
@@ -222,7 +225,7 @@ pub fn AuthorsIndexPage() -> Element {
                     for (letter, group) in letters.iter() {
                         section {
                             key: "{letter}",
-                            id: "letter-{letter}",
+                            id: "letter-{letter_frag(*letter)}",
                             class: "idx-letter-section",
                             div { class: "idx-letter-rail",
                                 div { class: "idx-letter-rail-glyph", "{letter}" }
@@ -302,6 +305,17 @@ fn render_author_card(a: &AuthorSummary, server_url: &str) -> Element {
                 }
             }
         }
+    }
+}
+
+/// URL-fragment-safe slug for a letter glyph. `#` cannot appear inside a
+/// fragment identifier — it would be parsed as a second fragment — so the
+/// non-alpha bucket renders as `letter-hash` instead.
+fn letter_frag(c: char) -> String {
+    if c == '#' {
+        "hash".to_string()
+    } else {
+        c.to_string()
     }
 }
 

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -173,15 +173,30 @@ pub fn AuthorsIndexPage() -> Element {
                     }
                 }
 
-                // Letter jump strip
+                // Letter jump strip. Letters that have at least one author
+                // render as same-page anchors targeting the section's
+                // `id="letter-{L}"` below — clicking jumps via the browser's
+                // native fragment scroll, no JS required. Letters with no
+                // authors stay as plain spans so there's nothing to jump
+                // to.
                 if show_letters {
                     div { class: "idx-letters",
                         for l in alphabet.iter() {
                             {
                                 let has = present_letters.contains(l);
-                                let class = if has { "idx-letter idx-letter-on" } else { "idx-letter" };
-                                rsx! {
-                                    span { class: "{class}", "{l}" }
+                                if has {
+                                    rsx! {
+                                        a {
+                                            class: "idx-letter idx-letter-on",
+                                            href: "#letter-{l}",
+                                            "data-testid": "authors-letter-{l}",
+                                            "{l}"
+                                        }
+                                    }
+                                } else {
+                                    rsx! {
+                                        span { class: "idx-letter", "{l}" }
+                                    }
                                 }
                             }
                         }
@@ -207,6 +222,7 @@ pub fn AuthorsIndexPage() -> Element {
                     for (letter, group) in letters.iter() {
                         section {
                             key: "{letter}",
+                            id: "letter-{letter}",
                             class: "idx-letter-section",
                             div { class: "idx-letter-rail",
                                 div { class: "idx-letter-rail-glyph", "{letter}" }

--- a/ui_tests/playwright/tests/flows/browse_indices.spec.ts
+++ b/ui_tests/playwright/tests/flows/browse_indices.spec.ts
@@ -60,6 +60,27 @@ test("authors index filters by name", async ({ page }) => {
   }
 });
 
+test("authors index letter strip jumps to the matching section", async ({ page }) => {
+  await gotoReady(page, "/authors");
+
+  // Wait for the index to render so the letter strip has populated.
+  // Ada Lovelace is in the fixture set, so the surname-sort bucket "L"
+  // is guaranteed to be present.
+  await expect(page.getByTestId("author-card").first()).toBeVisible();
+
+  const letter = page.getByTestId("authors-letter-L");
+  await expect(letter).toBeVisible();
+  // Active letters render as same-page anchors so the browser scrolls
+  // natively to the matching section — no JS required.
+  await expect(letter).toHaveAttribute("href", "#letter-L");
+
+  await letter.click();
+
+  await expect(page).toHaveURL(/#letter-L$/);
+  const section = page.locator("#letter-L");
+  await expect(section).toBeInViewport();
+});
+
 test("authors index card navigates to the detail page", async ({ page }) => {
   await gotoReady(page, "/authors");
 


### PR DESCRIPTION
## Summary

The A–Z alphabet strip at the top of the `/authors` index looked clickable but rendered as inert `<span>` elements, so users had no way to jump to a section of the alphabetical sort.

- Active letters (those with at least one author) now render as same-page anchors `<a href="#letter-L">` so the browser handles the scroll natively — no JS required.
- Each letter section in the body grows an `id="letter-{letter}"` for the anchor target.
- Inactive letters stay as plain `<span>` elements so there's nothing to jump to.
- CSS adds a hover background and focus-visible outline on the active anchors for clickable affordance + keyboard a11y.

## Acceptance criteria

- [x] AC1: Letters are clickable.
- [x] AC2: Clicking a letter takes the user to that part of the alphabetical sort (browser-native fragment scroll).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus -p omnibus-shared -p omnibus-frontend --all-targets -- -D warnings` (clean)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` (clean)
- [x] `cargo test -p omnibus -p omnibus-shared` (182 + 31 passed)
- [x] `cargo test -p omnibus-frontend --features server` (108 passed)
- [x] Playwright spec added: `authors index letter strip jumps to the matching section` in `ui_tests/playwright/tests/flows/browse_indices.spec.ts` — asserts the "L" anchor's `href`, clicks it, and verifies the URL hash flips to `#letter-L` and the section is in viewport. Uses the existing `authors-letter-{L}` test id added to active anchors. Not executed here (worker env has no Chromium / dev server).

## Notes

- `nix develop` was not available in the worker sandbox; all `cargo` commands ran against the raw toolchain (Rust 1.94.1). Output paths match what the Nix shell would produce.
- Markup contract change: active letters in `.idx-letters` are now `<a>` elements with `data-testid="authors-letter-{L}"` instead of `<span>`. The `.atrium a` global reset (`color: inherit; text-decoration: none`) keeps visual styling identical.

Closes #361

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJYP6ZVeQRY7rTKqrPWN2R)_