### PR TITLE
refactor: extract merge_books into snapshot/migrate/finalize helpers (#502)

### DIFF
--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -9,7 +9,7 @@ use omnibus_shared::MetadataOverrides;
 use crate::covers::{find_cover_file, write_cover_file};
 use crate::sync::delete_fts;
 
-use super::snapshot::build_snapshot;
+use super::snapshot::{build_snapshot, SourceSnapshot};
 use super::{MergeError, MergeOutcome};
 
 /// Merge the book identified by `source_uuid` into the one identified by
@@ -30,22 +30,10 @@ pub async fn merge_books(
     }
     let mut tx = pool.begin().await?;
 
-    let source_id = resolve_book(&mut tx, source_uuid).await?;
-    let target_id = resolve_book(&mut tx, target_uuid).await?;
-    if source_id == target_id {
-        return Err(MergeError::SameBook);
-    }
-    let snapshot = build_snapshot(&mut tx, source_id).await?;
+    let (source_id, target_id, snapshot) =
+        snapshot_source_book(&mut tx, source_uuid, target_uuid).await?;
 
-    move_book_files(
-        &mut tx,
-        source_id,
-        target_id,
-        &snapshot.library_path,
-        &snapshot.path,
-    )
-    .await?;
-    assign_ordinals_after_move(&mut tx, target_id, &snapshot.title).await?;
+    migrate_book_files(&mut tx, source_id, target_id, &snapshot).await?;
     move_links(&mut tx, source_id, target_id).await?;
     move_progress_and_history(&mut tx, source_id, target_id).await?;
     move_identifiers(&mut tx, source_id, target_id).await?;
@@ -79,21 +67,7 @@ pub async fn merge_books(
         .await?;
     }
 
-    let merge_log_id: i64 = sqlx::query_scalar(
-        "INSERT INTO merge_log (target_book_id, source_uuid, source_metadata, merged_by)
-         VALUES (?, ?, ?, ?) RETURNING id",
-    )
-    .bind(target_id)
-    .bind(source_uuid)
-    .bind(serde_json::to_string(&snapshot)?)
-    .bind(merged_by)
-    .fetch_one(&mut *tx)
-    .await?;
-
-    sqlx::query("DELETE FROM books WHERE id = ?")
-        .bind(source_id)
-        .execute(&mut *tx)
-        .await?;
+    let merge_log_id = finalize_merge(&mut tx, target_id, source_id, &snapshot, merged_by).await?;
 
     tx.commit().await?;
 
@@ -123,6 +97,70 @@ pub async fn merge_books(
         merge_log_id,
         target_uuid: target_uuid.to_owned(),
     })
+}
+
+/// Resolve both uuids to row ids, re-check same-book, then freeze the
+/// source book's metadata into a [`SourceSnapshot`] for the merge log.
+async fn snapshot_source_book(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    source_uuid: &str,
+    target_uuid: &str,
+) -> Result<(i64, i64, SourceSnapshot), MergeError> {
+    let source_id = resolve_book(tx, source_uuid).await?;
+    let target_id = resolve_book(tx, target_uuid).await?;
+    if source_id == target_id {
+        return Err(MergeError::SameBook);
+    }
+    let snapshot = build_snapshot(tx, source_id).await?;
+    Ok((source_id, target_id, snapshot))
+}
+
+/// Re-parent the source's `book_files` onto the target and renormalize
+/// the moved rows' ordinals/labels.
+async fn migrate_book_files(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    source_id: i64,
+    target_id: i64,
+    snapshot: &SourceSnapshot,
+) -> Result<(), sqlx::Error> {
+    move_book_files(
+        tx,
+        source_id,
+        target_id,
+        &snapshot.library_path,
+        &snapshot.path,
+    )
+    .await?;
+    assign_ordinals_after_move(tx, target_id, &snapshot.title).await?;
+    Ok(())
+}
+
+/// Append the merge-log entry and delete the source book row. Returns
+/// the new `merge_log.id` (the undo handle).
+async fn finalize_merge(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    target_id: i64,
+    source_id: i64,
+    snapshot: &SourceSnapshot,
+    merged_by: Option<i64>,
+) -> Result<i64, MergeError> {
+    let merge_log_id: i64 = sqlx::query_scalar(
+        "INSERT INTO merge_log (target_book_id, source_uuid, source_metadata, merged_by)
+         VALUES (?, ?, ?, ?) RETURNING id",
+    )
+    .bind(target_id)
+    .bind(&snapshot.uuid)
+    .bind(serde_json::to_string(snapshot)?)
+    .bind(merged_by)
+    .fetch_one(&mut **tx)
+    .await?;
+
+    sqlx::query("DELETE FROM books WHERE id = ?")
+        .bind(source_id)
+        .execute(&mut **tx)
+        .await?;
+
+    Ok(merge_log_id)
 }
 
 /// Resolve a uuid to its `books.id` — real rows only, no `merged_uuids`


