### PR TITLE
refactor: stop leaking sqlx::Error from backfill_scan_keys (#535)

### DIFF
--- a/db/src/identity.rs
+++ b/db/src/identity.rs
@@ -10,6 +10,13 @@
 
 use sqlx::SqlitePool;
 
+/// Errors returned by [`backfill_scan_keys`].
+#[derive(Debug, thiserror::Error)]
+pub enum IdentityError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
 /// Reconstruct a book/attachment's `scan_key` (its scanner-relative path)
 /// from the stored `(path, filename, format)` and the part count, matching
 /// exactly what the Phase-A walk would emit so the diff doesn't
@@ -37,7 +44,7 @@ fn reconstruct_scan_key(path: &str, filename: &str, format: &str, part_count: i6
 /// indexed before migration 0026. Idempotent — only touches rows where
 /// `scan_key IS NULL` — and pure DB work, so it runs on every boot from
 /// `init_db` and against in-memory test DBs.
-pub async fn backfill_scan_keys(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+pub async fn backfill_scan_keys(pool: &SqlitePool) -> Result<(), IdentityError> {
     backfill_books_scan_keys(pool).await?;
     backfill_merged_scan_keys(pool).await?;
     Ok(())

--- a/db/src/identity/tests.rs
+++ b/db/src/identity/tests.rs
@@ -65,3 +65,11 @@ async fn backfill_fills_null_scan_keys_once_and_is_idempotent() {
             .unwrap();
     assert_eq!(still.as_deref(), Some("Author/Title.epub"));
 }
+
+#[tokio::test]
+async fn backfill_scan_keys_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = backfill_scan_keys(&pool).await.unwrap_err();
+    assert!(matches!(err, IdentityError::Db(_)));
+}

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use sqlx::{sqlite::SqlitePoolOptions, Executor, SqlitePool};
 
 use crate::covers::covers_dir;
+use crate::identity::IdentityError;
 use crate::normalize::NormalizeError;
 
 /// Schema migrations embedded at compile time from `db/migrations/`.
@@ -21,6 +22,8 @@ pub enum InitDbError {
     Db(#[from] sqlx::Error),
     #[error(transparent)]
     Normalize(#[from] NormalizeError),
+    #[error(transparent)]
+    Identity(#[from] IdentityError),
     #[error(transparent)]
     SortKeys(#[from] crate::sort_keys::SortKeysError),
 }


### PR DESCRIPTION
## Summary

`db::identity::backfill_scan_keys` is a `pub async fn` reachable across the crate boundary as `omnibus_db::identity::backfill_scan_keys` (`db/src/lib.rs` declares `pub mod identity`). Its prior `Result<(), sqlx::Error>` return type violated the boundary rule in `.claude/rules/02-error-handling.md` ("Never return raw `sqlx::Error` across a module boundary").

This PR wraps the failure in a typed `IdentityError` enum — mirroring the existing `NormalizeError` / `SortKeysError` shape — and adds a matching `Identity(#[from] IdentityError)` variant to `InitDbError` so the only caller (`db/src/pool.rs` `init_db`) keeps propagating with `?` unchanged.

- `pub async fn backfill_scan_keys(...) -> Result<(), sqlx::Error>` → `Result<(), IdentityError>`
- New `IdentityError::Db(#[from] sqlx::Error)` in `db/src/identity.rs`
- New `InitDbError::Identity(#[from] IdentityError)` in `db/src/pool.rs`
- Private helpers `backfill_books_scan_keys` / `backfill_merged_scan_keys` keep their `Result<(), sqlx::Error>` signatures (they don't cross a module boundary).
- Added `backfill_scan_keys_propagates_db_error_when_pool_is_closed` mirroring the equivalent `NormalizeError::Db` coverage.

Continues the boundary-rule cleanup tracked in #305, #350, #399, #439, #518 (PR #533) — #535 was the last known remaining leak called out there.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 592 passed; 0 failed (includes the new test)
- [x] `cargo check -p omnibus -p omnibus-frontend -p omnibus-shared` — clean (mobile crate unchecked locally — system `gdk-3.0` unavailable in this sandbox; the touched API surface is internal to `omnibus-db` and unused by mobile)

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr8VwtVt2ebi8oTemj3Rah)_