### PR TITLE
fix: resolve merged uuids when recording sessions

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -27,7 +27,7 @@ mod tests;
 
 pub use get::{
     book_file_path, book_file_path_by_id, get_book, get_book_by_uuid, get_book_files,
-    resolve_book_id_by_uuid,
+    resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec,
 };
 pub use list::{
     collect_paths, count_books, count_books_for_paths, library_from_db, library_from_db_combined,

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -133,6 +133,21 @@ pub async fn resolve_book_id_by_uuid(
     pool: &SqlitePool,
     uuid: &str,
 ) -> Result<Option<i64>, super::BooksError> {
+    resolve_book_id_by_uuid_exec(pool, uuid).await
+}
+
+/// Executor-generic counterpart to [`resolve_book_id_by_uuid`], single-sourcing
+/// the `books`/`merged_uuids` UNION fallback so callers inside an open
+/// transaction (e.g. session inserts) resolve book identity identically to the
+/// pool-based read paths. Pass `&pool` for a standalone lookup or `&mut *tx`
+/// from within a transaction.
+pub async fn resolve_book_id_by_uuid_exec<'e, E>(
+    executor: E,
+    uuid: &str,
+) -> Result<Option<i64>, super::BooksError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     Ok(sqlx::query_scalar::<_, i64>(
         "SELECT id FROM books WHERE uuid = ?1
          UNION ALL
@@ -140,7 +155,7 @@ pub async fn resolve_book_id_by_uuid(
          LIMIT 1",
     )
     .bind(uuid)
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await?)
 }
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -42,8 +42,8 @@ pub use books::{
     count_search_books, get_book, get_book_by_uuid, get_book_files, library_from_db,
     library_from_db_combined, library_from_db_with_total, library_from_db_with_total_combined,
     list_books, list_books_for_paths, list_indexed_rows, list_indexed_rows_for_formats,
-    list_merged_rows_for_formats, resolve_book_id_by_uuid, search_books, search_books_with_total,
-    BooksError, IndexedRow, MAX_BOOKS_RETURNED,
+    list_merged_rows_for_formats, resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec,
+    search_books, search_books_with_total, BooksError, IndexedRow, MAX_BOOKS_RETURNED,
 };
 pub use browse::*;
 pub use covers::{covers_dir, get_cover, get_last_modified_epoch, CoversError};

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -1,15 +1,13 @@
-//! Server-authoritative reading and listening position sync, plus batched
-//! session reports.
-//!
-//! Position upserts are last-write-wins on `(user_id, book_id, format)`; the
-//! upsert always bumps `updated_at` to now so a newly-opened client can sync
-//! forward by reading the row back. Session inserts write into the
-//! per-format `reading_sessions` / `listening_sessions` tables.
+//! Server-authoritative reading/listening position sync plus batched
+//! session reports. Position upserts are last-write-wins on
+//! `(user_id, book_id, format)`; session inserts go to the per-format
+//! `reading_sessions` / `listening_sessions` tables. Both paths resolve
+//! `book_uuid` through the same merged-uuid-aware resolver.
 
 use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, SessionReport};
 use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
