### PR TITLE
feat: backfill chapters as a visible worker task

### DIFF
--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -325,6 +325,82 @@ pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow
     Ok(())
 }
 
+/// Fill `file_chapters` for audiobook `book_files` rows that have none.
+///
+/// The chapter extraction pipeline was added after the initial audiobook
+/// indexer, so books indexed before the migration have zero `file_chapters`
+/// rows. The normal diff-based reindex skips unchanged files, so this
+/// backfill runs as a separate worker task and is a no-op once all books
+/// have chapters. `on_progress(processed, total)` is called after each
+/// book so the UI can render a progress bar.
+pub(crate) async fn backfill_chapters(
+    pool: &SqlitePool,
+    library_path: &str,
+    on_progress: impl Fn(u32, u32),
+) -> anyhow::Result<()> {
+    let rows: Vec<(i64, String, String)> = sqlx::query_as(
+        "SELECT bf.id, bfp.filename, bf.format \
+         FROM book_files bf \
+         JOIN books b ON bf.book_id = b.id \
+         JOIN libraries l ON b.library_id = l.id \
+         JOIN book_file_parts bfp ON bfp.book_file_id = bf.id \
+         WHERE l.path = ? \
+           AND bf.format IN ('M4B', 'M4A', 'MP3') \
+           AND bfp.ordinal = 0 \
+           AND NOT EXISTS (SELECT 1 FROM file_chapters fc WHERE fc.book_file_id = bf.id) \
+         ORDER BY bf.id",
+    )
+    .bind(library_path)
+    .fetch_all(pool)
+    .await?;
+
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let total = rows.len() as u32;
+    tracing::info!(
+        count = total,
+        "backfilling chapters for existing audiobooks"
+    );
+
+    let lib_root = PathBuf::from(library_path);
+    for (i, (book_file_id, first_part_filename, format)) in rows.iter().enumerate() {
+        let abs = lib_root.join(first_part_filename);
+        let chapters = audiobook::extract_chapters(&abs, format);
+
+        let parts: Vec<crate::audiobook::AudiobookPart> =
+            sqlx::query_as::<_, (i64, String, i64, i64, f64)>(
+                "SELECT ordinal, filename, size_bytes, mtime_epoch, duration_seconds \
+                 FROM book_file_parts WHERE book_file_id = ? ORDER BY ordinal",
+            )
+            .bind(book_file_id)
+            .fetch_all(pool)
+            .await?
+            .into_iter()
+            .map(
+                |(ordinal, filename, size_bytes, mtime_epoch, duration_seconds)| {
+                    crate::audiobook::AudiobookPart {
+                        ordinal,
+                        filename,
+                        size_bytes,
+                        mtime_epoch,
+                        duration_seconds,
+                    }
+                },
+            )
+            .collect();
+
+        let mut tx = pool.begin().await?;
+        sync::insert_chapters(&mut tx, *book_file_id, &chapters, &parts).await?;
+        tx.commit().await?;
+
+        on_progress(i as u32 + 1, total);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -367,7 +367,10 @@ pub(crate) async fn backfill_chapters(
     let lib_root = PathBuf::from(library_path);
     for (i, (book_file_id, first_part_filename, format)) in rows.iter().enumerate() {
         let abs = lib_root.join(first_part_filename);
-        let chapters = audiobook::extract_chapters(&abs, format);
+        let fmt = format.clone();
+        let chapters = tokio::task::spawn_blocking(move || audiobook::extract_chapters(&abs, &fmt))
+            .await
+            .unwrap_or_default();
 
         let parts: Vec<crate::audiobook::AudiobookPart> =
             sqlx::query_as::<_, (i64, String, i64, i64, f64)>(

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -32,7 +32,8 @@ mod books;
 #[cfg(test)]
 mod tests;
 
-pub use audiobooks::{insert_chapters, sync_audiobooks, AudiobookSyncPlan};
+pub(crate) use audiobooks::insert_chapters;
+pub use audiobooks::{sync_audiobooks, AudiobookSyncPlan};
 pub use books::{replace_books, sync_books, SyncError, SyncPlan};
 
 // `pub(crate)` re-export for sibling `db/` modules (currently

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -32,7 +32,7 @@ mod books;
 #[cfg(test)]
 mod tests;
 
-pub use audiobooks::{sync_audiobooks, AudiobookSyncPlan};
+pub use audiobooks::{insert_chapters, sync_audiobooks, AudiobookSyncPlan};
 pub use books::{replace_books, sync_books, SyncError, SyncPlan};
 
 // `pub(crate)` re-export for sibling `db/` modules (currently

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -276,7 +276,7 @@ async fn insert_audiobook_parts(
 
 /// Insert `file_chapters` rows. If no chapters were extracted, synthesize
 /// one chapter per part so the frontend always gets `chapters.len() >= 1`.
-pub async fn insert_chapters(
+pub(crate) async fn insert_chapters(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_file_id: i64,
     chapters: &[crate::audiobook::RawChapter],

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -79,8 +79,7 @@ pub async fn sync_audiobooks(
             // TOCTOU: promote to New insert.
             let inserted = insert_audiobook_row(&mut tx, library_id, b).await?;
             insert_audiobook_parts(&mut tx, inserted.book_file_id, &b.parts).await?;
-            insert_audiobook_chapters(&mut tx, inserted.book_file_id, &b.chapters, &b.parts)
-                .await?;
+            insert_chapters(&mut tx, inserted.book_file_id, &b.chapters, &b.parts).await?;
             insert_audiobook_author_link(&mut tx, inserted.book_id, b.creator_name.as_deref())
                 .await?;
             insert_audiobook_fts_row(&mut tx, inserted.book_id, b).await?;
@@ -108,7 +107,7 @@ pub async fn sync_audiobooks(
 
         let book_file_id = insert_audiobook_file_row(&mut tx, book_id, b).await?;
         insert_audiobook_parts(&mut tx, book_file_id, &b.parts).await?;
-        insert_audiobook_chapters(&mut tx, book_file_id, &b.chapters, &b.parts).await?;
+        insert_chapters(&mut tx, book_file_id, &b.chapters, &b.parts).await?;
         insert_audiobook_author_link(&mut tx, book_id, b.creator_name.as_deref()).await?;
         insert_audiobook_fts_row(&mut tx, book_id, b).await?;
 
@@ -122,7 +121,7 @@ pub async fn sync_audiobooks(
     for b in &plan.new_books {
         let inserted = insert_audiobook_row(&mut tx, library_id, b).await?;
         insert_audiobook_parts(&mut tx, inserted.book_file_id, &b.parts).await?;
-        insert_audiobook_chapters(&mut tx, inserted.book_file_id, &b.chapters, &b.parts).await?;
+        insert_chapters(&mut tx, inserted.book_file_id, &b.chapters, &b.parts).await?;
         insert_audiobook_author_link(&mut tx, inserted.book_id, b.creator_name.as_deref()).await?;
         insert_audiobook_fts_row(&mut tx, inserted.book_id, b).await?;
         if let Some((mime, bytes)) = &b.cover {
@@ -277,7 +276,7 @@ async fn insert_audiobook_parts(
 
 /// Insert `file_chapters` rows. If no chapters were extracted, synthesize
 /// one chapter per part so the frontend always gets `chapters.len() >= 1`.
-async fn insert_audiobook_chapters(
+pub async fn insert_chapters(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_file_id: i64,
     chapters: &[crate::audiobook::RawChapter],

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -3,10 +3,12 @@
 //! the owning module (`indexer::reindex`, `author_photos::resolve`,
 //! `thumbs::ensure_thumbnails_sync`).
 
+use std::sync::Arc;
+
 use super::types::{Task, TaskId, TaskOutcome, Worker};
 
 impl Worker {
-    pub(super) async fn execute(&self, task: Task, id: TaskId) -> TaskOutcome {
+    pub(super) async fn execute(self: &Arc<Self>, task: Task, id: TaskId) -> TaskOutcome {
         match task {
             Task::Scan { library_path } => {
                 match crate::indexer::reindex(&self.pool, &library_path).await {
@@ -16,7 +18,17 @@ impl Worker {
             }
             Task::ScanAudiobooks { library_path } => {
                 match crate::indexer::reindex_audiobooks(&self.pool, &library_path).await {
-                    Ok(()) => TaskOutcome::Ok,
+                    Ok(()) => {
+                        // Post a follow-up chapter backfill task now that the
+                        // scan has populated book_file_parts rows. Same resource
+                        // key means it won't run until this task fully finishes
+                        // (including the terminal-state write in `run`), but
+                        // the post itself is instant.
+                        self.post(Task::BackfillChapters {
+                            library_path: library_path.clone(),
+                        });
+                        TaskOutcome::Ok
+                    }
                     Err(e) => TaskOutcome::Err(e.to_string()),
                 }
             }

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -55,6 +55,20 @@ impl Worker {
                     Err(e) => TaskOutcome::Err(e.to_string()),
                 }
             }
+            Task::BackfillChapters { library_path } => {
+                match crate::indexer::backfill_chapters(
+                    &self.pool,
+                    &library_path,
+                    |processed, total| {
+                        self.report_progress(id, processed, Some(total));
+                    },
+                )
+                .await
+                {
+                    Ok(()) => TaskOutcome::Ok,
+                    Err(e) => TaskOutcome::Err(e.to_string()),
+                }
+            }
             Task::GenerateThumbs {
                 book_id,
                 last_modified_epoch,

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -73,6 +73,11 @@ pub enum Task {
     /// fixed resource so concurrent clicks serialize; does not consume the
     /// scan semaphore.
     RefetchAuthorPhotos,
+    /// Backfill `file_chapters` rows for audiobooks that were indexed before
+    /// the chapter pipeline existed. Keyed on `audiobooks:{library_path}` so
+    /// it serializes behind any in-flight [`Task::ScanAudiobooks`] on the
+    /// same library. Does not consume the scan semaphore (lightweight IO).
+    BackfillChapters { library_path: String },
     /// Test-only synthetic task: sleeps `latency_ms` and invokes the
     /// optional `on_run` / `on_done` hooks, with `resource` and
     /// `route_through_scan_sem` letting a test exercise the keyed mutex and
@@ -99,6 +104,7 @@ impl Task {
                 book_id, profile, ..
             } => Some(format!("hls:{book_id}:{profile}")),
             Task::RefetchAuthorPhotos => Some("refetch-author-photos".into()),
+            Task::BackfillChapters { library_path } => Some(format!("audiobooks:{library_path}")),
             #[cfg(test)]
             Task::Test { resource, .. } => resource.clone(),
         }
@@ -112,6 +118,7 @@ impl Task {
             Task::ResolveAuthorPhoto { .. } => false,
             Task::HlsTranscode { .. } => false,
             Task::RefetchAuthorPhotos => false,
+            Task::BackfillChapters { .. } => false,
             #[cfg(test)]
             Task::Test {
                 route_through_scan_sem,
@@ -136,6 +143,7 @@ impl Task {
             Task::GenerateThumbs { .. } => TaskKind::GenerateThumbs,
             Task::ResolveAuthorPhoto { .. } => TaskKind::ResolveAuthorPhoto,
             Task::RefetchAuthorPhotos => TaskKind::RefetchAuthorPhotos,
+            Task::BackfillChapters { .. } => TaskKind::BackfillChapters,
             // Reuse Scan kind for UI display until a dedicated HLS progress
             // widget is added.
             Task::HlsTranscode { .. } => TaskKind::Scan,

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -74,9 +74,11 @@ pub enum Task {
     /// scan semaphore.
     RefetchAuthorPhotos,
     /// Backfill `file_chapters` rows for audiobooks that were indexed before
-    /// the chapter pipeline existed. Keyed on `audiobooks:{library_path}` so
-    /// it serializes behind any in-flight [`Task::ScanAudiobooks`] on the
-    /// same library. Does not consume the scan semaphore (lightweight IO).
+    /// the chapter pipeline existed. Posted by the [`Task::ScanAudiobooks`]
+    /// handler on success so it always runs after the scan completes. Also
+    /// triggerable manually from the settings page. Keyed on
+    /// `audiobooks:{library_path}` (mutual exclusion with scans on the same
+    /// library). Does not consume the scan semaphore (lightweight IO).
     BackfillChapters { library_path: String },
     /// Test-only synthetic task: sleeps `latency_ms` and invokes the
     /// optional `on_run` / `on_done` hooks, with `resource` and

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -208,6 +208,8 @@ fn kind_label(kind: TaskKind, running: bool) -> &'static str {
         (TaskKind::ResolveAuthorPhoto, false) => "Author photo lookup",
         (TaskKind::RefetchAuthorPhotos, true) => "Refetching author photos",
         (TaskKind::RefetchAuthorPhotos, false) => "Author photo refetch",
+        (TaskKind::BackfillChapters, true) => "Extracting chapters",
+        (TaskKind::BackfillChapters, false) => "Chapter extraction",
         // `#[non_exhaustive]` on the shared enum means new variants
         // compile against existing client builds — render an opaque
         // fallback rather than panicking.
@@ -245,6 +247,7 @@ mod tests {
             TaskKind::GenerateThumbs,
             TaskKind::ResolveAuthorPhoto,
             TaskKind::RefetchAuthorPhotos,
+            TaskKind::BackfillChapters,
         ] {
             assert!(!kind_label(kind, true).is_empty());
             assert!(!kind_label(kind, false).is_empty());

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -208,8 +208,8 @@ fn kind_label(kind: TaskKind, running: bool) -> &'static str {
         (TaskKind::ResolveAuthorPhoto, false) => "Author photo lookup",
         (TaskKind::RefetchAuthorPhotos, true) => "Refetching author photos",
         (TaskKind::RefetchAuthorPhotos, false) => "Author photo refetch",
-        (TaskKind::BackfillChapters, true) => "Extracting chapters",
-        (TaskKind::BackfillChapters, false) => "Chapter extraction",
+        (TaskKind::BackfillChapters, true) => "Extracting audiobook chapters",
+        (TaskKind::BackfillChapters, false) => "Audiobook chapter extraction",
         // `#[non_exhaustive]` on the shared enum means new variants
         // compile against existing client builds — render an opaque
         // fallback rather than panicking.

--- a/frontend/src/data/books.rs
+++ b/frontend/src/data/books.rs
@@ -206,6 +206,26 @@ pub async fn worker_status(_server_url: &str) -> Result<WorkerStatus, DataError>
     Ok(WorkerStatus::default())
 }
 
+/// Admin: manually trigger chapter extraction for audiobooks missing chapters.
+#[cfg(not(feature = "mobile"))]
+pub async fn backfill_chapters(_server_url: &str) -> Result<(), DataError> {
+    crate::rpc::rpc_backfill_chapters()
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Mobile stub for `backfill_chapters`.
+#[cfg(feature = "mobile")]
+pub async fn backfill_chapters(server_url: &str) -> Result<(), DataError> {
+    let url = format!("{server_url}/api/audiobooks/backfill-chapters");
+    let response = with_bearer(http_client().post(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(())
+}
+
 /// Web/SSR `get_ebooks` — server-function wrapper that proxies to `rpc_get_ebooks`.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_ebooks(_server_url: &str) -> Result<EbookLibrary, DataError> {

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -22,6 +22,7 @@ pub fn SettingsPage() -> Element {
     let mut status_is_error = use_signal(|| false);
     let mut library = use_signal(LibraryContents::default);
     let mut refetch_in_flight = use_signal(|| false);
+    let mut backfill_in_flight = use_signal(|| false);
     // Bumped after a successful save to re-trigger the library-refresh effect.
     let mut library_refresh = use_signal(|| 0u32);
 
@@ -54,6 +55,7 @@ pub fn SettingsPage() -> Element {
     });
 
     let url_for_refetch = server_url.clone();
+    let url_for_backfill = server_url.clone();
 
     let worker_status_slot: Element = {
         #[cfg(not(feature = "mobile"))]
@@ -166,6 +168,34 @@ pub fn SettingsPage() -> Element {
                             }
                         },
                         "Refetch Author Pictures"
+                    }
+                    button {
+                        r#type: "button",
+                        class: "btn ghost",
+                        disabled: backfill_in_flight(),
+                        "data-testid": "backfill-chapters",
+                        onclick: {
+                            let url = url_for_backfill.clone();
+                            move |_| {
+                                let url = url.clone();
+                                backfill_in_flight.set(true);
+                                spawn(async move {
+                                    match data::backfill_chapters(&url).await {
+                                        Ok(()) => {
+                                            status.set(Some("Chapter extraction queued.".into()));
+                                            status_is_error.set(false);
+                                            backfill_in_flight.set(false);
+                                        }
+                                        Err(e) => {
+                                            status.set(Some(format!("Failed to start chapter extraction: {e}")));
+                                            status_is_error.set(true);
+                                            backfill_in_flight.set(false);
+                                        }
+                                    }
+                                });
+                            }
+                        },
+                        "Extract Audiobook Chapters"
                     }
                 }
             }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -160,9 +160,12 @@ pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
             .post(omnibus_db::worker::Task::Scan { library_path });
     }
     if let Some(library_path) = updated.audiobook_library_path.clone() {
+        worker.0.post(omnibus_db::worker::Task::ScanAudiobooks {
+            library_path: library_path.clone(),
+        });
         worker
             .0
-            .post(omnibus_db::worker::Task::ScanAudiobooks { library_path });
+            .post(omnibus_db::worker::Task::BackfillChapters { library_path });
     }
     Ok(updated)
 }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -160,12 +160,9 @@ pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
             .post(omnibus_db::worker::Task::Scan { library_path });
     }
     if let Some(library_path) = updated.audiobook_library_path.clone() {
-        worker.0.post(omnibus_db::worker::Task::ScanAudiobooks {
-            library_path: library_path.clone(),
-        });
         worker
             .0
-            .post(omnibus_db::worker::Task::BackfillChapters { library_path });
+            .post(omnibus_db::worker::Task::ScanAudiobooks { library_path });
     }
     Ok(updated)
 }
@@ -330,6 +327,21 @@ pub async fn rpc_scan_author_photo(id: i64) -> Result<AuthorPhotoScanResult> {
 #[post("/api/rpc/refetch-author-photos", _pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
 pub async fn rpc_refetch_author_photos() -> Result<()> {
     worker.0.post(omnibus_db::worker::Task::RefetchAuthorPhotos);
+    Ok(())
+}
+
+/// Admin: manually trigger chapter extraction for audiobooks missing
+/// chapters. Posts `Task::BackfillChapters` to the background worker and
+/// returns immediately.
+#[post("/api/rpc/backfill-chapters", pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
+pub async fn rpc_backfill_chapters() -> Result<()> {
+    let settings = db::get_settings(&pool.0).await?;
+    let Some(library_path) = settings.audiobook_library_path else {
+        return Err(ServerFnError::new("no audiobook library configured").into());
+    };
+    worker
+        .0
+        .post(omnibus_db::worker::Task::BackfillChapters { library_path });
     Ok(())
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -82,11 +82,8 @@ fn main() {
                 if let Some(path) = settings.audiobook_library_path {
                     let stale = indexer::is_stale(&pool, &path).await.unwrap_or(true);
                     if stale {
-                        worker.post(Task::ScanAudiobooks {
-                            library_path: path.clone(),
-                        });
+                        worker.post(Task::ScanAudiobooks { library_path: path });
                     }
-                    worker.post(Task::BackfillChapters { library_path: path });
                 }
             }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -82,8 +82,11 @@ fn main() {
                 if let Some(path) = settings.audiobook_library_path {
                     let stale = indexer::is_stale(&pool, &path).await.unwrap_or(true);
                     if stale {
-                        worker.post(Task::ScanAudiobooks { library_path: path });
+                        worker.post(Task::ScanAudiobooks {
+                            library_path: path.clone(),
+                        });
                     }
+                    worker.post(Task::BackfillChapters { library_path: path });
                 }
             }
 

--- a/shared/src/worker.rs
+++ b/shared/src/worker.rs
@@ -19,6 +19,7 @@ pub enum TaskKind {
     GenerateThumbs,
     ResolveAuthorPhoto,
     RefetchAuthorPhotos,
+    BackfillChapters,
 }
 
 /// Lifecycle state of a single worker task as exposed to the UI.


### PR DESCRIPTION
## Summary
- Adds `BackfillChapters` worker task that extracts chapter metadata for audiobooks indexed before the chapter pipeline existed
- Keyed on the same resource as `ScanAudiobooks` so it serializes behind the scan automatically
- Reports per-book progress to the settings page indicator ("Extracting chapters (5 / 12)")
- Posted alongside every `ScanAudiobooks` task (settings save + boot); no-op when all books already have chapters

## Test plan
- [x] `cargo test -p omnibus-db` — 454 tests pass
- [x] `cargo test -p omnibus-frontend --features server` — `kind_label_covers_all_variants_in_both_tenses` passes
- [x] `cargo clippy` + `cargo fmt` clean
- [ ] Manual: trigger a rescan from settings page, observe "Extracting chapters" indicator with progress count