### PR TITLE
fix: bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4865,9 +4865,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
- Bumps `quinn-proto` `0.11.14 → 0.11.15` to patch **RUSTSEC-2026-0185** — a high-severity (CVSS 7.5) remote memory-exhaustion advisory from unbounded out-of-order stream reassembly.
- Transitive dependency (`quinn → reqwest`); **lockfile-only** bump, no `Cargo.toml` change.
- Clears the failing `cargo audit` gate that currently blocks every open PR (the advisory is present on `main`, e.g. #575).

## Test plan
- [x] `cargo audit --ignore RUSTSEC-2023-0071` (same invocation as CI) — exit 0, `vulnerabilities.count == 0` (was 1).
- [x] `jj diff --stat` — only `Cargo.lock` changed (2 lines).

## Notes
- Remaining audit output is pre-existing *allowed warnings* (unmaintained/unsound transitive crates), not gate failures.