### PR TITLE
refactor: remove cfg-gated RSX in format_switcher and user_menu (#519)

### DIFF
--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -56,10 +56,7 @@ pub fn FormatSwitcher(
 }
 
 #[component]
-fn FormatRow(
-    kind: FormatKind,
-    #[cfg_attr(feature = "mobile", allow(unused_variables))] uuid: String,
-) -> Element {
+fn FormatRow(kind: FormatKind, uuid: String) -> Element {
     let label = kind.label();
     let testid = format!("format-row-{}", label.to_ascii_lowercase());
     rsx! {
@@ -71,30 +68,11 @@ fn FormatRow(
             div { class: "format-actions",
                 match kind {
                     FormatKind::Epub => rsx! {
-                        {
-                            // F2.2: web routes into the immersive reader; mobile
-                            // stays disabled (no JS engine for epub.js — see F6.2).
-                            #[cfg(not(feature = "mobile"))]
-                            let read_action = rsx! {
-                                Link {
-                                    to: Route::BookRead { uuid: uuid.clone() },
-                                    class: "btn",
-                                    "data-testid": "action-read",
-                                    "Read"
-                                }
-                            };
-                            #[cfg(feature = "mobile")]
-                            let read_action = rsx! {
-                                button {
-                                    class: "btn",
-                                    disabled: true,
-                                    title: "Reading on mobile coming soon",
-                                    "data-testid": "action-read",
-                                    "Read"
-                                }
-                            };
-                            read_action
-                        }
+                        // F2.2: web routes into the immersive reader; mobile
+                        // stays disabled (no JS engine for epub.js — see F6.2).
+                        // The cfg lives at the helper definition (rule 07:
+                        // hydration parity — keep cfg gates out of rsx).
+                        {read_book_action(&uuid)}
                         button {
                             class: "btn",
                             disabled: true,
@@ -104,31 +82,10 @@ fn FormatRow(
                         }
                     },
                     FormatKind::M4b | FormatKind::Mp3 => rsx! {
-                        {
-                            // F2.3: web routes into the immersive player; mobile
-                            // stays disabled (no `<audio>` binding in the Dioxus
-                            // Native shell yet — see F6.x).
-                            #[cfg(not(feature = "mobile"))]
-                            let listen_action = rsx! {
-                                Link {
-                                    to: Route::BookListen { uuid: uuid.clone() },
-                                    class: "btn",
-                                    "data-testid": "action-listen",
-                                    "Listen"
-                                }
-                            };
-                            #[cfg(feature = "mobile")]
-                            let listen_action = rsx! {
-                                button {
-                                    class: "btn",
-                                    disabled: true,
-                                    title: "Listening on mobile coming soon",
-                                    "data-testid": "action-listen",
-                                    "Listen"
-                                }
-                            };
-                            listen_action
-                        }
+                        // F2.3: web routes into the immersive player; mobile
+                        // stays disabled (no `<audio>` binding in the Dioxus
+                        // Native shell yet — see F6.x).
+                        {listen_book_action(&uuid)}
                     },
                     FormatKind::Other(_) => rsx! {
                         span { class: "format-actions-empty", "No actions yet" }
@@ -142,11 +99,7 @@ fn FormatRow(
 /// Expandable row for formats with multiple files (after merge). Shows the
 /// format badge with a file count, and sub-rows for each file.
 #[component]
-fn MultiFileRow(
-    kind: FormatKind,
-    #[cfg_attr(feature = "mobile", allow(unused_variables))] uuid: String,
-    files: Vec<BookFileInfo>,
-) -> Element {
+fn MultiFileRow(kind: FormatKind, uuid: String, files: Vec<BookFileInfo>) -> Element {
     let label = kind.label();
     let testid = format!("format-row-{}", label.to_ascii_lowercase());
     let count = files.len();
@@ -165,6 +118,7 @@ fn MultiFileRow(
                 let file_label = file.label.clone()
                     .unwrap_or_else(|| format!("Part {}", file.ordinal + 1));
                 let file_testid = format!("format-file-{}", file.id);
+                let file_id = file.id;
                 rsx! {
                     div {
                         class: "format-row format-subrow",
@@ -172,57 +126,14 @@ fn MultiFileRow(
                         span { class: "format-sublabel", "{file_label}" }
                         div { class: "format-actions",
                             match kind {
+                                // Per-file actions delegate to platform-gated
+                                // helpers (rule 07: hydration parity — keep
+                                // cfg gates out of rsx bodies).
                                 FormatKind::Epub => rsx! {
-                                    {
-                                        #[cfg(not(feature = "mobile"))]
-                                        let read_action = {
-                                            let href = format!("/read/{uuid}?file_id={}", file.id);
-                                            rsx! {
-                                                Link {
-                                                    to: "{href}",
-                                                    class: "btn",
-                                                    "data-testid": "action-read",
-                                                    "Read"
-                                                }
-                                            }
-                                        };
-                                        #[cfg(feature = "mobile")]
-                                        let read_action = rsx! {
-                                            button {
-                                                class: "btn",
-                                                disabled: true,
-                                                "data-testid": "action-read",
-                                                "Read"
-                                            }
-                                        };
-                                        read_action
-                                    }
+                                    {read_file_action(&uuid, file_id)}
                                 },
                                 FormatKind::M4b | FormatKind::Mp3 => rsx! {
-                                    {
-                                        #[cfg(not(feature = "mobile"))]
-                                        let listen_action = {
-                                            let href = format!("/listen/{uuid}?file_id={}", file.id);
-                                            rsx! {
-                                                Link {
-                                                    to: "{href}",
-                                                    class: "btn",
-                                                    "data-testid": "action-listen",
-                                                    "Listen"
-                                                }
-                                            }
-                                        };
-                                        #[cfg(feature = "mobile")]
-                                        let listen_action = rsx! {
-                                            button {
-                                                class: "btn",
-                                                disabled: true,
-                                                "data-testid": "action-listen",
-                                                "Listen"
-                                            }
-                                        };
-                                        listen_action
-                                    }
+                                    {listen_file_action(&uuid, file_id)}
                                 },
                                 FormatKind::Other(_) => rsx! {
                                     span { class: "format-actions-empty", "No actions yet" }
@@ -232,6 +143,121 @@ fn MultiFileRow(
                     }
                 }
             }
+        }
+    }
+}
+
+// ── Per-target action helpers ────────────────────────────────────
+//
+// The cfg gate lives at the helper definition, not inside an rsx body.
+// SSR (`feature = "server"`) and WASM (`feature = "web"`) both hit the
+// `not(feature = "mobile")` arm and emit an identical `<a>` Link — so
+// hydration parity holds (rule 07). Mobile (`feature = "mobile"`) is
+// Dioxus Native, doesn't hydrate, and renders a disabled `<button>` as
+// a placeholder until F6.x lands the native reader/player.
+
+/// "Read" CTA for the book-level row. Web/SSR routes into the immersive
+/// reader; mobile renders a disabled placeholder.
+#[cfg(not(feature = "mobile"))]
+fn read_book_action(uuid: &str) -> Element {
+    rsx! {
+        Link {
+            to: Route::BookRead { uuid: uuid.to_string() },
+            class: "btn",
+            "data-testid": "action-read",
+            "Read"
+        }
+    }
+}
+
+#[cfg(feature = "mobile")]
+fn read_book_action(_uuid: &str) -> Element {
+    rsx! {
+        button {
+            class: "btn",
+            disabled: true,
+            title: "Reading on mobile coming soon",
+            "data-testid": "action-read",
+            "Read"
+        }
+    }
+}
+
+/// "Listen" CTA for the book-level row.
+#[cfg(not(feature = "mobile"))]
+fn listen_book_action(uuid: &str) -> Element {
+    rsx! {
+        Link {
+            to: Route::BookListen { uuid: uuid.to_string() },
+            class: "btn",
+            "data-testid": "action-listen",
+            "Listen"
+        }
+    }
+}
+
+#[cfg(feature = "mobile")]
+fn listen_book_action(_uuid: &str) -> Element {
+    rsx! {
+        button {
+            class: "btn",
+            disabled: true,
+            title: "Listening on mobile coming soon",
+            "data-testid": "action-listen",
+            "Listen"
+        }
+    }
+}
+
+/// Per-file "Read" CTA used inside a `MultiFileRow`. Routes carry a
+/// `file_id` query so the reader opens the chosen file.
+#[cfg(not(feature = "mobile"))]
+fn read_file_action(uuid: &str, file_id: i64) -> Element {
+    let href = format!("/read/{uuid}?file_id={file_id}");
+    rsx! {
+        Link {
+            to: "{href}",
+            class: "btn",
+            "data-testid": "action-read",
+            "Read"
+        }
+    }
+}
+
+#[cfg(feature = "mobile")]
+fn read_file_action(_uuid: &str, _file_id: i64) -> Element {
+    rsx! {
+        button {
+            class: "btn",
+            disabled: true,
+            "data-testid": "action-read",
+            "Read"
+        }
+    }
+}
+
+/// Per-file "Listen" CTA used inside a `MultiFileRow`.
+#[cfg(not(feature = "mobile"))]
+fn listen_file_action(uuid: &str, file_id: i64) -> Element {
+    let href = format!("/listen/{uuid}?file_id={file_id}");
+    rsx! {
+        Link {
+            to: "{href}",
+            class: "btn",
+            "data-testid": "action-listen",
+            "Listen"
+        }
+    }
+}
+
+#[cfg(feature = "mobile")]
+fn listen_file_action(_uuid: &str, _file_id: i64) -> Element {
+    rsx! {
+        button {
+            class: "btn",
+            disabled: true,
+            "data-testid": "action-listen",
+            "Listen"
         }
     }
 }

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -123,19 +123,16 @@ fn UserMenuPanel(user: UserSummary, open: Signal<bool>) -> Element {
     let on_signout = move |_| {
         // Spawn first; closing the menu unmounts the button mid-handler on
         // web, which can swallow work queued after `open.set(false)`.
-        #[cfg(feature = "web")]
-        {
-            spawn(async move {
-                let _ = crate::data::logout().await;
-                open.set(false);
-                nav.replace(Route::Login {});
-            });
-        }
-        #[cfg(not(feature = "web"))]
-        {
+        //
+        // Hydration parity (rule 07): the closure body must be identical
+        // across SSR/WASM. `data::logout` has a non-web `Ok(())` stub so
+        // this dispatches uniformly — SSR never fires click handlers, and
+        // WASM runs the real REST call.
+        spawn(async move {
+            let _ = crate::data::logout().await;
             open.set(false);
-            let _ = nav;
-        }
+            nav.replace(Route::Login {});
+        });
     };
 
     let on_keydown = move |evt: Event<KeyboardData>| {
@@ -153,14 +150,18 @@ fn UserMenuPanel(user: UserSummary, open: Signal<bool>) -> Element {
             "aria-label": "User menu",
             tabindex: "-1",
             onkeydown: on_keydown,
-            onmounted: move |_evt: MountedEvent| {
+            onmounted: move |evt: MountedEvent| {
                 // Focus the panel so the onkeydown listener above receives
                 // ESC presses — opening the menu via the trigger leaves
                 // focus on the (now-unmounted-from-DOM-tab-order) trigger
                 // otherwise. Defer to the next animation frame so the
                 // browser has finished layout before `.focus()` lands.
-                #[cfg(feature = "web")]
-                focus_user_menu_panel(&_evt);
+                //
+                // Hydration parity (rule 07): closure body stays identical
+                // across SSR/WASM; `focus_user_menu_panel` has a non-web
+                // no-op stub so the gate lives at the function definition,
+                // not inside the rsx-attached handler.
+                focus_user_menu_panel(&evt);
             },
 
             // ── Header ────────────────────────────────────────────
@@ -363,6 +364,13 @@ fn focus_user_menu_panel(evt: &MountedEvent) {
     });
     let _ = window.request_animation_frame(cb.unchecked_ref());
 }
+
+/// Non-web stub: SSR never paints the panel and native shells don't
+/// drive the user menu, so there is nothing to focus. Defined so the
+/// `onmounted` handler can call `focus_user_menu_panel` unconditionally
+/// (rule 07: hydration parity — keep cfg gates out of rsx bodies).
+#[cfg(not(feature = "web"))]
+fn focus_user_menu_panel(_evt: &MountedEvent) {}
 
 #[cfg(test)]
 mod tests {

--- a/frontend/src/data/auth.rs
+++ b/frontend/src/data/auth.rs
@@ -156,6 +156,17 @@ pub async fn logout() -> Result<(), String> {
     Ok(())
 }
 
+/// Non-web stub for `logout`. Mirrors the `current_user` SSR/mobile
+/// stub: the real REST call is web-only, but exposing a no-op under SSR
+/// (and any non-web build that compiles `UserMenu`) lets the sign-out
+/// closure call `data::logout()` unconditionally — so SSR and WASM emit
+/// identical RSX (rule 07-hydration), without each call site needing a
+/// `#[cfg]` gate inside its closure body.
+#[cfg(all(any(feature = "server", feature = "mobile"), not(feature = "web")))]
+pub async fn logout() -> Result<(), String> {
+    Ok(())
+}
+
 /// GET `/api/auth/me` (web) — resolve the currently-authenticated user, if any.
 #[cfg(feature = "web")]
 pub async fn current_user() -> Result<Option<UserSummary>, String> {


### PR DESCRIPTION
## Summary
- `.claude/rules/07-hydration.md` forbids feature-gating component bodies on `web`/`mobile`/`server` — SSR and the first WASM paint must emit the same RSX or Dioxus mis-adopts the DOM. Issue #468 fixed this in `BookDetailPage`; the same pattern was still present in `format_switcher` and `user_menu`. This change pulls the cfgs out of the rsx and pushes them onto helper definitions instead.
- `format_switcher.rs`: extract `read_book_action` / `listen_book_action` (book-level CTAs) and `read_file_action` / `listen_file_action` (per-file CTAs) into helpers with paired `#[cfg(not(feature = "mobile"))]` + `#[cfg(feature = "mobile")]` impls. Component bodies now just call the helpers — no inline cfgs around rsx fragments.
- `user_menu.rs`: drop the `#[cfg(feature = "web")]` branches inside the `on_signout` closure and the `onmounted` handler. The closure bodies are now identical across targets. `focus_user_menu_panel` grows a non-web no-op stub (mirroring `search_palette::focus_palette_input`), and `data::logout` grows a non-web `Ok(())` stub (mirroring `data::current_user`), so the call sites stay cfg-free.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo check -p omnibus-frontend --no-default-features --features mobile` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — 159 passed, 0 failed
- [ ] Playwright E2E (run_ui_tests label set) — exercises landing -> book-detail -> sign-out (format_switcher + user_menu markup)

## Notes
- **`search_palette/mod.rs:98` audit.** The `#[cfg(feature = "web")]` at line 98 gates the top-level function definition `use_palette_global_shortcut`, not an rsx body. Lines 127-128 supply the matching non-web no-op stub, and the App-level caller invokes it unconditionally. That is the *recommended* interop pattern under rule 07 (move the cfg to the helper, keep the call site unconditional), so no change is needed there. The third bullet of the issue's evidence list is a benign occurrence of the pattern, not a violation.
- `cargo clippy --no-default-features --features mobile` for the frontend crate hits a pre-existing `dead_code` error on `validate_author_photo_url` in `rpc.rs` that also fires from a clean `origin/main` checkout — unrelated to this change.
- `cargo clippy -p omnibus-mobile` was not run: the sandbox is missing the `gdk-3.0` system library that the mobile shell depends on. Daily lint covers it.
- Hydration parity holds because SSR (`feature = "server"`) and WASM (`feature = "web"`) both fall into the `not(feature = "mobile")` arm of each helper — they emit identical Link markup, exactly the invariant rule 07 requires.

Closes #519

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjvorRb6pEEaSwaovBwJ9d)_