### PR TITLE
refactor: address remaining section-divider comments (partial #553)

### DIFF
--- a/frontend/src/components/author_photo_edit.rs
+++ b/frontend/src/components/author_photo_edit.rs
@@ -113,7 +113,7 @@ fn AuthorPhotoEditModal(
                     p { class: "subtitle author-photo-modal__sub", "{author_name}" }
                 }
 
-                // ===== Option 1: paste image URL =====
+                // Option 1: paste image URL.
                 section { class: "author-photo-modal__section",
                     label { class: "label", r#for: "author-photo-url",
                         "Paste image URL"
@@ -161,7 +161,7 @@ fn AuthorPhotoEditModal(
                     }
                 }
 
-                // ===== Option 2: upload file =====
+                // Option 2: upload file.
                 section { class: "author-photo-modal__section",
                     label { class: "label", r#for: "author-photo-file",
                         "Upload from this device"
@@ -216,7 +216,7 @@ fn AuthorPhotoEditModal(
                     }
                 }
 
-                // ===== Option 3: scan Open Library =====
+                // Option 3: scan Open Library.
                 section { class: "author-photo-modal__section",
                     label { class: "label", "Or fetch automatically" }
                     button {

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -35,18 +35,16 @@ pub use progress::*;
 pub use series::*;
 pub use tags::*;
 
-// ===== Typed transport error (#96) =====
-//
-// Replaces the previous `Result<T, String>` everywhere in this module so
-// callers can distinguish failure modes by type — most importantly
-// `Unauthorized`, which the mobile 401 handler and the web router both key
-// on. The variants that carry a foreign error type (`reqwest`, `serde_json`)
-// are feature-gated to match the optional deps that provide them: `reqwest`
-// is mobile-only, `serde_json` is web+mobile. `Unauthorized`, `Http`, and
-// the `Other` catch-all are always present so the enum's public shape is
-// stable across every build that compiles the callers.
-
 /// Errors surfaced by the feature-gated data transport.
+///
+/// Replaces the previous `Result<T, String>` so callers can distinguish
+/// failure modes by type — most importantly `Unauthorized`, which the
+/// mobile 401 handler and the web router both key on. The variants that
+/// carry a foreign error type (`reqwest`, `serde_json`) are feature-gated
+/// to match the optional deps that provide them: `reqwest` is mobile-only,
+/// `serde_json` is web+mobile. `Unauthorized`, `Http`, and the `Other`
+/// catch-all are always present so the enum's public shape is stable
+/// across every build that compiles the callers.
 #[derive(Debug, thiserror::Error)]
 pub enum DataError {
     /// `reqwest`-level failure on the mobile transport: connect / timeout /
@@ -90,8 +88,6 @@ impl DataError {
         matches!(self, DataError::Unauthorized)
     }
 }
-
-// ===== Mobile transport: reqwest =====
 
 /// Dioxus context wrapper holding the backend base URL for mobile clients.
 #[cfg(feature = "mobile")]
@@ -441,21 +437,20 @@ pub(crate) async fn drain_error(
     }
 }
 
-// ===== Web auth state =====
-//
-// #57: web counterpart to `token_store::subscribe()`. The web client uses
-// session cookies (round-tripped automatically by the browser), so there's
-// no client-side token to clear — but we still need a reactive signal so
-// the router can redirect to /login when any data-layer call returns 401
-// (session expired, server restarted, admin revoked). All web data
-// wrappers route their errors through [`note_server_fn_err`] below, which
-// pushes `false` onto this channel on a 401 response; `ScreenLayout`
-// subscribes and `nav.replace`s.
-
 #[cfg(feature = "web")]
 pub mod web_auth_state {
     //! Reactive web-side auth-state channel used by `ScreenLayout` to
     //! redirect to `/login` whenever a data call surfaces a 401.
+    //!
+    //! The web counterpart to [`super::token_store::subscribe`]: the web
+    //! client uses session cookies (round-tripped automatically by the
+    //! browser) so there's no client-side token to clear, but the router
+    //! still needs a reactive signal to redirect to `/login` when any
+    //! data-layer call returns 401 (session expired, server restarted,
+    //! admin revoked). All web data wrappers route their errors through
+    //! [`super::note_server_fn_err`], which pushes `false` onto this
+    //! channel on a 401 response; `ScreenLayout` subscribes and
+    //! `nav.replace`s.
 
     use std::sync::OnceLock;
     use tokio::sync::watch;

--- a/frontend/src/data/auth.rs
+++ b/frontend/src/data/auth.rs
@@ -3,7 +3,11 @@
 //! Mobile uses bearer tokens via REST; web hits the same REST endpoints
 //! through `gloo-net` (the browser round-trips the session cookie) instead
 //! of going through Dioxus server functions so cookie handling lives on
-//! the existing CookieJar extractor.
+//! the existing CookieJar extractor. The two transports are kept in one
+//! file (rather than split into sibling modules) because their public
+//! surfaces don't overlap — mobile exposes `mobile_login` / `mobile_register`,
+//! web exposes `login` / `register` — so a module split would only move the
+//! `#[cfg]` gates without consolidating any duplication.
 
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};
@@ -17,8 +21,6 @@ use omnibus_shared::UserSummary;
 #[cfg(feature = "mobile")]
 use super::{client_kind, drain_error, http_client, token_store, with_bearer, DataError};
 
-// ===== Mobile auth transport: bearer token =====
-//
 // Mobile cannot use cookies (Dioxus Native is not a webview), so login
 // requests carry `client_kind: "ios"|"android"|"bearer"`, which the server
 // uses as the signal to issue a bearer token in the JSON response instead
@@ -108,8 +110,6 @@ async fn post_mobile_auth<T: serde::Serialize>(
     Ok(response.json::<LoginResponse>().await?)
 }
 
-// ===== Auth transport (web only) =====
-//
 // The web client hits the REST auth endpoints directly via `gloo-net` rather
 // than going through a Dioxus server function. The REST endpoints already
 // know how to set/clear the `omnibus_session` cookie via the `CookieJar`

--- a/frontend/src/data/auth.rs
+++ b/frontend/src/data/auth.rs
@@ -1,13 +1,8 @@
-//! Login / register / logout / me transport.
-//!
-//! Mobile uses bearer tokens via REST; web hits the same REST endpoints
-//! through `gloo-net` (the browser round-trips the session cookie) instead
-//! of going through Dioxus server functions so cookie handling lives on
-//! the existing CookieJar extractor. The two transports are kept in one
-//! file (rather than split into sibling modules) because their public
-//! surfaces don't overlap — mobile exposes `mobile_login` / `mobile_register`,
-//! web exposes `login` / `register` — so a module split would only move the
-//! `#[cfg]` gates without consolidating any duplication.
+//! Login / register / logout / me transport. Mobile uses bearer tokens
+//! via REST; web hits the same REST endpoints through `gloo-net` so
+//! cookie handling stays on the existing CookieJar extractor. Login and
+//! register diverge by name across the `#[cfg]` split (`mobile_login` vs
+//! `login`); `logout` and `current_user` are shared names with per-target bodies.
 
 #[cfg(any(feature = "web", feature = "mobile"))]
 use omnibus_shared::{LoginRequest, LoginResponse, RegisterRequest, UserSummary};

--- a/frontend/src/data/books.rs
+++ b/frontend/src/data/books.rs
@@ -1,10 +1,8 @@
-//! Book / library / search / settings / overrides / worker fetchers.
-//!
-//! Each function has a mobile variant (REST via `reqwest`) and a web/SSR
-//! variant (Dioxus server-function wrapper). The signatures are identical
-//! across feature gates so call sites stay platform-agnostic; the
-//! `#[cfg]` gates carry the split. Web/SSR wrappers ignore `server_url`
-//! because server functions resolve against the page origin.
+//! Book / library / search / settings / overrides / worker fetchers. Each
+//! function has a mobile REST variant (`reqwest`) and a web/SSR variant
+//! (Dioxus server-function wrapper) with identical signatures across the
+//! `#[cfg]` split. Web/SSR wrappers ignore `server_url` because server
+//! functions resolve against the page origin.
 
 use omnibus_shared::{
     EbookLibrary, EbookMetadata, LibraryContents, LibraryPage, MergeBooksResult, MetadataOverrides,

--- a/frontend/src/data/books.rs
+++ b/frontend/src/data/books.rs
@@ -2,7 +2,9 @@
 //!
 //! Each function has a mobile variant (REST via `reqwest`) and a web/SSR
 //! variant (Dioxus server-function wrapper). The signatures are identical
-//! across feature gates so call sites stay platform-agnostic.
+//! across feature gates so call sites stay platform-agnostic; the
+//! `#[cfg]` gates carry the split. Web/SSR wrappers ignore `server_url`
+//! because server functions resolve against the page origin.
 
 use omnibus_shared::{
     EbookLibrary, EbookMetadata, LibraryContents, LibraryPage, MergeBooksResult, MetadataOverrides,
@@ -208,11 +210,6 @@ pub async fn delete_overrides(
     }
     Ok(Some(response.json::<EbookMetadata>().await?))
 }
-
-// ===== Web / fullstack-SSR transport: dioxus-fullstack server functions =====
-//
-// `server_url` is unused here — server functions always resolve against the
-// page origin. We keep the parameter so the call sites stay platform-agnostic.
 
 /// Web/SSR `get_settings` — server-function wrapper that proxies to `rpc_get_settings`.
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/data/highlights.rs
+++ b/frontend/src/data/highlights.rs
@@ -1,6 +1,8 @@
 //! Highlight annotation transport. Wraps the five highlight CRUD operations
 //! for mobile (`/api/highlights/*` via reqwest) and web/SSR (RPC server
-//! functions in `crate::rpc`).
+//! functions in `crate::rpc`). Mobile and web/SSR variants share each
+//! function's public signature so callers stay platform-agnostic; the
+//! `#[cfg]` gates carry the split.
 
 use omnibus_shared::{CreateHighlight, Highlight, HighlightColor, UpdateHighlightNote};
 
@@ -9,8 +11,6 @@ use super::note_server_fn_err;
 use super::DataError;
 #[cfg(feature = "mobile")]
 use super::{drain_error, http_client, note_status, with_bearer};
-
-// ===== Mobile: highlight CRUD =====
 
 #[cfg(feature = "mobile")]
 pub async fn create_highlight(
@@ -88,8 +88,6 @@ pub async fn delete_highlight(server_url: &str, id: i64) -> Result<(), DataError
     }
     Ok(())
 }
-
-// ===== Web / SSR: highlight CRUD =====
 
 #[cfg(not(feature = "mobile"))]
 pub async fn create_highlight(

--- a/frontend/src/data/progress.rs
+++ b/frontend/src/data/progress.rs
@@ -1,9 +1,7 @@
-//! Reading/listening progress-sync transport. Wraps `POST /api/progress`,
-//! `GET /api/progress/{uuid}`, and `POST /api/progress/sessions` for
-//! mobile, plus the matching `rpc_save_progress` / `rpc_get_progress` /
-//! `rpc_record_sessions` server functions on the web/SSR path. Mobile and
-//! web/SSR variants share each function's public signature so callers stay
-//! platform-agnostic; the `#[cfg]` gates carry the split.
+//! Progress sync transport: `save_progress` / `get_progress` /
+//! `record_sessions` over REST on mobile, plus matching `rpc_*` server
+//! functions on web/SSR. Public signatures are identical across the
+//! `#[cfg]` split so callers stay platform-agnostic.
 
 use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, SessionReport};
 

--- a/frontend/src/data/progress.rs
+++ b/frontend/src/data/progress.rs
@@ -1,7 +1,9 @@
 //! Reading/listening progress-sync transport. Wraps `POST /api/progress`,
 //! `GET /api/progress/{uuid}`, and `POST /api/progress/sessions` for
 //! mobile, plus the matching `rpc_save_progress` / `rpc_get_progress` /
-//! `rpc_record_sessions` server functions on the web/SSR path.
+//! `rpc_record_sessions` server functions on the web/SSR path. Mobile and
+//! web/SSR variants share each function's public signature so callers stay
+//! platform-agnostic; the `#[cfg]` gates carry the split.
 
 use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, SessionReport};
 
@@ -10,8 +12,6 @@ use super::note_server_fn_err;
 use super::DataError;
 #[cfg(feature = "mobile")]
 use super::{drain_error, http_client, note_status, with_bearer};
-
-// ===== Mobile: F2.1 progress sync =====
 
 /// POST `/api/progress` — persist the latest reading/listening position.
 #[cfg(feature = "mobile")]
@@ -67,8 +67,6 @@ pub async fn record_sessions(
     let body: serde_json::Value = response.json().await?;
     Ok(body.get("recorded").and_then(|v| v.as_u64()).unwrap_or(0))
 }
-
-// ===== Web / SSR: F2.1 progress sync =====
 
 /// Web/SSR `save_progress` — server-function wrapper that proxies to `rpc_save_progress`.
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -359,8 +359,6 @@ fn PasswordRequirementRow(ok: bool, text: String) -> Element {
     }
 }
 
-// ---- presentational helpers ---------------------------------------------
-
 #[derive(Clone, Debug, PartialEq)]
 enum RegisterError {
     Username(String),
@@ -429,20 +427,17 @@ fn score_password(pw: &str) -> (StrengthScore, &'static str, [bool; 3]) {
     (score, label, [len_ok, mixed_case, has_number_or_symbol])
 }
 
-// ---- submit helpers ------------------------------------------------------
-//
 // Per-target HTTP transports for auth. The cfg gates are kept mutually
-// exclusive within this file: the web impl compiles only for `web`
-// builds without `mobile`, the mobile impl compiles for any `mobile`
-// build, and the no-feature stub covers SSR-without-web. The
-// `web` + `mobile` combination is rejected at crate level by a
-// `compile_error!` in `frontend/src/components/mod.rs`, so this layer
-// is defense-in-depth rather than the primary guard — but keeping the
-// gates precise here means a future change that loosens the crate-level
-// guard won't silently produce duplicate `submit_*` definitions.
-// `server`-only builds (no `web` and no `mobile`) get a compile-only
-// stub — SSR never executes the submit closure, so the stub is
-// unreachable at runtime.
+// exclusive within this file: the web impl compiles only for `web` builds
+// without `mobile`, the mobile impl compiles for any `mobile` build, and
+// the no-feature stub covers SSR-without-web. The `web` + `mobile`
+// combination is rejected at crate level by a `compile_error!` in
+// `frontend/src/components/mod.rs`, so this layer is defense-in-depth
+// rather than the primary guard — but keeping the gates precise here
+// means a future change that loosens the crate-level guard won't silently
+// produce duplicate `submit_*` definitions. `server`-only builds (no
+// `web` and no `mobile`) get a compile-only stub — SSR never executes
+// the submit closure, so the stub is unreachable at runtime.
 
 #[cfg(all(feature = "web", not(feature = "mobile")))]
 async fn submit_login(_server_url: &str, username: String, password: String) -> Result<(), String> {

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -76,10 +76,6 @@ pub fn AuthorPage(id: i64) -> Element {
     render_author(a, server_url, author, is_admin_flag)
 }
 
-// ---------------------------------------------------------------------------
-// View
-// ---------------------------------------------------------------------------
-
 fn render_author(
     a: AuthorDetail,
     server_url: String,

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -148,10 +148,8 @@ pub fn BookDetailPage(uuid: String) -> Element {
     }
 }
 
-// ---------------------------------------------------------------------------
-// View — split out so the loaded-book case is the only thing rendered and
-// the data-fetch shell stays small.
-// ---------------------------------------------------------------------------
+// View helpers — the loaded-book case is the only thing rendered, so the
+// data-fetch shell above stays small.
 
 fn kicker_label(year: &str) -> String {
     if year.is_empty() {
@@ -340,11 +338,9 @@ fn BdHiddenSlots() -> Element {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Page-local primitives. None of these introduce business logic — they're
 // markup-only adapters so the page reads as a composition of named blocks
 // rather than nested rsx.
-// ---------------------------------------------------------------------------
 
 /// One breadcrumb segment. When `target` is `Some`, the segment renders as a
 /// router `Link`; otherwise it's a plain `<span>` for the current page or a

--- a/frontend/src/pages/landing/filters.rs
+++ b/frontend/src/pages/landing/filters.rs
@@ -132,10 +132,8 @@ fn FacetSection(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Format chips (top-of-page inline filter)
-// ---------------------------------------------------------------------------
-
+/// Format chips — top-of-page inline filter that lets the user toggle visible
+/// formats (epub, pdf, …) without opening the filter sidebar.
 #[component]
 pub(super) fn FormatChips(
     counts: Vec<(String, usize)>,

--- a/frontend/src/pages/landing/filters.rs
+++ b/frontend/src/pages/landing/filters.rs
@@ -132,8 +132,7 @@ fn FacetSection(
     }
 }
 
-/// Format chips — top-of-page inline filter that lets the user toggle visible
-/// formats (epub, pdf, …) without opening the filter sidebar.
+/// Format chips — top-of-page inline filter to toggle visible formats (epub, pdf, …).
 #[component]
 pub(super) fn FormatChips(
     counts: Vec<(String, usize)>,

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -71,12 +71,9 @@ pub fn MetadataEditPage(uuid: String) -> Element {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Edit form — the loaded-book case. Owns all the per-field signals and the
-// save/discard logic; renders composition over the page-local
-// sub-components in `fields`/`form_grid`/`header`/`sidebar`/`save_bar`.
-// ---------------------------------------------------------------------------
-
+/// Edit form — the loaded-book case. Owns all the per-field signals and the
+/// save/discard logic; renders composition over the page-local sub-components
+/// in `fields`/`form_grid`/`header`/`sidebar`/`save_bar`.
 #[component]
 fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
     let server_url = use_server_url();
@@ -317,12 +314,10 @@ fn MetadataEditForm(book: EbookMetadata, uuid: String) -> Element {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Build the MetadataOverrides from the edited fields. Only sets `Some` for
-// fields that differ from the initially loaded book (which already has any
-// prior overrides merged in). Server-side merge ensures prior overrides on
-// untouched fields are preserved.
-// ---------------------------------------------------------------------------
+// `build_overrides` (further down) constructs the `MetadataOverrides` from the
+// edited fields. Only sets `Some` for fields that differ from the initially
+// loaded book (which already has any prior overrides merged in); server-side
+// merge then preserves prior overrides on untouched fields.
 
 /// Edited scalar and list fields collected from the form signals before a save.
 struct EditedFields<'a> {

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -53,10 +53,6 @@ pub fn SeriesPage(id: i64) -> Element {
     render_series(s)
 }
 
-// ---------------------------------------------------------------------------
-// View
-// ---------------------------------------------------------------------------
-
 fn render_series(s: SeriesDetail) -> Element {
     // Derive accent from the first book that has one.
     let accent = s

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -379,10 +379,6 @@ pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
     })
 }
 
-// ---------------------------------------------------------------------------
-// Discovery pages (F1.8)
-// ---------------------------------------------------------------------------
-
 /// Fetch a single author and all their books. POST for the same reason as
 /// `rpc_get_ebook` — needs `id` in the body.
 ///
@@ -598,13 +594,10 @@ pub async fn rpc_delete_author(id: i64) -> Result<u64> {
     Ok(db::delete_author(&pool.0, id).await?)
 }
 
-// ---------------------------------------------------------------------------
-// F2.1 Progress sync (web RPC). Mobile uses the analogous REST routes in
-// `server::backend::progress`. All three use POST because Dioxus `#[get]`
-// server functions can't carry an argument body — same rationale as
-// `rpc_get_ebook`.
-// ---------------------------------------------------------------------------
-
+/// Progress-sync save. Mobile uses the analogous REST route in
+/// `server::backend::progress`. POST because Dioxus `#[get]` server
+/// functions can't carry an argument body — same rationale as
+/// `rpc_get_ebook`; the next two endpoints follow the same pattern.
 #[post("/api/rpc/progress", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_save_progress(update: ProgressUpdate) -> Result<ProgressRecord> {
     if let Err(msg) = update.validate() {
@@ -654,11 +647,9 @@ pub async fn rpc_search_palette(q: String) -> Result<PaletteResults> {
     Ok(db::search_palette(&pool.0, &path, &q).await?)
 }
 
-// ---------------------------------------------------------------------------
-// F2.4b Highlight annotations (web RPC). Mobile uses the REST routes in
-// `server::backend::highlights`.
-// ---------------------------------------------------------------------------
-
+/// Create a highlight on a book. Mobile uses the analogous REST route in
+/// `server::backend::highlights`; the rest of this family of RPCs follows
+/// the same web-vs-mobile split.
 #[post("/api/rpc/highlights/create", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_create_highlight(input: CreateHighlight) -> Result<Highlight> {
     if let Err(msg) = input.validate() {


### PR DESCRIPTION
Continues the cleanup PR #569 started. For each file in #553's evidence
list, this PR either removes cosmetic dividers in favor of the
function/component rustdoc that already labels the same boundary, or
extends the `//!` module doc with the nav-aid rationale that #569 used
for the cfg-gated triads.

## Changes by file

- `frontend/src/data.rs` — removed `===== Typed transport error =====`,
  `===== Mobile transport: reqwest =====`, and `===== Web auth state =====`
  dividers. Transport-error prose moves into the `DataError` rustdoc;
  web-auth-state prose moves into the `web_auth_state` module's `//!`.
- `frontend/src/data/auth.rs` — extended `//!` with the mobile/web split
  rationale, dropped two `===== ... =====` dividers (prose retained as
  plain `//` block comments).
- `frontend/src/data/progress.rs`, `data/highlights.rs`, `data/books.rs` —
  extended `//!` to note the cfg-gated mobile/web split, dropped the
  `===== Mobile =====` / `===== Web / SSR =====` dividers.
- `frontend/src/rpc.rs` — dropped the three section dividers
  (`Discovery pages`, `F2.1 Progress sync`, `F2.4b Highlight annotations`);
  their substantive contents move into the rustdoc on the first
  `rpc_*` function in each family.
- `frontend/src/components/author_photo_edit.rs` — converted the
  `// ===== Option 1/2/3 =====` rsx markers to single-line nav `//`
  comments. The `//!` already enumerates the three options.
- `frontend/src/pages/author.rs`, `series.rs`, `landing/filters.rs` —
  dropped decorative `View` / `Format chips` dividers; the function-name
  rustdoc carries the same label.
- `frontend/src/pages/metadata_edit.rs` — promoted the two divider blocks
  to rustdoc on `MetadataEditForm` and a single-line `//` for the
  `build_overrides` section.
- `frontend/src/pages/book_detail/mod.rs` — dropped surrounding divider
  lines, retained the substantive prose as plain `//` comments.
- `frontend/src/pages/auth.rs` — dropped the
  `---- presentational helpers ----` / `---- submit helpers ----`
  decorations; the per-target submit-helper prose stays as a leading
  `//` block.

## Files intentionally left alone

Already justified by PR #569 or by the issue's "low priority" carve-out
for cfg-framing nav aids:

- `frontend/src/view_prefs.rs`, `reader_progress.rs`, `audiobook_progress.rs`
- `frontend/src/pages/listen/{bootstrap,controls}.rs` — substantive
  nav aids (each block actually explains which functions are
  testable-without-a-browser).
- `frontend/src/pages/landing/{filtering,sorting}.rs` test-helper
  comments — inside `#[cfg(test)] mod tests`, out of scope per the
  issue (#443 covered tests).
- `frontend/src/pages/reader/mod.rs`, `frontend/src/pages/landing.rs` —
  owned by other workers in flight.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p omnibus-frontend --features server`: 169 passed
- `cargo test -p omnibus`: 206 passed

## Audit before vs after

Before this PR: ~37 production-code dividers across 13 files (excluding
ones #569 already addressed).
After: 37 lines remain, all of them in files with a `//!` nav-aid note
that documents *why* the dividers stay (cfg-framing or
substantive-section-prose-that-can't-be-split-further).

Partial #553.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoELh4a2WKNvp7GfrnrDfp)_