### PR TITLE
feat: redesign search results page

### DIFF
--- a/db/src/palette/authors.rs
+++ b/db/src/palette/authors.rs
@@ -66,7 +66,14 @@ pub async fn search_authors(
         )
         SELECT a.id, a.name,
           (SELECT COUNT(*) FROM effective e
-            WHERE e.author_id = a.id OR e.author_name = a.name) AS book_count
+            WHERE e.author_id = a.id OR e.author_name = a.name) AS book_count,
+          (SELECT COALESCE(json_extract(mo3.overrides, '$.title'), b3.title)
+             FROM books_authors_link bal3
+             JOIN books b3 ON b3.id = bal3.book
+             JOIN scan_roots l3 ON l3.id = b3.library_id
+             LEFT JOIN metadata_overrides mo3 ON mo3.book_uuid = b3.uuid
+            WHERE bal3.author = a.id AND l3.path = ?1
+            ORDER BY b3.sort, b3.id LIMIT 1) AS lead_book_title
         FROM authors a
         WHERE a.name LIKE ?2 ESCAPE '\'
           AND EXISTS (
@@ -91,6 +98,34 @@ pub async fn search_authors(
             id: r.get("id"),
             name: r.get("name"),
             book_count: u32::try_from(r.get::<i32, _>("book_count")).unwrap_or(0),
+            lead_book_title: r.get("lead_book_title"),
         })
         .collect())
+}
+
+/// Count visible authors matching `like_pattern` in `library_path` — the
+/// uncapped total behind the palette's 5-hit author cap. "Visible" mirrors
+/// [`search_authors`]: the author needs at least one canonical link in this
+/// library (override-only names have no navigable id and are excluded).
+pub async fn count_authors(
+    pool: &SqlitePool,
+    library_path: &str,
+    like_pattern: &str,
+) -> Result<i64, PaletteError> {
+    Ok(sqlx::query_scalar::<_, i64>(
+        r"
+        SELECT COUNT(*) FROM authors a
+        WHERE a.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (
+            SELECT 1 FROM books_authors_link bal
+              JOIN books b ON b.id = bal.book
+              JOIN scan_roots l ON l.id = b.library_id
+             WHERE bal.author = a.id AND l.path = ?1
+          )
+        ",
+    )
+    .bind(library_path)
+    .bind(like_pattern)
+    .fetch_one(pool)
+    .await?)
 }

--- a/db/src/palette/books.rs
+++ b/db/src/palette/books.rs
@@ -14,20 +14,33 @@ use super::PaletteError;
 
 /// Run the FTS5 books arm of the palette for `trimmed` (already-trimmed,
 /// length-capped query) scoped to `library_path`, capped to `limit`.
-/// Returns an empty vec when `build_fts_match` can't produce a MATCH
+///
+/// Returns the (capped) display hits alongside the *true* FTS5 match count
+/// (before the cap), computed in a single pass: the `bm25` MATCH scan runs
+/// once inside a `MATERIALIZED` CTE and the total is a scalar `COUNT(*)` over
+/// it — so the results header can show "N books" even when only `limit` ship.
+/// Returns `(vec![], 0)` when `build_fts_match` can't produce a MATCH
 /// expression for the input.
 pub async fn search_books(
     pool: &SqlitePool,
     library_path: &str,
     trimmed: &str,
     limit: i32,
-) -> Result<Vec<PaletteBookHit>, PaletteError> {
+) -> Result<(Vec<PaletteBookHit>, i64), PaletteError> {
     let Some(match_expr) = build_fts_match(trimmed) else {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), 0));
     };
 
     let rows = sqlx::query(
         r"
+        WITH matches AS MATERIALIZED (
+            SELECT books_fts.rowid AS bid,
+                   bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0) AS rank
+            FROM books_fts
+            JOIN books b ON b.id = books_fts.rowid
+            JOIN scan_roots l ON l.id = b.library_id
+            WHERE books_fts MATCH ?1 AND l.path = ?2
+        )
         SELECT b.id, b.uuid, b.title, b.has_cover, b.accent_color,
                SUBSTR(b.pubdate, 1, 4) AS year,
 
@@ -40,13 +53,13 @@ pub async fn search_books(
                (SELECT json_group_array(format)
                   FROM (SELECT format FROM book_files
                          WHERE book_id = b.id
-                         ORDER BY format))                  AS formats_json
+                         ORDER BY format))                  AS formats_json,
 
-        FROM books_fts
-        JOIN books b ON b.id = books_fts.rowid
-        JOIN scan_roots l ON l.id = b.library_id
-        WHERE books_fts MATCH ?1 AND l.path = ?2
-        ORDER BY bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0), b.sort, b.id
+               (SELECT COUNT(*) FROM matches)               AS total_count
+
+        FROM matches m
+        JOIN books b ON b.id = m.bid
+        ORDER BY m.rank, b.sort, b.id
         LIMIT ?3
         ",
     )
@@ -55,6 +68,10 @@ pub async fn search_books(
     .bind(limit)
     .fetch_all(pool)
     .await?;
+
+    // `total_count` is the scalar COUNT over the materialized matches, so it's
+    // identical on every row; read it off the first. No rows ⇒ zero matches.
+    let total: i64 = rows.first().map(|r| r.get("total_count")).unwrap_or(0);
 
     let mut uuids: Vec<String> = Vec::with_capacity(rows.len());
     let mut hits: Vec<PaletteBookHit> = Vec::with_capacity(rows.len());
@@ -98,5 +115,5 @@ pub async fn search_books(
         }
     }
 
-    Ok(hits)
+    Ok((hits, total))
 }

--- a/db/src/palette/mod.rs
+++ b/db/src/palette/mod.rs
@@ -24,10 +24,10 @@ mod tests;
 // publicly exposed pre-split; the arm helpers stay reachable internally
 // for `search_palette` and externally only via the fully-qualified
 // `palette::authors::search_authors` path.
-use authors::search_authors;
+use authors::{count_authors, search_authors};
 use books::search_books;
-use series::search_series;
-use tags::search_tags;
+use series::{count_series, search_series};
+use tags::{count_tags, search_tags};
 
 /// Errors returned by the search palette.
 #[derive(Debug, thiserror::Error)]
@@ -35,6 +35,10 @@ pub enum PaletteError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
 }
+
+/// Per-category display cap. Each arm returns at most this many hits; the
+/// uncapped per-category totals (`book_total` etc.) are computed separately.
+const LIMIT: i32 = 5;
 
 /// Grouped command-palette results: up to 5 books, authors, series, and
 /// tags scoped to `library_path`, plus server-side timing in `duration_ms`.
