### PR TITLE
feat: surface processed/total progress on /settings worker indicator (#471)

### DIFF
--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -211,6 +211,18 @@ pub fn diff_library(
 /// elapses). Per-book parse failures are *not* fatal; they land in the
 /// DB as rows with `error = Some(_)`, same as before.
 pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
+    reindex_with_progress(pool, library_path, |_, _| {}).await
+}
+
+/// [`reindex`] variant that calls `on_progress(processed, total)` after
+/// each per-book write inside `sync_books`. Used by
+/// [`crate::worker::Worker`] to report determinate `processed / total`
+/// counts to the UI indicator.
+pub async fn reindex_with_progress(
+    pool: &SqlitePool,
+    library_path: &str,
+    on_progress: impl FnMut(u32, u32),
+) -> anyhow::Result<()> {
     let path_for_scan = library_path.to_owned();
     let library_key_for_scan = library_path.to_owned();
     let stat = tokio::task::spawn_blocking(move || {
@@ -256,7 +268,7 @@ pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()
         removed_uuids: diff.removed,
         backfill: diff.backfill,
     };
-    sync::sync_books(pool, library_path, plan).await?;
+    sync::sync_books_with_progress(pool, library_path, plan, on_progress).await?;
     Ok(())
 }
 
@@ -264,6 +276,18 @@ pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()
 /// reads multi-part tags, then calls [`sync::sync_audiobooks`] to write
 /// `book_file_parts` rows.
 pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
+    reindex_audiobooks_with_progress(pool, library_path, |_, _| {}).await
+}
+
+/// [`reindex_audiobooks`] variant that calls `on_progress(processed,
+/// total)` after each per-book write inside `sync_audiobooks`. Used by
+/// [`crate::worker::Worker`] to report determinate `processed / total`
+/// counts to the UI indicator.
+pub async fn reindex_audiobooks_with_progress(
+    pool: &SqlitePool,
+    library_path: &str,
+    on_progress: impl FnMut(u32, u32),
+) -> anyhow::Result<()> {
     // Phase A: stat every audio file.
     let path_for_scan = library_path.to_owned();
     let library_key = library_path.to_owned();
@@ -341,7 +365,7 @@ pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow
         removed_uuids: diff.removed,
         backfill: diff.backfill,
     };
-    sync::sync_audiobooks(pool, library_path, plan).await?;
+    sync::sync_audiobooks_with_progress(pool, library_path, plan, on_progress).await?;
     Ok(())
 }
 

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -41,8 +41,8 @@ mod fts;
 mod tests;
 
 pub(crate) use audiobooks::insert_chapters;
