### PR TITLE
docs: add missing rustdoc to 23 public omnibus-db functions (#441)

### DIFF
--- a/db/src/auth/device.rs
+++ b/db/src/auth/device.rs
@@ -47,14 +47,17 @@ fn validate_device_field(
     Ok(())
 }
 
+/// Validate a device name against format rules (max length, no control characters); `None` is accepted.
 pub fn validate_device_name(name: Option<&str>) -> AuthResult<()> {
     validate_device_field(name, MAX_DEVICE_NAME_CHARS, "device_name")
 }
 
+/// Validate a client version string against format rules (max length, no control characters); `None` is accepted.
 pub fn validate_client_version(version: Option<&str>) -> AuthResult<()> {
     validate_device_field(version, MAX_CLIENT_VERSION_CHARS, "client_version")
 }
 
+/// Register a new device for a user after validating the name and client version; returns the inserted device record.
 pub async fn register_device(
     pool: &SqlitePool,
     user_id: i64,
@@ -88,6 +91,7 @@ pub async fn register_device(
     })
 }
 
+/// List all registered devices for a user, ordered by most-recently-seen first.
 pub async fn list_devices_for_user(pool: &SqlitePool, user_id: i64) -> AuthResult<Vec<Device>> {
     let rows = sqlx::query(
         "SELECT id, user_id, name, client_kind, client_version, created_at, last_seen_at

--- a/db/src/auth/password.rs
+++ b/db/src/auth/password.rs
@@ -88,6 +88,7 @@ pub(crate) fn argon2_hasher() -> Argon2<'static> {
     Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
 }
 
+/// Validate a plaintext password against the policy rules (length bounds and common-password reject-list).
 pub fn validate_password(password: &str) -> AuthResult<()> {
     // Count Unicode scalar values, not bytes, so a few emoji can't satisfy
     // a byte-length floor. Argon2 itself is byte-oriented and imposes no
@@ -163,6 +164,7 @@ pub fn validate_username(username: &str) -> AuthResult<()> {
     Ok(())
 }
 
+/// Hash `password` with Argon2id using OWASP-recommended parameters; returns a PHC-format string suitable for storage.
 pub fn hash_password(password: &str) -> AuthResult<String> {
     let salt = SaltString::generate(&mut PhcOsRng);
     let phc = argon2_hasher()

--- a/db/src/auth/session.rs
+++ b/db/src/auth/session.rs
@@ -15,6 +15,7 @@ const SESSION_TOUCH_THRESHOLD_SECS: i64 = 5 * 60;
 /// (cookie absolute TTL is 30 days; bearer is 90).
 pub(crate) const SESSION_IDLE_TIMEOUT_SECS: i64 = 7 * 24 * 60 * 60;
 
+/// Create a new session for `user_id`, returning the session record and the raw (unhashed) token.
 pub async fn create_session(
     pool: &SqlitePool,
     user_id: i64,
@@ -230,6 +231,7 @@ pub async fn validate_session(
     }
 }
 
+/// Revoke a single session by id, setting its `revoked_at` timestamp so `lookup_session` rejects it.
 pub async fn revoke_session(pool: &SqlitePool, session_id: i64) -> AuthResult<()> {
     sqlx::query("UPDATE sessions SET revoked_at = ? WHERE id = ?")
         .bind(now_unix())
@@ -239,6 +241,7 @@ pub async fn revoke_session(pool: &SqlitePool, session_id: i64) -> AuthResult<()
     Ok(())
 }
 
+/// Revoke all active sessions for a user; returns the number of rows updated.
 pub async fn revoke_all_sessions_for_user(pool: &SqlitePool, user_id: i64) -> AuthResult<u64> {
     let r =
         sqlx::query("UPDATE sessions SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL")

--- a/db/src/auth/session_key.rs
+++ b/db/src/auth/session_key.rs
@@ -22,6 +22,7 @@ pub async fn load_or_create_session_key(pool: &SqlitePool) -> AuthResult<Vec<u8>
     Ok(key)
 }
 
+/// Retrieve the session signing key from the database, returning `None` if it has not been set yet.
 pub async fn get_session_key(pool: &SqlitePool) -> AuthResult<Option<Vec<u8>>> {
     let v: Option<Vec<u8>> = sqlx::query_scalar("SELECT value FROM secrets WHERE name = ?")
         .bind(SESSION_KEY_NAME)
@@ -30,6 +31,7 @@ pub async fn get_session_key(pool: &SqlitePool) -> AuthResult<Option<Vec<u8>>> {
     Ok(v)
 }
 
+/// Store or replace the session signing key in the database.
 pub async fn put_session_key(pool: &SqlitePool, key: &[u8]) -> AuthResult<()> {
     sqlx::query(
         "INSERT INTO secrets (name, value) VALUES (?, ?)

--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -96,6 +96,7 @@ pub async fn create_user(pool: &SqlitePool, username: &str, password: &str) -> A
     })
 }
 
+/// Look up a user record by username (case-insensitive); returns `None` if no match.
 pub async fn get_user_by_username(pool: &SqlitePool, username: &str) -> AuthResult<Option<User>> {
     let row = sqlx::query(
         "SELECT id, username, is_admin, can_upload, can_edit, can_download
@@ -107,6 +108,7 @@ pub async fn get_user_by_username(pool: &SqlitePool, username: &str) -> AuthResu
     Ok(row.as_ref().map(row_to_user))
 }
 
+/// Look up a user record by primary key; returns `None` if no match.
 pub async fn get_user_by_id(pool: &SqlitePool, id: i64) -> AuthResult<Option<User>> {
     let row = sqlx::query(
         "SELECT id, username, is_admin, can_upload, can_edit, can_download
@@ -129,6 +131,7 @@ pub async fn promote_to_admin(pool: &SqlitePool, username: &str) -> AuthResult<b
     Ok(result.rows_affected() > 0)
 }
 
+/// Enable or disable new user self-registration; persists the setting to the `settings` table.
 pub async fn set_registration_enabled(pool: &SqlitePool, enabled: bool) -> AuthResult<()> {
     let v = if enabled { "1" } else { "0" };
     sqlx::query(
@@ -141,6 +144,7 @@ pub async fn set_registration_enabled(pool: &SqlitePool, enabled: bool) -> AuthR
     Ok(())
 }
 
+/// Return whether new user self-registration is currently enabled.
 pub async fn registration_enabled(pool: &SqlitePool) -> AuthResult<bool> {
     let v: Option<String> =
         sqlx::query_scalar("SELECT value FROM settings WHERE key = 'registration_enabled'")

--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -29,6 +29,7 @@ pub enum AuthorPhotoSource {
 }
 
 impl AuthorPhotoSource {
+    /// Return the database string representation of this photo source variant.
     pub fn as_str(&self) -> &'static str {
         match self {
             AuthorPhotoSource::Manual => "manual",
@@ -37,6 +38,7 @@ impl AuthorPhotoSource {
         }
     }
 
+    /// Parse a database string into an `AuthorPhotoSource` variant; returns `None` for unrecognised values.
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "manual" => Some(Self::Manual),

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -72,6 +72,7 @@ pub struct ScanOptions {
     pub materialize_sidecars: bool,
 }
 
+/// Scan an ebook library directory and extract EPUB metadata, using default `ScanOptions`.
 pub fn scan_ebook_library(path: Option<&str>) -> ScanResult {
     scan_ebook_library_with(path, ScanOptions::default())
 }

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -13,7 +13,8 @@ use crate::covers::covers_dir;
 /// versions are recorded in the `_sqlx_migrations` table.
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
-/// Initialize or open the SQLite pool at `database_url`, apply per-connection PRAGMAs, and run any pending schema migrations.
+/// Initialize or open the SQLite pool at `database_url`, apply per-connection PRAGMAs, run pending
+/// migrations, and — on non-memory databases — perform a one-time legacy cover-cache directory purge.
 pub async fn init_db(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
     // PRAGMAs `foreign_keys`, `busy_timeout`, and `synchronous` are
     // *per-connection* settings — they only apply to the connection that

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -13,6 +13,7 @@ use crate::covers::covers_dir;
 /// versions are recorded in the `_sqlx_migrations` table.
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
+/// Initialize or open the SQLite pool at `database_url`, apply per-connection PRAGMAs, and run any pending schema migrations.
 pub async fn init_db(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
     // PRAGMAs `foreign_keys`, `busy_timeout`, and `synchronous` are
     // *per-connection* settings — they only apply to the connection that

--- a/db/src/scanner.rs
+++ b/db/src/scanner.rs
@@ -76,6 +76,7 @@ pub fn list_files(path: Option<&str>, extensions: &[&str]) -> LibrarySection {
 pub const EBOOK_EXTENSIONS: &[&str] = &["epub", "pdf"];
 pub const AUDIOBOOK_EXTENSIONS: &[&str] = &["m4b", "mp3"];
 
+/// Scan all configured library directories and return a combined `LibraryContents` with ebook and audiobook stat entries.
 pub fn scan_libraries(ebook_path: Option<&str>, audiobook_path: Option<&str>) -> LibraryContents {
     LibraryContents {
         ebooks: list_files(ebook_path, EBOOK_EXTENSIONS),

--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -30,7 +30,7 @@ impl ThumbSize {
         }
     }
 
-    /// Returns a slice of all `ThumbSize` variants in ascending size order.
+    /// Returns a fixed-size array of all `ThumbSize` variants in ascending size order.
     pub fn all() -> [ThumbSize; 3] {
         [ThumbSize::Sm, ThumbSize::Md, ThumbSize::Lg]
     }

--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -21,6 +21,7 @@ impl ThumbSize {
         }
     }
 
+    /// Returns the string key for this thumbnail size variant (`"sm"`, `"md"`, or `"lg"`).
     pub fn as_str(self) -> &'static str {
         match self {
             ThumbSize::Sm => "sm",
@@ -29,6 +30,7 @@ impl ThumbSize {
         }
     }
 
+    /// Returns a slice of all `ThumbSize` variants in ascending size order.
     pub fn all() -> [ThumbSize; 3] {
         [ThumbSize::Sm, ThumbSize::Md, ThumbSize::Lg]
     }

--- a/frontend/src/components/search_palette/results.rs
+++ b/frontend/src/components/search_palette/results.rs
@@ -299,8 +299,8 @@ fn book_thumb_url(server_url: &str, book: &PaletteBookHit) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::model::build_flat_items;
+    use super::*;
 
     #[test]
     fn book_thumb_url_uses_uuid_not_id() {


### PR DESCRIPTION
## Summary

- Pure documentation pass for `omnibus-db` — no logic or signature changes.
- Adds one-line `///` summaries to 23 public functions and methods in `omnibus-db` that were missing them, satisfying the style rule requiring `///` on every `pub` item.
- `cargo doc -p omnibus-db --no-deps` now reports zero "missing documentation" warnings.
- Also includes a `rustfmt`-only import reorder in `frontend/src/components/search_palette/results.rs` (`use super::super::model::...` must precede `use super::*` to satisfy alphabetical ordering) — no logic change.

## Files touched

| File | Functions documented |
|---|---|
| `db/src/auth/session.rs` | `create_session`, `revoke_session`, `revoke_all_sessions_for_user` |
| `db/src/auth/session_key.rs` | `get_session_key`, `put_session_key` |
| `db/src/auth/password.rs` | `validate_password`, `hash_password` |
| `db/src/auth/users.rs` | `get_user_by_username`, `get_user_by_id`, `set_registration_enabled`, `registration_enabled` |
| `db/src/auth/device.rs` | `validate_device_name`, `validate_client_version`, `register_device`, `list_devices_for_user` |
| `db/src/author_photos_data.rs` | `AuthorPhotoSource::as_str`, `AuthorPhotoSource::parse` |
| `db/src/scanner.rs` | `scan_libraries` |
| `db/src/pool.rs` | `init_db` |
| `db/src/ebook.rs` | `scan_ebook_library` |
| `db/src/thumbs.rs` | `ThumbSize::as_str`, `ThumbSize::all` |
| `frontend/src/components/search_palette/results.rs` | formatting-only import reorder |

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — no warnings
- [x] `cargo test -p omnibus-db` — all tests pass
- [x] `cargo doc -p omnibus-db --no-deps 2>&1 | grep "missing documentation"` — no output

Closes #441

https://claude.ai/code/session_01VrCsSLc5zoSxDY31iTLnBN