### PR TITLE
fix: include audiobook authors and series in browse indexes

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -27,7 +27,7 @@ mod tests;
 
 pub use get::{book_file_path, get_book, get_book_by_uuid, resolve_book_id_by_uuid};
 pub use list::{
-    count_books, count_books_for_paths, library_from_db, library_from_db_combined,
+    collect_paths, count_books, count_books_for_paths, library_from_db, library_from_db_combined,
     library_from_db_with_total, library_from_db_with_total_combined, list_books,
     list_books_for_paths, list_indexed_rows, list_indexed_rows_for_formats, IndexedRow,
 };

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -433,7 +433,7 @@ pub async fn library_from_db_with_total_combined(
     ))
 }
 
-fn collect_paths<'a>(ebook: Option<&'a str>, audiobook: Option<&'a str>) -> Vec<&'a str> {
+pub fn collect_paths<'a>(ebook: Option<&'a str>, audiobook: Option<&'a str>) -> Vec<&'a str> {
     // De-dup when the user points both at the same on-disk root — the
     // `IN` filter would still return one row per book, but the input
     // shape stays consistent with the single-library calls.

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -433,6 +433,7 @@ pub async fn library_from_db_with_total_combined(
     ))
 }
 
+/// Merge ebook + audiobook library paths into a de-duplicated list.
 pub fn collect_paths<'a>(ebook: Option<&'a str>, audiobook: Option<&'a str>) -> Vec<&'a str> {
     // De-dup when the user points both at the same on-disk root — the
     // `IN` filter would still return one row per book, but the input

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -1206,8 +1206,7 @@ async fn get_book_backfills_creator_ids_case_insensitively() {
 #[tokio::test]
 async fn get_book_leaves_creator_id_none_when_override_author_unknown() {
     // If the override sets an author name that doesn't exist in the
-    // `authors` table, backfill must leave the id None — same shape
-    // as get_book_leaves_series_id_none_when_override_series_unknown.
+    // `authors` table, backfill must leave the id None.
     let (pool, _guard) = seed_discovery_fixture().await;
     let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
         .await
@@ -1301,10 +1300,10 @@ async fn get_book_backfills_series_id_from_override_when_series_exists() {
     );
 }
 #[tokio::test]
-async fn get_book_leaves_series_id_none_when_override_series_unknown() {
-    // If the override sets a series name that no other book uses, the
-    // series table won't have a row to point at — backfill must
-    // leave series_id None rather than fabricating one.
+async fn get_book_populates_series_id_when_override_creates_series() {
+    // When an override sets a series name, `upsert_metadata_overrides`
+    // materializes the `series` row + `books_series_link` so the
+    // detail-page breadcrumb is clickable and `/series` lists it.
     let _covers = CoversTempDir::new("override_series_unknown");
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
@@ -1345,7 +1344,10 @@ async fn get_book_leaves_series_id_none_when_override_series_unknown() {
         merged.series.as_deref(),
         Some("A Series That Does Not Yet Exist")
     );
-    assert_eq!(merged.series_id, None);
+    assert!(
+        merged.series_id.is_some(),
+        "override should materialize series row so breadcrumb is clickable"
+    );
 }
 #[tokio::test]
 async fn list_books_merges_overrides_in_bulk() {

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -13,6 +13,13 @@ use omnibus_shared::{AuthorSummary, SeriesSummary};
 /// while leaving headroom past a 5k+ author library.
 const INDEX_LIMIT: i64 = 10_000;
 
+/// Build a `VALUES (?)` list for a CTE that materializes the library-path
+/// set once. At most two entries (ebook + audiobook), so the bind count
+/// stays trivial.
+fn placeholders(n: usize) -> String {
+    std::iter::repeat_n("(?)", n).collect::<Vec<_>>().join(", ")
+}
+
 /// Return every author with their book count and an optional cover-derived
 /// accent, scoped to `library_path`, ordered by name ascending and capped
 /// at [`INDEX_LIMIT`]. Empty list when `library_path` doesn't match a
@@ -25,32 +32,21 @@ const INDEX_LIMIT: i64 = 10_000;
 /// to books accessible to that user.
 pub async fn list_authors(
     pool: &SqlitePool,
-    library_path: &str,
+    library_paths: &[&str],
 ) -> Result<Vec<AuthorSummary>, sqlx::Error> {
-    // TODO: scope by `user_id` once per-user ACLs land.
-    //
-    // F5.1: count uses the effective (override-aware) creator set, not
-    // the raw `books_authors_link` rows — otherwise an author whose books
-    // were all reassigned through the metadata edit form keeps reporting
-    // the canonical count even though `/authors/:id` (override-aware
-    // since #153) shows the corrected list. Visibility still requires
-    // at least one canonical link in this library so we don't list
-    // authors that exist only inside override JSON — they'd have no
-    // navigable `authors.id`. The accent subquery is unchanged: accent
-    // comes from `books.accent_color` (cover-derived), which overrides
-    // can replace via `override_covers/<uuid>` materialisation but never
-    // by JSON edit, so the canonical-link lookup is still correct.
-    //
-    // Same shape as the palette author query (`search_palette`'s B
-    // block) so the two index surfaces report consistent counts.
-    let rows = sqlx::query(
+    if library_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ph = placeholders(library_paths.len());
+    let sql = format!(
         r#"
+        WITH lib_paths(p) AS (VALUES {ph})
         SELECT a.id, a.name, a.sort,
                (SELECT COUNT(*)
                   FROM books b
                   JOIN libraries l2 ON l2.id = b.library_id
                   LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-                 WHERE l2.path = ?1
+                 WHERE l2.path IN (SELECT p FROM lib_paths)
                    AND CASE
                          WHEN mo.book_uuid IS NOT NULL
                               AND json_type(mo.overrides, '$.creators') IS NOT NULL
@@ -69,7 +65,7 @@ pub async fn list_authors(
                   JOIN books b2 ON b2.id = bal2.book
                   JOIN libraries l2 ON l2.id = b2.library_id
                  WHERE bal2.author = a.id
-                   AND l2.path = ?1
+                   AND l2.path IN (SELECT p FROM lib_paths)
                    AND b2.accent_color IS NOT NULL
                  ORDER BY b2.sort, b2.id
                  LIMIT 1) AS accent,
@@ -84,16 +80,19 @@ pub async fn list_authors(
             SELECT 1 FROM books_authors_link bal
               JOIN books b ON b.id = bal.book
               JOIN libraries l ON l.id = b.library_id
-             WHERE bal.author = a.id AND l.path = ?1
+             WHERE bal.author = a.id
+               AND l.path IN (SELECT p FROM lib_paths)
           )
         ORDER BY COALESCE(a.sort, a.name) COLLATE NOCASE ASC
-        LIMIT ?2
-        "#,
-    )
-    .bind(library_path)
-    .bind(INDEX_LIMIT)
-    .fetch_all(pool)
-    .await?;
+        LIMIT ?
+        "#
+    );
+    let mut q = sqlx::query(&sql);
+    for path in library_paths {
+        q = q.bind(*path);
+    }
+    q = q.bind(INDEX_LIMIT);
+    let rows = q.fetch_all(pool).await?;
 
     Ok(rows
         .iter()
@@ -120,28 +119,21 @@ pub async fn list_authors(
 /// to books accessible to that user.
 pub async fn list_series(
     pool: &SqlitePool,
-    library_path: &str,
+    library_paths: &[&str],
 ) -> Result<Vec<SeriesSummary>, sqlx::Error> {
-    // TODO: scope by `user_id` once per-user ACLs land.
-    //
-    // F5.1: same overlay shape as `list_authors` and the palette series
-    // query. `overrides.series` (string) drives membership for `book_count`;
-    // `overrides.creators[0].name` drives `primary_author` when present so
-    // the by-line on the card matches what `/series/:id` (#153 + the
-    // empty-index follow-up) shows. Visibility still requires at least one
-    // canonical `books_series_link` row in this library — series that
-    // exist only as a string inside override JSON have no `series.id` to
-    // route to. Accent comes from cover-derived `books.accent_color`,
-    // which JSON overrides can't change, so the canonical-link lookup is
-    // still correct.
-    let rows = sqlx::query(
+    if library_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ph = placeholders(library_paths.len());
+    let sql = format!(
         r#"
+        WITH lib_paths(p) AS (VALUES {ph})
         SELECT s.id, s.name, s.sort,
                (SELECT COUNT(*)
                   FROM books b
                   JOIN libraries l2 ON l2.id = b.library_id
                   LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-                 WHERE l2.path = ?1
+                 WHERE l2.path IN (SELECT p FROM lib_paths)
                    AND CASE
                          WHEN mo.book_uuid IS NOT NULL
                               AND json_type(mo.overrides, '$.series') IS NOT NULL
@@ -166,7 +158,8 @@ pub async fn list_series(
                   JOIN books b2 ON b2.id = bsl2.book
                   JOIN libraries l2 ON l2.id = b2.library_id
                   LEFT JOIN metadata_overrides mo2 ON mo2.book_uuid = b2.uuid
-                 WHERE bsl2.series = s.id AND l2.path = ?1
+                 WHERE bsl2.series = s.id
+                   AND l2.path IN (SELECT p FROM lib_paths)
                  ORDER BY b2.series_index NULLS LAST, b2.sort, b2.id
                  LIMIT 1) AS primary_author,
                (SELECT b3.accent_color
@@ -174,7 +167,7 @@ pub async fn list_series(
                   JOIN books b3 ON b3.id = bsl3.book
                   JOIN libraries l3 ON l3.id = b3.library_id
                  WHERE bsl3.series = s.id
-                   AND l3.path = ?1
+                   AND l3.path IN (SELECT p FROM lib_paths)
                    AND b3.accent_color IS NOT NULL
                  ORDER BY b3.series_index NULLS LAST, b3.sort, b3.id
                  LIMIT 1) AS accent
@@ -183,16 +176,19 @@ pub async fn list_series(
             SELECT 1 FROM books_series_link bsl
               JOIN books b ON b.id = bsl.book
               JOIN libraries l ON l.id = b.library_id
-             WHERE bsl.series = s.id AND l.path = ?1
+             WHERE bsl.series = s.id
+               AND l.path IN (SELECT p FROM lib_paths)
           )
         ORDER BY COALESCE(s.sort, s.name) COLLATE NOCASE ASC
-        LIMIT ?2
-        "#,
-    )
-    .bind(library_path)
-    .bind(INDEX_LIMIT)
-    .fetch_all(pool)
-    .await?;
+        LIMIT ?
+        "#
+    );
+    let mut q = sqlx::query(&sql);
+    for path in library_paths {
+        q = q.bind(*path);
+    }
+    q = q.bind(INDEX_LIMIT);
+    let rows = q.fetch_all(pool).await?;
 
     Ok(rows
         .iter()
@@ -223,7 +219,7 @@ mod tests {
     #[tokio::test]
     async fn list_authors_returns_all_with_counts_and_alpha_order() {
         let (pool, _guard) = seed_discovery_fixture().await;
-        let authors = list_authors(&pool, "/lib").await.unwrap();
+        let authors = list_authors(&pool, &["/lib"]).await.unwrap();
 
         // Three distinct authors: Ada Lovelace, Grace Hopper, Niklaus Wirth.
         let names: Vec<_> = authors.iter().map(|a| a.name.clone()).collect();
@@ -252,7 +248,7 @@ mod tests {
     #[tokio::test]
     async fn list_authors_scopes_to_library_path() {
         let (pool, _guard) = seed_discovery_fixture().await;
-        let authors = list_authors(&pool, "/no-such-library").await.unwrap();
+        let authors = list_authors(&pool, &["/no-such-library"]).await.unwrap();
         assert!(
             authors.is_empty(),
             "unknown library path must yield empty list"
@@ -262,13 +258,13 @@ mod tests {
     async fn list_authors_returns_empty_for_empty_library() {
         let _guard = CoversTempDir::new("empty_authors");
         let pool = init_db("sqlite::memory:").await.unwrap();
-        let authors = list_authors(&pool, "/lib").await.unwrap();
+        let authors = list_authors(&pool, &["/lib"]).await.unwrap();
         assert!(authors.is_empty());
     }
     #[tokio::test]
     async fn list_series_returns_all_with_counts_and_alpha_order() {
         let (pool, _guard) = seed_discovery_fixture().await;
-        let series = list_series(&pool, "/lib").await.unwrap();
+        let series = list_series(&pool, &["/lib"]).await.unwrap();
 
         // Two series: Pioneers, Saga (NOCASE alpha).
         let names: Vec<_> = series.iter().map(|s| s.name.clone()).collect();
@@ -284,7 +280,7 @@ mod tests {
     #[tokio::test]
     async fn list_series_populates_primary_author_from_first_book() {
         let (pool, _guard) = seed_discovery_fixture().await;
-        let series = list_series(&pool, "/lib").await.unwrap();
+        let series = list_series(&pool, &["/lib"]).await.unwrap();
 
         let by_name: std::collections::HashMap<_, _> = series
             .iter()
@@ -298,7 +294,7 @@ mod tests {
     #[tokio::test]
     async fn list_series_scopes_to_library_path() {
         let (pool, _guard) = seed_discovery_fixture().await;
-        let series = list_series(&pool, "/no-such-library").await.unwrap();
+        let series = list_series(&pool, &["/no-such-library"]).await.unwrap();
         assert!(series.is_empty());
     }
     // F5.1 — index-page counts must follow the same override overlay
@@ -335,7 +331,7 @@ mod tests {
             .await
             .unwrap();
 
-        let authors = list_authors(&pool, "/lib").await.unwrap();
+        let authors = list_authors(&pool, &["/lib"]).await.unwrap();
         let by_name: std::collections::HashMap<_, _> = authors
             .iter()
             .map(|a| (a.name.clone(), a.book_count))
@@ -379,7 +375,7 @@ mod tests {
             .await
             .unwrap();
 
-        let authors = list_authors(&pool, "/lib").await.unwrap();
+        let authors = list_authors(&pool, &["/lib"]).await.unwrap();
         let ada = authors
             .iter()
             .find(|a| a.name == "Ada Lovelace")
@@ -415,7 +411,7 @@ mod tests {
             .await
             .unwrap();
 
-        let series = list_series(&pool, "/lib").await.unwrap();
+        let series = list_series(&pool, &["/lib"]).await.unwrap();
         let saga = series
             .iter()
             .find(|s| s.name == "Saga")
@@ -450,7 +446,7 @@ mod tests {
             .await
             .unwrap();
 
-        let series = list_series(&pool, "/lib").await.unwrap();
+        let series = list_series(&pool, &["/lib"]).await.unwrap();
         let saga = series
             .iter()
             .find(|s| s.name == "Saga")
@@ -470,14 +466,14 @@ mod tests {
         let (pool, _guard) = seed_discovery_fixture().await;
         let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
 
-        let initial = list_authors(&pool, "/lib").await.unwrap();
+        let initial = list_authors(&pool, &["/lib"]).await.unwrap();
         let ada = initial.iter().find(|a| a.id == ada_id).unwrap();
         assert!(!ada.has_photo, "no row should yield has_photo = false");
 
         upsert_author_photo(&pool, ada_id, AuthorPhotoSource::Letter, None, None, None)
             .await
             .unwrap();
-        let after_letter = list_authors(&pool, "/lib").await.unwrap();
+        let after_letter = list_authors(&pool, &["/lib"]).await.unwrap();
         let ada = after_letter.iter().find(|a| a.id == ada_id).unwrap();
         assert!(
             !ada.has_photo,
@@ -494,8 +490,140 @@ mod tests {
         )
         .await
         .unwrap();
-        let after_upload = list_authors(&pool, "/lib").await.unwrap();
+        let after_upload = list_authors(&pool, &["/lib"]).await.unwrap();
         let ada = after_upload.iter().find(|a| a.id == ada_id).unwrap();
         assert!(ada.has_photo, "manual upload should yield has_photo = true");
+    }
+
+    // -----------------------------------------------------------------
+    // Audiobook authors/series in browse indexes
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_authors_includes_audiobook_authors_from_separate_library() {
+        let guard = CoversTempDir::new("ab_authors");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        crate::sync::replace_books(
+            &pool,
+            "/ebooks",
+            vec![indexed(
+                "novel.epub",
+                Some("A Novel"),
+                &["Ebook Author"],
+                &[],
+                None,
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        crate::sync::sync_audiobooks(
+            &pool,
+            "/audiobooks",
+            crate::sync::AudiobookSyncPlan {
+                new_books: vec![indexed_audiobook(
+                    "narrator/book",
+                    "Audiobook Title",
+                    Some("Audio Author"),
+                )],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let ebook_only = list_authors(&pool, &["/ebooks"]).await.unwrap();
+        assert_eq!(ebook_only.len(), 1);
+        assert_eq!(ebook_only[0].name, "Ebook Author");
+
+        let audio_only = list_authors(&pool, &["/audiobooks"]).await.unwrap();
+        assert_eq!(audio_only.len(), 1);
+        assert_eq!(audio_only[0].name, "Audio Author");
+
+        let combined = list_authors(&pool, &["/ebooks", "/audiobooks"])
+            .await
+            .unwrap();
+        let names: Vec<_> = combined.iter().map(|a| a.name.clone()).collect();
+        assert!(names.contains(&"Audio Author".to_string()));
+        assert!(names.contains(&"Ebook Author".to_string()));
+        assert_eq!(combined.len(), 2);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn list_authors_returns_empty_for_no_paths() {
+        let _guard = CoversTempDir::new("no_paths");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let authors = list_authors(&pool, &[]).await.unwrap();
+        assert!(authors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_series_includes_series_from_audiobook_library() {
+        let guard = CoversTempDir::new("ab_series");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        crate::sync::replace_books(
+            &pool,
+            "/ebooks",
+            vec![indexed(
+                "dune.epub",
+                Some("Dune"),
+                &["Frank Herbert"],
+                &[],
+                Some(("Dune Chronicles", "1")),
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+        // Seed an audiobook under a separate library, then add a series
+        // override that references the existing "Dune Chronicles" series.
+        crate::sync::sync_audiobooks(
+            &pool,
+            "/audiobooks",
+            crate::sync::AudiobookSyncPlan {
+                new_books: vec![indexed_audiobook(
+                    "herbert/dune-audio",
+                    "Dune (Audio)",
+                    Some("Frank Herbert"),
+                )],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        upsert_metadata_overrides(
+            &pool,
+            "ab-uuid-herbert/dune-audio",
+            &MetadataOverrides {
+                series: Some("Dune Chronicles".into()),
+                series_index: Some("1".into()),
+                ..Default::default()
+            },
+            false,
+            user_id,
+        )
+        .await
+        .unwrap();
+
+        let ebook_series = list_series(&pool, &["/ebooks"]).await.unwrap();
+        assert_eq!(ebook_series.len(), 1);
+        assert_eq!(ebook_series[0].name, "Dune Chronicles");
+
+        let combined = list_series(&pool, &["/ebooks", "/audiobooks"])
+            .await
+            .unwrap();
+        assert_eq!(combined.len(), 1, "same series should not duplicate");
+        assert_eq!(
+            combined[0].book_count, 2,
+            "audiobook with series override should be counted"
+        );
+        drop(guard);
     }
 }

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -21,11 +21,8 @@ fn placeholders(n: usize) -> String {
 }
 
 /// Return every author with their book count and an optional cover-derived
-/// accent, scoped to `library_path`, ordered by name ascending and capped
-/// at [`INDEX_LIMIT`]. Empty list when `library_path` doesn't match a
-/// configured library. Accent is the `accent_color` of the first book by
-/// this author with a non-null value (book sort/id order); `NULL` falls
-/// back to the theme accent in the UI.
+/// accent, scoped to `library_paths`, ordered by name ascending and capped
+/// at [`INDEX_LIMIT`]. Empty list when no paths match or the slice is empty.
 ///
 /// Currently returns results across all users (single-tenant). When F4.x
 /// per-user ACL lands, add a `user_id: i64` parameter and scope the query
@@ -108,11 +105,8 @@ pub async fn list_authors(
 }
 
 /// Return every series with book count, primary author, and an optional
-/// accent, scoped to `library_path`, ordered by name ascending and capped
-/// at [`INDEX_LIMIT`]. `primary_author` is the first creator of the
-/// lowest-`series_index` book (with `book.sort, book.id` as tie-breakers);
-/// `None` when every book in the series has only override-supplied
-/// creators not yet linked to an `authors` row.
+/// accent, scoped to `library_paths`, ordered by name ascending and capped
+/// at [`INDEX_LIMIT`]. Empty list when no paths match or the slice is empty.
 ///
 /// Currently returns results across all users (single-tenant). When F4.x
 /// per-user ACL lands, add a `user_id: i64` parameter and scope the query
@@ -600,7 +594,7 @@ mod tests {
             .id;
         upsert_metadata_overrides(
             &pool,
-            "ab-uuid-herbert/dune-audio",
+            "ab-uuid-herbert-dune-audio",
             &MetadataOverrides {
                 series: Some("Dune Chronicles".into()),
                 series_index: Some("1".into()),

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -35,11 +35,11 @@ pub mod worker;
 // and mirrors how `db.rs` looked before the extraction.
 pub use author_photos_data::*;
 pub use books::{
-    book_file_path, count_books, count_books_for_paths, count_search_books, get_book,
-    get_book_by_uuid, library_from_db, library_from_db_combined, library_from_db_with_total,
-    library_from_db_with_total_combined, list_books, list_books_for_paths, list_indexed_rows,
-    list_indexed_rows_for_formats, resolve_book_id_by_uuid, search_books, search_books_with_total,
-    IndexedRow, MAX_BOOKS_RETURNED,
+    book_file_path, collect_paths, count_books, count_books_for_paths, count_search_books,
+    get_book, get_book_by_uuid, library_from_db, library_from_db_combined,
+    library_from_db_with_total, library_from_db_with_total_combined, list_books,
+    list_books_for_paths, list_indexed_rows, list_indexed_rows_for_formats,
+    resolve_book_id_by_uuid, search_books, search_books_with_total, IndexedRow, MAX_BOOKS_RETURNED,
 };
 pub use browse::*;
 pub use covers::{covers_dir, get_cover, get_last_modified_epoch};

--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -75,10 +75,9 @@ pub async fn upsert_metadata_overrides(
 ) -> Result<(), sqlx::Error> {
     let json = serde_json::to_string(overrides).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
     upsert_overrides_row(pool, book_uuid, &json, has_cover_override, user_id).await?;
-    // Best-effort FTS rebuild: log and continue on failure. The override
-    // write is the user's actual intent — a stale FTS row gets fixed on the
-    // next reindex, but surfacing a 500 here would make them think their
-    // save was lost. Matches the docstring contract above.
+    if let Err(e) = materialize_series_link(pool, book_uuid, overrides).await {
+        tracing::warn!(book_uuid, error = %e, "series link materialize after override upsert failed");
+    }
     if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
         tracing::warn!(book_uuid, error = %e, "books_fts rebuild after override upsert failed");
     }
@@ -126,8 +125,9 @@ pub async fn merge_metadata_overrides(
     upsert_overrides_row(&mut *tx, book_uuid, &json, has_cover_override, user_id).await?;
     tx.commit().await?;
 
-    // Best-effort FTS rebuild — same rationale as `upsert_metadata_overrides`.
-    // Kept outside the transaction so the write lock is released first.
+    if let Err(e) = materialize_series_link(pool, book_uuid, &merged).await {
+        tracing::warn!(book_uuid, error = %e, "series link materialize after override merge failed");
+    }
     if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
         tracing::warn!(book_uuid, error = %e, "books_fts rebuild after override merge failed");
     }
@@ -276,6 +276,53 @@ pub(crate) fn apply_overrides(
         book.cover_url = Some(format!("/api/covers/{uuid}"));
     }
     book.has_override = true;
+}
+
+/// When an override sets a series name, ensure a `series` row and
+/// `books_series_link` exist so the browse index and detail-page breadcrumb
+/// resolve. Without this, override-only series are invisible to
+/// `list_series` (which requires a canonical link for visibility) and the
+/// book detail page's `series_id` backfill can't find the `series.id`.
+async fn materialize_series_link(
+    pool: &SqlitePool,
+    book_uuid: &str,
+    overrides: &MetadataOverrides,
+) -> Result<(), sqlx::Error> {
+    let Some(ref series_name) = overrides.series else {
+        return Ok(());
+    };
+    if series_name.is_empty() {
+        return Ok(());
+    }
+    let Some(book_id) = sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
+        .bind(book_uuid)
+        .fetch_optional(pool)
+        .await?
+    else {
+        return Ok(());
+    };
+
+    sqlx::query(
+        "INSERT INTO series (name, sort) VALUES (?, ?) \
+         ON CONFLICT(name) DO UPDATE SET sort = COALESCE(series.sort, excluded.sort)",
+    )
+    .bind(series_name)
+    .bind(series_name)
+    .execute(pool)
+    .await?;
+
+    let series_id =
+        sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE name = ? COLLATE NOCASE")
+            .bind(series_name)
+            .fetch_one(pool)
+            .await?;
+
+    sqlx::query("INSERT OR IGNORE INTO books_series_link (book, series) VALUES (?, ?)")
+        .bind(book_id)
+        .bind(series_id)
+        .execute(pool)
+        .await?;
+    Ok(())
 }
 
 /// Rebuild the `books_fts` row for the book identified by `book_uuid` using
@@ -785,5 +832,64 @@ mod tests {
         assert_eq!(merged.publisher.as_deref(), Some("Edited Publisher"));
         // unset in both stays None
         assert_eq!(merged.language, None);
+    }
+    #[tokio::test]
+    async fn upsert_overrides_materializes_series_link_for_new_series() {
+        let _covers = CoversTempDir::new("materialize_series");
+        let pool = init_db("sqlite::memory:").await.unwrap();
+        let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+
+        crate::sync::sync_audiobooks(
+            &pool,
+            "/audio",
+            crate::sync::AudiobookSyncPlan {
+                new_books: vec![crate::test_support::indexed_audiobook(
+                    "author/book",
+                    "My Audiobook",
+                    Some("Narrator"),
+                )],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let book = list_books(&pool, "/audio").await.unwrap();
+        let uuid = book[0].unique_identifier.clone().unwrap();
+        let id = book[0].id;
+
+        assert!(
+            get_book(&pool, id)
+                .await
+                .unwrap()
+                .unwrap()
+                .series_id
+                .is_none(),
+            "no series before override"
+        );
+
+        upsert_metadata_overrides(
+            &pool,
+            &uuid,
+            &MetadataOverrides {
+                series: Some("My Series".into()),
+                series_index: Some("1".into()),
+                ..Default::default()
+            },
+            false,
+            user_id,
+        )
+        .await
+        .unwrap();
+
+        let book = get_book(&pool, id).await.unwrap().unwrap();
+        assert_eq!(book.series.as_deref(), Some("My Series"));
+        assert!(
+            book.series_id.is_some(),
+            "series_id should be set after override materializes the link"
+        );
     }
 }

--- a/db/src/metadata_overrides.rs
+++ b/db/src/metadata_overrides.rs
@@ -288,12 +288,14 @@ async fn materialize_series_link(
     book_uuid: &str,
     overrides: &MetadataOverrides,
 ) -> Result<(), sqlx::Error> {
-    let Some(ref series_name) = overrides.series else {
+    let series_name = overrides
+        .series
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let Some(series_name) = series_name else {
         return Ok(());
     };
-    if series_name.is_empty() {
-        return Ok(());
-    }
     let Some(book_id) = sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
         .bind(book_uuid)
         .fetch_optional(pool)
@@ -302,14 +304,10 @@ async fn materialize_series_link(
         return Ok(());
     };
 
-    sqlx::query(
-        "INSERT INTO series (name, sort) VALUES (?, ?) \
-         ON CONFLICT(name) DO UPDATE SET sort = COALESCE(series.sort, excluded.sort)",
-    )
-    .bind(series_name)
-    .bind(series_name)
-    .execute(pool)
-    .await?;
+    sqlx::query("INSERT OR IGNORE INTO series (name) VALUES (?)")
+        .bind(series_name)
+        .execute(pool)
+        .await?;
 
     let series_id =
         sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE name = ? COLLATE NOCASE")

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -187,7 +187,7 @@ pub fn indexed_audiobook(
     creator: Option<&str>,
 ) -> crate::audiobook::IndexedAudiobook {
     crate::audiobook::IndexedAudiobook {
-        uuid: format!("ab-uuid-{group_path}"),
+        uuid: format!("ab-uuid-{}", group_path.replace('/', "-")),
         group_path: group_path.into(),
         format: "M4B".into(),
         title: title.into(),

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -177,6 +177,37 @@ pub fn indexed_with_stat(
 }
 
 // ---------------------------------------------------------------------------
+// IndexedAudiobook factories
+// ---------------------------------------------------------------------------
+
+/// Shared `IndexedAudiobook` builder for tests that need audiobook rows.
+pub fn indexed_audiobook(
+    group_path: &str,
+    title: &str,
+    creator: Option<&str>,
+) -> crate::audiobook::IndexedAudiobook {
+    crate::audiobook::IndexedAudiobook {
+        uuid: format!("ab-uuid-{group_path}"),
+        group_path: group_path.into(),
+        format: "M4B".into(),
+        title: title.into(),
+        creator_name: creator.map(Into::into),
+        cover: None,
+        parts: vec![crate::audiobook::AudiobookPart {
+            ordinal: 0,
+            filename: format!("{group_path}/part1.m4b"),
+            size_bytes: 1000,
+            mtime_epoch: 100,
+            duration_seconds: 3600.0,
+        }],
+        total_size_bytes: 1000,
+        max_mtime_epoch: 100,
+        description: Some("Audiobook · 1h 00m".into()),
+        error: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Discovery fixture seeders (formerly `discovery::test_helpers`)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -368,24 +368,26 @@ pub async fn rpc_get_tag_cloud() -> Result<Vec<TagWeight>> {
     Ok(db::get_tag_cloud(&pool.0).await?)
 }
 
-/// `/authors` index: every author in the configured library.
+/// `/authors` index: every author across both ebook and audiobook libraries.
 #[get("/api/rpc/authors", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_list_authors() -> Result<Vec<AuthorSummary>> {
     let settings = db::get_settings(&pool.0).await?;
-    let Some(path) = settings.ebook_library_path else {
-        return Ok(Vec::new());
-    };
-    Ok(db::list_authors(&pool.0, &path).await?)
+    let paths = db::collect_paths(
+        settings.ebook_library_path.as_deref(),
+        settings.audiobook_library_path.as_deref(),
+    );
+    Ok(db::list_authors(&pool.0, &paths).await?)
 }
 
-/// `/series` index: every series in the configured library.
+/// `/series` index: every series across both ebook and audiobook libraries.
 #[get("/api/rpc/series-list", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_list_series() -> Result<Vec<SeriesSummary>> {
     let settings = db::get_settings(&pool.0).await?;
-    let Some(path) = settings.ebook_library_path else {
-        return Ok(Vec::new());
-    };
-    Ok(db::list_series(&pool.0, &path).await?)
+    let paths = db::collect_paths(
+        settings.ebook_library_path.as_deref(),
+        settings.audiobook_library_path.as_deref(),
+    );
+    Ok(db::list_series(&pool.0, &paths).await?)
 }
 
 /// Save metadata overrides for a book. Requires `can_edit` or admin.

--- a/server/src/backend/authors.rs
+++ b/server/src/backend/authors.rs
@@ -50,18 +50,18 @@ pub(super) async fn get_author_by_id(
     }
 }
 
-/// `/authors` index. Returns every author in the configured library with
-/// a book count and optional accent. Empty list when no library is
-/// configured.
+/// `/authors` index. Returns every author across both ebook and audiobook
+/// libraries with a book count and optional accent.
 pub(super) async fn get_authors(_user: AuthUser, State(state): State<AppState>) -> Response {
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,
         Err(e) => return internal("read settings", e),
     };
-    let Some(path) = settings.ebook_library_path else {
-        return Json(Vec::<omnibus_shared::AuthorSummary>::new()).into_response();
-    };
-    match db::list_authors(&state.pool, &path).await {
+    let paths = db::collect_paths(
+        settings.ebook_library_path.as_deref(),
+        settings.audiobook_library_path.as_deref(),
+    );
+    match db::list_authors(&state.pool, &paths).await {
         Ok(authors) => Json(authors).into_response(),
         Err(e) => internal("list authors", e),
     }

--- a/server/src/backend/series.rs
+++ b/server/src/backend/series.rs
@@ -14,17 +14,18 @@ use omnibus_db::{self as db};
 use super::{internal, AppState};
 use crate::auth::AuthUser;
 
-/// `/series` index. Returns every series in the configured library with
-/// a book count, primary author, and optional accent.
+/// `/series` index. Returns every series across both ebook and audiobook
+/// libraries with a book count, primary author, and optional accent.
 pub(super) async fn get_series(_user: AuthUser, State(state): State<AppState>) -> Response {
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,
         Err(e) => return internal("read settings", e),
     };
-    let Some(path) = settings.ebook_library_path else {
-        return Json(Vec::<omnibus_shared::SeriesSummary>::new()).into_response();
-    };
-    match db::list_series(&state.pool, &path).await {
+    let paths = db::collect_paths(
+        settings.ebook_library_path.as_deref(),
+        settings.audiobook_library_path.as_deref(),
+    );
+    match db::list_series(&state.pool, &paths).await {
         Ok(series) => Json(series).into_response(),
         Err(e) => internal("list series", e),
     }


### PR DESCRIPTION
## Summary
- `/authors` and `/series` browse pages only queried `ebook_library_path`, making audiobooks under a separate `audiobook_library_path` invisible.
- `list_authors` / `list_series` now accept `&[&str]` (multiple library paths) via a `WITH lib_paths` CTE; all four handler call sites (2 RPC + 2 REST) pass both configured paths through `collect_paths`.
- Saving a series via metadata override now materializes the `series` row + `books_series_link` so the breadcrumb is clickable and `/series` lists it.

## Test plan
- [x] 429 DB tests pass (4 new: audiobook authors across libraries, empty paths, audiobook series via override, series link materialization)
- [x] 182 server integration tests pass
- [x] `cargo clippy` clean across `omnibus-db`, `omnibus`, `omnibus-frontend`

>[!NOTE]
> Search routes (`/api/search`, `/api/rpc/search`) have the same ebook-only scoping bug — flagged as a follow-up, not addressed here.