@@ -54,14 +58,14 @@ pub async fn search_palette(
     let trimmed = trimmed.as_str();
 
     let start = std::time::Instant::now();
-    const LIMIT: i32 = 5;
 
     // A. Books — FTS5 MATCH with BM25 ranking, slim projection. After
     // hydration we overlay metadata_overrides so the title and author line
     // shown in the palette match the merged values the rest of the app
     // displays (FTS already matches on the merged text — see
-    // `rebuild_fts_for_book` in the override write path).
-    let books = search_books(pool, library_path, trimmed, LIMIT).await?;
+    // `rebuild_fts_for_book` in the override write path). The books arm also
+    // returns its uncapped total in the same FTS5 pass.
+    let (books, book_total) = search_books(pool, library_path, trimmed, LIMIT).await?;
 
     // Escape the query for LIKE pattern: backslash first (it's the ESCAPE char),
     // then the LIKE wildcards percent and underscore.
@@ -80,6 +84,20 @@ pub async fn search_palette(
     // D. Tags — substring match, scoped to library.
     let tags = search_tags(pool, library_path, &like_pattern, LIMIT).await?;
 
+    // Uncapped per-category totals for the full-page results header. Each is a
+    // cheap COUNT over the same visibility predicate the arm uses; books got
+    // theirs in-pass above. Skipped when the capped vec already holds the whole
+    // match set (len < LIMIT ⇒ no more rows to count).
+    let author_total = total_for(authors.len(), || {
+        count_authors(pool, library_path, &like_pattern)
+    })
+    .await?;
+    let series_total = total_for(series.len(), || {
+        count_series(pool, library_path, &like_pattern)
+    })
+    .await?;
+    let tag_total = total_for(tags.len(), || count_tags(pool, library_path, &like_pattern)).await?;
+
     let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
     Ok(PaletteResults {
@@ -89,5 +107,24 @@ pub async fn search_palette(
         series,
         tags,
         duration_ms,
+        book_total: u32::try_from(book_total).unwrap_or(u32::MAX),
+        author_total,
+        series_total,
+        tag_total,
     })
+}
+
+/// Resolve a category's uncapped total, skipping the COUNT query when the
+/// capped result already holds the entire match set. The arms cap at `LIMIT`,
+/// so a vec shorter than the cap is exhaustive and `len` *is* the total — only
+/// a full vec might be hiding further matches worth counting.
+async fn total_for<F, Fut>(returned: usize, count: F) -> Result<u32, PaletteError>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<i64, PaletteError>>,
+{
+    if returned < LIMIT as usize {
+        return Ok(u32::try_from(returned).unwrap_or(u32::MAX));
+    }
+    Ok(u32::try_from(count().await?).unwrap_or(u32::MAX))
 }

--- a/db/src/palette/series.rs
+++ b/db/src/palette/series.rs
@@ -78,7 +78,14 @@ pub async fn search_series(
              JOIN scan_roots l2 ON l2.id = b2.library_id
              LEFT JOIN metadata_overrides mo2 ON mo2.book_uuid = b2.uuid
             WHERE bsl2.series = s.id AND l2.path = ?1
-            ORDER BY b2.sort, b2.id LIMIT 1) AS author_display
+            ORDER BY b2.sort, b2.id LIMIT 1) AS author_display,
+          (SELECT COALESCE(json_extract(mo3.overrides, '$.title'), b3.title)
+             FROM books_series_link bsl3
+             JOIN books b3 ON b3.id = bsl3.book
+             JOIN scan_roots l3 ON l3.id = b3.library_id
+             LEFT JOIN metadata_overrides mo3 ON mo3.book_uuid = b3.uuid
+            WHERE bsl3.series = s.id AND l3.path = ?1
+            ORDER BY b3.sort, b3.id LIMIT 1) AS lead_book_title
         FROM series s
         WHERE s.name LIKE ?2 ESCAPE '\'
           AND EXISTS (
@@ -104,6 +111,33 @@ pub async fn search_series(
             name: r.get("name"),
             book_count: u32::try_from(r.get::<i32, _>("book_count")).unwrap_or(0),
             author_display: r.get("author_display"),
+            lead_book_title: r.get("lead_book_title"),
         })
         .collect())
+}
+
+/// Count visible series matching `like_pattern` in `library_path` — the
+/// uncapped total behind the palette's 5-hit series cap. Visibility mirrors
+/// [`search_series`]: at least one canonical link in this library.
+pub async fn count_series(
+    pool: &SqlitePool,
+    library_path: &str,
+    like_pattern: &str,
+) -> Result<i64, PaletteError> {
+    Ok(sqlx::query_scalar::<_, i64>(
+        r"
+        SELECT COUNT(*) FROM series s
+        WHERE s.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (
+            SELECT 1 FROM books_series_link bsl
+              JOIN books b ON b.id = bsl.book
+              JOIN scan_roots l ON l.id = b.library_id
+             WHERE bsl.series = s.id AND l.path = ?1
+          )
+        ",
+    )
+    .bind(library_path)
+    .bind(like_pattern)
+    .fetch_one(pool)
+    .await?)
 }

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -85,3 +85,29 @@ pub async fn search_tags(
         })
         .collect())
 }
