### PR TITLE
fix: add missing key: attributes to rsx! for-loops (#587)

### DIFF
--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -121,6 +121,7 @@ fn MultiFileRow(kind: FormatKind, uuid: String, files: Vec<BookFileInfo>) -> Ele
                 let file_id = file.id;
                 rsx! {
                     div {
+                        key: "{file_id}",
                         class: "format-row format-subrow",
                         "data-testid": "{file_testid}",
                         span { class: "format-sublabel", "{file_label}" }

--- a/frontend/src/components/merge_dialog.rs
+++ b/frontend/src/components/merge_dialog.rs
@@ -314,7 +314,7 @@ fn render_candidate(
                         }
                     }
                     for fmt in formats.iter() {
-                        span { class: "mg-fmt", "{fmt}" }
+                        span { key: "{fmt}", class: "mg-fmt", "{fmt}" }
                     }
                 }
             }

--- a/frontend/src/pages/tag_cloud.rs
+++ b/frontend/src/pages/tag_cloud.rs
@@ -63,7 +63,7 @@ pub fn TagCloudPage() -> Element {
             // The cloud
             div { class: "tag-cloud",
                 for tag in tag_list.iter() {
-                    { render_tag_item(tag, max_count) }
+                    TagCloudItem { key: "{tag.name}", tag: tag.clone(), max_count }
                 }
             }
         }
@@ -71,7 +71,8 @@ pub fn TagCloudPage() -> Element {
 }
 
 /// Render a single tag in the cloud with size/opacity scaled by weight.
-fn render_tag_item(tag: &TagWeight, max_count: usize) -> Element {
+#[component]
+fn TagCloudItem(tag: TagWeight, max_count: usize) -> Element {
     // Tag counts and library sizes both comfortably fit a `u32`, well within
     // the f64-exactly-representable integer range. Saturating cast guards
     // against the unlikely-but-possible >4B case rather than asserting.


### PR DESCRIPTION
## Summary
- Three Dioxus list renderers iterated variable-length collections in `rsx!` blocks without `key:` attributes. Without keys the reconciler falls back to positional diffing, so an insert/remove mid-list can rebind the wrong component instances to the wrong data.
- `frontend/src/pages/tag_cloud.rs` — refactored the `render_tag_item` helper into a `#[component] TagCloudItem` and key it by `tag.name` at the call site (matches the suggested approach in #587; `TagWeight` already derives `Clone`/`PartialEq` in `shared/src/discovery.rs`, so it satisfies Dioxus's `Properties`-bound prop types).
- `frontend/src/components/format_switcher.rs` — added `key: "{file_id}"` to the format-subrow `div` in the `for file in &files` loop inside `MultiFileRow`.
- `frontend/src/components/merge_dialog.rs` — added `key: "{fmt}"` to the `span.mg-fmt` in the `for fmt in formats.iter()` loop. The keyed `render_candidate` at line 262 was already correct and was left alone, per the implementer notes on #591.

## Test plan
- [ ] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [ ] `cargo test -p omnibus-frontend --features server`
- [ ] Existing Playwright specs covering the format switcher and merge dialog still pass.

## Notes
- The issue text for #587 cited `frontend/src/components/tag_cloud.rs:65`, but the file actually lives at `frontend/src/pages/tag_cloud.rs` (no `tag_cloud.rs` exists under `components/`). The loop and `render_tag_item` helper line up exactly with the issue's evidence, so this is just a stale-path note — the fix lands in the only `tag_cloud.rs` in the tree.
- The path correction also applies to issue #591's source citations (both `format_switcher.rs` and `merge_dialog.rs` are at the correct paths; #587 was the only mis-pathed citation).

>[!IMPORTANT]
> Local verification was blocked: the agent sandbox's egress proxy refuses `github.com`, so `cargo fetch`/`clippy`/`test` cannot resolve the `dioxus = { git = "...", tag = "v0.7.9" }` git deps pinned in `Cargo.toml`. Both `cargo clippy ... -- -D warnings` and `cargo test` failed at the dependency-fetch step with `403` from the proxy on every retry, before touching any source. The diffs themselves are mechanical:
> - `key:` is a first-class Dioxus rsx attribute, used identically on `frontend/src/pages/landing/grid.rs` (`key: "{book.filename}"`) and `frontend/src/pages/search.rs` (`key: "{tag.id}"`).
> - `TagCloudItem` follows the same `#[component] fn Foo(field: Type, ...) -> Element` shape as the existing `MultiFileRow` / `FormatRow` components in `format_switcher.rs` and takes `tag: TagWeight` (Clone + PartialEq already derived).
> Please run `just lint` and `just test` locally before merging.

Closes #587
Closes #591

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSbT36bMEAyoihumwHouEG)_