### PR TITLE
refactor: drop cfg(mobile) gates off hooks in App + BookDetailPage (#584)

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -151,30 +151,55 @@ fn ScreenLayout(children: Element) -> Element {
 /// the WASM bundle.
 const ATRIUM_CSS: Asset = asset!("/assets/atrium.css");
 
-/// Root app component. Renders global styles and the router.
-#[component]
-pub fn App() -> Element {
-    use_context_provider(|| SearchQuery(Signal::new(String::new())));
-    #[cfg(not(feature = "mobile"))]
+/// Install the search-palette context and the global `⌘K` shortcut.
+///
+/// Called unconditionally from [`App`] per rule 07 so the call site has no
+/// `cfg`-gated hooks; the mobile target compiles to a no-op body, so hook
+/// counts stay parallel between targets and a future hydration-sensitive
+/// build won't drift.
+#[cfg(not(feature = "mobile"))]
+fn use_palette_setup() {
     use_context_provider(|| components::search_palette::PaletteOpen(Signal::new(false)));
-
     // App mounts once for the app's lifetime; registering the keydown
     // listener here keeps a single closure alive across route changes.
-    #[cfg(not(feature = "mobile"))]
     components::search_palette::use_palette_global_shortcut();
+}
 
+/// Mobile stub: no palette, no global shortcut.
+#[cfg(feature = "mobile")]
+fn use_palette_setup() {}
+
+/// Install the cached-user and playback contexts. Web (and SSR) only;
+/// mobile uses bearer tokens via `token_store` and stubs the listen page.
+///
+/// Called unconditionally from [`App`] per rule 07 (cfg lives in the body,
+/// not at the call site).
+#[cfg(not(feature = "mobile"))]
+fn use_user_and_playback_contexts() {
     // Cached `/api/auth/me`. Provided unconditionally on non-mobile builds
     // so SSR can render the placeholder topbar without resolving anything;
     // the WASM hydration phase then runs the boot effect below to fill it
     // in once for the lifetime of the App instance.
-    #[cfg(not(feature = "mobile"))]
-    {
-        use_context_provider(|| CurrentUser(Signal::new(None)));
-        // App-wide audiobook playback. Provided unconditionally on
-        // not(mobile) so SSR markup matches the WASM client; the web-only
-        // driver below reacts to its `uuid` signal.
-        use_context_provider(PlaybackState::new);
-    }
+    use_context_provider(|| CurrentUser(Signal::new(None)));
+    // App-wide audiobook playback. Provided unconditionally on
+    // not(mobile) so SSR markup matches the WASM client; the web-only
+    // driver below reacts to its `uuid` signal.
+    use_context_provider(PlaybackState::new);
+}
+
+/// Mobile stub: no `/me` cache, no playback context.
+#[cfg(feature = "mobile")]
+fn use_user_and_playback_contexts() {}
+
+/// Root app component. Renders global styles and the router.
+#[component]
+pub fn App() -> Element {
+    use_context_provider(|| SearchQuery(Signal::new(String::new())));
+    // Per rule 07, hook calls in App() are unconditional — feature gates
+    // live inside the helper bodies so the call sequence is identical on
+    // every target.
+    use_palette_setup();
+    use_user_and_playback_contexts();
 
     // Single boot-time `/me` fetch (replaces the per-component effects in
     // user_menu / landing / author). Also subscribes to `web_auth_state`

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -153,10 +153,12 @@ const ATRIUM_CSS: Asset = asset!("/assets/atrium.css");
 
 /// Install the search-palette context and the global `⌘K` shortcut.
 ///
-/// Called unconditionally from [`App`] per rule 07 so the call site has no
-/// `cfg`-gated hooks; the mobile target compiles to a no-op body, so hook
-/// counts stay parallel between targets and a future hydration-sensitive
-/// build won't drift.
+/// Called unconditionally from [`App`] so the call site has no
+/// `cfg`-gated hooks — the cfg lives in the helper body. The mobile
+/// build compiles to a no-op stub below; hook-count parity across
+/// targets isn't claimed (the palette + shortcut aren't reachable on
+/// mobile), but rule 07's invariant for SSR-vs-WASM hydration within
+/// the web build is preserved.
 #[cfg(not(feature = "mobile"))]
 fn use_palette_setup() {
     use_context_provider(|| components::search_palette::PaletteOpen(Signal::new(false)));
@@ -172,8 +174,13 @@ fn use_palette_setup() {}
 /// Install the cached-user and playback contexts. Web (and SSR) only;
 /// mobile uses bearer tokens via `token_store` and stubs the listen page.
 ///
-/// Called unconditionally from [`App`] per rule 07 (cfg lives in the body,
-/// not at the call site).
+/// Called unconditionally from [`App`] so the cfg lives in the body,
+/// not at the call site. The mobile build compiles to a no-op stub
+/// (the underlying `CurrentUser`/`PlaybackState` types are themselves
+/// `cfg(not(mobile))` in `contexts.rs`, so true hook-count parity
+/// across mobile isn't reachable without lifting those gates — out of
+/// scope here). Rule 07's invariant for SSR-vs-WASM hydration within
+/// the web build is preserved because both targets share `not(mobile)`.
 #[cfg(not(feature = "mobile"))]
 fn use_user_and_playback_contexts() {
     // Cached `/api/auth/me`. Provided unconditionally on non-mobile builds

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -5,9 +5,7 @@
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
-use omnibus_shared::EbookMetadata;
-#[cfg(not(feature = "mobile"))]
-use omnibus_shared::MergeBooksResult;
+use omnibus_shared::{EbookMetadata, MergeBooksResult};
 
 use crate::{data, use_server_url, Route};
 
@@ -49,12 +47,17 @@ pub fn BookDetailPage(uuid: String) -> Element {
         });
     });
 
-    #[cfg(not(feature = "mobile"))]
+    // Merge dialog state. Declared unconditionally per rule 07 so the hook
+    // count is identical on every target — mobile compiles the signals but
+    // never reads them (the rsx that consumes them is still cfg-gated below
+    // and `build_merge_*` are stubbed to `None` on mobile).
     let merge_open = use_signal(|| false);
-    #[cfg(not(feature = "mobile"))]
     let merge_result: Signal<Option<MergeBooksResult>> = use_signal(|| None);
-    #[cfg(not(feature = "mobile"))]
     let undo_error: Signal<Option<String>> = use_signal(|| None);
+    // Mobile's merge builders are `None`-returning stubs that take no args,
+    // so the three signals above would otherwise be unused on that target.
+    #[cfg(feature = "mobile")]
+    let _ = (merge_open, merge_result, undo_error);
 
     let url = server_url.clone();
     use_effect(use_reactive!(|uuid| {


### PR DESCRIPTION
## Summary
- Drop `#[cfg(not(feature = "mobile"))]` from the three merge-dialog `use_signal` calls in `BookDetailPage` so the hook count is identical on every target, matching the existing `is_admin` precedent (rule 07). The rsx blocks that consume them keep their cfg gates and `merge::build_*` still stubs to `None` on mobile; a `let _ = (...)` discard suppresses the resulting mobile unused-var warnings.
- Pull the `cfg(not(mobile))` gates off the `use_context_provider` and `use_palette_global_shortcut` calls in `App()` by extracting them into `use_palette_setup` and `use_user_and_playback_contexts` helpers. The helpers are invoked unconditionally from `App()`; the `cfg` now lives inside the helper bodies (mobile compiles them to no-op stubs), so the App call sequence is identical on every target.
- Closes #584.

## Test plan
- [ ] `cargo fmt --check` (passes locally).
- [ ] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` (CI).
- [ ] `just test` (CI).
- [ ] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` (CI mobile path; verifies the `let _ = (merge_open, ...)` discard suppresses unused-var warnings).
- [ ] `ui-validate` book-detail SSR vs hydrated DOM comparison to confirm no hydration mismatch.

## Notes
- The existing `#[cfg(feature = "web")]` gates around `install_audio_bootstrap` and the `/me` boot `use_future` are left alone — the issue explicitly scopes them out as lower priority (web/server builds both include the `web` feature in practice, so the gate doesn't risk a hydration mismatch within either single build). This PR addresses only the `not(mobile)` violations called out in the acceptance criteria.
- `MergeBooksResult` is in the `shared` crate and always available, so the formerly cfg-gated `use` statement was prophylactic; consolidated into a single unconditional import alongside `EbookMetadata`.

>[!IMPORTANT]
> Local `cargo clippy` / `cargo test` could not be run in the agent sandbox — the egress proxy returns 403 for `github.com/DioxusLabs/dioxus` (the project's pinned git dependency), so `cargo` cannot resolve the workspace at all. Manual review and `cargo fmt --check` are the only local verification; the listed `cargo clippy` / `just test` steps fall to CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZy7NjSXNnYPA9n9RDDsBQ)_