### PR TITLE
refactor: batch audiobook parts and chapters inserts (#520)

### DIFF
--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -571,7 +571,8 @@ async fn insert_audiobook_parts(
 }
 
 /// Insert `file_chapters` rows. If no chapters were extracted, synthesize
-/// one chapter per part so the frontend always gets `chapters.len() >= 1`.
+/// one chapter per part — yielding zero rows only when both `chapters` and
+/// `parts` are empty (the empty-parts edge case).
 ///
 /// Both branches first materialize the row tuples and then hand them to
 /// [`bulk_insert_chapters`], which issues a single VALUES-list `INSERT` per
@@ -583,8 +584,14 @@ pub(crate) async fn insert_chapters(
     chapters: &[crate::audiobook::RawChapter],
     parts: &[crate::audiobook::AudiobookPart],
 ) -> Result<(), SyncError> {
-    // (ordinal, title, start_seconds, duration_seconds)
-    let mut rows: Vec<(i64, String, f64, f64)> = Vec::new();
+    // (ordinal, title, start_seconds, duration_seconds). Exactly one branch
+    // below runs, so the needed capacity is whichever input it drains.
+    let capacity = if chapters.is_empty() {
+        parts.len()
+    } else {
+        chapters.len()
+    };
+    let mut rows: Vec<(i64, String, f64, f64)> = Vec::with_capacity(capacity);
     if !chapters.is_empty() {
         let total_duration: f64 = parts.iter().map(|p| p.duration_seconds).sum();
         // Chapter timestamps are milliseconds; `f64` has 53 bits of

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -535,37 +535,56 @@ async fn insert_audiobook_file_row(
 }
 
 /// Batch-insert `book_file_parts` rows for the ordered part list.
+///
+/// One VALUES-list `INSERT` per chunk (chunked at 166 rows: 6 binds per row
+/// keeps each statement under SQLite's 999 bind-parameter cap) instead of
+/// one round-trip per part — the parent transaction's commit boundary is
+/// unchanged.
 async fn insert_audiobook_parts(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_file_id: i64,
     parts: &[crate::audiobook::AudiobookPart],
 ) -> Result<(), sqlx::Error> {
-    for p in parts {
-        sqlx::query(
+    // 6 binds per row × 166 rows = 996 binds, under SQLite's 999 cap.
+    for chunk in parts.chunks(166) {
+        let rows = std::iter::repeat_n("(?, ?, ?, ?, ?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
             "INSERT INTO book_file_parts \
                 (book_file_id, ordinal, filename, size_bytes, mtime_epoch, duration_seconds) \
-             VALUES (?, ?, ?, ?, ?, ?)",
-        )
-        .bind(book_file_id)
-        .bind(p.ordinal)
-        .bind(&p.filename)
-        .bind(p.size_bytes)
-        .bind(p.mtime_epoch)
-        .bind(p.duration_seconds)
-        .execute(&mut **tx)
-        .await?;
+             VALUES {rows}"
+        );
+        let mut q = sqlx::query(&sql);
+        for p in chunk {
+            q = q
+                .bind(book_file_id)
+                .bind(p.ordinal)
+                .bind(&p.filename)
+                .bind(p.size_bytes)
+                .bind(p.mtime_epoch)
+                .bind(p.duration_seconds);
+        }
+        q.execute(&mut **tx).await?;
     }
     Ok(())
 }
 
 /// Insert `file_chapters` rows. If no chapters were extracted, synthesize
 /// one chapter per part so the frontend always gets `chapters.len() >= 1`.
+///
+/// Both branches first materialize the row tuples and then hand them to
+/// [`bulk_insert_chapters`], which issues a single VALUES-list `INSERT` per
+/// chunk (199 rows × 5 binds = 995, under SQLite's 999 bind cap) instead of
+/// one round-trip per chapter.
 pub(crate) async fn insert_chapters(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_file_id: i64,
     chapters: &[crate::audiobook::RawChapter],
     parts: &[crate::audiobook::AudiobookPart],
 ) -> Result<(), SyncError> {
+    // (ordinal, title, start_seconds, duration_seconds)
+    let mut rows: Vec<(i64, String, f64, f64)> = Vec::new();
     if !chapters.is_empty() {
         let total_duration: f64 = parts.iter().map(|p| p.duration_seconds).sum();
         // Chapter timestamps are milliseconds; `f64` has 53 bits of
@@ -581,38 +600,47 @@ pub(crate) async fn insert_chapters(
             } else {
                 (total_duration - start_seconds).max(0.0)
             };
-            sqlx::query(
-                "INSERT INTO file_chapters \
-                    (book_file_id, ordinal, title, start_seconds, duration_seconds) \
-                 VALUES (?, ?, ?, ?, ?)",
-            )
-            .bind(book_file_id)
-            .bind(i as i64)
-            .bind(&ch.title)
-            .bind(start_seconds)
-            .bind(duration_seconds)
-            .execute(&mut **tx)
-            .await?;
+            rows.push((i as i64, ch.title.clone(), start_seconds, duration_seconds));
         }
     } else {
         // Synthetic fallback: one chapter per part.
         let mut cumulative = 0.0f64;
         for p in parts {
             let title = format!("Part {}", p.ordinal + 1);
-            sqlx::query(
-                "INSERT INTO file_chapters \
-                    (book_file_id, ordinal, title, start_seconds, duration_seconds) \
-                 VALUES (?, ?, ?, ?, ?)",
-            )
-            .bind(book_file_id)
-            .bind(p.ordinal)
-            .bind(&title)
-            .bind(cumulative)
-            .bind(p.duration_seconds)
-            .execute(&mut **tx)
-            .await?;
+            rows.push((p.ordinal, title, cumulative, p.duration_seconds));
             cumulative += p.duration_seconds;
         }
+    }
+    bulk_insert_chapters(tx, book_file_id, &rows).await?;
+    Ok(())
+}
+
+/// Bulk-insert pre-materialized `file_chapters` rows. Chunks at 199 rows so
+/// 5 binds per row stays under SQLite's 999 bind-parameter cap.
+async fn bulk_insert_chapters(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_file_id: i64,
+    rows: &[(i64, String, f64, f64)],
+) -> Result<(), sqlx::Error> {
+    for chunk in rows.chunks(199) {
+        let placeholders = std::iter::repeat_n("(?, ?, ?, ?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "INSERT INTO file_chapters \
+                (book_file_id, ordinal, title, start_seconds, duration_seconds) \
+             VALUES {placeholders}"
+        );
+        let mut q = sqlx::query(&sql);
+        for (ordinal, title, start_seconds, duration_seconds) in chunk {
+            q = q
+                .bind(book_file_id)
+                .bind(*ordinal)
+                .bind(title)
+                .bind(*start_seconds)
+                .bind(*duration_seconds);
+        }
+        q.execute(&mut **tx).await?;
     }
     Ok(())
 }

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -1457,12 +1457,7 @@ async fn sync_audiobooks_with_removed_above_bind_cap_succeeds() {
     );
 }
 
-// ── Bulk-insert of parts and chapters ─────────────────────────────
-//
-// `insert_audiobook_parts` and `insert_chapters` issue a single
-// VALUES-list `INSERT` per chunk (one round-trip), not one per row.
-// These tests pin the row contents identical to the previous one-at-a-time
-// loop so the batching is observably behavior-preserving.
+// Audiobook parts + chapters: row contents and edge cases.
 
 #[tokio::test]
 async fn sync_audiobooks_writes_all_parts_for_a_five_part_audiobook() {

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -1456,3 +1456,198 @@ async fn sync_audiobooks_with_removed_above_bind_cap_succeeds() {
         "FTS rows should be cleared for every ghosted audiobook"
     );
 }
+
+// ── Bulk-insert of parts and chapters ─────────────────────────────
+//
+// `insert_audiobook_parts` and `insert_chapters` issue a single
+// VALUES-list `INSERT` per chunk (one round-trip), not one per row.
+// These tests pin the row contents identical to the previous one-at-a-time
+// loop so the batching is observably behavior-preserving.
+
+#[tokio::test]
+async fn sync_audiobooks_writes_all_parts_for_a_five_part_audiobook() {
+    let _covers = CoversTempDir::new("ab_bulk_parts");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let mut book = indexed_audiobook("Author/Book", "Big Book", Some("Author"));
+    book.parts = (0..5)
+        .map(|i| crate::audiobook::AudiobookPart {
+            ordinal: i,
+            filename: format!("Author/Book/part{i:02}.m4b"),
+            size_bytes: 1000 + i,
+            mtime_epoch: 100 + i,
+            duration_seconds: 60.0 * (i + 1) as f64,
+        })
+        .collect();
+    // No embedded chapters → synthetic-fallback path writes one chapter per part.
+    book.chapters = vec![];
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![book],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let rows: Vec<(i64, String, i64, i64, f64)> = sqlx::query_as(
+        "SELECT ordinal, filename, size_bytes, mtime_epoch, duration_seconds \
+         FROM book_file_parts ORDER BY ordinal",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(rows.len(), 5);
+    for (i, (ordinal, filename, size_bytes, mtime_epoch, duration_seconds)) in
+        rows.iter().enumerate()
+    {
+        let i = i as i64;
+        assert_eq!(*ordinal, i);
+        assert_eq!(filename, &format!("Author/Book/part{i:02}.m4b"));
+        assert_eq!(*size_bytes, 1000 + i);
+        assert_eq!(*mtime_epoch, 100 + i);
+        assert_eq!(*duration_seconds, 60.0 * (i + 1) as f64);
+    }
+}
+
+#[tokio::test]
+async fn sync_audiobooks_writes_all_fifty_chapters_for_a_five_part_audiobook() {
+    let _covers = CoversTempDir::new("ab_bulk_chapters");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let mut book = indexed_audiobook("Author/Big.m4b", "Big Book", Some("Author"));
+    // One 60-minute part — chapter timestamps are absolute from book start.
+    book.parts = vec![crate::audiobook::AudiobookPart {
+        ordinal: 0,
+        filename: "Author/Big.m4b".into(),
+        size_bytes: 99_999,
+        mtime_epoch: 500,
+        duration_seconds: 3600.0,
+    }];
+    // 50 sequential chapters, each 60 s, with `end_ms == 0` so the gap-fill
+    // branch derives the duration from the next chapter's start.
+    book.chapters = (0..50)
+        .map(|i| crate::audiobook::RawChapter {
+            title: format!("Chapter {i}"),
+            start_ms: (i as u64) * 60_000,
+            end_ms: 0,
+        })
+        .collect();
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![book],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let chapters: Vec<(i64, String, f64, f64)> = sqlx::query_as(
+        "SELECT ordinal, title, start_seconds, duration_seconds \
+         FROM file_chapters ORDER BY ordinal",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(chapters.len(), 50);
+    for (i, (ordinal, title, start_seconds, duration_seconds)) in chapters.iter().enumerate() {
+        let i = i as i64;
+        assert_eq!(*ordinal, i);
+        assert_eq!(title, &format!("Chapter {i}"));
+        assert_eq!(*start_seconds, (i as f64) * 60.0);
+        // Chapters 0..=48 fall to the gap-fill branch (next chapter's start
+        // minus this chapter's start = 60 s). Chapter 49 has no next, so it
+        // falls back to `total_duration - start` = 3600 - 2940 = 660 s.
+        let expected = if i < 49 { 60.0 } else { 660.0 };
+        assert_eq!(*duration_seconds, expected, "ordinal {i} duration mismatch");
+    }
+}
+
+#[tokio::test]
+async fn sync_audiobooks_writes_zero_parts_and_synthesized_chapter_for_empty_parts_edge_case() {
+    let _covers = CoversTempDir::new("ab_bulk_empty");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let mut book = indexed_audiobook("Author/Only.m4b", "Only", Some("Author"));
+    book.parts = vec![];
+    book.chapters = vec![];
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![book],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let parts_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM book_file_parts")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(parts_count, 0, "empty `parts` writes no `book_file_parts`");
+
+    let chapters_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM file_chapters")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        chapters_count, 0,
+        "no parts and no chapters → synthetic fallback is also empty"
+    );
+}
+
+#[tokio::test]
+async fn sync_audiobooks_writes_one_chapter_when_single_chapter_provided() {
+    let _covers = CoversTempDir::new("ab_bulk_single_chap");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let mut book = indexed_audiobook("Author/One.m4b", "Solo", Some("Author"));
+    book.parts = vec![crate::audiobook::AudiobookPart {
+        ordinal: 0,
+        filename: "Author/One.m4b".into(),
+        size_bytes: 2048,
+        mtime_epoch: 42,
+        duration_seconds: 120.0,
+    }];
+    book.chapters = vec![crate::audiobook::RawChapter {
+        title: "Only".into(),
+        start_ms: 0,
+        end_ms: 0,
+    }];
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![book],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let rows: Vec<(i64, String, f64, f64)> = sqlx::query_as(
+        "SELECT ordinal, title, start_seconds, duration_seconds \
+         FROM file_chapters ORDER BY ordinal",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, 0);
+    assert_eq!(rows[0].1, "Only");
+    assert_eq!(rows[0].2, 0.0);
+    // Single chapter with end_ms == 0 → duration falls back to total_duration - start = 120 s.
+    assert_eq!(rows[0].3, 120.0);
+}


### PR DESCRIPTION
## Summary
- Replace the per-row `INSERT` loops inside `insert_audiobook_parts` and `insert_chapters` (`db/src/sync/audiobooks.rs`) with VALUES-list bulk inserts, mirroring the batching shape used by `backfill_chapters` (closed #425).
- Chunk sizes are derived from SQLite's 999 bind-parameter cap divided by the actual column counts:
  - `book_file_parts`: 6 columns per row → 166 rows × 6 = 996 binds per chunk
  - `file_chapters`: 5 columns per row → 199 rows × 5 = 995 binds per chunk
- For a 50-chapter, 5-part audiobook the in-tx round-trip count drops from 55 to 2.
- Behavior is unchanged: same column order, same `NULL`/synthetic-fallback handling, same parent `sync_audiobooks` transaction boundary — only the per-row round-trips inside it collapse.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-db` (566 passed, 0 failed)
- [x] Added 4 sibling tests in `db/src/sync/tests.rs`:
  - `sync_audiobooks_writes_all_parts_for_a_five_part_audiobook` — verifies every column round-trips for the 5-part case
  - `sync_audiobooks_writes_all_fifty_chapters_for_a_five_part_audiobook` — pins the 50-chapter happy path including the last-chapter `total_duration - start` fallback
  - `sync_audiobooks_writes_zero_parts_and_synthesized_chapter_for_empty_parts_edge_case` — empty/no-op edge
  - `sync_audiobooks_writes_one_chapter_when_single_chapter_provided` — single-item edge

## Notes
- Pure refactor: no schema change, no migration.
- The `insert_chapters` rewrite materializes row tuples first (so the synthetic and embedded branches share the same bulk-writer) and dispatches to a small `bulk_insert_chapters` helper.

Closes #520


---
_Generated by [Claude Code](https://claude.ai/code/session_01BjvorRb6pEEaSwaovBwJ9d)_