### PR TITLE
feat: unified bookmarks backend (db + REST + RPC + shared types)

### DIFF
--- a/db/src/bookmarks/mod.rs
+++ b/db/src/bookmarks/mod.rs
@@ -1,0 +1,143 @@
+//! Bookmark CRUD — create, list, update, and delete user bookmarks anchored
+//! to an opaque position token within a book. One model serves both the
+//! audiobook player (position = seconds) and the reader (position = EPUB CFI).
+
+use omnibus_shared::{Bookmark, CreateBookmark};
+use sqlx::{Row, SqlitePool};
+
+use crate::resolve_canonical_book_uuid;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BookmarkError {
+    #[error("book not found")]
+    BookNotFound,
+    #[error("bookmark not found")]
+    NotFound,
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+}
+
+impl From<crate::books::BooksError> for BookmarkError {
+    fn from(e: crate::books::BooksError) -> Self {
+        match e {
+            crate::books::BooksError::Db(inner) => Self::Sqlx(inner),
+            crate::books::BooksError::OverridesJson(inner) => {
+                Self::Sqlx(sqlx::Error::Decode(Box::new(inner)))
+            }
+        }
+    }
+}
+
+/// Create a bookmark and return the persisted row.
+pub async fn create_bookmark(
+    pool: &SqlitePool,
+    user_id: i64,
+    input: &CreateBookmark,
+) -> Result<Bookmark, BookmarkError> {
+    let book_uuid = resolve_canonical_book_uuid(pool, &input.book_uuid)
+        .await?
+        .ok_or(BookmarkError::BookNotFound)?;
+    let id = sqlx::query_scalar::<_, i64>(
+        "INSERT INTO bookmarks (user_id, book_uuid, position, title)
+         VALUES (?, ?, ?, ?) RETURNING id",
+    )
+    .bind(user_id)
+    .bind(&book_uuid)
+    .bind(&input.position)
+    .bind(input.title.as_deref())
+    .fetch_one(pool)
+    .await?;
+
+    get_bookmark_by_id(pool, user_id, id).await
+}
+
+/// List all bookmarks for a user + book, ordered by position then creation.
+pub async fn list_bookmarks(
+    pool: &SqlitePool,
+    user_id: i64,
+    book_uuid: &str,
+) -> Result<Vec<Bookmark>, BookmarkError> {
+    let Some(canonical) = resolve_canonical_book_uuid(pool, book_uuid).await? else {
+        return Ok(vec![]);
+    };
+    let rows = sqlx::query(
+        "SELECT id, book_uuid, position, title, created_at
+         FROM bookmarks
+         WHERE user_id = ? AND book_uuid = ?
+         ORDER BY created_at ASC",
+    )
+    .bind(user_id)
+    .bind(&canonical)
+    .fetch_all(pool)
+    .await?;
+
+    rows.iter().map(row_to_bookmark).collect()
+}
+
+/// Set or clear the title/note on a bookmark owned by the user.
+pub async fn update_bookmark(
+    pool: &SqlitePool,
+    user_id: i64,
+    bookmark_id: i64,
+    title: Option<&str>,
+) -> Result<(), BookmarkError> {
+    let result = sqlx::query("UPDATE bookmarks SET title = ? WHERE id = ? AND user_id = ?")
+        .bind(title)
+        .bind(bookmark_id)
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+    if result.rows_affected() == 0 {
+        return Err(BookmarkError::NotFound);
+    }
+    Ok(())
+}
+
+/// Delete a bookmark by id, scoped to the owning user.
+pub async fn delete_bookmark(
+    pool: &SqlitePool,
+    user_id: i64,
+    bookmark_id: i64,
+) -> Result<(), BookmarkError> {
+    let result = sqlx::query("DELETE FROM bookmarks WHERE id = ? AND user_id = ?")
+        .bind(bookmark_id)
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+    if result.rows_affected() == 0 {
+        return Err(BookmarkError::NotFound);
+    }
+    Ok(())
+}
+
+async fn get_bookmark_by_id(
+    pool: &SqlitePool,
+    user_id: i64,
+    bookmark_id: i64,
+) -> Result<Bookmark, BookmarkError> {
+    let row = sqlx::query(
+        "SELECT id, book_uuid, position, title, created_at
+         FROM bookmarks
+         WHERE id = ? AND user_id = ?",
+    )
+    .bind(bookmark_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or(BookmarkError::NotFound)?;
+
+    row_to_bookmark(&row)
+}
+
+fn row_to_bookmark(row: &sqlx::sqlite::SqliteRow) -> Result<Bookmark, BookmarkError> {
+    Ok(Bookmark {
+        id: row.try_get("id")?,
+        book_uuid: row.try_get::<String, _>("book_uuid")?,
+        position: row.try_get("position")?,
+        title: row.try_get("title")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/db/src/bookmarks/mod.rs
+++ b/db/src/bookmarks/mod.rs
@@ -51,7 +51,7 @@ pub async fn create_bookmark(
     get_bookmark_by_id(pool, user_id, id).await
 }
 
-/// List all bookmarks for a user + book, ordered by position then creation.
+/// List all bookmarks for a user + book, ordered by creation time (oldest first).
 pub async fn list_bookmarks(
     pool: &SqlitePool,
     user_id: i64,

--- a/db/src/bookmarks/tests.rs
+++ b/db/src/bookmarks/tests.rs
@@ -1,0 +1,178 @@
+//! Unit tests for the `bookmarks` CRUD module — create round-trip,
+//! BookNotFound / NotFound variants, list isolation, title updates, and
+//! delete behaviour.
+
+use super::*;
+use crate::{init_db, replace_books};
+use omnibus_shared::EbookMetadata;
+
+async fn seed(pool: &SqlitePool, library: &str, title: &str) -> (i64, String) {
+    replace_books(
+        pool,
+        library,
+        vec![crate::ebook::IndexedBook {
+            metadata: EbookMetadata {
+                filename: format!("{title}.epub").to_lowercase(),
+                title: Some(title.to_string()),
+                ..Default::default()
+            },
+            cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
+        }],
+    )
+    .await
+    .expect("seed book");
+    let books = crate::list_books(pool, library).await.unwrap();
+    let book = books
+        .into_iter()
+        .find(|b| b.title.as_deref() == Some(title))
+        .unwrap();
+    (book.id, book.unique_identifier.clone().unwrap())
+}
+
+async fn seed_user(pool: &SqlitePool, name: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "INSERT INTO users (username, password_hash, is_admin, can_upload, can_edit, can_download)
+         VALUES (?, '!x', 0, 0, 0, 1) RETURNING id",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+fn input(uuid: &str, position: &str, title: Option<&str>) -> CreateBookmark {
+    CreateBookmark {
+        book_uuid: uuid.into(),
+        position: position.into(),
+        title: title.map(str::to_string),
+    }
+}
+
+#[tokio::test]
+async fn create_bookmark_round_trips_fields() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+    let b = create_bookmark(&pool, user, &input(&uuid, "1234.5", Some("A mark")))
+        .await
+        .unwrap();
+    assert_eq!(b.book_uuid, uuid);
+    assert_eq!(b.position, "1234.5");
+    assert_eq!(b.title.as_deref(), Some("A mark"));
+    assert!(b.created_at > 0);
+}
+
+#[tokio::test]
+async fn create_bookmark_returns_book_not_found_for_unknown_uuid() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let err = create_bookmark(&pool, user, &input("no-such-uuid", "0", None))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, BookmarkError::BookNotFound));
+}
+
+#[tokio::test]
+async fn list_bookmarks_returns_empty_when_none_exist() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+    let list = list_bookmarks(&pool, user, &uuid).await.unwrap();
+    assert!(list.is_empty());
+}
+
+#[tokio::test]
+async fn list_bookmarks_isolates_by_user_and_book() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let alice = seed_user(&pool, "alice").await;
+    let bob = seed_user(&pool, "bob").await;
+    let (_, uuid_a) = seed(&pool, "/lib-a", "Book A").await;
+    let (_, uuid_b) = seed(&pool, "/lib-b", "Book B").await;
+
+    create_bookmark(&pool, alice, &input(&uuid_a, "10", None))
+        .await
+        .unwrap();
+    create_bookmark(&pool, alice, &input(&uuid_b, "20", None))
+        .await
+        .unwrap();
+    create_bookmark(&pool, bob, &input(&uuid_a, "30", None))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        list_bookmarks(&pool, alice, &uuid_a).await.unwrap().len(),
+        1
+    );
+    assert_eq!(
+        list_bookmarks(&pool, alice, &uuid_b).await.unwrap().len(),
+        1
+    );
+    assert_eq!(list_bookmarks(&pool, bob, &uuid_a).await.unwrap().len(), 1);
+    assert!(list_bookmarks(&pool, bob, &uuid_b)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn update_bookmark_sets_and_clears_title() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+    let b = create_bookmark(&pool, user, &input(&uuid, "5", None))
+        .await
+        .unwrap();
+    assert!(b.title.is_none());
+
+    update_bookmark(&pool, user, b.id, Some("come back here"))
+        .await
+        .unwrap();
+    let list = list_bookmarks(&pool, user, &uuid).await.unwrap();
+    assert_eq!(list[0].title.as_deref(), Some("come back here"));
+
+    update_bookmark(&pool, user, b.id, None).await.unwrap();
+    let list = list_bookmarks(&pool, user, &uuid).await.unwrap();
+    assert!(list[0].title.is_none());
+}
+
+#[tokio::test]
+async fn update_bookmark_returns_not_found_for_other_user() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let alice = seed_user(&pool, "alice").await;
+    let bob = seed_user(&pool, "bob").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+    let b = create_bookmark(&pool, alice, &input(&uuid, "5", None))
+        .await
+        .unwrap();
+    let err = update_bookmark(&pool, bob, b.id, Some("x"))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, BookmarkError::NotFound));
+}
+
+#[tokio::test]
+async fn delete_bookmark_removes_row() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+    let b = create_bookmark(&pool, user, &input(&uuid, "5", None))
+        .await
+        .unwrap();
+    delete_bookmark(&pool, user, b.id).await.unwrap();
+    assert!(list_bookmarks(&pool, user, &uuid).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn delete_bookmark_returns_not_found_for_other_user() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let alice = seed_user(&pool, "alice").await;
+    let bob = seed_user(&pool, "bob").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+    let b = create_bookmark(&pool, alice, &input(&uuid, "5", None))
+        .await
+        .unwrap();
+    let err = delete_bookmark(&pool, bob, b.id).await.unwrap_err();
+    assert!(matches!(err, BookmarkError::NotFound));
+}

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -8,6 +8,7 @@ pub mod audiobook;
 pub mod auth;
 pub mod author_photos;
 pub mod author_photos_data;
