### PR TITLE
fix: batch book ID lookup in sync_changed to eliminate N+1 SELECT (#442)

### DIFF
--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -1,6 +1,8 @@
 //! Multi-file audiobook sync. Mirrors `sync_books` but writes
 //! `book_file_parts` rows in addition to `books` and `book_files`.
 
+use std::collections::HashMap;
+
 use sqlx::{SqlitePool, Transaction};
 
 use crate::covers::delete_cover_files_for;
@@ -68,51 +70,64 @@ pub async fn sync_audiobooks(
 
     // --- Changed ----------------------------------------------------------
     let mut changed_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
-    for b in &plan.changed_books {
-        let Some(book_id) =
-            sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE library_id = ? AND uuid = ?")
-                .bind(library_id)
-                .bind(&b.uuid)
-                .fetch_optional(&mut *tx)
-                .await?
-        else {
-            // TOCTOU: promote to New insert.
-            let inserted = insert_audiobook_row(&mut tx, library_id, b).await?;
-            insert_audiobook_parts(&mut tx, inserted.book_file_id, &b.parts).await?;
-            insert_chapters(&mut tx, inserted.book_file_id, &b.chapters, &b.parts).await?;
-            insert_audiobook_author_link(&mut tx, inserted.book_id, b.creator_name.as_deref())
+    if !plan.changed_books.is_empty() {
+        // Pre-fetch all book ids in one batch query (chunked at 499 to stay
+        // under SQLite's 999-parameter cap). Audiobook UUIDs come from
+        // `b.uuid` directly — no stable_uuid call needed.
+        let all_uuids: Vec<String> = plan.changed_books.iter().map(|b| b.uuid.clone()).collect();
+        let mut id_map: HashMap<String, i64> = HashMap::new();
+        for chunk in all_uuids.chunks(499) {
+            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let id_sql = format!(
+                "SELECT uuid, id FROM books WHERE library_id = ? AND uuid IN ({placeholders})"
+            );
+            let mut q = sqlx::query_as::<_, (String, i64)>(&id_sql).bind(library_id);
+            for uuid in chunk {
+                q = q.bind(uuid);
+            }
+            id_map.extend(q.fetch_all(&mut *tx).await?);
+        }
+
+        for b in &plan.changed_books {
+            let Some(&book_id) = id_map.get(&b.uuid) else {
+                // TOCTOU: promote to New insert.
+                let inserted = insert_audiobook_row(&mut tx, library_id, b).await?;
+                insert_audiobook_parts(&mut tx, inserted.book_file_id, &b.parts).await?;
+                insert_chapters(&mut tx, inserted.book_file_id, &b.chapters, &b.parts).await?;
+                insert_audiobook_author_link(&mut tx, inserted.book_id, b.creator_name.as_deref())
+                    .await?;
+                insert_audiobook_fts_row(&mut tx, inserted.book_id, b).await?;
+                if let Some((mime, bytes)) = &b.cover {
+                    changed_covers.push((b.uuid.clone(), mime.clone(), bytes.clone()));
+                }
+                continue;
+            };
+
+            update_audiobook_row(&mut tx, book_id, b).await?;
+            // Wipe dependent rows; ON DELETE CASCADE handles book_file_parts when
+            // book_files is deleted.
+            sqlx::query("DELETE FROM books_authors_link WHERE book = ?")
+                .bind(book_id)
+                .execute(&mut *tx)
                 .await?;
-            insert_audiobook_fts_row(&mut tx, inserted.book_id, b).await?;
+            sqlx::query("DELETE FROM book_files WHERE book_id = ?")
+                .bind(book_id)
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("DELETE FROM books_fts WHERE rowid = ?")
+                .bind(book_id)
+                .execute(&mut *tx)
+                .await?;
+
+            let book_file_id = insert_audiobook_file_row(&mut tx, book_id, b).await?;
+            insert_audiobook_parts(&mut tx, book_file_id, &b.parts).await?;
+            insert_chapters(&mut tx, book_file_id, &b.chapters, &b.parts).await?;
+            insert_audiobook_author_link(&mut tx, book_id, b.creator_name.as_deref()).await?;
+            insert_audiobook_fts_row(&mut tx, book_id, b).await?;
+
             if let Some((mime, bytes)) = &b.cover {
                 changed_covers.push((b.uuid.clone(), mime.clone(), bytes.clone()));
             }
-            continue;
-        };
-
-        update_audiobook_row(&mut tx, book_id, b).await?;
-        // Wipe dependent rows; ON DELETE CASCADE handles book_file_parts when
-        // book_files is deleted.
-        sqlx::query("DELETE FROM books_authors_link WHERE book = ?")
-            .bind(book_id)
-            .execute(&mut *tx)
-            .await?;
-        sqlx::query("DELETE FROM book_files WHERE book_id = ?")
-            .bind(book_id)
-            .execute(&mut *tx)
-            .await?;
-        sqlx::query("DELETE FROM books_fts WHERE rowid = ?")
-            .bind(book_id)
-            .execute(&mut *tx)
-            .await?;
-
-        let book_file_id = insert_audiobook_file_row(&mut tx, book_id, b).await?;
-        insert_audiobook_parts(&mut tx, book_file_id, &b.parts).await?;
-        insert_chapters(&mut tx, book_file_id, &b.chapters, &b.parts).await?;
-        insert_audiobook_author_link(&mut tx, book_id, b.creator_name.as_deref()).await?;
-        insert_audiobook_fts_row(&mut tx, book_id, b).await?;
-
-        if let Some((mime, bytes)) = &b.cover {
-            changed_covers.push((b.uuid.clone(), mime.clone(), bytes.clone()));
         }
     }
 

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -5,6 +5,8 @@
 //! (`insert_book_row` / `update_book_row`) plus the metadata-link
 //! dispatcher, FTS row insert, and post-commit cover materialization.
 
+use std::collections::HashMap;
+
 use sqlx::{SqlitePool, Transaction};
 
 use omnibus_shared::EbookMetadata;
@@ -169,25 +171,42 @@ async fn sync_changed(
     library_path: &str,
     changed_books: &[crate::ebook::IndexedBook],
 ) -> Result<Vec<(String, String, Vec<u8>)>, sqlx::Error> {
+    if changed_books.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Pre-compute all UUIDs up front so we can batch the id lookup.
+    let all_uuids: Vec<String> = changed_books
+        .iter()
+        .map(|b| stable_uuid(library_path, &b.metadata.filename))
+        .collect();
+
+    // One batch SELECT per chunk (chunked at 499 to stay under SQLite's
+    // 999-parameter cap: 1 bind for library_id + up to 499 uuid binds).
+    // `sync_removed` uses the same pattern.
+    let mut id_map: HashMap<String, i64> = HashMap::new();
+    for chunk in all_uuids.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let id_sql =
+            format!("SELECT uuid, id FROM books WHERE library_id = ? AND uuid IN ({placeholders})");
+        let mut q = sqlx::query_as::<_, (String, i64)>(&id_sql).bind(library_id);
+        for uuid in chunk {
+            q = q.bind(uuid);
+        }
+        id_map.extend(q.fetch_all(&mut **tx).await?);
+    }
+
     // Wipe-and-rewrite the per-book link rows for each Changed entry,
     // then UPDATE the `books` row and re-insert FTS. This trades two
     // small per-book deletes for the much simpler "compute the link
     // diff" alternative, while preserving `books.id` — which is the
     // only invariant any external caller depends on.
     let mut changed_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
-    for b in changed_books {
-        let uuid = stable_uuid(library_path, &b.metadata.filename);
-        let Some(book_id) =
-            sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE library_id = ? AND uuid = ?")
-                .bind(library_id)
-                .bind(&uuid)
-                .fetch_optional(&mut **tx)
-                .await?
-        else {
-            // The diff said this uuid existed in the DB, but a concurrent
-            // process removed it between Phase A and the write. Promote
-            // to a New insert so the file still gets indexed; cleaner
-            // than failing the whole sync over a TOCTOU.
+    for (b, uuid) in changed_books.iter().zip(all_uuids.iter()) {
+        let Some(&book_id) = id_map.get(uuid) else {
+            // TOCTOU: the diff said this uuid existed in the DB, but a
+            // concurrent process removed it between Phase A and the write.
+            // Promote to a New insert so the file still gets indexed.
             let inserted = insert_book_row(tx, library_id, library_path, b).await?;
             insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
             insert_fts_row(
@@ -219,7 +238,7 @@ async fn sync_changed(
         insert_fts_row(tx, book_id, &title, first_isbn.as_deref(), &b.metadata).await?;
 
         if let Some((mime, bytes)) = &b.cover {
-            changed_covers.push((uuid, mime.clone(), bytes.clone()));
+            changed_covers.push((uuid.clone(), mime.clone(), bytes.clone()));
         }
     }
     Ok(changed_covers)

--- a/frontend/src/components/search_palette/results.rs
+++ b/frontend/src/components/search_palette/results.rs
@@ -299,8 +299,8 @@ fn book_thumb_url(server_url: &str, book: &PaletteBookHit) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::model::build_flat_items;
+    use super::*;
 
     #[test]
     fn book_thumb_url_uses_uuid_not_id() {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Before:** `sync_changed` in both `db/src/sync/books.rs` and `db/src/sync/audiobooks.rs` issued `SELECT id FROM books WHERE library_id = ? AND uuid = ?` inside the Changed loop — one DB round-trip per changed book. A 5,000-book full rescan produced 5,000 sequential SELECTs inside the write transaction.
- **After:** All UUIDs are collected upfront and resolved in a single batch `SELECT uuid, id FROM books WHERE library_id = ? AND uuid IN (…)` (chunked at 499 to stay under SQLite's 999-bind-param cap), building a `HashMap<String, i64>`. The per-book loop does a `HashMap::get` instead of a DB round-trip: **O(N) queries → O(N/499) queries**, capped at 1 for any library under ~500 changed books.
- The TOCTOU fallback (UUID vanished between diff and write → promote to New insert) is preserved unchanged via the HashMap miss branch.
- Write path logic (update_book_row, wipe/reinsert links, FTS) is unchanged.
- Pattern mirrors `sync_removed`'s existing `IN (…)` batch delete in the same file.

## Follow-on

`wipe_per_book_link_rows` (7 per-book per-table DELETEs inside the loop) is a noted further optimization — out of scope per issue #442 and left as a follow-on.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 454 passed, 0 failed

https://claude.ai/code/session_01TxNNbhipLXnfR5pErTEajC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxNNbhipLXnfR5pErTEajC)_