### PR TITLE
refactor(frontend): split BookReadPage (partial #377)

### DIFF
--- a/frontend/src/pages/reader/bootstrap.rs
+++ b/frontend/src/pages/reader/bootstrap.rs
@@ -1,0 +1,83 @@
+//! Reader bootstrap: builds the IIFE that polls for `window.OmnibusReader`
+//! and `window.ePub`, then calls `OmnibusReader.init(...)` with the chosen
+//! CFI and typography. Extracted from `BookReadPage` so the parent reads as
+//! plain Rust glue rather than JS template literals.
+
+/// Inputs to [`reader_bootstrap_js`]; all string values are JSON-quoted
+/// literals already (e.g. `"\"dark\""`, `"null"`), not raw values, so
+/// the caller can feed any string through `serde_json::to_string`.
+#[cfg_attr(not(feature = "web"), allow(dead_code))]
+pub(crate) struct BootstrapArgs<'a> {
+    pub url_lit: &'a str,
+    pub cfi_arg: &'a str,
+    pub font_size: i32,
+    pub theme_lit: &'a str,
+    pub font_family_lit: &'a str,
+    pub line_height_lit: &'a str,
+    pub max_width_lit: &'a str,
+    pub justify_val: bool,
+}
+
+/// Build the JS IIFE that mounts the reader once the vendored scripts are
+/// ready. Polls up to 200 x 50 ms (~10 s) before signalling `error` via
+/// `window.__omnibusOnStatus`.
+#[cfg_attr(not(feature = "web"), allow(dead_code))]
+pub(crate) fn reader_bootstrap_js(args: &BootstrapArgs<'_>) -> String {
+    let BootstrapArgs {
+        url_lit,
+        cfi_arg,
+        font_size,
+        theme_lit,
+        font_family_lit,
+        line_height_lit,
+        max_width_lit,
+        justify_val,
+    } = *args;
+    format!(
+        r#"(function(){{ var n=0; (function go(){{ if (window.OmnibusReader && window.ePub) {{ window.OmnibusReader.init("omnibus-viewer", {url_lit}, {{ cfi: {cfi_arg}, fontSize: {font_size}, theme: {theme_lit}, fontFamily: {font_family_lit}, lineHeight: {line_height_lit}, maxWidth: {max_width_lit}, justify: {justify_val} }}); }} else if (n++ < 200) {{ setTimeout(go, 50); }} else if (typeof window.__omnibusOnStatus === "function") {{ window.__omnibusOnStatus("error"); }} }})(); }})();"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reader_bootstrap_js_contains_init_call_and_polls_for_globals() {
+        let js = reader_bootstrap_js(&BootstrapArgs {
+            url_lit: "\"/api/ebooks/x/file\"",
+            cfi_arg: "null",
+            font_size: 18,
+            theme_lit: "\"dark\"",
+            font_family_lit: "null",
+            line_height_lit: "null",
+            max_width_lit: "null",
+            justify_val: false,
+        });
+        assert!(js.contains("window.OmnibusReader.init"));
+        assert!(js.contains("window.ePub"));
+        assert!(js.contains("fontSize: 18"));
+        assert!(js.contains("theme: \"dark\""));
+        assert!(js.contains("justify: false"));
+        assert!(js.contains("__omnibusOnStatus"));
+    }
+
+    #[test]
+    fn reader_bootstrap_js_threads_typography_literals_through() {
+        let js = reader_bootstrap_js(&BootstrapArgs {
+            url_lit: "\"u\"",
+            cfi_arg: "\"epubcfi(/6/2)\"",
+            font_size: 22,
+            theme_lit: "\"sepia\"",
+            font_family_lit: "\"Georgia, serif\"",
+            line_height_lit: "\"1.5\"",
+            max_width_lit: "\"42rem\"",
+            justify_val: true,
+        });
+        assert!(js.contains("cfi: \"epubcfi(/6/2)\""));
+        assert!(js.contains("fontFamily: \"Georgia, serif\""));
+        assert!(js.contains("lineHeight: \"1.5\""));
+        assert!(js.contains("maxWidth: \"42rem\""));
+        assert!(js.contains("justify: true"));
+    }
+}

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -468,10 +468,7 @@ pub fn BookReadPage(uuid: String) -> Element {
     }
 }
 
