### PR TITLE
chore: rename libraries table to scan_roots

### DIFF
--- a/db/migrations/0019_rename_libraries_to_scan_roots.sql
+++ b/db/migrations/0019_rename_libraries_to_scan_roots.sql
@@ -1,0 +1,12 @@
+-- F3: Rename the physical scan-root registry `libraries` -> `scan_roots`,
+-- freeing the name `libraries` for the F3.1 user-facing saved-filter concept.
+-- SQLite (sqlx bundles 3.45+, legacy_alter_table off) auto-rewrites the
+-- `REFERENCES libraries(id)` clause in `books` to point at the renamed table,
+-- so the FK and its ON DELETE CASCADE survive without a table recreate.
+-- `books.library_id` keeps its column name (renaming it would force a full
+-- books-table recreate for purely cosmetic gain).
+ALTER TABLE libraries RENAME TO scan_roots;
+
+-- SQLite has no RENAME INDEX, so drop and recreate the FK index.
+DROP INDEX IF EXISTS idx_books_library_id;
+CREATE INDEX idx_books_scan_root_id ON books(library_id);

--- a/db/migrations/0019_rename_libraries_to_scan_roots.sql
+++ b/db/migrations/0019_rename_libraries_to_scan_roots.sql
@@ -1,8 +1,11 @@
 -- F3: Rename the physical scan-root registry `libraries` -> `scan_roots`,
 -- freeing the name `libraries` for the F3.1 user-facing saved-filter concept.
