### PR TITLE
fix: remove compounding page margins from consolidated CSS

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -827,7 +827,7 @@ body.atrium,
 
 /* Hero — accent-gradient backdrop, avatar + name + stat */
 .disc-hero {
-  padding: 48px clamp(20px, 4vw, 56px) 24px;
+  padding: 48px 0 24px;
 }
 .disc-hero-grid {
   display: grid;
@@ -911,7 +911,7 @@ body.atrium,
 
 /* Body and sections */
 .disc-body {
-  padding: 32px clamp(20px, 4vw, 56px) 0;
+  padding: 32px 0 0;
 }
 .disc-section { margin-bottom: 40px; }
 .disc-section-head {
@@ -933,7 +933,7 @@ body.atrium,
 
 /* Series header (no avatar, simpler layout) */
 .disc-series-header {
-  padding: 48px clamp(20px, 4vw, 56px) 32px;
+  padding: 48px 0 32px;
 }
 .disc-series-head-row {
   display: flex;
@@ -989,7 +989,7 @@ body.atrium,
 
 /* Tag cloud page */
 .disc-tag-header {
-  padding: 48px clamp(20px, 4vw, 56px) 24px;
+  padding: 48px 0 24px;
 }
 .disc-tag-subtitle {
   margin-top: 8px;
@@ -999,7 +999,7 @@ body.atrium,
 
 /* Two-column layout for tag cloud + sidebar */
 .disc-two-col {
-  padding: 12px clamp(20px, 4vw, 56px) 48px;
+  padding: 12px 0 48px;
   display: grid;
   grid-template-columns: 1fr 280px;
   gap: 40px;
@@ -1040,7 +1040,7 @@ body.atrium,
 
 .idx-page { padding-bottom: 60px; }
 
-.idx-header { padding: 32px clamp(20px, 4vw, 56px) 20px; }
+.idx-header { padding: 32px 0 20px; }
 .idx-head-row {
   display: grid;
   grid-template-columns: 1fr;
@@ -1127,7 +1127,7 @@ a.idx-letter-on:focus-visible {
 .idx-letters-count { font-size: 11px; color: var(--ink-3); }
 
 /* Body */
-.idx-body { padding: 0 clamp(20px, 4vw, 56px); }
+.idx-body { padding: 0; }
 .idx-empty {
   padding: 48px 0;
   text-align: center;
@@ -2519,11 +2519,10 @@ body {
 }
 
 .app-shell {
-  max-width: 1400px;
-  margin: 0 auto;
+  width: 100%;
 }
 .app-shell > main {
-  padding: 0 clamp(1rem, 4vw, 2.5rem);
+  padding: 0 clamp(1.25rem, 4vw, 3.5rem);
 }
 
 .screen {


### PR DESCRIPTION
## Summary
- Remove the `max-width: 1400px` cap on `.app-shell` so all pages fill the viewport like the book detail page does
- Bump `.app-shell > main` horizontal padding to `clamp(1.25rem, 4vw, 3.5rem)` to match the book detail page's edge margins
- Strip redundant horizontal padding from `.disc-hero`, `.disc-body`, `.idx-header`, `.idx-body` — these stacked on top of `main`'s padding after the CSS consolidation in #393

## Test plan
- [ ] Landing page table fills the full viewport at 1700px wide (publisher/published columns visible)
- [ ] Authors index shows 4–5 cards per row at wide viewports (was 3, crammed into left half)
- [ ] Series index cards span the full content width
- [ ] Author detail hero and body fill the viewport
- [ ] Book detail page unchanged (hero still full-bleed, sidebar positioned correctly)
- [ ] No horizontal scrollbar at any viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)