### PR TITLE
docs: trim rate_limit module doc to summary, move details to item-level (#469)

### DIFF
--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -1,31 +1,8 @@
 //! Reusable in-memory per-IP rate limiter and axum middleware.
 //!
-//! Self-hosted scope is small — a single process, ≤ a few dozen users. A
-//! Redis-backed limiter is overkill; a `Mutex<HashMap<IpAddr, Bucket>>` fits
-//! in < 60 lines and is easy to reason about. Swap for `tower_governor` if
-//! the scope ever grows.
-//!
-//! Policy: fixed-window counter, `max` requests per `window` per principal.
-//! The principal is the request's peer IP (via `ConnectInfo<SocketAddr>`),
-//! with an optional opt-in `X-Forwarded-For` fallback when
-//! `OMNIBUS_TRUST_FORWARDED_FOR=1`.
-//!
-//! Mount via `axum::middleware::from_fn_with_state(limiter, rate_limit_by_ip)`
-//! on whichever sub-router needs limiting. The middleware itself does **not**
-//! filter on path — restriction happens at the router level, so the same
-//! primitive serves `/api/auth/{login,register}`, `/api/search/*`, and any
-//! future route that wants the same treatment without copy-paste.
-//!
-//! Default policy (`RateLimiter::new`) is tuned for the auth endpoints:
-//! 10 requests / 60s / IP. Search uses a separate limiter built via
-//! [`RateLimiter::with_policy`] with a tighter budget (30 / 10s).
-//!
-//! The auth limiter is mounted via [`rate_limit_paths`] with a prefix
-//! allow-list of `/api/auth/{login,register,logout}` — `/api/auth/me` is
-//! deliberately exempt. `/me` is an authenticated read of the caller's
-//! own row and presents no brute-force surface, so sharing the 10/60s
-//! bucket with credential endpoints just throttled legitimate UI boots
-//! (and parallel Playwright workers from the loopback IP).
+//! Fixed-window counter keyed on the request's peer IP (optionally
+//! `X-Forwarded-For` via `OMNIBUS_TRUST_FORWARDED_FOR=1`). Mounted
+//! per-router in `server/src/main.rs`.
 
 use axum::{
     extract::{ConnectInfo, Request, State},
@@ -74,12 +51,22 @@ pub struct RateLimiter {
 }
 
 impl RateLimiter {
-    /// Default policy: `MAX_REQUESTS` per `WINDOW_SECS`.
+    /// Default policy tuned for the auth endpoints: `MAX_REQUESTS` per
+    /// `WINDOW_SECS` per IP (10 / 60s). Mount on the auth sub-router via
+    /// `axum::middleware::from_fn_with_state(limiter, rate_limit_paths)`
+    /// with a prefix allow-list so authenticated reads like
+    /// `/api/auth/me` are exempt — see [`rate_limit_paths`].
     pub fn new() -> Self {
         Self::with_policy(Duration::from_secs(WINDOW_SECS), MAX_REQUESTS)
     }
 
     /// Construct a limiter with an explicit `(window, max requests)` policy.
+    ///
+    /// Used by the search family with a tighter budget (30 / 10s). The
+    /// returned limiter is otherwise identical to [`RateLimiter::new`] —
+    /// the same `Arc` can be shared across REST and RPC routers (via
+    /// [`rate_limit_by_ip`] and [`rate_limit_paths`] respectively) so
+    /// both consume from one per-IP budget.
     pub fn with_policy(window: Duration, max: u32) -> Self {
         Self {
             inner: Mutex::new(HashMap::new()),
@@ -172,6 +159,14 @@ pub async fn rate_limit_by_ip(
 /// Bucket map is shared with whatever limiter is passed in. `main.rs` passes the
 /// *same* `Arc` here and to the REST `/api/search/*` layer so both search
 /// families share one per-IP budget.
+///
+/// The auth sub-router mounts this with a prefix allow-list of
+/// `/api/auth/login`, `/api/auth/register`, and `/api/auth/logout`.
+/// `/api/auth/me` is deliberately omitted from the allow-list: it is an
+/// authenticated read of the caller's own row and presents no brute-force
+/// surface, so sharing the auth bucket with credential endpoints would
+/// throttle legitimate UI boots (and parallel Playwright workers from the
+/// loopback IP) for no security gain.
 pub async fn rate_limit_paths(
     State((limiter, prefixes)): State<(Arc<RateLimiter>, Arc<Vec<&'static str>>)>,
     req: Request,

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -51,11 +51,12 @@ pub struct RateLimiter {
 }
 
 impl RateLimiter {
-    /// Default policy tuned for the auth endpoints: `MAX_REQUESTS` per
-    /// `WINDOW_SECS` per IP (10 / 60s). Mount on the auth sub-router via
-    /// `axum::middleware::from_fn_with_state(limiter, rate_limit_paths)`
-    /// with a prefix allow-list so authenticated reads like
-    /// `/api/auth/me` are exempt — see [`rate_limit_paths`].
+    /// Default policy tuned for the auth endpoints: 10 requests per 60 s per IP.
+    ///
+    /// Mount on the auth sub-router via
+    /// `from_fn_with_state((limiter, prefixes), rate_limit_paths)` with a
+    /// prefix allow-list so authenticated reads like `/api/auth/me` are
+    /// exempt — see [`rate_limit_paths`] for the expected `prefixes` shape.
     pub fn new() -> Self {
         Self::with_policy(Duration::from_secs(WINDOW_SECS), MAX_REQUESTS)
     }


### PR DESCRIPTION
## Summary

- Trim `server/src/rate_limit.rs` `//!` from 28 lines to 5, complying with the ~5-line module-doc cap in `.claude/rules/05-rust-style.md`.
- Move the policy defaults (10/60s auth, 30/10s search) and mount instructions onto `///` blocks for `RateLimiter::new` and `RateLimiter::with_policy`, where they stay co-located with the constructors they describe.
- Move the `/api/auth/{login,register,logout}` allow-list and `/api/auth/me` exclusion rationale onto `rate_limit_paths`, where a router-config drift in `main.rs` will at least keep the doc near the function being called.
- No behaviour or signature changes — doc-only pass.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — passes
- [x] `cargo test -p omnibus` — 187 passed, 0 failed (rate_limit suite included)

## Notes

The previous module header named specific route prefixes (`/api/auth/{login,register,logout}`) that are configured in `server/src/main.rs`, with no compiler feedback if they drift. Moving that text onto `rate_limit_paths` doesn't fix the drift risk, but it puts the documentation closer to the call site that has to match it.

Closes #469

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwUy4VaWa9fd6GtP4tcVtW)_