### PR TITLE
refactor: drop production expects, anyhow-ify transcode, dedupe author_exists (#586)

### DIFF
--- a/db/src/auth/login.rs
+++ b/db/src/auth/login.rs
@@ -13,14 +13,20 @@ const LOCKOUT_DURATION_SECS: i64 = 15 * 60;
 
 /// Sentinel PHC string used when the username is unknown, so we still
 /// spend ~250ms in argon2 verify and don't leak username existence via
-/// response-timing. Generated once at module init.
-fn sentinel_hash() -> &'static str {
+/// response-timing. Generated lazily on first miss; an argon2 failure
+/// here is surfaced as `AuthError::Crypto` rather than crashing every
+/// subsequent login.
+fn sentinel_hash() -> AuthResult<&'static str> {
     use std::sync::OnceLock;
     static HASH: OnceLock<String> = OnceLock::new();
-    HASH.get_or_init(|| {
-        hash_password("__timing_equalizer_not_a_real_password__")
-            .expect("sentinel hash always succeeds")
-    })
+    if let Some(h) = HASH.get() {
+        return Ok(h.as_str());
+    }
+    let hashed = hash_password("__timing_equalizer_not_a_real_password__")?;
+    // The first racer wins; either the inserted value or the value already
+    // present is fine because both are valid PHC strings for the same
+    // sentinel password.
+    Ok(HASH.get_or_init(|| hashed).as_str())
 }
 
 /// Verify a login attempt. On success returns the user; on failure returns
@@ -39,8 +45,10 @@ pub async fn verify_login(pool: &SqlitePool, username: &str, password: &str) -> 
     let now = now_unix();
 
     let Some(row) = row else {
-        // Equalize timing against the found-user path.
-        let _ = verify_password(password, sentinel_hash());
+        // Equalize timing against the found-user path. A sentinel-hash
+        // failure here is treated as `AuthError::Crypto` (500) — better
+        // than swallowing it and silently leaking timing info.
+        let _ = verify_password(password, sentinel_hash()?);
         return Err(AuthError::InvalidCredentials);
     };
 

--- a/db/src/auth/password.rs
+++ b/db/src/auth/password.rs
@@ -77,15 +77,19 @@ const COMMON_PASSWORDS: &[&str] = &[
     "internet1",
 ];
 
-pub(crate) fn argon2_hasher() -> Argon2<'static> {
+pub(crate) fn argon2_hasher() -> AuthResult<Argon2<'static>> {
+    // `Params::new` is fallible because it validates the supplied tuning
+    // values at runtime. Our parameters are module-level `const`s and
+    // satisfy argon2's bounds today, but propagating the error keeps a
+    // future constants tweak from turning every auth call into a panic.
     let params = Params::new(
         ARGON2_MEMORY_KIB,
         ARGON2_ITERATIONS,
         ARGON2_PARALLELISM,
         None,
     )
-    .expect("argon2 params are compile-time valid");
-    Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+    .map_err(|e| AuthError::Crypto(format!("argon2 params invalid: {e}")))?;
+    Ok(Argon2::new(Algorithm::Argon2id, Version::V0x13, params))
 }
 
 /// Validate a plaintext password against the policy rules (length bounds and common-password reject-list).
