### PR TITLE
fix: post_sessions batch is now atomic with rollback on error (#455)

### DIFF
--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -7,7 +7,7 @@
 //! per-format `reading_sessions` / `listening_sessions` tables.
 
 use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, SessionReport};
-use sqlx::{Row, SqlitePool};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
 use crate::resolve_book_id_by_uuid;
 
@@ -135,18 +135,23 @@ pub async fn get_progress(
     }))
 }
 
-/// Append one session row to the per-format table. Returns `Ok(true)` when
-/// a row was inserted and `Ok(false)` when the report was skipped because
-/// the `book_uuid` is unknown (a session that outlived the book it referred
-/// to is best-effort telemetry, not an integrity failure). The handler
-/// surfaces the inserted count to the client so it can tell which queued
-/// reports actually persisted.
-pub async fn record_session(
-    pool: &SqlitePool,
+/// Append one session row inside an existing transaction. Returns `Ok(true)`
+/// when a row was inserted and `Ok(false)` when the report was skipped
+/// because the `book_uuid` is unknown (best-effort telemetry — a session
+/// that outlived its book is not an integrity failure).
+///
+/// The caller is responsible for committing or rolling back the transaction.
+/// Use this variant when inserting a batch so the entire batch is atomic.
+pub async fn record_session_tx(
+    tx: &mut Transaction<'_, Sqlite>,
     user_id: i64,
     report: &SessionReport,
 ) -> Result<bool, ProgressError> {
-    let Some(book_id) = resolve_book_id_by_uuid(pool, &report.book_uuid).await? else {
+    let book_id: Option<i64> = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?")
+        .bind(&report.book_uuid)
+        .fetch_optional(&mut **tx)
+        .await?;
+    let Some(book_id) = book_id else {
         return Ok(false);
     };
     match report.format {
@@ -162,7 +167,7 @@ pub async fn record_session(
             .bind(report.ended_at)
             .bind(report.progress_units)
             .bind(report.device_id)
-            .execute(pool)
+            .execute(&mut **tx)
             .await?;
         }
         ProgressFormat::Audio => {
@@ -177,11 +182,29 @@ pub async fn record_session(
             .bind(report.ended_at)
             .bind(report.progress_units)
             .bind(report.device_id)
-            .execute(pool)
+            .execute(&mut **tx)
             .await?;
         }
     }
     Ok(true)
+}
+
+/// Append one session row to the per-format table. Returns `Ok(true)` when
+/// a row was inserted and `Ok(false)` when the report was skipped because
+/// the `book_uuid` is unknown. The handler surfaces the inserted count to
+/// the client so it can tell which queued reports actually persisted.
+///
+/// For batch inserts, prefer [`record_session_tx`] inside a caller-managed
+/// transaction so the entire batch rolls back atomically on error.
+pub async fn record_session(
+    pool: &SqlitePool,
+    user_id: i64,
+    report: &SessionReport,
+) -> Result<bool, ProgressError> {
+    let mut tx = pool.begin().await?;
+    let result = record_session_tx(&mut tx, user_id, report).await?;
+    tx.commit().await?;
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -1,7 +1,8 @@
 //! Unit tests for the `progress` module — `upsert_progress`
 //! roundtrip + last-write-wins + per-user/format isolation,
-//! `BookNotFound` variant, `get_progress` empty-state, and
-//! `record_session` per-format dispatch with unknown-uuid skip.
+//! `BookNotFound` variant, `get_progress` empty-state,
+//! `record_session` per-format dispatch with unknown-uuid skip, and
+//! `record_session_tx` rollback behaviour.
 
 use super::*;
 use crate::{init_db, replace_books};
@@ -237,4 +238,78 @@ async fn record_session_inserts_per_format_row() {
     .await
     .unwrap();
     assert!(!skipped, "unknown uuid should be skipped (returns false)");
+}
+
+#[tokio::test]
+async fn record_session_tx_inserts_row_when_committed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+
+    let mut tx = pool.begin().await.unwrap();
+    let inserted = record_session_tx(
+        &mut tx,
+        user,
+        &SessionReport {
+            book_uuid: uuid.clone(),
+            format: ProgressFormat::Epub,
+            started_at: 100,
+            ended_at: 460,
+            progress_units: 360,
+            device_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(inserted);
+    tx.commit().await.unwrap();
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM reading_sessions WHERE user_id = ? AND book_id = ?",
+    )
+    .bind(user)
+    .bind(book_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+async fn record_session_tx_rollback_leaves_no_rows() {
+    // When the transaction is dropped without committing, no rows must
+    // remain — this is the invariant post_sessions relies on when a
+    // mid-batch error forces an early return.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+
+    {
+        let mut tx = pool.begin().await.unwrap();
+        record_session_tx(
+            &mut tx,
+            user,
+            &SessionReport {
+                book_uuid: uuid.clone(),
+                format: ProgressFormat::Epub,
+                started_at: 100,
+                ended_at: 460,
+                progress_units: 360,
+                device_id: None,
+            },
+        )
+        .await
+        .unwrap();
+        // tx is dropped here without commit → implicit rollback
+    }
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM reading_sessions WHERE user_id = ? AND book_id = ?",
+    )
+    .bind(user)
+    .bind(book_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 0, "dropped transaction must leave no committed rows");
 }

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -67,6 +67,10 @@ pub(super) async fn get_progress(
 /// book uuids are silently skipped inside the db layer (best-effort
 /// telemetry). `recorded` reflects the **inserted** row count so callers
 /// can tell which queued reports actually persisted.
+///
+/// The entire batch runs inside a single transaction — a DB error mid-loop
+/// rolls back all previously inserted rows so the client can safely retry
+/// without risking double-counts.
 pub(super) async fn post_sessions(
     user: AuthUser,
     State(state): State<AppState>,
@@ -77,13 +81,21 @@ pub(super) async fn post_sessions(
             return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
         }
     }
+    let mut tx = match state.pool.begin().await {
+        Ok(tx) => tx,
+        Err(e) => return internal("begin", e),
+    };
     let mut inserted = 0usize;
     for r in &reports {
-        match db::progress::record_session(&state.pool, user.id, r).await {
+        match db::progress::record_session_tx(&mut tx, user.id, r).await {
             Ok(true) => inserted += 1,
             Ok(false) => {}
+            // tx is dropped here, implicitly rolling back
             Err(e) => return internal("record_session", e),
         }
+    }
+    if let Err(e) = tx.commit().await {
+        return internal("commit", e);
     }
     Json(serde_json::json!({ "recorded": inserted })).into_response()
 }

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -90,7 +90,6 @@ pub(super) async fn post_sessions(
         match db::progress::record_session_tx(&mut tx, user.id, r).await {
             Ok(true) => inserted += 1,
             Ok(false) => {}
-            // tx is dropped here, implicitly rolling back
             Err(e) => return internal("record_session", e),
         }
     }

--- a/server/src/backend/progress/tests.rs
+++ b/server/src/backend/progress/tests.rs
@@ -267,3 +267,33 @@ async fn api_post_sessions_rejects_inverted_time_range() {
         .unwrap();
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
+
+#[tokio::test]
+async fn api_post_sessions_batch_of_two_records_both() {
+    // Two valid reports in one POST must both land atomically; `recorded`
+    // must reflect the full count (not a partial commit).
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let body = serde_json::json!([
+        { "book_uuid": uuid, "format": "epub",  "started_at": 100, "ended_at": 460, "progress_units": 360 },
+        { "book_uuid": uuid, "format": "audio", "started_at": 500, "ended_at": 900, "progress_units": 400 },
+    ]);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/progress/sessions")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["recorded"], 2);
+}

--- a/server/src/backend/progress/tests.rs
+++ b/server/src/backend/progress/tests.rs
@@ -297,3 +297,50 @@ async fn api_post_sessions_batch_of_two_records_both() {
     let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(v["recorded"], 2);
 }
+
+#[tokio::test]
+async fn api_post_sessions_rollback_on_second_insert_error() {
+    // Drop the audio-session table so the 2nd insert fails deterministically.
+    // This proves the batch-level transaction rolls back: the 1st (epub)
+    // row must NOT be committed even though the insert was called.
+    let (app, _state, pool) = fixture().await;
+    let (book_id, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    sqlx::query("DROP TABLE listening_sessions")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let body = serde_json::json!([
+        { "book_uuid": uuid, "format": "epub",  "started_at": 100, "ended_at": 460, "progress_units": 360 },
+        { "book_uuid": uuid, "format": "audio", "started_at": 500, "ended_at": 900, "progress_units": 400 },
+    ]);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/progress/sessions")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM reading_sessions WHERE user_id = ? AND book_id = ?",
+    )
+    .bind(user.id)
+    .bind(book_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        count, 0,
+        "rolled-back transaction must leave no reading_sessions rows"
+    );
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **What was broken:** `post_sessions` looped over each `SessionReport` calling `record_session` individually with no surrounding transaction. A DB error mid-batch left sessions 1..N-1 committed with the handler returning 500 — mobile clients retrying on reconnect would double-count those sessions.
- **What was changed:** Added `record_session_tx(tx: &mut Transaction<'_, Sqlite>, ...)` to `db/src/progress.rs` that runs the UUID lookup and insert inside a caller-managed transaction. `record_session` is now a thin wrapper that opens its own transaction and delegates to `record_session_tx`. The `post_sessions` handler now calls `pool.begin()` before the loop and `tx.commit()` after; an error mid-loop returns early and the transaction is implicitly rolled back when `tx` is dropped.
- **Tests added:**
  - `record_session_tx_inserts_row_when_committed` — db-level: verifies rows land when the tx is committed.
  - `record_session_tx_rollback_leaves_no_rows` — db-level: verifies that dropping the tx without commit leaves zero rows, which is the invariant `post_sessions` relies on for the early-return path.
  - `api_post_sessions_batch_of_two_records_both` — handler-level: POST with two valid reports returns `recorded: 2`, confirming the full transaction commits correctly.

## Test plan

- [ ] `cargo test -p omnibus` passes (186 tests, up from 185)
- [ ] `cargo test -p omnibus-db` passes (466 tests, up from 464)
- [ ] `cargo clippy -p omnibus -p omnibus-db --all-targets -- -D warnings` passes
- [ ] New db tests verify rollback leaves zero rows on dropped transaction
- [ ] New handler test verifies a two-report batch returns `recorded: 2`

## Pre-existing failures

None — baseline on `main` was 185 omnibus + 464 omnibus-db, all passing.

Closes #455
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sq662HrJ6dhnxniXdJWFt8)_