### PR TITLE
chore: drop redundant and dead schema objects

### DIFF
--- a/db/migrations/0020_session_stats_indexes.sql
+++ b/db/migrations/0020_session_stats_indexes.sql
@@ -1,0 +1,18 @@
+-- F3.4 stats: windowed-aggregate indexes for the session tables.
+--
+-- The stats feature groups a user's sessions by day over a date range
+-- (`GROUP BY date(started_at)`, `SUM(seconds_read)`) filtered by user,
+-- targeting < 250 ms cold on 10k events. The existing `(user_id, book_id)`
+-- indexes from 0013 can't range-scan a time window, so each `/stats`
+-- query would otherwise degrade to a per-user table scan filtered in
+-- memory by date. `(user_id, started_at)` lets SQLite range-scan the
+-- window directly.
+--
+-- `reading_progress` gets `(user_id, updated_at)` for most-recent-write
+-- ordering (the "continue reading" rail). No `(user_id, ended_at)` index
+-- is added — no current or roadmap query ranges or groups on `ended_at`
+-- (duration is the precomputed `seconds_read`/`seconds_listened` column),
+-- and the repo bans speculative indexes.
+CREATE INDEX idx_reading_sessions_user_started   ON reading_sessions(user_id, started_at);
+CREATE INDEX idx_listening_sessions_user_started ON listening_sessions(user_id, started_at);
+CREATE INDEX idx_reading_progress_user_updated   ON reading_progress(user_id, updated_at);

