### PR TITLE
chore: bump argon2, sha2, getrandom, rand_core in db (#523)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -414,7 +414,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -430,6 +430,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -667,6 +676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-serialize"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +972,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1068,7 +1101,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1141,10 +1174,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1610,10 +1654,10 @@ version = "0.7.9"
 source = "git+https://github.com/DioxusLabs/dioxus?tag=v0.7.9#3e43ffa6cf1488d5388c888eb5f2494a006ae6de"
 dependencies = [
  "base16",
- "digest",
+ "digest 0.10.7",
  "proc-macro2",
  "quote",
- "sha2",
+ "sha2 0.10.9",
  "slab",
  "syn 2.0.117",
 ]
@@ -2774,7 +2818,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2859,6 +2903,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3703,7 +3756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4180,7 +4233,7 @@ dependencies = [
  "base64",
  "deunicode",
  "epub",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "image",
  "lofty",
  "omnibus-shared",
@@ -4188,7 +4241,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
@@ -5210,8 +5263,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -5510,8 +5563,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5527,8 +5580,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5572,7 +5636,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5767,7 +5831,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -5805,7 +5869,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5827,7 +5891,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -5848,7 +5912,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5885,7 +5949,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7778,7 +7842,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle 0.6.2",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -34,10 +34,20 @@ tracing.workspace = true
 # crate for this security-critical path. rand_core is pinned to 0.6 (same
 # version already in the lock via password-hash) with `getrandom` enabled so
 # that OsRng is available for SaltString::generate in password.rs.
+#
+# Why the version mix isn't uniformly "latest":
+# * argon2 0.5 is the latest *stable* release; 0.6 is only available as
+#   pre-release (0.6.0-rc.*) and we don't ship release candidates of
+#   password-hashing code. 0.5.3 has no open advisories.
+# * rand_core stays at 0.6 because argon2 0.5's transitive `password-hash`
+#   pulls 0.6, and our direct dep only exists to flip on the `getrandom`
+#   feature on that *same* 0.6 instance — a 0.9 direct bump would be dead
+#   weight (separate version, doesn't reach argon2's OsRng). Lock-stepped
+#   with the argon2 bump above.
 argon2 = "0.5"
-getrandom = "0.2"
+getrandom = "0.3"
 rand_core = { version = "0.6", features = ["getrandom"] }
-sha2 = "0.10"
+sha2 = "0.11"
 base64 = "0.22"
 
 # F1.2 thumbnail pipeline: decode EPUB covers (JPEG/PNG/WebP) and re-encode

--- a/db/src/auth/session_key.rs
+++ b/db/src/auth/session_key.rs
@@ -16,7 +16,7 @@ pub async fn load_or_create_session_key(pool: &SqlitePool) -> AuthResult<Vec<u8>
         return Ok(bytes);
     }
     let mut key = vec![0u8; SESSION_KEY_LEN];
-    getrandom::getrandom(&mut key)
+    getrandom::fill(&mut key)
         .map_err(|e| AuthError::Crypto(format!("CSPRNG byte generation failed: {e}")))?;
     put_session_key(pool, &key).await?;
     Ok(key)

--- a/db/src/auth/token.rs
+++ b/db/src/auth/token.rs
@@ -9,7 +9,7 @@ use super::{AuthError, AuthResult, SessionKind};
 /// padding). ~43 chars, 256-bit entropy. Returned to the client exactly once.
 pub fn generate_token() -> AuthResult<String> {
     let mut bytes = [0u8; 32];
-    getrandom::getrandom(&mut bytes)
+    getrandom::fill(&mut bytes)
         .map_err(|e| AuthError::Crypto(format!("CSPRNG byte generation failed: {e}")))?;
     Ok(URL_SAFE_NO_PAD.encode(bytes))
 }


### PR DESCRIPTION
## Summary

Pre-1.0 RustCrypto / random crates in `db/Cargo.toml` audited and bumped to their newest tractable versions.

**Bumped:**
- `sha2` 0.10 → **0.11.0** — source-compatible `Digest` API. SHA-256 of session tokens at rest still produces identical 32-byte digests.
- `getrandom` 0.2 → **0.3.4** — `getrandom::getrandom()` renamed to `getrandom::fill()`. Two call sites updated:
  - `db::auth::token::generate_token`
  - `db::auth::session_key::load_or_create_session_key`

**Skipped (justified inline in `db/Cargo.toml`):**
- `argon2` 0.5 → latest stable is **0.5.3** (already on `0.5`); `0.6` is only available as pre-release (`0.6.0-rc.8`). We don't ship release candidates of password-hashing code. PHC hash format is forward-compatible across these versions, so a future `0.6` bump won't invalidate stored hashes.
- `rand_core` 0.6 → stays at 0.6 because `argon2` 0.5's transitive `password-hash` pulls `rand_core 0.6`. The direct dep in `db/Cargo.toml` only exists to flip on the `getrandom` feature for that **same 0.6 instance** so `argon2::password_hash::rand_core::OsRng` works in `SaltString::generate`. A direct bump to 0.9 would introduce a separate version that doesn't reach argon2's OsRng. Will move in lock-step the next time argon2 ships a stable major.

## Test plan

- [x] `cargo build -p omnibus-db` clean
- [x] `cargo test -p omnibus-db` — all 594 tests pass (592 lib + 2 integration), including:
  - `auth::password::tests::password_roundtrips` — exercises `argon2::PasswordHash::parse` round-trip
  - `auth::session_key::tests::session_key_is_created_and_stable` — covers the `getrandom::fill` path
  - `auth::token::tests::token_is_unique_and_base64url` + `token_hash_is_deterministic_and_32_bytes` — cover both `getrandom::fill` and `sha2::Sha256`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` clean
- [x] `cargo check -p omnibus` + `-p omnibus-frontend --features server` clean (no downstream breakage)
- [ ] `cargo audit` / `cargo deny check` — not available in this sandbox (no `nix develop .#audit` shell here); should be run in CI before merge

## Notes

- `Cargo.lock` updated (expected): adds `getrandom 0.3.4`, `sha2 0.11.0`. Older transitive versions remain in the lock because other deps still pin them (`getrandom 0.1/0.2/0.4`, `rand_core 0.5/0.9`, `sha2 0.10.9`) — that's normal and not addressable from this crate.
- No `unwrap()` / `expect()` introduced anywhere to make the bumps compile.

Closes #523

---
_Generated by [Claude Code](https://claude.ai/code/session_011JiufQemwRZTRy8RpnqCg5)_