### PR TITLE
refactor: split merge_books + SearchPage + MiniDock (partial #502)

### DIFF
--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -45,14 +45,36 @@ pub async fn merge_books(
     // links.
     delete_fts(&mut tx, source_id).await?;
 
-    // Re-point uuids of earlier merges/attachments into the source
-    // *before* the source delete cascades them away, then guard the
-    // source's own uuid so a reindex re-attaches its file to the target
-    // instead of resurrecting the duplicate.
+    rewire_merged_uuid_refs(&mut tx, source_id, target_id, source_uuid, &snapshot).await?;
+
+    let merge_log_id = finalize_merge(&mut tx, target_id, source_id, &snapshot, merged_by).await?;
+
+    tx.commit().await?;
+
+    run_post_commit_side_effects(pool, source_uuid, target_uuid, adopt_cover).await;
+
+    Ok(MergeOutcome {
+        merge_log_id,
+        target_uuid: target_uuid.to_owned(),
+    })
+}
+
+/// Re-point earlier merge/attach ledger rows from the source onto the
+/// target, then plant a guard row per native format so the next reindex
+/// re-attaches the source file by `scan_key` instead of resurrecting the
+/// duplicate. Must run before the source `books` row is deleted in
+/// `finalize_merge` — that delete cascades through `merged_uuids`.
+async fn rewire_merged_uuid_refs(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    source_id: i64,
+    target_id: i64,
+    source_uuid: &str,
+    snapshot: &SourceSnapshot,
+) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE merged_uuids SET book_id = ? WHERE book_id = ?")
         .bind(target_id)
         .bind(source_id)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
     // The source file's relative path (F2 scan_key) so the next reindex
     // recognizes the now-attached file by scan_key and classifies it
@@ -60,7 +82,7 @@ pub async fn merge_books(
     let source_scan_key: Option<String> =
         sqlx::query_scalar("SELECT scan_key FROM books WHERE id = ?")
             .bind(source_id)
-            .fetch_optional(&mut *tx)
+            .fetch_optional(&mut **tx)
             .await?;
     for fmt in &snapshot.native_formats {
         sqlx::query(
@@ -72,17 +94,22 @@ pub async fn merge_books(
         .bind(fmt)
         .bind(&snapshot.library_path)
         .bind(&source_scan_key)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
     }
+    Ok(())
+}
 
-    let merge_log_id = finalize_merge(&mut tx, target_id, source_id, &snapshot, merged_by).await?;
-
-    tx.commit().await?;
-
-    // Post-commit, best-effort: copy the source's cover file under the
-    // target's uuid (cover files are uuid-named) and rebuild the
-    // target's FTS row so the unioned authors/tags are searchable.
+/// Best-effort post-commit fixups: adopt the source's cover file under
+/// the target's uuid (cover files are uuid-named) and rebuild the
+/// target's FTS row so the unioned authors/tags are searchable. Failures
+/// are logged but never propagated — the commit has already landed.
+async fn run_post_commit_side_effects(
+    pool: &SqlitePool,
+    source_uuid: &str,
+    target_uuid: &str,
+    adopt_cover: bool,
+) {
     if adopt_cover {
         let src = source_uuid.to_owned();
         let tgt = target_uuid.to_owned();
@@ -101,11 +128,6 @@ pub async fn merge_books(
     {
         tracing::warn!(error = %e, uuid = %target_uuid, "merge: target FTS rebuild failed");
     }
-
-    Ok(MergeOutcome {
-        merge_log_id,
-        target_uuid: target_uuid.to_owned(),
-    })
 }
 
 /// Resolve both uuids to row ids, re-check same-book, then freeze the

--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -59,11 +59,10 @@ pub async fn merge_books(
     })
 }
 
-/// Re-point earlier merge/attach ledger rows from the source onto the
-/// target, then plant a guard row per native format so the next reindex
-/// re-attaches the source file by `scan_key` instead of resurrecting the
-/// duplicate. Must run before the source `books` row is deleted in
-/// `finalize_merge` — that delete cascades through `merged_uuids`.
+/// Re-point `merged_uuids` from source to target and plant per-format guard rows.
+///
+/// Must run before `finalize_merge` deletes the source `books` row — that
+/// delete cascades through `merged_uuids`.
 async fn rewire_merged_uuid_refs(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     source_id: i64,
@@ -100,10 +99,7 @@ async fn rewire_merged_uuid_refs(
     Ok(())
 }
 
-/// Best-effort post-commit fixups: adopt the source's cover file under
-/// the target's uuid (cover files are uuid-named) and rebuild the
-/// target's FTS row so the unioned authors/tags are searchable. Failures
-/// are logged but never propagated — the commit has already landed.
+/// Best-effort post-commit fixups: cover adopt + target FTS rebuild; failures are logged, not propagated.
 async fn run_post_commit_side_effects(
     pool: &SqlitePool,
     source_uuid: &str,

--- a/frontend/src/pages/listen/mini_dock.rs
+++ b/frontend/src/pages/listen/mini_dock.rs
@@ -46,55 +46,15 @@ pub fn MiniDock() -> Element {
         return rsx! { div { class: "mini-dock-host" } };
     };
 
-    let elapsed_sig = playback.elapsed;
-    let duration_sig = playback.duration;
-    let playing_sig = playback.playing;
-    let rate_sig = playback.rate;
-    let chapters_sig = playback.chapters;
-
-    let elapsed = elapsed_sig();
-    let duration = duration_sig();
-    let playing = playing_sig();
-    let rate = rate_sig();
-    let chapters = chapters_sig();
+    let elapsed = (playback.elapsed)();
+    let duration = (playback.duration)();
+    let playing = (playback.playing)();
+    let rate = (playback.rate)();
+    let chapters = (playback.chapters)();
 
     let idx = chapter_index_for_elapsed(&chapters, elapsed);
     let chapter_sub = chapter_sub_text(&chapters, idx);
-    let fill = format!("width: {:.1}%", progress_pct(elapsed, duration));
     let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
-    let play_label = if playing { "Pause" } else { "Play" }.to_string();
-    let rate_label = format!("{rate:.2}\u{00d7}");
-    let elapsed_label = format_hms(elapsed);
-    let total_label = format_hms(duration);
-
-    let on_toggle = move |_: MouseEvent| {
-        #[cfg(feature = "web")]
-        super::helpers::audio_call("toggle", "");
-    };
-    let on_skip_back = move |_: MouseEvent| {
-        #[cfg(feature = "web")]
-        super::helpers::audio_call("skip", "-30");
-    };
-    let on_skip_forward = move |_: MouseEvent| {
-        #[cfg(feature = "web")]
-        super::helpers::audio_call("skip", "30");
-    };
-    let on_dismiss = {
-        let mut uuid_sig = playback.uuid;
-        let mut book_sig = playback.book;
-        let mut playing_set = playback.playing;
-        move |_: MouseEvent| {
-            // Fully stop the shared element (pause + clear src + reset mode) so a
-            // media-key resume can't restart a dismissed book with no visible
-            // control. Clear `book` before `uuid` so the dock hides immediately
-            // and PlaybackState stays coherent for any other consumer.
-            #[cfg(feature = "web")]
-            super::helpers::audio_call("stop", "");
-            book_sig.set(None);
-            playing_set.set(false);
-            uuid_sig.set(None);
-        }
-    };
 
     rsx! {
         div { class: "mini-dock-host",
@@ -118,67 +78,130 @@ pub fn MiniDock() -> Element {
                     }
                 }
 
-                div { class: "mini-dock-track",
-                    div { class: "mini-dock-times",
-                        span { "{elapsed_label}" }
-                        span { "{total_label}" }
-                    }
-                    div { class: "pbar",
-                        i { style: "{fill}" }
-                    }
-                }
+                MiniDockProgress { elapsed: elapsed, duration: duration }
+                MiniDockControls { playing: playing, rate: rate }
+                MiniDockActions { uuid: uuid.clone() }
+            }
+        }
+    }
+}
 
-                div { class: "mini-dock-controls",
-                    button {
-                        class: "mini-dock-btn mini-dock-skip",
-                        r#type: "button",
-                        "data-testid": "mini-dock-skip-back",
-                        "aria-label": "Back 30 seconds",
-                        onclick: on_skip_back,
-                        "-30"
-                    }
-                    button {
-                        class: "mini-dock-play",
-                        r#type: "button",
-                        "data-testid": "mini-dock-toggle",
-                        "aria-label": "{play_label}",
-                        onclick: on_toggle,
-                        if playing {
-                            div { class: "mini-dock-ico-pause",
-                                div { class: "mini-dock-ico-pause-bar" }
-                                div { class: "mini-dock-ico-pause-bar" }
-                            }
-                        } else {
-                            div { class: "mini-dock-ico-play" }
-                        }
-                    }
-                    button {
-                        class: "mini-dock-btn mini-dock-skip",
-                        r#type: "button",
-                        "data-testid": "mini-dock-skip-forward",
-                        "aria-label": "Forward 30 seconds",
-                        onclick: on_skip_forward,
-                        "+30"
-                    }
-                    span { class: "mini-dock-rate", "data-testid": "mini-dock-rate", "{rate_label}" }
-                }
+/// Times + thin progress bar for the dock. Pure presentation — derives
+/// labels and the fill percent from the elapsed/duration props so the
+/// parent doesn't have to thread formatting helpers into the rsx.
+#[component]
+fn MiniDockProgress(elapsed: f64, duration: f64) -> Element {
+    let fill = format!("width: {:.1}%", progress_pct(elapsed, duration));
+    let elapsed_label = format_hms(elapsed);
+    let total_label = format_hms(duration);
+    rsx! {
+        div { class: "mini-dock-track",
+            div { class: "mini-dock-times",
+                span { "{elapsed_label}" }
+                span { "{total_label}" }
+            }
+            div { class: "pbar",
+                i { style: "{fill}" }
+            }
+        }
+    }
+}
 
-                div { class: "mini-dock-actions",
-                    Link {
-                        to: Route::BookListen { uuid: uuid.clone() },
-                        class: "mini-dock-btn mini-dock-expand-btn",
-                        "data-testid": "mini-dock-expand-btn",
-                        "\u{2191} Expand"
+/// Transport cluster: skip-back, play/pause, skip-forward, rate badge.
+/// Calls the shared `audio_call` seam directly so the parent doesn't
+/// re-define closures for what is a fixed transport contract.
+#[component]
+fn MiniDockControls(playing: bool, rate: f64) -> Element {
+    let play_label = if playing { "Pause" } else { "Play" }.to_string();
+    let rate_label = format!("{rate:.2}\u{00d7}");
+    let on_toggle = move |_: MouseEvent| {
+        #[cfg(feature = "web")]
+        super::helpers::audio_call("toggle", "");
+    };
+    let on_skip_back = move |_: MouseEvent| {
+        #[cfg(feature = "web")]
+        super::helpers::audio_call("skip", "-30");
+    };
+    let on_skip_forward = move |_: MouseEvent| {
+        #[cfg(feature = "web")]
+        super::helpers::audio_call("skip", "30");
+    };
+    rsx! {
+        div { class: "mini-dock-controls",
+            button {
+                class: "mini-dock-btn mini-dock-skip",
+                r#type: "button",
+                "data-testid": "mini-dock-skip-back",
+                "aria-label": "Back 30 seconds",
+                onclick: on_skip_back,
+                "-30"
+            }
+            button {
+                class: "mini-dock-play",
+                r#type: "button",
+                "data-testid": "mini-dock-toggle",
+                "aria-label": "{play_label}",
+                onclick: on_toggle,
+                if playing {
+                    div { class: "mini-dock-ico-pause",
+                        div { class: "mini-dock-ico-pause-bar" }
+                        div { class: "mini-dock-ico-pause-bar" }
                     }
-                    button {
-                        class: "mini-dock-btn mini-dock-dismiss",
-                        r#type: "button",
-                        "data-testid": "mini-dock-dismiss",
-                        "aria-label": "Stop and close player",
-                        onclick: on_dismiss,
-                        "\u{00d7}"
-                    }
+                } else {
+                    div { class: "mini-dock-ico-play" }
                 }
+            }
+            button {
+                class: "mini-dock-btn mini-dock-skip",
+                r#type: "button",
+                "data-testid": "mini-dock-skip-forward",
+                "aria-label": "Forward 30 seconds",
+                onclick: on_skip_forward,
+                "+30"
+            }
+            span { class: "mini-dock-rate", "data-testid": "mini-dock-rate", "{rate_label}" }
+        }
+    }
+}
+
+/// Expand link + dismiss button. The dismiss closure mutates the
+/// app-level [`crate::PlaybackState`] signals directly (read via
+/// `use_playback` inside the sub-component) so the parent doesn't have
+/// to thread three signal handles down as props.
+#[component]
+fn MiniDockActions(uuid: String) -> Element {
+    let playback = use_playback();
+    let on_dismiss = {
+        let mut uuid_sig = playback.uuid;
+        let mut book_sig = playback.book;
+        let mut playing_set = playback.playing;
+        move |_: MouseEvent| {
+            // Fully stop the shared element (pause + clear src + reset mode) so a
+            // media-key resume can't restart a dismissed book with no visible
+            // control. Clear `book` before `uuid` so the dock hides immediately
+            // and PlaybackState stays coherent for any other consumer.
+            #[cfg(feature = "web")]
+            super::helpers::audio_call("stop", "");
+            book_sig.set(None);
+            playing_set.set(false);
+            uuid_sig.set(None);
+        }
+    };
+    rsx! {
+        div { class: "mini-dock-actions",
+            Link {
+                to: Route::BookListen { uuid: uuid.clone() },
+                class: "mini-dock-btn mini-dock-expand-btn",
+                "data-testid": "mini-dock-expand-btn",
+                "\u{2191} Expand"
+            }
+            button {
+                class: "mini-dock-btn mini-dock-dismiss",
+                r#type: "button",
+                "data-testid": "mini-dock-dismiss",
+                "aria-label": "Stop and close player",
+                onclick: on_dismiss,
+                "\u{00d7}"
             }
         }
     }

--- a/frontend/src/pages/listen/mini_dock.rs
+++ b/frontend/src/pages/listen/mini_dock.rs
@@ -86,9 +86,7 @@ pub fn MiniDock() -> Element {
     }
 }
 
-/// Times + thin progress bar for the dock. Pure presentation — derives
-/// labels and the fill percent from the elapsed/duration props so the
-/// parent doesn't have to thread formatting helpers into the rsx.
+/// Elapsed/total labels and progress bar for the dock.
 #[component]
 fn MiniDockProgress(elapsed: f64, duration: f64) -> Element {
     let fill = format!("width: {:.1}%", progress_pct(elapsed, duration));
@@ -108,8 +106,6 @@ fn MiniDockProgress(elapsed: f64, duration: f64) -> Element {
 }
 
 /// Transport cluster: skip-back, play/pause, skip-forward, rate badge.
-/// Calls the shared `audio_call` seam directly so the parent doesn't
-/// re-define closures for what is a fixed transport contract.
 #[component]
 fn MiniDockControls(playing: bool, rate: f64) -> Element {
     let play_label = if playing { "Pause" } else { "Play" }.to_string();
@@ -164,10 +160,7 @@ fn MiniDockControls(playing: bool, rate: f64) -> Element {
     }
 }
 
-/// Expand link + dismiss button. The dismiss closure mutates the
-/// app-level [`crate::PlaybackState`] signals directly (read via
-/// `use_playback` inside the sub-component) so the parent doesn't have
-/// to thread three signal handles down as props.
+/// Expand link + dismiss button; dismiss clears [`crate::PlaybackState`] via `use_playback`.
 #[component]
 fn MiniDockActions(uuid: String) -> Element {
     let playback = use_playback();

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -76,90 +76,101 @@ pub fn SearchPage(query: String) -> Element {
         };
     };
 
-    let total = r.total_count();
     rsx! {
         section { class: "search-page",
             {header}
-            p { class: "subtitle", "data-testid": "search-result-count",
-                "{total} result{plural(total)} \u{00b7} {r.duration_ms}ms"
+            SearchResults { results: r, query: query.clone() }
+        }
+    }
+}
+
+/// Renders the grouped result lists plus the count subtitle. Extracted
+/// so `SearchPage` stays focused on the fetch effect; this component is
+/// pure presentation of an already-loaded [`PaletteResults`].
+#[component]
+fn SearchResults(results: PaletteResults, query: String) -> Element {
+    let total = results.total_count();
+    let r = results;
+    rsx! {
+        p { class: "subtitle", "data-testid": "search-result-count",
+            "{total} result{plural(total)} \u{00b7} {r.duration_ms}ms"
+        }
+        if total == 0 {
+            p { class: "subtitle", "data-testid": "search-empty",
+                "No results for \u{201c}{query}\u{201d}."
             }
-            if total == 0 {
-                p { class: "subtitle", "data-testid": "search-empty",
-                    "No results for \u{201c}{query}\u{201d}."
+        }
+        if !r.books.is_empty() {
+            SearchGroup { label: "Books", count: r.books.len() }
+            ul { class: "search-results",
+                for book in r.books.iter().cloned() {
+                    li {
+                        key: "{book.uuid}",
+                        Link {
+                            to: Route::BookDetail { uuid: book.uuid.clone() },
+                            class: "search-result-row",
+                            "data-testid": "search-book-row",
+                            div { class: "search-row-title", "{book.title}" }
+                            div { class: "search-row-sub", "{book.author_display}" }
+                        }
+                    }
                 }
             }
-            if !r.books.is_empty() {
-                SearchGroup { label: "Books", count: r.books.len() }
-                ul { class: "search-results",
-                    for book in r.books.iter().cloned() {
-                        li {
-                            key: "{book.uuid}",
-                            Link {
-                                to: Route::BookDetail { uuid: book.uuid.clone() },
-                                class: "search-result-row",
-                                "data-testid": "search-book-row",
-                                div { class: "search-row-title", "{book.title}" }
-                                div { class: "search-row-sub", "{book.author_display}" }
+        }
+        if !r.authors.is_empty() {
+            SearchGroup { label: "Authors", count: r.authors.len() }
+            ul { class: "search-results",
+                for author in r.authors.iter().cloned() {
+                    li {
+                        key: "{author.id}",
+                        Link {
+                            to: Route::AuthorDetail { id: author.id },
+                            class: "search-result-row",
+                            "data-testid": "search-author-row",
+                            div { class: "search-row-title", "{author.name}" }
+                            div { class: "search-row-sub",
+                                "{author.book_count} book{plural(author.book_count as usize)}"
                             }
                         }
                     }
                 }
             }
-            if !r.authors.is_empty() {
-                SearchGroup { label: "Authors", count: r.authors.len() }
-                ul { class: "search-results",
-                    for author in r.authors.iter().cloned() {
-                        li {
-                            key: "{author.id}",
-                            Link {
-                                to: Route::AuthorDetail { id: author.id },
-                                class: "search-result-row",
-                                "data-testid": "search-author-row",
-                                div { class: "search-row-title", "{author.name}" }
-                                div { class: "search-row-sub",
-                                    "{author.book_count} book{plural(author.book_count as usize)}"
+        }
+        if !r.series.is_empty() {
+            SearchGroup { label: "Series", count: r.series.len() }
+            ul { class: "search-results",
+                for s in r.series.iter().cloned() {
+                    li {
+                        key: "{s.id}",
+                        Link {
+                            to: Route::SeriesDetail { id: s.id },
+                            class: "search-result-row",
+                            "data-testid": "search-series-row",
+                            div { class: "search-row-title", "{s.name}" }
+                            div { class: "search-row-sub",
+                                "{s.book_count} book{plural(s.book_count as usize)}"
+                                if let Some(ref a) = s.author_display {
+                                    " \u{00b7} {a}"
                                 }
                             }
                         }
                     }
                 }
             }
-            if !r.series.is_empty() {
-                SearchGroup { label: "Series", count: r.series.len() }
-                ul { class: "search-results",
-                    for s in r.series.iter().cloned() {
-                        li {
-                            key: "{s.id}",
-                            Link {
-                                to: Route::SeriesDetail { id: s.id },
-                                class: "search-result-row",
-                                "data-testid": "search-series-row",
-                                div { class: "search-row-title", "{s.name}" }
-                                div { class: "search-row-sub",
-                                    "{s.book_count} book{plural(s.book_count as usize)}"
-                                    if let Some(ref a) = s.author_display {
-                                        " \u{00b7} {a}"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if !r.tags.is_empty() {
-                SearchGroup { label: "Tags", count: r.tags.len() }
-                ul { class: "search-results",
-                    for tag in r.tags.iter().cloned() {
-                        li {
-                            key: "{tag.id}",
-                            Link {
-                                to: Route::Search { query: format!("tag:{}", tag.name) },
-                                class: "search-result-row",
-                                "data-testid": "search-tag-row",
-                                div { class: "search-row-title", "# {tag.name}" }
-                                div { class: "search-row-sub",
-                                    "{tag.book_count} book{plural(tag.book_count as usize)}"
-                                }
+        }
+        if !r.tags.is_empty() {
+            SearchGroup { label: "Tags", count: r.tags.len() }
+            ul { class: "search-results",
+                for tag in r.tags.iter().cloned() {
+                    li {
+                        key: "{tag.id}",
+                        Link {
+                            to: Route::Search { query: format!("tag:{}", tag.name) },
+                            class: "search-result-row",
+                            "data-testid": "search-tag-row",
+                            div { class: "search-row-title", "# {tag.name}" }
+                            div { class: "search-row-sub",
+                                "{tag.book_count} book{plural(tag.book_count as usize)}"
                             }
                         }
                     }

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -84,9 +84,7 @@ pub fn SearchPage(query: String) -> Element {
     }
 }
 
-/// Renders the grouped result lists plus the count subtitle. Extracted
-/// so `SearchPage` stays focused on the fetch effect; this component is
-/// pure presentation of an already-loaded [`PaletteResults`].
+/// Grouped result lists + count subtitle for a loaded [`PaletteResults`].
 #[component]
 fn SearchResults(results: PaletteResults, query: String) -> Element {
     let total = results.total_count();


### PR DESCRIPTION
## Summary

Three more entries from the 80-line-cap punch list in #502 — one `db` extraction and two `frontend` ones.

| Function | File | Before | After |
|---|---|---:|---:|
| `merge_books` | `db/src/merge/transaction.rs` | 88 | 39 |
| `SearchPage` | `frontend/src/pages/search.rs` | 156 | 71 |
| `MiniDock` | `frontend/src/pages/listen/mini_dock.rs` | 154 | 56 |

All three now sit comfortably under the ~80-line soft cap in `.claude/rules/05-rust-style.md`.

## Extractions

### `merge_books` (db)

The body had two further blocks worth extracting:

- `rewire_merged_uuid_refs(&mut tx, ...)` — the `merged_uuids` re-pointing + per-format guard-row insert. Must run **before** the source `books` row is deleted (the source delete cascades `merged_uuids` rows that pointed at it), so it stays inside the same `tx`.
- `run_post_commit_side_effects(pool, ...)` — best-effort cover-file adopt + target FTS rebuild. Runs after `tx.commit()` and is intentionally fire-and-forget (warnings logged, errors swallowed) — the commit has already landed.

**Atomicity preserved:** both pre-commit helpers receive `&mut Transaction<'_, sqlx::Sqlite>` from `merge_books` so every write goes through the one transaction handle. The whole merge is still all-or-nothing.

### `SearchPage` (frontend)

Extracted `SearchResults { results: PaletteResults, query: String }` for the grouped result lists + count subtitle. The debounce effect, signal setup, loading/error/empty branches, and the header rsx all stay in `SearchPage`. Markup contract (`section.search-page` wrapper, all testids: `search-result-count`, `search-empty`, `search-book-row`, `search-author-row`, `search-series-row`, `search-tag-row`, `search-back`) unchanged.

### `MiniDock` (frontend)

Extracted three sub-components:

- `MiniDockProgress { elapsed, duration }` — times + thin progress bar (was the `mini-dock-track` div).
- `MiniDockControls { playing, rate }` — transport cluster (skip-back, play/pause, skip-forward, rate badge). Calls the shared `audio_call` seam directly, same closures as before just moved off the parent.
- `MiniDockActions { uuid }` — expand link + dismiss button. The dismiss closure mutates the app-level `PlaybackState` signals; the sub-component reads them via `use_playback()` itself rather than having the parent thread three signal handles through props.

All testids unchanged: `mini-dock`, `mini-dock-expand`, `mini-dock-title`, `mini-dock-skip-back`, `mini-dock-toggle`, `mini-dock-skip-forward`, `mini-dock-rate`, `mini-dock-expand-btn`, `mini-dock-dismiss`.

**Hydration parity:** no `#[cfg(feature = "web")]` was added around any rsx body. The existing pattern — gate only the `audio_call` interop inside the event closures — is preserved. SSR and first-WASM-paint markup are identical.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean
- `cargo clippy -p omnibus-frontend --features server --all-targets` — clean
- `cargo test -p omnibus-db` — 592 passed, 0 failed (merge tests included)
- `cargo test -p omnibus-frontend --features server` — 164 passed, 0 failed
- `cargo test -p omnibus` — clean
- `cargo test -p omnibus-shared` — 46 passed, 0 failed

Pre-existing limitation: `cargo clippy -p omnibus-mobile` and `cargo clippy --all-features` require the nix dev shell (system `gdk-3.0` for desktop targets / mobile-feature gates conflict with default features). Not exercised in this sandbox; not regressed by these changes (the touched `mini_dock` module is `#[cfg(not(feature = "mobile"))]`).

## Scope

This PR addresses three items from #502. `#502` stays open — many other oversized functions remain.

## Test plan

- [ ] CI: clippy + fmt + test matrix
- [ ] CI / local: `npx playwright test search.spec.ts listen.spec.ts` (mini-dock testids exercised by listen flow)
- [ ] Manual smoke (optional): `/search?query=…` results page, `/listen` mini-dock controls (play/pause, skip, dismiss)

Refs #502 (partial).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiJjx1YNP5UjVooaqp8EWv)_