### PR TITLE
chore(ci): test shared crate (#551)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,6 +104,9 @@ jobs:
       - name: cargo test (frontend)
         run: nix develop --command cargo test -p omnibus-frontend --features server
 
+      - name: cargo test (shared)
+        run: nix develop --command cargo test -p omnibus-shared
+
   security:
     name: cargo audit
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds a `cargo test (shared)` step to the CI `check` job so behavioral
tests in `omnibus-shared` (≈563 lines across progress, settings,
highlight, ebook serde) run on every PR and `main` push. Brings CI in
line with `just test`, which already covers all four crates.

Closes #551

## Test plan
- [ ] CI green on this PR (the new step runs against the unchanged shared/ tests)
