### PR TITLE
refactor(frontend): finish SeriesIndexPage extraction (partial #377)

### DIFF
--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -2,6 +2,8 @@
 //! surface, mirroring the `SeriesIndex` design comp from
 //! `screens/indices.jsx`.
 
+use std::cmp::Reverse;
+
 use dioxus::prelude::*;
 use dioxus_router::Link;
 use omnibus_shared::SeriesSummary;
@@ -55,11 +57,7 @@ pub fn SeriesIndexPage() -> Element {
     }
 }
 
-/// Spawn the one-shot `list_series` fetch and surface its outcome as three
-/// signals (data, loading flag, error message). Declaring the signals and the
-/// effect here keeps the hook order in `SeriesIndexPage` short and stable —
-/// every render still calls `use_signal` three times and `use_effect` once,
-/// in the same order, on every target.
+/// Hook: own the `list_series` fetch and surface (data, loading, error) signals.
 fn use_series_data(
     server_url: String,
 ) -> (
@@ -89,10 +87,7 @@ fn use_series_data(
     (series, loading, error)
 }
 
-/// Filter `items` by `query` (case-insensitive, matched against series name
-/// and primary author), then sort the remaining references by the chosen
-/// axis. Returns borrowed references so the caller can keep the original
-/// `Vec` alive without per-keystroke cloning.
+/// Filter by `query` (name + primary author, case-insensitive), then sort by `sort`.
 fn apply_filter_and_sort<'a>(
     items: &'a [SeriesSummary],
     query: &str,
@@ -113,13 +108,13 @@ fn apply_filter_and_sort<'a>(
             })
             .collect()
     };
+    // `sort_by_cached_key` evaluates the key once per element instead of
+    // re-running `to_lowercase()` on every comparison.
     match sort {
-        Sort::Name => filtered.sort_by_key(|a| sort_key(a).to_lowercase()),
-        Sort::BookCount => filtered.sort_by(|a, b| {
-            b.book_count
-                .cmp(&a.book_count)
-                .then_with(|| sort_key(a).to_lowercase().cmp(&sort_key(b).to_lowercase()))
-        }),
+        Sort::Name => filtered.sort_by_cached_key(|a| sort_key(a).to_lowercase()),
+        Sort::BookCount => {
+            filtered.sort_by_cached_key(|a| (Reverse(a.book_count), sort_key(a).to_lowercase()))
+        }
     }
     filtered
 }
@@ -139,9 +134,7 @@ fn render_error_state(msg: &str) -> Element {
     }
 }
 
