### PR TITLE
fix: validate highlight cfi/note length at handler boundary (#501)

### DIFF
--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -592,6 +592,9 @@ pub async fn rpc_search_palette(q: String) -> Result<PaletteResults> {
 
 #[post("/api/rpc/highlights/create", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_create_highlight(input: CreateHighlight) -> Result<Highlight> {
+    if let Err(msg) = input.validate() {
+        return Err(ServerFnError::new(msg).into());
+    }
     match db::highlights::create_highlight(&pool.0, user.id, &input).await {
         Ok(h) => Ok(h),
         Err(db::highlights::HighlightError::BookNotFound) => {
@@ -633,6 +636,9 @@ pub async fn rpc_update_highlight_color(id: i64, color: HighlightColor) -> Resul
 
 #[post("/api/rpc/highlights/update-note", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_update_highlight_note(id: i64, body: UpdateHighlightNote) -> Result<()> {
+    if let Err(msg) = body.validate() {
+        return Err(ServerFnError::new(msg).into());
+    }
     match db::highlights::update_highlight_note(&pool.0, user.id, id, body.note.as_deref()).await {
         Ok(()) => Ok(()),
         Err(db::highlights::HighlightError::NotFound) => {

--- a/server/src/backend/highlights.rs
+++ b/server/src/backend/highlights.rs
@@ -20,6 +20,9 @@ pub(super) async fn post_highlight(
     State(state): State<AppState>,
     Json(input): Json<CreateHighlight>,
 ) -> Response {
+    if let Err(msg) = input.validate() {
+        return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
+    }
     match db::highlights::create_highlight(&state.pool, user.id, &input).await {
         Ok(h) => Json(h).into_response(),
         Err(HighlightError::BookNotFound) => {
@@ -74,6 +77,9 @@ pub(super) async fn patch_highlight_note(
     Path(id): Path<i64>,
     Json(body): Json<UpdateHighlightNote>,
 ) -> Response {
+    if let Err(msg) = body.validate() {
+        return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
+    }
     match db::highlights::update_highlight_note(&state.pool, user.id, id, body.note.as_deref())
         .await
     {

--- a/server/src/backend/highlights/tests.rs
+++ b/server/src/backend/highlights/tests.rs
@@ -33,6 +33,87 @@ async fn api_post_highlight_requires_auth() {
 }
 
 #[tokio::test]
+async fn api_post_highlight_400_on_oversized_cfi() {
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let oversized = "a".repeat(omnibus_shared::CreateHighlight::EPUB_CFI_RANGE_MAX_LEN + 1);
+    let body = serde_json::json!({
+        "book_uuid": uuid,
+        "epub_cfi_range": oversized,
+        "color": "amber",
+    });
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/highlights")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let msg = String::from_utf8_lossy(&bytes);
+    assert!(msg.contains("epub_cfi_range"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn api_patch_highlight_note_400_on_oversized_note() {
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    // Create a highlight to patch.
+    let body = serde_json::json!({
+        "book_uuid": uuid,
+        "epub_cfi_range": "epubcfi(/6/4)",
+        "color": "amber",
+    });
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/highlights")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let created: Highlight = serde_json::from_slice(&bytes).unwrap();
+
+    let oversized = "n".repeat(omnibus_shared::UpdateHighlightNote::NOTE_MAX_LEN + 1);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/highlights/{}/note", created.id))
+                .method("PATCH")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(
+                    serde_json::json!({ "note": oversized }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let msg = String::from_utf8_lossy(&bytes);
+    assert!(msg.contains("note"), "got: {msg}");
+}
+
+#[tokio::test]
 async fn api_post_highlight_404_on_unknown_book() {
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;

--- a/shared/src/highlight.rs
+++ b/shared/src/highlight.rs
@@ -102,9 +102,8 @@ pub struct UpdateHighlightNote {
 }
 
 impl UpdateHighlightNote {
-    /// Maximum length (in chars) of a highlight note. Matches the
-    /// `MetadataOverrides.description`-style per-row text budget so the
-    /// API boundary rejects megabyte payloads up front.
+    /// Maximum length (in chars) of a highlight note — 4 KiB cap that lets
+    /// the API boundary reject megabyte payloads up front.
     pub const NOTE_MAX_LEN: usize = 4096;
 
     /// Validate the note length. `None` clears the note and is always

--- a/shared/src/highlight.rs
+++ b/shared/src/highlight.rs
@@ -66,8 +66,59 @@ pub struct CreateHighlight {
     pub color: HighlightColor,
 }
 
+impl CreateHighlight {
+    /// Maximum length (in chars) of an EPUB CFI range string. A real CFI
+    /// rarely exceeds a few hundred bytes; 4 KiB is a generous ceiling that
+    /// stops an authed client from persisting megabyte-sized blobs per row.
+    pub const EPUB_CFI_RANGE_MAX_LEN: usize = 4096;
+
+    /// Validate field lengths and required-ness. Call at the handler
+    /// boundary before persisting so over-long inputs surface as 400
+    /// instead of falling through to the DB.
+    ///
+    /// Length caps are measured in Unicode scalar values (`chars`),
+    /// matching `MetadataOverrides::validate`.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.book_uuid.trim().is_empty() {
+            return Err("book_uuid is required".into());
+        }
+        if self.epub_cfi_range.trim().is_empty() {
+            return Err("epub_cfi_range is required".into());
+        }
+        if self.epub_cfi_range.chars().count() > Self::EPUB_CFI_RANGE_MAX_LEN {
+            return Err(format!(
+                "epub_cfi_range exceeds {} characters",
+                Self::EPUB_CFI_RANGE_MAX_LEN
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Payload for updating a highlight's note text.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UpdateHighlightNote {
     pub note: Option<String>,
 }
+
+impl UpdateHighlightNote {
+    /// Maximum length (in chars) of a highlight note. Matches the
+    /// `MetadataOverrides.description`-style per-row text budget so the
+    /// API boundary rejects megabyte payloads up front.
+    pub const NOTE_MAX_LEN: usize = 4096;
+
+    /// Validate the note length. `None` clears the note and is always
+    /// permitted. Returns `Err` with a human-readable message when the
+    /// cap is exceeded.
+    pub fn validate(&self) -> Result<(), String> {
+        if let Some(ref note) = self.note {
+            if note.chars().count() > Self::NOTE_MAX_LEN {
+                return Err(format!("note exceeds {} characters", Self::NOTE_MAX_LEN));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/shared/src/highlight/tests.rs
+++ b/shared/src/highlight/tests.rs
@@ -1,0 +1,78 @@
+//! Unit tests for the highlight wire-type validators.
+
+use super::*;
+
+fn ok_create(cfi: &str) -> CreateHighlight {
+    CreateHighlight {
+        book_uuid: "uuid-1".into(),
+        epub_cfi_range: cfi.into(),
+        color: HighlightColor::Amber,
+    }
+}
+
+#[test]
+fn create_highlight_validate_accepts_well_formed_payload() {
+    let c = ok_create("epubcfi(/6/4!/4/2,/1:0,/1:100)");
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn create_highlight_validate_accepts_cfi_at_max_len() {
+    let c = ok_create(&"a".repeat(CreateHighlight::EPUB_CFI_RANGE_MAX_LEN));
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn create_highlight_validate_rejects_cfi_over_max_len() {
+    let c = ok_create(&"a".repeat(CreateHighlight::EPUB_CFI_RANGE_MAX_LEN + 1));
+    let err = c.validate().expect_err("over-long cfi must be rejected");
+    assert!(err.contains("epub_cfi_range"), "got: {err}");
+    assert!(
+        err.contains(&CreateHighlight::EPUB_CFI_RANGE_MAX_LEN.to_string()),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn create_highlight_validate_rejects_empty_book_uuid() {
+    let mut c = ok_create("epubcfi(/6/4)");
+    c.book_uuid = "   ".into();
+    let err = c.validate().expect_err("blank book_uuid must be rejected");
+    assert!(err.contains("book_uuid"), "got: {err}");
+}
+
+#[test]
+fn create_highlight_validate_rejects_empty_cfi() {
+    let c = ok_create("   ");
+    let err = c
+        .validate()
+        .expect_err("blank epub_cfi_range must be rejected");
+    assert!(err.contains("epub_cfi_range"), "got: {err}");
+}
+
+#[test]
+fn update_highlight_note_validate_accepts_none() {
+    let u = UpdateHighlightNote { note: None };
+    assert!(u.validate().is_ok());
+}
+
+#[test]
+fn update_highlight_note_validate_accepts_note_at_max_len() {
+    let u = UpdateHighlightNote {
+        note: Some("n".repeat(UpdateHighlightNote::NOTE_MAX_LEN)),
+    };
+    assert!(u.validate().is_ok());
+}
+
+#[test]
+fn update_highlight_note_validate_rejects_note_over_max_len() {
+    let u = UpdateHighlightNote {
+        note: Some("n".repeat(UpdateHighlightNote::NOTE_MAX_LEN + 1)),
+    };
+    let err = u.validate().expect_err("over-long note must be rejected");
+    assert!(err.contains("note"), "got: {err}");
+    assert!(
+        err.contains(&UpdateHighlightNote::NOTE_MAX_LEN.to_string()),
+        "got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `CreateHighlight::validate()` (4 KiB cap on `epub_cfi_range`, required-field checks) and `UpdateHighlightNote::validate()` (4 KiB cap on `note`) in `shared/src/highlight.rs`, mirroring the `Result<(), String>` shape of `MetadataOverrides::validate`.
- Wire both validators into the REST handlers in `server::backend::highlights` (`post_highlight`, `patch_highlight_note`) so over-sized inputs return 400 instead of being persisted, matching the `post_progress` / `post_sessions` pattern. Mirror the same check in `rpc_create_highlight` / `rpc_update_highlight_note` so web and mobile share the boundary.
- New unit tests in `shared/src/highlight/tests.rs` (happy path, at-cap, over-cap, blank uuid/cfi, note `None` / at-cap / over-cap) and two integration tests in `server/src/backend/highlights/tests.rs` asserting 400 on oversized cfi POST and oversized note PATCH.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-shared` (39 passed)
- [x] `cargo test -p omnibus` (197 passed; the 6 `backend::highlights::tests::*` include the two new BAD_REQUEST cases)
- [x] `cargo test -p omnibus-frontend --features server` (156 passed — covers the RPC wiring)
- [x] `cargo test -p omnibus-db` (539 passed — sanity-check the shared type change)

## Notes
- Caps chosen: 4 KiB for `epub_cfi_range` (real CFI fragments are a few hundred bytes; 4 KiB is a generous ceiling) and 4 KiB for `note` (matches the `MetadataOverrides.description`-style per-row text budget mentioned in the issue). Measured in `chars` so multibyte input is held to the same visible-character budget as ASCII, matching the `MetadataOverrides::validate` convention.
- The issue's "Notes for implementer" calls out a follow-up for the `search.rs` `SearchQuery.q` length cap. That is intentionally **out of scope** for this PR and should be picked up as a separate change.

Closes #501

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWSxyKrouXUWCSz18RSEbi)_