### PR TITLE
refactor: split oversized db/server functions (#445)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4151,6 +4151,7 @@ dependencies = [
 name = "omnibus"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "axum-extra",
  "dioxus",

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -2,16 +2,13 @@
 //! `resolve_book_id_by_uuid` helper that the covers/thumbs/mobile routes
 //! use to translate a stable uuid to the current id.
 
-use sqlx::{Row, SqlitePool};
+use sqlx::SqlitePool;
 
-use omnibus_shared::{Contributor, EbookMetadata, Identifier};
+use omnibus_shared::EbookMetadata;
 
-use crate::helpers::format_series_index;
 use crate::metadata_overrides::{apply_overrides, get_metadata_overrides};
 
-use super::projection::{
-    backfill_creator_ids, parse_json_array, sanitize_description, CreatorRow, IdentifierRow,
-};
+use super::projection::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
 
 /// Fetch a single book by its stable `books.id`. Returns `None` if not found.
 ///
@@ -32,156 +29,19 @@ pub async fn get_book(
     pool: &SqlitePool,
     id: i64,
 ) -> Result<Option<EbookMetadata>, super::BooksError> {
-    let row = sqlx::query(
-        r#"
-        SELECT
-            b.id, b.uuid, b.title, b.description, b.series_index, b.has_cover,
-            b.pubdate, b.last_modified, b.timestamp, b.accent_color,
-
-            (SELECT bf.filename FROM book_files bf
-              WHERE bf.book_id = b.id
-              ORDER BY (bf.format != 'EPUB'), bf.format
-              LIMIT 1)                                     AS primary_filename,
-
-            (SELECT bf.format FROM book_files bf
-              WHERE bf.book_id = b.id
-              ORDER BY (bf.format != 'EPUB'), bf.format
-              LIMIT 1)                                     AS primary_format,
-
-            (SELECT pub.name FROM books_publishers_link bpl
-              JOIN publishers pub ON pub.id = bpl.publisher
-             WHERE bpl.book = b.id ORDER BY pub.name LIMIT 1)
-                                                           AS publisher,
-
-            (SELECT lang.code FROM books_languages_link bll
-              JOIN languages lang ON lang.id = bll.language
-             WHERE bll.book = b.id ORDER BY lang.code LIMIT 1)
-                                                           AS language,
-
-            (SELECT s.name FROM books_series_link bsl
-              JOIN series s ON s.id = bsl.series
-             WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
-                                                           AS series_name,
-
-            (SELECT s.id FROM books_series_link bsl
-              JOIN series s ON s.id = bsl.series
-             WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
-                                                           AS series_link_id,
-
-            (SELECT json_group_array(json_object('id', a_id, 'name', name, 'sort', sort))
-               FROM (SELECT a.id AS a_id, a.name AS name, a.sort AS sort
-                       FROM books_authors_link bal
-                       JOIN authors a ON a.id = bal.author
-                      WHERE bal.book = b.id
-                      ORDER BY bal.position))              AS creators_json,
-
-            (SELECT json_group_array(name)
-               FROM (SELECT t.name AS name FROM books_tags_link btl
-                       JOIN tags t ON t.id = btl.tag
-                      WHERE btl.book = b.id
-                      ORDER BY t.name))                    AS subjects_json,
-
-            (SELECT json_group_array(json_object('scheme', scheme, 'value', value))
-               FROM (SELECT scheme, value FROM book_identifiers
-                      WHERE book_id = b.id
-                      ORDER BY scheme, value))             AS identifiers_json,
-
-            (SELECT json_group_array(format)
-               FROM (SELECT format FROM book_files
-                      WHERE book_id = b.id
-                      ORDER BY format))                    AS formats_json
-
-        FROM books b
-        WHERE b.id = ?
-        "#,
-    )
-    .bind(id)
-    .fetch_optional(pool)
-    .await?;
-
-    let Some(r) = row else {
+    let Some(row) = fetch_book_row(pool, id).await? else {
         return Ok(None);
     };
 
-    let book_id: i64 = r.get("id");
-    let has_cover: i64 = r.get("has_cover");
-    let series_index: Option<f64> = r.get("series_index");
-    let uuid: String = r.get("uuid");
-
-    let filename = match (
-        r.get::<Option<String>, _>("primary_filename"),
-        r.get::<Option<String>, _>("primary_format"),
-    ) {
-        (Some(stem), Some(fmt)) => format!("{stem}.{}", fmt.to_ascii_lowercase()),
-        _ => String::new(),
-    };
-
-    let creators: Vec<Contributor> = parse_json_array::<CreatorRow>(r.get("creators_json"))?
-        .into_iter()
-        .map(|c| Contributor {
-            name: c.name,
-            role: None,
-            file_as: c.sort.filter(|s| !s.is_empty()),
-            id: c.id,
-        })
-        .collect();
-
-    let subjects: Vec<String> = parse_json_array(r.get("subjects_json"))?;
-
-    let identifiers: Vec<Identifier> =
-        parse_json_array::<IdentifierRow>(r.get("identifiers_json"))?
-            .into_iter()
-            .map(|i| Identifier {
-                value: i.value,
-                scheme: Some(i.scheme),
-            })
-            .collect();
-
-    let formats: Vec<String> = parse_json_array(r.get("formats_json"))?;
-
-    let mut book = EbookMetadata {
-        id: book_id,
-        filename,
-        title: r.get("title"),
-        description: sanitize_description(r.get("description")),
-        publisher: r.get("publisher"),
-        published: r.get("pubdate"),
-        modified: r.get("last_modified"),
-        language: r.get("language"),
-        creators,
-        subjects,
-        identifiers,
-        series: r.get("series_name"),
-        series_index: series_index.map(format_series_index),
-        series_id: r.get("series_link_id"),
-        unique_identifier: Some(uuid.clone()),
-        cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
-        accent: r.get("accent_color"),
-        formats,
-        added_at: r.get("timestamp"),
-        error: None,
-        has_override: false,
-    };
+    let mut book = row_to_ebook(&row)?;
+    let uuid = book.unique_identifier.clone().unwrap_or_default();
 
     // F5.1: merge user-supplied metadata overrides.
     if let Some((ov, has_cover_ov)) = get_metadata_overrides(pool, &uuid).await? {
         apply_overrides(&mut book, &uuid, &ov, has_cover_ov);
     }
 
-    // `apply_overrides` rewrites `book.series` from the JSON blob but
-    // can't touch the relational `books_series_link` row, so a book
-    // whose series exists only as an override ends up with the series
-    // *name* but no `series_id`. Backfill it by looking up the series
-    // by name so the detail-page Link to /series/:id resolves.
-    if book.series_id.is_none() {
-        if let Some(name) = book.series.as_deref().filter(|s| !s.is_empty()) {
-            book.series_id = sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE name = ?")
-                .bind(name)
-                .fetch_optional(pool)
-                .await?;
-        }
-    }
-
+    backfill_series_id_by_name(pool, &mut book).await?;
     // Override Contributors are stored by name only — apply_overrides
     // therefore leaves `id` unset, which renders the breadcrumb /
     // "More by …" author link as an unclickable span even when an
@@ -190,6 +50,43 @@ pub async fn get_book(
     backfill_creator_ids(pool, std::slice::from_mut(&mut book)).await?;
 
     Ok(Some(book))
+}
+
+/// Run the single-row `SELECT … WHERE b.id = ?` against `books` with the
+/// shared `BOOK_COLUMNS` projection. Returns `None` if the id is unknown.
+async fn fetch_book_row(
+    pool: &SqlitePool,
+    id: i64,
+) -> Result<Option<sqlx::sqlite::SqliteRow>, sqlx::Error> {
+    let sql = format!(
+        r#"
+        SELECT {BOOK_COLUMNS}
+        FROM books b
+        WHERE b.id = ?
+        "#
+    );
+    sqlx::query(&sql).bind(id).fetch_optional(pool).await
+}
+
+/// `apply_overrides` rewrites `book.series` from the JSON blob but can't
+/// touch the relational `books_series_link` row, so a book whose series
+/// exists only as an override ends up with the series *name* but no
+/// `series_id`. Backfill it by looking up the series by name so the
+/// detail-page `Link` to `/series/:id` resolves.
+async fn backfill_series_id_by_name(
+    pool: &SqlitePool,
+    book: &mut EbookMetadata,
+) -> Result<(), sqlx::Error> {
+    if book.series_id.is_some() {
+        return Ok(());
+    }
+    if let Some(name) = book.series.as_deref().filter(|s| !s.is_empty()) {
+        book.series_id = sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE name = ?")
+            .bind(name)
+            .fetch_optional(pool)
+            .await?;
+    }
+    Ok(())
 }
 
 /// Look up a book by its stable `books.uuid` and return the same merged

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -2,7 +2,7 @@
 //! `resolve_book_id_by_uuid` helper that the covers/thumbs/mobile routes
 //! use to translate a stable uuid to the current id.
 
-use sqlx::SqlitePool;
+use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::EbookMetadata;
 
@@ -33,8 +33,8 @@ pub async fn get_book(
         return Ok(None);
     };
 
+    let uuid: String = row.try_get("uuid")?;
     let mut book = row_to_ebook(&row)?;
-    let uuid = book.unique_identifier.clone().unwrap_or_default();
 
     // F5.1: merge user-supplied metadata overrides.
     if let Some((ov, has_cover_ov)) = get_metadata_overrides(pool, &uuid).await? {

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -1,7 +1,7 @@
 //! Library-scoped list/count read paths plus the small `IndexedRow`
 //! projection used by the incremental reindex diff.
 
-use sqlx::SqlitePool;
+use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::{EbookLibrary, EbookMetadata};
 

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -1,15 +1,12 @@
 //! Library-scoped list/count read paths plus the small `IndexedRow`
 //! projection used by the incremental reindex diff.
 
-use sqlx::{Row, SqlitePool};
+use sqlx::SqlitePool;
 
-use omnibus_shared::{Contributor, EbookLibrary, EbookMetadata, Identifier};
-
-use crate::helpers::format_series_index;
-use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};
+use omnibus_shared::{EbookLibrary, EbookMetadata};
 
 use super::projection::{
-    backfill_creator_ids, parse_json_array, sanitize_description, CreatorRow, IdentifierRow,
+    backfill_creator_ids, merge_overrides_into_books, row_to_ebook, BOOK_COLUMNS,
     MAX_BOOKS_RETURNED,
 };
 
@@ -40,70 +37,34 @@ pub async fn list_books_for_paths(
     if library_paths.is_empty() {
         return Ok(Vec::new());
     }
-    // Inline placeholder list: `library_paths` is owned by the caller (at
-    // most two entries — ebook + audiobook), so there's no injection
-    // surface and a temp table would be heavier than the bind loop below.
+    let rows = fetch_list_rows(pool, library_paths).await?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for r in &rows {
+        out.push(row_to_ebook(r)?);
+    }
+
+    merge_overrides_into_books(pool, &mut out).await?;
+    backfill_creator_ids(pool, &mut out).await?;
+
+    Ok(out)
+}
+
+/// Build the `SELECT … FROM books … WHERE l.path IN (...)` statement and
+/// run it with one bind per path plus the trailing `LIMIT`. Inlines an
+/// `?, ?, …` placeholder list because `library_paths` is owned by the
+/// caller (at most two entries — ebook + audiobook), so there's no
+/// injection surface and a temp table would be heavier than the bind loop.
+async fn fetch_list_rows(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+) -> Result<Vec<sqlx::sqlite::SqliteRow>, sqlx::Error> {
     let placeholders = std::iter::repeat_n("?", library_paths.len())
         .collect::<Vec<_>>()
         .join(", ");
     let sql = format!(
         r#"
-        SELECT b.id, b.uuid,
-               b.title, b.description, b.series_index, b.has_cover,
-               b.pubdate, b.last_modified, b.timestamp, b.isbn, b.accent_color,
-
-               (SELECT bf.filename FROM book_files bf
-                 WHERE bf.book_id = b.id
-                 ORDER BY (bf.format != 'EPUB'), bf.format
-                 LIMIT 1)                                   AS primary_filename,
-
-               (SELECT bf.format FROM book_files bf
-                 WHERE bf.book_id = b.id
-                 ORDER BY (bf.format != 'EPUB'), bf.format
-                 LIMIT 1)                                   AS primary_format,
-
-               (SELECT pub.name FROM books_publishers_link bpl
-                  JOIN publishers pub ON pub.id = bpl.publisher
-                 WHERE bpl.book = b.id ORDER BY pub.name LIMIT 1)
-                                                            AS publisher_name,
-
-               (SELECT lang.code FROM books_languages_link bll
-                  JOIN languages lang ON lang.id = bll.language
-                 WHERE bll.book = b.id ORDER BY lang.code LIMIT 1)
-                                                            AS language_code,
-
-               (SELECT s.name FROM books_series_link bsl
-                  JOIN series s ON s.id = bsl.series
-                 WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
-                                                            AS series_name,
-
-               (SELECT s.id FROM books_series_link bsl
-                  JOIN series s ON s.id = bsl.series
-                 WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
-                                                            AS series_link_id,
-
-               (SELECT json_group_array(json_object('id', a_id, 'name', name, 'sort', sort))
-                  FROM (SELECT a.id AS a_id, a.name AS name, a.sort AS sort
-                          FROM books_authors_link bal
-                          JOIN authors a ON a.id = bal.author
-                         WHERE bal.book = b.id
-                         ORDER BY bal.position))            AS creators_json,
-
-               (SELECT json_group_array(name)
-                  FROM (SELECT t.name AS name FROM books_tags_link btl
-                          JOIN tags t ON t.id = btl.tag
-                         WHERE btl.book = b.id
-                         ORDER BY t.name))                  AS subjects_json,
-
-               (SELECT json_group_array(json_object('scheme', scheme, 'value', value))
-                  FROM (SELECT scheme, value FROM book_identifiers
-                         WHERE book_id = b.id
-                         ORDER BY scheme, value))           AS identifiers_json,
-
-               (SELECT json_group_array(format)
-                  FROM (SELECT format FROM book_files
-                         WHERE book_id = b.id
-                         ORDER BY format))                  AS formats_json
+        SELECT {BOOK_COLUMNS}
         FROM books b
         JOIN libraries l ON l.id = b.library_id
         WHERE l.path IN ({placeholders})
@@ -116,85 +77,7 @@ pub async fn list_books_for_paths(
         q = q.bind(*path);
     }
     q = q.bind(MAX_BOOKS_RETURNED);
-    let rows = q.fetch_all(pool).await?;
-
-    let mut out = Vec::with_capacity(rows.len());
-    for r in rows {
-        let id: i64 = r.get("id");
-        let has_cover: i64 = r.get("has_cover");
-        let primary_filename: Option<String> = r.get("primary_filename");
-        let primary_format: Option<String> = r.get("primary_format");
-        let filename = match (primary_filename, primary_format) {
-            (Some(stem), Some(fmt)) => format!("{stem}.{}", fmt.to_ascii_lowercase()),
-            _ => String::new(),
-        };
-        let series_index: Option<f64> = r.get("series_index");
-
-        let creators: Vec<Contributor> = parse_json_array::<CreatorRow>(r.get("creators_json"))?
-            .into_iter()
-            .map(|c| Contributor {
-                name: c.name,
-                role: None,
-                file_as: c.sort.filter(|s| !s.is_empty()),
-                id: c.id,
-            })
-            .collect();
-        let subjects: Vec<String> = parse_json_array(r.get("subjects_json"))?;
-        let identifiers: Vec<Identifier> =
-            parse_json_array::<IdentifierRow>(r.get("identifiers_json"))?
-                .into_iter()
-                .map(|i| Identifier {
-                    value: i.value,
-                    scheme: Some(i.scheme),
-                })
-                .collect();
-
-        let uuid: String = r.get("uuid");
-        out.push(EbookMetadata {
-            id,
-            filename,
-            title: r.get("title"),
-            description: sanitize_description(r.get("description")),
-            publisher: r.get("publisher_name"),
-            published: r.get("pubdate"),
-            modified: r.get("last_modified"),
-            language: r.get("language_code"),
-            creators,
-            subjects,
-            identifiers,
-            series: r.get("series_name"),
-            series_index: series_index.map(format_series_index),
-            series_id: r.get("series_link_id"),
-            unique_identifier: Some(uuid.clone()),
-            cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
-            accent: r.get("accent_color"),
-            formats: parse_json_array(r.get("formats_json"))?,
-            added_at: r.get("timestamp"),
-            error: None,
-            has_override: false,
-        });
-    }
-
-    // F5.1: bulk-merge metadata overrides.
-    let uuids: Vec<String> = out
-        .iter()
-        .filter_map(|b| b.unique_identifier.clone())
-        .collect();
-    let overrides_map = load_overrides_bulk(pool, &uuids).await?;
-    for book in &mut out {
-        // Snapshot uuid into an owned local so the borrow-check sees the
-        // overrides_map lookup as independent of the &mut book passed into
-        // apply_overrides below.
-        let uuid_owned = book.unique_identifier.clone();
-        if let Some(uuid) = uuid_owned.as_deref() {
-            if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
-                apply_overrides(book, uuid, ov, *has_cover_ov);
-            }
-        }
-    }
-    backfill_creator_ids(pool, &mut out).await?;
-
-    Ok(out)
+    q.fetch_all(pool).await
 }
 
 /// One row per book under `library_path`, carrying just the bits the

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -9,6 +9,7 @@ use sqlx::{Row, SqlitePool};
 use omnibus_shared::{Contributor, EbookMetadata, Identifier};
 
 use crate::helpers::format_series_index;
+use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};
 
 /// Hard server-side cap on the number of books any single list/search
 /// response returns. 50k is well above the client-side sort/filter
@@ -243,6 +244,31 @@ pub(crate) async fn backfill_creator_ids(
         for c in &mut b.creators {
             if c.id.is_none() {
                 c.id = name_to_id.get(&c.name.to_lowercase()).copied();
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Bulk-merge user-supplied `metadata_overrides` into every book in `books`
+/// in place. Snapshots each book's uuid first so the borrow checker sees
+/// the overrides_map lookup as independent of the `&mut book` passed into
+/// `apply_overrides`. Used by every list/search read path that returns
+/// `EbookMetadata` rows.
+pub(crate) async fn merge_overrides_into_books(
+    pool: &SqlitePool,
+    books: &mut [EbookMetadata],
+) -> Result<(), sqlx::Error> {
+    let uuids: Vec<String> = books
+        .iter()
+        .filter_map(|b| b.unique_identifier.clone())
+        .collect();
+    let overrides_map = load_overrides_bulk(pool, &uuids).await?;
+    for book in books.iter_mut() {
+        let uuid_owned = book.unique_identifier.clone();
+        if let Some(uuid) = uuid_owned.as_deref() {
+            if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
+                apply_overrides(book, uuid, ov, *has_cover_ov);
             }
         }
     }

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -250,11 +250,7 @@ pub(crate) async fn backfill_creator_ids(
     Ok(())
 }
 
-/// Bulk-merge user-supplied `metadata_overrides` into every book in `books`
-/// in place. Snapshots each book's uuid first so the borrow checker sees
-/// the overrides_map lookup as independent of the `&mut book` passed into
-/// `apply_overrides`. Used by every list/search read path that returns
-/// `EbookMetadata` rows.
+/// Bulk-merge user-supplied `metadata_overrides` into every book in `books` in place.
 pub(crate) async fn merge_overrides_into_books(
     pool: &SqlitePool,
     books: &mut [EbookMetadata],
@@ -265,6 +261,8 @@ pub(crate) async fn merge_overrides_into_books(
         .collect();
     let overrides_map = load_overrides_bulk(pool, &uuids).await?;
     for book in books.iter_mut() {
+        // Snapshot uuid first so the overrides_map lookup is independent
+        // of the `&mut book` passed into apply_overrides.
         let uuid_owned = book.unique_identifier.clone();
         if let Some(uuid) = uuid_owned.as_deref() {
             if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {

--- a/db/src/books/search.rs
+++ b/db/src/books/search.rs
@@ -5,13 +5,12 @@
 
 use sqlx::{Row, SqlitePool};
 
-use omnibus_shared::{Contributor, EbookMetadata, Identifier};
+use omnibus_shared::EbookMetadata;
 
-use crate::helpers::{build_fts_match, cap_query_len, format_series_index};
-use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};
+use crate::helpers::{build_fts_match, cap_query_len};
 
 use super::projection::{
-    backfill_creator_ids, parse_json_array, sanitize_description, CreatorRow, IdentifierRow,
+    backfill_creator_ids, merge_overrides_into_books, row_to_ebook, BOOK_COLUMNS,
     MAX_BOOKS_RETURNED,
 };
 
@@ -56,89 +55,7 @@ pub async fn search_books_with_total(
         return Ok((Vec::new(), 0));
     };
 
-    let rows = sqlx::query(
-        r#"
-        WITH matches AS MATERIALIZED (
-            -- Run the FTS5 MATCH + bm25 scan exactly once. bm25() is only
-            -- valid in a query that directly references books_fts, so it lives
-            -- here; the outer query then both counts and hydrates off the
-            -- materialized result without a second FTS5 pass (issue #241).
-            SELECT books_fts.rowid AS bid,
-                   bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0) AS rank
-            FROM books_fts
-            JOIN books b ON b.id = books_fts.rowid
-            JOIN libraries l ON l.id = b.library_id
-            WHERE books_fts MATCH ? AND l.path = ?
-        )
-        SELECT b.id, b.uuid,
-               b.title, b.description, b.series_index, b.has_cover,
-               b.pubdate, b.last_modified, b.timestamp, b.isbn, b.accent_color,
-
-               (SELECT COUNT(*) FROM matches)               AS total_count,
-
-               (SELECT bf.filename FROM book_files bf
-                 WHERE bf.book_id = b.id
-                 ORDER BY (bf.format != 'EPUB'), bf.format
-                 LIMIT 1)                                   AS primary_filename,
-
-               (SELECT bf.format FROM book_files bf
-                 WHERE bf.book_id = b.id
-                 ORDER BY (bf.format != 'EPUB'), bf.format
-                 LIMIT 1)                                   AS primary_format,
-
-               (SELECT pub.name FROM books_publishers_link bpl
-                  JOIN publishers pub ON pub.id = bpl.publisher
-                 WHERE bpl.book = b.id ORDER BY pub.name LIMIT 1)
-                                                            AS publisher_name,
-
-               (SELECT lang.code FROM books_languages_link bll
-                  JOIN languages lang ON lang.id = bll.language
-                 WHERE bll.book = b.id ORDER BY lang.code LIMIT 1)
-                                                            AS language_code,
-
-               (SELECT s.name FROM books_series_link bsl
-                  JOIN series s ON s.id = bsl.series
-                 WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
-                                                            AS series_name,
-
-               (SELECT s.id FROM books_series_link bsl
-                  JOIN series s ON s.id = bsl.series
-                 WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
-                                                            AS series_link_id,
-
-               (SELECT json_group_array(json_object('id', a_id, 'name', name, 'sort', sort))
-                  FROM (SELECT a.id AS a_id, a.name AS name, a.sort AS sort
-                          FROM books_authors_link bal
-                          JOIN authors a ON a.id = bal.author
-                         WHERE bal.book = b.id
-                         ORDER BY bal.position))            AS creators_json,
-
-               (SELECT json_group_array(name)
-                  FROM (SELECT t.name AS name FROM books_tags_link btl
-                          JOIN tags t ON t.id = btl.tag
-                         WHERE btl.book = b.id
-                         ORDER BY t.name))                  AS subjects_json,
-
-               (SELECT json_group_array(json_object('scheme', scheme, 'value', value))
-                  FROM (SELECT scheme, value FROM book_identifiers
-                         WHERE book_id = b.id
-                         ORDER BY scheme, value))           AS identifiers_json,
-
-               (SELECT json_group_array(format)
-                  FROM (SELECT format FROM book_files
-                         WHERE book_id = b.id
-                         ORDER BY format))                  AS formats_json
-        FROM matches m
-        JOIN books b ON b.id = m.bid
-        ORDER BY m.rank, b.sort, b.id
-        LIMIT ?
-        "#,
-    )
-    .bind(&match_expr)
-    .bind(library_path)
-    .bind(MAX_BOOKS_RETURNED)
-    .fetch_all(pool)
-    .await?;
+    let rows = fetch_search_rows(pool, library_path, &match_expr).await?;
 
     // `total_count` is the scalar `COUNT(*)` over the materialized matches, so
     // it's identical on every row; read it off the first. An empty result set
@@ -146,82 +63,50 @@ pub async fn search_books_with_total(
     let total: i64 = rows.first().map(|r| r.get("total_count")).unwrap_or(0);
 
     let mut out = Vec::with_capacity(rows.len());
-    for r in rows {
-        let id: i64 = r.get("id");
-        let has_cover: i64 = r.get("has_cover");
-        let primary_filename: Option<String> = r.get("primary_filename");
-        let primary_format: Option<String> = r.get("primary_format");
-        let filename = match (primary_filename, primary_format) {
-            (Some(stem), Some(fmt)) => format!("{stem}.{}", fmt.to_ascii_lowercase()),
-            _ => String::new(),
-        };
-        let series_index: Option<f64> = r.get("series_index");
-
-        let creators: Vec<Contributor> = parse_json_array::<CreatorRow>(r.get("creators_json"))?
-            .into_iter()
-            .map(|c| Contributor {
-                name: c.name,
-                role: None,
-                file_as: c.sort.filter(|s| !s.is_empty()),
-                id: c.id,
-            })
-            .collect();
-        let subjects: Vec<String> = parse_json_array(r.get("subjects_json"))?;
-        let identifiers: Vec<Identifier> =
-            parse_json_array::<IdentifierRow>(r.get("identifiers_json"))?
-                .into_iter()
-                .map(|i| Identifier {
-                    value: i.value,
-                    scheme: Some(i.scheme),
-                })
-                .collect();
-
-        let uuid: String = r.get("uuid");
-        out.push(EbookMetadata {
-            id,
-            filename,
-            title: r.get("title"),
-            description: sanitize_description(r.get("description")),
-            publisher: r.get("publisher_name"),
-            published: r.get("pubdate"),
-            modified: r.get("last_modified"),
-            language: r.get("language_code"),
-            creators,
-            subjects,
-            identifiers,
-            series: r.get("series_name"),
-            series_index: series_index.map(format_series_index),
-            series_id: r.get("series_link_id"),
-            unique_identifier: Some(uuid.clone()),
-            cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
-            accent: r.get("accent_color"),
-            formats: parse_json_array(r.get("formats_json"))?,
-            added_at: r.get("timestamp"),
-            error: None,
-            has_override: false,
-        });
+    for r in &rows {
+        out.push(row_to_ebook(r)?);
     }
 
-    // F5.1: bulk-merge metadata overrides.
-    let uuids: Vec<String> = out
-        .iter()
-        .filter_map(|b| b.unique_identifier.clone())
-        .collect();
-    let overrides_map = load_overrides_bulk(pool, &uuids).await?;
-    for book in &mut out {
-        // Snapshot uuid into an owned local so the borrow-check sees the
-        // overrides_map lookup as independent of the &mut book passed into
-        // apply_overrides below.
-        let uuid_owned = book.unique_identifier.clone();
-        if let Some(uuid) = uuid_owned.as_deref() {
-            if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
-                apply_overrides(book, uuid, ov, *has_cover_ov);
-            }
-        }
-    }
+    merge_overrides_into_books(pool, &mut out).await?;
     backfill_creator_ids(pool, &mut out).await?;
 
     Ok((out, total))
+}
+
+/// Run the single-pass FTS5 MATCH + hydrate query: bm25 scan inside a
+/// `MATERIALIZED` CTE, then the outer SELECT joins back to `books` with the
+/// shared `BOOK_COLUMNS` projection plus a scalar `(SELECT COUNT(*))`
+/// `total_count` column. bm25() is only valid in a query that directly
+/// references books_fts, so it must live inside the CTE.
+async fn fetch_search_rows(
+    pool: &SqlitePool,
+    library_path: &str,
+    match_expr: &str,
+) -> Result<Vec<sqlx::sqlite::SqliteRow>, sqlx::Error> {
+    let sql = format!(
+        r#"
+        WITH matches AS MATERIALIZED (
+            SELECT books_fts.rowid AS bid,
+                   bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0) AS rank
+            FROM books_fts
+            JOIN books b ON b.id = books_fts.rowid
+            JOIN libraries l ON l.id = b.library_id
+            WHERE books_fts MATCH ? AND l.path = ?
+        )
+        SELECT {BOOK_COLUMNS},
+               (SELECT COUNT(*) FROM matches)               AS total_count
+        FROM matches m
+        JOIN books b ON b.id = m.bid
+        ORDER BY m.rank, b.sort, b.id
+        LIMIT ?
+        "#
+    );
+    sqlx::query(&sql)
+        .bind(match_expr)
+        .bind(library_path)
+        .bind(MAX_BOOKS_RETURNED)
+        .fetch_all(pool)
+        .await
 }
 
 /// Total number of FTS5 hits for `q` under `library_path` (before the

--- a/db/src/discovery/authors.rs
+++ b/db/src/discovery/authors.rs
@@ -5,7 +5,7 @@
 
 use sqlx::{Row, SqlitePool};
 
-use omnibus_shared::AuthorDetail;
+use omnibus_shared::{AuthorDetail, EbookMetadata};
 
 use crate::books::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
 use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};
@@ -35,19 +35,35 @@ pub async fn get_author(
     };
     let author_name: String = a.get("name");
 
-    // F5.1: membership and ordering follow the merged (override-aware)
-    // view, not the raw `books_authors_link` table. `apply_overrides`
-    // replaces creators wholesale when the override JSON has the
-    // `creators` key, so the effective creator set for a book is:
-    //   - `overrides.creators` if the JSON has that key (including the
-    //     empty array, which clears all authors), else
-    //   - the canonical names from `books_authors_link`.
-    // Override creators carry only `name`, so we match by name against
-    // the target author. `series_index` overrides drive ordering the same
-    // way as in `get_series`.
-    let sql = format!(
-        r#"SELECT {BOOK_COLUMNS}
-           FROM books b
+    let mut books = fetch_author_books(pool, author_id, &author_name).await?;
+    let book_count = count_effective_author_members(pool, author_id, &author_name).await?;
+    merge_overrides_into_author_books(pool, &mut books).await?;
+    backfill_creator_ids(pool, &mut books).await?;
+    let has_photo = author_has_usable_photo(pool, author_id).await?;
+
+    Ok(Some(AuthorDetail {
+        id: a.get("id"),
+        name: a.get("name"),
+        sort: a.get("sort"),
+        book_count: book_count as usize,
+        books,
+        has_photo,
+    }))
+}
+
+/// SQL fragment expressing the override-aware effective author membership.
+/// Used by both `fetch_author_books` (with `SELECT BOOK_COLUMNS`) and
+/// `count_effective_author_members` (with `COUNT(*)`).
+///
+/// `apply_overrides` replaces creators wholesale when the override JSON
+/// has the `creators` key, so the effective creator set for a book is:
+/// - `overrides.creators` if the JSON has that key (including the empty
+///   array, which clears all authors), else
+/// - the canonical names from `books_authors_link`.
+///
+/// Override creators carry only `name`, so we match by name against the
+/// target author. Bind order: `?1` = author_name, `?2` = author_id.
+const EFFECTIVE_AUTHOR_PREDICATE: &str = r#"FROM books b
            LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
            WHERE
              CASE
@@ -55,13 +71,26 @@ pub async fn get_author(
                     AND json_type(mo.overrides, '$.creators') IS NOT NULL
                  THEN EXISTS (
                    SELECT 1 FROM json_each(mo.overrides, '$.creators') je
-                    WHERE json_extract(je.value, '$.name') = ? COLLATE NOCASE
+                    WHERE json_extract(je.value, '$.name') = ?1 COLLATE NOCASE
                  )
                ELSE EXISTS (
                  SELECT 1 FROM books_authors_link bal
-                  WHERE bal.book = b.id AND bal.author = ?
+                  WHERE bal.book = b.id AND bal.author = ?2
                )
-             END
+             END"#;
+
+/// Run the override-aware author SELECT and hydrate each row into
+/// [`EbookMetadata`]. `series_index` ordering follows the same
+/// override-aware NULLIF rule used in `get_series`. The returned vec is
+/// capped at [`MAX_DISCOVERY_BOOKS`].
+async fn fetch_author_books(
+    pool: &SqlitePool,
+    author_id: i64,
+    author_name: &str,
+) -> Result<Vec<EbookMetadata>, DiscoveryError> {
+    let sql = format!(
+        r#"SELECT {BOOK_COLUMNS}
+           {EFFECTIVE_AUTHOR_PREDICATE}
            ORDER BY
              CASE
                WHEN mo.book_uuid IS NOT NULL
@@ -75,10 +104,10 @@ pub async fn get_author(
                ELSE b.series_index
              END NULLS LAST,
              b.sort, b.id
-           LIMIT ?"#
+           LIMIT ?3"#
     );
     let rows = sqlx::query(&sql)
-        .bind(&author_name)
+        .bind(author_name)
         .bind(author_id)
         .bind(MAX_DISCOVERY_BOOKS)
         .fetch_all(pool)
@@ -88,44 +117,42 @@ pub async fn get_author(
     for r in &rows {
         books.push(row_to_ebook(r)?);
     }
+    Ok(books)
+}
 
-    // Issue #150: `books` above is capped at `MAX_DISCOVERY_BOOKS`, so its
-    // length can no longer stand in for the author's true shelf size.
-    // Count the (uncapped) effective membership separately using the same
-    // override-aware predicate as the SELECT so `book_count` stays
-    // truthful and callers can detect truncation as
-    // `book_count > books.len()`.
-    let book_count: i64 = sqlx::query_scalar(
+/// Count the (uncapped) effective shelf size using the same predicate as
+/// [`fetch_author_books`] so `book_count` stays truthful and truncation is
+/// detectable as `book_count > books.len()`.
+async fn count_effective_author_members(
+    pool: &SqlitePool,
+    author_id: i64,
+    author_name: &str,
+) -> Result<i64, sqlx::Error> {
+    let sql = format!(
         r#"SELECT COUNT(*)
-           FROM books b
-           LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE
-             CASE
-               WHEN mo.book_uuid IS NOT NULL
-                    AND json_type(mo.overrides, '$.creators') IS NOT NULL
-                 THEN EXISTS (
-                   SELECT 1 FROM json_each(mo.overrides, '$.creators') je
-                    WHERE json_extract(je.value, '$.name') = ? COLLATE NOCASE
-                 )
-               ELSE EXISTS (
-                 SELECT 1 FROM books_authors_link bal
-                  WHERE bal.book = b.id AND bal.author = ?
-               )
-             END"#,
-    )
-    .bind(&author_name)
-    .bind(author_id)
-    .fetch_one(pool)
-    .await?;
+           {EFFECTIVE_AUTHOR_PREDICATE}"#
+    );
+    sqlx::query_scalar(&sql)
+        .bind(author_name)
+        .bind(author_id)
+        .fetch_one(pool)
+        .await
+}
 
-    // Bulk-apply overrides so card titles / descriptions / covers reflect
-    // user edits, matching what `list_books` does for the landing grid.
+/// Bulk-apply overrides into each book so card titles / descriptions /
+/// covers reflect user edits, matching what `list_books` does for the
+/// landing grid. Unlike `merge_and_pin_series`, the author detail page
+/// does **not** rewrite `series_id` — only the merge happens here.
+async fn merge_overrides_into_author_books(
+    pool: &SqlitePool,
+    books: &mut [EbookMetadata],
+) -> Result<(), sqlx::Error> {
     let uuids: Vec<String> = books
         .iter()
         .filter_map(|b| b.unique_identifier.clone())
         .collect();
     let overrides_map = load_overrides_bulk(pool, &uuids).await?;
-    for book in &mut books {
+    for book in books.iter_mut() {
         let uuid_owned = book.unique_identifier.clone();
         if let Some(uuid) = uuid_owned.as_deref() {
             if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
@@ -133,13 +160,15 @@ pub async fn get_author(
             }
         }
     }
-    backfill_creator_ids(pool, &mut books).await?;
+    Ok(())
+}
 
-    // F1.11: surface whether a usable profile photo is cached so the
-    // frontend can render <img> vs the typographic letter avatar in one
-    // round trip. `'letter'` rows are the negative-cache marker and do
-    // not count as a usable photo.
-    let has_photo: bool = sqlx::query_scalar(
+/// Whether a usable profile photo is cached for `author_id`. F1.11 — the
+/// frontend uses this to render `<img>` vs the typographic letter avatar
+/// in one round trip. `'letter'` rows are the negative-cache marker and
+/// do not count as a usable photo.
+async fn author_has_usable_photo(pool: &SqlitePool, author_id: i64) -> Result<bool, sqlx::Error> {
+    sqlx::query_scalar(
         "SELECT EXISTS(
              SELECT 1 FROM author_photos
               WHERE author_id = ?
@@ -149,14 +178,5 @@ pub async fn get_author(
     )
     .bind(author_id)
     .fetch_one(pool)
-    .await?;
-
-    Ok(Some(AuthorDetail {
-        id: a.get("id"),
-        name: a.get("name"),
-        sort: a.get("sort"),
-        book_count: book_count as usize,
-        books,
-        has_photo,
-    }))
+    .await
 }

--- a/db/src/discovery/series.rs
+++ b/db/src/discovery/series.rs
@@ -6,7 +6,7 @@
 
 use sqlx::{Row, SqlitePool};
 
-use omnibus_shared::SeriesDetail;
+use omnibus_shared::{EbookMetadata, SeriesDetail};
 
 use crate::books::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
 use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};
@@ -30,36 +30,39 @@ pub async fn get_series(
     };
     let series_name: String = s.get("name");
 
-    // F5.1: membership and ordering follow the merged (override-aware)
-    // view, not the raw `books_series_link` table. `upsert_metadata_overrides`
-    // never writes to the relational link tables, so a book added to a
-    // series purely through the edit form would otherwise be invisible
-    // here even though `apply_overrides` shows it in that series everywhere
-    // else (book detail, landing grid). The effective series for a book is:
-    //   - `overrides.series` if the JSON has that key (including the empty
-    //     string, which means "clear the series"), else
-    //   - the canonical name from `books_series_link`.
-    // Same fallback for `series_index` so the override-set position drives
-    // ordering when present.
-    //
-    // Issue #154: the membership set is built as a single-pass UNION over
-    // (1) canonical link rows for *this* series whose book has no `series`
-    // override, and (2) override rows whose `overrides.series` matches this
-    // series' name. Both arms are scoped to the target series up front, so
-    // arm (1) drives through the `books_series_link(series)` index instead
-    // of scanning every book and computing a per-row correlated subquery.
-    // The empty-string clear-all case is handled naturally: a `Some("")`
-    // override removes the book from arm (1) (override IS NOT NULL) and the
-    // `'' = name` filter excludes it from arm (2). Case-insensitivity is
-    // preserved by the `COLLATE NOCASE` on arm (2)'s name comparison
-    // (canonical arm (1) needs none — it joins on `series.id`).
-    let sql = format!(
-        r#"WITH effective AS (
+    let mut books = fetch_series_books(pool, series_id, &series_name).await?;
+    let book_count = count_effective_series_members(pool, series_id, &series_name).await?;
+    merge_and_pin_series(pool, &mut books, series_id, &series_name).await?;
+    backfill_creator_ids(pool, &mut books).await?;
+
+    Ok(Some(SeriesDetail {
+        id: s.get("id"),
+        name: s.get("name"),
+        sort: s.get("sort"),
+        book_count: book_count as usize,
+        books,
+    }))
+}
+
+/// SQL CTE expressing the override-aware effective series membership. Used
+/// by both `fetch_series_books` (with the full `BOOK_COLUMNS` SELECT) and
+/// `count_effective_series_members` (with `COUNT(*)`).
+///
+/// Single-pass UNION over (1) canonical link rows for *this* series whose
+/// book has no `series` override, and (2) override rows whose
+/// `overrides.series` matches this series' name. Both arms are scoped to
+/// the target series up front, so arm (1) drives through the
+/// `books_series_link(series)` index instead of scanning every book.
+///
+/// The empty-string clear-all case is handled naturally: a `Some("")`
+/// override removes the book from arm (1) (override IS NOT NULL) and the
+/// `'' = name` filter excludes it from arm (2). Case-insensitivity is
+/// preserved by the `COLLATE NOCASE` on arm (2)'s name comparison.
+const EFFECTIVE_SERIES_CTE: &str = r#"WITH effective AS (
              -- (1) Canonical members of this series with no series override.
              -- A `series_index` override still drives ordering here even
-             -- when the series itself is canonical (the original `effective`
-             -- CTE computed the index independently of the name), so a user
-             -- who only repositions a book they didn't move keeps that order.
+             -- when the series itself is canonical, so a user who only
+             -- repositions a book they didn't move keeps that order.
              SELECT bsl.book AS book_id,
                     CASE
                       WHEN mo.book_uuid IS NOT NULL
@@ -78,8 +81,8 @@ pub async fn get_series(
              SELECT b.id AS book_id,
                     -- NULLIF: an override that explicitly clears the index
                     -- (`Some("")` from the edit form) would otherwise CAST
-                    -- to 0.0 and sort to the front of the series. Treat
-                    -- empty-string as "no index" and let NULLS LAST trail it.
+                    -- to 0.0 and sort to the front. Treat empty-string as
+                    -- "no index" and let NULLS LAST trail it.
                     CASE
                       WHEN json_type(mo.overrides, '$.series_index') IS NOT NULL
                         THEN CAST(NULLIF(json_extract(mo.overrides, '$.series_index'), '') AS REAL)
@@ -89,7 +92,18 @@ pub async fn get_series(
                JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
               WHERE json_type(mo.overrides, '$.series') IS NOT NULL
                 AND json_extract(mo.overrides, '$.series') = ?2 COLLATE NOCASE
-           )
+           )"#;
+
+/// Run the `effective`-CTE + `BOOK_COLUMNS` SELECT and hydrate each row
+/// into [`EbookMetadata`]. The nested vec is capped at
+/// [`MAX_DISCOVERY_BOOKS`].
+async fn fetch_series_books(
+    pool: &SqlitePool,
+    series_id: i64,
+    series_name: &str,
+) -> Result<Vec<EbookMetadata>, DiscoveryError> {
+    let sql = format!(
+        r#"{EFFECTIVE_SERIES_CTE}
            SELECT {BOOK_COLUMNS}
            FROM books b
            JOIN effective e ON e.book_id = b.id
@@ -98,7 +112,7 @@ pub async fn get_series(
     );
     let rows = sqlx::query(&sql)
         .bind(series_id)
-        .bind(&series_name)
+        .bind(series_name)
         .bind(MAX_DISCOVERY_BOOKS)
         .fetch_all(pool)
         .await?;
@@ -107,69 +121,56 @@ pub async fn get_series(
     for r in &rows {
         books.push(row_to_ebook(r)?);
     }
+    Ok(books)
+}
 
-    // Issue #150: `books` is capped at `MAX_DISCOVERY_BOOKS`. Count the
-    // uncapped effective membership separately — reusing the same
-    // single-pass effective-membership UNION as the SELECT (issue #154) —
-    // so `book_count` reflects the true series size and truncation is
-    // detectable as `book_count > books.len()`.
-    let book_count: i64 = sqlx::query_scalar(
-        r#"WITH effective AS (
-             SELECT bsl.book AS book_id
-               FROM books_series_link bsl
-               JOIN books b ON b.id = bsl.book
-               LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-              WHERE bsl.series = ?1
-                AND (mo.book_uuid IS NULL
-                     OR json_type(mo.overrides, '$.series') IS NULL)
-             UNION
-             SELECT b.id AS book_id
-               FROM books b
-               JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-              WHERE json_type(mo.overrides, '$.series') IS NOT NULL
-                AND json_extract(mo.overrides, '$.series') = ?2 COLLATE NOCASE
-           )
-           SELECT COUNT(*) FROM effective"#,
-    )
-    .bind(series_id)
-    .bind(&series_name)
-    .fetch_one(pool)
-    .await?;
+/// Count the (uncapped) effective membership for `(series_id, series_name)`
+/// using the same UNION as [`fetch_series_books`] so truncation is
+/// detectable as `book_count > books.len()`.
+async fn count_effective_series_members(
+    pool: &SqlitePool,
+    series_id: i64,
+    series_name: &str,
+) -> Result<i64, sqlx::Error> {
+    let sql = format!(
+        r#"{EFFECTIVE_SERIES_CTE}
+           SELECT COUNT(*) FROM effective"#
+    );
+    sqlx::query_scalar(&sql)
+        .bind(series_id)
+        .bind(series_name)
+        .fetch_one(pool)
+        .await
+}
 
-    // Merge overrides into each book so the series-card title/description
-    // /cover reflect user edits, matching what `list_books` does for the
-    // landing grid.
+/// Bulk-merge overrides into each book and **unconditionally** pin
+/// `series_id` / `series` to the parent series. A book that was canonically
+/// in series A but overridden into series B would otherwise come back with
+/// `series_id = Some(A)` (from the BOOK_COLUMNS subquery, which only reads
+/// `books_series_link`) — so the card on B's page would link back to
+/// /series/A. We're already on B's page by construction (the WHERE filter
+/// matched the effective series name), so pinning to the requested series
+/// is correct.
+async fn merge_and_pin_series(
+    pool: &SqlitePool,
+    books: &mut [EbookMetadata],
+    series_id: i64,
+    series_name: &str,
+) -> Result<(), sqlx::Error> {
     let uuids: Vec<String> = books
         .iter()
         .filter_map(|b| b.unique_identifier.clone())
         .collect();
     let overrides_map = load_overrides_bulk(pool, &uuids).await?;
-    for book in &mut books {
+    for book in books.iter_mut() {
         let uuid_owned = book.unique_identifier.clone();
         if let Some(uuid) = uuid_owned.as_deref() {
             if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
                 apply_overrides(book, uuid, ov, *has_cover_ov);
             }
         }
-        // Pin `series_id` / `series` to the parent series for every
-        // returned row, not just the override-only ones. A book that was
-        // canonically in series A but overridden into series B would
-        // otherwise come back here with `series_id = Some(A)` (from the
-        // BOOK_COLUMNS subquery, which only reads `books_series_link`)
-        // — so the card on B's page would link back to /series/A. We're
-        // already on B's page by construction (the WHERE filter matched
-        // the effective series name), so unconditionally pinning to the
-        // requested series is correct.
         book.series_id = Some(series_id);
-        book.series = Some(series_name.clone());
+        book.series = Some(series_name.to_string());
     }
-    backfill_creator_ids(pool, &mut books).await?;
-
-    Ok(Some(SeriesDetail {
-        id: s.get("id"),
-        name: s.get("name"),
-        sort: s.get("sort"),
-        book_count: book_count as usize,
-        books,
-    }))
+    Ok(())
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,6 +24,10 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"], optional = true }
 tracing = { workspace = true, optional = true }
 time = { version = "0.3", optional = true }
+# Re-exported by dioxus::serve as the return error type, and used by the
+# native startup helpers in main.rs that previously lived inside an inline
+# closure (where `?` upgraded any error via type inference).
+anyhow = { version = "1.0", optional = true }
 
 omnibus-shared = { path = "../shared" }
 # `features` here are forwarded via our own feature flags below. Leaving it
@@ -60,6 +64,7 @@ server = [
     "dep:tokio",
     "dep:tracing",
     "dep:time",
+    "dep:anyhow",
     "dep:omnibus-db",
     "dioxus/server",
     "omnibus-frontend/server",

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -18,191 +18,232 @@ fn main() {
 
     #[cfg(feature = "server")]
     {
-        dioxus::serve(|| async move {
-            use dioxus::server::axum::Extension;
-            use omnibus::{auth, backend, rate_limit, security_headers};
-            use omnibus_db::{
-                indexer,
-                worker::{Task, Worker},
-            };
-            use std::sync::Arc;
+        dioxus::serve(server::launch);
+    }
+}
 
-            // Capture process-start timestamp as the /api/_health build_id
-            // before anything else can race the first probe. Lazy init from
-            // the first request would label that timestamp "build_id" even
-            // though the process has been up for seconds — misleading for
-            // the rebuild-detection use case.
-            backend::init_build_id();
-            // Capture the workspace root (current working directory at
-            // boot) so /api/_health can announce which `jj` worktree this
-            // server belongs to. scripts/dev-server-up.sh uses this to
-            // distinguish "my workspace's server" from "a sibling
-            // workspace's server bound to the port I want".
-            backend::init_repo_root();
+/// Native fullstack startup. Gated behind the `server` feature so the WASM
+/// build never pulls these helpers (and their tokio + sqlx deps) into the
+/// browser bundle.
+#[cfg(feature = "server")]
+mod server {
+    use std::sync::Arc;
 
-            if rate_limit::trust_forwarded_for() {
-                tracing::warn!(
-                    target: "omnibus::startup",
-                    "OMNIBUS_TRUST_FORWARDED_FOR is enabled \u{2014} ensure a trusted reverse proxy is in front."
-                );
-            }
+    use axum::Router;
+    use dioxus::server::axum::Extension;
+    use omnibus::{auth, backend, rate_limit, security_headers};
+    use omnibus_db::{
+        indexer,
+        worker::{Task, Worker},
+    };
+    use sqlx::SqlitePool;
 
-            let database_url = std::env::var("DATABASE_URL")
-                .unwrap_or_else(|_| "sqlite://omnibus.db?mode=rwc".to_string());
+    use crate::App;
 
-            let pool = omnibus_db::init_db(&database_url).await?;
-            omnibus_db::seed_settings_from_env(&pool).await?;
+    /// Entry point passed to `dioxus::serve`. Boots the DB + worker, kicks off
+    /// any stale-index recovery scan, wires the auth/REST/RPC routers, and
+    /// layers the global middleware stack onto a single Axum `Router`.
+    pub(crate) async fn launch() -> anyhow::Result<Router> {
+        init_boot_metadata();
+        log_startup_warnings();
 
-            // Recovery hook: promote the named user to admin if
-            // OMNIBUS_INITIAL_ADMIN is set. No-op otherwise. Logs on
-            // promotion so the action is auditable.
-            auth::boot::apply_initial_admin(&pool).await?;
+        let pool = init_database().await?;
+        let state = backend::AppState::new(pool.clone());
+        let worker: Arc<Worker> = state.worker().clone();
 
-            // Dev convenience: create OMNIBUS_DEV_SEED_USER if set and the
-            // user doesn't yet exist. Sourced from `.env` (gitignored) via
-            // the flake.nix shellHook — production never sets it. Logs on
-            // seed so any stray prod-env occurrence is loud.
-            auth::boot::seed_dev_user(&pool).await?;
+        kick_recovery_scans(&pool, &worker).await;
+        spawn_session_pruner(pool.clone());
 
-            let state = backend::AppState::new(pool.clone());
-            let worker: Arc<Worker> = state.worker().clone();
+        let router = build_router(state, pool, worker);
+        Ok(apply_security_headers(router))
+    }
 
-            // Kick off a reindex through the shared worker if the index is
-            // empty or stale. The first user request reads whatever is
-            // currently in the DB; the refresh flows in next time the page
-            // loads. Treat read errors as "stale" so a malformed timestamp
-            // doesn't silently suppress the recovery scan.
-            if let Ok(settings) = omnibus_db::get_settings(&pool).await {
-                if let Some(path) = settings.ebook_library_path {
-                    let stale = indexer::is_stale(&pool, &path).await.unwrap_or(true);
-                    if stale {
-                        worker.post(Task::Scan { library_path: path });
-                    }
-                }
-                if let Some(path) = settings.audiobook_library_path {
-                    let stale = indexer::is_stale(&pool, &path).await.unwrap_or(true);
-                    if stale {
-                        worker.post(Task::ScanAudiobooks { library_path: path });
-                    }
-                }
-            }
+    /// Capture process-start timestamp + repo root before any request can race
+    /// the first `/api/_health` probe. Lazy init from the first request would
+    /// label the build_id seconds-after-boot, which is misleading for the
+    /// rebuild-detection use case.
+    fn init_boot_metadata() {
+        backend::init_build_id();
+        // scripts/dev-server-up.sh uses repo_root to distinguish "my
+        // workspace's server" from a sibling workspace's server bound to the
+        // port I want.
+        backend::init_repo_root();
+    }
 
-            // Prune sessions that can never authenticate again (revoked,
-            // absolute-expired, or idle-expired) so the table doesn't grow
-            // without bound. The first interval tick fires immediately, so
-            // this also runs at boot; thereafter daily.
-            {
-                let pool = pool.clone();
-                tokio::spawn(async move {
-                    let mut interval =
-                        tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
-                    loop {
-                        interval.tick().await;
-                        match omnibus_db::auth::prune_expired_sessions(&pool).await {
-                            Ok(n) if n > 0 => {
-                                tracing::info!(pruned = n, "pruned expired/revoked/idle sessions");
-                            }
-                            Ok(_) => {}
-                            Err(e) => {
-                                tracing::warn!(error = %e, "session prune failed");
-                            }
-                        }
-                    }
-                });
-            }
-
-            let auth_limiter = Arc::new(rate_limit::RateLimiter::new());
-            // Prefix-scope the auth limiter to credential-handling endpoints
-            // only. `/api/auth/me` is an authenticated read of the caller's
-            // own row — it's hit on every web App boot (and historically
-            // on every page mount) but presents no brute-force surface, so
-            // sharing the same 10-req/60s bucket as `/login`/`/register`
-            // just throttled legitimate UI rendering (and parallel
-            // Playwright workers from the same loopback IP). Logout stays
-            // limited because a stolen token could otherwise be used to
-            // DoS revoke endpoints.
-            let auth_limiter_prefixes: Arc<Vec<&'static str>> = Arc::new(vec![
-                "/api/auth/login",
-                "/api/auth/register",
-                "/api/auth/logout",
-            ]);
-            // One per-IP budget shared by the REST `/api/search/*` and RPC
-            // `/api/rpc/search-*` layers (same Arc), so neither reaches 2× (#249).
-            let search_limiter = Arc::new(rate_limit::RateLimiter::with_policy(
-                backend::SEARCH_RATE_LIMIT_WINDOW,
-                backend::SEARCH_RATE_LIMIT_MAX,
-            ));
-            // `starts_with` prefix covers both `/api/rpc/search` and
-            // `/api/rpc/search-palette` so neither bypasses the budget (#249).
-            let search_rpc_prefixes: Arc<Vec<&'static str>> = Arc::new(vec!["/api/rpc/search"]);
-            let router = dioxus::server::router(App)
-                .layer(axum::middleware::from_fn_with_state(
-                    (search_limiter.clone(), search_rpc_prefixes),
-                    rate_limit::rate_limit_paths,
-                ))
-                .merge(backend::rest_router_with_search_limiter(
-                    state.clone(),
-                    search_limiter,
-                ))
-                .merge(auth::auth_router(state.clone()).layer(
-                    axum::middleware::from_fn_with_state(
-                        (auth_limiter, auth_limiter_prefixes),
-                        rate_limit::rate_limit_paths,
-                    ),
-                ))
-                // Apply require_auth and origin_check at the top level so
-                // every cookie-authed /api/* request — not just /api/auth/* —
-                // is origin-checked. Bearer requests and safe methods are
-                // exempt inside origin_check; non-cookie requests short-circuit
-                // there too, so SSR and static assets pass through unchanged.
-                .layer(axum::middleware::from_fn_with_state(
-                    state,
-                    auth::require_auth,
-                ))
-                .layer(axum::middleware::from_fn(auth::origin_check))
-                .layer(Extension(pool))
-                .layer(Extension(worker))
-                // Global request-handling guards. A slow client or oversized
-                // body can otherwise hold a tokio worker indefinitely.
-                //
-                // - `TimeoutLayer` aborts any request that takes longer than
-                //   30s end-to-end. Long-running scans run on the background
-                //   `Worker` (not the request task), so 30s is safely above
-                //   any synchronous handler.
-                // - `DefaultBodyLimit` caps request bodies to 1 MiB by
-                //   default. Routes that legitimately need larger payloads
-                //   (e.g. `POST /api/ebooks/{id}/cover`) layer their own
-                //   `DefaultBodyLimit::max(...)` closer to the handler,
-                //   which takes precedence over this outer cap.
-                .layer(tower_http::timeout::TimeoutLayer::with_status_code(
-                    axum::http::StatusCode::REQUEST_TIMEOUT,
-                    std::time::Duration::from_secs(30),
-                ))
-                .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024));
-
-            // Global HTTP security response headers (#277). Applied as a
-            // separate `for` fold because `SetResponseHeaderLayer` is one
-            // layer per header, and Router::layer composes them one at a
-            // time. Placed here — outside the timeout/body-limit guards
-            // but inside the trace layer — so headers attach to every
-            // response, including the 408/413 short-circuits emitted by
-            // those guards above.
-            let secure_cookies = auth::handlers::parse_secure_cookies(
-                std::env::var("OMNIBUS_SECURE_COOKIES").ok().as_deref(),
+    /// Log a WARN if `OMNIBUS_TRUST_FORWARDED_FOR` is enabled — required only
+    /// behind a trusted reverse proxy, dangerous otherwise.
+    fn log_startup_warnings() {
+        if rate_limit::trust_forwarded_for() {
+            tracing::warn!(
+                target: "omnibus::startup",
+                "OMNIBUS_TRUST_FORWARDED_FOR is enabled \u{2014} ensure a trusted reverse proxy is in front."
             );
-            let mut router = router;
-            for layer in security_headers::baseline_layers() {
-                router = router.layer(layer);
-            }
-            if let Some(layer) = security_headers::hsts_layer(secure_cookies) {
-                router = router.layer(layer);
-            }
-            // TraceLayer last so it is the outermost layer and observes
-            // every response — including 408/413 short-circuits from the
-            // timeout and body-limit guards above.
-            let router = router.layer(tower_http::trace::TraceLayer::new_for_http());
+        }
+    }
 
-            Ok(router)
+    /// Open the SQLite pool, run migrations, seed env-driven settings, then
+    /// apply the boot-time admin / dev-user hooks.
+    async fn init_database() -> anyhow::Result<SqlitePool> {
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "sqlite://omnibus.db?mode=rwc".to_string());
+
+        let pool = omnibus_db::init_db(&database_url).await?;
+        omnibus_db::seed_settings_from_env(&pool).await?;
+
+        // Recovery hook: promote the named user to admin if
+        // OMNIBUS_INITIAL_ADMIN is set. No-op otherwise. Logs on
+        // promotion so the action is auditable.
+        auth::boot::apply_initial_admin(&pool).await?;
+
+        // Dev convenience: create OMNIBUS_DEV_SEED_USER if set and the
+        // user doesn't yet exist. Sourced from `.env` (gitignored) via
+        // the flake.nix shellHook — production never sets it. Logs on
+        // seed so any stray prod-env occurrence is loud.
+        auth::boot::seed_dev_user(&pool).await?;
+
+        Ok(pool)
+    }
+
+    /// Kick off a reindex through the shared worker if the index is empty or
+    /// stale. The first user request reads whatever is currently in the DB;
+    /// the refresh flows in next time the page loads. Treat read errors as
+    /// "stale" so a malformed timestamp doesn't silently suppress the
+    /// recovery scan.
+    async fn kick_recovery_scans(pool: &SqlitePool, worker: &Arc<Worker>) {
+        if let Ok(settings) = omnibus_db::get_settings(pool).await {
+            if let Some(path) = settings.ebook_library_path {
+                let stale = indexer::is_stale(pool, &path).await.unwrap_or(true);
+                if stale {
+                    worker.post(Task::Scan { library_path: path });
+                }
+            }
+            if let Some(path) = settings.audiobook_library_path {
+                let stale = indexer::is_stale(pool, &path).await.unwrap_or(true);
+                if stale {
+                    worker.post(Task::ScanAudiobooks { library_path: path });
+                }
+            }
+        }
+    }
+
+    /// Spawn a daily background task that prunes sessions which can never
+    /// authenticate again (revoked, absolute-expired, or idle-expired). The
+    /// first interval tick fires immediately, so this also runs at boot.
+    fn spawn_session_pruner(pool: SqlitePool) {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
+            loop {
+                interval.tick().await;
+                match omnibus_db::auth::prune_expired_sessions(&pool).await {
+                    Ok(n) if n > 0 => {
+                        tracing::info!(pruned = n, "pruned expired/revoked/idle sessions");
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(error = %e, "session prune failed");
+                    }
+                }
+            }
         });
+    }
+
+    /// Assemble the full Axum router: RPC search rate-limit, REST router,
+    /// auth router (with its own credential-handling rate-limit), then the
+    /// auth / origin-check / extensions / timeout / body-limit middleware
+    /// stack. Returns the router; security headers and the trace layer are
+    /// added by `apply_security_headers`.
+    fn build_router(state: backend::AppState, pool: SqlitePool, worker: Arc<Worker>) -> Router {
+        let auth_limiter = Arc::new(rate_limit::RateLimiter::new());
+        // Prefix-scope the auth limiter to credential-handling endpoints
+        // only. `/api/auth/me` is an authenticated read of the caller's
+        // own row — it's hit on every web App boot (and historically
+        // on every page mount) but presents no brute-force surface, so
+        // sharing the same 10-req/60s bucket as `/login`/`/register`
+        // just throttled legitimate UI rendering (and parallel
+        // Playwright workers from the same loopback IP). Logout stays
+        // limited because a stolen token could otherwise be used to
+        // DoS revoke endpoints.
+        let auth_limiter_prefixes: Arc<Vec<&'static str>> = Arc::new(vec![
+            "/api/auth/login",
+            "/api/auth/register",
+            "/api/auth/logout",
+        ]);
+        // One per-IP budget shared by the REST `/api/search/*` and RPC
+        // `/api/rpc/search-*` layers (same Arc), so neither reaches 2× (#249).
+        let search_limiter = Arc::new(rate_limit::RateLimiter::with_policy(
+            backend::SEARCH_RATE_LIMIT_WINDOW,
+            backend::SEARCH_RATE_LIMIT_MAX,
+        ));
+        // `starts_with` prefix covers both `/api/rpc/search` and
+        // `/api/rpc/search-palette` so neither bypasses the budget (#249).
+        let search_rpc_prefixes: Arc<Vec<&'static str>> = Arc::new(vec!["/api/rpc/search"]);
+
+        dioxus::server::router(App)
+            .layer(axum::middleware::from_fn_with_state(
+                (search_limiter.clone(), search_rpc_prefixes),
+                rate_limit::rate_limit_paths,
+            ))
+            .merge(backend::rest_router_with_search_limiter(
+                state.clone(),
+                search_limiter,
+            ))
+            .merge(
+                auth::auth_router(state.clone()).layer(axum::middleware::from_fn_with_state(
+                    (auth_limiter, auth_limiter_prefixes),
+                    rate_limit::rate_limit_paths,
+                )),
+            )
+            // Apply require_auth and origin_check at the top level so
+            // every cookie-authed /api/* request — not just /api/auth/* —
+            // is origin-checked. Bearer requests and safe methods are
+            // exempt inside origin_check; non-cookie requests short-circuit
+            // there too, so SSR and static assets pass through unchanged.
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                auth::require_auth,
+            ))
+            .layer(axum::middleware::from_fn(auth::origin_check))
+            .layer(Extension(pool))
+            .layer(Extension(worker))
+            // Global request-handling guards. A slow client or oversized
+            // body can otherwise hold a tokio worker indefinitely.
+            //
+            // - `TimeoutLayer` aborts any request that takes longer than
+            //   30s end-to-end. Long-running scans run on the background
+            //   `Worker` (not the request task), so 30s is safely above
+            //   any synchronous handler.
+            // - `DefaultBodyLimit` caps request bodies to 1 MiB by
+            //   default. Routes that legitimately need larger payloads
+            //   (e.g. `POST /api/ebooks/{id}/cover`) layer their own
+            //   `DefaultBodyLimit::max(...)` closer to the handler,
+            //   which takes precedence over this outer cap.
+            .layer(tower_http::timeout::TimeoutLayer::with_status_code(
+                axum::http::StatusCode::REQUEST_TIMEOUT,
+                std::time::Duration::from_secs(30),
+            ))
+            .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
+    }
+
+    /// Layer global HTTP security response headers (#277) onto `router`, plus
+    /// the optional HSTS layer (only when secure cookies are enabled) and the
+    /// outermost trace layer. Separate fold because `SetResponseHeaderLayer`
+    /// is one layer per header; placed outside the timeout/body-limit guards
+    /// but inside the trace layer so headers attach to every response —
+    /// including the 408/413 short-circuits emitted by those guards.
+    fn apply_security_headers(router: Router) -> Router {
+        let secure_cookies = auth::handlers::parse_secure_cookies(
+            std::env::var("OMNIBUS_SECURE_COOKIES").ok().as_deref(),
+        );
+        let mut router = router;
+        for layer in security_headers::baseline_layers() {
+            router = router.layer(layer);
+        }
+        if let Some(layer) = security_headers::hsts_layer(secure_cookies) {
+            router = router.layer(layer);
+        }
+        // TraceLayer last so it is the outermost layer and observes
+        // every response — including 408/413 short-circuits from the
+        // timeout and body-limit guards above.
+        router.layer(tower_http::trace::TraceLayer::new_for_http())
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -40,9 +40,7 @@ mod server {
 
     use crate::App;
 
-    /// Entry point passed to `dioxus::serve`. Boots the DB + worker, kicks off
-    /// any stale-index recovery scan, wires the auth/REST/RPC routers, and
-    /// layers the global middleware stack onto a single Axum `Router`.
+    /// Entry point handed to `dioxus::serve`: boots the stack and returns the wired Axum `Router`.
     pub(crate) async fn launch() -> anyhow::Result<Router> {
         init_boot_metadata();
         log_startup_warnings();


### PR DESCRIPTION
## Summary

Each of the 8 functions identified in #445 has been split down under the ~80-line soft cap (rule 05-rust-style) by extracting named helpers along responsibility lines, with one-line `///` doc summaries on every helper. Behavior is preserved — all existing tests pass unchanged.

| Function | File | Before LOC | After LOC | Extracted sub-units |
|---|---|---|---|---|
| `fn main` | `server/src/main.rs` | 196 | 11 | New `server` submodule with `launch`, `init_boot_metadata`, `log_startup_warnings`, `init_database`, `kick_recovery_scans`, `spawn_session_pruner`, `build_router`, `apply_security_headers` |
| `list_books_for_paths` | `db/src/books/list.rs` | 163 | 13 | `fetch_list_rows`; now reuses shared `BOOK_COLUMNS` + `row_to_ebook` + new `merge_overrides_into_books` |
| `search_books_with_total` | `db/src/books/search.rs` | 180 | 25 | `fetch_search_rows`; reuses shared `BOOK_COLUMNS` + `row_to_ebook` + `merge_overrides_into_books` |
| `get_book` | `db/src/books/get.rs` | 163 | 22 | `fetch_book_row`, `backfill_series_id_by_name`; reuses shared `BOOK_COLUMNS` + `row_to_ebook` |
| `parse_one_group` | `db/src/audiobook/parse.rs` | 160 | 45 | `parse_parts`, `read_part_tags`, `read_first_cover`, `derive_book_metadata`, `finalize_parts`, plus extracted `PartWork` struct + `UNTAGGED_TRACK` const |
| `get_series` | `db/src/discovery/series.rs` | 155 | 26 | `fetch_series_books`, `count_effective_series_members`, `merge_and_pin_series`, plus shared `EFFECTIVE_SERIES_CTE` const |
| `sync_audiobooks` | `db/src/sync/audiobooks.rs` | 151 | 29 | `sync_audiobooks_removed`, `sync_audiobooks_changed`, `sync_audiobooks_new`, `batch_lookup_book_ids`, `wipe_audiobook_dependent_rows`, `reinsert_audiobook_payload`, `insert_full_audiobook`, `backfill_audiobook_stats`, `stamp_last_indexed` |
| `get_author` | `db/src/discovery/authors.rs` | 139 | 29 | `fetch_author_books`, `count_effective_author_members`, `merge_overrides_into_author_books`, `author_has_usable_photo`, plus shared `EFFECTIVE_AUTHOR_PREDICATE` const |

A new `projection::merge_overrides_into_books` helper deduplicates the `load_overrides_bulk` + per-book `apply_overrides` loop that all four list-shaped read paths had inlined. Three near-duplicate ~150-line `SELECT` strings collapse into the shared `BOOK_COLUMNS` const + `row_to_ebook` mapper that `discovery::{authors,series}` already used. `sync_audiobooks` now mirrors the already-split `sync_books` shape.

**Cargo.lock**: one line added — `anyhow` is now a feature-gated dep of `omnibus`. The original `fn main`'s inline closure inferred `anyhow::Error` from `?` upgrades via the `dioxus::serve` signature; the extracted helpers need an explicit signature, and `dioxus::serve` expects `anyhow::Result<Router>`.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` (default-members) — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 457 passed, 0 failed
- [x] `cargo test -p omnibus` — 185 passed, 0 failed
- [x] `cargo build -p omnibus` — clean

**Pre-existing failures on `main`**: `cargo clippy --all-features` fails on `omnibus-frontend` because the `web` and `mobile` features are intentionally mutually exclusive (the crate emits a `compile_error!` when both are enabled, as a workspace-wide build would). Per-crate builds work fine. Verified the same failure on `origin/main` (12 errors) and confirmed this PR adds none of them.

## Adversarial self-review

- **`fn main` (196 → 11)** — Stayed well under 80 in every extracted helper (max 24 lines: `spawn_session_pruner`). No behavior change: the boot order, layer order, and tokio spawn semantics are byte-for-byte identical to the original closure. Added `anyhow` as a `dep:` feature, called out above. No prop signature change (not a frontend crate).
- **`list_books_for_paths` (163 → 13)** — Behavior preserved: the SQL is the same (now spelled via shared `BOOK_COLUMNS`), the bind order is the same (paths then `MAX_BOOKS_RETURNED`), the override merge + `backfill_creator_ids` happen in the same order. `row_to_ebook` produces the exact same `EbookMetadata` shape the inline code did.
- **`search_books_with_total` (180 → 25)** — Behavior preserved: the materialized-CTE SQL is unchanged (now spelled via `BOOK_COLUMNS`), bind order unchanged (`match_expr`, `library_path`, `MAX_BOOKS_RETURNED`), `total_count` still read off `rows.first()`. No prop signature change.
- **`get_book` (163 → 22)** — Behavior preserved: same single-row `SELECT … WHERE b.id = ?` (now spelled via `BOOK_COLUMNS`), same override merge, same `series_id` backfill, same creator-id backfill. The `series_id` backfill helper short-circuits when `book.series_id` is already `Some(_)`, matching the original `if let Some(name) = book.series.as_deref().filter(...)` inside the original `if book.series_id.is_none()` block.
- **`parse_one_group` (160 → 45)** — Behavior preserved: the per-part tag read, the first-cover snapshot, the `(track, filename)` sort, the title/creator/description fallbacks, and the chapter extraction all happen in the same order with the same fallback values. Pulled out the inline `999_999` magic number into a named `UNTAGGED_TRACK` constant; same value, clearer intent.
- **`get_series` (155 → 26)** — Behavior preserved: the membership UNION CTE is now in a shared const used by both the SELECT and the COUNT query (previously inline-duplicated), so the count and the page can no longer drift. Same override merge, same unconditional `series_id` / `series` pin (which the original called out as deliberate).
- **`sync_audiobooks` (151 → 29)** — Behavior preserved: the four-stage transaction (Removed → Changed → New → Backfill → stamp `last_indexed`) is reassembled in the same order with the same TOCTOU fallback in the Changed path. The cover triples are still collected during each stage and materialized post-commit on the blocking pool. Each stage returns `Result<_, SyncError>` so the `insert_chapters` propagation (which returns `SyncError`, not `sqlx::Error`) still works.
- **`get_author` (139 → 29)** — Behavior preserved: the override-aware predicate is now in a shared const used by both the SELECT and the COUNT query, mirroring the `get_series` split. Same override merge, same `backfill_creator_ids`, same `has_photo` lookup.

No function was scoped down — all 8 were finished. Cargo.lock change is a single `+ "anyhow",` line under the `omnibus` package's deps list.

Closes #445

---
_Generated by [Claude Code](https://claude.ai/code/session_014DekCs6injDChPgKTE7bmb)_