-/// Body grid: either the empty-state copy or the filtered card grid.
-/// `library_empty` distinguishes "no series indexed yet" from "filter
-/// matches nothing" so the copy can address each case directly.
+/// Body grid: empty-state copy when `filtered` is empty, otherwise the card grid.
 fn render_series_body(filtered: &[&SeriesSummary], library_empty: bool) -> Element {
     rsx! {
         div { class: "idx-body",

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -18,15 +18,61 @@ enum Sort {
 #[component]
 pub fn SeriesIndexPage() -> Element {
     let server_url = use_server_url();
+    let mut filter = use_signal(String::new);
+    let mut sort = use_signal(|| Sort::Name);
+    let (series, loading, error) = use_series_data(server_url);
+
+    if loading() {
+        return render_loading_state();
+    }
+    if let Some(msg) = error() {
+        return render_error_state(&msg);
+    }
+
+    // Borrow the signal's contents instead of cloning — see authors_index
+    // for the same shape and rationale (up to `INDEX_LIMIT` rows, copied
+    // on every keystroke would be wasted work).
+    let all = series.read();
+    let total_series = all.len();
+    let total_books: usize = all.iter().map(|s| s.book_count).sum();
+
+    let filter_text = filter();
+    let current_sort = sort();
+    let filtered = apply_filter_and_sort(&all, &filter_text, current_sort);
+
+    rsx! {
+        div { class: "idx-page",
+            SeriesIndexHeader {
+                total_series,
+                total_books,
+                filter: filter_text,
+                sort: current_sort,
+                on_filter: move |v| filter.set(v),
+                on_sort: move |s| sort.set(s),
+            }
+            {render_series_body(&filtered, all.is_empty())}
+        }
+    }
+}
+
+/// Spawn the one-shot `list_series` fetch and surface its outcome as three
+/// signals (data, loading flag, error message). Declaring the signals and the
+/// effect here keeps the hook order in `SeriesIndexPage` short and stable —
+/// every render still calls `use_signal` three times and `use_effect` once,
+/// in the same order, on every target.
+fn use_series_data(
+    server_url: String,
+) -> (
+    Signal<Vec<SeriesSummary>>,
+    Signal<bool>,
+    Signal<Option<String>>,
+) {
     let mut series: Signal<Vec<SeriesSummary>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
-    let mut filter = use_signal(String::new);
-    let mut sort = use_signal(|| Sort::Name);
 
-    let url = server_url.clone();
     use_effect(move || {
-        let url = url.clone();
+        let url = server_url.clone();
         spawn(async move {
             loading.set(true);
             match data::list_series(&url).await {
@@ -40,30 +86,24 @@ pub fn SeriesIndexPage() -> Element {
         });
     });
 
-    if loading() {
-        return rsx! {
-            p { class: "subtitle", "Loading\u{2026}" }
-        };
-    }
-    if let Some(msg) = error() {
-        return rsx! {
-            p { role: "alert", class: "subtitle", "{msg}" }
-            Link { to: Route::Landing {}, class: "btn", "Back to library" }
-        };
-    }
+    (series, loading, error)
+}
 
-    // Borrow the signal's contents instead of cloning — see authors_index
-    // for the same shape and rationale (up to `INDEX_LIMIT` rows, copied
-    // on every keystroke would be wasted work).
-    let all = series.read();
-    let total_series = all.len();
-    let total_books: usize = all.iter().map(|s| s.book_count).sum();
-
-    let q = filter.read().to_lowercase();
+/// Filter `items` by `query` (case-insensitive, matched against series name
+/// and primary author), then sort the remaining references by the chosen
+/// axis. Returns borrowed references so the caller can keep the original
+/// `Vec` alive without per-keystroke cloning.
+fn apply_filter_and_sort<'a>(
+    items: &'a [SeriesSummary],
+    query: &str,
+    sort: Sort,
+) -> Vec<&'a SeriesSummary> {
+    let q = query.to_lowercase();
     let mut filtered: Vec<&SeriesSummary> = if q.is_empty() {
-        all.iter().collect()
+        items.iter().collect()
     } else {
-        all.iter()
+        items
+            .iter()
             .filter(|s| {
                 s.name.to_lowercase().contains(&q)
                     || s.primary_author
@@ -73,7 +113,7 @@ pub fn SeriesIndexPage() -> Element {
             })
             .collect()
     };
-    match sort() {
+    match sort {
         Sort::Name => filtered.sort_by_key(|a| sort_key(a).to_lowercase()),
         Sort::BookCount => filtered.sort_by(|a, b| {
             b.book_count
@@ -81,31 +121,42 @@ pub fn SeriesIndexPage() -> Element {
                 .then_with(|| sort_key(a).to_lowercase().cmp(&sort_key(b).to_lowercase()))
         }),
     }
+    filtered
+}
 
+/// Loading placeholder shown while `list_series` is in flight.
+fn render_loading_state() -> Element {
     rsx! {
-        div { class: "idx-page",
-            SeriesIndexHeader {
-                total_series,
-                total_books,
-                filter: filter(),
-                sort: sort(),
-                on_filter: move |v| filter.set(v),
-                on_sort: move |s| sort.set(s),
-            }
-            div { class: "idx-body",
-                if filtered.is_empty() {
-                    p { class: "subtitle idx-empty",
-                        if all.is_empty() {
-                            "No series yet \u{2014} index a library to see them here."
-                        } else {
-                            "No series match that filter."
-                        }
+        p { class: "subtitle", "Loading\u{2026}" }
+    }
+}
+
+/// Error state with the fetch message and a link back to the library.
+fn render_error_state(msg: &str) -> Element {
+    rsx! {
+        p { role: "alert", class: "subtitle", "{msg}" }
+        Link { to: Route::Landing {}, class: "btn", "Back to library" }
+    }
+}
+
+/// Body grid: either the empty-state copy or the filtered card grid.
+/// `library_empty` distinguishes "no series indexed yet" from "filter
+/// matches nothing" so the copy can address each case directly.
+fn render_series_body(filtered: &[&SeriesSummary], library_empty: bool) -> Element {
+    rsx! {
+        div { class: "idx-body",
+            if filtered.is_empty() {
+                p { class: "subtitle idx-empty",
+                    if library_empty {
+                        "No series yet \u{2014} index a library to see them here."
+                    } else {
+                        "No series match that filter."
                     }
-                } else {
-                    div { class: "idx-series-grid",
-                        for s in filtered.iter() {
-                            div { key: "{s.id}", {render_series_card(s)} }
-                        }
+                }
+            } else {
+                div { class: "idx-series-grid",
+                    for s in filtered.iter() {
+                        div { key: "{s.id}", {render_series_card(s)} }
                     }
                 }
             }
@@ -266,5 +317,62 @@ mod tests {
         // "Theology" must not have "The" stripped — only the "The " word.
         assert_eq!(sort_key(&summary("Theology", None)), "Theology");
         assert_eq!(sort_key(&summary("Dune", None)), "Dune");
+    }
+
+    fn summary_full(name: &str, author: Option<&str>, book_count: usize) -> SeriesSummary {
+        SeriesSummary {
+            name: name.to_string(),
+            primary_author: author.map(String::from),
+            book_count,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_filter_and_sort_returns_all_when_query_is_empty() {
+        let items = vec![
+            summary_full("Foundation", Some("Asimov"), 7),
+            summary_full("Dune", Some("Herbert"), 6),
+        ];
+        let out = apply_filter_and_sort(&items, "", Sort::Name);
+        assert_eq!(out.len(), 2);
+        // Sort::Name orders alphabetically by sort_key.
+        assert_eq!(out[0].name, "Dune");
+        assert_eq!(out[1].name, "Foundation");
+    }
+
+    #[test]
+    fn apply_filter_and_sort_filters_by_name_case_insensitive() {
+        let items = vec![
+            summary_full("Foundation", Some("Asimov"), 7),
+            summary_full("Dune", Some("Herbert"), 6),
+        ];
+        let out = apply_filter_and_sort(&items, "FOUND", Sort::Name);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "Foundation");
+    }
+
+    #[test]
+    fn apply_filter_and_sort_filters_by_primary_author() {
+        let items = vec![
+            summary_full("Foundation", Some("Asimov"), 7),
+            summary_full("Dune", Some("Herbert"), 6),
+        ];
+        let out = apply_filter_and_sort(&items, "herbert", Sort::Name);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "Dune");
+    }
+
+    #[test]
+    fn apply_filter_and_sort_sorts_by_book_count_descending_then_name() {
+        let items = vec![
+            summary_full("Alpha", None, 3),
+            summary_full("Bravo", None, 7),
+            summary_full("Charlie", None, 7),
+        ];
+        let out = apply_filter_and_sort(&items, "", Sort::BookCount);
+        assert_eq!(out[0].name, "Bravo");
+        assert_eq!(out[1].name, "Charlie");
+        assert_eq!(out[2].name, "Alpha");
     }
 }


### PR DESCRIPTION
## Summary

Partial follow-up to #377 — covers the `SeriesIndexPage` item only. The other six oversized functions cited in that issue (`render_loaded` in `book_detail`, `ChipEditor`, `BookReadPage`, `LandingPage`, `AuthorsIndexPage`, `install_control_surface`) are each their own PR.

Earlier work on `frontend/src/pages/series_index.rs` already split out `SeriesIndexHeader`, `render_series_card`, and `sort_key`. The component body was still ~95 lines — over the 80-line soft cap in `.claude/rules/05-rust-style.md`. This PR finishes the extraction.

## Changes

- `use_series_data(server_url)` — owns the three data signals (`series`, `loading`, `error`) and the one-shot `list_series` `use_effect`. Hook order in `SeriesIndexPage` stays stable across renders, so SSR/WASM hydration parity holds (rule 07).
- `apply_filter_and_sort(items, query, sort)` — pure helper that filters by name + primary author (case-insensitive) and sorts by either name or descending book count. Returns borrowed references (no per-keystroke clone). Covered by four new unit tests.
- `render_loading_state` / `render_error_state` / `render_series_body` — small rsx helpers so the orchestrator reads top-down.

After: `SeriesIndexPage` body drops from ~95 lines to 44.

## Testids preserved

All four Playwright contract testids stay on the same elements:

- `series-filter` (filter input)
- `series-sort-name` (A–Z sort toggle)
- `series-sort-count` (most-books sort toggle)
- `series-card` (each link tile)

They live inside `SeriesIndexHeader` / `render_series_card`, neither of which moved.

## Verification

- `cargo fmt`
- `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- `cargo test -p omnibus-frontend --features server` — 164 passed, 0 failed (4 new `apply_filter_and_sort_*` tests)

## Test plan

- [ ] CI green
- [ ] `run_ui_tests` Playwright run (touches frontend markup; testids preserved but worth confirming)

Refs #377 (partial — does not close)