+pub mod bookmarks;
 pub mod books;
 pub mod browse;
 pub mod covers;

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -17,6 +17,7 @@
 
 mod auth;
 mod authors;
+mod bookmarks;
 mod books;
 mod highlights;
 mod progress;
@@ -29,6 +30,7 @@ mod tags;
 #[cfg(any(feature = "web", feature = "mobile", feature = "server"))]
 pub use auth::*;
 pub use authors::*;
+pub use bookmarks::*;
 pub use books::*;
 pub use highlights::*;
 pub use progress::*;

--- a/frontend/src/data/bookmarks.rs
+++ b/frontend/src/data/bookmarks.rs
@@ -1,0 +1,107 @@
+//! Bookmark transport. Wraps the four bookmark CRUD operations for mobile
+//! (`/api/bookmarks/*` via reqwest) and web/SSR (RPC server functions in
+//! `crate::rpc`). Mobile and web/SSR variants share each function's public
+//! signature so callers stay platform-agnostic; the `#[cfg]` gates carry the
+//! split. One model serves the audiobook player and the reader.
+
+use omnibus_shared::{Bookmark, CreateBookmark, UpdateBookmark};
+
+#[cfg(not(feature = "mobile"))]
+use super::note_server_fn_err;
+use super::DataError;
+#[cfg(feature = "mobile")]
+use super::{drain_error, http_client, note_status, with_bearer};
+
+#[cfg(feature = "mobile")]
+pub async fn create_bookmark(
+    server_url: &str,
+    input: CreateBookmark,
+) -> Result<Bookmark, DataError> {
+    let url = format!("{server_url}/api/bookmarks");
+    let response = with_bearer(http_client().post(&url).json(&input))
+        .send()
+        .await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<Bookmark>().await?)
+}
+
+#[cfg(feature = "mobile")]
+pub async fn list_bookmarks(server_url: &str, book_uuid: &str) -> Result<Vec<Bookmark>, DataError> {
+    let url = format!("{server_url}/api/bookmarks/book/{book_uuid}");
+    let response = with_bearer(http_client().get(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<Vec<Bookmark>>().await?)
+}
+
+#[cfg(feature = "mobile")]
+pub async fn update_bookmark(
+    server_url: &str,
+    id: i64,
+    title: Option<String>,
+) -> Result<(), DataError> {
+    let url = format!("{server_url}/api/bookmarks/{id}");
+    let body = UpdateBookmark { title };
+    let response = with_bearer(http_client().put(&url).json(&body))
+        .send()
+        .await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "mobile")]
+pub async fn delete_bookmark(server_url: &str, id: i64) -> Result<(), DataError> {
+    let url = format!("{server_url}/api/bookmarks/{id}");
+    let response = with_bearer(http_client().delete(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn create_bookmark(
+    _server_url: &str,
+    input: CreateBookmark,
+) -> Result<Bookmark, DataError> {
+    crate::rpc::rpc_create_bookmark(input)
+        .await
+        .map_err(note_server_fn_err)
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn list_bookmarks(
+    _server_url: &str,
+    book_uuid: &str,
+) -> Result<Vec<Bookmark>, DataError> {
+    crate::rpc::rpc_list_bookmarks(book_uuid.to_string())
+        .await
+        .map_err(note_server_fn_err)
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn update_bookmark(
+    _server_url: &str,
+    id: i64,
+    title: Option<String>,
+) -> Result<(), DataError> {
+    crate::rpc::rpc_update_bookmark(id, UpdateBookmark { title })
+        .await
+        .map_err(note_server_fn_err)
+}
+
+#[cfg(not(feature = "mobile"))]
+pub async fn delete_bookmark(_server_url: &str, id: i64) -> Result<(), DataError> {
+    crate::rpc::rpc_delete_bookmark(id)
+        .await
+        .map_err(note_server_fn_err)
+}

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -16,11 +16,11 @@
 use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
 use omnibus_shared::{
-    AuthorDetail, AuthorPhotoScanResult, AuthorSummary, CreateHighlight, EbookLibrary,
-    EbookMetadata, Highlight, HighlightColor, LibraryContents, LibraryPage, MergeBooksResult,
-    MetadataOverrides, PaletteResults, ProgressFormat, ProgressRecord, ProgressUpdate,
-    SeriesDetail, SeriesSummary, SessionReport, Settings, SortDir, SortKey, TagWeight,
-    UpdateHighlightNote, ViewFilters, WorkerStatus,
+    AuthorDetail, AuthorPhotoScanResult, AuthorSummary, Bookmark, CreateBookmark, CreateHighlight,
+    EbookLibrary, EbookMetadata, Highlight, HighlightColor, LibraryContents, LibraryPage,
+    MergeBooksResult, MetadataOverrides, PaletteResults, ProgressFormat, ProgressRecord,
+    ProgressUpdate, SeriesDetail, SeriesSummary, SessionReport, Settings, SortDir, SortKey,
+    TagWeight, UpdateBookmark, UpdateHighlightNote, ViewFilters, WorkerStatus,
 };
 
 // Only `validate_author_photo_url` (server-gated) and its tests reference this
@@ -767,6 +767,73 @@ pub async fn rpc_delete_highlight(id: i64) -> Result<()> {
         Err(db::highlights::HighlightError::Sqlx(e)) => {
             Err(ServerFnError::new(e.to_string()).into())
         }
+        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+    }
+}
+
+/// Create a bookmark on a book. Mobile uses the analogous REST route in
+/// `server::backend::bookmarks`; the rest of this family follows the same
+/// web-vs-mobile split. One model serves the audiobook player (position =
+/// seconds) and the reader (position = EPUB CFI).
+#[post("/api/rpc/bookmarks/create", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_create_bookmark(input: CreateBookmark) -> Result<Bookmark> {
+    if let Err(msg) = input.validate() {
+        return Err(ServerFnError::new(msg).into());
+    }
+    match db::bookmarks::create_bookmark(&pool.0, user.id, &input).await {
+        Ok(b) => Ok(b),
+        Err(db::bookmarks::BookmarkError::BookNotFound) => {
+            Err(ServerFnError::new("book not found").into())
+        }
+        Err(db::bookmarks::BookmarkError::NotFound) => {
+            Err(ServerFnError::new("bookmark not found").into())
+        }
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
+    }
+}
+
+/// List all bookmarks for the given book uuid, scoped to the current user and
+/// ordered by creation time. Returns an empty list — not an error — when the
+/// uuid is unknown or has no bookmarks yet.
+#[post("/api/rpc/bookmarks/list", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_list_bookmarks(book_uuid: String) -> Result<Vec<Bookmark>> {
+    match db::bookmarks::list_bookmarks(&pool.0, user.id, &book_uuid).await {
+        Ok(list) => Ok(list),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+    }
+}
+
+/// Set or clear the title/note on a bookmark owned by the current user.
+/// Validates `body` against `UpdateBookmark::validate()` and errors with
+/// `"bookmark not found"` when the id does not exist or belongs to another
+/// user (the two cases are deliberately indistinguishable).
+#[post("/api/rpc/bookmarks/update", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_update_bookmark(id: i64, body: UpdateBookmark) -> Result<()> {
+    if let Err(msg) = body.validate() {
+        return Err(ServerFnError::new(msg).into());
+    }
+    match db::bookmarks::update_bookmark(&pool.0, user.id, id, body.title.as_deref()).await {
+        Ok(()) => Ok(()),
+        Err(db::bookmarks::BookmarkError::NotFound) => {
+            Err(ServerFnError::new("bookmark not found").into())
+        }
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+    }
+}
+
+/// Delete a bookmark owned by the current user. Errors with
+/// `"bookmark not found"` when the id does not exist or belongs to another
+/// user (the two cases are deliberately indistinguishable).
+#[post("/api/rpc/bookmarks/delete", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_delete_bookmark(id: i64) -> Result<()> {
+    match db::bookmarks::delete_bookmark(&pool.0, user.id, id).await {
+        Ok(()) => Ok(()),
+        Err(db::bookmarks::BookmarkError::NotFound) => {
+            Err(ServerFnError::new("bookmark not found").into())
+        }
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
         Err(e) => Err(ServerFnError::new(e.to_string()).into()),
     }
 }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -771,6 +771,19 @@ pub async fn rpc_delete_highlight(id: i64) -> Result<()> {
     }
 }
 
