### PR TITLE
feat: add Docker / docker-compose deployment setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keep the build context small and reproducible. The builder runs a clean
+# `dx bundle`, so none of these are needed (and several would poison it).
+
+# Rust build output (multi-GB) — the image rebuilds from source.
+target/
+**/target/
+
+# Local DB + WAL/SHM — never bake a dev database into the image.
+omnibus.db
+omnibus.db-*
+
+# Runtime data that the compose volumes provide instead.
+config/
+cache/
+covers/
+thumbs/
+data/
+
+# Nix / direnv / editor / VCS cruft irrelevant to the build.
+.direnv/
+.git/
+.github/
+.zellij/
+result
+result-*
+
+# Node / Playwright (E2E only, not part of the server bundle).
+ui_tests/**/node_modules/
+
+# Local secrets — must not leak into an image layer.
+.env
+
+# Docker files themselves.
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@
 # needed here. The Dioxus libraries are patched to the v0.7.9 git tag (see
 # [patch.crates-io] in Cargo.toml), so the CLI is pinned to the same 0.7.9.
 ###############################################################################
-FROM rust:1-bookworm AS builder
+# Debian 13 (trixie) for glibc >= 2.39: the prebuilt `dx` release binary is
+# linked against GLIBC_2.39, which bookworm (2.36) doesn't provide. The runtime
+# stage must share this glibc baseline since the server binary is compiled here.
+FROM rust:1-trixie AS builder
 
 # `clang`/`pkg-config` cover the handful of -sys crates; `curl` is for the
 # cargo-binstall bootstrap below. sqlite is statically bundled by
@@ -41,7 +44,8 @@ RUN dx bundle --platform web --package omnibus --fullstack --release
 # probe), and gosu (privilege drop). Starts as root so the PUID/PGID
 # entrypoint can remap the app user, then drops to it before serving.
 ###############################################################################
