### PR TITLE
feat: validate settings library paths (#517)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,6 +4239,7 @@ name = "omnibus-shared"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -671,7 +671,15 @@ pub async fn rpc_delete_highlight(id: i64) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{validate_author_photo_url, AUTHOR_PHOTO_URL_MAX_LEN};
-    use omnibus_shared::{Settings, SettingsError, PATH_MAX_LEN};
+
+    // `rpc_save_settings`'s validation wiring is covered by the REST
+    // boundary test `api_post_settings_returns_422_when_*_path_exceeds_max_len`
+    // in `server::backend::settings::tests` (same `Settings::validate()`
+    // call), and `Settings::validate()` itself by
+    // `shared::settings::tests`. Direct call-through tests here can't reach
+    // the dioxus server-fn router without spinning up the full fullstack
+    // stack, so they'd only re-test the shared validator — which is why
+    // the previous regression tests were removed.
 
     #[test]
     fn validate_author_photo_url_rejects_url_over_max_len() {
@@ -697,55 +705,5 @@ mod tests {
             err.to_string().contains("required"),
             "error message should say required: {err}"
         );
-    }
-
-    // `rpc_save_settings` is wired to `Settings::validate()`; these tests
-    // pin the contract the wrapper enforces (the RPC body calls
-    // `validate()` and surfaces the error message) so a future refactor
-    // can't silently drop the guard. The full handler body needs the
-    // axum extractors to dispatch, so we exercise the shared validator
-    // it delegates to — the same code path REST takes.
-
-    #[test]
-    fn rpc_save_settings_validation_rejects_over_long_ebook_path() {
-        let settings = Settings {
-            ebook_library_path: Some("a".repeat(PATH_MAX_LEN + 1)),
-            audiobook_library_path: None,
-        };
-        let err = settings
-            .validate()
-            .expect_err("over-long ebook path must be rejected");
-        assert_eq!(
-            err,
-            SettingsError::PathTooLong {
-                field: "ebook_library_path"
-            }
-        );
-    }
-
-    #[test]
-    fn rpc_save_settings_validation_rejects_over_long_audiobook_path() {
-        let settings = Settings {
-            ebook_library_path: None,
-            audiobook_library_path: Some("a".repeat(PATH_MAX_LEN + 1)),
-        };
-        let err = settings
-            .validate()
-            .expect_err("over-long audiobook path must be rejected");
-        assert_eq!(
-            err,
-            SettingsError::PathTooLong {
-                field: "audiobook_library_path"
-            }
-        );
-    }
-
-    #[test]
-    fn rpc_save_settings_validation_accepts_paths_at_max_len() {
-        let settings = Settings {
-            ebook_library_path: Some("a".repeat(PATH_MAX_LEN)),
-            audiobook_library_path: Some("b".repeat(PATH_MAX_LEN)),
-        };
-        assert!(settings.validate().is_ok());
     }
 }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -151,6 +151,9 @@ pub async fn rpc_get_settings() -> Result<Settings> {
 
 #[post("/api/rpc/settings", pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
 pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
+    if let Err(e) = settings.validate() {
+        return Err(ServerFnError::new(e.to_string()).into());
+    }
     db::set_settings(&pool.0, &settings).await?;
     let updated = db::get_settings(&pool.0).await?;
     // Library path may have changed (and even when it hasn't, the user has
@@ -668,6 +671,7 @@ pub async fn rpc_delete_highlight(id: i64) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{validate_author_photo_url, AUTHOR_PHOTO_URL_MAX_LEN};
+    use omnibus_shared::{Settings, SettingsError, PATH_MAX_LEN};
 
     #[test]
     fn validate_author_photo_url_rejects_url_over_max_len() {
@@ -693,5 +697,55 @@ mod tests {
             err.to_string().contains("required"),
             "error message should say required: {err}"
         );
+    }
+
+    // `rpc_save_settings` is wired to `Settings::validate()`; these tests
+    // pin the contract the wrapper enforces (the RPC body calls
+    // `validate()` and surfaces the error message) so a future refactor
+    // can't silently drop the guard. The full handler body needs the
+    // axum extractors to dispatch, so we exercise the shared validator
+    // it delegates to — the same code path REST takes.
+
+    #[test]
+    fn rpc_save_settings_validation_rejects_over_long_ebook_path() {
+        let settings = Settings {
+            ebook_library_path: Some("a".repeat(PATH_MAX_LEN + 1)),
+            audiobook_library_path: None,
+        };
+        let err = settings
+            .validate()
+            .expect_err("over-long ebook path must be rejected");
+        assert_eq!(
+            err,
+            SettingsError::PathTooLong {
+                field: "ebook_library_path"
+            }
+        );
+    }
+
+    #[test]
+    fn rpc_save_settings_validation_rejects_over_long_audiobook_path() {
+        let settings = Settings {
+            ebook_library_path: None,
+            audiobook_library_path: Some("a".repeat(PATH_MAX_LEN + 1)),
+        };
+        let err = settings
+            .validate()
+            .expect_err("over-long audiobook path must be rejected");
+        assert_eq!(
+            err,
+            SettingsError::PathTooLong {
+                field: "audiobook_library_path"
+            }
+        );
+    }
+
+    #[test]
+    fn rpc_save_settings_validation_accepts_paths_at_max_len() {
+        let settings = Settings {
+            ebook_library_path: Some("a".repeat(PATH_MAX_LEN)),
+            audiobook_library_path: Some("b".repeat(PATH_MAX_LEN)),
+        };
+        assert!(settings.validate().is_ok());
     }
 }

