### PR TITLE
refactor: opaque AuthError::Internal so sqlx leaks stop at db (#580)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -50,11 +50,21 @@ pub enum AuthError {
     AccountLocked { until_unix: i64 },
     #[error("registration is disabled")]
     RegistrationDisabled,
-    #[error(transparent)]
-    Db(#[from] sqlx::Error),
+    /// Opaque internal failure (DB I/O, etc). The variant intentionally
+    /// carries no `sqlx::Error` so the storage backend doesn't leak
+    /// through `db::auth`'s public API (rule 02 — module-boundary).
+    /// Callers map this to HTTP 500.
+    #[error("internal database error: {0}")]
+    Internal(String),
     /// Argon2 hash/verify or CSPRNG byte-generation failure (maps to 500).
     #[error("{0}")]
     Crypto(String),
+}
+
+impl From<sqlx::Error> for AuthError {
+    fn from(e: sqlx::Error) -> Self {
+        AuthError::Internal(e.to_string())
+    }
 }
 
 impl From<argon2::password_hash::Error> for AuthError {
@@ -145,5 +155,20 @@ pub(crate) mod test_support {
 
     pub async fn pool() -> SqlitePool {
         init_db("sqlite::memory:").await.expect("pool init")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_error_from_sqlx_error_maps_to_internal_without_leaking_variant_type() {
+        // Use any sqlx::Error variant — the conversion must collapse it
+        // into the opaque `Internal` variant so server-side callers
+        // cannot match on a `sqlx::Error` value (rule 02).
+        let sqlx_err = sqlx::Error::RowNotFound;
+        let auth_err: AuthError = sqlx_err.into();
+        assert!(matches!(auth_err, AuthError::Internal(_)));
     }
 }

--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -50,10 +50,8 @@ pub enum AuthError {
     AccountLocked { until_unix: i64 },
     #[error("registration is disabled")]
     RegistrationDisabled,
-    /// Opaque internal failure (DB I/O, etc). The variant intentionally
-    /// carries no `sqlx::Error` so the storage backend doesn't leak
-    /// through `db::auth`'s public API (rule 02 — module-boundary).
-    /// Callers map this to HTTP 500.
+    /// Opaque internal failure (DB I/O, etc). Carries no `sqlx::Error`
+    /// so the storage backend doesn't leak through this crate's API.
     #[error("internal database error: {0}")]
     Internal(String),
     /// Argon2 hash/verify or CSPRNG byte-generation failure (maps to 500).

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -88,7 +88,7 @@ fn auth_error_to_response(e: AuthError) -> Response {
             (StatusCode::FORBIDDEN, "registration disabled").into_response()
         }
         AuthError::SessionNotFound => (StatusCode::UNAUTHORIZED, "unauthorized").into_response(),
-        AuthError::Db(e) => internal(e),
+        AuthError::Internal(e) => internal(e),
         AuthError::Crypto(e) => internal(e),
     }
 }


### PR DESCRIPTION
## Summary
- Replace `AuthError::Db(#[from] sqlx::Error)` in `db/src/auth.rs` with an opaque `Internal(String)` variant and a hand-written `impl From<sqlx::Error> for AuthError` that captures the storage error's `Display` message. `?` still propagates inside the `db::auth` submodules; callers can no longer name `sqlx::Error` on the `omnibus-db` → `omnibus-server` crate boundary (rule 02 — module-boundary).
- Update the only matching site in `server/src/auth/handlers.rs` (`auth_error_to_response`) from `AuthError::Db(e) => internal(e)` to `AuthError::Internal(e) => internal(e)`; the `internal` helper preserves the diagnostic in `tracing::error!` and returns the same 500. `server/src/auth/boot.rs` keeps returning `omnibus_db::auth::AuthError` — with the variant now opaque the type satisfies the issue's "(or the type no longer exposes `sqlx::Error`)" exit, so no signature churn was needed.
- Add an inline unit test covering the new `From<sqlx::Error>` conversion (collapses any `sqlx::Error` value into `AuthError::Internal(_)`).

Mirrors the resolution pattern from `SyncError` (#518) and the prior boundary fixes (#439, #535, #550). Closes #580.

## Test plan
- [ ] `cargo test -p omnibus-db` — exercises the existing `db::auth` happy/`thiserror` matrix plus the new `from_sqlx_error_maps_to_internal_without_leaking_variant_type` test.
- [ ] `cargo test -p omnibus` — exercises `server::auth::handlers` integration tests against the new variant name.
- [ ] `cargo clippy --all-targets -- -D warnings` across `omnibus-db` and `omnibus`.

## Notes
> [!WARNING]
> **Local verification blocked by the agent proxy.** This worktree's `cargo` cannot fetch the `dioxus` git dependency (`github.com/DioxusLabs/dioxus@v0.7.9`) — the proxy returns `403 permission_error: "Not authorized to access repository dioxuslabs/dioxus"`, so neither `cargo clippy` nor `cargo test` could be run locally. The change is small, mechanical, and ripgrep confirmed `AuthError::Db` has no other references in the workspace — CI is the source of truth here.

> [!NOTE]
> Behaviour at the HTTP layer is unchanged: both arms map to `500 internal server error` and log the underlying error via `tracing::error!`. The opaque variant's `Display` is `"internal database error: {msg}"` so the sqlx message is still surfaced in server logs.

Closes #580


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZy7NjSXNnYPA9n9RDDsBQ)_