### PR TITLE
chore(ci): enable cargo deny licenses check (#559)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -241,20 +241,15 @@ jobs:
           fi
 
       # cargo deny adds coverage cargo-audit lacks: advisories against the ~31
-      # git-pinned Dioxus crates, source allow-listing, and duplicate-version
-      # bans. deny.toml in the repo root is the config.
+      # git-pinned Dioxus crates, source allow-listing, duplicate-version bans,
+      # and license-allowlist enforcement. deny.toml in the repo root is the
+      # config.
       #
-      # Scoped to `advisories sources bans` for now — the `licenses` check is
-      # intentionally NOT run here yet: the workspace member crates carry no
-      # `license` field (they're unpublished), which cargo-deny reports as
-      # "unlicensed", and the full transitive license set hasn't been validated
-      # against deny.toml's allow-list locally. The [licenses] config is left in
-      # deny.toml so enabling it is a one-line follow-up once verified.
-      #
-      # Now a hard gate: a violation in advisories, sources, or bans fails the
-      # job. If a deny.toml policy needs to relax (e.g. a new git-pinned source
-      # appears for a Dioxus crate), update deny.toml's `[sources.allow-git]`
-      # or the relevant `ignore`/`skip` list rather than re-introducing
-      # `continue-on-error: true`.
+      # All four checks are hard gates: a violation in advisories, sources,
+      # bans, or licenses fails the job. If a policy needs to relax (e.g. a new
+      # git-pinned source appears for a Dioxus crate, or a transitive dep
+      # introduces a license not yet on the allowlist), update deny.toml's
+      # `[sources.allow-git]`, `[licenses].allow`, or the relevant
+      # `ignore`/`skip` list rather than re-introducing `continue-on-error: true`.
       - name: cargo deny check
-        run: nix develop .#audit --command cargo deny check advisories sources bans
+        run: nix develop .#audit --command cargo deny check advisories sources bans licenses

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,14 @@ members = ["server", "mobile", "shared", "frontend", "db"]
 default-members = ["server", "shared", "frontend"]
 resolver = "2"
 
+# Inherited package metadata. Members opt in with `<field>.workspace = true`
+# in their own `[package]` block. The `license` field is what flips
+# `cargo deny check licenses` from "unlicensed" to MIT for every workspace
+# crate — see LICENSE at the repo root and the `licenses` check in
+# `.github/workflows/rust.yml`.
+[workspace.package]
+license = "MIT"
+
 # Centralized dependency versions shared across crates. Crates pull these in
 # via `<dep>.workspace = true` (or `{ workspace = true, features = [...] }`
 # when they need extra features beyond the workspace baseline). Only deps

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -2,6 +2,7 @@
 name = "omnibus-db"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 # Server-side data layer: schema migrations, SQLite pool init, query layer,
 # and the indexing pipeline (file scanner → ebook metadata extraction →

--- a/deny.toml
+++ b/deny.toml
@@ -54,7 +54,9 @@ ignore = [
 # ---------------------------------------------------------------------------
 # Permissive set covering everything currently in the dependency tree.
 # Add entries here (never remove) when `cargo deny check licenses` reports
-# an unlicensed or denied crate after a dependency bump.
+# an unlicensed or denied crate after a dependency bump. Crate-specific
+# carve-outs go under `[[licenses.exceptions]]` below so the global allow
+# list stays minimal.
 [licenses]
 version = 2
 allow = [
@@ -64,15 +66,44 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
-    "Unicode-DFS-2016",
     "Unicode-3.0",
     "Zlib",
     "MPL-2.0",
     "CC0-1.0",
+    # Boost Software License — permissive, OSI-approved. Used by `xxhash-rust`
+    # (transitive via dioxus-fullstack).
+    "BSL-1.0",
+    # Community Data License Agreement, Permissive 2.0 — Linux Foundation
+    # license used by `webpki-roots` (Mozilla CA bundle data). Permissive;
+    # any TLS-via-rustls project hits this.
+    "CDLA-Permissive-2.0",
 ]
 # With version = 2 the allow-list above is authoritative: any license not
 # listed is denied, and a crate whose license cannot be determined is an
 # error. (The pre-v2 `unlicensed` / `copyleft` keys were removed in v2.)
+
+# Per-crate license carve-outs. Prefer this over expanding `allow` when a
+# single crate is the only user of an otherwise-undesirable license.
+[[licenses.exceptions]]
+# `epub` is GPL-3.0, used in `omnibus-db` to parse EPUB metadata. This is a
+# direct dependency carried over from before the licenses check was wired up;
+# the rest of the workspace is MIT. Scoping the GPL-3.0 acceptance to this one
+# crate keeps the policy honest — any other GPL crate sneaking in via a future
+# dependency bump still fails the check. Revisit by either porting metadata
+# extraction onto a non-GPL EPUB parser or accepting the copyleft posture
+# explicitly in LICENSE.
+allow = ["GPL-3.0"]
+name = "epub"
+
+[[licenses.exceptions]]
+# `libfuzzer-sys` is `(MIT OR Apache-2.0) AND NCSA`. NCSA (University of
+# Illinois/NCSA Open Source License) is permissive and OSI-approved, but is
+# the only crate in the tree that uses it, so scoping it here keeps the global
+# allow list lean. The crate enters the lock graph via `rav1e → ravif → image`
+# (and `dioxus-desktop`); our `image` features (`jpeg`, `png`, `webp`) do not
+# enable `avif`, so this never actually links into the runtime binary.
+allow = ["MIT", "Apache-2.0", "NCSA"]
+name = "libfuzzer-sys"
 
 # ---------------------------------------------------------------------------
 # Bans

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "omnibus-frontend"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 dioxus = { version = "0.7", features = ["fullstack"] }

--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -2,6 +2,7 @@
 name = "omnibus-mobile"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 dioxus = { version = "0.7", features = ["mobile"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "omnibus"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 # Unified Dioxus fullstack binary. Built twice by `dx serve`:
 # - Once as native (features: `server`) — axum backend + SSR + DB

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -2,6 +2,7 @@
 name = "omnibus-shared"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 serde.workspace = true


### PR DESCRIPTION
Closes #559.

## Summary

Adds `license` metadata to every workspace member and turns on the `licenses` cargo-deny check in CI, closing the "intentionally NOT run here yet" gap in `.github/workflows/rust.yml`.

## Changes

### License metadata (matches existing top-level `LICENSE`, MIT)

* `Cargo.toml`: new `[workspace.package]` block with `license = "MIT"`.
* `server/Cargo.toml`, `db/Cargo.toml`, `frontend/Cargo.toml`, `shared/Cargo.toml`, `mobile/Cargo.toml`: `license.workspace = true`.

`cargo metadata --no-deps` now reports `"license":"MIT"` for all five workspace crates.

### `deny.toml`

* Add `BSL-1.0` (Boost — permissive, used by `xxhash-rust` transitive via dioxus-fullstack).
* Add `CDLA-Permissive-2.0` (Linux Foundation data license — `webpki-roots` Mozilla CA bundle).
* Remove the unused `Unicode-DFS-2016` allow entry (cargo-deny was warning it was unmatched).
* Two scoped `[[licenses.exceptions]]` so the global `allow` stays minimal:
  * `epub` (`GPL-3.0`) — direct dep in `omnibus-db` for EPUB metadata parsing. **Pre-existing dependency, not introduced by this PR.** Worth flagging to a maintainer: the workspace is MIT, this lone GPL-3.0 transitive linker tug is the only copyleft component. Scoping the exception to this one crate means any future GPL dep still fails CI. Long-term options: port off `epub` to a non-GPL parser, or document the copyleft posture in `LICENSE`.
  * `libfuzzer-sys` (`NCSA`) — transitive via `rav1e → ravif → image`. Our `image` features (`jpeg`/`png`/`webp`) do not enable `avif`, so this never links into the runtime binary; `dioxus-desktop` is the only crate forcing it into the lock graph.

### `.github/workflows/rust.yml`

* `cargo deny check advisories sources bans` → `cargo deny check advisories sources bans licenses`.
* Replace the stale "intentionally NOT run here yet … one-line follow-up once verified" comment block with a short note describing the four-check hard gate.

## Verification

`cargo deny check advisories sources bans licenses` (locally, with `cargo-deny 0.19.9`):

```
advisories ok, bans ok, licenses ok, sources ok
```

Cargo.lock unchanged (license metadata add is resolver-inert), `cargo fmt --all --check` clean.

## Out of scope / "needs you"

* `epub` GPL-3.0 transitive linker concern — flagged above. This PR does not change the legal posture (the crate was already there); it just makes the linker-graph license set visible to CI. Worth a maintainer eyeball before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SiJjx1YNP5UjVooaqp8EWv)_