### PR TITLE
refactor: extract AuthorsIndexHeader sub-components (#502)

### DIFF
--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -260,68 +260,102 @@ fn AuthorsIndexHeader(
                 }
             }
             div { class: "idx-toolbar",
-                div { class: "idx-search",
-                    input {
-                        r#type: "search",
-                        placeholder: "Filter authors by name\u{2026}",
-                        aria_label: "Filter authors by name",
-                        value: "{filter}",
-                        "data-testid": "authors-filter",
-                        oninput: move |e| on_filter.call(e.value()),
-                    }
+                FilterInput { filter: filter.clone(), on_filter }
+                SortSelector { sort, on_sort }
+            }
+            if show_letters {
+                LetterNav {
+                    alphabet: alphabet.clone(),
+                    present_letters: present_letters.clone(),
+                    letter_count,
+                    filtered_count,
                 }
-                div { class: "idx-sort",
-                    span { class: "label", "Sort" }
-                    button {
-                        class: "idx-btn",
-                        "aria-pressed": if sort == Sort::Name { "true" } else { "false" },
-                        "data-testid": "authors-sort-name",
-                        onclick: move |_| on_sort.call(Sort::Name),
-                        "Last name A\u{2013}Z"
-                    }
-                    button {
-                        class: "idx-btn",
-                        "aria-pressed": if sort == Sort::BookCount { "true" } else { "false" },
-                        "data-testid": "authors-sort-count",
-                        onclick: move |_| on_sort.call(Sort::BookCount),
-                        "Most books"
+            }
+        }
+    }
+}
+
+/// Search input that filters the author list by display name as the admin types.
+#[component]
+fn FilterInput(filter: String, on_filter: EventHandler<String>) -> Element {
+    rsx! {
+        div { class: "idx-search",
+            input {
+                r#type: "search",
+                placeholder: "Filter authors by name\u{2026}",
+                aria_label: "Filter authors by name",
+                value: "{filter}",
+                "data-testid": "authors-filter",
+                oninput: move |e| on_filter.call(e.value()),
+            }
+        }
+    }
+}
+
+/// Two-button toolbar that picks between surname A–Z and most-books sort axes.
+#[component]
+fn SortSelector(sort: Sort, on_sort: EventHandler<Sort>) -> Element {
+    rsx! {
+        div { class: "idx-sort",
+            span { class: "label", "Sort" }
+            button {
+                class: "idx-btn",
+                "aria-pressed": if sort == Sort::Name { "true" } else { "false" },
+                "data-testid": "authors-sort-name",
+                onclick: move |_| on_sort.call(Sort::Name),
+                "Last name A\u{2013}Z"
+            }
+            button {
+                class: "idx-btn",
+                "aria-pressed": if sort == Sort::BookCount { "true" } else { "false" },
+                "data-testid": "authors-sort-count",
+                onclick: move |_| on_sort.call(Sort::BookCount),
+                "Most books"
+            }
+        }
+    }
+}
+
+/// A–Z (plus `#`) jump strip; present letters become same-page anchors targeting `id="letter-{L}"` sections.
+#[component]
+fn LetterNav(
+    alphabet: Vec<char>,
+    present_letters: std::collections::HashSet<char>,
+    letter_count: usize,
+    filtered_count: usize,
+) -> Element {
+    // Letter jump strip. Letters that have at least one author
+    // render as same-page anchors targeting the section's
+    // `id="letter-{L}"` below — clicking jumps via the browser's
+    // native fragment scroll, no JS required. Letters with no
+    // authors stay as plain spans so there's nothing to jump to.
+    rsx! {
+        div { class: "idx-letters",
+            for l in alphabet.iter() {
+                {
+                    let has = present_letters.contains(l);
+                    // `#` is not valid inside a URL fragment, so the
+                    // non-alpha bucket gets a textual slug instead.
+                    let frag = letter_frag(*l);
+                    if has {
+                        rsx! {
+                            a {
+                                class: "idx-letter idx-letter-on",
+                                href: "#letter-{frag}",
+                                "data-testid": "authors-letter-{frag}",
+                                "{l}"
+                            }
+                        }
+                    } else {
+                        rsx! {
+                            span { class: "idx-letter", "{l}" }
+                        }
                     }
                 }
             }
-            // Letter jump strip. Letters that have at least one author
-            // render as same-page anchors targeting the section's
-            // `id="letter-{L}"` below — clicking jumps via the browser's
-            // native fragment scroll, no JS required. Letters with no
-            // authors stay as plain spans so there's nothing to jump to.
-            if show_letters {
-                div { class: "idx-letters",
-                    for l in alphabet.iter() {
-                        {
-                            let has = present_letters.contains(l);
-                            // `#` is not valid inside a URL fragment, so the
-                            // non-alpha bucket gets a textual slug instead.
-                            let frag = letter_frag(*l);
-                            if has {
-                                rsx! {
-                                    a {
-                                        class: "idx-letter idx-letter-on",
-                                        href: "#letter-{frag}",
-                                        "data-testid": "authors-letter-{frag}",
-                                        "{l}"
-                                    }
-                                }
-                            } else {
-                                rsx! {
-                                    span { class: "idx-letter", "{l}" }
-                                }
-                            }
-                        }
-                    }
-                    span { class: "idx-letters-spacer" }
-                    span { class: "mono idx-letters-count",
-                        "{letter_count} letters \u{b7} {filtered_count} authors"
-                    }
-                }
+            span { class: "idx-letters-spacer" }
+            span { class: "mono idx-letters-count",
+                "{letter_count} letters \u{b7} {filtered_count} authors"
             }
         }
     }

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -260,7 +260,7 @@ fn AuthorsIndexHeader(
                 }
             }
             div { class: "idx-toolbar",
-                FilterInput { filter: filter.clone(), on_filter }
+                FilterInput { filter, on_filter }
                 SortSelector { sort, on_sort }
             }
             if show_letters {
@@ -324,11 +324,9 @@ fn LetterNav(
     letter_count: usize,
     filtered_count: usize,
 ) -> Element {
-    // Letter jump strip. Letters that have at least one author
-    // render as same-page anchors targeting the section's
-    // `id="letter-{L}"` below — clicking jumps via the browser's
-    // native fragment scroll, no JS required. Letters with no
-    // authors stay as plain spans so there's nothing to jump to.
+    // Present letters become real `<a href="#letter-{frag}">` anchors so the
+    // browser's native fragment scroll handles the jump (no JS); absent
+    // letters stay as plain spans to avoid dead links.
     rsx! {
         div { class: "idx-letters",
             for l in alphabet.iter() {


### PR DESCRIPTION
## Summary
Split the 108-line `AuthorsIndexHeader` in `frontend/src/pages/authors_index.rs` into three private `#[component]` sub-components — `FilterInput`, `SortSelector`, and `LetterNav` — so the parent header is now a thin composition under the ~80-line cap.

- Before: `AuthorsIndexHeader` body = **108 lines**
- After: `AuthorsIndexHeader` body = **56 lines** (the four extracted children sit alongside it, each with a one-line `///` doc summary)

Mirrors the shape from #505 / #506 / #509 (one offender per PR per the revealed convention; the issue spans 12 functions, this PR handles one).

## Test plan
- [x] `cargo fmt -p omnibus-frontend` (and `cargo fmt --check` passes)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-frontend --features server` — 159 passed, 0 failed
- [ ] Playwright (run via the `run_ui_tests` label) — the authors-index header markup is reached by the existing flows

## Notes
- **Hydration parity preserved (rule 07):** no new `#[cfg(feature = "web"/"mobile"/"server")]` gates were introduced around any rsx. Sub-components render the same on SSR and WASM.
- **DOM contracts preserved:** every `data-testid` (`authors-filter`, `authors-sort-name`, `authors-sort-count`, `authors-letter-{frag}`), every `class` (`idx-search`, `idx-sort`, `idx-btn`, `idx-letters`, `idx-letter`, `idx-letter-on`, `idx-letters-spacer`, `idx-letters-count`, `mono`, `label`), and every `aria-*` attribute (`aria-pressed`, `aria_label`) is identical to the pre-refactor markup — Playwright selectors keep working.
- **`AuthorsIndexHeader` prop signature unchanged:** the public-shape contract with `AuthorsIndexPage` is identical (`counts`, `filter_state`, `on_filter`, `on_sort`).
- The "ViewModeToggle" suggested in the issue body doesn't currently exist in `AuthorsIndexHeader` — only `Sort`/`Filter`/`Letter` controls are present in production today, so this PR extracts the three that exist.

Refs #502

Remaining offenders from #502 still open for follow-up PRs:
- `EbookRow` (298 lines, `frontend/src/pages/landing/table.rs`)
- `MetadataEditForm` (238 lines, `frontend/src/pages/metadata_edit.rs`)
- `render_author` (237 lines, `frontend/src/pages/author.rs`)
- `SettingsPage` (197 lines, `frontend/src/pages/settings.rs`)
- `AuthorPhotoEditModal` (193 lines, `frontend/src/components/author_photo_edit.rs`)
- `UserMenuPanel` (163 lines, `frontend/src/components/user_menu.rs`)
- `SearchPage` (156 lines, `frontend/src/pages/search.rs`)
- `MergeDialog` (155 lines, `frontend/src/components/merge_dialog.rs`)
- `MiniDock` (154 lines, `frontend/src/pages/listen/mini_dock.rs`)
- (`merge_books` and `WorkerStatusIndicator` already merged in #505 / #506)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka5Nut2vkzexaaLoFWS4oA)_