### PR TITLE
fix: search palette hotkey survives route changes (#360)

### DIFF
--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -39,13 +39,10 @@ pub struct PaletteOpen(pub Signal<bool>);
 pub fn SearchPaletteHost() -> Element {
     let open = use_context::<PaletteOpen>();
 
-    // The global ⌘K / Ctrl+K listener is registered once at App scope
-    // (see `use_palette_global_shortcut`), not here. `SearchPaletteHost`
-    // is mounted by `TopNav`, which re-mounts on every route change — if
-    // we registered the listener here, each navigation would leak an
-    // extra `keydown` closure. With N listeners flipping the same signal,
-    // ⌘K toggles the open state N times per press and the palette only
-    // appears to react on the route where it was first mounted (#360).
+    // Hotkey lives at App scope (see `use_palette_global_shortcut`):
+    // `TopNav` re-mounts on every route, so registering here would leak
+    // a fresh listener per visit and flip the signal multiple times per
+    // press.
 
     rsx! {
         SpTriggerButton { open }

--- a/frontend/src/components/search_palette.rs
+++ b/frontend/src/components/search_palette.rs
@@ -39,10 +39,13 @@ pub struct PaletteOpen(pub Signal<bool>);
 pub fn SearchPaletteHost() -> Element {
     let open = use_context::<PaletteOpen>();
 
-    // Register global ⌘K / Ctrl+K listener here (always-mounted) so the
-    // shortcut can open the palette from the closed state.
-    #[cfg(feature = "web")]
-    use_global_shortcut(open);
+    // The global ⌘K / Ctrl+K listener is registered once at App scope
+    // (see `use_palette_global_shortcut`), not here. `SearchPaletteHost`
+    // is mounted by `TopNav`, which re-mounts on every route change — if
+    // we registered the listener here, each navigation would leak an
+    // extra `keydown` closure. With N listeners flipping the same signal,
+    // ⌘K toggles the open state N times per press and the palette only
+    // appears to react on the route where it was first mounted (#360).
 
     rsx! {
         SpTriggerButton { open }
@@ -760,13 +763,17 @@ fn focus_palette_input(_evt: &MountedEvent) {
 // ── Global ⌘K shortcut (web only) ───────────────────────────────
 
 /// Register a global `keydown` listener that toggles the palette on `⌘K`
-/// (Mac) or `Ctrl+K` (other platforms). Only compiled for the web target
-/// so SSR builds don't pull in `web_sys`.
+/// (Mac) or `Ctrl+K` (other platforms).
+///
+/// Must be called from a component that mounts **exactly once** for the
+/// app's lifetime (i.e. `App`), not from a component that re-mounts on
+/// route changes. `use_hook` only guarantees "once per component
+/// instance", so a re-mounting host would accumulate listeners — each
+/// press would then toggle the signal N times and effectively no-op on
+/// the second route onward.
 #[cfg(feature = "web")]
-fn use_global_shortcut(open: PaletteOpen) {
-    let mut open = open;
-    // use_hook runs exactly once per component instance (not on re-renders),
-    // so the closure is registered once and leaked once — no duplicate listeners.
+pub fn use_palette_global_shortcut() {
+    let mut open = use_context::<PaletteOpen>();
     use_hook(move || {
         use wasm_bindgen::prelude::*;
 
@@ -790,3 +797,8 @@ fn use_global_shortcut(open: PaletteOpen) {
         closure.forget();
     });
 }
+
+/// Non-web no-op so the App component can call this unconditionally on
+/// non-mobile targets (SSR + native) without dragging in `web_sys`.
+#[cfg(all(not(feature = "web"), not(feature = "mobile")))]
+pub fn use_palette_global_shortcut() {}

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -154,6 +154,15 @@ pub fn App() -> Element {
     #[cfg(not(feature = "mobile"))]
     use_context_provider(|| components::search_palette::PaletteOpen(Signal::new(false)));
 
+    // Register the global ⌘K / Ctrl+K palette shortcut at App scope so
+    // it survives route changes. `SearchPaletteHost` lives inside
+    // `TopNav`, which re-mounts on every navigation; registering the
+    // listener there accumulates one closure per visited route and each
+    // press then toggles the open signal N times — the hotkey appears
+    // dead on every screen except the first one visited (#360).
+    #[cfg(not(feature = "mobile"))]
+    components::search_palette::use_palette_global_shortcut();
+
     // Cached `/api/auth/me`. Provided unconditionally on non-mobile builds
     // so SSR can render the placeholder topbar without resolving anything;
     // the WASM hydration phase then runs the boot effect below to fill it

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -154,12 +154,8 @@ pub fn App() -> Element {
     #[cfg(not(feature = "mobile"))]
     use_context_provider(|| components::search_palette::PaletteOpen(Signal::new(false)));
 
-    // Register the global ⌘K / Ctrl+K palette shortcut at App scope so
-    // it survives route changes. `SearchPaletteHost` lives inside
-    // `TopNav`, which re-mounts on every navigation; registering the
-    // listener there accumulates one closure per visited route and each
-    // press then toggles the open signal N times — the hotkey appears
-    // dead on every screen except the first one visited (#360).
+    // App mounts once for the app's lifetime; registering the keydown
+    // listener here keeps a single closure alive across route changes.
     #[cfg(not(feature = "mobile"))]
     components::search_palette::use_palette_global_shortcut();
 

--- a/ui_tests/playwright/tests/flows/search-palette.spec.ts
+++ b/ui_tests/playwright/tests/flows/search-palette.spec.ts
@@ -30,14 +30,10 @@ test("palette opens on Cmd+K", async ({ page }) => {
   await expect(panel).toBeVisible();
 });
 
-// Regression for #360: the ⌘K listener used to be registered inside
-// `SearchPaletteHost`, which re-mounts on every route change. After the
-// first navigation each press toggled the open signal twice (old + new
-// listener), so the hotkey appeared dead everywhere except the landing
-// page. Drive an in-app SPA navigation (not a full reload — which would
-// mask the bug by re-running App from scratch) into each of the other
-// pages that ships the search trigger, then verify ⌘K still opens the
-// palette.
+// Regression: drive an in-app SPA navigation (not a full reload — which
+// would mask the bug by re-running App from scratch) into each of the
+// other pages that ship the search trigger, then verify ⌘K still opens
+// the palette.
 for (const route of ["/authors", "/series"]) {
   test(`palette opens on Cmd+K after navigating to ${route}`, async ({
     page,

--- a/ui_tests/playwright/tests/flows/search-palette.spec.ts
+++ b/ui_tests/playwright/tests/flows/search-palette.spec.ts
@@ -30,6 +30,32 @@ test("palette opens on Cmd+K", async ({ page }) => {
   await expect(panel).toBeVisible();
 });
 
+// Regression for #360: the ⌘K listener used to be registered inside
+// `SearchPaletteHost`, which re-mounts on every route change. After the
+// first navigation each press toggled the open signal twice (old + new
+// listener), so the hotkey appeared dead everywhere except the landing
+// page. Drive an in-app SPA navigation (not a full reload — which would
+// mask the bug by re-running App from scratch) into each of the other
+// pages that ships the search trigger, then verify ⌘K still opens the
+// palette.
+for (const route of ["/authors", "/series"]) {
+  test(`palette opens on Cmd+K after navigating to ${route}`, async ({
+    page,
+  }) => {
+    await gotoReady(page, "/");
+    // Click an in-app `<Link>` so the router transitions in-place.
+    const linkName = route === "/authors" ? "Authors" : "Series";
+    await page
+      .getByRole("navigation", { name: "Primary" })
+      .getByRole("link", { name: linkName })
+      .click();
+    await expect.poll(async () => new URL(page.url()).pathname).toBe(route);
+
+    await page.keyboard.press("Meta+k");
+    await expect(page.getByTestId("sp-panel")).toBeVisible();
+  });
+}
+
 test("palette closes on Escape", async ({ page }) => {
   await gotoReady(page, "/");
   await page.getByTestId("search-trigger").click();


### PR DESCRIPTION
## Summary

The `⌘K` / `Ctrl+K` hotkey only worked on the landing page because the global `keydown` listener was being registered inside `SearchPaletteHost::use_hook`. `SearchPaletteHost` is mounted by `TopNav`, which the router re-mounts on every navigation — each visited route leaked one extra `keydown` closure pointing at the same `PaletteOpen` signal, so each press toggled the open state N times and the palette only appeared to react on the route where the first listener had been registered.

Hoist registration into the `App` component (mounts exactly once for the app's lifetime), gated `not(feature = "mobile")` so SSR + WASM both wire it up. The web body is unchanged; the SSR build gets a no-op definition so it can compile without `web_sys`.

- `frontend/src/components/search_palette.rs` — drop the per-host registration, expose `use_palette_global_shortcut()` (web impl + non-web no-op).
- `frontend/src/lib.rs` — call `use_palette_global_shortcut()` from `App` under `not(feature = "mobile")`.
- `ui_tests/playwright/tests/flows/search-palette.spec.ts` — regression: drive an in-app SPA navigation into `/authors` and `/series` (the `gotoReady` full-load path would mask the bug by re-running `App` from scratch), then `Meta+k` and assert the panel is visible.

## Acceptance criteria

- [x] Library page (already worked).
- [x] Book details page — reached via SPA nav from any palette result; same code path as the regression test.
- [x] Search results page — same.
- [x] Authors page — covered by the new `/authors` regression test.
- [x] Series page — covered by the new `/series` regression test.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --no-deps -- -D warnings` (workspace default members)
- [x] `cargo clippy -p omnibus-frontend --features server --no-deps -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (108 passed)
- [x] `cargo check -p omnibus-frontend --features mobile --no-default-features`
- [ ] CI runs Playwright with the new regression spec.

Closes #360

https://claude.ai/code/session_01RJYP6ZVeQRY7rTKqrPWN2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJYP6ZVeQRY7rTKqrPWN2R)_