### PR TITLE
fix: extract oklch accent from audiobook covers during indexing

### DIFF
--- a/db/src/audiobook.rs
+++ b/db/src/audiobook.rs
@@ -16,6 +16,8 @@ use std::path::{Path, PathBuf};
 
 use omnibus_shared::{Contributor, EbookMetadata};
 
+use crate::ebook::extract_accent;
+
 pub mod codec;
 mod cover;
 mod group;
@@ -77,6 +79,9 @@ pub fn build_indexed_book(path: &Path, filename: String) -> Result<IndexedBook, 
         let m = ((d % 3600.0) / 60.0) as i64;
         format!("Audiobook · {h}h {m:02}m")
     });
+    let accent = cover
+        .as_ref()
+        .and_then(|(_mime, bytes)| extract_accent(bytes));
 
     Ok(IndexedBook {
         metadata: EbookMetadata {
@@ -84,6 +89,7 @@ pub fn build_indexed_book(path: &Path, filename: String) -> Result<IndexedBook, 
             title: Some(title),
             description,
             creators,
+            accent,
             ..Default::default()
         },
         cover,

--- a/db/src/audiobook/parse.rs
+++ b/db/src/audiobook/parse.rs
@@ -16,6 +16,8 @@ use std::path::{Path, PathBuf};
 use lofty::file::{AudioFile, TaggedFileExt};
 use lofty::tag::Accessor;
 
+use crate::ebook::extract_accent;
+
 /// Predictable failure space for the audiobook parse + indexer dispatch.
 /// `Io` covers "could not open file"; `Tag` covers any lofty decode /
 /// container error; `Unsupported` is reserved for files whose extension
@@ -109,6 +111,9 @@ pub struct IndexedAudiobook {
     /// `(mime, bytes)` from the first part's embedded artwork. `None` when
     /// no artwork is present.
     pub cover: Option<(String, Vec<u8>)>,
+    /// Cover-derived `oklch(L C H)` accent color, or `None` when the cover
+    /// has no chromatic content or no cover was found.
+    pub accent: Option<String>,
     pub parts: Vec<AudiobookPart>,
     pub total_size_bytes: i64,
     pub max_mtime_epoch: i64,
@@ -268,6 +273,10 @@ fn parse_one_group(group: super::AudiobookGroup, library_root: &Path) -> Indexed
         })
         .collect();
 
+    let accent = first_cover
+        .as_ref()
+        .and_then(|(_mime, bytes)| extract_accent(bytes));
+
     IndexedAudiobook {
         uuid: group.uuid,
         group_path: group.group_path,
@@ -275,6 +284,7 @@ fn parse_one_group(group: super::AudiobookGroup, library_root: &Path) -> Indexed
         title,
         creator_name,
         cover: first_cover,
+        accent,
         parts,
         total_size_bytes: group.total_size_bytes,
         max_mtime_epoch: group.max_mtime_epoch,

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -614,6 +614,7 @@ mod tests {
                 title: "AudioTitle".to_string(),
                 creator_name: None,
                 cover: None,
+                accent: None,
                 parts: vec![],
                 total_size_bytes: 100,
                 max_mtime_epoch: 100,

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -4,6 +4,7 @@
 use sqlx::{SqlitePool, Transaction};
 
 use crate::covers::delete_cover_files_for;
+use crate::helpers::sanitize_accent_color;
 use crate::settings::upsert_library;
 
 use super::books::materialize_new_covers;
@@ -193,8 +194,8 @@ async fn insert_audiobook_row(
 
     let book_id = sqlx::query_scalar::<_, i64>(
         "INSERT INTO books \
-            (uuid, library_id, path, title, sort, author_sort, has_cover, description) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
+            (uuid, library_id, path, title, sort, author_sort, has_cover, description, accent_color) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
          RETURNING id",
     )
     .bind(&b.uuid)
@@ -205,6 +206,7 @@ async fn insert_audiobook_row(
     .bind(&b.creator_name)
     .bind(has_cover)
     .bind(&b.description)
+    .bind(sanitize_accent_color(b.accent.as_deref()))
     .fetch_one(&mut **tx)
     .await?;
 
@@ -336,7 +338,7 @@ async fn update_audiobook_row(
     sqlx::query(
         "UPDATE books SET \
             path = ?, title = ?, sort = ?, author_sort = ?, has_cover = ?, \
-            description = ?, last_modified = datetime('now') \
+            description = ?, accent_color = ?, last_modified = datetime('now') \
          WHERE id = ?",
     )
     .bind(&book_path)
@@ -345,6 +347,7 @@ async fn update_audiobook_row(
     .bind(&b.creator_name)
     .bind(has_cover)
     .bind(&b.description)
+    .bind(sanitize_accent_color(b.accent.as_deref()))
     .bind(book_id)
     .execute(&mut **tx)
     .await?;

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -6,7 +6,7 @@ use crate::helpers::stable_uuid;
 use crate::metadata_overrides::upsert_metadata_overrides;
 use crate::pool::init_db;
 use crate::settings::last_indexed_at;
-use crate::test_support::{indexed, indexed_with_stat, CoversTempDir};
+use crate::test_support::{indexed, indexed_audiobook, indexed_with_stat, CoversTempDir};
 use omnibus_shared::{Contributor, EbookMetadata, MetadataOverrides};
 
 #[tokio::test]
@@ -912,5 +912,111 @@ async fn reindex_blocklist_matches_case_insensitively() {
         names,
         vec!["Real Author"],
         "the mixed-case blocked contributor must be skipped"
+    );
+}
+
+#[tokio::test]
+async fn sync_audiobooks_round_trips_accent_color() {
+    let _covers = CoversTempDir::new("ab_accent_round_trip");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let mut with_accent = indexed_audiobook("Author/Book.m4b", "Accented Book", Some("Author"));
+    with_accent.accent = Some("oklch(0.660 0.130 245.0)".into());
+
+    let mut no_accent = indexed_audiobook("Author/Plain.m4b", "Plain Book", Some("Author"));
+    no_accent.accent = None;
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![with_accent, no_accent],
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("sync should succeed");
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let accented = books
+        .iter()
+        .find(|b| b.title.as_deref() == Some("Accented Book"))
+        .unwrap();
+    let plain = books
+        .iter()
+        .find(|b| b.title.as_deref() == Some("Plain Book"))
+        .unwrap();
+    assert_eq!(accented.accent.as_deref(), Some("oklch(0.660 0.130 245.0)"));
+    assert_eq!(plain.accent, None);
+
+    let detail = get_book(&pool, accented.id).await.unwrap().unwrap();
+    assert_eq!(detail.accent.as_deref(), Some("oklch(0.660 0.130 245.0)"));
+}
+
+#[tokio::test]
+async fn sync_audiobooks_updates_accent_color_on_changed() {
+    let _covers = CoversTempDir::new("ab_accent_update");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let book = indexed_audiobook("Author/Book.m4b", "Book", Some("Author"));
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![book],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(books[0].accent, None, "initially no accent");
+
+    let mut updated = indexed_audiobook("Author/Book.m4b", "Book", Some("Author"));
+    updated.accent = Some("oklch(0.700 0.100 180.0)".into());
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            changed_books: vec![updated],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(
+        books[0].accent.as_deref(),
+        Some("oklch(0.700 0.100 180.0)"),
+        "accent should be set after update"
+    );
+}
+
+#[tokio::test]
+async fn sync_audiobooks_drops_unsafe_accent_color() {
+    let _covers = CoversTempDir::new("ab_accent_unsafe");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let mut book = indexed_audiobook("Author/Shady.m4b", "Shady", Some("Author"));
+    book.accent = Some("red; background: url(x)".into());
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![book],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(
+        books[0].accent, None,
+        "unsafe accent must be sanitized to NULL"
     );
 }

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -193,6 +193,7 @@ pub fn indexed_audiobook(
         title: title.into(),
         creator_name: creator.map(Into::into),
         cover: None,
+        accent: None,
         parts: vec![crate::audiobook::AudiobookPart {
             ordinal: 0,
             filename: format!("{group_path}/part1.m4b"),


### PR DESCRIPTION
## Summary

Closes #386

- Add `accent` field to `IndexedAudiobook` and populate it via `extract_accent()` during both single-file and multi-file audiobook parsing
- Include `accent_color` in the audiobook sync INSERT and UPDATE SQL statements (matching the existing ebook path)
- Reuse the existing `sanitize_accent_color` helper for DB writes

The ebook indexing pipeline already extracted `oklch()` accent colors from covers, but the audiobook pipeline skipped this step — cover bytes were available but never processed through `extract_accent()`, leaving `books.accent_color` as NULL for all audiobooks.

## Test plan

- [x] `cargo clippy -p omnibus-db` — clean
- [x] `cargo clippy -p omnibus` — clean
- [x] `cargo test -p omnibus-db` — 446 tests pass
- [ ] Scan an audiobook library and verify `books.accent_color` is populated for audiobooks with covers

🤖 Generated with [Claude Code](https://claude.com/claude-code)