+/// Log a bookmark DB error server-side and return a generic client error so
+/// raw `sqlx` text (which can carry SQL / schema details) never reaches the
+/// authed client — mirrors the REST `internal(...)` helper.
+#[cfg(feature = "server")]
+fn bookmark_db_error<E, R>(op: &str, e: E) -> R
+where
+    E: std::fmt::Display,
+    R: From<ServerFnError>,
+{
+    tracing::error!(op = op, error = %e, "rpc bookmark db error");
+    ServerFnError::new("internal server error").into()
+}
+
 /// Create a bookmark on a book. Mobile uses the analogous REST route in
 /// `server::backend::bookmarks`; the rest of this family follows the same
 /// web-vs-mobile split. One model serves the audiobook player (position =
@@ -792,7 +805,7 @@ pub async fn rpc_create_bookmark(input: CreateBookmark) -> Result<Bookmark> {
             tracing::error!(error = %e, "rpc_create_bookmark: inserted row could not be re-read");
             Err(ServerFnError::new("internal server error").into())
         }
-        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(bookmark_db_error("create", e)),
     }
 }
 
@@ -803,8 +816,8 @@ pub async fn rpc_create_bookmark(input: CreateBookmark) -> Result<Bookmark> {
 pub async fn rpc_list_bookmarks(book_uuid: String) -> Result<Vec<Bookmark>> {
     match db::bookmarks::list_bookmarks(&pool.0, user.id, &book_uuid).await {
         Ok(list) => Ok(list),
-        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(bookmark_db_error("list", e)),
+        Err(e) => Err(bookmark_db_error("list", e)),
     }
 }
 
@@ -822,8 +835,8 @@ pub async fn rpc_update_bookmark(id: i64, body: UpdateBookmark) -> Result<()> {
         Err(db::bookmarks::BookmarkError::NotFound) => {
             Err(ServerFnError::new("bookmark not found").into())
         }
-        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(bookmark_db_error("update", e)),
+        Err(e) => Err(bookmark_db_error("update", e)),
     }
 }
 
