### PR TITLE
docs: remove roadmap phase refs from //! and /// docs (#440)

### DIFF
--- a/db/src/audiobook.rs
+++ b/db/src/audiobook.rs
@@ -8,9 +8,9 @@
 //! [`parse::parse_groups`] into [`parse::IndexedAudiobook`] rows ready for
 //! [`crate::sync::sync_audiobooks`].
 //!
-//! Scope (F2.3 + F2.3b): title, primary author, album, duration in
-//! seconds, embedded artwork, per-part track ordering, and chapter extraction
-//! from Nero chpl atoms (M4B) and ID3v2 CHAP frames (MP3).
+//! Covers title, primary author, album, duration in seconds, embedded
+//! artwork, per-part track ordering, and chapter extraction from Nero chpl
+//! atoms (M4B) and ID3v2 CHAP frames (MP3).
 
 use std::path::{Path, PathBuf};
 

--- a/db/src/auth/session.rs
+++ b/db/src/auth/session.rs
@@ -644,7 +644,7 @@ mod tests {
         assert_eq!(again, 0);
     }
 
-    /// #248: the idle DELETE must use `idx_sessions_last_used_at`, not scan.
+    /// The idle DELETE must use `idx_sessions_last_used_at`, not scan.
     /// Guards against regressing to the OR'd form (migration 0012).
     #[tokio::test]
     async fn prune_idle_delete_uses_last_used_index() {
@@ -666,7 +666,7 @@ mod tests {
         );
     }
 
