### PR TITLE
feat: add Refetch Author Pictures button to settings page

### DIFF
--- a/db/src/author_photos/cascade.rs
+++ b/db/src/author_photos/cascade.rs
@@ -8,7 +8,9 @@ use serde::Deserialize;
 use sqlx::SqlitePool;
 
 use crate::author_photos::shared::{default_user_agent, shared_client};
-use crate::author_photos_data::{author_photo_status, upsert_author_photo, AuthorPhotoSource};
+use crate::author_photos_data::{
+    author_photo_status, delete_author_photo, upsert_author_photo, AuthorPhotoSource,
+};
 
 /// Default request timeout for the Open Library search + cover calls.
 const OPEN_LIBRARY_TIMEOUT: Duration = Duration::from_secs(5);
@@ -124,6 +126,45 @@ pub async fn resolve_with(
                 "open library resolution failed (transient); leaving row absent for retry"
             );
         }
+    }
+    Ok(())
+}
+
+/// Bulk re-resolve all author photos. Clears non-manual cached photos and
+/// re-runs the Open Library cascade for every author. Manual uploads are
+/// preserved. Per-author errors are logged and skipped so a single failure
+/// does not abort the batch.
+pub async fn refetch_all(
+    pool: &SqlitePool,
+    on_progress: impl Fn(u32, Option<u32>),
+) -> Result<(), sqlx::Error> {
+    let author_ids: Vec<i64> = sqlx::query_scalar("SELECT id FROM authors ORDER BY id")
+        .fetch_all(pool)
+        .await?;
+    let total = author_ids.len() as u32;
+
+    for (i, author_id) in author_ids.iter().enumerate() {
+        match author_photo_status(pool, *author_id).await {
+            Ok(Some((AuthorPhotoSource::Manual, _))) => {
+                on_progress((i + 1) as u32, Some(total));
+                continue;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(author_id, error = %e, "refetch_all: status check failed, skipping");
+                on_progress((i + 1) as u32, Some(total));
+                continue;
+            }
+        }
+        if let Err(e) = delete_author_photo(pool, *author_id).await {
+            tracing::warn!(author_id, error = %e, "refetch_all: delete failed, skipping");
+            on_progress((i + 1) as u32, Some(total));
+            continue;
+        }
+        if let Err(e) = resolve(pool, *author_id).await {
+            tracing::warn!(author_id, error = %e, "refetch_all: resolve failed, continuing");
+        }
+        on_progress((i + 1) as u32, Some(total));
     }
     Ok(())
 }

--- a/db/src/author_photos/mod.rs
+++ b/db/src/author_photos/mod.rs
@@ -8,7 +8,7 @@ mod shared;
 pub mod cascade;
 pub mod remote;
 
