### PR TITLE
refactor: fix root causes behind #[allow()] suppressions in frontend/ (#405)

### DIFF
--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -21,17 +21,13 @@ mod progress;
 mod series;
 mod tags;
 
-#[allow(unused_imports)]
+// auth exports only exist under web or mobile; under server-only the module is empty.
+#[cfg(any(feature = "web", feature = "mobile"))]
 pub use auth::*;
-#[allow(unused_imports)]
 pub use authors::*;
-#[allow(unused_imports)]
 pub use books::*;
-#[allow(unused_imports)]
 pub use progress::*;
-#[allow(unused_imports)]
 pub use series::*;
-#[allow(unused_imports)]
 pub use tags::*;
 
 // ===== Typed transport error (#96) =====

--- a/frontend/src/pages/landing/filtering.rs
+++ b/frontend/src/pages/landing/filtering.rs
@@ -131,22 +131,24 @@ mod tests {
     use super::*;
     use omnibus_shared::Contributor;
 
-    #[allow(clippy::too_many_arguments)]
-    fn book(
+    struct BookSpec<'a> {
         id: i64,
-        filename: &str,
-        title: Option<&str>,
-        authors: &[(&str, Option<&str>)],
-        series: Option<(&str, &str)>,
-        modified: Option<&str>,
-        added_at: Option<&str>,
-        subjects: &[&str],
-    ) -> EbookMetadata {
+        filename: &'a str,
+        title: Option<&'a str>,
+        authors: &'a [(&'a str, Option<&'a str>)],
+        series: Option<(&'a str, &'a str)>,
+        modified: Option<&'a str>,
+        added_at: Option<&'a str>,
+        subjects: &'a [&'a str],
+    }
+
+    fn book(s: BookSpec<'_>) -> EbookMetadata {
         EbookMetadata {
-            id,
-            filename: filename.into(),
-            title: title.map(Into::into),
-            creators: authors
+            id: s.id,
+            filename: s.filename.into(),
+            title: s.title.map(Into::into),
+            creators: s
+                .authors
                 .iter()
                 .map(|(name, file_as)| Contributor {
                     name: (*name).into(),
@@ -155,11 +157,11 @@ mod tests {
                     id: None,
                 })
                 .collect(),
-            series: series.map(|(s, _)| s.into()),
-            series_index: series.map(|(_, i)| i.into()),
-            modified: modified.map(Into::into),
-            added_at: added_at.map(Into::into),
-            subjects: subjects.iter().map(|s| (*s).to_string()).collect(),
+            series: s.series.map(|(name, _)| name.into()),
+            series_index: s.series.map(|(_, idx)| idx.into()),
+            modified: s.modified.map(Into::into),
+            added_at: s.added_at.map(Into::into),
+            subjects: s.subjects.iter().map(|sub| (*sub).to_string()).collect(),
             ..Default::default()
         }
     }
@@ -170,36 +172,36 @@ mod tests {
 
     fn sample() -> Vec<EbookMetadata> {
         vec![
-            book(
-                1,
-                "alpha.epub",
-                Some("Alpha"),
-                &[("Tolkien, J.R.R.", Some("Tolkien, J.R.R."))],
-                Some(("Foundation", "1")),
-                Some("2024-01-01T00:00:00"),
-                Some("2025-03-10T00:00:00"),
-                &["Fantasy"],
-            ),
-            book(
-                2,
-                "beta.epub",
-                Some("Beta"),
-                &[("Asimov, Isaac", Some("Asimov, Isaac"))],
-                Some(("Foundation", "2")),
-                Some("2024-06-01T00:00:00"),
-                Some("2025-01-05T00:00:00"),
-                &["Sci-Fi"],
-            ),
-            book(
-                3,
-                "gamma.epub",
-                Some("Gamma"),
-                &[("Le Guin, Ursula", Some("Le Guin, Ursula"))],
-                None,
-                Some("2023-01-01T00:00:00"),
-                Some("2025-02-20T00:00:00"),
-                &["Fantasy", "Sci-Fi"],
-            ),
+            book(BookSpec {
+                id: 1,
+                filename: "alpha.epub",
+                title: Some("Alpha"),
+                authors: &[("Tolkien, J.R.R.", Some("Tolkien, J.R.R."))],
+                series: Some(("Foundation", "1")),
+                modified: Some("2024-01-01T00:00:00"),
+                added_at: Some("2025-03-10T00:00:00"),
+                subjects: &["Fantasy"],
+            }),
+            book(BookSpec {
+                id: 2,
+                filename: "beta.epub",
+                title: Some("Beta"),
+                authors: &[("Asimov, Isaac", Some("Asimov, Isaac"))],
+                series: Some(("Foundation", "2")),
+                modified: Some("2024-06-01T00:00:00"),
+                added_at: Some("2025-01-05T00:00:00"),
+                subjects: &["Sci-Fi"],
+            }),
+            book(BookSpec {
+                id: 3,
+                filename: "gamma.epub",
+                title: Some("Gamma"),
+                authors: &[("Le Guin, Ursula", Some("Le Guin, Ursula"))],
+                series: None,
+                modified: Some("2023-01-01T00:00:00"),
+                added_at: Some("2025-02-20T00:00:00"),
+                subjects: &["Fantasy", "Sci-Fi"],
+            }),
         ]
     }
 

--- a/frontend/src/pages/landing/sorting.rs
+++ b/frontend/src/pages/landing/sorting.rs
@@ -206,22 +206,24 @@ mod tests {
     use super::*;
     use omnibus_shared::Contributor;
 
-    #[allow(clippy::too_many_arguments)]
-    fn book(
+    struct BookSpec<'a> {
         id: i64,
-        filename: &str,
-        title: Option<&str>,
-        authors: &[(&str, Option<&str>)],
-        series: Option<(&str, &str)>,
-        modified: Option<&str>,
-        added_at: Option<&str>,
-        subjects: &[&str],
-    ) -> EbookMetadata {
+        filename: &'a str,
+        title: Option<&'a str>,
+        authors: &'a [(&'a str, Option<&'a str>)],
+        series: Option<(&'a str, &'a str)>,
+        modified: Option<&'a str>,
+        added_at: Option<&'a str>,
+        subjects: &'a [&'a str],
+    }
+
+    fn book(s: BookSpec<'_>) -> EbookMetadata {
         EbookMetadata {
-            id,
-            filename: filename.into(),
-            title: title.map(Into::into),
-            creators: authors
+            id: s.id,
+            filename: s.filename.into(),
+            title: s.title.map(Into::into),
+            creators: s
+                .authors
                 .iter()
                 .map(|(name, file_as)| Contributor {
                     name: (*name).into(),
@@ -230,11 +232,11 @@ mod tests {
                     id: None,
                 })
                 .collect(),
-            series: series.map(|(s, _)| s.into()),
-            series_index: series.map(|(_, i)| i.into()),
-            modified: modified.map(Into::into),
-            added_at: added_at.map(Into::into),
-            subjects: subjects.iter().map(|s| (*s).to_string()).collect(),
+            series: s.series.map(|(name, _)| name.into()),
+            series_index: s.series.map(|(_, idx)| idx.into()),
+            modified: s.modified.map(Into::into),
+            added_at: s.added_at.map(Into::into),
+            subjects: s.subjects.iter().map(|sub| (*sub).to_string()).collect(),
             ..Default::default()
         }
     }
@@ -270,36 +272,36 @@ mod tests {
 
     fn sample() -> Vec<EbookMetadata> {
         vec![
-            book(
-                1,
-                "alpha.epub",
-                Some("Alpha"),
-                &[("Tolkien, J.R.R.", Some("Tolkien, J.R.R."))],
-                Some(("Foundation", "1")),
-                Some("2024-01-01T00:00:00"),
-                Some("2025-03-10T00:00:00"),
-                &["Fantasy"],
-            ),
-            book(
-                2,
-                "beta.epub",
-                Some("Beta"),
-                &[("Asimov, Isaac", Some("Asimov, Isaac"))],
-                Some(("Foundation", "2")),
-                Some("2024-06-01T00:00:00"),
-                Some("2025-01-05T00:00:00"),
-                &["Sci-Fi"],
-            ),
-            book(
-                3,
-                "gamma.epub",
-                Some("Gamma"),
-                &[("Le Guin, Ursula", Some("Le Guin, Ursula"))],
-                None,
-                Some("2023-01-01T00:00:00"),
-                Some("2025-02-20T00:00:00"),
-                &["Fantasy", "Sci-Fi"],
-            ),
+            book(BookSpec {
+                id: 1,
+                filename: "alpha.epub",
+                title: Some("Alpha"),
+                authors: &[("Tolkien, J.R.R.", Some("Tolkien, J.R.R."))],
+                series: Some(("Foundation", "1")),
+                modified: Some("2024-01-01T00:00:00"),
+                added_at: Some("2025-03-10T00:00:00"),
+                subjects: &["Fantasy"],
+            }),
+            book(BookSpec {
+                id: 2,
+                filename: "beta.epub",
+                title: Some("Beta"),
+                authors: &[("Asimov, Isaac", Some("Asimov, Isaac"))],
+                series: Some(("Foundation", "2")),
+                modified: Some("2024-06-01T00:00:00"),
+                added_at: Some("2025-01-05T00:00:00"),
+                subjects: &["Sci-Fi"],
+            }),
+            book(BookSpec {
+                id: 3,
+                filename: "gamma.epub",
+                title: Some("Gamma"),
+                authors: &[("Le Guin, Ursula", Some("Le Guin, Ursula"))],
+                series: None,
+                modified: Some("2023-01-01T00:00:00"),
+                added_at: Some("2025-02-20T00:00:00"),
+                subjects: &["Fantasy", "Sci-Fi"],
+            }),
         ]
     }
 
@@ -351,36 +353,36 @@ mod tests {
         // book stays at the end (it doesn't get flipped to the top by the
         // direction reversal).
         let books = vec![
-            book(
-                1,
-                "old.epub",
-                Some("Old"),
-                &[],
-                None,
-                Some("2024-01-01T00:00:00"),
-                None,
-                &[],
-            ),
-            book(
-                2,
-                "new.epub",
-                Some("New"),
-                &[],
-                None,
-                Some("2025-01-01T00:00:00"),
-                None,
-                &[],
-            ),
-            book(
-                3,
-                "missing.epub",
-                Some("Missing"),
-                &[],
-                None,
-                None,
-                None,
-                &[],
-            ),
+            book(BookSpec {
+                id: 1,
+                filename: "old.epub",
+                title: Some("Old"),
+                authors: &[],
+                series: None,
+                modified: Some("2024-01-01T00:00:00"),
+                added_at: None,
+                subjects: &[],
+            }),
+            book(BookSpec {
+                id: 2,
+                filename: "new.epub",
+                title: Some("New"),
+                authors: &[],
+                series: None,
+                modified: Some("2025-01-01T00:00:00"),
+                added_at: None,
+                subjects: &[],
+            }),
+            book(BookSpec {
+                id: 3,
+                filename: "missing.epub",
+                title: Some("Missing"),
+                authors: &[],
+                series: None,
+                modified: None,
+                added_at: None,
+                subjects: &[],
+            }),
         ];
         let desc = sort_books(books.clone(), SortKey::LastUpdated, SortDir::Desc);
         assert_eq!(ids(&desc), vec![2, 1, 3]);
@@ -401,8 +403,26 @@ mod tests {
     fn sort_by_title_is_stable_on_equal_keys_via_id_tiebreak() {
         // Two books share the same title; the id tiebreak keeps a deterministic
         // order regardless of input order or sort direction.
-        let mut a = book(5, "a.epub", Some("Same"), &[], None, None, None, &[]);
-        let mut b = book(2, "b.epub", Some("Same"), &[], None, None, None, &[]);
+        let mut a = book(BookSpec {
+            id: 5,
+            filename: "a.epub",
+            title: Some("Same"),
+            authors: &[],
+            series: None,
+            modified: None,
+            added_at: None,
+            subjects: &[],
+        });
+        let mut b = book(BookSpec {
+            id: 2,
+            filename: "b.epub",
+            title: Some("Same"),
+            authors: &[],
+            series: None,
+            modified: None,
+            added_at: None,
+            subjects: &[],
+        });
         a.title = Some("Same".into());
         b.title = Some("Same".into());
         let asc = sort_books(vec![a.clone(), b.clone()], SortKey::Title, SortDir::Asc);

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -50,10 +50,6 @@ pub(super) fn post_audio_progress(uuid: String, seconds: f64) {
     });
 }
 
-#[cfg(all(not(feature = "web"), not(feature = "mobile")))]
-#[allow(dead_code)]
-pub(super) fn post_audio_progress(_uuid: String, _seconds: f64) {}
-
 #[cfg(test)]
 mod tests {
     use super::format_hms;

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -19,7 +19,6 @@ use super::stage::{PlaybackPosition, PlayerCallbacks, PlayerStage, ToolbarState,
 use crate::Nav;
 
 /// Render the ready-state player chrome and bind the transport handlers.
-#[allow(clippy::too_many_lines)]
 #[component]
 pub(super) fn ReadyPlayer(
     book: EbookMetadata,

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -235,15 +235,17 @@ fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
                 let o = orig();
                 let overrides = build_overrides(
                     &o,
-                    &title(),
-                    &description(),
-                    &publisher(),
-                    &published(),
-                    &language(),
-                    &series(),
-                    &series_index(),
-                    &authors(),
-                    &tags(),
+                    EditedFields {
+                        title: &title(),
+                        description: &description(),
+                        publisher: &publisher(),
+                        published: &published(),
+                        language: &language(),
+                        series: &series(),
+                        series_index: &series_index(),
+                        authors: &authors(),
+                        tags: &tags(),
+                    },
                 );
 
                 match data::save_overrides(&url, &uuid, &overrides).await {
@@ -318,19 +320,21 @@ fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
 // untouched fields are preserved.
 // ---------------------------------------------------------------------------
 
-#[allow(clippy::too_many_arguments)]
-fn build_overrides(
-    orig: &EbookMetadata,
-    title: &str,
-    description: &str,
-    publisher: &str,
-    published: &str,
-    language: &str,
-    series: &str,
-    series_index: &str,
-    authors: &[String],
-    tags: &[String],
-) -> MetadataOverrides {
+/// Edited scalar and list fields collected from the form signals before a save.
+struct EditedFields<'a> {
+    title: &'a str,
+    description: &'a str,
+    publisher: &'a str,
+    published: &'a str,
+    language: &'a str,
+    series: &'a str,
+    series_index: &'a str,
+    authors: &'a [String],
+    tags: &'a [String],
+}
+
+/// Build a [`MetadataOverrides`] from the current edit form values.
+fn build_overrides(orig: &EbookMetadata, edited: EditedFields<'_>) -> MetadataOverrides {
     let opt = |new: &str, old: Option<&str>| -> Option<String> {
         let old_val = old.unwrap_or("");
         if new != old_val {
@@ -341,9 +345,10 @@ fn build_overrides(
     };
 
     let orig_authors: Vec<String> = orig.creators.iter().map(|c| c.name.clone()).collect();
-    let creators = if authors != orig_authors.as_slice() {
+    let creators = if edited.authors != orig_authors.as_slice() {
         Some(
-            authors
+            edited
+                .authors
                 .iter()
                 .map(|name| Contributor {
                     name: name.clone(),
@@ -357,20 +362,20 @@ fn build_overrides(
         None
     };
 
-    let subjects = if tags != orig.subjects.as_slice() {
-        Some(tags.to_vec())
+    let subjects = if edited.tags != orig.subjects.as_slice() {
+        Some(edited.tags.to_vec())
     } else {
         None
     };
 
     MetadataOverrides {
-        title: opt(title, orig.title.as_deref()),
-        description: opt(description, orig.description.as_deref()),
-        publisher: opt(publisher, orig.publisher.as_deref()),
-        published: opt(published, orig.published.as_deref()),
-        language: opt(language, orig.language.as_deref()),
-        series: opt(series, orig.series.as_deref()),
-        series_index: opt(series_index, orig.series_index.as_deref()),
+        title: opt(edited.title, orig.title.as_deref()),
+        description: opt(edited.description, orig.description.as_deref()),
+        publisher: opt(edited.publisher, orig.publisher.as_deref()),
+        published: opt(edited.published, orig.published.as_deref()),
+        language: opt(edited.language, orig.language.as_deref()),
+        series: opt(edited.series, orig.series.as_deref()),
+        series_index: opt(edited.series_index, orig.series_index.as_deref()),
         creators,
         subjects,
     }
@@ -395,20 +400,36 @@ mod tests {
         }
     }
 
+    fn edited<'a>(
+        title: &'a str,
+        publisher: &'a str,
+        authors: &'a [String],
+        tags: &'a [String],
+    ) -> EditedFields<'a> {
+        EditedFields {
+            title,
+            description: "",
+            publisher,
+            published: "",
+            language: "",
+            series: "",
+            series_index: "",
+            authors,
+            tags,
+        }
+    }
+
     #[test]
     fn build_overrides_no_changes_yields_all_none() {
         let orig = book_with(Some("Dune"), &["Frank Herbert"], &["scifi"]);
         let ov = build_overrides(
             &orig,
-            "Dune",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            &["Frank Herbert".to_string()],
-            &["scifi".to_string()],
+            edited(
+                "Dune",
+                "",
+                &["Frank Herbert".to_string()],
+                &["scifi".to_string()],
+            ),
         );
         assert_eq!(ov, MetadataOverrides::default());
     }
@@ -418,15 +439,7 @@ mod tests {
         let orig = book_with(Some("Dune"), &["Frank Herbert"], &[]);
         let ov = build_overrides(
             &orig,
-            "Dune: Messiah",
-            "",
-            "Ace",
-            "",
-            "",
-            "",
-            "",
-            &["Frank Herbert".to_string()],
-            &[],
+            edited("Dune: Messiah", "Ace", &["Frank Herbert".to_string()], &[]),
         );
         assert_eq!(ov.title.as_deref(), Some("Dune: Messiah"));
         assert_eq!(ov.publisher.as_deref(), Some("Ace"));
@@ -440,26 +453,17 @@ mod tests {
         // orig.title = "Dune", edited to "" -> the override must carry the
         // empty string so the merge clears it rather than leaving it untouched.
         let orig = book_with(Some("Dune"), &[], &[]);
-        let ov = build_overrides(&orig, "", "", "", "", "", "", "", &[], &[]);
+        let ov = build_overrides(&orig, edited("", "", &[], &[]));
         assert_eq!(ov.title.as_deref(), Some(""));
     }
 
     #[test]
     fn build_overrides_replaces_full_creator_and_subject_lists() {
         let orig = book_with(Some("Dune"), &["Frank Herbert"], &["scifi"]);
-        let ov = build_overrides(
-            &orig,
-            "Dune",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            &["Frank Herbert".to_string(), "Brian Herbert".to_string()],
-            &["scifi".to_string(), "classic".to_string()],
-        );
-        let creators = ov.creators.unwrap_or_default();
+        let authors = vec!["Frank Herbert".to_string(), "Brian Herbert".to_string()];
+        let tags = vec!["scifi".to_string(), "classic".to_string()];
+        let ov = build_overrides(&orig, edited("Dune", "", &authors, &tags));
+        let creators = ov.creators.expect("creators should be set");
         assert_eq!(creators.len(), 2);
         assert_eq!(creators[0].name, "Frank Herbert");
         assert_eq!(creators[1].name, "Brian Herbert");
@@ -475,15 +479,12 @@ mod tests {
         let orig = book_with(Some("Dune"), &["Frank Herbert"], &["scifi"]);
         let ov = build_overrides(
             &orig,
-            "Dune",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            &["Frank Herbert".to_string()],
-            &["scifi".to_string()],
+            edited(
+                "Dune",
+                "",
+                &["Frank Herbert".to_string()],
+                &["scifi".to_string()],
+            ),
         );
         assert!(ov.creators.is_none());
         assert!(ov.subjects.is_none());


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`data.rs`**: Replace six blanket `#[allow(unused_imports)]` suppressions on `pub use` glob re-exports. Only `auth::*` was genuinely needed (the `data/auth.rs` module exports nothing under `feature = "server"` alone); guard it with `#[cfg(any(feature = "web", feature = "mobile"))]`. Remove the five redundant suppressions from the other modules.
- **`helpers.rs`**: Remove the dead-code stub `post_audio_progress` (lines 53–55) and its `#[allow(dead_code)]`. The stub was gated `cfg(all(not(feature = "web"), not(feature = "mobile")))`, but its only caller (`bootstrap.rs`) is `#[cfg(feature = "web")]` — making the stub unreachable in every build where it would compile.
- **`filtering.rs` / `sorting.rs`**: Replace the 8-argument `book()` test helper (exceeds Clippy's 7-arg threshold) with a `BookSpec<'a>` struct. Update all call sites to named-field syntax. Remove the `#[allow(clippy::too_many_arguments)]` suppressions.
- **`metadata_edit.rs`**: Introduce `EditedFields<'a>` struct to group the 9 arguments of `build_overrides`. Update the single production call site and five test call sites. Remove `#[allow(clippy::too_many_arguments)]`.
- **`ready_player.rs`**: Remove `#[allow(clippy::too_many_lines)]`. Investigation showed `clippy::too_many_lines` is in Clippy's default **allow** group — the lint is never emitted without `-W clippy::too_many_lines`, so the suppression was suppressing nothing. Confirmed: `cargo clippy … -- -D warnings` passes after removal.

## Adversarial self-review

- All six suppressions from #405 are gone. No new `#[allow]` added anywhere.
- Each removal addresses the root cause, not just the suppression: `auth::*` gets a proper `#[cfg]` guard; the dead stub is deleted; the over-argument functions are genuinely refactored.
- `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` passes cleanly.
- 108 tests pass (`cargo test -p omnibus-frontend --features server`).
- `cargo fmt` applied; no format drift.
- Scope is limited to the six suppressions listed in #405. No unrelated changes.
- `ready_player.rs` note: `too_many_lines` is an allow-by-default lint. The suppression was redundant from the start and its removal is safe without any refactoring. Issue #377 tracks the actual function-length debt for other components; `ReadyPlayer` was not listed in #377.

## Test plan

- [ ] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [ ] `cargo test -p omnibus-frontend --features server` — 108 tests pass
- [ ] `cargo fmt --check -p omnibus-frontend` — no drift
- [ ] `grep -rn '#\[allow' frontend/src/data.rs frontend/src/pages/listen/helpers.rs frontend/src/pages/landing/filtering.rs frontend/src/pages/landing/sorting.rs frontend/src/pages/metadata_edit.rs frontend/src/pages/listen/ready_player.rs` — returns empty

Closes #405

https://claude.ai/code/session_01R5vNCSZuZGARTy7VRhCrRj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5vNCSZuZGARTy7VRhCrRj)_