### PR TITLE
fix: cap POST /api/progress/sessions batch size at 500 (#585)

### DIFF
--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -61,9 +61,7 @@ pub(super) async fn get_progress(
     }
 }
 
-/// Hard cap on records per batch — keeps a single request from holding
-/// the SQLite WAL write lock for an unbounded time, since the global 1
-/// MiB body limit alone permits thousands of compact `SessionReport`s.
+/// Hard cap on `SessionReport`s per `post_sessions` batch.
 pub(super) const MAX_SESSION_BATCH: usize = 500;
 
 /// Append a batch of session reports. Mobile posts these on reconnect; web

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -61,12 +61,18 @@ pub(super) async fn get_progress(
     }
 }
 
+/// Hard cap on records per batch — keeps a single request from holding
+/// the SQLite WAL write lock for an unbounded time, since the global 1
+/// MiB body limit alone permits thousands of compact `SessionReport`s.
+pub(super) const MAX_SESSION_BATCH: usize = 500;
+
 /// Append a batch of session reports. Mobile posts these on reconnect; web
 /// posts best-effort on unmount. Each report is validated at the API
 /// boundary (negative durations / inverted time ranges → 400); unknown
 /// book uuids are silently skipped inside the db layer (best-effort
 /// telemetry). `recorded` reflects the **inserted** row count so callers
-/// can tell which queued reports actually persisted.
+/// can tell which queued reports actually persisted. Batches larger than
+/// `MAX_SESSION_BATCH` are rejected with 422 before any DB work.
 ///
 /// The entire batch runs inside a single transaction — a DB error mid-loop
 /// rolls back all previously inserted rows so the client can safely retry
@@ -76,6 +82,14 @@ pub(super) async fn post_sessions(
     State(state): State<AppState>,
     Json(reports): Json<Vec<SessionReport>>,
 ) -> Response {
+    if reports.len() > MAX_SESSION_BATCH {
+        let msg = format!(
+            "batch too large: {} records exceeds maximum of {}",
+            reports.len(),
+            MAX_SESSION_BATCH
+        );
+        return (axum::http::StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
+    }
     for r in &reports {
         if let Err(msg) = r.validate() {
             return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();

--- a/server/src/backend/progress/tests.rs
+++ b/server/src/backend/progress/tests.rs
@@ -308,7 +308,7 @@ async fn post_sessions_rejects_oversized_batch() {
     let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
     let user = auth_test_support::create_user(&pool, "alice").await;
     let token = auth_test_support::bearer_token(&pool, user.id).await;
-    let reports: Vec<_> = (0..MAX_SESSION_BATCH + 1)
+    let reports: Vec<_> = (0..=MAX_SESSION_BATCH)
         .map(|_| {
             serde_json::json!({
                 "book_uuid": uuid,

--- a/server/src/backend/progress/tests.rs
+++ b/server/src/backend/progress/tests.rs
@@ -299,6 +299,55 @@ async fn api_post_sessions_batch_of_two_records_both() {
 }
 
 #[tokio::test]
+async fn post_sessions_rejects_oversized_batch() {
+    // Batches larger than MAX_SESSION_BATCH must be rejected with 422
+    // before any DB work — the global 1 MiB body limit permits thousands
+    // of compact reports, so the per-batch cap is the real defense
+    // against a client holding the WAL write lock open.
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let reports: Vec<_> = (0..MAX_SESSION_BATCH + 1)
+        .map(|_| {
+            serde_json::json!({
+                "book_uuid": uuid,
+                "format": "epub",
+                "started_at": 100,
+                "ended_at": 460,
+                "progress_units": 360,
+            })
+        })
+        .collect();
+    let body = serde_json::Value::Array(reports);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/progress/sessions")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let written: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM reading_sessions WHERE user_id = ? AND book_uuid = ?",
+    )
+    .bind(user.id)
+    .bind(&uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        written, 0,
+        "oversized batch must reject before any DB write"
+    );
+}
+
+#[tokio::test]
 async fn api_post_sessions_rollback_on_second_insert_error() {
     // Drop the audio-session table so the 2nd insert fails deterministically.
     // This proves the batch-level transaction rolls back: the 1st (epub)


### PR DESCRIPTION
## Summary
- `post_sessions` now rejects batches larger than `MAX_SESSION_BATCH = 500` with `422 UNPROCESSABLE_ENTITY` before opening the write transaction, so a single client cannot hold the SQLite WAL write lock open by submitting a large batch.
- The global 1 MiB body limit alone permits thousands of compact `SessionReport` rows; the per-batch record cap is the real defense, matching the validate-then-write pattern from the highlights handlers (closed #501).
- New const lives adjacent to the handler in `server/src/backend/progress.rs`. New test `post_sessions_rejects_oversized_batch` posts `MAX_SESSION_BATCH + 1` reports via `tower::ServiceExt::oneshot` and asserts both the 422 status and that no `reading_sessions` rows were written.

## Test plan
- [ ] `cargo test -p omnibus backend::progress::tests::post_sessions_rejects_oversized_batch`
- [ ] `cargo test -p omnibus` (full server suite — existing session tests unchanged)
- [ ] `cargo clippy -p omnibus --all-targets -- -D warnings`

## Notes
>[!IMPORTANT]
> **Deviation from the issue's suggested signature.** The issue body sketches `Result<StatusCode, anyhow::Error>` for `post_sessions`, but the live handler returns `Response` (so it can carry per-status response bodies for both 400 validation errors and 5xx DB errors). I kept the existing `Response` signature and returned `(StatusCode::UNPROCESSABLE_ENTITY, msg).into_response()`, which matches the surrounding code and the `BAD_REQUEST` validation arm directly above. The acceptance criteria (422 with descriptive body, named constant adjacent to handler, test, no behavior change to existing tests) are all satisfied.

>[!WARNING]
> **Local checks not runnable in this sandbox.** `cargo fmt` / `clippy` / `test` all require fetching `github.com/DioxusLabs/dioxus` at tag v0.7.9, and the agent egress proxy denies that host with HTTP 403 ("Not authorized to access repository dioxuslabs/dioxus"). The diff is small (one constant, one early-return branch, one test) and the test mirrors the existing `api_post_sessions_*` tests verbatim, but please confirm CI green before merge — I could not run the matrix locally.

Files touched: `server/src/backend/progress.rs`, `server/src/backend/progress/tests.rs`.

Closes #585

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSbT36bMEAyoihumwHouEG)_