-FROM debian:bookworm-slim AS runtime
+# Must match the builder's glibc (trixie) — the server binary is linked against it.
+FROM debian:trixie-slim AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ffmpeg ca-certificates curl gosu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1
+
+###############################################################################
+# Builder — compiles the Dioxus fullstack web bundle (native Axum server +
+# the hydrated WASM client). Mirrors the CI bundle step in
+# .github/workflows/e2e.yml: `dx bundle --platform web --package omnibus
+# --fullstack --release`, which emits target/dx/omnibus/release/web/.
+#
+# This deliberately does NOT use the Nix dev shell — a plain Rust toolchain
+# keeps the image conventional and light. `dx` downloads the matching
+# wasm-bindgen + wasm-opt itself, so the wasm-bindgen pin in flake.nix is not
+# needed here. The Dioxus libraries are patched to the v0.7.9 git tag (see
+# [patch.crates-io] in Cargo.toml), so the CLI is pinned to the same 0.7.9.
+###############################################################################
+FROM rust:1-bookworm AS builder
+
+# `clang`/`pkg-config` cover the handful of -sys crates; `curl` is for the
+# cargo-binstall bootstrap below. sqlite is statically bundled by
+# libsqlite3-sys and TLS is rustls, so no libsqlite3/openssl dev packages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        clang pkg-config curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add wasm32-unknown-unknown
+
+# Pull the prebuilt Dioxus CLI release binary (compiling it from source would
+# add many minutes). Pinned to v0.7.9 to match the patched Dioxus libraries.
+RUN curl -L --proto '=https' --tlsv1.2 -sSf \
+        https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
+    && cargo binstall -y dioxus-cli@0.7.9
+
+WORKDIR /src
+COPY . .
+
+# Produces /src/target/dx/omnibus/release/web/{server, public/, ...}.
+RUN dx bundle --platform web --package omnibus --fullstack --release
+
+###############################################################################
+# Runtime — slim image carrying just the bundle, ffmpeg (audiobook HLS
+# transcode), CA certs (remote cover/author-photo fetches), curl (health
+# probe), and gosu (privilege drop). Starts as root so the PUID/PGID
+# entrypoint can remap the app user, then drops to it before serving.
+###############################################################################
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg ca-certificates curl gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --uid 1000 --user-group --create-home --shell /usr/sbin/nologin omnibus
+
+WORKDIR /app
+# The server locates its `public/` assets relative to the binary, so keep the
+# whole bundle directory intact.
+COPY --from=builder /src/target/dx/omnibus/release/web/ /app/
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Bind on all interfaces (Dioxus defaults to 127.0.0.1, unreachable from
+# outside the container) and default the persistent paths into the /config
+# and /cache volumes. Everything here is overridable in docker-compose.yml.
+ENV IP=0.0.0.0 \
+    PORT=3000 \
+    DATABASE_URL="sqlite:///config/omnibus.db?mode=rwc" \
+    OMNIBUS_COVERS_DIR=/config/covers \
+    OMNIBUS_THUMBS_DIR=/cache/thumbs \
+    OMNIBUS_DATA_DIR=/cache/data
+
+EXPOSE 3000
+VOLUME ["/config", "/cache"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${PORT}/api/_health" || exit 1
+
+# Runs as root; the entrypoint applies PUID/PGID and drops to the omnibus user.
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/app/server"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Self-hosted ebook and audiobook library — the Plex/Jellyfin for your book coll
 > **Status:** early development. Foundations and browse/discovery have shipped and reading/listening is in progress — landing grid/table, EPUB reader, audiobook player, command-palette search, and auth are live. See [docs/roadmap/0-0-summary.md](docs/roadmap/0-0-summary.md) for the full roadmap.
 
 ## Running
+
+> **Just want to deploy it?** See [docs/docker.md](docs/docker.md) for a
+> Jellyfin-style `docker compose` setup (bind-mount your library, durable
+> state in `/config`, cache in `/cache`). The Nix flow below is for development.
+
 This project utilizes [Nix](https://wiki.nixos.org/wiki/NixOS_Wiki) to save all dependencies.
 ```bash
 # Launch the nix shell (slim default — daily cargo/clippy/test)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,67 @@
+# Omnibus — self-hosted ebook/audiobook library.
+#
+# Quick start:
+#   1. Edit the two `:ro` library bind mounts below to point at your books.
+#   2. Set OMNIBUS_PUBLIC_ORIGIN to the URL you'll actually open in a browser.
+#   3. `docker compose up -d --build`
+#   4. Open the app and register — the FIRST account created becomes admin.
+#
+# Volume model (Jellyfin-style):
+#   /config      durable state — SQLite DB + cover images (back this up)
+#   /cache       regenerable — WebP thumbnails + HLS transcode segments
+#   /books       your ebook library      (read-only)
+#   /audiobooks  your audiobook library  (read-only)
+
+services:
+  omnibus:
+    build: .
+    # Once you publish an image you can swap the build for:
+    # image: ghcr.io/youruser/omnibus:latest
+    container_name: omnibus
+    restart: unless-stopped
+
+    ports:
+      # host:container — change the host side if 3000 is taken.
+      - "3000:3000"
+
+    volumes:
+      # Persistent app state and regenerable cache. Created on first run.
+      - ./config:/config
+      - ./cache:/cache
+      # Your media. Edit the left side; keep `:ro` so Omnibus never writes here.
+      - /path/to/your/ebooks:/books:ro
+      - /path/to/your/audiobooks:/audiobooks:ro
+
+    environment:
+      # Run the server as this host user/group so it can write ./config and
+      # ./cache and so files land owned by you. Set to your `id -u` / `id -g`
+      # (default 1000:1000). Same convention as the linuxserver.io images.
+      PUID: "1000"
+      PGID: "1000"
+
+      # The origin(s) you load the app from. MUST match the browser URL or
+      # logged-in POSTs are rejected (403). Comma-separate multiple origins,
+      # e.g. "http://localhost:3000,http://192.168.1.10:3000".
+      OMNIBUS_PUBLIC_ORIGIN: "http://localhost:3000"
+
+      # Serving over plain http:// (LAN / no TLS) requires this, otherwise the
+      # session cookie is marked Secure and never sent — login silently fails.
+      # Set to 1 (or remove) when you put Omnibus behind HTTPS.
+      OMNIBUS_SECURE_COOKIES: "0"
+
+      # Library locations inside the container. These are the mount targets
+      # above. Leave them set to scan on every boot, or comment BOTH out to
+      # instead configure libraries from the in-app Settings page (setting
+      # only one clears the other).
+      EBOOK_LIBRARY_PATH: "/books"
+      AUDIOBOOK_LIBRARY_PATH: "/audiobooks"
+
+      # --- Optional tuning (sensible defaults baked into the image) ----------
+      # OMNIBUS_THUMBS_CAP_BYTES: "5368709120"   # thumbnail cache cap (5 GiB)
+      # OMNIBUS_HLS_CAP_BYTES: "5368709120"      # HLS transcode cache cap (5 GiB)
+      # OMNIBUS_HLS_TRANSCODE_TIMEOUT_SECS: "1800"
+
+      # --- One-time admin recovery ------------------------------------------
+      # If you lock yourself out, set this to an existing username, restart
+      # once to regain admin, then REMOVE it (it re-promotes on every boot).
+      # OMNIBUS_INITIAL_ADMIN: "yourusername"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# PUID/PGID entrypoint, linuxserver.io-style. The container starts as root so
+# it can remap the unprivileged `omnibus` user to the host UID/GID the operator
+# wants, fix ownership of the writable volumes, then drop privileges before
+# exec'ing the server. Defaults to 1000:1000 when PUID/PGID are unset.
+set -e
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+# Remap the baked-in omnibus user/group to the requested ids. `-o` allows
+# non-unique ids (e.g. sharing 1000 with another account) and these are no-ops
+# when the ids already match.
+groupmod -o -g "$PGID" omnibus
+usermod  -o -u "$PUID" omnibus
+
+# Own only the volume mount roots, not their (potentially huge) contents — the
+# server runs as omnibus and creates covers/thumbs/data files itself. Migrating
+# pre-existing data owned by a different uid? chown it once on the host.
+chown omnibus:omnibus /config /cache 2>/dev/null || true
+
+echo "omnibus: starting as uid=${PUID} gid=${PGID}"
+exec gosu omnibus:omnibus "$@"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,99 @@
+# Running Omnibus with Docker
+
+Omnibus ships a multi-stage [`Dockerfile`](../Dockerfile) and a
+[`docker-compose.yml`](../docker-compose.yml) modelled on the Jellyfin
+convention: bind-mount your media read-only, keep durable state in `/config`
+and a regenerable cache in `/cache`, and configure everything through env.
+
+> The Nix dev shell (see the [README](../README.md)) is still the supported way
+> to *develop*. Docker is for *deploying* a built server.
+
+## Quick start
+
+```bash
+# 1. Point the library mounts at your books and set your access URL.
+$EDITOR docker-compose.yml
+
+# 2. Build the bundle and start (first build is slow — it compiles the
+#    workspace and the WASM client).
+docker compose up -d --build
+
+# 3. Open http://localhost:3000 (or whatever you set) and register.
+#    The FIRST account created is automatically the admin.
+```
+
+## Volumes
+
+| Container path | Contents | Back up? | Compose default |
+|---|---|---|---|
+| `/config` | SQLite DB (`omnibus.db`) + cover images | **Yes** | `./config` |
+| `/cache` | WebP thumbnails + HLS transcode segments | No (regenerated) | `./cache` |
+| `/books` | Ebook library | n/a (your data) | edit the `:ro` mount |
+| `/audiobooks` | Audiobook library | n/a (your data) | edit the `:ro` mount |
+
+Covers live under `/config` because they aren't reconstructible from the
+library files; thumbnails and HLS segments live under `/cache` because the
+server rebuilds them on demand and evicts them under a size cap.
+
+## Key environment variables
+
+| Variable | Why it matters |
+|---|---|
+| `OMNIBUS_PUBLIC_ORIGIN` | Must list the exact URL(s) you open in the browser, or authenticated POSTs are rejected with 403. Comma-separate multiples. |
+| `OMNIBUS_SECURE_COOKIES` | Set `0` when serving plain `http://` (LAN/no TLS) — otherwise the session cookie is `Secure`-only and login silently fails. Set `1` behind HTTPS. |
+| `EBOOK_LIBRARY_PATH` / `AUDIOBOOK_LIBRARY_PATH` | The in-container mount targets. Set both or neither (setting one clears the other). Omit both to configure libraries from the Settings UI instead. |
+| `IP` / `PORT` | Bind address. The image defaults to `IP=0.0.0.0` so the container is reachable; `PORT` defaults to `3000`. |
+
+The image bakes sensible defaults for `DATABASE_URL`, `OMNIBUS_COVERS_DIR`,
+`OMNIBUS_THUMBS_DIR`, and `OMNIBUS_DATA_DIR` so they land in the volumes above —
+override only if you change the mount layout. See [`.env.example`](../.env.example)
+for the full annotated list of supported variables.
+
+## File ownership (PUID / PGID)
+
+Same convention as the linuxserver.io images: set `PUID` and `PGID` to your host
+user's IDs (find them with `id -u` and `id -g`) so the server writes `./config`
+and `./cache` as you, and files land owned by your account rather than root.
+They default to `1000:1000`.
+
+```yaml
+environment:
+  PUID: "1000"
+  PGID: "1000"
+```
+
+The container starts as root only long enough for the entrypoint to apply these
+IDs and fix ownership of the two volume roots, then drops to the unprivileged
+`omnibus` user before running the server. The read-only library mounts just need
+to be readable by that user. Migrating data that's currently owned by a
+different UID? `chown` it once on the host — the entrypoint only adjusts the
+mount roots, not their existing contents.
+
+## Behind a reverse proxy (HTTPS)
+
+Terminate TLS at nginx/Caddy/Traefik, proxy to the container's port, then:
+
+- set `OMNIBUS_PUBLIC_ORIGIN` to your public `https://` origin,
+- remove `OMNIBUS_SECURE_COOKIES` (or set `1`),
+- only set `OMNIBUS_TRUST_FORWARDED_FOR=1` if the proxy strips inbound
+  `X-Forwarded-For` — otherwise clients can spoof the rate-limit key. See the
+  warning in [`.env.example`](../.env.example).
+
+## Admin recovery
+
+There is no separate admin-seed for production (the dev seed is compiled out of
+release builds). If you lose admin access, set `OMNIBUS_INITIAL_ADMIN=<username>`
+on an existing account, restart once, then **remove it** — it re-promotes on
+every boot while set.
+
+## Troubleshooting
+
+- **Login does nothing / 403 on POST** — `OMNIBUS_PUBLIC_ORIGIN` doesn't match
+  the browser URL, or `OMNIBUS_SECURE_COOKIES` is on over plain http.
+- **Container unreachable** — confirm `IP=0.0.0.0` (the image default) and that
+  the host port mapping isn't already taken.
+- **No audiobook playback** — ffmpeg is bundled in the image; check the
+  container logs for transcode errors and that the audiobook mount is populated.
+- **Empty library** — verify the `:ro` mounts resolve to real directories on the
+  host and that `EBOOK_LIBRARY_PATH` / `AUDIOBOOK_LIBRARY_PATH` match the mount
+  targets.


### PR DESCRIPTION
## What

Adds a Jellyfin-style Docker deployment so Omnibus can be self-hosted without the Nix dev shell.

- **Multi-stage `Dockerfile`** — a `rust:1-trixie` builder runs the same bundle command CI uses (`dx bundle --platform web --package omnibus --fullstack --release`), then a `debian:trixie-slim` runtime carries the bundle plus `ffmpeg` (audiobook HLS transcode), CA certs, and `curl` (health probe). Sets `IP=0.0.0.0` so the container is reachable (Dioxus defaults to `127.0.0.1`).
- **PUID/PGID entrypoint** (`docker/entrypoint.sh`) — linuxserver.io convention: boots as root, remaps the `omnibus` user to the requested IDs, chowns the volume roots, then drops privileges via `gosu`.
- **`docker-compose.yml`** — Jellyfin volume model: `/config` (durable: SQLite DB + covers), `/cache` (regenerable: thumbnails + HLS segments), and read-only `/books` / `/audiobooks` library mounts.
- **`.dockerignore`**, **`docs/docker.md`** deployment guide, and a README pointer.

## Why

There was no container deployment path — the only documented way to run the server was the Nix flow, which is development-oriented. This gives self-hosters the familiar `docker compose up -d` experience.

## Verification

Built and ran the image end-to-end locally:

- ✅ `docker build` succeeds; bundle lands at `target/dx/omnibus/release/web/{server,public}`.
- ✅ Server boots, registers routes, and `GET /api/_health` returns `200`.
- ✅ PUID/PGID privilege drop works — PID 1 (the server) runs as uid/gid `1000`.
- ✅ On a Linux-native volume, the SQLite DB files are owned by the requested `1000:1000`.

(On Docker Desktop **macOS** bind mounts, files cosmetically display as root — a known virtualization-layer artifact; real Linux hosts map UIDs correctly, as the named-volume test confirms.)

## Notes for reviewers

- **Base image is Debian 13 (trixie)**, not bookworm: the prebuilt `dx` 0.7.9 binary is linked against `GLIBC_2.39`, which bookworm (2.36) lacks. Builder and runtime share the trixie glibc baseline because the server binary is compiled in the builder.
- **dx pinned to `v0.7.9`** to match the `[patch.crates-io]` Dioxus git-tag pin in `Cargo.toml`; the CLI is fetched prebuilt via `cargo-binstall` rather than the Nix `dioxus-cli`. dx self-manages the matching `wasm-bindgen`.
- Verified against the codebase: build output path (per `.github/workflows/e2e.yml`), `IP`/`PORT` bind env, first-registered-user-is-admin, and that `OMNIBUS_DEV_SEED_USER` is compiled out of release builds (docs point at `OMNIBUS_INITIAL_ADMIN` for admin recovery instead).
- The docs surface the two login footguns: `OMNIBUS_PUBLIC_ORIGIN` must match the browser URL or authed POSTs 403, and `OMNIBUS_SECURE_COOKIES=0` is needed over plain http.

🤖 Generated with [Claude Code](https://claude.com/claude-code)