### PR TITLE
refactor: drop dead reader fields and their JS payload (#521)

### DIFF
--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -34,8 +34,8 @@
  *
  * Selection callback:
  *   - `__omnibusOnSelection(json)` — invoked when the user selects text,
- *     with { cfiRange, text, rect: { x, y, width, height } } where rect
- *     is in viewport coordinates.
+ *     with { cfiRange, rect: { x, y, width } } where rect is in viewport
+ *     coordinates.
  */
 (function () {
   "use strict";
@@ -209,7 +209,6 @@
       if (!contents || !contents.window) return;
       var sel = contents.window.getSelection();
       if (!sel || sel.isCollapsed || !sel.toString().trim()) return;
-      var text = sel.toString().trim();
       var range = sel.getRangeAt(0);
       var iframeRect = { x: 0, y: 0 };
       try {
@@ -224,11 +223,9 @@
         x: r.left + iframeRect.x,
         y: r.top + iframeRect.y,
         width: r.width,
-        height: r.height,
       };
       window.__omnibusOnSelection(JSON.stringify({
         cfiRange: cfiRange,
-        text: text,
         rect: rect,
       }));
     });

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -41,16 +41,12 @@ enum ReaderStatus {
 }
 
 /// Relocated event data from epub.js glue (deserialized from JSON).
-// INVARIANT: full deserialize shape preserved for forward-compat with
-// the epub.js glue payload. The render path consumes every field on
-// `web`, where epub.js deserializes the event; on non-`web` targets the
-// reader compiles but the deserialize call is `#[cfg]`'d out, so
-// dead_code fires on `cfi`. The allow holds the schema steady across
-// feature combos.
 #[derive(Clone, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct RelocateData {
+    // Only the web-feature progress-save path reads `cfi`; the other
+    // fields are read unconditionally by the bottom-bar render.
+    #[cfg_attr(not(feature = "web"), allow(dead_code))]
     cfi: Option<String>,
     page: u32,
     total_pages: u32,

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -44,8 +44,7 @@ enum ReaderStatus {
 #[derive(Clone, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RelocateData {
-    // Only the web-feature progress-save path reads `cfi`; the other
-    // fields are read unconditionally by the bottom-bar render.
+    // Only the web-feature progress-save path reads `cfi`; the other fields are read unconditionally by the bottom-bar render.
     #[cfg_attr(not(feature = "web"), allow(dead_code))]
     cfi: Option<String>,
     page: u32,

--- a/frontend/src/pages/reader/selection.rs
+++ b/frontend/src/pages/reader/selection.rs
@@ -6,31 +6,19 @@ use dioxus::prelude::*;
 use omnibus_shared::HighlightColor;
 
 /// Selection event data from epub.js glue (deserialized from JSON).
-// INVARIANT: full deserialize shape preserved for forward-compat with
-// the epub.js glue payload. `text` isn't surfaced in the popover today,
-// but the glue always sends it and downstream highlight-export work
-// needs it; thinning the schema now would force a re-add when that
-// lands.
 #[derive(Clone, Default, serde::Deserialize)]
-#[allow(dead_code)]
 pub(crate) struct SelectionData {
     #[serde(rename = "cfiRange")]
     pub(crate) cfi_range: String,
-    pub(crate) text: String,
     pub(crate) rect: SelectionRect,
 }
 
-// INVARIANT: full deserialize shape kept even though `height` isn't
-// read — the popover only positions horizontally today, but the glue
-// always emits all four fields and a vertical-flip placement is on
-// deck.
+/// Bounding rect of a live selection in viewport coordinates.
 #[derive(Clone, Default, serde::Deserialize)]
-#[allow(dead_code)]
 pub(crate) struct SelectionRect {
     pub(crate) x: f64,
     pub(crate) y: f64,
     pub(crate) width: f64,
-    pub(crate) height: f64,
 }
 
 /// Floating popover shown over a text selection with highlight color swatches.


### PR DESCRIPTION
## Summary

Resolves the `#[allow(dead_code)]` placeholders flagged in #521 on the reader module.

- **`SelectionData.text`** — deleted from the Rust struct AND from the epub.js glue selection payload. No Rust reader and no tracked feature issue justifying a placeholder.
- **`SelectionRect.height`** — deleted from the Rust struct AND from the JS rect object. The popover only positions horizontally; no consumer and no tracked issue.
- **`RelocateData.cfi`** — kept (it IS read, at `frontend/src/pages/reader/mod.rs:206` inside `#[cfg(feature = "web")]`, to persist progress). The broad struct-level `#[allow(dead_code)]` was hiding that cfi is the only field that goes unread under `--features server`; the other six fields are consumed unconditionally by the bottom-bar render at lines 402-419. Replaced the suppression with a narrow field-level `#[cfg_attr(not(feature = "web"), allow(dead_code))]` on `cfi` plus a one-line invariant comment.

## Notes

- For the two selection structs I took the **delete** path — there is no tracked feature issue to point a `// TODO(#N):` at, and the structs lose nothing today.
- For `RelocateData` I took the **narrow-the-suppression** path — deleting `cfi` would silently regress progress-save in the web reader, since it's the persisted CFI. The new `cfg_attr` makes the cross-feature invariant explicit instead of hiding behind a struct-wide allow.
- Updated the epub.js glue header comment to reflect the slimmed payload schema (`cfiRange`, `rect: { x, y, width }`).

## Acceptance criteria

- [x] Each suppressed field is removed OR has its suppression narrowed with an invariant comment (no tracked issues exist to point a `// TODO(#N):` at, so the deletion path was used for `text` and `height`).
- [x] No `#[allow(dead_code)]` remains without a one-line comment explaining the invariant.
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` passes.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` (the AC's exact command) passes
- [x] `cargo clippy` (default members) passes
- [x] `cargo test -p omnibus-frontend --features server` — 160 / 160 pass
- [x] `cargo test --workspace --exclude omnibus-mobile` — 1005 / 1005 pass
- [ ] Manual: open an EPUB in the web reader, select text, confirm the highlight popover still positions correctly and the highlight write lands (covered transitively by the `run_ui_tests` label).

Closes #521

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr8VwtVt2ebi8oTemj3Rah)_