### PR TITLE
feat: audiobook bookmarks + sleep timer (F2.3b PR4 + PR5)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -2507,6 +2507,92 @@ a.idx-letter-on:focus-visible {
   color: var(--ink-3); max-width: 28ch; line-height: 1.5;
 }
 
+/* Bookmark drawer header actions + rows (PR4) */
+.lp-drawer-head-actions { display: flex; align-items: center; gap: 8px; }
+
+.lp-bm-row {
+  display: grid; grid-template-columns: 1fr auto;
+  grid-template-areas: "main del" "note del";
+  gap: 2px 8px; align-items: center;
+  padding: 10px 12px; border-radius: var(--r-md, 10px);
+  margin-bottom: 4px; cursor: default;
+  box-shadow: inset 0 0 0 1px transparent;
+  transition: box-shadow .15s, background .15s;
+}
+.lp-bm-row.fresh {
+  background: color-mix(in oklch, var(--accent) 14%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent) 35%, transparent);
+}
+.lp-bm-main {
+  grid-area: main; display: flex; align-items: center; gap: 10px;
+  background: transparent; border: 0; cursor: pointer; padding: 0;
+  color: var(--ink-0); text-align: left; min-width: 0;
+}
+.lp-bm-flag { color: var(--accent); flex: 0 0 auto; }
+.lp-bm-label {
+  font-family: var(--serif); font-style: italic; font-size: 16px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.lp-bm-time {
+  font-family: var(--mono); font-size: 11px; color: var(--ink-3);
+  margin-left: auto; flex: 0 0 auto;
+}
+.lp-bm-note { grid-area: note; }
+.lp-bm-note-text {
+  background: transparent; border: 0; cursor: text; padding: 2px 0;
+  font-size: 12.5px; color: var(--ink-2); text-align: left;
+}
+.lp-bm-note-empty { color: var(--ink-3); font-style: italic; }
+.lp-bm-note-input {
+  width: 100%; background: var(--bg-2); color: var(--ink-0);
+  border: 1px solid var(--line-2); border-radius: 8px;
+  padding: 6px 9px; font-size: 12.5px;
+}
+.lp-bm-del {
+  grid-area: del; width: 28px; height: 28px; border-radius: 8px;
+  background: transparent; border: 1px solid transparent;
+  color: var(--ink-3); cursor: pointer; font-size: 18px; line-height: 1;
+  transition: background .15s, color .15s;
+}
+.lp-bm-del:hover { background: var(--bg-2); color: var(--ink-0); }
+
+/* Bookmark confirmation toast (PR4) */
+.lp-toast {
+  position: absolute; top: 86px; left: 50%; transform: translateX(-50%);
+  z-index: 50; display: flex; align-items: center; gap: 12px;
+  padding: 12px 18px; border-radius: 999px;
+  background: var(--accent); color: var(--accent-ink);
+  box-shadow: 0 18px 40px -10px color-mix(in oklch, var(--accent) 60%, transparent);
+}
+.lp-toast-icon { font-size: 16px; }
+.lp-toast-text { font-weight: 600; font-size: 13.5px; }
+.lp-toast-meta { font-family: var(--mono); font-size: 12px; opacity: .8; }
+
+/* Sleep-timer fade toggle (PR5) */
+.lp-sleep-fade {
+  width: 100%; height: 44px; margin-top: 8px;
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 14px; font-size: 13px; cursor: pointer;
+  background: var(--bg-2); color: var(--ink-1);
+  border: 1px solid var(--line-2); border-radius: 10px;
+  transition: background .15s;
+}
+.lp-sleep-fade:hover { background: var(--bg-3); }
+.lp-sleep-fade-track {
+  width: 40px; height: 23px; border-radius: 999px;
+  background: var(--bg-3); position: relative; flex: 0 0 auto;
+  transition: background .15s;
+}
+.lp-sleep-fade.on .lp-sleep-fade-track { background: var(--accent); }
+.lp-sleep-fade-thumb {
+  position: absolute; top: 2.5px; left: 2.5px;
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--ink-2); transition: transform .15s, background .15s;
+}
+.lp-sleep-fade.on .lp-sleep-fade-thumb {
+  transform: translateX(17px); background: var(--accent-ink);
+}
+
 /* Overlay status (failed / preparing) */
 .lp-overlay {
   position: absolute; inset: 0; z-index: 10;

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -29,6 +29,8 @@ use dioxus_router::Link;
 use crate::{use_playback, Route};
 
 #[cfg(not(feature = "mobile"))]
+mod bookmarks;
+#[cfg(not(feature = "mobile"))]
 mod bookmarks_drawer;
 #[cfg(feature = "web")]
 mod bootstrap;
@@ -45,6 +47,8 @@ mod mini_dock;
 mod overlays;
 #[cfg(not(feature = "mobile"))]
 mod ready_player;
+#[cfg(not(feature = "mobile"))]
+mod sleep;
 #[cfg(not(feature = "mobile"))]
 mod sleep_panel;
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/pages/listen/bookmarks.rs
+++ b/frontend/src/pages/listen/bookmarks.rs
@@ -1,0 +1,194 @@
+//! Bookmark state for the listen page.
+//!
+//! Owns the loaded list, the freshly-created id (for the accent ring), and
+//! the confirmation toast. Pure helpers derive the chapter label and toast
+//! text from a bookmark's stored position. `ready_player` drives creation;
+//! `bookmarks_drawer` renders the list.
+
+#![cfg(not(feature = "mobile"))]
+
+use dioxus::prelude::*;
+use omnibus_shared::{Bookmark, ChapterInfo};
+
+use super::helpers::format_hms;
+use super::ready_player::chapter_index_for_elapsed;
+
+/// Transient "Bookmark saved" toast payload.
+#[derive(Clone, PartialEq, Eq)]
+pub(super) struct BookmarkToast {
+    pub time_label: String,
+    pub chapter_label: String,
+}
+
+/// Parse a bookmark's opaque position token as audiobook seconds.
+pub(super) fn bookmark_position_seconds(b: &Bookmark) -> f64 {
+    b.position.parse::<f64>().unwrap_or(0.0)
+}
+
+/// Human chapter label for a position, e.g. "Ch. 14 · A Sea of Glass and Fire".
+/// Falls back to a bare ordinal, then a generic label when no chapters exist.
+pub(super) fn chapter_label_at(position_secs: f64, chapters: &[ChapterInfo]) -> String {
+    if chapters.is_empty() {
+        return "Bookmark".to_string();
+    }
+    let idx = chapter_index_for_elapsed(chapters, position_secs);
+    match chapters.get(idx) {
+        Some(c) if !c.title.is_empty() => format!("Ch. {} \u{00b7} {}", idx + 1, c.title),
+        Some(_) => format!("Chapter {}", idx + 1),
+        None => "Bookmark".to_string(),
+    }
+}
+
+/// Bookmark-state handle returned by [`use_bookmarks`]. Cheap to copy.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct BookmarksController {
+    pub list: Signal<Vec<Bookmark>>,
+    pub fresh_id: Signal<Option<i64>>,
+    pub toast: Signal<Option<BookmarkToast>>,
+    uuid: Signal<String>,
+}
+
+impl BookmarksController {
+    /// Create a bookmark at `position_secs`, push it onto the list, flag it as
+    /// fresh, and raise an auto-dismissing toast. Web-only side effects.
+    pub fn create(&self, position_secs: f64, chapters: &[ChapterInfo]) {
+        let _chapter_label = chapter_label_at(position_secs, chapters);
+        let _time_label = format_hms(position_secs);
+        #[cfg(feature = "web")]
+        {
+            let uuid = self.uuid.peek().clone();
+            let mut list = self.list;
+            let mut fresh_id = self.fresh_id;
+            let mut toast = self.toast;
+            let input = omnibus_shared::CreateBookmark {
+                book_uuid: uuid,
+                position: position_secs.to_string(),
+                title: None,
+            };
+            spawn(async move {
+                if let Ok(b) = crate::data::create_bookmark("", input).await {
+                    fresh_id.set(Some(b.id));
+                    list.write().push(b);
+                    toast.set(Some(BookmarkToast {
+                        time_label: _time_label,
+                        chapter_label: _chapter_label,
+                    }));
+                    gloo_timers::future::sleep(std::time::Duration::from_secs(3)).await;
+                    toast.set(None);
+                }
+            });
+        }
+    }
+
+    /// Persist a new title/note on a bookmark and update the local row.
+    pub fn rename(&self, id: i64, title: Option<String>) {
+        #[cfg(feature = "web")]
+        {
+            let mut list = self.list;
+            let title_for_local = title.clone();
+            spawn(async move {
+                if crate::data::update_bookmark("", id, title).await.is_ok() {
+                    if let Some(row) = list.write().iter_mut().find(|b| b.id == id) {
+                        row.title = title_for_local;
+                    }
+                }
+            });
+        }
+        #[cfg(not(feature = "web"))]
+        let _ = (id, title);
+    }
+
+    /// Delete a bookmark and drop it from the local list.
+    pub fn remove(&self, id: i64) {
+        #[cfg(feature = "web")]
+        {
+            let mut list = self.list;
+            spawn(async move {
+                if crate::data::delete_bookmark("", id).await.is_ok() {
+                    list.write().retain(|b| b.id != id);
+                }
+            });
+        }
+        #[cfg(not(feature = "web"))]
+        let _ = id;
+    }
+}
+
+/// Install the bookmark signals and load the existing list after mount.
+/// The load effect is declared unconditionally (hook-order parity); only the
+/// fetch is web-gated, so SSR renders an empty list and the client reconciles.
+pub(super) fn use_bookmarks(uuid: String) -> BookmarksController {
+    let list = use_signal(Vec::<Bookmark>::new);
+    let fresh_id = use_signal(|| None::<i64>);
+    let toast = use_signal(|| None::<BookmarkToast>);
+    let uuid_sig = use_signal(|| uuid);
+
+    use_effect(move || {
+        let _uuid = uuid_sig.peek().clone();
+        let mut _list = list;
+        #[cfg(feature = "web")]
+        spawn(async move {
+            if let Ok(items) = crate::data::list_bookmarks("", &_uuid).await {
+                _list.set(items);
+            }
+        });
+    });
+
+    BookmarksController {
+        list,
+        fresh_id,
+        toast,
+        uuid: uuid_sig,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch(start: f64, title: &str) -> ChapterInfo {
+        ChapterInfo {
+            ordinal: 1,
+            title: title.into(),
+            start_seconds: start,
+            duration_seconds: 300.0,
+        }
+    }
+
+    fn bm(position: &str) -> Bookmark {
+        Bookmark {
+            id: 1,
+            book_uuid: "u".into(),
+            position: position.into(),
+            title: None,
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn bookmark_position_seconds_parses_decimal() {
+        assert!((bookmark_position_seconds(&bm("123.5")) - 123.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn bookmark_position_seconds_defaults_to_zero_on_garbage() {
+        assert_eq!(bookmark_position_seconds(&bm("epubcfi(/6/4)")), 0.0);
+    }
+
+    #[test]
+    fn chapter_label_at_returns_generic_when_no_chapters() {
+        assert_eq!(chapter_label_at(10.0, &[]), "Bookmark");
+    }
+
+    #[test]
+    fn chapter_label_at_formats_titled_chapter() {
+        let chs = vec![ch(0.0, "Intro"), ch(300.0, "Part One")];
+        assert_eq!(chapter_label_at(420.0, &chs), "Ch. 2 \u{00b7} Part One");
+    }
+
+    #[test]
+    fn chapter_label_at_falls_back_to_ordinal_for_untitled() {
+        let chs = vec![ch(0.0, "")];
+        assert_eq!(chapter_label_at(10.0, &chs), "Chapter 1");
+    }
+}

--- a/frontend/src/pages/listen/bookmarks.rs
+++ b/frontend/src/pages/listen/bookmarks.rs
@@ -129,7 +129,16 @@ pub(super) fn use_bookmarks(uuid: String) -> BookmarksController {
         #[cfg(feature = "web")]
         spawn(async move {
             if let Ok(items) = crate::data::list_bookmarks("", &_uuid).await {
-                _list.set(items);
+                // The unified table can also hold reader bookmarks (CFI
+                // positions) for a dual-format book; the listen drawer is
+                // audio-only, so drop any non-numeric position rather than
+                // render it as 0:00 and seek to the start.
+                _list.set(
+                    items
+                        .into_iter()
+                        .filter(|b| b.position.parse::<f64>().is_ok())
+                        .collect(),
+                );
             }
         });
     });

--- a/frontend/src/pages/listen/bookmarks_drawer.rs
+++ b/frontend/src/pages/listen/bookmarks_drawer.rs
@@ -20,7 +20,9 @@ pub(super) fn BookmarksDrawer(
     on_add: EventHandler<()>,
     on_close: EventHandler<()>,
 ) -> Element {
-    let marks = controller.list.read().clone();
+    // Hold the read guard and iterate it directly — no need to clone the whole
+    // list on every render (rows clone individual bookmarks as they need them).
+    let marks = controller.list.read();
     let fresh = (controller.fresh_id)();
     let count = marks.len();
 

--- a/frontend/src/pages/listen/bookmarks_drawer.rs
+++ b/frontend/src/pages/listen/bookmarks_drawer.rs
@@ -1,20 +1,29 @@
 //! Bookmarks drawer for the listen page.
 //!
-//! Right-side full-height panel showing saved bookmarks. Currently
-//! renders an empty state because the bookmarks CRUD endpoint ships
-//! in PR 4. The visual shell matches the design.
+//! Right-side full-height panel listing saved bookmarks. Each row seeks on
+//! click, shows the derived chapter label + timestamp, an inline note editor,
+//! and a delete action. The freshest bookmark gets an accent ring.
 
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
+use omnibus_shared::{Bookmark, ChapterInfo};
 
-// Pure presentational shell — no branching logic to unit-test.
-// No Playwright spec opens this drawer today; smoke coverage of the
-// empty state will ship alongside the bookmarks-persistence backend.
+use super::bookmarks::{bookmark_position_seconds, chapter_label_at, BookmarksController};
+use super::helpers::format_hms;
 
-/// Bookmarks drawer — empty state until bookmark persistence ships.
 #[component]
-pub(super) fn BookmarksDrawer(on_close: EventHandler<()>) -> Element {
+pub(super) fn BookmarksDrawer(
+    controller: BookmarksController,
+    chapters: Vec<ChapterInfo>,
+    on_seek: EventHandler<f64>,
+    on_add: EventHandler<()>,
+    on_close: EventHandler<()>,
+) -> Element {
+    let marks = controller.list.read().clone();
+    let fresh = (controller.fresh_id)();
+    let count = marks.len();
+
     rsx! {
         div {
             class: "lp-scrim",
@@ -24,24 +33,130 @@ pub(super) fn BookmarksDrawer(on_close: EventHandler<()>) -> Element {
         div { class: "lp-drawer", "data-testid": "bookmarks-drawer",
             div { class: "lp-drawer-head",
                 div {
-                    div { class: "lp-panel-kicker", "Bookmarks" }
+                    div { class: "lp-panel-kicker", "Bookmarks \u{00b7} {count}" }
                     div { class: "lp-panel-title", "Your marks" }
                 }
-                button {
-                    class: "btn ghost sm",
-                    r#type: "button",
-                    onclick: move |_| on_close.call(()),
-                    "Close \u{2193}"
+                div { class: "lp-drawer-head-actions",
+                    button {
+                        class: "btn sm",
+                        r#type: "button",
+                        "data-testid": "bookmark-add",
+                        onclick: move |_| on_add.call(()),
+                        "+ Bookmark"
+                    }
+                    button {
+                        class: "btn ghost sm",
+                        r#type: "button",
+                        onclick: move |_| on_close.call(()),
+                        "Close \u{2193}"
+                    }
                 }
             }
             div { class: "lp-drawer-body",
-                div { class: "lp-drawer-empty",
-                    p { class: "lp-drawer-empty-title", "No bookmarks yet" }
-                    p { class: "lp-drawer-empty-detail",
-                        "Tap the Bookmark button while listening to save "
-                        "your place. Bookmarks with notes will appear here."
+                if marks.is_empty() {
+                    div { class: "lp-drawer-empty",
+                        p { class: "lp-drawer-empty-title", "No bookmarks yet" }
+                        p { class: "lp-drawer-empty-detail",
+                            "Tap the Bookmark button while listening to save "
+                            "your place. Add a note to any mark below."
+                        }
+                    }
+                } else {
+                    for mark in marks.iter() {
+                        BookmarkRow {
+                            key: "{mark.id}",
+                            bookmark: mark.clone(),
+                            chapters: chapters.clone(),
+                            is_fresh: fresh == Some(mark.id),
+                            on_seek,
+                            controller,
+                        }
                     }
                 }
+            }
+        }
+    }
+}
+
+#[component]
+fn BookmarkRow(
+    bookmark: Bookmark,
+    chapters: Vec<ChapterInfo>,
+    is_fresh: bool,
+    on_seek: EventHandler<f64>,
+    controller: BookmarksController,
+) -> Element {
+    let mut editing = use_signal(|| false);
+    let mut draft = use_signal(|| bookmark.title.clone().unwrap_or_default());
+
+    let pos = bookmark_position_seconds(&bookmark);
+    let label = chapter_label_at(pos, &chapters);
+    let time_label = format_hms(pos);
+    let row_class = if is_fresh {
+        "lp-bm-row fresh"
+    } else {
+        "lp-bm-row"
+    };
+    let note = bookmark.title.clone();
+    let id = bookmark.id;
+
+    // `Fn` (not `FnMut`) so it can be copied into both the blur and keydown
+    // handlers: it mutates a local copy of the `editing` signal, not a
+    // captured-by-mut binding.
+    let do_commit = move || {
+        let mut editing = editing;
+        let text = draft.peek().trim().to_string();
+        let next = if text.is_empty() { None } else { Some(text) };
+        controller.rename(id, next);
+        editing.set(false);
+    };
+
+    rsx! {
+        div { class: "{row_class}", "data-testid": "bookmark-row",
+            button {
+                class: "lp-bm-main",
+                r#type: "button",
+                onclick: move |_| on_seek.call(pos),
+                span { class: "lp-bm-flag", "\u{2691}" }
+                span { class: "lp-bm-label", "{label}" }
+                span { class: "lp-bm-time", "{time_label}" }
+            }
+            div { class: "lp-bm-note",
+                if editing() {
+                    input {
+                        class: "lp-bm-note-input",
+                        r#type: "text",
+                        placeholder: "Add a note\u{2026}",
+                        autofocus: true,
+                        value: "{draft}",
+                        oninput: move |e| draft.set(e.value()),
+                        onblur: move |_| do_commit(),
+                        onkeydown: move |e| {
+                            if e.key() == Key::Enter {
+                                do_commit();
+                            }
+                        },
+                    }
+                } else {
+                    button {
+                        class: "lp-bm-note-text",
+                        r#type: "button",
+                        onclick: move |_| editing.set(true),
+                        if let Some(n) = note.clone() {
+                            "{n}"
+                        } else {
+                            span { class: "lp-bm-note-empty", "Add a note\u{2026}" }
+                        }
+                    }
+                }
+            }
+            button {
+                class: "lp-bm-del",
+                r#type: "button",
+                "aria-label": "Delete bookmark",
+                title: "Delete bookmark",
+                onclick: move |_| controller.remove(id),
+                "\u{00d7}"
             }
         }
     }

--- a/frontend/src/pages/listen/bootstrap.rs
+++ b/frontend/src/pages/listen/bootstrap.rs
@@ -340,6 +340,9 @@ fn transport_controls_js() -> &'static str {
       pause:   function(){ el.pause(); },
       toggle:  function(){ if (el.paused) { this.play(); } else { this.pause(); } },
       setRate: function(r){ try { el.playbackRate = r; } catch(_) {} },
+      // Sleep-timer volume fade. Clamps to [0,1]; the Rust countdown ramps
+      // this down over the final seconds and restores 1.0 on cancel/expiry.
+      setVolume: function(v){ try { el.volume = Math.max(0, Math.min(1, v)); } catch(_) {} },
 
       // Hard stop for the dock's dismiss: pause, drop the source so a
       // media-key resume can't restart it, and reset direct-mode state.

--- a/frontend/src/pages/listen/controls.rs
+++ b/frontend/src/pages/listen/controls.rs
@@ -27,15 +27,6 @@ pub(super) fn toolbar_btn_class(active: bool) -> &'static str {
     }
 }
 
-/// Label for the sleep toolbar button, reflecting active state.
-pub(super) fn sleep_label(active: bool) -> &'static str {
-    if active {
-        "Sleep \u{00b7} on"
-    } else {
-        "Sleep \u{00b7} off"
-    }
-}
-
 /// Label for the chapters toolbar button, reflecting open/closed state.
 pub(super) fn chapters_toggle_label(open: bool) -> &'static str {
     if open {
@@ -173,16 +164,6 @@ mod tests {
     }
 
     #[test]
-    fn sleep_label_inactive_shows_off() {
-        assert_eq!(sleep_label(false), "Sleep \u{00b7} off");
-    }
-
-    #[test]
-    fn sleep_label_active_shows_on() {
-        assert_eq!(sleep_label(true), "Sleep \u{00b7} on");
-    }
-
-    #[test]
     fn chapters_toggle_label_closed_shows_up_arrow() {
         assert_eq!(chapters_toggle_label(false), "Chapters \u{2191}");
     }
@@ -200,6 +181,7 @@ mod tests {
 #[component]
 pub(super) fn Toolbar(
     sleep_active: bool,
+    sleep_label: String,
     bookmarks_active: bool,
     chapters_active: bool,
     on_sleep: EventHandler<MouseEvent>,
@@ -209,7 +191,6 @@ pub(super) fn Toolbar(
     let sleep_cls = toolbar_btn_class(sleep_active);
     let bm_class = toolbar_btn_class(bookmarks_active);
     let ch_class = toolbar_btn_class(chapters_active);
-    let slp_label = sleep_label(sleep_active);
     let ch_label = chapters_toggle_label(chapters_active);
 
     rsx! {
@@ -217,12 +198,14 @@ pub(super) fn Toolbar(
             button {
                 class: sleep_cls,
                 r#type: "button",
+                "data-testid": "listen-sleep",
                 onclick: move |evt| on_sleep.call(evt),
-                "{slp_label}"
+                "{sleep_label}"
             }
             button {
                 class: bm_class,
                 r#type: "button",
+                "data-testid": "listen-bookmark",
                 onclick: move |evt| on_bookmark.call(evt),
                 "Bookmark"
             }

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -9,9 +9,11 @@
 use dioxus::prelude::*;
 use omnibus_shared::{ChapterInfo, EbookMetadata};
 
+use super::bookmarks::use_bookmarks;
 use super::bookmarks_drawer::BookmarksDrawer;
 use super::chapters_drawer::ChaptersDrawer;
 use super::overlays::{FailedOverlay, PreparingOverlay};
+use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep_timer};
 use super::sleep_panel::SleepPanel;
 use super::speed_panel::SpeedPanel;
 use super::stage::{PlaybackPosition, PlayerCallbacks, PlayerStage, ToolbarState, TransportState};
@@ -167,6 +169,12 @@ pub(super) fn ReadyPlayer(
     let mut bookmarks_open = use_signal(|| false);
     let mut chapters_open = use_signal(|| false);
 
+    // Sleep timer + bookmark state. Both are custom hooks declared
+    // unconditionally so SSR/WASM hook order matches (rule 07); their web
+    // interop is gated internally.
+    let sleep = use_sleep_timer();
+    let bookmarks = use_bookmarks(uuid.clone());
+
     // Derive current chapter index from elapsed position.
     let current_chapter_index = use_memo(move || {
         let chs = chapters();
@@ -249,6 +257,15 @@ pub(super) fn ReadyPlayer(
     let chs = chapters();
     let ch_idx = current_chapter_index();
 
+    // Reactive sleep-timer reads — re-render the toolbar label + panel live.
+    let sleep_remaining = (sleep.remaining)();
+    let sleep_choice = (sleep.choice)();
+    let sleep_fade = (sleep.fade)();
+    let sleep_active = matches!(sleep_remaining, Some(s) if s > 0);
+    let sleep_btn_label = sleep_toolbar_label(sleep_remaining);
+    let has_chapters = !chs.is_empty();
+    let bookmark_toast = (bookmarks.toast)();
+
     rsx! {
         div { class: "lp-root", style: "{accent_style}",
             div { class: "lp-backdrop" }
@@ -289,7 +306,8 @@ pub(super) fn ReadyPlayer(
                     on_chapter_seek: EventHandler::new(on_chapter_seek),
                 },
                 toolbar: ToolbarState {
-                    sleep_active: sleep_panel_open(),
+                    sleep_active: sleep_active || sleep_panel_open(),
+                    sleep_label: sleep_btn_label,
                     bookmarks_active: bookmarks_open(),
                     chapters_active: chapters_open(),
                     on_sleep: EventHandler::new(move |_| {
@@ -333,12 +351,40 @@ pub(super) fn ReadyPlayer(
             }
             if sleep_panel_open() {
                 SleepPanel {
+                    remaining: sleep_remaining,
+                    choice: sleep_choice,
+                    fade: sleep_fade,
+                    has_chapters,
+                    on_select: move |secs: i32| sleep.select_seconds(secs),
+                    on_end_of_chapter: move |_| {
+                        let chs_now = chapters.peek().clone();
+                        let idx = current_chapter_index();
+                        if let Some(secs) = end_of_chapter_seconds(&chs_now, idx, *elapsed.peek()) {
+                            sleep.select_end_of_chapter(secs);
+                        }
+                    },
+                    on_toggle_fade: move |_| sleep.toggle_fade(),
                     on_close: move |_| sleep_panel_open.set(false),
                 }
             }
             if bookmarks_open() {
                 BookmarksDrawer {
+                    controller: bookmarks,
+                    chapters: chs.clone(),
+                    on_seek: EventHandler::new(on_chapter_seek),
+                    on_add: EventHandler::new(move |_| {
+                        let chs_now = chapters.peek().clone();
+                        bookmarks.create(*elapsed.peek(), &chs_now);
+                    }),
                     on_close: move |_| bookmarks_open.set(false),
+                }
+            }
+
+            if let Some(toast) = bookmark_toast {
+                div { class: "lp-toast", "data-testid": "bookmark-toast",
+                    span { class: "lp-toast-icon", "\u{2691}" }
+                    span { class: "lp-toast-text", "Bookmark saved" }
+                    span { class: "lp-toast-meta", "{toast.time_label} \u{00b7} {toast.chapter_label}" }
                 }
             }
             if chapters_open() {

--- a/frontend/src/pages/listen/sleep.rs
+++ b/frontend/src/pages/listen/sleep.rs
@@ -1,0 +1,257 @@
+//! Sleep-timer state machine for the listen page.
+//!
+//! Owns the countdown signal and the self-re-arming 1 s tick, plus pure
+//! helpers (preset table, countdown formatting, end-of-chapter math). The
+//! panel in `sleep_panel` renders this controller; `ready_player` drives it.
+//! Session-only — not persisted across page loads.
+
+#![cfg(not(feature = "mobile"))]
+
+use dioxus::prelude::*;
+use omnibus_shared::ChapterInfo;
+
+/// Duration presets shown in the panel grid. `0` seconds == "Off".
+pub(super) const PRESETS: &[(&str, i32)] = &[
+    ("Off", 0),
+    ("15 min", 900),
+    ("30 min", 1800),
+    ("45 min", 2700),
+    ("1 hour", 3600),
+    ("2 hours", 7200),
+    ("3 hours", 10800),
+    ("4 hours", 14400),
+];
+
+/// Seconds over which the volume ramps to zero before the timer fires.
+/// Only read by the web-gated fade ramp in [`use_sleep_timer`].
+#[cfg(feature = "web")]
+const FADE_SECONDS: i32 = 30;
+
+/// Which sleep option is currently selected — drives the panel highlight.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum SleepChoice {
+    Off,
+    Preset(i32),
+    EndOfChapter,
+}
+
+/// Format a non-negative countdown as `M:SS` (or `H:MM:SS` past an hour).
+pub(super) fn format_countdown(secs: i32) -> String {
+    let s = secs.max(0);
+    let h = s / 3600;
+    let m = (s % 3600) / 60;
+    let sec = s % 60;
+    if h > 0 {
+        format!("{h}:{m:02}:{sec:02}")
+    } else {
+        format!("{m}:{sec:02}")
+    }
+}
+
+/// Toolbar Sleep-button label, showing the live countdown when active.
+pub(super) fn sleep_toolbar_label(remaining: Option<i32>) -> String {
+    match remaining {
+        Some(s) if s > 0 => format!("Sleep \u{00b7} {}", format_countdown(s)),
+        _ => "Sleep \u{00b7} off".to_string(),
+    }
+}
+
+/// Seconds left until the end of the current chapter, for the "End of
+/// chapter" option. `None` when `idx` is out of range (empty/stale list).
+pub(super) fn end_of_chapter_seconds(
+    chapters: &[ChapterInfo],
+    idx: usize,
+    elapsed: f64,
+) -> Option<i32> {
+    let ch = chapters.get(idx)?;
+    let end = ch.start_seconds + ch.duration_seconds;
+    let rem = (end - elapsed).max(0.0).min(f64::from(i32::MAX));
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    Some(rem.ceil() as i32)
+}
+
+/// Sleep-timer handle returned by [`use_sleep_timer`]. Cheap to copy; the
+/// controller methods bump an internal session token so an in-flight tick
+/// from a cancelled session is ignored.
+#[derive(Clone, Copy)]
+pub(super) struct SleepController {
+    pub remaining: Signal<Option<i32>>,
+    pub choice: Signal<SleepChoice>,
+    pub fade: Signal<bool>,
+    token: Signal<u32>,
+}
+
+impl SleepController {
+    /// Select a preset (seconds). `0` turns the timer off.
+    pub fn select_seconds(&self, secs: i32) {
+        let mut remaining = self.remaining;
+        let mut choice = self.choice;
+        let mut token = self.token;
+        let next_token = (*token.peek()).wrapping_add(1);
+        token.set(next_token);
+        if secs <= 0 {
+            remaining.set(None);
+            choice.set(SleepChoice::Off);
+            #[cfg(feature = "web")]
+            super::helpers::audio_call("setVolume", "1");
+        } else {
+            remaining.set(Some(secs));
+            choice.set(SleepChoice::Preset(secs));
+        }
+    }
+
+    /// Arm the timer to fire at the end of the current chapter.
+    pub fn select_end_of_chapter(&self, secs: i32) {
+        let mut remaining = self.remaining;
+        let mut choice = self.choice;
+        let mut token = self.token;
+        let next_token = (*token.peek()).wrapping_add(1);
+        token.set(next_token);
+        remaining.set(Some(secs.max(1)));
+        choice.set(SleepChoice::EndOfChapter);
+    }
+
+    /// Toggle the volume-fade preference. Turning it off restores full volume.
+    pub fn toggle_fade(&self) {
+        let mut fade = self.fade;
+        let was_on = *fade.peek();
+        fade.set(!was_on);
+        #[cfg(feature = "web")]
+        if was_on {
+            super::helpers::audio_call("setVolume", "1");
+        }
+    }
+}
+
+/// Install the sleep-timer signals and the self-re-arming countdown effect.
+/// The effect is declared unconditionally (hook-order parity across SSR and
+/// WASM); only the audio interop and the 1 s tick are web-gated.
+pub(super) fn use_sleep_timer() -> SleepController {
+    let remaining = use_signal(|| None::<i32>);
+    let choice = use_signal(|| SleepChoice::Off);
+    let fade = use_signal(|| true);
+    let token = use_signal(|| 0u32);
+
+    use_effect(move || {
+        let Some(secs) = remaining() else {
+            return;
+        };
+        let fade_on = fade();
+
+        // Final-stretch volume ramp.
+        #[cfg(feature = "web")]
+        if fade_on && (0..=FADE_SECONDS).contains(&secs) {
+            let v = (f64::from(secs) / f64::from(FADE_SECONDS)).clamp(0.0, 1.0);
+            super::helpers::audio_call("setVolume", &v.to_string());
+        }
+        let _ = fade_on;
+
+        if secs <= 0 {
+            // Expiry: pause playback and restore volume for next time.
+            #[cfg(feature = "web")]
+            {
+                super::helpers::audio_call("pause", "");
+                super::helpers::audio_call("setVolume", "1");
+            }
+            let mut remaining = remaining;
+            let mut choice = choice;
+            remaining.set(None);
+            choice.set(SleepChoice::Off);
+        } else {
+            // Arm the next tick, guarded by the session token so a cancelled
+            // session's in-flight sleep does not keep decrementing.
+            #[cfg(feature = "web")]
+            {
+                let my_token = *token.peek();
+                let mut remaining = remaining;
+                let token = token;
+                spawn(async move {
+                    gloo_timers::future::sleep(std::time::Duration::from_secs(1)).await;
+                    if *token.peek() != my_token {
+                        return;
+                    }
+                    let cur = *remaining.peek();
+                    if let Some(c) = cur {
+                        remaining.set(Some(c - 1));
+                    }
+                });
+            }
+        }
+    });
+
+    SleepController {
+        remaining,
+        choice,
+        fade,
+        token,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch(start: f64, dur: f64) -> ChapterInfo {
+        ChapterInfo {
+            ordinal: 1,
+            title: "x".into(),
+            start_seconds: start,
+            duration_seconds: dur,
+        }
+    }
+
+    #[test]
+    fn format_countdown_under_one_hour_is_m_ss() {
+        assert_eq!(format_countdown(0), "0:00");
+        assert_eq!(format_countdown(5), "0:05");
+        assert_eq!(format_countdown(125), "2:05");
+        assert_eq!(format_countdown(1722), "28:42");
+    }
+
+    #[test]
+    fn format_countdown_past_one_hour_is_h_mm_ss() {
+        assert_eq!(format_countdown(3600), "1:00:00");
+        assert_eq!(format_countdown(7325), "2:02:05");
+    }
+
+    #[test]
+    fn format_countdown_clamps_negative_to_zero() {
+        assert_eq!(format_countdown(-9), "0:00");
+    }
+
+    #[test]
+    fn sleep_toolbar_label_off_when_none_or_zero() {
+        assert_eq!(sleep_toolbar_label(None), "Sleep \u{00b7} off");
+        assert_eq!(sleep_toolbar_label(Some(0)), "Sleep \u{00b7} off");
+    }
+
+    #[test]
+    fn sleep_toolbar_label_shows_countdown_when_active() {
+        assert_eq!(sleep_toolbar_label(Some(1722)), "Sleep \u{00b7} 28:42");
+    }
+
+    #[test]
+    fn end_of_chapter_seconds_returns_remaining_in_current_chapter() {
+        let chs = vec![ch(0.0, 300.0), ch(300.0, 600.0)];
+        // 120 s into chapter 2 (start 300, dur 600 → ends 900); elapsed 420 → 480 left.
+        assert_eq!(end_of_chapter_seconds(&chs, 1, 420.0), Some(480));
+    }
+
+    #[test]
+    fn end_of_chapter_seconds_floors_at_zero_past_end() {
+        let chs = vec![ch(0.0, 300.0)];
+        assert_eq!(end_of_chapter_seconds(&chs, 0, 999.0), Some(0));
+    }
+
+    #[test]
+    fn end_of_chapter_seconds_none_for_out_of_range_index() {
+        let chs = vec![ch(0.0, 300.0)];
+        assert_eq!(end_of_chapter_seconds(&chs, 5, 10.0), None);
+    }
+
+    #[test]
+    fn presets_start_with_off_and_cover_four_hours() {
+        assert_eq!(PRESETS.first(), Some(&("Off", 0)));
+        assert_eq!(PRESETS.last(), Some(&("4 hours", 14400)));
+    }
+}

--- a/frontend/src/pages/listen/sleep_panel.rs
+++ b/frontend/src/pages/listen/sleep_panel.rs
@@ -1,25 +1,42 @@
 //! Sleep-timer overlay for the listen page.
 //!
-//! Shows a preset grid of durations (Off through 4 hours) plus an
-//! "End of chapter" option. Currently visual-only — the actual
-//! countdown timer ships in PR 5.
+//! Renders the preset grid (Off through 4 hours), an "End of chapter" option,
+//! a live countdown status, and a fade-out toggle. State lives in the
+//! [`super::sleep::SleepController`] owned by `ready_player`.
 
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
 
-const PRESETS: &[&str] = &[
-    "Off", "15 min", "30 min", "45 min", "1 hour", "2 hours", "3 hours", "4 hours",
-];
+use super::sleep::{format_countdown, SleepChoice, PRESETS};
 
-// Pure presentational shell — no branching logic to unit-test.
-// Open/close state is owned by `ready_player`. No Playwright spec opens
-// this panel today (listen.spec.ts only asserts the player chrome and
-// overlays); smoke coverage of the preset grid is tracked as follow-up.
-
-/// Frosted-glass sleep-timer panel with duration presets.
 #[component]
-pub(super) fn SleepPanel(on_close: EventHandler<()>) -> Element {
+pub(super) fn SleepPanel(
+    remaining: Option<i32>,
+    choice: SleepChoice,
+    fade: bool,
+    has_chapters: bool,
+    on_select: EventHandler<i32>,
+    on_end_of_chapter: EventHandler<()>,
+    on_toggle_fade: EventHandler<()>,
+    on_close: EventHandler<()>,
+) -> Element {
+    let status = match remaining {
+        Some(s) if s > 0 => format_countdown(s),
+        _ => "\u{2014}".to_string(),
+    };
+    let status_label = if matches!(remaining, Some(s) if s > 0) {
+        "remaining"
+    } else {
+        "inactive"
+    };
+    let eoc_on = matches!(choice, SleepChoice::EndOfChapter);
+    let fade_cls = if fade {
+        "lp-sleep-fade on"
+    } else {
+        "lp-sleep-fade"
+    };
+
     rsx! {
         div {
             class: "lp-scrim",
@@ -33,23 +50,27 @@ pub(super) fn SleepPanel(on_close: EventHandler<()>) -> Element {
                     div { class: "lp-panel-title", "Drift off" }
                 }
                 div { class: "lp-sleep-status",
-                    div { class: "lp-sleep-status-value", "\u{2014}" }
-                    div { class: "label", "inactive" }
+                    div { class: "lp-sleep-status-value", "data-testid": "sleep-status", "{status}" }
+                    div { class: "label", "{status_label}" }
                 }
             }
 
             div { class: "lp-sleep-grid",
-                for preset in PRESETS.iter() {
+                for (label , secs) in PRESETS.iter().copied() {
                     {
-                        let is_off = *preset == "Off";
-                        let class = if is_off { "lp-sleep-btn on" } else { "lp-sleep-btn" };
+                        let active = match choice {
+                            SleepChoice::Off => secs == 0,
+                            SleepChoice::Preset(p) => p == secs && secs != 0,
+                            SleepChoice::EndOfChapter => false,
+                        };
+                        let class = if active { "lp-sleep-btn on" } else { "lp-sleep-btn" };
                         rsx! {
                             button {
-                                key: "{preset}",
+                                key: "{label}",
                                 class: class,
                                 r#type: "button",
-                                disabled: !is_off,
-                                "{preset}"
+                                onclick: move |_| on_select.call(secs),
+                                "{label}"
                             }
                         }
                     }
@@ -57,11 +78,22 @@ pub(super) fn SleepPanel(on_close: EventHandler<()>) -> Element {
             }
 
             button {
-                class: "lp-sleep-eoc",
+                class: if eoc_on { "lp-sleep-eoc on" } else { "lp-sleep-eoc" },
                 r#type: "button",
-                disabled: true,
+                disabled: !has_chapters,
+                onclick: move |_| on_end_of_chapter.call(()),
                 span { class: "lp-sleep-eoc-dot" }
                 "End of chapter"
+            }
+
+            button {
+                class: fade_cls,
+                r#type: "button",
+                onclick: move |_| on_toggle_fade.call(()),
+                span { class: "lp-sleep-fade-track",
+                    span { class: "lp-sleep-fade-thumb" }
+                }
+                "Fade out volume"
             }
         }
     }

--- a/frontend/src/pages/listen/sleep_panel.rs
+++ b/frontend/src/pages/listen/sleep_panel.rs
@@ -89,6 +89,8 @@ pub(super) fn SleepPanel(
             button {
                 class: fade_cls,
                 r#type: "button",
+                "aria-pressed": fade,
+                "aria-label": "Fade out volume",
                 onclick: move |_| on_toggle_fade.call(()),
                 span { class: "lp-sleep-fade-track",
                     span { class: "lp-sleep-fade-thumb" }

--- a/frontend/src/pages/listen/stage.rs
+++ b/frontend/src/pages/listen/stage.rs
@@ -120,6 +120,7 @@ pub(super) struct PlayerCallbacks {
 #[derive(Clone, PartialEq)]
 pub(super) struct ToolbarState {
     pub sleep_active: bool,
+    pub sleep_label: String,
     pub bookmarks_active: bool,
     pub chapters_active: bool,
     pub on_sleep: EventHandler<MouseEvent>,
@@ -183,6 +184,7 @@ pub(super) fn PlayerStage(
 
                 Toolbar {
                     sleep_active: toolbar.sleep_active,
+                    sleep_label: toolbar.sleep_label,
                     bookmarks_active: toolbar.bookmarks_active,
                     chapters_active: toolbar.chapters_active,
                     on_sleep: toolbar.on_sleep,

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -321,7 +321,10 @@ test("opens bookmarks drawer and shows empty state", async ({
   page,
   request,
 }) => {
-  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  // Use the M4B book — no other spec creates bookmarks against it, so the
+  // empty state holds even on the shared, persistent dev DB. (The create
+  // flow below bookmarks MP3_BOOK, so reusing it here would be flaky.)
+  const uuid = await fetchBookUuidByTitle(request, M4B_BOOK.title);
   await gotoReady(page, `/listen/${uuid}`);
   await waitForPlayerReady(page);
 
@@ -336,6 +339,63 @@ test("opens bookmarks drawer and shows empty state", async ({
   await expect(
     page.getByText("Tap the Bookmark button while listening to save"),
   ).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// 9b. Bookmark create → toast → row (PR4)
+// ---------------------------------------------------------------------------
+
+test("saves a bookmark from the drawer and shows a confirmation toast", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+
+  // Open the drawer, then add a bookmark at the current position. The create
+  // RPC must fire with the book uuid before the row + toast appear.
+  await page.getByRole("button", { name: "Bookmark" }).click();
+  await expect(page.getByTestId("bookmarks-drawer")).toBeVisible();
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: /\/api\/rpc\/bookmarks\/create(?:\?|$)/,
+      expectedStatus: 200,
+    },
+    async () => page.getByTestId("bookmark-add").click(),
+  );
+
+  // The freshly-created bookmark row and the confirmation toast appear.
+  await expect(page.getByTestId("bookmark-row").first()).toBeVisible();
+  await expect(page.getByTestId("bookmark-toast")).toBeVisible();
+  await expect(page.getByText("Bookmark saved")).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// 8b. Sleep timer countdown (PR5)
+// ---------------------------------------------------------------------------
+
+test("arms a sleep preset and shows a live countdown", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+
+  await page.getByRole("button", { name: /^sleep/i }).click();
+  await expect(page.getByTestId("sleep-panel")).toBeVisible();
+
+  // Selecting "15 min" arms the timer; the status shows a sub-15-minute
+  // countdown (it begins decrementing immediately).
+  await page.getByRole("button", { name: "15 min" }).click();
+  await expect(page.getByTestId("sleep-status")).toHaveText(/^1[45]:\d\d$/);
+
+  // The toolbar Sleep button reflects the live countdown.
+  await expect(page.getByRole("button", { name: /^Sleep · 1[45]:/ })).toBeVisible();
 });
 
 // ---------------------------------------------------------------------------

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -299,18 +299,21 @@ test("opens sleep panel and shows preset duration rail", async ({
   await page.getByRole("button", { name: /^sleep/i }).click();
 
   // Panel container is in the DOM.
-  await expect(page.getByTestId("sleep-panel")).toBeVisible();
+  const panel = page.getByTestId("sleep-panel");
+  await expect(panel).toBeVisible();
 
-  // Preset rail: Off through 4 hours.
-  await expect(page.getByRole("button", { name: "Off" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "15 min" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "30 min" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "45 min" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "1 hour" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "2 hours" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "3 hours" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "4 hours" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "End of chapter" })).toBeVisible();
+  // Preset rail: Off through 4 hours. Scope to the panel — the toolbar Sleep
+  // button reads "Sleep · off" when no timer is armed, which would otherwise
+  // also match a bare { name: "Off" } and trip Playwright's strict mode.
+  await expect(panel.getByRole("button", { name: "Off" })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "15 min" })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "30 min" })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "45 min" })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "1 hour" })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "2 hours" })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "3 hours" })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "4 hours" })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "End of chapter" })).toBeVisible();
 });
 
 // ---------------------------------------------------------------------------
@@ -321,10 +324,11 @@ test("opens bookmarks drawer and shows empty state", async ({
   page,
   request,
 }) => {
-  // Use the M4B book — no other spec creates bookmarks against it, so the
-  // empty state holds even on the shared, persistent dev DB. (The create
-  // flow below bookmarks MP3_BOOK, so reusing it here would be flaky.)
-  const uuid = await fetchBookUuidByTitle(request, M4B_BOOK.title);
+  // Use the multipart generated MP3 — it reaches direct-play mode reliably in
+  // headless (unlike the large public-domain M4B), and no other spec creates
+  // bookmarks against it, so the empty state holds on the shared dev DB. (The
+  // create flow below bookmarks MP3_BOOK, so reusing that here would be flaky.)
+  const uuid = await fetchBookUuidByTitle(request, MULTIPART_MP3_BOOK.title);
   await gotoReady(page, `/listen/${uuid}`);
   await waitForPlayerReady(page);
 


### PR DESCRIPTION
Re-opened against `main` after #616 merged (the original #617 auto-closed when its base branch was deleted). Branch rebased onto the post-#616 main; all Copilot threads were resolved on #617.

## Summary
- **PR4 — Bookmarks:** listen-page bookmarks drawer (list / create / inline note / delete) + "Bookmark saved" toast on the unified bookmarks backend.
- **PR5 — Sleep timer:** self-re-arming countdown (presets + end-of-chapter), live `Sleep · MM:SS` toolbar label, pause + optional 30s volume fade on expiry.

## Test plan
- [x] `cargo check --workspace --all-targets` on the rebased branch
- [x] CI (clippy + test + playwright) green on the pre-rebase commit; re-running on this base