### PR TITLE
chore: remove dead listen Scrubber and fix Blob type_ deprecation

### DIFF
--- a/frontend/src/data/authors.rs
+++ b/frontend/src/data/authors.rs
@@ -191,8 +191,8 @@ pub async fn upload_author_photo(
     let u8 = js_sys::Uint8Array::from(bytes.as_slice());
     let parts = js_sys::Array::new();
     parts.push(&u8);
-    let mut opts = web_sys::BlobPropertyBag::new();
-    opts.type_(&mime);
+    let opts = web_sys::BlobPropertyBag::new();
+    opts.set_type(&mime);
     let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(&parts, &opts)
         .map_err(|e| DataError::Other(format!("Blob::new: {e:?}")))?;
     form.append_with_blob_and_filename("photo", &blob, &filename)

--- a/frontend/src/pages/listen/controls.rs
+++ b/frontend/src/pages/listen/controls.rs
@@ -1,4 +1,4 @@
-//! Transport controls, scrubber, toolbar, and top bar for the listen page.
+//! Transport controls, toolbar, and top bar for the listen page.
 //!
 //! Pure presentation: receives playback-state values plus per-action handlers
 //! from `ready_player`. The eval/interop layer lives in `bootstrap.rs`.
@@ -6,8 +6,6 @@
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
-
-use super::helpers::format_hms;
 
 // --- Pure helpers extracted so they can be unit-tested without a renderer.
 
@@ -47,12 +45,6 @@ pub(super) fn chapters_toggle_label(open: bool) -> &'static str {
     }
 }
 
-/// CSS fill style string for the scrubber track (0–100 range).
-#[cfg_attr(not(feature = "web"), allow(dead_code))]
-pub(super) fn scrub_fill_style(pct: f64) -> String {
-    format!("--fill: {pct:.1}%")
-}
-
 /// The hidden HTML5 `<audio>` element bound by the JS shim. Mounted once at
 /// the App root (not per-route) so playback persists across navigation.
 #[component]
@@ -63,43 +55,6 @@ pub(crate) fn AudioElement() -> Element {
             "data-testid": "listen-audio",
             style: "display:none;",
             preload: "auto",
-        }
-    }
-}
-
-/// Scrub bar with custom-styled range input + elapsed / remaining / total.
-#[component]
-pub(super) fn Scrubber(
-    elapsed: f64,
-    duration: f64,
-    remaining: f64,
-    scrub_max: f64,
-    fill_pct: f64,
-    on_seek: EventHandler<Event<FormData>>,
-) -> Element {
-    let fill_style = scrub_fill_style(fill_pct);
-
-    rsx! {
-        div { class: "lp-scrubber",
-            input {
-                r#type: "range",
-                class: "lp-scrub-input",
-                min: "0",
-                max: "{scrub_max}",
-                step: "0.5",
-                value: "{elapsed}",
-                style: "{fill_style}",
-                "aria-label": "Seek",
-                "data-testid": "listen-scrub",
-                oninput: move |evt| on_seek.call(evt),
-            }
-            div { class: "lp-scrub-times",
-                span { "{format_hms(elapsed)}" }
-                span { class: "lp-scrub-remaining",
-                    "\u{00b7} {format_hms(remaining)} remaining"
-                }
-                span { "{format_hms(duration)}" }
-            }
         }
     }
 }
@@ -235,16 +190,6 @@ mod tests {
     #[test]
     fn chapters_toggle_label_open_shows_down_arrow() {
         assert_eq!(chapters_toggle_label(true), "Chapters \u{2193}");
-    }
-
-    #[test]
-    fn scrub_fill_style_formats_css_custom_property() {
-        assert_eq!(scrub_fill_style(42.5), "--fill: 42.5%");
-    }
-
-    #[test]
-    fn scrub_fill_style_formats_zero_fill() {
-        assert_eq!(scrub_fill_style(0.0), "--fill: 0.0%");
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove the listen page's range-input `Scrubber` component and its only helper `scrub_fill_style` — superseded by `ChapterMap` and no longer rendered anywhere (`PlayerStage` mounts `ChapterMap` + `Toolbar`/`TransportButtons`).
- Replace the deprecated `web_sys::BlobPropertyBag::type_` with `set_type` in `data::authors`.

## Test plan
- [ ] `cargo clippy -p omnibus-frontend --features web --target wasm32-unknown-unknown --all-targets -- -D warnings` — clean (both warnings previously fired here)
- [ ] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [ ] `cargo test -p omnibus-frontend --features server` — 170 pass (2 obsolete `scrub_fill_style` tests removed)
- [ ] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` + `cargo fmt --check` — clean

## Notes
- Both warnings were pre-existing on `main`, spotted while fixing the mobile clippy gate in #600. Web clippy with `-D warnings` isn't a CI gate, so they weren't blocking — this is pure cleanup.