### PR TITLE
refactor: group ReadyPlayer playback signals into struct (#599)

### DIFF
--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -53,7 +53,7 @@ mod speed_panel;
 mod stage;
 
 #[cfg(not(feature = "mobile"))]
-use ready_player::ReadyPlayer;
+use ready_player::{PlaybackSignals, ReadyPlayer};
 
 // App-root re-exports: the audio element + dock are mounted by `App` /
 // `ScreenLayout`, and the playback driver is called once from `App`.
@@ -116,11 +116,13 @@ pub fn BookListenPage(uuid: String) -> Element {
                     ReadyPlayer {
                         book: b,
                         uuid: uuid.clone(),
-                        duration: playback.duration,
-                        elapsed: playback.elapsed,
-                        playing: playback.playing,
-                        rate: playback.rate,
-                        hls_ready: playback.hls_ready,
+                        signals: PlaybackSignals {
+                            duration: playback.duration,
+                            elapsed: playback.elapsed,
+                            playing: playback.playing,
+                            rate: playback.rate,
+                            hls_ready: playback.hls_ready,
+                        },
                         playback_failed: playback.playback_failed,
                         chapters: playback.chapters,
                     }

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -138,9 +138,7 @@ mod tests {
     }
 }
 
-/// Live playback-state signals consumed by [`ReadyPlayer`] and any future
-/// sub-components that read them together. Grouped because all five are
-/// written and read by the same HLS + transport layer and travel as a unit.
+/// Grouped playback signals (duration, elapsed, playing, rate, hls_ready).
 #[derive(Clone, Copy, PartialEq)]
 pub(super) struct PlaybackSignals {
     pub duration: Signal<f64>,

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -138,19 +138,32 @@ mod tests {
     }
 }
 
+/// Live playback-state signals consumed by [`ReadyPlayer`] and any future
+/// sub-components that read them together. Grouped because all five are
+/// written and read by the same HLS + transport layer and travel as a unit.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct PlaybackSignals {
+    pub duration: Signal<f64>,
+    pub elapsed: Signal<f64>,
+    pub playing: Signal<bool>,
+    pub rate: Signal<f64>,
+    pub hls_ready: Signal<bool>,
+}
+
 /// Render the ready-state player chrome and bind the transport handlers.
 #[component]
 pub(super) fn ReadyPlayer(
     book: EbookMetadata,
     uuid: String,
-    duration: Signal<f64>,
-    elapsed: Signal<f64>,
-    playing: Signal<bool>,
-    rate: Signal<f64>,
-    hls_ready: Signal<bool>,
+    signals: PlaybackSignals,
     playback_failed: Signal<bool>,
     chapters: Signal<Vec<ChapterInfo>>,
 ) -> Element {
+    let duration = signals.duration;
+    let elapsed = signals.elapsed;
+    let playing = signals.playing;
+    let rate = signals.rate;
+    let hls_ready = signals.hls_ready;
     let mut speed_panel_open = use_signal(|| false);
     let mut sleep_panel_open = use_signal(|| false);
     let mut bookmarks_open = use_signal(|| false);


### PR DESCRIPTION
## Summary

Grouped the five tightly-coupled live playback-state signals on `ReadyPlayer` (`duration`, `elapsed`, `playing`, `rate`, `hls_ready`) into a new `PlaybackSignals` struct, dropping the component's prop count from 9 to 5. The signals are all written and read by the same HLS + transport layer in `bootstrap.rs`, so they arrive and change together — exactly the case where the rsx-prop pattern PlayerStage already uses (`PlaybackPosition` / `TransportState` / `PlayerCallbacks` / `ToolbarState`) is the right shape.

## What changed

- `frontend/src/pages/listen/ready_player.rs` — added `#[derive(Clone, Copy, PartialEq)] pub(super) struct PlaybackSignals { … }` next to the component that consumes it (mirrors the in-module struct pattern in `stage.rs`). `ReadyPlayer` now takes `signals: PlaybackSignals` instead of the five flat signal props; internal reads are unchanged because the function body destructures the struct back into local `Signal`s at the top, so the existing `duration()`, `elapsed()`, `playing()`, `rate()`, `hls_ready()` call sites need no further edits.
- `frontend/src/pages/listen.rs` — call site in `BookListenPage` constructs `PlaybackSignals { … }` and passes it. (Note: the plan referenced `bootstrap.rs` as the call site, but the actual call site is in `listen.rs`'s `BookListenPage` — `bootstrap.rs` owns the App-level driver, not the per-route render.) `book`, `uuid`, `playback_failed`, and `chapters` remain flat per the issue's acceptance criteria.

## Deviations from the plan

- Defined `PlaybackSignals` inline in `ready_player.rs` rather than `bootstrap.rs` or a new `types.rs` — it sits directly above the only consumer and matches the existing `PlaybackPosition` / `TransportState` pattern in `stage.rs`.
- Call site is `listen.rs`'s `BookListenPage`, not `bootstrap.rs` (the plan had this slightly wrong — `bootstrap.rs` is the web-only `OmnibusAudio` driver and never renders `ReadyPlayer`).

## Test plan

- [ ] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [ ] `cargo test -p omnibus-frontend --features server`
- [ ] Existing Playwright specs should still pass — no markup or contract changes.

## Blocker — local checks not run

The dev sandbox's egress proxy denies the `DioxusLabs/dioxus` git source (`403 Not authorized to access repository dioxuslabs/dioxus`), which the workspace patches every dioxus-* crate to via git tag in the root `Cargo.toml`. With no pre-populated cargo cache in this fresh worktree, `cargo fmt`, `cargo clippy`, and `cargo test` cannot pull the dep and all fail at the source-load step. The refactor is small, mechanical, and reviewed by hand:
- `Signal<T>` is already `Clone + Copy + PartialEq` (we lean on this pattern in `frontend/src/pages/author.rs::AuthorDeleteState`, which is `#[derive(Clone, Copy, PartialEq)]` over a struct of `Signal`s).
- The `#[component]` macro already accepts plain struct props (see `PlayerStage` consuming `PlaybackPosition` etc.).
- `pub(super)` on `PlaybackSignals` lets `listen.rs` (the parent module) name the type, which it does in the `use` import.

Please run `just check` in CI / a Nix dev shell to confirm.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZy7NjSXNnYPA9n9RDDsBQ)_