@@ -837,8 +850,8 @@ pub async fn rpc_delete_bookmark(id: i64) -> Result<()> {
         Err(db::bookmarks::BookmarkError::NotFound) => {
             Err(ServerFnError::new("bookmark not found").into())
         }
-        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(bookmark_db_error("delete", e)),
+        Err(e) => Err(bookmark_db_error("delete", e)),
     }
 }
 

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -785,8 +785,12 @@ pub async fn rpc_create_bookmark(input: CreateBookmark) -> Result<Bookmark> {
         Err(db::bookmarks::BookmarkError::BookNotFound) => {
             Err(ServerFnError::new("book not found").into())
         }
-        Err(db::bookmarks::BookmarkError::NotFound) => {
-            Err(ServerFnError::new("bookmark not found").into())
+        // NotFound on create means the just-inserted row couldn't be re-read —
+        // a server invariant break, not a missing client resource. Log it and
+        // surface a generic internal error rather than a misleading 404.
+        Err(e @ db::bookmarks::BookmarkError::NotFound) => {
+            tracing::error!(error = %e, "rpc_create_bookmark: inserted row could not be re-read");
+            Err(ServerFnError::new("internal server error").into())
         }
         Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
     }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -23,6 +23,7 @@ use crate::rate_limit::{rate_limit_by_ip, RateLimiter};
 mod audiobooks;
 mod author_photos;
 mod authors;
+mod bookmarks;
 mod covers;
 mod ebooks;
 mod health;
@@ -228,6 +229,18 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
             patch(highlights::patch_highlight_note),
         )
         .route("/api/highlights/{id}", delete(highlights::delete_highlight))
+        // Bookmarks — mobile-facing REST. Web hits the analogous
+        // `/api/rpc/bookmarks/*` server functions. One model serves both the
+        // audiobook player and the reader (position = seconds or EPUB CFI).
+        .route("/api/bookmarks", post(bookmarks::post_bookmark))
+        .route(
+            "/api/bookmarks/book/{book_uuid}",
+            get(bookmarks::get_bookmarks),
+        )
+        .route(
+            "/api/bookmarks/{id}",
+            put(bookmarks::put_bookmark).delete(bookmarks::delete_bookmark),
+        )
         // GET/DELETE for author photos carry no upload body (DELETE mutates,
         // but cheaply — it clears photo state, it doesn't ingest one), so
         // they stay outside the rate-limited `upload_router`. Only the binary

--- a/server/src/backend/bookmarks.rs
+++ b/server/src/backend/bookmarks.rs
@@ -1,0 +1,89 @@
+//! Bookmark REST handlers for the mobile client (`/api/bookmarks*`).
+//!
+//! Web clients use the `/api/rpc/bookmarks/*` server functions defined in
+//! `omnibus_frontend::rpc`. One model serves both the audiobook player and the
+//! reader — `position` is seconds-as-string or an EPUB CFI respectively.
+
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Response},
+    Json,
+};
+use omnibus_db::{self as db, bookmarks::BookmarkError};
+use omnibus_shared::{CreateBookmark, UpdateBookmark};
+
+use super::{internal, AppState};
+use crate::auth::AuthUser;
+
+/// Create a bookmark on a book.
+pub(super) async fn post_bookmark(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Json(input): Json<CreateBookmark>,
+) -> Response {
+    if let Err(msg) = input.validate() {
+        return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
+    }
+    match db::bookmarks::create_bookmark(&state.pool, user.id, &input).await {
+        Ok(b) => Json(b).into_response(),
+        Err(BookmarkError::BookNotFound) => {
+            (axum::http::StatusCode::NOT_FOUND, "book not found").into_response()
+        }
+        // NotFound on create means the just-inserted row couldn't be re-read —
+        // a server invariant break, not a missing client resource. Surface 500.
+        Err(e @ BookmarkError::NotFound) => internal("create_bookmark", e),
+        Err(BookmarkError::Sqlx(e)) => internal("create_bookmark", e),
+    }
+}
+
+/// List all bookmarks for a user on a specific book.
+pub(super) async fn get_bookmarks(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(book_uuid): Path<String>,
+) -> Response {
+    match db::bookmarks::list_bookmarks(&state.pool, user.id, &book_uuid).await {
+        Ok(list) => Json(list).into_response(),
+        Err(BookmarkError::Sqlx(e)) => internal("list_bookmarks", e),
+        Err(e) => internal("list_bookmarks", e),
+    }
+}
+
+/// Update the title/note on an existing bookmark.
+pub(super) async fn put_bookmark(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(body): Json<UpdateBookmark>,
+) -> Response {
+    if let Err(msg) = body.validate() {
+        return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
+    }
+    match db::bookmarks::update_bookmark(&state.pool, user.id, id, body.title.as_deref()).await {
+        Ok(()) => axum::http::StatusCode::NO_CONTENT.into_response(),
+        Err(BookmarkError::NotFound) => {
+            (axum::http::StatusCode::NOT_FOUND, "bookmark not found").into_response()
+        }
+        Err(BookmarkError::Sqlx(e)) => internal("update_bookmark", e),
+        Err(e) => internal("update_bookmark", e),
+    }
+}
+
+/// Delete a bookmark by id, scoped to the owning user.
+pub(super) async fn delete_bookmark(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
+    match db::bookmarks::delete_bookmark(&state.pool, user.id, id).await {
+        Ok(()) => axum::http::StatusCode::NO_CONTENT.into_response(),
+        Err(BookmarkError::NotFound) => {
+            (axum::http::StatusCode::NOT_FOUND, "bookmark not found").into_response()
+        }
+        Err(BookmarkError::Sqlx(e)) => internal("delete_bookmark", e),
+        Err(e) => internal("delete_bookmark", e),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/src/backend/bookmarks/tests.rs
+++ b/server/src/backend/bookmarks/tests.rs
@@ -1,0 +1,234 @@
+//! Integration tests for bookmark REST handlers.
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header::AUTHORIZATION, Request, StatusCode},
+};
+use omnibus_shared::Bookmark;
+use tower::ServiceExt;
+
+use crate::auth::test_support as auth_test_support;
+use crate::backend::test_support::*;
+
+#[tokio::test]
+async fn api_post_bookmark_requires_auth() {
+    let (app, _state, _pool) = fixture().await;
+    let body = serde_json::json!({ "book_uuid": "x", "position": "10.0", "title": null });
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/bookmarks")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_post_bookmark_400_on_oversized_position() {
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let oversized = "a".repeat(omnibus_shared::CreateBookmark::POSITION_MAX_LEN + 1);
+    let body = serde_json::json!({ "book_uuid": uuid, "position": oversized, "title": null });
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/bookmarks")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let msg = String::from_utf8_lossy(&bytes);
+    assert!(msg.contains("position"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn api_post_bookmark_404_on_unknown_book() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let body = serde_json::json!({ "book_uuid": "no-such-uuid", "position": "1.0", "title": null });
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/bookmarks")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn api_bookmark_crud_round_trip() {
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    // Create
+    let body = serde_json::json!({ "book_uuid": uuid, "position": "1234.5", "title": "A mark" });
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/bookmarks")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let created: Bookmark = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(created.position, "1234.5");
+    assert_eq!(created.title.as_deref(), Some("A mark"));
+
+    // List
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/api/bookmarks/book/{uuid}"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let list: Vec<Bookmark> = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].id, created.id);
+
+    // Update title
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/bookmarks/{}", created.id))
+                .method("PUT")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(
+                    serde_json::json!({ "title": "renamed" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+    // Verify update via list
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/api/bookmarks/book/{uuid}"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let list: Vec<Bookmark> = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(list[0].title.as_deref(), Some("renamed"));
+
+    // Delete
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/bookmarks/{}", created.id))
+                .method("DELETE")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+    // Verify deletion
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/bookmarks/book/{uuid}"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let list: Vec<Bookmark> = serde_json::from_slice(&bytes).unwrap();
+    assert!(list.is_empty());
+}
+
+#[tokio::test]
+async fn api_bookmark_user_isolation() {
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let alice = auth_test_support::create_user(&pool, "alice").await;
+    let alice_token = auth_test_support::bearer_token(&pool, alice.id).await;
+    let bob = auth_test_support::create_user(&pool, "bob").await;
+    let bob_token = auth_test_support::bearer_token(&pool, bob.id).await;
+
+    // Alice creates a bookmark
+    let body = serde_json::json!({ "book_uuid": uuid, "position": "9.0", "title": null });
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/bookmarks")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {alice_token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let created: Bookmark = serde_json::from_slice(&bytes).unwrap();
+
+    // Bob cannot see Alice's bookmarks
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/api/bookmarks/book/{uuid}"),
+            &bob_token,
+        ))
+        .await
+        .unwrap();
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let list: Vec<Bookmark> = serde_json::from_slice(&bytes).unwrap();
+    assert!(list.is_empty());
+
+    // Bob cannot delete Alice's bookmark
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/bookmarks/{}", created.id))
+                .method("DELETE")
+                .header(AUTHORIZATION, format!("Bearer {bob_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}

--- a/shared/src/bookmark.rs
+++ b/shared/src/bookmark.rs
@@ -1,11 +1,7 @@
-//! Bookmark wire types shared between web and mobile clients.
-//!
-//! A single bookmark model serves both surfaces. `position` is an opaque
-//! location token — seconds-as-string for the audiobook player, an EPUB CFI
-//! for the reader — and `title` is the optional user-entered name/note. The
-//! backing `bookmarks` table (migration 0013, soft-ref'd to `book_uuid` by
-//! 0027) has no dedicated note column, so `title` carries the user's text and
-//! the chapter label shown in the UI is derived from `position` at render.
+//! Bookmark wire types shared between web and mobile clients. One model
+//! serves both surfaces: `position` is an opaque location token (seconds for
+//! the audiobook player, an EPUB CFI for the reader) and `title` is the
+//! optional user name/note (the `bookmarks` table has no separate note column).
 
 use serde::{Deserialize, Serialize};
 

--- a/shared/src/bookmark.rs
+++ b/shared/src/bookmark.rs
@@ -1,0 +1,86 @@
+//! Bookmark wire types shared between web and mobile clients.
+//!
+//! A single bookmark model serves both surfaces. `position` is an opaque
+//! location token — seconds-as-string for the audiobook player, an EPUB CFI
+//! for the reader — and `title` is the optional user-entered name/note. The
+//! backing `bookmarks` table (migration 0013, soft-ref'd to `book_uuid` by
+//! 0027) has no dedicated note column, so `title` carries the user's text and
+//! the chapter label shown in the UI is derived from `position` at render.
+
+use serde::{Deserialize, Serialize};
+
+/// A persisted bookmark.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Bookmark {
+    pub id: i64,
+    pub book_uuid: String,
+    pub position: String,
+    pub title: Option<String>,
+    pub created_at: i64,
+}
+
+/// Payload for creating a new bookmark.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreateBookmark {
+    pub book_uuid: String,
+    pub position: String,
+    pub title: Option<String>,
+}
+
+impl CreateBookmark {
+    /// Maximum length (in chars) of a position token. An audiobook position is
+    /// a short decimal and a CFI rarely exceeds a few hundred bytes; 4 KiB is a
+    /// generous ceiling that stops an authed client persisting huge blobs.
+    pub const POSITION_MAX_LEN: usize = 4096;
+    /// Maximum length (in chars) of the user-entered title/note.
+    pub const TITLE_MAX_LEN: usize = 512;
+
+    /// Validate field lengths and required-ness. Call at the handler boundary
+    /// before persisting so over-long inputs surface as 400 instead of falling
+    /// through to the DB. Lengths are measured in Unicode scalar values.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.book_uuid.trim().is_empty() {
+            return Err("book_uuid is required".into());
+        }
+        if self.position.trim().is_empty() {
+            return Err("position is required".into());
+        }
+        if self.position.chars().count() > Self::POSITION_MAX_LEN {
+            return Err(format!(
+                "position exceeds {} characters",
+                Self::POSITION_MAX_LEN
+            ));
+        }
+        if let Some(ref title) = self.title {
+            if title.chars().count() > Self::TITLE_MAX_LEN {
+                return Err(format!("title exceeds {} characters", Self::TITLE_MAX_LEN));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Payload for updating a bookmark's title/note. `None` clears the title.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpdateBookmark {
+    pub title: Option<String>,
+}
+
+impl UpdateBookmark {
+    /// Mirror of [`CreateBookmark::TITLE_MAX_LEN`] so both boundaries agree.
+    pub const TITLE_MAX_LEN: usize = CreateBookmark::TITLE_MAX_LEN;
+
+    /// Validate the title length. `None` clears the title and is always
+    /// permitted. Returns `Err` with a human-readable message when over cap.
+    pub fn validate(&self) -> Result<(), String> {
+        if let Some(ref title) = self.title {
+            if title.chars().count() > Self::TITLE_MAX_LEN {
+                return Err(format!("title exceeds {} characters", Self::TITLE_MAX_LEN));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/shared/src/bookmark/tests.rs
+++ b/shared/src/bookmark/tests.rs
@@ -1,0 +1,89 @@
+//! Unit tests for the bookmark wire-type validators.
+
+use super::*;
+
+fn ok_create(position: &str) -> CreateBookmark {
+    CreateBookmark {
+        book_uuid: "uuid-1".into(),
+        position: position.into(),
+        title: Some("A mark".into()),
+    }
+}
+
+#[test]
+fn create_bookmark_validate_accepts_well_formed_payload() {
+    assert!(ok_create("1234.5").validate().is_ok());
+    assert!(ok_create("epubcfi(/6/4!/4/2)").validate().is_ok());
+}
+
+#[test]
+fn create_bookmark_validate_accepts_none_title() {
+    let mut c = ok_create("12.0");
+    c.title = None;
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn create_bookmark_validate_accepts_position_and_title_at_max_len() {
+    let mut c = ok_create(&"a".repeat(CreateBookmark::POSITION_MAX_LEN));
+    c.title = Some("t".repeat(CreateBookmark::TITLE_MAX_LEN));
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn create_bookmark_validate_rejects_empty_book_uuid() {
+    let mut c = ok_create("12.0");
+    c.book_uuid = "   ".into();
+    let err = c.validate().expect_err("blank book_uuid must be rejected");
+    assert!(err.contains("book_uuid"), "got: {err}");
+}
+
+#[test]
+fn create_bookmark_validate_rejects_empty_position() {
+    let c = ok_create("   ");
+    let err = c.validate().expect_err("blank position must be rejected");
+    assert!(err.contains("position"), "got: {err}");
+}
+
+#[test]
+fn create_bookmark_validate_rejects_position_over_max_len() {
+    let c = ok_create(&"a".repeat(CreateBookmark::POSITION_MAX_LEN + 1));
+    let err = c
+        .validate()
+        .expect_err("over-long position must be rejected");
+    assert!(err.contains("position"), "got: {err}");
+    assert!(
+        err.contains(&CreateBookmark::POSITION_MAX_LEN.to_string()),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn create_bookmark_validate_rejects_title_over_max_len() {
+    let mut c = ok_create("12.0");
+    c.title = Some("t".repeat(CreateBookmark::TITLE_MAX_LEN + 1));
+    let err = c.validate().expect_err("over-long title must be rejected");
+    assert!(err.contains("title"), "got: {err}");
+}
+
+#[test]
+fn update_bookmark_validate_accepts_none() {
+    assert!(UpdateBookmark { title: None }.validate().is_ok());
+}
+
+#[test]
+fn update_bookmark_validate_accepts_title_at_max_len() {
+    let u = UpdateBookmark {
+        title: Some("t".repeat(UpdateBookmark::TITLE_MAX_LEN)),
+    };
+    assert!(u.validate().is_ok());
+}
+
+#[test]
+fn update_bookmark_validate_rejects_title_over_max_len() {
+    let u = UpdateBookmark {
+        title: Some("t".repeat(UpdateBookmark::TITLE_MAX_LEN + 1)),
+    };
+    let err = u.validate().expect_err("over-long title must be rejected");
+    assert!(err.contains("title"), "got: {err}");
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod audiobook;
 pub mod auth;
+pub mod bookmark;
 pub mod discovery;
 pub mod ebook;
 pub mod highlight;
@@ -25,6 +26,7 @@ pub const AUTHOR_PHOTO_URL_MAX_LEN: usize = 2048;
 
 pub use audiobook::*;
 pub use auth::*;
+pub use bookmark::*;
 pub use discovery::*;
 pub use ebook::*;
 pub use highlight::*;


### PR DESCRIPTION
## Summary
- Adds a unified bookmarks data layer — shared `Bookmark`/`CreateBookmark`/`UpdateBookmark`, `db::bookmarks` CRUD, `/api/bookmarks*` REST, and `/api/rpc/bookmarks/*` server functions — reusing the existing `bookmarks` table (no migration).
- One model serves both surfaces: `position` is seconds-as-string for the audiobook player and an EPUB CFI for the reader.
- UUIDs resolve through `resolve_canonical_book_uuid`, so orphaned bookmarks survive reindex/merge (mirrors the highlights pattern).

## Test plan
- [x] `cargo test -p omnibus-shared` (validators), `-p omnibus-db` (CRUD + user isolation), `-p omnibus` (REST round-trip / auth / isolation)
- [x] `just lint` (fmt + clippy across the matrix)

## Notes
- Base of a 3-PR stack (head: `u/sloan/reader-drawers-notes-3`). The audiobook and reader bookmark UIs consume this layer.