-use crate::resolve_book_id_by_uuid;
+use crate::{resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProgressError {
@@ -137,8 +135,10 @@ pub async fn get_progress(
 
 /// Append one session row inside an existing transaction. Returns `Ok(true)`
 /// when a row was inserted and `Ok(false)` when the report was skipped
-/// because the `book_uuid` is unknown (best-effort telemetry — a session
-/// that outlived its book is not an integrity failure).
+/// because the `book_uuid` resolves to neither a `books` row nor a
+/// `merged_uuids` entry (best-effort telemetry — a session that outlived its
+/// book is not an integrity failure). A format-merged or auto-attached uuid
+/// resolves to the surviving book and is recorded.
 ///
 /// The caller is responsible for committing or rolling back the transaction.
 /// Use this variant when inserting a batch so the entire batch is atomic.
@@ -147,11 +147,12 @@ pub async fn record_session_tx(
     user_id: i64,
     report: &SessionReport,
 ) -> Result<bool, ProgressError> {
-    let book_id: Option<i64> = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?")
-        .bind(&report.book_uuid)
-        .fetch_optional(&mut **tx)
-        .await?;
-    let Some(book_id) = book_id else {
+    // Resolve through the same merged-uuid-aware path as `upsert_progress`,
+    // so a uuid that was format-merged or auto-attached after the session
+    // started still records against the surviving book instead of being
+    // silently dropped. `Ok(false)` now means "unknown in neither `books`
+    // nor `merged_uuids`".
+    let Some(book_id) = resolve_book_id_by_uuid_exec(&mut **tx, &report.book_uuid).await? else {
         return Ok(false);
     };
     match report.format {

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -1,12 +1,29 @@
-//! Unit tests for the `progress` module — `upsert_progress`
-//! roundtrip + last-write-wins + per-user/format isolation,
-//! `BookNotFound` variant, `get_progress` empty-state,
-//! `record_session` per-format dispatch with unknown-uuid skip, and
-//! `record_session_tx` rollback behaviour.
+//! Unit tests for the `progress` module: `upsert_progress` roundtrip,
+//! last-write-wins, per-user/format isolation, `BookNotFound`,
+//! `get_progress` empty-state, `record_session` per-format dispatch and
+//! unknown-uuid skip, merged-uuid resolution, and `record_session_tx`
+//! rollback.
 
 use super::*;
 use crate::{init_db, replace_books};
 use omnibus_shared::EbookMetadata;
+
+/// Map a merged/auto-attached `uuid` onto an existing `book_id` the way the
+/// merge transaction does (`db/src/merge/transaction.rs`), so the session path
+/// has a row to resolve through the `merged_uuids` UNION fallback.
+async fn seed_merged_uuid(pool: &SqlitePool, uuid: &str, book_id: i64, format: &str) {
+    sqlx::query(
+        "INSERT OR REPLACE INTO merged_uuids (uuid, book_id, format, library_path)
+         VALUES (?, ?, ?, ?)",
+    )
+    .bind(uuid)
+    .bind(book_id)
+    .bind(format)
+    .bind("/lib")
+    .execute(pool)
+    .await
+    .expect("seed merged uuid");
+}
 
 async fn seed(pool: &SqlitePool, library: &str, title: &str) -> (i64, String) {
     replace_books(
@@ -333,4 +350,80 @@ async fn migration_0020_adds_windowed_session_indexes_for_stats() {
                 .unwrap();
         assert_eq!(found.as_deref(), Some(index), "missing index {index}");
     }
+}
+
+#[tokio::test]
+async fn record_session_resolves_merged_uuid_and_records_against_canonical_book() {
+    // A uuid that only exists in `merged_uuids` (the file was format-merged
+    // into the surviving book after the session started) must resolve to the
+    // canonical book and record the session, not be dropped with Ok(false).
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, _survivor_uuid) = seed(&pool, "/lib", "Book A").await;
+    seed_merged_uuid(&pool, "merged-uuid", book_id, "epub").await;
+
+    let recorded = record_session(
+        &pool,
+        user,
+        &SessionReport {
+            book_uuid: "merged-uuid".into(),
+            format: ProgressFormat::Epub,
+            started_at: 100,
+            ended_at: 460,
+            progress_units: 360,
+            device_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(recorded, "merged uuid should resolve and record, not skip");
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM reading_sessions WHERE user_id = ? AND book_id = ?",
+    )
+    .bind(user)
+    .bind(book_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 1, "session must land against the canonical book");
+}
+
+#[tokio::test]
+async fn record_session_resolves_merged_audio_uuid_to_canonical_book() {
+    // Per-format dispatch counterpart: a merged audio uuid records into
+    // `listening_sessions` against the surviving book.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, _survivor_uuid) = seed(&pool, "/lib", "Book A").await;
+    seed_merged_uuid(&pool, "merged-audio-uuid", book_id, "audio").await;
+
+    let recorded = record_session(
+        &pool,
+        user,
+        &SessionReport {
+            book_uuid: "merged-audio-uuid".into(),
+            format: ProgressFormat::Audio,
+            started_at: 200,
+            ended_at: 800,
+            progress_units: 600,
+            device_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(recorded, "merged audio uuid should resolve and record");
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM listening_sessions WHERE user_id = ? AND book_id = ?",
+    )
+    .bind(user)
+    .bind(book_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        count, 1,
+        "listening session must land against the canonical book"
+    );
 }


### PR DESCRIPTION
## Summary
- `record_session_tx` resolved books with a bare `SELECT id FROM books WHERE uuid = ?` and skipped (`Ok(false)`) on miss, while `upsert_progress` already used the merged-uuid-aware `resolve_book_id_by_uuid`. A batched session report for a book whose file was format-merged / auto-attached after the session started was silently dropped — lost reading/listening minutes that feed Phase-3 stats.
- Extracted the resolver into an executor-generic `resolve_book_id_by_uuid_exec` (single-sources the `books`/`merged_uuids` UNION); `record_session_tx` now calls it with the transaction handle. Both paths agree on identity; `Ok(false)` only when the uuid is in neither `books` nor `merged_uuids`.

## Test plan
- [x] `cargo test -p omnibus-db --lib progress` — 31 pass, incl. merged-uuid epub + audio regression tests
- [x] `cargo test -p omnibus-db --lib books` — 85 pass (resolver call sites unchanged)
- [x] `cargo clippy -p omnibus-db` + `cargo fmt --check` clean; `cargo build -p omnibus` clean

## Notes
- Addresses `docs/review/db.md` finding F9. No migration — `merged_uuids` (migration 0016) already exists.