### PR TITLE
test: add Playwright smoke tests for listen-page panels (#446)

### DIFF
--- a/frontend/src/components/search_palette/results.rs
+++ b/frontend/src/components/search_palette/results.rs
@@ -299,8 +299,8 @@ fn book_thumb_url(server_url: &str, book: &PaletteBookHit) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::model::build_flat_items;
+    use super::*;
 
     #[test]
     fn book_thumb_url_uses_uuid_not_id() {

--- a/frontend/src/pages/listen/bookmarks_drawer.rs
+++ b/frontend/src/pages/listen/bookmarks_drawer.rs
@@ -17,7 +17,7 @@ pub(super) fn BookmarksDrawer(on_close: EventHandler<()>) -> Element {
             onclick: move |_| on_close.call(()),
         }
 
-        div { class: "lp-drawer",
+        div { class: "lp-drawer", "data-testid": "bookmarks-drawer",
             div { class: "lp-drawer-head",
                 div {
                     div { class: "lp-panel-kicker", "Bookmarks" }

--- a/frontend/src/pages/listen/chapters_drawer.rs
+++ b/frontend/src/pages/listen/chapters_drawer.rs
@@ -25,7 +25,7 @@ pub(super) fn ChaptersDrawer(
             onclick: move |_| on_close.call(()),
         }
 
-        div { class: "lp-drawer",
+        div { class: "lp-drawer", "data-testid": "chapters-drawer",
             div { class: "lp-drawer-head",
                 div {
                     div { class: "lp-panel-kicker", "Chapters" }
@@ -58,6 +58,13 @@ pub(super) fn ChaptersDrawer(
                             } else {
                                 "lp-drawer-row"
                             };
+                            let row_testid = if is_current {
+                                "chapter-row-current"
+                            } else if is_played {
+                                "chapter-row-played"
+                            } else {
+                                "chapter-row-upcoming"
+                            };
 
                             let dur_label = format_hms(ch.duration_seconds);
                             let remaining_in_ch = if is_current {
@@ -78,6 +85,7 @@ pub(super) fn ChaptersDrawer(
                             rsx! {
                                 button {
                                     class: "{row_class}",
+                                    "data-testid": "{row_testid}",
                                     r#type: "button",
                                     onclick: move |_| on_seek.call(ch_start),
                                     span { class: "lp-drawer-ord",

--- a/frontend/src/pages/listen/sleep_panel.rs
+++ b/frontend/src/pages/listen/sleep_panel.rs
@@ -21,7 +21,7 @@ pub(super) fn SleepPanel(on_close: EventHandler<()>) -> Element {
             onclick: move |_| on_close.call(()),
         }
 
-        div { class: "lp-panel lp-sleep-panel",
+        div { class: "lp-panel lp-sleep-panel", "data-testid": "sleep-panel",
             div { class: "lp-panel-head",
                 div {
                     div { class: "lp-panel-kicker", "Sleep timer" }

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -15,6 +15,7 @@ test.beforeAll(async ({ request }) => {
 
 const MP3_BOOK = AUDIOBOOK_BOOKS.find((b) => b.format === "MP3" && b.source === "generated")!;
 const M4B_BOOK = AUDIOBOOK_BOOKS.find((b) => b.format === "M4B")!;
+const MULTIPART_MP3_BOOK = AUDIOBOOK_BOOKS.find((b) => b.format === "MP3" && b.parts > 1)!;
 
 /**
  * Wait until the listen page's manifest fetch has resolved and
@@ -280,6 +281,90 @@ test("shows not-found message for unknown audiobook uuid", async ({ page }) => {
   await expect(
     page.getByRole("link", { name: "Back to library" }),
   ).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// 8. Sleep panel
+// ---------------------------------------------------------------------------
+
+test("opens sleep panel and shows preset duration rail", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+
+  // Open the sleep panel via the toolbar button.
+  await page.getByRole("button", { name: /^sleep/i }).click();
+
+  // Panel container is in the DOM.
+  await expect(page.getByTestId("sleep-panel")).toBeVisible();
+
+  // Preset rail: Off through 4 hours.
+  await expect(page.getByRole("button", { name: "Off" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "15 min" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "30 min" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "45 min" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "1 hour" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "2 hours" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "3 hours" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "4 hours" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "End of chapter" })).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// 9. Bookmarks drawer
+// ---------------------------------------------------------------------------
+
+test("opens bookmarks drawer and shows empty state", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+
+  // Open the bookmarks drawer via the toolbar button.
+  await page.getByRole("button", { name: "Bookmark" }).click();
+
+  // Drawer container is in the DOM.
+  await expect(page.getByTestId("bookmarks-drawer")).toBeVisible();
+
+  // Empty state copy — no bookmarks have been saved yet.
+  await expect(page.getByText("No bookmarks yet")).toBeVisible();
+  await expect(
+    page.getByText("Tap the Bookmark button while listening to save"),
+  ).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// 10. Chapters drawer
+// ---------------------------------------------------------------------------
+
+test("opens chapters drawer and shows played/current/upcoming row states", async ({
+  page,
+  request,
+}) => {
+  // Use the multi-part MP3 book so at least two synthetic chapters are
+  // present (one per part): the first is "current" at elapsed=0, the
+  // second is "upcoming". The synthetic fallback always produces
+  // file_chapters.len() >= 1, so even books without embedded markers work.
+  const uuid = await fetchBookUuidByTitle(request, MULTIPART_MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+
+  // Open the chapters drawer via the toolbar button.
+  await page.getByRole("button", { name: /^chapters/i }).click();
+
+  // Drawer container is in the DOM.
+  await expect(page.getByTestId("chapters-drawer")).toBeVisible();
+
+  // At elapsed=0 the first chapter is current and the rest are upcoming.
+  // getByTestId returns all matching elements; we need at least one current
+  // and at least one upcoming row.
+  await expect(page.getByTestId("chapter-row-current").first()).toBeVisible();
+  await expect(page.getByTestId("chapter-row-upcoming").first()).toBeVisible();
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds three Playwright smoke tests to `listen.spec.ts` for the sleep panel, bookmarks drawer, and chapters drawer (follow-up from #411 / PR #437)
- Adds `data-testid` attributes to `sleep_panel.rs`, `bookmarks_drawer.rs`, and `chapters_drawer.rs` for stable E2E selectors
- Chapter rows in `chapters_drawer.rs` now expose `chapter-row-current`, `chapter-row-played`, and `chapter-row-upcoming` testids derived from the existing CSS class logic

**What each test covers:**

| Test | Panel opened | Assertions |
|---|---|---|
| `opens sleep panel and shows preset duration rail` | Sleep panel via `Sleep · off` toolbar button | `sleep-panel` testid visible; all 9 preset buttons (Off, 15 min … 4 hours, End of chapter) visible |
| `opens bookmarks drawer and shows empty state` | Bookmarks drawer via `Bookmark` toolbar button | `bookmarks-drawer` testid visible; "No bookmarks yet" and detail copy visible |
| `opens chapters drawer and shows played/current/upcoming row states` | Chapters drawer via `Chapters ↑` toolbar button | `chapters-drawer` testid visible; at least one `chapter-row-current` and one `chapter-row-upcoming` row visible |

**Chapters test design note:** uses the two-part MP3 fixture ("The Compiled Tales") so the indexer's synthetic-fallback always produces two `file_chapters` rows (one per part). At `elapsed=0` the first row is `current` and the second is `upcoming`, satisfying the acceptance criterion without needing a fixture with embedded CHAP frames.

**Selectors used:** `getByRole("button", { name: /^sleep/i })` and `getByRole("button", { name: /^chapters/i })` (regex partial match on the dynamic label), `getByRole("button", { name: "Bookmark" })` (exact), `getByTestId(...)` for panel containers and chapter row states.

---

### Reviewer findings addressed

**Item 1 — `MULTIPART_MP3_BOOK` fixture field (`parts`):** Verified — `parts` is a first-class field on the `ExpectedAudiobook` interface in `tests/fixtures/audiobooks.ts` (line 25: `parts: number`). The `find(b => b.format === "MP3" && b.parts > 1)` call is valid TypeScript and matches "The Compiled Tales" (2 parts). `tsc --noEmit` produces zero errors in `listen.spec.ts`; the three pre-existing errors reported by the checker are in unrelated files (`book_detail.spec.ts`, `landing.spec.ts`, `metadata_edit.spec.ts`) and were present before this PR.

**Item 2 — `chapter-row-played` not assertable at `elapsed=0`:** This is an intentional limitation of this smoke test. When the player opens at the beginning of a book, no chapter has been played, so `chapter-row-played` cannot be asserted here without driving real audio playback. The `chapter-row-played` testid IS present in the markup — it is emitted by `chapters_drawer.rs` from the same `is_played` bool already used for the CSS class, so the selector is stable and correct. The `played` state will be exercised when chapter-navigation E2E tests are added (a natural follow-on to this smoke coverage).

**Item 3 — "3 hours" sleep preset:** Confirmed the assertion is correct. `sleep_panel.rs` defines `PRESETS: &[&str] = &["Off", "15 min", "30 min", "45 min", "1 hour", "2 hours", "3 hours", "4 hours"]` — 8 buttons — plus a separate "End of chapter" button rendered outside the grid, for 9 total. All 9 are asserted in the test. The issue spec listed only 8 presets, but the component ships 9; the test accurately reflects what the component renders.

---

## Test plan

- [ ] `npx tsc --noEmit` passes with no new errors in `listen.spec.ts` (verified — pre-existing errors in other spec files are unrelated)
- [ ] `cargo clippy -p omnibus-frontend --features server` passes clean
- [ ] `cargo fmt -p omnibus-frontend` produces no changes
- [ ] Full E2E suite not run against a live server (no server available in this agent session); the new tests follow the exact same navigation/seeding pattern as the existing 7 listen-page tests which have passed CI

Closes #446

https://claude.ai/code/session_01TxNNbhipLXnfR5pErTEajC