### PR TITLE
fix: compute tag cloud counts in a single pass

### DIFF
--- a/db/src/discovery/tags.rs
+++ b/db/src/discovery/tags.rs
@@ -35,18 +35,30 @@ pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, Discover
     // Issue #154: counts are taken from an `effective` membership CTE —
     // the UNION of (1) canonical `books_tags_link` rows whose book has no
     // `subjects` override and (2) override-extracted `(tag_name, book_id)`
-    // pairs from `json_each(mo.overrides, '$.subjects')`. The per-tag count
-    // is a correlated scalar subquery against `effective` (one pass per
-    // tag, not one pass total — see the `t.id`/`t.name` join predicate),
-    // bounded by the `LIMIT ?` on the outer select. The empty-array
-    // clear-all case falls out naturally: a `Some([])` override drops the
-    // book from arm (1) and yields no rows from `json_each` in arm (2).
-    // Override match stays BINARY (`je.value = t.name`, no COLLATE) to
-    // match the prior behavior. Visibility still requires ≥1 canonical
-    // link (the `EXISTS`), so a tag that exists only inside override JSON
-    // never surfaces.
+    // pairs from `json_each(mo.overrides, '$.subjects')`. The CTE is
+    // `AS MATERIALIZED` (like `matches` in `fetch_search_rows`) so the
+    // override extraction — `json_each` over every `metadata_overrides`
+    // row — is built once per call rather than re-scanned per tag. Counts
+    // come from a single `GROUP BY` pass: `effective` is `LEFT JOIN`ed to
+    // `tags` on the OR predicate (`e.tag_id = t.id OR e.tag_name = t.name`)
+    // and aggregated with `COUNT(e.book_id)`. The `LEFT JOIN` preserves the
+    // prior correlated-subquery `cnt = 0` semantics for a visible tag whose
+    // every canonical book got overridden away (the `EXISTS` keeps it
+    // visible while `COUNT(e.book_id)` over zero matched rows yields 0).
+    // The two arms are disjoint on the key columns (arm 1 sets
+    // `tag_name = NULL`, arm 2 sets `tag_id = NULL`), and a book with a
+    // subjects override is excluded from arm 1, so no single book reaches a
+    // tag through both arms — the OR-join sums without double-counting.
+    // The empty-array clear-all case falls out naturally: a `Some([])`
+    // override drops the book from arm (1) and yields no rows from
+    // `json_each` in arm (2). UNION (not ALL) in arm (2) dedupes duplicate
+    // subject strings within one override array so a book tagged
+    // `["fiction","fiction"]` still counts once. Override match stays
+    // BINARY (`je.value = t.name`, no COLLATE) to match the prior behavior.
+    // Visibility still requires ≥1 canonical link (the `EXISTS`), so a tag
+    // that exists only inside override JSON never surfaces.
     let rows = sqlx::query(
-        r#"WITH effective AS (
+        r#"WITH effective AS MATERIALIZED (
              -- (1) Canonical tag memberships with no subjects override.
              SELECT btl.tag AS tag_id, NULL AS tag_name, btl.book AS book_id
                FROM books_tags_link btl
@@ -65,13 +77,14 @@ pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, Discover
                JOIN json_each(mo.overrides, '$.subjects') je
               WHERE json_type(mo.overrides, '$.subjects') IS NOT NULL
            )
-           SELECT t.name,
-             (SELECT COUNT(*) FROM effective e
-               WHERE e.tag_id = t.id OR e.tag_name = t.name) AS cnt
+           SELECT t.name, COUNT(e.book_id) AS cnt
            FROM tags t
+           LEFT JOIN effective e
+             ON e.tag_id = t.id OR e.tag_name = t.name
            WHERE EXISTS (
              SELECT 1 FROM books_tags_link btl WHERE btl.tag = t.id
            )
+           GROUP BY t.id, t.name
            ORDER BY cnt DESC, t.name ASC
            LIMIT ?"#,
     )

--- a/db/src/discovery/tests.rs
+++ b/db/src/discovery/tests.rs
@@ -234,6 +234,109 @@ async fn get_tag_cloud_counts_reflect_overrides() {
     );
 }
 #[tokio::test]
