### PR TITLE
refactor: group >5-prop Dioxus components into structs (#467)

### DIFF
--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -279,10 +279,12 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
                 }
                 if !filtered.is_empty() || show_create_row {
                     SuggestionDropdown {
-                        filtered: filtered.clone(),
-                        show_create_row,
-                        typed: typed.clone(),
-                        highlight: highlight(),
+                        selection: DropdownSelectionState {
+                            filtered: filtered.clone(),
+                            show_create_row,
+                            typed: typed.clone(),
+                            highlight: highlight(),
+                        },
                         dropdown_header: props.dropdown_header.clone(),
                         testid: testid_suggestions.clone(),
                         on_pick: move |name: String| commit(name),
@@ -338,18 +340,34 @@ fn ChipList(
     }
 }
 
-/// Autocomplete dropdown — filtered suggestion rows plus an optional
-/// "+ Create" trailing row. `on_pick` fires with the chosen name.
-#[component]
-fn SuggestionDropdown(
+/// Per-render selection state for the dropdown: the visible suggestion
+/// rows, whether a "+ Create" trailing row is shown, the raw text to
+/// quote inside that row, and the keyboard highlight cursor. Grouped
+/// so the dropdown signature stays compact as new pieces of selection
+/// state accrete.
+#[derive(Clone, PartialEq)]
+struct DropdownSelectionState {
     filtered: Vec<SuggestionItem>,
     show_create_row: bool,
     typed: String,
     highlight: Option<usize>,
+}
+
+/// Autocomplete dropdown — filtered suggestion rows plus an optional
+/// "+ Create" trailing row. `on_pick` fires with the chosen name.
+#[component]
+fn SuggestionDropdown(
+    selection: DropdownSelectionState,
     dropdown_header: String,
     testid: String,
     on_pick: EventHandler<String>,
 ) -> Element {
+    let DropdownSelectionState {
+        filtered,
+        show_create_row,
+        typed,
+        highlight,
+    } = selection;
     let create_row_index = filtered.len();
     rsx! {
         ul {

--- a/frontend/src/components/search_palette/keyboard.rs
+++ b/frontend/src/components/search_palette/keyboard.rs
@@ -9,10 +9,7 @@ use super::model::{facet_query, FlatItem};
 use super::PaletteOpen;
 use crate::Route;
 
-/// Everything the palette's keydown handler needs to read or mutate.
-/// Bundled so [`make_keydown_handler`] doesn't take a long parameter
-/// list; the fields are all `Copy` (Dioxus signals + the navigator)
-/// so the struct is itself cheap to move into the returned closure.
+/// Inputs read or mutated by the palette's keydown handler.
 pub(super) struct KeyboardContext {
     pub(super) open: PaletteOpen,
     pub(super) selected: Signal<usize>,

--- a/frontend/src/components/search_palette/keyboard.rs
+++ b/frontend/src/components/search_palette/keyboard.rs
@@ -9,15 +9,29 @@ use super::model::{facet_query, FlatItem};
 use super::PaletteOpen;
 use crate::Route;
 
+/// Everything the palette's keydown handler needs to read or mutate.
+/// Bundled so [`make_keydown_handler`] doesn't take a long parameter
+/// list; the fields are all `Copy` (Dioxus signals + the navigator)
+/// so the struct is itself cheap to move into the returned closure.
+pub(super) struct KeyboardContext {
+    pub(super) open: PaletteOpen,
+    pub(super) selected: Signal<usize>,
+    pub(super) has_navigated: Signal<bool>,
+    pub(super) flat_items: Memo<Vec<FlatItem>>,
+    pub(super) query: Signal<String>,
+    pub(super) nav: dioxus_router::Navigator,
+}
+
 /// Build the `onkeydown` event handler for the palette panel.
-pub(super) fn make_keydown_handler(
-    mut open: PaletteOpen,
-    mut selected: Signal<usize>,
-    mut has_navigated: Signal<bool>,
-    flat_items: Memo<Vec<FlatItem>>,
-    query: Signal<String>,
-    nav: dioxus_router::Navigator,
-) -> impl FnMut(Event<KeyboardData>) {
+pub(super) fn make_keydown_handler(ctx: KeyboardContext) -> impl FnMut(Event<KeyboardData>) {
+    let KeyboardContext {
+        mut open,
+        mut selected,
+        mut has_navigated,
+        flat_items,
+        query,
+        nav,
+    } = ctx;
     move |evt: Event<KeyboardData>| {
         let key = evt.key();
         match key {

--- a/frontend/src/components/search_palette/overlay.rs
+++ b/frontend/src/components/search_palette/overlay.rs
@@ -8,7 +8,7 @@ use dioxus::prelude::*;
 use dioxus_router::use_navigator;
 use omnibus_shared::PaletteResults;
 
-use super::keyboard::make_keydown_handler;
+use super::keyboard::{make_keydown_handler, KeyboardContext};
 use super::model::{build_flat_items, plural};
 use super::results::SpResultsList;
 use super::PaletteOpen;
@@ -41,7 +41,14 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
         open.0.set(false);
     };
 
-    let on_keydown = make_keydown_handler(open, selected, has_navigated, flat_items, query, nav);
+    let on_keydown = make_keydown_handler(KeyboardContext {
+        open,
+        selected,
+        has_navigated,
+        flat_items,
+        query,
+        nav,
+    });
 
     // Debounced search. Uses gloo_timers on web, tokio::time on server.
     // Each keystroke cancels the prior task (debounce sleep + RPC) before

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -245,9 +245,11 @@ fn render_author(
                         author_name: a.name.clone(),
                         book_count: a.book_count,
                         server_url: server_url.clone(),
-                        show_confirm,
-                        deleting,
-                        delete_error,
+                        state: AuthorDeleteState {
+                            show_confirm,
+                            deleting,
+                            delete_error,
+                        },
                     }
                 });
                 #[cfg(feature = "mobile")]
@@ -316,6 +318,19 @@ fn render_author(
     }
 }
 
+/// Transient state for the delete-author modal: whether the confirm
+/// pane is open, whether a delete RPC is in flight, and the most
+/// recent error message (if any). Grouped because all three change
+/// together across the confirm/run/error lifecycle, and keep the
+/// modal's signature focused on the stable identity props.
+#[cfg(not(feature = "mobile"))]
+#[derive(Clone, Copy, PartialEq)]
+struct AuthorDeleteState {
+    show_confirm: Signal<bool>,
+    deleting: Signal<bool>,
+    delete_error: Signal<Option<String>>,
+}
+
 /// Confirmation modal for the admin "Delete author" action. On confirm,
 /// hits the `rpc_delete_author` server fn (which un-links every book,
 /// inserts the name into `ignored_authors`, and refreshes FTS) then
@@ -330,10 +345,13 @@ fn AuthorDeleteModal(
     author_name: String,
     book_count: usize,
     server_url: String,
-    show_confirm: Signal<bool>,
-    deleting: Signal<bool>,
-    delete_error: Signal<Option<String>>,
+    state: AuthorDeleteState,
 ) -> Element {
+    let AuthorDeleteState {
+        show_confirm,
+        deleting,
+        delete_error,
+    } = state;
     let mut show_confirm = show_confirm;
     let mut deleting = deleting;
     let mut delete_error = delete_error;

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -18,6 +18,28 @@ enum Sort {
     BookCount,
 }
 
+/// Library-wide totals rendered in the header's subtitle. Grouped so the
+/// header doesn't grow a long `total_*` prop list.
+#[derive(Clone, PartialEq, Eq)]
+struct AuthorIndexCounts {
+    total_authors: usize,
+    total_books: usize,
+}
+
+/// Filter + sort + alphabet-strip state for the header. The strip's
+/// visibility, glyphs, and footnote totals all change together as the
+/// filtered set changes, so they ride the same struct.
+#[derive(Clone, PartialEq, Eq)]
+struct AuthorIndexFilter {
+    filter: String,
+    sort: Sort,
+    show_letters: bool,
+    alphabet: Vec<char>,
+    present_letters: std::collections::HashSet<char>,
+    letter_count: usize,
+    filtered_count: usize,
+}
+
 /// Authors index page — browse all authors in the library.
 #[component]
 pub fn AuthorsIndexPage() -> Element {
@@ -120,18 +142,25 @@ pub fn AuthorsIndexPage() -> Element {
 
     let any_in_library = !all.is_empty();
 
+    let counts = AuthorIndexCounts {
+        total_authors,
+        total_books,
+    };
+    let filter_state = AuthorIndexFilter {
+        filter: filter(),
+        sort: sort(),
+        show_letters,
+        alphabet: alphabet.clone(),
+        present_letters: present_letters.clone(),
+        letter_count: letters.len(),
+        filtered_count: filtered.len(),
+    };
+
     rsx! {
         div { class: "idx-page",
             AuthorsIndexHeader {
-                total_authors,
-                total_books,
-                filter: filter(),
-                sort: sort(),
-                show_letters,
-                alphabet: alphabet.clone(),
-                present_letters: present_letters.clone(),
-                letter_count: letters.len(),
-                filtered_count: filtered.len(),
+                counts,
+                filter_state,
                 on_filter: move |v| filter.set(v),
                 on_sort: move |s| sort.set(s),
             }
@@ -190,18 +219,24 @@ fn authors_index_body<'a>(
 /// Header: breadcrumb, hero, filter/sort toolbar, optional A–Z letter strip.
 #[component]
 fn AuthorsIndexHeader(
-    total_authors: usize,
-    total_books: usize,
-    filter: String,
-    sort: Sort,
-    show_letters: bool,
-    alphabet: Vec<char>,
-    present_letters: std::collections::HashSet<char>,
-    letter_count: usize,
-    filtered_count: usize,
+    counts: AuthorIndexCounts,
+    filter_state: AuthorIndexFilter,
     on_filter: EventHandler<String>,
     on_sort: EventHandler<Sort>,
 ) -> Element {
+    let AuthorIndexCounts {
+        total_authors,
+        total_books,
+    } = counts;
+    let AuthorIndexFilter {
+        filter,
+        sort,
+        show_letters,
+        alphabet,
+        present_letters,
+        letter_count,
+        filtered_count,
+    } = filter_state;
     rsx! {
         div { class: "idx-header",
             nav {

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -22,7 +22,7 @@ use filtering::{apply_filters, facet_counts};
 use filters::{EmptyFiltered, FilterSidebar, FormatChips};
 use grid::BookGrid;
 use sorting::{default_dir_for, sort_books, toggle_dir};
-use table::BookTable;
+use table::{BookTable, BookTableContext};
 use toolbar::Toolbar;
 
 /// Landing page — primary library surface.
@@ -256,10 +256,12 @@ pub fn LandingPage() -> Element {
                                         save(next);
                                     }
                                 },
-                                server_url: server_url_for_row.clone(),
-                                is_admin: is_admin(),
-                                author_suggestions,
-                                tag_suggestions,
+                                ctx: BookTableContext {
+                                    server_url: server_url_for_row.clone(),
+                                    is_admin: is_admin(),
+                                    author_suggestions: author_suggestions.into(),
+                                    tag_suggestions: tag_suggestions.into(),
+                                },
                             }
                         },
                         ViewMode::Grid => rsx! {

--- a/frontend/src/pages/landing/table.rs
+++ b/frontend/src/pages/landing/table.rs
@@ -33,18 +33,30 @@ enum EditField {
     Authors,
 }
 
+/// Per-page context threaded through `BookTable` → `EbookRow` → cells:
+/// the configured server origin (empty on web, prefixed on mobile),
+/// whether the current viewer can inline-edit, and the canonical
+/// author/tag suggestion pools used by the chip editors. Wrapped in
+/// a struct so the table and row signatures don't grow a long
+/// passthrough prop list as more per-page context is added.
+///
+/// The `ReadSignal` handles stay as fields so the suggestion pools
+/// are still forwarded by reference (no clones at intermediate
+/// layers) — the struct itself only carries the handle.
+#[derive(Clone, PartialEq)]
+pub(super) struct BookTableContext {
+    pub(super) server_url: String,
+    pub(super) is_admin: bool,
+    pub(super) author_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    pub(super) tag_suggestions: ReadSignal<Vec<SuggestionItem>>,
+}
+
 #[component]
 pub(super) fn BookTable(
     books: Vec<EbookMetadata>,
     prefs: ViewPrefs,
     on_sort: EventHandler<SortKey>,
-    server_url: String,
-    is_admin: bool,
-    // Forwarded by reference (ReadSignal) all the way down so the
-    // suggestion pool isn't cloned at any intermediate layer — even on
-    // libraries with thousands of authors.
-    author_suggestions: ReadSignal<Vec<SuggestionItem>>,
-    tag_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    ctx: BookTableContext,
 ) -> Element {
     rsx! {
         div {
@@ -101,10 +113,7 @@ pub(super) fn BookTable(
                         EbookRow {
                             key: "{book.filename}",
                             book: book,
-                            server_url: server_url.clone(),
-                            is_admin,
-                            author_suggestions,
-                            tag_suggestions,
+                            ctx: ctx.clone(),
                         }
                     }
                 }
@@ -146,13 +155,13 @@ fn SortableHeader(
 }
 
 #[component]
-fn EbookRow(
-    book: EbookMetadata,
-    server_url: String,
-    is_admin: bool,
-    author_suggestions: ReadSignal<Vec<SuggestionItem>>,
-    tag_suggestions: ReadSignal<Vec<SuggestionItem>>,
-) -> Element {
+fn EbookRow(book: EbookMetadata, ctx: BookTableContext) -> Element {
+    let BookTableContext {
+        server_url,
+        is_admin,
+        author_suggestions,
+        tag_suggestions,
+    } = ctx;
     // Stable per-book uuid drives both the detail-route URL and the
     // thumbnail URL — see `Route::BookDetail` for why it's keyed on the
     // uuid instead of `books.id`.

--- a/frontend/src/pages/landing/table.rs
+++ b/frontend/src/pages/landing/table.rs
@@ -33,16 +33,7 @@ enum EditField {
     Authors,
 }
 
-/// Per-page context threaded through `BookTable` → `EbookRow` → cells:
-/// the configured server origin (empty on web, prefixed on mobile),
-/// whether the current viewer can inline-edit, and the canonical
-/// author/tag suggestion pools used by the chip editors. Wrapped in
-/// a struct so the table and row signatures don't grow a long
-/// passthrough prop list as more per-page context is added.
-///
-/// The `ReadSignal` handles stay as fields so the suggestion pools
-/// are still forwarded by reference (no clones at intermediate
-/// layers) — the struct itself only carries the handle.
+/// Per-page context threaded through `BookTable` → `EbookRow` → cells.
 #[derive(Clone, PartialEq)]
 pub(super) struct BookTableContext {
     pub(super) server_url: String,

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -19,7 +19,7 @@ mod sidebar;
 
 use form_grid::{FormFields, FormGrid, FormSuggestions};
 use header::{Breadcrumb, PageHeader};
-use save_bar::SaveBar;
+use save_bar::{DirtyState, SaveBar, SaveStatus};
 use sidebar::Sidebar;
 
 /// Top-level metadata edit page component, mounted at `/books/:uuid/edit`.
@@ -303,10 +303,14 @@ fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
 
             SaveBar {
                 uuid,
-                dirty_fields,
-                dirty_count,
-                saving,
-                save_error,
+                dirty: DirtyState {
+                    fields: dirty_fields,
+                    count: dirty_count,
+                },
+                status: SaveStatus {
+                    saving,
+                    error: save_error,
+                },
                 on_save,
             }
         }

--- a/frontend/src/pages/metadata_edit/save_bar.rs
+++ b/frontend/src/pages/metadata_edit/save_bar.rs
@@ -9,19 +9,14 @@ use dioxus_router::Link;
 
 use crate::Route;
 
-/// Dirty-tracking memos forwarded to the save bar. Grouped because
-/// the list of edited field labels and their count are always derived
-/// from the same parent computation.
+/// Dirty-tracking memos forwarded to the save bar.
 #[derive(Clone, Copy, PartialEq)]
 pub(super) struct DirtyState {
     pub(super) fields: Memo<Vec<&'static str>>,
     pub(super) count: Memo<usize>,
 }
 
-/// In-flight save status: whether a POST is on the wire, and the most
-/// recent error message if the last save failed. Grouped because the
-/// button label and the inline error text are both functions of the
-/// same lifecycle.
+/// In-flight save status: in-progress flag plus last error message.
 #[derive(Clone, Copy, PartialEq)]
 pub(super) struct SaveStatus {
     pub(super) saving: Signal<bool>,

--- a/frontend/src/pages/metadata_edit/save_bar.rs
+++ b/frontend/src/pages/metadata_edit/save_bar.rs
@@ -9,16 +9,41 @@ use dioxus_router::Link;
 
 use crate::Route;
 
+/// Dirty-tracking memos forwarded to the save bar. Grouped because
+/// the list of edited field labels and their count are always derived
+/// from the same parent computation.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct DirtyState {
+    pub(super) fields: Memo<Vec<&'static str>>,
+    pub(super) count: Memo<usize>,
+}
+
+/// In-flight save status: whether a POST is on the wire, and the most
+/// recent error message if the last save failed. Grouped because the
+/// button label and the inline error text are both functions of the
+/// same lifecycle.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct SaveStatus {
+    pub(super) saving: Signal<bool>,
+    pub(super) error: Signal<Option<String>>,
+}
+
 /// Dirty-field summary + Discard/Save actions.
 #[component]
 pub(super) fn SaveBar(
     uuid: String,
-    dirty_fields: Memo<Vec<&'static str>>,
-    dirty_count: Memo<usize>,
-    saving: Signal<bool>,
-    save_error: Signal<Option<String>>,
+    dirty: DirtyState,
+    status: SaveStatus,
     on_save: EventHandler<()>,
 ) -> Element {
+    let DirtyState {
+        fields: dirty_fields,
+        count: dirty_count,
+    } = dirty;
+    let SaveStatus {
+        saving,
+        error: save_error,
+    } = status;
     rsx! {
         div { class: "me-save-bar",
             if dirty_count() > 0 {


### PR DESCRIPTION
## Summary

Replaces long passthrough prop lists on six `frontend/` components with grouped `#[derive(PartialEq, Clone)]` structs so each `#[component]` function takes <=5 params. Pure structural change — no behavior, testid, or markup-contract changes.

Per the issue, Dioxus diffing widens its equality surface with every prop, and long call sites bury what changes. Each refactor groups props that already change together, so call sites stay readable without sacrificing diff granularity.

## Per-component breakdown

| Component | File | Props before | Props after | Grouping |
| --- | --- | ---: | ---: | --- |
| `AuthorsIndexHeader` | `frontend/src/pages/authors_index.rs` | 11 | 4 | `AuthorIndexCounts` (totals) + `AuthorIndexFilter` (filter/sort/alphabet strip) + 2 callbacks |
| `BookTable` / `EbookRow` | `frontend/src/pages/landing/table.rs` | 7 / 5 | 4 / 2 | `BookTableContext` groups `server_url`/`is_admin`/`author_suggestions`/`tag_suggestions`; threaded through the row via the same struct |
| `SuggestionDropdown` | `frontend/src/components/chip_editor.rs` | 7 | 4 | `DropdownSelectionState` groups `filtered`/`show_create_row`/`typed`/`highlight` |
| `AuthorDeleteModal` | `frontend/src/pages/author.rs` | 7 | 5 | `AuthorDeleteState` groups the three transient `Signal`s (`show_confirm`/`deleting`/`delete_error`) |
| `SaveBar` | `frontend/src/pages/metadata_edit/save_bar.rs` | 6 | 4 | `DirtyState` groups dirty memos; `SaveStatus` groups saving/error signals |
| `make_keydown_handler` (plain fn) | `frontend/src/components/search_palette/keyboard.rs` | 6 | 1 | `KeyboardContext` bundles the palette signals + memo + navigator |

Callbacks (`EventHandler<T>`) are kept as standalone params throughout — grouping them into a struct would only add noise.

## Notes

- `BookTableContext` keeps `ReadSignal<Vec<SuggestionItem>>` handles as fields so the suggestion pool is still forwarded by reference — no clones at intermediate layers. The call site in `landing.rs` uses `.into()` to convert the parent's `Signal<...>` to a `ReadSignal<...>` explicitly (Dioxus's component-prop coercion doesn't fire inside a struct literal).
- All grouping structs implement `PartialEq` (and `Clone`/`Copy` as appropriate) so Dioxus diffing still compares them field-wise — diff granularity is preserved.
- Scope was kept strict: no unrelated cleanups, no markup changes, no testid renames.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-frontend --features server` — 152 passed, 0 failed
- [x] `cargo check -p omnibus-frontend --features web` — clean (pre-existing warnings unchanged)
- [x] `cargo check -p omnibus-frontend --features mobile` — clean (pre-existing warning unchanged)
- [ ] Playwright re-run via the `run_ui_tests` label — exercises the affected pages (landing table, authors index, author detail, metadata edit, search palette)

Closes #467

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwUy4VaWa9fd6GtP4tcVtW)_