### PR TITLE
fix: guard numeric casts against truncation and sign loss (#479)

### DIFF
--- a/db/src/audiobook.rs
+++ b/db/src/audiobook.rs
@@ -77,8 +77,7 @@ pub fn build_indexed_book(path: &Path, filename: String) -> Result<IndexedBook, 
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| filename_stem(&filename));
     let description = meta.duration_seconds.map(|d| {
-        let h = (d / 3600.0) as i64;
-        let m = ((d % 3600.0) / 60.0) as i64;
+        let (h, m) = duration_to_hm(d);
         format!("Audiobook · {h}h {m:02}m")
     });
     let accent = cover
@@ -109,4 +108,24 @@ fn filename_stem(filename: &str) -> String {
         .and_then(|s| s.to_str())
         .map(|s| s.to_string())
         .unwrap_or_else(|| filename.to_string())
+}
+
+/// Split a duration in seconds into `(hours, minutes)` for the human-readable
+/// `Audiobook · {h}h {m:02}m` description. Tag-supplied durations can be
+/// `NaN`/`inf`/negative when a file is corrupt; without this guard those
+/// values get cast straight to `i64::MIN`, surfacing as
+/// `-9223372036854775808h` in the UI. Clamp to a sane upper bound so the
+/// final cast cannot truncate.
+pub(super) fn duration_to_hm(d: f64) -> (i64, i64) {
+    if !d.is_finite() || d < 0.0 {
+        return (0, 0);
+    }
+    let d = d.min(f64::from(i32::MAX));
+    // The `is_finite`+`>= 0` filter and the `i32::MAX` clamp above guarantee
+    // both quotients land in `[0, i32::MAX]` — far inside `i64` range, so
+    // the `as i64` cast is now an in-range truncation, not the saturate-to
+    // `-9223372036854775808` that this helper exists to prevent.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let hm = ((d / 3600.0) as i64, ((d % 3600.0) / 60.0) as i64);
+    hm
 }

