### PR TITLE
fix: wrap sqlx::Error at db/ module boundaries per error-handling rules (#399)

### DIFF
--- a/db/src/author_photos/cascade.rs
+++ b/db/src/author_photos/cascade.rs
@@ -10,6 +10,7 @@ use sqlx::SqlitePool;
 use crate::author_photos::shared::{default_user_agent, shared_client};
 use crate::author_photos_data::{
     author_photo_status, delete_author_photo, upsert_author_photo, AuthorPhotoSource,
+    AuthorPhotosDataError,
 };
 
 /// Default request timeout for the Open Library search + cover calls.
@@ -137,7 +138,7 @@ pub async fn resolve_with(
 pub async fn refetch_all(
     pool: &SqlitePool,
     on_progress: impl Fn(u32, Option<u32>),
-) -> Result<(), sqlx::Error> {
+) -> Result<(), AuthorPhotosDataError> {
     let author_ids: Vec<i64> = sqlx::query_scalar("SELECT id FROM authors ORDER BY id")
         .fetch_all(pool)
         .await?;

--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -10,10 +10,10 @@ use sqlx::SqlitePool;
 
 use crate::metadata_overrides::rebuild_fts_for_book;
 
-/// Errors returned by the author-photos data layer. The single
-/// transparent `Db` variant honors the `02-error-handling` boundary rule
-/// (no raw `sqlx::Error` leaving the module) while keeping `?`
-/// propagation clean at the call sites.
+/// Errors returned by the author-photos data layer. The single transparent
+/// `Db` variant wraps `sqlx::Error` at the module boundary per the
+/// `02-error-handling` boundary rule, keeping `?` propagation clean at
+/// every call site.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthorPhotosDataError {
     #[error(transparent)]
@@ -54,7 +54,7 @@ impl AuthorPhotoSource {
 pub async fn get_author_photo(
     pool: &SqlitePool,
     author_id: i64,
-) -> Result<Option<(String, Vec<u8>)>, sqlx::Error> {
+) -> Result<Option<(String, Vec<u8>)>, AuthorPhotosDataError> {
     // Filter `letter` rows in SQL as well as via the schema CHECK constraint
     // so a malformed row (e.g. left over from a future migration drift)
     // can never accidentally serve `letter` bytes as a real image. Belt +
@@ -80,7 +80,7 @@ pub async fn get_author_photo(
 pub async fn author_photo_status(
     pool: &SqlitePool,
     author_id: i64,
-) -> Result<Option<(AuthorPhotoSource, String)>, sqlx::Error> {
+) -> Result<Option<(AuthorPhotoSource, String)>, AuthorPhotosDataError> {
     let row: Option<(String, String)> =
         sqlx::query_as("SELECT source, fetched_at FROM author_photos WHERE author_id = ?")
             .bind(author_id)
@@ -99,7 +99,7 @@ pub async fn upsert_author_photo(
     url: Option<&str>,
     mime: Option<&str>,
     bytes: Option<&[u8]>,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), AuthorPhotosDataError> {
     sqlx::query(
         "INSERT INTO author_photos (author_id, source, url, mime, bytes, fetched_at)
               VALUES (?, ?, ?, ?, ?, datetime('now'))

--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -34,7 +34,6 @@ pub use list::{
 pub use projection::MAX_BOOKS_RETURNED;
 pub use search::{count_search_books, search_books, search_books_with_total};
 
-/// Errors returned by the book read paths (`get_book`, `count_books`).
 /// Errors returned by the books read path.
 #[derive(Debug, thiserror::Error)]
 pub enum BooksError {

--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -35,14 +35,25 @@ pub use projection::MAX_BOOKS_RETURNED;
 pub use search::{count_search_books, search_books, search_books_with_total};
 
 /// Errors returned by the book read paths (`get_book`, `count_books`).
-/// The single transparent `Db` variant honors the `02-error-handling`
-/// boundary rule (no raw `sqlx::Error` across the module boundary) while
-/// keeping `?` propagation clean at the call sites that still use sqlx
-/// internally.
+/// Errors returned by the books read path.
 #[derive(Debug, thiserror::Error)]
 pub enum BooksError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
+    /// Corrupt JSON in the `metadata_overrides` blob.
+    #[error("overrides deserialization failed: {0}")]
+    OverridesJson(serde_json::Error),
+}
+
+impl From<crate::metadata_overrides::MetadataOverridesError> for BooksError {
+    fn from(e: crate::metadata_overrides::MetadataOverridesError) -> Self {
+        match e {
+            crate::metadata_overrides::MetadataOverridesError::Db(inner) => BooksError::Db(inner),
+            crate::metadata_overrides::MetadataOverridesError::Serialization(inner) => {
+                BooksError::OverridesJson(inner)
+            }
+        }
+    }
 }
 
 // `pub(crate)` re-exports for sibling `db/` modules (`discovery`, `palette`,

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -8,6 +8,13 @@ use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::{AuthorSummary, SeriesSummary};
 
+/// Errors returned by the browse index queries.
+#[derive(Debug, thiserror::Error)]
+pub enum BrowseError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Hard cap on rows returned by [`list_authors`] / [`list_series`]. Keeps
 /// the JSON envelope under ~1 MB even with the optional accent string,
 /// while leaving headroom past a 5k+ author library.
@@ -30,7 +37,7 @@ fn placeholders(n: usize) -> String {
 pub async fn list_authors(
     pool: &SqlitePool,
     library_paths: &[&str],
-) -> Result<Vec<AuthorSummary>, sqlx::Error> {
+) -> Result<Vec<AuthorSummary>, BrowseError> {
     if library_paths.is_empty() {
         return Ok(Vec::new());
     }
@@ -114,7 +121,7 @@ pub async fn list_authors(
 pub async fn list_series(
     pool: &SqlitePool,
     library_paths: &[&str],
-) -> Result<Vec<SeriesSummary>, sqlx::Error> {
+) -> Result<Vec<SeriesSummary>, BrowseError> {
     if library_paths.is_empty() {
         return Ok(Vec::new());
     }

--- a/db/src/hls.rs
+++ b/db/src/hls.rs
@@ -14,11 +14,9 @@ use std::time::{Duration, SystemTime};
 use sqlx::SqlitePool;
 use tokio::io::AsyncBufReadExt;
 
-/// Errors returned by `get_parts`. Other public functions in this module
-/// still return `sqlx::Error` directly (`resolve_audiobook`) or
-/// `anyhow::Result` (`transcode_book`, where ffmpeg + filesystem +
-/// timeouts dominate the failure space); widening the boundary cleanup
-/// is tracked separately.
+/// Errors returned by the HLS DB queries. `transcode_book` uses
+/// `anyhow::Result` because ffmpeg + filesystem + timeouts dominate its
+/// failure space and callers just propagate.
 #[derive(Debug, thiserror::Error)]
 pub enum HlsError {
     #[error(transparent)]
@@ -187,7 +185,7 @@ pub struct ResolvedAudiobook {
 pub async fn resolve_audiobook(
     pool: &SqlitePool,
     uuid: &str,
-) -> Result<Option<ResolvedAudiobook>, sqlx::Error> {
+) -> Result<Option<ResolvedAudiobook>, HlsError> {
     let row = sqlx::query_as::<_, (i64, i64, String)>(
         "SELECT b.id, bf.id, l.path \
          FROM books b \

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -52,6 +52,14 @@ pub enum IndexerError {
     Db(#[from] sqlx::Error),
 }
 
+impl From<crate::settings::SettingsError> for IndexerError {
+    fn from(e: crate::settings::SettingsError) -> Self {
+        match e {
+            crate::settings::SettingsError::Db(inner) => IndexerError::Db(inner),
+        }
+    }
+}
+
 /// Reindex if the last successful index is older than this. One hour is a
 /// compromise between responsiveness to on-disk changes and avoiding
 /// thrashing the disk for users who leave the app open all day.

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -16,7 +16,7 @@ use super::links::materialize_series_link;
 #[derive(Debug, thiserror::Error)]
 pub enum MetadataOverridesError {
     /// A JSON serialization or deserialization failure on the `overrides` blob.
-    #[error("serialization failed: {0}")]
+    #[error("JSON (de)serialization failed: {0}")]
     Serialization(#[from] serde_json::Error),
     #[error(transparent)]
     Db(#[from] sqlx::Error),

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -12,11 +12,12 @@ use omnibus_shared::{EbookMetadata, MetadataOverrides};
 use super::fts::rebuild_fts_for_book;
 use super::links::materialize_series_link;
 
-/// Errors returned by `get_book_uuid` and `rebuild_fts_for_book`. Other
-/// public functions in this module still return `sqlx::Error` directly —
-/// widening that is tracked separately.
+/// Errors returned by the metadata overrides data layer.
 #[derive(Debug, thiserror::Error)]
 pub enum MetadataOverridesError {
+    /// A JSON serialization or deserialization failure on the `overrides` blob.
+    #[error("serialization failed: {0}")]
+    Serialization(#[from] serde_json::Error),
     #[error(transparent)]
     Db(#[from] sqlx::Error),
 }
@@ -25,6 +26,9 @@ impl From<crate::books::BooksError> for MetadataOverridesError {
     fn from(e: crate::books::BooksError) -> Self {
         match e {
             crate::books::BooksError::Db(inner) => MetadataOverridesError::Db(inner),
+            crate::books::BooksError::OverridesJson(inner) => {
+                MetadataOverridesError::Serialization(inner)
+            }
         }
     }
 }
@@ -76,8 +80,8 @@ pub async fn upsert_metadata_overrides(
     overrides: &MetadataOverrides,
     has_cover_override: bool,
     user_id: i64,
-) -> Result<(), sqlx::Error> {
-    let json = serde_json::to_string(overrides).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+) -> Result<(), MetadataOverridesError> {
+    let json = serde_json::to_string(overrides)?;
     upsert_overrides_row(pool, book_uuid, &json, has_cover_override, user_id).await?;
     if let Err(e) = materialize_series_link(pool, book_uuid, overrides).await {
         tracing::warn!(book_uuid, error = %e, "series link materialize after override upsert failed");
@@ -100,7 +104,7 @@ pub async fn merge_metadata_overrides(
     book_uuid: &str,
     incoming: &MetadataOverrides,
     user_id: i64,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), MetadataOverridesError> {
     // `begin_with("BEGIN IMMEDIATE")` gives the same RESERVED-lock-at-start
     // semantics as the old hand-rolled statement (so concurrent edits to the
     // same book serialize instead of interleaving), but returns a real
@@ -118,14 +122,13 @@ pub async fn merge_metadata_overrides(
 
     let (merged, has_cover_override) = match existing {
         Some((json, has_cover)) => {
-            let prior: MetadataOverrides =
-                serde_json::from_str(&json).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
+            let prior: MetadataOverrides = serde_json::from_str(&json)?;
             (prior.merge(incoming), has_cover != 0)
         }
         None => (incoming.clone(), false),
     };
 
-    let json = serde_json::to_string(&merged).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+    let json = serde_json::to_string(&merged)?;
     upsert_overrides_row(&mut *tx, book_uuid, &json, has_cover_override, user_id).await?;
     tx.commit().await?;
 
@@ -143,7 +146,7 @@ pub async fn merge_metadata_overrides(
 pub async fn get_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
-) -> Result<Option<(MetadataOverrides, bool)>, sqlx::Error> {
+) -> Result<Option<(MetadataOverrides, bool)>, MetadataOverridesError> {
     let row: Option<(String, i64)> = sqlx::query_as(
         "SELECT overrides, has_cover_override FROM metadata_overrides WHERE book_uuid = ?",
     )
@@ -153,8 +156,7 @@ pub async fn get_metadata_overrides(
 
     match row {
         Some((json, has_cover)) => {
-            let ov: MetadataOverrides =
-                serde_json::from_str(&json).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
+            let ov: MetadataOverrides = serde_json::from_str(&json)?;
             Ok(Some((ov, has_cover != 0)))
         }
         None => Ok(None),
@@ -169,7 +171,7 @@ pub async fn get_metadata_overrides(
 pub async fn delete_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), MetadataOverridesError> {
     sqlx::query("DELETE FROM metadata_overrides WHERE book_uuid = ?")
         .bind(book_uuid)
         .execute(pool)

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -92,7 +92,7 @@ pub async fn get_progress(
     user_id: i64,
     book_uuid: &str,
     format: ProgressFormat,
-) -> Result<Option<ProgressRecord>, sqlx::Error> {
+) -> Result<Option<ProgressRecord>, ProgressError> {
     let Some(book_id) = resolve_book_id_by_uuid(pool, book_uuid).await? else {
         return Ok(None);
     };
@@ -129,7 +129,7 @@ pub async fn record_session(
     pool: &SqlitePool,
     user_id: i64,
     report: &SessionReport,
-) -> Result<bool, sqlx::Error> {
+) -> Result<bool, ProgressError> {
     let Some(book_id) = resolve_book_id_by_uuid(pool, &report.book_uuid).await? else {
         return Ok(false);
     };

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -16,9 +16,7 @@ pub use omnibus_shared::Settings;
 const EBOOK_LIBRARY_PATH_KEY: &str = "ebook_library_path";
 const AUDIOBOOK_LIBRARY_PATH_KEY: &str = "audiobook_library_path";
 
-/// Errors returned by `get_settings`, `set_settings`, and
-/// `seed_settings_from_env`. Other public functions in this module still
-/// return `sqlx::Error` directly — widening that is tracked separately.
+/// Errors returned by the settings data layer.
 #[derive(Debug, thiserror::Error)]
 pub enum SettingsError {
     #[error(transparent)]
@@ -102,7 +100,7 @@ pub async fn set_settings(pool: &SqlitePool, settings: &Settings) -> Result<(), 
 pub(crate) async fn prune_orphan_libraries(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     keep: &[Option<&str>],
-) -> Result<Vec<String>, sqlx::Error> {
+) -> Result<Vec<String>, SettingsError> {
     let orphans: Vec<(i64, String)> = sqlx::query_as("SELECT id, path FROM libraries")
         .fetch_all(&mut **tx)
         .await?
@@ -213,7 +211,7 @@ pub async fn seed_settings_from_env(pool: &SqlitePool) -> Result<(), SettingsErr
 pub(crate) async fn upsert_library(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     path: &str,
-) -> Result<i64, sqlx::Error> {
+) -> Result<i64, SettingsError> {
     let display_name = Path::new(path)
         .file_name()
         .and_then(|s| s.to_str())
@@ -240,12 +238,14 @@ pub(crate) async fn upsert_library(
 pub async fn last_indexed_at(
     pool: &SqlitePool,
     library_path: &str,
-) -> Result<Option<i64>, sqlx::Error> {
-    sqlx::query_scalar::<_, Option<i64>>("SELECT last_indexed FROM libraries WHERE path = ?")
-        .bind(library_path)
-        .fetch_optional(pool)
-        .await
-        .map(|opt| opt.flatten())
+) -> Result<Option<i64>, SettingsError> {
+    Ok(
+        sqlx::query_scalar::<_, Option<i64>>("SELECT last_indexed FROM libraries WHERE path = ?")
+            .bind(library_path)
+            .fetch_optional(pool)
+            .await?
+            .flatten(),
+    )
 }
 
 #[cfg(test)]

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -7,7 +7,7 @@ use crate::covers::delete_cover_files_for;
 use crate::helpers::sanitize_accent_color;
 use crate::settings::upsert_library;
 
-use super::books::materialize_new_covers;
+use super::books::{materialize_new_covers, SyncError};
 
 /// Per-bucket payload for [`sync_audiobooks`]. Mirrors [`SyncPlan`] for
 /// the ebook path but carries [`crate::audiobook::IndexedAudiobook`] rows
@@ -38,7 +38,7 @@ pub async fn sync_audiobooks(
     pool: &SqlitePool,
     library_path: &str,
     plan: AudiobookSyncPlan,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), SyncError> {
     let mut tx = pool.begin().await?;
     let library_id = upsert_library(&mut tx, library_path).await?;
 
@@ -281,7 +281,7 @@ pub(crate) async fn insert_chapters(
     book_file_id: i64,
     chapters: &[crate::audiobook::RawChapter],
     parts: &[crate::audiobook::AudiobookPart],
-) -> Result<(), sqlx::Error> {
+) -> Result<(), SyncError> {
     if !chapters.is_empty() {
         let total_duration: f64 = parts.iter().map(|p| p.duration_seconds).sum();
         for (i, ch) in chapters.iter().enumerate() {

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -26,6 +26,14 @@ pub enum SyncError {
     Db(#[from] sqlx::Error),
 }
 
+impl From<crate::settings::SettingsError> for SyncError {
+    fn from(e: crate::settings::SettingsError) -> Self {
+        match e {
+            crate::settings::SettingsError::Db(inner) => SyncError::Db(inner),
+        }
+    }
+}
+
 /// Per-bucket payload for [`sync_books`]. Built by
 /// `crate::indexer::diff_library` (plus the Phase-B parse for new + changed).
 ///


### PR DESCRIPTION
## Summary

Fixes the eight boundary violations cited in #399 where `pub` (and `pub(crate)`) functions in `db/` returned raw `sqlx::Error` despite the [boundary rule](/.claude/rules/02-error-handling.md). All callers in `server/` and `frontend/rpc.rs` already propagated errors via `?` into `anyhow::Error` or `ServerFnError`, so the change is transparent at call sites.

### Modules fixed

| Module | Change |
|---|---|
| `progress.rs` | `get_progress` + `record_session` → `ProgressError` (enum existed, fns bypassed it) |
| `author_photos_data.rs` | `get_author_photo` + `author_photo_status` + `upsert_author_photo` → `AuthorPhotosDataError` (enum existed, fns bypassed it) |
| `browse.rs` | Added `BrowseError { Db(#[from] sqlx::Error) }`; `list_authors` + `list_series` → `BrowseError` |
| `hls.rs` | `resolve_audiobook` → `HlsError` (enum existed, only `get_parts`/`get_chapters` used it) |
| `metadata_overrides.rs` | Added `Serialization(#[from] serde_json::Error)` to `MetadataOverridesError`; `upsert_metadata_overrides`, `merge_metadata_overrides`, `get_metadata_overrides`, `delete_metadata_overrides` → `MetadataOverridesError`; replaced three `serde_json::Error` → `sqlx::Error::Encode/Decode` misuses with direct `?` propagation via `Serialization` |
| `settings.rs` | `prune_orphan_libraries` + `upsert_library` + `last_indexed_at` → `SettingsError` |
| `sync/audiobooks.rs` | `sync_audiobooks` + `insert_chapters` → `SyncError` (re-used from `sync/books.rs`) |
| `author_photos/cascade.rs` | `refetch_all` → `AuthorPhotosDataError` |

### Cascading `From` impls

- `SyncError: From<SettingsError>` — `upsert_library` is called from both sync paths
- `IndexerError: From<SettingsError>` — `last_indexed_at` in the staleness check
- `BooksError: From<MetadataOverridesError>` — `get_book` calls `get_metadata_overrides`; `BooksError` also got an `OverridesJson(serde_json::Error)` variant
- `MetadataOverridesError: From<BooksError>` updated to cover the new `OverridesJson` variant

### Adversarial self-review

- No `pub` or `pub(crate)` fn in the 8 cited modules still returns `-> Result<_, sqlx::Error>` except `load_overrides_bulk` (see Deferred)
- The `serde_json::Error → sqlx::Error::Encode/Decode` misuse in `metadata_overrides.rs` is fully removed — all three call sites now use `?` via the new `Serialization` variant
- All callers compile without changes (verified `cargo build -p omnibus`)
- No scope creep: only the modules named in the issue were touched

### Deferred

- `load_overrides_bulk` (`pub(crate)` in `metadata_overrides.rs`) still returns `sqlx::Error` — its callers (`books/search.rs`, `discovery/`, `palette/`) all return `sqlx::Error` themselves; fixing those modules is a broader follow-on pass
- Private helper fns in `sync/books.rs` and `taxonomy.rs` — not boundary violations

## Test plan

- [x] `cargo test -p omnibus-db` — 454 passed, 0 failed
- [x] `cargo test -p omnibus` — 185 passed, 0 failed
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — no changes

Closes #399

https://claude.ai/code/session_01R5vNCSZuZGARTy7VRhCrRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5vNCSZuZGARTy7VRhCrRj)_