### PR DESCRIPTION
## Summary
- **1 of 12 functions from #502** — the db-crate `merge_books` orchestrator in `db/src/merge/transaction.rs`. The other 11 frontend functions stay open under #502 for follow-up PRs.
- `pub async fn merge_books` was 105 lines (issue cited 107); now 79 lines, under the ~80-line soft cap from rule `05-rust-style`.
- Three private helpers extracted, mirroring the stages the issue suggested:
  - `snapshot_source_book(tx, source_uuid, target_uuid)` — resolves both uuids, re-checks the same-book guard, and freezes the source-book metadata via `build_snapshot`.
  - `migrate_book_files(tx, source_id, target_id, snapshot)` — re-parents `book_files` and renormalizes ordinals/labels via the existing `move_book_files` + `assign_ordinals_after_move` pair.
  - `finalize_merge(tx, target_id, source_id, snapshot, merged_by)` — writes the `merge_log` row and deletes the source book; returns the new `merge_log.id`.
- All three helpers accept `&mut Transaction<'_, sqlx::Sqlite>` and propagate errors via `?`. None of them call `tx.commit()` — the orchestrator still owns the single commit, so the merge stays a single atomic unit.
- Error type at the boundary is unchanged: `merge_books` still returns `Result<MergeOutcome, MergeError>`. Helpers reuse `MergeError` (for stages that touch `serde_json` / same-book) or `sqlx::Error` (for the pure-DB helper).

## Test plan
- [x] `cargo fmt -p omnibus-db -- --check` — clean.
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — passes with no warnings.
- [x] `cargo test -p omnibus-db` — 539 unit tests + 2 integration tests pass (same counts as `main`). The existing `merge::tests` module pins the contract via the public `merge_books` API.
- [x] `merge_books` line count after refactor: **79 lines** (was 105).
- [x] Atomicity preserved: only `merge_books` calls `tx.commit()`; helpers borrow `&mut tx` and propagate via `?`.

## Notes
- This PR addresses 1 of the 12 functions listed in #502. The remaining 11 stay for follow-up PRs and #502 stays open:
  - `frontend/src/pages/landing/table.rs` — `fn EbookRow` (298)
  - `frontend/src/pages/metadata_edit.rs` — `fn MetadataEditForm` (238)
  - `frontend/src/pages/author.rs` — `fn render_author` (237)
  - `frontend/src/pages/settings.rs` — `pub fn SettingsPage` (197)
  - `frontend/src/components/author_photo_edit.rs` — `fn AuthorPhotoEditModal` (193)
  - `frontend/src/components/user_menu.rs` — `fn UserMenuPanel` (163)
  - `frontend/src/pages/search.rs` — `pub fn SearchPage` (156)
  - `frontend/src/components/merge_dialog.rs` — `pub fn MergeDialog` (155)
  - `frontend/src/pages/listen/mini_dock.rs` — `pub fn MiniDock` (154)
  - `frontend/src/pages/authors_index.rs` — `fn AuthorsIndexHeader` (108)
  - `frontend/src/components/worker_status.rs` — `pub fn WorkerStatusIndicator` (106)
- No new `#[allow(...)]` suppressions, no public-API changes, no schema or behavior changes.

Refs #502

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWSxyKrouXUWCSz18RSEbi)_