### PR TITLE
feat: reader TOC + highlights drawers, popover actions, note composer

### DIFF
--- a/db/migrations/0030_highlight_text.sql
+++ b/db/migrations/0030_highlight_text.sql
@@ -1,0 +1,8 @@
+-- F2.4b Store the highlighted text alongside each highlight.
+--
+-- The CFI range locates the span in the book's DOM, but resolving it back to
+-- the underlying prose requires the rendered epub.js document. Persisting the
+-- selected text lets the highlights drawer and quote cards render the passage
+-- without re-opening the book. Nullable + no backfill: highlights created
+-- before this migration simply have no stored text.
+ALTER TABLE highlights ADD COLUMN text TEXT;

--- a/db/src/highlights/mod.rs
+++ b/db/src/highlights/mod.rs
@@ -37,13 +37,14 @@ pub async fn create_highlight(
         .await?
         .ok_or(HighlightError::BookNotFound)?;
     let id = sqlx::query_scalar::<_, i64>(
-        "INSERT INTO highlights (user_id, book_uuid, epub_cfi_range, color)
-         VALUES (?, ?, ?, ?) RETURNING id",
+        "INSERT INTO highlights (user_id, book_uuid, epub_cfi_range, color, text)
+         VALUES (?, ?, ?, ?, ?) RETURNING id",
     )
     .bind(user_id)
     .bind(&book_uuid)
     .bind(&input.epub_cfi_range)
     .bind(input.color.as_str())
+    .bind(input.text.as_deref())
     .fetch_one(pool)
     .await?;
 
@@ -60,7 +61,7 @@ pub async fn list_highlights(
         return Ok(vec![]);
     };
     let rows = sqlx::query(
-        "SELECT h.id, h.book_uuid, h.epub_cfi_range, h.color, h.note, h.created_at
+        "SELECT h.id, h.book_uuid, h.epub_cfi_range, h.color, h.note, h.text, h.created_at
          FROM highlights h
          WHERE h.user_id = ? AND h.book_uuid = ?
          ORDER BY h.created_at ASC",
@@ -134,7 +135,7 @@ async fn get_highlight_by_id(
     highlight_id: i64,
 ) -> Result<Highlight, HighlightError> {
     let row = sqlx::query(
-        "SELECT h.id, h.book_uuid, h.epub_cfi_range, h.color, h.note, h.created_at
+        "SELECT h.id, h.book_uuid, h.epub_cfi_range, h.color, h.note, h.text, h.created_at
          FROM highlights h
          WHERE h.id = ? AND h.user_id = ?",
     )
@@ -156,6 +157,7 @@ fn row_to_highlight(row: &sqlx::sqlite::SqliteRow) -> Result<Highlight, Highligh
         epub_cfi_range: row.try_get("epub_cfi_range")?,
         color,
         note: row.try_get("note")?,
+        text: row.try_get("text")?,
         created_at: row.try_get("created_at")?,
     })
 }

--- a/db/src/highlights/tests.rs
+++ b/db/src/highlights/tests.rs
@@ -51,11 +51,13 @@ async fn create_highlight_round_trips_fields() {
         book_uuid: uuid.clone(),
         epub_cfi_range: "epubcfi(/6/4!/4/2,/1:0,/1:100)".into(),
         color: HighlightColor::Blue,
+        text: Some("the quoted passage".into()),
     };
     let h = create_highlight(&pool, user, &input).await.unwrap();
     assert_eq!(h.book_uuid, uuid);
     assert_eq!(h.epub_cfi_range, "epubcfi(/6/4!/4/2,/1:0,/1:100)");
     assert_eq!(h.color, HighlightColor::Blue);
+    assert_eq!(h.text.as_deref(), Some("the quoted passage"));
     assert!(h.note.is_none());
     assert!(h.created_at > 0);
 }
@@ -68,6 +70,7 @@ async fn create_highlight_returns_book_not_found_for_unknown_uuid() {
         book_uuid: "no-such-uuid".into(),
         epub_cfi_range: "epubcfi(/6/4)".into(),
         color: HighlightColor::Amber,
+        text: None,
     };
     let err = create_highlight(&pool, user, &input).await.unwrap_err();
     assert!(matches!(err, HighlightError::BookNotFound));
@@ -94,11 +97,13 @@ async fn list_highlights_isolates_by_user_and_book() {
         book_uuid: uuid_a.clone(),
         epub_cfi_range: "epubcfi(/6/4)".into(),
         color: HighlightColor::Amber,
+        text: None,
     };
     let input_b = CreateHighlight {
         book_uuid: uuid_b.clone(),
         epub_cfi_range: "epubcfi(/6/8)".into(),
         color: HighlightColor::Green,
+        text: None,
     };
     create_highlight(&pool, alice, &input_a).await.unwrap();
     create_highlight(&pool, alice, &input_b).await.unwrap();
@@ -126,6 +131,7 @@ async fn update_highlight_color_changes_color() {
             book_uuid: uuid.clone(),
             epub_cfi_range: "epubcfi(/6/4)".into(),
             color: HighlightColor::Amber,
+            text: None,
         },
     )
     .await
@@ -151,6 +157,7 @@ async fn update_highlight_color_returns_not_found_for_other_user() {
             book_uuid: uuid.clone(),
             epub_cfi_range: "epubcfi(/6/4)".into(),
             color: HighlightColor::Amber,
+            text: None,
         },
     )
     .await
@@ -174,6 +181,7 @@ async fn update_highlight_note_sets_and_clears() {
             book_uuid: uuid.clone(),
             epub_cfi_range: "epubcfi(/6/4)".into(),
             color: HighlightColor::Green,
+            text: None,
         },
     )
     .await
@@ -205,6 +213,7 @@ async fn delete_highlight_removes_row() {
             book_uuid: uuid.clone(),
             epub_cfi_range: "epubcfi(/6/4)".into(),
             color: HighlightColor::Rose,
+            text: None,
         },
     )
     .await
@@ -228,6 +237,7 @@ async fn delete_highlight_returns_not_found_for_other_user() {
             book_uuid: uuid.clone(),
             epub_cfi_range: "epubcfi(/6/4)".into(),
             color: HighlightColor::Blue,
+            text: None,
         },
     )
     .await

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -390,6 +390,7 @@ async fn merge_moves_highlights_to_target() {
             book_uuid: source.clone(),
             epub_cfi_range: "epubcfi(/6/4!/4/2,/1:0,/1:100)".into(),
             color: omnibus_shared::HighlightColor::Blue,
+            text: None,
         },
     )
     .await

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3868,6 +3868,94 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .rd-swatch[data-color="rose"]   { background: rgba(244,63,94,.7); }
 .rd-swatch[data-color="violet"] { background: rgba(139,92,246,.7); }
 
+/* Palette tokens reused by drawer rows + filter chips. */
+.rd-surface {
+  --hl-amber: rgb(245,158,11); --hl-green: rgb(34,197,94);
+  --hl-blue: rgb(59,130,246); --hl-rose: rgb(244,63,94);
+  --hl-violet: rgb(139,92,246);
+}
+
+/* Popover action buttons (Note / Copy / Share) + divider (F2.4b). */
+.rd-pop-div { width: 1px; align-self: stretch; margin: 0 4px;
+  background: var(--line-2); }
+.rd-act { display: inline-flex; align-items: center; gap: 6px;
+  height: 30px; padding: 0 10px; border-radius: 8px; border: 0;
+  background: transparent; color: var(--ink-1); cursor: pointer;
+  font-family: var(--sans); font-size: 12.5px; white-space: nowrap;
+  transition: background .14s, color .14s; }
+.rd-act:hover { background: var(--bg-2); color: var(--ink-0); }
+.rd-act.sm { height: 26px; padding: 0 8px; font-size: 11.5px; }
+
+/* Right-side reader drawers (contents / highlights) (F2.4b). */
+.rd-drawer { position: absolute; top: 0; right: 0; bottom: 0; width: 380px;
+  z-index: 19; background: var(--bg-1); border-left: 1px solid var(--line);
+  box-shadow: -30px 0 60px -30px rgba(0,0,0,.6);
+  display: flex; flex-direction: column; }
+.rd-drawer-head { display: flex; align-items: center;
+  justify-content: space-between; padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--line-2); }
+.rd-drawer-title { font-family: var(--serif); font-size: 22px; margin: 0;
+  display: flex; align-items: baseline; gap: 10px; }
+.rd-drawer-count { font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+.rd-drawer-body { flex: 1; overflow: auto; padding: 12px 16px 24px;
+  display: flex; flex-direction: column; gap: 4px; }
+.rd-drawer-empty { padding: 48px 16px; text-align: center;
+  color: var(--ink-3); font-size: 14px; }
+.rd-x { display: grid; place-items: center; width: 30px; height: 30px;
+  border-radius: 8px; background: transparent; border: 1px solid transparent;
+  color: var(--ink-2); cursor: pointer; font-size: 18px; line-height: 1;
+  transition: background .14s, color .14s; }
+.rd-x:hover { background: var(--bg-2); color: var(--ink-0); border-color: var(--line-2); }
+
+/* Contents drawer rows. */
+.rd-toc-row { display: block; width: 100%; text-align: left;
+  padding: 8px 10px; border: 0; border-left: 2px solid transparent;
+  border-radius: 8px; background: transparent; color: var(--ink-1);
+  font-family: var(--serif); font-size: 14px; cursor: pointer;
+  transition: background .14s, color .14s; }
+.rd-toc-row:hover { background: var(--bg-2); color: var(--ink-0); }
+.rd-toc-row.current { background: var(--bg-2); color: var(--ink-0);
+  border-left-color: var(--accent); font-style: italic; }
+
+/* Highlights drawer: filter chips + rows. */
+.rd-filter-row { display: flex; gap: 6px; flex-wrap: wrap;
+  padding: 12px 20px; border-bottom: 1px solid var(--line-2); }
+.rd-chip { display: inline-flex; align-items: center; gap: 6px;
+  height: 28px; padding: 0 10px; border-radius: 999px; cursor: pointer;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--ink-2); font-size: 12px; }
+.rd-chip.on { border-color: var(--accent); color: var(--ink-0); }
+.rd-chip-dot { width: 10px; height: 10px; border-radius: 50%; }
+.rd-chip-dot[data-color="amber"]  { background: var(--hl-amber); }
+.rd-chip-dot[data-color="green"]  { background: var(--hl-green); }
+.rd-chip-dot[data-color="blue"]   { background: var(--hl-blue); }
+.rd-chip-dot[data-color="rose"]   { background: var(--hl-rose); }
+.rd-chip-dot[data-color="violet"] { background: var(--hl-violet); }
+.rd-hl-row { display: flex; flex-direction: column; gap: 6px;
+  padding: 8px 10px 10px 14px; border-left: 3px solid var(--accent); }
+.rd-hl-quote { text-align: left; background: transparent; border: 0;
+  cursor: pointer; padding: 0; color: var(--ink-0);
+  font-family: var(--serif); font-style: italic; font-size: 16px; line-height: 1.42; }
+.rd-hl-note { display: flex; gap: 7px; font-size: 12.5px; color: var(--ink-2);
+  line-height: 1.45; }
+.rd-hl-actions { display: flex; gap: 2px; }
+
+/* Note composer (centered card over a scrim). */
+.rd-note-composer { position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%, -50%); z-index: 21; width: 360px;
+  background: var(--bg-1); border: 1px solid var(--line); border-radius: 13px;
+  box-shadow: 0 18px 50px -16px rgba(0,0,0,.7); padding: 16px; }
+.rd-note-quote { font-family: var(--serif); font-style: italic; font-size: 14px;
+  color: var(--ink-2); margin-bottom: 10px; }
+.rd-note-input { width: 100%; min-height: 90px; resize: vertical;
+  background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 9px;
+  padding: 11px 13px; font-family: var(--serif); font-size: 15px;
+  line-height: 1.5; color: var(--ink-0); }
+.rd-note-actions { display: flex; align-items: center;
+  justify-content: space-between; margin-top: 12px; }
+.rd-note-hint { font-family: var(--mono); font-size: 10px; color: var(--ink-3); }
+.rd-note-buttons { display: flex; gap: 8px; }
+
 /* ── F5.10 merge dialog (book detail) — "Merge duplicates" redesign ──
  * Wide modal: pinned keeper rail + search + result rows with covers.
  * Three-zone flex column (head / scrolling body / foot). Replaces the

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -30,12 +30,19 @@
  *   addAnnotation(cfiRange, color)
  *   removeAnnotation(cfiRange)
  *   clearAnnotations()
+ *   requestToc()                    re-emits __omnibusOnToc
+ *   display(target)                 navigate to a TOC href or CFI
+ *   copyText(text)                  clipboard write
+ *   shareText(text)                 navigator.share, clipboard fallback
  *   destroy()
  *
  * Selection callback:
  *   - `__omnibusOnSelection(json)` — invoked when the user selects text,
- *     with { cfiRange, rect: { x, y, width } } where rect is in viewport
- *     coordinates.
+ *     with { cfiRange, text, rect: { x, y, width } } where rect is in
+ *     viewport coordinates.
+ * Table-of-contents callback:
+ *   - `__omnibusOnToc(json)` — invoked once the book is ready (and on
+ *     requestToc()), with a flat [{ label, href, level }] array.
  */
 (function () {
   "use strict";
@@ -171,6 +178,7 @@
         if (book.navigation && book.navigation.toc) {
           flattenToc(book.navigation.toc, tocFlat);
         }
+        emitToc();
         return book.locations.generate(1024);
       })
       .then(function () {
@@ -226,6 +234,7 @@
       };
       window.__omnibusOnSelection(JSON.stringify({
         cfiRange: cfiRange,
+        text: sel.toString(),
         rect: rect,
       }));
     });
@@ -323,6 +332,68 @@
     teardown();
   }
 