-pub use cascade::{resolve, resolve_with, OpenLibraryConfig};
+pub use cascade::{refetch_all, resolve, resolve_with, OpenLibraryConfig};
 pub use remote::{
     fetch_remote_image, fetch_remote_image_with, FetchRemoteImageError, RemoteImageConfig,
     REMOTE_IMAGE_MAX_BYTES,

--- a/db/src/author_photos/tests.rs
+++ b/db/src/author_photos/tests.rs
@@ -10,7 +10,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use super::cascade::{fetch_open_library, resolve_with, OpenLibraryConfig};
+use super::cascade::{fetch_open_library, refetch_all, resolve_with, OpenLibraryConfig};
 use super::remote::{
     fetch_remote_image_with, is_blocked_address, FetchRemoteImageError, RemoteImageConfig,
 };
@@ -485,4 +485,86 @@ async fn resolve_leaves_row_absent_on_transient_network_error() {
         author_photo_status(&pool, id).await.unwrap().is_none(),
         "transient network error must leave the row absent for retry"
     );
+}
+
+// ── refetch_all ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn refetch_all_skips_manual_and_reports_progress() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let manual_id: i64 = sqlx::query_scalar(
+        "INSERT INTO authors (name, sort) VALUES ('Manual Author', 'Manual Author') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let letter_id: i64 = sqlx::query_scalar(
+        "INSERT INTO authors (name, sort) VALUES ('Letter Author', 'Letter Author') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let empty_id: i64 = sqlx::query_scalar(
+        "INSERT INTO authors (name, sort) VALUES ('No Photo', 'No Photo') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    upsert_author_photo(
+        &pool,
+        manual_id,
+        AuthorPhotoSource::Manual,
+        Some("https://example.com/manual.jpg"),
+        Some("image/jpeg"),
+        Some(&[0xFF; 2048]),
+    )
+    .await
+    .unwrap();
+    upsert_author_photo(
+        &pool,
+        letter_id,
+        AuthorPhotoSource::Letter,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let progress = std::sync::Mutex::new(Vec::new());
+    refetch_all(&pool, |processed, total| {
+        progress.lock().unwrap().push((processed, total));
+    })
+    .await
+    .unwrap();
+
+    let calls = progress.into_inner().unwrap();
+    assert_eq!(calls.len(), 3, "one progress call per author");
+    assert_eq!(calls[0], (1, Some(3)));
+    assert_eq!(calls[1], (2, Some(3)));
+    assert_eq!(calls[2], (3, Some(3)));
+
+    let (src, _) = author_photo_status(&pool, manual_id)
+        .await
+        .unwrap()
+        .expect("manual row should be preserved");
+    assert_eq!(src, AuthorPhotoSource::Manual);
+
+    // letter row was deleted + resolve re-ran. With real OL, the search
+    // returns nothing for "Letter Author" so a new letter marker is written.
+    // The key invariant: the old row was cleared and the cascade ran again.
+    match author_photo_status(&pool, letter_id).await.unwrap() {
+        Some((AuthorPhotoSource::Letter, _)) => {} // re-resolved to letter (expected)
+        None => {}                                 // transient network error left absent
+        other => panic!("unexpected status for letter author: {other:?}"),
+    }
+
+    // "No Photo" had no row — resolve ran (OL search miss → letter marker,
+    // or transient error → absent). Either is fine; the point is the cascade
+    // executed without error.
+    match author_photo_status(&pool, empty_id).await.unwrap() {
+        Some((AuthorPhotoSource::Letter, _)) | None => {}
+        other => panic!("unexpected status for empty author: {other:?}"),
+    }
 }

--- a/db/src/worker/exec.rs
+++ b/db/src/worker/exec.rs
@@ -62,7 +62,7 @@ impl Worker {
             None
         };
 
-        let outcome = self.execute(task).await;
+        let outcome = self.execute(task, id).await;
         // Project the outcome into the wire-facing terminal state. We pull
         // the last reported `processed` count out of the progress map so a
         // Phase-2 in-flight progress report stays reflected in the final

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -3,10 +3,10 @@
 //! the owning module (`indexer::reindex`, `author_photos::resolve`,
 //! `thumbs::ensure_thumbnails_sync`).
 
