### PR TITLE
refactor(frontend): add key: props to dynamic rsx! loops (#379)

### DIFF
--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -25,7 +25,7 @@ pub fn FormatSwitcher(formats: Vec<String>, uuid: String) -> Element {
             aria_label: "Available formats",
             "data-testid": "format-switcher",
             for row in rows {
-                FormatRow { kind: row, uuid: uuid.clone() }
+                FormatRow { key: "{row.label()}", kind: row, uuid: uuid.clone() }
             }
         }
     }

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -233,7 +233,7 @@ pub fn AuthorsIndexPage() -> Element {
                             }
                             div { class: "idx-card-grid",
                                 for a in group.iter() {
-                                    {render_author_card(a, &server_url_for_cards)}
+                                    div { key: "{a.id}", {render_author_card(a, &server_url_for_cards)} }
                                 }
                             }
                         }
@@ -241,7 +241,7 @@ pub fn AuthorsIndexPage() -> Element {
                 } else {
                     div { class: "idx-card-grid idx-card-grid--flat",
                         for a in filtered.iter() {
-                            {render_author_card(a, &server_url_for_cards)}
+                            div { key: "{a.id}", {render_author_card(a, &server_url_for_cards)} }
                         }
                     }
                 }

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -148,7 +148,7 @@ pub fn SeriesIndexPage() -> Element {
                 } else {
                     div { class: "idx-series-grid",
                         for s in filtered.iter() {
-                            {render_series_card(s)}
+                            div { key: "{s.id}", {render_series_card(s)} }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Closes #379.

Four `for … in …` loops inside `rsx!` blocks were rendering dynamic lists without a `key:` prop. Without keys, Dioxus reconciles by index — on reorder/filter/remove this leaks state (focus, animation, cached layout) from one item into another. This PR adds stable id-derived keys to all four sites:

| Site | Key |
|---|---|
| `frontend/src/components/format_switcher.rs:27` — `FormatRow` loop | `key: "{row.label()}"` (passed directly to the `#[component]`; labels are unique after `prepare_rows` dedupes case-insensitively) |
| `frontend/src/pages/authors_index.rs:235` — grouped `render_author_card` loop | wrapping `div { key: "{a.id}", … }` |
| `frontend/src/pages/authors_index.rs:243` — flat-layout `render_author_card` loop | wrapping `div { key: "{a.id}", … }` |
| `frontend/src/pages/series_index.rs:150` — `render_series_card` loop | wrapping `div { key: "{s.id}", … }` |

Approach notes:
- `FormatRow` is already a `#[component]`, so `key:` is passed directly as the component's special key prop.
- For `render_author_card` / `render_series_card`, the helpers return a `Link { class: "idx-card …", style: "--accent: …" }` as their root. Wrapping with an outer `div { key, … }` is the simplest shape — the wrapper becomes the grid child and the inner `Link` keeps its `display: grid` chrome (border/background/hover) untouched. CSS Grid (`auto-fill, minmax(…)`) still tracks columns correctly because the wrapper has no display override.
- Keys are stable per item — never `enumerate()` index, per the issue's acceptance criteria.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — passes (the acceptance check)
- [x] `cargo test -p omnibus-frontend --features server` — 108/108 pass
- [ ] Manual: scroll/filter authors and series indexes; confirm card chrome (border, hover ring, avatar) stays attached to the right author/series when the filter narrows or sort changes

Pre-existing on `main` (unrelated to this PR): `cargo clippy --all-targets --all-features` fails because `--all-features` enables both `web` and `mobile`, which are mutually exclusive (`use_current_user` / `CurrentUser` are `#[cfg(not(feature = "mobile"))]`), plus duplicated `#[server]` function definitions across feature gates. Not addressed here — out of scope.

https://claude.ai/code/session_016qWRUAmng2dafLazNsSShe

---
_Generated by [Claude Code](https://claude.ai/code/session_016qWRUAmng2dafLazNsSShe)_