+  // Walk the nested TOC into a flat [{label, href, level}] list and hand it
+  // to the Rust side. Level is the nesting depth (0 = top), used to indent
+  // the contents drawer. Re-emittable on demand via requestToc().
+  function collectToc(items, level, out) {
+    if (!items) return;
+    for (var i = 0; i < items.length; i++) {
+      out.push({
+        label: (items[i].label || "").trim(),
+        href: items[i].href || "",
+        level: level,
+      });
+      if (items[i].subitems) collectToc(items[i].subitems, level + 1, out);
+    }
+  }
+
+  function emitToc() {
+    if (typeof window.__omnibusOnToc !== "function") return;
+    var out = [];
+    if (book && book.navigation && book.navigation.toc) {
+      collectToc(book.navigation.toc, 0, out);
+    }
+    try {
+      window.__omnibusOnToc(JSON.stringify(out));
+    } catch (e) {
+      /* ignore handler errors */
+    }
+  }
+
+  function requestToc() {
+    emitToc();
+  }
+
+  // Navigate to a TOC href or a CFI (highlight / bookmark target).
+  function display(target) {
+    if (!rendition || !target) return;
+    rendition.display(target);
+  }
+
+  function copyText(text) {
+    if (!text) return;
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text);
+      }
+    } catch (e) {
+      /* clipboard unavailable */
+    }
+  }
+
+  function shareText(text) {
+    if (!text) return;
+    try {
+      if (navigator.share) {
+        navigator.share({ text: text }).catch(function () {});
+      } else {
+        copyText(text);
+      }
+    } catch (e) {
+      copyText(text);
+    }
+  }
+
   window.OmnibusReader = {
     init: init,
     next: next,
@@ -336,6 +407,10 @@
     addAnnotation: addAnnotation,
     removeAnnotation: removeAnnotation,
     clearAnnotations: clearAnnotations,
+    requestToc: requestToc,
+    display: display,
+    copyText: copyText,
+    shareText: shareText,
     destroy: destroy,
   };
 })();

--- a/frontend/src/pages/reader/chrome_handlers.rs
+++ b/frontend/src/pages/reader/chrome_handlers.rs
@@ -7,14 +7,26 @@ use dioxus::prelude::*;
 #[cfg(not(feature = "mobile"))]
 use dioxus_router::use_navigator;
 
+use omnibus_shared::Highlight;
+
 use super::selection::SelectionData;