+
+/// Count visible tags matching `like_pattern` in `library_path` — the
+/// uncapped total behind the palette's 5-hit tag cap. Visibility mirrors
+/// [`search_tags`]: at least one canonical link in this library.
+pub async fn count_tags(
+    pool: &SqlitePool,
+    library_path: &str,
+    like_pattern: &str,
+) -> Result<i64, PaletteError> {
+    Ok(sqlx::query_scalar::<_, i64>(
+        r"
+        SELECT COUNT(*) FROM tags t
+        WHERE t.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (
+            SELECT 1 FROM books_tags_link btl
+              JOIN books b ON b.id = btl.book
+              JOIN scan_roots l ON l.id = b.library_id
+             WHERE btl.tag = t.id AND l.path = ?1
+          )
+        ",
+    )
+    .bind(library_path)
+    .bind(like_pattern)
+    .fetch_one(pool)
+    .await?)
+}

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -1067,5 +1067,5 @@ async fn palette_totals_report_uncapped_counts() {
     assert_eq!(results.authors.len(), 1);
     assert_eq!(results.tag_total, 1, "one matching tag");
     assert_eq!(results.series_total, 0, "no series seeded");
-    assert_eq!(results.total_count(), 7 + 1 + 0 + 1);
+    assert_eq!(results.total_count(), 7 + 1 + 1, "books + authors + tags (no series)");
 }

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -70,6 +70,13 @@ async fn palette_authors_match_substring() {
     assert!(!results.authors.is_empty(), "should match author substring");
     assert_eq!(results.authors[0].name, "R. F. Kuang");
     assert_eq!(results.authors[0].book_count, 1);
+    // F1 results page: the "incl. <title>" line draws on the author's first
+    // book in the library.
+    assert_eq!(
+        results.authors[0].lead_book_title.as_deref(),
+        Some("Babel"),
+        "author hit should carry its lead book title"
+    );
 }
 #[tokio::test]
 async fn palette_series_match() {
@@ -104,6 +111,13 @@ async fn palette_series_match() {
     assert!(!results.series.is_empty(), "should match series substring");
     assert_eq!(results.series[0].name, "Poppy War");
     assert_eq!(results.series[0].book_count, 2);
+    // F1 results page: the "incl. <title>" line draws on the first book in
+    // the series by sort order.
+    assert_eq!(
+        results.series[0].lead_book_title.as_deref(),
+        Some("Book One"),
+        "series hit should carry its lead book title"
+    );
 }
 #[tokio::test]
 async fn palette_tags_match() {
@@ -1018,4 +1032,40 @@ async fn palette_taxonomy_query_plans_use_indexes() {
         !plan.contains("SCAN books_tags_link") && !plan.contains("SCAN btl"),
         "tags plan should not full-scan the link table:\n{plan}"
     );
+}
+/// F1 results-page header: per-category totals report the true match count
+/// even when the 5-hit display cap clips the returned vec. Seven books share
+/// a title token, one author, and one tag — so the books arm caps at 5 hits
+/// but `book_total` is 7, while `author_total`/`tag_total` (under the cap)
+/// equal their vec lengths. `total_count()` sums the true totals.
+#[tokio::test]
+async fn palette_totals_report_uncapped_counts() {
+    let _covers = CoversTempDir::new("palette_totals");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let books: Vec<_> = (0..7)
+        .map(|i| {
+            indexed(
+                &format!("q{i}.epub"),
+                Some(&format!("Quest {i}")),
+                &["Quest Author"],
+                &["questing"],
+                None,
+                None,
+            )
+        })
+        .collect();
+    replace_books(&pool, "/lib", books).await.unwrap();
+
+    let results = search_palette(&pool, "/lib", "quest").await.unwrap();
+
+    assert_eq!(results.books.len(), 5, "books arm caps display at 5");
+    assert_eq!(
+        results.book_total, 7,
+        "book_total is the uncapped match count"
+    );
+    assert_eq!(results.author_total, 1, "one matching author");
+    assert_eq!(results.authors.len(), 1);
+    assert_eq!(results.tag_total, 1, "one matching tag");
+    assert_eq!(results.series_total, 0, "no series seeded");
+    assert_eq!(results.total_count(), 7 + 1 + 0 + 1);
 }

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -11,7 +11,7 @@ use crate::test_support::{indexed, CoversTempDir};
 use omnibus_shared::{Contributor, MetadataOverrides};
 use sqlx::{Row, SqlitePool};
 
-// ── search_palette ──────────────────────────────────────────────
+// ── search_palette ───────────────────────────────────────────────
 #[tokio::test]
 async fn palette_books_match_title() {
     let _covers = CoversTempDir::new("palette_books");
@@ -1067,5 +1067,9 @@ async fn palette_totals_report_uncapped_counts() {
     assert_eq!(results.authors.len(), 1);
     assert_eq!(results.tag_total, 1, "one matching tag");
     assert_eq!(results.series_total, 0, "no series seeded");
-    assert_eq!(results.total_count(), 7 + 1 + 1, "books + authors + tags (no series)");
+    assert_eq!(
+        results.total_count(),
+        7 + 1 + 1,
+        "books + authors + tags (no series)"
+    );
 }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -341,25 +341,136 @@ body.atrium,
 }
 
 /* ── /search results page ──────────────────────────────────────── */
-.search-page { padding: 16px 0 48px; }
-.search-page-header { display: flex; align-items: center; gap: 16px; margin-bottom: 16px; }
-.search-page-title {
-  font-family: var(--serif, "Iowan Old Style", Palatino, Georgia, serif);
-  font-size: 28px; font-weight: 500; color: var(--ink-0); margin: 0;
+.search-page { padding: 8px 0 56px; }
+
+/* Header: kicker + big serif title on the left, sort/view on the right. */
+.search-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 24px; flex-wrap: wrap; margin-bottom: 4px;
 }
-.search-page-query { font-style: italic; color: var(--ink-1); }
-.search-group-head { margin: 28px 0 12px; }
-.search-results { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px; }
-.search-result-row {
-  display: flex; flex-direction: column; gap: 4px;
-  padding: 14px 18px; border-radius: 10px;
-  background: var(--bg-1); border: 1px solid var(--line-2);
-  color: var(--ink-0); text-decoration: none;
+.search-title {
+  font-family: var(--serif); font-weight: 400; color: var(--ink-0);
+  font-size: clamp(32px, 5vw, 52px); line-height: 1.0;
+  margin: 10px 0 0; letter-spacing: -0.01em;
+}
+.search-title-n { font-style: italic; }
+.search-hit { font-style: inherit; font-weight: 600; color: var(--accent); }
+.search-controls { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.search-view-active { background: var(--bg-3); }
+.search-summary {
+  font-size: 11px; color: var(--ink-3); margin: 14px 0 30px;
+}
+
+.search-layout {
+  display: grid; grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 56px; align-items: start;
+}
+.search-main { min-width: 0; }
+.search-section-slot { display: contents; }
+.search-section { scroll-margin-top: 84px; }
+.search-section-head {
+  display: flex; align-items: baseline; gap: 12px;
+  flex-wrap: wrap; margin-bottom: 16px;
+}
+.search-section-count { font-size: 11px; color: var(--ink-3); }
+.search-section-sub { margin-left: auto; font-size: 12px; color: var(--ink-3); }
+
+/* Books — dense cover grid with the matched term lit in the title. */
+.search-cover-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 28px 20px;
+}
+.search-cover-card { display: block; text-decoration: none; color: inherit; }
+.search-cover-thumb {
+  display: block; width: 100%; aspect-ratio: 2 / 3; object-fit: cover;
+  border-radius: var(--r-sm); border: 1px solid var(--line-2);
+  background: var(--bg-2); transition: border-color .15s;
+}
+.search-cover-fallback {
+  display: grid; place-items: center;
+  font-family: var(--serif); font-style: italic; font-size: 30px;
+  color: var(--cover-fallback-ink);
+}
+.search-cover-card:hover .search-cover-thumb { border-color: var(--accent); }
+.search-cover-title {
+  margin-top: 8px; font-size: 13px; color: var(--ink-0);
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+}
+.search-cover-card:hover .search-cover-title { color: var(--accent); }
+.search-cover-sub {
+  font-size: 12px; color: var(--ink-2); margin-top: 1px;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+}
+
+/* Authors & series — two-up entity cards. */
+.search-card-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+.search-entity {
+  display: flex; gap: 14px; align-items: center;
+  padding: 14px 16px; border-radius: 12px;
+  border: 1px solid var(--line-2); background: var(--bg-1);
+  text-decoration: none; color: inherit;
   transition: border-color .15s, background .15s;
 }
-.search-result-row:hover { border-color: var(--accent); background: var(--bg-2); }
-.search-row-title { font-size: 14px; font-weight: 500; }
-.search-row-sub { font-size: 12px; color: var(--ink-2); }
+.search-entity:hover { border-color: var(--accent); background: var(--bg-2); }
+.search-avatar {
+  flex: 0 0 44px; width: 44px; height: 44px; border-radius: 999px;
+  background: var(--bg-3); display: grid; place-items: center;
+  font-family: var(--serif); font-style: italic; font-size: 20px; color: var(--ink-1);
+}
+.search-avatar-series { border-radius: 8px; }
+.search-entity-body { flex: 1; min-width: 0; }
+.search-entity-title {
+  font-size: 16px; color: var(--ink-0);
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+}
+.search-entity-title-serif { font-family: var(--serif); font-style: italic; }
+.search-entity-sub {
+  font-size: 11px; color: var(--ink-3); margin-top: 2px;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+}
+.search-entity-arrow { flex: 0 0 auto; color: var(--ink-3); font-size: 18px; }
+.search-entity-n { flex: 0 0 auto; color: var(--ink-2); font-size: 12px; }
+
+/* Tags — chips, matched names lit. */
+.search-tags { display: flex; gap: 8px; flex-wrap: wrap; }
+.search-tag { text-decoration: none; }
+.search-tag-matched {
+  background: var(--bg-2); border-color: var(--accent); color: var(--ink-0);
+}
+.search-tag-count { color: var(--ink-3); }
+
+/* Right rail — jump links + a context card. */
+.search-rail { position: sticky; top: 80px; align-self: start; }
+.search-rail-head { margin-bottom: 12px; }
+.search-rail-list { display: flex; flex-direction: column; gap: 2px; }
+.search-rail-item {
+  display: flex; justify-content: space-between; gap: 12px;
+  padding: 9px 12px; border-radius: 8px; color: var(--ink-1);
+  text-decoration: none; border-left: 2px solid transparent;
+  font-size: 13.5px; transition: background .15s;
+}
+.search-rail-item:hover { background: var(--bg-1); }
+.search-rail-item-active { background: var(--bg-2); border-left-color: var(--accent); }
+.search-rail-count { color: var(--ink-3); font-size: 11px; }
+.search-refine {
+  padding: 16px; border-radius: 12px;
+  border: 1px solid var(--line-2); background: var(--bg-1);
+}
+.search-refine-title {
+  font-family: var(--serif); font-style: italic; font-size: 17px; color: var(--ink-0);
+}
+.search-refine-body {
+  font-size: 12.5px; color: var(--ink-2); margin-top: 6px; line-height: 1.5;
+}
+.search-refine-btn { margin-top: 12px; width: 100%; justify-content: center; }
+
+@media (max-width: 900px) {
+  .search-layout { grid-template-columns: 1fr; gap: 28px; }
+  .search-rail { position: static; }
+}
 
 /* ── Buttons ────────────────────────────────────────────────────── */
 .btn {

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -1,10 +1,8 @@
-//! Search results page — the full page you land on when you press Enter on
-//! the command-palette input (or click a Tag result). Reuses the
-//! `data::search_palette` RPC and groups the hits by type (Books, Authors,
-//! Series, Tags), each section linking into the relevant detail page. The
-//! matched term is highlighted throughout, an "On this page" rail jumps
-//! between sections, and a query that lands inside tag names leads with the
-//! Tags group.
+//! Search results page — the full page reached from the command palette.
+//! Reuses the `data::search_palette` RPC and groups hits by type (Books,
+//! Authors, Series, Tags) with the matched term highlighted, an "On this
+//! page" jump rail, and a tags-first ordering when the query matches tag
+//! names.
 
 use dioxus::prelude::*;
 use dioxus_router::Link;

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -1,13 +1,16 @@
-//! Search results page — full-page version of the command palette.
-//! Reached from the palette by pressing Enter on the input (without
-//! arrow-key navigation), or by clicking a Tag result. Reuses the
-//! `data::search_palette` RPC and the same `PaletteResults` shape; each
-//! row is a single [`Link`] to the relevant detail page so there's no
-//! interactive selection state to coordinate with the palette overlay.
+//! Search results page — the full page you land on when you press Enter on
+//! the command-palette input (or click a Tag result). Reuses the
+//! `data::search_palette` RPC and groups the hits by type (Books, Authors,
+//! Series, Tags), each section linking into the relevant detail page. The
+//! matched term is highlighted throughout, an "On this page" rail jumps
+//! between sections, and a query that lands inside tag names leads with the
+//! Tags group.
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
-use omnibus_shared::PaletteResults;
+use omnibus_shared::{
+    PaletteAuthorHit, PaletteBookHit, PaletteResults, PaletteSeriesHit, PaletteTagHit,
+};
 
 use crate::{data, use_server_url, Route};
 
@@ -37,17 +40,14 @@ pub fn SearchPage(query: String) -> Element {
     }));
 
     let header = rsx! {
-        div { class: "search-page-header",
+        nav { class: "breadcrumb",
             Link {
                 to: Route::Landing {},
-                class: "btn ghost",
                 "data-testid": "search-back",
-                "\u{2190} Back to library"
+                "Library"
             }
-            h1 { class: "search-page-title",
-                "Results for "
-                span { class: "search-page-query", "\u{201c}{query}\u{201d}" }
-            }
+            span { class: "breadcrumb-sep", "\u{203a}" }
+            span { "Search" }
         }
     };
 
@@ -84,93 +84,188 @@ pub fn SearchPage(query: String) -> Element {
     }
 }
 
-/// Grouped result lists + count subtitle for a loaded [`PaletteResults`].
+/// Which result group a section renders. Drives both the main column order
+/// and the "On this page" rail.
+#[derive(Clone, Copy, PartialEq)]
+enum Section {
+    Books,
+    Authors,
+    Series,
+    Tags,
+}
+
+impl Section {
+    fn label(self) -> &'static str {
+        match self {
+            Section::Books => "Books",
+            Section::Authors => "Authors",
+            Section::Series => "Series",
+            Section::Tags => "Tags",
+        }
+    }
+
+    /// In-page anchor id used by the "On this page" jump links.
+    fn anchor(self) -> &'static str {
+        match self {
+            Section::Books => "results-books",
+            Section::Authors => "results-authors",
+            Section::Series => "results-series",
+            Section::Tags => "results-tags",
+        }
+    }
+
+    fn count(self, r: &PaletteResults) -> u32 {
+        match self {
+            Section::Books => r.book_total,
+            Section::Authors => r.author_total,
+            Section::Series => r.series_total,
+            Section::Tags => r.tag_total,
+        }
+    }
+}
+
+/// Grouped, highlighted result sections + an "On this page" rail for a loaded
+/// [`PaletteResults`].
 #[component]
 fn SearchResults(results: PaletteResults, query: String) -> Element {
-    let total = results.total_count();
+    let server_url = use_server_url();
     let r = results;
+    let q = query;
+    let total = r.total_count();
+
+    if total == 0 {
+        return rsx! {
+            div { class: "search-head",
+                div {
+                    div { class: "label", "Search results" }
+                    h1 { class: "search-title",
+                        "No results for \u{201c}"
+                        {highlight(&q, &q)}
+                        "\u{201d}"
+                    }
+                }
+            }
+            p { class: "subtitle", "data-testid": "search-result-count",
+                "0 results \u{00b7} fts5 \u{00b7} {r.duration_ms}ms"
+            }
+        };
+    }
+
+    // A query that lands inside tag names leads with the Tags group (the
+    // second design artboard); otherwise the canonical type order.
+    let q_lower = q.to_lowercase();
+    let tag_match = r
+        .tags
+        .iter()
+        .any(|t| t.name.to_lowercase().contains(&q_lower));
+    let canonical = [
+        Section::Books,
+        Section::Authors,
+        Section::Series,
+        Section::Tags,
+    ];
+    let tags_first = [
+        Section::Tags,
+        Section::Books,
+        Section::Authors,
+        Section::Series,
+    ];
+    let order: Vec<Section> = if tag_match { tags_first } else { canonical }
+        .into_iter()
+        .filter(|s| s.count(&r) > 0)
+        .collect();
+
+    let result_word = if total == 1 { "result" } else { "results" };
+
     rsx! {
-        p { class: "subtitle", "data-testid": "search-result-count",
-            "{total} result{plural(total)} \u{00b7} {r.duration_ms}ms"
-        }
-        if total == 0 {
-            p { class: "subtitle", "data-testid": "search-empty",
-                "No results for \u{201c}{query}\u{201d}."
+        div { class: "search-head",
+            div {
+                div { class: "label", "Search results" }
+                h1 { class: "search-title",
+                    span { class: "search-title-n", "{total}" }
+                    " {result_word} for \u{201c}"
+                    {highlight(&q, &q)}
+                    "\u{201d}"
+                }
+            }
+            div { class: "search-controls",
+                span { class: "label", "Sort" }
+                button { class: "btn sm", "Relevance \u{2193}" }
+                span { class: "label", "View" }
+                button { class: "btn sm search-view-active", "Grid" }
+                button { class: "btn ghost sm", "Table" }
             }
         }
-        if !r.books.is_empty() {
-            SearchGroup { label: "Books", count: r.books.len() }
-            ul { class: "search-results",
+        p { class: "search-summary mono", "data-testid": "search-result-count",
+            {summary_line(&r)}
+        }
+
+        div { class: "search-layout",
+            div { class: "search-main",
+                for (i, sec) in order.iter().enumerate() {
+                    div { key: "{sec.label()}", class: "search-section-slot",
+                        if i > 0 {
+                            div { class: "divider" }
+                        }
+                        {section_node(*sec, &r, &q, tag_match, &server_url)}
+                    }
+                }
+            }
+            {on_this_page(&order, &r, tag_match, &q)}
+        }
+    }
+}
+
+// ── Section renderers ────────────────────────────────────────────────────
+
+/// Dispatch one [`Section`] to its group renderer.
+fn section_node(
+    sec: Section,
+    r: &PaletteResults,
+    q: &str,
+    tag_match: bool,
+    server_url: &str,
+) -> Element {
+    match sec {
+        Section::Books => books_group(r, q, tag_match, server_url),
+        Section::Authors => authors_group(r, q),
+        Section::Series => series_group(r, q),
+        Section::Tags => tags_group(r, q, tag_match),
+    }
+}
+
+/// Section heading: `LABEL · count` with an optional right-aligned hint.
+fn section_head(sec: Section, count: u32, sub: Option<&str>) -> Element {
+    rsx! {
+        div { class: "search-section-head",
+            div { class: "label", "{sec.label()}" }
+            div { class: "mono search-section-count", "\u{00b7} {count}" }
+            if let Some(sub) = sub {
+                div { class: "search-section-sub", "{sub}" }
+            }
+        }
+    }
+}
+
+fn books_group(r: &PaletteResults, q: &str, tag_match: bool, server_url: &str) -> Element {
+    let sub = if tag_match {
+        Some("in matched tags")
+    } else {
+        None
+    };
+    rsx! {
+        section { id: "{Section::Books.anchor()}", class: "search-section",
+            {section_head(Section::Books, r.book_total, sub)}
+            div { class: "search-cover-grid",
                 for book in r.books.iter().cloned() {
-                    li {
+                    Link {
                         key: "{book.uuid}",
-                        Link {
-                            to: Route::BookDetail { uuid: book.uuid.clone() },
-                            class: "search-result-row",
-                            "data-testid": "search-book-row",
-                            div { class: "search-row-title", "{book.title}" }
-                            div { class: "search-row-sub", "{book.author_display}" }
-                        }
-                    }
-                }
-            }
-        }
-        if !r.authors.is_empty() {
-            SearchGroup { label: "Authors", count: r.authors.len() }
-            ul { class: "search-results",
-                for author in r.authors.iter().cloned() {
-                    li {
-                        key: "{author.id}",
-                        Link {
-                            to: Route::AuthorDetail { id: author.id },
-                            class: "search-result-row",
-                            "data-testid": "search-author-row",
-                            div { class: "search-row-title", "{author.name}" }
-                            div { class: "search-row-sub",
-                                "{author.book_count} book{plural(author.book_count as usize)}"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if !r.series.is_empty() {
-            SearchGroup { label: "Series", count: r.series.len() }
-            ul { class: "search-results",
-                for s in r.series.iter().cloned() {
-                    li {
-                        key: "{s.id}",
-                        Link {
-                            to: Route::SeriesDetail { id: s.id },
-                            class: "search-result-row",
-                            "data-testid": "search-series-row",
-                            div { class: "search-row-title", "{s.name}" }
-                            div { class: "search-row-sub",
-                                "{s.book_count} book{plural(s.book_count as usize)}"
-                                if let Some(ref a) = s.author_display {
-                                    " \u{00b7} {a}"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if !r.tags.is_empty() {
-            SearchGroup { label: "Tags", count: r.tags.len() }
-            ul { class: "search-results",
-                for tag in r.tags.iter().cloned() {
-                    li {
-                        key: "{tag.id}",
-                        Link {
-                            to: Route::Search { query: format!("tag:{}", tag.name) },
-                            class: "search-result-row",
-                            "data-testid": "search-tag-row",
-                            div { class: "search-row-title", "# {tag.name}" }
-                            div { class: "search-row-sub",
-                                "{tag.book_count} book{plural(tag.book_count as usize)}"
-                            }
-                        }
+                        to: Route::BookDetail { uuid: book.uuid.clone() },
+                        class: "search-cover-card",
+                        "data-testid": "search-book-row",
+                        {book_cover(server_url, &book)}
+                        div { class: "search-cover-title", {highlight(&book.title, q)} }
+                        div { class: "search-cover-sub", "{book.author_display}" }
                     }
                 }
             }
@@ -178,16 +273,269 @@ fn SearchResults(results: PaletteResults, query: String) -> Element {
     }
 }
 
-#[component]
-fn SearchGroup(label: &'static str, count: usize) -> Element {
+fn authors_group(r: &PaletteResults, q: &str) -> Element {
     rsx! {
-        h2 { class: "search-group-head label",
-            "{label} \u{00b7} {count}"
+        section { id: "{Section::Authors.anchor()}", class: "search-section",
+            {section_head(Section::Authors, r.author_total, None)}
+            div { class: "search-card-grid",
+                for author in r.authors.iter().cloned() {
+                    {author_card(&author, q)}
+                }
+            }
         }
     }
 }
 
-fn plural(n: usize) -> &'static str {
+fn author_card(author: &PaletteAuthorHit, q: &str) -> Element {
+    let initial = author
+        .name
+        .chars()
+        .next()
+        .unwrap_or('?')
+        .to_uppercase()
+        .to_string();
+    let books = format!("{} book{}", author.book_count, plural(author.book_count));
+    rsx! {
+        Link {
+            key: "{author.id}",
+            to: Route::AuthorDetail { id: author.id },
+            class: "search-entity",
+            "data-testid": "search-author-row",
+            div { class: "search-avatar", "{initial}" }
+            div { class: "search-entity-body",
+                div { class: "search-entity-title", {highlight(&author.name, q)} }
+                div { class: "search-entity-sub mono",
+                    "{books}"
+                    if let Some(ref lead) = author.lead_book_title {
+                        " \u{00b7} incl. {lead}"
+                    }
+                }
+            }
+            span { class: "search-entity-arrow", "\u{2192}" }
+        }
+    }
+}
+
+fn series_group(r: &PaletteResults, q: &str) -> Element {
+    rsx! {
+        section { id: "{Section::Series.anchor()}", class: "search-section",
+            {section_head(Section::Series, r.series_total, None)}
+            div { class: "search-card-grid",
+                for s in r.series.iter().cloned() {
+                    {series_card(&s, q)}
+                }
+            }
+        }
+    }
+}
+
+fn series_card(s: &PaletteSeriesHit, q: &str) -> Element {
+    rsx! {
+        Link {
+            key: "{s.id}",
+            to: Route::SeriesDetail { id: s.id },
+            class: "search-entity",
+            "data-testid": "search-series-row",
+            div { class: "search-avatar search-avatar-series", "\u{224b}" }
+            div { class: "search-entity-body",
+                div { class: "search-entity-title search-entity-title-serif", {highlight(&s.name, q)} }
+                div { class: "search-entity-sub mono",
+                    if let Some(ref lead) = s.lead_book_title {
+                        "incl. {lead}"
+                    } else {
+                        "{s.book_count} book{plural(s.book_count)}"
+                    }
+                    if let Some(ref a) = s.author_display {
+                        " \u{00b7} {a}"
+                    }
+                }
+            }
+            span { class: "search-entity-n mono", "{s.book_count}" }
+        }
+    }
+}
+
+fn tags_group(r: &PaletteResults, q: &str, tag_match: bool) -> Element {
+    let sub = if tag_match {
+        "matched in tag name"
+    } else {
+        "related to your matches"
+    };
+    let q_lower = q.to_lowercase();
+    rsx! {
+        section { id: "{Section::Tags.anchor()}", class: "search-section",
+            {section_head(Section::Tags, r.tag_total, Some(sub))}
+            div { class: "search-tags",
+                for tag in r.tags.iter().cloned() {
+                    {tag_chip(&tag, q, &q_lower)}
+                }
+            }
+        }
+    }
+}
+
+fn tag_chip(tag: &PaletteTagHit, q: &str, q_lower: &str) -> Element {
+    let matched = tag.name.to_lowercase().contains(q_lower);
+    let class = if matched {
+        "chip search-tag search-tag-matched"
+    } else {
+        "chip search-tag"
+    };
+    rsx! {
+        Link {
+            key: "{tag.id}",
+            to: Route::Search { query: format!("tag:{}", tag.name) },
+            class: "{class}",
+            "data-testid": "search-tag-row",
+            {highlight(&tag.name, q)}
+            span { class: "search-tag-count", " \u{00b7} {tag.book_count}" }
+        }
+    }
+}
+
+/// Right-rail "On this page" jump list plus a context card. A tag-name match
+/// offers the tag cloud; everything else just lists the sections.
+fn on_this_page(order: &[Section], r: &PaletteResults, tag_match: bool, q: &str) -> Element {
+    rsx! {
+        aside { class: "search-rail",
+            div { class: "label search-rail-head", "On this page" }
+            div { class: "search-rail-list",
+                for (i, sec) in order.iter().enumerate() {
+                    a {
+                        key: "{sec.label()}",
+                        href: "#{sec.anchor()}",
+                        class: if i == 0 { "search-rail-item search-rail-item-active" } else { "search-rail-item" },
+                        span { "{sec.label()}" }
+                        span { class: "search-rail-count mono", "{sec.count(r)}" }
+                    }
+                }
+            }
+            if tag_match {
+                div { class: "divider" }
+                div { class: "search-refine",
+                    div { class: "search-refine-title", "Browse by tag instead?" }
+                    div { class: "search-refine-body",
+                        "See the whole tag cloud and how \u{201c}{q}\u{201d} overlaps with neighbouring tags."
+                    }
+                    Link {
+                        to: Route::TagCloud {},
+                        class: "btn sm search-refine-btn",
+                        "Open tag cloud \u{2192}"
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/// Book cover thumbnail for a palette hit, falling back to an accent-backed
+/// initial plate when the book has no cover (mirrors the palette rows).
+fn book_cover(server_url: &str, book: &PaletteBookHit) -> Element {
+    if book.cover_url.is_some() {
+        let url = format!("{server_url}/api/thumbs/{}/md", book.uuid);
+        rsx! {
+            img { class: "search-cover-thumb", src: "{url}", alt: "", loading: "lazy" }
+        }
+    } else {
+        let initial = book
+            .title
+            .chars()
+            .next()
+            .unwrap_or('?')
+            .to_uppercase()
+            .to_string();
+        let bg = book.accent.as_deref().unwrap_or("var(--bg-2)");
+        rsx! {
+            div { class: "search-cover-thumb search-cover-fallback", style: "background: {bg};",
+                "{initial}"
+            }
+        }
+    }
+}
+
+/// Render `text` with every case-insensitive occurrence of `q` wrapped in an
+/// accented `<em class="search-hit">`. Returns the plain text untouched when
+/// `q` is empty or doesn't occur, so non-matching fields stay free of stray
+/// markup.
+fn highlight(text: &str, q: &str) -> Element {
+    let q_lower = q.to_lowercase();
+    let qn = q_lower.chars().count();
+    if qn == 0 {
+        return rsx! { "{text}" };
+    }
+    let q_chars: Vec<char> = q_lower.chars().collect();
+    let text_chars: Vec<char> = text.chars().collect();
+    // Compare against a per-char lowercased copy. One char → one char holds
+    // for ASCII and the Latin script titles carry, which is all the search
+    // box realistically sees; exotic multi-char lowercasings just won't match.
+    let lower: Vec<char> = text_chars
+        .iter()
+        .map(|c| c.to_lowercase().next().unwrap_or(*c))
+        .collect();
+
+    let mut segments: Vec<(String, bool)> = Vec::new();
+    let mut buf = String::new();
+    let mut i = 0;
+    while i < text_chars.len() {
+        if i + qn <= text_chars.len() && lower[i..i + qn] == q_chars[..] {
+            if !buf.is_empty() {
+                segments.push((std::mem::take(&mut buf), false));
+            }
+            segments.push((text_chars[i..i + qn].iter().collect(), true));
+            i += qn;
+        } else {
+            buf.push(text_chars[i]);
+            i += 1;
+        }
+    }
+    if !buf.is_empty() {
+        segments.push((buf, false));
+    }
+
+    // No hit → emit the original string with no wrapper markup.
+    if !segments.iter().any(|(_, hit)| *hit) {
+        return rsx! { "{text}" };
+    }
+
+    rsx! {
+        for (idx, (seg, hit)) in segments.into_iter().enumerate() {
+            if hit {
+                em { key: "{idx}", class: "search-hit", "{seg}" }
+            } else {
+                span { key: "{idx}", "{seg}" }
+            }
+        }
+    }
+}
+
+/// Mono summary line under the header: per-category totals, then engine + time.
+fn summary_line(r: &PaletteResults) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if r.book_total > 0 {
+        let word = if r.book_total == 1 { "title" } else { "titles" };
+        parts.push(format!("{} {word}", r.book_total));
+    }
+    if r.author_total > 0 {
+        parts.push(format!(
+            "{} author{}",
+            r.author_total,
+            plural(r.author_total)
+        ));
+    }
+    if r.series_total > 0 {
+        parts.push(format!("{} series", r.series_total));
+    }
+    if r.tag_total > 0 {
+        parts.push(format!("{} tag{}", r.tag_total, plural(r.tag_total)));
+    }
+    parts.push("fts5".to_string());
+    parts.push(format!("{}ms", r.duration_ms));
+    parts.join(" \u{00b7} ")
+}
+
+fn plural(n: u32) -> &'static str {
     if n == 1 {
         ""
     } else {
@@ -208,7 +556,8 @@ mod tests {
     }
 
     #[test]
-    fn palette_results_total_count_sums_groups() {
+    fn total_count_sums_per_category_totals_not_capped_lengths() {
+        // Vecs hold the 5-hit display cap; the totals carry the true counts.
         let r = PaletteResults {
             query: "x".into(),
             books: vec![PaletteBookHit::default()],
@@ -216,7 +565,45 @@ mod tests {
             series: vec![],
             tags: vec![],
             duration_ms: 0,
+            book_total: 40,
+            author_total: 2,
+            series_total: 0,
+            tag_total: 3,
         };
-        assert_eq!(r.total_count(), 3);
+        assert_eq!(r.total_count(), 45);
+    }
+
+    #[test]
+    fn summary_line_lists_present_categories_with_engine_and_time() {
+        let r = PaletteResults {
+            query: "wind".into(),
+            duration_ms: 24,
+            book_total: 2,
+            author_total: 2,
+            series_total: 2,
+            tag_total: 4,
+            ..Default::default()
+        };
+        assert_eq!(
+            summary_line(&r),
+            "2 titles \u{00b7} 2 authors \u{00b7} 2 series \u{00b7} 4 tags \u{00b7} fts5 \u{00b7} 24ms"
+        );
+    }
+
+    #[test]
+    fn summary_line_singularizes_and_omits_empty_categories() {
+        let r = PaletteResults {
+            query: "x".into(),
+            duration_ms: 3,
+            book_total: 0,
+            author_total: 1,
+            series_total: 0,
+            tag_total: 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            summary_line(&r),
+            "1 author \u{00b7} 1 tag \u{00b7} fts5 \u{00b7} 3ms"
+        );
     }
 }

--- a/shared/src/discovery.rs
+++ b/shared/src/discovery.rs
@@ -172,12 +172,9 @@ pub struct PaletteResults {
     pub series: Vec<PaletteSeriesHit>,
     pub tags: Vec<PaletteTagHit>,
     pub duration_ms: u64,
-    /// True match counts per category, *before* the 5-hit display cap. The
-    /// full-page results header ("N results") and the per-group counts read
-    /// these rather than the capped `Vec` lengths, so a query that matches
-    /// 40 books still reports 40 even though only 5 hits ship. `#[serde(default)]`
-    /// keeps older/partial payloads (and the command palette, which ignores
-    /// them) deserializing.
+    /// True match counts per category, before the 5-hit display cap.
+    // `#[serde(default)]` keeps older/partial payloads (and the command
+    // palette, which ignores these) deserializing.
     #[serde(default)]
     pub book_total: u32,
     #[serde(default)]

--- a/shared/src/discovery.rs
+++ b/shared/src/discovery.rs
@@ -172,12 +172,27 @@ pub struct PaletteResults {
     pub series: Vec<PaletteSeriesHit>,
     pub tags: Vec<PaletteTagHit>,
     pub duration_ms: u64,
+    /// True match counts per category, *before* the 5-hit display cap. The
+    /// full-page results header ("N results") and the per-group counts read
+    /// these rather than the capped `Vec` lengths, so a query that matches
+    /// 40 books still reports 40 even though only 5 hits ship. `#[serde(default)]`
+    /// keeps older/partial payloads (and the command palette, which ignores
+    /// them) deserializing.
+    #[serde(default)]
+    pub book_total: u32,
+    #[serde(default)]
+    pub author_total: u32,
+    #[serde(default)]
+    pub series_total: u32,
+    #[serde(default)]
+    pub tag_total: u32,
 }
 
 impl PaletteResults {
-    /// Total number of hits across every result category.
+    /// Total number of matches across every result category, using the true
+    /// per-category totals (not the capped `Vec` lengths).
     pub fn total_count(&self) -> usize {
-        self.books.len() + self.authors.len() + self.series.len() + self.tags.len()
+        (self.book_total + self.author_total + self.series_total + self.tag_total) as usize
     }
 }
 
@@ -207,6 +222,11 @@ pub struct PaletteAuthorHit {
     pub name: String,
     /// Number of books by this author in the active library.
     pub book_count: u32,
+    /// Title of this author's first book in the library (by sort order),
+    /// used for the "incl. <title>" line on the results page. `None` when
+    /// the author has no resolvable book title.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lead_book_title: Option<String>,
 }
 
 /// Series hit for the search palette.
@@ -217,6 +237,11 @@ pub struct PaletteSeriesHit {
     pub book_count: u32,
     /// Primary author of the first book in the series, if any.
     pub author_display: Option<String>,
+    /// Title of the first book in the series (by sort order), used for the
+    /// "incl. <title>" line on the results page. `None` when the series has
+    /// no resolvable book title.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lead_book_title: Option<String>,
 }
 
 /// Tag hit for the search palette.

--- a/ui_tests/playwright/tests/flows/search.spec.ts
+++ b/ui_tests/playwright/tests/flows/search.spec.ts
@@ -91,24 +91,37 @@ test("tag substring shows tag or book results", async ({ page }) => {
 
 // ── /search/:query full-page route ────────────────────────────────────
 
-test("renders the /search results page with back link and results", async ({ page }) => {
+test("renders the /search results page layout", async ({ page }) => {
   await gotoReady(page, "/search/dracula");
 
-  // Back affordance always present and routes to /.
-  const back = page.getByTestId("search-back");
-  await expect(back).toBeVisible();
+  // Breadcrumb back affordance present.
+  await expect(page.getByTestId("search-back")).toBeVisible();
 
-  // Result count line shows up once the RPC settles.
+  // Heading echoes the query, and the summary stat line shows the engine +
+  // timing once the RPC settles.
+  await expect(page.getByRole("heading", { level: 1 })).toContainText(/dracula/i);
   await expect
     .poll(async () => page.getByTestId("search-result-count").count())
     .toBe(1);
-  await expect(page.getByTestId("search-result-count")).toContainText(/result/);
+  await expect(page.getByTestId("search-result-count")).toContainText(/fts5/);
 
-  // At least one book row for "dracula".
+  // At least one book cover card for "dracula".
   await expect
     .poll(async () => page.getByTestId("search-book-row").count())
     .toBeGreaterThanOrEqual(1);
 
+  // The matched term is highlighted at least once on the page.
+  await expect(page.locator(".search-hit").first()).toBeVisible();
+
+  // "On this page" jump rail is present.
+  await expect(page.getByText("On this page")).toBeVisible();
+});
+
+test("search back link returns to the library", async ({ page }) => {
+  await gotoReady(page, "/search/dracula");
+
+  const back = page.getByTestId("search-back");
+  await expect(back).toBeVisible();
   await back.click();
   await expect(page).toHaveURL(/\/$/);
 });


### PR DESCRIPTION
## Summary
- Rebuilds `/search/:query` to match the new design: a large highlighted "N results for …" header, a per-category stats line, and grouped Books (cover grid) / Authors / Series / Tags sections with the matched term lit throughout.
- Adds an "On this page" jump rail; a query that lands inside tag names leads with the Tags group and offers the tag cloud (mirrors the two design artboards).
- Extends `PaletteResults` with true per-category totals (uncapped, behind the 5-hit display cap) and author/series lead-book titles ("incl. <title>"), wired through the db palette arms.

## Test plan
- [ ] `just test` — full matrix green, incl. new palette totals/lead-title coverage (`db/src/palette/tests.rs`) and summary/total-count tests (`frontend/src/pages/search.rs`).
- [ ] `just lint` — fmt + clippy clean across the crate/feature matrix.
- [ ] Playwright `search.spec.ts` updated to the new markup; runs in CI (`run_ui_tests`).

## Notes
- "Inside the text" passage search is intentionally out of scope: there is no cross-library full-text *content* index yet (only per-book in-reader search), so that design section is deferred. Series "planned-count" fractions (e.g. "1/5") aren't tracked in schema either — the page shows the derivable in-library count + lead title instead.
- Sort/View controls are visual affordances matching the design; wiring them to real sort/view state is follow-up.