### PR TITLE
feat: redesign merge-duplicates UI

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3767,18 +3767,78 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .rd-swatch[data-color="rose"]   { background: rgba(244,63,94,.7); }
 .rd-swatch[data-color="violet"] { background: rgba(139,92,246,.7); }
 
-/* ── F5.10 merge dialog + toast (book detail) ──────────────────── */
-.bd-merge-modal { max-width: 520px; width: 100%; }
-.bd-merge-results { list-style: none; margin: 10px 0 0; padding: 0;
-  display: flex; flex-direction: column; gap: 6px; max-height: 320px; overflow-y: auto; }
-.bd-merge-candidate { display: flex; flex-direction: column; align-items: flex-start;
-  gap: 2px; width: 100%; text-align: left; }
-.bd-merge-candidate-title { font-size: 14.5px; color: var(--ink-0); }
-.bd-merge-candidate-meta { font-size: 11px; color: var(--ink-2); }
-.bd-merge-confirm-copy { font-size: 14px; line-height: 1.55; color: var(--ink-1); }
-.bd-merge-confirm-actions { display: flex; gap: 10px; margin-top: 14px; }
-.bd-merge-error { color: var(--danger, #e5484d); font-size: 13px; margin-top: 10px; }
-.bd-merge-foot { display: flex; justify-content: flex-end; margin-top: 12px; }
+/* ── F5.10 merge dialog (book detail) — "Merge duplicates" redesign ──
+ * Wide modal: pinned keeper rail + search + result rows with covers.
+ * Three-zone flex column (head / scrolling body / foot). Replaces the
+ * earlier stacked-button layout whose `.btn` line-height fought the
+ * two-line candidate and overlapped the text. */
+.mg-modal { width: min(720px, 100%); max-height: calc(100vh - 40px);
+  display: flex; flex-direction: column; overflow: hidden;
+  background: var(--bg-1); border: 1px solid var(--line); border-radius: var(--r-xl);
+  box-shadow: 0 40px 90px -20px color-mix(in oklch, #000 70%, transparent), 0 0 0 1px var(--line-2); }
+.mg-head { padding: 26px 30px 0; }
+.mg-kicker { color: var(--accent); margin-bottom: 8px; }
+.mg-title { margin: 0; font-family: var(--serif); font-style: italic; font-size: 38px; line-height: 1; }
+.mg-body { display: flex; flex-direction: column; gap: 16px; padding: 16px 30px 4px; overflow-y: auto; }
+.mg-intro { margin: 0; max-width: 540px; font-size: 15px; line-height: 1.5; color: var(--ink-1); }
+
+/* Pinned "everything folds into" keeper context. */
+.mg-target-rail { display: flex; align-items: center; gap: 14px;
+  padding: 12px 14px; border-radius: var(--r-md);
+  background: var(--bg-2); border: 1px solid var(--line-2); }
+.mg-target-cover { width: 38px; flex: 0 0 38px; border-radius: 3px; overflow: hidden; }
+.mg-target-main { flex: 1; min-width: 0; }
+.mg-target-kicker { margin-bottom: 3px; font-size: 9.5px; color: var(--ink-3); }
+.mg-target-name { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+.mg-target-title { font-family: var(--serif); font-style: italic; font-size: 18px; color: var(--ink-0);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mg-target-sub { flex: 0 0 auto; font-size: 11px; color: var(--ink-3); white-space: nowrap; }
+.mg-target-note { flex: 0 0 auto; font-size: 10px; color: var(--ink-3); }
+
+/* Search field. */
+.mg-search { display: flex; align-items: center; gap: 12px;
+  height: 50px; padding: 0 16px; border-radius: var(--r-md);
+  background: var(--bg-0); border: 1px solid var(--line); }
+.mg-search:focus-within { border-color: var(--accent); }
+.mg-search-icon { flex: 0 0 18px; color: var(--ink-3); }
+.mg-search-input { flex: 1; min-width: 0; background: transparent; border: 0; outline: none;
+  color: var(--ink-0); font-size: 16px; font-family: var(--sans); }
+.mg-search-input::placeholder { color: var(--ink-3); }
+
+/* Result rows: cover · title/meta · signal + format badges. */
+.mg-results-head { display: flex; align-items: center; justify-content: space-between; }
+.mg-results-hint { font-size: 10px; color: var(--ink-3); }
+.mg-results { list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 2px; max-height: 340px; overflow-y: auto; }
+.mg-row { display: flex; align-items: center; gap: 14px; width: 100%; text-align: left;
+  padding: 10px 12px; border-radius: var(--r-md); cursor: pointer;
+  background: transparent; border: 1px solid transparent; }
+.mg-row:hover, .mg-row:focus-visible { background: var(--bg-2); border-color: var(--line-2); outline: none; }
+.mg-row-cover { width: 40px; flex: 0 0 40px; border-radius: 3px; overflow: hidden; }
+.mg-row-main { flex: 1; min-width: 0; }
+.mg-row-title { font-size: 15px; color: var(--ink-0);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mg-row-meta { margin-top: 3px; font-size: 11px; color: var(--ink-3);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mg-row-aside { display: flex; align-items: center; gap: 10px; flex: 0 0 auto; }
+.mg-row-signal { display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 10px; color: var(--ok); }
+.mg-row-dot { width: 6px; height: 6px; border-radius: 999px; background: var(--ok); }
+.mg-fmt { display: inline-flex; align-items: center; padding: 3px 7px;
+  border: 1px solid var(--line-2); border-radius: 5px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--ink-2); }
+
+/* Confirm step (kept functional; field-by-field reconciliation deferred). */
+.mg-confirm { display: flex; flex-direction: column; gap: 14px; }
+.mg-confirm-copy { margin: 0; font-size: 14px; line-height: 1.55; color: var(--ink-1); }
+.mg-confirm-actions { display: flex; gap: 10px; }
+
+/* Footer: reversibility note + Cancel, pinned below the scrolling body. */
+.mg-foot { display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  padding: 16px 30px; border-top: 1px solid var(--line-2); }
+.mg-foot-note { font-size: 11px; color: var(--ink-3); }
+.bd-merge-error { color: var(--bad); font-size: 13px; margin: 4px 0 0; }
 .bd-merge-toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
   z-index: 110; display: flex; align-items: center; gap: 12px; padding: 12px 16px;
   box-shadow: 0 6px 24px rgba(0,0,0,.35); }

--- a/frontend/src/components/merge_dialog.rs
+++ b/frontend/src/components/merge_dialog.rs
@@ -162,8 +162,12 @@ pub fn MergeDialog(
                                 id: "bd-merge-search",
                                 class: "mg-search-input",
                                 "data-testid": "merge-search",
+                                "aria-label": "Search your library for a book to merge",
                                 r#type: "search",
-                                placeholder: "Search your library \u{2014} title, author, ISBN\u{2026}",
+                                // Merge search scopes to title/authors/series only
+                                // (`db::search_books` excludes ISBN), so the
+                                // placeholder must not advertise ISBN.
+                                placeholder: "Search your library \u{2014} title, author, series\u{2026}",
                                 value: "{query}",
                                 autofocus: true,
                                 oninput: move |evt| {

--- a/frontend/src/components/merge_dialog.rs
+++ b/frontend/src/components/merge_dialog.rs
@@ -8,17 +8,25 @@ use dioxus::core::Task;
 use dioxus::prelude::*;
 use omnibus_shared::{EbookMetadata, MergeBooksResult};
 
+use crate::components::atrium::Cover;
 use crate::{data, use_server_url};
 
-/// Modal dialog: search input → candidate rows → confirm panel.
+/// Modal dialog: target rail → search input → candidate rows → confirm
+/// panel. The current book (`target`) is always the merge keeper; every
+/// duplicate folds into it.
 #[component]
 pub fn MergeDialog(
-    target_uuid: String,
-    target_title: String,
+    target: EbookMetadata,
     on_merged: EventHandler<MergeBooksResult>,
     on_close: EventHandler<()>,
 ) -> Element {
     let server_url = use_server_url();
+    let target_uuid = target.unique_identifier.clone().unwrap_or_default();
+    let target_title = target
+        .title
+        .clone()
+        .unwrap_or_else(|| target.filename.clone());
+
     let mut query = use_signal(String::new);
     let mut results: Signal<Vec<EbookMetadata>> = use_signal(Vec::new);
     let mut selected: Signal<Option<EbookMetadata>> = use_signal(|| None);
@@ -103,6 +111,9 @@ pub fn MergeDialog(
         });
     };
 
+    let target_series = target.series.clone();
+    let result_count = results().len();
+
     rsx! {
         div {
             class: "author-photo-modal-backdrop",
@@ -117,44 +128,71 @@ pub fn MergeDialog(
                 }
             },
             div {
-                class: "author-photo-modal bd-merge-modal",
+                class: "mg-modal",
                 onclick: move |evt| evt.stop_propagation(),
-                div { class: "author-photo-modal__head",
-                    h2 { class: "author-photo-modal__title", "Merge with\u{2026}" }
-                    p { class: "subtitle author-photo-modal__sub",
-                        "Pick the duplicate to fold into \u{201c}{target_title}\u{201d}."
-                    }
+                div { class: "mg-head",
+                    div { class: "label mg-kicker", "Merge duplicate" }
+                    h2 { class: "mg-title", "Merge with\u{2026}" }
                 }
-                if let Some(src) = selected() {
-                    {render_confirm(src, target_title.clone(), busy(), do_merge, move |_| selected.set(None))}
-                } else {
-                    section { class: "author-photo-modal__section",
-                        label { class: "label", r#for: "bd-merge-search", "Search your library" }
-                        input {
-                            id: "bd-merge-search",
-                            class: "me-input",
-                            "data-testid": "merge-search",
-                            r#type: "search",
-                            placeholder: "Title, author\u{2026}",
-                            value: "{query}",
-                            autofocus: true,
-                            oninput: move |evt| {
-                                let q = evt.value();
-                                query.set(q.clone());
-                                run_search(q);
-                            },
+                div { class: "mg-body",
+                    if let Some(src) = selected() {
+                        {render_confirm(src, target_title.clone(), busy(), do_merge, move |_| selected.set(None))}
+                    } else {
+                        p { class: "mg-intro",
+                            "Find the other copy of this book. Its files, tags, highlights and reading "
+                            "progress move onto the entry you\u{2019}re viewing \u{2014} and the duplicate disappears."
                         }
-                        ul { class: "bd-merge-results",
-                            for book in results() {
-                                {render_candidate(book, selected)}
+                        {render_target_rail(target.clone(), target_title.clone())}
+                        div { class: "mg-search",
+                            svg {
+                                class: "mg-search-icon",
+                                width: "18",
+                                height: "18",
+                                view_box: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_width: "2",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                "aria-hidden": "true",
+                                circle { cx: "11", cy: "11", r: "8" }
+                                line { x1: "21", y1: "21", x2: "16.65", y2: "16.65" }
+                            }
+                            input {
+                                id: "bd-merge-search",
+                                class: "mg-search-input",
+                                "data-testid": "merge-search",
+                                r#type: "search",
+                                placeholder: "Search your library \u{2014} title, author, ISBN\u{2026}",
+                                value: "{query}",
+                                autofocus: true,
+                                oninput: move |evt| {
+                                    let q = evt.value();
+                                    query.set(q.clone());
+                                    run_search(q);
+                                },
+                            }
+                        }
+                        if result_count > 0 {
+                            div { class: "mg-results-head",
+                                span { class: "label", "Results \u{00b7} {result_count}" }
+                                span { class: "mono mg-results-hint", "matched on title, author \u{0026} series" }
+                            }
+                            ul { class: "mg-results",
+                                for book in results() {
+                                    {render_candidate(book, target_series.clone(), selected)}
+                                }
                             }
                         }
                     }
+                    if let Some(msg) = error() {
+                        p { role: "alert", class: "bd-merge-error", "{msg}" }
+                    }
                 }
-                if let Some(msg) = error() {
-                    p { role: "alert", class: "bd-merge-error", "{msg}" }
-                }
-                div { class: "bd-merge-foot",
+                div { class: "mg-foot",
+                    span { class: "mono mg-foot-note",
+                        "Nothing is deleted \u{2014} every merge can be undone."
+                    }
                     button {
                         class: "btn ghost sm",
                         "data-testid": "merge-cancel",
@@ -180,33 +218,108 @@ async fn async_sleep_ms(ms: u32) {
     tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
 }
 
-/// One search hit: title, author line, and format badges.
-fn render_candidate(book: EbookMetadata, mut selected: Signal<Option<EbookMetadata>>) -> Element {
-    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
-    let authors = book
+/// Pinned "this is the keeper" context shown above the search field: the
+/// current book's cover + title + author/series, with a "stays" note.
+fn render_target_rail(target: EbookMetadata, title: String) -> Element {
+    let author = target
         .creators
-        .iter()
+        .first()
         .map(|c| c.name.clone())
-        .collect::<Vec<_>>()
-        .join(", ");
-    let formats = book.formats.join(" · ").to_uppercase();
+        .unwrap_or_default();
+    let mut sub = author;
+    if let Some(series) = target.series.as_deref() {
+        if !sub.is_empty() {
+            sub.push_str(" \u{00b7} ");
+        }
+        sub.push_str(series);
+        if let Some(idx) = target.series_index.as_deref() {
+            sub.push_str(&format!(" #{idx}"));
+        }
+    }
+    rsx! {
+        div { class: "mg-target-rail",
+            div { class: "mg-target-cover", Cover { book: target.clone() } }
+            div { class: "mg-target-main",
+                div { class: "label mg-target-kicker", "Everything folds into" }
+                div { class: "mg-target-name",
+                    span { class: "mg-target-title", "{title}" }
+                    if !sub.is_empty() {
+                        span { class: "mono mg-target-sub", "{sub}" }
+                    }
+                }
+            }
+            span { class: "mono mg-target-note", "this entry stays" }
+        }
+    }
+}
+
+/// One search hit: cover, title, author · year, an optional "same series"
+/// signal, and format badges. Clicking it picks the merge source.
+fn render_candidate(
+    book: EbookMetadata,
+    target_series: Option<String>,
+    mut selected: Signal<Option<EbookMetadata>>,
+) -> Element {
+    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    // Primary author only — joining every creator surfaces calibre's
+    // book-producer contributor ("calibre (x.y) [url]") as junk, and the
+    // keeper rail above already shows just the lead author.
+    let author = book
+        .creators
+        .first()
+        .map(|c| c.name.clone())
+        .unwrap_or_default();
+    let year = book
+        .published
+        .as_deref()
+        .and_then(|p| p.get(0..4))
+        .unwrap_or("");
+    let meta = match (author.is_empty(), year.is_empty()) {
+        (false, false) => format!("{author} \u{00b7} {year}"),
+        (false, true) => author,
+        (true, false) => year.to_string(),
+        (true, true) => String::new(),
+    };
+    // A shared series is the strongest "same book, other format" signal —
+    // the common ebook↔audiobook merge case.
+    let same_series = matches!(
+        (target_series.as_deref(), book.series.as_deref()),
+        (Some(t), Some(b)) if t.eq_ignore_ascii_case(b)
+    );
+    let formats = book.formats.clone();
+    let cover_book = book.clone();
     let key = book.unique_identifier.clone().unwrap_or_default();
     rsx! {
         li { key: "{key}",
             button {
-                class: "btn ghost bd-merge-candidate",
+                class: "mg-row",
                 "data-testid": "merge-candidate",
                 onclick: move |_| selected.set(Some(book.clone())),
-                span { class: "bd-merge-candidate-title", "{title}" }
-                span { class: "mono bd-merge-candidate-meta",
-                    if authors.is_empty() { "{formats}" } else { "{authors} \u{00b7} {formats}" }
+                div { class: "mg-row-cover", Cover { book: cover_book.clone() } }
+                div { class: "mg-row-main",
+                    div { class: "mg-row-title", "{title}" }
+                    if !meta.is_empty() {
+                        div { class: "mg-row-meta mono", "{meta}" }
+                    }
+                }
+                div { class: "mg-row-aside",
+                    if same_series {
+                        span { class: "mg-row-signal",
+                            span { class: "mg-row-dot" }
+                            "Same series"
+                        }
+                    }
+                    for fmt in formats.iter() {
+                        span { class: "mg-fmt", "{fmt}" }
+                    }
                 }
             }
         }
     }
 }
 
-/// Confirm panel once a candidate is picked.
+/// Confirm panel once a candidate is picked. (The richer field-by-field
+/// reconciliation design is deferred; this keeps the merge actionable.)
 fn render_confirm(
     source: EbookMetadata,
     target_title: String,
@@ -221,14 +334,14 @@ fn render_confirm(
         .clone()
         .unwrap_or_else(|| source.filename.clone());
     rsx! {
-        section { class: "author-photo-modal__section",
-            p { class: "bd-merge-confirm-copy",
+        div { class: "mg-confirm",
+            p { class: "mg-confirm-copy",
                 strong { "\u{201c}{source_title}\u{201d}" }
                 " will be merged into "
                 strong { "\u{201c}{target_title}\u{201d}" }
                 ". Its files, tags, and reading progress move here; the other entry disappears. This can be undone."
             }
-            div { class: "bd-merge-confirm-actions",
+            div { class: "mg-confirm-actions",
                 button {
                     class: "btn primary",
                     "data-testid": "merge-confirm",

--- a/frontend/src/pages/book_detail/merge.rs
+++ b/frontend/src/pages/book_detail/merge.rs
@@ -5,7 +5,7 @@
 #[cfg(not(feature = "mobile"))]
 use dioxus::prelude::*;
 #[cfg(not(feature = "mobile"))]
-use omnibus_shared::MergeBooksResult;
+use omnibus_shared::{EbookMetadata, MergeBooksResult};
 
 #[cfg(not(feature = "mobile"))]
 use crate::components::MergeDialog;
@@ -44,15 +44,13 @@ pub(super) fn build_merge_ui(
     mut undo_error: Signal<Option<String>>,
     mut refresh: Signal<u32>,
     server_url: String,
-    page_uuid: String,
-    page_title: String,
+    target: EbookMetadata,
 ) -> Option<Element> {
     let undo_url = server_url;
     Some(rsx! {
         if merge_open() {
             MergeDialog {
-                target_uuid: page_uuid.clone(),
-                target_title: page_title.clone(),
+                target: target.clone(),
                 on_merged: move |res: MergeBooksResult| {
                     merge_open.set(false);
                     undo_error.set(None);

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -121,10 +121,6 @@ pub fn BookDetailPage(uuid: String) -> Element {
     // client after `current_user()` resolves an admin user, so this read
     // returns `false` during SSR and for non-admins on every platform.
     let is_admin_flag = is_admin();
-    #[cfg_attr(feature = "mobile", allow(unused_variables))]
-    let page_title = b.title.clone().unwrap_or_else(|| b.filename.clone());
-    #[cfg_attr(feature = "mobile", allow(unused_variables))]
-    let page_uuid = b.unique_identifier.clone().unwrap_or_default();
 
     // Rail "Merge with…" button (admin, web only) — threaded down as a
     // prebuilt Element so the rail component stays platform-agnostic.
@@ -140,8 +136,7 @@ pub fn BookDetailPage(uuid: String) -> Element {
         undo_error,
         refresh,
         server_url.clone(),
-        page_uuid,
-        page_title,
+        b.clone(),
     );
     #[cfg(feature = "mobile")]
     let merge_ui: Option<Element> = merge::build_merge_ui();


### PR DESCRIPTION
## Summary
- Redesign the admin "Merge with…" dialog to the Claude Design **"Merge duplicates"** spec (states 1–2): wide modal, accent kicker + italic title, a pinned **"Everything folds into"** keeper rail, a styled search field, and clean horizontal result rows (cover · title · author/year · "Same series" signal · format badges).
- Fixes the overlapping text the old layout had — the candidate row was a `.btn` with `flex-direction: column` whose line-height collided the two text lines; rows are now a plain horizontal flex with ellipsis truncation.
- Result rows show the **primary author only** (drops calibre's book-producer contributor junk). The dialog now receives the full target book so the keeper rail can render its cover + series.
- State 3 (Confirm/reconcile) intentionally omitted; the existing confirm step stays functional.

## Test plan
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` clean; `cargo fmt`.
- [x] `cargo test -p omnibus-frontend --features server` — 166 pass.
- [x] Mobile crate compiles (dialog `cfg`-excluded).
- [x] Browser-verified the redesigned modal renders to spec with no text overlap.
- [ ] CI re-runs the full lint/test matrix + Playwright `merge.spec.ts`.

## Notes
- E2E contract unchanged: `role="dialog"` / aria-label "Merge with another book", `merge-search` / `merge-candidate` / `merge-confirm` / `merge-cancel` testids, error `role="alert"`.
- The "Same series" signal only renders when both books carry series metadata.