### PR TITLE
refactor: stop leaking sqlx::Error through SyncError (#518)

### DIFF
--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -42,7 +42,7 @@ mod tests;
 
 pub(crate) use audiobooks::insert_chapters;
 pub use audiobooks::{sync_audiobooks, sync_audiobooks_with_progress, AudiobookSyncPlan};
-pub use books::{replace_books, sync_books, sync_books_with_progress, SyncError, SyncPlan};
+pub use books::{replace_books, sync_books, sync_books_with_progress, SyncPlan};
 
 // The single `books_fts` door. `upsert_fts` / `delete_fts` are
 // `pub(crate)` for the in-tx write sites (sync / merge / undo /

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -45,7 +45,7 @@ pub async fn sync_audiobooks(
     pool: &SqlitePool,
     library_path: &str,
     plan: AudiobookSyncPlan,
-) -> Result<(), SyncError> {
+) -> anyhow::Result<()> {
     sync_audiobooks_with_progress(pool, library_path, plan, |_, _| {}).await
 }
 
@@ -58,7 +58,7 @@ pub async fn sync_audiobooks_with_progress(
     library_path: &str,
     plan: AudiobookSyncPlan,
     mut on_progress: impl FnMut(u32, u32),
-) -> Result<(), SyncError> {
+) -> anyhow::Result<()> {
     let total: u32 = (plan.changed_books.len() + plan.new_books.len())
         .try_into()
         .unwrap_or(u32::MAX);

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -27,12 +27,7 @@ use super::authors::insert_author_links;
 use super::backfill::backfill_stat_chunks;
 use super::fts::{delete_fts, upsert_fts};
 
-/// Internal error type for the sync write path. `pub(crate)` so it cannot
-/// be observed (or pattern-matched on its inner `sqlx::Error`) outside the
-/// `db` crate — the public sync entry points return `anyhow::Result<()>` and
-/// callers see only an opaque `anyhow::Error`. Internal helpers in
-/// [`super::books`] and [`super::audiobooks`] use this enum so `?` keeps
-/// converting `sqlx::Error` cleanly without a per-call `.context(...)`.
+/// Crate-internal error wrapping `sqlx::Error` so `?` propagates cleanly in the audiobook sync helpers.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SyncError {
     #[error(transparent)]

--- a/db/src/sync/books.rs
+++ b/db/src/sync/books.rs
@@ -27,9 +27,14 @@ use super::authors::insert_author_links;
 use super::backfill::backfill_stat_chunks;
 use super::fts::{delete_fts, upsert_fts};
 
-/// Errors returned by the public sync write path.
+/// Internal error type for the sync write path. `pub(crate)` so it cannot
+/// be observed (or pattern-matched on its inner `sqlx::Error`) outside the
+/// `db` crate — the public sync entry points return `anyhow::Result<()>` and
+/// callers see only an opaque `anyhow::Error`. Internal helpers in
+/// [`super::books`] and [`super::audiobooks`] use this enum so `?` keeps
+/// converting `sqlx::Error` cleanly without a per-call `.context(...)`.
 #[derive(Debug, thiserror::Error)]
-pub enum SyncError {
+pub(crate) enum SyncError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
 }
@@ -87,7 +92,7 @@ pub async fn sync_books(
     pool: &SqlitePool,
     library_path: &str,
     plan: SyncPlan,
-) -> Result<(), SyncError> {
+) -> anyhow::Result<()> {
     sync_books_with_progress(pool, library_path, plan, |_, _| {}).await
 }
 
@@ -102,7 +107,7 @@ pub async fn sync_books_with_progress(
     library_path: &str,
     plan: SyncPlan,
     mut on_progress: impl FnMut(u32, u32),
-) -> Result<(), SyncError> {
+) -> anyhow::Result<()> {
     let total: u32 = (plan.changed_books.len() + plan.new_books.len())
         .try_into()
         .unwrap_or(u32::MAX);
@@ -684,7 +689,7 @@ pub async fn replace_books(
     pool: &SqlitePool,
     library_path: &str,
     books: Vec<crate::ebook::IndexedBook>,
-) -> Result<(), SyncError> {
+) -> anyhow::Result<()> {
     let removed_uuids: Vec<String> = sqlx::query_scalar(
         "SELECT b.uuid FROM books b
          JOIN scan_roots l ON l.id = b.library_id

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -237,9 +237,10 @@ pub enum AuthError {
 into every downstream caller: any future migration to a different DB
 crate becomes a workspace-wide rename, and `sqlx::Error` carries
 unrelated variants (`PoolTimedOut`, `Configuration`, …) the caller
-can't meaningfully handle. It now returns `Result<(), SyncError>` — a
-module-local enum in `db/src/sync/books.rs` that wraps `sqlx::Error`
-via `#[error(transparent)] #[from]`. Wrap, don't leak.
+can't meaningfully handle. It now returns `anyhow::Result<()>` — the
+internal `SyncError` enum in `db/src/sync/books.rs` is `pub(crate)`,
+so external callers see only an opaque `anyhow::Error` and `sqlx::Error`
+stays inside the `db` crate. Wrap, don't leak.
 
 ---
 


### PR DESCRIPTION
## Summary
- Chose **Option B** from the issue: change `sync_books` / `sync_books_with_progress` / `replace_books` / `sync_audiobooks` / `sync_audiobooks_with_progress` to return `anyhow::Result<()>`, demote `SyncError` to `pub(crate)`, and drop it from the `pub use sync::*` re-export. External callers can no longer reach `SyncError` (let alone its inner `sqlx::Error`) — the boundary rule from `.claude/rules/02-error-handling.md` holds again.
- Picked B over A because the caller audit (`grep -rn "SyncError" server/ frontend/ shared/ mobile/`) returned **zero** hits — no code outside `db/` pattern-matches on a variant, and the sole `db`-side consumer (`db::indexer::reindex*`) already returns `anyhow::Result<()>`. Option A (wrapping the inner `sqlx::Error` in `anyhow::Error` and keeping `SyncError` `pub`) would have preserved a now-unused public surface for no benefit.
- Internal helpers in `db/src/sync/books.rs` and `db/src/sync/audiobooks.rs` keep returning `Result<_, SyncError>` so `?` on `sqlx::Error` stays ergonomic; the typed-error → `anyhow::Error` conversion happens once, at the public function boundary, via the blanket `From<E: std::error::Error + Send + Sync + 'static>` impl.
- Refreshed the worked example in `docs/style-guide.md` ("Never leak `sqlx::Error`") to describe the new shape instead of the old `Result<(), SyncError>` signature.

## Test plan
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 562 unit + 2 integration tests pass
- [x] `cargo test -p omnibus` — 197 tests pass
- [x] `cargo fmt` — no diff
- [x] Boundary verification: `grep -rn "SyncError" server/ frontend/ shared/ mobile/` returns no matches.

## Notes
- Prior rounds on the same boundary rule: #305, #350, #399, #439.
- Per the runbook, the CI canary (`grep -rn "sqlx::Error" db/src --include="*.rs" | grep "pub "`) is **out of scope** for this PR — flagging it here for a follow-up. The grep currently still surfaces two other `pub` functions returning `Result<_, sqlx::Error>` (`identity::backfill_scan_keys` and `sync::fts::rebuild_all_fts`); those are separate leaks for separate issues, not within `SyncError`'s blast radius.
- `From<crate::settings::SettingsError> for SyncError` is kept — still useful for any internal helper that needs to bubble a `SettingsError` via `SyncError` (e.g. the existing `upsert_library` callsite which is `?`'d inside an internal `SyncError`-returning helper layer).
- `docs/design/db-review-f13-change-tracking.md` references "the `SyncError` pattern at `db/src/sync/books.rs:25`" as a forward-looking design note for a future module's typed error enum. Left as-is: the conceptual model (module-local `thiserror` enum that wraps `sqlx::Error` via `#[error(transparent)] #[from]`) is unchanged; only the visibility (`pub(crate)` instead of `pub`) is new and is the recommendation any future module should follow anyway.

Closes #518.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjvorRb6pEEaSwaovBwJ9d)_