### PR TITLE
chore: drop the write-only book_files.mtime column

### DIFF
--- a/db/migrations/0024_drop_book_files_mtime.sql
+++ b/db/migrations/0024_drop_book_files_mtime.sql
@@ -1,0 +1,18 @@
+-- F19 — drop the dead `book_files.mtime` column. It held the OPF
+-- `dcterms:modified` Dublin Core string (NOT filesystem state), written on
+-- every `book_files` insert but never SELECTed by any read path:
+--   * Incremental reindex — the change-detection diff compares only
+--     `(mtime_epoch, size_bytes)`. `list_indexed_rows` and friends
+--     (db/src/books/list.rs) project `MAX(bf.mtime_epoch)`, never `mtime`.
+--   * Backfill — the stat-only bucket (db/src/sync/backfill.rs,
+--     db/src/sync/audiobooks.rs) UPDATEs `(mtime_epoch, size_bytes)` only.
+-- The live filesystem stat lives in `mtime_epoch INTEGER` (migration 0009),
+-- which this migration leaves untouched.
+--
+-- Forward-only. `book_files.mtime` is a bare `TEXT NOT NULL` with no index,
+-- FK, PK, generated column, trigger, or view depending on it (the only
+-- `book_files` indexes are on `book_id` and `(book_id, format)`), so SQLite
+-- (>= 3.35, runtime here is far newer) drops it in place with no
+-- table-recreate. No backfill: the discarded data has no reader. A fresh DB
+-- built from 0001..0024 and an upgraded DB converge on the same schema.
+ALTER TABLE book_files DROP COLUMN mtime;

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -542,8 +542,8 @@ async fn list_books_returns_one_row_per_book_with_multi_format() {
     .unwrap();
     let id = list_books(&pool, "/lib").await.unwrap()[0].id;
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime)
-         VALUES (?, 'M4B', 'alpha', 0, '')",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes)
+         VALUES (?, 'M4B', 'alpha', 0)",
     )
     .bind(id)
     .execute(&pool)
@@ -580,8 +580,8 @@ async fn search_books_returns_one_row_per_book_with_multi_format() {
     .unwrap();
     let id = list_books(&pool, "/lib").await.unwrap()[0].id;
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime)
-         VALUES (?, 'M4B', 'alpha', 0, '')",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes)
+         VALUES (?, 'M4B', 'alpha', 0)",
     )
     .bind(id)
     .execute(&pool)
@@ -791,8 +791,8 @@ async fn get_book_is_deterministic_with_multiple_files_and_links() {
 
     // Add a second physical file in another format.
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime)
-         VALUES (?, 'M4B', 'alpha', 0, '')",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes)
+         VALUES (?, 'M4B', 'alpha', 0)",
     )
     .bind(id)
     .execute(&pool)
@@ -1668,8 +1668,8 @@ async fn book_file_path_returns_absolute_path_for_epub() {
     .unwrap()
     .last_insert_rowid();
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime) \
-         VALUES (?, 'EPUB', 'some-book', 0, '')",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'some-book', 0)",
     )
     .bind(book_id)
     .execute(&pool)
@@ -1747,9 +1747,9 @@ async fn list_indexed_rows_for_formats_returns_only_matching_format_rows() {
     .await
     .unwrap();
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch) \
-         VALUES (?, 'EPUB', 'EpubTitle', 100, '', 100), \
-                (?, 'M4B',  'AudioTitle', 200, '', 200)",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch) \
+         VALUES (?, 'EPUB', 'EpubTitle', 100, 100), \
+                (?, 'M4B',  'AudioTitle', 200, 200)",
     )
     .bind(epub_id)
     .bind(m4b_id)
@@ -1770,6 +1770,30 @@ async fn list_indexed_rows_for_formats_returns_only_matching_format_rows() {
         .unwrap();
     assert_eq!(audiobooks.len(), 1);
     assert_eq!(audiobooks[0].uuid, "uuid-m4b");
+}
+
+// ---------- migration 0024: drop dead book_files.mtime (F19) ----------
+
+#[tokio::test]
+async fn migration_drops_book_files_mtime_text_column_but_keeps_mtime_epoch() {
+    // F19: the OPF `dcterms:modified` TEXT column was write-only and is
+    // dropped by 0024; the filesystem-stat `mtime_epoch` (used by the
+    // incremental reindex diff) must survive.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let columns: Vec<String> = sqlx::query_scalar(
+        "SELECT name FROM pragma_table_info('book_files') WHERE name IN ('mtime', 'mtime_epoch')",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert!(
+        !columns.iter().any(|c| c == "mtime"),
+        "book_files.mtime should be dropped by migration 0024"
+    );
+    assert!(
+        columns.iter().any(|c| c == "mtime_epoch"),
+        "book_files.mtime_epoch must remain for change detection"
+    );
 }
 
 #[tokio::test]
@@ -1793,8 +1817,8 @@ async fn list_indexed_rows_for_formats_returns_empty_for_empty_allow_list() {
     .await
     .unwrap();
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch) \
-         VALUES (?, 'EPUB', 'a', 0, '', 0)",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch) \
+         VALUES (?, 'EPUB', 'a', 0, 0)",
     )
     .bind(book_id)
     .execute(&pool)

