### PR TITLE
docs: design docs for 8 deferred db-review schema findings

### DIFF
--- a/docs/design/db-review-f1-user-data-soft-refs.md
+++ b/docs/design/db-review-f1-user-data-soft-refs.md
@@ -1,0 +1,401 @@
+# F1 — User data: `book_id` CASCADE → `book_uuid` soft-ref
+
+Status: Proposed — deferred from db.md F1, awaiting decision.
+
+This doc frames a data-model decision the operator must make before any
+schema or code is written. It is **not** an implementation plan; the SQL
+and code below are sketches to make the trade-offs concrete. No `.sql` or
+`.rs` file is to be changed until the [Decision required](#decision-required)
+section is resolved.
+
+## Problem
+
+Five user-data tables key on the numeric `books.id` with
+`ON DELETE CASCADE`:
+
+- `reading_progress`, `bookmarks`, `reading_sessions`, `listening_sessions`
+  — `book_id INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE`
+  (`db/migrations/0013_reading_progress.sql:15,39,52,65`).
+- `highlights` — same shape
+  (`db/migrations/0017_highlights.sql:10`).
+
+`books.id` is **not durable**. A reindex's Removed bucket hard-deletes
+the row — `DELETE FROM books WHERE library_id = ? AND uuid IN (...)` in
+`sync_removed` (`db/src/sync/books.rs:154-160`) — and the cascade silently
+takes every reading position, bookmark, session, and highlight with it.
+The nuke-and-pave `replace_books` (`db/src/sync/books.rs:538-563`) is
+worse: it lists every existing uuid as Removed, so a single full reindex
+of a library wipes **all** user data for that library. `books.id` also
+moves when `library_id` cascades from a settings library-path change, so
+even a path edit can destroy the lot.
+
+The roadmap forbids exactly this pattern. `docs/roadmap/3-2-ratings-journaling.md:30`:
+"Do not use `book_id` (INT FK with `ON DELETE CASCADE`) for user data.
+Cascade-delete is appropriate for ephemeral derived data (covers, FTS
+index) but not for user-generated data." It prescribes a `book_uuid TEXT
+NOT NULL` soft reference (no FK, no cascade) so a pruned book's row
+*detaches* and auto-relinks when the same uuid reappears.
+
+The schema is already internally inconsistent: `metadata_overrides`
+follows the correct pattern (`book_uuid TEXT NOT NULL PRIMARY KEY`, no
+FK — `db/migrations/0007_metadata_overrides.sql:16-22`), and `sync_books`
+explicitly documents leaving it untouched across reindex
+(`db/src/sync/books.rs:77-80`). The five user-data tables are the
+holdouts.
+
+Who this bites: **F3.2 ratings/journaling** and **F3.4 stats** (which
+reads `reading_sessions`/`listening_sessions`) build directly on these
+tables. Once real ratings, journals, and session history accumulate, a
+reindex or path change is a data-loss event with no recovery — and the
+fix gets more expensive the longer it waits, because the migration has to
+preserve live user rows rather than empty schema.
+
+Two adjacent defects fall inside the same column and should travel with
+this change:
+
+- **F9** — `record_session_tx` resolves the book with a bare
+  `SELECT id FROM books WHERE uuid = ?` (`db/src/progress.rs:150`) that
+  ignores `merged_uuids`, so a session for a since-merged book is silently
+  dropped (`Ok(false)`). The canonical resolver `resolve_book_id_by_uuid`
+  (`db/src/books/get.rs:132-145`) already folds in `merged_uuids`; the
+  write paths `upsert_progress` / `create_highlight` use it
+  (`db/src/progress.rs:63`, `db/src/highlights/mod.rs:36`).
+- **Merge omits highlights** — `move_progress_and_history`
+  (`db/src/merge/transaction.rs:298-340`) re-parents `reading_progress`
+  (with latest-wins dedupe), `bookmarks`, `reading_sessions`, and
+  `listening_sessions` by `book_id`, but never touches `highlights`. A
+  manual merge today loses the source book's highlights. The rewrite to
+  `book_uuid` must add `highlights` to the re-parent set.
+
+## Decision required
+
+The operator must resolve two coupled model choices. Everything else in
+this doc is mechanical once these are fixed.
+
+**Decision 1 — Survival semantics.** When a book is removed from disk and
+its `books` row is gone, soft-ref user rows now survive as orphans. Pick:
+
+- **(1a) Survive indefinitely, no GC.** Orphan rows linger forever and
+  auto-relink if the same uuid reappears on a future scan. Matches
+  `metadata_overrides` behavior exactly. Simplest; unbounded orphan growth
+  (overlaps F10's no-GC concern).
+- **(1b) Relink/GC pass at `init_db`.** An idempotent boot pass prunes (or
+  relinks) rows whose `book_uuid` is in neither `books.uuid` nor
+  `merged_uuids`. Bounds orphan growth; adds a destructive boot path that
+  must be conservative or it becomes a *new* data-loss surface.
+
+**Decision 2 — `BookNotFound` write guard.** Today `upsert_progress` and
+`create_highlight` reject writes for an unknown uuid
+(`ProgressError::BookNotFound` / `HighlightError::BookNotFound`). With a
+soft ref we could:
+
+- **(2a) Keep the guard.** A write still resolves the uuid against
+  `books`/`merged_uuids` first; you cannot record progress for a book the
+  server has never indexed. Smallest blast radius — the resolver call
+  stays, only the *stored* column changes from `id` to `uuid`.
+- **(2b) Relax the guard.** Accept a write for any uuid, indexed or not
+  (the row simply starts detached). Enables offline-first clients writing
+  ahead of an index, but lets a typo'd uuid persist forever and couples
+  tightly to Decision 1b's GC to ever clean those up.
+
+These are co-dependent with **F2** (the uuid must be *stable* — a
+path-derived `stable_uuid` re-keys every book on a library-root change, so
+even uuid-soft-ref rows orphan) and **F10** (a shared reconcile/GC that
+`metadata_overrides` also needs). See
+[Sequencing & dependencies](#sequencing--dependencies).
+
+## Options
+
+All three options share the **same migration** (Option A below is the
+migration; B and C layer survival policy on top). SQLite reality
+constrains the shape: you cannot drop an FK/cascade or change a column
+type in place, so each table needs a full **table-recreate dance**
+(`CREATE … _new`, `INSERT … SELECT` backfill, `DROP`, `RENAME`, recreate
+indexes/CHECK/UNIQUE). Migrations are append-only and forward-only
+(rule 06).
+
+### Option A — Soft-ref columns only, survive-no-GC (Decision 1a + 2a)
+
+**How it works.** Recreate the five tables with `book_uuid TEXT NOT NULL`
+replacing `book_id`, dropping the FK and cascade. Backfill `book_uuid`
+in-migration by joining the old `book_id` to `books.uuid`. Write paths
+keep the resolver (guard stays) but store and key on `book_uuid` instead
+of resolving to `id`. No boot GC: orphans linger and auto-relink, exactly
+like `metadata_overrides`.
+
+**Migration shape.** One `0019_user_data_soft_ref.sql`, five table
+recreates. Backfill is the `INSERT … SELECT … JOIN books` itself — no
+boot-time pass needed, because every existing row is already
+uuid-addressable through its current `book_id`. Rows whose book is already
+gone (already lost today) are simply not carried forward.
+
+**Blast radius.** `db/src/progress.rs`, `db/src/highlights/mod.rs`,
+`db/src/merge/transaction.rs` and their sibling tests; server integration
+tests. No new boot code path. ~L effort, concentrated in the migration +
+the three modules.
+
+**Pros.** Matches the one correct precedent in the schema
+(`metadata_overrides`); smallest new surface; no destructive boot path to
+get wrong; fully reversible-in-spirit (orphans are harmless data, not
+deletions). **Cons.** Unbounded orphan growth over time; dead rows slow
+any future `LEFT JOIN` against these tables (the same drag F10 notes for
+`metadata_overrides`); defers the GC question rather than answering it.
+
+### Option B — Soft-ref + idempotent relink/GC at boot (Decision 1b + 2a)
+
+**How it works.** Same migration as A, plus an idempotent
+`reconcile_user_data` pass in `init_db` (modeled on
+`normalize::backfill_norm_columns`) that, on every boot, deletes user rows
+whose `book_uuid` matches neither `books.uuid` nor `merged_uuids`.
+
+**Migration shape.** Identical `0019` migration as A, plus a new function
+in `db/src/normalize.rs` (or a sibling reconcile module) called from
+`db/src/pool.rs` right after `backfill_norm_columns` at line 56.
+
+**Blast radius.** A's surface plus a destructive boot path that runs
+against every developer DB and production on every start. Needs a grace
+mechanism so a *legitimately detached-pending-reindex* row (book removed
+this boot, re-added next reindex) is not pruned in the window between.
+Without a grace window this re-introduces a data-loss path — the exact
+class of bug F1 exists to kill.
+
+**Pros.** Bounds orphan growth; keeps the join tables lean; lands the GC
+that F10 wants for `metadata_overrides` too (shareable). **Cons.** A
+boot-time `DELETE` on user data is the highest-risk code in this whole
+change; getting the grace window wrong silently deletes the data we just
+protected; couples F1's timeline to F10's design. Pruning is irreversible
+once it runs.
+
+### Option C — Soft-ref + relax write guard (Decision 1a/1b + 2b)
+
+**How it works.** Same migration; additionally drop the `BookNotFound`
+guard so `upsert_progress`/`create_highlight` accept any uuid. Rows for
+not-yet-indexed books start detached and bind when the book appears.
+
+**Migration shape.** Same `0019`. Code change is *removing* the resolver
+call and the `BookNotFound` variant from the write paths.
+
+**Blast radius.** Touches the public error contract: `ProgressError` and
+`HighlightError` lose a variant, so the handlers and their tests that
+assert the 404/4xx on unknown-book change. Without a GC (1a) every typo'd
+or stale-client uuid persists forever; effectively forces Option B's GC to
+stay sane, so C realistically means B+C.
+
+**Pros.** Enables offline-first / write-ahead clients (a Phase-4 device-sync
+nicety). **Cons.** Removes a cheap correctness check for a feature nothing
+needs yet; widens the GC requirement; changes a wire-visible error
+contract for no current consumer. Premature.
+
+## Recommendation
+
+**Adopt Option A: soft-ref columns only, survive-no-GC, keep the write
+guard (Decision 1a + 2a).** Defer GC to a combined **F1 + F10** cleanup
+once F2 (stable uuid) has landed.
+
+Rationale:
+
+- **A is the only option that doesn't add a new data-loss surface.** The
+  entire point of F1 is to stop reindex from silently destroying user
+  data. Option B's boot-time `DELETE` re-introduces that risk if the grace
+  window is wrong; shipping it in the same change as the protection itself
+  is the wrong order of operations.
+- **It matches the one correct precedent.** `metadata_overrides` survives
+  without GC today and the system tolerates it. Treat the five user-data
+  tables identically; revisit orphan accumulation for *all* soft-ref
+  tables at once in F10, not piecemeal.
+- **Orphan growth is not yet a real problem.** These tables are
+  schema-only-to-lightly-used this cycle; the join-drag F10 worries about
+  is negligible at current volumes. GC is a real feature with its own
+  grace-window design — it deserves its own change, not a rider.
+- **The write guard is cheap insurance.** Keeping `resolve_book_id_by_uuid`
+  at the write boundary costs one query and blocks garbage uuids from ever
+  entering the tables. Relaxing it (Option C) buys a Phase-4 capability no
+  current client uses.
+
+**Reversibility / cost of delay.** The migration is forward-only and, once
+it runs against any DB, frozen (rule 06). But A is the *low-regret* base:
+it changes only the reference column and preserves all live rows, so a
+later F1+F10 GC layers cleanly on top without re-touching the schema. The
+cost of *delaying the whole change* is the opposite — every rating,
+journal entry, and session that accumulates before the migration is a row
+the migration must carry, and every reindex in the meantime is a live
+data-loss event. Land A before F3.2 populates these tables.
+
+## Migration plan
+
+> **Sketch only — not to be applied until the decision is ratified.**
+
+`db/migrations/0019_user_data_soft_ref.sql`. Next zero-padded number after
+`0018_multiformat_book_files.sql`. SQLite cannot drop a cascade FK or
+change a column in place, so each of the five tables is a full recreate.
+`PRAGMA foreign_keys` is per-connection (ON at runtime); DDL inside the
+migration runs fine. The backfill is the `INSERT … SELECT … JOIN books`
+itself — no separate boot pass.
+
+Pattern, shown for `reading_progress` (repeat for all five):
+
+```sql
+CREATE TABLE reading_progress_new (
+  id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id                INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  book_uuid              TEXT    NOT NULL,            -- soft ref: no FK, no cascade
+  format                 TEXT    NOT NULL CHECK (format IN ('epub','audio')),
+  epub_cfi               TEXT,
+  audio_position_seconds REAL,
+  updated_at             INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  CHECK ((format='epub'  AND epub_cfi IS NOT NULL AND audio_position_seconds IS NULL)
+      OR (format='audio' AND audio_position_seconds IS NOT NULL AND epub_cfi IS NULL)),
+  UNIQUE (user_id, book_uuid, format)
+);
+INSERT INTO reading_progress_new
+  (id,user_id,book_uuid,format,epub_cfi,audio_position_seconds,updated_at)
+  SELECT rp.id, rp.user_id, b.uuid, rp.format, rp.epub_cfi,
+         rp.audio_position_seconds, rp.updated_at
+  FROM reading_progress rp JOIN books b ON b.id = rp.book_id;
+DROP TABLE reading_progress;
+ALTER TABLE reading_progress_new RENAME TO reading_progress;
+CREATE INDEX reading_progress_user_book_idx ON reading_progress(user_id, book_uuid);
+```
+
+Per-table notes for the remaining four:
+
+- **`bookmarks`** — no UNIQUE today; keep that. Index
+  `bookmarks_user_book_idx(user_id, book_uuid)`.
+- **`reading_sessions` / `listening_sessions`** — **preserve the
+  `device_id INTEGER REFERENCES devices(id) ON DELETE SET NULL` FK**; that
+  cascade is on *device*, not book, and is correct. Recreate
+  `*_sessions_user_book_idx(user_id, book_uuid)`. (Note: the windowed
+  `(user_id, started_at)` index F-session-stats wants is a *separate*
+  finding; do not fold it in here unless explicitly scoped.)
+- **`highlights`** — preserve the `color` CHECK + `'amber'` default, the
+  `note` column, and `created_at`. Index
+  `idx_highlights_user_book(user_id, book_uuid)`.
+
+**Boot backfill:** **none** for Option A — the `INSERT … SELECT` JOIN does
+all the work in-migration. (Option B *would* add an idempotent
+`reconcile_user_data(pool)` to `db/src/normalize.rs`, called from
+`db/src/pool.rs:56` after `backfill_norm_columns`, shaped like
+`backfill_norm_columns` — no-op once caught up. Not part of the
+recommended scope.)
+
+## Affected code
+
+From the scout spec, scoped to Option A:
+
+- **`db/migrations/0019_user_data_soft_ref.sql`** *(new)* — table-recreate
+  all five tables to `book_uuid TEXT NOT NULL` soft-ref; backfill via
+  `INSERT … SELECT JOIN books`; recreate every index/CHECK/UNIQUE;
+  preserve the `device_id` FK on the two session tables.
+- **`db/src/progress.rs`** — `upsert_progress`, `get_progress`,
+  `record_session_tx`, `record_session`. Bind/store `book_uuid` directly;
+  key the `ON CONFLICT` and the read-back on `(user_id, book_uuid,
+  format)`. Keep the `resolve_book_id_by_uuid` call for the guard but use
+  it to confirm existence + resolve the **canonical uuid** (not the id).
+  Fix `record_session_tx`'s bare `SELECT id FROM books WHERE uuid = ?` to
+  resolve through the same merged-uuid-aware path — **closes F9**.
+- **`db/src/highlights/mod.rs`** — `create_highlight` stores `book_uuid`;
+  `list_highlights` and `get_highlight_by_id` drop the
+  `JOIN books b ON b.id = h.book_id` and read `book_uuid` as a direct
+  column; `row_to_highlight` reads `book_uuid` instead of `uuid` from the
+  join.
+- **`db/src/merge/transaction.rs`** — rewrite `move_progress_and_history`
+  to dedupe + re-parent on `book_uuid` (`source_uuid` → `target_uuid`),
+  and **add `highlights` to the re-parent set** (currently missing).
+  `merge_books` already holds both uuids, so pass them through.
+- **`.claude/architecture.md`** — note the soft-ref convention now covers
+  the five user-data tables (rule 99 docs sync).
+
+## Test plan
+
+Per rule 03: sibling `<mod>/tests.rs`, `sqlite::memory:`, happy path +
+one test per `thiserror` variant. The **acceptance test that must fail on
+the old schema** is the reindex-survival test.
+
+- **`db/src/progress/tests.rs`** — retarget existing raw assertions from
+  `WHERE book_id = ?` to `WHERE book_uuid = ?`; `seed` returns the uuid.
+  Keep the happy-path upsert + `BookNotFound` variant tests. **Add** the
+  acceptance regression: seed a book + a `reading_progress` row, run
+  `replace_books` with an empty set (full Removed), assert the row
+  **survives** (`book_uuid` still present). This must fail on the old
+  cascade schema. **Add** an F9 test: a session whose uuid is a
+  `merged_uuid` resolves to the surviving canonical uuid and persists
+  (`record_session` returns `Ok(true)`), not `Ok(false)`.
+- **`db/src/highlights/tests.rs`** — same retarget; **add** the
+  reindex-survival test for `highlights`.
+- **`db/src/merge/tests.rs`** — assert `move_progress_and_history`
+  re-parents all five tables **including `highlights`** by uuid, and that
+  the `reading_progress` latest-wins dedupe still holds across the uuid
+  key.
+- **`server/src/backend/progress/tests.rs`** and
+  **`server/src/backend/highlights/tests.rs`** — drive
+  `rest_router(AppState::new(pool))` via `tower::ServiceExt::oneshot`
+  against an in-memory DB: POST a progress/highlight, trigger a reindex,
+  GET it back, assert `200` + data intact.
+
+Run: `cargo test -p omnibus-db`, then `cargo test -p omnibus`, then
+`just test` for the full matrix.
+
+## Risks & rollback
+
+- **Forward-only, fix-forward.** Migration `0019` is frozen once it runs
+  anywhere (rule 06); any correction is a `0020`. There are no
+  down-migrations.
+- **Backfill drops already-orphaned rows.** The `INSERT … SELECT JOIN
+  books` does not carry rows whose `book_id` no longer joins to a `books`
+  row. Those rows are *already lost* under the current cascade, so this is
+  a no-op in practice — but it is worth stating that the migration is not a
+  recovery mechanism for data the old schema already destroyed.
+- **What's irreversible once data accumulates:** the choice of `book_uuid`
+  as the durable key is load-bearing across `metadata_overrides`,
+  `merged_uuids`, cover filenames, and route URLs. This is precisely why
+  **F2 (stable uuid) must land first or alongside** — migrating to a soft
+  ref on an *unstable* uuid buys a smaller, not zero, data-loss surface
+  (a path change still re-keys every uuid). See sequencing.
+- **Option B-specific (not recommended now):** a boot-time GC `DELETE`
+  with a too-aggressive grace window would delete legitimately-detached
+  rows — the exact failure F1 exists to prevent. Keeping GC out of this
+  change removes that risk entirely.
+
+## Sequencing & dependencies
+
+The F1 ↔ F2 ↔ F10 chain:
+
+- **F2 (path-based `stable_uuid` → content-anchored) must land first, or
+  in the same train.** A soft ref on an unstable uuid still orphans every
+  row on a library-root change, because the uuid itself moves. F1 without
+  F2 is a partial fix; the roadmap lists the uuid fix as a hard dependency
+  of F3.2 (`docs/roadmap/3-2-ratings-journaling.md:46-57`). Recommended
+  order: **F2 → F1 (Option A) → F3.2**.
+- **F9 (`record_session_tx` merged-uuid resolution) folds into F1.** It
+  touches the same `record_session_tx` column and resolver; fix it in the
+  same change (covered in [Affected code](#affected-code) and
+  [Test plan](#test-plan)).
+- **The latent merge-highlights omission folds into F1.** Same module,
+  same rewrite.
+- **F10 (shared reconcile/GC for soft-ref tables) comes after.** Once F1
+  lands, `metadata_overrides` and the five user-data tables all have the
+  same orphan-without-GC shape. F10 designs one reusable, grace-windowed
+  reconcile for all of them — that is the right home for Decision 1b, not
+  this change.
+- The scout flags conflicts with **F11** and **F12** (other db.md
+  findings); confirm those don't co-edit the same migration ordering before
+  scheduling, but they are not blockers for the decision framed here.
+
+## Open questions
+
+1. **Grace window shape (deferred to F10).** When GC eventually lands,
+   what disqualifies a row from pruning — uuid absent from both
+   `books.uuid` and `merged_uuids` for N boots? A timestamp column? This is
+   F10's to answer; flagged here because Decision 1b would force it early.
+2. **F2 anchor for backfill.** If F2 re-keys uuids in the same train, does
+   `0019`'s backfill run before or after the re-key migration? They must be
+   ordered so the `JOIN books` sees post-re-key uuids — likely F2's re-key
+   migration is a lower number than `0019`, but confirm during sequencing.
+3. **Override-cover orphans (F10 territory).** `metadata_overrides`
+   orphans also leak `override-<uuid>.<ext>` cover files. The five
+   user-data tables have no file side-effects, so this is not an F1
+   concern, but the eventual GC should sweep both — noted so F10 scopes it.
+4. **Should `bookmarks` gain a UNIQUE on the soft-ref migration?** Today it
+   has none. The recreate is a natural moment to add one if the model
+   wants at-most-one-bookmark-per-position, but that is a behavior change
+   out of scope for F1 — default is to preserve current (no UNIQUE).

--- a/docs/design/db-review-f1-user-data-soft-refs.md
+++ b/docs/design/db-review-f1-user-data-soft-refs.md
@@ -123,7 +123,8 @@ keep the resolver (guard stays) but store and key on `book_uuid` instead
 of resolving to `id`. No boot GC: orphans linger and auto-relink, exactly
 like `metadata_overrides`.
 
-**Migration shape.** One `0019_user_data_soft_ref.sql`, five table
+**Migration shape.** One `NNNN_user_data_soft_ref.sql` (number allocated at
+implementation time), five table
 recreates. Backfill is the `INSERT … SELECT … JOIN books` itself — no
 boot-time pass needed, because every existing row is already
 uuid-addressable through its current `book_id`. Rows whose book is already
@@ -148,7 +149,7 @@ any future `LEFT JOIN` against these tables (the same drag F10 notes for
 `normalize::backfill_norm_columns`) that, on every boot, deletes user rows
 whose `book_uuid` matches neither `books.uuid` nor `merged_uuids`.
 
-**Migration shape.** Identical `0019` migration as A, plus a new function
+**Migration shape.** Identical `NNNN` migration as A, plus a new function
 in `db/src/normalize.rs` (or a sibling reconcile module) called from
 `db/src/pool.rs` right after `backfill_norm_columns` at line 56.
 
@@ -172,7 +173,7 @@ once it runs.
 guard so `upsert_progress`/`create_highlight` accept any uuid. Rows for
 not-yet-indexed books start detached and bind when the book appears.
 
-**Migration shape.** Same `0019`. Code change is *removing* the resolver
+**Migration shape.** Same `NNNN`. Code change is *removing* the resolver
 call and the `BookNotFound` variant from the write paths.
 
 **Blast radius.** Touches the public error contract: `ProgressError` and
@@ -225,8 +226,9 @@ data-loss event. Land A before F3.2 populates these tables.
 
 > **Sketch only — not to be applied until the decision is ratified.**
 
-`db/migrations/0019_user_data_soft_ref.sql`. Next zero-padded number after
-`0018_multiformat_book_files.sql`. SQLite cannot drop a cascade FK or
+`db/migrations/NNNN_user_data_soft_ref.sql` — the next zero-padded number is
+allocated at implementation time (`0018_multiformat_book_files.sql` is the
+latest applied as of writing). SQLite cannot drop a cascade FK or
 change a column in place, so each of the five tables is a full recreate.
 `PRAGMA foreign_keys` is per-connection (ON at runtime); DDL inside the
 migration runs fine. The backfill is the `INSERT … SELECT … JOIN books`
@@ -282,7 +284,7 @@ recommended scope.)
 
 From the scout spec, scoped to Option A:
 
-- **`db/migrations/0019_user_data_soft_ref.sql`** *(new)* — table-recreate
+- **`db/migrations/NNNN_user_data_soft_ref.sql`** *(new)* — table-recreate
   all five tables to `book_uuid TEXT NOT NULL` soft-ref; backfill via
   `INSERT … SELECT JOIN books`; recreate every index/CHECK/UNIQUE;
   preserve the `device_id` FK on the two session tables.
@@ -337,8 +339,8 @@ Run: `cargo test -p omnibus-db`, then `cargo test -p omnibus`, then
 
 ## Risks & rollback
 
-- **Forward-only, fix-forward.** Migration `0019` is frozen once it runs
-  anywhere (rule 06); any correction is a `0020`. There are no
+- **Forward-only, fix-forward.** The new migration is frozen once it runs
+  anywhere (rule 06); any correction is a later migration. There are no
   down-migrations.
 - **Backfill drops already-orphaned rows.** The `INSERT … SELECT JOIN
   books` does not carry rows whose `book_id` no longer joins to a `books`
@@ -388,9 +390,10 @@ The F1 ↔ F2 ↔ F10 chain:
    `books.uuid` and `merged_uuids` for N boots? A timestamp column? This is
    F10's to answer; flagged here because Decision 1b would force it early.
 2. **F2 anchor for backfill.** If F2 re-keys uuids in the same train, does
-   `0019`'s backfill run before or after the re-key migration? They must be
-   ordered so the `JOIN books` sees post-re-key uuids — likely F2's re-key
-   migration is a lower number than `0019`, but confirm during sequencing.
+   this migration's backfill run before or after the re-key migration? They
+   must be ordered so the `JOIN books` sees post-re-key uuids — likely F2's
+   re-key migration takes a lower number than this one, but confirm during
+   sequencing.
 3. **Override-cover orphans (F10 territory).** `metadata_overrides`
    orphans also leak `override-<uuid>.<ext>` cover files. The five
    user-data tables have no file side-effects, so this is not an F1

--- a/docs/design/db-review-f10-override-gc.md
+++ b/docs/design/db-review-f10-override-gc.md
@@ -149,10 +149,13 @@ Result<u64, MetadataOverridesError>` in
 
 ```sql
 SELECT book_uuid FROM metadata_overrides
- WHERE updated_at < datetime('now', ?-grace)
+ WHERE updated_at < datetime('now', '-' || ? || ' days')
    AND book_uuid NOT IN (SELECT uuid FROM books)
    AND book_uuid NOT IN (SELECT uuid FROM merged_uuids)
 ```
+
+The bound parameter is an integer day count: SQLite concatenates it into a
+valid relative modifier (e.g. `7` → `'-7 days'`).
 
 then `delete_overrides_for_uuids(tx, &uuids)` (chunked at 500, mirroring
 `load_overrides_bulk` and `prune_orphan_libraries`) and a defensive
@@ -190,7 +193,8 @@ time, not *detach* time.
 ### Option C — Soft-detach (`detached_at`), F3.2-aligned
 
 **How it works.** Add an append-only migration
-`0019_metadata_overrides_detached.sql`:
+`NNNN_metadata_overrides_detached.sql` (the next free number, allocated at
+implementation time):
 
 ```sql
 ALTER TABLE metadata_overrides ADD COLUMN detached_at TEXT;  -- NULL = attached
@@ -279,7 +283,7 @@ that is the only condition under which C beats B today.
    - `pub(crate) async fn delete_overrides_for_uuids(tx, uuids: &[String]) -> Result<(), sqlx::Error>`
      — chunked at 500, `DELETE FROM metadata_overrides WHERE book_uuid IN (...)`.
    - `pub async fn reconcile_orphan_overrides(pool, grace_secs) -> Result<u64, MetadataOverridesError>`
-     — SELECT orphans (predicate above + `updated_at < datetime('now', ?-grace)`),
+     — SELECT orphans (predicate above + `updated_at < datetime('now', '-' || ? || ' days')`),
      `delete_overrides_for_uuids`, defensive `delete_override_cover` per uuid
      off-runtime via `spawn_blocking` (mirror `settings.rs:80-85`). Reuse
      `MetadataOverridesError::Db`.
@@ -299,7 +303,7 @@ that is the only condition under which C beats B today.
 **Option C (only if chosen): one append-only migration.**
 
 ```sql
--- db/migrations/0019_metadata_overrides_detached.sql
+-- db/migrations/NNNN_metadata_overrides_detached.sql
 -- Soft-detach marker for override rows whose book has disappeared.
 -- NULL = attached (the default for every existing row, so no backfill).
 -- Set on first reconcile that finds no books/merged_uuids match; cleared
@@ -331,7 +335,7 @@ From the scout spec, for Option B:
 | `db/src/metadata_overrides/tests.rs` | new reconcile + `delete_overrides_for_uuids` tests |
 | `db/src/settings.rs` (tests mod) | prune-deletes-override-rows test |
 
-For Option C additionally: `db/migrations/0019_metadata_overrides_detached.sql`;
+For Option C additionally: `db/migrations/NNNN_metadata_overrides_detached.sql`;
 `detached_at IS NULL` predicate on `db/src/browse.rs:52,150,175` and
 `db/src/discovery/authors.rs:67`; clear-on-relink write on the reindex path.
 
@@ -382,7 +386,7 @@ rows.
 - **Forward-only, fix-forward.** Per rule 06 there are no down-migrations.
   Option B has no migration to roll back at all. Option C's `ADD COLUMN` is
   irreversible in place; a regret is corrected by a *new* migration, never
-  by editing `0019`.
+  by editing the `NNNN` one once it has run.
 - **Data-loss surface (the real risk).** Option B hard-deletes. The only
   guard against a wrong delete is the grace window + the `merged_uuids`
   arm. The acute failure is the **F2 interaction**: if `stable_uuid`

--- a/docs/design/db-review-f10-override-gc.md
+++ b/docs/design/db-review-f10-override-gc.md
@@ -1,0 +1,455 @@
+# F10 — `metadata_overrides` reconcile / GC for orphans
+
+Status: Proposed — deferred from db.md F10, awaiting decision.
+
+This doc frames a data-model decision the operator must make before any
+schema or code is written. It is decision-support, not an implementation
+plan: nothing here should be applied until the choice in
+[Decision required](#decision-required) is made.
+
+---
+
+## Problem
+
+`metadata_overrides` is keyed by `book_uuid TEXT NOT NULL PRIMARY KEY`
+with **no FK to `books`** (`db/migrations/0007_metadata_overrides.sql:16-22`).
+That is deliberate: the indexer wipes-and-rewrites `books` on every
+Changed/Removed reindex, and the override layer must survive that cycle so
+a user's hand edits aren't lost when a file's mtime bumps. The
+module/comment contract spells this out at `sync_books` in
+`db/src/sync/books.rs:77-80` ("`metadata_overrides` is intentionally not
+touched").
+
+The trade-off the contract creates: **nothing ever removes an override row
+whose book is permanently gone.** The only deletes are user-driven
+(`delete_metadata_overrides`, the `DELETE` at
+`db/src/metadata_overrides/upsert.rs:175`) and merge-source-driven
+(`db/src/merge/transaction.rs:409`). Neither the Removed-bucket cascade
+(`sync_removed`, `db/src/sync/books.rs:125-163`, which deletes only
+`books_fts` + `books`) nor the explicit library prune
+(`prune_orphan_libraries`, `db/src/settings.rs:100-163`, which deletes
+`books_fts` + `books` + `libraries`) touches `metadata_overrides`. So a
+file that is permanently deleted, or a whole library root that is removed
+in settings, leaves its override **row** behind forever.
+
+Two consequences:
+
+1. **Dead rows accumulate and slow the hot path.** Every browse/discovery
+   count query `LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid`
+   (`db/src/browse.rs:52,150,175`, `db/src/discovery/authors.rs:67`). The
+   join itself is PK-indexed, but orphan rows inflate the table the
+   planner scans on the override-extracted-subjects path.
+2. **Path-based `stable_uuid` makes the leak permanent and total.** Today
+   an orphan re-attaches for free when the same file is re-indexed (same
+   uuid). But `stable_uuid` is derived from `library_path + filename`
+   (db.md "Path-based stable_uuid breaks durability", finding F2), so a
+   library-root change re-keys *every* uuid at once — every override row
+   orphans permanently with no possibility of re-link.
+
+Already handled (do not re-solve): orphan override **cover files**
+(`override-<uuid>.<ext>`) are already swept. `delete_cover_files_for`
+(`db/src/covers.rs:144-150`) unlinks both `<uuid>.<ext>` and the override
+variant; `set_settings` calls it for pruned uuids
+(`db/src/settings.rs:80-85`) and `sync_books` calls it for Removed uuids
+(`db/src/sync/books.rs:110-114`). The gap is the **row**, not the file —
+though a hard-delete path should still call `delete_override_cover`
+(`db/src/metadata_overrides/upsert.rs:303`) defensively for uuids that
+reach reconcile by a route other than those two sweeps.
+
+**Why it bites a named feature.** F3.2 ratings & journaling
+(`docs/roadmap/3-2-ratings-journaling.md`) mandates the *same* soft-ref
+pattern for `user_ratings` / `user_journal_entries` — `book_uuid TEXT NOT
+NULL`, no FK, no cascade (lines 32-44). When a book is pruned those rows
+"become detached rather than deleted" (line 44) and the roadmap wants them
+surfaced as "unlinked annotations" rather than silently lost (line 51).
+F3.2 therefore inherits this exact orphan-forever shape, and whatever
+reconcile/GC mechanism we build for `metadata_overrides` is the one F3.2
+will reuse. Building the wrong shape now means redoing it under user-data
+load.
+
+---
+
+## Decision required
+
+Two coupled decisions, both for the operator:
+
+**D1 — Disposition of an orphan: hard-delete vs. soft-detach.** When a
+reconcile finds an override row whose `book_uuid` is in neither `books`
+nor `merged_uuids`, does it (a) `DELETE` the row outright, or (b) mark it
+`detached_at` and keep it, so it can re-link when the book reappears and be
+surfaced as "unlinked" in the UI? Hard-delete matches the immediate
+problem (dead rows, slow joins) and ships with zero schema change.
+Soft-detach is the F3.2-aligned pattern but adds a column, a clear-on-relink
+write, and a UI surface that doesn't exist yet.
+
+**D2 — When GC runs, and the grace window.** Does reconcile run
+post-*every*-reindex, or only on explicit library-root removal? And how
+long after a book disappears before its override is eligible for GC? This
+is the dangerous knob: a path-based `stable_uuid` re-key (F2) orphans every
+row simultaneously, so an aggressive post-every-reindex GC with a short
+grace window would **nuke every user edit on a single library move**. The
+grace window exists to protect rows whose book is *legitimately detached
+pending the next reindex* (mid-library-swap, a transient scan failure)
+from being mistaken for permanent orphans.
+
+These two are coupled: a long grace window matters far less under
+soft-detach (a wrongly-detached row just re-links, no data lost) than under
+hard-delete (a wrongly-deleted row is gone). The conservative combination
+is *soft-detach + short grace*; the aggressive one is *hard-delete +
+per-every-reindex + short grace*, which is a footgun next to F2.
+
+---
+
+## Options
+
+All three use the same orphan predicate, which needs **no schema change**:
+
+```sql
+book_uuid NOT IN (SELECT uuid FROM books)
+AND book_uuid NOT IN (SELECT uuid FROM merged_uuids)
+```
+
+`book_uuid` is the PK; `books.uuid` is `UNIQUE` and `merged_uuids.uuid` is
+a PK, so both sub-selects are index-served. The `merged_uuids` arm is
+load-bearing: a uuid that was cross-format-merged/attached into another
+book has no `books.uuid` row but is a *legitimate* attachment, and must
+survive — this mirrors the `resolve_book_id_by_uuid` fallback in
+`db/src/books/get.rs:132-145`.
+
+### Option A — Minimal prune on explicit library removal only
+
+**How it works.** Extend `prune_orphan_libraries`
+(`db/src/settings.rs:100-163`) with a chunked
+`DELETE FROM metadata_overrides WHERE book_uuid IN (...)` over the
+`orphan_uuids` it already collects (`:125-135`), inside the same
+transaction. No post-reindex hook, no grace window, no new function on the
+reindex path. Override cover files for those uuids are already swept by
+`set_settings`' `delete_cover_files_for` call — no extra fs work.
+
+- **Migration shape.** None. Pure code change in one function.
+- **Blast radius.** One function, one tx, plus a test. The Removed-bucket
+  cascade (`sync_removed`) is *not* covered, so a single permanently
+  deleted file still leaks a row until its library is removed — but that
+  row re-attaches for free if the file returns (same uuid), so the only
+  permanent leak left is the library-removal one this option closes.
+- **Pros.** Smallest possible change; zero risk of nuking edits on a
+  library swap because it only fires when the operator *explicitly removed*
+  the root. No grace-window judgement call.
+- **Cons.** Doesn't reconcile single-file Removed orphans, doesn't address
+  the F2 mass-orphan case (a path *change* runs prune for the old root —
+  this actually does fire there, deleting every old-root override, which
+  may be *too* aggressive without a grace window or detach). Not reusable
+  for F3.2's "surface as unlinked" requirement.
+
+### Option B — Hard-delete reconcile with a grace window (recommended)
+
+**How it works.** Add `reconcile_orphan_overrides(pool, grace_secs) ->
+Result<u64, MetadataOverridesError>` in
+`db/src/metadata_overrides/upsert.rs`:
+
+```sql
+SELECT book_uuid FROM metadata_overrides
+ WHERE updated_at < datetime('now', ?-grace)
+   AND book_uuid NOT IN (SELECT uuid FROM books)
+   AND book_uuid NOT IN (SELECT uuid FROM merged_uuids)
+```
+
+then `delete_overrides_for_uuids(tx, &uuids)` (chunked at 500, mirroring
+`load_overrides_bulk` and `prune_orphan_libraries`) and a defensive
+`delete_override_cover` per uuid off the runtime via `spawn_blocking`.
+Returns the count for logging. Wire it in two places: (1) `set_settings` /
+`prune_orphan_libraries` as in Option A (immediate, no grace — explicit
+removal is unambiguous); (2) `reindex` in `db/src/indexer.rs` after
+`sync::sync_books` (`:259`), best-effort/logged, gated behind a grace
+window of **days** so a transient mid-swap detach is not GC'd.
+
+The grace window reuses the existing `updated_at` column
+(`0007_metadata_overrides.sql:21`) — `updated_at < datetime('now',
+'-N days')` — so **no new column** is required. Note the semantic
+caveat in [Open questions](#open-questions): `updated_at` is *last-edit*
+time, not *detach* time.
+
+- **Migration shape.** None. The orphan + grace predicate runs entirely
+  off the existing schema. (An optional, redundant `idx_metadata_overrides_uuid`
+  is *not* needed — the PK already covers the join.)
+- **Blast radius.** New `pub fn` + private helper in `upsert.rs`, a
+  re-export in `mod.rs:21-25`, one best-effort call site in `indexer.rs`,
+  the `settings.rs` prune extension, a doc-comment touch at
+  `sync/books.rs:77-80`. Reuses `MetadataOverridesError::Db` — no new
+  `thiserror` variant (the failure space is just `sqlx`, predictable, so
+  `thiserror` is correct per rule 02).
+- **Pros.** Closes both leak paths (Removed cascade *and* library prune),
+  reusable shape for F3.2, idempotent, no schema migration, cheap once
+  caught up. The grace window blunts the F2 mass-orphan footgun.
+- **Cons.** Hard-delete is irreversible — a wrongly-GC'd row is gone, and
+  the grace window is the only guard. Does *not* deliver the F3.2 "surface
+  as unlinked" UX; F3.2 would still have to add `detached_at` later and
+  decide whether to retrofit it onto `metadata_overrides`. The `updated_at`
+  grace proxy is imperfect (see Open questions).
+
+### Option C — Soft-detach (`detached_at`), F3.2-aligned
+
+**How it works.** Add an append-only migration
+`0019_metadata_overrides_detached.sql`:
+
+```sql
+ALTER TABLE metadata_overrides ADD COLUMN detached_at TEXT;  -- NULL = attached
+```
+
+Reconcile *sets* `detached_at = datetime('now')` on first pass that finds
+no book, *clears* it (back to NULL) when a re-index makes the book resolve
+again, and a separate, much longer sweep hard-deletes rows whose
+`detached_at` is older than a long retention (e.g. 90 days). Browse/discovery
+joins gain `AND mo.detached_at IS NULL` so detached rows stop affecting the
+read path immediately without being destroyed. The UI surfaces detached
+overrides as "unlinked."
+
+- **Migration shape.** One forward-only `ALTER TABLE … ADD COLUMN`,
+  nullable, **no backfill** (existing rows default NULL = attached). This
+  is a plain column add — *not* a PK/constraint change — so the SQLite
+  pre-3.35 table-recreate dance (create-new, copy, drop, rename) does
+  **not** apply here. Forward-only per rule 06.
+- **Blast radius.** Migration + the reconcile fn (now an UPDATE-then-maybe-DELETE
+  state machine) + every browse/discovery join gains a `detached_at IS NULL`
+  predicate (`browse.rs:52,150,175`, `discovery/authors.rs:67`) + a UI
+  surface + the re-link-clears-detached_at write on the reindex path. The
+  largest of the three.
+- **Pros.** No data loss on a wrong detach — rows re-link. Directly the
+  pattern F3.2 wants; build once, reuse for ratings/journals. Read path is
+  protected immediately (filtered out) while data is retained.
+- **Cons.** Most code and the only schema migration. Adds a predicate to
+  four hot queries. Needs a UI surface that doesn't exist yet to be
+  user-visible — without it, detached rows are invisible *and* retained,
+  i.e. all cost, deferred benefit. Over-builds for the immediate problem
+  (dead rows slowing joins) if F3.2 slips.
+
+---
+
+## Recommendation
+
+**Adopt Option B (hard-delete reconcile + grace window) now**, structured
+so Option C is a clean follow-on rather than a rewrite.
+
+Rationale:
+
+- The immediate, named pain (dead rows, slow browse/discovery joins, a
+  permanent leak on library removal) is fully closed by B with **zero
+  schema migration** — the lowest-cost, lowest-risk fix that actually
+  solves today's problem.
+- B's grace window directly defuses the one genuinely dangerous
+  interaction (F2 mass re-key orphaning every row at once): gate the
+  per-reindex GC behind a grace window of days, and have the explicit-removal
+  path fire immediately (an operator who removed a root meant it).
+- **Reversibility / cost of delay.** B is cheap to *extend* into C: the
+  `reconcile_orphan_overrides` choke-point, the orphan predicate, the
+  chunked delete helper, and the call sites are all exactly what C needs.
+  Adding `detached_at` later is a pure additive migration plus swapping the
+  reconcile body from DELETE to UPDATE-then-retention-DELETE. Nothing in B
+  has to be torn out. So choosing B does **not** foreclose C.
+- The one thing B gives up vs. C — "surface as unlinked" and no-data-loss
+  on wrong detach — is a *user-data* concern that only becomes real when
+  F3.2 ships ratings/journals. Until there is durable, non-regenerable user
+  data behind the soft-ref, hard-delete of a *regenerable-by-re-edit*
+  metadata override is an acceptable loss. (An override can be re-entered;
+  a journal entry cannot.) Building C's machinery before its consumer
+  exists is speculative.
+
+**Explicit guidance to ship with B:** make the per-reindex grace window a
+named constant (suggest 7 days) and the explicit-removal path immediate;
+log the GC count at `info`; and add a one-line note in
+`docs/roadmap/3-2-ratings-journaling.md` that user-data tables must adopt
+`detached_at` (Option C) rather than hard-delete, since their rows are not
+regenerable. **Do not** point the per-reindex GC at the future user-data
+tables — those must wait for C.
+
+If the operator expects F3.2 to land *imminently* and wants to avoid two
+migrations on adjacent tables, jumping straight to C is defensible — but
+that is the only condition under which C beats B today.
+
+---
+
+## Migration plan
+
+> **SKETCH — not to be applied.** Numbers/DDL shown for the chosen option
+> only. Option B (recommended) needs **no migration at all**.
+
+**Option B (recommended): no migration.** All work is in Rust:
+
+1. `db/src/metadata_overrides/upsert.rs`
+   - `pub(crate) async fn delete_overrides_for_uuids(tx, uuids: &[String]) -> Result<(), sqlx::Error>`
+     — chunked at 500, `DELETE FROM metadata_overrides WHERE book_uuid IN (...)`.
+   - `pub async fn reconcile_orphan_overrides(pool, grace_secs) -> Result<u64, MetadataOverridesError>`
+     — SELECT orphans (predicate above + `updated_at < datetime('now', ?-grace)`),
+     `delete_overrides_for_uuids`, defensive `delete_override_cover` per uuid
+     off-runtime via `spawn_blocking` (mirror `settings.rs:80-85`). Reuse
+     `MetadataOverridesError::Db`.
+2. `db/src/metadata_overrides/mod.rs` — re-export `reconcile_orphan_overrides`
+   in the `pub use` block (`:21-25`); update the `//!` doc to mention GC.
+3. `db/src/settings.rs` — in `prune_orphan_libraries`, after collecting
+   `orphan_uuids`, add the chunked `DELETE FROM metadata_overrides WHERE
+   book_uuid IN (...)` inside the same tx (no grace — explicit removal).
+4. `db/src/indexer.rs` — in `reindex`, after `sync::sync_books` (`:259`),
+   call `reconcile_orphan_overrides(pool, GRACE_SECS)` best-effort; log the
+   returned count, never fail the reindex (matches the best-effort
+   cover/FTS pattern).
+5. `db/src/sync/books.rs:77-80` — update the comment to note overrides are
+   now reconciled out-of-band; the sync path still intentionally doesn't
+   touch them inline.
+
+**Option C (only if chosen): one append-only migration.**
+
+```sql
+-- db/migrations/0019_metadata_overrides_detached.sql
+-- Soft-detach marker for override rows whose book has disappeared.
+-- NULL = attached (the default for every existing row, so no backfill).
+-- Set on first reconcile that finds no books/merged_uuids match; cleared
+-- back to NULL when a reindex makes the book resolve again. Plain ADD
+-- COLUMN (not a PK/constraint change) — no table-recreate needed.
+ALTER TABLE metadata_overrides ADD COLUMN detached_at TEXT;
+```
+
+No boot backfill is required for C (NULL default *is* the correct
+"attached" state). If one were ever needed, it would follow the idempotent
+`backfill_norm_columns` model (`db/src/normalize.rs:53-82`, called from
+`init_db` in `db/src/pool.rs:56`): guarded on `detached_at IS NULL`, a
+no-op once caught up, run on every boot. We deliberately do **not** add one
+here.
+
+---
+
+## Affected code
+
+From the scout spec, for Option B:
+
+| File | Symbol(s) |
+|---|---|
+| `db/src/metadata_overrides/upsert.rs` | NEW `reconcile_orphan_overrides`; NEW `delete_overrides_for_uuids`; reuse `MetadataOverridesError`, `delete_override_cover` |
+| `db/src/metadata_overrides/mod.rs` | re-export `reconcile_orphan_overrides`; `//!` doc update |
+| `db/src/settings.rs` | `prune_orphan_libraries` — add chunked override DELETE in-tx; `set_settings` cover sweep already covers files |
+| `db/src/indexer.rs` | `reindex` — best-effort `reconcile_orphan_overrides` call after `sync::sync_books` (`:259`) |
+| `db/src/sync/books.rs` | comment at `:77-80` — note out-of-band reconcile |
+| `db/src/metadata_overrides/tests.rs` | new reconcile + `delete_overrides_for_uuids` tests |
+| `db/src/settings.rs` (tests mod) | prune-deletes-override-rows test |
+
+For Option C additionally: `db/migrations/0019_metadata_overrides_detached.sql`;
+`detached_at IS NULL` predicate on `db/src/browse.rs:52,150,175` and
+`db/src/discovery/authors.rs:67`; clear-on-relink write on the reindex path.
+
+---
+
+## Test plan
+
+Per rule 03: sibling-file tests against `sqlite::memory:` via the crate's
+`test_support` pool init; happy path + one per failure mode.
+
+In `db/src/metadata_overrides/tests.rs` (existing sibling file):
+
+- `reconcile_orphan_overrides_deletes_row_when_book_and_merged_uuid_absent`
+  — **the acceptance test that must fail on the old schema/code**: seed a
+  book + override, drop the book, assert reconcile (grace=0) removes the
+  override row and returns count 1. On `main` (no reconcile fn) this can't
+  even compile/pass — it is the red test.
+- `reconcile_orphan_overrides_keeps_row_when_book_present` — override for a
+  live book survives.
+- `reconcile_orphan_overrides_keeps_row_when_merged_uuid_present` — uuid
+  only in `merged_uuids` (cross-format attachment) survives; guards the
+  `resolve_book_id_by_uuid` fallback shape.
+- `reconcile_orphan_overrides_respects_grace_window` — orphan with recent
+  `updated_at` survives a non-zero grace; an old one is GC'd.
+- `reconcile_orphan_overrides_unlinks_override_cover_file` —
+  `write_override_cover` then orphan + reconcile; assert
+  `find_override_cover_file` returns `None`.
+- `reconcile_orphan_overrides_propagates_db_error_when_pool_closed` — the
+  one `MetadataOverridesError::Db` variant path.
+- (only if `delete_overrides_for_uuids` is the chunked bulk helper)
+  `delete_overrides_for_uuids_chunks_over_500` — happy path, large vec.
+
+In `db/src/settings.rs` inline tests mod:
+
+- `prune_orphan_libraries_deletes_override_rows_for_pruned_books` — seed
+  two libraries each with an override, prune one via `set_settings`, assert
+  the pruned library's override rows are gone and the kept library's
+  remain.
+
+If Option C is chosen, add: an orphan flips `detached_at` non-NULL; a
+re-indexed book clears it back to NULL; browse counts exclude detached
+rows.
+
+---
+
+## Risks & rollback
+
+- **Forward-only, fix-forward.** Per rule 06 there are no down-migrations.
+  Option B has no migration to roll back at all. Option C's `ADD COLUMN` is
+  irreversible in place; a regret is corrected by a *new* migration, never
+  by editing `0019`.
+- **Data-loss surface (the real risk).** Option B hard-deletes. The only
+  guard against a wrong delete is the grace window + the `merged_uuids`
+  arm. The acute failure is the **F2 interaction**: if `stable_uuid`
+  re-keys on a library-path change while the per-reindex GC has a short
+  grace, every pre-change override is eligible and gets wiped. Mitigations:
+  (1) keep the per-reindex grace at days, not minutes; (2) keep the
+  explicit-removal path the only *immediate* GC; (3) **sequence F10 after
+  F2** so the uuid is stable before GC runs on the reindex path (see below).
+- **Irreversible once data accumulates.** Whatever disposition ships
+  becomes load-bearing once F3.2 user data exists behind the soft-ref —
+  retrofitting from hard-delete to soft-detach *after* journals are being
+  GC'd would mean having already lost detached journal entries. This is the
+  core reason the recommendation is "B now, but do not point per-reindex GC
+  at user-data tables until C lands."
+- **Best-effort GC must never fail a reindex.** The `indexer.rs` call site
+  logs and swallows errors, matching the existing best-effort cover/FTS
+  pattern. A GC failure leaving stale rows is strictly better than a GC
+  failure aborting an index.
+
+---
+
+## Sequencing & dependencies
+
+This finding sits in the F1↔F2↔F10 user-data-durability chain and the scout
+flags it co-dependent with F2, F3, F6, F8, F11, F12, F13, F16, F17, F18.
+The load-bearing edges:
+
+- **F2 (path-based `stable_uuid`) must land first** if the per-reindex GC
+  is enabled. While the uuid moves on every path change, a per-reindex GC
+  is a mass-deletion hazard. With F2 fixed (`dc:identifier`/content-hash
+  anchored uuid), an orphan genuinely means "the file is gone," and GC is
+  safe. **If F2 has not landed, ship Option A / B's explicit-removal arm
+  only and leave the per-reindex hook disabled.**
+- **F1 (migrate the five user-data tables to `book_uuid` soft-refs)** is
+  the sibling problem: those tables have the *opposite* bug today
+  (cascade-delete on reindex). F10's reconcile is the GC half of the
+  soft-ref pattern F1 introduces. Order: F1 converts the tables → F10/C
+  provides their reconcile. F10 for `metadata_overrides` (already soft-ref)
+  can proceed independently of F1.
+- **F3.2 ratings/journaling is the consumer** that decides whether C is
+  worth its cost. If F3.2 is near, prefer C to avoid two migrations on
+  adjacent tables. If F3.2 is far, ship B and defer C.
+
+Minimum safe slice if nothing else has landed: **Option A** (explicit-removal
+prune only) — it has no F2 dependency because it fires only when the
+operator removed a root, where mass-orphaning is intended.
+
+---
+
+## Open questions
+
+1. **Grace-window semantics.** `updated_at` is *last user edit* time, not
+   *detach* time. A row last edited a year ago whose book vanished
+   yesterday is immediately past any reasonable grace — so the grace window
+   protects *recently-edited* orphans, not *recently-detached* ones, which
+   is subtly wrong. Is that acceptable for B, or does even B want a cheap
+   `detached_at`-style marker to measure grace from detach? (Leaning:
+   acceptable for B, because a recently-detached-but-long-untouched override
+   is exactly the low-value case; revisit if it bites.)
+2. **Grace length.** 7 days proposed for the per-reindex path. Long enough
+   to span a library swap an admin would notice, short enough to bound dead
+   rows. Operator's call.
+3. **Should the explicit-removal arm get a grace at all?** Recommendation
+   says no — removing a root is unambiguous intent. Confirm.
+4. **F3.2 retention under C.** If C ships, how long are detached rows kept
+   before the long-retention sweep hard-deletes them (90 days?), and is
+   that per-table configurable?
+5. **Observability.** Is the `info`-level GC count log sufficient, or does
+   this warrant a metric / an admin-visible "N orphaned overrides pruned"
+   surface (ties to the F3.2 "unlinked annotations" UI)?

--- a/docs/design/db-review-f11-timestamp-unification.md
+++ b/docs/design/db-review-f11-timestamp-unification.md
@@ -101,7 +101,7 @@ the same for `timestamp AS added_at`). `build_metadata` keeps
 `r.get::<String,_>(...)`. `shared::EbookMetadata` and the entire `frontend/`
 sort + render path are **untouched**.
 
-**Migration shape.** `0019_*.sql` recreates the five tables → INTEGER.
+**Migration shape.** A new `NNNN_*.sql` recreates the five tables → INTEGER.
 
 **Blast radius.** DB crate only. `shared/` and `frontend/` see zero diff. No
 change to `sorting.rs` / `table.rs` / `filtering.rs` or their fixtures.
@@ -164,7 +164,7 @@ completeness.
 ## Recommendation
 
 **Adopt Option A.** Migrate all five DB columns to INTEGER unix-seconds via the
-`0019` table-recreate, and format `added_at` / `modified` back to fixed-width ISO
+`NNNN` table-recreate, and format `added_at` / `modified` back to fixed-width ISO
 on the `projection.rs` read path so `shared::EbookMetadata` and the entire
 frontend stay byte-for-byte unchanged.
 
@@ -198,7 +198,8 @@ sort (`sorting.rs` `cmp_with_missing_last`) keeps working.
 
 ## Migration plan (SKETCH — not to be applied)
 
-`db/migrations/0019_unify_timestamps_to_unix_seconds.sql`, forward-only per
+`db/migrations/NNNN_unify_timestamps_to_unix_seconds.sql` (number allocated at
+implementation time), forward-only per
 rule 06. The in-DDL `CAST(strftime('%s', col) AS INTEGER)` **is** the backfill —
 no separate Rust boot hook is needed (unlike the `_norm` pattern), because the
 conversion is pure SQL and every writer of these columns used
@@ -206,7 +207,7 @@ conversion is pure SQL and every writer of these columns used
 `'YYYY-MM-DD HH:MM:SS'` UTC that `strftime('%s', …)` parses exactly.
 
 ```sql
--- 0019_unify_timestamps_to_unix_seconds.sql  (forward-only)
+-- NNNN_unify_timestamps_to_unix_seconds.sql  (forward-only)
 -- foreign_keys is ON (init_db sets it). Wrap in the migrator's implicit txn.
 
 -- books: timestamp + last_modified TEXT -> INTEGER. Recreate because the column
@@ -303,7 +304,7 @@ from `db/src/pool.rs:56`) — but none exists today, so the in-DDL CAST suffices
 
 ## Affected code (Option A)
 
-**Migration (new):** `db/migrations/0019_unify_timestamps_to_unix_seconds.sql`.
+**Migration (new):** `db/migrations/NNNN_unify_timestamps_to_unix_seconds.sql`.
 
 **Write sites — `datetime('now')` → `strftime('%s','now')`:**
 
@@ -346,7 +347,7 @@ Option B would change.)
 ## Test plan
 
 Per rule 03: sibling `<mod>/tests.rs`, `sqlite::memory:` via `init_db` (which
-runs all migrations including `0019`), happy + per-variant.
+runs all migrations including the new one), happy + per-variant.
 
 - **Column type post-migration.** In a migration/`pool.rs` test: insert a row
   and assert the stored value is an INTEGER unix-second for each migrated column
@@ -354,8 +355,8 @@ runs all migrations including `0019`), happy + per-variant.
   `author_photos.fetched_at`, `merge_log.merged_at`, `ignored_authors.ignored_at`
   (fetch as `i64`, assert `> 0`; or `SELECT typeof(col) = 'integer'`).
 - **Backfill conversion (the acceptance test that MUST fail on the old schema).**
-  A `sqlite::memory:` DB running `0019` immediately can't hold pre-migration TEXT
-  rows, so lock the conversion *semantics* directly:
+  A `sqlite::memory:` DB running the new migration immediately can't hold
+  pre-migration TEXT rows, so lock the conversion *semantics* directly:
   `SELECT CAST(strftime('%s','2024-01-02 03:04:05') AS INTEGER)` must equal
   `1704164645`. This is the conversion the old TEXT rows depend on; it is the
   parsing case rule 03 says to cover. Pair it with a test that inserts via the
@@ -376,7 +377,7 @@ runs all migrations including `0019`), happy + per-variant.
   query simplifies).
 - Run: `cargo test -p omnibus-db`, `cargo test -p omnibus-frontend --features
   server`, `cargo test -p omnibus-shared`, `cargo test -p omnibus` (`just test`),
-  then `just dev-bounce` so `0019` applies to the live dev DB.
+  then `just dev-bounce` so the new migration applies to the live dev DB.
 
 (Under Option B, additionally: replace ISO-string fixtures in `sorting.rs`
 281-302 / 362-383 and `filtering.rs` with `i64`, and assert `NewestAdded` /
@@ -387,8 +388,8 @@ runs all migrations including `0019`), happy + per-variant.
 ## Risks & rollback
 
 - **Forward-only, fix-forward (rule 06).** There is no down-migration. A mistake
-  in `0019` is corrected by a `0020`, never by editing `0019` once it has run
-  anywhere (sqlx checksums it).
+  in the new migration is corrected by a later one, never by editing it once it
+  has run anywhere (sqlx checksums it).
 - **Data-loss surface = the table recreate of `books`.** `books` is FK-parent to
   `book_files` and the link tables and is external-content for `books_fts`
   (0005). The `INSERT…SELECT … id` preserves primary keys, so children stay
@@ -406,7 +407,7 @@ runs all migrations including `0019`), happy + per-variant.
   `DROP TABLE books` may drop them; the recreate must re-establish them. Confirm
   during authoring and add to the migration if so — a missing FTS trigger
   silently breaks search on subsequently-indexed books.
-- **Mitigation.** Author and run `0019` against a *copy* of a real
+- **Mitigation.** Author and run the new migration against a *copy* of a real
   Calibre-derived DB (not just `sqlite::memory:`, which starts empty) to exercise
   the CAST path on actual `datetime('now')` rows before merge.
 
@@ -425,9 +426,9 @@ Recommended ordering:
   the `books_new` column list and the `BOOK_COLUMNS` edits will need rework. In
   particular the F1 ↔ F2 ↔ F10 chain (book-identity / merge / override-orphan
   reconcile) all touch `books` and `merge_log`; sequencing F11 last among the
-  `books`-table migrations means `0019` recreates the *final* column set once,
-  rather than chasing intermediate shapes.
-- If F11 must go first, keep `0019` purely additive-in-spirit (type-only
+  `books`-table migrations means this migration recreates the *final* column set
+  once, rather than chasing intermediate shapes.
+- If F11 must go first, keep this migration purely additive-in-spirit (type-only
   conversion, no column add/drop) so a later `books` migration rebases cleanly on
   top.
 - **Independent of the index findings.** The "session indexes don't support
@@ -445,8 +446,8 @@ Recommended ordering:
    Library reskin that owns date rendering is landing concurrently and wants the
    `i64`.
 2. **`books_fts` trigger fate on recreate.** Does 0005 define AFTER
-   insert/update/delete triggers on `books`? If yes, `0019` must drop+recreate
-   them. (Verify at authoring time; gates a correct migration.)
+   insert/update/delete triggers on `books`? If yes, this migration must
+   drop+recreate them. (Verify at authoring time; gates a correct migration.)
 3. **Books-table migration ordering.** Does any of F1/F2/F10 add or remove a
    `books` column before F11 lands? If so, F11's `books_new` column list must be
    authored against that later shape — coordinate the merge order.

--- a/docs/design/db-review-f11-timestamp-unification.md
+++ b/docs/design/db-review-f11-timestamp-unification.md
@@ -1,0 +1,460 @@
+# Unify machine timestamps on INTEGER unix-seconds (F11)
+
+**Status: Proposed — deferred from db.md F11, awaiting decision.**
+
+Source: `docs/review/db.md` → *"Three inconsistent time representations"*. This
+doc exists to make the one blocking decision tractable — the **wire/serde shape
+for `books.timestamp` / `books.last_modified`** — and to scope the migration that
+follows. No schema or Rust changes are made here; the DDL below is a sketch.
+
+---
+
+## Problem
+
+The schema encodes "machine" timestamps three different ways:
+
+1. **INTEGER unix-seconds** (the target) via `strftime('%s','now')` — all auth
+   tables (`db/migrations/0004_auth.sql:26-71`), the progress/session tables
+   (`0013_reading_progress.sql:19,42,53-55,67-68`), `highlights.created_at`
+   (`0017_highlights.sql:15`), `libraries.last_indexed` (`0002:19`),
+   `book_files.mtime_epoch` (`0009:15`).
+2. **TEXT** via `datetime('now')` (`'YYYY-MM-DD HH:MM:SS'`) — `books.timestamp`
+   and `books.last_modified` (`0002_normalized_schema.sql:33-34`),
+   `metadata_overrides.updated_at` (`0007:21`), `author_photos.fetched_at`
+   (`0008:18`), `merge_log.merged_at` / `merge_log.undone_at` (`0016:53-54`).
+3. **DATETIME** via `CURRENT_TIMESTAMP` — `ignored_authors.ignored_at`
+   (`0010:18`). SQLite has no real `DATETIME` affinity, so this is the same
+   fixed-width TEXT as (2), just a third spelling.
+
+`books.pubdate` (`0002:32`) is a genuinely partial **human** date and is
+correctly excluded — it stays TEXT.
+
+**Why it bites today (not just cosmetics):**
+
+- `books.timestamp` / `books.last_modified` are read raw as `String` into
+  `EbookMetadata.added_at` / `modified`
+  (`db/src/books/projection.rs:33,176,188`;
+  `shared/src/ebook/metadata.rs:53,83-88`), and the landing page sorts those
+  **lexicographically** as strings (`frontend/src/pages/landing/sorting.rs:71-78`
+  → `RowKey.plain: Option<String>` compared via `String: Ord`). This works
+  *only because* fixed-width zero-padded ISO sorts the same as chronological
+  order. The instant a writer stores a bare unix-second string instead, the
+  sort silently corrupts (`'9999999999' > '10000000000'`).
+- `db/src/covers.rs` `get_last_modified_epoch` already pays for the mismatch:
+  `SELECT CAST(strftime('%s', last_modified) AS INTEGER)` — a per-call string
+  parse that would be a plain column read if the column were INTEGER.
+
+**Why it bites a named roadmap feature:** F3.4 stats
+(`docs/roadmap/3-4-stats.md:18`) aggregates the INTEGER session tables with
+`GROUP BY date(start_at, 'unixepoch')` and `SUM(end_at - start_at)`. Any join or
+unified timeline that mixes `books.timestamp` ("date added") or a future
+`journal.created_at` with those session tables can't `GROUP BY date(...)`
+uniformly: INTEGER columns need `date(col,'unixepoch')`, TEXT ones need bare
+`date(col)`. F3.2 ratings/journaling specs *more* TEXT `updated_at` columns
+adjacent to the INTEGER session tables, so the divergence compounds rather than
+stabilizes. Mixed types also defeat a single Rust-side serialization helper.
+
+The convention to standardize on is INTEGER unix-seconds — the auth migration
+argued it and every table since has followed it. This finding migrates the five
+laggard tables to match.
+
+---
+
+## Decision required
+
+Two decisions, one of which is load-bearing:
+
+**D1 (blocking) — the wire/serde shape for `added_at` / `modified`.** The DB
+columns *will* become INTEGER regardless. The open question is whether that type
+change is allowed to cross the HTTP/RPC boundary:
+
+- **Keep the wire `String`** (`EbookMetadata.added_at/modified: Option<String>`
+  stay as-is), formatting the epoch back to fixed-width ISO on the DB read path.
+  Frontend untouched, lexicographic sort still correct. **OR**
+- **Change the wire to `i64`** (`Option<i64>`), and fix the frontend sort to be
+  numeric and the table cell to format the epoch for display.
+
+**D2 (mechanical, not really optional) — migration mechanism.** SQLite cannot
+`ALTER COLUMN` a type, cannot redefine a `NOT NULL DEFAULT (datetime('now'))` in
+place, and cannot drop a column on old engines. So every affected table is
+**recreated** (`CREATE … _new` → `INSERT…SELECT` with `strftime('%s', col)` →
+`DROP` → `RENAME`), converting existing values in the same statement. This is the
+only viable shape; it's listed as a "decision" only so the operator signs off on
+the table-recreate of `books` (heavily FK-referenced) and the consequent index
+re-creation.
+
+The rest of this doc assumes D2 = table-recreate and focuses on resolving D1.
+
+---
+
+## Options
+
+All three migrate the DB columns to INTEGER identically; they differ only on D1
+(the wire shape) and therefore on blast radius.
+
+### Option A — DB columns INTEGER, wire stays `String` (DB-side ISO formatting)
+
+**How it works.** In `db/src/books/projection.rs` `BOOK_COLUMNS`, wrap the two
+columns:
+`strftime('%Y-%m-%dT%H:%M:%SZ', last_modified, 'unixepoch') AS modified` (and
+the same for `timestamp AS added_at`). `build_metadata` keeps
+`r.get::<String,_>(...)`. `shared::EbookMetadata` and the entire `frontend/`
+sort + render path are **untouched**.
+
+**Migration shape.** `0019_*.sql` recreates the five tables → INTEGER.
+
+**Blast radius.** DB crate only. `shared/` and `frontend/` see zero diff. No
+change to `sorting.rs` / `table.rs` / `filtering.rs` or their fixtures.
+
+**Pros.** Smallest surface; isolates the change to the crate that owns the
+columns; preserves the existing lexicographic-sort correctness invariant by
+construction (ISO output is still fixed-width). Lowest conflict footprint against
+the other in-flight PRs that touch `projection.rs` (see Sequencing).
+
+**Cons.** The wire contract stays "stringly-typed time," so a *future* consumer
+still can't do arithmetic on `added_at` without re-parsing. Adds a tiny
+`strftime` cost to every book read (negligible vs. the existing `CAST` already in
+`covers.rs`, and the projection already runs subqueries per row).
+
+### Option B — DB columns INTEGER, wire becomes `i64`
+
+**How it works.** `EbookMetadata.added_at/modified: Option<i64>`
+(`shared/src/ebook/metadata.rs:53,83-88`). `projection.rs` reads the INTEGER
+columns directly. `frontend/src/pages/landing/sorting.rs` `RowKey.plain` can no
+longer be a single `Option<String>` that serves title/author/time keys — the
+time keys need numeric compare. Either retype `plain` to carry an enum
+(string-or-i64) or add a parallel `epoch: Option<i64>` field and branch in
+`cmp_with_missing_last`. `table.rs:305-306` must format the epoch to a human
+string for display; `filtering.rs` fixtures (`140-163,181-202`) and
+`sorting.rs` fixtures (`281-302,362-383`) move from ISO strings to integers.
+
+**Blast radius.** Three crates: `db/`, `shared/`, `frontend/`. Touches the
+landing sort comparator, the table renderer, and two fixture sets.
+
+**Pros.** "Correct" end state — the wire type matches the storage type, numeric
+sort is unambiguous, downstream consumers (a future combined stats timeline,
+device-sync cursors) get an `i64` they can compute on directly. Removes the
+fragile "this only sorts right because ISO is fixed-width" footgun entirely.
+
+**Cons.** Largest surface, and it lands the frontend display-formatting decision
+(locale? relative "3 days ago"? UTC ISO?) right now, which is really an Atrium/UX
+question, not a DB-hygiene one. Heaviest conflict with concurrent
+`projection.rs` / `sorting.rs` work. Bundles a UI change into a schema-hygiene
+PR.
+
+### Option C — Status quo + a read-time normalization helper (do not migrate columns)
+
+**How it works.** Leave the columns TEXT. Add one Rust helper
+`to_epoch(&str) -> i64` and use it everywhere a TEXT timestamp must be compared
+to an INTEGER one (e.g. the F3.4 join).
+
+**Migration shape.** None.
+
+**Pros.** Zero migration risk; no table recreate.
+
+**Cons.** Doesn't solve the problem — the SQL-level `GROUP BY date(...)`
+non-uniformity (`docs/roadmap/3-4-stats.md`) is *in the query engine*, not in
+Rust, so a Rust helper can't normalize a `GROUP BY` across mixed columns. Leaves
+the lexicographic-sort footgun live. Every new TEXT-timestamp column (F3.2) makes
+it worse. This is the "we'll regret it later" non-fix; recorded only for
+completeness.
+
+---
+
+## Recommendation
+
+**Adopt Option A.** Migrate all five DB columns to INTEGER unix-seconds via the
+`0019` table-recreate, and format `added_at` / `modified` back to fixed-width ISO
+on the `projection.rs` read path so `shared::EbookMetadata` and the entire
+frontend stay byte-for-byte unchanged.
+
+Rationale:
+
+- It fixes the **actual** problem the roadmap cares about — the SQL-level type
+  uniformity that lets F3.4 `GROUP BY date(col,'unixepoch')` across books and
+  sessions, and lets F3.2's new `updated_at` columns be born INTEGER in a schema
+  that's now uniformly INTEGER.
+- It does so with the **smallest reversible surface**: DB-crate-only. The wire
+  shape is unchanged, so the migration is not entangled with the
+  not-yet-decided UI question of *how* to render a timestamp (relative vs.
+  absolute vs. locale). Option B's wire-to-`i64` change is the strictly-better
+  end state, but it should ride along with the Atrium Library reskin that owns
+  date rendering — not block schema hygiene on a UX call.
+- **Reversibility / cost of delay.** The *schema* change is forward-only and
+  effectively irreversible once production rows convert (see Risks). But the
+  *wire* decision under Option A is fully reversible: because the wire stays
+  `String`, we can later flip to Option B's `i64` as an additive frontend PR
+  without re-touching the schema. Choosing A now therefore does **not** foreclose
+  B; choosing B now *does* foreclose deferring the UI decision. Delay cost is
+  real: every new TEXT-timestamp column added before this lands (F3.2) is another
+  column to recreate later.
+
+The one invariant Option A must preserve and test: the ISO string emitted by
+`strftime('%Y-%m-%dT%H:%M:%SZ', …, 'unixepoch')` is fixed-width and sorts
+identically to the old `datetime('now')` output, so the landing lexicographic
+sort (`sorting.rs` `cmp_with_missing_last`) keeps working.
+
+---
+
+## Migration plan (SKETCH — not to be applied)
+
+`db/migrations/0019_unify_timestamps_to_unix_seconds.sql`, forward-only per
+rule 06. The in-DDL `CAST(strftime('%s', col) AS INTEGER)` **is** the backfill —
+no separate Rust boot hook is needed (unlike the `_norm` pattern), because the
+conversion is pure SQL and every writer of these columns used
+`datetime('now')` / `CURRENT_TIMESTAMP`, both of which produce
+`'YYYY-MM-DD HH:MM:SS'` UTC that `strftime('%s', …)` parses exactly.
+
+```sql
+-- 0019_unify_timestamps_to_unix_seconds.sql  (forward-only)
+-- foreign_keys is ON (init_db sets it). Wrap in the migrator's implicit txn.
+
+-- books: timestamp + last_modified TEXT -> INTEGER. Recreate because the column
+-- DEFAULT changes; ids are preserved via INSERT...SELECT so FK children and the
+-- books_fts (0005) external-content index stay valid (no relink, no FTS rebuild).
+CREATE TABLE books_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  uuid TEXT NOT NULL UNIQUE,
+  library_id INTEGER NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+  path TEXT NOT NULL,
+  title TEXT NOT NULL COLLATE NOCASE,
+  sort TEXT COLLATE NOCASE, author_sort TEXT COLLATE NOCASE,
+  series_index REAL, pubdate TEXT,
+  timestamp     INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  last_modified INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  has_cover INTEGER NOT NULL DEFAULT 0,
+  description TEXT COLLATE NOCASE, isbn TEXT COLLATE NOCASE,
+  accent_color TEXT,                 -- 0006
+  title_norm TEXT, author_norm TEXT  -- 0016
+);
+INSERT INTO books_new SELECT
+  id, uuid, library_id, path, title, sort, author_sort, series_index, pubdate,
+  CAST(strftime('%s', timestamp)     AS INTEGER),
+  CAST(strftime('%s', last_modified) AS INTEGER),
+  has_cover, description, isbn, accent_color, title_norm, author_norm
+FROM books;
+DROP TABLE books;
+ALTER TABLE books_new RENAME TO books;
+-- Recreate EVERY books index from 0002/0006/0016: idx_books_uuid, _sort,
+-- _author_sort, _series_index, _last_modified, _timestamp, _library_id,
+-- idx_books_accent_null (0006), idx_books_norm (0016).
+-- Confirm the books_fts triggers (0005) and re-create them if the recreate
+-- dropped them; the bulk INSERT...SELECT into books_new fires no AFTER triggers
+-- on `books`, but DROP TABLE books may cascade-drop FTS triggers — verify.
+
+-- metadata_overrides.updated_at TEXT -> INTEGER (recreate).
+CREATE TABLE metadata_overrides_new (
+  book_uuid TEXT NOT NULL PRIMARY KEY,
+  overrides TEXT NOT NULL DEFAULT '{}',
+  has_cover_override INTEGER NOT NULL DEFAULT 0,
+  updated_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+INSERT INTO metadata_overrides_new SELECT book_uuid, overrides, has_cover_override,
+  updated_by, CAST(strftime('%s', updated_at) AS INTEGER) FROM metadata_overrides;
+DROP TABLE metadata_overrides;
+ALTER TABLE metadata_overrides_new RENAME TO metadata_overrides;
+
+-- author_photos.fetched_at TEXT -> INTEGER (recreate; preserve both CHECKs).
+CREATE TABLE author_photos_new (
+  author_id INTEGER PRIMARY KEY REFERENCES authors(id) ON DELETE CASCADE,
+  source TEXT NOT NULL CHECK (source IN ('manual','openlibrary','letter')),
+  url TEXT, bytes BLOB, mime TEXT,
+  fetched_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  CHECK ((source='letter' AND bytes IS NULL AND mime IS NULL)
+      OR (source<>'letter' AND bytes IS NOT NULL AND mime IS NOT NULL))
+);
+INSERT INTO author_photos_new SELECT author_id, source, url, bytes, mime,
+  CAST(strftime('%s', fetched_at) AS INTEGER) FROM author_photos;
+DROP TABLE author_photos; ALTER TABLE author_photos_new RENAME TO author_photos;
+
+-- merge_log.merged_at TEXT -> INTEGER; undone_at TEXT -> INTEGER (nullable).
+CREATE TABLE merge_log_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  target_book_id INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  source_uuid TEXT NOT NULL, source_metadata TEXT NOT NULL,
+  merged_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  merged_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  undone_at INTEGER
+);
+INSERT INTO merge_log_new SELECT id, target_book_id, source_uuid, source_metadata,
+  merged_by, CAST(strftime('%s', merged_at) AS INTEGER),
+  CASE WHEN undone_at IS NULL THEN NULL ELSE CAST(strftime('%s', undone_at) AS INTEGER) END
+FROM merge_log;
+DROP TABLE merge_log; ALTER TABLE merge_log_new RENAME TO merge_log;
+CREATE INDEX idx_merge_log_target ON merge_log(target_book_id);
+
+-- ignored_authors.ignored_at DATETIME -> INTEGER (recreate).
+CREATE TABLE ignored_authors_new (
+  name TEXT NOT NULL PRIMARY KEY COLLATE NOCASE,
+  ignored_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+INSERT INTO ignored_authors_new SELECT name, CAST(strftime('%s', ignored_at) AS INTEGER)
+FROM ignored_authors;
+DROP TABLE ignored_authors; ALTER TABLE ignored_authors_new RENAME TO ignored_authors;
+```
+
+No boot hook in `normalize.rs` / `pool.rs` is required. If we ever discover a
+writer that stored a non-`datetime('now')` value, we'd add an idempotent
+`backfill_*` next to `backfill_norm_columns` (`db/src/normalize.rs:53`, called
+from `db/src/pool.rs:56`) — but none exists today, so the in-DDL CAST suffices.
+
+---
+
+## Affected code (Option A)
+
+**Migration (new):** `db/migrations/0019_unify_timestamps_to_unix_seconds.sql`.
+
+**Write sites — `datetime('now')` → `strftime('%s','now')`:**
+
+- `db/src/sync/books.rs` `last_modified = datetime('now')` (~509).
+- `db/src/sync/audiobooks.rs` same (~524).
+- `db/src/merge/undo.rs` `UPDATE merge_log SET undone_at = datetime('now')`
+  (~77) and `recreate_source_row` `COALESCE(?, datetime('now'))` (~120).
+- `db/src/merge/transaction.rs` `metadata_overrides` upsert `updated_at`
+  (~396,401).
+- `db/src/metadata_overrides/upsert.rs` INSERT `updated_at` (~52,58).
+- `db/src/author_photos_data.rs` `upsert_author_photo` `fetched_at` (~107).
+
+**Read / round-trip sites:**
+
+- `db/src/merge/snapshot.rs` `SourceSnapshot.timestamp: Option<String>` →
+  `Option<i64>` (line 22); the `SELECT b.timestamp` (~95) now yields INTEGER;
+  serde round-trip field type follows.
+- `db/src/author_photos_data.rs` `author_photo_status` SELECT tuple
+  `(String, String)` → `(String, i64)`, or simply drop `fetched_at` from the
+  SELECT — every caller ignores it (`db/src/author_photos_data.rs:86-91`;
+  callers use only `source` at `cascade.rs:90,148`).
+- `db/src/merge/undo.rs` `undone_at` presence check is unchanged —
+  `Option<i64>::is_some()` still gates `AlreadyUndone`.
+- `db/src/covers.rs` `get_last_modified_epoch` (~246): replace
+  `CAST(strftime('%s', last_modified) AS INTEGER)` with a plain
+  `SELECT last_modified` (now already INTEGER).
+
+**Read site — DB-side ISO formatting (the Option-A keystone):**
+
+- `db/src/books/projection.rs` `BOOK_COLUMNS` (line 33): wrap `b.last_modified`
+  / `b.timestamp` in `strftime('%Y-%m-%dT%H:%M:%SZ', col, 'unixepoch') AS …` so
+  `build_metadata` (lines 176,188) still reads `String`.
+
+**Unchanged under Option A:** `shared/src/ebook/metadata.rs`,
+`frontend/src/pages/landing/{sorting,table,filtering}.rs`. (These are the files
+Option B would change.)
+
+---
+
+## Test plan
+
+Per rule 03: sibling `<mod>/tests.rs`, `sqlite::memory:` via `init_db` (which
+runs all migrations including `0019`), happy + per-variant.
+
+- **Column type post-migration.** In a migration/`pool.rs` test: insert a row
+  and assert the stored value is an INTEGER unix-second for each migrated column
+  — `books.timestamp`, `books.last_modified`, `metadata_overrides.updated_at`,
+  `author_photos.fetched_at`, `merge_log.merged_at`, `ignored_authors.ignored_at`
+  (fetch as `i64`, assert `> 0`; or `SELECT typeof(col) = 'integer'`).
+- **Backfill conversion (the acceptance test that MUST fail on the old schema).**
+  A `sqlite::memory:` DB running `0019` immediately can't hold pre-migration TEXT
+  rows, so lock the conversion *semantics* directly:
+  `SELECT CAST(strftime('%s','2024-01-02 03:04:05') AS INTEGER)` must equal
+  `1704164645`. This is the conversion the old TEXT rows depend on; it is the
+  parsing case rule 03 says to cover. Pair it with a test that inserts via the
+  new default and reads back a plausible "now" epoch.
+- **`projection.rs` (Option-A keystone).** A `list_books` / `get_book` test
+  asserting `added_at` / `modified` are well-formed fixed-width ISO strings
+  (`YYYY-MM-DDTHH:MM:SSZ`) and that two known rows sort correctly under the
+  landing lexicographic comparator — i.e. the sort contract that the old TEXT
+  columns provided still holds.
+- **`merge/snapshot.rs` + `undo.rs`.** Existing merge/undo round-trip tests pass
+  with `timestamp: Option<i64>`; add one asserting a merged-then-undone book's
+  restored `timestamp` is a positive integer and `undone_at` presence still
+  gates `AlreadyUndone`.
+- **`author_photos_data.rs`.** `author_photo_status` happy path still returns the
+  right `source` after the tuple-type change.
+- **`covers.rs`.** `get_last_modified_epoch` returns `Some(positive i64)` for an
+  indexed book and `None` for a missing id (re-verify existing tests after the
+  query simplifies).
+- Run: `cargo test -p omnibus-db`, `cargo test -p omnibus-frontend --features
+  server`, `cargo test -p omnibus-shared`, `cargo test -p omnibus` (`just test`),
+  then `just dev-bounce` so `0019` applies to the live dev DB.
+
+(Under Option B, additionally: replace ISO-string fixtures in `sorting.rs`
+281-302 / 362-383 and `filtering.rs` with `i64`, and assert `NewestAdded` /
+`LastUpdated` order numerically incl. missing-last behavior.)
+
+---
+
+## Risks & rollback
+
+- **Forward-only, fix-forward (rule 06).** There is no down-migration. A mistake
+  in `0019` is corrected by a `0020`, never by editing `0019` once it has run
+  anywhere (sqlx checksums it).
+- **Data-loss surface = the table recreate of `books`.** `books` is FK-parent to
+  `book_files` and the link tables and is external-content for `books_fts`
+  (0005). The `INSERT…SELECT … id` preserves primary keys, so children stay
+  linked and FTS stays valid — *provided the column list is exact*. The single
+  biggest hazard is silently dropping a `books` column added by an intervening
+  migration (e.g. `accent_color` from 0006, the `_norm` columns from 0016): the
+  recreate must enumerate the **current** `books` shape, not the 0002 shape.
+  Verify against the live schema at authoring time.
+- **Irreversible once data accumulates.** After production rows convert to
+  INTEGER, the original TEXT strings are gone (only the second-resolution epoch
+  remains — which is all `datetime('now')` ever carried, so no precision is
+  lost). But you cannot un-convert without another migration and you cannot
+  recover the exact original string formatting.
+- **FTS triggers.** If `books_fts` (0005) installs AFTER triggers on `books`,
+  `DROP TABLE books` may drop them; the recreate must re-establish them. Confirm
+  during authoring and add to the migration if so — a missing FTS trigger
+  silently breaks search on subsequently-indexed books.
+- **Mitigation.** Author and run `0019` against a *copy* of a real
+  Calibre-derived DB (not just `sqlite::memory:`, which starts empty) to exercise
+  the CAST path on actual `datetime('now')` rows before merge.
+
+---
+
+## Sequencing & dependencies
+
+This is a **big mechanical surface** that conflicts with most other db-review
+PRs — the scout spec lists `conflictsWith: F1, F2, F3, F7, F8, F10, F17, F18`.
+The collisions are concentrated in `db/src/sync/books.rs` and
+`db/src/books/projection.rs`, which several findings also edit.
+
+Recommended ordering:
+
+- **Land this AFTER the `books`-identity / projection-shape findings settle**, or
+  the `books_new` column list and the `BOOK_COLUMNS` edits will need rework. In
+  particular the F1 ↔ F2 ↔ F10 chain (book-identity / merge / override-orphan
+  reconcile) all touch `books` and `merge_log`; sequencing F11 last among the
+  `books`-table migrations means `0019` recreates the *final* column set once,
+  rather than chasing intermediate shapes.
+- If F11 must go first, keep `0019` purely additive-in-spirit (type-only
+  conversion, no column add/drop) so a later `books` migration rebases cleanly on
+  top.
+- **Independent of the index findings.** The "session indexes don't support
+  stats" finding adds `(user_id, started_at)` indexes to the session tables — no
+  overlap with the five tables here, so it can land in parallel.
+- **Unblocks F3.4 / F3.2** rather than depending on them: those features want a
+  uniformly-INTEGER timestamp space, so this should precede their schema work.
+
+---
+
+## Open questions
+
+1. **D1 final call.** Confirm Option A (wire stays `String`) vs. Option B (wire
+   `i64`). The recommendation is A; B is a defensible "do it once" if the Atrium
+   Library reskin that owns date rendering is landing concurrently and wants the
+   `i64`.
+2. **`books_fts` trigger fate on recreate.** Does 0005 define AFTER
+   insert/update/delete triggers on `books`? If yes, `0019` must drop+recreate
+   them. (Verify at authoring time; gates a correct migration.)
+3. **Books-table migration ordering.** Does any of F1/F2/F10 add or remove a
+   `books` column before F11 lands? If so, F11's `books_new` column list must be
+   authored against that later shape — coordinate the merge order.
+4. **`merge_log.source_metadata` JSON.** The snapshot blob round-trips
+   `b.timestamp` (`db/src/merge/snapshot.rs:22`). Confirm no *persisted* merge
+   snapshot JSON already on disk encodes `timestamp` as a string that would
+   deserialize-fail once the field becomes `Option<i64>`. If old snapshots exist,
+   add a serde compatibility shim or a one-time snapshot rewrite.
+5. **Display formatting (only if B).** If Option B, where does the epoch→human
+   formatting live and what format (UTC ISO, locale, relative)? That is an
+   Atrium/UX decision, not a DB one — another reason A defers it cleanly.

--- a/docs/design/db-review-f13-change-tracking.md
+++ b/docs/design/db-review-f13-change-tracking.md
@@ -1,0 +1,482 @@
+# F13 — Phase-4 device-sync change tracking
+
+Status: Proposed — deferred from db.md F13, awaiting decision.
+
+This doc frames the data-model decision that must land *before* any
+schema or code is written. It does not prescribe an implementation; it
+gives the operator the choice, the trade-offs, and a recommended path
+with an honest accounting of cost-of-delay and reversibility.
+
+---
+
+## Problem
+
+Phase-4 device sync (Kobo F4.1, OPDS-incremental) needs the server to
+answer one question per device: *"what changed since your last sync?"* —
+including **deletions**, so a device can drop a book that is no longer in
+the library. The current schema cannot answer that question.
+
+Three concrete gaps, confirmed against the code:
+
+1. **No monotonic cursor.** `books.last_modified` is `TEXT NOT NULL
+   DEFAULT (datetime('now'))` at one-second resolution
+   (`db/migrations/0002_normalized_schema.sql:34`, indexed at `:80`). It
+   is overwritten **in place** on every Changed book — see the
+   `last_modified = datetime('now')` clause in `update_book_row`
+   (`db/src/sync/books.rs:484`) and `update_audiobook_row`
+   (`db/src/sync/audiobooks.rs`). A second-resolution, in-place,
+   non-gap-free high-water mark is unusable as a sync cursor: two books
+   changed in the same second collapse to one timestamp, and a client
+   that syncs mid-second can miss a row forever.
+
+2. **Deletions vanish.** Removed books are hard-`DELETE`d through the
+   `ON DELETE CASCADE` FK on `books` (`0002:26`). `sync_removed`
+   (`db/src/sync/books.rs:125`) clears the FTS twin then deletes the
+   `books` row; the audiobook Removed branch does the same inline
+   (`db/src/sync/audiobooks.rs:50-76`). Once the row is gone there is no
+   record it ever existed, so the sync endpoint **cannot** tell a device
+   "this book is gone." The device keeps a phantom book indefinitely.
+
+3. **No per-device cursor store.** F4.1 names a `kobo_sync_tokens` table
+   keyed on user (`docs/roadmap/4-1-kobo-sync.md:30`) but lists its only
+   schema dependency as the uuid index — already satisfied by
+   `uuid TEXT NOT NULL UNIQUE` (`0002:25`). That undersells the gap: the
+   token table is the *easy* part; the change feed it points into does
+   not exist.
+
+Why it bites a named feature: F4.1's `/kobo/v1/library/sync` is, by
+spec, "only books changed since the client's last token," and Kobo's
+protocol requires explicit delete notifications. The roadmap promotes
+native Kobo sync ahead of OPDS precisely because it is the better UX on
+the platform that matters most (`4-1-kobo-sync.md:13`). Delivering it on
+today's schema means a retrofit onto the hot indexer write path under
+deadline — exactly the refactor this doc exists to pre-empt.
+
+This is a **data-model** gap, not a missing endpoint. The endpoint is
+cheap once the feed exists; the feed is what needs deciding now.
+
+---
+
+## Decision required
+
+The operator must pick **one** primary model and resolve two secondary
+questions. All three are recorded here so a later implementer inherits a
+settled design, not an open one.
+
+1. **Primary — change-tracking model.** Either
+   - **(A) Soft-delete + monotonic `change_seq` on `books`** — every
+     read path must learn to filter `deleted_at IS NULL`; or
+   - **(B) A separate `book_changes` audit feed** written by the sync
+     writers — read paths and hard-delete semantics untouched.
+
+   This is the heart of the decision: A and B diverge in **which files
+   they touch**, and A is expensive to walk back once read paths depend
+   on `deleted_at`.
+
+2. **Secondary — counter mechanism.** SQLite has no sequences. The
+   monotonic source is either a single-row `change_counter` table bumped
+   inside the sync transaction (works for A *and* B), or
+   `INTEGER PRIMARY KEY AUTOINCREMENT` on the audit table (B only). Pick
+   per the model chosen.
+
+3. **Secondary — cursor scope.** Is the change feed **global** (one
+   sequence space for the whole library) or **per-user**? The library
+   today is single-tenant at the catalog level — every user sees the
+   same books — so a global feed with per-`(user, device)` cursors is
+   the natural fit. Per-user change rows only become necessary if/when
+   per-user catalog visibility (shelves, private uploads) lands, which is
+   not in any current phase.
+
+---
+
+## Options
+
+All DDL below is **additive** (`ADD COLUMN` + `CREATE TABLE/INDEX`). No
+option alters a primary key, drops a column, or changes an FK, so **none
+require the SQLite table-recreate dance** (`CREATE new` → `INSERT … SELECT`
+→ `DROP old` → `ALTER … RENAME`). Migrations stay append-only and
+forward-only per rule 06.
+
+### Option A — soft-delete `deleted_at` + monotonic `change_seq` on `books`
+
+**How it works.** Add two columns to `books`: `change_seq INTEGER` (the
+cursor) and `deleted_at INTEGER` (epoch secs; NULL = live). A single-row
+`change_counter` table is bumped inside the sync transaction; every
+insert/update stamps the new value into `books.change_seq`, every removal
+sets `deleted_at` and bumps `change_seq` **instead of** deleting the row.
+A device syncs by selecting `books WHERE change_seq > :cursor ORDER BY
+change_seq`, mapping `deleted_at IS NOT NULL` to a delete notification.
+
+**Migration shape.**
+```sql
+ALTER TABLE books ADD COLUMN change_seq INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE books ADD COLUMN deleted_at INTEGER;            -- NULL = live
+CREATE INDEX idx_books_change_seq ON books(change_seq);
+CREATE INDEX idx_books_deleted_at ON books(deleted_at);
+CREATE TABLE change_counter (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  value INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO change_counter (id, value) VALUES (1, 0);
+```
+
+**Blast radius — large.** Soft-delete is viral: **every** read path that
+lists or counts books must add `deleted_at IS NULL`, or soft-deleted
+books leak back into the UI. That means `BOOK_COLUMNS` and the
+list/get/search queries in `db/src/books/projection.rs`, plus browse,
+discovery (`get_author`/`get_series`), taxonomy CTEs, and the FTS-backed
+search join. The cascade also changes meaning: today removing a book
+cascade-clears `book_files`, link rows, and the FTS twin
+(`0002:26`, `sync_removed`). Under soft-delete the operator must decide
+whether those satellite rows stay (so a re-add restores the book whole)
+or still get cleared (so only the `books` tombstone survives) — and the
+FTS twin **must** be cleared regardless, or deleted books keep matching
+search.
+
+**Pros.** One sequence space, gap-free, trivially correct cursor
+arithmetic. No second table to garbage-collect. "Current state" and
+"change record" are the same row — no join to resolve what a book looks
+like now.
+
+**Cons.** Highest blast radius and the **hardest to reverse**: once a
+dozen read paths filter `deleted_at`, backing out means re-auditing all
+of them. A forgotten read path is a latent correctness bug (deleted book
+reappears) that won't surface until Phase-4 actually soft-deletes
+something. `books` accumulates tombstone rows forever unless a separate
+reaper is built (which then has to respect the *slowest* device cursor).
+
+### Option B — separate `book_changes` audit feed
+
+**How it works.** Leave `books` and its hard-delete cascade exactly as
+they are. Add an append-only `book_changes` table; the sync writers emit
+one row per mutation (`'upsert'` on insert/update, `'delete'` in
+`sync_removed` **before** the cascade fires). The row is keyed by
+`book_uuid` (a *soft* reference, no FK) so it survives the hard-delete —
+the same durable-reference pattern `metadata_overrides` uses
+(`0007_metadata_overrides.sql`, and rule 06's book-identity guidance). A
+device syncs by selecting `book_changes WHERE seq > :cursor ORDER BY
+seq`, joining live `books` for upserts and reporting `kind='delete'`
+rows as removals.
+
+**Migration shape.**
+```sql
+CREATE TABLE book_changes (
+  seq        INTEGER PRIMARY KEY AUTOINCREMENT,   -- monotonic cursor
+  book_uuid  TEXT    NOT NULL,                     -- soft ref; survives delete
+  kind       TEXT    NOT NULL,                     -- 'upsert' | 'delete'
+  changed_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+CREATE INDEX idx_book_changes_uuid ON book_changes(book_uuid);
+```
+`AUTOINCREMENT` (not bare `INTEGER PRIMARY KEY`) is deliberate: it
+guarantees a strictly increasing `seq` that is **never reused** even
+after the highest row is deleted by the reaper — a reused seq would let a
+caught-up device silently skip a change.
+
+**Blast radius — small and contained.** Read paths are untouched —
+`projection.rs`, browse, discovery, taxonomy, search all stay exactly as
+they are. The only write-path change is one `record_change(tx, uuid,
+kind)` call added at four existing choke points (`insert_book_row`,
+`update_book_row`, `sync_removed`, and the three audiobook mirrors). No
+new `deleted_at IS NULL` predicate anywhere.
+
+**Pros.** Minimal, localized blast radius; near-zero correctness risk to
+existing features (a forgotten call site under-reports a change to a
+device, never corrupts the library). Hard-delete semantics preserved, so
+the cascade keeps satellite tables clean for free. Trivial to GC: delete
+`book_changes` rows below the slowest device cursor, with coalescing
+(only the latest row per uuid matters to a fresh device). Easy to walk
+back — drop the table, remove four calls.
+
+**Cons.** A second table to write and eventually GC. Resolving "what does
+this book look like now" requires a join back to `books` (for `upsert`
+rows). A book changed N times before a device's first sync produces N
+rows unless coalesced — handled by the GC's per-uuid coalescing, not a
+hot-path concern.
+
+### Option C — do nothing now; lean on `last_modified`
+
+**How it works.** Defer entirely; when F4.1 lands, widen
+`last_modified` to a monotonic integer and bolt on a tombstone table
+under deadline.
+
+**Why it's listed and rejected.** It is the implicit status quo, so it
+belongs in the comparison. But it pushes the *exact same* data-model
+decision into the middle of F4.1 implementation, where it competes with
+protocol work for attention and lands as a rushed retrofit on the hot
+write path. Cost-of-delay is real but the *cost-of-deciding* is what this
+doc removes; C throws that away. Not recommended.
+
+---
+
+## Recommendation
+
+**Adopt Option B (separate `book_changes` audit feed), with a global
+sequence space (`AUTOINCREMENT`) and per-`(user_id, device_id)`
+cursors.** Land migration `0019` now (additive, zero read-path risk) and
+the writer wiring; defer the GC/reaper and all `/kobo/*` endpoints to
+F4.1.
+
+Rationale:
+
+- **Reversibility dominates here.** This is forward-looking infra for a
+  feature that isn't built yet; the operator should keep the cheapest
+  exit. B is a table plus four call sites — trivially droppable. A bakes
+  `deleted_at` into a dozen read paths; once data accumulates and the UI
+  depends on the filter, unwinding it is a second migration *plus* a
+  read-path re-audit. Pay the reversible cost, not the irreversible one.
+
+- **Blast radius matches confidence.** We do not yet know F4.1's exact
+  needs (Kobo's protocol is undocumented; the roadmap scopes it as
+  "parity with Calibre-Web," `4-1-kobo-sync.md:42`). Touching only the
+  write path keeps the uncommitted surface small until the protocol is
+  pinned down.
+
+- **It composes with the existing soft-reference grain.** `book_uuid`
+  with no FK is the same durable-reference pattern as
+  `metadata_overrides` and the `merged_uuids` resolver
+  (`resolve_book_id_by_uuid` in `db/src/books/get.rs:132` already
+  UNION-falls-back through `merged_uuids`). The change feed slots into a
+  pattern the codebase already endorses, so a delete row keyed by uuid is
+  idiomatic, not novel.
+
+- **Cost-of-delay is bounded but not zero.** The longer we wait, the more
+  the eventual backfill must synthesize. B's backfill is a one-time
+  "emit one `upsert` per existing book" seed — bounded by library size,
+  idempotent, identical in spirit to `backfill_norm_columns`. A's
+  backfill (`change_seq = rowid` for every book) is comparable, but A's
+  *ongoing* cost — every new read path remembering the filter — never
+  ends. B has no recurring tax.
+
+The one place A genuinely wins — no join to resolve current state — does
+not justify viral read-path changes for infra we may tune again when F4.1
+forces the protocol's real shape into view.
+
+**Both options ship `kobo_sync_tokens` unchanged** (it is orthogonal to
+A-vs-B):
+```sql
+CREATE TABLE kobo_sync_tokens (
+  user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  device_id  TEXT    NOT NULL,
+  last_seq   INTEGER NOT NULL DEFAULT 0,   -- cursor into book_changes.seq
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  PRIMARY KEY (user_id, device_id)
+);
+```
+
+---
+
+## Migration plan (SKETCH — do not apply yet)
+
+`db/migrations/0019_change_tracking.sql` — next number after the highest
+on disk (`0018_multiformat_book_files.sql`). Forward-only, additive only,
+so **no table-recreate dance** is needed:
+
+```sql
+-- 0019_change_tracking.sql  (Option B, recommended)
+CREATE TABLE book_changes (
+  seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+  book_uuid  TEXT    NOT NULL,
+  kind       TEXT    NOT NULL,            -- 'upsert' | 'delete'
+  changed_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+CREATE INDEX idx_book_changes_uuid ON book_changes(book_uuid);
+
+CREATE TABLE kobo_sync_tokens (
+  user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  device_id  TEXT    NOT NULL,
+  last_seq   INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  PRIMARY KEY (user_id, device_id)
+);
+```
+
+**Boot backfill** — add a `backfill_initial_changes(pool)` step in
+`init_db` (`db/src/pool.rs`), called right after
+`backfill_norm_columns(&pool)` at `pool.rs:56`, mirroring its idempotency
+contract exactly:
+
+- Guard: `SELECT 1 FROM book_changes LIMIT 1` — if any change row exists,
+  return early (no-op once caught up). Same shape as
+  `backfill_norm_columns`'s `if rows.is_empty() { return Ok(()) }` guard
+  (`db/src/normalize.rs:53`).
+- Otherwise, in one transaction, `INSERT INTO book_changes (book_uuid,
+  kind) SELECT uuid, 'upsert' FROM books` so a device's very first sync
+  sees the whole library.
+
+This makes a pre-`0019` database converge with a fresh one on the next
+boot, with no manual step — the rule-06 backfill contract.
+
+(If Option A is chosen instead, the migration adds the two `books`
+columns + indexes + `change_counter` single-row table per the Option A
+sketch above, and the backfill stamps `change_seq = id` for every
+existing book under the same idempotency guard.)
+
+---
+
+## Affected code
+
+From the scout spec, scoped to **Option B** (A's extra read-path files
+are noted inline):
+
+- `db/migrations/0019_change_tracking.sql` — **new**: `book_changes` +
+  `kobo_sync_tokens` + indexes (Option A: `books.change_seq` /
+  `books.deleted_at` columns + `change_counter` instead).
+- `db/src/change_feed/{mod.rs,tests.rs}` — **new module**:
+  `record_change(tx, uuid, kind)` writer and `changes_since(pool,
+  cursor)` reader; `kobo_sync_tokens` get/advance accessors. Module
+  `//!` + per-`pub` `///` per rule 05; `thiserror` enum with
+  `#[error(transparent)] #[from] sqlx::Error` per rule 02 — never leak
+  raw `sqlx::Error` across the boundary (the `SyncError` pattern at
+  `db/src/sync/books.rs:25` is the local model).
+- `db/src/sync/books.rs` — `insert_book_row` (emit `upsert`),
+  `update_book_row` (`:484`, emit `upsert`), `sync_removed` (`:125`,
+  emit `delete` **before** the cascade DELETE at `:154-160`). Extract a
+  shared `record_book_change(tx, …)` helper rather than inlining, to stay
+  under the rule-05 ~80-line cap.
+- `db/src/sync/audiobooks.rs` — mirror in `insert_audiobook_row`,
+  `update_audiobook_row`, and the inline Removed branch (`:50-76`).
+- `db/src/sync.rs` — update the module `//!` doc; re-export the new
+  `change_feed` writer if it lives under `sync/`.
+- `db/src/pool.rs` — `init_db`: call `backfill_initial_changes` after
+  `backfill_norm_columns` (`:56`).
+- **Option A only:** `db/src/books/projection.rs` (`BOOK_COLUMNS` +
+  list/get/search), `db/src/browse.rs`, `db/src/discovery/*`,
+  `db/src/taxonomy.rs`, and the FTS search join all gain
+  `deleted_at IS NULL`. This file set is the blast-radius difference
+  between the two options.
+- `docs/roadmap/4-1-kobo-sync.md` — update the schema-dependency note
+  (`:29-30`) to point at this initiative; record `.claude/architecture.md`
+  per rule 99.
+
+---
+
+## Test plan
+
+Per rule 03: sibling `db/src/change_feed/tests.rs`, `sqlite::memory:` via
+`test_support`, happy path + one test per `thiserror` variant. The
+migrator runs on every `init_db("sqlite::memory:")`, so `0019` is
+exercised transitively by the whole suite.
+
+New `db/src/change_feed/tests.rs`:
+
+- `record_change_emits_upsert_when_book_inserted` — a new book produces
+  one `upsert` row.
+- `record_change_seq_is_monotonic_when_book_updated_twice` — two updates
+  produce strictly increasing `seq` values.
+- **The acceptance test that must fail on the old schema:**
+  `removed_book_is_still_reportable_after_books_row_is_gone` — remove a
+  book, assert a `delete` change row exists keyed by the (now-deleted)
+  uuid. On today's hard-delete schema there is no feed at all, so this
+  test cannot even compile against `main` without `0019` — it is the
+  red bar proving the gap is closed. (Option A variant: assert
+  `deleted_at IS NOT NULL` and `change_seq` bumped, and that the row is
+  excluded from `list_books`.)
+- `changes_since_returns_only_rows_above_cursor_in_seq_order` — and is
+  empty when caught up.
+- `kobo_sync_tokens_cursor_round_trips_per_user_and_device` — get/advance
+  is scoped to `(user_id, device_id)`.
+- `changes_since_propagates_db_error_when_pool_is_closed` — the
+  `Db`/`#[from] sqlx::Error` variant.
+
+Extend `db/src/sync/tests.rs`:
+
+- `sync_books_writes_change_rows_inside_committed_transaction` — assert a
+  rolled-back tx leaves **no** change row (atomicity with the data
+  write).
+
+`db/src/pool.rs` (or `normalize`-adjacent) backfill test:
+
+- `backfill_initial_changes_seeds_one_upsert_per_pre_0019_book` and is a
+  no-op on second call (idempotency, mirroring the
+  `backfill_norm_columns` test).
+
+Option A only: add read-path tests proving soft-deleted books are
+excluded from list/browse/discovery/search/taxonomy.
+
+---
+
+## Risks & rollback
+
+- **Forward-only, fix-forward.** Migrations are append-only (rule 06).
+  An error in `0019` is corrected by a `0020`, never by editing `0019`
+  once applied anywhere — `sqlx` checksums each file and a changed
+  applied migration fails startup.
+- **Option B is cheaply reversible** *until devices hold cursors.* Drop
+  `book_changes` + `kobo_sync_tokens` and remove four call sites. Once
+  real Kobo devices have synced and stored a `last_seq`, dropping the
+  feed strands those cursors — but that only happens in F4.1, long after
+  this lands.
+- **Option A is the irreversible surface.** Once read paths depend on
+  `deleted_at IS NULL` and tombstone rows accumulate, you cannot drop the
+  column without a table-recreate migration *and* re-auditing every read
+  path. A single missed read path is a silent correctness bug
+  (soft-deleted book reappears) that won't surface until something is
+  actually soft-deleted in Phase-4. This asymmetry is the core reason the
+  recommendation is B.
+- **Data-loss surface.** Both options are additive — neither destroys
+  existing data on apply. The live risk is the **GC/reaper** (deferred to
+  F4.1): if it prunes `book_changes` rows below the *slowest* device
+  cursor incorrectly, a lagging device misses changes. The reaper must
+  read `MIN(last_seq)` across `kobo_sync_tokens` before deleting, and
+  coalesce rather than gap the sequence. Out of scope for `0019`;
+  flagged so it isn't forgotten.
+- **Counter contention.** Both the single-row `change_counter` (A) and
+  `AUTOINCREMENT` (B) serialize on the sync transaction. Sync is already
+  a single transactional choke point (`sync_books` at `:81`), so this
+  adds no new contention — the write was already serialized.
+
+---
+
+## Sequencing & dependencies
+
+The scout flags F13 as coupling with **F1, F11, F12, F14, F17, F18**.
+The load-bearing ordering constraints:
+
+- **F1 ↔ F2 ↔ F10 (book-identity chain) must settle first.** F13's
+  change rows are keyed by `book_uuid` as a durable soft reference. If a
+  later finding changes how book identity is anchored (path-derived
+  `stable_uuid` is itself flagged in db.md as fragile, and `merged_uuids`
+  already complicates uuid resolution), the change-feed key inherits that
+  decision. Land the identity model before wiring the feed key, or the
+  feed points at an unstable anchor. The `resolve_book_id_by_uuid`
+  fallback (`db/src/books/get.rs:132`) is the existing seam the reader
+  must respect.
+- **F14 / F17 / F18 (other schema-pass findings).** If any of these
+  also add `books` columns or touch the sync write path, batch them into
+  the same `0019`/`002x` schema pass so the hot write path is
+  instrumented once, not thrice. Coordinate the migration numbering so
+  they don't collide.
+- **F4.1 depends on F13, not the reverse.** This doc *unblocks* F4.1 —
+  `kobo_sync_tokens` and the change feed are F4.1's listed prerequisites
+  (`4-1-kobo-sync.md:30,35`). F13 should land in the next schema pass so
+  F4.1 consumes a ready feed rather than building one under deadline.
+- **What must land first:** the book-identity decision (F1 chain). What
+  can land in parallel: nothing blocks the *table* creation, but the
+  *writer wiring* should wait on identity so the key is final.
+
+---
+
+## Open questions
+
+1. **Cursor scope confirmation.** This doc assumes a **global** sequence
+   space with per-`(user, device)` cursors, justified by today's
+   single-tenant catalog. If per-user catalog visibility (private
+   uploads, per-user shelves) is on any horizon, the feed may need a
+   `user_id` dimension — decide before `0019` since adding it later is a
+   non-additive change to `book_changes`.
+2. **Reading-state vs. catalog changes.** F4.1 routes *reading state*
+   (bookmarks, progress) through F2.1 internally (`4-1-kobo-sync.md:31`),
+   separate from *catalog* changes. This doc covers only catalog change
+   tracking (book add/update/delete). Confirm the two feeds stay
+   separate — conflating them would over-couple F13 to F2.1.
+3. **Coalescing policy for the backfill + GC.** Does a device's first
+   sync need one row per book (simple) or can the reader coalesce on the
+   fly? Affects whether the backfill emits per-book rows or the reader
+   collapses them. Recommend per-book backfill + GC-time coalescing;
+   confirm at F4.1 implementation.
+4. **kepubify cache invalidation hook.** F4.1 invalidates the KEPUB cache
+   on `book.last_modified` bump (`4-1-kobo-sync.md:21`). If `change_seq`
+   (Option A) or a `book_changes` upsert (Option B) becomes the canonical
+   "this book changed" signal, the invalidation should key off that, not
+   the coarse `last_modified`. Note for F4.1, not a blocker for `0019`.

--- a/docs/design/db-review-f13-change-tracking.md
+++ b/docs/design/db-review-f13-change-tracking.md
@@ -213,7 +213,7 @@ doc removes; C throws that away. Not recommended.
 
 **Adopt Option B (separate `book_changes` audit feed), with a global
 sequence space (`AUTOINCREMENT`) and per-`(user_id, device_id)`
-cursors.** Land migration `0019` now (additive, zero read-path risk) and
+cursors.** Land the new migration now (additive, zero read-path risk) and
 the writer wiring; defer the GC/reaper and all `/kobo/*` endpoints to
 F4.1.
 
@@ -268,12 +268,13 @@ CREATE TABLE kobo_sync_tokens (
 
 ## Migration plan (SKETCH — do not apply yet)
 
-`db/migrations/0019_change_tracking.sql` — next number after the highest
-on disk (`0018_multiformat_book_files.sql`). Forward-only, additive only,
+`db/migrations/NNNN_change_tracking.sql` — the number is allocated at
+implementation time (next after the highest on disk, currently
+`0018_multiformat_book_files.sql`). Forward-only, additive only,
 so **no table-recreate dance** is needed:
 
 ```sql
--- 0019_change_tracking.sql  (Option B, recommended)
+-- NNNN_change_tracking.sql  (Option B, recommended)
 CREATE TABLE book_changes (
   seq        INTEGER PRIMARY KEY AUTOINCREMENT,
   book_uuid  TEXT    NOT NULL,
@@ -304,7 +305,7 @@ contract exactly:
   kind) SELECT uuid, 'upsert' FROM books` so a device's very first sync
   sees the whole library.
 
-This makes a pre-`0019` database converge with a fresh one on the next
+This makes a pre-migration database converge with a fresh one on the next
 boot, with no manual step — the rule-06 backfill contract.
 
 (If Option A is chosen instead, the migration adds the two `books`
@@ -319,7 +320,7 @@ existing book under the same idempotency guard.)
 From the scout spec, scoped to **Option B** (A's extra read-path files
 are noted inline):
 
-- `db/migrations/0019_change_tracking.sql` — **new**: `book_changes` +
+- `db/migrations/NNNN_change_tracking.sql` — **new**: `book_changes` +
   `kobo_sync_tokens` + indexes (Option A: `books.change_seq` /
   `books.deleted_at` columns + `change_counter` instead).
 - `db/src/change_feed/{mod.rs,tests.rs}` — **new module**:
@@ -355,7 +356,7 @@ are noted inline):
 
 Per rule 03: sibling `db/src/change_feed/tests.rs`, `sqlite::memory:` via
 `test_support`, happy path + one test per `thiserror` variant. The
-migrator runs on every `init_db("sqlite::memory:")`, so `0019` is
+migrator runs on every `init_db("sqlite::memory:")`, so the new migration is
 exercised transitively by the whole suite.
 
 New `db/src/change_feed/tests.rs`:
@@ -368,7 +369,7 @@ New `db/src/change_feed/tests.rs`:
   `removed_book_is_still_reportable_after_books_row_is_gone` — remove a
   book, assert a `delete` change row exists keyed by the (now-deleted)
   uuid. On today's hard-delete schema there is no feed at all, so this
-  test cannot even compile against `main` without `0019` — it is the
+  test cannot even compile against `main` without the new migration — it is the
   red bar proving the gap is closed. (Option A variant: assert
   `deleted_at IS NOT NULL` and `change_seq` bumped, and that the row is
   excluded from `list_books`.)
@@ -387,7 +388,7 @@ Extend `db/src/sync/tests.rs`:
 
 `db/src/pool.rs` (or `normalize`-adjacent) backfill test:
 
-- `backfill_initial_changes_seeds_one_upsert_per_pre_0019_book` and is a
+- `backfill_initial_changes_seeds_one_upsert_per_pre_migration_book` and is a
   no-op on second call (idempotency, mirroring the
   `backfill_norm_columns` test).
 
@@ -399,8 +400,8 @@ excluded from list/browse/discovery/search/taxonomy.
 ## Risks & rollback
 
 - **Forward-only, fix-forward.** Migrations are append-only (rule 06).
-  An error in `0019` is corrected by a `0020`, never by editing `0019`
-  once applied anywhere — `sqlx` checksums each file and a changed
+  An error in the new migration is corrected by a later one, never by
+  editing it once applied anywhere — `sqlx` checksums each file and a changed
   applied migration fails startup.
 - **Option B is cheaply reversible** *until devices hold cursors.* Drop
   `book_changes` + `kobo_sync_tokens` and remove four call sites. Once
@@ -419,7 +420,7 @@ excluded from list/browse/discovery/search/taxonomy.
   F4.1): if it prunes `book_changes` rows below the *slowest* device
   cursor incorrectly, a lagging device misses changes. The reaper must
   read `MIN(last_seq)` across `kobo_sync_tokens` before deleting, and
-  coalesce rather than gap the sequence. Out of scope for `0019`;
+  coalesce rather than gap the sequence. Out of scope for this migration;
   flagged so it isn't forgotten.
 - **Counter contention.** Both the single-row `change_counter` (A) and
   `AUTOINCREMENT` (B) serialize on the sync transaction. Sync is already
@@ -444,7 +445,7 @@ The load-bearing ordering constraints:
   must respect.
 - **F14 / F17 / F18 (other schema-pass findings).** If any of these
   also add `books` columns or touch the sync write path, batch them into
-  the same `0019`/`002x` schema pass so the hot write path is
+  the same adjacent schema pass so the hot write path is
   instrumented once, not thrice. Coordinate the migration numbering so
   they don't collide.
 - **F4.1 depends on F13, not the reverse.** This doc *unblocks* F4.1 —
@@ -463,8 +464,8 @@ The load-bearing ordering constraints:
    space with per-`(user, device)` cursors, justified by today's
    single-tenant catalog. If per-user catalog visibility (private
    uploads, per-user shelves) is on any horizon, the feed may need a
-   `user_id` dimension — decide before `0019` since adding it later is a
-   non-additive change to `book_changes`.
+   `user_id` dimension — decide before authoring the migration since adding
+   it later is a non-additive change to `book_changes`.
 2. **Reading-state vs. catalog changes.** F4.1 routes *reading state*
    (bookmarks, progress) through F2.1 internally (`4-1-kobo-sync.md:31`),
    separate from *catalog* changes. This doc covers only catalog change
@@ -479,4 +480,4 @@ The load-bearing ordering constraints:
    on `book.last_modified` bump (`4-1-kobo-sync.md:21`). If `change_seq`
    (Option A) or a `book_changes` upsert (Option B) becomes the canonical
    "this book changed" signal, the invalidation should key off that, not
-   the coarse `last_modified`. Note for F4.1, not a blocker for `0019`.
+   the coarse `last_modified`. Note for F4.1, not a blocker for this migration.

--- a/docs/design/db-review-f14-series-model.md
+++ b/docs/design/db-review-f14-series-model.md
@@ -1,0 +1,447 @@
+# Series model: `series_index` placement vs. many-to-many `books_series_link`
+
+Status: Proposed — deferred from db.md F14, awaiting decision.
+
+This doc frames a single data-model choice — **may a book belong to more than
+one series?** — and lays out the two coherent schema resolutions so the
+operator can decide before the series browse/detail pages cement the current
+arbitrary behaviour. It does not propose application code beyond the migration
+sketch; nothing here is to be applied until the decision lands.
+
+---
+
+## Problem
+
+`books_series_link` is structurally a many-to-many join table —
+`PRIMARY KEY(book, series)` with **no `UNIQUE(book)`**
+([0002_normalized_schema.sql:61](../../db/migrations/0002_normalized_schema.sql)) —
+so the schema permits a book to link to N series. But a book's
+position-within-series is a **single scalar on the work row**,
+`books.series_index REAL`
+([0002_normalized_schema.sql:31](../../db/migrations/0002_normalized_schema.sql)),
+not on the membership row. The data model therefore claims "a book can be in
+many series" while only being able to store one position for it. A book that is
+#1 in one series and #4 in another cannot represent both numbers.
+
+The read path has already silently resolved this contradiction by **picking one
+series arbitrarily**. The shared projection's series subqueries
+(`BOOK_COLUMNS`,
+[db/src/books/projection.rs:55-63](../../db/src/books/projection.rs)) select
+`series_name` and `series_link_id` with
+`... FROM books_series_link bsl JOIN series s ... WHERE bsl.book = b.id ORDER BY s.name LIMIT 1`.
+If a book ever held two series rows, both the surfaced name and the surfaced id
+would be whichever series sorts first alphabetically, and the other membership
+would vanish from every list, detail, and search response.
+
+**The bug is latent, not active.** The application is single-series end-to-end
+today, so the join table never holds more than one row per book:
+
+- The wire type is single-valued: `EbookMetadata.series: Option<String>` /
+  `series_index: Option<String>`
+  ([shared/src/ebook/metadata.rs:61-62](../../shared/src/ebook/metadata.rs)).
+- The write path inserts **at most one** link row per book —
+  `insert_metadata_links` resolves `m.series` (a single `Option<String>`) and
+  runs one `INSERT OR IGNORE INTO books_series_link`
+  ([db/src/sync/books.rs:665-672](../../db/src/sync/books.rs)). Its own comment
+  states the assumption outright: *"Series / publisher / language are
+  single-valued per book, so they keep the simple resolve-then-link path"*
+  (books.rs:656-657).
+- The override store mirrors the scalar shape — `metadata_overrides` carries
+  `series` / `series_index` as single JSON scalars edited from one frontend
+  form.
+- Both override-aware read CTEs read the index off the work row
+  (`b.series_index`): `EFFECTIVE_SERIES_CTE` in
+  [db/src/discovery/series.rs:61-95](../../db/src/discovery/series.rs) and
+  `series_index_sql` in [db/src/browse.rs](../../db/src/browse.rs) (~138-202).
+
+So `LIMIT 1` always returns the single existing row and `series_index` is
+unambiguous **only as long as the one-series-per-book convention holds** — a
+convention enforced nowhere in the schema.
+
+**Why it bites a named roadmap feature.** F3.1 (Libraries with metadata filters,
+[docs/roadmap/3-1-libraries.md](../roadmap/3-1-libraries.md)) builds saved
+filter collections over the normalized columns, and series-by-detail / browse-
+by-series pages are the surfaces that will read `series_name` and order by
+`series_index`. Once those pages and any series filter rule
+(`series = ?`, `ORDER BY series_index`) ship, they harden around whichever model
+the schema implicitly has. Choosing afterward means re-deriving an answer under
+pressure with live data and live UI contracts in the way. The cost of deciding
+is lowest **now**, while the join table provably holds ≤1 row per book.
+
+---
+
+## Decision required
+
+**Product question (the heart of this doc): is a book allowed to belong to more
+than one series at once, each with its own position?**
+
+Concrete examples that force the call:
+
+- A novella that is both #2 in *The Expanse* main sequence and #1 in a curated
+  *Expanse: Novellas* collection.
+- An omnibus edition that is #1 in a publisher's "definitive editions" series
+  while its constituent works sit at #3–#5 of the original series.
+- A short story anthologized into two different themed collections.
+
+If the answer is **no** (one canonical series per book — the model every current
+code path already assumes), the schema should *say so* and stop the read path
+from silently arbitrating. If the answer is **yes**, the position number has to
+move onto the membership row and a per-series position must ripple through the
+wire type, parser, write path, both read CTEs, and the frontend.
+
+A non-answer is itself a choice — it keeps a many-to-many table with an
+arbitrary-pick read, the worst of both worlds. The decision must be made before
+F3.1's series surfaces land.
+
+---
+
+## Options
+
+SQLite reality that constrains all options: you **cannot** add a `UNIQUE`
+constraint, change a `PRIMARY KEY`, drop a column, or alter an FK in place. Each
+requires the table-recreate dance (`CREATE … _new` / `INSERT … SELECT` /
+`DROP` / `ALTER … RENAME`). Migrations are append-only and forward-only per
+[rule 06](../../.claude/rules/06-migrations.md); the same migrator runs against
+`sqlite::memory:` in tests, so a migration green in the suite is green in
+production.
+
+### Option A — Commit to single-series; add `UNIQUE(book)`
+
+**How it works.** Declare the product model explicitly: one series per book.
+Add `UNIQUE(book)` to `books_series_link` so the schema enforces the 1:1 that
+the parser, wire type, write path, and override store already assume.
+`series_index` stays on the `books` row — now provably unambiguous because each
+book has ≤1 series. The `ORDER BY s.name LIMIT 1` in the projection becomes
+honest (it can only ever return one row), and `BOOK_COLUMNS` gains a one-line
+invariant comment instead of a behaviour change.
+
+**Migration shape.** Table-recreate of `books_series_link` adding
+`UNIQUE(book)`, with a deterministic dedup collapse
+(`SELECT book, MIN(series) GROUP BY book`) so the new constraint can't fail on
+any pre-existing duplicate. In practice this collapse affects **0 rows** on
+current data, but it makes the migration safe on any DB that somehow accumulated
+a second row. `series_index` is untouched. Sketch in
+[Migration plan](#migration-plan).
+
+**Blast radius.** Schema-only. No change to the parser, `EbookMetadata`, the
+write path (the existing single `INSERT OR IGNORE` is already
+`UNIQUE(book)`-compatible), or either read CTE. Two new tests; one optional
+invariant comment in `projection.rs`. Effort **S–M**.
+
+**Pros.**
+- Matches reality everywhere; closes the latent arbitrary-pick by construction.
+- Cheapest path, smallest diff, lowest review surface.
+- Makes a real invariant machine-checked instead of convention-only.
+
+**Cons.**
+- Forecloses multi-series. Reversing later (→ Option B) is a second
+  table-recreate plus the full B ripple — not free, but no worse than doing B
+  from scratch.
+- A future Calibre import where one book legitimately appears in two collections
+  silently keeps only `MIN(series)` (collapse) or fails the second
+  `INSERT OR IGNORE` (which already no-ops today). Acceptable only if "no" is
+  genuinely the product answer.
+
+### Option B — Commit to multi-series; move `series_index` onto the link row
+
+**How it works.** Move the position number off the work and onto the membership:
+`books_series_link(book, series, series_index)`, keeping `PRIMARY KEY(book, series)`
+(no `UNIQUE(book)`). Each membership carries its own position. Read paths surface
+**per-series** position; the projection stops `LIMIT 1`-picking and instead
+returns a list of `{series_id, series_name, series_index}` memberships. The wire
+type grows a `Vec<SeriesMembership>` (or similar), the parser learns to emit more
+than one membership, and both override-aware CTEs are rewritten to read
+`bsl.series_index` from the link row rather than `b.series_index`.
+
+**Migration shape.** Table-recreate of `books_series_link` adding
+`series_index REAL`, backfilled from the current `books.series_index` for the
+single existing membership per book. `books.series_index` is left in place
+(dead) or dropped via a second forward-only recreate of `books`. Recreate
+`idx_books_series_series`; add `idx_books_series_link_index` for ordering.
+
+**Blast radius.** Large and cross-cutting — this is the ripple the scout spec
+flags as XL:
+- `shared/src/ebook/metadata.rs` — new multi-membership wire field; every
+  consumer of `EbookMetadata.series` / `series_index` / `series_id`.
+- `db/src/ebook/parse.rs` — `collect_series` must return N memberships, not one.
+- `db/src/sync/books.rs` — write path moves the index onto the link insert and
+  loops over memberships.
+- `db/src/books/projection.rs` — `BOOK_COLUMNS` series subqueries become a
+  `json_group_array` aggregate; `row_to_ebook` decodes a list.
+- `db/src/discovery/series.rs` (`EFFECTIVE_SERIES_CTE`) and
+  `db/src/browse.rs` (`series_index_sql`) — both rewritten to read the link-row
+  index, including the override-merge logic that currently coalesces
+  `b.series_index`.
+- Frontend series UI — book detail must render multiple series + positions;
+  the override edit form must edit per-membership index.
+
+Effort **XL**. Gated on its own implementation plan — this doc only frames it.
+
+**Pros.**
+- The only model that can represent the legitimate two-series cases above.
+- No data is ever silently discarded by an arbitrary pick.
+
+**Cons.**
+- Largest change in the repo's data layer; touches every series read and the
+  wire contract.
+- All cost is paid up front for a feature with no current product demand
+  (no UI, no parser source, no user request on the roadmap).
+- Higher ongoing complexity in every series query forever.
+
+### Option C — Defer (status quo): do nothing
+
+Keep the many-to-many table with the scalar index and the arbitrary-pick read.
+**Not recommended.** It leaves the contradiction in place and lets F3.1's series
+surfaces harden around undefined behaviour. Listed only to name it as the
+default-if-nothing-decided, which the operator should explicitly reject.
+
+---
+
+## Recommendation
+
+**Take Option A: commit to single-series and add `UNIQUE(book)`.**
+
+Rationale:
+
+1. **It matches every existing decision in the codebase.** The parser, the wire
+   type, the write path (with its explicit "single-valued per book" comment),
+   the override store, and both read CTEs were all written single-series. Option
+   A makes the schema agree with code that already shipped; Option B contradicts
+   it everywhere.
+2. **No product demand for multi-series exists.** The roadmap names no feature
+   requiring a book in two series; F3.1 filters on `series = ?`, which a
+   single-series model serves cleanly. Paying Option B's XL cost now is
+   speculative.
+3. **It closes the actual finding.** The defect is that the read path arbitrates
+   silently. Option A removes the arbitration by making >1 membership impossible;
+   Option B removes it by surfacing all memberships. Both fix F14; A is an
+   order of magnitude cheaper.
+
+**Reversibility and cost-of-delay.** Option A is not a one-way door, but it is a
+*sticky* one. While `books_series_link` provably holds ≤1 row per book, the
+collapse is a no-op and reversing to B costs exactly what doing B from scratch
+costs. The irreversibility risk grows only **after** a multi-series import path
+exists and real second-series rows accumulate — at which point A's
+`MIN(series)` collapse would silently drop user data. That is the trigger to
+revisit, not today. The cost of *delaying the decision* is higher than the cost
+of picking A: every series surface shipped under the status quo is one more
+consumer hardened around arbitrary-pick that a later B (or A) must rewrite.
+
+Pick A now; gate any future B on this doc plus a concrete multi-series feature.
+
+---
+
+## Migration plan
+
+> **Sketch only — not to be applied.** DDL below is illustrative and lands only
+> after the decision is recorded. Confirm `0019` is still the next free number
+> at authoring time (highest on disk is currently `0018`). Forward-only; never
+> edit an applied migration ([rule 06](../../.claude/rules/06-migrations.md)).
+
+### Option A — `db/migrations/0019_series_link_unique.sql`
+
+```sql
+-- F14: commit to single-series. Add UNIQUE(book) to books_series_link so the
+-- 1:1 the parser / wire type / write path already assume is enforced by the
+-- schema, and the projection's ORDER BY s.name LIMIT 1 is provably a no-op.
+-- SQLite can't add a UNIQUE constraint in place -> table-recreate.
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE books_series_link_new (
+    book   INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    series INTEGER NOT NULL REFERENCES series(id),
+    PRIMARY KEY(book, series),
+    UNIQUE(book)                         -- enforces one series per book
+);
+
+-- Deterministic collapse: keep the lowest series id per book so the UNIQUE
+-- insert cannot fail on any pre-existing duplicate. 0 rows affected on
+-- current data; defensive for any DB that accreted a second row.
+INSERT INTO books_series_link_new (book, series)
+  SELECT book, MIN(series) FROM books_series_link GROUP BY book;
+
+DROP TABLE books_series_link;
+ALTER TABLE books_series_link_new RENAME TO books_series_link;
+
+-- Recreate the reverse index dropped with the old table.
+CREATE INDEX idx_books_series_series ON books_series_link(series);
+
+PRAGMA foreign_keys=ON;
+-- series_index stays on books — now unambiguous (each book has <=1 series).
+```
+
+Notes:
+- The `PRAGMA foreign_keys=OFF; … ON;` bracket keeps the `DROP` of the old table
+  from tripping its own `series` FK during the swap. Each migration file runs in
+  the migrator's implicit transaction against `sqlite::memory:` in tests.
+- **No boot backfill is required.** Unlike `backfill_norm_columns` in
+  `normalize.rs` (which fills `title_norm` / `author_norm` at boot because SQL
+  can't compute them), Option A computes everything in DDL — the collapse INSERT
+  is the entire data step and is idempotent by construction. No `pool.rs` /
+  `normalize.rs` change.
+- No write-path change: `insert_metadata_links`
+  ([db/src/sync/books.rs:665-672](../../db/src/sync/books.rs)) already inserts a
+  single row via `INSERT OR IGNORE`, which satisfies `UNIQUE(book)`. Optionally
+  add a `// invariant: UNIQUE(book) => <=1 row` comment near `BOOK_COLUMNS`
+  ([projection.rs:55-63](../../db/src/books/projection.rs)) documenting why
+  `LIMIT 1` is now provably safe.
+
+### Option B — `db/migrations/0019_series_index_on_link.sql` (sketch, not recommended)
+
+```sql
+-- F14 (multi-series): move position onto the membership row.
+PRAGMA foreign_keys=OFF;
+CREATE TABLE books_series_link_new (
+    book         INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    series       INTEGER NOT NULL REFERENCES series(id),
+    series_index REAL,                   -- moved off books
+    PRIMARY KEY(book, series)
+);
+INSERT INTO books_series_link_new (book, series, series_index)
+  SELECT bsl.book, bsl.series, b.series_index
+    FROM books_series_link bsl JOIN books b ON b.id = bsl.book;
+DROP TABLE books_series_link;
+ALTER TABLE books_series_link_new RENAME TO books_series_link;
+CREATE INDEX idx_books_series_series       ON books_series_link(series);
+CREATE INDEX idx_books_series_link_index   ON books_series_link(series_index);
+PRAGMA foreign_keys=ON;
+-- books.series_index left dead (or dropped via a second forward-only recreate
+-- of books). Option B's app-code ripple is XL and gated on its own plan.
+```
+
+After either migration, run `just dev-bounce` so a live `dx serve` picks up the
+new file — migrations apply only at startup (rule 06).
+
+---
+
+## Affected code
+
+From the scout spec, by option.
+
+**Option A (recommended):**
+
+| File | Symbol | Change |
+|---|---|---|
+| `db/migrations/0019_series_link_unique.sql` | new file | table-recreate adding `UNIQUE(book)` + collapse INSERT |
+| `db/src/books/projection.rs` | `BOOK_COLUMNS` (55-63) | optional invariant comment; **no behaviour change** |
+| `db/src/sync/books.rs` | `insert_metadata_links` (665-672) | **none** — existing `INSERT OR IGNORE` already compatible |
+| `db/src/sync/tests.rs` | new tests | UNIQUE-rejection + reindex-idempotence |
+
+**Option B (not recommended; XL — listed for completeness):**
+
+| File | Symbol |
+|---|---|
+| `db/migrations/0019_series_index_on_link.sql` | new file — add `series_index` to link table + recreate indexes |
+| `shared/src/ebook/metadata.rs` | `EbookMetadata.series` / `series_index` / `series_id` (61-66) → multi-membership field |
+| `db/src/ebook/parse.rs` | `collect_series` (≈159-161) → N memberships |
+| `db/src/sync/books.rs` | `insert_metadata_links` (665-672); `update_book_row` / `insert_book_row` `series_index` binds |
+| `db/src/books/projection.rs` | `BOOK_COLUMNS` series subqueries; `row_to_ebook` `series_index` read (148/182) |
+| `db/src/discovery/series.rs` | `EFFECTIVE_SERIES_CTE` (61-95), `fetch_series_books`, `count_effective_series_members` |
+| `db/src/browse.rs` | `list_series` / `series_index_sql` (≈121-202) |
+| `db/src/test_support.rs` | seed factory writing `series_index` (≈252, 420) → write index on link row |
+
+---
+
+## Test plan
+
+Per [rule 03](../../.claude/rules/03-unit-testing.md): sibling `<mod>/tests.rs`,
+`sqlite::memory:` via `init_db("sqlite::memory:")` (which runs every migration,
+so `0019` is smoke-tested by the whole suite), happy path + one test per failure
+variant. Names in the long-sentence `fn_under_test_does_X_when_Y` style.
+
+For **Option A**, in `db/src/sync/tests.rs` (the sibling file already exists):
+
+1. **The acceptance test that must fail on the old schema** —
+   `books_series_link_rejects_second_series_for_same_book`: seed one book + one
+   series via the `test_support` factories, then run a **raw**
+   `INSERT INTO books_series_link (book, series)` for a *second, distinct*
+   series id and assert it returns a `UNIQUE`-constraint `sqlx::Error`. Raw
+   INSERT (not the write path, which uses `INSERT OR IGNORE` and would swallow
+   the conflict) is what proves the constraint exists. **On the pre-0019 schema
+   this insert succeeds** — that's the regression guard.
+2. `series_link_unique_is_idempotent_for_reindex`: run the book replace/sync
+   path twice over the same fixture and assert exactly **one**
+   `books_series_link` row per book — guards that
+   `wipe_per_book_link_rows` + re-insert still satisfies `UNIQUE(book)`.
+3. Keep the existing `series_index_sorts_numerically`
+   (`db/src/sync/tests.rs:659`) green — it asserts `REAL` ordering on the books
+   row and is unchanged by Option A.
+
+Run `cargo test -p omnibus-db`.
+
+For **Option B**, the test surface is far larger: parser emits N memberships,
+projection returns a membership list, both CTEs order by the link-row index, and
+the wire round-trips a `Vec`. Out of scope here — it ships with B's own plan.
+
+---
+
+## Risks & rollback
+
+- **Forward-only, fix-forward.** There are no down-migrations. A bad `0019` is
+  corrected by a *new* `0020`, never by editing the applied file (rule 06's
+  checksum mismatch fails startup otherwise).
+- **Option A data-loss surface (currently empty).** The collapse INSERT keeps
+  `MIN(series)` per book. On any DB where a book genuinely has two series rows it
+  would **discard the higher-id membership**. Current data has zero such rows
+  (no code path inserts a second), so the collapse is a no-op today — but this is
+  the one place A can lose data, and it is exactly why the decision must precede
+  any future multi-series import.
+- **What becomes irreversible.** Once a multi-series *import path* exists and
+  real second-series rows accumulate, switching A→B can no longer recover the
+  pre-collapse memberships (they were dropped at migration time). Before that
+  point, A↔B is reversible at the cost of one more table-recreate. The trigger to
+  revisit is "a feature wants a book in two series," not calendar time.
+- **Option B risk** is breadth, not data loss: a rewrite of every series read
+  and the wire contract, each a chance to regress series ordering or the override
+  merge. Mitigated only by the large test surface above — another reason to
+  prefer A unless multi-series is a committed product goal.
+
+---
+
+## Sequencing & dependencies
+
+The scout spec marks F14 as conflicting with **F1, F6, F8, F10, F16, F17, F18** —
+all of which touch the same hot tables/files (`books`, `books_series_link`,
+`BOOK_COLUMNS`, the sync write path). Practical ordering:
+
+- **F1 ↔ F2 ↔ F10 chain (stable_uuid / user-data soft-refs / overrides GC).**
+  These are the schema's correctness core and reshape book identity and the
+  reindex reconcile step. F14 does **not** depend on their outcome — it touches
+  only the `series` membership shape — but landing F14 Option A as an isolated,
+  schema-only migration *before* the larger identity rework keeps it off the
+  critical path and avoids merge churn in the recreate DDL. Sequence F14-A early
+  and small; do not entangle it with the identity chain.
+- **F6 / F8 (landing projection / browse rewrites).** These rewrite the queries
+  that *read* series (`BOOK_COLUMNS`, `series_index_sql`). Option A leaves those
+  reads untouched, so order is free. Option B **must** land before or with F6/F8
+  or it re-rewrites them — another reason A de-risks the sequence.
+- **F16/F17/F18 (timestamps, redundant/speculative indexes, dead columns).**
+  Independent cleanup migrations; no ordering constraint with F14. Note F14-A
+  recreates `idx_books_series_series` — coordinate the migration number so it
+  doesn't collide with an index-cleanup migration authored in parallel.
+
+**Must land first:** nothing. F14-A is self-contained. **Should land before
+F14:** nothing — but F3.1's series surfaces and any series filter rule **must
+land after** the decision, or they harden around the arbitrary pick this doc
+exists to remove.
+
+---
+
+## Open questions
+
+1. **Product call (blocking):** does any roadmap-tracked feature require a book
+   in two series? If a stakeholder can name one, Option B's cost is justified and
+   this doc's recommendation flips. If not, Option A stands.
+2. **Calibre import fidelity:** does the source library format Omnibus imports
+   from ever express multi-series membership we'd want to preserve? If Calibre
+   itself is single-series (it is, via `series` + `series_index` columns), that
+   is strong corroboration for Option A.
+3. **`books.series_index` index under Option B:** if B is ever chosen,
+   `idx_books_series_index` on the now-dead `books.series_index` should be dropped
+   in the same migration that moves the index — fold that into B's plan, not a
+   separate cleanup.
+4. **Invariant documentation:** under Option A, should the `UNIQUE(book)`
+   assumption be asserted in code (e.g. a debug-only check that the projection
+   never sees >1 series row) in addition to the schema constraint, or is the
+   schema constraint + the new test sufficient? Recommendation: schema + test is
+   enough; skip the runtime check.

--- a/docs/design/db-review-f14-series-model.md
+++ b/docs/design/db-review-f14-series-model.md
@@ -234,11 +234,12 @@ Pick A now; gate any future B on this doc plus a concrete multi-series feature.
 ## Migration plan
 
 > **Sketch only — not to be applied.** DDL below is illustrative and lands only
-> after the decision is recorded. Confirm `0019` is still the next free number
-> at authoring time (highest on disk is currently `0018`). Forward-only; never
-> edit an applied migration ([rule 06](../../.claude/rules/06-migrations.md)).
+> after the decision is recorded. The migration number (`NNNN`) is allocated at
+> authoring time — the next free number then (highest on disk is currently
+> `0018`). Forward-only; never edit an applied migration
+> ([rule 06](../../.claude/rules/06-migrations.md)).
 
-### Option A — `db/migrations/0019_series_link_unique.sql`
+### Option A — `db/migrations/NNNN_series_link_unique.sql`
 
 ```sql
 -- F14: commit to single-series. Add UNIQUE(book) to books_series_link so the
@@ -286,7 +287,7 @@ Notes:
   ([projection.rs:55-63](../../db/src/books/projection.rs)) documenting why
   `LIMIT 1` is now provably safe.
 
-### Option B — `db/migrations/0019_series_index_on_link.sql` (sketch, not recommended)
+### Option B — `db/migrations/NNNN_series_index_on_link.sql` (sketch, not recommended)
 
 ```sql
 -- F14 (multi-series): move position onto the membership row.
@@ -322,7 +323,7 @@ From the scout spec, by option.
 
 | File | Symbol | Change |
 |---|---|---|
-| `db/migrations/0019_series_link_unique.sql` | new file | table-recreate adding `UNIQUE(book)` + collapse INSERT |
+| `db/migrations/NNNN_series_link_unique.sql` | new file | table-recreate adding `UNIQUE(book)` + collapse INSERT |
 | `db/src/books/projection.rs` | `BOOK_COLUMNS` (55-63) | optional invariant comment; **no behaviour change** |
 | `db/src/sync/books.rs` | `insert_metadata_links` (665-672) | **none** — existing `INSERT OR IGNORE` already compatible |
 | `db/src/sync/tests.rs` | new tests | UNIQUE-rejection + reindex-idempotence |
@@ -331,7 +332,7 @@ From the scout spec, by option.
 
 | File | Symbol |
 |---|---|
-| `db/migrations/0019_series_index_on_link.sql` | new file — add `series_index` to link table + recreate indexes |
+| `db/migrations/NNNN_series_index_on_link.sql` | new file — add `series_index` to link table + recreate indexes |
 | `shared/src/ebook/metadata.rs` | `EbookMetadata.series` / `series_index` / `series_id` (61-66) → multi-membership field |
 | `db/src/ebook/parse.rs` | `collect_series` (≈159-161) → N memberships |
 | `db/src/sync/books.rs` | `insert_metadata_links` (665-672); `update_book_row` / `insert_book_row` `series_index` binds |
@@ -346,8 +347,8 @@ From the scout spec, by option.
 
 Per [rule 03](../../.claude/rules/03-unit-testing.md): sibling `<mod>/tests.rs`,
 `sqlite::memory:` via `init_db("sqlite::memory:")` (which runs every migration,
-so `0019` is smoke-tested by the whole suite), happy path + one test per failure
-variant. Names in the long-sentence `fn_under_test_does_X_when_Y` style.
+so the new migration is smoke-tested by the whole suite), happy path + one test
+per failure variant. Names in the long-sentence `fn_under_test_does_X_when_Y` style.
 
 For **Option A**, in `db/src/sync/tests.rs` (the sibling file already exists):
 
@@ -357,8 +358,8 @@ For **Option A**, in `db/src/sync/tests.rs` (the sibling file already exists):
    `INSERT INTO books_series_link (book, series)` for a *second, distinct*
    series id and assert it returns a `UNIQUE`-constraint `sqlx::Error`. Raw
    INSERT (not the write path, which uses `INSERT OR IGNORE` and would swallow
-   the conflict) is what proves the constraint exists. **On the pre-0019 schema
-   this insert succeeds** — that's the regression guard.
+   the conflict) is what proves the constraint exists. **On the pre-migration
+   schema this insert succeeds** — that's the regression guard.
 2. `series_link_unique_is_idempotent_for_reindex`: run the book replace/sync
    path twice over the same fixture and assert exactly **one**
    `books_series_link` row per book — guards that
@@ -377,8 +378,8 @@ the wire round-trips a `Vec`. Out of scope here — it ships with B's own plan.
 
 ## Risks & rollback
 
-- **Forward-only, fix-forward.** There are no down-migrations. A bad `0019` is
-  corrected by a *new* `0020`, never by editing the applied file (rule 06's
+- **Forward-only, fix-forward.** There are no down-migrations. A bad migration is
+  corrected by a *new* one, never by editing the applied file (rule 06's
   checksum mismatch fails startup otherwise).
 - **Option A data-loss surface (currently empty).** The collapse INSERT keeps
   `MIN(series)` per book. On any DB where a book genuinely has two series rows it

--- a/docs/design/db-review-f15-author-photos-fs.md
+++ b/docs/design/db-review-f15-author-photos-fs.md
@@ -1,0 +1,427 @@
+# F15 — Move author-photo BLOBs to the filesystem
+
+Status: Proposed — deferred from db.md F15, awaiting decision.
+
+This doc frames the one data-model decision the operator must settle before any
+schema or code is written: **what happens to the inline image bytes on the
+cutover, and what key names the file on disk.** No `.sql` or `.rs` is touched
+until that decision lands. The migration DDL and code shapes below are
+*sketches* to make the trade-offs concrete, not work to apply.
+
+---
+
+## Problem
+
+`author_photos.bytes` stores the full image — manual admin upload or a fetched
+Open Library photo — as a `BLOB` inline in the primary SQLite database
+(`0008_author_photos.sql:16`). Book covers were deliberately moved the other
+way: they live on disk under `covers_dir()` (`db/src/covers.rs`, `covers_dir`),
+and `0003_drop_legacy_tables.sql` dropped the legacy `book_covers` BLOB table.
+Author photos diverge from that established pattern for no stated reason.
+
+Inline image BLOBs are costly in exactly the ways the covers move was meant to
+avoid:
+
+- They inflate the main DB file and are copied wholesale by `VACUUM` and any
+  backup/replication of the SQLite file (assumption A1: single-instance,
+  file-backed deployments — the DB file *is* the backup unit).
+- They sit on the same pages the hot taxonomy/browse queries scan. Two hot paths
+  probe `author_photos` **per author row**:
+  - `list_authors` inlines `EXISTS(... WHERE source IN ('manual','openlibrary')
+    AND bytes IS NOT NULL)` as a `has_photo` projection column
+    (`db/src/browse.rs:76-81`) — one probe per author in the taxonomy grid.
+  - `author_has_usable_photo` runs the same `EXISTS` per author
+    (`db/src/discovery/authors.rs:170-182`), called from `get_author`.
+
+  Both key the "has a real photo" decision on `bytes IS NOT NULL` to distinguish
+  a usable photo from a `'letter'` negative-cache marker. With a 10 MiB upload
+  cap (`server/src/backend/author_photos.rs:112`, referenced by the comment at
+  `db/src/ebook/accent.rs:9`), a library of a few hundred authors can carry tens
+  of MiB of image data on pages the author grid walks every render.
+
+**Who it bites.** The author-discovery surface — F1.11 Author profiles and F1.12
+Browse authors & series (roadmap `0-0-summary.md` Phase 1) — is precisely the
+feature that runs these per-row probes at scale. The grid was the motivation for
+`has_photo` being a projection column in the first place; leaving image bytes on
+those pages is a self-inflicted N-author scan tax on the page that reads the flag
+hardest.
+
+The CRUD that has to move is small and already located:
+`get_author_photo` SELECTs `bytes` (`db/src/author_photos_data.rs:64-76`),
+`upsert_author_photo` binds `bytes` (`:105-123`), `delete_author_photo`
+(`:127-136`). `author_photo_status` (`:82-92`) is already byte-free. Writers:
+the OL/letter cascade (`db/src/author_photos/cascade.rs:104-118`), the server
+multipart + URL upload handlers (`server/src/backend/author_photos.rs`), and the
+RPC URL upload (`frontend/src/rpc.rs`). The serve route streams bytes from
+`db::get_author_photo` (`server/src/backend/author_photos.rs:34-45`).
+
+---
+
+## Decision required
+
+Two coupled choices, both forced by SQLite reality (no in-place column drop here;
+table-recreate required — see Options) and by the append-only migration rule
+([rule 06](../../.claude/rules/06-migrations.md)).
+
+1. **Cutover semantics for the existing bytes — drain or discard?**
+   The migration that drops the `bytes` column runs *inside* `init_db` via the
+   embedded `MIGRATOR` (`db/src/pool.rs:49-52`), *before* any app code we could
+   write to read those bytes. So the table-recreate's `INSERT … SELECT` either
+   carries the bytes forward (into a staging table, for a later boot pass to
+   drain) or drops them on the floor. Concretely:
+   - **(a) Discard** — treat all cached photos as a rebuildable cache; let the OL
+     cascade re-resolve `openlibrary` rows on next view. **Manual admin uploads
+     are permanently lost** (OL has no copy to re-fetch).
+   - **(b) Drain** — a transitional staging table preserves the bytes through the
+     migration, and a one-time idempotent boot pass writes every BLOB to the new
+     photos dir before clearing staging. Preserves manual uploads; costs one
+     staging table and one boot backfill.
+
+2. **Filename key on disk — `author_id` or a per-row token?**
+   - `author_id` (e.g. `<photos_dir>/<author_id>.<ext>`) is stable, simple, and
+     mirrors covers' `<uuid>.<ext>`. Risk: SQLite reuses rowids, so a
+     *deleted-then-re-added* author can inherit an old id and a stale file —
+     unless `upsert`/`delete` always rewrite/unlink the file (which we control).
+   - A per-row random token stored in the row (`photo_token TEXT`) eliminates id
+     reuse entirely at the cost of an extra column, a `find_*_file` that must read
+     the token first, and orphan files when a row is replaced without unlinking.
+
+These two are the heart of the doc. Everything else (FS helpers, predicate swap,
+docs) is mechanical and identical across options.
+
+---
+
+## Options
+
+All options share the migration's structural core: SQLite cannot cleanly
+`DROP COLUMN bytes` here. The column participates in the table-level `CHECK`
+(`0008:23-26` ties `bytes`/`mime` presence to `source`), and SQLite refuses to
+drop a column referenced by a CHECK (and pre-3.35 cannot `DROP COLUMN` at all).
+The fix is a forward-only **table-recreate**: build `author_photos_new` keyed on
+`mime` instead of `bytes`, `INSERT … SELECT`, `DROP`, `RENAME`. They differ only
+in what the SELECT carries and what runs at boot.
+
+### Option A — Discard bytes, key by `author_id` (cache-rebuild)
+
+**How it works.** The recreate's `INSERT … SELECT` omits `bytes` entirely. On
+first boot after upgrade, `openlibrary` rows still exist (source/url/mime kept)
+but no file is on disk, so `get_author_photo` returns `None` → serve 404 →
+background `ResolveAuthorPhoto` re-fetches from OL and writes the file. `'letter'`
+markers survive untouched (they never had bytes). Manual uploads become broken
+`manual` rows pointing at a missing file → 404 forever until re-uploaded.
+
+**Migration shape.** One file, table-recreate, no staging table, no boot pass.
+The new `CHECK` keys on `mime` (`source <> 'letter'` ⟺ `mime IS NOT NULL`).
+
+**Blast radius.** Migration + FS helpers + CRUD rewrite + two predicate swaps +
+docs. No `pool.rs` boot change. Smallest diff.
+
+**Pros.** Simplest; lowest-risk code; no transitional table to clean up later; no
+boot-time I/O sweep. Honest about photos being a cache for the OL-sourced
+majority.
+**Cons.** Silently discards admin-uploaded photos — the one class of photo that
+is *not* rebuildable. A library that curated 50 author headshots loses all 50 on
+upgrade with no warning unless we surface it in release notes.
+
+### Option B — Drain bytes to disk, key by `author_id` (preserve uploads)
+
+**How it works.** Migration `00NN` adds a transitional staging table
+(`author_photo_bytes_staging(author_id, mime, bytes)`) and copies every
+non-letter row's bytes into it *before* the recreate drops the column. A new
+idempotent boot pass `backfill_author_photos_to_fs` in `init_db` (after
+`MIGRATOR.run`, mirroring `normalize::backfill_norm_columns` at `pool.rs:56`)
+reads staging in batches, writes each `<author_id>.<ext>` via the FS helper,
+deletes the staged row on success, and is a no-op once staging is empty. When
+staging drains to zero, the pass is free on every subsequent boot.
+
+**Migration shape.** Same recreate as A, plus a `CREATE TABLE … staging` +
+`INSERT INTO staging SELECT author_id, mime, bytes FROM author_photos` *ahead of*
+the `DROP`. The staging table is left in place (forward-only); the boot pass
+empties it. A later cleanup migration may drop the empty staging table once we're
+confident every install has drained.
+
+**Blast radius.** Everything in A plus a `pool.rs` boot pass and its tests. One
+extra migration concept (staging) that lingers until a follow-up drop.
+
+**Pros.** Zero data loss — manual uploads and already-fetched OL photos both
+survive the move, so the first post-upgrade render is identical to pre-upgrade.
+No thundering re-resolve against Open Library on first boot.
+**Cons.** More moving parts: a transitional table, a boot pass that does
+synchronous `std::fs` writes (must run on `spawn_blocking` like the cover purge,
+`pool.rs:66-84`), and an eventual cleanup migration. The staging table holds the
+full BLOB set *twice* transiently (original rows + staging) during the single
+migration transaction — fine for a personal library, noted for honesty.
+
+### Option C — Per-row token key (orthogonal to A/B on the bytes question)
+
+**How it works.** Instead of `<author_id>.<ext>`, store a random `photo_token`
+on the row and name files `<photo_token>.<ext>`. `upsert` generates a fresh token
+(invalidating the old file, which it unlinks), `find` reads the token then the
+file. Combine with either A or B for the bytes question.
+
+**Migration shape.** Adds a `photo_token TEXT` column to the recreated table.
+
+**Blast radius.** Same as A/B plus a column, token generation on every upsert, and
+a token read on every serve (the `EXISTS` probes don't need it — they still key on
+`source`).
+**Pros.** Immune to rowid reuse; a stale file can never be served as a new
+author's photo even if the unlink is skipped.
+**Cons.** Extra column and indirection for a problem we already control:
+`upsert`/`delete` own the file lifecycle, so an `author_id`-keyed file is
+overwritten on re-upload and unlinked on delete. The reuse window only opens if a
+write path forgets to touch the file — which is exactly what tests pin down.
+`sha2` is already a workspace dep if we want content-addressed tokens, but that
+re-introduces dedup/refcount questions covers never needed.
+
+---
+
+## Recommendation
+
+**Option B — drain to disk, keyed by `author_id`.** Rationale:
+
+- **The asymmetry decides it.** OL-sourced photos are rebuildable; manual uploads
+  are not. Option A's "it's just a cache" framing is true for the majority and
+  false for the one class a human curated by hand. Once a library accumulates
+  manual uploads, discarding them on a *storage-layout* migration is a data-loss
+  surprise with no user-facing cause — the worst kind. The cost of avoiding it is
+  one idempotent boot pass we already have a worked model for
+  (`backfill_norm_columns`, `purge_legacy_covers_once`).
+- **Reject the token (Option C).** The rowid-reuse risk is real but fully closed
+  by making `upsert_author_photo` always (re)write the file and
+  `delete_author_photo` / `delete_author` always unlink it — behavior the test
+  plan pins. A token buys insurance against a bug the tests already forbid, at the
+  cost of a column and a serve-path read on the hottest image route. Mirror
+  covers: `author_id` is to photos what `uuid` is to covers.
+- **Reversibility / cost of delay.** The bytes-vs-FS choice is *reversible while
+  the data is small and few installs exist* — today. Once real libraries
+  accumulate manual uploads, Option A becomes irreversibly lossy and Option B's
+  drain becomes the only safe path anyway. Deciding now, for B, costs the least;
+  deferring raises the floor to B regardless and risks an A-shaped accident in
+  the interim. The migration is forward-only either way (rule 06), so there is no
+  "undo" — only fix-forward.
+
+If the operator knows no manual uploads exist in any live install, **Option A is
+acceptable and strictly simpler** — it collapses to "drop bytes, let OL
+re-resolve." That is the single fact that flips the recommendation. The default,
+absent that certainty, is B.
+
+---
+
+## Migration plan (SKETCH — not to be applied)
+
+New file `db/migrations/00NN_author_photos_fs.sql` (next zero-padded number after
+the current highest; **do not** hardcode `0019` here — renumber at authoring time
+per rule 06). Table-recreate with the new `CHECK` keyed on `mime`. The staging
+lines are the **Option-B** additions; Option A omits them.
+
+```sql
+-- 00NN_author_photos_fs.sql
+-- Move author-photo bytes to the filesystem (mirrors covers). Row keeps only
+-- (source, url, mime, fetched_at); bytes live at
+-- <OMNIBUS_AUTHOR_PHOTOS_DIR>/<author_id>.<ext>.
+
+-- [Option B only] Preserve bytes across the column drop. A boot pass drains
+-- this to disk and empties it; a later migration drops the empty table.
+CREATE TABLE author_photo_bytes_staging (
+    author_id INTEGER PRIMARY KEY,
+    mime      TEXT NOT NULL,
+    bytes     BLOB NOT NULL
+);
+INSERT INTO author_photo_bytes_staging (author_id, mime, bytes)
+    SELECT author_id, mime, bytes
+      FROM author_photos
+     WHERE source <> 'letter' AND bytes IS NOT NULL;
+
+-- Recreate without `bytes`; CHECK now keys on mime, not bytes.
+CREATE TABLE author_photos_new (
+    author_id  INTEGER PRIMARY KEY REFERENCES authors(id) ON DELETE CASCADE,
+    source     TEXT NOT NULL CHECK (source IN ('manual','openlibrary','letter')),
+    url        TEXT,
+    mime       TEXT,
+    fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+    -- 'letter' = negative-cache marker, no image; non-letter rows carry a mime
+    -- and a file on disk at author_photos_dir()/<author_id>.<ext>.
+    CHECK (
+        (source =  'letter' AND mime IS NULL)
+     OR (source <> 'letter' AND mime IS NOT NULL)
+    )
+);
+INSERT INTO author_photos_new (author_id, source, url, mime, fetched_at)
+    SELECT author_id, source, url, mime, fetched_at FROM author_photos;
+DROP TABLE author_photos;
+ALTER TABLE author_photos_new RENAME TO author_photos;
+```
+
+Notes:
+- `PRAGMA foreign_keys` is already `ON` per-connection (`pool.rs:37`). The migrator
+  runs each migration in its own transaction; SQLite defers FK enforcement to
+  commit, and `ON DELETE CASCADE` from `authors` survives the rename. Confirm in
+  the migration test (see Test plan) that the FK is intact post-rename — do **not**
+  hand-toggle `PRAGMA foreign_keys` inside the migration body.
+- **Option-B boot pass.** Add `backfill_author_photos_to_fs(&pool)` called from
+  `init_db` after `MIGRATOR.run` and after `backfill_norm_columns` (`pool.rs:56`),
+  gated `!is_memory` like the cover purge so the test suite never touches a real
+  dir, and run under `tokio::task::spawn_blocking` (`pool.rs:66-84` is the model).
+  It reads staging in batches, writes each file via the new FS helper, deletes the
+  staged row on success, and returns early when staging is empty or absent.
+  Idempotent: a second boot finds an empty table and does nothing.
+
+---
+
+## Affected code
+
+From the F15 scout spec, confirmed against current line numbers:
+
+- **`db/migrations/00NN_author_photos_fs.sql`** — NEW. Table-recreate above.
+- **`db/src/author_photos.rs`** (or a new `db/src/author_photos/files.rs`) — NEW
+  FS layer mirroring `covers.rs`: `author_photos_dir()` reading
+  `OMNIBUS_AUTHOR_PHOTOS_DIR` (default `./author-photos`),
+  `write_author_photo_file(author_id, mime, bytes)`,
+  `find_author_photo_file(author_id) -> Option<(String, Vec<u8>)>`,
+  `delete_author_photo_file(author_id)`. Reuse `covers::ImageFormat` (promote its
+  `pub(crate)` visibility crate-wide, or copy the small format table).
+- **`db/src/author_photos_data.rs`** — `upsert_author_photo` writes bytes to FS
+  then upserts `(source,url,mime,fetched_at)` only; `get_author_photo` reads `mime`
+  from the row and bytes from FS via `spawn_blocking` (return `None` on missing
+  file, like covers); `delete_author_photo` unlinks then deletes the row;
+  `delete_author` (`:156-216`) unlinks the deleted author's file; consider an `Io`
+  variant on `AuthorPhotosDataError` (or swallow-to-`None` on the read path like
+  covers). Update the module `//!` doc.
+- **`db/src/browse.rs:76-81`** — swap the `has_photo` `EXISTS` off `bytes IS NOT
+  NULL` to `source IN ('manual','openlibrary')` (a non-letter row now implies a
+  file should exist).
+- **`db/src/discovery/authors.rs:170-182`** — same predicate swap in
+  `author_has_usable_photo`.
+- **`db/src/covers.rs`** — `ImageFormat` visibility for reuse (or duplicate).
+- **`db/src/pool.rs`** — Option B only: `backfill_author_photos_to_fs` boot pass.
+- **`server/src/backend/author_photos.rs`** (serve `:34-45`, uploads) and
+  **`frontend/src/rpc.rs`** URL upload — **no signature change**; they call
+  `db::get_author_photo` / `db::upsert_author_photo`, which keep their
+  `(mime, Vec<u8>)` shapes. The DB layer hides the FS.
+- **`db/src/author_photos/cascade.rs:104-118`** — unchanged at the call site; it
+  already passes `(url, mime, bytes)` to `upsert_author_photo`.
+- **Docs** — `.env.example`, `.claude/rules/01-dev-environment.md` (new
+  `OMNIBUS_AUTHOR_PHOTOS_DIR`, mirror `OMNIBUS_COVERS_DIR`),
+  `.claude/architecture.md` (new dir), and refresh the `0008` BLOB reference in
+  the `db/src/ebook/accent.rs:9` comment + the `0008_author_photos.sql` header
+  comment, which still describes `bytes`/`mime` as NULL-for-letter.
+
+---
+
+## Test plan
+
+Per [rule 03](../../.claude/rules/03-unit-testing.md): db tests in the existing
+`#[cfg(test)] mod tests` in `db/src/author_photos_data.rs` (`:218+`), against
+`init_db("sqlite::memory:")`. Add an `AuthorPhotosTempDir` RAII guard to
+`test_support` mirroring `CoversTempDir` (`db/src/test_support.rs:145-184`) that
+points `OMNIBUS_AUTHOR_PHOTOS_DIR` at a unique temp dir under a held env lock.
+
+**The acceptance test that must fail on the old schema.** A migration/PRAGMA test
+asserting `author_photos` has **no `bytes` column** after the new migration:
+`PRAGMA table_info(author_photos)` contains no `bytes` row. This fails today
+(column present at `0008:16`) and is the red bar the change turns green.
+
+**Update existing cases** to round-trip bytes through the FS:
+- `author_photo_roundtrips_manual_upload` (`:227`) — upsert writes a file; read
+  returns it.
+- `author_photo_letter_marker_returns_none` (`:247`) — a letter marker writes **no**
+  file.
+- `author_photo_status_none_when_unset` (`:261`) — unchanged contract.
+- `author_photo_upsert_replaces_existing_row` (`:268`) — replacing a row rewrites
+  the file (and, with `author_id` keying, the old extension's file is gone or
+  overwritten).
+- `author_photo_delete_clears_row` (`:293`) — delete unlinks the file.
+
+**New cases:**
+- `get_author_photo` returns `None` when the row exists but the FS file was
+  removed out-from-under it (mirror `cover_returns_none_when_file_missing`,
+  `db/src/covers.rs:264`).
+- `delete_author` also unlinks the deleted author's photo file.
+- per-variant coverage for any new `Io` variant on `AuthorPhotosDataError`
+  (happy + one representative FS-failure), or document the swallow-to-`None`
+  choice if no `Io` variant is added.
+- **Option B:** `backfill_author_photos_to_fs` drains a seeded staging row to a
+  file and empties staging; a second call is a no-op; a missing/empty staging
+  table is a no-op.
+
+**Predicate-swap regressions:** `db/src/browse/tests.rs`
+(`list_authors_populates_has_photo`, ~`:262`) and `db/src/discovery/tests.rs`
+(`get_author_populates_has_photo`, ~`:768`) — manual/letter/none must still flip
+`has_photo` correctly now that the `EXISTS` keys on `source`, not `bytes`. They
+upsert-then-read, so they pass if upsert writes the file; verify the predicate no
+longer mentions `bytes`.
+
+**Server round-trip:** `server/src/backend/author_photos/tests.rs` — 404-when-unset,
+upload-then-GET-200, `has_photo` flips after upload — run unchanged to confirm the
+FS round-trip survives the HTTP boundary.
+
+---
+
+## Risks & rollback
+
+- **Forward-only, no down-migration** (rule 06). The recreate is irreversible once
+  applied; recovery from a bad migration is a *new* `00NN+1` file, never an edit to
+  the applied one.
+- **Data-loss surface (the whole reason this is a decision).** Option A
+  permanently discards manual uploads; Option B preserves them but the drain pass
+  does synchronous FS writes that can fail (full disk, perms). The drain must be
+  best-effort-but-retried: leave the staged row in place on a write failure so the
+  next boot retries (do **not** delete-on-attempt), and log loudly — mirror the
+  cover purge's logged-and-swallowed posture but *without* the "give up forever"
+  sentinel, because losing a staged upload is not a rebuildable-cache failure.
+- **Irreversible once data accumulates.** The moment a live install gathers manual
+  uploads, Option A stops being a safe choice retroactively — there is no later
+  point at which "discard" becomes free again. This is the cost-of-delay: the
+  decision is cheap now and only gets more constrained.
+- **rowid reuse (Option-A/B `author_id` keying).** A deleted-then-re-added author
+  can reuse an id; the mitigation is that `upsert` always rewrites and `delete`
+  always unlinks, pinned by tests. Accepted over Option C's column.
+- **Boot-time I/O (Option B).** The drain sweeps every staged BLOB on first boot
+  after upgrade; on `spawn_blocking`, gated `!is_memory`, awaited like the cover
+  purge so the runtime stays schedulable but boot still blocks until it finishes.
+
+---
+
+## Sequencing & dependencies
+
+- **Reindex durability (F1 "user data cascade-deletes on reindex" / F2
+  "path-based `stable_uuid` breaks durability").** These govern how stable author
+  identity is across reindex. F15 keys files by `author_id`, which is stable
+  across reindex *today* (authors are resolved/deduped, not recreated per scan),
+  so F15 does not depend on F1/F2 landing first. But if F1/F2's fix ever changes
+  how author rows survive a reindex, the `author_id`-keyed file lifecycle is the
+  thing to re-check — note the coupling so the F1/F2 work re-reads this doc. There
+  is no ordering constraint; there is a "don't break the other's assumption"
+  constraint.
+- **`metadata_overrides` FS cutover (F10).** The override-cover path
+  (`covers_dir()/override-<uuid>.<ext>`, see `db/src/covers.rs:153`) is the closest
+  precedent for "user-curated image on disk, soft-referenced from a row." F15
+  should mirror its file-naming and 404-on-miss conventions so the two image FS
+  layers stay consistent. No ordering constraint; F15 can land independently.
+- **Must land first:** nothing. F15 is self-contained — a migration, a FS layer, a
+  CRUD rewrite, and two predicate swaps. It is sequenced *after the decision in
+  this doc*, not after any other finding.
+- **Co-changes in the same PR:** the migration + FS layer + CRUD + predicate swaps
+  + the `OMNIBUS_AUTHOR_PHOTOS_DIR` docs must ship together — the predicate swap is
+  only correct once a non-letter row implies a file exists.
+
+---
+
+## Open questions
+
+1. **Manual uploads in the wild?** Does any live install hold admin-uploaded
+   author photos? If verifiably none, Option A is acceptable and simpler. This is
+   the single fact that flips the recommendation from B to A.
+2. **Default dir name.** `./author-photos` (mirrors `./covers`) vs nesting under a
+   shared data dir like `OMNIBUS_DATA_DIR/author-photos`. Covers use a flat
+   sibling dir; HLS uses `OMNIBUS_DATA_DIR/hls/`. Pick one and document it in
+   `.env.example`.
+3. **Drop the staging table when?** If Option B ships, when is it safe to add the
+   follow-up migration that drops the (now-empty) `author_photo_bytes_staging`
+   table? Proposal: one release after the drain ships, once every install has
+   booted on the draining version at least once.
+4. **`Io` variant vs swallow-to-`None`.** Should FS read failures surface as a
+   typed `AuthorPhotosDataError::Io`, or fold into `None` like covers' read path?
+   Covers swallow; consistency argues swallow, but a manual-upload 404 from a perms
+   error is more confusing than a missing cover. Lean swallow-on-read, surface-on-
+   write (upload must not silently 200 if the file didn't land).

--- a/docs/design/db-review-f2-stable-uuid-identity.md
+++ b/docs/design/db-review-f2-stable-uuid-identity.md
@@ -1,4 +1,4 @@
-# Durable book identity — re-anchor `stable_uuid` off path
+# F2 — Durable book identity: re-anchor `stable_uuid` off path
 
 Status: Proposed — deferred from db.md F2, awaiting decision.
 
@@ -198,11 +198,12 @@ take that risk to unblock F3.2.
 
 ## Migration plan (SKETCH — not to be applied yet)
 
-Next free number is `0019` (highest applied is
-`0018_multiformat_book_files.sql`). Forward-only, append-only per rule 06.
+The migration number (`NNNN`) is allocated at implementation time — the next
+free number after the highest applied at that point (`0018_multiformat_book_files.sql`
+is the latest as of writing). Forward-only, append-only per rule 06.
 
 ```sql
--- 0019_book_identity_uuid.sql  (SKETCH — additive identity model)
+-- NNNN_book_identity_uuid.sql  (SKETCH — additive identity model)
 ALTER TABLE books ADD COLUMN identity_uuid TEXT;   -- nullable; backfilled at boot
 ALTER TABLE books ADD COLUMN content_hash  TEXT;   -- SHA-256 hex of file bytes
 
@@ -237,7 +238,8 @@ pub async fn backfill_identity_uuids(pool: &SqlitePool) -> Result<(), sqlx::Erro
 Covers are a rebuildable cache, so a missed rename regenerates on the next
 reindex — the rename is best-effort, like the existing `#94` purge. A
 **later** migration (`0020+`) can re-key `merged_uuids` / `metadata_overrides`
-PKs to `identity_uuid` once it is the canonical key; do not do that in `0019`.
+PKs to `identity_uuid` once it is the canonical key; do not do that in this
+`NNNN` migration.
 
 ## Affected code
 
@@ -264,7 +266,7 @@ From the scout spec (current symbols, not line anchors — anchors rot):
 - `db/src/books/projection.rs` — `row_to_ebook` surfaces the persisted
   `identity_uuid` as `unique_identifier` instead of echoing `books.uuid`.
 - `db/src/audiobook/group.rs` — content-hash anchor (no `dc:identifier`).
-- `db/migrations/0019_book_identity_uuid.sql` — additive columns + partial
+- `db/migrations/NNNN_book_identity_uuid.sql` — additive columns + partial
   unique index.
 - `db/src/normalize.rs` (or new `identity.rs`) — `backfill_identity_uuids`,
   wired into `db/src/pool.rs` `init_db`.
@@ -291,7 +293,7 @@ the durable anchor lands.
 - `db/src/books/tests.rs` — `resolve_book_id_by_uuid` resolves by
   `identity_uuid`, by legacy path-uuid, and by `merged_uuids` (one happy per
   branch).
-- Backfill test — seed a row with NULL `identity_uuid` (simulate pre-0019),
+- Backfill test — seed a row with NULL `identity_uuid` (simulate pre-migration),
   run `backfill_identity_uuids` twice, assert it populates once and is a
   no-op the second time (idempotent, like the `backfill_norm_columns` tests).
 - Reconcile test — detach a `metadata_overrides` row via a root change, run
@@ -299,14 +301,14 @@ the durable anchor lands.
   `identity_uuid`.
 - Audiobook test — content-hash anchor stable across a root change for an MP3
   group (`db/src/audiobook` tests).
-- Migration test — assert `0019` adds the column + partial unique index and
-  that a duplicate `identity_uuid` is rejected. The `MIGRATOR` runs `0019`
-  in every existing memory-DB test, so the migration is already exercised.
+- Migration test — assert the new migration adds the column + partial unique
+  index and that a duplicate `identity_uuid` is rejected. The `MIGRATOR` runs
+  it in every existing memory-DB test, so the migration is already exercised.
 
 ## Risks & rollback
 
-- **Forward-only / fix-forward.** No down-migrations (rule 06). A bug in
-  `0019` is corrected by `0020`, never by editing `0019`.
+- **Forward-only / fix-forward.** No down-migrations (rule 06). A bug in the
+  new migration is corrected by a later one, never by editing it once applied.
 - **Data-loss surfaces.** The reconcile pass deletes/relinks override and
   merged rows; a wrong `(author, title)` match could *mis*-link an override
   to the wrong book. Mitigate with exact-normalized matching only (reuse
@@ -332,8 +334,9 @@ F2 sits in a tight chain with F1 and F10:
   the five user-data tables still key on numeric `book_id`, so today only
   `metadata_overrides` + `merged_uuids` detach on a re-key. F1 must move user
   data to `book_uuid` soft-refs first; only *then* does a stable uuid matter
-  for ratings/progress. Land **F1 then F2**, or as a stacked pair sharing
-  migrations `0019`/`0020`. F2 without F1 fixes the identity but leaves user
+  for ratings/progress. Land **F1 then F2**, or as a stacked pair sharing two
+  adjacent migration numbers (allocated at implementation time). F2 without F1
+  fixes the identity but leaves user
   data cascade-deleting; F1 without F2 makes the soft-ref contract a lie on
   path change. Both are needed before F3.2.
 - **F10 (override GC / reconcile).** The reconcile/relink pass this doc adds
@@ -344,7 +347,7 @@ F2 sits in a tight chain with F1 and F10:
 - **Audiobook anchor (decision 3)** can land in the same change or a fast
   follow; it is independent of the ebook `dc:identifier` path.
 
-Must land first: F1's table moves (or at least its `0019` migration shape)
+Must land first: F1's table moves (or at least its migration shape)
 so F2 and F1 don't fight over the migration number. Confirm whether they
 stack on one migration or two before authoring either.
 

--- a/docs/design/db-review-f2-stable-uuid-identity.md
+++ b/docs/design/db-review-f2-stable-uuid-identity.md
@@ -1,0 +1,370 @@
+# Durable book identity — re-anchor `stable_uuid` off path
+
+Status: Proposed — deferred from db.md F2, awaiting decision.
+
+This doc frames the data-model decision that must be made *before* any
+schema or code is written. It does not prescribe DDL to apply today — the
+migration section is a sketch contingent on the decision below. Companion
+findings: F1 (user-data soft-refs) and F10 (override GC / reconcile).
+
+## Problem
+
+A book's durable identity is derived from its filesystem location, not its
+content. `stable_uuid(library_path, filename)` is
+`Uuid::new_v5(NAMESPACE_URL, "{library_path}\0{filename}")` —
+`db/src/helpers.rs` (`stable_uuid`). The uuid is minted in **Phase A**, the
+pure filesystem stat that never opens the zip: `db/src/ebook/stat.rs`
+stamps `StatEntry.uuid` from `stable_uuid(library_path_key, &relative)`.
+That uuid is then the join key for the *entire* incremental diff —
+`diff_library` in `db/src/indexer.rs` keys disk-vs-DB rows on it
+(`disk_by_uuid` / `db_by_uuid`), and the sync writers
+(`insert_book_row`, `sync_changed`, `try_attach_new_ebook`,
+`attach_ebook_file` in `db/src/sync/books.rs`) recompute the same value to
+locate the row they are about to write.
+
+Because the key embeds `library_path`, **any change to the library root
+re-mints a brand-new uuid for every book**: a settings edit that points the
+ebook library at a new path, the F0.6 filesystem reorg, or simply moving the
+data directory. Settings prune then hard-deletes the old `books` rows
+(`prune_orphan_libraries`, `db/src/settings.rs`), the next scan inserts
+fresh rows under new uuids, and everything keyed on the old uuid silently
+detaches:
+
+- `metadata_overrides.book_uuid` (PK, no FK — `0007_metadata_overrides.sql`).
+- `merged_uuids.uuid` (PK — `0016_format_merge.sql`), the cross-format
+  attach/merge ledger.
+- Cover and thumbnail files named `<uuid>.<ext>`, and every
+  `/api/covers/{uuid}` / `/api/thumbs/{uuid}` URL.
+- The resolver `resolve_book_id_by_uuid` (`db/src/books/get.rs`) returns
+  `None`, so old detail-page links and in-flight progress POSTs 404.
+
+This bites the roadmap directly. F3.2 ratings & journaling
+(`docs/roadmap/3-2-ratings-journaling.md`) specs user-data tables that
+soft-reference `book_uuid TEXT` precisely so a pruned book's rating
+*detaches and auto-relinks* when the file reappears. That contract is a lie
+while the uuid itself moves on a path change: the row detaches and never
+relinks. The roadmap lists the fix as a hard pre-req — "the current
+`stable_uuid(library_path, filename)` scheme breaks this … must land before
+this feature ships."
+
+Two facts the original review under-stated, both load-bearing for the fix:
+
+1. **The anchor is not available in Phase A.** The OPF `dc:identifier` is
+   parsed only in Phase B (`collect_identifiers` / `doc.unique_identifier`
+   in `db/src/ebook/parse.rs`), which opens the zip. The uuid is needed in
+   Phase A as the diff key. So we cannot "just re-derive `books.uuid` from
+   `dc:identifier`" without either opening every zip on every scan (killing
+   incremental-scan perf) or splitting identity into two keys.
+2. **`dc:identifier` is parsed but never persisted.** There is no DB column
+   for it. `db/src/books/projection.rs` (`row_to_ebook`) sets
+   `unique_identifier: Some(uuid.clone())` — it just echoes `books.uuid`.
+   The "primary anchor" the roadmap names is not even stored yet.
+
+Audiobooks have no `dc:identifier` at all (folder-grouped MP3/M4B —
+`stable_uuid(library_path_key, &dir)` in `db/src/audiobook/group.rs`), so any
+`dc:identifier`-primary scheme is ebook-only; audiobooks need a content-hash
+anchor. `sha2::Sha256` is already a `db` dependency
+(`db/Cargo.toml`, used by `db/src/auth/token.rs`), so the hash fallback needs
+no new crate.
+
+## Decision required
+
+Four choices, in priority order. The first is the deep one and gates the
+rest. None is cheaply reversible once real cover files, merged_uuids rows,
+and (post-F1) user data accumulate under the chosen scheme.
+
+1. **Two-key split vs. re-key `books.uuid` in place.** Keep a cheap
+   path-derived **scan key** for the Phase-A diff and add a separate durable
+   **identity key** resolved in Phase B? Or make `books.uuid` itself the
+   durable identity, forcing a table-recreate and a boot re-key that breaks
+   every cover filename, `merged_uuids` row, and override at once?
+2. **Anchor precedence and the "unstable id" detector.** Proposed:
+   `dc:identifier` (when stable) > SHA-256 of file bytes > scan-key
+   fallback. Confirm the rule for rejecting an unstable `dc:identifier`
+   (per-export random `urn:uuid:` ids — many EPUB editors mint a fresh one
+   each export), and whether the content hash is computed at Phase-A stat
+   time (re-reads every file — costly) or only for New/Changed books in
+   Phase B.
+3. **Audiobook anchor.** No `dc:identifier` exists. Content-hash of the
+   first part? A hash of all part sizes+names? Decide separately from the
+   ebook scheme.
+4. **Reconcile / relink policy.** When the identity moves anyway (a true
+   re-export with a new id and changed bytes), how are detached
+   `metadata_overrides` / `merged_uuids` / (post-F1) user-data rows
+   re-linked — by `(author, title)` similarity — and are unmatched rows
+   surfaced as "unlinked" in the UI or silently dropped?
+
+## Options
+
+### Option A — Additive identity column, scan-key stays the diff key (two-key split)
+
+How it works. `books.uuid` keeps its current `stable_uuid(library_path,
+filename)` semantics and remains the Phase-A diff key — `diff_library` and
+the sync writers are unchanged. Add `books.identity_uuid TEXT` (nullable)
+and `books.content_hash TEXT`, both resolved in **Phase B** where the OPF is
+already open. A new helper `book_identity_uuid(opf_identifier, content_hash,
+scan_key)` picks: stable `dc:identifier` → UUIDv5 over it; else SHA-256 of
+file bytes; else fall back to the scan key so a parse-less file still gets a
+value. `metadata_overrides` and the F1 user-data tables move to reference
+`identity_uuid`; `merged_uuids` and cover files migrate to it over a
+transition window during which `resolve_book_id_by_uuid` UNIONs both keys.
+
+Migration shape. Purely additive — `ALTER TABLE books ADD COLUMN
+identity_uuid`, `ADD COLUMN content_hash`, plus a partial unique index. No
+table-recreate. A boot backfill (`backfill_identity_uuids`, mirroring
+`backfill_norm_columns`) populates the new columns for pre-migration rows.
+Forward-only, idempotent, complies with rule 06.
+
+Blast radius. New columns + one helper + Phase-B persistence in the sync
+writers + a dual-resolver UNION + a boot backfill + a cover-file relink. The
+hot Phase-A diff path is untouched, so incremental-scan perf is unchanged.
+Two identity concepts coexist (scan key for diffing, identity key for
+durability), which is conceptual overhead but each has a single clear job.
+
+Pros. Lowest risk; reversible (drop the columns, nothing else moved);
+incremental scan perf preserved; no force-recompute of existing cover URLs
+on day one. Cons. Two columns to reason about forever; `books.uuid` keeps a
+misleading name (it is the scan key, not the identity); a later cleanup
+migration is needed if you ever want to retire the legacy key.
+
+### Option B — Re-key `books.uuid` in place to the durable identity (one key)
+
+How it works. `books.uuid` *becomes* the durable identity (dc:identifier /
+content-hash). A second, non-durable column (`books.scan_key`) takes over
+the Phase-A diff role. Every consumer of "the uuid" — covers, routes,
+`merged_uuids`, overrides, F1 user data — now references the durable value
+directly; no dual-resolver needed long-term.
+
+Migration shape. SQLite cannot `ALTER` a `UNIQUE`/derivation in place, so
+this is the **table-recreate dance**: `CREATE books_new` with the new
+semantics, `INSERT … SELECT`, `DROP`, `RENAME`, recreate every `idx_books_*`
+and re-point child tables. Critically, **the new uuid cannot be computed in
+SQL** — it needs `dc:identifier` from the OPF / the file bytes, neither in
+the DB. So the `.sql` can only add the column; the actual re-key must happen
+in Rust at boot (open each file, read/hash, UPDATE, re-point
+`merged_uuids` + `metadata_overrides` + rename `<old>.<ext>` →
+`<new>.<ext>`).
+
+Blast radius. Largest. Recreate `books`, re-point all uuid-keyed children,
+re-key every cover file, and run a one-shot boot migration that opens every
+file in the library. Any failure mid-migration leaves a partially re-keyed
+DB. Every external `/api/covers/{old-uuid}` URL breaks at the cutover unless
+the dual-resolver is kept anyway.
+
+Pros. One canonical identity; clean long-term model; `unique_identifier`
+projection becomes truthful for free. Cons. High-risk irreversible
+migration; opens every file at boot; force-breaks cover URLs and
+`merged_uuids` simultaneously; the table-recreate must be perfectly ordered
+against FKs; effectively still needs Option A's dual-resolver during the
+cutover, so it is "Option A plus a destructive recreate."
+
+### Option C — Defer: ship F1 soft-refs now, block F3.2 on F2
+
+How it works. Recognize that the co-dependency with F1 is **currently
+latent**: the five user-data tables still key on numeric `book_id`
+(`0013`, `0017`), so today only `metadata_overrides` + `merged_uuids`
+actually detach on a re-key. Land F1 (move user data to `book_uuid`
+soft-refs) first, then revisit F2 with the full set of durable consumers
+known. F3.2 stays blocked until F2 lands, per the roadmap.
+
+Migration shape. None for F2 now. Cons. Does not solve the problem; just
+sequences it. Including it here only to make explicit that F2 *can* slip
+behind F1 without new data loss — but every day F3.2 is blocked is a day the
+"my library, my notes" pitch is unbuildable.
+
+## Recommendation
+
+**Option A (additive identity column, two-key split).**
+
+Rationale. The architectural blocker — the anchor is unavailable in Phase A
+— makes the two-key split not a stylistic preference but the shape the
+indexer forces on us. We *need* a cheap path-derived key for the diff
+regardless; Option B keeps that key too (renamed `scan_key`) and pays for a
+destructive table-recreate on top. The marginal benefit of B (one canonical
+column, a truthful `unique_identifier`) does not justify a boot-time
+re-key that opens every file and force-breaks every cover URL and
+`merged_uuids` row at once, on a schema whose user-data tables haven't even
+moved to uuids yet (F1).
+
+Reversibility / cost-of-delay. Option A is the only reversible choice: until
+the legacy key is retired, dropping `identity_uuid`/`content_hash` restores
+the status quo. Once F3.2 ratings and F1 user data accumulate under *any*
+scheme, the choice hardens — re-keying live ratings/journals by hand is
+exactly the irreversible cost the roadmap warns about. So the cheap,
+additive, reversible model is the right one to commit to *before* that data
+exists. The path to B remains open later (retire the legacy key in a future
+migration) if the two-column model proves confusing — but we never have to
+take that risk to unblock F3.2.
+
+## Migration plan (SKETCH — not to be applied yet)
+
+Next free number is `0019` (highest applied is
+`0018_multiformat_book_files.sql`). Forward-only, append-only per rule 06.
+
+```sql
+-- 0019_book_identity_uuid.sql  (SKETCH — additive identity model)
+ALTER TABLE books ADD COLUMN identity_uuid TEXT;   -- nullable; backfilled at boot
+ALTER TABLE books ADD COLUMN content_hash  TEXT;   -- SHA-256 hex of file bytes
+
+-- Durable identity is unique among rows that have one; NULLs (pre-backfill,
+-- or files that never parsed) are exempt via the partial index.
+CREATE UNIQUE INDEX idx_books_identity_uuid
+    ON books(identity_uuid) WHERE identity_uuid IS NOT NULL;
+```
+
+The `.sql` is additive only. The actual identity derivation **cannot** live
+in SQL (it needs the OPF / file bytes), so a boot backfill in Rust does the
+work, mirroring `normalize::backfill_norm_columns` and wired into `init_db`
+in `db/src/pool.rs` right after it:
+
+```rust
+// db/src/normalize.rs (or a new identity.rs) — SKETCH
+// Idempotent: only touches rows WHERE identity_uuid IS NULL.
+// Gated off in-memory DBs the same way the #94 cover purge is in
+// init_db, so the rapid-fire test suite doesn't hit the filesystem.
+pub async fn backfill_identity_uuids(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    // SELECT id, library_path, filename FROM books WHERE identity_uuid IS NULL
+    // for each: open file -> read dc:identifier / hash bytes ->
+    //   identity = book_identity_uuid(opf_id, hash, existing_uuid)
+    //   UPDATE books SET identity_uuid = ?, content_hash = ? WHERE id = ?
+    //   re-point metadata_overrides.book_uuid + merged_uuids.uuid whose old
+    //   value no longer resolves but whose (author,title) matches this row
+    //   rename covers/<old-uuid>.<ext> -> covers/<identity_uuid>.<ext>
+    Ok(())
+}
+```
+
+Covers are a rebuildable cache, so a missed rename regenerates on the next
+reindex — the rename is best-effort, like the existing `#94` purge. A
+**later** migration (`0020+`) can re-key `merged_uuids` / `metadata_overrides`
+PKs to `identity_uuid` once it is the canonical key; do not do that in `0019`.
+
+## Affected code
+
+From the scout spec (current symbols, not line anchors — anchors rot):
+
+- `db/src/helpers.rs` — keep `stable_uuid` as the scan key (consider
+  renaming to `scan_key_uuid`); add `book_identity_uuid(opf_identifier,
+  content_hash, scan_key)` and `is_unstable_opf_identifier()` (detects
+  per-export `urn:uuid:` ids).
+- `db/src/ebook/parse.rs` — `extract_metadata` already collects
+  `identifiers` + `unique_identifier`; add the content-hash hook only if
+  hashing happens here.
+- `db/src/ebook/stat.rs` — `StatEntry.uuid` stays the path scan key (Phase A
+  can't see the OPF); no identity change here.
+- `db/src/sync/books.rs` — `insert_book_row`, `sync_changed`,
+  `try_attach_new_ebook`, `attach_ebook_file`: compute and persist
+  `identity_uuid` + `content_hash`; keep the scan key for diff and
+  `merged_uuids` matching.
+- `db/src/indexer.rs` — `diff_library` keeps matching on the scan key;
+  `reindex` gains a reconcile/relink pass after `sync_books`.
+- `db/src/books/get.rs` — `resolve_book_id_by_uuid` UNION extended to resolve
+  by `identity_uuid` AND legacy `books.uuid` AND `merged_uuids` during the
+  transition.
+- `db/src/books/projection.rs` — `row_to_ebook` surfaces the persisted
+  `identity_uuid` as `unique_identifier` instead of echoing `books.uuid`.
+- `db/src/audiobook/group.rs` — content-hash anchor (no `dc:identifier`).
+- `db/migrations/0019_book_identity_uuid.sql` — additive columns + partial
+  unique index.
+- `db/src/normalize.rs` (or new `identity.rs`) — `backfill_identity_uuids`,
+  wired into `db/src/pool.rs` `init_db`.
+- `db/src/test_support.rs` — seed factories updated for the new scheme.
+- `db/src/helpers/tests.rs` — new identity-derivation tests.
+
+## Test plan
+
+Per rule 03: sibling `<mod>/tests.rs`, all against `sqlite::memory:`. The
+**acceptance test that must fail on the old schema** is the root-change
+survival test below — on today's code the identity moves, so it fails until
+the durable anchor lands.
+
+- `db/src/helpers/tests.rs` — `book_identity_uuid`: stable `dc:identifier`
+  wins (happy); falls back to SHA-256 when the id is absent/empty;
+  falls back to the scan key when no file/hash; determinism + UUIDv5
+  version/variant checks mirroring the existing `stable_uuid_*` tests;
+  `is_unstable_opf_identifier` detects per-export `urn:uuid:` ids.
+- `db/src/sync/tests.rs` — **acceptance:** seed a book, reindex under a *new*
+  `library_path`, assert the SAME `identity_uuid` and that
+  `metadata_overrides` + `merged_uuids` still resolve. Assert
+  `insert_book_row` / `sync_changed` / the attach paths all persist
+  `identity_uuid`.
+- `db/src/books/tests.rs` — `resolve_book_id_by_uuid` resolves by
+  `identity_uuid`, by legacy path-uuid, and by `merged_uuids` (one happy per
+  branch).
+- Backfill test — seed a row with NULL `identity_uuid` (simulate pre-0019),
+  run `backfill_identity_uuids` twice, assert it populates once and is a
+  no-op the second time (idempotent, like the `backfill_norm_columns` tests).
+- Reconcile test — detach a `metadata_overrides` row via a root change, run
+  `reindex`, assert it re-links by `(author, title)` to the surviving
+  `identity_uuid`.
+- Audiobook test — content-hash anchor stable across a root change for an MP3
+  group (`db/src/audiobook` tests).
+- Migration test — assert `0019` adds the column + partial unique index and
+  that a duplicate `identity_uuid` is rejected. The `MIGRATOR` runs `0019`
+  in every existing memory-DB test, so the migration is already exercised.
+
+## Risks & rollback
+
+- **Forward-only / fix-forward.** No down-migrations (rule 06). A bug in
+  `0019` is corrected by `0020`, never by editing `0019`.
+- **Data-loss surfaces.** The reconcile pass deletes/relinks override and
+  merged rows; a wrong `(author, title)` match could *mis*-link an override
+  to the wrong book. Mitigate with exact-normalized matching only (reuse
+  `normalize_title`/`normalize_author`, which is deliberately exact — a miss
+  costs a manual relink, a false positive corrupts a book) and surface
+  unmatched rows as "unlinked" rather than deleting them.
+- **What's irreversible once data accumulates.** Once F3.2 ratings/journals
+  and F1 user data are keyed on `identity_uuid`, the anchor *definition*
+  (precedence rules, the unstable-id detector) is frozen — changing it later
+  re-keys live user data with no SQL-computable mapping. Lock decision 2
+  before that data exists.
+- **Rollback for Option A specifically.** Until a later migration retires the
+  legacy `books.uuid` key, the additive columns can be ignored and the
+  dual-resolver falls back to the legacy key — so a botched rollout degrades
+  to today's behavior rather than data loss. This reversibility is the whole
+  reason for recommending A.
+
+## Sequencing & dependencies
+
+F2 sits in a tight chain with F1 and F10:
+
+- **F1 (user-data soft-refs) ↔ F2.** Co-dependent but currently *latent*:
+  the five user-data tables still key on numeric `book_id`, so today only
+  `metadata_overrides` + `merged_uuids` detach on a re-key. F1 must move user
+  data to `book_uuid` soft-refs first; only *then* does a stable uuid matter
+  for ratings/progress. Land **F1 then F2**, or as a stacked pair sharing
+  migrations `0019`/`0020`. F2 without F1 fixes the identity but leaves user
+  data cascade-deleting; F1 without F2 makes the soft-ref contract a lie on
+  path change. Both are needed before F3.2.
+- **F10 (override GC / reconcile).** The reconcile/relink pass this doc adds
+  to `reindex` is the same machinery F10 needs to GC orphaned overrides and
+  cover files. Build the reconcile pass once, shared.
+- **F3.2 ratings & journaling** is the downstream feature blocked on this —
+  the roadmap lists the uuid fix as "must land before this feature ships."
+- **Audiobook anchor (decision 3)** can land in the same change or a fast
+  follow; it is independent of the ebook `dc:identifier` path.
+
+Must land first: F1's table moves (or at least its `0019` migration shape)
+so F2 and F1 don't fight over the migration number. Confirm whether they
+stack on one migration or two before authoring either.
+
+## Open questions
+
+1. **Hash timing.** Compute `content_hash` at Phase-A stat (re-reads every
+   file every scan — costly) or only for New/Changed books in Phase B
+   (cheap, but Unchanged books never get a hash until they next change)?
+   Leaning Phase-B-only, accepting that the backfill fills the rest once.
+2. **Unstable-id heuristic precision.** Is "`urn:uuid:` prefix without a
+   stable publisher/ISBN companion identifier" the right detector, or do we
+   need a per-publisher allowlist? A false "stable" classification pins
+   identity to a per-export random id and defeats the whole fix.
+3. **Audiobook anchor exact form** — first-part content hash vs. a manifest
+   hash of all parts' (name, size). The latter survives re-encoding a single
+   chapter; the former is cheaper.
+4. **Reconcile UI surface** — do we build the "unlinked annotations" view now
+   (F3.2 mentions it) or stub it to a log line and a count until F3.2's
+   detail page exists?
+5. **Legacy-key retirement** — do we ever run the `0020` re-key of
+   `merged_uuids`/`metadata_overrides` to `identity_uuid`, or keep the
+   dual-resolver indefinitely? Cheap to defer; decide when the two-column
+   model proves either fine or confusing in practice.

--- a/docs/design/db-review-f5b-landing-pagination.md
+++ b/docs/design/db-review-f5b-landing-pagination.md
@@ -1,0 +1,453 @@
+# F5b — Landing/search keyset pagination (wire-API change)
+
+Status: Proposed — deferred from db.md F5b, awaiting decision.
+
+This doc covers **only** the pagination half of review finding F5. The
+mechanical half — collapsing the duplicate `book_files` / `books_series_link`
+subquery pairs in `BOOK_COLUMNS` and adding the `(library_id, sort, id)`
+index — ships as code in PR **F5a** with no contract change and is not
+discussed here except where the two interact. F5b is the part that changes a
+wire API and the landing UX, so it needs an operator decision before any code
+is written.
+
+---
+
+## Problem
+
+`list_books_for_paths` (`db/src/books/list.rs`, `fetch_list_rows`) materializes
+an entire library in one statement —
+`SELECT {BOOK_COLUMNS} … ORDER BY b.sort, b.id LIMIT ?` with the bind set to
+`MAX_BOOKS_RETURNED = 50_000` (`db/src/books/projection.rs`,
+`MAX_BOOKS_RETURNED`). There is no SQL keyset; the cap is the *only* bound. The
+module doc on `MAX_BOOKS_RETURNED` says cursor pagination is "intentionally
+deferred", so on every landing and search load the whole library is selected,
+decoded into `Vec<EbookMetadata>`, run through two more full passes in Rust
+(`merge_overrides_into_books`, then `backfill_creator_ids` in `list.rs`),
+JSON-encoded, and shipped to the client in one response.
+
+The web path makes this worse: `rpc_get_ebooks` (`frontend/src/rpc.rs`) returns
+the full `EbookLibrary` and the landing page sorts and filters it **client-side**
+over a hydrated signal — `frontend/src/pages/landing/sorting.rs` re-sorts the
+whole `Vec` by any of `SortKey::{Title, Author, Series, LastUpdated,
+NewestAdded}` × `SortDir::{Asc, Desc}`, and `filtering.rs` applies the facet
+filters in memory. This is a deliberate design (`docs/roadmap/1-3-library-views.md`:
+"Client-side sort on already-hydrated lists for libraries ≤10k books … the
+biggest perceived-speed win over Calibre-Web"), but it hard-couples "first
+paint" to "download the entire library."
+
+Why it bites a named feature:
+
+- **F1.3 Library views** sets the ≤10k-book client-sort ceiling and *also*
+  states "Keyset pagination on `(sort, id)` — never `OFFSET`" as the long-term
+  fix. The ceiling is a stopgap; above it the current path degrades from "slow
+  first paint" to "unusable."
+- **F3.1 Libraries with metadata filters** wraps this exact projection in
+  additional `WHERE` predicates over normalized columns. Once a saved library
+  is "every unread sci-fi book," the query is `filter → temp-sort → cap`, and
+  the absence of a `(library_id, sort, id)` index (only `idx_books_sort` on
+  `books(sort)` global, and `idx_books_library_id`, exist today —
+  `0002_normalized_schema.sql`) forces a full temp-sort. F5a's composite index
+  fixes the *sort*; it does not bound the *result-set size*, which is what
+  pagination is for.
+
+The truncation signal already exists but is one-directional: the REST handler
+`get_ebooks` (`server/src/backend/ebooks.rs`) wraps the response in
+`with_pagination_headers` (`server/src/backend.rs`), emitting `X-Total-Count`
+and (when truncated) `X-Total-Cap`. The web RPC path can't even do that —
+Dioxus server functions don't expose response headers — so the web client has
+no way to know it got a truncated library. There is no way to fetch page 2.
+
+---
+
+## Decision required
+
+The operator must decide **how far to take pagination**, which decomposes into
+four bound choices:
+
+1. **Cursor key.** The natural keyset is `(b.sort, b.id)` — the existing
+   `ORDER BY`. But the web client re-sorts by five different axes after
+   hydration. A single `(sort, id)` cursor serves exactly **one** of those ten
+   orderings server-side; the other nine are client-side re-sorts over whatever
+   page the cursor returned. So the decision is really: **does the cursor own
+   the sort order, or does the client?** (You cannot have both with one cursor.)
+
+2. **Cursor encoding.** Opaque base64-of-`(last_sort, last_id)` vs. raw query
+   params vs. plain integer `OFFSET`. The roadmap forbids `OFFSET`
+   (`1-3-library-views.md`: "never `OFFSET`"; Calibre-Web's offset paging is the
+   named large-library killer), which removes one option but not the
+   opaque-vs-transparent question.
+
+3. **Surface scope.** Paginate **only the REST/mobile path** (`get_ebooks`,
+   which already has headers and a list client), **only the web/RPC path**, or
+   **unify** both on one paged `db::list_books_page`. The web path additionally
+   requires a UX rearchitecture (infinite-scroll/append) because today it
+   assumes a complete Vec.
+
+4. **Page size** and the client's list strategy — fixed page size, and whether
+   the web landing moves to infinite-scroll append (roadmap-preferred) or stays
+   on the full-Vec model below the 10k ceiling and only paginates above it.
+
+These four are the heart of the doc; the options below are concrete bundles of
+answers to them.
+
+---
+
+## Options
+
+All options share the same DB primitive: a `list_books_page(pool, paths,
+last_sort: Option<&str>, last_id: Option<i64>, limit: i64)` that appends a
+NULL-aware keyset predicate before `ORDER BY b.sort, b.id LIMIT ?`:
+
+```sql
+-- after the existing WHERE l.path IN (...)
+AND ( :last_sort IS NULL
+   OR b.sort > :last_sort
+   OR (b.sort = :last_sort AND b.id > :last_id) )
+ORDER BY b.sort, b.id
+LIMIT :limit
+```
+
+`b.sort` is `TEXT COLLATE NOCASE` (`0002_normalized_schema.sql`), so the cursor
+comparison and the index must agree on collation — F5a's
+`(library_id, sort, id)` index is `COLLATE NOCASE` on `sort` for exactly this.
+Rows with `sort IS NULL` collate first under SQLite and need the
+`:last_sort IS NULL` short-circuit on the first page; the boundary test below
+covers it.
+
+No option requires a table-recreate. SQLite can't drop a column, change a PK,
+or alter an FK in place — those force the create-new / copy / drop / rename
+dance — but every F5b change is either a pure secondary index (populated on
+`CREATE INDEX`) or a Rust SQL-string change. Migrations stay append-only and
+forward-only per rule 06.
+
+### Option A — Opaque base64 keyset cursor, REST-first, web stays full-Vec
+
+**How it works.** Add `list_books_page` to the db crate. Extend the REST
+`get_ebooks` handler with `?cursor=<base64>&limit=<n>` query params; the cursor
+encodes `(last_sort, last_id)`. The server orders by `(sort, id)` only and
+returns a `next_cursor` (null at end of stream) alongside the page. The
+`X-Total-Count` header stays. The **web/RPC path is unchanged** — `rpc_get_ebooks`
+keeps returning the capped full library and the client keeps sorting in memory
+below the 10k ceiling.
+
+**Migration shape.** None beyond F5a's `(library_id, sort, id)` index. The
+cursor is computed in Rust; no schema. (`base64` 0.22 and `sha2` 0.10 are
+already db-crate deps — `db/Cargo.toml` — if we later want to HMAC-sign the
+cursor; for an internal app a plain base64 of the tuple is enough since the
+cursor is non-authoritative and any tampering only mis-positions the reader's
+own page.)
+
+**Blast radius.** db: one new fn + tests. server: `get_ebooks` signature gains
+query params, plus a `next_cursor` field — to avoid breaking the
+`EbookLibrary` body contract, carry `next_cursor` as a **response header**
+(`X-Next-Cursor`) so the JSON body stays byte-compatible for existing mobile
+clients, mirroring the `X-Total-Count` precedent. frontend: untouched.
+
+**Pros.** Smallest blast radius. Ships the actual large-library fix where it's
+provably needed first (the mobile list client, which has no client-sort luxury).
+No web UX rework. Reversible — adding query params with sane defaults is
+backward-compatible; the old "no cursor = first page, capped" behavior is the
+default branch.
+
+**Cons.** Leaves the web path's "download everything" problem unsolved above
+10k. Two divergent read paths (paged REST, full-Vec RPC) until a later increment
+unifies them. The cursor only ever serves `(sort, id)`; mobile gets server-sort
+order, not the five client axes (acceptable — mobile can sort its own page or
+adopt server-side sort keys later).
+
+### Option B — Opaque cursor, unified web + REST, infinite-scroll landing
+
+**How it works.** Option A's db primitive, but **both** surfaces paginate.
+`rpc_get_ebooks` gains `last_sort`/`last_id`/`limit` args (RPC POST body, since
+`#[get]` server fns can't carry a body — same reason `rpc_search` is POST). The
+landing page moves from "hydrate full Vec, sort in memory" to **infinite-scroll
+append**. Because the server owns the `(sort, id)` order, the client sort
+toolbar must either drive a server-side `sort_key` param (a different `ORDER BY`
++ matching index per axis) or be dropped in favor of server order. This is the
+roadmap's stated end-state (`1-3-library-views.md`).
+
+**Migration shape.** Beyond F5a's index, *server-side* sort on the other axes
+needs a composite index each — `(library_id, author_sort, id)`,
+`(library_id, timestamp, id)`, `(library_id, last_modified, id)`,
+`(library_id, series_id, series_index, id)` — one append-only
+`CREATE INDEX IF NOT EXISTS` per file. No table-recreate.
+
+**Blast radius.** db: paged fn + a sort-axis → `(ORDER BY, index)` mapping +
+per-axis tests. server + frontend/rpc: both signatures change. frontend:
+`landing/` is substantially rearchitected — `sorting.rs`/`filtering.rs` move
+server-side (or per-page), grid/table gain scroll-sentinel append, and a
+`view_prefs` sort change triggers a refetch instead of an in-memory re-sort.
+Playwright landing specs change.
+
+**Pros.** One read path. Scales past 10k everywhere. Matches the roadmap
+end-state. Kills the whole-library first-paint cost on web.
+
+**Cons.** Largest blast radius by far — a landing-page rewrite, not a db change.
+Multi-axis server sort multiplies indexes. **F3.1's dynamic filters interact
+badly with multi-axis keyset**: every `(filter, sort)` pair wants its own
+covering index, which doesn't scale combinatorially — arbitrary saved-library
+predicates fall back to filter-then-temp-sort anyway. Hard to reverse once the
+landing UX is rewritten.
+
+### Option C — Hybrid: ship A now, design B's contract but gate the web rewrite
+
+**How it works.** Land Option A (REST cursor + db primitive) immediately.
+*Simultaneously* fix the `next_cursor` and `limit` contract shape — header name,
+base64 layout, default page size, end-of-stream sentinel — so the eventual web
+adoption (Option B) reuses the exact same db fn and wire shape without a second
+migration of the contract. Keep the web full-Vec path until a library actually
+crosses the 10k ceiling, then flip the landing page to infinite-scroll as a
+follow-on PR that touches only `frontend/landing/` and `rpc.rs`, against an
+already-proven server primitive.
+
+**Migration shape.** Same as A now (none beyond F5a). B's extra sort-axis
+indexes are deferred to the web-adoption PR and only added if multi-axis
+*server* sort is actually chosen then (the web rewrite may keep client-sort
+*within* a larger page window instead).
+
+**Blast radius.** Now: identical to Option A. Later: identical to Option B's
+frontend slice, but de-risked because the db + wire contract is already in
+production.
+
+**Pros.** Decouples the irreversible UX decision (B) from the safe, useful db
++ REST win (A). Lets real library sizes drive when — and whether — the web
+rewrite is worth it (per assumption A3: most users have ≤100k books, and the
+≤10k client-sort ceiling already covers the overwhelming majority). Cheapest
+reversibility: A is additive; the B trigger is a product signal, not a
+deadline.
+
+**Cons.** Requires getting the cursor/contract shape right up front without the
+web consumer in hand — a small risk of designing a header/encoding the web path
+later finds awkward. Two read paths coexist for an unbounded interval.
+
+---
+
+## Recommendation
+
+**Option C.** Ship the opaque base64 `(last_sort, last_id)` keyset cursor on the
+REST/mobile `get_ebooks` path now, with the `next_cursor`/`limit` contract
+designed to be the same one the web path will eventually adopt — but do **not**
+rewrite the web landing page in this work.
+
+Rationale:
+
+- **The db primitive is the load-bearing, reusable, low-risk part.**
+  `list_books_page` is additive, testable in isolation against
+  `sqlite::memory:`, and serves both surfaces unchanged. Building it now retires
+  the "no keyset at all" finding regardless of what the web UX becomes.
+- **The web rewrite is the irreversible, expensive, product-gated part** and
+  the roadmap's own ≤10k client-sort ceiling means it is **not yet on the
+  critical path** for the typical install (assumption A3). Spending the landing
+  rewrite now would be pre-paying a cost we can defer cheaply.
+- **`OFFSET` is off the table** by roadmap mandate; opaque base64 keyset is the
+  prescribed shape, and a *signed* cursor is unnecessary for a single-tenant
+  self-hosted app — the cursor is non-authoritative (it positions the reader's
+  own page; tampering only mis-positions that same reader), so plain base64 of
+  the tuple is the right weight. `sha2`/`base64` are already deps if we ever
+  want HMAC, so that door stays open at zero new-dependency cost.
+- **Single `(sort, id)` cursor is the right scope.** Don't build multi-axis
+  server sort (Option B's index fan-out) until the web rewrite forces the
+  question — and when it does, F3.1's arbitrary filter predicates mean we'll
+  likely keep some client-side or temp-sort path anyway, so over-investing in
+  per-axis covering indexes now is speculative.
+
+Cost-of-delay: low. The REST consumer (mobile) is the surface that *can't*
+client-sort its way around the problem, so it benefits most and soonest. The web
+surface is protected by the 10k ceiling and the existing cap, so deferring its
+rewrite costs nothing until a real library crosses that line — at which point
+Option C's already-shipped primitive makes the rewrite a frontend-only change.
+
+---
+
+## Migration plan (SKETCH — do not apply)
+
+F5b itself needs **no new schema** beyond F5a's index — the cursor lives in
+Rust. The only migration in this neighborhood is F5a's, repeated here for
+sequencing clarity:
+
+```sql
+-- db/migrations/0019_books_landing_sort_index.sql   (ships in F5a, NOT F5b)
+-- Append-only; latest applied is 0018. Pure secondary index, no backfill.
+CREATE INDEX IF NOT EXISTS idx_books_library_sort
+    ON books (library_id, sort, id);
+```
+
+This index is what makes the keyset seek `(b.sort > ? OR (b.sort = ? AND b.id >
+?))` an index range-scan instead of a temp-sort under a `library_id` filter.
+`sort` is `COLLATE NOCASE`, so the index inherits that collation and the cursor
+comparison must run under the same collation (SQLite uses the column's declared
+collation for the index automatically).
+
+If Option B/C ever adds server-side multi-axis sort, each axis gets its own
+append-only file, e.g.:
+
+```sql
+-- db/migrations/00NN_books_sort_axis_indexes.sql   (only if multi-axis server sort lands)
+CREATE INDEX IF NOT EXISTS idx_books_library_added    ON books (library_id, timestamp, id);
+CREATE INDEX IF NOT EXISTS idx_books_library_modified ON books (library_id, last_modified, id);
+```
+
+**Boot backfill:** none. There is no `_norm`-style column to populate. The
+cursor is computed at read time from columns that already exist, so there is no
+analog to `normalize::backfill_norm_columns` here — nothing in `pool.rs` /
+`init_db` changes. (If a future denormalized book-card read-model is built — the
+review's stretch suggestion — *that* would need an idempotent indexer-time
+backfill modeled on `backfill_norm_columns`; out of scope for F5b.)
+
+---
+
+## Affected code
+
+From the F5 scout spec, scoped to the F5b (pagination) slice:
+
+- `db/src/books/list.rs` — **new** `list_books_page(pool, paths, last_sort,
+  last_id, limit)`; `fetch_list_rows` grows the keyset predicate (or a sibling
+  `fetch_list_page_rows`). `library_from_db_combined` gains a paged companion.
+- `db/src/books/projection.rs` — `MAX_BOOKS_RETURNED` stays as the unpaged
+  ceiling / default `limit` source; `BOOK_COLUMNS` and `row_to_ebook` are
+  reused unchanged (their collapse is F5a).
+- `db/src/books/search.rs` — `fetch_search_rows` already orders by
+  `(m.rank, b.sort, b.id)`; a paged search cursor is a **separate, harder**
+  problem (the cursor key is the bm25 rank, not `sort`) and is explicitly **out
+  of scope** for this doc — list-pagination first.
+- `db/src/books/tests.rs` — keyset paging tests (below).
+- `server/src/backend/ebooks.rs` — `get_ebooks` gains `?cursor=&limit=` query
+  params and emits `X-Next-Cursor`; reuses `with_pagination_headers`
+  (`server/src/backend.rs`) for `X-Total-Count`.
+- `shared/src/discovery.rs` — `EbookLibrary` body stays byte-compatible
+  (cursor rides in a header, like `X-Total-Count`); no field added in Option
+  A/C. Only Option B would add a body field.
+- `frontend/src/rpc.rs` (`rpc_get_ebooks`) and `frontend/src/pages/landing/*`
+  — **untouched in Option A/C**; rewritten only if/when the web-adoption
+  follow-on (Option B) is triggered.
+
+---
+
+## Test plan
+
+Per rule 03: sibling `db/src/books/tests.rs`, `sqlite::memory:` via
+`test_support::new_in_memory_pool`, long-sentence names, happy + per-variant.
+
+The **acceptance test that must fail on the old schema/code** (it can't even
+compile against today's `list_books_for_paths`, which takes no cursor):
+
+- `list_books_page_returns_first_then_next_page_via_cursor_with_no_overlap` —
+  seed `page_size + N` books with distinct `sort` values, fetch page 1 with
+  `(last_sort=None, last_id=None, limit=page_size)`, derive the cursor from the
+  last row, fetch page 2, assert: page 1 has exactly `page_size` rows, page 2
+  continues from the boundary, the two pages are disjoint, and their union is
+  the full ordered set. This is the test the deferred work is gated on.
+
+Supporting cases:
+
+- `list_books_page_handles_null_sort_rows_at_first_page_boundary` — seed rows
+  with `sort IS NULL` (collate first) plus non-null, assert the
+  `:last_sort IS NULL` short-circuit returns them on page 1 and the cursor
+  advances past them without skipping or duplicating.
+- `list_books_page_breaks_sort_ties_by_id_deterministically` — seed multiple
+  rows with identical `sort`, assert the `(sort = ? AND id > ?)` arm yields a
+  stable, gap-free order across the page boundary (this is what the
+  `(library_id, sort, id)` index's trailing `id` exists for).
+- `list_books_page_respects_library_path_filter` — two libraries, assert a
+  cursor in library A never returns library B rows.
+- `list_books_page_returns_empty_at_end_of_stream` — cursor past the last row
+  returns zero rows and a null `next_cursor`.
+
+REST layer (`server/src/backend/ebooks.rs` sibling tests, `oneshot` against an
+in-memory pool per rule 03):
+
+- `get_ebooks_returns_first_page_and_next_cursor_header_when_truncated`
+- `get_ebooks_returns_no_next_cursor_header_at_end_of_stream`
+- `get_ebooks_rejects_malformed_cursor_with_400` — a non-decodable base64 /
+  bad tuple is a client error, not a 500.
+
+Migration coverage is automatic: `init_db` runs F5a's `0019` against the
+in-memory pool, so every db test exercises the new index. `BooksError::Db`
+stays covered by the existing pool-closed test; no new error variant is
+introduced (a bad cursor is a server-layer 400, decoded before the db call).
+
+Playwright: **no change** under Option A/C — the web landing still loads a full
+(capped) library, so existing `landing.spec.ts` contracts hold. Only the Option
+B follow-on touches E2E.
+
+---
+
+## Risks & rollback
+
+- **Forward-only, fix-forward.** No down-migrations (rule 06). F5a's index is
+  `IF NOT EXISTS` and droppable in a later forward migration if it ever proves
+  wrong; the cursor logic is pure Rust and reverts with a code change, no data
+  involved.
+- **No data-loss surface.** F5b reads only — it adds no column, no destructive
+  DDL, no backfill that mutates rows. There is nothing to corrupt and nothing
+  irreversible once data accumulates. This is the key reason the db slice is
+  safe to ship ahead of the UX decision.
+- **Cursor stability across reindex.** `books.id` renumbers on reindex (the
+  reason public URLs key on `uuid`, per `rpc_get_ebook`). A cursor is a
+  *transient* scroll position, not a durable handle, so a stale cursor after a
+  reindex simply mis-positions the next page — acceptable, and identical to how
+  any keyset reader behaves under concurrent writes. Do **not** persist cursors.
+- **Collation drift.** If the keyset comparison runs under a different
+  collation than the index, the seek silently falls back to a temp-sort
+  (correct results, lost performance). The tie-break test guards the *order*;
+  an `EXPLAIN QUERY PLAN` assertion (or a comment pinning the collation
+  contract) guards the *plan*. Note in the F5a index file that the cursor
+  depends on its `COLLATE NOCASE`.
+- **Irreversible only at the UX layer.** The one genuinely hard-to-reverse step
+  is the Option B web rewrite (infinite-scroll replacing the full-Vec model) —
+  which is exactly why the recommendation defers it behind a product trigger
+  rather than baking it into this change.
+
+---
+
+## Sequencing & dependencies
+
+- **F5a must land first.** The `(library_id, sort, id)` index is what makes the
+  keyset seek a range-scan; without it the cursor is correct but slow under a
+  library filter. F5b's db primitive depends on F5a's index and on F5a's
+  `BOOK_COLUMNS` subquery-collapse being settled (both touch the same SELECT).
+- **F3.1 (libraries-as-filters) is the downstream consumer that constrains the
+  design.** F3.1 wraps this projection in arbitrary normalized-column
+  predicates. A single `(sort, id)` cursor composes cleanly with an added
+  `WHERE` (the keyset predicate is just another conjunct); arbitrary
+  `(filter, sort)` *server-side* sort does **not** compose without combinatorial
+  indexes. This is the strongest argument for the single-cursor scope in the
+  recommendation — build the cursor so F3.1 can bolt filters in front of it,
+  and let F3.1 decide its own sort story.
+- **Search pagination is a separate finding.** `search_books` orders by bm25
+  `rank` first; its cursor key is the rank, not `sort`, so it needs its own
+  design pass. Do not let F5b's list cursor leak a false assumption that search
+  paging is "the same thing."
+- **Coupling to the F1↔F2↔F10 user-data chain:** none directly — F5b touches no
+  user-data table (progress/sessions/bookmarks/highlights). It is independent of
+  that chain and can be sequenced purely against F5a and F3.1.
+- **Recommended order:** F5a → F5b (db primitive + REST cursor, Option A/C) →
+  [product trigger: a real library crosses ~10k] → Option B web rewrite →
+  (separately) search keyset.
+
+---
+
+## Open questions
+
+1. **Default and max `limit`.** What page size? A grid renders ~30–60 cards
+   above the fold; the table renders more. Proposal: default 100, hard-cap at
+   `MAX_BOOKS_RETURNED` so an unbounded `limit` degrades to today's behavior.
+   Operator to confirm.
+2. **Cursor opacity vs. debuggability.** Plain base64 of `last_sort\x00last_id`
+   is trivially decodable by anyone who looks — fine for a self-hosted app, and
+   it keeps cursors greppable in logs. Confirm we don't want HMAC signing (we
+   have `sha2` if we change our mind).
+3. **Does the web path *ever* adopt server sort, or stay client-sort within a
+   bigger page window?** This is the Option B fork and decides whether the
+   per-axis index fan-out is ever needed. Defer until the web rewrite is
+   actually triggered.
+4. **Should `count_books_for_paths` still run on every paged request?** The
+   `X-Total-Count` header needs the true total, but recomputing `COUNT(*)` per
+   page is wasteful. Option: compute the count only on the first page
+   (`last_sort IS NULL`) and let the client cache it. Operator to confirm
+   acceptable.
+5. **Denormalized book-card read-model** (the review's stretch suggestion) —
+   out of scope here, but if list-card hydration cost (the per-row subqueries +
+   two follow-up passes) dominates even a *paged* response, a materialized
+   read-model refreshed at index time is the next lever. Flag for a separate
+   design.

--- a/docs/design/db-review-f5b-landing-pagination.md
+++ b/docs/design/db-review-f5b-landing-pagination.md
@@ -266,8 +266,9 @@ Rust. The only migration in this neighborhood is F5a's, repeated here for
 sequencing clarity:
 
 ```sql
--- db/migrations/0019_books_landing_sort_index.sql   (ships in F5a, NOT F5b)
--- Append-only; latest applied is 0018. Pure secondary index, no backfill.
+-- db/migrations/NNNN_books_landing_sort_index.sql   (ships in F5a, NOT F5b)
+-- Append-only; number allocated at implementation time (latest applied is
+-- 0018). Pure secondary index, no backfill.
 CREATE INDEX IF NOT EXISTS idx_books_library_sort
     ON books (library_id, sort, id);
 ```
@@ -361,7 +362,7 @@ in-memory pool per rule 03):
 - `get_ebooks_rejects_malformed_cursor_with_400` — a non-decodable base64 /
   bad tuple is a client error, not a 500.
 
-Migration coverage is automatic: `init_db` runs F5a's `0019` against the
+Migration coverage is automatic: `init_db` runs F5a's index migration against the
 in-memory pool, so every db test exercises the new index. `BooksError::Db`
 stays covered by the existing pool-closed test; no new error variant is
 introduced (a bad cursor is a server-layer 400, decoded before the db call).


### PR DESCRIPTION
## Summary
- Eight checked-in design docs (`docs/design/db-review-f*.md`) for the `docs/review/db.md` findings deferred from immediate implementation because each needs a data-model decision before any schema or code is written.
- Covers F1 (user-data `book_id`→`book_uuid` soft-refs), F2 (durable book identity / `stable_uuid` re-anchor), F5b (landing keyset pagination), F10 (override GC), F11 (timestamp unification), F13 (Phase-4 change-tracking), F14 (series model), F15 (author photos → filesystem).
- Each doc lays out the problem with current `file:line` citations, the explicit decision required, 2–3 concrete options with migration shape + blast radius, a recommendation, a migration sketch (not applied), test plan, risks/rollback, and cross-finding sequencing.

## Test plan
- [ ] N/A — docs only.

## Notes
- Companion to the mechanical-fix PR stack landing separately under the same `u/sloan/db-review/*` family (F3, F4, F5a, F6, F7, F8, F9, F12, F16, F17, F18, F19).
- The F1↔F2↔F10 docs are explicitly co-dependent; recommended landing order is documented in each doc's "Sequencing & dependencies" section.