### PR TITLE
refactor: justify or remove section-divider comments in 6 files (partial #553)

### DIFF
--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -12,12 +12,7 @@
 //! for an instant local position, then reconciles against the server
 //! before mounting. Saves write here AND fire-and-forget POST to the
 //! server. The stored value is the raw second-offset (no JSON envelope).
-//!
-//! The `#[cfg(feature = ...)]` blocks below carry the three per-target
-//! implementations of `load_impl`/`save_impl`/`load_rate_impl`/
-//! `save_rate_impl`. A directory split would force one `mod.rs` per target
-//! plus a re-export shim, so the framing dividers between web / mobile /
-//! SSR / tests stay as in-file nav aids.
+//! In-file `#[cfg]`-framing dividers retained per rule 05's nav-aid exception.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.listening::";

--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -12,6 +12,12 @@
 //! for an instant local position, then reconciles against the server
 //! before mounting. Saves write here AND fire-and-forget POST to the
 //! server. The stored value is the raw second-offset (no JSON envelope).
+//!
+//! The `#[cfg(feature = ...)]` blocks below carry the three per-target
+//! implementations of `load_impl`/`save_impl`/`load_rate_impl`/
+//! `save_rate_impl`. A directory split would force one `mod.rs` per target
+//! plus a re-export shim, so the framing dividers between web / mobile /
+//! SSR / tests stay as in-file nav aids.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.listening::";

--- a/frontend/src/reader_progress.rs
+++ b/frontend/src/reader_progress.rs
@@ -3,6 +3,11 @@
 //! no-op. Now the offline / first-paint cache for the progress-sync
 //! endpoint: reader reads here synchronously then reconciles against
 //! the server; saves write here AND fire-and-forget POST.
+//!
+//! The `#[cfg(feature = ...)]` blocks below carry the three per-target
+//! implementations of `load_impl`/`save_impl`. A directory split would force
+//! one `mod.rs` per target plus a re-export shim, so the framing dividers
+//! between web / mobile / SSR / tests stay as in-file nav aids.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.reading::";

--- a/frontend/src/reader_progress.rs
+++ b/frontend/src/reader_progress.rs
@@ -1,13 +1,8 @@
 //! Reading-position persistence — saved EPUB CFI per book. Web stores
 //! per-UUID in `localStorage`, mobile keeps an in-memory map, SSR is a
-//! no-op. Now the offline / first-paint cache for the progress-sync
-//! endpoint: reader reads here synchronously then reconciles against
-//! the server; saves write here AND fire-and-forget POST.
-//!
-//! The `#[cfg(feature = ...)]` blocks below carry the three per-target
-//! implementations of `load_impl`/`save_impl`. A directory split would force
-//! one `mod.rs` per target plus a re-export shim, so the framing dividers
-//! between web / mobile / SSR / tests stay as in-file nav aids.
+//! no-op. Offline / first-paint cache for the progress-sync endpoint:
+//! reader reads sync, saves write here AND fire-and-forget POST.
+//! In-file `#[cfg]`-framing dividers retained per rule 05's nav-aid exception.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.reading::";

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -2,6 +2,11 @@
 //! per library-path in `localStorage`, mobile keeps an in-memory map, SSR
 //! returns defaults so first-hydration markup matches the WASM client.
 //! Shape lives in `omnibus-shared` so a future server endpoint can reuse it.
+//!
+//! The `#[cfg(feature = ...)]` blocks below carry the three per-target
+//! implementations of `load_impl`/`save_impl`. A directory split would force
+//! one `mod.rs` per target plus a re-export shim, so the framing dividers
+//! between web / mobile / SSR / tests stay as in-file nav aids.
 
 use omnibus_shared::ViewPrefs;
 

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -2,11 +2,7 @@
 //! per library-path in `localStorage`, mobile keeps an in-memory map, SSR
 //! returns defaults so first-hydration markup matches the WASM client.
 //! Shape lives in `omnibus-shared` so a future server endpoint can reuse it.
-//!
-//! The `#[cfg(feature = ...)]` blocks below carry the three per-target
-//! implementations of `load_impl`/`save_impl`. A directory split would force
-//! one `mod.rs` per target plus a re-export shim, so the framing dividers
-//! between web / mobile / SSR / tests stay as in-file nav aids.
+//! In-file `#[cfg]`-framing dividers retained per rule 05's nav-aid exception.
 
 use omnibus_shared::ViewPrefs;
 

--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -5,10 +5,6 @@
 //! `DELETE` accepts an uploaded photo or a remote URL via the SSRF-guarded
 //! `fetch_remote_image` helper.
 
-// ---------------------------------------------------------------------------
-// F1.11 Author profile photos.
-// ---------------------------------------------------------------------------
-
 use axum::{
     extract::{Path, State},
     http::header,

--- a/server/src/backend/covers.rs
+++ b/server/src/backend/covers.rs
@@ -154,10 +154,6 @@ mod tests {
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 
-    // -------------------------------------------------------------------
-    // /api/thumbs — thumbnail pipeline endpoint
-    // -------------------------------------------------------------------
-
     #[tokio::test]
     async fn api_thumbs_returns_400_for_bad_size() {
         let (app, _, pool) = fixture().await;

--- a/server/src/backend/overrides.rs
+++ b/server/src/backend/overrides.rs
@@ -4,10 +4,6 @@
 //! reads happen via the standard ebook endpoints, which merge overrides
 //! into the wire DTO. Mounted on the REST router in [`super::rest_router`].
 
-// ---------------------------------------------------------------------------
-// F5.1 Metadata overrides (REST — mobile client).
-// ---------------------------------------------------------------------------
-
 use axum::{
     extract::{Path, State},
     response::{IntoResponse, Response},


### PR DESCRIPTION
## Summary
- Delete 3 redundant module-level / in-tests dividers in `server/src/backend/` where the divider text simply duplicated info already in the `//!` block.
- Add a short `//!` block note to 3 frontend persistence files (`view_prefs.rs`, `reader_progress.rs`, `audiobook_progress.rs`) explaining why their internal `#[cfg(feature = ...)]`-framing dividers remain (per rule 05's "tolerated when a function can't be split further" exception).
- No behavior changes — comment / doc edits only.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` — 169/169 pass
- [x] `cargo test -p omnibus` — 206/206 pass

## Notes
**Files touched** (action per file):
- `server/src/backend/author_photos.rs` — delete divider (info already in `//!`)
- `server/src/backend/overrides.rs` — delete divider (info already in `//!`)
- `server/src/backend/covers.rs` — delete in-tests divider above thumbnail group (test-name prefixes `api_covers_*` vs `api_thumbs_*` carry the nav signal)
- `frontend/src/view_prefs.rs` — add `//!` note justifying `#[cfg]`-framing dividers; keep dividers
- `frontend/src/reader_progress.rs` — add `//!` note; keep dividers
- `frontend/src/audiobook_progress.rs` — add `//!` note; keep dividers

**Partial #553** — does NOT close. Remaining work in scope of the issue:
- `frontend/src/data/{auth,books,highlights,progress}.rs` and `frontend/src/data.rs` use the **identical** `#[cfg(feature = ...)]`-framing pattern as the 3 frontend files treated here. Same `//!` justification recipe applies — left for a follow-up to keep this PR focused.
- `frontend/src/rpc.rs:382,601,657` carries 3 non-`#[cfg]` dividers labeled with roadmap phase numbers ("F1.8"). Roadmap-phase refs in comments violate rule 05; deletable independent of any file split.
- `frontend/src/pages/{auth,metadata_edit,series,author,book_detail/mod,landing/filters,landing/filtering,landing/sorting,listen/bootstrap,listen/controls}.rs` and `frontend/src/components/author_photo_edit.rs` — mix of intra-function nav aids and thematic markers; need per-file evaluation in subsequent PRs.

Hydration safety: doc-comment-only edits to hydration-sensitive files (`view_prefs.rs` etc.); no rsx or signal-init code paths modified, SSR/WASM parity preserved.

Refs #553 (partial — do not auto-close)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CX5CsESk2PrfzDGNS5R9H6)_