+async fn get_tag_cloud_counts_canonical_and_override_subjects_without_double_count() {
+    // Regression guard for the single-pass GROUP BY rewrite: one tag
+    // ("essay") must sum exactly one canonical member and one
+    // override-only member without double-counting either. Arm 1
+    // (canonical link, `tag_name = NULL`) and arm 2 (override subject,
+    // `tag_id = NULL`) are disjoint per book, so the OR-join must add the
+    // two distinct books to cnt=2 — not 1 (under-count) and not 3+
+    // (double-count via the OR predicate).
+    let _guard = CoversTempDir::new("tag_cloud_no_double_count");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            // a.epub: canonically "essay".
+            indexed("a.epub", Some("A"), &["X"], &["essay"], None, None),
+            // b.epub: canonically "fiction"; will be overridden to "essay".
+            indexed("b.epub", Some("B"), &["X"], &["fiction"], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Override b.epub to "essay" so it reaches the tag via arm 2 only,
+    // while a.epub reaches it via arm 1 only.
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let b = books.iter().find(|x| x.filename == "b.epub").unwrap();
+    let uuid = b.unique_identifier.clone().unwrap();
+    let ov = MetadataOverrides {
+        subjects: Some(vec!["essay".into()]),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+        .await
+        .unwrap();
+
+    let tags = get_tag_cloud(&pool).await.unwrap();
+    let essay = tags
+        .iter()
+        .find(|t| t.name == "essay")
+        .expect("essay present");
+    assert_eq!(
+        essay.count, 2,
+        "essay must sum the canonical and override members exactly once each, got {tags:?}",
+    );
+    // "fiction" loses its only member to the override; the tag stays
+    // visible via its canonical link but its merged count drops to 0.
+    let fiction = tags
+        .iter()
+        .find(|t| t.name == "fiction")
+        .expect("fiction stays visible via canonical link");
+    assert_eq!(
+        fiction.count, 0,
+        "a fully-overridden-away tag stays visible at cnt=0, got {tags:?}",
+    );
+}
+#[tokio::test]
+async fn get_tag_cloud_dedupes_duplicate_subject_strings_within_one_override() {
+    // The UNION (not UNION ALL) in arm (2) collapses a `["essay","essay"]`
+    // override to a single effective row, so the GROUP BY pass counts the
+    // book once. A naive UNION ALL rewrite would double-count it.
+    let _guard = CoversTempDir::new("tag_cloud_dedupe_override");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed("a.epub", Some("A"), &["X"], &["essay"], None, None)],
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let a = books.iter().find(|x| x.filename == "a.epub").unwrap();
+    let uuid = a.unique_identifier.clone().unwrap();
+    let ov = MetadataOverrides {
+        subjects: Some(vec!["essay".into(), "essay".into()]),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+        .await
+        .unwrap();
+
+    let tags = get_tag_cloud(&pool).await.unwrap();
+    let essay = tags
+        .iter()
+        .find(|t| t.name == "essay")
+        .expect("essay present");
+    assert_eq!(
+        essay.count, 1,
+        "duplicate subject strings in one override must count the book once, got {tags:?}",
+    );
+}
+#[tokio::test]
 async fn get_author_includes_books_whose_override_names_this_author() {
     // Repro of the bug where renaming a book's author via the
     // metadata form (e.g. "Sanderson, Brandon" → "Brandon Sanderson")


### PR DESCRIPTION
## Summary
- `get_tag_cloud` computed each tag's count with a correlated scalar subquery over a non-materialized `effective` CTE, re-scanning the override-extraction (`json_each` over every override row) once per surviving tag — "one pass per tag, not one pass total", as the old comment admitted.
- Rewrote to a single `GROUP BY` pass over an `AS MATERIALIZED` CTE, `LEFT JOIN`-ed to `tags` on the same `e.tag_id = t.id OR e.tag_name = t.name` predicate. Result semantics are unchanged (same tags, counts, `cnt DESC, name ASC` order, `LIMIT 500`); the `LEFT JOIN` + `EXISTS` visibility filter preserve the `cnt = 0` edge for a tag whose canonical books were all overridden away.

## Test plan
- [x] `cargo test -p omnibus-db discovery` — 23 pass, incl. 2 new regression guards (canonical+override no-double-count; duplicate-subject dedup)
- [x] `cargo clippy -p omnibus-db` clean; `cargo fmt --check` clean

## Notes
- Addresses `docs/review/db.md` finding F16. No behavior change — query-shape optimization only.