### PR TITLE
docs: add /// summaries to public frontend items (#544)

### DIFF
--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -108,10 +108,14 @@ mod mobile_store {
         MAP.get_or_init(|| RwLock::new(HashMap::new()))
     }
 
+    /// Read the cached position (seconds) for `uuid` from the process-local map.
+    /// Returns `None` when no entry exists or the lock is poisoned.
     pub fn get(uuid: &str) -> Option<f64> {
         map().read().ok().and_then(|g| g.get(uuid).copied())
     }
 
+    /// Insert/overwrite the cached position (seconds) for `uuid` in the process-local map.
+    /// Silently no-ops if the lock is poisoned; the in-memory copy resets on cold launch.
     pub fn set(uuid: &str, seconds: f64) {
         if let Ok(mut g) = map().write() {
             g.insert(uuid.to_string(), seconds);
@@ -121,12 +125,16 @@ mod mobile_store {
     fn rate_key(uuid: &str) -> String {
         format!("rate::{uuid}")
     }
+    /// Read the cached playback-rate preference for `uuid` from the process-local map.
+    /// Returns `None` when no entry exists or the lock is poisoned.
     pub fn get_rate(uuid: &str) -> Option<f64> {
         map()
             .read()
             .ok()
             .and_then(|g| g.get(&rate_key(uuid)).copied())
     }
+    /// Insert/overwrite the cached playback-rate preference for `uuid` in the process-local map.
+    /// Silently no-ops if the lock is poisoned; the in-memory copy resets on cold launch.
     pub fn set_rate(uuid: &str, r: f64) {
         if let Ok(mut g) = map().write() {
             g.insert(rate_key(uuid), r);

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -37,6 +37,8 @@ pub enum Theme {
 }
 
 impl Theme {
+    /// Map this theme variant to its `data-theme` HTML attribute string
+    /// (e.g. `"dark"`, `"light"`, `"sepia"`).
     pub fn as_attr(self) -> &'static str {
         match self {
             Theme::Dark => "dark",
@@ -45,6 +47,8 @@ impl Theme {
         }
     }
 
+    /// Parse a `data-theme` attribute string back into a [`Theme`].
+    /// Returns `None` for any value outside the known set.
     pub fn from_attr(s: &str) -> Option<Self> {
         match s {
             "dark" => Some(Theme::Dark),

--- a/frontend/src/components/auth/strength.rs
+++ b/frontend/src/components/auth/strength.rs
@@ -21,6 +21,7 @@ impl StrengthScore {
         Self(raw.min(Self::MAX))
     }
 
+    /// Return the underlying clamped score (0..=[`Self::MAX`]).
     pub fn value(self) -> u8 {
         self.0
     }

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -22,8 +22,7 @@ pub struct SuggestionItem {
 }
 
 impl SuggestionItem {
-    /// Build a [`SuggestionItem`] from a canonical name and the count of
-    /// books currently linked to it (display-only).
+    /// Build a [`SuggestionItem`] from a canonical name and its linked-book count (display-only).
     pub fn new(name: impl Into<String>, count: usize) -> Self {
         Self {
             name: name.into(),

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -22,6 +22,8 @@ pub struct SuggestionItem {
 }
 
 impl SuggestionItem {
+    /// Build a [`SuggestionItem`] from a canonical name and the count of
+    /// books currently linked to it (display-only).
     pub fn new(name: impl Into<String>, count: usize) -> Self {
         Self {
             name: name.into(),

--- a/frontend/src/reader_progress.rs
+++ b/frontend/src/reader_progress.rs
@@ -61,10 +61,14 @@ mod mobile_store {
         MAP.get_or_init(|| RwLock::new(HashMap::new()))
     }
 
+    /// Read the cached CFI for `uuid` from the process-local map.
+    /// Returns `None` when no entry exists or the lock is poisoned.
     pub fn get(uuid: &str) -> Option<String> {
         map().read().ok().and_then(|g| g.get(uuid).cloned())
     }
 
+    /// Insert/overwrite the cached CFI for `uuid` in the process-local map.
+    /// Silently no-ops if the lock is poisoned; the in-memory copy resets on cold launch.
     pub fn set(uuid: &str, cfi: String) {
         if let Ok(mut g) = map().write() {
             g.insert(uuid.to_string(), cfi);

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -73,6 +73,8 @@ mod mobile_store {
         MAP.get_or_init(|| RwLock::new(HashMap::new()))
     }
 
+    /// Read the cached prefs for `library_path` from the process-local map.
+    /// Returns [`ViewPrefs::default`] when no entry exists or the lock is poisoned.
     pub fn get(library_path: &str) -> ViewPrefs {
         map()
             .read()
@@ -81,6 +83,8 @@ mod mobile_store {
             .unwrap_or_default()
     }
 
+    /// Insert/overwrite the cached prefs for `library_path` in the process-local map.
+    /// Silently no-ops if the lock is poisoned; the in-memory copy resets on cold launch.
     pub fn set(library_path: &str, prefs: ViewPrefs) {
         if let Ok(mut g) = map().write() {
             g.insert(library_path.to_string(), prefs);


### PR DESCRIPTION
## Summary

Pure documentation pass — no logic changes. Adds the required one-line `///` rustdoc summary to twelve public items in the `omnibus-frontend` crate that were missing one, mirroring the doc-only strategy of #441 for the `db` crate.

Items covered:

- `view_prefs::mobile_store::{get, set}` — process-local map accessors
- `reader_progress::mobile_store::{get, set}` — CFI cache accessors
- `audiobook_progress::mobile_store::{get, set, get_rate, set_rate}` — seconds + playback-rate cache accessors
- `Theme::{as_attr, from_attr}` on `components::atrium::Theme`
- `StrengthScore::value` on `components::auth::strength::StrengthScore`
- `SuggestionItem::new` on `components::chip_editor::SuggestionItem`

### Refinement notes

The issue listed `pub fn get` / `pub fn set` / `pub fn get_rate` / `pub fn set_rate` against `view_prefs.rs`, `reader_progress.rs`, and `audiobook_progress.rs`. The **top-level** public API in those files (`load`, `save`, `load_rate`, `save_rate`) already has rustdoc summaries — the matching `get`/`set`/`get_rate`/`set_rate` symbols actually live inside each file's `#[cfg(feature = "mobile")] mod mobile_store`. Those mobile-store accessors were the ones missing `///`, so that's what this PR documents. Behaviour is the in-memory process-local map; the outer `load`/`save` already explain the SSR no-op contract.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (160 passed)

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JiufQemwRZTRy8RpnqCg5

---
_Generated by [Claude Code](https://claude.ai/code/session_011JiufQemwRZTRy8RpnqCg5)_