--- a/db/migrations/0021_drop_dead_schema.sql
+++ b/db/migrations/0021_drop_dead_schema.sql
@@ -1,0 +1,37 @@
+-- Schema cleanup: drop dead and redundant objects. Forward-only; every
+-- statement is `IF EXISTS` so a fresh DB and an upgraded DB converge.
+--
+-- F17 — four indexes that duplicate a UNIQUE/PK auto-index or are a strict
+-- prefix of a composite. SQLite serves an equality/range probe from the
+-- leading columns of a composite index, so the narrower duplicate carries
+-- no read benefit and only adds write amplification:
+--   idx_books_uuid              — books.uuid is UNIQUE (0002), which builds
+--                                 its own auto-index; the explicit copy is
+--                                 redundant.
+--   idx_book_files_book_id      — strict prefix of idx_book_files_book_format
+--                                 (book_id, format) (0018).
+--   idx_book_file_parts_lookup  — duplicates the UNIQUE(book_file_id, ordinal)
+--                                 auto-index (0014).
+--   reading_progress_user_book_idx — leftmost prefix of the
+--                                 UNIQUE(user_id, book_id, format) auto-index
+--                                 (0013).
+-- The bookmarks/reading_sessions/listening_sessions (user_id, book_id)
+-- indexes from 0013 are deliberately kept: those tables have no covering
+-- UNIQUE, so they are not redundant.
+DROP INDEX IF EXISTS idx_books_uuid;
+DROP INDEX IF EXISTS idx_book_files_book_id;
+DROP INDEX IF EXISTS idx_book_file_parts_lookup;
+DROP INDEX IF EXISTS reading_progress_user_book_idx;
+
+-- F18 — speculative partial index added in 0006 for a "backfill missing
+-- accents" worker that was never built. No query filters on
+-- `accent_color IS NULL`; the only real consumers use IS NOT NULL
+-- (db/src/browse.rs), which a NULL-only partial index cannot serve. It only
+-- adds write amplification.
+DROP INDEX IF EXISTS idx_books_accent_null;
+
+-- F20 — vestigial single-row `app_state` table from the pre-normalization
+-- counter-app placeholder, seeded with value 0 in 0001 and never read or
+-- written by any code. The `settings` KV table covers any real global-state
+-- need.
+DROP TABLE IF EXISTS app_state;

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -198,6 +198,113 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn migration_0021_drops_redundant_and_dead_schema_objects() {
+        let pool = init_db("sqlite::memory:").await.unwrap();
+
+        // F17 + F18: the four redundant indexes and the speculative
+        // NULL-accent partial index must be gone after the migrator runs.
+        for index in [
+            "idx_books_uuid",
+            "idx_book_files_book_id",
+            "idx_book_file_parts_lookup",
+            "reading_progress_user_book_idx",
+            "idx_books_accent_null",
+        ] {
+            let count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?",
+            )
+            .bind(index)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(count, 0, "index {index} should have been dropped by 0021");
+        }
+
+        // F20: the vestigial single-row table must be gone.
+        let app_state: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='app_state'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            app_state, 0,
+            "app_state table should have been dropped by 0021"
+        );
+
+        // The covering composite index that supersedes idx_book_files_book_id
+        // must still be present (kept, not dropped).
+        let kept_composite: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_book_files_book_format'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            kept_composite, 1,
+            "idx_book_files_book_format must survive — it covers book_id-only lookups"
+        );
+
+        // The (user_id, book_id) session indexes from 0013 have no covering
+        // UNIQUE, so they must NOT have been dropped.
+        for kept in [
+            "bookmarks_user_book_idx",
+            "reading_sessions_user_book_idx",
+            "listening_sessions_user_book_idx",
+        ] {
+            let count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?",
+            )
+            .bind(kept)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                count, 1,
+                "index {kept} has no covering UNIQUE and must be kept"
+            );
+        }
+
+        // The UNIQUE(user_id, book_id, format) auto-index that supersedes
+        // reading_progress_user_book_idx must still enforce uniqueness: a
+        // duplicate (user_id, book_id, format) insert must fail.
+        sqlx::query("INSERT INTO users (username, password_hash, is_admin) VALUES ('u', 'h', 0)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        // `libraries` was renamed to `scan_roots` in 0019; `books.library_id`
+        // keeps its column name and FK.
+        sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'Lib')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO books (uuid, library_id, path, title) \
+             VALUES ('bk-uuid', 1, '/lib/bk', 'Book')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO reading_progress (user_id, book_id, format, epub_cfi) \
+             VALUES (1, 1, 'epub', 'cfi-1')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let dup = sqlx::query(
+            "INSERT INTO reading_progress (user_id, book_id, format, epub_cfi) \
+             VALUES (1, 1, 'epub', 'cfi-2')",
+        )
+        .execute(&pool)
+        .await;
+        assert!(
+            dup.is_err(),
+            "UNIQUE(user_id, book_id, format) must still reject a duplicate row"
+        );
+    }
+
+    #[tokio::test]
     async fn migrator_is_idempotent_on_rerun() {
         let tmp = std::env::temp_dir().join(format!(
             "omnibus-migrate-{}-{}.db",

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -313,3 +313,24 @@ async fn record_session_tx_rollback_leaves_no_rows() {
     .unwrap();
     assert_eq!(count, 0, "dropped transaction must leave no committed rows");
 }
+
+#[tokio::test]
+async fn migration_0020_adds_windowed_session_indexes_for_stats() {
+    // F3.4 stats range-scans sessions by `(user_id, started_at)` and the
+    // progress rail orders by `(user_id, updated_at)`. Assert migration
+    // 0020 created each index so those windowed queries can use them.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    for index in [
+        "idx_reading_sessions_user_started",
+        "idx_listening_sessions_user_started",
+        "idx_reading_progress_user_updated",
+    ] {
+        let found: Option<String> =
+            sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+                .bind(index)
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert_eq!(found.as_deref(), Some(index), "missing index {index}");
+    }
+}


### PR DESCRIPTION
## Summary
Migration `0021` drops six dead/redundant schema objects, each verified to have no consumer and (for indexes) a still-present covering index:
- **F17** — `idx_books_uuid` (dup of `uuid UNIQUE`), `idx_book_files_book_id` (prefix of `idx_book_files_book_format`), `idx_book_file_parts_lookup` (dup of `UNIQUE(book_file_id, ordinal)`), `reading_progress_user_book_idx` (prefix of `UNIQUE(user_id, book_id, format)`).
- **F18** — `idx_books_accent_null` (speculative NULL-only partial index; only `accent_color IS NOT NULL` queries exist, which it can't serve).
- **F20** — `app_state` (vestigial single-row scratch table, never read or written).

Kept `bookmarks_user_book_idx` + the two `*_sessions_user_book_idx` — their tables have no covering `(user_id, book_id)` UNIQUE, so they are NOT redundant.

## Test plan
- [x] `cargo test -p omnibus-db` — 514 pass, incl. new `migration_0021_drops_redundant_and_dead_schema_objects` (asserts each object is gone + the covering indexes/UNIQUE remain)
- [x] `cargo test -p omnibus` — 191 pass
- [x] `cargo clippy` + `cargo fmt --check` clean
- [x] grep-verified zero consumers of `app_state` and `accent_color IS NULL`

## Notes
- Addresses `docs/review/db.md` findings F17, F18, F20. **Stacked on #489 (F12)**.