### PR TITLE
refactor(frontend): split EbookRow + render_loaded (#502)

### DIFF
--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -205,12 +205,23 @@ fn build_crumbs(
     crumbs
 }
 
-/// Render the fully-loaded book detail view.
-fn render_loaded(
-    b: EbookMetadata,
-    author_books: Vec<EbookMetadata>,
-    merge_button: Option<Element>,
-) -> Element {
+/// Pre-derived strings + flags ready to feed the loaded-book sections.
+/// Split out of [`render_loaded`] so the rsx body stays a thin composition
+/// of named sub-components.
+struct LoadedBookView {
+    title: String,
+    primary_author: String,
+    authors_line: String,
+    kicker: String,
+    series: Option<String>,
+    accent_style: String,
+    has_audio: bool,
+    has_ebook: bool,
+    crumbs: Vec<BdCrumbItem>,
+}
+
+/// Compute the per-section display fields from the loaded book.
+fn derive_loaded_view(b: &EbookMetadata) -> LoadedBookView {
     let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
     let primary_author = b
         .creators
@@ -236,7 +247,6 @@ fn render_loaded(
         .as_deref()
         .map(|a| format!("--accent: {a};"))
         .unwrap_or_default();
-
     let has_audio = b
         .formats
         .iter()
@@ -245,15 +255,44 @@ fn render_loaded(
         .formats
         .iter()
         .any(|f| f.eq_ignore_ascii_case("epub") || f.eq_ignore_ascii_case("pdf"));
+    let crumbs = build_crumbs(b, &title, &primary_author, &series);
+    LoadedBookView {
+        title,
+        primary_author,
+        authors_line,
+        kicker,
+        series,
+        accent_style,
+        has_audio,
+        has_ebook,
+        crumbs,
+    }
+}
 
-    let crumbs = build_crumbs(&b, &title, &primary_author, &series);
+/// Render the fully-loaded book detail view.
+fn render_loaded(
+    b: EbookMetadata,
+    author_books: Vec<EbookMetadata>,
+    merge_button: Option<Element>,
+) -> Element {
+    let LoadedBookView {
+        title,
+        primary_author,
+        authors_line,
+        kicker,
+        series,
+        accent_style,
+        has_audio,
+        has_ebook,
+        crumbs,
+    } = derive_loaded_view(&b);
 
     rsx! {
         div { class: "bd-root", style: "{accent_style}",
             BdHeroSection {
                 b: b.clone(),
                 title: title.clone(),
-                kicker: kicker.clone(),
+                kicker,
                 crumbs,
                 has_ebook,
                 has_audio,
@@ -261,36 +300,42 @@ fn render_loaded(
             section { class: "bd-body-grid",
                 BdBodyMain {
                     title: title.clone(),
-                    primary_author: primary_author.clone(),
-                    author_books: author_books.clone(),
+                    primary_author,
+                    author_books,
                 }
                 BdRailSection {
-                    b: b.clone(),
-                    title: title.clone(),
-                    authors_line: authors_line.clone(),
-                    series: series.clone(),
+                    b,
+                    title,
+                    authors_line,
+                    series,
                     merge_button,
                 }
             }
             div { class: "bd-footer",
                 Link { to: Route::Landing {}, class: "btn", "Back to library" }
             }
-            // Hidden slots preserved for the F1.4 contract — the hero
-            // rating card and the cover-fan strips are the visible
-            // surfaces; these stay attached so anything keying off the
-            // slot testids still finds them.
-            div {
-                class: "ratings-slot",
-                "data-testid": "ratings-slot",
-                aria_label: "Ratings \u{2014} coming soon",
-                hidden: true,
-            }
-            div {
-                class: "suggestions-slot",
-                "data-testid": "suggestions-slot",
-                aria_label: "Suggestions \u{2014} coming soon",
-                hidden: true,
-            }
+            BdHiddenSlots {}
+        }
+    }
+}
+
+/// Reserved hidden slots — the F1.4 contract still has anything keying off
+/// the `ratings-slot` / `suggestions-slot` testids; the hero rating card
+/// and cover-fan strips are the visible surfaces.
+#[component]
+fn BdHiddenSlots() -> Element {
+    rsx! {
+        div {
+            class: "ratings-slot",
+            "data-testid": "ratings-slot",
+            aria_label: "Ratings \u{2014} coming soon",
+            hidden: true,
+        }
+        div {
+            class: "suggestions-slot",
+            "data-testid": "suggestions-slot",
+            aria_label: "Suggestions \u{2014} coming soon",
+            hidden: true,
         }
     }
 }

--- a/frontend/src/pages/landing/table.rs
+++ b/frontend/src/pages/landing/table.rs
@@ -153,26 +153,42 @@ fn EbookRow(book: EbookMetadata, ctx: BookTableContext) -> Element {
         author_suggestions,
         tag_suggestions,
     } = ctx;
-    // Stable per-book uuid drives both the detail-route URL and the
-    // thumbnail URL — see `Route::BookDetail` for why it's keyed on the
-    // uuid instead of `books.id`.
-    let uuid = book.unique_identifier.clone().unwrap_or_default();
-    let row_testid = format!("ebook-row-{}", row_slug(&book.filename));
-    let has_cover = book.cover_url.is_some();
-    let thumb_base = format!("{server_url}/api/thumbs/{uuid}");
     let _ = tag_suggestions; // reserved for a future inline-tag editor
 
-    // Optimistic per-row state: we render from `book_state` rather than
-    // the raw `book` prop so a successful inline save updates the row
-    // immediately, without a full library refetch. The server-side
-    // merge in `rpc_save_overrides` returns the canonical merged
-    // EbookMetadata which we install verbatim.
-    //
-    // Resync from the prop when the upstream `book` changes (library
-    // refetch / sort change reusing the same EbookRow instance via the
-    // filename key) — but only when no cell is mid-edit, so a save
-    // round-trip doesn't clobber an open input. `use_reactive!` keys
-    // the effect on `book` itself.
+    let uuid = book.unique_identifier.clone().unwrap_or_default();
+    let (book_state, editing, authors_draft) = use_row_state(book.clone());
+    let save_field = build_save_field(uuid.clone(), server_url.clone(), book_state);
+    let save_authors = build_save_authors(uuid.clone(), server_url.clone(), book_state);
+    let display = derive_row_display(&book_state.read(), &server_url, &uuid);
+
+    rsx! {
+        EbookRowMarkup {
+            display,
+            uuid,
+            is_admin,
+            editing,
+            authors_draft,
+            author_suggestions,
+            save_field,
+            save_authors,
+        }
+    }
+}
+
+/// Per-row reactive state — optimistic book copy, current editing cell, and
+/// the authors chip-editor draft. The optimistic copy lets a successful
+/// inline save update the row immediately without a full library refetch;
+/// the `book` prop is resynced into it on upstream changes only when no
+/// cell is mid-edit (so a save round-trip doesn't clobber an open input).
+/// `authors_draft` mirrors `book_state.creators` so the chip editor sees
+/// canonical names after a save without dropping in-progress chip edits.
+fn use_row_state(
+    book: EbookMetadata,
+) -> (
+    Signal<EbookMetadata>,
+    Signal<Option<EditField>>,
+    Signal<Vec<String>>,
+) {
     let mut book_state: Signal<EbookMetadata> = use_signal(|| book.clone());
     let editing: Signal<Option<EditField>> = use_signal(|| None);
     use_effect(use_reactive!(|book| {
@@ -181,21 +197,91 @@ fn EbookRow(book: EbookMetadata, ctx: BookTableContext) -> Element {
         }
     }));
 
-    let nav = use_navigator();
-    let uuid_click = uuid.clone();
-    let uuid_key = uuid.clone();
-    let uuid_for_save = uuid.clone();
-    let url_for_save = server_url.clone();
+    let initial_authors: Vec<String> = book_state
+        .read()
+        .creators
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    let mut authors_draft: Signal<Vec<String>> = use_signal(|| initial_authors);
+    use_effect(move || {
+        let canonical: Vec<String> = book_state
+            .read()
+            .creators
+            .iter()
+            .map(|c| c.name.clone())
+            .collect();
+        if *authors_draft.peek() != canonical {
+            authors_draft.set(canonical);
+        }
+    });
 
-    // Common save callback used by every inline cell. Builds a sparse
-    // `MetadataOverrides`, POSTs to the existing F5.1 endpoint, then
-    // installs the server-returned merged metadata into `book_state`.
-    // Empty strings clear the override for the field (None — the
-    // scanned value re-surfaces); non-empty strings persist as
-    // `Some(value)`.
-    let save_field = move |field: EditField, value: String| {
-        let uuid = uuid_for_save.clone();
-        let url = url_for_save.clone();
+    (book_state, editing, authors_draft)
+}
+
+/// Pre-derived, ready-to-render display strings for a single row. Kept in
+/// one struct so `EbookRowMarkup` reads cleanly and the row body stays
+/// under the 80-line cap.
+#[derive(Clone, PartialEq)]
+struct RowDisplay {
+    book: EbookMetadata,
+    row_testid: String,
+    thumb_base: String,
+    has_cover: bool,
+    title: String,
+    series_line: String,
+    series_text: String,
+    authors_text: String,
+    updated: String,
+    added: String,
+    publisher: String,
+    published: String,
+    language: String,
+}
+
+/// Compute the per-cell display strings from the optimistic book state.
+/// Pulled out of [`EbookRow`] so the closures and rsx live in their own
+/// scopes.
+fn derive_row_display(book: &EbookMetadata, server_url: &str, uuid: &str) -> RowDisplay {
+    let row_testid = format!("ebook-row-{}", row_slug(&book.filename));
+    let thumb_base = format!("{server_url}/api/thumbs/{uuid}");
+    let title = book.title.as_deref().unwrap_or(&book.filename).to_string();
+    let series_line = match (book.series.as_deref(), book.series_index.as_deref()) {
+        (Some(s), Some(i)) => format!("{s} #{i}"),
+        (Some(s), None) => s.to_string(),
+        _ => String::new(),
+    };
+    RowDisplay {
+        row_testid,
+        thumb_base,
+        has_cover: book.cover_url.is_some(),
+        title,
+        series_line,
+        series_text: book.series.clone().unwrap_or_default(),
+        authors_text: contributor_names(&book.creators),
+        updated: book.modified.as_deref().unwrap_or("").to_string(),
+        added: book.added_at.as_deref().unwrap_or("").to_string(),
+        publisher: book.publisher.clone().unwrap_or_default(),
+        published: book.published.clone().unwrap_or_default(),
+        language: book.language.clone().unwrap_or_default(),
+        book: book.clone(),
+    }
+}
+
+/// Build the common per-cell save callback. Empty strings clear the
+/// override (None — the scanned value re-surfaces); non-empty strings
+/// persist as `Some(value)`. The server-side merge in `rpc_save_overrides`
+/// returns the canonical merged metadata which we install verbatim into
+/// the optimistic `book_state` signal.
+fn build_save_field(
+    uuid: String,
+    server_url: String,
+    mut book_state: Signal<EbookMetadata>,
+) -> impl FnMut((EditField, String)) + 'static {
+    move |args: (EditField, String)| {
+        let (field, value) = args;
+        let uuid = uuid.clone();
+        let url = server_url.clone();
         spawn(async move {
             let mut overrides = MetadataOverrides::default();
             let trimmed = value.trim();
@@ -210,60 +296,33 @@ fn EbookRow(book: EbookMetadata, ctx: BookTableContext) -> Element {
                 EditField::Publisher => overrides.publisher = value,
                 EditField::Published => overrides.published = value,
                 EditField::Language => overrides.language = value,
-                EditField::Authors => {
-                    // Authors is handled below — this branch is reserved
-                    // for the chip-editor on_change path which sets
-                    // `creators` instead.
-                    return;
-                }
+                // Authors edits go through `build_save_authors` so they
+                // can set the `creators` override instead of a scalar.
+                EditField::Authors => return,
             }
             if overrides.validate().is_err() {
-                // Validation rejects payloads that exceed the F5.1
-                // length caps. The display reverts on the next
-                // refetch; a toast / inline error message ships in a
-                // follow-up PR.
+                // F5.1 length caps rejected the payload. The display
+                // reverts on the next refetch; a toast / inline error
+                // message ships in a follow-up PR.
                 return;
             }
             if let Ok(Some(merged)) = data::save_overrides(&url, &uuid, &overrides).await {
                 book_state.set(merged);
             }
         });
-    };
-    // Authors chip editor lifts the canonical creator list out of the
-    // optimistic row state into a Signal so ChipEditor can drive it
-    // directly. Edits go through `save_authors` (separate callback so
-    // it can build the `creators` override; the text-cell path is
-    // scalar-only).
-    let initial_authors: Vec<String> = book_state
-        .read()
-        .creators
-        .iter()
-        .map(|c| c.name.clone())
-        .collect();
-    let mut authors_draft: Signal<Vec<String>> = use_signal(|| initial_authors);
-    // Keep `authors_draft` in sync with `book_state.creators` so a
-    // save round-trip (which may canonicalize / reorder names on the
-    // server) doesn't leave the chip editor showing stale chips, and
-    // re-opening the cell after an external update shows the current
-    // truth. The effect is a no-op when the values already match, so
-    // the user's in-progress chip edits aren't clobbered between
-    // `on_change` and the optimistic `book_state` install.
-    use_effect(move || {
-        let canonical: Vec<String> = book_state
-            .read()
-            .creators
-            .iter()
-            .map(|c| c.name.clone())
-            .collect();
-        if *authors_draft.peek() != canonical {
-            authors_draft.set(canonical);
-        }
-    });
-    let uuid_for_authors = uuid.clone();
-    let url_for_authors = server_url.clone();
-    let save_authors = move |new_names: Vec<String>| {
-        let uuid = uuid_for_authors.clone();
-        let url = url_for_authors.clone();
+    }
+}
+
+/// Build the authors-cell save callback. Mirrors [`build_save_field`] but
+/// posts a `creators` override (full replacement list) instead of a scalar.
+fn build_save_authors(
+    uuid: String,
+    server_url: String,
+    mut book_state: Signal<EbookMetadata>,
+) -> impl FnMut(Vec<String>) + 'static {
+    move |new_names: Vec<String>| {
+        let uuid = uuid.clone();
+        let url = server_url.clone();
         spawn(async move {
             let creators: Vec<Contributor> = new_names
                 .iter()
@@ -283,165 +342,274 @@ fn EbookRow(book: EbookMetadata, ctx: BookTableContext) -> Element {
                 book_state.set(merged);
             }
         });
-    };
+    }
+}
 
-    // Pull values from the optimistic state so a save's returned
-    // merged metadata is what we render.
-    let display_book = book_state.read().clone();
-    let display_title = display_book
-        .title
-        .as_deref()
-        .unwrap_or(&display_book.filename)
-        .to_string();
-    let series_line = match (
-        display_book.series.as_deref(),
-        display_book.series_index.as_deref(),
-    ) {
-        (Some(s), Some(i)) => format!("{s} #{i}"),
-        (Some(s), None) => s.to_string(),
-        _ => String::new(),
-    };
-    let authors_text = contributor_names(&display_book.creators);
-    let updated = display_book.modified.as_deref().unwrap_or("").to_string();
-    let added = display_book.added_at.as_deref().unwrap_or("").to_string();
-    let publisher = display_book.publisher.clone().unwrap_or_default();
-    let published = display_book.published.clone().unwrap_or_default();
-    let language = display_book.language.clone().unwrap_or_default();
-    let series_text = display_book.series.clone().unwrap_or_default();
+/// Inner row markup — the `<tr>` + every `<td>`. Split out of [`EbookRow`]
+/// so the parent stays a thin state-setup shell. All inputs are already
+/// derived; this component does no signal seeding of its own.
+#[component]
+fn EbookRowMarkup(
+    display: RowDisplay,
+    uuid: String,
+    is_admin: bool,
+    editing: Signal<Option<EditField>>,
+    authors_draft: Signal<Vec<String>>,
+    author_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    save_field: EventHandler<(EditField, String)>,
+    save_authors: EventHandler<Vec<String>>,
+) -> Element {
+    let nav = use_navigator();
+    let uuid_click = uuid.clone();
+    let uuid_key = uuid;
+    let row_testid = display.row_testid.clone();
+    let aria_title = display.title.clone();
 
     rsx! {
         tr {
-                class: "ebook-row",
-                "data-testid": "{row_testid}",
-                id: "{row_testid}",
-                role: "button",
-                tabindex: "0",
-                aria_label: "Open details for {display_title}",
-                onclick: move |_| {
-                    // Row-level click navigates only when no cell-level
-                    // edit is in progress. Each editable cell stops
-                    // propagation on click already, but a click on a
-                    // non-editable area (cover, formats, dates) while
-                    // a cell is open would otherwise blur+save the
-                    // input AND fire the navigation. Bailing on the
-                    // editing-is-some path keeps the user on the page
-                    // while the blur-save lands.
-                    if editing().is_some() {
-                        return;
-                    }
-                    nav.push(Route::BookDetail { uuid: uuid_click.clone() });
-                },
-                onkeydown: move |evt: Event<KeyboardData>| {
-                    if editing().is_some() {
-                        return;
-                    }
-                    let key = evt.key();
-                    if key == Key::Enter || key == Key::Character(" ".to_string()) {
-                        evt.prevent_default();
-                        nav.push(Route::BookDetail { uuid: uuid_key.clone() });
-                    }
-                },
-                td { class: "ebook-col-cover", "data-testid": "ebook-cell-cover",
-                    if has_cover {
-                        img {
-                            class: "ebook-thumb",
-                            src: "{thumb_base}/md",
-                            srcset: "{thumb_base}/sm 160w, {thumb_base}/md 320w, {thumb_base}/lg 640w",
-                            sizes: "(max-width: 640px) 160px, (max-width: 1280px) 320px, 640px",
-                            alt: "Cover of {display_title}",
-                            loading: "lazy",
-                            width: "320",
-                            height: "480",
-                        }
-                    } else {
-                        div { class: "ebook-thumb ebook-thumb-fallback", "—" }
-                    }
+            class: "ebook-row",
+            "data-testid": "{row_testid}",
+            id: "{row_testid}",
+            role: "button",
+            tabindex: "0",
+            aria_label: "Open details for {aria_title}",
+            onclick: move |_| {
+                // Row-level click navigates only when no cell-level edit
+                // is in progress. Each editable cell stops propagation on
+                // click already, but a click on a non-editable area
+                // (cover, formats, dates) while a cell is open would
+                // otherwise blur+save the input AND fire the navigation.
+                // Bailing on the editing-is-some path keeps the user on
+                // the page while the blur-save lands.
+                if editing().is_some() {
+                    return;
                 }
-                EditableCell {
-                    col_class: "ebook-col-title".to_string(),
-                    cell_testid: "ebook-cell-title".to_string(),
-                    field: EditField::Title,
-                    display_value: display_title.clone(),
-                    is_admin,
-                    editing,
-                    placeholder: "Title".to_string(),
-                    on_save: { let save = save_field.clone(); move |v: String| save(EditField::Title, v) },
-                    error: display_book.error.clone(),
+                nav.push(Route::BookDetail { uuid: uuid_click.clone() });
+            },
+            onkeydown: move |evt: Event<KeyboardData>| {
+                if editing().is_some() {
+                    return;
                 }
-                AuthorsCell {
-                    is_admin,
-                    editing,
-                    authors_draft,
-                    authors_text: authors_text.clone(),
-                    suggestions: author_suggestions,
-                    on_change: {
-                        let save = save_authors;
-                        move |names: Vec<String>| save(names)
-                    },
+                let key = evt.key();
+                if key == Key::Enter || key == Key::Character(" ".to_string()) {
+                    evt.prevent_default();
+                    nav.push(Route::BookDetail { uuid: uuid_key.clone() });
                 }
-                EditableCell {
-                    col_class: "ebook-col-series".to_string(),
-                    cell_testid: "ebook-cell-series".to_string(),
-                    field: EditField::Series,
-                    // Display: "Pioneers #1" (name + index, F1.3 standard).
-                    // Edit:    "Pioneers"    (the series-name override is
-                    //                         scalar; index lives in
-                    //                         `series_index` which the
-                    //                         landing-table doesn't
-                    //                         currently expose for edit).
-                    display_value: series_line.clone(),
-                    edit_value: Some(series_text.clone()),
-                    is_admin,
-                    editing,
-                    placeholder: "Series".to_string(),
-                    on_save: { let save = save_field.clone(); move |v: String| save(EditField::Series, v) },
-                    error: None,
+            },
+            EbookRowCells {
+                display,
+                is_admin,
+                editing,
+                authors_draft,
+                author_suggestions,
+                save_field,
+                save_authors,
+            }
+        }
+    }
+}
+
+/// Flat list of `<td>` cells inside an [`EbookRow`]. Split out of
+/// [`EbookRowMarkup`] so the row-level event handlers and the per-cell
+/// wiring live in separate functions.
+#[component]
+fn EbookRowCells(
+    display: RowDisplay,
+    is_admin: bool,
+    editing: Signal<Option<EditField>>,
+    authors_draft: Signal<Vec<String>>,
+    author_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    save_field: EventHandler<(EditField, String)>,
+    save_authors: EventHandler<Vec<String>>,
+) -> Element {
+    let RowDisplay {
+        book,
+        row_testid: _,
+        thumb_base,
+        has_cover,
+        title,
+        series_line,
+        series_text,
+        authors_text,
+        updated,
+        added,
+        publisher,
+        published,
+        language,
+    } = display;
+    let cover_alt = title.clone();
+
+    rsx! {
+        EbookRowCoverCell { thumb_base, has_cover, alt_title: cover_alt }
+        RowTitleCell {
+            title,
+            error: book.error.clone(),
+            is_admin,
+            editing,
+            save_field,
+        }
+        AuthorsCell {
+            is_admin,
+            editing,
+            authors_draft,
+            authors_text,
+            suggestions: author_suggestions,
+            on_change: move |names: Vec<String>| save_authors.call(names),
+        }
+        RowSeriesCell { series_line, series_text, is_admin, editing, save_field }
+        RowScalarCell {
+            col_class: "ebook-col-publisher".to_string(),
+            cell_testid: "ebook-cell-publisher".to_string(),
+            field: EditField::Publisher,
+            value: publisher,
+            placeholder: "Publisher".to_string(),
+            is_admin,
+            editing,
+            save_field,
+        }
+        RowScalarCell {
+            col_class: "ebook-col-published".to_string(),
+            cell_testid: "ebook-cell-published".to_string(),
+            field: EditField::Published,
+            value: published,
+            placeholder: "YYYY-MM-DD".to_string(),
+            is_admin,
+            editing,
+            save_field,
+        }
+        EbookRowFormatsCell { formats: book.formats.clone() }
+        td { class: "ebook-col-updated", "data-testid": "ebook-cell-updated", "{updated}" }
+        td { class: "ebook-col-added", "data-testid": "ebook-cell-added", "{added}" }
+        RowScalarCell {
+            col_class: "ebook-col-language".to_string(),
+            cell_testid: "ebook-cell-language".to_string(),
+            field: EditField::Language,
+            value: language,
+            placeholder: "en".to_string(),
+            is_admin,
+            editing,
+            save_field,
+        }
+    }
+}
+
+/// Title cell wrapper — pre-wires the title field's [`EditableCell`] props
+/// and routes its `on_save` through the shared row save callback.
+#[component]
+fn RowTitleCell(
+    title: String,
+    error: Option<String>,
+    is_admin: bool,
+    editing: Signal<Option<EditField>>,
+    save_field: EventHandler<(EditField, String)>,
+) -> Element {
+    rsx! {
+        EditableCell {
+            col_class: "ebook-col-title".to_string(),
+            cell_testid: "ebook-cell-title".to_string(),
+            field: EditField::Title,
+            display_value: title,
+            is_admin,
+            editing,
+            placeholder: "Title".to_string(),
+            on_save: move |v: String| save_field.call((EditField::Title, v)),
+            error,
+        }
+    }
+}
+
+/// Series cell wrapper — display shows "Name #Index" (F1.3), edit input
+/// seeds with just the series name (the index lives on the full edit page).
+#[component]
+fn RowSeriesCell(
+    series_line: String,
+    series_text: String,
+    is_admin: bool,
+    editing: Signal<Option<EditField>>,
+    save_field: EventHandler<(EditField, String)>,
+) -> Element {
+    rsx! {
+        EditableCell {
+            col_class: "ebook-col-series".to_string(),
+            cell_testid: "ebook-cell-series".to_string(),
+            field: EditField::Series,
+            display_value: series_line,
+            edit_value: Some(series_text),
+            is_admin,
+            editing,
+            placeholder: "Series".to_string(),
+            on_save: move |v: String| save_field.call((EditField::Series, v)),
+            error: None,
+        }
+    }
+}
+
+/// Plain scalar-text cell wrapper for publisher / published / language —
+/// collapses the boilerplate of wiring `EditableCell` to the shared
+/// `save_field` callback.
+#[component]
+fn RowScalarCell(
+    col_class: String,
+    cell_testid: String,
+    field: EditField,
+    value: String,
+    placeholder: String,
+    is_admin: bool,
+    editing: Signal<Option<EditField>>,
+    save_field: EventHandler<(EditField, String)>,
+) -> Element {
+    rsx! {
+        EditableCell {
+            col_class,
+            cell_testid,
+            field,
+            display_value: value,
+            is_admin,
+            editing,
+            placeholder,
+            on_save: move |v: String| save_field.call((field, v)),
+            error: None,
+        }
+    }
+}
+
+/// Cover-thumbnail `<td>` — image with srcset when a cover exists, em-dash
+/// fallback otherwise.
+#[component]
+fn EbookRowCoverCell(thumb_base: String, has_cover: bool, alt_title: String) -> Element {
+    rsx! {
+        td { class: "ebook-col-cover", "data-testid": "ebook-cell-cover",
+            if has_cover {
+                img {
+                    class: "ebook-thumb",
+                    src: "{thumb_base}/md",
+                    srcset: "{thumb_base}/sm 160w, {thumb_base}/md 320w, {thumb_base}/lg 640w",
+                    sizes: "(max-width: 640px) 160px, (max-width: 1280px) 320px, 640px",
+                    alt: "Cover of {alt_title}",
+                    loading: "lazy",
+                    width: "320",
+                    height: "480",
                 }
-                EditableCell {
-                    col_class: "ebook-col-publisher".to_string(),
-                    cell_testid: "ebook-cell-publisher".to_string(),
-                    field: EditField::Publisher,
-                    display_value: publisher.clone(),
-                    is_admin,
-                    editing,
-                    placeholder: "Publisher".to_string(),
-                    on_save: { let save = save_field.clone(); move |v: String| save(EditField::Publisher, v) },
-                    error: None,
-                }
-                EditableCell {
-                    col_class: "ebook-col-published".to_string(),
-                    cell_testid: "ebook-cell-published".to_string(),
-                    field: EditField::Published,
-                    display_value: published.clone(),
-                    is_admin,
-                    editing,
-                    placeholder: "YYYY-MM-DD".to_string(),
-                    on_save: { let save = save_field.clone(); move |v: String| save(EditField::Published, v) },
-                    error: None,
-                }
-                td { class: "ebook-col-formats", "data-testid": "ebook-cell-formats",
-                    if display_book.formats.is_empty() {
-                        span { class: "ebook-cell-formats-empty", "—" }
-                    } else {
-                        for fmt in display_book.formats.iter() {
-                            span { key: "{fmt}", class: "format-badge", "{format_badge_label(fmt)}" }
-                        }
-                    }
-                }
-                td { class: "ebook-col-updated", "data-testid": "ebook-cell-updated", "{updated}" }
-                td { class: "ebook-col-added", "data-testid": "ebook-cell-added", "{added}" }
-                EditableCell {
-                    col_class: "ebook-col-language".to_string(),
-                    cell_testid: "ebook-cell-language".to_string(),
-                    field: EditField::Language,
-                    display_value: language.clone(),
-                    is_admin,
-                    editing,
-                    placeholder: "en".to_string(),
-                    on_save: { let save = save_field.clone(); move |v: String| save(EditField::Language, v) },
-                    error: None,
+            } else {
+                div { class: "ebook-thumb ebook-thumb-fallback", "—" }
+            }
+        }
+    }
+}
+
+/// Formats `<td>` — one badge span per format, em-dash when empty.
+#[component]
+fn EbookRowFormatsCell(formats: Vec<String>) -> Element {
+    rsx! {
+        td { class: "ebook-col-formats", "data-testid": "ebook-cell-formats",
+            if formats.is_empty() {
+                span { class: "ebook-cell-formats-empty", "—" }
+            } else {
+                for fmt in formats.iter() {
+                    span { key: "{fmt}", class: "format-badge", "{format_badge_label(fmt)}" }
                 }
             }
+        }
     }
 }
 

--- a/frontend/src/pages/landing/table.rs
+++ b/frontend/src/pages/landing/table.rs
@@ -443,7 +443,7 @@ fn EbookRowCells(
         EbookRowCoverCell { thumb_base, has_cover, alt_title: cover_alt }
         RowTitleCell {
             title,
-            error: book.error.clone(),
+            error: book.error,
             is_admin,
             editing,
             save_field,
@@ -477,7 +477,7 @@ fn EbookRowCells(
             editing,
             save_field,
         }
-        EbookRowFormatsCell { formats: book.formats.clone() }
+        EbookRowFormatsCell { formats: book.formats }
         td { class: "ebook-col-updated", "data-testid": "ebook-cell-updated", "{updated}" }
         td { class: "ebook-col-added", "data-testid": "ebook-cell-added", "{added}" }
         RowScalarCell {


### PR DESCRIPTION
## Summary
- Splits the two remaining 80-line-cap offenders called out in the **2026-06-20 audit on #502** into per-responsibility sub-components.
- `EbookRow` (`frontend/src/pages/landing/table.rs`): **308 → 28 lines**. Extracted `use_row_state`, `derive_row_display` + `RowDisplay` struct, `build_save_field`, `build_save_authors`, `EbookRowMarkup`, `EbookRowCells`, `EbookRowCoverCell`, `EbookRowFormatsCell`, plus `RowTitleCell` / `RowSeriesCell` / `RowScalarCell` thin wrappers that pre-bind the shared save callback so the cell list reads as a flat composition.
- `render_loaded` (`frontend/src/pages/book_detail/mod.rs`): **107 → 48 lines**. Extracted `derive_loaded_view` returning a `LoadedBookView` struct, plus a `BdHiddenSlots` component for the F1.4 reserved slots.
- `SearchPage` (third item in the audit) is already 74 lines on `origin/main` after #563 — not re-touched here.
- No behavior changes: every signal, effect, prop, and event handler preserved; rendered markup identical.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` — 169 passed
- [ ] CI confirms full crate matrix
- [ ] Manual smoke (`/ui-validate`): landing table inline-edit (click title cell, save), book-detail page render (hero + rail + footer + hidden slots) — no SSR/WASM hydration warning in `preview_console_logs`

## Notes
- **Coordination with #377**: `render_loaded` appeared in both #502 and #377. I claimed it here because this PR already touches `book_detail/mod.rs`. The #377 PR has already reverted its overlap (commit `0015a8b`).
- `EbookRowCells` lands at 79 lines (under the 80-line soft cap by a hair). It's a flat composition of 10 named cell components with one local `let cover_alt` — no control flow, no event handlers. Splitting further would only push prop-wiring into wrapper functions.
- `frontend/src/pages/landing/table.rs` now sits at **799 lines**, right at the ~800-line file soft cap. The next change to this file should split into a `landing/table/{mod,cells,editable,state}.rs` subdir per rule 05's sub-topic pattern. Not blocking this PR.
- **Partial #502**: pre-existing 109-line `EditableCell` in the same file (NOT in this issue's audit list) is over cap and worth a batch-3 follow-up. The other 9-ish cited offenders from the original 2026-06-14 issue body were resolved by prior PRs.
- Hydration parity: no `#[cfg(feature = ...)]` gates inside rsx; `BdHiddenSlots` renders unconditional markup.

Closes #502


---
_Generated by [Claude Code](https://claude.ai/code/session_01CX5CsESk2PrfzDGNS5R9H6)_