### PR TITLE
feat: chapter extraction infrastructure (migration, parser, query, API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2013,6 +2034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible_collections"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,6 +2696,15 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -3787,6 +3826,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mp4parse"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570"
+dependencies = [
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "log",
+ "num-traits",
+ "static_assertions",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,6 +4235,7 @@ dependencies = [
  "getrandom 0.2.17",
  "image",
  "lofty",
+ "mp4parse",
  "omnibus-shared",
  "rand_core 0.6.4",
  "reqwest",
@@ -5921,6 +5975,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,15 +397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "bitreader"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2034,15 +2013,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible_collections"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,15 +2666,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -3826,20 +3787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mp4parse"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570"
-dependencies = [
- "bitreader",
- "byteorder",
- "fallible_collections",
- "log",
- "num-traits",
- "static_assertions",
-]
-
-[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,7 +4182,6 @@ dependencies = [
  "getrandom 0.2.17",
  "image",
  "lofty",
- "mp4parse",
  "omnibus-shared",
  "rand_core 0.6.4",
  "reqwest",
@@ -5975,12 +5921,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -58,9 +58,6 @@ ammonia = "4"
 # ffprobe fallback.
 lofty = "0.22"
 
-# F2.3b chapter extraction: parse MP4 box tree (moov/udta/chpl Nero chapters
-# and QuickTime chapter tracks) from m4b/m4a containers.
-mp4parse = { version = "0.17", features = ["unstable-api"] }
 
 # Stable, toolchain-independent UUIDv5 derivation for cover ids (issue #94).
 # `std::collections::hash_map::DefaultHasher` is documented as subject to

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -58,6 +58,10 @@ ammonia = "4"
 # ffprobe fallback.
 lofty = "0.22"
 
+# F2.3b chapter extraction: parse MP4 box tree (moov/udta/chpl Nero chapters
+# and QuickTime chapter tracks) from m4b/m4a containers.
+mp4parse = { version = "0.17", features = ["unstable-api"] }
+
 # Stable, toolchain-independent UUIDv5 derivation for cover ids (issue #94).
 # `std::collections::hash_map::DefaultHasher` is documented as subject to
 # change between Rust versions, so a toolchain bump would silently rotate

--- a/db/migrations/0015_file_chapters.sql
+++ b/db/migrations/0015_file_chapters.sql
@@ -1,0 +1,20 @@
+-- Chapter markers extracted from audiobook containers.
+--
+-- M4B files embed chapter atoms (Nero chpl or QuickTime chapter track).
+-- MP3 files may carry ID3v2 CHAP/CTOC frames. Multi-file books without
+-- embedded chapters get one synthetic row per part so the frontend can
+-- always assume file_chapters.len() >= 1.
+--
+-- start_seconds is absolute (from book start), not relative to a part.
+
+CREATE TABLE file_chapters (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_file_id     INTEGER NOT NULL REFERENCES book_files(id) ON DELETE CASCADE,
+    ordinal          INTEGER NOT NULL,
+    title            TEXT    NOT NULL DEFAULT '',
+    start_seconds    REAL    NOT NULL DEFAULT 0,
+    duration_seconds REAL    NOT NULL DEFAULT 0,
+    UNIQUE(book_file_id, ordinal)
+);
+
+CREATE INDEX idx_file_chapters_book_file ON file_chapters(book_file_id);

--- a/db/src/audiobook.rs
+++ b/db/src/audiobook.rs
@@ -8,9 +8,9 @@
 //! [`parse::parse_groups`] into [`parse::IndexedAudiobook`] rows ready for
 //! [`crate::sync::sync_audiobooks`].
 //!
-//! Scope (F2.3 HLS player): title, primary author, album, duration in
-//! seconds, embedded artwork, and per-part track ordering. Chapter atoms are
-//! NOT parsed here — the chapter-list UI is deferred to a later increment.
+//! Scope (F2.3 + F2.3b): title, primary author, album, duration in
+//! seconds, embedded artwork, per-part track ordering, and chapter extraction
+//! from Nero chpl atoms (M4B) and ID3v2 CHAP frames (MP3).
 
 use std::path::{Path, PathBuf};
 
@@ -18,6 +18,7 @@ use omnibus_shared::{Contributor, EbookMetadata};
 
 use crate::ebook::extract_accent;
 
+pub mod chapters;
 pub mod codec;
 mod cover;
 mod group;
@@ -27,6 +28,7 @@ mod stat;
 #[cfg(test)]
 mod tests;
 
+pub use chapters::{extract_chapters, RawChapter};
 pub use codec::{classify_filenames, is_direct_playable, mime_for_filename, PlaybackMode};
 pub use group::{group_into_books, AudiobookGroup};
 pub use parse::{

--- a/db/src/audiobook/chapters.rs
+++ b/db/src/audiobook/chapters.rs
@@ -1,0 +1,297 @@
+//! Chapter extraction from audiobook containers.
+//!
+//! M4B/M4A files store chapters as Nero `chpl` atoms (`moov/udta/chpl`) or
+//! QuickTime chapter tracks. MP3 files may embed ID3v2 CHAP/CTOC frames.
+//! This module extracts both via a unified [`RawChapter`] output that the
+//! sync layer converts to absolute-timeline `file_chapters` rows.
+
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+/// A chapter extracted from an audiobook container, prior to absolute-time
+/// normalization. Times are in milliseconds relative to the file.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawChapter {
+    pub title: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+}
+
+/// Extract chapters from an audiobook file. Returns an empty vec (not an
+/// error) when no chapters are found or the file cannot be parsed — chapter
+/// absence is non-fatal and triggers the synthetic-fallback path.
+pub fn extract_chapters(path: &Path, format: &str) -> Vec<RawChapter> {
+    match format.to_uppercase().as_str() {
+        "M4B" | "M4A" => extract_mp4_chapters(path).unwrap_or_default(),
+        "MP3" => extract_id3_chapters(path).unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+/// Walk the MP4 box tree to find `moov/udta/chpl` (Nero chapters).
+fn extract_mp4_chapters(path: &Path) -> Option<Vec<RawChapter>> {
+    let mut file = std::fs::File::open(path).ok()?;
+    let file_len = file.metadata().ok()?.len();
+    let moov = find_box(&mut file, file_len, b"moov")?;
+    let udta = find_child_box(&mut file, moov.data_offset, moov.data_size, b"udta")?;
+    let chpl = find_child_box(&mut file, udta.data_offset, udta.data_size, b"chpl")?;
+    parse_chpl_payload(&mut file, chpl.data_offset, chpl.data_size)
+}
+
+struct BoxInfo {
+    data_offset: u64,
+    data_size: u64,
+}
+
+/// Find a box at the current level starting from offset 0.
+fn find_box(file: &mut std::fs::File, file_len: u64, target: &[u8; 4]) -> Option<BoxInfo> {
+    find_child_box(file, 0, file_len, target)
+}
+
+/// Find a child box within a parent box's data region.
+fn find_child_box(
+    file: &mut std::fs::File,
+    parent_offset: u64,
+    parent_size: u64,
+    target: &[u8; 4],
+) -> Option<BoxInfo> {
+    let end = parent_offset + parent_size;
+    let mut pos = parent_offset;
+
+    while pos + 8 <= end {
+        file.seek(SeekFrom::Start(pos)).ok()?;
+        let mut header = [0u8; 8];
+        file.read_exact(&mut header).ok()?;
+
+        let size = u32::from_be_bytes([header[0], header[1], header[2], header[3]]) as u64;
+        let box_type = &header[4..8];
+
+        let (box_size, data_offset) = if size == 1 {
+            // 64-bit extended size
+            let mut ext = [0u8; 8];
+            file.read_exact(&mut ext).ok()?;
+            let ext_size = u64::from_be_bytes(ext);
+            (ext_size, pos + 16)
+        } else if size == 0 {
+            // Box extends to end of file
+            (end - pos, pos + 8)
+        } else {
+            (size, pos + 8)
+        };
+
+        if box_size < 8 {
+            return None;
+        }
+
+        if box_type == target {
+            let data_size = box_size - (data_offset - pos);
+            return Some(BoxInfo {
+                data_offset,
+                data_size,
+            });
+        }
+
+        pos += box_size;
+    }
+    None
+}
+
+/// Parse the Nero `chpl` atom payload into chapter entries.
+///
+/// Format: version (1 byte) + flags (3 bytes) + entry count (4 bytes for
+/// v0, 1 byte for v1) + N entries of (start_100ns: u64, title_len: u8,
+/// title: [u8; title_len]).
+fn parse_chpl_payload(file: &mut std::fs::File, offset: u64, size: u64) -> Option<Vec<RawChapter>> {
+    if size < 5 {
+        return None;
+    }
+    file.seek(SeekFrom::Start(offset)).ok()?;
+    let mut ver_flags = [0u8; 4];
+    file.read_exact(&mut ver_flags).ok()?;
+    let version = ver_flags[0];
+
+    let count = if version >= 1 {
+        let mut buf = [0u8; 1];
+        file.read_exact(&mut buf).ok()?;
+        buf[0] as usize
+    } else {
+        let mut buf = [0u8; 4];
+        file.read_exact(&mut buf).ok()?;
+        u32::from_be_bytes(buf) as usize
+    };
+
+    if count == 0 || count > 10_000 {
+        return None;
+    }
+
+    let mut chapters = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut ts_buf = [0u8; 8];
+        file.read_exact(&mut ts_buf).ok()?;
+        let start_100ns = u64::from_be_bytes(ts_buf);
+        let start_ms = start_100ns / 10_000;
+
+        let mut len_buf = [0u8; 1];
+        file.read_exact(&mut len_buf).ok()?;
+        let title_len = len_buf[0] as usize;
+
+        let mut title_buf = vec![0u8; title_len];
+        file.read_exact(&mut title_buf).ok()?;
+        let title = String::from_utf8_lossy(&title_buf).to_string();
+
+        chapters.push(RawChapter {
+            title,
+            start_ms,
+            end_ms: 0,
+        });
+    }
+
+    // Fill end_ms from next chapter's start_ms
+    for i in 0..chapters.len().saturating_sub(1) {
+        chapters[i].end_ms = chapters[i + 1].start_ms;
+    }
+
+    Some(chapters)
+}
+
+/// Extract ID3v2 CHAP frames from an MP3 file.
+///
+/// MP3 audiobooks are almost always folder-of-files where each file IS a
+/// chapter — the synthetic fallback handles that perfectly. Embedded CHAP
+/// frames in a single-file MP3 are extremely rare for audiobooks, so this
+/// path reads the raw bytes directly rather than fighting lofty's unified
+/// tag abstraction (which doesn't expose CHAP frame timing data).
+fn extract_id3_chapters(path: &Path) -> Option<Vec<RawChapter>> {
+    let data = std::fs::read(path).ok()?;
+    parse_id3v2_chap_frames(&data)
+}
+
+/// Scan raw file bytes for an ID3v2 tag and extract CHAP frames.
+fn parse_id3v2_chap_frames(data: &[u8]) -> Option<Vec<RawChapter>> {
+    // ID3v2 header: "ID3" + version(2) + flags(1) + size(4 syncsafe)
+    if data.len() < 10 || &data[0..3] != b"ID3" {
+        return None;
+    }
+    let tag_size = syncsafe_u32(&data[6..10]) as usize;
+    let tag_end = (10 + tag_size).min(data.len());
+    let mut pos = 10;
+
+    let mut chapters = Vec::new();
+
+    while pos + 10 <= tag_end {
+        let frame_id = &data[pos..pos + 4];
+        let frame_size = u32::from_be_bytes(data[pos + 4..pos + 8].try_into().ok()?) as usize;
+        let content_start = pos + 10; // 4 id + 4 size + 2 flags
+        let content_end = content_start + frame_size;
+
+        if frame_size == 0 || content_end > tag_end {
+            break;
+        }
+
+        if frame_id == b"CHAP" {
+            if let Some(ch) = parse_chap_frame_body(&data[content_start..content_end]) {
+                chapters.push(ch);
+            }
+        }
+
+        pos = content_end;
+    }
+
+    if chapters.is_empty() {
+        return None;
+    }
+    chapters.sort_by_key(|c| c.start_ms);
+    Some(chapters)
+}
+
+fn syncsafe_u32(data: &[u8]) -> u32 {
+    ((data[0] as u32) << 21) | ((data[1] as u32) << 14) | ((data[2] as u32) << 7) | (data[3] as u32)
+}
+
+/// Parse a CHAP frame body: element_id(null-terminated) + start(u32 ms) +
+/// end(u32 ms) + start_offset(u32) + end_offset(u32) + sub-frames.
+fn parse_chap_frame_body(data: &[u8]) -> Option<RawChapter> {
+    let null_pos = data.iter().position(|&b| b == 0)?;
+    if data.len() < null_pos + 1 + 16 {
+        return None;
+    }
+    let t = null_pos + 1;
+    let start_ms = u32::from_be_bytes(data[t..t + 4].try_into().ok()?) as u64;
+    let end_ms = u32::from_be_bytes(data[t + 4..t + 8].try_into().ok()?) as u64;
+
+    let sub_start = t + 16;
+    let title = extract_tit2_from_subframes(&data[sub_start..]).unwrap_or_default();
+
+    Some(RawChapter {
+        title,
+        start_ms,
+        end_ms,
+    })
+}
+
+/// Scan sub-frames for a TIT2 frame and decode its text.
+fn extract_tit2_from_subframes(data: &[u8]) -> Option<String> {
+    let mut pos = 0;
+    while pos + 10 <= data.len() {
+        let frame_id = &data[pos..pos + 4];
+        let frame_size = u32::from_be_bytes(data[pos + 4..pos + 8].try_into().ok()?) as usize;
+        let content_start = pos + 10;
+        let content_end = content_start + frame_size;
+
+        if frame_size == 0 || content_end > data.len() {
+            break;
+        }
+
+        if frame_id == b"TIT2" && frame_size > 1 {
+            let encoding = data[content_start];
+            let text_bytes = &data[content_start + 1..content_end];
+            return Some(decode_id3_text(encoding, text_bytes));
+        }
+
+        pos = content_end;
+    }
+    None
+}
+
+/// Decode ID3v2 text given the encoding byte.
+fn decode_id3_text(encoding: u8, data: &[u8]) -> String {
+    match encoding {
+        0 => data
+            .iter()
+            .take_while(|&&b| b != 0)
+            .map(|&b| b as char)
+            .collect(),
+        1 | 2 => {
+            if data.len() < 2 {
+                return String::new();
+            }
+            let (is_be, skip) = if data[0] == 0xFF && data[1] == 0xFE {
+                (false, 2)
+            } else if data[0] == 0xFE && data[1] == 0xFF {
+                (true, 2)
+            } else {
+                (encoding == 2, 0)
+            };
+            let codepoints: Vec<u16> = data[skip..]
+                .chunks_exact(2)
+                .map(|p| {
+                    if is_be {
+                        u16::from_be_bytes([p[0], p[1]])
+                    } else {
+                        u16::from_le_bytes([p[0], p[1]])
+                    }
+                })
+                .take_while(|&c| c != 0)
+                .collect();
+            String::from_utf16_lossy(&codepoints)
+        }
+        3 => {
+            let end = data.iter().position(|&b| b == 0).unwrap_or(data.len());
+            String::from_utf8_lossy(&data[..end]).to_string()
+        }
+        _ => String::from_utf8_lossy(data).to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/db/src/audiobook/chapters.rs
+++ b/db/src/audiobook/chapters.rs
@@ -1,9 +1,9 @@
 //! Chapter extraction from audiobook containers.
 //!
-//! M4B/M4A files store chapters as Nero `chpl` atoms (`moov/udta/chpl`) or
-//! QuickTime chapter tracks. MP3 files may embed ID3v2 CHAP/CTOC frames.
-//! This module extracts both via a unified [`RawChapter`] output that the
-//! sync layer converts to absolute-timeline `file_chapters` rows.
+//! M4B/M4A: extracts Nero `chpl` atoms (`moov/udta/chpl`).
+//! MP3: extracts ID3v2 CHAP frames (v2.3 big-endian and v2.4 syncsafe sizes).
+//! Returns [`RawChapter`] entries that the sync layer converts to
+//! absolute-timeline `file_chapters` rows.
 
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
@@ -168,10 +168,11 @@ fn extract_id3_chapters(path: &Path) -> Option<Vec<RawChapter>> {
 
 /// Scan raw file bytes for an ID3v2 tag and extract CHAP frames.
 fn parse_id3v2_chap_frames(data: &[u8]) -> Option<Vec<RawChapter>> {
-    // ID3v2 header: "ID3" + version(2) + flags(1) + size(4 syncsafe)
+    // ID3v2 header: "ID3" + major_version(1) + revision(1) + flags(1) + size(4 syncsafe)
     if data.len() < 10 || &data[0..3] != b"ID3" {
         return None;
     }
+    let major_version = data[3];
     let tag_size = syncsafe_u32(&data[6..10]) as usize;
     let tag_end = (10 + tag_size).min(data.len());
     let mut pos = 10;
@@ -180,7 +181,12 @@ fn parse_id3v2_chap_frames(data: &[u8]) -> Option<Vec<RawChapter>> {
 
     while pos + 10 <= tag_end {
         let frame_id = &data[pos..pos + 4];
-        let frame_size = u32::from_be_bytes(data[pos + 4..pos + 8].try_into().ok()?) as usize;
+        // v2.4 uses syncsafe integers for frame sizes; v2.3 uses plain BE u32
+        let frame_size = if major_version >= 4 {
+            syncsafe_u32(&data[pos + 4..pos + 8]) as usize
+        } else {
+            u32::from_be_bytes(data[pos + 4..pos + 8].try_into().ok()?) as usize
+        };
         let content_start = pos + 10; // 4 id + 4 size + 2 flags
         let content_end = content_start + frame_size;
 

--- a/db/src/audiobook/chapters.rs
+++ b/db/src/audiobook/chapters.rs
@@ -102,7 +102,7 @@ fn find_child_box(
 /// v0, 1 byte for v1) + N entries of (start_100ns: u64, title_len: u8,
 /// title: [u8; title_len]).
 fn parse_chpl_payload(file: &mut std::fs::File, offset: u64, size: u64) -> Option<Vec<RawChapter>> {
-    if size < 5 {
+    if size < 9 {
         return None;
     }
     file.seek(SeekFrom::Start(offset)).ok()?;
@@ -111,6 +111,8 @@ fn parse_chpl_payload(file: &mut std::fs::File, offset: u64, size: u64) -> Optio
     let version = ver_flags[0];
 
     let count = if version >= 1 {
+        let mut _reserved = [0u8; 4];
+        file.read_exact(&mut _reserved).ok()?;
         let mut buf = [0u8; 1];
         file.read_exact(&mut buf).ok()?;
         buf[0] as usize

--- a/db/src/audiobook/chapters/tests.rs
+++ b/db/src/audiobook/chapters/tests.rs
@@ -172,8 +172,8 @@ fn make_id3v2_chap_fixture(
         chap_body.extend_from_slice(element_id.as_bytes());
         chap_body.extend_from_slice(&start.to_be_bytes());
         chap_body.extend_from_slice(&end.to_be_bytes());
-        chap_body.extend_from_slice(&[0xFF; 4]); // start offset (unused)
-        chap_body.extend_from_slice(&[0xFF; 4]); // end offset (unused)
+        chap_body.extend_from_slice(&[0xFF; 4]);
+        chap_body.extend_from_slice(&[0xFF; 4]);
         // TIT2 sub-frame: 4 id + 4 size + 2 flags + body
         chap_body.extend_from_slice(b"TIT2");
         if major_version >= 4 {
@@ -205,9 +205,9 @@ fn make_id3v2_chap_fixture(
     let tag_size = frames.len() as u32;
     let mut data = Vec::new();
     data.extend_from_slice(b"ID3");
-    data.push(major_version); // version major
-    data.push(0);             // version revision
-    data.push(0);             // flags
+    data.push(major_version);
+    data.push(0);
+    data.push(0);
     // syncsafe tag size
     data.push(((tag_size >> 21) & 0x7F) as u8);
     data.push(((tag_size >> 14) & 0x7F) as u8);

--- a/db/src/audiobook/chapters/tests.rs
+++ b/db/src/audiobook/chapters/tests.rs
@@ -1,0 +1,156 @@
+//! Unit tests for chapter extraction.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use super::*;
+
+/// Build a minimal MP4 file with a Nero `chpl` atom containing the given
+/// chapter entries. Returns the path to a temp file.
+fn make_chpl_fixture(chapters: &[(u64, &str)]) -> (tempfile::NamedTempFile, PathBuf) {
+    let mut chpl_body = Vec::new();
+    // version=0, flags=0x000000
+    chpl_body.extend_from_slice(&[0u8; 4]);
+    // chapter count (u32 BE for version 0)
+    chpl_body.extend_from_slice(&(chapters.len() as u32).to_be_bytes());
+    for (start_100ns, title) in chapters {
+        chpl_body.extend_from_slice(&start_100ns.to_be_bytes());
+        let title_bytes = title.as_bytes();
+        chpl_body.push(title_bytes.len() as u8);
+        chpl_body.extend_from_slice(title_bytes);
+    }
+
+    let chpl_size = (8 + chpl_body.len()) as u32;
+    let mut chpl_box = Vec::new();
+    chpl_box.extend_from_slice(&chpl_size.to_be_bytes());
+    chpl_box.extend_from_slice(b"chpl");
+    chpl_box.extend_from_slice(&chpl_body);
+
+    let udta_size = (8 + chpl_box.len()) as u32;
+    let mut udta_box = Vec::new();
+    udta_box.extend_from_slice(&udta_size.to_be_bytes());
+    udta_box.extend_from_slice(b"udta");
+    udta_box.extend_from_slice(&chpl_box);
+
+    let moov_size = (8 + udta_box.len()) as u32;
+    let mut moov_box = Vec::new();
+    moov_box.extend_from_slice(&moov_size.to_be_bytes());
+    moov_box.extend_from_slice(b"moov");
+    moov_box.extend_from_slice(&udta_box);
+
+    // Prepend a minimal ftyp box so the file looks like a real MP4
+    let mut ftyp = Vec::new();
+    let ftyp_size: u32 = 16; // 8 header + 4 brand + 4 minor
+    ftyp.extend_from_slice(&ftyp_size.to_be_bytes());
+    ftyp.extend_from_slice(b"ftyp");
+    ftyp.extend_from_slice(b"M4B ");
+    ftyp.extend_from_slice(&0u32.to_be_bytes());
+
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(&ftyp).unwrap();
+    file.write_all(&moov_box).unwrap();
+    file.flush().unwrap();
+
+    let path = file.path().to_path_buf();
+    (file, path)
+}
+
+#[test]
+fn extract_mp4_chapters_parses_nero_chpl() {
+    let chapters = vec![
+        (0u64, "Introduction"),
+        (300_000_0000u64, "Chapter 1"),   // 5 min in 100ns units
+        (900_000_0000u64, "Chapter 2"),   // 15 min
+        (1_800_000_0000u64, "Chapter 3"), // 30 min
+    ];
+    let (_file, path) = make_chpl_fixture(&chapters);
+
+    let result = extract_chapters(&path, "M4B");
+    assert_eq!(result.len(), 4);
+    assert_eq!(result[0].title, "Introduction");
+    assert_eq!(result[0].start_ms, 0);
+    assert_eq!(result[0].end_ms, 300_000); // 5 minutes in ms
+    assert_eq!(result[1].title, "Chapter 1");
+    assert_eq!(result[1].start_ms, 300_000);
+    assert_eq!(result[1].end_ms, 900_000);
+    assert_eq!(result[2].title, "Chapter 2");
+    assert_eq!(result[2].start_ms, 900_000);
+    assert_eq!(result[3].title, "Chapter 3");
+    assert_eq!(result[3].start_ms, 1_800_000);
+    assert_eq!(result[3].end_ms, 0); // Last chapter has no end
+}
+
+#[test]
+fn extract_chapters_returns_empty_for_missing_chpl() {
+    // File with moov but no udta/chpl
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    let moov_size: u32 = 8;
+    file.write_all(&moov_size.to_be_bytes()).unwrap();
+    file.write_all(b"moov").unwrap();
+    file.flush().unwrap();
+
+    let result = extract_chapters(file.path(), "M4B");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn extract_chapters_returns_empty_for_nonexistent_file() {
+    let result = extract_chapters(Path::new("/nonexistent/file.m4b"), "M4B");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn extract_chapters_returns_empty_for_unknown_format() {
+    let result = extract_chapters(Path::new("/some/file.flac"), "FLAC");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn extract_mp4_chapters_handles_version_1_chpl() {
+    // Version 1 uses a 1-byte count instead of 4-byte
+    let mut chpl_body = Vec::new();
+    chpl_body.extend_from_slice(&[1, 0, 0, 0]); // version=1, flags=0
+    chpl_body.push(2); // 1-byte count = 2
+
+    // Chapter 1: start at 0
+    chpl_body.extend_from_slice(&0u64.to_be_bytes());
+    let title = b"Prologue";
+    chpl_body.push(title.len() as u8);
+    chpl_body.extend_from_slice(title);
+
+    // Chapter 2: start at 10 minutes (in 100ns units)
+    let ten_min_100ns: u64 = 10 * 60 * 10_000_000;
+    chpl_body.extend_from_slice(&ten_min_100ns.to_be_bytes());
+    let title2 = b"Act One";
+    chpl_body.push(title2.len() as u8);
+    chpl_body.extend_from_slice(title2);
+
+    let chpl_size = (8 + chpl_body.len()) as u32;
+    let mut chpl_box = Vec::new();
+    chpl_box.extend_from_slice(&chpl_size.to_be_bytes());
+    chpl_box.extend_from_slice(b"chpl");
+    chpl_box.extend_from_slice(&chpl_body);
+
+    let udta_size = (8 + chpl_box.len()) as u32;
+    let mut udta_box = Vec::new();
+    udta_box.extend_from_slice(&udta_size.to_be_bytes());
+    udta_box.extend_from_slice(b"udta");
+    udta_box.extend_from_slice(&chpl_box);
+
+    let moov_size = (8 + udta_box.len()) as u32;
+    let mut moov_box = Vec::new();
+    moov_box.extend_from_slice(&moov_size.to_be_bytes());
+    moov_box.extend_from_slice(b"moov");
+    moov_box.extend_from_slice(&udta_box);
+
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(&moov_box).unwrap();
+    file.flush().unwrap();
+
+    let result = extract_chapters(file.path(), "M4A");
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].title, "Prologue");
+    assert_eq!(result[0].start_ms, 0);
+    assert_eq!(result[1].title, "Act One");
+    assert_eq!(result[1].start_ms, 600_000); // 10 min in ms
+}

--- a/db/src/audiobook/chapters/tests.rs
+++ b/db/src/audiobook/chapters/tests.rs
@@ -107,9 +107,10 @@ fn extract_chapters_returns_empty_for_unknown_format() {
 
 #[test]
 fn extract_mp4_chapters_handles_version_1_chpl() {
-    // Version 1 uses a 1-byte count instead of 4-byte
+    // Version 1: 4-byte reserved field before the 1-byte count
     let mut chpl_body = Vec::new();
     chpl_body.extend_from_slice(&[1, 0, 0, 0]); // version=1, flags=0
+    chpl_body.extend_from_slice(&[0u8; 4]); // reserved
     chpl_body.push(2); // 1-byte count = 2
 
     // Chapter 1: start at 0

--- a/db/src/audiobook/chapters/tests.rs
+++ b/db/src/audiobook/chapters/tests.rs
@@ -59,9 +59,9 @@ fn make_chpl_fixture(chapters: &[(u64, &str)]) -> (tempfile::NamedTempFile, Path
 fn extract_mp4_chapters_parses_nero_chpl() {
     let chapters = vec![
         (0u64, "Introduction"),
-        (300_000_0000u64, "Chapter 1"),   // 5 min in 100ns units
-        (900_000_0000u64, "Chapter 2"),   // 15 min
-        (1_800_000_0000u64, "Chapter 3"), // 30 min
+        (3_000_000_000u64, "Chapter 1"),  // 5 min in 100ns units
+        (9_000_000_000u64, "Chapter 2"),  // 15 min
+        (18_000_000_000u64, "Chapter 3"), // 30 min
     ];
     let (_file, path) = make_chpl_fixture(&chapters);
 
@@ -153,4 +153,99 @@ fn extract_mp4_chapters_handles_version_1_chpl() {
     assert_eq!(result[0].start_ms, 0);
     assert_eq!(result[1].title, "Act One");
     assert_eq!(result[1].start_ms, 600_000); // 10 min in ms
+}
+
+/// Build a minimal ID3v2.3 tag with one CHAP frame containing a TIT2 sub-frame.
+fn make_id3v2_chap_fixture(
+    major_version: u8,
+    chapters: &[(u32, u32, &str)], // (start_ms, end_ms, title)
+) -> Vec<u8> {
+    let mut frames = Vec::new();
+    for (i, (start, end, title)) in chapters.iter().enumerate() {
+        // CHAP frame body: element_id(null-terminated) + start(4) + end(4) + offsets(8) + TIT2
+        let element_id = format!("ch{i}\0");
+        let mut tit2_body = vec![3u8]; // encoding = UTF-8
+        tit2_body.extend_from_slice(title.as_bytes());
+        let tit2_size = tit2_body.len() as u32;
+
+        let mut chap_body = Vec::new();
+        chap_body.extend_from_slice(element_id.as_bytes());
+        chap_body.extend_from_slice(&start.to_be_bytes());
+        chap_body.extend_from_slice(&end.to_be_bytes());
+        chap_body.extend_from_slice(&[0xFF; 4]); // start offset (unused)
+        chap_body.extend_from_slice(&[0xFF; 4]); // end offset (unused)
+        // TIT2 sub-frame: 4 id + 4 size + 2 flags + body
+        chap_body.extend_from_slice(b"TIT2");
+        if major_version >= 4 {
+            // syncsafe size
+            chap_body.push(((tit2_size >> 21) & 0x7F) as u8);
+            chap_body.push(((tit2_size >> 14) & 0x7F) as u8);
+            chap_body.push(((tit2_size >> 7) & 0x7F) as u8);
+            chap_body.push((tit2_size & 0x7F) as u8);
+        } else {
+            chap_body.extend_from_slice(&tit2_size.to_be_bytes());
+        }
+        chap_body.extend_from_slice(&[0u8; 2]); // flags
+        chap_body.extend_from_slice(&tit2_body);
+
+        let chap_size = chap_body.len() as u32;
+        frames.extend_from_slice(b"CHAP");
+        if major_version >= 4 {
+            frames.push(((chap_size >> 21) & 0x7F) as u8);
+            frames.push(((chap_size >> 14) & 0x7F) as u8);
+            frames.push(((chap_size >> 7) & 0x7F) as u8);
+            frames.push((chap_size & 0x7F) as u8);
+        } else {
+            frames.extend_from_slice(&chap_size.to_be_bytes());
+        }
+        frames.extend_from_slice(&[0u8; 2]); // flags
+        frames.extend_from_slice(&chap_body);
+    }
+
+    let tag_size = frames.len() as u32;
+    let mut data = Vec::new();
+    data.extend_from_slice(b"ID3");
+    data.push(major_version); // version major
+    data.push(0);             // version revision
+    data.push(0);             // flags
+    // syncsafe tag size
+    data.push(((tag_size >> 21) & 0x7F) as u8);
+    data.push(((tag_size >> 14) & 0x7F) as u8);
+    data.push(((tag_size >> 7) & 0x7F) as u8);
+    data.push((tag_size & 0x7F) as u8);
+    data.extend_from_slice(&frames);
+    data
+}
+
+#[test]
+fn extract_id3v2_3_chap_frames() {
+    let data = make_id3v2_chap_fixture(3, &[(0, 60_000, "Intro"), (60_000, 180_000, "Chapter 1")]);
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(&data).unwrap();
+    file.flush().unwrap();
+
+    let result = extract_chapters(file.path(), "MP3");
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].title, "Intro");
+    assert_eq!(result[0].start_ms, 0);
+    assert_eq!(result[0].end_ms, 60_000);
+    assert_eq!(result[1].title, "Chapter 1");
+    assert_eq!(result[1].start_ms, 60_000);
+    assert_eq!(result[1].end_ms, 180_000);
+}
+
+#[test]
+fn extract_id3v2_4_chap_uses_syncsafe_sizes() {
+    let data = make_id3v2_chap_fixture(4, &[(0, 120_000, "Part A"), (120_000, 300_000, "Part B")]);
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(&data).unwrap();
+    file.flush().unwrap();
+
+    let result = extract_chapters(file.path(), "MP3");
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].title, "Part A");
+    assert_eq!(result[0].start_ms, 0);
+    assert_eq!(result[1].title, "Part B");
+    assert_eq!(result[1].start_ms, 120_000);
+    assert_eq!(result[1].end_ms, 300_000);
 }

--- a/db/src/audiobook/parse.rs
+++ b/db/src/audiobook/parse.rs
@@ -115,6 +115,9 @@ pub struct IndexedAudiobook {
     /// has no chromatic content or no cover was found.
     pub accent: Option<String>,
     pub parts: Vec<AudiobookPart>,
+    /// Chapters extracted from container metadata. Empty when the format has
+    /// no embedded chapter markers (the sync layer synthesizes one-per-part).
+    pub chapters: Vec<super::chapters::RawChapter>,
     pub total_size_bytes: i64,
     pub max_mtime_epoch: i64,
     /// Human-readable duration, e.g. `"Audiobook · 14h 07m"`.
@@ -277,6 +280,16 @@ fn parse_one_group(group: super::AudiobookGroup, library_root: &Path) -> Indexed
         .as_ref()
         .and_then(|(_mime, bytes)| extract_accent(bytes));
 
+    // Extract chapters from the first part (single-file M4B/M4A) or from
+    // the first MP3 (rare: ID3v2 CHAP frames). Multi-file MP3 folders
+    // without embedded CHAP frames get the synthetic fallback at sync time.
+    let chapters = if let Some(first) = group.parts.first() {
+        let abs = library_root.join(&first.filename);
+        super::chapters::extract_chapters(&abs, &group.format)
+    } else {
+        Vec::new()
+    };
+
     IndexedAudiobook {
         uuid: group.uuid,
         group_path: group.group_path,
@@ -286,6 +299,7 @@ fn parse_one_group(group: super::AudiobookGroup, library_root: &Path) -> Indexed
         cover: first_cover,
         accent,
         parts,
+        chapters,
         total_size_bytes: group.total_size_bytes,
         max_mtime_epoch: group.max_mtime_epoch,
         description,

--- a/db/src/hls.rs
+++ b/db/src/hls.rs
@@ -232,6 +232,36 @@ pub async fn get_parts(pool: &SqlitePool, book_file_id: i64) -> Result<Vec<HlsPa
         .collect())
 }
 
+/// Fetch chapter markers for a `book_file_id`. Always returns at least one
+/// row because the sync layer writes synthetic chapters when none are
+/// extracted from the container.
+pub async fn get_chapters(
+    pool: &SqlitePool,
+    book_file_id: i64,
+) -> Result<Vec<omnibus_shared::ChapterInfo>, HlsError> {
+    let rows = sqlx::query_as::<_, (i64, String, f64, f64)>(
+        "SELECT ordinal, title, start_seconds, duration_seconds \
+         FROM file_chapters \
+         WHERE book_file_id = ? \
+         ORDER BY ordinal",
+    )
+    .bind(book_file_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(ordinal, title, start_seconds, duration_seconds)| omnibus_shared::ChapterInfo {
+                ordinal,
+                title,
+                start_seconds,
+                duration_seconds,
+            },
+        )
+        .collect())
+}
+
 /// Build an HLS VOD manifest from the stored part durations.
 ///
 /// Each segment is 10 seconds; the last segment gets the remainder.

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -616,6 +616,7 @@ mod tests {
                 cover: None,
                 accent: None,
                 parts: vec![],
+                chapters: vec![],
                 total_size_bytes: 100,
                 max_mtime_epoch: 100,
                 description: None,

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -284,12 +284,15 @@ async fn insert_audiobook_chapters(
     parts: &[crate::audiobook::AudiobookPart],
 ) -> Result<(), sqlx::Error> {
     if !chapters.is_empty() {
+        let total_duration: f64 = parts.iter().map(|p| p.duration_seconds).sum();
         for (i, ch) in chapters.iter().enumerate() {
             let start_seconds = ch.start_ms as f64 / 1000.0;
             let duration_seconds = if ch.end_ms > ch.start_ms {
                 (ch.end_ms - ch.start_ms) as f64 / 1000.0
+            } else if i + 1 < chapters.len() {
+                (chapters[i + 1].start_ms - ch.start_ms) as f64 / 1000.0
             } else {
-                0.0
+                (total_duration - start_seconds).max(0.0)
             };
             sqlx::query(
                 "INSERT INTO file_chapters \

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -79,6 +79,8 @@ pub async fn sync_audiobooks(
             // TOCTOU: promote to New insert.
             let inserted = insert_audiobook_row(&mut tx, library_id, b).await?;
             insert_audiobook_parts(&mut tx, inserted.book_file_id, &b.parts).await?;
+            insert_audiobook_chapters(&mut tx, inserted.book_file_id, &b.chapters, &b.parts)
+                .await?;
             insert_audiobook_author_link(&mut tx, inserted.book_id, b.creator_name.as_deref())
                 .await?;
             insert_audiobook_fts_row(&mut tx, inserted.book_id, b).await?;
@@ -106,6 +108,7 @@ pub async fn sync_audiobooks(
 
         let book_file_id = insert_audiobook_file_row(&mut tx, book_id, b).await?;
         insert_audiobook_parts(&mut tx, book_file_id, &b.parts).await?;
+        insert_audiobook_chapters(&mut tx, book_file_id, &b.chapters, &b.parts).await?;
         insert_audiobook_author_link(&mut tx, book_id, b.creator_name.as_deref()).await?;
         insert_audiobook_fts_row(&mut tx, book_id, b).await?;
 
@@ -119,6 +122,7 @@ pub async fn sync_audiobooks(
     for b in &plan.new_books {
         let inserted = insert_audiobook_row(&mut tx, library_id, b).await?;
         insert_audiobook_parts(&mut tx, inserted.book_file_id, &b.parts).await?;
+        insert_audiobook_chapters(&mut tx, inserted.book_file_id, &b.chapters, &b.parts).await?;
         insert_audiobook_author_link(&mut tx, inserted.book_id, b.creator_name.as_deref()).await?;
         insert_audiobook_fts_row(&mut tx, inserted.book_id, b).await?;
         if let Some((mime, bytes)) = &b.cover {
@@ -267,6 +271,58 @@ async fn insert_audiobook_parts(
         .bind(p.duration_seconds)
         .execute(&mut **tx)
         .await?;
+    }
+    Ok(())
+}
+
+/// Insert `file_chapters` rows. If no chapters were extracted, synthesize
+/// one chapter per part so the frontend always gets `chapters.len() >= 1`.
+async fn insert_audiobook_chapters(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_file_id: i64,
+    chapters: &[crate::audiobook::RawChapter],
+    parts: &[crate::audiobook::AudiobookPart],
+) -> Result<(), sqlx::Error> {
+    if !chapters.is_empty() {
+        for (i, ch) in chapters.iter().enumerate() {
+            let start_seconds = ch.start_ms as f64 / 1000.0;
+            let duration_seconds = if ch.end_ms > ch.start_ms {
+                (ch.end_ms - ch.start_ms) as f64 / 1000.0
+            } else {
+                0.0
+            };
+            sqlx::query(
+                "INSERT INTO file_chapters \
+                    (book_file_id, ordinal, title, start_seconds, duration_seconds) \
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(book_file_id)
+            .bind(i as i64)
+            .bind(&ch.title)
+            .bind(start_seconds)
+            .bind(duration_seconds)
+            .execute(&mut **tx)
+            .await?;
+        }
+    } else {
+        // Synthetic fallback: one chapter per part.
+        let mut cumulative = 0.0f64;
+        for p in parts {
+            let title = format!("Part {}", p.ordinal + 1);
+            sqlx::query(
+                "INSERT INTO file_chapters \
+                    (book_file_id, ordinal, title, start_seconds, duration_seconds) \
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(book_file_id)
+            .bind(p.ordinal)
+            .bind(&title)
+            .bind(cumulative)
+            .bind(p.duration_seconds)
+            .execute(&mut **tx)
+            .await?;
+            cumulative += p.duration_seconds;
+        }
     }
     Ok(())
 }

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -201,6 +201,7 @@ pub fn indexed_audiobook(
             mtime_epoch: 100,
             duration_seconds: 3600.0,
         }],
+        chapters: vec![],
         total_size_bytes: 1000,
         max_mtime_epoch: 100,
         description: Some("Audiobook · 1h 00m".into()),

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -130,9 +130,17 @@ pub(super) async fn get_audiobook_manifest(
                     mime: audiobook::mime_for_filename(&p.filename).to_string(),
                 })
                 .collect();
+            let chapters = match hls::get_chapters(&state.pool, resolved.book_file_id).await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(uuid = %uuid, error = %e, "failed to fetch chapters");
+                    Vec::new()
+                }
+            };
             AudiobookManifest::Direct {
                 parts: manifest_parts,
                 total_duration_seconds,
+                chapters,
             }
         }
         PlaybackMode::Hls => AudiobookManifest::Hls {

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -132,10 +132,7 @@ pub(super) async fn get_audiobook_manifest(
                 .collect();
             let chapters = match hls::get_chapters(&state.pool, resolved.book_file_id).await {
                 Ok(c) => c,
-                Err(e) => {
-                    tracing::warn!(uuid = %uuid, error = %e, "failed to fetch chapters");
-                    Vec::new()
-                }
+                Err(e) => return internal("get_chapters", e),
             };
             AudiobookManifest::Direct {
                 parts: manifest_parts,

--- a/shared/src/audiobook.rs
+++ b/shared/src/audiobook.rs
@@ -15,6 +15,15 @@ pub struct ManifestPart {
     pub mime: String,
 }
 
+/// Chapter marker within an audiobook's timeline.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChapterInfo {
+    pub ordinal: i64,
+    pub title: String,
+    pub start_seconds: f64,
+    pub duration_seconds: f64,
+}
+
 /// Response payload for `GET /api/audiobooks/{uuid}/manifest`.
 ///
 /// `direct` lists per-part URLs the client streams over HTTP Range —
@@ -27,6 +36,8 @@ pub enum AudiobookManifest {
     Direct {
         parts: Vec<ManifestPart>,
         total_duration_seconds: f64,
+        #[serde(default)]
+        chapters: Vec<ChapterInfo>,
     },
     Hls {
         playlist_url: String,


### PR DESCRIPTION
## Summary
- Add `file_chapters` table (migration 0015) storing per-book-file chapter markers with ordinal, title, start/duration.
- New `db::audiobook::chapters` module extracts Nero `chpl` atoms from M4B/M4A and ID3v2 CHAP frames from MP3 via raw binary parsing.
- Sync layer writes extracted chapters during indexing; falls back to one synthetic chapter per part when no embedded markers exist.
- Manifest endpoint (`GET /api/audiobooks/:uuid/manifest`) now returns `chapters: Vec<ChapterInfo>` in the Direct variant (`#[serde(default)]` for backward compat).

## Test plan
- [x] `cargo test -p omnibus-db` — 449 tests pass (includes 5 new chapter extraction tests)
- [x] `cargo test -p omnibus` — 185 server tests pass
- [x] `cargo clippy` clean

>[!NOTE]
> Stack: **1 of 2** — chapter UI ships in `u/sloan/chapter-ui-2`.