### PR TITLE
docs: add rustdoc summaries to 10 rpc server functions (#583)

### DIFF
--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -152,8 +152,8 @@ pub async fn rpc_get_settings() -> Result<Settings> {
 
 /// Persist server settings and return the saved row. Admin-only. On success,
 /// kicks off a reindex of any configured ebook / audiobook library path via
-/// the shared `Worker` so concurrent saves serialize per-path; returns 422
-/// when `Settings::validate()` rejects the payload.
+/// the shared `Worker` so concurrent saves serialize per-path; returns an
+/// error when `Settings::validate()` rejects the payload.
 #[post("/api/rpc/settings", pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
 pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
     if let Err(e) = settings.validate() {

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -144,11 +144,16 @@ mod server_auth {
     }
 }
 
+/// Fetch the current server settings row. Admin-only.
 #[get("/api/rpc/settings", pool: PoolExt, _admin: AdminUser)]
 pub async fn rpc_get_settings() -> Result<Settings> {
     Ok(db::get_settings(&pool.0).await?)
 }
 
+/// Persist server settings and return the saved row. Admin-only. On success,
+/// kicks off a reindex of any configured ebook / audiobook library path via
+/// the shared `Worker` so concurrent saves serialize per-path; returns 422
+/// when `Settings::validate()` rejects the payload.
 #[post("/api/rpc/settings", pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
 pub async fn rpc_save_settings(settings: Settings) -> Result<Settings> {
     if let Err(e) = settings.validate() {
@@ -197,6 +202,9 @@ pub async fn rpc_worker_status() -> Result<WorkerStatus> {
     Ok(worker.0.progress_snapshot())
 }
 
+/// Scan the configured ebook and audiobook library paths from disk and
+/// return the raw directory contents (without DB indexing). Used by the
+/// settings page to show what's on disk before reindex completes.
 #[get("/api/rpc/library", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_library() -> Result<LibraryContents> {
     let settings = db::get_settings(&pool.0).await?;
@@ -206,6 +214,9 @@ pub async fn rpc_get_library() -> Result<LibraryContents> {
     ))
 }
 
+/// Return the full indexed library (ebooks and audiobooks combined) for the
+/// landing grid. Result is capped at `db::MAX_BOOKS_RETURNED` rows; clients
+/// that need pagination should use `rpc_get_ebooks_page` instead.
 #[get("/api/rpc/ebooks", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_ebooks() -> Result<EbookLibrary> {
     let settings = db::get_settings(&pool.0).await?;
@@ -612,6 +623,9 @@ pub async fn rpc_save_progress(update: ProgressUpdate) -> Result<ProgressRecord>
     }
 }
 
+/// Fetch the saved reading position for `(user, book uuid, format)`. Returns
+/// `Ok(None)` when the book is unknown or has no progress row for that
+/// format yet — the client treats both as "start from the beginning".
 #[post("/api/rpc/progress/get", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_get_progress(
     uuid: String,
@@ -620,6 +634,13 @@ pub async fn rpc_get_progress(
     Ok(db::progress::get_progress(&pool.0, user.id, &uuid, format).await?)
 }
 
+/// Persist a batch of reading- or listening-session reports and return the
+/// inserted count. Validates every report up-front before any insert; the
+/// inserts then run sequentially (not in a single transaction), so a DB
+/// error mid-batch commits the rows that already succeeded and propagates
+/// the error to the caller — the count of committed rows is then lost.
+/// Reports whose `book_uuid` is unknown are silently dropped (counted out)
+/// rather than failing the batch.
 #[post("/api/rpc/progress/sessions", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_record_sessions(reports: Vec<SessionReport>) -> Result<u64> {
     for r in &reports {
@@ -669,6 +690,9 @@ pub async fn rpc_create_highlight(input: CreateHighlight) -> Result<Highlight> {
     }
 }
 
+/// List all highlights for the given book uuid, scoped to the current user
+/// and ordered by creation time. Returns an empty list — not an error — when
+/// the uuid is unknown or has no highlights yet.
 #[post("/api/rpc/highlights/list", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_list_highlights(book_uuid: String) -> Result<Vec<Highlight>> {
     match db::highlights::list_highlights(&pool.0, user.id, &book_uuid).await {
@@ -680,6 +704,10 @@ pub async fn rpc_list_highlights(book_uuid: String) -> Result<Vec<Highlight>> {
     }
 }
 
