### PR TITLE
fix: wrap upsert_metadata_overrides side effects in a transaction (#576)

### DIFF
--- a/db/src/metadata_overrides/links.rs
+++ b/db/src/metadata_overrides/links.rs
@@ -16,10 +16,10 @@ use omnibus_shared::MetadataOverrides;
 ///
 /// Takes `&mut SqliteConnection` so the caller can run the four statements
 /// (book lookup, series upsert, series read, link insert) inside an open
-/// transaction — pass `&mut *tx` from a `sqlx::Transaction`. Running
-/// outside a transaction would split the materialize across separate
-/// connections and reopen the partial-failure window this helper exists to
-/// close.
+/// transaction — pass `&mut tx` from a `sqlx::Transaction`. Running
+/// outside a transaction would let each statement commit independently
+/// in autocommit mode, reopening the partial-failure window this helper
+/// exists to close.
 pub(super) async fn materialize_series_link(
     conn: &mut SqliteConnection,
     book_uuid: &str,

--- a/db/src/metadata_overrides/links.rs
+++ b/db/src/metadata_overrides/links.rs
@@ -4,7 +4,7 @@
 //! read time via `apply_overrides` and doesn't yet need a sibling helper
 //! here.
 
-use sqlx::SqlitePool;
+use sqlx::SqliteConnection;
 
 use omnibus_shared::MetadataOverrides;
 
@@ -13,8 +13,15 @@ use omnibus_shared::MetadataOverrides;
 /// resolve. Without this, override-only series are invisible to
 /// `list_series` (which requires a canonical link for visibility) and the
 /// book detail page's `series_id` backfill can't find the `series.id`.
+///
+/// Takes `&mut SqliteConnection` so the caller can run the four statements
+/// (book lookup, series upsert, series read, link insert) inside an open
+/// transaction — pass `&mut *tx` from a `sqlx::Transaction`. Running
+/// outside a transaction would split the materialize across separate
+/// connections and reopen the partial-failure window this helper exists to
+/// close.
 pub(super) async fn materialize_series_link(
-    pool: &SqlitePool,
+    conn: &mut SqliteConnection,
     book_uuid: &str,
     overrides: &MetadataOverrides,
 ) -> Result<(), sqlx::Error> {
@@ -26,47 +33,53 @@ pub(super) async fn materialize_series_link(
     let Some(series_name) = series_name else {
         return Ok(());
     };
-    let Some(book_id) = lookup_book_id(pool, book_uuid).await? else {
+    let Some(book_id) = lookup_book_id(&mut *conn, book_uuid).await? else {
         return Ok(());
     };
-    let series_id = find_or_create_series(pool, series_name).await?;
-    link_book_to_series(pool, book_id, series_id).await
+    let series_id = find_or_create_series(&mut *conn, series_name).await?;
+    link_book_to_series(&mut *conn, book_id, series_id).await
 }
 
 /// Resolve `books.uuid` → `books.id`. Returns `None` if the row was
 /// deleted out from under the override write path.
-async fn lookup_book_id(pool: &SqlitePool, book_uuid: &str) -> Result<Option<i64>, sqlx::Error> {
+async fn lookup_book_id(
+    conn: &mut SqliteConnection,
+    book_uuid: &str,
+) -> Result<Option<i64>, sqlx::Error> {
     sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
         .bind(book_uuid)
-        .fetch_optional(pool)
+        .fetch_optional(conn)
         .await
 }
 
 /// Idempotent series-row materialization: INSERT-OR-IGNORE the name, then
 /// SELECT the id case-insensitively so the read matches the same NOCASE
 /// uniqueness the canonical scan path uses.
-async fn find_or_create_series(pool: &SqlitePool, series_name: &str) -> Result<i64, sqlx::Error> {
+async fn find_or_create_series(
+    conn: &mut SqliteConnection,
+    series_name: &str,
+) -> Result<i64, sqlx::Error> {
     sqlx::query("INSERT OR IGNORE INTO series (name) VALUES (?)")
         .bind(series_name)
-        .execute(pool)
+        .execute(&mut *conn)
         .await?;
     sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE name = ? COLLATE NOCASE")
         .bind(series_name)
-        .fetch_one(pool)
+        .fetch_one(conn)
         .await
 }
 
 /// Idempotent `books_series_link` insert — repeated overrides on the
 /// same (book, series) pair are a no-op.
 async fn link_book_to_series(
-    pool: &SqlitePool,
+    conn: &mut SqliteConnection,
     book_id: i64,
     series_id: i64,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("INSERT OR IGNORE INTO books_series_link (book, series) VALUES (?, ?)")
         .bind(book_id)
         .bind(series_id)
-        .execute(pool)
+        .execute(conn)
         .await?;
     Ok(())
 }

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -500,3 +500,67 @@ async fn upsert_overrides_materializes_series_link_for_new_series() {
         "series_id should be set after override materializes the link"
     );
 }
+
+/// The override row and the `books_series_link` row must land
+/// atomically: after `upsert_metadata_overrides` commits, a direct
+/// SELECT on `books_series_link` must already reflect the new series.
+/// Guards the post-#576 invariant that the link materialize runs inside
+/// the same transaction as the override row, so the book detail page
+/// never observes a fresh override against a stale link.
+#[tokio::test]
+async fn upsert_overrides_persists_books_series_link_row_for_new_series() {
+    let _covers = CoversTempDir::new("series_link_row");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed(
+            "link.epub",
+            Some("A Book"),
+            &["Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let uuid = books[0].unique_identifier.clone().unwrap();
+    let book_id = books[0].id;
+
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            series: Some("Linked Series".into()),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let linked_series: Option<String> = sqlx::query_scalar(
+        "SELECT s.name
+           FROM books_series_link bsl
+           JOIN series s ON s.id = bsl.series
+          WHERE bsl.book = ?",
+    )
+    .bind(book_id)
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        linked_series.as_deref(),
+        Some("Linked Series"),
+        "books_series_link should reflect the new override series after upsert commits"
+    );
+}

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -88,12 +88,13 @@ pub async fn upsert_metadata_overrides(
     let json = serde_json::to_string(overrides)?;
 
     // `begin_with("BEGIN IMMEDIATE")` matches `merge_metadata_overrides` — the
-    // RESERVED lock at start serializes concurrent writers to the same book,
-    // and the returned `sqlx::Transaction` issues a structured ROLLBACK on
-    // any `?` early-return below.
+    // RESERVED lock at start makes this writer wait for any in-flight writer
+    // (SQLite is single-writer at the database level), and the returned
+    // `sqlx::Transaction` issues a structured ROLLBACK on any `?` early-return
+    // below.
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     upsert_overrides_row(&mut *tx, book_uuid, &json, has_cover_override, user_id).await?;
-    materialize_series_link(&mut *tx, book_uuid, overrides).await?;
+    materialize_series_link(&mut tx, book_uuid, overrides).await?;
     tx.commit().await?;
 
     if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
@@ -117,11 +118,12 @@ pub async fn merge_metadata_overrides(
     user_id: i64,
 ) -> Result<(), MetadataOverridesError> {
     // `begin_with("BEGIN IMMEDIATE")` gives the same RESERVED-lock-at-start
-    // semantics as the old hand-rolled statement (so concurrent edits to the
-    // same book serialize instead of interleaving), but returns a real
-    // `sqlx::Transaction`. Any `?` early-return below drops `tx` without a
-    // commit, and the Drop impl issues a structured ROLLBACK — no reliance on
-    // connection-drop implicit cleanup.
+    // semantics as the old hand-rolled statement (SQLite is single-writer at
+    // the database level, so this writer waits for any in-flight writer
+    // before acquiring), but returns a real `sqlx::Transaction`. Any `?`
+    // early-return below drops `tx` without a commit, and the Drop impl
+    // issues a structured ROLLBACK — no reliance on connection-drop implicit
+    // cleanup.
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
 
     let existing: Option<(String, i64)> = sqlx::query_as(
@@ -141,7 +143,7 @@ pub async fn merge_metadata_overrides(
 
     let json = serde_json::to_string(&merged)?;
     upsert_overrides_row(&mut *tx, book_uuid, &json, has_cover_override, user_id).await?;
-    materialize_series_link(&mut *tx, book_uuid, &merged).await?;
+    materialize_series_link(&mut tx, book_uuid, &merged).await?;
     tx.commit().await?;
 
     if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -69,11 +69,15 @@ where
 /// Upsert user metadata overrides for a book identified by its stable UUID.
 /// The `overrides` are JSON-serialized into the `metadata_overrides` table.
 ///
-/// After the upsert, the book's `books_fts` row is rebuilt from the merged
-/// (canonical + override) metadata so that search results stay consistent
-/// with what the UI displays. The FTS rebuild is best-effort: rebuild
-/// failures are logged but do not fail the override save, since the
-/// override write is the user's actual intent.
+/// The override row write and the `books_series_link` materialization run
+/// inside one `BEGIN IMMEDIATE` transaction — matching the
+/// [`merge_metadata_overrides`] pattern — so a failure in the series-link
+/// materialize rolls back the override row instead of leaving the book
+/// detail page reading a fresh override against a stale series link.
+///
+/// The `books_fts` rebuild runs best-effort after commit: a stale FTS row
+/// is recoverable (next reindex / next save corrects it) and is far less
+/// user-visible than a stale series association.
 pub async fn upsert_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
@@ -82,10 +86,16 @@ pub async fn upsert_metadata_overrides(
     user_id: i64,
 ) -> Result<(), MetadataOverridesError> {
     let json = serde_json::to_string(overrides)?;
-    upsert_overrides_row(pool, book_uuid, &json, has_cover_override, user_id).await?;
-    if let Err(e) = materialize_series_link(pool, book_uuid, overrides).await {
-        tracing::warn!(book_uuid, error = %e, "series link materialize after override upsert failed");
-    }
+
+    // `begin_with("BEGIN IMMEDIATE")` matches `merge_metadata_overrides` — the
+    // RESERVED lock at start serializes concurrent writers to the same book,
+    // and the returned `sqlx::Transaction` issues a structured ROLLBACK on
+    // any `?` early-return below.
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+    upsert_overrides_row(&mut *tx, book_uuid, &json, has_cover_override, user_id).await?;
+    materialize_series_link(&mut *tx, book_uuid, overrides).await?;
+    tx.commit().await?;
+
     if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
         tracing::warn!(book_uuid, error = %e, "books_fts rebuild after override upsert failed");
     }
@@ -97,8 +107,9 @@ pub async fn upsert_metadata_overrides(
 /// transaction, so two concurrent edits to the same book can't interleave
 /// and silently drop each other's changes. The existing `has_cover_override`
 /// flag is carried forward — a text-only edit must not clear a cover the
-/// user uploaded earlier. The `books_fts` rebuild runs best-effort after
-/// commit.
+/// user uploaded earlier. The series-link materialization runs inside the
+/// same transaction so the override row and `books_series_link` land
+/// atomically; the `books_fts` rebuild runs best-effort after commit.
 pub async fn merge_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
@@ -130,11 +141,9 @@ pub async fn merge_metadata_overrides(
 
     let json = serde_json::to_string(&merged)?;
     upsert_overrides_row(&mut *tx, book_uuid, &json, has_cover_override, user_id).await?;
+    materialize_series_link(&mut *tx, book_uuid, &merged).await?;
     tx.commit().await?;
 
-    if let Err(e) = materialize_series_link(pool, book_uuid, &merged).await {
-        tracing::warn!(book_uuid, error = %e, "series link materialize after override merge failed");
-    }
     if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
         tracing::warn!(book_uuid, error = %e, "books_fts rebuild after override merge failed");
     }


### PR DESCRIPTION
## Summary
- `upsert_metadata_overrides` wrote the override row atomically but then called `materialize_series_link` and `rebuild_fts_for_book` as separate pool operations, swallowing their errors with `tracing::warn!`. A failed series-link materialize left the override row pointing at a new series while `books_series_link` still reflected the old one, so the book detail page rendered the wrong series until the next reindex.
- Wrap the override-row upsert and the series-link materialize in one `BEGIN IMMEDIATE` transaction, matching the existing pattern in `merge_metadata_overrides`. The `books_fts` rebuild stays best-effort after commit since a stale FTS row is recoverable and far less user-visible than a stale series association.
- Brought the merge path's materialize into its existing transaction too so the two functions converge on identical commit semantics (the issue explicitly asked us to confirm they don't need to converge — they did).
- Widened `materialize_series_link` and its three private helpers in `links.rs` to take `&mut SqliteConnection` instead of `&SqlitePool`, mirroring the `resolve_book_id_by_uuid_exec` generalisation already used in `db/src/books/get.rs`. `&mut *tx` from a `sqlx::Transaction` derefs cleanly so no caller restructuring was needed beyond the two sites that already pass `pool`.

## Test plan
- [ ] `cargo test -p omnibus-db` — covers the new `upsert_overrides_persists_books_series_link_row_for_new_series` test plus the existing series-materialize, FTS-rebuild, and concurrent-merge tests.
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo fmt --check`

## Notes
- New test `upsert_overrides_persists_books_series_link_row_for_new_series` in `db/src/metadata_overrides/tests.rs` asserts the `books_series_link` table directly reflects the new series after `upsert_metadata_overrides` commits — guards the post-transaction atomicity invariant separately from the existing `get_book(...).series_id.is_some()` test (which doesn't pin down the link-table row specifically).

>[!IMPORTANT]
> **Local check matrix could not run.** This worktree's network sandbox blocks the egress proxy from fetching `github.com/DioxusLabs/dioxus` (workspace pulls the pinned `dioxus@v0.7.9` git tag), so `cargo build`/`cargo check`/`cargo test`/`cargo clippy` all bail at the dependency-resolution step with `revision 3e43ffa6cf1488d5388c888eb5f2494a006ae6de not found`. The proxy is restricted to the seamus-sloan/omnibus repo only. `rustfmt --edition 2021 --check` passes on the touched files. The change is mechanical (executor-widening pattern already established in the same crate, transaction shape copied verbatim from `merge_metadata_overrides`) — please verify locally / let CI confirm.

Closes #576

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSbT36bMEAyoihumwHouEG)_