### PR TITLE
refactor(frontend): split LandingPage (partial #377)

### DIFF
--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -205,23 +205,12 @@ fn build_crumbs(
     crumbs
 }
 
-/// Derived strings + flags `render_loaded` threads into the hero / rail /
-/// body sub-components. Computed once per render so the rsx stays a clean
-/// composition rather than re-doing every `.first()` / `.iter()` inline.
-struct BdViewData {
-    title: String,
-    primary_author: String,
-    authors_line: String,
-    kicker: String,
-    series: Option<String>,
-    accent_style: String,
-    has_audio: bool,
-    has_ebook: bool,
-    crumbs: Vec<BdCrumbItem>,
-}
-
-/// Compute the per-render derived view data for a loaded book.
-fn derive_view_data(b: &EbookMetadata) -> BdViewData {
+/// Render the fully-loaded book detail view.
+fn render_loaded(
+    b: EbookMetadata,
+    author_books: Vec<EbookMetadata>,
+    merge_button: Option<Element>,
+) -> Element {
     let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
     let primary_author = b
         .creators
@@ -240,59 +229,46 @@ fn derive_view_data(b: &EbookMetadata) -> BdViewData {
         .and_then(|p| p.get(0..4))
         .unwrap_or("")
         .to_string();
+    let kicker = kicker_label(&year);
     let series = series_label(b.series.as_deref(), b.series_index.as_deref());
-    let crumbs = build_crumbs(b, &title, &primary_author, &series);
-    BdViewData {
-        kicker: kicker_label(&year),
-        accent_style: b
-            .accent
-            .as_deref()
-            .map(|a| format!("--accent: {a};"))
-            .unwrap_or_default(),
-        has_audio: b
-            .formats
-            .iter()
-            .any(|f| f.eq_ignore_ascii_case("m4b") || f.eq_ignore_ascii_case("mp3")),
-        has_ebook: b
-            .formats
-            .iter()
-            .any(|f| f.eq_ignore_ascii_case("epub") || f.eq_ignore_ascii_case("pdf")),
-        title,
-        primary_author,
-        authors_line,
-        series,
-        crumbs,
-    }
-}
+    let accent_style = b
+        .accent
+        .as_deref()
+        .map(|a| format!("--accent: {a};"))
+        .unwrap_or_default();
 
-/// Render the fully-loaded book detail view.
-fn render_loaded(
-    b: EbookMetadata,
-    author_books: Vec<EbookMetadata>,
-    merge_button: Option<Element>,
-) -> Element {
-    let v = derive_view_data(&b);
+    let has_audio = b
+        .formats
+        .iter()
+        .any(|f| f.eq_ignore_ascii_case("m4b") || f.eq_ignore_ascii_case("mp3"));
+    let has_ebook = b
+        .formats
+        .iter()
+        .any(|f| f.eq_ignore_ascii_case("epub") || f.eq_ignore_ascii_case("pdf"));
+
+    let crumbs = build_crumbs(&b, &title, &primary_author, &series);
+
     rsx! {
-        div { class: "bd-root", style: "{v.accent_style}",
+        div { class: "bd-root", style: "{accent_style}",
             BdHeroSection {
                 b: b.clone(),
-                title: v.title.clone(),
-                kicker: v.kicker,
-                crumbs: v.crumbs,
-                has_ebook: v.has_ebook,
-                has_audio: v.has_audio,
+                title: title.clone(),
+                kicker: kicker.clone(),
+                crumbs,
+                has_ebook,
+                has_audio,
             }
             section { class: "bd-body-grid",
                 BdBodyMain {
-                    title: v.title.clone(),
-                    primary_author: v.primary_author,
-                    author_books,
+                    title: title.clone(),
+                    primary_author: primary_author.clone(),
+                    author_books: author_books.clone(),
                 }
                 BdRailSection {
-                    b,
-                    title: v.title,
-                    authors_line: v.authors_line,
-                    series: v.series,
+                    b: b.clone(),
+                    title: title.clone(),
+                    authors_line: authors_line.clone(),
+                    series: series.clone(),
                     merge_button,
                 }
             }

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -205,12 +205,23 @@ fn build_crumbs(
     crumbs
 }
 
-/// Render the fully-loaded book detail view.
-fn render_loaded(
-    b: EbookMetadata,
-    author_books: Vec<EbookMetadata>,
-    merge_button: Option<Element>,
-) -> Element {
+/// Derived strings + flags `render_loaded` threads into the hero / rail /
+/// body sub-components. Computed once per render so the rsx stays a clean
+/// composition rather than re-doing every `.first()` / `.iter()` inline.
+struct BdViewData {
+    title: String,
+    primary_author: String,
+    authors_line: String,
+    kicker: String,
+    series: Option<String>,
+    accent_style: String,
+    has_audio: bool,
+    has_ebook: bool,
+    crumbs: Vec<BdCrumbItem>,
+}
+
+/// Compute the per-render derived view data for a loaded book.
+fn derive_view_data(b: &EbookMetadata) -> BdViewData {
     let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
     let primary_author = b
         .creators
@@ -229,46 +240,59 @@ fn render_loaded(
         .and_then(|p| p.get(0..4))
         .unwrap_or("")
         .to_string();
-    let kicker = kicker_label(&year);
     let series = series_label(b.series.as_deref(), b.series_index.as_deref());
-    let accent_style = b
-        .accent
-        .as_deref()
-        .map(|a| format!("--accent: {a};"))
-        .unwrap_or_default();
+    let crumbs = build_crumbs(b, &title, &primary_author, &series);
+    BdViewData {
+        kicker: kicker_label(&year),
+        accent_style: b
+            .accent
+            .as_deref()
+            .map(|a| format!("--accent: {a};"))
+            .unwrap_or_default(),
+        has_audio: b
+            .formats
+            .iter()
+            .any(|f| f.eq_ignore_ascii_case("m4b") || f.eq_ignore_ascii_case("mp3")),
+        has_ebook: b
+            .formats
+            .iter()
+            .any(|f| f.eq_ignore_ascii_case("epub") || f.eq_ignore_ascii_case("pdf")),
+        title,
+        primary_author,
+        authors_line,
+        series,
+        crumbs,
+    }
+}
 
-    let has_audio = b
-        .formats
-        .iter()
-        .any(|f| f.eq_ignore_ascii_case("m4b") || f.eq_ignore_ascii_case("mp3"));
-    let has_ebook = b
-        .formats
-        .iter()
-        .any(|f| f.eq_ignore_ascii_case("epub") || f.eq_ignore_ascii_case("pdf"));
-
-    let crumbs = build_crumbs(&b, &title, &primary_author, &series);
-
+/// Render the fully-loaded book detail view.
+fn render_loaded(
+    b: EbookMetadata,
+    author_books: Vec<EbookMetadata>,
+    merge_button: Option<Element>,
+) -> Element {
+    let v = derive_view_data(&b);
     rsx! {
-        div { class: "bd-root", style: "{accent_style}",
+        div { class: "bd-root", style: "{v.accent_style}",
             BdHeroSection {
                 b: b.clone(),
-                title: title.clone(),
-                kicker: kicker.clone(),
-                crumbs,
-                has_ebook,
-                has_audio,
+                title: v.title.clone(),
+                kicker: v.kicker,
+                crumbs: v.crumbs,
+                has_ebook: v.has_ebook,
+                has_audio: v.has_audio,
             }
             section { class: "bd-body-grid",
                 BdBodyMain {
-                    title: title.clone(),
-                    primary_author: primary_author.clone(),
-                    author_books: author_books.clone(),
+                    title: v.title.clone(),
+                    primary_author: v.primary_author,
+                    author_books,
                 }
                 BdRailSection {
-                    b: b.clone(),
-                    title: title.clone(),
-                    authors_line: authors_line.clone(),
-                    series: series.clone(),
+                    b,
+                    title: v.title,
+                    authors_line: v.authors_line,
+                    series: v.series,
                     merge_button,
                 }
             }

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -10,32 +10,35 @@
 //! [`crate::view_prefs`].
 
 use dioxus::prelude::*;
-use omnibus_shared::{
-    EbookMetadata, FacetCounts as ServerFacetCounts, SortKey, TagWeight, ViewFilters, ViewMode,
-    ViewPrefs,
-};
+use omnibus_shared::{EbookMetadata, FacetCounts as ServerFacetCounts, ViewFilters, ViewPrefs};
 
-use crate::components::chip_editor::{collect_suggestions, SuggestionItem};
-use crate::{data, use_search_query, use_server_url, view_prefs};
+use crate::components::chip_editor::SuggestionItem;
+use crate::{use_search_query, use_server_url, view_prefs};
 
+mod effects;
 mod filtering;
 mod filters;
 mod grid;
+mod sections;
 mod sorting;
 mod table;
 mod toolbar;
 
+#[cfg(feature = "web")]
+use effects::spawn_load_more_observer;
+use effects::{
+    spawn_load_more_effect, spawn_page_fetch_effect, spawn_suggestion_pools_effect, FetchSignals,
+    SuggestionPools,
+};
 use filtering::{apply_filters, facet_counts, FacetCounts};
-use filters::{EmptyFiltered, FilterSidebar, FormatChips};
-use grid::BookGrid;
-use sorting::{default_dir_for, sort_books, toggle_dir};
-use table::{BookTable, BookTableContext};
-use toolbar::Toolbar;
+use filters::FormatChips;
+use sections::{LandingContent, LandingContentProps, LandingHeader};
+use sorting::sort_books;
 
 /// Keyset page size for the browse path (F5b open question #1). A grid renders
 /// ~30–60 cards above the fold and the table more; 100 covers both without an
 /// oversized first paint.
-const PAGE_SIZE: i64 = 100;
+pub(super) const PAGE_SIZE: i64 = 100;
 
 /// Landing page — primary library surface. See the module doc for the
 /// browse-paginates / search-stays-client-side split.
@@ -44,15 +47,15 @@ pub fn LandingPage() -> Element {
     let server_url = use_server_url();
     // Accumulated result rows: one growing browse list, or the capped search
     // result set. `next_cursor` is `Some` only while more browse pages remain.
-    let mut books = use_signal(Vec::<EbookMetadata>::new);
-    let mut next_cursor = use_signal(|| None::<String>);
-    let mut server_facets = use_signal(|| None::<ServerFacetCounts>);
-    let mut total = use_signal(|| None::<i64>);
-    let mut lib_path = use_signal(|| None::<String>);
-    let mut lib_error = use_signal(|| None::<String>);
-    let mut loading = use_signal(|| true);
-    let mut loading_more = use_signal(|| false);
-    let mut error = use_signal(|| None::<String>);
+    let books = use_signal(Vec::<EbookMetadata>::new);
+    let next_cursor = use_signal(|| None::<String>);
+    let server_facets = use_signal(|| None::<ServerFacetCounts>);
+    let total = use_signal(|| None::<i64>);
+    let lib_path = use_signal(|| None::<String>);
+    let lib_error = use_signal(|| None::<String>);
+    let loading = use_signal(|| true);
+    let loading_more = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
     let mut prefs = use_signal(ViewPrefs::default);
     // Bumped by the Load-more button and the web scroll observer; one effect
     // watches it and appends the next page.
@@ -61,7 +64,7 @@ pub fn LandingPage() -> Element {
     // page-1 fetch or load-more append captures the epoch and drops its result
     // if a newer fetch (sort/dir/filter/query change) superseded it mid-flight
     // — otherwise it would splice an old result stream onto the new list.
-    let mut fetch_epoch = use_signal(|| 0u64);
+    let fetch_epoch = use_signal(|| 0u64);
     // Search box lives in the top nav; the query is shared via context.
     let query = use_search_query().0;
 
@@ -79,33 +82,11 @@ pub fn LandingPage() -> Element {
 
     // Suggestion pools for the inline Authors chip editor and the
     // (future-reserved) Tags pool, each carrying the dropdown book-count.
-    let mut author_suggestions: Signal<Vec<SuggestionItem>> = use_signal(Vec::new);
-    let mut tag_suggestions: Signal<Vec<SuggestionItem>> = use_signal(Vec::new);
-    {
-        let url = server_url.clone();
-        use_effect(move || {
-            if !is_admin() {
-                return;
-            }
-            let url = url.clone();
-            spawn(async move {
-                if let Ok(authors) = data::list_authors(&url).await {
-                    let items: Vec<SuggestionItem> = authors
-                        .into_iter()
-                        .map(|a| SuggestionItem::new(a.name, a.book_count))
-                        .collect();
-                    author_suggestions.set(collect_suggestions(items));
-                }
-                if let Ok(tags) = data::get_tag_cloud(&url).await {
-                    let items: Vec<SuggestionItem> = tags
-                        .into_iter()
-                        .map(|t: TagWeight| SuggestionItem::new(t.name, t.count))
-                        .collect();
-                    tag_suggestions.set(collect_suggestions(items));
-                }
-            });
-        });
-    }
+    let pools = SuggestionPools {
+        authors: use_signal(Vec::<SuggestionItem>::new),
+        tags: use_signal(Vec::<SuggestionItem>::new),
+    };
+    spawn_suggestion_pools_effect(server_url.clone(), is_admin, pools);
 
     // Refetch page 1 whenever the search query or a *data-affecting* pref
     // (sort axis/dir or filters) changes. The `use_memo` keys the effect on
@@ -119,142 +100,22 @@ pub fn LandingPage() -> Element {
             p.filters.clone(),
         )
     });
-    {
-        let url = server_url.clone();
-        use_effect(move || {
-            let (q, sort_key, sort_dir, filters) = fetch_key();
-            let epoch = {
-                fetch_epoch.with_mut(|e| *e += 1);
-                *fetch_epoch.peek()
-            };
-            let url = url.clone();
-            spawn(async move {
-                loading.set(true);
-                error.set(None);
-                next_cursor.set(None);
-                if q.is_empty() {
-                    // Browse: server keyset page 1 (server-side sort + filter,
-                    // facets + total ride along on the first page).
-                    let result =
-                        data::get_ebooks_page(&url, sort_key, sort_dir, filters, None, PAGE_SIZE)
-                            .await;
-                    if *fetch_epoch.peek() != epoch {
-                        return; // a newer fetch superseded us — drop this result
-                    }
-                    match result {
-                        Ok(page) => {
-                            lib_path.set(page.path);
-                            lib_error.set(None);
-                            next_cursor.set(page.next_cursor);
-                            total.set(page.total);
-                            server_facets.set(page.facets);
-                            books.set(page.books);
-                        }
-                        Err(e) => {
-                            error.set(Some(e.to_string()));
-                            // Clear the derived signals so the error state doesn't
-                            // render a stale header count or facet sidebar.
-                            books.set(Vec::new());
-                            total.set(None);
-                            server_facets.set(None);
-                            lib_error.set(None);
-                        }
-                    }
-                } else {
-                    // Search: capped full result set, sorted/filtered client-side.
-                    let result = data::search_ebooks(&url, &q).await;
-                    if *fetch_epoch.peek() != epoch {
-                        return;
-                    }
-                    match result {
-                        Ok(lib) => {
-                            lib_path.set(lib.path);
-                            lib_error.set(lib.error);
-                            total.set(lib.total);
-                            server_facets.set(None); // client computes search facets
-                            books.set(lib.books);
-                        }
-                        Err(e) => {
-                            error.set(Some(e.to_string()));
-                            books.set(Vec::new());
-                            total.set(None);
-                            server_facets.set(None);
-                            lib_error.set(None);
-                        }
-                    }
-                }
-                loading.set(false);
-            });
-        });
-    }
-
-    // Append the next browse page when `want_more` is bumped (button click or
-    // the web scroll observer). Guards against concurrent/empty loads.
-    {
-        let url = server_url.clone();
-        use_effect(move || {
-            let trigger = want_more();
-            if trigger == 0 || *loading_more.peek() || next_cursor.peek().is_none() {
-                return;
-            }
-            let p = prefs.peek().clone();
-            let cursor = next_cursor.peek().clone();
-            let epoch = *fetch_epoch.peek();
-            let url = url.clone();
-            loading_more.set(true);
-            spawn(async move {
-                let result = data::get_ebooks_page(
-                    &url, p.sort_key, p.sort_dir, p.filters, cursor, PAGE_SIZE,
-                )
-                .await;
-                // Drop the append if a page-1 refetch (sort/filter/query change)
-                // superseded us mid-flight — otherwise we'd splice an old result
-                // stream onto the new list and overwrite its cursor.
-                if *fetch_epoch.peek() != epoch {
-                    loading_more.set(false);
-                    return;
-                }
-                match result {
-                    Ok(page) => {
-                        books.with_mut(|b| b.extend(page.books));
-                        next_cursor.set(page.next_cursor);
-                    }
-                    Err(e) => error.set(Some(e.to_string())),
-                }
-                loading_more.set(false);
-            });
-        });
-    }
-
-    // Web: auto-load when the Load-more sentinel nears the viewport. The
-    // `IntersectionObserver` simply `.click()`s the button, whose Dioxus
-    // `onclick` bumps `want_more` — one-way `eval` only (the established
-    // interop pattern; no markup divergence, since the button renders on every
-    // target and only the observer is gated). The effect reads `next_cursor`
-    // so it re-arms after each page append, disconnecting the prior observer
-    // first so they can't accumulate.
+    let sigs = FetchSignals {
+        books,
+        next_cursor,
+        server_facets,
+        total,
+        lib_path,
+        lib_error,
+        loading,
+        loading_more,
+        error,
+        fetch_epoch,
+    };
+    spawn_page_fetch_effect(server_url.clone(), fetch_key, sigs);
+    spawn_load_more_effect(server_url.clone(), want_more, prefs, sigs);
     #[cfg(feature = "web")]
-    {
-        use_effect(move || {
-            let _rearm_on = next_cursor.read().is_some();
-            let _ = dioxus::document::eval(
-                r#"
-                if (window.__omnibusLoadMoreObs) {
-                    window.__omnibusLoadMoreObs.disconnect();
-                    window.__omnibusLoadMoreObs = null;
-                }
-                const el = document.querySelector('[data-testid="lib-load-more"]');
-                if (el) {
-                    const obs = new IntersectionObserver((entries) => {
-                        if (entries.some((e) => e.isIntersecting)) { el.click(); }
-                    }, { rootMargin: "400px" });
-                    obs.observe(el);
-                    window.__omnibusLoadMoreObs = obs;
-                }
-                "#,
-            );
-        });
-    }
+    spawn_load_more_observer(next_cursor);
 
     // Hydrate persisted prefs when the library path resolves. The `!=` guard
     // makes this idempotent: re-running it after a page-1 refetch (which re-sets
@@ -327,135 +188,70 @@ pub fn LandingPage() -> Element {
     let visible_count = visible_books.len();
     let filters_for_chips = prefs().filters.clone();
 
+    let on_prefs_change = {
+        let mut save = save.clone();
+        move |next: ViewPrefs| save(next)
+    };
+    let on_formats_change = {
+        let mut save = save.clone();
+        move |formats: Vec<String>| {
+            let mut next = prefs.peek().clone();
+            next.filters.formats = formats;
+            save(next);
+        }
+    };
+    let on_load_more = move |_| {
+        want_more.with_mut(|n| *n += 1);
+    };
+    let on_clear_filters = {
+        let mut save = save.clone();
+        move |_| {
+            let mut next = prefs.peek().clone();
+            next.filters = ViewFilters::default();
+            save(next);
+        }
+    };
+    let books_empty = books().is_empty();
+
     rsx! {
-        header { class: "lib-header", "data-testid": "lib-header",
-            div { class: "lib-header-kicker",
-                h1 { class: "label lib-header-kicker-title", "Your Library" }
-                if !path_subtitle.is_empty() {
-                    span { class: "mono lib-header-path", " · {path_subtitle}" }
-                }
-            }
-            div { class: "lib-header-row",
-                p { class: "lib-header-title",
-                    em { "{book_count}" }
-                    " "
-                    if book_count == 1 { "book" } else { "books" }
-                }
-                Toolbar {
-                    prefs: prefs(),
-                    on_change: save.clone(),
-                }
-            }
-            if path_value.is_none() {
-                p { class: "lib-header-hint",
-                    "Configure your ebook library path in Settings."
-                }
-            }
-            if let Some(msg) = page_error.as_ref() {
-                p { class: "error", "⚠ {msg}" }
-            }
-            if let Some(msg) = lib_err.as_ref() {
-                p { class: "error", "⚠ {msg}" }
-            }
+        LandingHeader {
+            path_subtitle,
+            book_count,
+            prefs: prefs(),
+            on_prefs_change: on_prefs_change.clone(),
+            path_missing: path_value.is_none(),
+            page_error: page_error.clone(),
+            lib_err: lib_err.clone(),
         }
 
         FormatChips {
             counts: facet_counts_view.formats.clone(),
-            visible_count: visible_count,
-            book_count: book_count,
+            visible_count,
+            book_count,
             selected: filters_for_chips.formats.clone(),
-            on_change: {
-                let mut save = save.clone();
-                move |formats: Vec<String>| {
-                    let mut next = prefs.peek().clone();
-                    next.filters.formats = formats;
-                    save(next);
-                }
-            },
+            on_change: on_formats_change,
         }
 
-        div { class: if prefs().filters_open { "lib-layout" } else { "lib-layout lib-layout--collapsed" },
-            FilterSidebar {
-                facets: facet_counts_view,
-                filters: prefs().filters.clone(),
-                on_change: {
-                    let mut save = save.clone();
-                    move |filters: ViewFilters| {
-                        let mut next = prefs.peek().clone();
-                        next.filters = filters;
-                        save(next);
-                    }
-                },
-            }
-
-            div { class: "lib-main",
-                if is_loading {
-                    p { class: "library-empty", "Loading..." }
-                } else if !visible_is_empty || lib_err.is_some() || page_error.is_some() {
-                    match view_mode {
-                        ViewMode::Table => rsx! {
-                            BookTable {
-                                books: visible_books.clone(),
-                                prefs: prefs(),
-                                on_sort: {
-                                    let mut save = save.clone();
-                                    move |key: SortKey| {
-                                        let mut next = prefs.peek().clone();
-                                        next.sort_dir = if next.sort_key == key {
-                                            toggle_dir(next.sort_dir)
-                                        } else {
-                                            default_dir_for(key)
-                                        };
-                                        next.sort_key = key;
-                                        save(next);
-                                    }
-                                },
-                                ctx: BookTableContext {
-                                    server_url: server_url_for_row.clone(),
-                                    is_admin: is_admin(),
-                                    author_suggestions: author_suggestions.into(),
-                                    tag_suggestions: tag_suggestions.into(),
-                                },
-                            }
-                        },
-                        ViewMode::Grid => rsx! {
-                            BookGrid {
-                                books: visible_books.clone(),
-                                server_url: server_url_for_row.clone(),
-                            }
-                        },
-                    }
-                    // Browse pagination sentinel — the button is the
-                    // deterministic (mobile + Playwright) trigger; on web an
-                    // IntersectionObserver auto-bumps it as it nears the
-                    // viewport. Absent in search mode (no `next_cursor`).
-                    if has_more {
-                        div { class: "lib-load-more-row",
-                            button {
-                                class: "btn lib-load-more",
-                                "data-testid": "lib-load-more",
-                                disabled: is_loading_more,
-                                onclick: move |_| {
-                                    want_more.with_mut(|n| *n += 1);
-                                },
-                                if is_loading_more { "Loading…" } else { "Load more" }
-                            }
-                        }
-                    }
-                } else if books().is_empty() {
-                    p { class: "library-empty", "No ebooks found." }
-                } else {
-                    EmptyFiltered {
-                        on_clear: {
-                            let mut save = save.clone();
-                            move |_| {
-                                let mut next = prefs.peek().clone();
-                                next.filters = ViewFilters::default();
-                                save(next);
-                            }
-                        },
-                    }
-                }
+        LandingContent {
+            ..LandingContentProps {
+                is_loading,
+                visible_books,
+                visible_is_empty,
+                books_empty,
+                lib_err,
+                page_error,
+                view_mode,
+                prefs: prefs(),
+                facet_counts_view,
+                has_more,
+                is_loading_more,
+                server_url: server_url_for_row.clone(),
+                is_admin: is_admin(),
+                author_suggestions: pools.authors.into(),
+                tag_suggestions: pools.tags.into(),
+                on_prefs_change: EventHandler::new(on_prefs_change),
+                on_load_more: EventHandler::new(on_load_more),
+                on_clear_filters: EventHandler::new(on_clear_filters),
             }
         }
     }

--- a/frontend/src/pages/landing/effects.rs
+++ b/frontend/src/pages/landing/effects.rs
@@ -10,18 +10,14 @@ use crate::data;
 
 use super::PAGE_SIZE;
 
-/// Per-page handle on the suggestion pool signals; `LandingPage` constructs
-/// one and passes the bundle into render so the chip-editor `ReadSignal`s
-/// stay stable across re-renders.
+/// Stable per-page handle on the chip-editor suggestion pool signals (authors, tags).
 #[derive(Copy, Clone)]
 pub(super) struct SuggestionPools {
     pub(super) authors: Signal<Vec<SuggestionItem>>,
     pub(super) tags: Signal<Vec<SuggestionItem>>,
 }
 
-/// Page-1 fetch + epoch bookkeeping handles. Bundled so the
-/// `LandingPage` body can pass one struct into [`spawn_page_fetch_effect`]
-/// rather than ten signals.
+/// Bundle of fetch-target signals + epoch counter passed into [`spawn_page_fetch_effect`].
 #[derive(Copy, Clone)]
 pub(super) struct FetchSignals {
     pub(super) books: Signal<Vec<EbookMetadata>>,
@@ -36,9 +32,7 @@ pub(super) struct FetchSignals {
     pub(super) fetch_epoch: Signal<u64>,
 }
 
-/// Fetch the admin-only suggestion pools (authors + tags) when `is_admin`
-/// flips true. Idempotent — the effect re-runs whenever the admin signal
-/// changes, and the pools overwrite themselves on each fetch.
+/// Refetch the admin-only author/tag suggestion pools whenever `is_admin` changes.
 pub(super) fn spawn_suggestion_pools_effect(
     server_url: String,
     is_admin: Signal<bool>,
@@ -72,9 +66,7 @@ pub(super) fn spawn_suggestion_pools_effect(
     });
 }
 
-/// Refetch page 1 whenever the search query or a *data-affecting* pref
-/// (sort axis/dir or filters) changes. Captures the fetch epoch so a stale
-/// in-flight request drops its result instead of overwriting newer state.
+/// Refetch page 1 on query/sort/filter changes; epoch-guarded so stale in-flight requests drop.
 pub(super) fn spawn_page_fetch_effect(
     server_url: String,
     fetch_key: Memo<(
@@ -163,9 +155,7 @@ pub(super) fn spawn_page_fetch_effect(
     });
 }
 
-/// Append the next browse page when `want_more` is bumped (button click or
-/// the web scroll observer). Guards against concurrent/empty loads and
-/// drops the append if a page-1 refetch superseded it mid-flight.
+/// Append the next page when `want_more` bumps; drops the append if a page-1 refetch supersedes it.
 pub(super) fn spawn_load_more_effect(
     server_url: String,
     want_more: Signal<u32>,
@@ -213,11 +203,7 @@ pub(super) fn spawn_load_more_effect(
     });
 }
 
-/// Web: auto-load when the Load-more sentinel nears the viewport. The
-/// `IntersectionObserver` simply `.click()`s the button, whose Dioxus
-/// `onclick` bumps `want_more` — one-way `eval` only (no markup
-/// divergence, since the button renders on every target). The effect
-/// reads `next_cursor` so it re-arms after each page append.
+/// Web-only: arm an `IntersectionObserver` on the load-more sentinel; re-arms after each page append.
 #[cfg(feature = "web")]
 pub(super) fn spawn_load_more_observer(next_cursor: Signal<Option<String>>) {
     use_effect(move || {

--- a/frontend/src/pages/landing/effects.rs
+++ b/frontend/src/pages/landing/effects.rs
@@ -1,0 +1,242 @@
+//! Data-fetch + side-effect helpers spawned from [`super::LandingPage`].
+//! Each function captures the signals it mutates and registers the matching
+//! `use_effect` so the page body stays a small composition of named stages.
+
+use dioxus::prelude::*;
+use omnibus_shared::{EbookMetadata, FacetCounts as ServerFacetCounts, TagWeight, ViewPrefs};
+
+use crate::components::chip_editor::{collect_suggestions, SuggestionItem};
+use crate::data;
+
+use super::PAGE_SIZE;
+
+/// Per-page handle on the suggestion pool signals; `LandingPage` constructs
+/// one and passes the bundle into render so the chip-editor `ReadSignal`s
+/// stay stable across re-renders.
+#[derive(Copy, Clone)]
+pub(super) struct SuggestionPools {
+    pub(super) authors: Signal<Vec<SuggestionItem>>,
+    pub(super) tags: Signal<Vec<SuggestionItem>>,
+}
+
+/// Page-1 fetch + epoch bookkeeping handles. Bundled so the
+/// `LandingPage` body can pass one struct into [`spawn_page_fetch_effect`]
+/// rather than ten signals.
+#[derive(Copy, Clone)]
+pub(super) struct FetchSignals {
+    pub(super) books: Signal<Vec<EbookMetadata>>,
+    pub(super) next_cursor: Signal<Option<String>>,
+    pub(super) server_facets: Signal<Option<ServerFacetCounts>>,
+    pub(super) total: Signal<Option<i64>>,
+    pub(super) lib_path: Signal<Option<String>>,
+    pub(super) lib_error: Signal<Option<String>>,
+    pub(super) loading: Signal<bool>,
+    pub(super) loading_more: Signal<bool>,
+    pub(super) error: Signal<Option<String>>,
+    pub(super) fetch_epoch: Signal<u64>,
+}
+
+/// Fetch the admin-only suggestion pools (authors + tags) when `is_admin`
+/// flips true. Idempotent — the effect re-runs whenever the admin signal
+/// changes, and the pools overwrite themselves on each fetch.
+pub(super) fn spawn_suggestion_pools_effect(
+    server_url: String,
+    is_admin: Signal<bool>,
+    pools: SuggestionPools,
+) {
+    let SuggestionPools {
+        mut authors,
+        mut tags,
+    } = pools;
+    use_effect(move || {
+        if !is_admin() {
+            return;
+        }
+        let url = server_url.clone();
+        spawn(async move {
+            if let Ok(list) = data::list_authors(&url).await {
+                let items: Vec<SuggestionItem> = list
+                    .into_iter()
+                    .map(|a| SuggestionItem::new(a.name, a.book_count))
+                    .collect();
+                authors.set(collect_suggestions(items));
+            }
+            if let Ok(list) = data::get_tag_cloud(&url).await {
+                let items: Vec<SuggestionItem> = list
+                    .into_iter()
+                    .map(|t: TagWeight| SuggestionItem::new(t.name, t.count))
+                    .collect();
+                tags.set(collect_suggestions(items));
+            }
+        });
+    });
+}
+
+/// Refetch page 1 whenever the search query or a *data-affecting* pref
+/// (sort axis/dir or filters) changes. Captures the fetch epoch so a stale
+/// in-flight request drops its result instead of overwriting newer state.
+pub(super) fn spawn_page_fetch_effect(
+    server_url: String,
+    fetch_key: Memo<(
+        String,
+        omnibus_shared::SortKey,
+        omnibus_shared::SortDir,
+        omnibus_shared::ViewFilters,
+    )>,
+    sigs: FetchSignals,
+) {
+    let FetchSignals {
+        mut books,
+        mut next_cursor,
+        mut server_facets,
+        mut total,
+        mut lib_path,
+        mut lib_error,
+        mut loading,
+        loading_more: _,
+        mut error,
+        mut fetch_epoch,
+    } = sigs;
+    use_effect(move || {
+        let (q, sort_key, sort_dir, filters) = fetch_key();
+        let epoch = {
+            fetch_epoch.with_mut(|e| *e += 1);
+            *fetch_epoch.peek()
+        };
+        let url = server_url.clone();
+        spawn(async move {
+            loading.set(true);
+            error.set(None);
+            next_cursor.set(None);
+            if q.is_empty() {
+                // Browse: server keyset page 1 (server-side sort + filter,
+                // facets + total ride along on the first page).
+                let result =
+                    data::get_ebooks_page(&url, sort_key, sort_dir, filters, None, PAGE_SIZE).await;
+                if *fetch_epoch.peek() != epoch {
+                    return; // a newer fetch superseded us — drop this result
+                }
+                match result {
+                    Ok(page) => {
+                        lib_path.set(page.path);
+                        lib_error.set(None);
+                        next_cursor.set(page.next_cursor);
+                        total.set(page.total);
+                        server_facets.set(page.facets);
+                        books.set(page.books);
+                    }
+                    Err(e) => {
+                        error.set(Some(e.to_string()));
+                        // Clear the derived signals so the error state doesn't
+                        // render a stale header count or facet sidebar.
+                        books.set(Vec::new());
+                        total.set(None);
+                        server_facets.set(None);
+                        lib_error.set(None);
+                    }
+                }
+            } else {
+                // Search: capped full result set, sorted/filtered client-side.
+                let result = data::search_ebooks(&url, &q).await;
+                if *fetch_epoch.peek() != epoch {
+                    return;
+                }
+                match result {
+                    Ok(lib) => {
+                        lib_path.set(lib.path);
+                        lib_error.set(lib.error);
+                        total.set(lib.total);
+                        server_facets.set(None); // client computes search facets
+                        books.set(lib.books);
+                    }
+                    Err(e) => {
+                        error.set(Some(e.to_string()));
+                        books.set(Vec::new());
+                        total.set(None);
+                        server_facets.set(None);
+                        lib_error.set(None);
+                    }
+                }
+            }
+            loading.set(false);
+        });
+    });
+}
+
+/// Append the next browse page when `want_more` is bumped (button click or
+/// the web scroll observer). Guards against concurrent/empty loads and
+/// drops the append if a page-1 refetch superseded it mid-flight.
+pub(super) fn spawn_load_more_effect(
+    server_url: String,
+    want_more: Signal<u32>,
+    prefs: Signal<ViewPrefs>,
+    sigs: FetchSignals,
+) {
+    let FetchSignals {
+        mut books,
+        mut next_cursor,
+        mut loading_more,
+        mut error,
+        fetch_epoch,
+        ..
+    } = sigs;
+    use_effect(move || {
+        let trigger = want_more();
+        if trigger == 0 || *loading_more.peek() || next_cursor.peek().is_none() {
+            return;
+        }
+        let p = prefs.peek().clone();
+        let cursor = next_cursor.peek().clone();
+        let epoch = *fetch_epoch.peek();
+        let url = server_url.clone();
+        loading_more.set(true);
+        spawn(async move {
+            let result =
+                data::get_ebooks_page(&url, p.sort_key, p.sort_dir, p.filters, cursor, PAGE_SIZE)
+                    .await;
+            // Drop the append if a page-1 refetch (sort/filter/query change)
+            // superseded us mid-flight — otherwise we'd splice an old result
+            // stream onto the new list and overwrite its cursor.
+            if *fetch_epoch.peek() != epoch {
+                loading_more.set(false);
+                return;
+            }
+            match result {
+                Ok(page) => {
+                    books.with_mut(|b| b.extend(page.books));
+                    next_cursor.set(page.next_cursor);
+                }
+                Err(e) => error.set(Some(e.to_string())),
+            }
+            loading_more.set(false);
+        });
+    });
+}
+
+/// Web: auto-load when the Load-more sentinel nears the viewport. The
+/// `IntersectionObserver` simply `.click()`s the button, whose Dioxus
+/// `onclick` bumps `want_more` — one-way `eval` only (no markup
+/// divergence, since the button renders on every target). The effect
+/// reads `next_cursor` so it re-arms after each page append.
+#[cfg(feature = "web")]
+pub(super) fn spawn_load_more_observer(next_cursor: Signal<Option<String>>) {
+    use_effect(move || {
+        let _rearm_on = next_cursor.read().is_some();
+        let _ = dioxus::document::eval(
+            r#"
+            if (window.__omnibusLoadMoreObs) {
+                window.__omnibusLoadMoreObs.disconnect();
+                window.__omnibusLoadMoreObs = null;
+            }
+            const el = document.querySelector('[data-testid="lib-load-more"]');
+            if (el) {
+                const obs = new IntersectionObserver((entries) => {
+                    if (entries.some((e) => e.isIntersecting)) { el.click(); }
+                }, { rootMargin: "400px" });
+                obs.observe(el);
+                window.__omnibusLoadMoreObs = obs;
+            }
+            "#,
+        );
+    });
+}

--- a/frontend/src/pages/landing/sections.rs
+++ b/frontend/src/pages/landing/sections.rs
@@ -1,0 +1,200 @@
+//! Markup sub-components for the landing page. Stateless: each takes the
+//! current snapshot of derived data and an `on_change` (or per-action)
+//! handler so [`super::LandingPage`] keeps ownership of the canonical
+//! `prefs` signal and the data pipeline.
+
+use dioxus::prelude::*;
+use omnibus_shared::{EbookMetadata, SortKey, ViewFilters, ViewMode, ViewPrefs};
+
+use crate::components::chip_editor::SuggestionItem;
+
+use super::filtering::FacetCounts;
+use super::filters::{EmptyFiltered, FilterSidebar};
+use super::grid::BookGrid;
+use super::sorting::{default_dir_for, toggle_dir};
+use super::table::{BookTable, BookTableContext};
+use super::toolbar::Toolbar;
+
+/// Sticky page header: kicker + title + count + toolbar, with the
+/// `data-testid="lib-header"` contract the E2E specs hook into. Errors
+/// (page-level fetch + library-path) render here too.
+#[component]
+pub(super) fn LandingHeader(
+    path_subtitle: String,
+    book_count: usize,
+    prefs: ViewPrefs,
+    on_prefs_change: EventHandler<ViewPrefs>,
+    path_missing: bool,
+    page_error: Option<String>,
+    lib_err: Option<String>,
+) -> Element {
+    rsx! {
+        header { class: "lib-header", "data-testid": "lib-header",
+            div { class: "lib-header-kicker",
+                h1 { class: "label lib-header-kicker-title", "Your Library" }
+                if !path_subtitle.is_empty() {
+                    span { class: "mono lib-header-path", " · {path_subtitle}" }
+                }
+            }
+            div { class: "lib-header-row",
+                p { class: "lib-header-title",
+                    em { "{book_count}" }
+                    " "
+                    if book_count == 1 { "book" } else { "books" }
+                }
+                Toolbar {
+                    prefs: prefs,
+                    on_change: move |next: ViewPrefs| on_prefs_change.call(next),
+                }
+            }
+            if path_missing {
+                p { class: "lib-header-hint",
+                    "Configure your ebook library path in Settings."
+                }
+            }
+            if let Some(msg) = page_error.as_ref() {
+                p { class: "error", "⚠ {msg}" }
+            }
+            if let Some(msg) = lib_err.as_ref() {
+                p { class: "error", "⚠ {msg}" }
+            }
+        }
+    }
+}
+
+/// Per-render snapshot of the data the table/grid + load-more sentinel need.
+#[derive(Clone, PartialEq, Props)]
+pub(super) struct LandingContentProps {
+    pub is_loading: bool,
+    pub visible_books: Vec<EbookMetadata>,
+    pub visible_is_empty: bool,
+    pub books_empty: bool,
+    pub lib_err: Option<String>,
+    pub page_error: Option<String>,
+    pub view_mode: ViewMode,
+    pub prefs: ViewPrefs,
+    pub facet_counts_view: FacetCounts,
+    pub has_more: bool,
+    pub is_loading_more: bool,
+    pub server_url: String,
+    pub is_admin: bool,
+    pub author_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    pub tag_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    pub on_prefs_change: EventHandler<ViewPrefs>,
+    pub on_load_more: EventHandler<()>,
+    pub on_clear_filters: EventHandler<()>,
+}
+
+/// Sidebar + main column: facet sidebar, the grid/table switch, the
+/// load-more sentinel, and the empty/filtered fallbacks. Stateless —
+/// every mutation routes back through the parent's handlers.
+#[component]
+pub(super) fn LandingContent(props: LandingContentProps) -> Element {
+    let LandingContentProps {
+        is_loading,
+        visible_books,
+        visible_is_empty,
+        books_empty,
+        lib_err,
+        page_error,
+        view_mode,
+        prefs,
+        facet_counts_view,
+        has_more,
+        is_loading_more,
+        server_url,
+        is_admin,
+        author_suggestions,
+        tag_suggestions,
+        on_prefs_change,
+        on_load_more,
+        on_clear_filters,
+    } = props;
+
+    let layout_class = if prefs.filters_open {
+        "lib-layout"
+    } else {
+        "lib-layout lib-layout--collapsed"
+    };
+    let prefs_for_sidebar = prefs.clone();
+    let on_filters_change = {
+        let prefs = prefs.clone();
+        move |filters: ViewFilters| {
+            let mut next = prefs.clone();
+            next.filters = filters;
+            on_prefs_change.call(next);
+        }
+    };
+    let on_sort = {
+        let prefs = prefs.clone();
+        move |key: SortKey| {
+            let mut next = prefs.clone();
+            next.sort_dir = if next.sort_key == key {
+                toggle_dir(next.sort_dir)
+            } else {
+                default_dir_for(key)
+            };
+            next.sort_key = key;
+            on_prefs_change.call(next);
+        }
+    };
+
+    rsx! {
+        div { class: "{layout_class}",
+            FilterSidebar {
+                facets: facet_counts_view,
+                filters: prefs_for_sidebar.filters.clone(),
+                on_change: on_filters_change,
+            }
+
+            div { class: "lib-main",
+                if is_loading {
+                    p { class: "library-empty", "Loading..." }
+                } else if !visible_is_empty || lib_err.is_some() || page_error.is_some() {
+                    match view_mode {
+                        ViewMode::Table => rsx! {
+                            BookTable {
+                                books: visible_books.clone(),
+                                prefs: prefs.clone(),
+                                on_sort,
+                                ctx: BookTableContext {
+                                    server_url: server_url.clone(),
+                                    is_admin,
+                                    author_suggestions,
+                                    tag_suggestions,
+                                },
+                            }
+                        },
+                        ViewMode::Grid => rsx! {
+                            BookGrid {
+                                books: visible_books.clone(),
+                                server_url: server_url.clone(),
+                            }
+                        },
+                    }
+                    // Browse pagination sentinel — the button is the
+                    // deterministic (mobile + Playwright) trigger; on web an
+                    // IntersectionObserver auto-bumps it as it nears the
+                    // viewport. Absent in search mode (no `next_cursor`).
+                    if has_more {
+                        div { class: "lib-load-more-row",
+                            button {
+                                class: "btn lib-load-more",
+                                "data-testid": "lib-load-more",
+                                disabled: is_loading_more,
+                                onclick: move |_| on_load_more.call(()),
+                                if is_loading_more { "Loading…" } else { "Load more" }
+                            }
+                        }
+                    }
+                } else if books_empty {
+                    p { class: "library-empty", "No ebooks found." }
+                } else {
+                    EmptyFiltered {
+                        on_clear: move |_| on_clear_filters.call(()),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/pages/landing/sections.rs
+++ b/frontend/src/pages/landing/sections.rs
@@ -15,9 +15,7 @@ use super::sorting::{default_dir_for, toggle_dir};
 use super::table::{BookTable, BookTableContext};
 use super::toolbar::Toolbar;
 
-/// Sticky page header: kicker + title + count + toolbar, with the
-/// `data-testid="lib-header"` contract the E2E specs hook into. Errors
-/// (page-level fetch + library-path) render here too.
+/// Sticky `data-testid="lib-header"` header; also renders page-level + library-path errors.
 #[component]
 pub(super) fn LandingHeader(
     path_subtitle: String,
@@ -85,9 +83,7 @@ pub(super) struct LandingContentProps {
     pub on_clear_filters: EventHandler<()>,
 }
 
-/// Sidebar + main column: facet sidebar, the grid/table switch, the
-/// load-more sentinel, and the empty/filtered fallbacks. Stateless —
-/// every mutation routes back through the parent's handlers.
+/// Sidebar + grid/table column with load-more sentinel; stateless, mutations route through parent handlers.
 #[component]
 pub(super) fn LandingContent(props: LandingContentProps) -> Element {
     let LandingContentProps {


### PR DESCRIPTION
## Summary
- `LandingPage` (`frontend/src/pages/landing.rs`): **420 → 213 lines**. The page-1 fetch, load-more append, suggestion-pool fetch, and IntersectionObserver bring-up moved into a new `landing/effects.rs` as named `spawn_*` helpers; the header and sidebar/main markup moved into `LandingHeader` + `LandingContent` sub-components in a new `landing/sections.rs`.
- Hydration parity preserved: no component bodies are feature-gated on `web`/`mobile`/`server`; effect installers retain their existing compile-time `#[cfg(feature = "web")]` gates (rule 07).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` — 169/169 pass
- [ ] CI confirms full crate matrix
- [ ] Manual smoke (`/ui-validate`): landing page loads grid + table modes, sort/filter sidebar works, load-more observer fires on scroll, no console hydration warnings

## Notes
- **Partial #377** — does NOT close the issue. Leaves 2 cited offenders deferred to follow-ups:
  - `ChipEditor` in `frontend/src/components/chip_editor.rs` (~95 lines, marginal — already well-split into `ChipList`/`SuggestionDropdown`/`ChipInput`)
  - `BookReadPage` in `frontend/src/pages/reader/mod.rs` (~392 lines — needs deeper web/SSR interop refactor; prior `partial #377` commit `b3af653` extracted `ReaderLayout` but the page body itself stayed large)
- `LandingPage` body remains 213 lines after this PR — still over the ~80-line soft cap. Real improvement (−207 lines) but a follow-up could extract a derived-view helper to bring it under cap.
- **Coordination with #502**: an earlier draft of this branch also split `render_loaded` in `book_detail/mod.rs`. Reverted in commit `0015a8b` because PR for #502 claimed that function first and lands a slightly more thorough split (also extracts `BdHiddenSlots`). This PR is now LandingPage-only.
- **Architecture doc gap**: per rule 99 step 1, the new `landing/effects.rs` + `landing/sections.rs` submodules should be added to `.claude/architecture.md`'s frontend per-crate module map. Worker hit a permission denial there — please add the one-liner on merge, or call out as a follow-up.

Refs #377 (partial — do not auto-close)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CX5CsESk2PrfzDGNS5R9H6)_