### PR TITLE
fix: wrap sqlx::Error in typed errors at db boundaries (#439)

### DIFF
--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -218,11 +218,13 @@ pub async fn get_book_by_uuid(
 pub async fn resolve_book_id_by_uuid(
     pool: &SqlitePool,
     uuid: &str,
-) -> Result<Option<i64>, sqlx::Error> {
-    sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
-        .bind(uuid)
-        .fetch_optional(pool)
-        .await
+) -> Result<Option<i64>, super::BooksError> {
+    Ok(
+        sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
+            .bind(uuid)
+            .fetch_optional(pool)
+            .await?,
+    )
 }
 
 /// Resolve the on-disk path of a book's file for the given format
@@ -237,7 +239,7 @@ pub async fn book_file_path(
     pool: &SqlitePool,
     id: i64,
     format: &str,
-) -> Result<Option<std::path::PathBuf>, sqlx::Error> {
+) -> Result<Option<std::path::PathBuf>, super::BooksError> {
     let row = sqlx::query_as::<_, (String, String, String)>(
         "SELECT l.path, b.path, bf.filename FROM books b \
          JOIN libraries l ON l.id = b.library_id \

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -19,7 +19,7 @@ use super::projection::{
 pub async fn list_books(
     pool: &SqlitePool,
     library_path: &str,
-) -> Result<Vec<EbookMetadata>, sqlx::Error> {
+) -> Result<Vec<EbookMetadata>, super::BooksError> {
     list_books_for_paths(pool, &[library_path]).await
 }
 
@@ -36,7 +36,7 @@ pub async fn list_books(
 pub async fn list_books_for_paths(
     pool: &SqlitePool,
     library_paths: &[&str],
-) -> Result<Vec<EbookMetadata>, sqlx::Error> {
+) -> Result<Vec<EbookMetadata>, super::BooksError> {
     if library_paths.is_empty() {
         return Ok(Vec::new());
     }
@@ -221,7 +221,7 @@ pub struct IndexedRow {
 pub async fn list_indexed_rows(
     pool: &SqlitePool,
     library_path: &str,
-) -> Result<Vec<IndexedRow>, sqlx::Error> {
+) -> Result<Vec<IndexedRow>, super::BooksError> {
     let rows = sqlx::query(
         r#"
         SELECT b.uuid                                  AS uuid,
@@ -267,7 +267,7 @@ pub async fn list_indexed_rows_for_formats(
     pool: &SqlitePool,
     library_path: &str,
     formats: &[&str],
-) -> Result<Vec<IndexedRow>, sqlx::Error> {
+) -> Result<Vec<IndexedRow>, super::BooksError> {
     if formats.is_empty() {
         return Ok(Vec::new());
     }
@@ -309,7 +309,7 @@ pub async fn list_indexed_rows_for_formats(
 /// Total number of books currently indexed under `library_path`. Thin
 /// wrapper around [`count_books_for_paths`] for single-library callers.
 pub async fn count_books(pool: &SqlitePool, library_path: &str) -> Result<i64, super::BooksError> {
-    Ok(count_books_for_paths(pool, &[library_path]).await?)
+    count_books_for_paths(pool, &[library_path]).await
 }
 
 /// Total number of books currently indexed under any of `library_paths`.
@@ -322,7 +322,7 @@ pub async fn count_books(pool: &SqlitePool, library_path: &str) -> Result<i64, s
 pub async fn count_books_for_paths(
     pool: &SqlitePool,
     library_paths: &[&str],
-) -> Result<i64, sqlx::Error> {
+) -> Result<i64, super::BooksError> {
     if library_paths.is_empty() {
         return Ok(0);
     }
@@ -341,7 +341,7 @@ pub async fn count_books_for_paths(
     for path in library_paths {
         q = q.bind(*path);
     }
-    q.fetch_one(pool).await
+    Ok(q.fetch_one(pool).await?)
 }
 
 /// Build an `EbookLibrary` from whatever is currently in the DB for
@@ -356,7 +356,7 @@ pub async fn count_books_for_paths(
 pub async fn library_from_db(
     pool: &SqlitePool,
     library_path: Option<&str>,
-) -> Result<EbookLibrary, sqlx::Error> {
+) -> Result<EbookLibrary, super::BooksError> {
     library_from_db_combined(pool, library_path, None).await
 }
 
@@ -367,7 +367,7 @@ pub async fn library_from_db(
 pub async fn library_from_db_with_total(
     pool: &SqlitePool,
     library_path: Option<&str>,
-) -> Result<(EbookLibrary, i64), sqlx::Error> {
+) -> Result<(EbookLibrary, i64), super::BooksError> {
     library_from_db_with_total_combined(pool, library_path, None).await
 }
 
@@ -384,7 +384,7 @@ pub async fn library_from_db_combined(
     pool: &SqlitePool,
     ebook_path: Option<&str>,
     audiobook_path: Option<&str>,
-) -> Result<EbookLibrary, sqlx::Error> {
+) -> Result<EbookLibrary, super::BooksError> {
     let paths = collect_paths(ebook_path, audiobook_path);
     if paths.is_empty() {
         return Ok(EbookLibrary::default());
@@ -410,7 +410,7 @@ pub async fn library_from_db_with_total_combined(
     pool: &SqlitePool,
     ebook_path: Option<&str>,
     audiobook_path: Option<&str>,
-) -> Result<(EbookLibrary, i64), sqlx::Error> {
+) -> Result<(EbookLibrary, i64), super::BooksError> {
     let paths = collect_paths(ebook_path, audiobook_path);
     if paths.is_empty() {
         return Ok((EbookLibrary::default(), 0));

--- a/db/src/books/search.rs
+++ b/db/src/books/search.rs
@@ -31,7 +31,7 @@ pub async fn search_books(
     pool: &SqlitePool,
     library_path: &str,
     q: &str,
-) -> Result<Vec<EbookMetadata>, sqlx::Error> {
+) -> Result<Vec<EbookMetadata>, super::BooksError> {
     let (books, _total) = search_books_with_total(pool, library_path, q).await?;
     Ok(books)
 }
@@ -47,7 +47,7 @@ pub async fn search_books_with_total(
     pool: &SqlitePool,
     library_path: &str,
     q: &str,
-) -> Result<(Vec<EbookMetadata>, i64), sqlx::Error> {
+) -> Result<(Vec<EbookMetadata>, i64), super::BooksError> {
     // Cap query length before parsing to bound the FTS5 MATCH expression size,
     // matching `search_palette` (issue #189). Normal/short queries are
     // unaffected; see `cap_query_len`.
@@ -231,7 +231,7 @@ pub async fn count_search_books(
     pool: &SqlitePool,
     library_path: &str,
     q: &str,
-) -> Result<i64, sqlx::Error> {
+) -> Result<i64, super::BooksError> {
     // Cap query length before parsing to mirror `search_books` /
     // `search_palette` (issue #189). Normal/short queries are unaffected;
     // see `cap_query_len`.
@@ -239,7 +239,7 @@ pub async fn count_search_books(
     let Some(match_expr) = build_fts_match(&capped) else {
         return Ok(0);
     };
-    sqlx::query_scalar::<_, i64>(
+    Ok(sqlx::query_scalar::<_, i64>(
         r#"
         SELECT COUNT(*)
           FROM books_fts
@@ -251,5 +251,5 @@ pub async fn count_search_books(
     .bind(&match_expr)
     .bind(library_path)
     .fetch_one(pool)
-    .await
+    .await?)
 }

--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -8,6 +8,17 @@ use std::path::PathBuf;
 
 use sqlx::SqlitePool;
 
+/// Errors returned by the on-disk cover read path.
+///
+/// Today the only failure mode is the DB lookup that resolves a book id to
+/// its uuid + cover flags; filesystem misses are treated as "no cover"
+/// (`Ok(None)`) per the module-level contract, not as errors.
+#[derive(Debug, thiserror::Error)]
+pub enum CoversError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Root directory for cover files. Override with `OMNIBUS_COVERS_DIR`.
 pub fn covers_dir() -> PathBuf {
     std::env::var("OMNIBUS_COVERS_DIR")
@@ -165,7 +176,7 @@ pub(crate) fn find_override_cover_file(uuid: &str) -> Option<(String, Vec<u8>)> 
 pub async fn get_cover(
     pool: &SqlitePool,
     book_id: i64,
-) -> Result<Option<(String, Vec<u8>)>, sqlx::Error> {
+) -> Result<Option<(String, Vec<u8>)>, CoversError> {
     // `COALESCE(mo.has_cover_override, 0)` keeps the flag at 0 when no
     // override row exists (the LEFT JOIN yields NULL in that case), so the
     // row tuple can decode into `i64` instead of `Option<i64>`.
@@ -228,13 +239,13 @@ pub async fn get_cover(
 pub async fn get_last_modified_epoch(
     pool: &SqlitePool,
     book_id: i64,
-) -> Result<Option<i64>, sqlx::Error> {
-    sqlx::query_scalar(
+) -> Result<Option<i64>, CoversError> {
+    Ok(sqlx::query_scalar(
         "SELECT CAST(strftime('%s', last_modified) AS INTEGER) FROM books WHERE id = ?",
     )
     .bind(book_id)
     .fetch_optional(pool)
-    .await
+    .await?)
 }
 
 #[cfg(test)]

--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -10,9 +10,11 @@ use sqlx::SqlitePool;
 
 /// Errors returned by the on-disk cover read path.
 ///
-/// Today the only failure mode is the DB lookup that resolves a book id to
-/// its uuid + cover flags; filesystem misses are treated as "no cover"
-/// (`Ok(None)`) per the module-level contract, not as errors.
+/// Today the only failure mode that surfaces here is the DB lookup that
+/// resolves a book id to its uuid + cover flags. Filesystem probes
+/// (`find_cover_file` / `find_override_cover_file`) swallow every
+/// `std::fs::read` failure and return `Ok(None)` — they don't distinguish
+/// a missing file from a permissions or I/O error.
 #[derive(Debug, thiserror::Error)]
 pub enum CoversError {
     #[error(transparent)]

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -39,10 +39,11 @@ pub use books::{
     get_book, get_book_by_uuid, library_from_db, library_from_db_combined,
     library_from_db_with_total, library_from_db_with_total_combined, list_books,
     list_books_for_paths, list_indexed_rows, list_indexed_rows_for_formats,
-    resolve_book_id_by_uuid, search_books, search_books_with_total, IndexedRow, MAX_BOOKS_RETURNED,
+    resolve_book_id_by_uuid, search_books, search_books_with_total, BooksError, IndexedRow,
+    MAX_BOOKS_RETURNED,
 };
 pub use browse::*;
-pub use covers::{covers_dir, get_cover, get_last_modified_epoch};
+pub use covers::{covers_dir, get_cover, get_last_modified_epoch, CoversError};
 pub use discovery::*;
 pub use helpers::{build_fts_match, sanitize_fts_query};
 pub use metadata_overrides::*;

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -19,6 +19,22 @@ pub enum ProgressError {
     Sqlx(#[from] sqlx::Error),
 }
 
+impl From<crate::books::BooksError> for ProgressError {
+    fn from(e: crate::books::BooksError) -> Self {
+        match e {
+            crate::books::BooksError::Db(inner) => ProgressError::Sqlx(inner),
+            // `resolve_book_id_by_uuid` is the only `BooksError`-returning
+            // call this module makes, and it never decodes JSON, so the
+            // `OverridesJson` variant is unreachable here in practice. Fold
+            // it into a generic decode error rather than panicking so a
+            // future caller can't introduce an unhandled path silently.
+            crate::books::BooksError::OverridesJson(inner) => {
+                ProgressError::Sqlx(sqlx::Error::Decode(Box::new(inner)))
+            }
+        }
+    }
+}
+
 fn format_str(f: ProgressFormat) -> &'static str {
     match f {
         ProgressFormat::Epub => "epub",


### PR DESCRIPTION
## Summary

Aligns the 15 public functions in `omnibus-db` that previously returned `Result<_, sqlx::Error>` with the existing typed-error pattern, so the DB implementation detail no longer leaks into `server/` or `frontend/`.

**Before**
```rust
pub async fn list_books(
    pool: &SqlitePool,
    library_path: &str,
) -> Result<Vec<EbookMetadata>, sqlx::Error> { ... }
```

**After**
```rust
pub async fn list_books(
    pool: &SqlitePool,
    library_path: &str,
) -> Result<Vec<EbookMetadata>, super::BooksError> { ... }
```

**Functions updated (15 total):**

`db/src/books/list.rs` (9):
- `list_books`, `list_books_for_paths`, `list_indexed_rows`, `list_indexed_rows_for_formats`, `count_books_for_paths`, `library_from_db`, `library_from_db_with_total`, `library_from_db_combined`, `library_from_db_with_total_combined`

`db/src/books/search.rs` (3):
- `search_books`, `search_books_with_total`, `count_search_books`

`db/src/books/get.rs` (2):
- `resolve_book_id_by_uuid`, `book_file_path`

`db/src/covers.rs` (2):
- `get_cover`, `get_last_modified_epoch`

**Error type choices:**

- All 13 functions in `books/` now return `BooksError` (already exists, already wraps `sqlx::Error` via `#[error(transparent)] Db(#[from] sqlx::Error)`).
- A new `CoversError` enum is introduced in `covers.rs` rather than reusing `BooksError`. The covers module is its own surface (separate from the books read path) and today only fails on the DB lookup — filesystem misses are `Ok(None)` per the module-level contract. The shape mirrors `BooksError` exactly.
- `db/src/lib.rs` re-exports `BooksError` and `CoversError` alongside the existing public API.

**Downstream impact:**

- `server/src/backend/{covers,ebooks,overrides,search}.rs` and `server/src/backend.rs` continue to compile unchanged — the `internal()` helper takes any `Display`, and the typed errors implement `Display + Error` via `thiserror`.
- `frontend/src/rpc.rs` continues to compile unchanged — `?` against `Result<T, ServerFnError>` propagates any `std::error::Error`.
- Within the db crate, only one downstream caller needed a conversion: `db/src/progress.rs` calls `resolve_book_id_by_uuid` and returns `ProgressError`. Added `impl From<BooksError> for ProgressError` mirroring the existing `impl From<MetadataOverridesError> for ProgressError` pattern.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-db` — 457 passed
- [x] `cargo test -p omnibus` — 185 passed
- [x] `cargo test -p omnibus-frontend --features server` — 149 passed

Workspace-wide `cargo clippy --all-targets --all-features` is intentionally skipped — the `omnibus-frontend` `web` / `mobile` features are mutually exclusive (documented in `.claude/architecture.md`), so feature unification fails by design. Per-crate clippy is the project convention.

## Adversarial self-review

- **All 15 cited line numbers were verified at HEAD before editing** — every offender existed and matched the function-name list in the issue.
- **`count_books` (already on `BooksError`)** had a `Ok(...await?)` that became a `clippy::needless_question_mark` once `count_books_for_paths` started returning `BooksError`. Collapsed to a direct `.await` return. Trivially correct and visible in the diff.
- **`projection.rs` helpers still return `sqlx::Error`** — they are `pub(crate)` (`parse_json_array`, `row_to_ebook`, `backfill_creator_ids`), so they are not boundary-crossers and are out of scope for this issue. They feed into the public `BooksError`-returning functions and propagate cleanly via `?`.
- **`ProgressError::From<BooksError>`** folds the unreachable `OverridesJson` variant into `Sqlx(sqlx::Error::Decode(...))` rather than panicking. `resolve_book_id_by_uuid` does no JSON decoding so this path is currently unreachable, but folding rather than panicking keeps the conversion total in case a future caller in `progress.rs` reaches for a JSON-decoding `BooksError`-returning helper.
- **No call site needed a downstream signature change.** Handlers in `server/` all funnel into `internal::<impl Display>(...)`, and the dioxus server fn `?` propagation accepts any `Error`. The only typed-boundary fix was within the db crate (`progress.rs`).
- **Out of scope and intentionally not touched:** `Cargo.lock` (no dependency changes), `architecture.md` (no new module — just one new type), the playwright suite (no markup changes).

Closes #439

---
_Generated by [Claude Code](https://claude.ai/code/session_014DekCs6injDChPgKTE7bmb)_