+
+/// Overlay-dismissal signals threaded into the Escape handler so a single
+/// Escape press peels back the topmost open overlay before navigating away.
+#[derive(Copy, Clone)]
+pub(super) struct OverlaySignals {
+    pub show_aa: Signal<bool>,
+    pub show_toc: Signal<bool>,
+    pub show_highlights: Signal<bool>,
+    pub note_target: Signal<Option<Highlight>>,
+}
 
 /// Build the `(on_back, on_prev, on_next, on_keydown)` handlers consumed
 /// by `ReaderLayout`. Each handler closes over the passed signals and
 /// (where applicable) the router navigator.
 pub(super) fn install_chrome_handlers(
     selection: Signal<Option<SelectionData>>,
-    show_aa: Signal<bool>,
+    overlays: OverlaySignals,
 ) -> (
     EventHandler<MouseEvent>,
     EventHandler<MouseEvent>,
@@ -33,7 +45,7 @@ pub(super) fn install_chrome_handlers(
         handle_keydown(
             evt,
             selection,
-            show_aa,
+            overlays,
             #[cfg(not(feature = "mobile"))]
             nav,
         );
@@ -62,12 +74,13 @@ fn advance_page(mut selection: Signal<Option<SelectionData>>, dir: Direction) {
 #[cfg(not(feature = "web"))]
 fn advance_page(_: Signal<Option<SelectionData>>, _: Direction) {}
 
-/// Reader keyboard map: arrows page the book; Escape closes a live
-/// selection, then the AA panel, then navigates back.
+/// Reader keyboard map: arrows page the book; Escape peels back the topmost
+/// overlay (selection → note composer → contents → highlights → AA panel)
+/// before navigating back.
 fn handle_keydown(
     evt: KeyboardEvent,
     selection: Signal<Option<SelectionData>>,
-    show_aa: Signal<bool>,
+    overlays: OverlaySignals,
     #[cfg(not(feature = "mobile"))] nav: dioxus_router::Navigator,
 ) {
     match evt.key() {
@@ -84,9 +97,18 @@ fn handle_keydown(
         Key::Escape => {
             evt.prevent_default();
             let mut selection = selection;
-            let mut show_aa = show_aa;
+            let mut show_aa = overlays.show_aa;
+            let mut show_toc = overlays.show_toc;
+            let mut show_highlights = overlays.show_highlights;
+            let mut note_target = overlays.note_target;
             if selection.read().is_some() {
                 selection.set(None);
+            } else if note_target.read().is_some() {
+                note_target.set(None);
+            } else if *show_toc.read() {
+                show_toc.set(false);
+            } else if *show_highlights.read() {
+                show_highlights.set(false);
             } else if *show_aa.read() {
                 show_aa.set(false);
             } else {

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -106,6 +106,9 @@ fn HighlightRow(highlight: Highlight, highlights: Signal<Vec<Highlight>>) -> Ele
     let note = highlight.note.clone();
     let cfi = highlight.epub_cfi_range.clone();
     let copy_src = highlight.text.clone().unwrap_or_default();
+    // Legacy highlights created before the text column have nothing to copy;
+    // disable the action rather than offer a silent no-op.
+    let has_text = highlight.text.is_some();
     let id = highlight.id;
 
     let on_delete = move |_| {
@@ -142,6 +145,7 @@ fn HighlightRow(highlight: Highlight, highlights: Signal<Vec<Highlight>>) -> Ele
                 button {
                     class: "rd-act sm",
                     r#type: "button",
+                    disabled: !has_text,
                     onclick: move |_| copy_text(&copy_src),
                     "Copy"
                 }

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -1,0 +1,158 @@
+//! Highlights & notes drawer for the reader. Lists every highlight for the
+//! open book, filterable by palette color. Clicking a row navigates to the
+//! highlight's CFI; rows also expose copy and delete actions.
+
+use dioxus::prelude::*;
+
+use omnibus_shared::{Highlight, HighlightColor};
+
+const PALETTE: [(HighlightColor, &str); 5] = [
+    (HighlightColor::Amber, "amber"),
+    (HighlightColor::Green, "green"),
+    (HighlightColor::Blue, "blue"),
+    (HighlightColor::Rose, "rose"),
+    (HighlightColor::Violet, "violet"),
+];
+
+/// Navigate the rendition to a CFI (web only).
+#[cfg_attr(not(feature = "web"), allow(unused_variables))]
+fn navigate_to(cfi: &str) {
+    #[cfg(feature = "web")]
+    {
+        let lit = serde_json::to_string(cfi).unwrap_or_else(|_| "\"\"".into());
+        super::reader_call("display", &lit);
+    }
+}
+
+/// Copy text to the clipboard via the glue (web only).
+#[cfg_attr(not(feature = "web"), allow(unused_variables))]
+fn copy_text(text: &str) {
+    #[cfg(feature = "web")]
+    {
+        let lit = serde_json::to_string(text).unwrap_or_else(|_| "\"\"".into());
+        super::reader_call("copyText", &lit);
+    }
+}
+
+#[component]
+pub(super) fn HighlightsDrawer(
+    highlights: Signal<Vec<Highlight>>,
+    on_close: EventHandler<()>,
+) -> Element {
+    let mut filter = use_signal(|| None::<HighlightColor>);
+
+    let all = highlights.read().clone();
+    let active = filter();
+    let shown: Vec<Highlight> = all
+        .iter()
+        .filter(|h| active.is_none() || active == Some(h.color))
+        .cloned()
+        .collect();
+
+    rsx! {
+        div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
+        div { class: "rd-drawer", "data-testid": "reader-highlights-drawer",
+            div { class: "rd-drawer-head",
+                h4 { class: "rd-drawer-title",
+                    "Highlights & notes "
+                    span { class: "rd-drawer-count", "{all.len()}" }
+                }
+                button {
+                    class: "rd-x",
+                    r#type: "button",
+                    "aria-label": "Close",
+                    onclick: move |_| on_close.call(()),
+                    "\u{00d7}"
+                }
+            }
+            div { class: "rd-filter-row",
+                button {
+                    class: if active.is_none() { "rd-chip on" } else { "rd-chip" },
+                    r#type: "button",
+                    onclick: move |_| filter.set(None),
+                    "All {all.len()}"
+                }
+                for (color, name) in PALETTE {
+                    button {
+                        key: "{name}",
+                        class: if active == Some(color) { "rd-chip on" } else { "rd-chip" },
+                        r#type: "button",
+                        "aria-label": "Filter {name}",
+                        onclick: move |_| filter.set(Some(color)),
+                        span { class: "rd-chip-dot", "data-color": "{name}" }
+                    }
+                }
+            }
+            div { class: "rd-drawer-body",
+                if shown.is_empty() {
+                    div { class: "rd-drawer-empty", "No highlights yet." }
+                } else {
+                    for h in shown.iter() {
+                        HighlightRow { key: "{h.id}", highlight: h.clone(), highlights }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn HighlightRow(highlight: Highlight, highlights: Signal<Vec<Highlight>>) -> Element {
+    let color = highlight.color.as_str();
+    let quote = highlight
+        .text
+        .clone()
+        .unwrap_or_else(|| "(highlighted passage)".to_string());
+    let note = highlight.note.clone();
+    let cfi = highlight.epub_cfi_range.clone();
+    let copy_src = highlight.text.clone().unwrap_or_default();
+    let id = highlight.id;
+
+    let on_delete = move |_| {
+        let mut highlights = highlights;
+        let cfi = cfi.clone();
+        spawn(async move {
+            if crate::data::delete_highlight("", id).await.is_ok() {
+                #[cfg(feature = "web")]
+                {
+                    let lit = serde_json::to_string(&cfi).unwrap_or_else(|_| "\"\"".into());
+                    super::reader_call("removeAnnotation", &lit);
+                }
+                let _ = &cfi;
+                highlights.write().retain(|h| h.id != id);
+            }
+        });
+    };
+
+    let nav_cfi = highlight.epub_cfi_range.clone();
+
+    rsx! {
+        div { class: "rd-hl-row", "data-testid": "reader-highlight-row",
+            style: "border-left-color: var(--hl-{color});",
+            button {
+                class: "rd-hl-quote",
+                r#type: "button",
+                onclick: move |_| navigate_to(&nav_cfi),
+                "\u{201c}{quote}\u{201d}"
+            }
+            if let Some(n) = note {
+                div { class: "rd-hl-note", "{n}" }
+            }
+            div { class: "rd-hl-actions",
+                button {
+                    class: "rd-act sm",
+                    r#type: "button",
+                    onclick: move |_| copy_text(&copy_src),
+                    "Copy"
+                }
+                button {
+                    class: "rd-act sm",
+                    r#type: "button",
+                    "data-testid": "highlight-delete",
+                    onclick: on_delete,
+                    "Delete"
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -9,6 +9,7 @@ use omnibus_shared::Highlight;
 
 use super::prefs::ReaderPrefs;
 use super::selection::SelectionData;
+use super::toc_drawer::TocEntry;
 use super::ReaderStatus;
 
 /// All the signals the reader needs to drive from JS callbacks; passed as
@@ -21,6 +22,7 @@ pub(crate) struct InteropSignals {
     pub loc: Signal<super::RelocateData>,
     pub selection: Signal<Option<SelectionData>>,
     pub highlights: Signal<Vec<Highlight>>,
+    pub toc: Signal<Vec<TocEntry>>,
 }
 
 /// Boxed list of the `__omnibusOn*` window callbacks. Held on the heap
@@ -50,6 +52,7 @@ pub(crate) fn install_reader_web_interop(uuid: String, prefs: ReaderPrefs, sigs:
         mut loc,
         mut selection,
         mut highlights,
+        mut toc,
     } = sigs;
 
     let uuid_for_mount = uuid.clone();
@@ -119,6 +122,11 @@ pub(crate) fn install_reader_web_interop(uuid: String, prefs: ReaderPrefs, sigs:
                     selection.set(Some(data));
                 }
             });
+            let on_toc = Closure::<dyn FnMut(String)>::new(move |json: String| {
+                if let Ok(entries) = serde_json::from_str::<Vec<TocEntry>>(&json) {
+                    toc.set(entries);
+                }
+            });
             let _ = js_sys::Reflect::set(
                 &window,
                 &JsValue::from_str("__omnibusOnStatus"),
@@ -129,7 +137,12 @@ pub(crate) fn install_reader_web_interop(uuid: String, prefs: ReaderPrefs, sigs:
                 &JsValue::from_str("__omnibusOnSelection"),
                 on_selection.as_ref().unchecked_ref(),
             );
-            *cb_holder.borrow_mut() = vec![relocate, on_status, on_selection];
+            let _ = js_sys::Reflect::set(
+                &window,
+                &JsValue::from_str("__omnibusOnToc"),
+                on_toc.as_ref().unchecked_ref(),
+            );
+            *cb_holder.borrow_mut() = vec![relocate, on_status, on_selection, on_toc];
         }
 
         let uuid_for_fetch = uuid.clone();

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -527,7 +527,7 @@ fn ReaderTopChrome(
                         width: "19", height: "19", view_box: "0 0 24 24",
                         fill: "none", stroke: "currentColor",
                         stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        path { d: "M4 19.5l1.6-4 8.2-8.2 3 3-8.2 8.2-4.6.0z" }
+                        path { d: "M4 19.5l1.6-4 8.2-8.2 3 3-8.2 8.2-4.6 0z" }
                         path { d: "M13.2 6.1l2.7-2.7a1.3 1.3 0 0 1 1.9 0l1.8 1.8a1.3 1.3 0 0 1 0 1.9l-2.7 2.7" }
                     }
                     if highlight_count > 0 {

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -7,10 +7,13 @@
 mod aa_panel;
 mod bootstrap;
 mod chrome_handlers;
+mod highlights_drawer;
 #[cfg(feature = "web")]
 mod interop;
+mod note_composer;
 mod prefs;
 mod selection;
+mod toc_drawer;
 mod typography;
 
 use dioxus::prelude::*;
@@ -22,10 +25,13 @@ use crate::data;
 use omnibus_shared::{EbookMetadata, Highlight, HighlightColor};
 
 use aa_panel::ReaderAaPanel;
+use highlights_drawer::HighlightsDrawer;
 #[cfg(feature = "web")]
 use interop::{install_reader_web_interop, InteropSignals};
+use note_composer::NoteComposer;
 use prefs::init_reader_prefs;
 use selection::{SelectionData, SelectionPopover};
+use toc_drawer::{TocDrawer, TocEntry};
 
 const JSZIP_JS: Asset = asset!("/assets/vendor/jszip.min.js");
 const EPUBJS_JS: Asset = asset!("/assets/vendor/epub.min.js");
@@ -62,6 +68,52 @@ pub(crate) struct RelocateData {
 fn reader_call(method: &str, arg_js: &str) {
     let js = format!("window.OmnibusReader && window.OmnibusReader.{method}({arg_js});");
     let _ = dioxus::document::eval(&js);
+}
+
+/// Optimistically annotate the selection, persist the highlight, and — when
+/// `open_note` — open the note composer on the created row. Shared by the
+/// swatch (highlight) and Note popover actions. Rolls the optimistic
+/// annotation back if the write fails.
+fn spawn_create_highlight(
+    uuid: String,
+    cfi: String,
+    color: HighlightColor,
+    text: String,
+    mut highlights: Signal<Vec<Highlight>>,
+    mut note_target: Signal<Option<Highlight>>,
+    open_note: bool,
+) {
+    #[cfg(feature = "web")]
+    {
+        let cfi_lit = serde_json::to_string(&cfi).unwrap_or_else(|_| "\"\"".into());
+        let color_lit =
+            serde_json::to_string(color.as_str()).unwrap_or_else(|_| "\"amber\"".into());
+        reader_call("addAnnotation", &format!("{cfi_lit}, {color_lit}"));
+    }
+    let create = omnibus_shared::CreateHighlight {
+        book_uuid: uuid,
+        epub_cfi_range: cfi.clone(),
+        color,
+        text: if text.is_empty() { None } else { Some(text) },
+    };
+    spawn(async move {
+        match data::create_highlight("", create).await {
+            Ok(h) => {
+                highlights.write().push(h.clone());
+                if open_note {
+                    note_target.set(Some(h));
+                }
+            }
+            Err(_) => {
+                #[cfg(feature = "web")]
+                {
+                    let cfi_lit = serde_json::to_string(&cfi).unwrap_or_else(|_| "\"\"".into());
+                    reader_call("removeAnnotation", &cfi_lit);
+                }
+                let _ = &cfi;
+            }
+        }
+    });
 }
 
 /// Extract `file_id` from the current URL's query string (`?file_id=N`),
@@ -132,6 +184,10 @@ pub fn BookReadPage(uuid: String) -> Element {
     let show_aa = use_signal(|| false);
     let selection: Signal<Option<SelectionData>> = use_signal(|| None);
     let highlights: Signal<Vec<Highlight>> = use_signal(Vec::new);
+    let toc: Signal<Vec<TocEntry>> = use_signal(Vec::new);
+    let show_toc = use_signal(|| false);
+    let show_highlights = use_signal(|| false);
+    let note_target: Signal<Option<Highlight>> = use_signal(|| None);
     let loc = use_signal(RelocateData::default);
     let book_meta = use_book_metadata(uuid.clone());
 
@@ -144,11 +200,19 @@ pub fn BookReadPage(uuid: String) -> Element {
             loc,
             selection,
             highlights,
+            toc,
         },
     );
 
-    let (on_back, on_prev, on_next, on_keydown) =
-        chrome_handlers::install_chrome_handlers(selection, show_aa);
+    let (on_back, on_prev, on_next, on_keydown) = chrome_handlers::install_chrome_handlers(
+        selection,
+        chrome_handlers::OverlaySignals {
+            show_aa,
+            show_toc,
+            show_highlights,
+            note_target,
+        },
+    );
 
     let (page_str, chapter_str) = format_progress_labels(&loc.read());
     let pct = loc.read().pct;
@@ -177,6 +241,10 @@ pub fn BookReadPage(uuid: String) -> Element {
             show_aa,
             selection,
             highlights,
+            toc,
+            show_toc,
+            show_highlights,
+            note_target,
             on_keydown,
             on_back,
             on_prev,
@@ -198,11 +266,16 @@ fn ReaderLayout(
     show_aa: Signal<bool>,
     selection: Signal<Option<SelectionData>>,
     highlights: Signal<Vec<Highlight>>,
+    toc: Signal<Vec<TocEntry>>,
+    show_toc: Signal<bool>,
+    show_highlights: Signal<bool>,
+    note_target: Signal<Option<Highlight>>,
     on_keydown: EventHandler<KeyboardEvent>,
     on_back: EventHandler<MouseEvent>,
     on_prev: EventHandler<MouseEvent>,
     on_next: EventHandler<MouseEvent>,
 ) -> Element {
+    let highlight_count = highlights.read().len();
     rsx! {
         document::Script { src: JSZIP_JS }
         document::Script { src: EPUBJS_JS }
@@ -220,10 +293,31 @@ fn ReaderLayout(
                 book_title: book_title.clone(),
                 chapter_title: chapter_title.clone(),
                 show_aa: show_aa(),
+                toc_active: show_toc(),
+                highlights_active: show_highlights(),
+                highlight_count,
                 on_back,
                 on_toggle_aa: move |_| {
                     let mut show_aa = show_aa;
                     show_aa.set(!show_aa());
+                },
+                on_toggle_toc: move |_| {
+                    let mut show_toc = show_toc;
+                    let mut show_highlights = show_highlights;
+                    let next = !show_toc();
+                    show_toc.set(next);
+                    if next {
+                        show_highlights.set(false);
+                    }
+                },
+                on_toggle_highlights: move |_| {
+                    let mut show_toc = show_toc;
+                    let mut show_highlights = show_highlights;
+                    let next = !show_highlights();
+                    show_highlights.set(next);
+                    if next {
+                        show_toc.set(false);
+                    }
                 },
             }
 
@@ -249,51 +343,112 @@ fn ReaderLayout(
             }
 
             if let Some(sel) = selection.read().as_ref() {
-                SelectionPopover {
-                    sel_rect_x: sel.rect.x,
-                    sel_rect_y: sel.rect.y,
-                    sel_rect_width: sel.rect.width,
-                    sel_cfi: sel.cfi_range.clone(),
-                    on_dismiss: move |_| {
-                        let mut selection = selection;
-                        selection.set(None);
-                    },
-                    on_highlight: move |(cfi, color): (String, HighlightColor)| {
-                        #[cfg(feature = "web")]
-                        {
-                            let cfi_lit = serde_json::to_string(&cfi)
-                                .unwrap_or_else(|_| "\"\"".into());
-                            let color_lit = serde_json::to_string(color.as_str())
-                                .unwrap_or_else(|_| "\"amber\"".into());
-                            reader_call("addAnnotation", &format!("{cfi_lit}, {color_lit}"));
-                        }
-
-                        let create = omnibus_shared::CreateHighlight {
-                            book_uuid: uuid.clone(),
-                            epub_cfi_range: cfi.clone(),
-                            color,
-                        };
-                        #[cfg(feature = "web")]
-                        let cfi_rollback = cfi.clone();
-                        let mut selection = selection;
-                        let mut highlights = highlights;
-                        selection.set(None);
-                        spawn(async move {
-                            if let Ok(h) = data::create_highlight("", create).await {
-                                highlights.write().push(h);
-                            } else {
-                                // The annotation was added optimistically above;
-                                // if the write didn't land, roll it back so a
-                                // failed create doesn't leave a highlight that
-                                // vanishes on the next reload.
+                {
+                    let uuid_pop = uuid.clone();
+                    rsx! {
+                        SelectionPopover {
+                            sel_rect_x: sel.rect.x,
+                            sel_rect_y: sel.rect.y,
+                            sel_rect_width: sel.rect.width,
+                            sel_cfi: sel.cfi_range.clone(),
+                            sel_text: sel.text.clone(),
+                            on_dismiss: move |_| {
+                                let mut selection = selection;
+                                selection.set(None);
+                            },
+                            on_highlight: {
+                                let uuid_pop = uuid_pop.clone();
+                                move |(cfi, color, text): (String, HighlightColor, String)| {
+                                    let mut selection = selection;
+                                    selection.set(None);
+                                    spawn_create_highlight(
+                                        uuid_pop.clone(), cfi, color, text,
+                                        highlights, note_target, false,
+                                    );
+                                }
+                            },
+                            on_note: {
+                                let uuid_pop = uuid_pop.clone();
+                                move |(cfi, text): (String, String)| {
+                                    let mut selection = selection;
+                                    selection.set(None);
+                                    spawn_create_highlight(
+                                        uuid_pop.clone(), cfi, HighlightColor::Amber, text,
+                                        highlights, note_target, true,
+                                    );
+                                }
+                            },
+                            on_copy: move |text: String| {
                                 #[cfg(feature = "web")]
                                 {
-                                    let cfi_lit = serde_json::to_string(&cfi_rollback)
+                                    let lit = serde_json::to_string(&text)
                                         .unwrap_or_else(|_| "\"\"".into());
-                                    reader_call("removeAnnotation", &cfi_lit);
+                                    reader_call("copyText", &lit);
                                 }
-                            }
-                        });
+                                let _ = &text;
+                                let mut selection = selection;
+                                selection.set(None);
+                            },
+                            on_share: move |text: String| {
+                                #[cfg(feature = "web")]
+                                {
+                                    let lit = serde_json::to_string(&text)
+                                        .unwrap_or_else(|_| "\"\"".into());
+                                    reader_call("shareText", &lit);
+                                }
+                                let _ = &text;
+                                let mut selection = selection;
+                                selection.set(None);
+                            },
+                        }
+                    }
+                }
+            }
+
+            if show_toc() {
+                TocDrawer {
+                    entries: toc.read().clone(),
+                    current_title: chapter_title.clone(),
+                    on_navigate: move |href: String| {
+                        #[cfg(feature = "web")]
+                        {
+                            let lit = serde_json::to_string(&href).unwrap_or_else(|_| "\"\"".into());
+                            reader_call("display", &lit);
+                        }
+                        let _ = &href;
+                        let mut show_toc = show_toc;
+                        show_toc.set(false);
+                    },
+                    on_close: move |_| {
+                        let mut show_toc = show_toc;
+                        show_toc.set(false);
+                    },
+                }
+            }
+
+            if show_highlights() {
+                HighlightsDrawer {
+                    highlights,
+                    on_close: move |_| {
+                        let mut show_highlights = show_highlights;
+                        show_highlights.set(false);
+                    },
+                }
+            }
+
+            if let Some(h) = note_target.read().clone() {
+                NoteComposer {
+                    highlight: h,
+                    on_saved: move |(id, note): (i64, Option<String>)| {
+                        let mut highlights = highlights;
+                        let idx = highlights.read().iter().position(|x| x.id == id);
+                        if let Some(i) = idx {
+                            highlights.write()[i].note = note;
+                        }
+                    },
+                    on_close: move |_| {
+                        let mut note_target = note_target;
+                        note_target.set(None);
                     },
                 }
             }
@@ -307,8 +462,13 @@ fn ReaderTopChrome(
     book_title: String,
     chapter_title: String,
     show_aa: bool,
+    toc_active: bool,
+    highlights_active: bool,
+    highlight_count: usize,
     on_back: EventHandler<MouseEvent>,
     on_toggle_aa: EventHandler<MouseEvent>,
+    on_toggle_toc: EventHandler<MouseEvent>,
+    on_toggle_highlights: EventHandler<MouseEvent>,
 ) -> Element {
     rsx! {
         div {
@@ -337,12 +497,42 @@ fn ReaderTopChrome(
             div {
                 style: "display:flex; align-items:center; gap:2px;",
                 button {
+                    class: if toc_active { "rd-tool on" } else { "rd-tool" },
+                    r#type: "button",
+                    "data-testid": "reader-toc",
+                    "aria-label": "Contents",
+                    onclick: on_toggle_toc,
+                    svg {
+                        width: "19", height: "19", view_box: "0 0 24 24",
+                        fill: "none", stroke: "currentColor",
+                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                        path { d: "M4 6h16M4 12h16M4 18h11" }
+                    }
+                }
+                button {
                     class: if show_aa { "rd-tool rd-aa on" } else { "rd-tool rd-aa" },
                     r#type: "button",
                     "data-testid": "reader-aa",
                     "aria-label": "Display settings",
                     onclick: on_toggle_aa,
                     "Aa"
+                }
+                button {
+                    class: if highlights_active { "rd-tool on" } else { "rd-tool" },
+                    r#type: "button",
+                    "data-testid": "reader-highlights",
+                    "aria-label": "Highlights and notes",
+                    onclick: on_toggle_highlights,
+                    svg {
+                        width: "19", height: "19", view_box: "0 0 24 24",
+                        fill: "none", stroke: "currentColor",
+                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                        path { d: "M4 19.5l1.6-4 8.2-8.2 3 3-8.2 8.2-4.6.0z" }
+                        path { d: "M13.2 6.1l2.7-2.7a1.3 1.3 0 0 1 1.9 0l1.8 1.8a1.3 1.3 0 0 1 0 1.9l-2.7 2.7" }
+                    }
+                    if highlight_count > 0 {
+                        span { class: "rd-badge", "{highlight_count}" }
+                    }
                 }
                 button {
                     class: "rd-tool",

--- a/frontend/src/pages/reader/note_composer.rs
+++ b/frontend/src/pages/reader/note_composer.rs
@@ -1,0 +1,70 @@
+//! Note composer for a highlight. A small centered card (with scrim) holding
+//! a markdown-capable textarea; saving persists via `update_highlight_note`
+//! and reconciles the in-memory highlights list through `on_saved`.
+
+use dioxus::prelude::*;
+
+use omnibus_shared::Highlight;
+
+#[component]
+pub(super) fn NoteComposer(
+    highlight: Highlight,
+    on_saved: EventHandler<(i64, Option<String>)>,
+    on_close: EventHandler<()>,
+) -> Element {
+    let id = highlight.id;
+    let mut draft = use_signal(|| highlight.note.clone().unwrap_or_default());
+    let quote = highlight
+        .text
+        .clone()
+        .unwrap_or_else(|| "your highlight".to_string());
+
+    let on_save = move |_| {
+        let text = draft.peek().trim().to_string();
+        let note = if text.is_empty() { None } else { Some(text) };
+        let note_for_event = note.clone();
+        spawn(async move {
+            if crate::data::update_highlight_note("", id, note.clone())
+                .await
+                .is_ok()
+            {
+                on_saved.call((id, note_for_event));
+                on_close.call(());
+            }
+        });
+    };
+
+    rsx! {
+        div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
+        div { class: "rd-note-composer", "data-testid": "reader-note-composer",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
+            div { class: "rd-note-quote", "\u{201c}{quote}\u{201d}" }
+            textarea {
+                class: "rd-note-input",
+                "data-testid": "reader-note-input",
+                placeholder: "Add a note\u{2026} (markdown ok)",
+                autofocus: true,
+                value: "{draft}",
+                oninput: move |e| draft.set(e.value()),
+            }
+            div { class: "rd-note-actions",
+                span { class: "rd-note-hint", "markdown ok" }
+                div { class: "rd-note-buttons",
+                    button {
+                        class: "btn ghost sm",
+                        r#type: "button",
+                        onclick: move |_| on_close.call(()),
+                        "Cancel"
+                    }
+                    button {
+                        class: "btn primary sm",
+                        r#type: "button",
+                        "data-testid": "reader-note-save",
+                        onclick: on_save,
+                        "Save note"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/pages/reader/selection.rs
+++ b/frontend/src/pages/reader/selection.rs
@@ -10,6 +10,8 @@ use omnibus_shared::HighlightColor;
 pub(crate) struct SelectionData {
     #[serde(rename = "cfiRange")]
     pub(crate) cfi_range: String,
+    #[serde(default)]
+    pub(crate) text: String,
     pub(crate) rect: SelectionRect,
 }
 
@@ -21,18 +23,23 @@ pub(crate) struct SelectionRect {
     pub(crate) width: f64,
 }
 
-/// Floating popover shown over a text selection with highlight color swatches.
+/// Floating popover shown over a text selection: highlight color swatches
+/// plus Note / Copy / Share actions.
 #[component]
 pub(crate) fn SelectionPopover(
     sel_rect_x: f64,
     sel_rect_y: f64,
     sel_rect_width: f64,
     sel_cfi: String,
+    sel_text: String,
     on_dismiss: EventHandler<MouseEvent>,
-    on_highlight: EventHandler<(String, HighlightColor)>,
+    on_highlight: EventHandler<(String, HighlightColor, String)>,
+    on_note: EventHandler<(String, String)>,
+    on_copy: EventHandler<String>,
+    on_share: EventHandler<String>,
 ) -> Element {
     let top = (sel_rect_y - 52.0).max(8.0);
-    let left = (sel_rect_x + sel_rect_width / 2.0 - 90.0).clamp(8.0, 600.0);
+    let left = (sel_rect_x + sel_rect_width / 2.0 - 150.0).clamp(8.0, 560.0);
     let style = format!("top:{top}px; left:{left}px;");
 
     let colors = [
@@ -54,16 +61,49 @@ pub(crate) fn SelectionPopover(
                 for (color, name) in colors {
                     {
                         let cfi = sel_cfi.clone();
+                        let text = sel_text.clone();
                         rsx! {
                             button {
                                 class: "rd-swatch",
                                 r#type: "button",
                                 "data-color": "{name}",
                                 "aria-label": "Highlight {name}",
-                                onclick: move |_| on_highlight.call((cfi.clone(), color)),
+                                onclick: move |_| on_highlight.call((cfi.clone(), color, text.clone())),
                             }
                         }
                     }
+                }
+                span { class: "rd-pop-div" }
+                button {
+                    class: "rd-act",
+                    r#type: "button",
+                    "data-testid": "selection-note",
+                    onclick: {
+                        let cfi = sel_cfi.clone();
+                        let text = sel_text.clone();
+                        move |_| on_note.call((cfi.clone(), text.clone()))
+                    },
+                    "Note"
+                }
+                button {
+                    class: "rd-act",
+                    r#type: "button",
+                    "data-testid": "selection-copy",
+                    onclick: {
+                        let text = sel_text.clone();
+                        move |_| on_copy.call(text.clone())
+                    },
+                    "Copy"
+                }
+                button {
+                    class: "rd-act",
+                    r#type: "button",
+                    "data-testid": "selection-share",
+                    onclick: {
+                        let text = sel_text.clone();
+                        move |_| on_share.call(text.clone())
+                    },
+                    "Share"
                 }
             }
         }

--- a/frontend/src/pages/reader/toc_drawer.rs
+++ b/frontend/src/pages/reader/toc_drawer.rs
@@ -1,0 +1,70 @@
+//! Table-of-contents drawer for the reader. The flat TOC arrives from the
+//! epub.js glue via the `__omnibusOnToc` callback (registered in `interop`);
+//! clicking an entry navigates the rendition to that href.
+
+use dioxus::prelude::*;
+
+/// One flattened table-of-contents entry from the glue. `level` is the
+/// nesting depth (0 = top) used to indent nested chapters.
+#[derive(Clone, Default, PartialEq, serde::Deserialize)]
+pub(crate) struct TocEntry {
+    pub label: String,
+    pub href: String,
+    #[serde(default)]
+    pub level: u32,
+}
+
+/// Right-side contents drawer. `current_title` highlights the entry matching
+/// the reader's current chapter.
+#[component]
+pub(super) fn TocDrawer(
+    entries: Vec<TocEntry>,
+    current_title: String,
+    on_navigate: EventHandler<String>,
+    on_close: EventHandler<()>,
+) -> Element {
+    rsx! {
+        div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
+        div { class: "rd-drawer", "data-testid": "reader-toc-drawer",
+            div { class: "rd-drawer-head",
+                h4 { class: "rd-drawer-title", "Contents" }
+                button {
+                    class: "rd-x",
+                    r#type: "button",
+                    "aria-label": "Close",
+                    onclick: move |_| on_close.call(()),
+                    "\u{00d7}"
+                }
+            }
+            div { class: "rd-drawer-body",
+                if entries.is_empty() {
+                    div { class: "rd-drawer-empty", "No table of contents." }
+                } else {
+                    for entry in entries.iter() {
+                        {
+                            let is_current = !current_title.is_empty()
+                                && entry.label == current_title;
+                            let href = entry.href.clone();
+                            let row_class = if is_current {
+                                "rd-toc-row current"
+                            } else {
+                                "rd-toc-row"
+                            };
+                            let indent = format!("padding-left:{}px;", 14 + entry.level * 16);
+                            rsx! {
+                                button {
+                                    class: "{row_class}",
+                                    style: "{indent}",
+                                    r#type: "button",
+                                    "data-testid": "reader-toc-row",
+                                    onclick: move |_| on_navigate.call(href.clone()),
+                                    "{entry.label}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/highlight.rs
+++ b/shared/src/highlight.rs
@@ -55,6 +55,10 @@ pub struct Highlight {
     pub epub_cfi_range: String,
     pub color: HighlightColor,
     pub note: Option<String>,
+    /// The highlighted prose. `None` for highlights created before the text
+    /// column shipped (migration 0030).
+    #[serde(default)]
+    pub text: Option<String>,
     pub created_at: i64,
 }
 
@@ -64,6 +68,10 @@ pub struct CreateHighlight {
     pub book_uuid: String,
     pub epub_cfi_range: String,
     pub color: HighlightColor,
+    /// The selected prose at creation time. Optional so older clients (and
+    /// the mobile REST body) can omit it.
+    #[serde(default)]
+    pub text: Option<String>,
 }
 
 impl CreateHighlight {
@@ -71,6 +79,10 @@ impl CreateHighlight {
     /// rarely exceeds a few hundred bytes; 4 KiB is a generous ceiling that
     /// stops an authed client from persisting megabyte-sized blobs per row.
     pub const EPUB_CFI_RANGE_MAX_LEN: usize = 4096;
+
+    /// Maximum length (in chars) of the stored highlighted text. A single
+    /// selection is at most a few paragraphs; 8 KiB is a generous ceiling.
+    pub const TEXT_MAX_LEN: usize = 8192;
 
     /// Validate field lengths and required-ness. Call at the handler
     /// boundary before persisting so over-long inputs surface as 400
@@ -90,6 +102,11 @@ impl CreateHighlight {
                 "epub_cfi_range exceeds {} characters",
                 Self::EPUB_CFI_RANGE_MAX_LEN
             ));
+        }
+        if let Some(ref text) = self.text {
+            if text.chars().count() > Self::TEXT_MAX_LEN {
+                return Err(format!("text exceeds {} characters", Self::TEXT_MAX_LEN));
+            }
         }
         Ok(())
     }

--- a/shared/src/highlight/tests.rs
+++ b/shared/src/highlight/tests.rs
@@ -7,6 +7,7 @@ fn ok_create(cfi: &str) -> CreateHighlight {
         book_uuid: "uuid-1".into(),
         epub_cfi_range: cfi.into(),
         color: HighlightColor::Amber,
+        text: None,
     }
 }
 
@@ -48,6 +49,21 @@ fn create_highlight_validate_rejects_empty_cfi() {
         .validate()
         .expect_err("blank epub_cfi_range must be rejected");
     assert!(err.contains("epub_cfi_range"), "got: {err}");
+}
+
+#[test]
+fn create_highlight_validate_accepts_text_at_max_len() {
+    let mut c = ok_create("epubcfi(/6/4)");
+    c.text = Some("t".repeat(CreateHighlight::TEXT_MAX_LEN));
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn create_highlight_validate_rejects_text_over_max_len() {
+    let mut c = ok_create("epubcfi(/6/4)");
+    c.text = Some("t".repeat(CreateHighlight::TEXT_MAX_LEN + 1));
+    let err = c.validate().expect_err("over-long text must be rejected");
+    assert!(err.contains("text"), "got: {err}");
 }
 
 #[test]

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../fixtures/test";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { expectMutation } from "../utils/api";
 import { fetchBookUuidByTitle } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
 import { fixturesDir, seedLibrary } from "../utils/seed";
@@ -11,8 +12,11 @@ test.beforeAll(async ({ request }) => {
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
 });
 
-// A fixture with predictable, distinctive metadata to drive both tests.
+// A fixture with predictable, distinctive metadata to drive most tests.
 const TARGET = FIXTURE_BOOKS.find((b) => b.slug === "alpha")!;
+// A separate book for the highlight action test so seeding/deleting highlights
+// doesn't pollute the empty-state assertions on TARGET (tests run in parallel).
+const HL_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "beta")!;
 
 test("renders the reader layout", async ({ page, request }) => {
   // Deep-link straight to the immersive reader by the book's stable uuid,
@@ -64,6 +68,50 @@ test("opens the contents and highlights drawers from the top chrome", async ({
   // Contents drawer opens from the top chrome.
   await page.getByTestId("reader-toc").click();
   await expect(page.getByTestId("reader-toc-drawer")).toBeVisible();
+});
+
+test("seeds a highlight and deletes it from the highlights drawer", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, HL_BOOK.title);
+
+  // Seed a highlight via the REST API (bearer-authed request fixture) so the
+  // reader loads it into the drawer on mount. A unique quote keeps the test
+  // robust against the shared, persistent dev DB.
+  const quote = `seeded passage ${Date.now()}`;
+  const created = await request.post("/api/highlights", {
+    data: {
+      book_uuid: uuid,
+      epub_cfi_range: "epubcfi(/6/4!/4/2,/1:0,/1:40)",
+      color: "amber",
+      text: quote,
+    },
+  });
+  expect(created.status(), "seed highlight").toBe(200);
+
+  await gotoReady(page, `/read/${uuid}`);
+  await expect(page.getByTestId("reader-viewer")).toBeVisible();
+
+  // Open the highlights drawer — the seeded highlight is listed.
+  await page.getByTestId("reader-highlights").click();
+  await expect(page.getByTestId("reader-highlights-drawer")).toBeVisible();
+  const row = page
+    .getByTestId("reader-highlight-row")
+    .filter({ hasText: quote });
+  await expect(row).toHaveCount(1);
+
+  // Delete it — the delete RPC must fire, and the row disappears.
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: /\/api\/rpc\/highlights\/delete(?:\?|$)/,
+      expectedStatus: 200,
+    },
+    async () => row.getByTestId("highlight-delete").click(),
+  );
+  await expect(page.getByText(quote)).toHaveCount(0);
 });
 
 test("opens the reader from the book detail Read action", async ({ page, request }) => {

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -27,9 +27,11 @@ test("renders the reader layout", async ({ page, request }) => {
   // SSR markup and are robust to that.
   await expect(page.getByTestId("reader-viewer")).toBeVisible();
 
-  // Top chrome: back button, Aa display settings, bookmark.
+  // Top chrome: back, contents, Aa display settings, highlights, bookmark.
   await expect(page.getByTestId("reader-back")).toBeVisible();
+  await expect(page.getByTestId("reader-toc")).toBeVisible();
   await expect(page.getByTestId("reader-aa")).toBeVisible();
+  await expect(page.getByTestId("reader-highlights")).toBeVisible();
   await expect(page.getByTestId("reader-bookmark")).toBeVisible();
 
   // Page-turn gutters.
@@ -40,6 +42,28 @@ test("renders the reader layout", async ({ page, request }) => {
   await page.getByTestId("reader-aa").click();
   await expect(page.getByTestId("reader-font-decrease")).toBeVisible();
   await expect(page.getByTestId("reader-font-increase")).toBeVisible();
+});
+
+test("opens the contents and highlights drawers from the top chrome", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await gotoReady(page, `/read/${uuid}`);
+  await expect(page.getByTestId("reader-viewer")).toBeVisible();
+
+  // Highlights drawer opens with the (empty) palette filter rail.
+  await page.getByTestId("reader-highlights").click();
+  await expect(page.getByTestId("reader-highlights-drawer")).toBeVisible();
+  await expect(page.getByText("No highlights yet")).toBeVisible();
+
+  // Escape peels the drawer back (its scrim otherwise covers the chrome).
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("reader-highlights-drawer")).toHaveCount(0);
+
+  // Contents drawer opens from the top chrome.
+  await page.getByTestId("reader-toc").click();
+  await expect(page.getByTestId("reader-toc-drawer")).toBeVisible();
 });
 
 test("opens the reader from the book detail Read action", async ({ page, request }) => {


### PR DESCRIPTION
## Summary
- Selection popover gains Note / Copy / Share actions; a new note composer is wired to the existing highlight-note API.
- New right-side **Contents** drawer (from the epub.js TOC via a `__omnibusOnToc` callback) and a color-filterable **Highlights & notes** drawer (navigate / copy / delete).
- Stores the highlighted prose (migration 0029 adds `highlights.text`, nullable, no backfill) so the drawer — and the upcoming quote cards — can render the passage without re-opening the book.

## Test plan
- [x] `just test` (full matrix: shared / db / server / frontend-server)
- [x] `cargo check --target wasm32-unknown-unknown --features web` + `just lint`
- [x] Playwright (live server): top-chrome buttons, Contents + Highlights drawers, and Escape dismissal pass

## Notes
- Stacked on `u/sloan/audiobook-bookmarks-sleep-2`. Migration 0029 is forward-only and nullable.