--- a/db/src/hls/tests.rs
+++ b/db/src/hls/tests.rs
@@ -330,8 +330,8 @@ async fn transcode_book_clears_orphan_progress_on_restart() {
     .await
     .unwrap();
     let file_id = sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime) \
-         VALUES (?, 'MP3', 'b', 0, '')",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'MP3', 'b', 0)",
     )
     .bind(book_id)
     .execute(&pool)

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -453,8 +453,8 @@ async fn seed_audiobook_for_backfill(
     .unwrap();
 
     let book_file_id: i64 = sqlx::query_scalar(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch) \
-         VALUES (?, ?, ?, 100, '', 100) RETURNING id",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch) \
+         VALUES (?, ?, ?, 100, 100) RETURNING id",
     )
     .bind(book_id)
     .bind(format)

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -367,8 +367,8 @@ async fn insert_audiobook_file_row(
 
     let id = sqlx::query_scalar::<_, i64>(
         "INSERT INTO book_files \
-            (book_id, format, filename, size_bytes, mtime, mtime_epoch) \
-         VALUES (?, ?, ?, ?, '', ?) \
+            (book_id, format, filename, size_bytes, mtime_epoch) \
+         VALUES (?, ?, ?, ?, ?) \
          RETURNING id",
     )
     .bind(book_id)

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -445,16 +445,14 @@ async fn insert_book_file_row(
 ) -> Result<(), sqlx::Error> {
     let m = &b.metadata;
     let (_, file_stem, file_ext) = split_filename(&m.filename);
-    let mtime = m.modified.clone().unwrap_or_default();
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch)
-         VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch)
+         VALUES (?, ?, ?, ?, ?)",
     )
     .bind(book_id)
     .bind(&file_ext)
     .bind(&file_stem)
     .bind(b.size_bytes)
-    .bind(&mtime)
     .bind(b.mtime_epoch)
     .execute(&mut **tx)
     .await?;
@@ -592,20 +590,16 @@ async fn insert_book_row(
     .fetch_one(&mut **tx)
     .await?;
 
-    // The legacy `mtime TEXT` column holds the OPF `dcterms:modified` value
-    // (Dublin Core, not filesystem state) — kept for backward compat. The
-    // new `mtime_epoch INTEGER` column holds the filesystem stat the
-    // incremental diff compares against (migration 0009).
-    let mtime = m.modified.clone().unwrap_or_default();
+    // `mtime_epoch INTEGER` holds the filesystem stat the incremental diff
+    // compares against (migration 0009).
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime, mtime_epoch)
-         VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch)
+         VALUES (?, ?, ?, ?, ?)",
     )
     .bind(book_id)
     .bind(&file_ext)
     .bind(&file_stem)
     .bind(b.size_bytes)
-    .bind(&mtime)
     .bind(b.mtime_epoch)
     .execute(&mut **tx)
     .await?;

--- a/server/src/backend/audiobooks/tests.rs
+++ b/server/src/backend/audiobooks/tests.rs
@@ -39,8 +39,8 @@ async fn seed_one_audiobook(pool: &sqlx::SqlitePool) -> String {
             .unwrap()
             .last_insert_rowid();
     let file_id = sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime) \
-         VALUES (?, 'MP3', 'the-princess-knight', 100, '')",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'MP3', 'the-princess-knight', 100)",
     )
     .bind(book_id)
     .execute(pool)
@@ -272,8 +272,8 @@ async fn seed_audiobook_with_parts(
             .unwrap()
             .last_insert_rowid();
     let file_id = sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime) \
-         VALUES (?, ?, 'book', 0, '')",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, ?, 'book', 0)",
     )
     .bind(book_id)
     .bind(format)

--- a/server/src/backend/ebooks/tests.rs
+++ b/server/src/backend/ebooks/tests.rs
@@ -392,8 +392,8 @@ async fn api_get_ebook_file_returns_200_with_epub_bytes() {
             .unwrap()
             .last_insert_rowid();
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime) \
-         VALUES (?, 'EPUB', ?, 0, '')",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', ?, 0)",
     )
     .bind(book_id)
     .bind(stem)


### PR DESCRIPTION
## Summary
- `book_files` carried two mtime columns: `mtime TEXT` (the OPF `dcterms:modified` value) and `mtime_epoch INTEGER` (the filesystem stat). Only `mtime_epoch` is used — the incremental diff and change detection read it. The TEXT `mtime` was written on every insert but never read back.
- Migration `0024` drops it with `ALTER TABLE book_files DROP COLUMN mtime` (verified no dependent index/trigger). Removed the redundant writes in `sync/books.rs` + `sync/audiobooks.rs`; `mtime_epoch` is kept everywhere and the upstream `Metadata.modified` parse is left intact (just no longer persisted).

## Test plan
- [x] `cargo test -p omnibus-db` — 526 pass, incl. `migration_drops_book_files_mtime_text_column_but_keeps_mtime_epoch`; incremental change-detection coverage (`diff_classifies_mtime_drift_as_changed`, the backfill round-trip) stays green
- [x] `cargo test -p omnibus` — 194 pass
- [x] `cargo clippy` + `cargo fmt --check` clean

## Notes
- Addresses `docs/review/db.md` finding F19. **Stacked on #493 (F8).**