### PR TITLE
fix: collapse duplicate landing-projection subqueries, add sort index

### DIFF
--- a/db/migrations/0025_books_landing_sort_index.sql
+++ b/db/migrations/0025_books_landing_sort_index.sql
@@ -1,0 +1,21 @@
+-- F5 — composite index supporting the library-scoped landing/browse sort.
+-- The landing projection (`list_books_for_paths`, db/src/books/list.rs) joins
+-- `books -> scan_roots` on `library_id`, filters to the configured library
+-- path(s), then `ORDER BY b.sort, b.id`. The only pre-existing covering
+-- indexes are the global `idx_books_sort ON books(sort)` (0002) and the FK
+-- index `idx_books_scan_root_id ON books(library_id)` (0019) — neither can
+-- both seek the `library_id` filter AND supply the sort, so the planner does
+-- a filter-then-temp-sort once the library predicate is in play. This
+-- composite lets the planner seek `library_id` and walk `(sort, id)` in
+-- order, eliminating the temp B-tree sort for the landing/browse read path.
+--
+-- `books.library_id` kept its column name after the F3 `libraries -> scan_roots`
+-- rename (0019). `IF NOT EXISTS` keeps the migration idempotent against any
+-- hand-created index of the same name.
+--
+-- Forward-only, pure secondary index — populated on CREATE with no backfill,
+-- no table recreate (no column types, PKs, or constraints change). A fresh DB
+-- built from 0001..0025 and an upgraded DB converge on the same schema. The
+-- now-partially-redundant global `idx_books_sort` is left in place
+-- deliberately — dropping it is a separate change (F17).
+CREATE INDEX IF NOT EXISTS idx_books_library_sort ON books(library_id, sort, id);

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -27,20 +27,23 @@ pub const MAX_BOOKS_RETURNED: i64 = 50_000;
 /// pattern as `list_books` / `search_books` — one row per `books.id` with
 /// all m2m relations inlined as JSON aggregates. Re-used by the discovery
 /// read paths (`get_author`, `get_series`) via `pub(crate)`.
+///
+/// Single-valued joins that need two columns from the *same* picked row
+/// (the primary `book_files` row, the primary `books_series_link` row) are
+/// pulled as one `json_object` subquery rather than two correlated scalar
+/// subqueries scanning the same table twice — mirroring the `json_object`
+/// shape already used for creators/identifiers. `row_to_ebook` decodes
+/// these blobs.
 pub(crate) const BOOK_COLUMNS: &str = r#"
     b.id, b.uuid,
     b.title, b.description, b.series_index, b.has_cover,
     b.pubdate, b.last_modified, b.timestamp, b.accent_color,
 
-    (SELECT bf.filename FROM book_files bf
+    (SELECT json_object('filename', bf.filename, 'format', bf.format)
+       FROM book_files bf
       WHERE bf.book_id = b.id
       ORDER BY (bf.format != 'EPUB'), bf.format
-      LIMIT 1)                                   AS primary_filename,
-
-    (SELECT bf.format FROM book_files bf
-      WHERE bf.book_id = b.id
-      ORDER BY (bf.format != 'EPUB'), bf.format
-      LIMIT 1)                                   AS primary_format,
+      LIMIT 1)                                   AS primary_file_json,
 
     (SELECT pub.name FROM books_publishers_link bpl
        JOIN publishers pub ON pub.id = bpl.publisher
@@ -52,15 +55,11 @@ pub(crate) const BOOK_COLUMNS: &str = r#"
       WHERE bll.book = b.id ORDER BY lang.code LIMIT 1)
                                                   AS language_code,
 
