### PR TITLE
fix: compute author/series browse counts in one pass

### DIFF
--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -1,8 +1,11 @@
 //! Browse-all index pages: `/authors` and `/series`. Returns every row
 //! (capped at `INDEX_LIMIT`) so the UI's client-side sort/filter has the
 //! full list to work with; per-row counts come back override-aware so the
-//! index stays consistent with the discovery-detail reads. Single-tenant
-//! today — no per-user ACL filtering.
+//! index stays consistent with the discovery-detail reads. Counts are
+//! computed in a single reverse-index-driven `GROUP BY` pass (one
+//! `effective` membership CTE, not a correlated subquery per row) so a
+//! multi-thousand-author library doesn't pay an O(rows × books) cost.
+//! Single-tenant today — no per-user ACL filtering.
 
 use sqlx::{Row, SqlitePool};
 
@@ -42,28 +45,45 @@ pub async fn list_authors(
         return Ok(Vec::new());
     }
     let ph = placeholders(library_paths.len());
+    // `effective(author_id, book_id)` is the override-aware membership set,
+    // built once: arm (1) canonical link rows whose book has no creators
+    // override, arm (2) override-derived `(authors.id, book_id)` pairs.
+    // A single `GROUP BY author_id` over it replaces the old per-author
+    // correlated `COUNT(*)` subquery, so the books table is scanned once
+    // rather than once per author. UNION (not ALL) collapses a duplicate
+    // author name inside one override array, matching the old `EXISTS`.
     let sql = format!(
         r#"
-        WITH lib_paths(p) AS (VALUES {ph})
+        WITH lib_paths(p) AS (VALUES {ph}),
+        effective AS (
+            -- (1) Canonical authorship with no creators override.
+            SELECT bal.author AS author_id, bal.book AS book_id
+              FROM books_authors_link bal
+              JOIN books b ON b.id = bal.book
+              JOIN scan_roots l ON l.id = b.library_id
+              LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+             WHERE l.path IN (SELECT p FROM lib_paths)
+               AND (mo.book_uuid IS NULL
+                    OR json_type(mo.overrides, '$.creators') IS NULL)
+            UNION
+            -- (2) Override creators resolved (NOCASE) to an authors row.
+            SELECT a2.id AS author_id, b.id AS book_id
+              FROM books b
+              JOIN scan_roots l ON l.id = b.library_id
+              JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+              JOIN json_each(mo.overrides, '$.creators') je
+              JOIN authors a2
+                ON a2.name = json_extract(je.value, '$.name') COLLATE NOCASE
+             WHERE l.path IN (SELECT p FROM lib_paths)
+               AND json_type(mo.overrides, '$.creators') IS NOT NULL
+        ),
+        counts AS (
+            SELECT author_id, COUNT(*) AS book_count
+              FROM effective
+             GROUP BY author_id
+        )
         SELECT a.id, a.name, a.sort,
-               (SELECT COUNT(*)
-                  FROM books b
-                  JOIN scan_roots l2 ON l2.id = b.library_id
-                  LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-                 WHERE l2.path IN (SELECT p FROM lib_paths)
-                   AND CASE
-                         WHEN mo.book_uuid IS NOT NULL
-                              AND json_type(mo.overrides, '$.creators') IS NOT NULL
-                           THEN EXISTS (
-                             SELECT 1 FROM json_each(mo.overrides, '$.creators') je
-                              WHERE json_extract(je.value, '$.name') = a.name COLLATE NOCASE
-                           )
-                         ELSE EXISTS (
-                           SELECT 1 FROM books_authors_link bal
-                            WHERE bal.book = b.id AND bal.author = a.id
-                         )
-                       END
-               ) AS book_count,
+               COALESCE(c.book_count, 0) AS book_count,
                (SELECT b2.accent_color
                   FROM books_authors_link bal2
                   JOIN books b2 ON b2.id = bal2.book
@@ -80,6 +100,7 @@ pub async fn list_authors(
                     AND ap.bytes IS NOT NULL
                ) AS has_photo
         FROM authors a
+        LEFT JOIN counts c ON c.author_id = a.id
         WHERE EXISTS (
             SELECT 1 FROM books_authors_link bal
               JOIN books b ON b.id = bal.book
@@ -136,29 +157,44 @@ pub async fn list_series(
 }
 
 /// Build the `list_series` SQL for `n` library-path placeholders. Uses a CTE
-/// to materialize the path set once so the four correlated subqueries each see
-/// the same `lib_paths` without repeated inline VALUES lists.
+/// to materialize the path set once so the correlated subqueries (accent,
+/// primary author) each see the same `lib_paths` without repeated inline
+/// VALUES lists. `book_count` comes from a single `GROUP BY` over the
+/// `effective` membership set rather than a per-series correlated subquery,
+/// so the books table is scanned once instead of once per series.
 fn series_index_sql(n: usize) -> String {
     let ph = placeholders(n);
     format!(
         r#"
-        WITH lib_paths(p) AS (VALUES {ph})
+        WITH lib_paths(p) AS (VALUES {ph}),
+        effective AS (
+            -- (1) Canonical members with no series override.
+            SELECT bsl.series AS series_id, bsl.book AS book_id
+              FROM books_series_link bsl
+              JOIN books b ON b.id = bsl.book
+              JOIN scan_roots l ON l.id = b.library_id
+              LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+             WHERE l.path IN (SELECT p FROM lib_paths)
+               AND (mo.book_uuid IS NULL
+                    OR json_type(mo.overrides, '$.series') IS NULL)
+            UNION
+            -- (2) Books whose `overrides.series` names a series (NOCASE).
+            SELECT s2.id AS series_id, b.id AS book_id
+              FROM books b
+              JOIN scan_roots l ON l.id = b.library_id
+              JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+              JOIN series s2
+                ON s2.name = json_extract(mo.overrides, '$.series') COLLATE NOCASE
+             WHERE l.path IN (SELECT p FROM lib_paths)
+               AND json_type(mo.overrides, '$.series') IS NOT NULL
+        ),
+        counts AS (
+            SELECT series_id, COUNT(*) AS book_count
+              FROM effective
+             GROUP BY series_id
+        )
         SELECT s.id, s.name, s.sort,
-               (SELECT COUNT(*)
-                  FROM books b
-                  JOIN scan_roots l2 ON l2.id = b.library_id
-                  LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-                 WHERE l2.path IN (SELECT p FROM lib_paths)
-                   AND CASE
-                         WHEN mo.book_uuid IS NOT NULL
-                              AND json_type(mo.overrides, '$.series') IS NOT NULL
-                           THEN json_extract(mo.overrides, '$.series') = s.name COLLATE NOCASE
-                         ELSE EXISTS (
-                           SELECT 1 FROM books_series_link bsl
-                            WHERE bsl.book = b.id AND bsl.series = s.id
-                         )
-                       END
-               ) AS book_count,
+               COALESCE(c.book_count, 0) AS book_count,
                (SELECT
                   CASE
                     WHEN mo2.book_uuid IS NOT NULL
@@ -187,6 +223,7 @@ fn series_index_sql(n: usize) -> String {
                  ORDER BY b3.series_index NULLS LAST, b3.sort, b3.id
                  LIMIT 1) AS accent
         FROM series s
+        LEFT JOIN counts c ON c.series_id = s.id
         WHERE EXISTS (
             SELECT 1 FROM books_series_link bsl
               JOIN books b ON b.id = bsl.book

--- a/db/src/browse/tests.rs
+++ b/db/src/browse/tests.rs
@@ -144,6 +144,75 @@ async fn list_authors_book_count_follows_override_creators() {
         "Grace picks up saga2 from the override",
     );
 }
+// F6 — the GROUP BY rewrite computes counts from a single `effective`
+// membership CTE (canonical-link arm UNION override-creators arm). These
+// guard that each arm is independently correct and that grouping does not
+// collapse a book shared by two distinct authors into one author's count.
+#[tokio::test]
+async fn list_authors_book_count_independently_reflects_each_override_arm() {
+    // Override saga2 (canonically Ada) so its single creator is Grace.
+    // Arm exercised:
+    //   - override-OUT: Ada must shed saga2 (it now carries a creators
+    //     override and its canonical-link row is excluded from arm (1)).
+    //   - override-IN:  Grace must gain saga2 via the override arm (2),
+    //     even though Grace has no canonical link to saga2.
+    // Expected effective counts: Ada → 2 (saga1 + standalone),
+    // Grace → 2 (saga1 canonical + saga2 override).
+    let (pool, _guard) = seed_discovery_fixture().await;
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let saga2 = books.iter().find(|b| b.filename == "saga2.epub").unwrap();
+    let uuid = saga2.unique_identifier.clone().unwrap();
+
+    let ov = MetadataOverrides {
+        creators: Some(vec![Contributor {
+            name: "Grace Hopper".into(),
+            role: Some("aut".into()),
+            file_as: None,
+            id: None,
+        }]),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+        .await
+        .unwrap();
+
+    let authors = list_authors(&pool, &["/lib"]).await.unwrap();
+    let by_name: std::collections::HashMap<_, _> = authors
+        .iter()
+        .map(|a| (a.name.clone(), a.book_count))
+        .collect();
+    assert_eq!(
+        by_name.get("Ada Lovelace").copied(),
+        Some(2),
+        "override-out arm: Ada drops the overridden book",
+    );
+    assert_eq!(
+        by_name.get("Grace Hopper").copied(),
+        Some(2),
+        "override-in arm: Grace gains the overridden book by name",
+    );
+}
+#[tokio::test]
+async fn list_authors_book_count_counts_a_shared_book_for_both_authors() {
+    // saga1 canonically lists both Ada and Grace. The GROUP BY over the
+    // effective set must emit a `(author_id, book_id)` row for each, so
+    // the single shared book counts toward both authors — grouping must
+    // not collapse cross-author membership.
+    let (pool, _guard) = seed_discovery_fixture().await;
+    let authors = list_authors(&pool, &["/lib"]).await.unwrap();
+    let by_name: std::collections::HashMap<_, _> = authors
+        .iter()
+        .map(|a| (a.name.clone(), a.book_count))
+        .collect();
+    // Ada: saga1 + saga2 + standalone = 3; Grace: saga1 = 1. Both include
+    // the shared saga1, proving it is not deduped across authors.
+    assert_eq!(by_name.get("Ada Lovelace").copied(), Some(3));
+    assert_eq!(by_name.get("Grace Hopper").copied(), Some(1));
+}
 #[tokio::test]
 async fn list_authors_book_count_matches_canonical_creator_case_insensitively() {
     // `authors.name` is `UNIQUE COLLATE NOCASE`; an override that

--- a/db/src/discovery/authors.rs
+++ b/db/src/discovery/authors.rs
@@ -51,8 +51,8 @@ pub async fn get_author(
     }))
 }
 
-/// SQL fragment expressing the override-aware effective author membership.
-/// Used by both `fetch_author_books` (with `SELECT BOOK_COLUMNS`) and
+/// SQL CTE expressing the override-aware effective author membership. Used
+/// by both `fetch_author_books` (with the full `BOOK_COLUMNS` SELECT) and
 /// `count_effective_author_members` (with `COUNT(*)`).
 ///
 /// `apply_overrides` replaces creators wholesale when the override JSON
@@ -61,26 +61,58 @@ pub async fn get_author(
 ///   array, which clears all authors), else
 /// - the canonical names from `books_authors_link`.
 ///
-/// Override creators carry only `name`, so we match by name against the
-/// target author. Bind order: `?1` = author_name, `?2` = author_id.
-const EFFECTIVE_AUTHOR_PREDICATE: &str = r#"FROM books b
-           LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE
-             CASE
-               WHEN mo.book_uuid IS NOT NULL
-                    AND json_type(mo.overrides, '$.creators') IS NOT NULL
-                 THEN EXISTS (
-                   SELECT 1 FROM json_each(mo.overrides, '$.creators') je
-                    WHERE json_extract(je.value, '$.name') = ?1 COLLATE NOCASE
-                 )
-               ELSE EXISTS (
-                 SELECT 1 FROM books_authors_link bal
-                  WHERE bal.book = b.id AND bal.author = ?2
-               )
-             END"#;
+/// Single-pass UNION over (1) canonical link rows for *this* author whose
+/// book has no `creators` override, and (2) override rows whose
+/// `overrides.creators` array names this author. Arm (1) is scoped to
+/// `bal.author = ?2` up front so it drives through the
+/// `idx_books_authors_author` reverse index instead of scanning every
+/// book — mirroring the `EFFECTIVE_SERIES_CTE` shape. Override creators
+/// carry only `name`, so arm (2) matches by name (NOCASE) against `?1`.
+///
+/// Each arm carries the override-aware `series_index` (the same NULLIF
+/// rule `get_series` uses) so the detail page can order by it. An
+/// index-only override on a canonical member still re-sorts here because
+/// arm (1) reads `mo.overrides.series_index` even when creators are
+/// canonical. Bind order: `?1` = author_name, `?2` = author_id.
+const EFFECTIVE_AUTHOR_CTE: &str = r#"WITH effective AS (
+             -- (1) Canonical authorship of this author with no creators
+             -- override. A `series_index` override still drives ordering.
+             SELECT bal.book AS book_id,
+                    CASE
+                      WHEN mo.book_uuid IS NOT NULL
+                           AND json_type(mo.overrides, '$.series_index') IS NOT NULL
+                        THEN CAST(NULLIF(json_extract(mo.overrides, '$.series_index'), '') AS REAL)
+                      ELSE b.series_index
+                    END AS series_index
+               FROM books_authors_link bal
+               JOIN books b ON b.id = bal.book
+               LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+              WHERE bal.author = ?2
+                AND (mo.book_uuid IS NULL
+                     OR json_type(mo.overrides, '$.creators') IS NULL)
+             UNION
+             -- (2) Books whose `overrides.creators` names this author.
+             SELECT b.id AS book_id,
+                    -- NULLIF: an override that explicitly clears the index
+                    -- (`Some("")` from the edit form) would otherwise CAST
+                    -- to 0.0 and sort to the front. Treat empty-string as
+                    -- "no index" and let NULLS LAST trail it.
+                    CASE
+                      WHEN json_type(mo.overrides, '$.series_index') IS NOT NULL
+                        THEN CAST(NULLIF(json_extract(mo.overrides, '$.series_index'), '') AS REAL)
+                      ELSE b.series_index
+                    END AS series_index
+               FROM books b
+               JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+              WHERE json_type(mo.overrides, '$.creators') IS NOT NULL
+                AND EXISTS (
+                  SELECT 1 FROM json_each(mo.overrides, '$.creators') je
+                   WHERE json_extract(je.value, '$.name') = ?1 COLLATE NOCASE
+                )
+           )"#;
 
-/// Run the override-aware author SELECT and hydrate each row into
-/// [`EbookMetadata`]. `series_index` ordering follows the same
+/// Run the `effective`-CTE + `BOOK_COLUMNS` SELECT and hydrate each row
+/// into [`EbookMetadata`]. `series_index` ordering follows the same
 /// override-aware NULLIF rule used in `get_series`. The returned vec is
 /// capped at [`MAX_DISCOVERY_BOOKS`].
 async fn fetch_author_books(
@@ -89,21 +121,11 @@ async fn fetch_author_books(
     author_name: &str,
 ) -> Result<Vec<EbookMetadata>, DiscoveryError> {
     let sql = format!(
-        r#"SELECT {BOOK_COLUMNS}
-           {EFFECTIVE_AUTHOR_PREDICATE}
-           ORDER BY
-             CASE
-               WHEN mo.book_uuid IS NOT NULL
-                    AND json_type(mo.overrides, '$.series_index') IS NOT NULL
-                 -- NULLIF: an override that explicitly clears the index
-                 -- (`Some("")` from the edit form) would otherwise CAST to
-                 -- 0.0 and sort to the front. Treat empty-string as "no
-                 -- index" so ORDER BY's NULLS LAST trails it — matching
-                 -- get_series.
-                 THEN CAST(NULLIF(json_extract(mo.overrides, '$.series_index'), '') AS REAL)
-               ELSE b.series_index
-             END NULLS LAST,
-             b.sort, b.id
+        r#"{EFFECTIVE_AUTHOR_CTE}
+           SELECT {BOOK_COLUMNS}
+           FROM books b
+           JOIN effective e ON e.book_id = b.id
+           ORDER BY e.series_index NULLS LAST, b.sort, b.id
            LIMIT ?3"#
     );
     let rows = sqlx::query(&sql)
@@ -120,7 +142,7 @@ async fn fetch_author_books(
     Ok(books)
 }
 
-/// Count the (uncapped) effective shelf size using the same predicate as
+/// Count the (uncapped) effective shelf size using the same UNION as
 /// [`fetch_author_books`] so `book_count` stays truthful and truncation is
 /// detectable as `book_count > books.len()`.
 async fn count_effective_author_members(
@@ -129,8 +151,8 @@ async fn count_effective_author_members(
     author_name: &str,
 ) -> Result<i64, sqlx::Error> {
     let sql = format!(
-        r#"SELECT COUNT(*)
-           {EFFECTIVE_AUTHOR_PREDICATE}"#
+        r#"{EFFECTIVE_AUTHOR_CTE}
+           SELECT COUNT(*) FROM effective"#
     );
     sqlx::query_scalar(&sql)
         .bind(author_name)

--- a/db/src/discovery/tests.rs
+++ b/db/src/discovery/tests.rs
@@ -434,6 +434,62 @@ async fn get_author_includes_books_whose_override_names_this_author() {
     );
 }
 #[tokio::test]
+async fn get_author_returns_both_canonical_and_override_members_under_reanchored_predicate() {
+    // F6 re-anchor guard: the author-detail predicate now drives through
+    // `books_authors_link WHERE author = ?` (arm 1) UNION the
+    // override-creators set (arm 2). For an author with BOTH a canonical
+    // book and a book overridden INTO them, the detail page must return
+    // the union of both — same books as the old `FROM books` scan.
+    let (pool, _guard) = seed_discovery_fixture().await;
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    // Niklaus canonically has only "Other Story" (Pioneers). Override the
+    // standalone book (canonically Ada's) so its single creator becomes
+    // Niklaus, pulling it into Niklaus's effective set via arm (2).
+    let niklaus_id = author_id_by_name(&pool, "Niklaus Wirth").await;
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let standalone = books
+        .iter()
+        .find(|b| b.filename == "standalone.epub")
+        .unwrap();
+    let uuid = standalone.unique_identifier.clone().unwrap();
+
+    let ov = MetadataOverrides {
+        creators: Some(vec![Contributor {
+            name: "Niklaus Wirth".into(),
+            role: Some("aut".into()),
+            file_as: None,
+            id: None,
+        }]),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+        .await
+        .unwrap();
+
+    let niklaus = get_author(&pool, niklaus_id)
+        .await
+        .unwrap()
+        .expect("author exists");
+    assert_eq!(
+        niklaus.book_count, 2,
+        "canonical (Other Story) + override-in (Standalone) = 2",
+    );
+    let mut titles: Vec<_> = niklaus
+        .books
+        .iter()
+        .map(|b| b.title.clone().unwrap_or_default())
+        .collect();
+    titles.sort();
+    assert_eq!(
+        titles,
+        vec!["Other Story".to_string(), "Standalone".to_string()],
+        "detail predicate must union the canonical and override members",
+    );
+}
+#[tokio::test]
 async fn get_author_excludes_books_whose_override_clears_authors() {
     // A book whose override sets creators to the empty array should
     // disappear from every author's page, matching what the book


### PR DESCRIPTION
## Summary
- `list_authors` / `list_series` computed each row's `book_count` with a correlated scalar subquery joining `books × scan_roots × metadata_overrides` plus a per-book `EXISTS` — once per author/series (quadratic on large libraries). Rewrote to a single `GROUP BY` pass over an effective-membership CTE that UNIONs the canonical-link arm with the override-creators arm, preserving exact counts, ordering, the visibility filter, and the accent / has_photo values.
- Re-anchored the author-detail predicate (`EFFECTIVE_AUTHOR_PREDICATE` → `EFFECTIVE_AUTHOR_CTE`) to drive `FROM books_authors_link WHERE author = ?` (seeking `idx_books_authors_author`) instead of `FROM books b` + correlated `EXISTS`, matching the already-correct series-detail CTE.

## Test plan
- [x] `cargo test -p omnibus-db` — 533 pass; all **14 browse + 21 discovery existing tests** (override-in/out, NOCASE, clear-all, primary-author-follows-override, …) stay green **unchanged** = the result-identity oracle; + 3 new override/detail tests
- [x] `cargo test -p omnibus` — 194 pass
- [x] `cargo test -p omnibus-frontend --features server` — 156 pass
- [x] `cargo clippy` + `cargo fmt --check` clean

## Notes
- Addresses `docs/review/db.md` finding F6. No migration (`idx_books_authors_author` already exists). **Final PR in the db-review stack — stacked on #495 (F5a).**