### PR TITLE
refactor(db): stop leaking sqlx::Error across module boundaries (#350)

### DIFF
--- a/db/src/author_photos/mod.rs
+++ b/db/src/author_photos/mod.rs
@@ -115,7 +115,7 @@ struct AuthorSearchHit {
 ///      leave the row absent so the next page view can retry. Otherwise a
 ///      single Open Library outage would permanently brick resolution for
 ///      that author until an admin cleared it.
-pub async fn resolve(pool: &SqlitePool, author_id: i64) -> Result<(), sqlx::Error> {
+pub async fn resolve(pool: &SqlitePool, author_id: i64) -> anyhow::Result<()> {
     resolve_with(pool, author_id, &OpenLibraryConfig::default()).await
 }
 
@@ -123,7 +123,7 @@ pub async fn resolve_with(
     pool: &SqlitePool,
     author_id: i64,
     config: &OpenLibraryConfig,
-) -> Result<(), sqlx::Error> {
+) -> anyhow::Result<()> {
     // Existing row wins. `'letter'` markers are sticky so we don't re-hit
     // Open Library for authors with no entry on every page view.
     if author_photo_status(pool, author_id).await?.is_some() {

--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -10,6 +10,16 @@ use sqlx::SqlitePool;
 
 use crate::metadata_overrides::rebuild_fts_for_book;
 
+/// Errors returned by the author-photos data layer. The single
+/// transparent `Db` variant honors the `02-error-handling` boundary rule
+/// (no raw `sqlx::Error` leaving the module) while keeping `?`
+/// propagation clean at the call sites.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthorPhotosDataError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Source-of-truth marker for a cached author photo row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthorPhotoSource {
@@ -112,7 +122,10 @@ pub async fn upsert_author_photo(
 
 /// Drop the cache row for an author so the next page view re-queues
 /// resolution. Used by admin DELETE.
-pub async fn delete_author_photo(pool: &SqlitePool, author_id: i64) -> Result<(), sqlx::Error> {
+pub async fn delete_author_photo(
+    pool: &SqlitePool,
+    author_id: i64,
+) -> Result<(), AuthorPhotosDataError> {
     sqlx::query("DELETE FROM author_photos WHERE author_id = ?")
         .bind(author_id)
         .execute(pool)
@@ -138,7 +151,10 @@ pub async fn delete_author_photo(pool: &SqlitePool, author_id: i64) -> Result<()
 /// [`crate::metadata_overrides::upsert_metadata_overrides`]: a stale FTS
 /// row is fixed on the next reindex, but a refresh failure must not undo
 /// the admin's intent.
-pub async fn delete_author(pool: &SqlitePool, author_id: i64) -> Result<u64, sqlx::Error> {
+pub async fn delete_author(
+    pool: &SqlitePool,
+    author_id: i64,
+) -> Result<u64, AuthorPhotosDataError> {
     let mut tx = pool.begin().await?;
 
     let Some(name): Option<String> = sqlx::query_scalar("SELECT name FROM authors WHERE id = ?")

--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -34,6 +34,17 @@ pub use list::{
 pub use projection::MAX_BOOKS_RETURNED;
 pub use search::{count_search_books, search_books, search_books_with_total};
 
+/// Errors returned by the book read paths (`get_book`, `count_books`).
+/// The single transparent `Db` variant honors the `02-error-handling`
+/// boundary rule (no raw `sqlx::Error` across the module boundary) while
+/// keeping `?` propagation clean at the call sites that still use sqlx
+/// internally.
+#[derive(Debug, thiserror::Error)]
+pub enum BooksError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 // `pub(crate)` re-exports for sibling `db/` modules (`discovery`, `palette`,
 // `metadata_overrides`) that referenced these items at `crate::books::…`
 // before the split.

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -28,7 +28,10 @@ use super::projection::{
 /// punctuation that a delimiter-based encoding would corrupt. The Rust side
 /// parses each blob with `serde_json`. Empty aggregates come back as `"[]"`,
 /// so the `Option<String>` path only fires when the column itself was NULL.
-pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata>, sqlx::Error> {
+pub async fn get_book(
+    pool: &SqlitePool,
+    id: i64,
+) -> Result<Option<EbookMetadata>, super::BooksError> {
     let row = sqlx::query(
         r#"
         SELECT
@@ -198,7 +201,7 @@ pub async fn get_book(pool: &SqlitePool, id: i64) -> Result<Option<EbookMetadata
 pub async fn get_book_by_uuid(
     pool: &SqlitePool,
     uuid: &str,
-) -> Result<Option<EbookMetadata>, sqlx::Error> {
+) -> Result<Option<EbookMetadata>, super::BooksError> {
     let Some(id) = resolve_book_id_by_uuid(pool, uuid).await? else {
         return Ok(None);
     };

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -308,8 +308,8 @@ pub async fn list_indexed_rows_for_formats(
 
 /// Total number of books currently indexed under `library_path`. Thin
 /// wrapper around [`count_books_for_paths`] for single-library callers.
-pub async fn count_books(pool: &SqlitePool, library_path: &str) -> Result<i64, sqlx::Error> {
-    count_books_for_paths(pool, &[library_path]).await
+pub async fn count_books(pool: &SqlitePool, library_path: &str) -> Result<i64, super::BooksError> {
+    Ok(count_books_for_paths(pool, &[library_path]).await?)
 }
 
 /// Total number of books currently indexed under any of `library_paths`.

--- a/db/src/hls.rs
+++ b/db/src/hls.rs
@@ -12,12 +12,11 @@ use std::path::PathBuf;
 
 use sqlx::SqlitePool;
 
-/// Errors returned by the HLS data-layer reads (`get_parts`). Kept tiny —
-/// the transparent `Db` variant honors the `02-error-handling` boundary
-/// rule (no raw `sqlx::Error` across the module boundary) while letting
-/// internal call sites keep `?` propagation. `transcode_book` still
-/// returns `anyhow::Result` because it spans ffmpeg + filesystem +
-/// timeouts (foreign-system failure space).
+/// Errors returned by `get_parts`. Other public functions in this module
+/// still return `sqlx::Error` directly (`resolve_audiobook`) or
+/// `anyhow::Result` (`transcode_book`, where ffmpeg + filesystem +
+/// timeouts dominate the failure space); widening the boundary cleanup
+/// is tracked separately.
 #[derive(Debug, thiserror::Error)]
 pub enum HlsError {
     #[error(transparent)]

--- a/db/src/hls.rs
+++ b/db/src/hls.rs
@@ -12,6 +12,18 @@ use std::path::PathBuf;
 
 use sqlx::SqlitePool;
 
+/// Errors returned by the HLS data-layer reads (`get_parts`). Kept tiny —
+/// the transparent `Db` variant honors the `02-error-handling` boundary
+/// rule (no raw `sqlx::Error` across the module boundary) while letting
+/// internal call sites keep `?` propagation. `transcode_book` still
+/// returns `anyhow::Result` because it spans ffmpeg + filesystem +
+/// timeouts (foreign-system failure space).
+#[derive(Debug, thiserror::Error)]
+pub enum HlsError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// The only HLS audio profile shipped today. Future: add `"audio128"` for
 /// music audiobooks that warrant higher fidelity.
 pub const AUDIO64: &str = "audio64";
@@ -146,7 +158,7 @@ pub async fn resolve_audiobook(
 }
 
 /// Fetch ordered `book_file_parts` for `book_file_id`.
-pub async fn get_parts(pool: &SqlitePool, book_file_id: i64) -> Result<Vec<HlsPart>, sqlx::Error> {
+pub async fn get_parts(pool: &SqlitePool, book_file_id: i64) -> Result<Vec<HlsPart>, HlsError> {
     let rows = sqlx::query_as::<_, (i64, String, f64)>(
         "SELECT ordinal, filename, duration_seconds \
          FROM book_file_parts \

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -40,6 +40,18 @@ use sqlx::SqlitePool;
 
 use crate::{audiobook, books, ebook, sync};
 
+/// Errors returned by the pure-DB indexer reads (`is_stale`). The
+/// transparent `Db` variant honors the `02-error-handling` boundary rule
+/// — no raw `sqlx::Error` across the module boundary — while keeping the
+/// `?` propagation clean. `reindex` and `reindex_audiobooks` stay on
+/// `anyhow::Result` because they span filesystem scans + parsing
+/// (foreign-system failure space).
+#[derive(Debug, thiserror::Error)]
+pub enum IndexerError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Reindex if the last successful index is older than this. One hour is a
 /// compromise between responsiveness to on-disk changes and avoiding
 /// thrashing the disk for users who leave the app open all day.
@@ -65,7 +77,7 @@ pub const REFRESH_AFTER_SECS: i64 = 60 * 60;
 /// factored into the pure [`is_stale_decision`] so the window boundaries
 /// and this clock-failure fallback (`now == last`) are pinned by the
 /// `is_stale_decision_*` tests below; change it only with intent.
-pub async fn is_stale(pool: &SqlitePool, library_path: &str) -> Result<bool, sqlx::Error> {
+pub async fn is_stale(pool: &SqlitePool, library_path: &str) -> Result<bool, IndexerError> {
     let Some(last) = crate::settings::last_indexed_at(pool, library_path).await? else {
         return Ok(true);
     };

--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -8,6 +8,24 @@ use sqlx::{Executor, SqlitePool};
 
 use omnibus_shared::{EbookMetadata, MetadataOverrides};
 
+/// Errors returned by the metadata-overrides data layer. The single
+/// transparent `Db` variant honors the `02-error-handling` boundary rule
+/// — `sqlx::Error` does not cross the module boundary — while keeping
+/// `?` propagation clean at the call sites.
+#[derive(Debug, thiserror::Error)]
+pub enum MetadataOverridesError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
+impl From<crate::books::BooksError> for MetadataOverridesError {
+    fn from(e: crate::books::BooksError) -> Self {
+        match e {
+            crate::books::BooksError::Db(inner) => MetadataOverridesError::Db(inner),
+        }
+    }
+}
+
 /// Execute the `metadata_overrides` INSERT…ON CONFLICT against any executor —
 /// a `&SqlitePool` for the fire-and-forget [`upsert_metadata_overrides`] path,
 /// or a transaction connection for the serialized [`merge_metadata_overrides`]
@@ -162,11 +180,14 @@ pub async fn delete_metadata_overrides(
 
 /// Look up the UUID for a given `books.id`. Used by the override-save
 /// endpoints to bridge the id-based API with the uuid-keyed overrides table.
-pub async fn get_book_uuid(pool: &SqlitePool, book_id: i64) -> Result<Option<String>, sqlx::Error> {
-    sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
+pub async fn get_book_uuid(
+    pool: &SqlitePool,
+    book_id: i64,
+) -> Result<Option<String>, MetadataOverridesError> {
+    Ok(sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
         .bind(book_id)
         .fetch_optional(pool)
-        .await
+        .await?)
 }
 
 /// Bulk-load overrides for a set of UUIDs. Returns a map from UUID to
@@ -269,7 +290,7 @@ pub(crate) fn apply_overrides(
 pub(crate) async fn rebuild_fts_for_book(
     pool: &SqlitePool,
     book_uuid: &str,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), MetadataOverridesError> {
     let Some(book_id) = sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
         .bind(book_uuid)
         .fetch_optional(pool)

--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -8,10 +8,9 @@ use sqlx::{Executor, SqlitePool};
 
 use omnibus_shared::{EbookMetadata, MetadataOverrides};
 
-/// Errors returned by the metadata-overrides data layer. The single
-/// transparent `Db` variant honors the `02-error-handling` boundary rule
-/// — `sqlx::Error` does not cross the module boundary — while keeping
-/// `?` propagation clean at the call sites.
+/// Errors returned by `get_book_uuid` and `rebuild_fts_for_book`. Other
+/// public functions in this module still return `sqlx::Error` directly —
+/// widening that is tracked separately.
 #[derive(Debug, thiserror::Error)]
 pub enum MetadataOverridesError {
     #[error(transparent)]

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -16,10 +16,9 @@ pub use omnibus_shared::Settings;
 const EBOOK_LIBRARY_PATH_KEY: &str = "ebook_library_path";
 const AUDIOBOOK_LIBRARY_PATH_KEY: &str = "audiobook_library_path";
 
-/// Errors returned by the settings KV layer. The single transparent `Db`
-/// variant honors the `02-error-handling` boundary rule (no raw
-/// `sqlx::Error` leaking across the module boundary) while keeping `?`
-/// propagation clean for the internal call paths.
+/// Errors returned by `get_settings`, `set_settings`, and
+/// `seed_settings_from_env`. Other public functions in this module still
+/// return `sqlx::Error` directly — widening that is tracked separately.
 #[derive(Debug, thiserror::Error)]
 pub enum SettingsError {
     #[error(transparent)]

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -16,10 +16,20 @@ pub use omnibus_shared::Settings;
 const EBOOK_LIBRARY_PATH_KEY: &str = "ebook_library_path";
 const AUDIOBOOK_LIBRARY_PATH_KEY: &str = "audiobook_library_path";
 
+/// Errors returned by the settings KV layer. The single transparent `Db`
+/// variant honors the `02-error-handling` boundary rule (no raw
+/// `sqlx::Error` leaking across the module boundary) while keeping `?`
+/// propagation clean for the internal call paths.
+#[derive(Debug, thiserror::Error)]
+pub enum SettingsError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Read the ebook and audiobook library paths from the `settings` KV table.
 /// Missing keys map to `None` rather than an error — the first-run UI relies
 /// on this to detect an unconfigured server.
-pub async fn get_settings(pool: &SqlitePool) -> Result<Settings, sqlx::Error> {
+pub async fn get_settings(pool: &SqlitePool) -> Result<Settings, SettingsError> {
     let ebook_library_path =
         sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
             .bind(EBOOK_LIBRARY_PATH_KEY)
@@ -42,7 +52,7 @@ pub async fn get_settings(pool: &SqlitePool) -> Result<Settings, sqlx::Error> {
 /// the matching cover files from disk *after* commit so filesystem
 /// side-effects don't run inside the DB transaction. Callers should kick
 /// off a reindex afterwards — this function does not touch the indexer.
-pub async fn set_settings(pool: &SqlitePool, settings: &Settings) -> Result<(), sqlx::Error> {
+pub async fn set_settings(pool: &SqlitePool, settings: &Settings) -> Result<(), SettingsError> {
     let mut tx = pool.begin().await?;
     upsert_or_clear(
         &mut tx,
@@ -183,7 +193,7 @@ async fn upsert_or_clear(
 /// unset, so production deployments that configure libraries through the
 /// UI are unaffected. Delegates writes through [`set_settings`], so
 /// orphan-cleanup runs the same way as a user-initiated save.
-pub async fn seed_settings_from_env(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+pub async fn seed_settings_from_env(pool: &SqlitePool) -> Result<(), SettingsError> {
     let ebook_library_path = std::env::var("EBOOK_LIBRARY_PATH").ok();
     let audiobook_library_path = std::env::var("AUDIOBOOK_LIBRARY_PATH").ok();
     if ebook_library_path.is_some() || audiobook_library_path.is_some() {


### PR DESCRIPTION
## Summary

Closes #350.

Eleven `pub fn`s in `omnibus_db` still returned `Result<_, sqlx::Error>` directly, violating the `02-error-handling.md` boundary rule (no raw `sqlx::Error` across module boundaries). Each touched module now exposes a typed error enum with `#[error(transparent)] #[from] sqlx::Error`, or — for `author_photos::resolve`, which spans both DB and outbound HTTP — switches to `anyhow::Result`.

## Modules touched

| File | New / reused type | Functions migrated |
|---|---|---|
| `db/src/settings.rs` | new `SettingsError` | `get_settings`, `set_settings`, `seed_settings_from_env` |
| `db/src/metadata_overrides.rs` | new `MetadataOverridesError` (+ `From<BooksError>` bridge) | `get_book_uuid` (plus `pub(crate) rebuild_fts_for_book` migrated so the in-body `get_book` `?` propagation still type-checks) |
| `db/src/author_photos_data.rs` | new `AuthorPhotosDataError` | `delete_author_photo`, `delete_author` |
| `db/src/author_photos/mod.rs` | `anyhow::Result` | `resolve` (+ test-only `resolve_with`) |
| `db/src/hls.rs` | new `HlsError` | `get_parts` |
| `db/src/indexer.rs` | new `IndexerError` | `is_stale` |
| `db/src/books/get.rs` + `db/src/books.rs` | new module-level `BooksError` | `get_book`; `get_book_by_uuid` migrated transitively (it's a one-line delegate) |
| `db/src/books/list.rs` | reuse `BooksError` | `count_books` |

`?` propagation works at every existing call site:
- Each new enum carries `#[error(transparent)] #[from] sqlx::Error`, so module-internal sqlx queries keep using `?`.
- `frontend/src/rpc.rs` server functions return `ServerFnError`, which accepts anything `Display + Send + Sync` (already exercised by the existing `anyhow`-returning helpers).
- `/api/*` handlers in `server/src/backend/*.rs` forward errors through the existing `internal()` helper, which is generic over `Display`.
- `db/src/worker/handlers.rs` already calls `.to_string()` on every task error, so the switch to `anyhow::Result` in `author_photos::resolve` is a no-op there.

## Scope note

Per the worker runbook ("stay in scope: only the cited functions. Don't refactor adjacent code") I converted exactly the 11 functions named in the issue. Other `pub fn`s in the same files (e.g. `last_indexed_at`, `book_file_path`, `list_books`, `get_metadata_overrides`, `resolve_audiobook`, etc.) still return `sqlx::Error` and remain a follow-up. The issue's AC bullet `No pub fn in the listed files returns Result<_, sqlx::Error>` is interpreted here as the cited 11 — happy to widen scope in a sibling PR if preferred.

## Acceptance criteria

- [x] No cited `pub fn` returns `Result<_, sqlx::Error>` directly.
- [x] Each module exposes a typed error enum with `#[error(transparent)] #[from] sqlx::Error` (or switches to `anyhow` per the network-touching guidance).
- [x] All call sites in `server/` and `frontend/` still compile with `?`.
- [x] `cargo test -p omnibus-db` — 425 passed.
- [x] `cargo test -p omnibus` — 182 passed.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean on default features; the `--all-features` failure is the pre-existing `web`+`mobile` mutual-exclusion `compile_error!` in `frontend/src/components/mod.rs`, unrelated to this PR)
- [x] `cargo test -p omnibus-db`
- [x] `cargo test -p omnibus`

Closes #350

https://claude.ai/code/session_01RJYP6ZVeQRY7rTKqrPWN2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJYP6ZVeQRY7rTKqrPWN2R)_