-    (SELECT s.name FROM books_series_link bsl
+    (SELECT json_object('name', s.name, 'id', s.id)
+       FROM books_series_link bsl
        JOIN series s ON s.id = bsl.series
       WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
-                                                  AS series_name,
-
-    (SELECT s.id FROM books_series_link bsl
-       JOIN series s ON s.id = bsl.series
-      WHERE bsl.book = b.id ORDER BY s.name LIMIT 1)
-                                                  AS series_link_id,
+                                                  AS series_json,
 
     (SELECT json_group_array(json_object('id', a_id, 'name', name, 'sort', sort))
        FROM (SELECT a.id AS a_id, a.name AS name, a.sort AS sort
@@ -101,6 +100,39 @@ pub(crate) struct IdentifierRow {
     pub(crate) value: String,
 }
 
+/// Decoded `primary_file_json` blob: the filename stem + format of the
+/// primary `book_files` row (EPUB-preferred). Both columns come from the
+/// *same* picked row, so a single subquery replaces the former pair.
+#[derive(serde::Deserialize)]
+pub(crate) struct PrimaryFileRow {
+    pub(crate) filename: String,
+    pub(crate) format: String,
+}
+
+/// Decoded `series_json` blob: the name + id of the primary
+/// `books_series_link` row (alphabetical by name). Both columns come from
+/// the *same* picked row, so a single subquery replaces the former pair.
+#[derive(serde::Deserialize)]
+pub(crate) struct SeriesRow {
+    pub(crate) name: String,
+    pub(crate) id: i64,
+}
+
+/// Decode a single `json_object` blob produced by a `LIMIT 1` subquery.
+/// `None` (SQLite NULL — the subquery matched no row) maps to `Ok(None)`,
+/// so callers tolerate the "no primary file" / "no series" case exactly as
+/// the former two-NULL-column pair did.
+pub(crate) fn parse_json_object<T: serde::de::DeserializeOwned>(
+    blob: Option<String>,
+) -> Result<Option<T>, sqlx::Error> {
+    match blob {
+        Some(s) => serde_json::from_str(&s)
+            .map(Some)
+            .map_err(|e| sqlx::Error::Decode(Box::new(e))),
+        None => Ok(None),
+    }
+}
+
 /// Decode a `json_group_array` blob produced by SQLite. Returns `"[]"` for an
 /// aggregate over zero rows, so a `None` here only means the column itself was
 /// NULL (which the subqueries never produce, but we tolerate it defensively).
@@ -139,11 +171,15 @@ pub(crate) fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata,
     let id: i64 = r.get("id");
     let uuid: String = r.get("uuid");
     let has_cover: i64 = r.get("has_cover");
-    let primary_filename: Option<String> = r.get("primary_filename");
-    let primary_format: Option<String> = r.get("primary_format");
-    let filename = match (primary_filename, primary_format) {
-        (Some(stem), Some(fmt)) => format!("{stem}.{}", fmt.to_ascii_lowercase()),
-        _ => String::new(),
+    let primary_file = parse_json_object::<PrimaryFileRow>(r.get("primary_file_json"))?;
+    let filename = match primary_file {
+        Some(pf) => format!("{}.{}", pf.filename, pf.format.to_ascii_lowercase()),
+        None => String::new(),
+    };
+    let series = parse_json_object::<SeriesRow>(r.get("series_json"))?;
+    let (series_name, series_link_id) = match series {
+        Some(s) => (Some(s.name), Some(s.id)),
+        None => (None, None),
     };
     let series_index: Option<f64> = r.get("series_index");
 
@@ -178,9 +214,9 @@ pub(crate) fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata,
         creators,
         subjects,
         identifiers,
-        series: r.get("series_name"),
+        series: series_name,
         series_index: series_index.map(format_series_index),
-        series_id: r.get("series_link_id"),
+        series_id: series_link_id,
         unique_identifier: Some(uuid.clone()),
         cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
         accent: r.get("accent_color"),

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -1830,3 +1830,126 @@ async fn list_indexed_rows_for_formats_returns_empty_for_empty_allow_list() {
         .unwrap();
     assert!(rows.is_empty());
 }
+
+// ---------- F5: collapsed json_object projection (primary file + series) ----------
+
+#[tokio::test]
+async fn list_books_returns_collapsed_primary_file_and_series_for_book_with_series_and_multiple_formats(
+) {
+    // F5: `primary_filename`/`primary_format` and `series_name`/`series_link_id`
+    // each used to be two correlated subqueries scanning the same row twice;
+    // they're now single `json_object` subqueries. This is the equality oracle:
+    // a book that HAS a series AND multiple formats must still yield the
+    // EPUB-primary filename/format and the right series name + id.
+    let _covers = CoversTempDir::new("collapse_primary_and_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed(
+            "saga-book.epub",
+            Some("Saga Book"),
+            &["Author A"],
+            &[],
+            Some(("Saga", "3")),
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    let id = list_books(&pool, "/lib").await.unwrap()[0].id;
+    // Add a second physical format so the EPUB-preferred tiebreak is exercised.
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes)
+         VALUES (?, 'M4B', 'saga-book', 0)",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(books.len(), 1, "multi-format must not duplicate rows");
+    let book = &books[0];
+    // Collapsed primary_file_json: EPUB wins the tiebreak, format lowercased.
+    assert_eq!(book.filename, "saga-book.epub");
+    assert_eq!(book.formats, vec!["EPUB".to_string(), "M4B".to_string()]);
+    // Collapsed series_json: name + id come from the same picked row.
+    assert_eq!(book.series.as_deref(), Some("Saga"));
+    assert_eq!(book.series_index.as_deref(), Some("3"));
+    let expected_series_id = series_id_by_name(&pool, "Saga").await;
+    assert_eq!(book.series_id, Some(expected_series_id));
+}
+
+#[tokio::test]
+async fn get_book_returns_collapsed_primary_file_and_series_for_book_with_series() {
+    // Same collapsed projection on the single-book read path (`get_book`
+    // shares `BOOK_COLUMNS` verbatim through `row_to_ebook`).
+    let _covers = CoversTempDir::new("collapse_get_book");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed(
+            "lonely.epub",
+            Some("Lonely"),
+            &["Author B"],
+            &[],
+            Some(("Saga", "1")),
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    let id = list_books(&pool, "/lib").await.unwrap()[0].id;
+
+    let book = get_book(&pool, id).await.unwrap().expect("book exists");
+    assert_eq!(book.filename, "lonely.epub");
+    assert_eq!(book.series.as_deref(), Some("Saga"));
+    assert_eq!(book.series_id, Some(series_id_by_name(&pool, "Saga").await));
+}
+
+#[tokio::test]
+async fn list_books_returns_no_series_when_book_has_none_after_collapse() {
+    // The collapsed `series_json` subquery returns SQLite NULL (decoded to
+    // `None`) for a book with no `books_series_link` row — same shape the
+    // former two-NULL-column pair produced.
+    let _covers = CoversTempDir::new("collapse_no_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed(
+            "standalone.epub",
+            Some("Standalone"),
+            &["Author C"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(books.len(), 1);
+    assert_eq!(books[0].filename, "standalone.epub");
+    assert_eq!(books[0].series, None);
+    assert_eq!(books[0].series_id, None);
+}
+
+// ---------- migration 0025: library-scoped landing-sort index (F5) ----------
+
+#[tokio::test]
+async fn migration_creates_composite_library_sort_index_for_landing_projection() {
+    // F5: the `(library_id, sort, id)` composite index lets the planner seek
+    // the library filter and supply `ORDER BY sort, id` without a temp sort.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let exists: Option<String> = sqlx::query_scalar(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_books_library_sort'",
+    )
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    assert_eq!(exists.as_deref(), Some("idx_books_library_sort"));
+}


### PR DESCRIPTION
## Summary
- `BOOK_COLUMNS` (the shared landing/search/discovery projection) embedded two pairs of duplicated correlated subqueries: `primary_filename`/`primary_format` scanned `book_files` twice for the same row, and `series_name`/`series_link_id` scanned `books_series_link` twice. Collapsed each pair into a single `json_object` subquery (mirroring the existing creators/identifiers pattern) — 11→9 subqueries per row. Both pairs already used identical `ORDER BY … LIMIT 1`, so the picked row and wire output are byte-identical.
- Migration `0025` adds `idx_books_library_sort ON books(library_id, sort, id)` so the library-scoped landing/browse `ORDER BY sort, id` seeks instead of temp-sorting (the global `idx_books_sort` can't both filter by library and supply the sort).

## Test plan
- [x] `cargo test -p omnibus-db` — 530 pass, incl. 3 new collapse/index tests; the existing list_books / get_book / search_books projection tests are the byte-identity oracle
- [x] `cargo test -p omnibus` — 194 pass
- [x] `cargo test -p omnibus-frontend --features server` — 156 pass
- [x] `cargo clippy` + `cargo fmt --check` clean

## Notes
- **F5a** — the mechanical half of `docs/review/db.md` finding F5. The keyset-pagination half (F5b, a wire-API change) is in the deferred design docs (#485). **Stacked on #494 (F19).**