--- SQLite (sqlx bundles 3.45+, legacy_alter_table off) auto-rewrites the
--- `REFERENCES libraries(id)` clause in `books` to point at the renamed table,
--- so the FK and its ON DELETE CASCADE survive without a table recreate.
+-- Modern SQLite (>= 3.25, with the default legacy_alter_table off) auto-rewrites
+-- the `REFERENCES libraries(id)` clause in `books` to point at the renamed table,
+-- so the FK and its ON DELETE CASCADE survive without a table recreate. The
+-- runtime SQLite is the environment's (the Nix shells provide pkgs.sqlite via
+-- libsqlite3-sys), and the fk_cascade_survives_libraries_rename_to_scan_roots
+-- test enforces the behavior we rely on.
 -- `books.library_id` keeps its column name (renaming it would force a full
 -- books-table recreate for purely cosmetic gain).
 ALTER TABLE libraries RENAME TO scan_roots;

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -156,7 +156,7 @@ pub async fn book_file_path(
         "SELECT COALESCE(bf.library_path, l.path), COALESCE(bf.path, b.path), \
                 bf.filename, bf.format \
          FROM books b \
-         JOIN libraries l ON l.id = b.library_id \
+         JOIN scan_roots l ON l.id = b.library_id \
          JOIN book_files bf ON bf.book_id = b.id \
          WHERE b.id = ? AND bf.format = ? COLLATE NOCASE \
          ORDER BY bf.ordinal LIMIT 1",
@@ -187,14 +187,14 @@ pub async fn book_file_path_by_id(
                 bf.filename, bf.format \
          FROM book_files bf \
          JOIN books b ON b.id = bf.book_id \
-         JOIN libraries l ON l.id = b.library_id \
+         JOIN scan_roots l ON l.id = b.library_id \
          WHERE bf.id = ?1 AND bf.book_id = ?2 AND bf.format = ?3 COLLATE NOCASE"
     } else {
         "SELECT COALESCE(bf.library_path, l.path), COALESCE(bf.path, b.path), \
                 bf.filename, bf.format \
          FROM book_files bf \
          JOIN books b ON b.id = bf.book_id \
-         JOIN libraries l ON l.id = b.library_id \
+         JOIN scan_roots l ON l.id = b.library_id \
          WHERE bf.id = ?1 AND bf.book_id = ?2"
     };
     let mut q = sqlx::query_as::<_, (String, String, String, String)>(sql)

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -66,7 +66,7 @@ async fn fetch_list_rows(
         r#"
         SELECT {BOOK_COLUMNS}
         FROM books b
-        JOIN libraries l ON l.id = b.library_id
+        JOIN scan_roots l ON l.id = b.library_id
         WHERE l.path IN ({placeholders})
         ORDER BY b.sort, b.id
         LIMIT ?
@@ -111,7 +111,7 @@ pub async fn list_indexed_rows(
                COALESCE(MAX(bf.mtime_epoch), 0)        AS mtime_epoch,
                COALESCE(MAX(bf.size_bytes), 0)         AS size_bytes
           FROM books b
-          JOIN libraries l   ON l.id = b.library_id
+          JOIN scan_roots l   ON l.id = b.library_id
           LEFT JOIN book_files bf ON bf.book_id = b.id
          WHERE l.path = ?
          GROUP BY b.id, b.uuid
@@ -166,7 +166,7 @@ pub async fn list_indexed_rows_for_formats(
                COALESCE(MAX(bf.mtime_epoch), 0)        AS mtime_epoch,
                COALESCE(MAX(bf.size_bytes), 0)         AS size_bytes
           FROM books b
-          JOIN libraries l   ON l.id = b.library_id
+          JOIN scan_roots l   ON l.id = b.library_id
           JOIN book_files bf ON bf.book_id = b.id
          WHERE l.path = ?
            AND bf.format IN ({placeholders})
@@ -266,7 +266,7 @@ pub async fn count_books_for_paths(
         r#"
         SELECT COUNT(*)
           FROM books b
-          JOIN libraries l ON l.id = b.library_id
+          JOIN scan_roots l ON l.id = b.library_id
          WHERE l.path IN ({placeholders})
         "#
     );

--- a/db/src/books/search.rs
+++ b/db/src/books/search.rs
@@ -90,7 +90,7 @@ async fn fetch_search_rows(
                    bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0) AS rank
             FROM books_fts
             JOIN books b ON b.id = books_fts.rowid
-            JOIN libraries l ON l.id = b.library_id
+            JOIN scan_roots l ON l.id = b.library_id
             WHERE books_fts MATCH ? AND l.path = ?
         )
         SELECT {BOOK_COLUMNS},
@@ -129,7 +129,7 @@ pub async fn count_search_books(
         SELECT COUNT(*)
           FROM books_fts
           JOIN books b ON b.id = books_fts.rowid
-          JOIN libraries l ON l.id = b.library_id
+          JOIN scan_roots l ON l.id = b.library_id
          WHERE books_fts MATCH ? AND l.path = ?
         "#,
     )

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -836,7 +836,7 @@ async fn get_book_handles_book_with_no_relations() {
     // a populated `EbookMetadata` with empty vecs and an empty filename
     // rather than erroring out on the missing data.
     let pool = init_db("sqlite::memory:").await.unwrap();
-    let lib_res = sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+    let lib_res = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
         .execute(&pool)
         .await
         .unwrap();
@@ -1594,7 +1594,7 @@ async fn search_books_returns_empty_for_unknown_library() {
 #[tokio::test]
 async fn book_file_path_returns_absolute_path_for_epub() {
     let pool = init_db("sqlite::memory:").await.unwrap();
-    let lib_id = sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
         .execute(&pool)
         .await
         .unwrap()
@@ -1637,7 +1637,7 @@ async fn book_file_path_returns_none_for_missing_book() {
 #[tokio::test]
 async fn book_file_path_returns_none_when_no_file_row_for_format() {
     let pool = init_db("sqlite::memory:").await.unwrap();
-    let lib_id = sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
         .execute(&pool)
         .await
         .unwrap()
@@ -1669,7 +1669,7 @@ async fn list_indexed_rows_for_formats_returns_only_matching_format_rows() {
     // the same `libraries.path` string only via the second seed adding
     // its own row, so we instead insert both books under the same id.
     let lib_id: i64 = sqlx::query_scalar(
-        "INSERT INTO libraries (path, display_name) VALUES ('/shared', '/shared') RETURNING id",
+        "INSERT INTO scan_roots (path, display_name) VALUES ('/shared', '/shared') RETURNING id",
     )
     .fetch_one(&pool)
     .await
@@ -1723,7 +1723,7 @@ async fn list_indexed_rows_for_formats_returns_empty_for_empty_allow_list() {
     // every row (which would re-introduce the #328 bug).
     let pool = init_db("sqlite::memory:").await.unwrap();
     let lib_id: i64 = sqlx::query_scalar(
-        "INSERT INTO libraries (path, display_name) VALUES ('/lib', '/lib') RETURNING id",
+        "INSERT INTO scan_roots (path, display_name) VALUES ('/lib', '/lib') RETURNING id",
     )
     .fetch_one(&pool)
     .await

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -48,7 +48,7 @@ pub async fn list_authors(
         SELECT a.id, a.name, a.sort,
                (SELECT COUNT(*)
                   FROM books b
-                  JOIN libraries l2 ON l2.id = b.library_id
+                  JOIN scan_roots l2 ON l2.id = b.library_id
                   LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
                  WHERE l2.path IN (SELECT p FROM lib_paths)
                    AND CASE
@@ -67,7 +67,7 @@ pub async fn list_authors(
                (SELECT b2.accent_color
                   FROM books_authors_link bal2
                   JOIN books b2 ON b2.id = bal2.book
-                  JOIN libraries l2 ON l2.id = b2.library_id
+                  JOIN scan_roots l2 ON l2.id = b2.library_id
                  WHERE bal2.author = a.id
                    AND l2.path IN (SELECT p FROM lib_paths)
                    AND b2.accent_color IS NOT NULL
@@ -83,7 +83,7 @@ pub async fn list_authors(
         WHERE EXISTS (
             SELECT 1 FROM books_authors_link bal
               JOIN books b ON b.id = bal.book
-              JOIN libraries l ON l.id = b.library_id
+              JOIN scan_roots l ON l.id = b.library_id
              WHERE bal.author = a.id
                AND l.path IN (SELECT p FROM lib_paths)
           )
@@ -146,7 +146,7 @@ fn series_index_sql(n: usize) -> String {
         SELECT s.id, s.name, s.sort,
                (SELECT COUNT(*)
                   FROM books b
-                  JOIN libraries l2 ON l2.id = b.library_id
+                  JOIN scan_roots l2 ON l2.id = b.library_id
                   LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
                  WHERE l2.path IN (SELECT p FROM lib_paths)
                    AND CASE
@@ -171,7 +171,7 @@ fn series_index_sql(n: usize) -> String {
                   END
                 FROM books_series_link bsl2
                   JOIN books b2 ON b2.id = bsl2.book
-                  JOIN libraries l2 ON l2.id = b2.library_id
+                  JOIN scan_roots l2 ON l2.id = b2.library_id
                   LEFT JOIN metadata_overrides mo2 ON mo2.book_uuid = b2.uuid
                  WHERE bsl2.series = s.id
                    AND l2.path IN (SELECT p FROM lib_paths)
@@ -180,7 +180,7 @@ fn series_index_sql(n: usize) -> String {
                (SELECT b3.accent_color
                   FROM books_series_link bsl3
                   JOIN books b3 ON b3.id = bsl3.book
-                  JOIN libraries l3 ON l3.id = b3.library_id
+                  JOIN scan_roots l3 ON l3.id = b3.library_id
                  WHERE bsl3.series = s.id
                    AND l3.path IN (SELECT p FROM lib_paths)
                    AND b3.accent_color IS NOT NULL
@@ -190,7 +190,7 @@ fn series_index_sql(n: usize) -> String {
         WHERE EXISTS (
             SELECT 1 FROM books_series_link bsl
               JOIN books b ON b.id = bsl.book
-              JOIN libraries l ON l.id = b.library_id
+              JOIN scan_roots l ON l.id = b.library_id
              WHERE bsl.series = s.id
                AND l.path IN (SELECT p FROM lib_paths)
           )

--- a/db/src/hls.rs
+++ b/db/src/hls.rs
@@ -175,7 +175,7 @@ pub struct ResolvedAudiobook {
     pub book_id: i64,
     /// `book_files.id`
     pub book_file_id: i64,
-    /// `libraries.path` — the library root on disk.
+    /// `scan_roots.path` — the library root on disk.
     pub library_path: String,
 }
 
@@ -202,7 +202,7 @@ pub async fn resolve_audiobook_file(
             "SELECT b.id, bf.id, COALESCE(bf.library_path, l.path) \
              FROM books b \
              JOIN book_files bf ON bf.book_id = b.id \
-             JOIN libraries l ON l.id = b.library_id \
+             JOIN scan_roots l ON l.id = b.library_id \
              WHERE b.uuid = ? \
                AND bf.id = ? \
                AND bf.format IN ('M4B', 'M4A', 'MP3')",
@@ -216,7 +216,7 @@ pub async fn resolve_audiobook_file(
             "SELECT b.id, bf.id, COALESCE(bf.library_path, l.path) \
              FROM books b \
              JOIN book_files bf ON bf.book_id = b.id \
-             JOIN libraries l ON l.id = b.library_id \
+             JOIN scan_roots l ON l.id = b.library_id \
              WHERE b.uuid = ? \
                AND bf.format IN ('M4B', 'M4A', 'MP3') \
              ORDER BY bf.ordinal \

--- a/db/src/hls/tests.rs
+++ b/db/src/hls/tests.rs
@@ -315,7 +315,7 @@ async fn transcode_book_clears_orphan_progress_on_restart() {
     // `get_parts` returns at least one entry — otherwise `transcode_book`
     // short-circuits before the orphan check would matter.
     let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
-    let lib_id = sqlx::query("INSERT INTO libraries (path, display_name) VALUES (?, 'lib')")
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
         .bind("/lib")
         .execute(&pool)
         .await

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -372,7 +372,7 @@ pub(crate) async fn backfill_chapters(
         "SELECT bf.id, bfp.filename, bf.format \
          FROM book_files bf \
          JOIN books b ON bf.book_id = b.id \
-         JOIN libraries l ON b.library_id = l.id \
+         JOIN scan_roots l ON b.library_id = l.id \
          JOIN book_file_parts bfp ON bfp.book_file_id = bf.id \
          WHERE l.path = ? \
            AND bf.format IN ('M4B', 'M4A', 'MP3') \

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -15,7 +15,7 @@ use crate::test_support::{indexed, CoversTempDir};
 /// stamps "now"), so the `is_stale` window tests insert the row
 /// directly — exactly the columns `last_indexed_at` reads back.
 async fn seed_last_indexed(pool: &SqlitePool, path: &str, last_indexed: i64) {
-    sqlx::query("INSERT INTO libraries (path, display_name, last_indexed) VALUES (?, ?, ?)")
+    sqlx::query("INSERT INTO scan_roots (path, display_name, last_indexed) VALUES (?, ?, ?)")
         .bind(path)
         .bind(path)
         .bind(last_indexed)
@@ -424,7 +424,7 @@ async fn seed_audiobook_for_backfill(
     format: &str,
 ) -> i64 {
     sqlx::query(
-        "INSERT INTO libraries (path, display_name) VALUES (?, ?) \
+        "INSERT INTO scan_roots (path, display_name) VALUES (?, ?) \
          ON CONFLICT(path) DO NOTHING",
     )
     .bind(library_path)
@@ -433,7 +433,7 @@ async fn seed_audiobook_for_backfill(
     .await
     .unwrap();
 
-    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM libraries WHERE path = ?")
+    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM scan_roots WHERE path = ?")
         .bind(library_path)
         .fetch_one(pool)
         .await

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -9,7 +9,7 @@ use crate::pool::init_db;
 use crate::sync::replace_books;
 use crate::test_support::{indexed, CoversTempDir};
 
-/// Seed a `libraries` row for `path` with an explicit `last_indexed`
+/// Seed a `scan_roots` row for `path` with an explicit `last_indexed`
 /// epoch-seconds value. There's no public writer for `last_indexed`
 /// that lets a test set an arbitrary timestamp (`sync_books` always
 /// stamps "now"), so the `is_stale` window tests insert the row

--- a/db/src/merge/snapshot.rs
+++ b/db/src/merge/snapshot.rs
@@ -10,7 +10,7 @@ use sqlx::Transaction;
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct SourceSnapshot {
     pub uuid: String,
-    /// The source book's `libraries.path` (re-resolved or recreated on
+    /// The source book's `scan_roots.path` (re-resolved or recreated on
     /// undo) — also the `merged_uuids.library_path` for the guard row.
     pub library_path: String,
     pub path: String,
@@ -94,7 +94,7 @@ pub(super) async fn build_snapshot(
         "SELECT b.uuid, l.path, b.path, b.title, b.sort, b.author_sort, b.series_index,
                 b.pubdate, b.timestamp, b.has_cover, b.description, b.isbn, b.accent_color,
                 b.title_norm, b.author_norm
-           FROM books b JOIN libraries l ON l.id = b.library_id
+           FROM books b JOIN scan_roots l ON l.id = b.library_id
           WHERE b.id = ?",
     )
     .bind(book_id)

--- a/db/src/normalize/tests.rs
+++ b/db/src/normalize/tests.rs
@@ -47,7 +47,7 @@ fn normalize_author_swaps_single_comma_last_first() {
 #[tokio::test]
 async fn backfill_norm_columns_fills_only_null_rows_and_is_idempotent() {
     let pool = init_db("sqlite::memory:").await.unwrap();
-    sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
         .execute(&pool)
         .await
         .unwrap();

--- a/db/src/palette/authors.rs
+++ b/db/src/palette/authors.rs
@@ -48,7 +48,7 @@ pub async fn search_authors(
           SELECT bal.author AS author_id, NULL AS author_name, bal.book AS book_id
             FROM books_authors_link bal
             JOIN books b ON b.id = bal.book
-            JOIN libraries l2 ON l2.id = b.library_id
+            JOIN scan_roots l2 ON l2.id = b.library_id
             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
            WHERE l2.path = ?1
              AND (mo.book_uuid IS NULL
@@ -58,7 +58,7 @@ pub async fn search_authors(
                  json_extract(je.value, '$.name') AS author_name,
                  b.id AS book_id
             FROM books b
-            JOIN libraries l2 ON l2.id = b.library_id
+            JOIN scan_roots l2 ON l2.id = b.library_id
             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
             JOIN json_each(mo.overrides, '$.creators') je
            WHERE l2.path = ?1
@@ -72,7 +72,7 @@ pub async fn search_authors(
           AND EXISTS (
             SELECT 1 FROM books_authors_link bal
               JOIN books b ON b.id = bal.book
-              JOIN libraries l ON l.id = b.library_id
+              JOIN scan_roots l ON l.id = b.library_id
              WHERE bal.author = a.id AND l.path = ?1
           )
         ORDER BY book_count DESC, a.name

--- a/db/src/palette/books.rs
+++ b/db/src/palette/books.rs
@@ -44,7 +44,7 @@ pub async fn search_books(
 
         FROM books_fts
         JOIN books b ON b.id = books_fts.rowid
-        JOIN libraries l ON l.id = b.library_id
+        JOIN scan_roots l ON l.id = b.library_id
         WHERE books_fts MATCH ?1 AND l.path = ?2
         ORDER BY bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0), b.sort, b.id
         LIMIT ?3

--- a/db/src/palette/series.rs
+++ b/db/src/palette/series.rs
@@ -45,7 +45,7 @@ pub async fn search_series(
           SELECT bsl.series AS series_id, NULL AS series_name, bsl.book AS book_id
             FROM books_series_link bsl
             JOIN books b ON b.id = bsl.book
-            JOIN libraries l2 ON l2.id = b.library_id
+            JOIN scan_roots l2 ON l2.id = b.library_id
             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
            WHERE l2.path = ?1
              AND (mo.book_uuid IS NULL
@@ -55,7 +55,7 @@ pub async fn search_series(
                  json_extract(mo.overrides, '$.series') AS series_name,
                  b.id AS book_id
             FROM books b
-            JOIN libraries l2 ON l2.id = b.library_id
+            JOIN scan_roots l2 ON l2.id = b.library_id
             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
            WHERE l2.path = ?1
              AND json_type(mo.overrides, '$.series') IS NOT NULL
@@ -75,7 +75,7 @@ pub async fn search_series(
              END
            FROM books_series_link bsl2
              JOIN books b2 ON b2.id = bsl2.book
-             JOIN libraries l2 ON l2.id = b2.library_id
+             JOIN scan_roots l2 ON l2.id = b2.library_id
              LEFT JOIN metadata_overrides mo2 ON mo2.book_uuid = b2.uuid
             WHERE bsl2.series = s.id AND l2.path = ?1
             ORDER BY b2.sort, b2.id LIMIT 1) AS author_display
@@ -84,7 +84,7 @@ pub async fn search_series(
           AND EXISTS (
             SELECT 1 FROM books_series_link bsl
               JOIN books b ON b.id = bsl.book
-              JOIN libraries l ON l.id = b.library_id
+              JOIN scan_roots l ON l.id = b.library_id
              WHERE bsl.series = s.id AND l.path = ?1
           )
         ORDER BY book_count DESC, s.name

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -41,7 +41,7 @@ pub async fn search_tags(
           SELECT btl.tag AS tag_id, NULL AS tag_name, btl.book AS book_id
             FROM books_tags_link btl
             JOIN books b ON b.id = btl.book
-            JOIN libraries l2 ON l2.id = b.library_id
+            JOIN scan_roots l2 ON l2.id = b.library_id
             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
            WHERE l2.path = ?1
              AND (mo.book_uuid IS NULL
@@ -49,7 +49,7 @@ pub async fn search_tags(
           UNION
           SELECT NULL AS tag_id, je.value AS tag_name, b.id AS book_id
             FROM books b
-            JOIN libraries l2 ON l2.id = b.library_id
+            JOIN scan_roots l2 ON l2.id = b.library_id
             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
             JOIN json_each(mo.overrides, '$.subjects') je
            WHERE l2.path = ?1
@@ -63,7 +63,7 @@ pub async fn search_tags(
           AND EXISTS (
             SELECT 1 FROM books_tags_link btl
               JOIN books b ON b.id = btl.book
-              JOIN libraries l ON l.id = b.library_id
+              JOIN scan_roots l ON l.id = b.library_id
              WHERE btl.tag = t.id AND l.path = ?1
           )
         ORDER BY book_count DESC, t.name

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -912,14 +912,14 @@ async fn palette_taxonomy_query_plans_use_indexes() {
            SELECT bal.author AS author_id, NULL AS author_name, bal.book AS book_id \
              FROM books_authors_link bal \
              JOIN books b ON b.id = bal.book \
-             JOIN libraries l2 ON l2.id = b.library_id \
+             JOIN scan_roots l2 ON l2.id = b.library_id \
              LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
             WHERE l2.path = ?1 \
               AND (mo.book_uuid IS NULL OR json_type(mo.overrides, '$.creators') IS NULL) \
            UNION \
            SELECT NULL AS author_id, json_extract(je.value, '$.name') AS author_name, b.id AS book_id \
              FROM books b \
-             JOIN libraries l2 ON l2.id = b.library_id \
+             JOIN scan_roots l2 ON l2.id = b.library_id \
              JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
              JOIN json_each(mo.overrides, '$.creators') je \
             WHERE l2.path = ?1 AND json_type(mo.overrides, '$.creators') IS NOT NULL \
@@ -931,7 +931,7 @@ async fn palette_taxonomy_query_plans_use_indexes() {
          WHERE a.name LIKE ?2 ESCAPE '\\' \
            AND EXISTS (SELECT 1 FROM books_authors_link bal \
                          JOIN books b ON b.id = bal.book \
-                         JOIN libraries l ON l.id = b.library_id \
+                         JOIN scan_roots l ON l.id = b.library_id \
                         WHERE bal.author = a.id AND l.path = ?1) \
          ORDER BY book_count DESC, a.name \
          LIMIT ?3",
@@ -951,14 +951,14 @@ async fn palette_taxonomy_query_plans_use_indexes() {
            SELECT bsl.series AS series_id, NULL AS series_name, bsl.book AS book_id \
              FROM books_series_link bsl \
              JOIN books b ON b.id = bsl.book \
-             JOIN libraries l2 ON l2.id = b.library_id \
+             JOIN scan_roots l2 ON l2.id = b.library_id \
              LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
             WHERE l2.path = ?1 \
               AND (mo.book_uuid IS NULL OR json_type(mo.overrides, '$.series') IS NULL) \
            UNION \
            SELECT NULL AS series_id, json_extract(mo.overrides, '$.series') AS series_name, b.id AS book_id \
              FROM books b \
-             JOIN libraries l2 ON l2.id = b.library_id \
+             JOIN scan_roots l2 ON l2.id = b.library_id \
              JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
             WHERE l2.path = ?1 AND json_type(mo.overrides, '$.series') IS NOT NULL \
          ) \
@@ -969,7 +969,7 @@ async fn palette_taxonomy_query_plans_use_indexes() {
          WHERE s.name LIKE ?2 ESCAPE '\\' \
            AND EXISTS (SELECT 1 FROM books_series_link bsl \
                          JOIN books b ON b.id = bsl.book \
-                         JOIN libraries l ON l.id = b.library_id \
+                         JOIN scan_roots l ON l.id = b.library_id \
                         WHERE bsl.series = s.id AND l.path = ?1) \
          ORDER BY book_count DESC, s.name \
          LIMIT ?3",
@@ -989,14 +989,14 @@ async fn palette_taxonomy_query_plans_use_indexes() {
            SELECT btl.tag AS tag_id, NULL AS tag_name, btl.book AS book_id \
              FROM books_tags_link btl \
              JOIN books b ON b.id = btl.book \
-             JOIN libraries l2 ON l2.id = b.library_id \
+             JOIN scan_roots l2 ON l2.id = b.library_id \
              LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
             WHERE l2.path = ?1 \
               AND (mo.book_uuid IS NULL OR json_type(mo.overrides, '$.subjects') IS NULL) \
            UNION \
            SELECT NULL AS tag_id, je.value AS tag_name, b.id AS book_id \
              FROM books b \
-             JOIN libraries l2 ON l2.id = b.library_id \
+             JOIN scan_roots l2 ON l2.id = b.library_id \
              JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
              JOIN json_each(mo.overrides, '$.subjects') je \
             WHERE l2.path = ?1 AND json_type(mo.overrides, '$.subjects') IS NOT NULL \
@@ -1008,7 +1008,7 @@ async fn palette_taxonomy_query_plans_use_indexes() {
          WHERE t.name LIKE ?2 ESCAPE '\\' \
            AND EXISTS (SELECT 1 FROM books_tags_link btl \
                          JOIN books b ON b.id = btl.book \
-                         JOIN libraries l ON l.id = b.library_id \
+                         JOIN scan_roots l ON l.id = b.library_id \
                         WHERE btl.tag = t.id AND l.path = ?1) \
          ORDER BY book_count DESC, t.name \
          LIMIT ?3",

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -1,9 +1,8 @@
 //! Settings KV CRUD, scan-root row upserts, and orphan-scan-root pruning.
 //!
-//! The `settings` KV keys (`ebook_library_path` / `audiobook_library_path`)
-//! are read by the UI and translated into `scan_roots` rows by the indexer.
-//! Saving settings prunes any scan root whose path is no longer configured
-//! along with its books, FTS rows, and on-disk covers.
+//! `settings` KV keys (`ebook_library_path` / `audiobook_library_path`) are
+//! read by the UI and translated into `scan_roots` rows by the indexer; saving
+//! settings prunes any orphan root and its books, FTS rows, and on-disk covers.
 
 use std::path::Path;
 

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -1,8 +1,8 @@
-//! Settings KV CRUD, library row upserts, and orphan-library pruning.
+//! Settings KV CRUD, scan-root row upserts, and orphan-scan-root pruning.
 //!
 //! The `settings` KV keys (`ebook_library_path` / `audiobook_library_path`)
-//! are read by the UI and translated into `libraries` rows by the indexer.
-//! Saving settings prunes any library whose path is no longer configured
+//! are read by the UI and translated into `scan_roots` rows by the indexer.
+//! Saving settings prunes any scan root whose path is no longer configured
 //! along with its books, FTS rows, and on-disk covers.
 
 use std::path::Path;
@@ -45,7 +45,7 @@ pub async fn get_settings(pool: &SqlitePool) -> Result<Settings, SettingsError> 
 
 /// Persist library paths and reconcile dependent state in a single
 /// transaction: upserts each path into `settings`, prunes orphaned
-/// `libraries` rows (and their books / FTS rows via cascade), then deletes
+/// `scan_roots` rows (and their books / FTS rows via cascade), then deletes
 /// the matching cover files from disk *after* commit so filesystem
 /// side-effects don't run inside the DB transaction. Callers should kick
 /// off a reindex afterwards — this function does not touch the indexer.
@@ -86,10 +86,10 @@ pub async fn set_settings(pool: &SqlitePool, settings: &Settings) -> Result<(), 
     Ok(())
 }
 
-/// Delete every `libraries` row whose `path` is not in `keep`, along with
+/// Delete every `scan_roots` row whose `path` is not in `keep`, along with
 /// its books, dependent rows removed by book-level cascades, FTS rows, and
 /// on-disk cover files. Settings has at most one ebook and one audiobook
-/// path, so any library whose path isn't one of those is orphaned and must
+/// path, so any scan root whose path isn't one of those is orphaned and must
 /// go — otherwise switching the configured path leaves the old library's
 /// rows behind and `list_books` callers for the old path continue to see
 /// its data.
@@ -101,7 +101,7 @@ pub(crate) async fn prune_orphan_libraries(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     keep: &[Option<&str>],
 ) -> Result<Vec<String>, SettingsError> {
-    let orphans: Vec<(i64, String)> = sqlx::query_as("SELECT id, path FROM libraries")
+    let orphans: Vec<(i64, String)> = sqlx::query_as("SELECT id, path FROM scan_roots")
         .fetch_all(&mut **tx)
         .await?
         .into_iter()
@@ -151,12 +151,12 @@ pub(crate) async fn prune_orphan_libraries(
         }
         books_delete.execute(&mut **tx).await?;
 
-        let libraries_sql = format!("DELETE FROM libraries WHERE id IN ({placeholders})");
-        let mut libraries_delete = sqlx::query(&libraries_sql);
+        let scan_roots_sql = format!("DELETE FROM scan_roots WHERE id IN ({placeholders})");
+        let mut scan_roots_delete = sqlx::query(&scan_roots_sql);
         for id in chunk {
-            libraries_delete = libraries_delete.bind(id);
+            scan_roots_delete = scan_roots_delete.bind(id);
         }
-        libraries_delete.execute(&mut **tx).await?;
+        scan_roots_delete.execute(&mut **tx).await?;
     }
 
     Ok(orphan_uuids)
@@ -206,7 +206,7 @@ pub async fn seed_settings_from_env(pool: &SqlitePool) -> Result<(), SettingsErr
     Ok(())
 }
 
-/// Upsert a `libraries` row for `path` (display_name derived from basename).
+/// Upsert a `scan_roots` row for `path` (display_name derived from basename).
 /// Used by the indexer write path in `sync`.
 pub(crate) async fn upsert_library(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
@@ -218,14 +218,14 @@ pub(crate) async fn upsert_library(
         .unwrap_or(path)
         .to_string();
     sqlx::query(
-        "INSERT INTO libraries (path, display_name) VALUES (?, ?)
+        "INSERT INTO scan_roots (path, display_name) VALUES (?, ?)
          ON CONFLICT(path) DO UPDATE SET display_name = excluded.display_name",
     )
     .bind(path)
     .bind(&display_name)
     .execute(&mut **tx)
     .await?;
-    let id: i64 = sqlx::query_scalar("SELECT id FROM libraries WHERE path = ?")
+    let id: i64 = sqlx::query_scalar("SELECT id FROM scan_roots WHERE path = ?")
         .bind(path)
         .fetch_one(&mut **tx)
         .await?;
@@ -234,13 +234,13 @@ pub(crate) async fn upsert_library(
 
 /// Unix-seconds timestamp of the last successful index for `library_path`,
 /// or `None` if the library has never been indexed (or doesn't exist in the
-/// `libraries` table yet).
+/// `scan_roots` table yet).
 pub async fn last_indexed_at(
     pool: &SqlitePool,
     library_path: &str,
 ) -> Result<Option<i64>, SettingsError> {
     Ok(
-        sqlx::query_scalar::<_, Option<i64>>("SELECT last_indexed FROM libraries WHERE path = ?")
+        sqlx::query_scalar::<_, Option<i64>>("SELECT last_indexed FROM scan_roots WHERE path = ?")
             .bind(library_path)
             .fetch_optional(pool)
             .await?

--- a/db/src/settings/tests.rs
+++ b/db/src/settings/tests.rs
@@ -153,7 +153,7 @@ async fn set_settings_prunes_library_when_ebook_path_changes() {
     .unwrap();
 
     assert!(list_books(&pool, "/old").await.unwrap().is_empty());
-    let library_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM libraries")
+    let library_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM scan_roots")
         .fetch_one(&pool)
         .await
         .unwrap();
@@ -233,7 +233,7 @@ async fn set_settings_none_removes_library_data() {
     .await
     .unwrap();
 
-    let library_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM libraries")
+    let library_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM scan_roots")
         .fetch_one(&pool)
         .await
         .unwrap();
@@ -268,7 +268,7 @@ async fn prune_orphan_libraries_batches_across_many_libraries() {
     for i in 0..LIBRARY_COUNT {
         let path = format!("/orphan-{i}");
         let library_id: i64 = sqlx::query_scalar(
-            "INSERT INTO libraries (path, display_name) VALUES (?, ?) RETURNING id",
+            "INSERT INTO scan_roots (path, display_name) VALUES (?, ?) RETURNING id",
         )
         .bind(&path)
         .bind(format!("Orphan {i}"))
@@ -311,7 +311,7 @@ async fn prune_orphan_libraries_batches_across_many_libraries() {
         "every orphaned book's cover UUID should be collected across all chunks"
     );
 
-    let library_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM libraries")
+    let library_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM scan_roots")
         .fetch_one(&pool)
         .await
         .unwrap();
@@ -331,4 +331,49 @@ async fn prune_orphan_libraries_batches_across_many_libraries() {
             "cover for {uuid} should be deleted"
         );
     }
+}
+
+/// Migration 0019 renames `libraries` -> `scan_roots` via
+/// `ALTER TABLE ... RENAME`. SQLite auto-rewrites the `books.library_id`
+/// FK to reference the renamed table, so deleting a scan-root row must
+/// still cascade-delete its books. A bug in the rename (e.g. a stray
+/// table recreate that dropped the FK) would leave the book row behind.
+#[tokio::test]
+async fn fk_cascade_survives_libraries_rename_to_scan_roots() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let scan_root_id: i64 = sqlx::query_scalar(
+        "INSERT INTO scan_roots (path, display_name) VALUES (?, ?) RETURNING id",
+    )
+    .bind("/lib")
+    .bind("lib")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, ?)")
+        .bind("uuid-cascade")
+        .bind(scan_root_id)
+        .bind("/lib/book.epub")
+        .bind("Cascade Book")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    sqlx::query("DELETE FROM scan_roots WHERE id = ?")
+        .bind(scan_root_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let book_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books WHERE library_id = ?")
+        .bind(scan_root_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        book_count, 0,
+        "deleting the scan_roots row should cascade-delete its books \
+         after the libraries->scan_roots rename"
+    );
 }

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -29,13 +29,13 @@ pub struct AudiobookSyncPlan {
 /// but writes `book_file_parts` rows in addition to `books` and `book_files`.
 ///
 /// Transaction order:
-/// 1. Upsert `libraries` row.
+/// 1. Upsert `scan_roots` row.
 /// 2. Delete Removed (explicit FTS clear + cascade DELETE from `books`).
 /// 3. Update Changed in-place: wipe `book_files` + `book_file_parts` + author
 ///    link + FTS, then re-insert them.
 /// 4. Insert New.
 /// 5. Backfill `book_files.(mtime_epoch, size_bytes)` only.
-/// 6. Stamp `libraries.last_indexed`.
+/// 6. Stamp `scan_roots.last_indexed`.
 ///
 /// Post-commit: write / delete cover files (best-effort, same as sync_books).
 pub async fn sync_audiobooks(
@@ -196,7 +196,7 @@ pub async fn sync_audiobooks(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
-    sqlx::query("UPDATE libraries SET last_indexed = ? WHERE id = ?")
+    sqlx::query("UPDATE scan_roots SET last_indexed = ? WHERE id = ?")
         .bind(now)
         .bind(library_id)
         .execute(&mut *tx)

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -58,7 +58,7 @@ pub struct SyncPlan {
 /// books are UPDATEd in place so their `books.id` is preserved too.
 ///
 /// Inside a single transaction, in this order:
-/// 1. Upsert the `libraries` row.
+/// 1. Upsert the `scan_roots` row.
 /// 2. Delete Removed: explicit FTS clear + cascade DELETE from `books`.
 /// 3. Update Changed in place (preserves `books.id`); wipe-and-rewrite
 ///    link rows + FTS row for each.
@@ -66,7 +66,7 @@ pub struct SyncPlan {
 /// 5. Backfill: UPDATE `book_files.(mtime_epoch, size_bytes)` only — no
 ///    OPF re-parse, no link writes, no FTS write. See the Backfill rule
 ///    in the [`crate::indexer`] module doc.
-/// 6. Stamp `libraries.last_indexed`.
+/// 6. Stamp `scan_roots.last_indexed`.
 ///
 /// Post-commit (best-effort, logged on failure — covers are a
 /// rebuildable cache):
@@ -384,7 +384,7 @@ async fn attach_ebook_file(
     Ok(())
 }
 
-/// Stamp `libraries.last_indexed` with the current wall-clock seconds.
+/// Stamp `scan_roots.last_indexed` with the current wall-clock seconds.
 async fn stamp_last_indexed(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
@@ -393,7 +393,7 @@ async fn stamp_last_indexed(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
-    sqlx::query("UPDATE libraries SET last_indexed = ? WHERE id = ?")
+    sqlx::query("UPDATE scan_roots SET last_indexed = ? WHERE id = ?")
         .bind(now)
         .bind(library_id)
         .execute(&mut **tx)
@@ -542,7 +542,7 @@ pub async fn replace_books(
 ) -> Result<(), SyncError> {
     let removed_uuids: Vec<String> = sqlx::query_scalar(
         "SELECT b.uuid FROM books b
-         JOIN libraries l ON l.id = b.library_id
+         JOIN scan_roots l ON l.id = b.library_id
          WHERE l.path = ?",
     )
     .bind(library_path)

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -195,11 +195,11 @@ impl Drop for CoversTempDir {
 /// need rows to exist (e.g. response-cap tests) avoid the multi-second
 /// cost of running the full pipeline.
 pub async fn seed_minimal_books(pool: &SqlitePool, count: i64) {
-    sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
         .execute(pool)
         .await
         .unwrap();
-    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM libraries WHERE path = '/lib'")
+    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM scan_roots WHERE path = '/lib'")
         .fetch_one(pool)
         .await
         .unwrap();
@@ -393,11 +393,11 @@ pub async fn series_id_by_name(pool: &SqlitePool, name: &str) -> i64 {
 /// depend on link rows existing — keeping the test fast even past the
 /// 1k cap. Returns `(author_id, series_id)`.
 pub async fn seed_books_for_one_author_and_series(pool: &SqlitePool, count: i64) -> (i64, i64) {
-    sqlx::query("INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib')")
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
         .execute(pool)
         .await
         .unwrap();
-    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM libraries WHERE path = '/lib'")
+    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM scan_roots WHERE path = '/lib'")
         .fetch_one(pool)
         .await
         .unwrap();

--- a/server/src/backend/audiobooks/tests.rs
+++ b/server/src/backend/audiobooks/tests.rs
@@ -21,12 +21,13 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 /// Seed one audiobook book + book_files + book_file_parts row for tests.
 async fn seed_one_audiobook(pool: &sqlx::SqlitePool) -> String {
-    let lib_id = sqlx::query("INSERT INTO libraries (path, display_name) VALUES (?, 'audiobooks')")
-        .bind("/audiobooks")
-        .execute(pool)
-        .await
-        .unwrap()
-        .last_insert_rowid();
+    let lib_id =
+        sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'audiobooks')")
+            .bind("/audiobooks")
+            .execute(pool)
+            .await
+            .unwrap()
+            .last_insert_rowid();
     let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
     let book_id =
         sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, 'PK')")
@@ -254,7 +255,7 @@ async fn seed_audiobook_with_parts(
     format: &str,
     parts: &[(i64, &str, f64)],
 ) -> String {
-    let lib_id = sqlx::query("INSERT INTO libraries (path, display_name) VALUES (?, 'lib')")
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
         .bind(library_path)
         .execute(pool)
         .await

--- a/server/src/backend/ebooks/tests.rs
+++ b/server/src/backend/ebooks/tests.rs
@@ -203,7 +203,7 @@ async fn api_get_ebooks_sets_total_cap_header_when_truncated() {
     // the indexer's full m2m wiring isn't relevant here.
     let total = db::MAX_BOOKS_RETURNED + 5;
     let lib_id: i64 = sqlx::query_scalar(
-        "INSERT INTO libraries (path, display_name) VALUES ('/lib', 'lib') RETURNING id",
+        "INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib') RETURNING id",
     )
     .fetch_one(&pool)
     .await
@@ -375,7 +375,7 @@ async fn api_get_ebook_file_returns_200_with_epub_bytes() {
     let file_path = tmp.join(format!("{stem}.epub"));
     std::fs::write(&file_path, b"PK\x03\x04 fake-epub").unwrap();
 
-    let lib_id = sqlx::query("INSERT INTO libraries (path, display_name) VALUES (?, 'lib')")
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
         .bind(tmp.to_str().unwrap())
         .execute(&pool)
         .await
@@ -472,7 +472,7 @@ async fn api_get_ebook_file_returns_500_when_book_file_path_fails() {
     let user = auth_test_support::create_user(&pool, "alice").await;
     let token = auth_test_support::bearer_token(&pool, user.id).await;
 
-    let lib_id = sqlx::query("INSERT INTO libraries (path, display_name) VALUES (?, 'lib')")
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
         .bind("/lib")
         .execute(&pool)
         .await

--- a/server/src/backend/test_support.rs
+++ b/server/src/backend/test_support.rs
@@ -51,7 +51,7 @@ pub(crate) fn get_anon(uri: &str) -> Request<Body> {
 
 /// Seed a book row with `has_cover = 0`. Returns the inserted book id.
 pub(crate) async fn seed_book_no_cover(pool: &sqlx::SqlitePool) -> i64 {
-    // Insert a minimal library row first (FK requirement).
+    // Insert a minimal scan_roots row first (FK requirement).
     sqlx::query(
         "INSERT OR IGNORE INTO scan_roots(path, display_name) VALUES ('/test/library', 'Test')",
     )

--- a/server/src/backend/test_support.rs
+++ b/server/src/backend/test_support.rs
@@ -53,13 +53,13 @@ pub(crate) fn get_anon(uri: &str) -> Request<Body> {
 pub(crate) async fn seed_book_no_cover(pool: &sqlx::SqlitePool) -> i64 {
     // Insert a minimal library row first (FK requirement).
     sqlx::query(
-        "INSERT OR IGNORE INTO libraries(path, display_name) VALUES ('/test/library', 'Test')",
+        "INSERT OR IGNORE INTO scan_roots(path, display_name) VALUES ('/test/library', 'Test')",
     )
     .execute(pool)
     .await
     .expect("insert library");
     let library_id: i64 =
-        sqlx::query_scalar("SELECT id FROM libraries WHERE path = '/test/library'")
+        sqlx::query_scalar("SELECT id FROM scan_roots WHERE path = '/test/library'")
             .fetch_one(pool)
             .await
             .expect("library id");


### PR DESCRIPTION
## Summary
- The schema's `libraries` table is the physical on-disk scan-root registry, but roadmap F3.1 wants the name `libraries` for a user-facing saved-filter collection. This renames the physical-roots table to `scan_roots` now, while it holds 1–2 rows and the blast radius is internal.
- Migration `0019` does `ALTER TABLE libraries RENAME TO scan_roots` and recreates the FK index as `idx_books_scan_root_id`. SQLite auto-rewrites the `books` FK clause, so `ON DELETE CASCADE` survives untouched (new test proves it).
- Swept the SQL references across 13 db modules + the test fixtures in the db + server crates. `books.library_id` column, the `scan_libraries` scanner fn, settings KV keys, and the `upsert_library` / `prune_orphan_libraries` fn names are intentionally unchanged — this is the table rename only.

## Test plan
- [x] `cargo test -p omnibus-db` — 512 pass (incl. new `fk_cascade_survives_libraries_rename_to_scan_roots`)
- [x] `cargo test -p omnibus` — 191 pass
- [x] `cargo clippy` + `cargo fmt --check` clean
- [x] grep-verify: zero stray table refs to `libraries` outside the frozen `0002` and the new `0019` rename

## Notes
- Addresses `docs/review/db.md` finding F3. This is the **base of the db-review mechanical stack** — subsequent stack PRs (F12, F4, F7, F8, F19, F5a, F6) build on it and must merge after it.