@@ -167,7 +171,7 @@ pub fn validate_username(username: &str) -> AuthResult<()> {
 /// Hash `password` with Argon2id using OWASP-recommended parameters; returns a PHC-format string suitable for storage.
 pub fn hash_password(password: &str) -> AuthResult<String> {
     let salt = SaltString::generate(&mut PhcOsRng);
-    let phc = argon2_hasher()
+    let phc = argon2_hasher()?
         .hash_password(password.as_bytes(), &salt)?
         .to_string();
     Ok(phc)
@@ -177,7 +181,7 @@ pub fn hash_password(password: &str) -> AuthResult<String> {
 /// internal equality check. Returns Ok(true) only on match.
 pub fn verify_password(password: &str, phc: &str) -> AuthResult<bool> {
     let parsed = PasswordHash::new(phc)?;
-    match argon2_hasher().verify_password(password.as_bytes(), &parsed) {
+    match argon2_hasher()?.verify_password(password.as_bytes(), &parsed) {
         Ok(()) => Ok(true),
         Err(argon2::password_hash::Error::Password) => Ok(false),
         Err(e) => Err(e.into()),

--- a/db/src/hls/transcode.rs
+++ b/db/src/hls/transcode.rs
@@ -6,6 +6,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use anyhow::Context;
 use sqlx::SqlitePool;
 use tokio::io::AsyncBufReadExt;
 
@@ -93,9 +94,8 @@ pub async fn transcode_book(
     let _ = std::fs::write(&progress_file, "0.01");
 
     let total_secs: f64 = parts.iter().map(|p| p.duration_seconds).sum();
-    let outcome = run_ffmpeg_with_progress(book_id, profile, &concat_path, &outdir, total_secs)
-        .await
-        .map_err(anyhow::Error::msg);
+    let outcome =
+        run_ffmpeg_with_progress(book_id, profile, &concat_path, &outdir, total_secs).await;
     finalize_transcode(book_id, profile, outcome)
 }
 
@@ -144,17 +144,14 @@ async fn run_ffmpeg_with_progress(
     concat_path: &Path,
     outdir: &Path,
     total_secs: f64,
-) -> Result<FfmpegOutcome, String> {
+) -> anyhow::Result<FfmpegOutcome> {
     let timeout_secs: u64 = std::env::var("OMNIBUS_HLS_TRANSCODE_TIMEOUT_SECS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1800);
 
     let mut child = spawn_ffmpeg(concat_path, outdir)?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "ffmpeg stdout pipe missing".to_string())?;
+    let stdout = child.stdout.take().context("ffmpeg stdout pipe missing")?;
 
     let progress_file = progress_path(book_id, profile);
     let progress_task = tokio::spawn(stream_progress(stdout, progress_file, total_secs));
@@ -163,7 +160,7 @@ async fn run_ffmpeg_with_progress(
 }
 
 /// Spawn the ffmpeg child process for HLS transcoding with piped stdout/stderr.
-fn spawn_ffmpeg(concat_path: &Path, outdir: &Path) -> Result<tokio::process::Child, String> {
+fn spawn_ffmpeg(concat_path: &Path, outdir: &Path) -> anyhow::Result<tokio::process::Child> {
     let ffmpeg = std::env::var("OMNIBUS_FFMPEG_PATH").unwrap_or_else(|_| "ffmpeg".into());
     let seg_pattern = outdir.join("seg-%04d.ts");
     let manifest_out = outdir.join("index.m3u8");
@@ -204,7 +201,7 @@ fn spawn_ffmpeg(concat_path: &Path, outdir: &Path) -> Result<tokio::process::Chi
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true)
         .spawn()
-        .map_err(|e| format!("ffmpeg spawn failed: {e}"))
+        .with_context(|| format!("ffmpeg spawn failed (binary: {ffmpeg})"))
 }
 
 /// Await ffmpeg exit under `timeout_secs`, then map the result to
@@ -215,7 +212,7 @@ async fn wait_for_ffmpeg(
     child: tokio::process::Child,
     progress_task: tokio::task::JoinHandle<()>,
     timeout_secs: u64,
-) -> Result<FfmpegOutcome, String> {
+) -> anyhow::Result<FfmpegOutcome> {
     let wait_result = tokio::time::timeout(
         std::time::Duration::from_secs(timeout_secs),
         child.wait_with_output(),
@@ -237,7 +234,7 @@ async fn wait_for_ffmpeg(
         }
         Ok(Err(io_err)) => {
             let _ = progress_task.await;
-            Err(format!("ffmpeg wait failed: {io_err}"))
+            Err(anyhow::Error::new(io_err).context("ffmpeg wait failed"))
         }
         Err(_elapsed) => {
             // `kill_on_drop(true)` reaps the child when the wait future is

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -20,6 +20,8 @@ static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 pub enum InitDbError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
+    #[error("database migrations failed: {0}")]
+    Migrate(#[from] sqlx::migrate::MigrateError),
     #[error(transparent)]
     Normalize(#[from] NormalizeError),
     #[error(transparent)]
@@ -61,10 +63,12 @@ pub async fn init_db(database_url: &str) -> Result<SqlitePool, InitDbError> {
         .connect(database_url)
         .await?;
 
-    MIGRATOR
-        .run(&pool)
-        .await
-        .map_err(|e| sqlx::Error::Migrate(Box::new(e)))?;
+    // Migration failures surface as `InitDbError::Migrate` via `#[from]`;
+    // previously this hand-wrapped `sqlx::migrate::MigrateError` inside
+    // `sqlx::Error::Migrate` just so the `?` could ride the
+    // `From<sqlx::Error>` impl — pointless indirection that buried the
+    // category of failure under a generic `sqlx::Error` envelope.
+    MIGRATOR.run(&pool).await?;
 
     // One-time fill of the auto-attach match key for rows indexed before
     // migration 0016. Idempotent and a no-op once caught up.

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -63,11 +63,7 @@ pub async fn init_db(database_url: &str) -> Result<SqlitePool, InitDbError> {
         .connect(database_url)
         .await?;
 
-    // Migration failures surface as `InitDbError::Migrate` via `#[from]`;
-    // previously this hand-wrapped `sqlx::migrate::MigrateError` inside
-    // `sqlx::Error::Migrate` just so the `?` could ride the
-    // `From<sqlx::Error>` impl — pointless indirection that buried the
-    // category of failure under a generic `sqlx::Error` envelope.
+    // Migration failures surface as `InitDbError::Migrate` via `#[from]`.
     MIGRATOR.run(&pool).await?;
 
     // One-time fill of the auto-attach match key for rows indexed before

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -63,7 +63,6 @@ pub async fn init_db(database_url: &str) -> Result<SqlitePool, InitDbError> {
         .connect(database_url)
         .await?;
 
-    // Migration failures surface as `InitDbError::Migrate` via `#[from]`.
     MIGRATOR.run(&pool).await?;
 
     // One-time fill of the auto-attach match key for rows indexed before

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -22,6 +22,7 @@
 use axum::{
     body::Body,
     extract::{Path, Query, Request, State},
+    http::HeaderValue,
     response::{IntoResponse, Response},
     Json,
 };
@@ -37,6 +38,12 @@ use tower_http::services::ServeFile;
 
 use super::{internal, AppState};
 use crate::auth::AuthUser;
+
+/// Content-Type for MPEG-TS audio segments served by the HLS fallback.
+/// Defined at module scope so the per-request `HeaderValue` insert is a
+/// cheap clone of a compile-time-validated static instead of a `.parse()`
+/// + `.expect()` on every segment fetch.
+static MPEGTS_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("video/MP2T");
 
 /// Query parameters for `GET /api/audiobooks/{uuid}/manifest`.
 #[derive(Deserialize)]
@@ -324,7 +331,7 @@ pub(super) async fn get_audiobook_segment(
     let (mut parts, body) = res.into_parts();
     parts.headers.insert(
         axum::http::header::CONTENT_TYPE,
-        "video/MP2T".parse().expect("static content-type"),
+        MPEGTS_CONTENT_TYPE.clone(),
     );
     Response::from_parts(parts, Body::new(body))
 }

--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -14,9 +14,22 @@ use axum::{
 use omnibus_db::{self as db, worker::Task};
 use omnibus_shared::detect_image_format;
 use serde::Deserialize;
+use sqlx::SqlitePool;
 
 use super::{internal, AppState};
 use crate::auth::{AdminUser, AuthUser};
+
+/// Returns `true` when an `authors` row with `id` exists. Extracted because
+/// the three admin-mutation handlers below all need an "author exists?"
+/// preflight before doing any side-effecting work; a future change (e.g.
+/// a soft-delete column) then has exactly one query to touch.
+async fn author_exists(pool: &SqlitePool, id: i64) -> Result<bool, sqlx::Error> {
+    sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .map(|v| v != 0)
+}
 
 /// Serve a cached author profile photo. Returns 404 when no photo is cached
 /// (including `'letter'` negative-cache markers) — the frontend keeps the
@@ -65,16 +78,11 @@ pub(super) async fn put_author_photo(
 ) -> Response {
     // Confirm the author exists before reading multipart so a malformed
     // upload to a missing id fails fast with 404 (not 400).
-    let author_exists: bool =
-        match sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
-            .bind(id)
-            .fetch_one(&state.pool)
-            .await
-        {
-            Ok(v) => v != 0,
-            Err(e) => return internal("author exists check", e),
-        };
-    if !author_exists {
+    let exists = match author_exists(&state.pool, id).await {
+        Ok(v) => v,
+        Err(e) => return internal("author exists check", e),
+    };
+    if !exists {
         return (axum::http::StatusCode::NOT_FOUND, "author not found").into_response();
     }
 
@@ -184,16 +192,11 @@ pub(super) async fn post_author_photo_scan(
 ) -> Response {
     // Verify the author exists first so a typo on the id gets a 404 instead
     // of a successful no-op scan.
-    let author_exists: bool =
-        match sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
-            .bind(id)
-            .fetch_one(&state.pool)
-            .await
-        {
-            Ok(v) => v != 0,
-            Err(e) => return internal("author exists check", e),
-        };
-    if !author_exists {
+    let exists = match author_exists(&state.pool, id).await {
+        Ok(v) => v,
+        Err(e) => return internal("author exists check", e),
+    };
+    if !exists {
         return (axum::http::StatusCode::NOT_FOUND, "author not found").into_response();
     }
     // Manual uploads win — don't delete or overwrite. Treat scan as a no-op
@@ -247,16 +250,11 @@ pub(super) async fn put_author_photo_url(
     Path(id): Path<i64>,
     Json(body): Json<AuthorPhotoUrlBody>,
 ) -> Response {
-    let author_exists: bool =
-        match sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
-            .bind(id)
-            .fetch_one(&state.pool)
-            .await
-        {
-            Ok(v) => v != 0,
-            Err(e) => return internal("author exists check", e),
-        };
-    if !author_exists {
+    let exists = match author_exists(&state.pool, id).await {
+        Ok(v) => v,
+        Err(e) => return internal("author exists check", e),
+    };
+    if !exists {
         return (axum::http::StatusCode::NOT_FOUND, "author not found").into_response();
     }
 


### PR DESCRIPTION
## Summary

Low-batch Rust-style cleanup grouped because all three issues touch small helper layers in `db/` + `server/` with no overlap risk and the same review surface.

- **#586** Drop three production `.expect()` calls. `server/src/backend/audiobooks.rs` hoists `"video/MP2T".parse().expect(...)` into a module-scope `static MPEGTS_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("video/MP2T")`, so the per-segment header insert is a cheap clone of a compile-time-validated value instead of a parse + expect on every HLS segment fetch. `db/src/auth/password.rs` makes `argon2_hasher()` return `AuthResult<Argon2>` so a `Params::new(...)` validation failure surfaces as `AuthError::Crypto` (500) rather than panicking; `hash_password` / `verify_password` were already fallible, so external callers needed no change. `db/src/auth/login.rs` updates `sentinel_hash()` to return `AuthResult<&'static str>` (lazy fill on first miss into the same `OnceLock`) and has the unknown-user branch in `verify_login` propagate the error instead of panicking on every login attempt with an unknown username.
- **#588** Two error-handling pattern fixes. `db/src/hls/transcode.rs` swings the three private helpers (`run_ffmpeg_with_progress`, `spawn_ffmpeg`, `wait_for_ffmpeg`) from `Result<_, String>` + `format!`-error to `anyhow::Result<_>` + `anyhow::Context::context` / `.with_context(...)`, matching the unpredictable-failure-space guidance in rule 02. `transcode_book` drops the now-redundant `.map_err(anyhow::Error::msg)` shim. `db/src/pool.rs` adds a typed `InitDbError::Migrate(#[from] sqlx::migrate::MigrateError)` variant and lets `?` propagate the migrate error directly — removing the `sqlx::Error::Migrate(Box::new(e))` indirection that was only there so `?` could ride the `From<sqlx::Error>` impl.
- **#592** Extract a private `async fn author_exists(pool: &SqlitePool, id: i64) -> Result<bool, sqlx::Error>` helper at the top of `server/src/backend/author_photos.rs` and replace the three identical 8-line `SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)` blocks in `put_author_photo`, `post_author_photo_scan`, and `put_author_photo_url` with helper calls. Behavior is byte-identical.

## Files touched

- `db/src/auth/login.rs` — `sentinel_hash` now fallible; unknown-user branch propagates `AuthError::Crypto`.
- `db/src/auth/password.rs` — `argon2_hasher` returns `AuthResult<Argon2>`; `hash_password` + `verify_password` use `?`.
- `db/src/hls/transcode.rs` — three private helpers on `anyhow::Result<_>` + `Context`; `transcode_book` drops the boundary shim.
- `db/src/pool.rs` — new `InitDbError::Migrate(#[from] sqlx::migrate::MigrateError)` variant; the migrate call propagates directly.
- `server/src/backend/audiobooks.rs` — `static MPEGTS_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("video/MP2T")` at module scope; segment insert clones it.
- `server/src/backend/author_photos.rs` — private `author_exists(pool, id)` helper; three handlers call it instead of inlining the SQL.

## Notes on the selector plan

- The plan suggested `.with_context(|| "database migrations failed")` for `pool.rs`, but `init_db` already returns the typed `InitDbError`, not `anyhow::Result` (the plan's premise of "wraps as `sqlx::Error::Migrate` only to coerce to `anyhow::Error`" doesn't match the actual signature). I followed the spirit of issue #588 — "Never return raw `sqlx::Error` across a module boundary" — by giving the migration failure its own typed `InitDbError::Migrate` variant via `#[error] #[from]`. That keeps the surface typed, lets a future caller branch on migrate vs. db-open failure, and still removes the pointless re-wrap.
- All three issues are addressed in one PR per the orchestrator's Low-batch sanction (`#586+588+592`); collapsed because they touch disjoint files and the review effort is concentrated.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean across `omnibus`, `omnibus-db`, `omnibus-frontend` (also with `--features server`)
- [x] `cargo test -p omnibus-db` — 592 passed
- [x] `cargo test -p omnibus` — 206 passed
- [x] `cargo test -p omnibus-frontend --features server` — 172 passed
- [x] `cargo test -p omnibus-shared` — 46 passed

## Flags for the owner

- Sandbox lacks `nix`, so verification used the system Rust toolchain (1.94.1) directly with `CARGO_NET_GIT_FETCH_WITH_CLI=true GIT_CONFIG_GLOBAL=/dev/null` to bypass the agent proxy's git-rewrite for the Dioxus git deps. CI on its `nix` shells should be the source of truth.
- Behavior change to flag: previously, a `Params::new(...)` validation failure inside `argon2_hasher` would panic every auth-touching request; now it surfaces as `AuthError::Crypto` (500). Same for `sentinel_hash`'s one-shot init failing on first miss. Both paths are practically unreachable today (the inputs are module-level `const`s), but a future tuning of `ARGON2_*` constants will fail loudly instead of silently bringing down login.

Closes #586
Closes #588
Closes #592

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSbT36bMEAyoihumwHouEG)_