### PR TITLE
refactor: extract WorkerStatusIndicator helpers (#502)

### DIFF
--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -80,10 +80,7 @@ pub fn WorkerStatusIndicator() -> Element {
     }
 }
 
-/// Drop dismissed ids that the server has already evicted, so the set
-/// stays bounded by `len(recent_complete)` rather than growing
-/// monotonically across the session. Writes only when something
-/// actually changed to avoid signal-write churn on every poll.
+/// Drop dismissed ids the server has already evicted so the set stays bounded by `recent_complete`.
 fn prune_dismissed(mut dismissed: Signal<std::collections::HashSet<u64>>, snap: &WorkerStatus) {
     let current = dismissed();
     let live: std::collections::HashSet<u64> = current
@@ -96,8 +93,7 @@ fn prune_dismissed(mut dismissed: Signal<std::collections::HashSet<u64>>, snap: 
     }
 }
 
-/// Render a single terminal-state row, dispatching on `task.state` to
-/// the matching `DoneRow` / `FailedRow` / defensive `ActiveRow` element.
+/// Render a single terminal-state row, dispatching on `task.state` to the matching row component.
 fn terminal_row(
     task: &TaskProgress,
     mut dismissed: Signal<std::collections::HashSet<u64>>,

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -28,7 +28,7 @@ pub fn WorkerStatusIndicator() -> Element {
     // Pruned on every render to ids still present in `recent_complete`
     // so the set can't grow past the server's own ~10 s retention
     // window (see snapshot loop below).
-    let mut dismissed = use_signal(std::collections::HashSet::<u64>::new);
+    let dismissed = use_signal(std::collections::HashSet::<u64>::new);
 
     let url_for_poll = server_url.clone();
     use_future(move || {
@@ -48,21 +48,7 @@ pub fn WorkerStatusIndicator() -> Element {
     });
 
     let snap = status();
-    // Drop any dismissed ids that the server has already evicted, so the
-    // set stays bounded by `len(recent_complete)` rather than growing
-    // monotonically across the session. Only writes when something
-    // actually changed to avoid signal-write churn on every poll.
-    {
-        let current = dismissed();
-        let live: std::collections::HashSet<u64> = current
-            .iter()
-            .copied()
-            .filter(|id| snap.recent_complete.iter().any(|p| p.task_id == *id))
-            .collect();
-        if live.len() != current.len() {
-            dismissed.set(live);
-        }
-    }
+    prune_dismissed(dismissed, &snap);
     let visible_terminals: Vec<TaskProgress> = snap
         .recent_complete
         .iter()
@@ -88,42 +74,65 @@ pub fn WorkerStatusIndicator() -> Element {
             // Recently-finished tasks. Done → inline success row that
             // fades client-side; Failed → red banner with dismiss.
             for task in visible_terminals.iter() {
-                {
-                    let id = task.task_id;
-                    match &task.state {
-                        ProgressState::Done { .. } => rsx! {
-                            DoneRow {
-                                key: "{id}",
-                                kind: task.kind,
-                                on_dismiss: move |_| {
-                                    let mut set = dismissed();
-                                    set.insert(id);
-                                    dismissed.set(set);
-                                },
-                            }
-                        },
-                        ProgressState::Failed { message } => rsx! {
-                            FailedRow {
-                                key: "{id}",
-                                kind: task.kind,
-                                message: message.clone(),
-                                on_dismiss: move |_| {
-                                    let mut set = dismissed();
-                                    set.insert(id);
-                                    dismissed.set(set);
-                                },
-                            }
-                        },
-                        // Defensive: a Running entry shouldn't be in
-                        // recent_complete, but render it as active rather
-                        // than panicking on the unreachable arm.
-                        ProgressState::Running { .. } => rsx! {
-                            ActiveRow { key: "{id}", task: task.clone() }
-                        },
-                    }
-                }
+                {terminal_row(task, dismissed)}
             }
         }
+    }
+}
+
+/// Drop dismissed ids that the server has already evicted, so the set
+/// stays bounded by `len(recent_complete)` rather than growing
+/// monotonically across the session. Writes only when something
+/// actually changed to avoid signal-write churn on every poll.
+fn prune_dismissed(mut dismissed: Signal<std::collections::HashSet<u64>>, snap: &WorkerStatus) {
+    let current = dismissed();
+    let live: std::collections::HashSet<u64> = current
+        .iter()
+        .copied()
+        .filter(|id| snap.recent_complete.iter().any(|p| p.task_id == *id))
+        .collect();
+    if live.len() != current.len() {
+        dismissed.set(live);
+    }
+}
+
+/// Render a single terminal-state row, dispatching on `task.state` to
+/// the matching `DoneRow` / `FailedRow` / defensive `ActiveRow` element.
+fn terminal_row(
+    task: &TaskProgress,
+    mut dismissed: Signal<std::collections::HashSet<u64>>,
+) -> Element {
+    let id = task.task_id;
+    match &task.state {
+        ProgressState::Done { .. } => rsx! {
+            DoneRow {
+                key: "{id}",
+                kind: task.kind,
+                on_dismiss: move |_| {
+                    let mut set = dismissed();
+                    set.insert(id);
+                    dismissed.set(set);
+                },
+            }
+        },
+        ProgressState::Failed { message } => rsx! {
+            FailedRow {
+                key: "{id}",
+                kind: task.kind,
+                message: message.clone(),
+                on_dismiss: move |_| {
+                    let mut set = dismissed();
+                    set.insert(id);
+                    dismissed.set(set);
+                },
+            }
+        },
+        // Defensive: a Running entry shouldn't be in recent_complete,
+        // but render it as active rather than panicking on the
+        // unreachable arm.
+        ProgressState::Running { .. } => rsx! {
+            ActiveRow { key: "{id}", task: task.clone() }
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

- 1 of 12 oversized functions from #502 — narrowed scope: the frontend `WorkerStatusIndicator` in `frontend/src/components/worker_status.rs`.
- Split the 106-line component body into ~59 lines by extracting two named helpers in the same file:
  - `prune_dismissed` — bounded-set maintenance for client-suppressed terminal task ids.
  - `terminal_row` — match-on-state row dispatch (`Done` / `Failed` / defensive `Running`).
- The 1 Hz polling effect stays in the parent component, per the issue suggestion.
- A separate concurrent PR addresses `merge_books` in `db/src/merge/transaction.rs` (the other narrowed scope of #502).

## Test plan

- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` passes.
- [x] `cargo test -p omnibus-frontend --features server` passes (156 tests, 0 failures, unchanged from main).
- [x] `cargo fmt` clean.

## Notes

- **Hydration parity preserved**: no new `#[cfg(feature = "web"/"server"/"mobile")]` gates around any rsx. The only target-gated code remains the existing `async_sleep_ms` sleeper outside the component body, exactly as before. Helper signatures take `Signal<HashSet<u64>>` so the parent owns hook ordering — no new hook calls inside the helpers.
- Helpers carry one-line `///` doc summaries per project convention.

Refs #502

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWSxyKrouXUWCSz18RSEbi)_