### PR TITLE
chore: drop the denormalized books.isbn column

### DIFF
--- a/db/migrations/0023_drop_books_isbn.sql
+++ b/db/migrations/0023_drop_books_isbn.sql
@@ -1,0 +1,18 @@
+-- F8 — drop the denormalized `books.isbn` column. It held a copy of the
+-- first ISBN-scheme identifier, but that value is already canonical in
+-- `book_identifiers` (one row per scheme/value). No read path consumes it:
+--   * FTS — `upsert_fts` (db/src/sync/fts.rs) already sources the `isbn`
+--     token from `book_identifiers` (F4), not from `books.isbn`.
+--   * Projection — `row_to_ebook` (db/src/books/projection.rs) rebuilds the
+--     identifier list from a `book_identifiers` JSON aggregate.
+--   * Merge undo — the source snapshot replays identifiers into
+--     `book_identifiers`, so the recreated row's ISBN survives without the
+--     column.
+--
+-- Forward-only. `books.isbn` is a bare `TEXT COLLATE NOCASE` with no index,
+-- FK, PK, generated column, trigger, or view depending on it, so SQLite
+-- (>= 3.35, runtime here is far newer) drops it in place with no
+-- table-recreate. The frozen 0005_fts5.sql backfill reads `b.isbn` but only
+-- runs once on a fresh, empty `books` table; on an upgraded DB it ran long
+-- before this migration. Both paths converge on the same schema.
+ALTER TABLE books DROP COLUMN isbn;

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -30,7 +30,7 @@ pub const MAX_BOOKS_RETURNED: i64 = 50_000;
 pub(crate) const BOOK_COLUMNS: &str = r#"
     b.id, b.uuid,
     b.title, b.description, b.series_index, b.has_cover,
-    b.pubdate, b.last_modified, b.timestamp, b.isbn, b.accent_color,
+    b.pubdate, b.last_modified, b.timestamp, b.accent_color,
 
     (SELECT bf.filename FROM book_files bf
       WHERE bf.book_id = b.id

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -701,6 +701,62 @@ async fn list_and_search_books_return_multi_valued_fields() {
     );
     assert_eq!(hits[0].identifiers.len(), 2);
 }
+
+/// F8 regression: the denormalized `books.isbn` column was dropped (migration
+/// 0023). A book's ISBN must still surface through the identifier projection,
+/// which reads the canonical `book_identifiers` rows — proving the read path
+/// never depended on the removed column.
+#[tokio::test]
+async fn get_book_and_list_books_surface_isbn_from_book_identifiers_after_column_drop() {
+    let _covers = CoversTempDir::new("isbn_after_drop");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![IndexedBook {
+            metadata: EbookMetadata {
+                filename: "isbn.epub".into(),
+                title: Some("ISBN Book".into()),
+                identifiers: vec![Identifier {
+                    value: "9780000000000".into(),
+                    scheme: Some("isbn".into()),
+                }],
+                ..Default::default()
+            },
+            cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
+        }],
+    )
+    .await
+    .unwrap();
+
+    // The `books` table no longer has an `isbn` column at all.
+    let has_isbn_col: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM pragma_table_info('books') WHERE name = 'isbn'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(has_isbn_col, 0, "books.isbn must be dropped");
+
+    let list = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(list.len(), 1);
+    let list_isbn = list[0]
+        .identifiers
+        .iter()
+        .find(|i| i.scheme.as_deref() == Some("isbn"))
+        .map(|i| i.value.as_str());
+    assert_eq!(list_isbn, Some("9780000000000"));
+
+    let detail = get_book(&pool, list[0].id).await.unwrap().unwrap();
+    let detail_isbn = detail
+        .identifiers
+        .iter()
+        .find(|i| i.scheme.as_deref() == Some("isbn"))
+        .map(|i| i.value.as_str());
+    assert_eq!(detail_isbn, Some("9780000000000"));
+}
+
 #[tokio::test]
 async fn get_book_returns_none_for_missing_id() {
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/merge/snapshot.rs
+++ b/db/src/merge/snapshot.rs
@@ -22,7 +22,6 @@ pub(super) struct SourceSnapshot {
     pub timestamp: Option<String>,
     pub has_cover: i64,
     pub description: Option<String>,
-    pub isbn: Option<String>,
     pub accent_color: Option<String>,
     pub title_norm: Option<String>,
     pub author_norm: Option<String>,
@@ -70,7 +69,6 @@ pub(super) async fn build_snapshot(
         timestamp,
         has_cover,
         description,
-        isbn,
         accent_color,
         title_norm,
         author_norm,
@@ -89,10 +87,9 @@ pub(super) async fn build_snapshot(
         Option<String>,
         Option<String>,
         Option<String>,
-        Option<String>,
     ) = sqlx::query_as(
         "SELECT b.uuid, l.path, b.path, b.title, b.sort, b.author_sort, b.series_index,
-                b.pubdate, b.timestamp, b.has_cover, b.description, b.isbn, b.accent_color,
+                b.pubdate, b.timestamp, b.has_cover, b.description, b.accent_color,
                 b.title_norm, b.author_norm
            FROM books b JOIN scan_roots l ON l.id = b.library_id
           WHERE b.id = ?",
@@ -178,7 +175,6 @@ pub(super) async fn build_snapshot(
         timestamp,
         has_cover,
         description,
-        isbn,
         accent_color,
         title_norm,
         author_norm,

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -119,8 +119,8 @@ async fn recreate_source_row(
     let id: i64 = sqlx::query_scalar(
         "INSERT INTO books
             (uuid, library_id, path, title, sort, author_sort, series_index, pubdate,
-             timestamp, has_cover, description, isbn, accent_color, title_norm, author_norm)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?)
+             timestamp, has_cover, description, accent_color, title_norm, author_norm)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?)
          RETURNING id",
     )
     .bind(&snap.uuid)
@@ -134,7 +134,6 @@ async fn recreate_source_row(
     .bind(&snap.timestamp)
     .bind(snap.has_cover)
     .bind(&snap.description)
-    .bind(&snap.isbn)
     .bind(&snap.accent_color)
     .bind(&snap.title_norm)
     .bind(&snap.author_norm)

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -461,18 +461,6 @@ async fn insert_book_file_row(
     Ok(())
 }
 
-/// First ISBN-scheme identifier, case-insensitive on the scheme name.
-fn first_isbn(idents: &[omnibus_shared::Identifier]) -> Option<String> {
-    idents
-        .iter()
-        .find(|id| {
-            id.scheme
-                .as_deref()
-                .is_some_and(|s| s.eq_ignore_ascii_case("isbn"))
-        })
-        .map(|id| id.value.clone())
-}
-
 /// UPDATE the `books` row for a Changed entry in place (preserving id).
 /// All scalar columns that `insert_book_row` writes get refreshed; the
 /// link tables and FTS row are handled by the caller.
@@ -490,13 +478,12 @@ async fn update_book_row(
         .first()
         .and_then(|c| c.file_as.clone())
         .or_else(|| m.creators.first().map(|c| c.name.clone()));
-    let first_isbn = first_isbn(&m.identifiers);
     let has_cover = i64::from(b.cover.is_some());
 
     sqlx::query(
         "UPDATE books SET
             path = ?, title = ?, sort = ?, author_sort = ?, series_index = ?,
-            pubdate = ?, has_cover = ?, description = ?, isbn = ?, accent_color = ?,
+            pubdate = ?, has_cover = ?, description = ?, accent_color = ?,
             title_norm = ?, author_norm = ?,
             last_modified = datetime('now')
          WHERE id = ?",
@@ -509,7 +496,6 @@ async fn update_book_row(
     .bind(&m.published)
     .bind(has_cover)
     .bind(&m.description)
-    .bind(&first_isbn)
     .bind(sanitize_accent_color(m.accent.as_deref()))
     .bind(normalize_title(&title))
     .bind(m.creators.first().and_then(|c| normalize_author(&c.name)))
@@ -581,14 +567,13 @@ async fn insert_book_row(
         .first()
         .and_then(|c| c.file_as.clone())
         .or_else(|| m.creators.first().map(|c| c.name.clone()));
-    let first_isbn = first_isbn(&m.identifiers);
     let has_cover = i64::from(b.cover.is_some());
 
     let book_id = sqlx::query_scalar::<_, i64>(
         "INSERT INTO books
             (uuid, library_id, path, title, sort, author_sort, series_index,
-             pubdate, has_cover, description, isbn, accent_color, title_norm, author_norm)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             pubdate, has_cover, description, accent_color, title_norm, author_norm)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          RETURNING id",
     )
     .bind(&uuid)
@@ -601,7 +586,6 @@ async fn insert_book_row(
     .bind(&m.published)
     .bind(has_cover)
     .bind(&m.description)
-    .bind(&first_isbn)
     .bind(sanitize_accent_color(m.accent.as_deref()))
     .bind(normalize_title(&title))
     .bind(m.creators.first().and_then(|c| normalize_author(&c.name)))

--- a/db/src/sync/fts.rs
+++ b/db/src/sync/fts.rs
@@ -27,8 +27,8 @@ pub(crate) async fn upsert_fts(
     // `authors` / `series` / `tags` mirror the rename-trigger projections
     // in 0005_fts5.sql so the inline upsert and the triggers agree on the
     // same text. `isbn` takes the first ISBN-scheme identifier
-    // (case-insensitive), matching the per-site `first_isbn` the sync
-    // path used to write inline.
+    // (case-insensitive) straight from `book_identifiers` — the canonical
+    // source now that the denormalized `books.isbn` column is gone (F8).
     sqlx::query(
         "INSERT INTO books_fts(rowid, title, authors, series, tags, description, isbn)
          SELECT


### PR DESCRIPTION
## Summary
- `books.isbn` was a denormalized copy of the first ISBN already canonical in `book_identifiers`, kept in lockstep by hand. F4 already moved the FTS isbn token to source from `book_identifiers`, so the column had no remaining consumer — the projection rebuilds the identifier list from a `book_identifiers` JSON aggregate, and merge-undo replays identifiers separately.
- Migration `0023` drops it with a plain `ALTER TABLE books DROP COLUMN isbn` (verified no index / trigger / view / generated column depends on it). Removed the redundant write, the now-dead `first_isbn` helper, and the dead `b.isbn` selects in the projection and merge snapshot/undo.

## Test plan
- [x] `cargo test -p omnibus-db` — 525 pass, incl. `get_book_and_list_books_surface_isbn_from_book_identifiers_after_column_drop`
- [x] `cargo test -p omnibus` — 194 pass
- [x] `cargo test -p omnibus-frontend --features server` — 156 pass (confirms no wire ripple)
- [x] `cargo clippy` + `cargo fmt --check` clean

## Notes
- Addresses `docs/review/db.md` finding F8. **Stacked on #492 (F7).** Pairs with F7 — together they make `book_identifiers` the single source of truth for ISBNs (incl. multi-value).