-use super::types::{Task, TaskOutcome, Worker};
+use super::types::{Task, TaskId, TaskOutcome, Worker};
 
 impl Worker {
-    pub(super) async fn execute(&self, task: Task) -> TaskOutcome {
+    pub(super) async fn execute(&self, task: Task, id: TaskId) -> TaskOutcome {
         match task {
             Task::Scan { library_path } => {
                 match crate::indexer::reindex(&self.pool, &library_path).await {
@@ -41,6 +41,16 @@ impl Worker {
             }
             Task::ResolveAuthorPhoto { author_id } => {
                 match crate::author_photos::resolve(&self.pool, author_id).await {
+                    Ok(()) => TaskOutcome::Ok,
+                    Err(e) => TaskOutcome::Err(e.to_string()),
+                }
+            }
+            Task::RefetchAuthorPhotos => {
+                match crate::author_photos::refetch_all(&self.pool, |processed, total| {
+                    self.report_progress(id, processed, total);
+                })
+                .await
+                {
                     Ok(()) => TaskOutcome::Ok,
                     Err(e) => TaskOutcome::Err(e.to_string()),
                 }

--- a/db/src/worker/progress.rs
+++ b/db/src/worker/progress.rs
@@ -74,15 +74,10 @@ impl Worker {
         }
     }
 
-    /// Phase-2 seam: write the in-flight progress count for `id`. The
-    /// terminal state is written separately at the end of [`Worker::run`]
-    /// so a mid-task report can't accidentally flip a task to `Done`.
-    /// Only exercised by tests today (see `report_progress_updates_running_count`),
-    /// so it lives behind `#[cfg(test)]` rather than an untraceable
-    /// `#[allow(dead_code)]`. Un-gate it — and drop this cfg — when
-    /// `indexer::reindex` learns to thread a progress callback through its
-    /// per-EPUB loop (#220).
-    #[cfg(test)]
+    /// Write the in-flight progress count for `id`. The terminal state is
+    /// written separately at the end of [`Worker::run`] so a mid-task
+    /// report can't accidentally flip a task to `Done`. Used by
+    /// `RefetchAuthorPhotos` to report per-author progress.
     pub(crate) fn report_progress(&self, id: TaskId, processed: u32, total: Option<u32>) {
         let mut map = lock_unpoison(&self.progress);
         if let Some(entry) = map.get_mut(&id) {

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -67,6 +67,12 @@ pub enum Task {
         library_path: String,
         profile: String,
     },
+    /// Bulk re-resolve all author photos. Clears non-manual cached photos
+    /// and re-runs the Open Library cascade for every author. Reports
+    /// progress as `(processed, total)` for the UI indicator. Keyed on a
+    /// fixed resource so concurrent clicks serialize; does not consume the
+    /// scan semaphore.
+    RefetchAuthorPhotos,
     /// Test-only synthetic task: sleeps `latency_ms` and invokes the
     /// optional `on_run` / `on_done` hooks, with `resource` and
     /// `route_through_scan_sem` letting a test exercise the keyed mutex and
@@ -92,6 +98,7 @@ impl Task {
             Task::HlsTranscode {
                 book_id, profile, ..
             } => Some(format!("hls:{book_id}:{profile}")),
+            Task::RefetchAuthorPhotos => Some("refetch-author-photos".into()),
             #[cfg(test)]
             Task::Test { resource, .. } => resource.clone(),
         }
@@ -104,6 +111,7 @@ impl Task {
             Task::GenerateThumbs { .. } => false,
             Task::ResolveAuthorPhoto { .. } => false,
             Task::HlsTranscode { .. } => false,
+            Task::RefetchAuthorPhotos => false,
             #[cfg(test)]
             Task::Test {
                 route_through_scan_sem,
@@ -127,6 +135,7 @@ impl Task {
             Task::ScanAudiobooks { .. } => TaskKind::Scan,
             Task::GenerateThumbs { .. } => TaskKind::GenerateThumbs,
             Task::ResolveAuthorPhoto { .. } => TaskKind::ResolveAuthorPhoto,
+            Task::RefetchAuthorPhotos => TaskKind::RefetchAuthorPhotos,
             // Reuse Scan kind for UI display until a dedicated HLS progress
             // widget is added.
             Task::HlsTranscode { .. } => TaskKind::Scan,

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -206,6 +206,8 @@ fn kind_label(kind: TaskKind, running: bool) -> &'static str {
         (TaskKind::GenerateThumbs, false) => "Thumbnail generation",
         (TaskKind::ResolveAuthorPhoto, true) => "Resolving author photo",
         (TaskKind::ResolveAuthorPhoto, false) => "Author photo lookup",
+        (TaskKind::RefetchAuthorPhotos, true) => "Refetching author photos",
+        (TaskKind::RefetchAuthorPhotos, false) => "Author photo refetch",
         // `#[non_exhaustive]` on the shared enum means new variants
         // compile against existing client builds — render an opaque
         // fallback rather than panicking.
@@ -242,6 +244,7 @@ mod tests {
             TaskKind::Scan,
             TaskKind::GenerateThumbs,
             TaskKind::ResolveAuthorPhoto,
+            TaskKind::RefetchAuthorPhotos,
         ] {
             assert!(!kind_label(kind, true).is_empty());
             assert!(!kind_label(kind, false).is_empty());

--- a/frontend/src/data/authors.rs
+++ b/frontend/src/data/authors.rs
@@ -85,6 +85,18 @@ pub async fn scan_author_photo(
     Ok(response.json::<AuthorPhotoScanResult>().await?)
 }
 
+/// Admin: bulk re-resolve all author photos via the background worker.
+#[cfg(feature = "mobile")]
+pub async fn refetch_author_photos(server_url: &str) -> Result<(), DataError> {
+    let url = format!("{server_url}/api/authors/refetch-photos");
+    let response = with_bearer(http_client().post(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(())
+}
+
 /// GET `/api/authors` — fetch the full authors index for browse / autocomplete.
 #[cfg(feature = "mobile")]
 pub async fn list_authors(server_url: &str) -> Result<Vec<AuthorSummary>, DataError> {
@@ -112,6 +124,14 @@ pub async fn scan_author_photo(
     id: i64,
 ) -> Result<AuthorPhotoScanResult, DataError> {
     crate::rpc::rpc_scan_author_photo(id)
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Web/SSR `refetch_author_photos` — posts a worker task via server function.
+#[cfg(not(feature = "mobile"))]
+pub async fn refetch_author_photos(_server_url: &str) -> Result<(), DataError> {
+    crate::rpc::rpc_refetch_author_photos()
         .await
         .map_err(note_server_fn_err)
 }

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -21,6 +21,7 @@ pub fn SettingsPage() -> Element {
     let mut status = use_signal(|| None::<String>);
     let mut status_is_error = use_signal(|| false);
     let mut library = use_signal(LibraryContents::default);
+    let mut refetch_in_flight = use_signal(|| false);
     // Bumped after a successful save to re-trigger the library-refresh effect.
     let mut library_refresh = use_signal(|| 0u32);
 
@@ -51,6 +52,8 @@ pub fn SettingsPage() -> Element {
             }
         });
     });
+
+    let url_for_refetch = server_url.clone();
 
     let worker_status_slot: Element = {
         #[cfg(not(feature = "mobile"))]
@@ -134,7 +137,35 @@ pub fn SettingsPage() -> Element {
                 // Element outside the macro and embedded by reference.
                 {worker_status_slot}
 
-                button { r#type: "submit", class: "btn", "Save" }
+                div { class: "settings-actions",
+                    button { r#type: "submit", class: "btn", "Save" }
+                    button {
+                        r#type: "button",
+                        class: "btn ghost",
+                        disabled: refetch_in_flight(),
+                        "data-testid": "refetch-author-photos",
+                        onclick: {
+                            let url = url_for_refetch.clone();
+                            move |_| {
+                                let url = url.clone();
+                                refetch_in_flight.set(true);
+                                spawn(async move {
+                                    match data::refetch_author_photos(&url).await {
+                                        Ok(()) => {
+                                            refetch_in_flight.set(false);
+                                        }
+                                        Err(e) => {
+                                            status.set(Some(format!("Failed to start photo refetch: {e}")));
+                                            status_is_error.set(true);
+                                            refetch_in_flight.set(false);
+                                        }
+                                    }
+                                });
+                            }
+                        },
+                        "Refetch Author Pictures"
+                    }
+                }
             }
 
             p {

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -152,6 +152,8 @@ pub fn SettingsPage() -> Element {
                                 spawn(async move {
                                     match data::refetch_author_photos(&url).await {
                                         Ok(()) => {
+                                            status.set(Some("Author photo refetch queued.".into()));
+                                            status_is_error.set(false);
                                             refetch_in_flight.set(false);
                                         }
                                         Err(e) => {

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -320,6 +320,16 @@ pub async fn rpc_scan_author_photo(id: i64) -> Result<AuthorPhotoScanResult> {
     Ok(AuthorPhotoScanResult { resolved })
 }
 
+/// Admin-only: bulk re-resolve all author photos. Posts a single
+/// `Task::RefetchAuthorPhotos` to the background worker and returns
+/// immediately. Progress is surfaced via the existing `rpc_worker_status`
+/// polling loop.
+#[post("/api/rpc/refetch-author-photos", _pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
+pub async fn rpc_refetch_author_photos() -> Result<()> {
+    worker.0.post(omnibus_db::worker::Task::RefetchAuthorPhotos);
+    Ok(())
+}
+
 /// Persist an author photo by URL. Admin-gated server-side (the
 /// `user.is_admin` check below mirrors `rpc_scan_author_photo`). The
 /// server fetches the URL via `db::author_photos::fetch_remote_image`,

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -197,6 +197,10 @@ pub fn rest_router_with_search_limiter(
         .route("/api/thumbs/{uuid}/{size}", get(covers::get_thumb))
         .route("/api/authors", get(authors::get_authors))
         .route(
+            "/api/authors/refetch-photos",
+            post(author_photos::post_refetch_author_photos),
+        )
+        .route(
             "/api/authors/{id}/photo/scan",
             post(author_photos::post_author_photo_scan),
         )

--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -222,6 +222,17 @@ pub(super) async fn post_author_photo_scan(
     Json(omnibus_shared::AuthorPhotoScanResult { resolved }).into_response()
 }
 
+/// Admin: bulk re-resolve all author photos via the background worker.
+/// Returns 202 Accepted immediately; progress is polled via
+/// `/api/rpc/worker_status`.
+pub(super) async fn post_refetch_author_photos(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+) -> Response {
+    state.worker.post(Task::RefetchAuthorPhotos);
+    axum::http::StatusCode::ACCEPTED.into_response()
+}
+
 /// JSON body for [`put_author_photo_url`]. Kept inline because the shape is
 /// trivial and not shared with any other call site (the RPC server function
 /// passes the URL as a positional arg).

--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -941,4 +941,60 @@ mod tests {
         assert_eq!(author.id, id);
         assert!(!author.has_photo, "no row yet means has_photo = false");
     }
+
+    #[tokio::test]
+    async fn api_refetch_author_photos_requires_auth() {
+        let (app, _state, _pool) = fixture().await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/authors/refetch-photos")
+                    .method("POST")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_refetch_author_photos_requires_admin() {
+        let (app, _state, pool) = fixture().await;
+        let user = auth_test_support::create_user(&pool, "alice").await;
+        let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/authors/refetch-photos")
+                    .method("POST")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn api_refetch_author_photos_returns_202_for_admin() {
+        let (app, _state, pool) = fixture().await;
+        let admin = auth_test_support::create_admin(&pool, "admin").await;
+        let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/authors/refetch-photos")
+                    .method("POST")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::ACCEPTED);
+    }
 }

--- a/shared/src/worker.rs
+++ b/shared/src/worker.rs
@@ -18,6 +18,7 @@ pub enum TaskKind {
     Scan,
     GenerateThumbs,
     ResolveAuthorPhoto,
+    RefetchAuthorPhotos,
 }
 
 /// Lifecycle state of a single worker task as exposed to the UI.


### PR DESCRIPTION
## Summary
- Adds a "Refetch Author Pictures" admin button to the settings page that bulk re-runs the Open Library cascade for every author in the background.
- Introduces `Task::RefetchAuthorPhotos` in the worker — a single task that loops all authors, skips manual uploads, clears stale/letter rows, and reports `(processed / total)` progress. The existing `WorkerStatusIndicator` picks it up automatically.
- Un-gates `report_progress` (previously test-only) so the refetch task can surface per-author progress counts to the UI's 1 Hz poller.
- REST endpoint `POST /api/authors/refetch-photos` mirrors the RPC for mobile parity.

## Test plan
- [x] `cargo clippy` + `cargo fmt` — clean
- [x] `cargo test -p omnibus-db` — 443 passed
- [x] `cargo test -p omnibus` — 182 passed
- [x] `cargo test -p omnibus-frontend --features server` — 108 passed
- [x] Browser: Settings → "Refetch Author Pictures" → `WorkerStatusIndicator` shows "Author photo refetch" done row → no console errors

## Notes
- Manual photo uploads (`source = 'manual'`) are preserved; only `openlibrary` and `letter` rows are cleared and re-resolved.
- The fixed resource key `"refetch-author-photos"` serializes rapid double-clicks server-side.