### PR TITLE
fix: replace panic!() and .expect() in Dioxus component bodies (#398)

### DIFF
--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -574,7 +574,7 @@ mod tests {
     fn classify_register_error_routes_username() {
         match classify_register_error("username already exists") {
             RegisterError::Username(m) => assert_eq!(m, "username already exists"),
-            other => panic!("expected Username variant, got {other:?}"),
+            other => unreachable!("expected Username variant, got {other:?}"),
         }
     }
 
@@ -582,7 +582,7 @@ mod tests {
     fn classify_register_error_routes_password() {
         match classify_register_error("password is too short") {
             RegisterError::Password(m) => assert_eq!(m, "password is too short"),
-            other => panic!("expected Password variant, got {other:?}"),
+            other => unreachable!("expected Password variant, got {other:?}"),
         }
     }
 
@@ -590,7 +590,7 @@ mod tests {
     fn classify_register_error_falls_back_to_other() {
         match classify_register_error("500: internal server error") {
             RegisterError::Other(m) => assert_eq!(m, "500: internal server error"),
-            other => panic!("expected Other variant, got {other:?}"),
+            other => unreachable!("expected Other variant, got {other:?}"),
         }
     }
 

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -459,7 +459,7 @@ mod tests {
             &["Frank Herbert".to_string(), "Brian Herbert".to_string()],
             &["scifi".to_string(), "classic".to_string()],
         );
-        let creators = ov.creators.expect("creators should be set");
+        let creators = ov.creators.unwrap_or_default();
         assert_eq!(creators.len(), 2);
         assert_eq!(creators[0].name, "Frank Herbert");
         assert_eq!(creators[1].name, "Brian Herbert");


### PR DESCRIPTION
## Summary
- `frontend/src/pages/auth.rs` lines 577/585/593 — the three `_ => panic!("...")` catch-all match arms become `unreachable!("...")`. They are genuinely unreachable given the `RegisterError` enum contract, but `unreachable!` documents that invariant without being the production-path panic the style guide bans.
- `frontend/src/pages/metadata_edit.rs:462` — `ov.creators.expect(...)` becomes `ov.creators.unwrap_or_default()`. `creators: None` is a valid DB state for any book that has never been metadata-edited; an empty creators list renders correctly. The surrounding `assert_eq!(creators.len(), 2)` still catches a regression: with `unwrap_or_default()` an unexpected `None` produces an empty vec whose length is 0, which fails the assertion.

## Test plan
- [x] `cargo fmt` (clean)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` (clean)
- [x] `cargo test -p omnibus-frontend --features server` (108 passed; 0 failed)

## Notes
- `nix` was not available in this sandbox, so I fell back to bare `cargo` (the runbook permits this). All three checks pass.
- No `#[allow(...)]` suppressions added.
- No `Cargo.toml` / `Cargo.lock` changes.
- **Heads-up on the issue's framing.** Reading the four call sites in context, all four live inside `#[cfg(test)] mod tests { ... }` blocks (`auth.rs` starts at line 516, `metadata_edit.rs` inside `#[test] fn build_overrides_replaces_full_creator_and_subject_lists`). They are not live `#[component]` bodies and cannot 500 an SSR render in production — the `#[cfg(test)]` gate keeps them out of any non-test build. The style guide explicitly permits `unwrap()` / `expect()` / `panic!()` in test code. The edits are still defensible quality improvements (`unreachable!` is the idiomatic catch-all for a match arm guaranteed unreachable; `unwrap_or_default()` keeps the test asserting via `assert_eq!` rather than via a panic message), but the SSR-500 risk profile cited in the issue does not apply here. Worth re-scanning the codebase if there are *actual* live-render panics elsewhere — `frontend/src/pages/metadata_edit.rs` has no other `panic!`/`expect` outside the test module, and the three auth.rs hits I touched are all the file's `panic!` occurrences.

Closes #398

---
_Generated by [Claude Code](https://claude.ai/code/session_011ymQMTNJJ1wQKYN59DiG2Q)_