-pub use audiobooks::{sync_audiobooks, AudiobookSyncPlan};
-pub use books::{replace_books, sync_books, SyncError, SyncPlan};
+pub use audiobooks::{sync_audiobooks, sync_audiobooks_with_progress, AudiobookSyncPlan};
+pub use books::{replace_books, sync_books, sync_books_with_progress, SyncError, SyncPlan};
 
 // The single `books_fts` door. `upsert_fts` / `delete_fts` are
 // `pub(crate)` for the in-tx write sites (sync / merge / undo /

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -46,14 +46,48 @@ pub async fn sync_audiobooks(
     library_path: &str,
     plan: AudiobookSyncPlan,
 ) -> Result<(), SyncError> {
+    sync_audiobooks_with_progress(pool, library_path, plan, |_, _| {}).await
+}
+
+/// [`sync_audiobooks`] variant that calls `on_progress(processed, total)`
+/// after each per-book write. `total` counts the buckets that loop per
+/// book — Changed + New. Removed and Backfill are batched and not
+/// reported as per-book ticks.
+pub async fn sync_audiobooks_with_progress(
+    pool: &SqlitePool,
+    library_path: &str,
+    plan: AudiobookSyncPlan,
+    mut on_progress: impl FnMut(u32, u32),
+) -> Result<(), SyncError> {
+    let total: u32 = (plan.changed_books.len() + plan.new_books.len())
+        .try_into()
+        .unwrap_or(u32::MAX);
+    // Emit (0, total) before any per-book work so the UI flips from
+    // indeterminate spinner to determinate bar on the first poll.
+    on_progress(0, total);
+    let mut processed: u32 = 0;
+
     let mut tx = pool.begin().await?;
     let library_id = upsert_library(&mut tx, library_path).await?;
 
     sync_audiobooks_removed(&mut tx, library_id, &plan.removed_uuids).await?;
-    let changed_covers =
-        sync_audiobooks_changed(&mut tx, library_id, library_path, &plan.changed_books).await?;
+    let changed_covers = sync_audiobooks_changed(
+        &mut tx,
+        library_id,
+        library_path,
+        &plan.changed_books,
+        || {
+            processed = processed.saturating_add(1);
+            on_progress(processed, total);
+        },
+    )
+    .await?;
     let new_covers =
-        sync_audiobooks_new(&mut tx, library_id, library_path, &plan.new_books).await?;
+        sync_audiobooks_new(&mut tx, library_id, library_path, &plan.new_books, || {
+            processed = processed.saturating_add(1);
+            on_progress(processed, total);
+        })
+        .await?;
     backfill_audiobook_stats(&mut tx, library_id, &plan.backfill).await?;
     stamp_audiobooks_last_indexed(&mut tx, library_id).await?;
 
@@ -125,6 +159,7 @@ async fn sync_audiobooks_changed(
     library_id: i64,
     library_path: &str,
     changed_books: &[crate::audiobook::IndexedAudiobook],
+    mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, SyncError> {
     let mut changed_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
     if changed_books.is_empty() {
@@ -154,9 +189,11 @@ async fn sync_audiobooks_changed(
             if let Some((target_id, format)) = attach::attach_target_by_uuid(tx, &b.uuid).await? {
                 attach_audiobook_file(tx, target_id, &format, library_path, b, &mut changed_covers)
                     .await?;
+                on_book_written();
                 continue;
             }
             insert_new_audiobook(tx, library_id, b, &mut changed_covers).await?;
+            on_book_written();
             continue;
         };
 
@@ -186,6 +223,7 @@ async fn sync_audiobooks_changed(
         if let Some((mime, bytes)) = &b.cover {
             changed_covers.push((b.uuid.clone(), mime.clone(), bytes.clone()));
         }
+        on_book_written();
     }
     Ok(changed_covers)
 }
@@ -198,13 +236,16 @@ async fn sync_audiobooks_new(
     library_id: i64,
     library_path: &str,
     new_books: &[crate::audiobook::IndexedAudiobook],
+    mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, SyncError> {
     let mut new_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
     for b in new_books {
         if try_attach_new_audiobook(tx, library_path, b, &mut new_covers).await? {
+            on_book_written();
             continue;
         }
         insert_new_audiobook(tx, library_id, b, &mut new_covers).await?;
+        on_book_written();
     }
     Ok(new_covers)
 }

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -86,6 +86,28 @@ pub async fn sync_books(
     library_path: &str,
     plan: SyncPlan,
 ) -> Result<(), SyncError> {
+    sync_books_with_progress(pool, library_path, plan, |_, _| {}).await
+}
+
+/// [`sync_books`] variant that calls `on_progress(processed, total)`
+/// after each per-book write so the worker can surface a determinate
+/// progress bar. `total` is the count of buckets that loop per book —
+/// Changed + New. Removed and Backfill are batched and not reported as
+/// per-book progress (they're invisible to the user-facing "Scanning"
+/// step).
+pub async fn sync_books_with_progress(
+    pool: &SqlitePool,
+    library_path: &str,
+    plan: SyncPlan,
+    mut on_progress: impl FnMut(u32, u32),
+) -> Result<(), SyncError> {
+    let total: u32 = (plan.changed_books.len() + plan.new_books.len())
+        .try_into()
+        .unwrap_or(u32::MAX);
+    // Emit an initial (0, total) tick so the UI flips from indeterminate
+    // spinner to determinate bar before the first per-book write lands.
+    on_progress(0, total);
+
     let mut tx = pool.begin().await?;
     let library_id = upsert_library(&mut tx, library_path).await?;
 
@@ -94,9 +116,23 @@ pub async fn sync_books(
     // row — drop their `book_files` row + `merged_uuids` entry instead
     // (the target book survives, possibly fileless).
     attach::remove_attached_files(&mut tx, &plan.removed_uuids).await?;
-    let changed_covers =
-        sync_changed(&mut tx, library_id, library_path, &plan.changed_books).await?;
-    let new_covers = sync_new(&mut tx, library_id, library_path, &plan.new_books).await?;
+    let mut processed: u32 = 0;
+    let changed_covers = sync_changed(
+        &mut tx,
+        library_id,
+        library_path,
+        &plan.changed_books,
+        || {
+            processed = processed.saturating_add(1);
+            on_progress(processed, total);
+        },
+    )
+    .await?;
+    let new_covers = sync_new(&mut tx, library_id, library_path, &plan.new_books, || {
+        processed = processed.saturating_add(1);
+        on_progress(processed, total);
+    })
+    .await?;
     backfill_stat_chunks(&mut tx, library_id, &plan.backfill).await?;
     stamp_last_indexed(&mut tx, library_id).await?;
 
@@ -182,6 +218,7 @@ async fn sync_changed(
     library_id: i64,
     library_path: &str,
     changed_books: &[crate::ebook::IndexedBook],
+    mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, sqlx::Error> {
     if changed_books.is_empty() {
         return Ok(Vec::new());
@@ -215,51 +252,76 @@ async fn sync_changed(
     // only invariant any external caller depends on.
     let mut changed_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
     for (b, uuid) in changed_books.iter().zip(all_uuids.iter()) {
-        let Some(&book_id) = id_map.get(uuid) else {
-            // No books row with this uuid. Either the file is an
-            // attachment on another book (its uuid lives in
-            // merged_uuids — refresh that book_files row, leaving the
-            // target book's metadata alone) …
-            if let Some((target_id, format)) = attach::attach_target_by_uuid(tx, uuid).await? {
-                attach_ebook_file(
-                    tx,
-                    target_id,
-                    &format,
-                    library_path,
-                    uuid,
-                    b,
-                    &mut changed_covers,
-                )
-                .await?;
-                continue;
-            }
-            // … or a TOCTOU: the diff said this uuid existed in the DB,
-            // but a concurrent process removed it between Phase A and
-            // the write. Promote to a New insert so the file still gets
-            // indexed.
-            let inserted = insert_book_row(tx, library_id, library_path, b).await?;
-            insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
-            // Source the FTS row from the rows we just wrote via the door.
-            upsert_fts(tx, inserted.book_id).await?;
-            if let Some((mime, bytes)) = &b.cover {
-                changed_covers.push((inserted.uuid, mime.clone(), bytes.clone()));
-            }
-            continue;
-        };
-
-        update_book_row(tx, book_id, b).await?;
-        let (_, _, file_ext) = split_filename(&b.metadata.filename);
-        wipe_per_book_link_rows(tx, book_id, &file_ext).await?;
-        insert_book_file_row(tx, book_id, b).await?;
-        insert_metadata_links(tx, book_id, &b.metadata).await?;
-        // Refresh the FTS row from the freshly-rewritten links via the door.
-        upsert_fts(tx, book_id).await?;
-
-        if let Some((mime, bytes)) = &b.cover {
-            changed_covers.push((uuid.clone(), mime.clone(), bytes.clone()));
-        }
+        sync_changed_one(
+            tx,
+            library_id,
+            library_path,
+            b,
+            uuid,
+            &id_map,
+            &mut changed_covers,
+        )
+        .await?;
+        on_book_written();
     }
     Ok(changed_covers)
+}
+
+/// Apply a single Changed entry — extracted so `sync_changed`'s outer
+/// loop stays a clean per-book progress tick.
+async fn sync_changed_one(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    library_id: i64,
+    library_path: &str,
+    b: &crate::ebook::IndexedBook,
+    uuid: &str,
+    id_map: &HashMap<String, i64>,
+    changed_covers: &mut Vec<(String, String, Vec<u8>)>,
+) -> Result<(), sqlx::Error> {
+    let Some(&book_id) = id_map.get(uuid) else {
+        // No books row with this uuid. Either the file is an
+        // attachment on another book (its uuid lives in
+        // merged_uuids — refresh that book_files row, leaving the
+        // target book's metadata alone) …
+        if let Some((target_id, format)) = attach::attach_target_by_uuid(tx, uuid).await? {
+            attach_ebook_file(
+                tx,
+                target_id,
+                &format,
+                library_path,
+                uuid,
+                b,
+                changed_covers,
+            )
+            .await?;
+            return Ok(());
+        }
+        // … or a TOCTOU: the diff said this uuid existed in the DB,
+        // but a concurrent process removed it between Phase A and
+        // the write. Promote to a New insert so the file still gets
+        // indexed.
+        let inserted = insert_book_row(tx, library_id, library_path, b).await?;
+        insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
+        // Source the FTS row from the rows we just wrote via the door.
+        upsert_fts(tx, inserted.book_id).await?;
+        if let Some((mime, bytes)) = &b.cover {
+            changed_covers.push((inserted.uuid, mime.clone(), bytes.clone()));
+        }
+        return Ok(());
+    };
+
+    update_book_row(tx, book_id, b).await?;
+    let (_, _, file_ext) = split_filename(&b.metadata.filename);
+    wipe_per_book_link_rows(tx, book_id, &file_ext).await?;
+    insert_book_file_row(tx, book_id, b).await?;
+    insert_metadata_links(tx, book_id, &b.metadata).await?;
+    // Refresh the FTS row from the freshly-rewritten links via the door.
+    upsert_fts(tx, book_id).await?;
+
+    if let Some((mime, bytes)) = &b.cover {
+        changed_covers.push((uuid.to_string(), mime.clone(), bytes.clone()));
+    }
+    Ok(())
 }
 
 /// Insert a batch of New entries: canonical `books` + `book_files` row,
@@ -269,10 +331,12 @@ async fn sync_new(
     library_id: i64,
     library_path: &str,
     new_books: &[crate::ebook::IndexedBook],
+    mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, sqlx::Error> {
     let mut new_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
     for b in new_books {
         if try_attach_new_ebook(tx, library_path, b, &mut new_covers).await? {
+            on_book_written();
             continue;
         }
         let inserted = insert_book_row(tx, library_id, library_path, b).await?;
@@ -281,6 +345,7 @@ async fn sync_new(
         if let Some((mime, bytes)) = &b.cover {
             new_covers.push((inserted.uuid, mime.clone(), bytes.clone()));
         }
+        on_book_written();
     }
     Ok(new_covers)
 }

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -1020,6 +1020,144 @@ async fn sync_audiobooks_drops_unsafe_accent_color() {
     );
 }
 
+// ── Progress-callback contract ────────────────────────────────────
+//
+// `sync_books_with_progress` and `sync_audiobooks_with_progress` feed
+// the worker's `report_progress` so the UI indicator can render a
+// determinate `processed / total` bar. The contract: emit `(0, total)`
+// before any per-book write, then tick `processed` monotonically up to
+// `total` (one tick per New + Changed book), with `total` constant
+// across the run. Removed/Backfill counts are deliberately excluded
+// from `total` — they're batched and invisible to the user-facing
+// "Scanning books… N / M" step.
+
+#[tokio::test]
+async fn sync_books_with_progress_emits_initial_zero_and_monotonic_ticks() {
+    let _covers = CoversTempDir::new("progress_books");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let plan = SyncPlan {
+        new_books: vec![
+            indexed_with_stat("a.epub", Some("A"), 1, 1),
+            indexed_with_stat("b.epub", Some("B"), 2, 2),
+            indexed_with_stat("c.epub", Some("C"), 3, 3),
+        ],
+        ..Default::default()
+    };
+    let ticks = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(u32, u32)>::new()));
+    let ticks_cb = ticks.clone();
+    sync_books_with_progress(&pool, "/lib", plan, move |p, t| {
+        ticks_cb.lock().unwrap().push((p, t));
+    })
+    .await
+    .unwrap();
+
+    let ticks = ticks.lock().unwrap().clone();
+    // First tick is (0, total) so the UI can flip from indeterminate
+    // spinner to a determinate bar before the first per-book write.
+    assert_eq!(ticks.first(), Some(&(0u32, 3u32)));
+    // Last tick is (total, total) — we processed every book.
+    assert_eq!(ticks.last(), Some(&(3u32, 3u32)));
+    // Monotonic non-decreasing processed counter; constant total.
+    for pair in ticks.windows(2) {
+        assert!(
+            pair[0].0 <= pair[1].0,
+            "processed must not regress: {ticks:?}"
+        );
+        assert_eq!(pair[0].1, pair[1].1, "total must stay constant: {ticks:?}");
+    }
+}
+
+#[tokio::test]
+async fn sync_books_with_progress_reports_zero_total_for_no_op_plan() {
+    let _covers = CoversTempDir::new("progress_books_noop");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let ticks = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(u32, u32)>::new()));
+    let ticks_cb = ticks.clone();
+    sync_books_with_progress(&pool, "/lib", SyncPlan::default(), move |p, t| {
+        ticks_cb.lock().unwrap().push((p, t));
+    })
+    .await
+    .unwrap();
+    // Even when there's nothing to do we still emit the initial (0, 0)
+    // tick so the UI's "switch to determinate bar" code path runs
+    // consistently.
+    let ticks = ticks.lock().unwrap().clone();
+    assert_eq!(ticks, vec![(0u32, 0u32)]);
+}
+
+#[tokio::test]
+async fn sync_books_with_progress_excludes_removed_and_backfill_from_total() {
+    // Total counts the buckets that loop per-book (Changed + New). The
+    // Removed and Backfill phases are batched SQL — reporting them as
+    // per-book ticks would either inflate `total` for work the user
+    // can't see, or under-count `processed` mid-run.
+    let _covers = CoversTempDir::new("progress_books_buckets");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed("gone.epub", Some("Gone"), &[], &[], None, None),
+            indexed("survivor.epub", Some("Survivor"), &[], &[], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+    let survivor_uuid = stable_uuid("/lib", "survivor.epub");
+    let gone_uuid = stable_uuid("/lib", "gone.epub");
+
+    let plan = SyncPlan {
+        new_books: vec![indexed_with_stat("new.epub", Some("New"), 10, 10)],
+        removed_uuids: vec![gone_uuid],
+        backfill: vec![(survivor_uuid, 42, 42)],
+        ..Default::default()
+    };
+    let ticks = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(u32, u32)>::new()));
+    let ticks_cb = ticks.clone();
+    sync_books_with_progress(&pool, "/lib", plan, move |p, t| {
+        ticks_cb.lock().unwrap().push((p, t));
+    })
+    .await
+    .unwrap();
+
+    let ticks = ticks.lock().unwrap().clone();
+    // 1 New, 0 Changed → total = 1; Removed + Backfill don't bump it.
+    let totals: std::collections::BTreeSet<u32> = ticks.iter().map(|(_, t)| *t).collect();
+    assert_eq!(totals.into_iter().collect::<Vec<_>>(), vec![1u32]);
+    assert_eq!(ticks.last(), Some(&(1u32, 1u32)));
+}
+
+#[tokio::test]
+async fn sync_audiobooks_with_progress_emits_initial_zero_and_monotonic_ticks() {
+    let _covers = CoversTempDir::new("progress_audiobooks");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let plan = AudiobookSyncPlan {
+        new_books: vec![
+            indexed_audiobook("Author/A.m4b", "A", Some("Author")),
+            indexed_audiobook("Author/B.m4b", "B", Some("Author")),
+        ],
+        ..Default::default()
+    };
+    let ticks = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(u32, u32)>::new()));
+    let ticks_cb = ticks.clone();
+    sync_audiobooks_with_progress(&pool, "/lib", plan, move |p, t| {
+        ticks_cb.lock().unwrap().push((p, t));
+    })
+    .await
+    .unwrap();
+
+    let ticks = ticks.lock().unwrap().clone();
+    assert_eq!(ticks.first(), Some(&(0u32, 2u32)));
+    assert_eq!(ticks.last(), Some(&(2u32, 2u32)));
+    for pair in ticks.windows(2) {
+        assert!(
+            pair[0].0 <= pair[1].0,
+            "processed must not regress: {ticks:?}"
+        );
+        assert_eq!(pair[0].1, pair[1].1, "total must stay constant: {ticks:?}");
+    }
+}
+
 /// Build a one-book index entry whose OPF carries the given identifiers.
 fn book_with_identifiers(filename: &str, idents: Vec<Identifier>) -> IndexedBook {
     IndexedBook {

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -11,13 +11,29 @@ impl Worker {
     pub(super) async fn execute(self: &Arc<Self>, task: Task, id: TaskId) -> TaskOutcome {
         match task {
             Task::Scan { library_path } => {
-                match crate::indexer::reindex(&self.pool, &library_path).await {
+                match crate::indexer::reindex_with_progress(
+                    &self.pool,
+                    &library_path,
+                    |processed, total| {
+                        self.report_progress(id, processed, Some(total));
+                    },
+                )
+                .await
+                {
                     Ok(()) => TaskOutcome::Ok,
                     Err(e) => TaskOutcome::Err(e.to_string()),
                 }
             }
             Task::ScanAudiobooks { library_path } => {
-                match crate::indexer::reindex_audiobooks(&self.pool, &library_path).await {
+                match crate::indexer::reindex_audiobooks_with_progress(
+                    &self.pool,
+                    &library_path,
+                    |processed, total| {
+                        self.report_progress(id, processed, Some(total));
+                    },
+                )
+                .await
+                {
                     Ok(()) => {
                         // Post a follow-up chapter backfill task now that the
                         // scan has populated book_file_parts rows. Same resource


### PR DESCRIPTION
## Summary

Background scans (`Task::Scan`, `Task::ScanAudiobooks`) previously held the `/settings` worker indicator on an indeterminate spinner with `processed: 0` until the scan completed — minutes of silence on a library with hundreds of files. The shared `ProgressState::Running { processed, total: Option<u32> }` wire type and the `WorkerStatusIndicator`'s `"(N / M)"` suffix already existed; this PR threads progress callbacks through the backend so they actually populate.

### Schema change to `WorkerState::Running`

None — `total: Option<u32>` was already on the shared `ProgressState::Running` variant (mapped by the indicator's existing `count_suffix` branch). No DTO change required; the wire format stays compatible.

### Backend wiring

- New `sync_books_with_progress` / `sync_audiobooks_with_progress` accept a per-book `on_progress(processed, total)` callback (existing `sync_books` / `sync_audiobooks` delegate with a no-op so all callers keep compiling).
- `total = changed_books.len() + new_books.len()` — the Removed and Backfill buckets are batched SQL with no per-row work the user can see, so they're deliberately excluded from `total`.
- An initial `(0, total)` tick fires before any per-book write so the indicator flips from indeterminate spinner to a determinate bar on the first poll.
- New `reindex_with_progress` / `reindex_audiobooks_with_progress` thread the callback from `Worker::execute` (where it bridges into `Worker::report_progress`) down through the sync orchestrators.
- `sync_changed` in `sync/books.rs` was refactored to extract the per-book body into `sync_changed_one` so the outer loop emits exactly one progress tick per iteration regardless of which branch (attach / TOCTOU / regular update) the book takes.

Out of scope per the issue: HLS transcode and author photo resolution remain indeterminate until a follow-up.

### Frontend render

No render changes — the existing `ActiveRow` in `frontend/src/components/worker_status.rs` already renders `" ({processed} / {total})"` when `state == Running { total: Some(_) }`, and the indeterminate spinner stays the fallback when `total` is `None`. The Playwright `worker-status.spec.ts` already asserts the `"(3 / 10)"` suffix renders against a mocked snapshot, so the frontend contract is locked in by that spec.

### Hydration parity note

No component changes, so the hydration invariant from `.claude/rules/07-hydration.md` is unaffected — `WorkerStatusIndicator` already emits the same rsx on every target (its only target-gated code is the 1 Hz poll sleeper, which lives in a `use_future`, not in the markup).

### Tests added

- `db/src/sync/tests.rs`:
  - `sync_books_with_progress_emits_initial_zero_and_monotonic_ticks` — happy path, asserts initial `(0, total)`, monotonic `processed`, constant `total`, terminal `(total, total)`.
  - `sync_books_with_progress_reports_zero_total_for_no_op_plan` — empty plan still emits `(0, 0)` so the UI's "switch to determinate bar" path runs uniformly.
  - `sync_books_with_progress_excludes_removed_and_backfill_from_total` — Removed + Backfill buckets do not inflate `total`.
  - `sync_audiobooks_with_progress_emits_initial_zero_and_monotonic_ticks` — same contract on the audiobook code path.

The existing Playwright `worker-status.spec.ts` already covers the rendered `"(3 / 10)"` suffix; markup contracts didn't change so no spec update was needed (`run_ui_tests` label not added).

## Test plan

- [x] `cargo test -p omnibus-db` (515 passed)
- [x] `cargo test -p omnibus` (191 passed)
- [x] `cargo test -p omnibus-frontend --features server` (156 passed)
- [x] `cargo test -p omnibus-shared` (31 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default-members)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [ ] Manual smoke on `/settings` — observe `"Scanning library… 42 / 404"` style readout during a real scan (left to reviewer; the Playwright spec covers the rendered shape).

Closes #471

---
_Generated by [Claude Code](https://claude.ai/code/session_0142dHPkiUyKjrudKrF4EAsi)_