### PR TITLE
docs: document EBOOK_LIBRARY_PATH and AUDIOBOOK_LIBRARY_PATH seed vars (#404)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,12 @@
 # change it only if you understand both will follow you.
 OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
 
-# Optional: pre-seed library paths on first boot. When either var is set, the
-# server boot hook `seed_settings_from_env` writes them to the settings row,
-# overwriting any existing value — useful for CI, Docker, or dev-up scripting.
-# Leave unset in production deployments that configure libraries through the UI.
+# Optional: pre-seed library paths via the `seed_settings_from_env` boot hook,
+# which runs on EVERY server boot. When either var is set, the hook overwrites
+# the settings row with BOTH values — so setting only one var clears the other
+# path, which triggers orphan-library pruning. Set both together (or neither)
+# to avoid surprising the operator. Useful for CI, Docker, or dev-up scripting;
+# leave unset in production deployments that configure libraries through the UI.
 # EBOOK_LIBRARY_PATH=/path/to/ebooks
 # AUDIOBOOK_LIBRARY_PATH=/path/to/audiobooks
 

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,13 @@
 # change it only if you understand both will follow you.
 OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
 
+# Optional: pre-seed library paths on first boot. When either var is set, the
+# server boot hook `seed_settings_from_env` writes them to the settings row,
+# overwriting any existing value — useful for CI, Docker, or dev-up scripting.
+# Leave unset in production deployments that configure libraries through the UI.
+# EBOOK_LIBRARY_PATH=/path/to/ebooks
+# AUDIOBOOK_LIBRARY_PATH=/path/to/audiobooks
+
 # Session cookie Secure flag. Defaults to true (cookies sent over HTTPS only).
 # Browsers treat http://localhost as a secure context, so the Nix dev shell
 # does NOT need this override. Set to 0 only when serving plain http:// from a


### PR DESCRIPTION
## Summary
- Adds documentation for `EBOOK_LIBRARY_PATH` and `AUDIOBOOK_LIBRARY_PATH` to `.env.example` — both are consumed by `seed_settings_from_env` (db/src/settings.rs) but missed in #355.
- Wording adjusted from the issue's suggested block to reflect the actual semantics: `seed_settings_from_env` calls `set_settings` unconditionally when either var is present, so it **overwrites** any existing value rather than only seeding when no library section exists yet.

## Test plan
- [x] `.env.example` reviewed by inspection — no code changes; no build/test required.

## Notes
- The acceptance criteria also mentioned an optional update to `.claude/rules/01-dev-environment.md`, but the harness denied permission to edit that file. The env var is now documented in `.env.example`, which the rule file already points to as the source of truth (`[`.env.example`](../../.env.example) is checked in and documents every supported var`). Maintainer may want to add a one-line bullet there as a follow-up.
- No `Cargo.toml` / `Cargo.lock` changes.

Closes #404

---
_Generated by [Claude Code](https://claude.ai/code/session_011ymQMTNJJ1wQKYN59DiG2Q)_