### PR TITLE
refactor: declare BookDetailPage admin hooks unconditionally to match SSR/WASM (#468)

### DIFF
--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -21,8 +21,10 @@ mod progress;
 mod series;
 mod tags;
 
-// auth exports only exist under web or mobile; under server-only the module is empty.
-#[cfg(any(feature = "web", feature = "mobile"))]
+// auth exports exist under web, mobile, and server-only (the last only
+// re-exports the SSR `current_user` stub so pages can call `data::current_user`
+// unconditionally without diverging hook order between SSR and WASM).
+#[cfg(any(feature = "web", feature = "mobile", feature = "server"))]
 pub use auth::*;
 pub use authors::*;
 pub use books::*;

--- a/frontend/src/data/auth.rs
+++ b/frontend/src/data/auth.rs
@@ -7,6 +7,12 @@
 
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
+// Server-only (no web) build still needs `UserSummary` for the SSR
+// `current_user` stub below. The mobile-build `current_user` stub uses the
+// import above; the wider `cfg` here keeps SSR self-sufficient without
+// dragging in the unused `LoginRequest` / `LoginResponse` / `RegisterRequest`.
+#[cfg(all(feature = "server", not(any(feature = "web", feature = "mobile"))))]
+use omnibus_shared::UserSummary;
 
 #[cfg(feature = "mobile")]
 use super::{client_kind, drain_error, http_client, token_store, with_bearer, DataError};
@@ -168,6 +174,18 @@ pub async fn current_user() -> Result<Option<UserSummary>, String> {
     let user = res.json::<UserSummary>().await.map_err(|e| e.to_string())?;
     super::web_auth_state::notify_authorized();
     Ok(Some(user))
+}
+
+/// Non-web stub for `current_user`. The real `/api/auth/me` call is
+/// web-only — under SSR (`feature = "server"` without `"web"`) there's no
+/// browser cookie jar to resolve, and the mobile build never renders the
+/// admin-only affordances driven off this signal. Returning `Ok(None)`
+/// lets pages declare the `use_signal` + `use_effect` pair unconditionally
+/// (so SSR and WASM hook counts match) without any admin surface leaking
+/// into the prerendered markup or appearing on mobile.
+#[cfg(all(any(feature = "server", feature = "mobile"), not(feature = "web")))]
+pub async fn current_user() -> Result<Option<UserSummary>, String> {
+    Ok(None)
 }
 
 #[cfg(feature = "web")]

--- a/frontend/src/pages/book_detail.rs
+++ b/frontend/src/pages/book_detail.rs
@@ -45,12 +45,17 @@ pub fn BookDetailPage(uuid: String) -> Element {
     // (signals read inside `use_effect` re-arm it).
     let refresh = use_signal(|| 0u32);
 
-    // Admin gating for the "Merge with…" affordance. Web-only — mobile
-    // renders no admin surfaces; the server-side `AdminUser` extractor
-    // on `rpc_merge_books` is the actual security boundary.
-    #[cfg(feature = "web")]
+    // Admin gating for the "Merge with…" affordance. The signal and the
+    // effect are declared unconditionally so SSR and the hydrating WASM
+    // bundle agree on hook count and order — Dioxus tracks hooks
+    // positionally, and a cfg-gated declaration would diverge the two.
+    // The effect itself only runs on the client (Dioxus skips `use_effect`
+    // during SSR), and `data::current_user()` resolves to an
+    // `Ok(None)`-returning stub under server-only builds, so no admin
+    // surface ever leaks into the prerendered markup. Mobile renders no
+    // admin surfaces; the server-side `AdminUser` extractor on
+    // `rpc_merge_books` is the actual security boundary.
     let mut is_admin = use_signal(|| false);
-    #[cfg(feature = "web")]
     use_effect(move || {
         spawn(async move {
             if let Ok(Some(user)) = data::current_user().await {
@@ -127,10 +132,10 @@ pub fn BookDetailPage(uuid: String) -> Element {
         };
     };
 
-    #[cfg(feature = "web")]
+    // `is_admin` starts at `false` and only flips to `true` on the web
+    // client after `current_user()` resolves an admin user, so this read
+    // returns `false` during SSR and for non-admins on every platform.
     let is_admin_flag = is_admin();
-    #[cfg(not(feature = "web"))]
-    let is_admin_flag = false;
     #[cfg_attr(feature = "mobile", allow(unused_variables))]
     let page_title = b.title.clone().unwrap_or_else(|| b.filename.clone());
     #[cfg_attr(feature = "mobile", allow(unused_variables))]


### PR DESCRIPTION
## Summary

- Remove the `#[cfg(feature = "web")]` guards on the `is_admin` `use_signal` and the populating `use_effect` in `BookDetailPage`. Dioxus tracks hooks positionally; gating these declarations on `feature = "web"` made the SSR (`feature = "server"`) hook count diverge from the hydrating WASM client, a latent source of unexpected re-renders / state mismatches.
- Add an `Ok(None)`-returning `current_user` stub in `frontend/src/data/auth.rs` for builds that don't have `feature = "web"` (i.e. server-only SSR and mobile-only), and extend the `data::auth` re-export in `frontend/src/data.rs` to cover the `server` feature so the stub is reachable as `data::current_user`.
- Collapse the cfg-split `is_admin_flag` derivation into a single read of the signal. `is_admin` starts at `false` and only flips to `true` on the web client after `current_user()` resolves an admin user, preserving the invariant that the merge affordance only appears for admins on web.

## Invariant preservation

- The admin check still only fires on the web client. `use_effect` is client-only by design in Dioxus (skipped during SSR), and under server-only / mobile-only builds `data::current_user()` short-circuits to `Ok(None)` — so SSR never embeds admin markup, and mobile never shows it.
- `#[cfg(not(feature = "mobile"))]` guards on `merge_open` / `merge_result` / `undo_error` are deliberately untouched (out of scope per the issue). Those cfgs match between SSR (`server`, not `mobile`) and WASM (`web`, not `mobile`), so they don't desynchronize hook order.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — 152 passed, 0 failed
- [ ] `--features web` clippy skipped: `wasm32-unknown-unknown` rustup target not installed in this sandbox
- [ ] Playwright E2E (`run_ui_tests` label set) — covers admin vs. non-admin book detail paths

## Notes

- Pre-existing default-feature compilation errors around `async_sleep_ms` in `merge_dialog` / `search_palette` / `worker_status` exist on `origin/main` and are unrelated to this change.
- `frontend/src/pages/author.rs` carries the same cfg-gated admin hook pattern (`#[cfg(feature = "web")]` on `use_signal` + `use_effect`); the issue explicitly scoped this pass to `book_detail.rs`, so author.rs is left for a follow-up.

Closes #468

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwUy4VaWa9fd6GtP4tcVtW)_