-    /// #248: the revoked DELETE must use the partial `idx_sessions_revoked_at`,
+    /// The revoked DELETE must use the partial `idx_sessions_revoked_at`,
     /// not scan. Guards against regressing to the OR'd form (migration 0012).
     #[tokio::test]
     async fn prune_revoked_delete_uses_revoked_index() {

--- a/db/src/author_photos/remote.rs
+++ b/db/src/author_photos/remote.rs
@@ -26,8 +26,8 @@ const REMOTE_IMAGE_TIMEOUT: Duration = Duration::from_secs(15);
 pub enum FetchRemoteImageError {
     #[error("URL must start with http:// or https://")]
     BadScheme,
-    /// Issue #275 — SSRF guard. The supplied URL parsed cleanly, but either
-    /// its host could not be resolved or one of the resolved IPs falls into a
+    /// SSRF guard triggered. The supplied URL parsed cleanly, but either its
+    /// host could not be resolved or one of the resolved IPs falls into a
     /// blocked range (loopback / private RFC1918 / link-local / multicast /
     /// IPv6 ULA / IPv6 site-local / unspecified / broadcast / documentation).
     /// We reject *before* any TCP connect so a hostile admin URL can't be

--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -276,10 +276,10 @@ mod tests {
         let _ = std::fs::remove_file(cover_path_for(&uuid, "jpg"));
         assert!(get_cover(&pool, books[0].id).await.unwrap().is_none());
     }
-    /// F5.1 / #107: when a `metadata_overrides` row sets
-    /// `has_cover_override = 1` and an `override-<uuid>.<ext>` file exists
-    /// on disk, `get_cover` returns the override bytes — not the scanned
-    /// cover. Single-query form must preserve this precedence.
+    /// When a `metadata_overrides` row sets `has_cover_override = 1` and an
+    /// `override-<uuid>.<ext>` file exists on disk, `get_cover` returns the
+    /// override bytes — not the scanned cover. Single-query form must
+    /// preserve this precedence.
     #[tokio::test]
     async fn cover_returns_override_when_flag_set() {
         let _covers = CoversTempDir::new("override_set");
@@ -316,9 +316,9 @@ mod tests {
         let cover = get_cover(&pool, books[0].id).await.unwrap();
         assert_eq!(cover, Some(("image/png".into(), b"OVERRIDE".to_vec())));
     }
-    /// F5.1 / #107: with no `metadata_overrides` row, `get_cover` falls
-    /// through to the scanned `<uuid>.<ext>` cover. The LEFT JOIN must
-    /// not filter the book out when no override row exists.
+    /// With no `metadata_overrides` row, `get_cover` falls through to the
+    /// scanned `<uuid>.<ext>` cover. The LEFT JOIN must not filter the book
+    /// out when no override row exists.
     #[tokio::test]
     async fn cover_returns_original_when_no_override_row() {
         let _covers = CoversTempDir::new("override_absent");
@@ -343,9 +343,9 @@ mod tests {
         let cover = get_cover(&pool, books[0].id).await.unwrap();
         assert_eq!(cover, Some(("image/jpeg".into(), b"ORIGINAL".to_vec())));
     }
-    /// F5.1 / #107: a `metadata_overrides` row with
-    /// `has_cover_override = 0` (text-only edits, no cover swap) must
-    /// resolve to the scanned cover, not the override path.
+    /// A `metadata_overrides` row with `has_cover_override = 0` (text-only
+    /// edits, no cover swap) must resolve to the scanned cover, not the
+    /// override path.
     #[tokio::test]
     async fn cover_returns_original_when_override_flag_unset() {
         let _covers = CoversTempDir::new("override_flag_off");
@@ -390,8 +390,8 @@ mod tests {
         let cover = get_cover(&pool, books[0].id).await.unwrap();
         assert_eq!(cover, Some(("image/jpeg".into(), b"ORIGINAL".to_vec())));
     }
-    /// #107: `get_cover` for a non-existent book id returns `Ok(None)`
-    /// (not an error). The LEFT JOIN must not change this contract.
+    /// `get_cover` for a non-existent book id returns `Ok(None)` (not an
+    /// error). The LEFT JOIN must not change this contract.
     #[tokio::test]
     async fn cover_returns_none_for_missing_book_id() {
         let _covers = CoversTempDir::new("missing_book");

--- a/db/src/discovery/series.rs
+++ b/db/src/discovery/series.rs
@@ -17,9 +17,7 @@ use super::{DiscoveryError, MAX_DISCOVERY_BOOKS};
 /// `None` if the series ID doesn't exist. The nested `books` vec is
 /// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
 ///
-/// Currently returns results across all users (single-tenant). When F4.x
-/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
-/// to books accessible to that user.
+/// Currently returns results across all users (single-tenant).
 pub async fn get_series(
     pool: &SqlitePool,
     series_id: i64,

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -254,9 +254,9 @@ pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()
     Ok(())
 }
 
-/// Audiobook-library sibling of [`reindex`]. Uses Phase A.5 group-by-folder,
-/// Phase B multi-part tag-reads, and [`sync::sync_audiobooks`] which writes
-/// `book_file_parts` rows for the HLS pipeline.
+/// Audiobook-library sibling of [`reindex`]. Groups audio files by folder,
+/// reads multi-part tags, then calls [`sync::sync_audiobooks`] to write
+/// `book_file_parts` rows.
 pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
     // Phase A: stat every audio file.
     let path_for_scan = library_path.to_owned();

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -254,9 +254,9 @@ pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()
     Ok(())
 }
 
-/// F2.3 sibling of [`reindex`] for the audiobook library. Uses Phase A.5
-/// group-by-folder, Phase B multi-part tag-reads, and [`sync::sync_audiobooks`]
-/// which writes `book_file_parts` rows for the HLS pipeline.
+/// Audiobook-library sibling of [`reindex`]. Uses Phase A.5 group-by-folder,
+/// Phase B multi-part tag-reads, and [`sync::sync_audiobooks`] which writes
+/// `book_file_parts` rows for the HLS pipeline.
 pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
     // Phase A: stat every audio file.
     let path_for_scan = library_path.to_owned();

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the `indexer` module — `diff_library` classifiers,
 //! `is_stale` window logic, `reindex` preservation-on-failure, and the
-//! #328 shared-path cross-format deletion guard.
+//! shared-path cross-format deletion guard.
 
 use super::*;
 use crate::books::{list_books, IndexedRow};

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -104,13 +104,13 @@ async fn merge_metadata_overrides_creates_row_when_absent() {
     assert_eq!(loaded.title, Some("Fresh".into()));
     assert!(!has_cover, "a brand-new merged row has no cover override");
 }
-/// #243: two concurrent saves to the same book (e.g. the F5.1 edit form
-/// open in two tabs, or a network retry firing twice) each touch a
-/// different field. Because the rpc/REST save paths route through
-/// `merge_metadata_overrides` — whose read-merge-write runs under a single
-/// `BEGIN IMMEDIATE` — neither write may be silently dropped: both fields
-/// must survive regardless of interleaving. A barrier releases both tasks
-/// into the merge at the same instant so the test exercises real contention
+/// Two concurrent saves to the same book (e.g. the edit form open in two
+/// tabs, or a network retry firing twice) each touch a different field.
+/// Because the rpc/REST save paths route through `merge_metadata_overrides`
+/// — whose read-merge-write runs under a single `BEGIN IMMEDIATE` — neither
+/// write may be silently dropped: both fields must survive regardless of
+/// interleaving. A barrier releases both tasks into the merge at the same
+/// instant so the test exercises real contention
 /// rather than letting the first save finish before the second starts.
 #[tokio::test]
 async fn merge_metadata_overrides_concurrent_saves_dont_drop_writes() {

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -484,9 +484,9 @@ async fn palette_duration_populated() {
     // duration_ms should be populated (at least 0 — we just check it's set)
     assert!(results.duration_ms < 10000, "duration should be reasonable");
 }
-/// #127 regression coverage: after collapsing the correlated
-/// `book_count` / `EXISTS` subqueries into a single JOIN+GROUP BY,
-/// `l.path = ?1` must still be applied **before** the aggregate so the
+/// Regression coverage: after collapsing the correlated `book_count` /
+/// `EXISTS` subqueries into a single JOIN+GROUP BY, `l.path = ?1` must
+/// still be applied **before** the aggregate so the
 /// scoped library's count doesn't pick up rows from sibling libraries.
 /// This exercises all three taxonomies (authors, series, tags) plus
 /// ordering — the seeded set has 3 matching books in /lib-a and 2 in
@@ -878,9 +878,9 @@ async fn palette_series_author_display_reflects_override() {
         "palette author line must follow override.creators, got {results:?}",
     );
 }
-/// #127: capture `EXPLAIN QUERY PLAN` for each of the three rewritten
-/// taxonomy queries and assert the planner uses the link-table indexes.
-/// This is a structural check — it doesn't pin the literal plan string
+/// Capture `EXPLAIN QUERY PLAN` for each of the three rewritten taxonomy
+/// queries and assert the planner uses the link-table indexes. This is a
+/// structural check — it doesn't pin the literal plan string
 /// (SQLite's wording can shift across point releases) but it does fail
 /// loudly if any of the link tables fall back to a full SCAN, which
 /// would defeat the whole point of this optimization.

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -1,5 +1,5 @@
-//! F2.1 progress sync — server-authoritative reading/listening position and
-//! batched session reports.
+//! Server-authoritative reading and listening position sync, plus batched
+//! session reports.
 //!
 //! Position upserts are last-write-wins on `(user_id, book_id, format)`; the
 //! upsert always bumps `updated_at` to now so a newly-opened client can sync

--- a/db/src/settings/tests.rs
+++ b/db/src/settings/tests.rs
@@ -290,9 +290,9 @@ async fn set_settings_none_removes_library_data() {
         .unwrap();
     assert_eq!(library_count, 0);
 }
-/// Exercises the batched (#149) `prune_orphan_libraries` path across more
-/// than one chunk. The IN-list is chunked at 500 ids to stay under
-/// SQLite's bind-parameter cap, so seeding more orphaned libraries than a
+/// Exercises the batched `prune_orphan_libraries` path across more than
+/// one chunk. The IN-list is chunked at 500 ids to stay under SQLite's
+/// bind-parameter cap, so seeding more orphaned libraries than a
 /// single chunk holds is what actually verifies the chunking loop iterates
 /// (a regression that dropped or mis-bound a later chunk would otherwise go
 /// undetected). Seeds 1001 libraries — three chunks of 500 / 500 / 1 — each

--- a/db/src/sync/backfill.rs
+++ b/db/src/sync/backfill.rs
@@ -7,9 +7,9 @@ use sqlx::Transaction;
 /// Apply the Backfill bucket as a single `UPDATE ... FROM (VALUES ..)`
 /// per chunk. One statement per chunk instead of one per book so a
 /// post-migration run over a large library doesn't hold the write lock
-/// for thousands of individual writes (issue #245). Chunked to stay
-/// well under SQLite's bound-parameter limit (3 binds per row, plus 1
-/// for library_id).
+/// for thousands of individual writes. Chunked to stay well under
+/// SQLite's bound-parameter limit (3 binds per row, plus 1 for
+/// library_id).
 pub(super) async fn backfill_stat_chunks(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -505,10 +505,9 @@ async fn insert_book_row(
 /// inline by name (NOCASE) — no separate id-resolution `SELECT`. Each batched
 /// statement is chunked to stay under SQLite's bound-parameter limit. This
 /// collapses the old ~4-queries-per-author / 2-queries-per-tag fan-out into a
-/// constant handful per book, which keeps
-/// the SQLite write lock from being held for the whole of a bulk import
-/// (issue #242). Series / publisher / language are single-valued per book,
-/// so they keep the simple resolve-then-link path.
+/// constant handful per book, which keeps the SQLite write lock from being
+/// held for the whole of a bulk import. Series / publisher / language are
+/// single-valued per book, so they keep the simple resolve-then-link path.
 async fn insert_metadata_links(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -78,11 +78,10 @@ async fn replace_books_inserts_metadata_and_covers() {
 
     assert!(last_indexed_at(&pool, "/lib").await.unwrap().is_some());
 }
-/// F1.7 Atrium accent round-trip. `replace_books` writes
-/// `metadata.accent` into `books.accent_color`; `list_books` /
-/// `get_book` / `search_books` read it back into
-/// `EbookMetadata.accent`. Verify the column survives the trip and
-/// `None` stays `None` (not coerced to an empty string).
+/// Atrium accent round-trip. `replace_books` writes `metadata.accent`
+/// into `books.accent_color`; `list_books` / `get_book` / `search_books`
+/// read it back into `EbookMetadata.accent`. Verify the column survives
+/// the trip and `None` stays `None` (not coerced to an empty string).
 #[tokio::test]
 async fn replace_books_round_trips_accent_color() {
     let _covers = CoversTempDir::new("accent_round_trip");
@@ -141,9 +140,9 @@ async fn replace_books_round_trips_accent_color() {
     let detail_plain = get_book(&pool, plain.id).await.unwrap().unwrap();
     assert_eq!(detail_plain.accent, None);
 }
-/// #125: the write-boundary gate must accept the exact `oklch(L C H)`
-/// shape the indexer emits, and reject anything else — including raw
-/// hex, CSS keywords, and injection payloads that try to break out of
+/// The write-boundary gate must accept the exact `oklch(L C H)` shape
+/// the indexer emits, and reject anything else — including raw hex, CSS
+/// keywords, and injection payloads that try to break out of
 /// the `style="background: {bg}"` attribute used by Atrium consumers.
 ///
 /// End-to-end gate: writing an `IndexedBook` whose `accent` carries an

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -39,9 +39,9 @@ pub enum Task {
     /// library serialize while different libraries scan in parallel; counts
     /// against the scan-concurrency semaphore.
     Scan { library_path: String },
-    /// F2.3 sibling of [`Task::Scan`] for the audiobook library. Same
-    /// keying (one resource lock per path) and same scan-semaphore
-    /// participation; routes to [`crate::indexer::reindex_audiobooks`].
+    /// Audiobook-library sibling of [`Task::Scan`]. Same keying (one
+    /// resource lock per path) and same scan-semaphore participation;
+    /// routes to [`crate::indexer::reindex_audiobooks`].
     ScanAudiobooks { library_path: String },
     /// (Re)generate cached WebP thumbnails for `book_id`'s cover.
     /// `last_modified_epoch` lets the handler skip work when the cached
@@ -51,14 +51,14 @@ pub enum Task {
         book_id: i64,
         last_modified_epoch: i64,
     },
-    /// F1.11: resolve and cache an author's profile photo. The resolver
-    /// hits Open Library at most once per author per (admin-DELETE-able)
-    /// cache window; a `'letter'` marker is written on any miss so future
-    /// page views skip the network entirely. Keyed on
-    /// `author-photo:{author_id}` and does not consume the scan semaphore.
+    /// Resolve and cache an author's profile photo. The resolver hits Open
+    /// Library at most once per author per (admin-DELETE-able) cache window;
+    /// a `'letter'` marker is written on any miss so future page views skip
+    /// the network entirely. Keyed on `author-photo:{author_id}` and does
+    /// not consume the scan semaphore.
     ResolveAuthorPhoto { author_id: i64 },
-    /// F2.3 HLS transcode for one `(book_id, profile)` pair. Acquires the
-    /// HLS semaphore (capped at [`WorkerConfig::hls_concurrency`]) and the
+    /// HLS transcode for one `(book_id, profile)` pair. Acquires the HLS
+    /// semaphore (capped at [`WorkerConfig::hls_concurrency`]) and the
     /// per-`(book_id, profile)` keyed mutex so duplicate transcode posts are
     /// serialized rather than running concurrently.
     HlsTranscode {

--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -1,13 +1,13 @@
-//! F2.3 listening-position persistence — the saved `currentTime`
-//! (seconds, float) for each audiobook.
+//! Listening-position persistence — the saved `currentTime` (seconds, float)
+//! for each audiobook.
 //!
 //! Mirrors [`crate::reader_progress`] in shape: web persists to
 //! `localStorage` keyed by uuid; mobile keeps an in-memory map (resets on
 //! cold launch); server (SSR) is a no-op so the rendered markup never
 //! depends on a stored position.
 //!
-//! Also the offline / first-paint cache layer for the F2.1 progress-sync
-//! endpoint (`POST /api/progress` with `format: "audio"` and
+//! Also the offline / first-paint cache layer for the progress-sync endpoint
+//! (`POST /api/progress` with `format: "audio"` and
 //! `audio_position_seconds`): the listen page reads this synchronously
 //! for an instant local position, then reconciles against the server
 //! before mounting. Saves write here AND fire-and-forget POST to the

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -74,14 +74,13 @@ pub struct ChipEditorProps {
     /// dropdown surfaces on first paint. Used by the landing-page
     /// Authors cell so admins don't have to click twice (once to
     /// enter edit mode, once to focus the input). Off by default to
-    /// keep the F5.1 metadata-edit page from stealing focus from the
-    /// page's other fields on mount.
+    /// keep the metadata-edit page from stealing focus from the page's
+    /// other fields on mount.
     #[props(default = false)]
     pub autofocus: bool,
     /// Optional uppercase mini-header rendered at the top of the
-    /// suggestion dropdown — "ADD AUTHOR" / "ADD TAG" in the F5.9-lite
-    /// design comp. Empty string (the default) suppresses the header
-    /// entirely.
+    /// suggestion dropdown — "ADD AUTHOR" / "ADD TAG". Empty string (the
+    /// default) suppresses the header entirely.
     #[props(default)]
     pub dropdown_header: String,
     /// Fired when the user presses Escape inside the input. Useful for

--- a/frontend/src/components/search_palette/results.rs
+++ b/frontend/src/components/search_palette/results.rs
@@ -299,8 +299,8 @@ fn book_thumb_url(server_url: &str, book: &PaletteBookHit) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::model::build_flat_items;
+    use super::*;
 
     #[test]
     fn book_thumb_url_uses_uuid_not_id() {

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -116,12 +116,12 @@ pub mod token_store {
     //!   `mobile_register`, the 401 handler in `note_status`) never block
     //!   on flash I/O.
     //!
-    //! **TODO (F0.3 follow-up):** in debug builds the token is held in
-    //! process memory and persisted to a plaintext file under the user's
-    //! home directory. Release builds skip persistence entirely. Replace
-    //! with iOS Keychain / Android Keystore via a platform-specific
-    //! abstraction before flipping persistence on for release builds.
-    //! Tracked in `docs/roadmap/0-3-auth.md`.
+    //! **TODO:** in debug builds the token is held in process memory and
+    //! persisted to a plaintext file under the user's home directory.
+    //! Release builds skip persistence entirely. Replace with iOS Keychain /
+    //! Android Keystore via a platform-specific abstraction before flipping
+    //! persistence on for release builds. Tracked in
+    //! `docs/roadmap/0-3-auth.md`.
     use std::path::{Path, PathBuf};
     use std::sync::{mpsc, LockResult, Mutex, OnceLock, RwLock};
     use tokio::sync::watch;

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -120,8 +120,7 @@ pub mod token_store {
     //! persisted to a plaintext file under the user's home directory.
     //! Release builds skip persistence entirely. Replace with iOS Keychain /
     //! Android Keystore via a platform-specific abstraction before flipping
-    //! persistence on for release builds. Tracked in
-    //! `docs/roadmap/0-3-auth.md`.
+    //! persistence on for release builds.
     use std::path::{Path, PathBuf};
     use std::sync::{mpsc, LockResult, Mutex, OnceLock, RwLock};
     use tokio::sync::watch;

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -1,4 +1,4 @@
-//! F2.3 immersive audiobook player with direct-play + HLS fallback (#339).
+//! Immersive audiobook player with direct-play and HLS fallback.
 //!
 //! Renders a full-screen "Now playing" surface: cover + title + author on the
 //! left, scrub bar + transport controls on the right.
@@ -12,11 +12,11 @@
 //!    per-part durations.
 //! 3. For HLS mode, fall back to the legacy `/status` poll + hls.js attach.
 //!    If `/status` reports `state: "failed"`, render an error overlay
-//!    instead of polling forever (Bug 4 from #338).
+//!    instead of polling forever.
 //!
 //! Position lives in [`crate::audiobook_progress`] — localStorage on web,
 //! in-memory on mobile, no-op under SSR. Writes both there AND fire-and-
-//! forget POST `/api/rpc/progress` (F2.1) with `format: "audio"` +
+//! forget POST `/api/rpc/progress` with `format: "audio"` +
 //! `audio_position_seconds`, so a position written on one device syncs
 //! forward on the next open. Across direct-mode parts the JS shim reports
 //! absolute (cross-part) seconds so the same shape works for both modes.

--- a/frontend/src/pages/reader.rs
+++ b/frontend/src/pages/reader.rs
@@ -1,4 +1,4 @@
-//! Immersive full-screen EPUB reader (F2.4). Loads the vendored epub.js +
+//! Immersive full-screen EPUB reader. Loads the vendored epub.js +
 //! JSZip glue (`window.OmnibusReader`) via `dioxus::document::eval`, streams
 //! bytes from cookie-gated `GET /api/ebooks/:uuid/file`, and persists
 //! position via [`crate::reader_progress`]. Chrome compiles on every

--- a/frontend/src/routes.rs
+++ b/frontend/src/routes.rs
@@ -91,9 +91,9 @@ pub fn BookRead(uuid: String) -> Element {
     }
 }
 
-/// Route target for `/listen/:uuid` — the F2.3 immersive audiobook
-/// player. Same uuid-keyed stability + no-chrome rationale as
-/// [`BookRead`]; the player owns its own slim top bar.
+/// Route target for `/listen/:uuid` — the immersive audiobook player.
+/// Same uuid-keyed stability + no-chrome rationale as [`BookRead`]; the
+/// player owns its own slim top bar.
 #[component]
 pub fn BookListen(uuid: String) -> Element {
     rsx! {

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -72,8 +72,8 @@ mod server_auth {
     pub struct AuthUser {
         pub id: i64,
         pub is_admin: bool,
-        /// F5.1: metadata edit permission. `true` for the first user (admin)
-        /// and any user explicitly granted `can_edit`.
+        /// Metadata edit permission. `true` for the first user (admin) and
+        /// any user explicitly granted `can_edit`.
         pub can_edit: bool,
     }
 

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -73,11 +73,11 @@ fn internal<E: std::fmt::Display>(context: &'static str, e: E) -> Response {
 pub struct AppState {
     pool: SqlitePool,
     worker: Arc<Worker>,
-    /// Issue #275 SSRF guard config for `put_author_photo_url`. Defaults to
-    /// strict (`allow_private_addresses = false`). Integration tests that
-    /// drive the handler against a `wiremock` server bound to `127.0.0.1`
-    /// construct `AppState` via [`AppState::new_with_remote_image_config`]
-    /// with the flag flipped on; production code must never do this.
+    /// SSRF guard config for `put_author_photo_url`. Defaults to strict
+    /// (`allow_private_addresses = false`). Integration tests that drive the
+    /// handler against a `wiremock` server bound to `127.0.0.1` construct
+    /// `AppState` via [`AppState::new_with_remote_image_config`] with the
+    /// flag flipped on; production code must never do this.
     remote_image_config: Arc<db::author_photos::RemoteImageConfig>,
 }
 
@@ -96,7 +96,7 @@ impl AppState {
     /// [`AppState::new`] so the SQLite pool + worker stay identical and only
     /// the [`db::author_photos::RemoteImageConfig`] field differs. Marked
     /// `#[cfg(test)]` so production callers cannot accidentally flip
-    /// `allow_private_addresses` (#275).
+    /// `allow_private_addresses`.
     #[cfg(test)]
     pub(crate) fn new_with_remote_image_config(
         pool: SqlitePool,

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -1,5 +1,5 @@
-//! F2.3 audiobook streaming — direct-play manifest (#339) + Range-served
-//! part files, with the legacy HLS pipeline retained as a fallback for
+//! Audiobook streaming routes: direct-play manifest + Range-served part
+//! files, with the legacy HLS pipeline retained as a fallback for
 //! non-natively-playable codecs.
 //!
 //! - `GET /api/audiobooks/{uuid}/manifest` — JSON describing how the
@@ -89,12 +89,10 @@ pub(super) async fn get_audiobook_playlist(
         .into_response()
 }
 
-/// Returns the playback manifest for `uuid`. Routes direct-playable
-/// books (m4b / m4a / mp3) to per-part HTTP Range URLs and everything
-/// else (mixed folders containing flac / ac3 / …) to the legacy HLS
-/// playlist. The codec gate lives in [`omnibus_db::audiobook::codec`];
-/// see [#339](https://github.com/seamus-sloan/omnibus/issues/339) for
-/// the design.
+/// Returns the playback manifest for `uuid`. Routes direct-playable books
+/// (m4b / m4a / mp3) to per-part HTTP Range URLs and everything else (mixed
+/// folders containing flac / ac3 / …) to the legacy HLS playlist. The codec
+/// gate lives in [`omnibus_db::audiobook::codec`].
 pub(super) async fn get_audiobook_manifest(
     _user: AuthUser,
     State(state): State<AppState>,
@@ -317,8 +315,8 @@ pub(super) async fn get_audiobook_segment(
 
 /// Terminal-vs-in-flight discriminator for the status JSON. Lets the
 /// frontend distinguish "transcode is preparing" from "transcode
-/// permanently failed" — the legacy `{ready: false, progress: 0}`
-/// shape collapsed both into the same response, which is Bug 4 of #338.
+/// permanently failed" — the legacy `{ready: false, progress: 0}` shape
+/// collapsed both into the same ambiguous response.
 #[derive(Serialize)]
 #[serde(rename_all = "lowercase")]
 enum StatusState {

--- a/server/src/backend/author_photos/tests.rs
+++ b/server/src/backend/author_photos/tests.rs
@@ -1,7 +1,7 @@
-//! Integration tests for the F1.11 author profile photo endpoints. Covers
-//! GET / PUT / DELETE on `/api/authors/{id}/photo` plus the rescan-from-
-//! Open-Library trigger, including auth + admin gating, upload-validation
-//! failure paths, and 5xx DB-failure paths.
+//! Integration tests for the author profile photo endpoints. Covers GET /
+//! PUT / DELETE on `/api/authors/{id}/photo` plus the rescan-from-Open-
+//! Library trigger, including auth + admin gating, upload-validation failure
+//! paths, and 5xx DB-failure paths.
 
 use axum::{
     body::{to_bytes, Body},
@@ -303,9 +303,9 @@ async fn api_put_author_photo_url_rejects_empty_url() {
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
 
-/// Issue #275 — admin SSRF regression. The default `AppState` (built by
-/// `fixture()`) must reject IP-literal URLs that point at the loopback /
-/// cloud-metadata / RFC1918 address space *before* any TCP connect.
+/// SSRF regression: the default `AppState` (built by `fixture()`) must
+/// reject IP-literal URLs that point at the loopback / cloud-metadata /
+/// RFC1918 address space *before* any TCP connect.
 /// Every URL listed below is one a hostile or compromised admin could
 /// plausibly try; each must surface 400.
 #[tokio::test]

--- a/server/src/backend/settings/tests.rs
+++ b/server/src/backend/settings/tests.rs
@@ -175,12 +175,11 @@ async fn post_settings_triggers_scan_via_worker() {
     // it) cleans up on Drop here.
 }
 
-/// Regression test for issue #112: when the worker's scan fails (here,
-/// because the configured library path doesn't exist on disk), the
-/// `/api/reindex` handler must surface the failure as a 500 via the
-/// `internal()` helper rather than panicking the spawned task or
-/// returning a misleading 200. This is the live request path the
-/// original `panic!("worker scan failed: ...")` was masking.
+/// When the worker's scan fails (here, because the configured library path
+/// doesn't exist on disk), the `/api/reindex` handler must surface the
+/// failure as a 500 via the `internal()` helper rather than panicking the
+/// spawned task or returning a misleading 200. This is the live request
+/// path the original `panic!("worker scan failed: ...")` was masking.
 #[tokio::test]
 async fn reindex_returns_500_when_worker_fails() {
     let (app, _state, pool) = fixture().await;

--- a/server/src/backend/test_support.rs
+++ b/server/src/backend/test_support.rs
@@ -16,9 +16,9 @@ pub(crate) async fn fixture() -> (Router, AppState, sqlx::SqlitePool) {
     (app, state, pool)
 }
 
-/// Variant of [`fixture`] that flips the SSRF guard off (issue #275) so
-/// the wiremock-backed `put_author_photo_url` tests can drive the
-/// handler against a server bound to `127.0.0.1`. Production paths
+/// Variant of [`fixture`] that flips the SSRF guard off so the
+/// wiremock-backed `put_author_photo_url` tests can drive the handler
+/// against a server bound to `127.0.0.1`. Production paths
 /// always construct `AppState::new` and therefore always block private
 /// IPs.
 pub(crate) async fn fixture_loopback_remote_image() -> (Router, AppState, sqlx::SqlitePool) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Pure documentation pass — no logic changes whatsoever
- Removes all `Fx.y` phase labels, `#NNN` issue numbers, and `Bug N from #NNN` references from `//!` module doc blocks and `///` function/variant/field doc comments across 28 files in `db/`, `frontend/`, and `server/`
- Each removed label is replaced with plain prose describing what the code currently does

## Files touched

**Originally listed in issue:**
- `db/src/progress.rs` — `//!` block
- `db/src/audiobook.rs` — `//!` block
- `server/src/backend/audiobooks.rs` — `//!` block + `///` docs
- `frontend/src/pages/listen.rs` — `//!` block
- `frontend/src/pages/reader.rs` — `//!` block
- `frontend/src/audiobook_progress.rs` — `//!` block
- `db/src/discovery/series.rs` — `/// get_series` doc

**Additional `///` and `//!` doc lines found and cleaned:**
- `db/src/worker/types.rs` — three `Task` variant docs
- `db/src/covers.rs` — three test function docs
- `db/src/indexer.rs` — `/// reindex_audiobooks` doc
- `db/src/indexer/tests.rs` — `//!` block
- `db/src/auth/session.rs` — two test function docs
- `db/src/author_photos/remote.rs` — error variant doc
- `db/src/metadata_overrides/tests.rs` — one test doc
- `db/src/palette/tests.rs` — two test docs
- `db/src/settings/tests.rs` — one test doc
- `db/src/sync/backfill.rs` — one function doc
- `db/src/sync/books.rs` — one function doc
- `db/src/sync/tests.rs` — two test docs
- `frontend/src/components/chip_editor.rs` — two prop docs
- `frontend/src/data.rs` — `//!` sub-block TODO note
- `frontend/src/routes.rs` — one function doc
- `frontend/src/rpc.rs` — one field doc
- `server/src/backend.rs` — two field/function docs
- `server/src/backend/author_photos/tests.rs` — `//!` block + one test doc
- `server/src/backend/settings/tests.rs` — one test doc
- `server/src/backend/test_support.rs` — one function doc

## Test plan

- [ ] `cargo fmt` — no diff (run clean)
- [ ] `cargo clippy` — no warnings
- [ ] No `//!` or `///` lines contain `F[0-9]+.[0-9]+`, `#NNN`, or `Bug N from #` (verified with grep)

https://claude.ai/code/session_01TxNNbhipLXnfR5pErTEajC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxNNbhipLXnfR5pErTEajC)_