### PR TITLE
refactor(frontend): group PlayerStage/FormGrid props into structs (#378)

### DIFF
--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -15,7 +15,7 @@ use super::controls::AudioElement;
 use super::overlays::{FailedOverlay, PreparingOverlay};
 use super::sleep_panel::SleepPanel;
 use super::speed_panel::SpeedPanel;
-use super::stage::PlayerStage;
+use super::stage::{PlaybackPosition, PlayerCallbacks, PlayerStage, ToolbarState, TransportState};
 use crate::Nav;
 
 /// Render the ready-state player chrome and bind the transport handlers.
@@ -102,48 +102,56 @@ pub(super) fn ReadyPlayer(
                 book: book.clone(),
                 title,
                 author,
-                elapsed: elapsed_now,
-                duration: dur,
-                remaining,
-                scrub_max,
-                play_label,
-                playing: playing(),
-                rate_label,
-                rate_active: speed_panel_open(),
-                sleep_active: sleep_panel_open(),
-                bookmarks_active: bookmarks_open(),
-                chapters_active: chapters_open(),
-                on_seek,
-                on_toggle,
-                on_skip_back,
-                on_skip_forward,
-                on_rate,
-                on_sleep: move |_| {
-                    let cur = *sleep_panel_open.peek();
-                    sleep_panel_open.set(!cur);
-                    if !cur {
-                        speed_panel_open.set(false);
-                        bookmarks_open.set(false);
-                        chapters_open.set(false);
-                    }
+                position: PlaybackPosition {
+                    elapsed: elapsed_now,
+                    duration: dur,
+                    remaining,
+                    scrub_max,
                 },
-                on_bookmark: move |_| {
-                    let cur = *bookmarks_open.peek();
-                    bookmarks_open.set(!cur);
-                    if !cur {
-                        speed_panel_open.set(false);
-                        sleep_panel_open.set(false);
-                        chapters_open.set(false);
-                    }
+                transport: TransportState {
+                    play_label,
+                    playing: playing(),
+                    rate_label,
+                    rate_active: speed_panel_open(),
                 },
-                on_chapters: move |_| {
-                    let cur = *chapters_open.peek();
-                    chapters_open.set(!cur);
-                    if !cur {
-                        speed_panel_open.set(false);
-                        sleep_panel_open.set(false);
-                        bookmarks_open.set(false);
-                    }
+                callbacks: PlayerCallbacks {
+                    on_seek: EventHandler::new(on_seek),
+                    on_toggle: EventHandler::new(on_toggle),
+                    on_skip_back: EventHandler::new(on_skip_back),
+                    on_skip_forward: EventHandler::new(on_skip_forward),
+                    on_rate: EventHandler::new(on_rate),
+                },
+                toolbar: ToolbarState {
+                    sleep_active: sleep_panel_open(),
+                    bookmarks_active: bookmarks_open(),
+                    chapters_active: chapters_open(),
+                    on_sleep: EventHandler::new(move |_| {
+                        let cur = *sleep_panel_open.peek();
+                        sleep_panel_open.set(!cur);
+                        if !cur {
+                            speed_panel_open.set(false);
+                            bookmarks_open.set(false);
+                            chapters_open.set(false);
+                        }
+                    }),
+                    on_bookmark: EventHandler::new(move |_| {
+                        let cur = *bookmarks_open.peek();
+                        bookmarks_open.set(!cur);
+                        if !cur {
+                            speed_panel_open.set(false);
+                            sleep_panel_open.set(false);
+                            chapters_open.set(false);
+                        }
+                    }),
+                    on_chapters: EventHandler::new(move |_| {
+                        let cur = *chapters_open.peek();
+                        chapters_open.set(!cur);
+                        if !cur {
+                            speed_panel_open.set(false);
+                            sleep_panel_open.set(false);
+                            bookmarks_open.set(false);
+                        }
+                    }),
                 },
             }
 

--- a/frontend/src/pages/listen/stage.rs
+++ b/frontend/src/pages/listen/stage.rs
@@ -11,34 +11,61 @@ use omnibus_shared::EbookMetadata;
 use super::controls::{Scrubber, Toolbar, TransportButtons};
 use crate::components::atrium::Cover;
 
-#[allow(clippy::too_many_arguments)]
+/// Scrubber timing: current position plus the derived totals the bar
+/// renders alongside it (duration, remaining, and the slider's max).
+#[derive(Clone, PartialEq)]
+pub(super) struct PlaybackPosition {
+    pub elapsed: f64,
+    pub duration: f64,
+    pub remaining: f64,
+    pub scrub_max: f64,
+}
+
+/// Play/skip/rate button labels and on/off state shared by the
+/// transport row.
+#[derive(Clone, PartialEq)]
+pub(super) struct TransportState {
+    pub play_label: String,
+    pub playing: bool,
+    pub rate_label: String,
+    pub rate_active: bool,
+}
+
+/// Transport-row event handlers wired through to the scrubber + play /
+/// skip / rate buttons.
+#[derive(Clone, PartialEq)]
+pub(super) struct PlayerCallbacks {
+    pub on_seek: EventHandler<Event<FormData>>,
+    pub on_toggle: EventHandler<MouseEvent>,
+    pub on_skip_back: EventHandler<MouseEvent>,
+    pub on_skip_forward: EventHandler<MouseEvent>,
+    pub on_rate: EventHandler<MouseEvent>,
+}
+
+/// Toolbar row (sleep / bookmark / chapters): per-button highlight state
+/// plus the toggle handlers their containing panels listen on.
+#[derive(Clone, PartialEq)]
+pub(super) struct ToolbarState {
+    pub sleep_active: bool,
+    pub bookmarks_active: bool,
+    pub chapters_active: bool,
+    pub on_sleep: EventHandler<MouseEvent>,
+    pub on_bookmark: EventHandler<MouseEvent>,
+    pub on_chapters: EventHandler<MouseEvent>,
+}
+
 #[component]
 pub(super) fn PlayerStage(
     book: EbookMetadata,
     title: String,
     author: String,
-    elapsed: f64,
-    duration: f64,
-    remaining: f64,
-    scrub_max: f64,
-    play_label: String,
-    playing: bool,
-    rate_label: String,
-    rate_active: bool,
-    on_seek: EventHandler<Event<FormData>>,
-    on_toggle: EventHandler<MouseEvent>,
-    on_skip_back: EventHandler<MouseEvent>,
-    on_skip_forward: EventHandler<MouseEvent>,
-    on_rate: EventHandler<MouseEvent>,
-    sleep_active: bool,
-    bookmarks_active: bool,
-    chapters_active: bool,
-    on_sleep: EventHandler<MouseEvent>,
-    on_bookmark: EventHandler<MouseEvent>,
-    on_chapters: EventHandler<MouseEvent>,
+    position: PlaybackPosition,
+    transport: TransportState,
+    callbacks: PlayerCallbacks,
+    toolbar: ToolbarState,
 ) -> Element {
-    let fill_pct = if scrub_max > 0.0 {
-        (elapsed / scrub_max * 100.0).min(100.0)
+    let fill_pct = if position.scrub_max > 0.0 {
+        (position.elapsed / position.scrub_max * 100.0).min(100.0)
     } else {
         0.0
     };
@@ -57,32 +84,32 @@ pub(super) fn PlayerStage(
                 div { class: "lp-chapter-sub" }
 
                 Scrubber {
-                    elapsed,
-                    duration,
-                    remaining,
-                    scrub_max,
+                    elapsed: position.elapsed,
+                    duration: position.duration,
+                    remaining: position.remaining,
+                    scrub_max: position.scrub_max,
                     fill_pct,
-                    on_seek,
+                    on_seek: callbacks.on_seek,
                 }
 
                 TransportButtons {
-                    play_label,
-                    playing,
-                    rate_label,
-                    rate_active,
-                    on_toggle,
-                    on_skip_back,
-                    on_skip_forward,
-                    on_rate,
+                    play_label: transport.play_label,
+                    playing: transport.playing,
+                    rate_label: transport.rate_label,
+                    rate_active: transport.rate_active,
+                    on_toggle: callbacks.on_toggle,
+                    on_skip_back: callbacks.on_skip_back,
+                    on_skip_forward: callbacks.on_skip_forward,
+                    on_rate: callbacks.on_rate,
                 }
 
                 Toolbar {
-                    sleep_active,
-                    bookmarks_active,
-                    chapters_active,
-                    on_sleep,
-                    on_bookmark,
-                    on_chapters,
+                    sleep_active: toolbar.sleep_active,
+                    bookmarks_active: toolbar.bookmarks_active,
+                    chapters_active: toolbar.chapters_active,
+                    on_sleep: toolbar.on_sleep,
+                    on_bookmark: toolbar.on_bookmark,
+                    on_chapters: toolbar.on_chapters,
                 }
             }
         }

--- a/frontend/src/pages/listen/stage.rs
+++ b/frontend/src/pages/listen/stage.rs
@@ -11,8 +11,7 @@ use omnibus_shared::EbookMetadata;
 use super::controls::{Scrubber, Toolbar, TransportButtons};
 use crate::components::atrium::Cover;
 
-/// Scrubber timing: current position plus the derived totals the bar
-/// renders alongside it (duration, remaining, and the slider's max).
+/// Scrubber timing — elapsed plus the derived totals (duration, remaining, slider max).
 #[derive(Clone, PartialEq)]
 pub(super) struct PlaybackPosition {
     pub elapsed: f64,
@@ -21,8 +20,7 @@ pub(super) struct PlaybackPosition {
     pub scrub_max: f64,
 }
 
-/// Play/skip/rate button labels and on/off state shared by the
-/// transport row.
+/// Play/skip/rate button labels and on/off state shared by the transport row.
 #[derive(Clone, PartialEq)]
 pub(super) struct TransportState {
     pub play_label: String,
@@ -31,8 +29,7 @@ pub(super) struct TransportState {
     pub rate_active: bool,
 }
 
-/// Transport-row event handlers wired through to the scrubber + play /
-/// skip / rate buttons.
+/// Transport-row event handlers wired through to the scrubber + play/skip/rate buttons.
 #[derive(Clone, PartialEq)]
 pub(super) struct PlayerCallbacks {
     pub on_seek: EventHandler<Event<FormData>>,
@@ -42,8 +39,7 @@ pub(super) struct PlayerCallbacks {
     pub on_rate: EventHandler<MouseEvent>,
 }
 
-/// Toolbar row (sleep / bookmark / chapters): per-button highlight state
-/// plus the toggle handlers their containing panels listen on.
+/// Toolbar row (sleep/bookmark/chapters) — per-button highlight state plus toggle handlers.
 #[derive(Clone, PartialEq)]
 pub(super) struct ToolbarState {
     pub sleep_active: bool,

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -17,7 +17,7 @@ mod header;
 mod save_bar;
 mod sidebar;
 
-use form_grid::FormGrid;
+use form_grid::{FormFields, FormGrid, FormSuggestions};
 use header::{Breadcrumb, PageHeader};
 use save_bar::SaveBar;
 use sidebar::Sidebar;
@@ -274,19 +274,23 @@ fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
             div { class: "me-layout",
                 FormGrid {
                     orig,
-                    title,
-                    description,
-                    publisher,
-                    published,
-                    language,
-                    series,
-                    series_index,
-                    authors,
-                    tags,
-                    sort_by,
-                    filename,
-                    author_suggestions,
-                    tag_suggestions,
+                    fields: FormFields {
+                        title,
+                        description,
+                        publisher,
+                        published,
+                        language,
+                        series,
+                        series_index,
+                        authors,
+                        tags,
+                        sort_by,
+                        filename,
+                    },
+                    suggestions: FormSuggestions {
+                        authors: author_suggestions,
+                        tags: tag_suggestions,
+                    },
                 }
                 Sidebar {
                     book: book.clone(),

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -8,33 +8,53 @@ use omnibus_shared::EbookMetadata;
 use super::fields::{MeArea, MeField, MeLabel};
 use crate::components::chip_editor::{ChipEditor, SuggestionItem};
 
+/// Per-field editable signals owned by the parent `MetadataEditForm` and
+/// threaded through the form rows. Each signal is `Copy`, so this struct
+/// stays cheap to clone for Dioxus's `PartialEq` prop comparison.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct FormFields {
+    pub title: Signal<String>,
+    pub description: Signal<String>,
+    pub publisher: Signal<String>,
+    pub published: Signal<String>,
+    pub language: Signal<String>,
+    pub series: Signal<String>,
+    pub series_index: Signal<String>,
+    pub authors: Signal<Vec<String>>,
+    pub tags: Signal<Vec<String>>,
+    pub sort_by: Signal<String>,
+    pub filename: Signal<String>,
+}
+
+/// Suggestion pools backing the author + tag chip-editor dropdowns. Empty
+/// signals render no dropdown; populated by the parent's mount-time fetch.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct FormSuggestions {
+    pub authors: Signal<Vec<SuggestionItem>>,
+    pub tags: Signal<Vec<SuggestionItem>>,
+}
+
 /// Composed form grid plus the tags + series sections that live in the
 /// same left-column container on the page.
 #[component]
-#[allow(clippy::too_many_arguments)]
 pub(super) fn FormGrid(
     orig: Signal<EbookMetadata>,
-    title: Signal<String>,
-    description: Signal<String>,
-    publisher: Signal<String>,
-    published: Signal<String>,
-    language: Signal<String>,
-    series: Signal<String>,
-    series_index: Signal<String>,
-    authors: Signal<Vec<String>>,
-    tags: Signal<Vec<String>>,
-    sort_by: Signal<String>,
-    filename: Signal<String>,
-    author_suggestions: Signal<Vec<SuggestionItem>>,
-    tag_suggestions: Signal<Vec<SuggestionItem>>,
+    fields: FormFields,
+    suggestions: FormSuggestions,
 ) -> Element {
-    let mut title = title;
-    let mut description = description;
-    let mut publisher = publisher;
-    let mut published = published;
-    let mut language = language;
-    let mut series = series;
-    let mut series_index = series_index;
+    let mut title = fields.title;
+    let mut description = fields.description;
+    let mut publisher = fields.publisher;
+    let mut published = fields.published;
+    let mut language = fields.language;
+    let mut series = fields.series;
+    let mut series_index = fields.series_index;
+    let authors = fields.authors;
+    let tags = fields.tags;
+    let sort_by = fields.sort_by;
+    let filename = fields.filename;
+    let author_suggestions = suggestions.authors;
+    let tag_suggestions = suggestions.tags;
 
     rsx! {
         div { class: "me-form",

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -8,9 +8,7 @@ use omnibus_shared::EbookMetadata;
 use super::fields::{MeArea, MeField, MeLabel};
 use crate::components::chip_editor::{ChipEditor, SuggestionItem};
 
-/// Per-field editable signals owned by the parent `MetadataEditForm` and
-/// threaded through the form rows. Each signal is `Copy`, so this struct
-/// stays cheap to clone for Dioxus's `PartialEq` prop comparison.
+/// Per-field editable signals threaded through the form rows from `MetadataEditForm`.
 #[derive(Clone, Copy, PartialEq)]
 pub(super) struct FormFields {
     pub title: Signal<String>,
@@ -26,8 +24,7 @@ pub(super) struct FormFields {
     pub filename: Signal<String>,
 }
 
-/// Suggestion pools backing the author + tag chip-editor dropdowns. Empty
-/// signals render no dropdown; populated by the parent's mount-time fetch.
+/// Suggestion pools backing the author + tag chip-editor dropdowns.
 #[derive(Clone, Copy, PartialEq)]
 pub(super) struct FormSuggestions {
     pub authors: Signal<Vec<SuggestionItem>>,


### PR DESCRIPTION
## Summary

Removes the `#[allow(clippy::too_many_arguments)]` escape hatches on two Dioxus components (`PlayerStage` had 22 props, `FormGrid` had 14) by grouping related props into named `(Clone, PartialEq)` structs.

### `PlayerStage` — 22 props → 7

New types in `frontend/src/pages/listen/stage.rs`:

- **`PlaybackPosition`** — `elapsed`, `duration`, `remaining`, `scrub_max` (scrubber timing)
- **`TransportState`** — `play_label`, `playing`, `rate_label`, `rate_active` (transport-row labels + on/off)
- **`PlayerCallbacks`** — `on_seek`, `on_toggle`, `on_skip_back`, `on_skip_forward`, `on_rate` (transport handlers)
- **`ToolbarState`** — `sleep_active`/`bookmarks_active`/`chapters_active` + `on_sleep`/`on_bookmark`/`on_chapters` (toolbar row state + handlers)

Remaining standalone props: `book`, `title`, `author`, plus the four structs above.

### `FormGrid` — 14 props → 3

New types in `frontend/src/pages/metadata_edit/form_grid.rs`:

- **`FormFields`** — every editable signal (`title`, `description`, `publisher`, `published`, `language`, `series`, `series_index`, `authors`, `tags`, `sort_by`, `filename`). `Copy` since Dioxus `Signal<T>` is `Copy`.
- **`FormSuggestions`** — author + tag suggestion-pool signals backing the `ChipEditor` dropdowns.

`orig` stays a top-level prop — it's the dirty-comparison anchor used pervasively in the grid.

### Call sites updated

- `frontend/src/pages/listen/ready_player.rs` — constructs the four new structs (handlers wrapped via `EventHandler::new(...)` since the macro's auto-conversion only applies to direct component args, not struct fields).
- `frontend/src/pages/metadata_edit.rs` — packs the per-field signals into `FormFields` / `FormSuggestions`.

No markup or rendered-DOM changes; this is a pure prop-shape refactor.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — passes without the `#[allow]` attributes (acceptance criterion)
- [x] `cargo clippy --all-targets -- -D warnings` (default workspace members: server, shared, frontend) — passes
- [x] `cargo test -p omnibus-frontend --features server` — 108/108 pass
- [x] `cargo test -p omnibus` — 185/185 pass

Pre-existing `main` failure: `cargo clippy --all-features` fails because the frontend crate has a `compile_error!` enforcing that `web` and `mobile` features are mutually exclusive — not introduced by this PR.

Closes #378

https://claude.ai/code/session_016qWRUAmng2dafLazNsSShe

---
_Generated by [Claude Code](https://claude.ai/code/session_016qWRUAmng2dafLazNsSShe)_