### PR TITLE
feat: fix book detail page — enable listen/read CTAs, populate author books, fix margins

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -500,10 +500,8 @@ body.atrium,
  */
 
 .bd-root {
-  width: 100vw;
-  position: relative;
-  left: 50%;
-  margin-left: -50vw;
+  margin-left: calc(-1 * clamp(1rem, 4vw, 2.5rem));
+  margin-right: calc(-1 * clamp(1rem, 4vw, 2.5rem));
 }
 
 /* Hero */

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -500,9 +500,10 @@ body.atrium,
  */
 
 .bd-root {
-  width: auto;
-  margin-left: calc(-1 * clamp(1rem, 4vw, 2.5rem));
-  margin-right: calc(-1 * clamp(1rem, 4vw, 2.5rem));
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  margin-left: -50vw;
 }
 
 /* Hero */

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -150,6 +150,8 @@ body.atrium,
   position: sticky; top: 0;
   background: color-mix(in oklch, var(--bg-0) 92%, transparent);
   backdrop-filter: blur(10px); z-index: 5;
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
 }
 .atrium-brand {
   display: flex; align-items: center; gap: 10px;

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -499,7 +499,11 @@ body.atrium,
  * book has no extracted accent.
  */
 
-.bd-root { width: 100%; }
+.bd-root {
+  width: 100%;
+  margin-left: calc(-1 * clamp(1rem, 4vw, 2.5rem));
+  margin-right: calc(-1 * clamp(1rem, 4vw, 2.5rem));
+}
 
 /* Hero */
 .bd-hero {
@@ -711,6 +715,31 @@ body.atrium,
 .bd-stub-strip {
   padding: 22px 24px;
   text-align: center;
+}
+
+/* "From the same hand" horizontal cover scroll */
+.bd-author-books-row {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  padding: 4px 0 12px;
+  scroll-snap-type: x proximity;
+  -webkit-overflow-scrolling: touch;
+}
+.bd-author-book-tile {
+  flex: 0 0 140px;
+  scroll-snap-align: start;
+  display: block;
+  text-decoration: none;
+  cursor: pointer;
+}
+.bd-author-book-tile:hover .cover-wrap {
+  transform: translateY(-4px) scale(1.01);
+  filter: drop-shadow(0 22px 26px color-mix(in oklch, black 55%, transparent))
+          drop-shadow(0 2px 0 color-mix(in oklch, black 30%, transparent));
+}
+.bd-author-books-empty {
+  padding: 22px 24px;
 }
 
 /* Body — rail */

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -500,7 +500,7 @@ body.atrium,
  */
 
 .bd-root {
-  width: 100%;
+  width: auto;
   margin-left: calc(-1 * clamp(1rem, 4vw, 2.5rem));
   margin-right: calc(-1 * clamp(1rem, 4vw, 2.5rem));
 }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -500,8 +500,8 @@ body.atrium,
  */
 
 .bd-root {
-  margin-left: calc(-1 * clamp(1rem, 4vw, 2.5rem));
-  margin-right: calc(-1 * clamp(1rem, 4vw, 2.5rem));
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
 }
 
 /* Hero */

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -33,23 +33,36 @@ use crate::{data, use_server_url, Route};
 pub fn BookDetailPage(uuid: String) -> Element {
     let server_url = use_server_url();
     let mut book: Signal<Option<EbookMetadata>> = use_signal(|| None);
+    let mut author_books: Signal<Vec<EbookMetadata>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
-    // `use_reactive!` declares `uuid` as an explicit dependency so the
-    // effect re-runs when the router swaps the route param in place.
-    // Without this, navigating `/books/A` → `/books/B` reuses the same
-    // component instance and leaves the page rendering the stale book —
-    // Dioxus' implicit subscription tracking only covers signals, not
-    // plain props.
     let url = server_url.clone();
     use_effect(use_reactive!(|uuid| {
         let url = url.clone();
         let uuid = uuid.clone();
         spawn(async move {
             loading.set(true);
+            author_books.set(Vec::new());
             match data::get_ebook(&url, &uuid).await {
                 Ok(b) => {
+                    if let Some(ref inner) = b {
+                        let author_id = inner.creators.first().and_then(|c| c.id);
+                        let current_uuid = inner.unique_identifier.clone();
+                        if let Some(aid) = author_id {
+                            let url2 = url.clone();
+                            spawn(async move {
+                                if let Ok(Some(ad)) = data::get_author(&url2, aid).await {
+                                    let others: Vec<EbookMetadata> = ad
+                                        .books
+                                        .into_iter()
+                                        .filter(|ab| ab.unique_identifier != current_uuid)
+                                        .collect();
+                                    author_books.set(others);
+                                }
+                            });
+                        }
+                    }
                     book.set(b);
                     error.set(None);
                 }
@@ -77,7 +90,7 @@ pub fn BookDetailPage(uuid: String) -> Element {
         };
     };
 
-    render_loaded(b)
+    render_loaded(b, author_books())
 }
 
 // ---------------------------------------------------------------------------
@@ -131,7 +144,7 @@ mod tests {
     }
 }
 
-fn render_loaded(b: EbookMetadata) -> Element {
+fn render_loaded(b: EbookMetadata, author_books: Vec<EbookMetadata>) -> Element {
     let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
     let primary_author = b
         .creators
@@ -288,21 +301,49 @@ fn render_loaded(b: EbookMetadata) -> Element {
                                     start_reading
                                 }
                             } else if has_audio {
-                                button {
-                                    class: "btn primary lg",
-                                    disabled: true,
-                                    title: "Audio player coming soon",
-                                    // TODO(F2.3): open audiobook player
-                                    "Start listening"
+                                {
+                                    #[cfg(not(feature = "mobile"))]
+                                    let start_listening = rsx! {
+                                        Link {
+                                            to: Route::BookListen { uuid: b.unique_identifier.clone().unwrap_or_default() },
+                                            class: "btn primary lg",
+                                            "data-testid": "start-listening",
+                                            "Start listening"
+                                        }
+                                    };
+                                    #[cfg(feature = "mobile")]
+                                    let start_listening = rsx! {
+                                        button {
+                                            class: "btn primary lg",
+                                            disabled: true,
+                                            title: "Listening on mobile coming soon",
+                                            "Start listening"
+                                        }
+                                    };
+                                    start_listening
                                 }
                             }
                             if has_audio && has_ebook {
-                                button {
-                                    class: "btn lg",
-                                    disabled: true,
-                                    title: "Audio player coming soon",
-                                    // TODO(F2.3): open audiobook player
-                                    "Listen"
+                                {
+                                    #[cfg(not(feature = "mobile"))]
+                                    let listen_btn = rsx! {
+                                        Link {
+                                            to: Route::BookListen { uuid: b.unique_identifier.clone().unwrap_or_default() },
+                                            class: "btn lg",
+                                            "data-testid": "listen-secondary",
+                                            "Listen"
+                                        }
+                                    };
+                                    #[cfg(feature = "mobile")]
+                                    let listen_btn = rsx! {
+                                        button {
+                                            class: "btn lg",
+                                            disabled: true,
+                                            title: "Listening on mobile coming soon",
+                                            "Listen"
+                                        }
+                                    };
+                                    listen_btn
                                 }
                             }
                             button {
@@ -404,13 +445,25 @@ fn render_loaded(b: EbookMetadata) -> Element {
 
                     div { class: "divider" }
 
-                    // More by this author — TODO(F3.3)
                     BdSectionHead {
                         kicker: if primary_author.is_empty() { "More to read".to_string() } else { format!("More by {primary_author}") },
                         title: "From the same hand".to_string(),
                     }
-                    div { class: "bd-stub-strip card", aria_hidden: "true",
-                        p { class: "bd-stub-hint mono", "Author pages land in F3.3." }
+                    if author_books.is_empty() {
+                        div { class: "bd-author-books-empty card",
+                            p { class: "mono", "No other books by this author in your library." }
+                        }
+                    } else {
+                        div { class: "bd-author-books-row",
+                            for ab in author_books.iter() {
+                                Link {
+                                    key: "{ab.id}",
+                                    to: Route::BookDetail { uuid: ab.unique_identifier.clone().unwrap_or_default() },
+                                    class: "bd-author-book-tile",
+                                    Cover { book: ab.clone() }
+                                }
+                            }
+                        }
                     }
 
                     div { class: "divider" }

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -57,10 +57,9 @@ pub fn BookDetailPage(uuid: String) -> Element {
                     loading.set(false);
                     if let Some((Some(aid), current_uuid)) = author_fetch {
                         if let Ok(Some(ad)) = data::get_author(&url, aid).await {
-                            let still_current = book()
-                                .as_ref()
-                                .and_then(|b| b.unique_identifier.as_ref())
-                                == current_uuid.as_ref();
+                            let still_current =
+                                book().as_ref().and_then(|b| b.unique_identifier.as_ref())
+                                    == current_uuid.as_ref();
                             if still_current {
                                 let others: Vec<EbookMetadata> = ad
                                     .books

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -46,29 +46,37 @@ pub fn BookDetailPage(uuid: String) -> Element {
             author_books.set(Vec::new());
             match data::get_ebook(&url, &uuid).await {
                 Ok(b) => {
-                    if let Some(ref inner) = b {
-                        let author_id = inner.creators.first().and_then(|c| c.id);
-                        let current_uuid = inner.unique_identifier.clone();
-                        if let Some(aid) = author_id {
-                            let url2 = url.clone();
-                            spawn(async move {
-                                if let Ok(Some(ad)) = data::get_author(&url2, aid).await {
-                                    let others: Vec<EbookMetadata> = ad
-                                        .books
-                                        .into_iter()
-                                        .filter(|ab| ab.unique_identifier != current_uuid)
-                                        .collect();
-                                    author_books.set(others);
-                                }
-                            });
-                        }
-                    }
+                    let author_fetch = b.as_ref().map(|inner| {
+                        (
+                            inner.creators.first().and_then(|c| c.id),
+                            inner.unique_identifier.clone(),
+                        )
+                    });
                     book.set(b);
                     error.set(None);
+                    loading.set(false);
+                    if let Some((Some(aid), current_uuid)) = author_fetch {
+                        if let Ok(Some(ad)) = data::get_author(&url, aid).await {
+                            let still_current = book()
+                                .as_ref()
+                                .and_then(|b| b.unique_identifier.as_ref())
+                                == current_uuid.as_ref();
+                            if still_current {
+                                let others: Vec<EbookMetadata> = ad
+                                    .books
+                                    .into_iter()
+                                    .filter(|ab| ab.unique_identifier != current_uuid)
+                                    .collect();
+                                author_books.set(others);
+                            }
+                        }
+                    }
                 }
-                Err(e) => error.set(Some(e.to_string())),
+                Err(e) => {
+                    error.set(Some(e.to_string()));
+                    loading.set(false);
+                }
             }
-            loading.set(false);
         });
     }));
 

--- a/frontend/src/styles/globals.rs
+++ b/frontend/src/styles/globals.rs
@@ -19,8 +19,10 @@ body {
 .app-shell {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 2rem clamp(1rem, 4vw, 2.5rem);
-  overflow-x: hidden;
+  padding: 2rem 0;
+}
+.app-shell > main {
+  padding: 0 clamp(1rem, 4vw, 2.5rem);
 }
 
 .screen {

--- a/frontend/src/styles/globals.rs
+++ b/frontend/src/styles/globals.rs
@@ -19,7 +19,6 @@ body {
 .app-shell {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 2rem 0;
 }
 .app-shell > main {
   padding: 0 clamp(1rem, 4vw, 2.5rem);

--- a/frontend/src/styles/globals.rs
+++ b/frontend/src/styles/globals.rs
@@ -20,6 +20,7 @@ body {
   max-width: 1400px;
   margin: 0 auto;
   padding: 2rem clamp(1rem, 4vw, 2.5rem);
+  overflow-x: hidden;
 }
 
 .screen {


### PR DESCRIPTION
## Summary
- Enable "Start listening" and secondary "Listen" hero buttons as working links to `/listen/:uuid` (were disabled stubs)
- Populate "From the same hand" section with the primary author's other books via `data::get_author`, excluding the current book
- Fix compounding side margins on the book detail page — `.bd-root` breaks out of `.app-shell` padding with negative margins; `overflow-x: hidden` prevents scrollbar

## Test plan
- [ ] Navigate to an audio-only book → "Start listening" links to `/listen/:uuid`
- [ ] Navigate to a dual-format book → both "Start reading" and "Listen" link correctly
- [ ] "From the same hand" shows other books by the same author, not the current book
- [ ] Book detail hero extends edge-to-edge within the max-width (no double padding)
- [ ] Landing page margins are unchanged (no regression)
- [ ] `cargo clippy` clean