-/// Reader chrome + panels: top bar, viewer stage, page-turn gutters, bottom
-/// status bar, Aa panel, and selection popover. State that the layout
-/// itself mutates (`show_aa`, `selection`, `highlights`) is passed by
-/// `Signal` so the parent and child observe the same source of truth.
+/// Reader chrome + panels (top bar, viewer stage, gutters, status bar, Aa panel, selection popover).
 #[component]
 #[allow(clippy::too_many_arguments)]
 fn ReaderLayout(

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -5,6 +5,7 @@
 //! target; the JS interop that mounts a book is web-only.
 
 mod aa_panel;
+mod bootstrap;
 mod selection;
 mod typography;
 
@@ -19,6 +20,8 @@ use crate::data;
 use omnibus_shared::{EbookMetadata, Highlight, HighlightColor};
 
 use aa_panel::ReaderAaPanel;
+#[cfg(feature = "web")]
+use bootstrap::{reader_bootstrap_js, BootstrapArgs};
 use selection::{SelectionData, SelectionPopover};
 #[cfg(feature = "web")]
 use typography::{load_reader_pref, save_reader_pref};
@@ -263,9 +266,16 @@ pub fn BookReadPage(uuid: String) -> Element {
                 .and_then(|r| r.epub_cfi);
                 let chosen = server_cfi.or(local_saved);
                 let cfi_arg = serde_json::to_string(&chosen).unwrap_or_else(|_| "null".into());
-                let js = format!(
-                    r#"(function(){{ var n=0; (function go(){{ if (window.OmnibusReader && window.ePub) {{ window.OmnibusReader.init("omnibus-viewer", {url_lit}, {{ cfi: {cfi_arg}, fontSize: {size}, theme: {theme_lit}, fontFamily: {font_family_lit}, lineHeight: {line_height_lit}, maxWidth: {max_width_lit}, justify: {justify_val} }}); }} else if (n++ < 200) {{ setTimeout(go, 50); }} else if (typeof window.__omnibusOnStatus === "function") {{ window.__omnibusOnStatus("error"); }} }})(); }})();"#
-                );
+                let js = reader_bootstrap_js(&BootstrapArgs {
+                    url_lit: &url_lit,
+                    cfi_arg: &cfi_arg,
+                    font_size: size,
+                    theme_lit: &theme_lit,
+                    font_family_lit: &font_family_lit,
+                    line_height_lit: &line_height_lit,
+                    max_width_lit: &max_width_lit,
+                    justify_val,
+                });
                 let _ = dioxus::document::eval(&js);
 
                 let hl_uuid = uuid_for_fetch.clone();
@@ -426,6 +436,74 @@ pub fn BookReadPage(uuid: String) -> Element {
     let font_pct = (font_offset / 20.0 * 100.0).clamp(0.0, 100.0);
 
     rsx! {
+        ReaderLayout {
+            uuid: uuid.clone(),
+            book_title,
+            chapter_title: chapter_title_display,
+            page_str,
+            chapter_str,
+            pct,
+            status: status(),
+            theme: *theme.read(),
+            font_pct,
+            typeface: typeface(),
+            line_spacing: line_spacing(),
+            margins: margins(),
+            justify: justify(),
+            show_aa,
+            selection,
+            highlights,
+            on_keydown,
+            on_back,
+            on_prev,
+            on_next,
+            on_set_theme: set_theme,
+            on_font_decrease,
+            on_font_increase,
+            on_set_typeface,
+            on_set_line_spacing,
+            on_set_margins,
+            on_toggle_justify,
+        }
+    }
+}
+
+/// Reader chrome + panels: top bar, viewer stage, page-turn gutters, bottom
+/// status bar, Aa panel, and selection popover. State that the layout
+/// itself mutates (`show_aa`, `selection`, `highlights`) is passed by
+/// `Signal` so the parent and child observe the same source of truth.
+#[component]
+#[allow(clippy::too_many_arguments)]
+fn ReaderLayout(
+    uuid: String,
+    book_title: String,
+    chapter_title: String,
+    page_str: String,
+    chapter_str: String,
+    pct: u32,
+    status: ReaderStatus,
+    theme: Theme,
+    font_pct: f32,
+    typeface: Typeface,
+    line_spacing: LineSpacing,
+    margins: Margins,
+    justify: bool,
+    show_aa: Signal<bool>,
+    selection: Signal<Option<SelectionData>>,
+    highlights: Signal<Vec<Highlight>>,
+    on_keydown: EventHandler<KeyboardEvent>,
+    on_back: EventHandler<MouseEvent>,
+    on_prev: EventHandler<MouseEvent>,
+    on_next: EventHandler<MouseEvent>,
+    on_set_theme: EventHandler<Theme>,
+    on_font_decrease: EventHandler<MouseEvent>,
+    on_font_increase: EventHandler<MouseEvent>,
+    on_set_typeface: EventHandler<Typeface>,
+    on_set_line_spacing: EventHandler<LineSpacing>,
+    on_set_margins: EventHandler<Margins>,
+    on_toggle_justify: EventHandler<MouseEvent>,
+) -> Element {
+    rsx! {
         document::Script { src: JSZIP_JS }
         document::Script { src: EPUBJS_JS }
         document::Script { src: READER_GLUE_JS }
@@ -434,19 +512,22 @@ pub fn BookReadPage(uuid: String) -> Element {
             class: "rd-surface",
             tabindex: "0",
             autofocus: true,
-            onkeydown: on_keydown,
+            onkeydown: move |evt| on_keydown.call(evt),
 
             div { class: "rd-wash" }
 
             ReaderTopChrome {
                 book_title: book_title.clone(),
-                chapter_title: chapter_title_display.clone(),
+                chapter_title: chapter_title.clone(),
                 show_aa: show_aa(),
                 on_back,
-                on_toggle_aa: move |_| show_aa.set(!show_aa()),
+                on_toggle_aa: move |_| {
+                    let mut show_aa = show_aa;
+                    show_aa.set(!show_aa());
+                },
             }
 
-            ReaderViewerStage { status: status() }
+            ReaderViewerStage { status }
 
             ReaderPageTurnButtons { on_prev, on_next }
 
@@ -460,20 +541,23 @@ pub fn BookReadPage(uuid: String) -> Element {
 
             if show_aa() {
                 ReaderAaPanel {
-                    theme: *theme.read(),
+                    theme,
                     font_pct,
-                    typeface: typeface(),
-                    line_spacing: line_spacing(),
-                    margins: margins(),
-                    justify: justify(),
-                    on_set_theme: set_theme,
+                    typeface,
+                    line_spacing,
+                    margins,
+                    justify,
+                    on_set_theme,
                     on_font_decrease,
                     on_font_increase,
                     on_set_typeface,
                     on_set_line_spacing,
                     on_set_margins,
                     on_toggle_justify,
-                    on_close: move |_| show_aa.set(false),
+                    on_close: move |_| {
+                        let mut show_aa = show_aa;
+                        show_aa.set(false);
+                    },
                 }
             }
 
@@ -483,7 +567,10 @@ pub fn BookReadPage(uuid: String) -> Element {
                     sel_rect_y: sel.rect.y,
                     sel_rect_width: sel.rect.width,
                     sel_cfi: sel.cfi_range.clone(),
-                    on_dismiss: move |_| selection.set(None),
+                    on_dismiss: move |_| {
+                        let mut selection = selection;
+                        selection.set(None);
+                    },
                     on_highlight: move |(cfi, color): (String, HighlightColor)| {
                         #[cfg(feature = "web")]
                         {
@@ -501,6 +588,8 @@ pub fn BookReadPage(uuid: String) -> Element {
                         };
                         #[cfg(feature = "web")]
                         let cfi_rollback = cfi.clone();
+                        let mut selection = selection;
+                        let mut highlights = highlights;
                         selection.set(None);
                         spawn(async move {
                             if let Ok(h) = data::create_highlight("", create).await {


### PR DESCRIPTION
## Summary

Partial fix for #377: extracts the two biggest chunks out of the regressed
`BookReadPage` (was 454 lines, ~5.7× the 80-line cap).

* **`reader_bootstrap_js`** in new `frontend/src/pages/reader/bootstrap.rs`
  — takes a `BootstrapArgs` struct of already-JSON-quoted literals plus
  font size + justify flag, and emits the IIFE that polls for
  `window.OmnibusReader` + `window.ePub` before calling `init(...)`. Two
  unit tests cover the IIFE shape and parameter threading.
* **`ReaderLayout`** sub-component (still in `pages/reader/mod.rs`)
  — takes the derived display strings + typography by value, and
  `show_aa` / `selection` / `highlights` as `Signal<T>` props so the
  layout's internal closures can still mutate them through the parent's
  source of truth.

## Before / after

| Function | Before | After |
|---|---|---|
| `BookReadPage` | 454 lines | **392 lines** |
| `ReaderLayout` | (didn't exist) | 139 lines |
| `bootstrap.rs` total | (didn't exist) | 83 lines (incl. tests) |

`BookReadPage` is still over the 80-line cap. The remaining bulk is:
* ~50 lines of cfg-gated typography signal initializers (each loads from
  `localStorage` on web, falls back on SSR);
* the ~125-line web-feature interop block (Closure setup + the mount
  `use_effect` that wires `__omnibusOnRelocate` / `__omnibusOnStatus` /
  `__omnibusOnSelection` on `window`);
* ~110 lines of event handlers that all close over live signals.

All three depend on the Dioxus runtime + signal context, so they can't be
hoisted into free functions without scope creep. Further splitting (e.g.
moving the prefs to a typed-bundle helper) is intentionally left out of
this PR.

## Hydration safety

Per [`.claude/rules/07-hydration.md`](.claude/rules/07-hydration.md): no
`#[cfg(feature = "web")]` was added around any rsx, and `ReaderStatus`
still defaults to `Loading` so the `rd-overlay` loading node is present
in both SSR and first-paint WASM. The existing
`reader_status_default_is_loading_for_ssr_wasm_parity` SSR test still
passes. (Note: #515 is a separate hydration bug on this component — not
touched here.)

## Out of scope

`LandingPage` (the other offender called out in #377, ~423 lines) is
left for a follow-up worker.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (166 passed, incl. 2 new bootstrap tests + existing SSR-parity test)
- [ ] Playwright reader flow (CI)

Refs #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiJjx1YNP5UjVooaqp8EWv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiJjx1YNP5UjVooaqp8EWv)_