--- a/db/src/audiobook/parse.rs
+++ b/db/src/audiobook/parse.rs
@@ -312,8 +312,7 @@ fn build_parts_list(
 
     let total_secs: f64 = parts_work.iter().map(|p| p.duration_seconds).sum();
     let description = if total_secs > 0.0 {
-        let h = (total_secs / 3600.0) as i64;
-        let m = ((total_secs % 3600.0) / 60.0) as i64;
+        let (h, m) = super::duration_to_hm(total_secs);
         Some(format!("Audiobook · {h}h {m:02}m"))
     } else {
         None
@@ -323,7 +322,7 @@ fn build_parts_list(
         .into_iter()
         .enumerate()
         .map(|(i, p)| AudiobookPart {
-            ordinal: i as i64,
+            ordinal: i64::try_from(i).unwrap_or(i64::MAX),
             filename: p.filename,
             size_bytes: p.size_bytes,
             mtime_epoch: p.mtime_epoch,
@@ -357,7 +356,19 @@ fn apply_chapters(
         let abs = library_root.join(&part.filename);
         let part_chapters = super::chapters::extract_chapters(&abs, format);
         chapters.extend(offset_chapters(part_chapters, offset_ms));
-        offset_ms += (part.duration_seconds * 1000.0).round().max(0.0) as u64;
+        // `duration_seconds` is a tag-supplied f64; guard against NaN/inf
+        // and oversize values so the cumulative `offset_ms` stays
+        // monotonic and bounded. Rust's float→int `as` saturates
+        // (NaN→0, overflow→u64::MAX) rather than being undefined, but a
+        // saturated `u64::MAX` would still wreck every subsequent chapter
+        // offset — hence the explicit finite/positive/min-cap guard below.
+        let ms = (part.duration_seconds * 1000.0).round();
+        if ms.is_finite() && ms > 0.0 {
+            let bounded = ms.min(1.0e18);
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let added = bounded as u64;
+            offset_ms = offset_ms.saturating_add(added);
+        }
     }
     chapters
 }

--- a/db/src/audiobook/tests.rs
+++ b/db/src/audiobook/tests.rs
@@ -126,3 +126,31 @@ fn audiobook_error_unsupported_variant_renders_format_token() {
     let s = err.to_string();
     assert!(s.contains("xyz"), "got {s:?}");
 }
+
+#[test]
+fn duration_to_hm_splits_finite_seconds_into_hours_and_minutes() {
+    assert_eq!(duration_to_hm(3661.0), (1, 1));
+    assert_eq!(duration_to_hm(0.0), (0, 0));
+    assert_eq!(duration_to_hm(59.0), (0, 0));
+    assert_eq!(duration_to_hm(7200.0), (2, 0));
+}
+
+#[test]
+fn duration_to_hm_returns_zero_for_non_finite_or_negative_input() {
+    // The bug this guards against: an `f64 as i64` cast of a NaN/inf
+    // duration produced `-9223372036854775808` in the description,
+    // surfacing as a garbled `-9223372036854775808h …m` in the UI.
+    assert_eq!(duration_to_hm(f64::NAN), (0, 0));
+    assert_eq!(duration_to_hm(f64::INFINITY), (0, 0));
+    assert_eq!(duration_to_hm(f64::NEG_INFINITY), (0, 0));
+    assert_eq!(duration_to_hm(-1.0), (0, 0));
+}
+
+#[test]
+fn duration_to_hm_clamps_implausibly_large_values_to_in_range_cast() {
+    // f64 values larger than i32::MAX are clamped so the final `as i64`
+    // cast cannot wrap or saturate-to-MIN.
+    let (h, m) = duration_to_hm(f64::MAX);
+    assert!(h >= 0 && m >= 0);
+    assert!(h <= i64::from(i32::MAX) / 3600 + 1);
+}

--- a/db/src/author_photos/cascade.rs
+++ b/db/src/author_photos/cascade.rs
@@ -142,30 +142,31 @@ pub async fn refetch_all(
     let author_ids: Vec<i64> = sqlx::query_scalar("SELECT id FROM authors ORDER BY id")
         .fetch_all(pool)
         .await?;
-    let total = author_ids.len() as u32;
+    let total = u32::try_from(author_ids.len()).unwrap_or(u32::MAX);
 
     for (i, author_id) in author_ids.iter().enumerate() {
+        let done = u32::try_from(i).unwrap_or(u32::MAX).saturating_add(1);
         match author_photo_status(pool, *author_id).await {
             Ok(Some((AuthorPhotoSource::Manual, _))) => {
-                on_progress((i + 1) as u32, Some(total));
+                on_progress(done, Some(total));
                 continue;
             }
             Ok(_) => {}
             Err(e) => {
                 tracing::warn!(author_id, error = %e, "refetch_all: status check failed, skipping");
-                on_progress((i + 1) as u32, Some(total));
+                on_progress(done, Some(total));
                 continue;
             }
         }
         if let Err(e) = delete_author_photo(pool, *author_id).await {
             tracing::warn!(author_id, error = %e, "refetch_all: delete failed, skipping");
-            on_progress((i + 1) as u32, Some(total));
+            on_progress(done, Some(total));
             continue;
         }
         if let Err(e) = resolve(pool, *author_id).await {
             tracing::warn!(author_id, error = %e, "refetch_all: resolve failed, continuing");
         }
-        on_progress((i + 1) as u32, Some(total));
+        on_progress(done, Some(total));
     }
     Ok(())
 }

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -125,7 +125,7 @@ pub async fn list_authors(
             id: r.get("id"),
             name: r.get("name"),
             sort: r.get("sort"),
-            book_count: r.get::<i64, _>("book_count") as usize,
+            book_count: usize::try_from(r.get::<i64, _>("book_count")).unwrap_or(0),
             accent: r.get("accent"),
             has_photo: r.get::<i64, _>("has_photo") != 0,
         })
@@ -243,7 +243,7 @@ fn map_series_row(r: &sqlx::sqlite::SqliteRow) -> SeriesSummary {
         id: r.get("id"),
         name: r.get("name"),
         sort: r.get("sort"),
-        book_count: r.get::<i64, _>("book_count") as usize,
+        book_count: usize::try_from(r.get::<i64, _>("book_count")).unwrap_or(0),
         primary_author: r.get("primary_author"),
         accent: r.get("accent"),
     }

--- a/db/src/discovery/authors.rs
+++ b/db/src/discovery/authors.rs
@@ -45,7 +45,7 @@ pub async fn get_author(
         id: a.get("id"),
         name: a.get("name"),
         sort: a.get("sort"),
-        book_count: book_count as usize,
+        book_count: usize::try_from(book_count).unwrap_or(0),
         books,
         has_photo,
     }))

--- a/db/src/discovery/series.rs
+++ b/db/src/discovery/series.rs
@@ -39,7 +39,7 @@ pub async fn get_series(
         id: s.get("id"),
         name: s.get("name"),
         sort: s.get("sort"),
-        book_count: book_count as usize,
+        book_count: usize::try_from(book_count).unwrap_or(0),
         books,
     }))
 }

--- a/db/src/discovery/tags.rs
+++ b/db/src/discovery/tags.rs
@@ -96,7 +96,7 @@ pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, Discover
         .iter()
         .map(|r| TagWeight {
             name: r.get("name"),
-            count: r.get::<i64, _>("cnt") as usize,
+            count: usize::try_from(r.get::<i64, _>("cnt")).unwrap_or(0),
         })
         .collect())
 }

--- a/db/src/ebook/accent.rs
+++ b/db/src/ebook/accent.rs
@@ -50,6 +50,10 @@ pub fn extract_accent(bytes: &[u8]) -> Option<String> {
         };
         let sat = if max == 0.0 { 0.0 } else { delta / max };
         let weight = sat * max;
+        // `hue` is in [0.0, 360.0) from the HSV formula above, so the
+        // floored quotient is a small non-negative integer (≤ 12)
+        // before `.min(11)` clamps it into the bucket array.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let idx = ((hue / 30.0).floor() as usize).min(11);
         buckets[idx].r += r * weight;
         buckets[idx].g += g * weight;

--- a/db/src/helpers.rs
+++ b/db/src/helpers.rs
@@ -219,8 +219,18 @@ fn sanitize_fts_tokens(tokens: &[&str]) -> Option<String> {
 }
 
 pub(crate) fn format_series_index(v: f64) -> String {
+    if !v.is_finite() {
+        return format!("{v}");
+    }
     if (v - v.trunc()).abs() < f64::EPSILON {
-        format!("{}", v.trunc() as i64)
+        // Clamp to the f64-exactly-representable integer range before the
+        // cast so an out-of-range value can't saturate to `i64::MIN`/MAX
+        // and surface as `-9223372036854775808` in the UI.
+        const LIMIT: f64 = 9.0e15;
+        let bounded = v.trunc().clamp(-LIMIT, LIMIT);
+        #[allow(clippy::cast_possible_truncation)]
+        let i = bounded as i64;
+        format!("{i}")
     } else {
         format!("{v}")
     }

--- a/db/src/helpers/tests.rs
+++ b/db/src/helpers/tests.rs
@@ -231,3 +231,23 @@ fn stable_uuid_is_version_5() {
         "must use RFC 4122 variant bits"
     );
 }
+
+#[test]
+fn format_series_index_strips_trailing_zeros_for_integer_values() {
+    assert_eq!(format_series_index(1.0), "1");
+    assert_eq!(format_series_index(7.0), "7");
+}
+
+#[test]
+fn format_series_index_keeps_decimal_for_fractional_values() {
+    assert_eq!(format_series_index(1.5), "1.5");
+}
+
+#[test]
+fn format_series_index_passes_through_non_finite_values_verbatim() {
+    // The guarded cast would otherwise saturate `NaN`/`inf` to
+    // `i64::MIN`/`i64::MAX` and surface as a garbled integer.
+    assert_eq!(format_series_index(f64::NAN), "NaN");
+    assert_eq!(format_series_index(f64::INFINITY), "inf");
+    assert_eq!(format_series_index(f64::NEG_INFINITY), "-inf");
+}

--- a/db/src/hls.rs
+++ b/db/src/hls.rs
@@ -296,25 +296,40 @@ pub async fn get_chapters(
 /// resource before the first real transcode finishes.
 pub fn build_manifest(parts: &[HlsPart]) -> String {
     const TARGET: f64 = 10.0;
+    // Cap: 100 hours of audio at 10s/segment. Real audiobooks max out
+    // well below this; anything past it is corrupt tag data and we'd
+    // rather serve the minimal stub than allocate ~100MB of `#EXTINF:`
+    // text from a NaN-derived loop count.
+    const MAX_SEGMENTS: f64 = 36_000.0;
+    // Minimal stub so hls.js/Safari can discover the URL is valid before
+    // the duration probe / transcode finishes. Also the safety fallback
+    // for non-finite / out-of-range totals.
+    const MIN_STUB: &str = concat!(
+        "#EXTM3U\n",
+        "#EXT-X-VERSION:3\n",
+        "#EXT-X-TARGETDURATION:10\n",
+        "#EXT-X-PLAYLIST-TYPE:VOD\n",
+        "#EXT-X-MEDIA-SEQUENCE:0\n",
+        "#EXTINF:0.001,\n",
+        "seg-0000.ts\n",
+        "#EXT-X-ENDLIST\n"
+    );
+
     let total_secs: f64 = parts.iter().map(|p| p.duration_seconds).sum();
 
-    if total_secs <= 0.0 {
-        // Minimal stub so hls.js/Safari can discover the URL is valid before
-        // the duration probe / transcode finishes.
-        return concat!(
-            "#EXTM3U\n",
-            "#EXT-X-VERSION:3\n",
-            "#EXT-X-TARGETDURATION:10\n",
-            "#EXT-X-PLAYLIST-TYPE:VOD\n",
-            "#EXT-X-MEDIA-SEQUENCE:0\n",
-            "#EXTINF:0.001,\n",
-            "seg-0000.ts\n",
-            "#EXT-X-ENDLIST\n"
-        )
-        .to_string();
+    // `<= 0.0` doesn't catch NaN — guard both, otherwise a corrupt tag's
+    // NaN propagates through the division below and emits `#EXTINF:NaN`.
+    if !total_secs.is_finite() || total_secs <= 0.0 {
+        return MIN_STUB.to_string();
     }
 
-    let num_segments = (total_secs / TARGET).ceil() as usize;
+    let segments_f = (total_secs / TARGET).ceil();
+    if segments_f > MAX_SEGMENTS {
+        return MIN_STUB.to_string();
+    }
+    let segments_f = segments_f.max(1.0);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let num_segments = segments_f as usize;
     let mut m3u8 = String::with_capacity(num_segments * 40);
     m3u8.push_str("#EXTM3U\n");
     m3u8.push_str("#EXT-X-VERSION:3\n");
@@ -324,11 +339,16 @@ pub fn build_manifest(parts: &[HlsPart]) -> String {
 
     for i in 0..num_segments {
         let dur = if i == num_segments - 1 {
-            total_secs - (i as f64) * TARGET
+            // `num_segments` is clamped above to a value well within the
+            // f64-exactly-representable integer range, so the `i as f64`
+            // cast cannot lose precision here.
+            #[allow(clippy::cast_precision_loss)]
+            let i_f = i as f64;
+            total_secs - i_f * TARGET
         } else {
             TARGET
         };
-        m3u8.push_str(&format!("#EXTINF:{:.3},\nseg-{:04}.ts\n", dur, i));
+        m3u8.push_str(&format!("#EXTINF:{dur:.3},\nseg-{i:04}.ts\n"));
     }
     m3u8.push_str("#EXT-X-ENDLIST\n");
     m3u8
@@ -364,11 +384,21 @@ pub fn parse_ffmpeg_progress_us(line: &str) -> Option<u64> {
 /// success sentinel `1.0` is reserved for [`finalize_transcode`].
 /// Public for unit testing.
 pub fn ffmpeg_progress_fraction(out_time_us: u64, total_secs: f64) -> f32 {
-    if total_secs <= 0.0 {
+    // `<= 0.0` doesn't catch NaN — guard both so a corrupt-tag NaN
+    // total can't propagate through the division and leak NaN into
+    // the `.progress` sentinel.
+    if !total_secs.is_finite() || total_secs <= 0.0 {
         return 0.05;
     }
+    // `out_time_us` is microseconds since transcode start; even at the
+    // f64-exact ceiling (~2^53 µs ≈ 285 years) precision is well beyond
+    // anything ffmpeg would report.
+    #[allow(clippy::cast_precision_loss)]
     let elapsed_secs = (out_time_us as f64) / 1_000_000.0;
-    (elapsed_secs / total_secs).clamp(0.01, 0.95) as f32
+    let frac = (elapsed_secs / total_secs).clamp(0.01, 0.95);
+    #[allow(clippy::cast_possible_truncation)]
+    let f32_frac = frac as f32;
+    f32_frac
 }
 
 /// Transcode all parts for `(book_id, profile)` to HLS segments via ffmpeg.

--- a/db/src/hls/tests.rs
+++ b/db/src/hls/tests.rs
@@ -233,6 +233,52 @@ fn ffmpeg_progress_fraction_uses_safe_default_when_total_unknown() {
     );
 }
 
+#[test]
+fn ffmpeg_progress_fraction_returns_safe_default_for_non_finite_total() {
+    // Corrupt tag data can surface NaN/inf as the parts' summed
+    // duration. `<= 0.0` doesn't catch NaN, so without the explicit
+    // `is_finite()` guard the function would return NaN and leak it
+    // into the on-disk `.progress` sentinel.
+    let pct = ffmpeg_progress_fraction(60_000_000, f64::NAN);
+    assert!(pct.is_finite() && pct > 0.0, "expected finite, got {pct}");
+    let pct = ffmpeg_progress_fraction(60_000_000, f64::INFINITY);
+    assert!(pct.is_finite() && pct > 0.0, "expected finite, got {pct}");
+    let pct = ffmpeg_progress_fraction(60_000_000, f64::NEG_INFINITY);
+    assert!(pct.is_finite() && pct > 0.0, "expected finite, got {pct}");
+}
+
+#[test]
+fn build_manifest_returns_stub_for_non_finite_total_secs() {
+    // A NaN/inf summed duration from corrupt tag data must NOT make
+    // build_manifest emit `#EXTINF:NaN` or loop over an arbitrary
+    // segment count — it has to fall back to the minimal stub.
+    for d in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let m = build_manifest(&[HlsPart {
+            ordinal: 0,
+            filename: "track.mp3".into(),
+            duration_seconds: d,
+        }]);
+        assert!(!m.contains("NaN"), "manifest leaked NaN for {d}: {m}");
+        assert!(!m.contains("inf"), "manifest leaked inf for {d}: {m}");
+        assert!(m.contains("seg-0000.ts"), "stub missing for {d}: {m}");
+        assert!(m.contains("#EXT-X-ENDLIST"), "stub missing for {d}: {m}");
+    }
+}
+
+#[test]
+fn build_manifest_returns_stub_when_segment_count_exceeds_cap() {
+    // 100 hours = 36000 segments is the documented cap. Anything past
+    // it is corrupt tag data, and we'd rather serve the stub than
+    // allocate ~100MB of `#EXTINF:` text. 200 hours blows the cap.
+    let m = build_manifest(&[HlsPart {
+        ordinal: 0,
+        filename: "track.mp3".into(),
+        duration_seconds: 200.0 * 3600.0,
+    }]);
+    assert!(m.contains("seg-0000.ts"));
+    assert!(!m.contains("seg-0001.ts"), "over-cap manifest leaked: {m}");
+}
+
 // ---------------------------------------------------------------------------
 // Orphan-progress recovery (Bug 1 of #338)
 // ---------------------------------------------------------------------------

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -91,9 +91,10 @@ pub async fn is_stale(pool: &SqlitePool, library_path: &str) -> Result<bool, Ind
     };
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        // Clock unreadable: substitute `last` so `now - last == 0` and we
-        // serve stale (see the doc comment above).
+        .ok()
+        .and_then(|d| i64::try_from(d.as_secs()).ok())
+        // Clock unreadable (or post-Y292B overflow): substitute `last` so
+        // `now - last == 0` and we serve stale (see the doc comment above).
         .unwrap_or(last);
     Ok(is_stale_decision(last, now))
 }
@@ -412,7 +413,7 @@ pub(crate) async fn backfill_chapters(
         return Ok(());
     }
 
-    let total = rows.len() as u32;
+    let total = u32::try_from(rows.len()).unwrap_or(u32::MAX);
     tracing::info!(
         count = total,
         "backfilling chapters for existing audiobooks"
@@ -485,7 +486,10 @@ pub(crate) async fn backfill_chapters(
             sync::insert_chapters(&mut tx, *book_file_id, &chapters, parts).await?;
 
             let global_idx = batch_idx * 250 + i;
-            on_progress(global_idx as u32 + 1, total);
+            let progress = u32::try_from(global_idx)
+                .unwrap_or(u32::MAX)
+                .saturating_add(1);
+            on_progress(progress, total);
         }
         tx.commit().await?;
     }

--- a/db/src/palette/authors.rs
+++ b/db/src/palette/authors.rs
@@ -90,7 +90,7 @@ pub async fn search_authors(
         .map(|r| PaletteAuthorHit {
             id: r.get("id"),
             name: r.get("name"),
-            book_count: r.get::<i32, _>("book_count") as u32,
+            book_count: u32::try_from(r.get::<i32, _>("book_count")).unwrap_or(0),
         })
         .collect())
 }

--- a/db/src/palette/mod.rs
+++ b/db/src/palette/mod.rs
@@ -80,7 +80,7 @@ pub async fn search_palette(
     // D. Tags — substring match, scoped to library.
     let tags = search_tags(pool, library_path, &like_pattern, LIMIT).await?;
 
-    let duration_ms = start.elapsed().as_millis() as u64;
+    let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
     Ok(PaletteResults {
         query: trimmed.to_string(),

--- a/db/src/palette/series.rs
+++ b/db/src/palette/series.rs
@@ -102,7 +102,7 @@ pub async fn search_series(
         .map(|r| PaletteSeriesHit {
             id: r.get("id"),
             name: r.get("name"),
-            book_count: r.get::<i32, _>("book_count") as u32,
+            book_count: u32::try_from(r.get::<i32, _>("book_count")).unwrap_or(0),
             author_display: r.get("author_display"),
         })
         .collect())

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -81,7 +81,7 @@ pub async fn search_tags(
         .map(|r| PaletteTagHit {
             id: r.get("id"),
             name: r.get("name"),
-            book_count: r.get::<i32, _>("book_count") as u32,
+            book_count: u32::try_from(r.get::<i32, _>("book_count")).unwrap_or(0),
         })
         .collect())
 }

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -510,6 +510,10 @@ pub(crate) async fn insert_chapters(
 ) -> Result<(), SyncError> {
     if !chapters.is_empty() {
         let total_duration: f64 = parts.iter().map(|p| p.duration_seconds).sum();
+        // Chapter timestamps are milliseconds; `f64` has 53 bits of
+        // integer precision, so it represents every millisecond exactly
+        // up to ~2^53 ms ≈ 285,000 years — well past any real audiobook.
+        #[allow(clippy::cast_precision_loss)]
         for (i, ch) in chapters.iter().enumerate() {
             let start_seconds = ch.start_ms as f64 / 1000.0;
             let duration_seconds = if ch.end_ms > ch.start_ms {

--- a/db/src/sync/authors.rs
+++ b/db/src/sync/authors.rs
@@ -25,7 +25,13 @@ pub(super) async fn insert_author_links(
         .creators
         .iter()
         .enumerate()
-        .map(|(pos, c)| (c.name.as_str(), c.file_as.as_deref(), pos as i64))
+        .map(|(pos, c)| {
+            (
+                c.name.as_str(),
+                c.file_as.as_deref(),
+                i64::try_from(pos).unwrap_or(i64::MAX),
+            )
+        })
         .collect();
     if entries.is_empty() {
         return Ok(());

--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -96,7 +96,7 @@ fn mtime_epoch(meta: &std::fs::Metadata) -> i64 {
     meta.modified()
         .ok()
         .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-        .map(|d| d.as_secs() as i64)
+        .and_then(|d| i64::try_from(d.as_secs()).ok())
         .unwrap_or(0)
 }
 

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -282,7 +282,8 @@ pub(super) fn lock_unpoison<T>(m: &StdMutex<T>) -> MutexGuard<'_, T> {
 pub(super) fn wall_clock_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_millis()).ok())
         .unwrap_or(0)
 }
 

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -371,7 +371,17 @@ pub(super) fn BdFormatBadge(fmt: String) -> Element {
 /// integer in the stub; the interactive widget will replace this later.
 #[component]
 pub(super) fn BdStars(value: f32) -> Element {
-    let full = value.floor().clamp(0.0, 5.0) as u32;
+    // Clamped to `[0, 5]` so the cast is a trivial in-range truncation.
+    // NaN gets the explicit `is_nan()` branch — Rust's `f32::clamp`
+    // returns NaN for NaN inputs, so the branch is required for the
+    // collapse-to-0 behavior.
+    let bounded = if value.is_nan() {
+        0.0
+    } else {
+        value.floor().clamp(0.0, 5.0)
+    };
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let full = bounded as u32;
     rsx! {
         span { class: "bd-stars-row",
             for i in 0..5u32 {

--- a/frontend/src/pages/landing/sorting.rs
+++ b/frontend/src/pages/landing/sorting.rs
@@ -63,7 +63,7 @@ fn row_key(book: &EbookMetadata, key: SortKey) -> RowKey {
                     .series_index
                     .as_deref()
                     .and_then(|raw| raw.parse::<f64>().ok())
-                    .map(|f| (f * 1000.0).round() as i64)
+                    .map(series_index_to_sort_key)
                     .unwrap_or(0);
                 (s.to_ascii_lowercase(), idx)
             }),
@@ -77,6 +77,24 @@ fn row_key(book: &EbookMetadata, key: SortKey) -> RowKey {
             series: None,
         },
     }
+}
+
+/// Pack a parsed `series_index` (`f64`) into a deterministic integer sort
+/// key by scaling by 1000 (3 decimal places of precision). Guards the cast
+/// so a NaN/inf parsed from a corrupt OPF can't collapse to `i64::MIN` and
+/// shove the book to the top of the series sort.
+fn series_index_to_sort_key(f: f64) -> i64 {
+    if !f.is_finite() {
+        return 0;
+    }
+    // Series indices in practice are small positive decimals (book 1.5 in
+    // a trilogy, etc.). Cap to a sane range — well within the
+    // f64-exactly-representable integer range — so the cast cannot wrap.
+    const MAX_SCALED: f64 = 1.0e15;
+    let scaled = (f * 1000.0).round().clamp(-MAX_SCALED, MAX_SCALED);
+    #[allow(clippy::cast_possible_truncation)]
+    let key = scaled as i64;
+    key
 }
 
 /// Compare two `Option<K>` values where missing always sorts last regardless
@@ -430,5 +448,33 @@ mod tests {
         // Reversed direction does not reverse the tiebreak: ids stay ascending.
         let desc = sort_books(vec![a, b], SortKey::Title, SortDir::Desc);
         assert_eq!(ids(&desc), vec![2, 5]);
+    }
+
+    #[test]
+    fn series_index_to_sort_key_scales_finite_values_by_one_thousand() {
+        assert_eq!(series_index_to_sort_key(1.0), 1_000);
+        assert_eq!(series_index_to_sort_key(1.5), 1_500);
+        assert_eq!(series_index_to_sort_key(0.0), 0);
+        assert_eq!(series_index_to_sort_key(-2.0), -2_000);
+    }
+
+    #[test]
+    fn series_index_to_sort_key_returns_zero_for_non_finite_input() {
+        // The bug this guards against: a NaN/inf parsed from a corrupt OPF
+        // would `as i64` to `i64::MIN`, shoving the book to the top of the
+        // series sort.
+        assert_eq!(series_index_to_sort_key(f64::NAN), 0);
+        assert_eq!(series_index_to_sort_key(f64::INFINITY), 0);
+        assert_eq!(series_index_to_sort_key(f64::NEG_INFINITY), 0);
+    }
+
+    #[test]
+    fn series_index_to_sort_key_clamps_extreme_finite_values_in_range() {
+        let huge = series_index_to_sort_key(1.0e30);
+        let tiny = series_index_to_sort_key(-1.0e30);
+        // Both fall in the f64-exact range so the cast can't saturate to
+        // the wrong sign.
+        assert!(huge > 0);
+        assert!(tiny < 0);
     }
 }

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -22,7 +22,12 @@ pub(super) fn format_hms(seconds: f64) -> String {
     if !seconds.is_finite() || seconds < 0.0 {
         return "0:00".into();
     }
-    let s_total = seconds as u64;
+    // Cap to ~136 years so the cast cannot wrap. Combined with the
+    // finite/non-negative check above, the `as u64` is an in-range
+    // truncation, never a saturation to `u64::MAX`.
+    let bounded = seconds.min(f64::from(u32::MAX));
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let s_total = bounded as u64;
     let h = s_total / 3600;
     let m = (s_total % 3600) / 60;
     let s = s_total % 60;

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -423,7 +423,11 @@ pub fn BookReadPage(uuid: String) -> Element {
         .and_then(|b| b.title.clone())
         .unwrap_or_default();
 
-    let font_pct = ((font_size() - 12) as f32 / 20.0 * 100.0).clamp(0.0, 100.0);
+    // Font size is a small i32 slider value in `[12, 32]`; the `as f32`
+    // cast is exact within that range.
+    #[allow(clippy::cast_precision_loss)]
+    let font_offset = (font_size() - 12) as f32;
+    let font_pct = (font_offset / 20.0 * 100.0).clamp(0.0, 100.0);
 
     rsx! {
         document::Script { src: JSZIP_JS }

--- a/frontend/src/pages/tag_cloud.rs
+++ b/frontend/src/pages/tag_cloud.rs
@@ -77,7 +77,12 @@ pub fn TagCloudPage() -> Element {
 
 /// Render a single tag in the cloud with size/opacity scaled by weight.
 fn render_tag_item(tag: &TagWeight, max_count: usize) -> Element {
-    let weight = tag.count as f64 / max_count as f64;
+    // Tag counts and library sizes both comfortably fit a `u32`, well within
+    // the f64-exactly-representable integer range. Saturating cast guards
+    // against the unlikely-but-possible >4B case rather than asserting.
+    let count_f = f64::from(u32::try_from(tag.count).unwrap_or(u32::MAX));
+    let max_f = f64::from(u32::try_from(max_count).unwrap_or(u32::MAX));
+    let weight = if max_f == 0.0 { 0.0 } else { count_f / max_f };
     let size = 16.0 + (weight * 56.0);
     let opacity = 0.55 + (weight * 0.45);
     let is_high = weight > 0.7;

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -61,10 +61,15 @@ fn auth_error_to_response(e: AuthError) -> Response {
         // "invalid credentials" body as a wrong password, but with 429 and
         // a `Retry-After` header so a well-behaved client can back off.
         AuthError::AccountLocked { until_unix } => {
+            // Fall open at `until_unix` if SystemTime is unreadable or
+            // doesn't fit i64 — that makes `retry_after = 0` rather than
+            // an enormous header that prolongs the lockout for a clock
+            // glitch the client didn't cause.
             let now_unix = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
+                .ok()
+                .and_then(|d| i64::try_from(d.as_secs()).ok())
+                .unwrap_or(until_unix);
             let retry_after = until_unix.saturating_sub(now_unix).max(0);
             let mut headers = HeaderMap::new();
             if let Ok(v) = retry_after.to_string().parse() {


### PR DESCRIPTION
## Summary

Replaces silent `as` casts in production code with `try_from` and clamp-and-guard patterns so corrupt or pathological inputs can no longer silently truncate or saturate to a wrong value.

### Headline user-visible fix

The motivating bug from #479: `db/src/audiobook.rs` built the
`Audiobook · {h}h {m:02}m` description by casting an `f64`
duration straight to `i64`. A NaN/inf duration (which can come
out of a corrupt audio tag) surfaced as
`-9223372036854775808h …m` in the library UI.

The new `duration_to_hm(d: f64) -> (i64, i64)` helper rejects
non-finite values, clamps to a sane upper bound (`i32::MAX`
seconds, well over a billion years of audiobook), and only then
performs the integer cast. The same helper is reused by
`audiobook::parse` so the parts-flow description gets the same
guarantee.

### Companion fixes (same `as` → `try_from` / clamped-cast idiom)

- `i64 as usize` book/tag counts from SQL `COUNT(*)` →
  `usize::try_from(...).unwrap_or(0)`
  (`discovery::{authors,series,tags}`, `browse`,
  `palette::{authors,series,tags}`).
- `u64 as i64` Unix timestamps and `u128 as i64` elapsed-ms →
  `i64::try_from(...).ok().unwrap_or(...)`
  (`auth::handlers`, `worker::types`, `thumbs`,
  `indexer::is_stale`).
- `usize as u32` progress counters → saturating
  `u32::try_from(...).unwrap_or(u32::MAX)`
  (`author_photos::cascade`, `indexer`).
- `f64 as u64` / `f64 as i64` for series-index sort key
  (`landing::sorting`), `format_hms` (`listen::helpers`),
  `format_series_index` (`db::helpers`), and HLS manifest
  (`db::hls`) → guarded with finite checks and clamped to a
  known-safe range before the cast.
- `i32 as u32` star rating / tag-cloud counts → `try_from`.
- `u128 as u64` palette duration → saturating `try_from`.
- `f32 as u32` star count in `book_detail::BdStars` → NaN guarded
  with the existing clamp.

A handful of casts remain after the guard / clamp prologue (e.g.
the final `as i64` inside `duration_to_hm` after the value has
been clamped into `[0, i32::MAX]`). Each one carries a tightly
scoped `#[allow(clippy::cast_possible_truncation, …)]` with a
comment documenting why the cast is sound — reviewers can verify
the safety argument without re-running clippy.

### Verification

- `cargo clippy --all-targets -- -W clippy::cast_possible_truncation -W clippy::cast_sign_loss -W clippy::cast_precision_loss` reports
  **no warnings in production code**. The single remaining
  warning is `server/src/rate_limit.rs:425`, inside a `#[tokio::test]`
  body — the issue explicitly allows test-only casts.
- `cargo clippy --all-targets -- -D warnings` (default lints) is clean.
- `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- Test suite (run sequentially, the parallel run hit a workspace
  disk pressure limit, not a test failure):
  - `cargo test -p omnibus-db --lib` — **514 passed**
  - `cargo test -p omnibus --lib` — **191 passed**
  - `cargo test -p omnibus-frontend --features server --lib` —
    **156 passed**
- New unit coverage:
  - `db::audiobook::tests` — three cases pinning
    `duration_to_hm` (finite happy path, non-finite returns
    `(0, 0)`, extreme clamp).
  - `db::helpers::tests` — `format_series_index` integer /
    fractional / non-finite paths.
  - `frontend::pages::landing::sorting::tests` — three cases
    pinning `series_index_to_sort_key` against the original
    `i64::MIN` failure mode.

### Notes for the reviewer

- The mobile crate could not be linted from this sandbox
  (`gdk-3.0` is provided by `nix develop .#mobile`, unavailable
  here). No mobile sources were touched, so this is a tooling
  gap rather than a coverage gap.
- The acceptance criterion called for "no warnings in production
  code", which is broader than the 20 cited sites. The fix
  therefore also touches obvious sibling sites the issue did not
  cite by name (e.g. `db::browse` book counts, mirroring
  `discovery::{authors,series}`; `palette::series` mirroring
  `palette::{authors,tags}`; `db::helpers::format_series_index`;
  `worker::types::wall_clock_ms`; HLS manifest segments). Any
  *remaining* pedantic-cast cleanup elsewhere in the workspace
  (non-cast `clippy::pedantic` warnings, mobile sources) stays
  out of scope for #480.

Closes #479

---
_Generated by [Claude Code](https://claude.ai/code/session_0142dHPkiUyKjrudKrF4EAsi)_