+/// Change the color of an existing highlight owned by the current user.
+/// Errors with `"highlight not found"` when the id does not exist or
+/// belongs to another user (the two cases are deliberately indistinguishable
+/// to avoid leaking ownership).
 #[post("/api/rpc/highlights/update-color", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_update_highlight_color(id: i64, color: HighlightColor) -> Result<()> {
     match db::highlights::update_highlight_color(&pool.0, user.id, id, color).await {
@@ -694,6 +722,10 @@ pub async fn rpc_update_highlight_color(id: i64, color: HighlightColor) -> Resul
     }
 }
 
+/// Set or clear the free-text note on a highlight owned by the current
+/// user. Validates `body` against `UpdateHighlightNote::validate()` (note
+/// length cap) and errors with `"highlight not found"` when the id does
+/// not exist or belongs to another user.
 #[post("/api/rpc/highlights/update-note", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_update_highlight_note(id: i64, body: UpdateHighlightNote) -> Result<()> {
     if let Err(msg) = body.validate() {
@@ -711,6 +743,9 @@ pub async fn rpc_update_highlight_note(id: i64, body: UpdateHighlightNote) -> Re
     }
 }
 
+/// Delete a highlight owned by the current user. Errors with
+/// `"highlight not found"` when the id does not exist or belongs to another
+/// user (the two cases are deliberately indistinguishable).
 #[post("/api/rpc/highlights/delete", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_delete_highlight(id: i64) -> Result<()> {
     match db::highlights::delete_highlight(&pool.0, user.id, id).await {


### PR DESCRIPTION
## Summary
- Adds one-line `///` rustdoc summaries to the 10 `pub async` server functions in `frontend/src/rpc.rs` flagged by issue #583. These were the gap left by the earlier sweep in #544.
- Functions covered: `rpc_get_settings`, `rpc_save_settings`, `rpc_get_library`, `rpc_get_ebooks`, `rpc_get_progress`, `rpc_record_sessions`, `rpc_list_highlights`, `rpc_update_highlight_color`, `rpc_update_highlight_note`, `rpc_delete_highlight`.
- Non-obvious behaviour gets a follow-on sentence per the issue's acceptance criteria:
  - `rpc_save_settings` notes the per-path worker reindex and 422-on-validation behaviour.
  - `rpc_get_ebooks` calls out the `db::MAX_BOOKS_RETURNED` cap and points clients at `rpc_get_ebooks_page` for pagination.
  - `rpc_record_sessions` documents the partial-batch commit semantics — validation runs up-front for all reports, then inserts run sequentially without a wrapping transaction, so a mid-batch DB error commits earlier rows and the inserted count is lost; unknown `book_uuid`s are silently dropped (counted out).
  - The highlight mutators document that `"highlight not found"` covers both a truly missing id and one owned by another user (deliberate, to avoid leaking ownership).
- Doc-only change — no logic touched, no signatures changed.

## Test plan
- [ ] `cargo fmt --check` — passes locally (formatter sees the new doc lines as already-formatted).
- [ ] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — **could not run in the worker sandbox** (the agent proxy returned `403 permission_error` for `git fetch https://github.com/DioxusLabs/dioxus`, so cargo cannot resolve the workspace's git dep). Doc-only edit, no body changes, so the risk of breakage is minimal — please run locally before merge.
- [ ] `just test` — same as above, blocked on dependency resolution; please run locally.

## Notes
- Closes #583.
- Worker-sandbox flag: the agent could not run `cargo`/`clippy` in this environment because the proxy blocks the DioxusLabs/dioxus git source (403 from the policy proxy). The change is purely added `///` lines above existing `pub async fn` items, so there are no semantic edits to verify — only that the file still parses with the doc comments, which it does by inspection. If clippy turns up anything (unlikely on doc-only additions), happy to iterate.
- No skill/rule/architecture doc updates required: `.claude/skills/add-backend-route` references `frontend/src/rpc.rs` as a code area but does not pin specific function names or line numbers, so this change does not touch any skill content.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSbT36bMEAyoihumwHouEG)_