### PR TITLE
refactor(db): replace unwrap with Option::insert in thumbs.rs (#380)

### DIFF
--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -193,12 +193,10 @@ pub fn ensure_thumbnails_sync(
         }
         let img = match decoded.as_ref() {
             Some(img) => img,
-            None => {
-                let d = image::load_from_memory(&cover_bytes)
-                    .map_err(|e| ThumbError::Decode(e.to_string()))?;
-                decoded = Some(d);
-                decoded.as_ref().unwrap()
-            }
+            None => decoded.insert(
+                image::load_from_memory(&cover_bytes)
+                    .map_err(|e| ThumbError::Decode(e.to_string()))?,
+            ),
         };
         write_thumbnail(book_id, size, img)?;
     }


### PR DESCRIPTION
## Summary
- Replace `decoded.as_ref().unwrap()` in `db/src/thumbs.rs::ensure_thumbnails_sync` with `Option::insert(...)`, which returns the inserted reference directly. The previous pattern only worked because the reader had to notice the `decoded = Some(d)` assignment two lines earlier; the new code is structurally panic-free.
- Removes a violation of `.claude/rules/05-rust-style.md` § Mechanics, which bans `.unwrap()` in production paths.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — passes (per the acceptance criteria on the issue)
- [x] `cargo clippy --all-targets -- -D warnings` (default-members) — passes
- [x] `cargo test -p omnibus-db` — 444 unit tests + 2 integration tests pass, including the `thumbs::tests::*` module (`generate_thumbnail_produces_valid_webp`, `is_stale_*`, `evict_if_over_cap_*`, `thumb_path_for_format`, `thumbs_dir_*`, `thumb_size_from_str_roundtrip`)

## Notes
- No observable behaviour change: same single decode per call, same reference reused across stale sizes, same error type/variant on decode failure.
- `cargo clippy --all-targets --all-features` surfaces unrelated pre-existing failures in `omnibus-frontend` (`CurrentUser` feature gating in `frontend/src/lib.rs` and a `web_sys::BlobPropertyBag::type_` deprecation in `frontend/src/data/authors.rs`). These exist on `origin/main` and are out of scope for this PR.

Closes #380

---
_Generated by [Claude Code](https://claude.ai/code/session_016qWRUAmng2dafLazNsSShe)_