### PR TITLE
refactor: remove F1.13 placeholder aside from tag_cloud (#525)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -997,19 +997,6 @@ body.atrium,
   font-size: 14px;
 }
 
-/* Two-column layout for tag cloud + sidebar */
-.disc-two-col {
-  padding: 12px 0 48px;
-  display: grid;
-  grid-template-columns: 1fr 280px;
-  gap: 40px;
-  align-items: flex-start;
-}
-@media (max-width: 900px) {
-  .disc-two-col { grid-template-columns: 1fr; }
-  .disc-two-col > aside { display: none; }
-}
-
 /* Tag cloud container */
 .tag-cloud {
   display: flex;

--- a/frontend/src/pages/tag_cloud.rs
+++ b/frontend/src/pages/tag_cloud.rs
@@ -60,16 +60,11 @@ pub fn TagCloudPage() -> Element {
                 }
             }
 
-            // Two-column: cloud + sidebar stub
-            div { class: "disc-two-col",
-                // The cloud
-                div { class: "tag-cloud",
-                    for tag in tag_list.iter() {
-                        { render_tag_item(tag, max_count) }
-                    }
+            // The cloud
+            div { class: "tag-cloud",
+                for tag in tag_list.iter() {
+                    { render_tag_item(tag, max_count) }
                 }
-                // TODO(F1.13): Tag overlap matrix — related-tag panel.
-                aside { class: "card", aria_hidden: "true" }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Removes the empty `<aside class="card" aria-hidden="true">` placeholder from `frontend/src/pages/tag_cloud.rs` along with its `TODO(F1.13)` comment — the related-tag panel it was reserving space for has no tracked issue, and the empty element was being rendered to every visitor as a stray DOM node.
- Drops the now-unused `.disc-two-col` grid declaration from `frontend/assets/atrium.css` (verified no other markup references the class). The remaining `.tag-cloud` flow now sits directly under `.disc-page`, so the layout still works without the wrapper.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean (the acceptance-criteria check from the issue)
- [x] `cargo test -p omnibus-frontend --features server` — 160 passed
- [ ] Playwright run — labeled `run_ui_tests` for CI to cover the markup change

## Notes

Markup-only change. No DOM contract that any spec relies on (the aside had no role/label/testid and was `aria-hidden`).

Closes #525

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr8VwtVt2ebi8oTemj3Rah)_