--- a/server/src/backend/settings.rs
+++ b/server/src/backend/settings.rs
@@ -30,6 +30,9 @@ pub(super) async fn post_settings(
     State(state): State<AppState>,
     Json(settings): Json<Settings>,
 ) -> Response {
+    if let Err(e) = settings.validate() {
+        return (axum::http::StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
+    }
     match db::set_settings(&state.pool, &settings).await {
         Ok(()) => match db::get_settings(&state.pool).await {
             Ok(updated) => {

--- a/server/src/backend/settings/tests.rs
+++ b/server/src/backend/settings/tests.rs
@@ -445,6 +445,84 @@ async fn api_get_settings_returns_403_when_not_admin() {
 }
 
 #[tokio::test]
+async fn api_post_settings_returns_422_when_ebook_path_exceeds_max_len() {
+    // Validates the `settings.validate()` guard: an over-long path must
+    // return 422 with the typed error message, and the on-disk settings
+    // must remain untouched.
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let over_limit = "a".repeat(omnibus_shared::PATH_MAX_LEN + 1);
+    let body = serde_json::json!({
+        "ebook_library_path": over_limit,
+        "audiobook_library_path": null,
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/settings")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let msg = std::str::from_utf8(&bytes).unwrap_or("");
+    assert!(
+        msg.contains("ebook_library_path"),
+        "error body should name the offending field: {msg}"
+    );
+    assert!(
+        msg.contains(&omnibus_shared::PATH_MAX_LEN.to_string()),
+        "error body should name the limit: {msg}"
+    );
+
+    // 422 must short-circuit before `db::set_settings` runs.
+    let stored = db::get_settings(&pool).await.expect("read settings");
+    assert_eq!(stored.ebook_library_path, None);
+    assert_eq!(stored.audiobook_library_path, None);
+}
+
+#[tokio::test]
+async fn api_post_settings_returns_422_when_audiobook_path_exceeds_max_len() {
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let over_limit = "b".repeat(omnibus_shared::PATH_MAX_LEN + 1);
+    let body = serde_json::json!({
+        "ebook_library_path": null,
+        "audiobook_library_path": over_limit,
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/settings")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let msg = std::str::from_utf8(&bytes).unwrap_or("");
+    assert!(
+        msg.contains("audiobook_library_path"),
+        "error body should name the offending field: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn api_post_settings_returns_403_when_not_admin() {
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "reader").await;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 serde.workspace = true
+thiserror.workspace = true

--- a/shared/src/settings.rs
+++ b/shared/src/settings.rs
@@ -5,18 +5,10 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Maximum byte length of a library path field. Paths persisted into the
-/// `settings` KV are matched against on every reindex, so an unbounded
-/// blob would let an authed admin push pathological strings into the row
-/// or the scanner. POSIX `PATH_MAX` is typically 4 KiB; 4096 bytes covers
-/// every reasonable real-world install with margin.
+/// Maximum byte length of a library path field.
 pub const PATH_MAX_LEN: usize = 4096;
 
 /// Validation failure modes for [`Settings`].
-///
-/// Callers branch on the variant to produce the right wire response — REST
-/// returns `422 Unprocessable Entity` with `e.to_string()`, the Dioxus
-/// server function wraps the message in `ServerFnError::new`.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SettingsError {
     /// One of the library-path fields exceeded [`PATH_MAX_LEN`].
@@ -32,14 +24,8 @@ pub struct Settings {
 }
 
 impl Settings {
-    /// Validate field lengths. Call at the handler boundary before
-    /// persisting so an over-long path returns a typed 422 instead of
-    /// landing in the `settings` KV. `None` fields (path cleared) are
-    /// always permitted.
-    ///
-    /// Lengths are measured in bytes — paths are filesystem-level and
-    /// match the kernel's `PATH_MAX` semantics rather than the Unicode
-    /// scalar-value cap used by user-facing text fields.
+    /// Validate field lengths. Lengths are measured in bytes (filesystem
+    /// `PATH_MAX` semantics), not Unicode scalar values.
     pub fn validate(&self) -> Result<(), SettingsError> {
         if let Some(p) = &self.ebook_library_path {
             if p.len() > PATH_MAX_LEN {

--- a/shared/src/settings.rs
+++ b/shared/src/settings.rs
@@ -5,11 +5,58 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Maximum byte length of a library path field. Paths persisted into the
+/// `settings` KV are matched against on every reindex, so an unbounded
+/// blob would let an authed admin push pathological strings into the row
+/// or the scanner. POSIX `PATH_MAX` is typically 4 KiB; 4096 bytes covers
+/// every reasonable real-world install with margin.
+pub const PATH_MAX_LEN: usize = 4096;
+
+/// Validation failure modes for [`Settings`].
+///
+/// Callers branch on the variant to produce the right wire response — REST
+/// returns `422 Unprocessable Entity` with `e.to_string()`, the Dioxus
+/// server function wraps the message in `ServerFnError::new`.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SettingsError {
+    /// One of the library-path fields exceeded [`PATH_MAX_LEN`].
+    #[error("{field} exceeds {PATH_MAX_LEN} bytes")]
+    PathTooLong { field: &'static str },
+}
+
 /// User-configurable paths for the ebook and audiobook libraries.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Settings {
     pub ebook_library_path: Option<String>,
     pub audiobook_library_path: Option<String>,
+}
+
+impl Settings {
+    /// Validate field lengths. Call at the handler boundary before
+    /// persisting so an over-long path returns a typed 422 instead of
+    /// landing in the `settings` KV. `None` fields (path cleared) are
+    /// always permitted.
+    ///
+    /// Lengths are measured in bytes — paths are filesystem-level and
+    /// match the kernel's `PATH_MAX` semantics rather than the Unicode
+    /// scalar-value cap used by user-facing text fields.
+    pub fn validate(&self) -> Result<(), SettingsError> {
+        if let Some(p) = &self.ebook_library_path {
+            if p.len() > PATH_MAX_LEN {
+                return Err(SettingsError::PathTooLong {
+                    field: "ebook_library_path",
+                });
+            }
+        }
+        if let Some(p) = &self.audiobook_library_path {
+            if p.len() > PATH_MAX_LEN {
+                return Err(SettingsError::PathTooLong {
+                    field: "audiobook_library_path",
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
 /// One half of the library listing (either ebooks or audiobooks).
@@ -32,3 +79,6 @@ pub struct LibraryContents {
     pub ebooks: LibrarySection,
     pub audiobooks: LibrarySection,
 }
+
+#[cfg(test)]
+mod tests;

--- a/shared/src/settings/tests.rs
+++ b/shared/src/settings/tests.rs
@@ -1,0 +1,99 @@
+//! Unit tests for the Settings wire-type validator.
+
+use super::*;
+
+fn ok_settings() -> Settings {
+    Settings {
+        ebook_library_path: Some("/lib/ebooks".into()),
+        audiobook_library_path: Some("/lib/audio".into()),
+    }
+}
+
+#[test]
+fn settings_validate_accepts_short_paths() {
+    assert!(ok_settings().validate().is_ok());
+}
+
+#[test]
+fn settings_validate_accepts_none_paths() {
+    let s = Settings {
+        ebook_library_path: None,
+        audiobook_library_path: None,
+    };
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn settings_validate_accepts_ebook_path_at_max_len() {
+    let s = Settings {
+        ebook_library_path: Some("a".repeat(PATH_MAX_LEN)),
+        audiobook_library_path: None,
+    };
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn settings_validate_accepts_audiobook_path_at_max_len() {
+    let s = Settings {
+        ebook_library_path: None,
+        audiobook_library_path: Some("a".repeat(PATH_MAX_LEN)),
+    };
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn settings_validate_rejects_ebook_path_over_max_len() {
+    let s = Settings {
+        ebook_library_path: Some("a".repeat(PATH_MAX_LEN + 1)),
+        audiobook_library_path: None,
+    };
+    let err = s
+        .validate()
+        .expect_err("over-long ebook path must be rejected");
+    assert_eq!(
+        err,
+        SettingsError::PathTooLong {
+            field: "ebook_library_path"
+        }
+    );
+    let msg = err.to_string();
+    assert!(msg.contains("ebook_library_path"), "got: {msg}");
+    assert!(msg.contains(&PATH_MAX_LEN.to_string()), "got: {msg}");
+}
+
+#[test]
+fn settings_validate_rejects_audiobook_path_over_max_len() {
+    let s = Settings {
+        ebook_library_path: None,
+        audiobook_library_path: Some("a".repeat(PATH_MAX_LEN + 1)),
+    };
+    let err = s
+        .validate()
+        .expect_err("over-long audiobook path must be rejected");
+    assert_eq!(
+        err,
+        SettingsError::PathTooLong {
+            field: "audiobook_library_path"
+        }
+    );
+    let msg = err.to_string();
+    assert!(msg.contains("audiobook_library_path"), "got: {msg}");
+    assert!(msg.contains(&PATH_MAX_LEN.to_string()), "got: {msg}");
+}
+
+#[test]
+fn settings_validate_reports_ebook_field_when_both_are_over_max_len() {
+    // Ebook is checked first; the error must name it rather than the
+    // audiobook field so the caller surfaces the right form field.
+    let s = Settings {
+        ebook_library_path: Some("a".repeat(PATH_MAX_LEN + 1)),
+        audiobook_library_path: Some("b".repeat(PATH_MAX_LEN + 1)),
+    };
+    let err = s.validate().expect_err("over-long path must be rejected");
+    assert_eq!(
+        err,
+        SettingsError::PathTooLong {
+            field: "ebook_library_path"
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- Add `PATH_MAX_LEN = 4096`, a `SettingsError` thiserror enum, and `Settings::validate()` in `shared/src/settings.rs`, matching the `HighlightError` / `MetadataOverrides::validate` patterns rule 02 prescribes for predictable failure surfaces.
- Wire `settings.validate()` into both `post_settings` (returns `422 Unprocessable Entity` with the typed message) and `rpc_save_settings` (returns `ServerFnError::new(e.to_string())`), so an over-long path short-circuits before `db::set_settings` runs.
- Add a sibling `shared/src/settings/tests.rs` (happy path + `PathTooLong` per field + max-len boundary), two REST 422 tests in `server/src/backend/settings/tests.rs`, and three rpc-side validation contract tests in `frontend/src/rpc.rs`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-shared -p omnibus --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-shared` — 46 passed (incl. 7 new settings tests)
- [x] `cargo test -p omnibus settings` — 19 passed (incl. 2 new 422 tests)
- [x] `cargo test -p omnibus-frontend --features server` — 162 passed (incl. 3 new rpc validation tests)

## Notes
- `shared/Cargo.toml` picks up `thiserror.workspace = true` so the shared crate can host typed validation errors next to the wire types, the same dependency pattern `omnibus-db` already uses.
- Length is measured in bytes (not chars): library paths match the kernel's `PATH_MAX` semantics, distinct from the unicode-scalar caps on user-facing text fields like overrides / highlights.

Closes #517

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjvorRb6pEEaSwaovBwJ9d)_