### PR TITLE
docs: add /// one-liners to pub items in db/hls.rs and server/ (#407)

### DIFF
--- a/server/src/auth/csrf.rs
+++ b/server/src/auth/csrf.rs
@@ -37,6 +37,7 @@ fn has_session_cookie(jar: &CookieJar) -> bool {
     jar.get(SESSION_COOKIE_HOST_PREFIXED).is_some() || jar.get(SESSION_COOKIE).is_some()
 }
 
+/// Reject state-changing cookie-authed requests whose `Origin`/`Referer` doesn't match the allowlist or `Host`.
 pub async fn origin_check(req: Request, next: Next) -> Response {
     let method = req.method();
     if matches!(method, &Method::GET | &Method::HEAD | &Method::OPTIONS) {

--- a/server/src/auth/extractor.rs
+++ b/server/src/auth/extractor.rs
@@ -28,6 +28,7 @@ pub struct AuthUser {
 }
 
 impl AuthUser {
+    /// Project this extractor result to the wire-shape `UserSummary` returned by `/api/auth/me`.
     pub fn summary(&self) -> UserSummary {
         UserSummary {
             id: self.id,

--- a/server/src/auth/gate.rs
+++ b/server/src/auth/gate.rs
@@ -36,6 +36,7 @@ use omnibus_db::auth as auth_db;
 use super::extractor::extract_token;
 use crate::backend::AppState;
 
+/// Reject `/api/*` requests without a live session with `401 Unauthorized`, after exempting `/api/auth/*` and `/api/_health`.
 pub async fn require_auth(State(state): State<AppState>, req: Request, next: Next) -> Response {
     let path = req.uri().path();
     if !path.starts_with("/api/")

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -79,6 +79,7 @@ impl RateLimiter {
         Self::with_policy(Duration::from_secs(WINDOW_SECS), MAX_REQUESTS)
     }
 
+    /// Construct a limiter with an explicit `(window, max requests)` policy.
     pub fn with_policy(window: Duration, max: u32) -> Self {
         Self {
             inner: Mutex::new(HashMap::new()),
@@ -87,6 +88,7 @@ impl RateLimiter {
         }
     }
 
+    /// Record a request from `ip`; returns `false` once the per-IP bucket exceeds `max` within `window`.
     pub async fn allow(&self, ip: IpAddr) -> bool {
         let now = Instant::now();
         let mut map = self.inner.lock().await;


### PR DESCRIPTION
## Summary
- Audits every pub item enumerated in #407 Evidence across `db/src/hls.rs` (12 items) and the server crate (`auth/extractor.rs`, `auth/strategy.rs`, `auth/gate.rs`, `auth/csrf.rs`, `auth/handlers.rs`, `auth/mod.rs`, `backend.rs`, `rate_limit.rs`, `security_headers.rs`).
- Adds a behaviour-describing `///` one-liner to the 5 items in that list that were genuinely missing one: `AuthUser::summary`, `gate::require_auth`, `csrf::origin_check`, `RateLimiter::with_policy`, `RateLimiter::allow`.
- Per the style guide (`.claude/rules/05-rust-style.md` § Comments & docs), each docstring is a single behaviour-describing line. No `# Errors` / `# Examples` sections added.

## Test plan
- [x] `cargo fmt` clean (no diff)
- [x] `cargo clippy -p omnibus-db -p omnibus --all-targets -- -D warnings` passes
- [x] `cargo test -p omnibus-db -p omnibus` — all 641 tests pass (185 omnibus + 454 omnibus-db + fixture tests)

## Notes
- The issue title cites 22 items; the Evidence list enumerates 33 items across 10 files. Auditing each item by name (line numbers had drifted since filing), 28 of the 33 already had `///` one-liners — added since the issue was filed by intervening PRs. This PR documents the remaining 5 so the full Evidence list is covered.
- Items still verified-as-documented (no change): all 12 in `db/src/hls.rs`; `AuthUser`, `AdminUser` in `extractor.rs`; `AuthenticatedUser`, `PasswordStrategy` in `strategy.rs`; `AppState`, `new`, `pool`, `worker` in `backend.rs`; `RateLimiter`, `new`, `rate_limit_by_ip`, `rate_limit_paths` in `rate_limit.rs`; `parse_secure_cookies` in `handlers.rs`; `session_cookie_name` in `mod.rs`; `baseline_layers`, `hsts_layer` in `security_headers.rs`.
- No `Cargo.toml` / `Cargo.lock` changes.

Closes #407

https://claude.ai/code/session_011ymQMTNJJ1wQKYN59DiG2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_011ymQMTNJJ1wQKYN59DiG2Q)_