### PR TITLE
fix: add stable key: to creator byline loop in book_detail (#402)

### DIFF
--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -465,14 +465,14 @@ fn BdTitleCol(
                         if i > 0 { ", " }
                         if let Some(author_id) = creator.id {
                             Link {
-                                key: "{i}-{creator.name}",
+                                key: "id-{author_id}",
                                 to: Route::AuthorDetail { id: author_id },
                                 class: "bd-author-link",
                                 "{creator.name}"
                             }
                         } else {
                             span {
-                                key: "{i}-{creator.name}",
+                                key: "name-{creator.name}-{creator.role:?}-{creator.file_as:?}",
                                 class: "bd-author-link",
                                 "{creator.name}"
                             }

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -464,9 +464,18 @@ fn BdTitleCol(
                     for (i, creator) in b.creators.iter().enumerate() {
                         if i > 0 { ", " }
                         if let Some(author_id) = creator.id {
-                            Link { to: Route::AuthorDetail { id: author_id }, class: "bd-author-link", "{creator.name}" }
+                            Link {
+                                key: "{i}-{creator.name}",
+                                to: Route::AuthorDetail { id: author_id },
+                                class: "bd-author-link",
+                                "{creator.name}"
+                            }
                         } else {
-                            span { class: "bd-author-link", "{creator.name}" }
+                            span {
+                                key: "{i}-{creator.name}",
+                                class: "bd-author-link",
+                                "{creator.name}"
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- PR #410 already addressed five of the six list-loop sites flagged in #402; the issue was reopened against the creator byline in `frontend/src/pages/book_detail.rs` per a follow-up comment.
- Add `key: "{i}-{creator.name}"` to both the `Link` (author present) and `span` (author missing) branches of the `for (i, creator) in b.creators.iter().enumerate()` loop under `BdTitleCol`. Dioxus now reconciles by stable identity instead of position when creators are added/removed/reordered (e.g. via a metadata override).
- The literal `", "` separator between creators stays unkeyed — text nodes don't need keys.

## Notes vs. the issue runbook

- Sites 1-5 (`series.rs`, `listen/{speed,sleep}_panel.rs`, `landing/table.rs`, `landing/filters.rs`) already carry `key:` attributes on `main` from PR #410, so no changes in those files in this PR.
- The runbook also suggested renaming the destructured `key` in `landing/filters.rs` to `facet` to avoid shadowing the `key:` rsx attribute name. PR #410's body called that site a "Sniffer false positive" — the existing `key: "{key}"` interpolation works correctly because `key:` is parsed as an rsx attribute, not a Rust binding. Leaving that file untouched to keep this PR scoped to the reopen reason; the rename can be a separate cleanup if desired.
- `series.rs` uses `book.id` rather than the issue's suggested `book.uuid` because `EbookMetadata` has `id: i64` (always present) and `unique_identifier: Option<String>` (nullable). That call was made in PR #410 and remains correct.

## Test plan

- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -p omnibus-frontend --features server` — 149 passed, 0 failed
- [x] `cargo fmt` — no changes

This touches markup contracts (no role/label/testid changes, only a virtual-DOM hint), so it should not require new Playwright coverage — but `run_ui_tests` is set on the PR as a safety check.

Closes #402

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSYobgzHvj4g9bnYoFQVdx)_