### PR TITLE
docs: propagate ACL single-tenant TODO note to discovery/browse fns (#232)

### DIFF
--- a/db/src/discovery/authors.rs
+++ b/db/src/discovery/authors.rs
@@ -21,6 +21,10 @@ pub const MAX_DISCOVERY_BOOKS: i64 = 1_000;
 /// Fetch an author by ID with their books across every library. Returns
 /// `None` if the author ID doesn't exist. The nested `books` vec is
 /// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
+///
+/// Currently returns results across all users (single-tenant). When F4.x
+/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
+/// to books accessible to that user.
 pub async fn get_author(
     pool: &SqlitePool,
     author_id: i64,

--- a/db/src/discovery/series.rs
+++ b/db/src/discovery/series.rs
@@ -16,6 +16,10 @@ use super::{DiscoveryError, MAX_DISCOVERY_BOOKS};
 /// Fetch a series by ID with its books, ordered by series index. Returns
 /// `None` if the series ID doesn't exist. The nested `books` vec is
 /// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
+///
+/// Currently returns results across all users (single-tenant). When F4.x
+/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
+/// to books accessible to that user.
 pub async fn get_series(
     pool: &SqlitePool,
     series_id: i64,


### PR DESCRIPTION
## Summary

- Adds the existing single-tenant / F4.x ACL rustdoc note (already present on `get_tag_cloud` and on `list_authors` / `list_series` in `browse.rs`) to `get_author` (`db/src/discovery/authors.rs`) and `get_series` (`db/src/discovery/series.rs`).
- Docs-only — no signature changes, no `user_id` parameter, no behavior change.
- Closes the doc-consistency half of #232. The F4.x per-user ACL rewrite (adding a `user_id: i64` parameter and a JOIN to a per-user access-control table on each of these five reads) remains explicitly deferred until Phase F4.x lands.

## Notes on scope vs. the issue body

The issue body cites pre-refactor names (`get_author_detail`, `get_series_detail`, `browse_authors`, `browse_series`). After PR #308 split `db/src/discovery.rs` into `db/src/discovery/{authors,series,tags}.rs` and `browse.rs` was renamed to `list_authors` / `list_series`, the current state is:

- `discovery::tags::get_tag_cloud` — already carries the note (skipped).
- `browse::list_authors` / `browse::list_series` — already carry the note (skipped).
- `discovery::authors::get_author` — **note added** here.
- `discovery::series::get_series` — **note added** here.

Each function already carries the inline `// TODO: scope by user_id once per-user ACLs land (single-tenant today).` in its body; this PR lifts that note up to the `///` rustdoc so it shows in API docs and on hover, matching the established pattern on the sibling reads.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` clean
- [x] `cargo test -p omnibus-db --lib` — 552 passed, 0 failed

Closes #232

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka5Nut2vkzexaaLoFWS4oA)_