### PR TITLE
feat: add windowed session indexes for stats

### DIFF
--- a/db/migrations/0020_session_stats_indexes.sql
+++ b/db/migrations/0020_session_stats_indexes.sql
@@ -1,0 +1,18 @@
+-- F3.4 stats: windowed-aggregate indexes for the session tables.
+--
+-- The stats feature groups a user's sessions by day over a date range
+-- (`GROUP BY date(started_at)`, `SUM(seconds_read)`) filtered by user,
+-- targeting < 250 ms cold on 10k events. The existing `(user_id, book_id)`
+-- indexes from 0013 can't range-scan a time window, so each `/stats`
+-- query would otherwise degrade to a per-user table scan filtered in
+-- memory by date. `(user_id, started_at)` lets SQLite range-scan the
+-- window directly.
+--
+-- `reading_progress` gets `(user_id, updated_at)` for most-recent-write
+-- ordering (the "continue reading" rail). No `(user_id, ended_at)` index
+-- is added — no current or roadmap query ranges or groups on `ended_at`
+-- (duration is the precomputed `seconds_read`/`seconds_listened` column),
+-- and the repo bans speculative indexes.
+CREATE INDEX idx_reading_sessions_user_started   ON reading_sessions(user_id, started_at);
+CREATE INDEX idx_listening_sessions_user_started ON listening_sessions(user_id, started_at);
+CREATE INDEX idx_reading_progress_user_updated   ON reading_progress(user_id, updated_at);

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -313,3 +313,24 @@ async fn record_session_tx_rollback_leaves_no_rows() {
     .unwrap();
     assert_eq!(count, 0, "dropped transaction must leave no committed rows");
 }
+
+#[tokio::test]
+async fn migration_0020_adds_windowed_session_indexes_for_stats() {
+    // F3.4 stats range-scans sessions by `(user_id, started_at)` and the
+    // progress rail orders by `(user_id, updated_at)`. Assert migration
+    // 0020 created each index so those windowed queries can use them.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    for index in [
+        "idx_reading_sessions_user_started",
+        "idx_listening_sessions_user_started",
+        "idx_reading_progress_user_updated",
+    ] {
+        let found: Option<String> =
+            sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+                .bind(index)
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert_eq!(found.as_deref(), Some(index), "missing index {index}");
+    }
+}


### PR DESCRIPTION
## Summary
- Migration `0020` adds `(user_id, started_at)` to `reading_sessions` + `listening_sessions`, and `(user_id, updated_at)` to `reading_progress`, for the F3.4 stats windowed aggregation and the continue-reading rail. Omits `(user_id, ended_at)` per the no-speculative-index rule.

## Test plan
- [x] `cargo test -p omnibus-db` green incl. `migration_0020_adds_windowed_session_indexes_for_stats`

## Notes
- Addresses `docs/review/db.md` finding F12. Replaces #489 (auto-closed when the F3 base branch was deleted during merge); rebased onto current `main`. Base of the remaining db-review stack.