### PR TITLE
feat: Hardcover read-alike suggestions cache + worker + key storage

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -56,6 +56,7 @@ Key vars (see `.env.example` for the full annotated list):
 - `OMNIBUS_DEV_SEED_USER=username:password` — creates a named admin user on server boot if absent. Dev convenience for `ui-validate` and parallel agents; never set in production. Password must satisfy `db::auth` validation (≥10 chars, not in `COMMON_PASSWORDS`).
 - `OMNIBUS_SECURE_COOKIES=0` — disables the `Secure` flag on session cookies. The default is `true` (secure-by-default). Browsers treat `http://localhost` as a secure context, so the Nix dev shell does not need this override; only set `0` when serving plain `http://` from a non-localhost origin (e.g. an IP-based dev server on a LAN). Never set in production.
 - `EBOOK_LIBRARY_PATH` / `AUDIOBOOK_LIBRARY_PATH` — pre-seed library paths via the `seed_settings_from_env` boot hook (runs every boot; overwrites the settings row with BOTH values, so set both together or neither). For CI / Docker / dev-up; leave unset in production.
+- `HARDCOVER_API_KEY` — account-level Hardcover Bearer token for F3.3 "Readers also enjoyed" suggestions. Unlike the library paths, the **Settings page is the source of truth**: the `seed_hardcover_key_from_env` boot hook seeds this value only when none is saved (settings wins thereafter), and `effective_hardcover_api_key` falls back to it when settings is empty. Server-wide, never per-user; leave unset to keep suggestions disabled.
 
 **Security-sensitive (never set casually in production):**
 

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,14 @@ OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
 # EBOOK_LIBRARY_PATH=/path/to/ebooks
 # AUDIOBOOK_LIBRARY_PATH=/path/to/audiobooks
 
+# F3.3 "Readers also enjoyed" suggestions — account-level Hardcover API token
+# (Bearer). Server-wide, never per-user. The Settings page is the source of
+# truth; this env var only SEEDS the saved value on first boot when none is set
+# (settings wins thereafter), and is the read-time fallback when nothing is
+# saved. Leave unset to keep suggestions disabled (the section shows a connect
+# message). Read by db::settings::effective_hardcover_api_key.
+#HARDCOVER_API_KEY=hc_live_xxxxxxxxxxxxxxxx
+
 # Session cookie Secure flag. Defaults to true (cookies sent over HTTPS only).
 # Browsers treat http://localhost as a secure context, so the Nix dev shell
 # does NOT need this override. Set to 0 only when serving plain http:// from a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/db/migrations/0033_hardcover_suggestions.sql
+++ b/db/migrations/0033_hardcover_suggestions.sql
@@ -1,0 +1,34 @@
+-- F3.3 Suggestions ("Readers also enjoyed"). Per-book read-alike results
+-- mined from Hardcover community-list co-occurrence, fetched off-request by
+-- the F0.5 worker and cached with a 30-day TTL.
+--
+-- Suggested books are *external* (Hardcover catalog, usually not in the
+-- library), so rows store the external metadata directly and soft-reference
+-- the source library book by `book_uuid` (no FK, no cascade — durable-identity
+-- convention, mirrors `user_ratings` in 0031). A reindex never wipes a cache
+-- row; it just goes stale and re-resolves.
+
+-- Cached suggestions: 0..N rows per source book, ordered by `rank`.
+CREATE TABLE book_suggestions (
+    book_uuid      TEXT    NOT NULL,              -- source library book (soft ref)
+    rank           INTEGER NOT NULL,              -- 0-based, by co-listing count desc
+    hardcover_id   INTEGER NOT NULL,              -- external Hardcover book id
+    hardcover_slug TEXT,                           -- outbound /books/{slug} URL (may be null)
+    title          TEXT    NOT NULL,
+    author         TEXT    NOT NULL,
+    list_count     INTEGER NOT NULL DEFAULT 0,     -- co-listing count (relevance signal)
+    cover_mime     TEXT,                           -- null when no cover was fetched
+    cover_bytes    BLOB,
+    PRIMARY KEY (book_uuid, rank)
+);
+
+-- Per-book cache marker carrying the 30-day TTL clock and the de-duplication
+-- state. `pending` = a resolution was enqueued and is in flight (debounces a
+-- burst of viewers into one Hardcover round-trip); `resolved` = results cached
+-- (`book_suggestions` may hold 0..N rows); `empty` = sticky negative marker
+-- (Hardcover matched nothing usable — stays quiet until the TTL lapses).
+CREATE TABLE book_suggestion_state (
+    book_uuid  TEXT PRIMARY KEY,
+    state      TEXT    NOT NULL CHECK (state IN ('pending', 'resolved', 'empty')),
+    fetched_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -32,6 +32,7 @@ pub mod ratings;
 pub mod scanner;
 pub mod settings;
 pub mod sort_keys;
+pub mod suggestions;
 pub mod sync;
 mod taxonomy;
 #[cfg(any(test, feature = "test-support"))]
@@ -67,5 +68,12 @@ pub use palette::*;
 pub use pool::*;
 pub use settings::*;
 pub use sort_keys::{backfill_series_sort, series_sort_value, SortKeysError};
+// Flatten the suggestions data layer (cache CRUD + the de-dup state machine).
+// `resolve`/`resolve_with` stay namespaced under `suggestions::` to avoid
+// colliding with `author_photos::resolve`.
+pub use suggestions::{
+    decide, get_suggestion_cover, get_suggestions, mark_pending, suggestion_state, CacheDecision,
+    CachedSuggestion, SuggestionState, SuggestionsDataError,
+};
 pub use sync::*;
 pub use thumbs::{thumb_path_for, thumbs_dir, ThumbError, ThumbSize};

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -14,6 +14,10 @@ pub use omnibus_shared::Settings;
 /// indexer, settings handlers, and tests all reference the same identifier.
 const EBOOK_LIBRARY_PATH_KEY: &str = "ebook_library_path";
 const AUDIOBOOK_LIBRARY_PATH_KEY: &str = "audiobook_library_path";
+/// `settings` KV key for the F3.3 Hardcover API token. Stored directly (not via
+/// the [`Settings`] struct) so saving it never triggers the scan-root
+/// reconciliation `set_settings` runs.
+const HARDCOVER_API_KEY_KEY: &str = "hardcover_api_key";
 
 /// Errors returned by the settings data layer.
 #[derive(Debug, thiserror::Error)]
@@ -250,6 +254,69 @@ pub async fn seed_settings_from_env(pool: &SqlitePool) -> Result<(), SettingsErr
             },
         )
         .await?;
+    }
+    Ok(())
+}
+
+/// Read the Hardcover API key saved in `settings`, or `None` when unset/blank.
+/// This is the raw secret — callers serving it to a client MUST mask it.
+pub async fn get_hardcover_api_key(pool: &SqlitePool) -> Result<Option<String>, SettingsError> {
+    let v = sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(HARDCOVER_API_KEY_KEY)
+        .fetch_optional(pool)
+        .await?;
+    Ok(v.filter(|s| !s.trim().is_empty()))
+}
+
+/// Persist (or clear, when `None`/blank) the Hardcover API key in `settings`.
+pub async fn set_hardcover_api_key(
+    pool: &SqlitePool,
+    key: Option<&str>,
+) -> Result<(), SettingsError> {
+    match key.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(v) => {
+            sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+                .bind(HARDCOVER_API_KEY_KEY)
+                .bind(v)
+                .execute(pool)
+                .await?;
+        }
+        None => {
+            sqlx::query("DELETE FROM settings WHERE key = ?")
+                .bind(HARDCOVER_API_KEY_KEY)
+                .execute(pool)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+/// The effective Hardcover key: the saved settings value wins; the
+/// `HARDCOVER_API_KEY` env var is the fallback when no value is saved. Returns
+/// `None` (feature disabled) when neither is set.
+pub async fn effective_hardcover_api_key(
+    pool: &SqlitePool,
+) -> Result<Option<String>, SettingsError> {
+    if let Some(saved) = get_hardcover_api_key(pool).await? {
+        return Ok(Some(saved));
+    }
+    Ok(std::env::var("HARDCOVER_API_KEY")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty()))
+}
+
+/// Boot hook: seed the Hardcover key from `HARDCOVER_API_KEY` **only** when no
+/// value is already saved, so the env var works out of the box without
+/// clobbering a key set through Settings on every restart (settings wins).
+pub async fn seed_hardcover_key_from_env(pool: &SqlitePool) -> Result<(), SettingsError> {
+    if get_hardcover_api_key(pool).await?.is_some() {
+        return Ok(());
+    }
+    if let Ok(env_key) = std::env::var("HARDCOVER_API_KEY") {
+        if !env_key.trim().is_empty() {
+            set_hardcover_api_key(pool, Some(&env_key)).await?;
+        }
     }
     Ok(())
 }

--- a/db/src/settings/tests.rs
+++ b/db/src/settings/tests.rs
@@ -111,6 +111,80 @@ async fn seed_settings_from_env_is_noop_when_vars_unset() {
     assert_eq!(result.audiobook_library_path, None);
 }
 
+// ── Hardcover API key (F3.3) — settings wins, env seeds-if-unset ──
+
+#[tokio::test]
+async fn hardcover_key_set_get_and_clear_roundtrips() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    assert_eq!(get_hardcover_api_key(&pool).await.unwrap(), None);
+
+    set_hardcover_api_key(&pool, Some("  hc_secret  "))
+        .await
+        .unwrap();
+    assert_eq!(
+        get_hardcover_api_key(&pool).await.unwrap().as_deref(),
+        Some("hc_secret")
+    );
+
+    // Blank clears (treated as None).
+    set_hardcover_api_key(&pool, Some("   ")).await.unwrap();
+    assert_eq!(get_hardcover_api_key(&pool).await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn effective_hardcover_key_prefers_saved_over_env() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", Some("env-key"));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    set_hardcover_api_key(&pool, Some("settings-key"))
+        .await
+        .unwrap();
+    assert_eq!(
+        effective_hardcover_api_key(&pool).await.unwrap().as_deref(),
+        Some("settings-key")
+    );
+}
+
+#[tokio::test]
+async fn effective_hardcover_key_falls_back_to_env_when_unset() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", Some("env-key"));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    assert_eq!(
+        effective_hardcover_api_key(&pool).await.unwrap().as_deref(),
+        Some("env-key")
+    );
+}
+
+#[tokio::test]
+async fn effective_hardcover_key_is_none_when_neither_set() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    assert_eq!(effective_hardcover_api_key(&pool).await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn seed_hardcover_key_seeds_only_when_unset() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", Some("env-key"));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    // No saved value → env seeds it.
+    seed_hardcover_key_from_env(&pool).await.unwrap();
+    assert_eq!(
+        get_hardcover_api_key(&pool).await.unwrap().as_deref(),
+        Some("env-key")
+    );
+
+    // A subsequent settings save wins, and re-seeding does NOT clobber it.
+    set_hardcover_api_key(&pool, Some("settings-key"))
+        .await
+        .unwrap();
+    seed_hardcover_key_from_env(&pool).await.unwrap();
+    assert_eq!(
+        get_hardcover_api_key(&pool).await.unwrap().as_deref(),
+        Some("settings-key")
+    );
+}
+
 /// F2 repoint-in-place: changing the ebook path moves the existing
 /// `scan_roots` row (keeping its id) so every book — and its durable
 /// `books.uuid` — survives the move under the new path. Nothing is deleted.

--- a/db/src/suggestions/cascade.rs
+++ b/db/src/suggestions/cascade.rs
@@ -1,0 +1,157 @@
+//! Resolution orchestration for F3.3 suggestions. Mirrors
+//! `author_photos::cascade`: a single `resolve` entry point the worker drives,
+//! plus a `resolve_with` that takes injectable configs for tests.
+//!
+//! Flow: resolve the library book to a Hardcover book (ISBN-first, title
+//! fallback) → collect its curated lists → rank co-listed books → filter to
+//! different-author / different-series / entry-point survivors → fetch cover
+//! bytes → cache the top 10. A clean miss writes the sticky `empty` marker; a
+//! transient network error leaves the marker untouched so the debounce window
+//! re-posts later.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use sqlx::SqlitePool;
+
+use crate::author_photos::{fetch_remote_image_with, RemoteImageConfig};
+use crate::suggestions::data::{
+    replace_suggestions, suggestion_state, NewSuggestion, SuggestionState, SUGGESTIONS_TTL_SECS,
+};
+use crate::suggestions::filter::filter_candidates;
+use crate::suggestions::hardcover::{
+    co_listed_counts, curated_list_ids, fetch_candidates, resolve_book, HardcoverConfig,
+};
+
+/// Final strip size — at most 10 survivors are cached.
+const FINAL_LIMIT: usize = 10;
+
+/// Current unix time in seconds.
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_secs()).ok())
+        .unwrap_or(0)
+}
+
+/// Resolve and cache suggestions for `book_uuid`. Reads the effective Hardcover
+/// key (settings → env); a missing key is a no-op (the UI shows a connect
+/// message). Driven by [`crate::worker::Task::ResolveSuggestions`].
+pub async fn resolve(pool: &SqlitePool, book_uuid: &str) -> anyhow::Result<()> {
+    let Some(key) = crate::settings::effective_hardcover_api_key(pool).await? else {
+        return Ok(());
+    };
+    resolve_with(
+        pool,
+        book_uuid,
+        &HardcoverConfig::new(key),
+        &RemoteImageConfig::default(),
+    )
+    .await
+}
+
+/// [`resolve`] with injectable Hardcover + remote-image configs (tests point
+/// these at a local `wiremock` server).
+pub async fn resolve_with(
+    pool: &SqlitePool,
+    book_uuid: &str,
+    config: &HardcoverConfig,
+    image_config: &RemoteImageConfig,
+) -> anyhow::Result<()> {
+    // A sibling task (serialized behind us on the same resource key) may have
+    // already produced a fresh result — skip the network work if so. We do NOT
+    // skip on `pending`: that's our own in-flight marker, set by the RPC.
+    if let Some((state, at)) = suggestion_state(pool, book_uuid).await? {
+        let fresh = now_secs().saturating_sub(at) <= SUGGESTIONS_TTL_SECS;
+        if matches!(state, SuggestionState::Resolved | SuggestionState::Empty) && fresh {
+            return Ok(());
+        }
+    }
+
+    let Some(book) = crate::get_book_by_uuid(pool, book_uuid).await? else {
+        // Book vanished (reindex/ghost) — nothing to resolve.
+        return Ok(());
+    };
+    let title = book.title.clone().unwrap_or_default();
+    let author = book.creators.first().map(|c| c.name.clone());
+    let isbns = extract_isbns(&book);
+
+    // Resolve the library book to a Hardcover book.
+    let Some(resolved) = resolve_book(config, &isbns, &title, author.as_deref()).await? else {
+        // Hardcover has no matching book — sticky negative until the TTL lapses.
+        replace_suggestions(pool, book_uuid, &[], SuggestionState::Empty).await?;
+        return Ok(());
+    };
+
+    // Collect curated lists → rank co-listed books → hydrate the deep pool.
+    let list_ids = curated_list_ids(config, resolved.id).await?;
+    let ranked = co_listed_counts(config, &list_ids, resolved.id).await?;
+    let candidates = fetch_candidates(config, &ranked).await?;
+
+    // Filter to different-author / different-series / entry-point survivors.
+    let survivors = filter_candidates(
+        &candidates,
+        &resolved.author_names,
+        resolved.series.as_deref(),
+        FINAL_LIMIT,
+    );
+
+    // Build cache rows, fetching cover bytes best-effort (a cover miss must not
+    // drop the suggestion — `Cover` falls back to a typographic plate).
+    let mut rows: Vec<NewSuggestion> = Vec::with_capacity(survivors.len());
+    for c in survivors {
+        let cover = match &c.cover_url {
+            Some(url) => fetch_remote_image_with(url, image_config).await.ok(),
+            None => None,
+        };
+        // Persist a cover only when the fetch returned real bytes. An empty
+        // body (e.g. a 200 with no payload) would set `cover_bytes != NULL` —
+        // making `get_suggestions` report `has_cover = true` while the cover
+        // endpoint serves a 404 (it rejects empty bytes). Treat empty as none.
+        let (cover_mime, cover_bytes) = match cover {
+            Some((mime, bytes)) if !bytes.is_empty() => (Some(mime), Some(bytes)),
+            _ => (None, None),
+        };
+        rows.push(NewSuggestion {
+            hardcover_id: c.hardcover_id,
+            hardcover_slug: c.slug,
+            title: c.title,
+            author: c.author,
+            list_count: c.list_count,
+            cover_mime,
+            cover_bytes,
+        });
+    }
+
+    let state = if rows.is_empty() {
+        SuggestionState::Empty
+    } else {
+        SuggestionState::Resolved
+    };
+    replace_suggestions(pool, book_uuid, &rows, state).await?;
+    Ok(())
+}
+
+/// Pull candidate ISBNs from a book's identifiers. Accepts identifiers whose
+/// scheme names ISBN, plus any value that *looks* like a 10/13-digit ISBN
+/// (covers the common `scheme = "unknown"` case). Hyphens/spaces stripped.
+fn extract_isbns(book: &omnibus_shared::EbookMetadata) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for ident in &book.identifiers {
+        let scheme_is_isbn = ident
+            .scheme
+            .as_deref()
+            .map(|s| s.to_lowercase().contains("isbn"))
+            .unwrap_or(false);
+        let cleaned: String = ident
+            .value
+            .chars()
+            .filter(|c| c.is_ascii_digit() || *c == 'X' || *c == 'x')
+            .collect();
+        let looks_like_isbn = matches!(cleaned.len(), 10 | 13);
+        if (scheme_is_isbn || looks_like_isbn) && !cleaned.is_empty() && !out.contains(&cleaned) {
+            out.push(cleaned);
+        }
+    }
+    out
+}

--- a/db/src/suggestions/data.rs
+++ b/db/src/suggestions/data.rs
@@ -1,0 +1,281 @@
+//! Cache CRUD + de-duplication state machine for F3.3 suggestions.
+//!
+//! Two tables back this (migration 0033): `book_suggestion_state` holds one
+//! marker per source book (the TTL clock + `pending`/`resolved`/`empty`
+//! state), and `book_suggestions` holds 0..N cached result rows. The pure
+//! [`decide`] function turns the marker into a "serve cached? enqueue a
+//! refetch?" verdict — the single place that guarantees a page refresh or a
+//! burst of concurrent viewers never re-hits Hardcover while a result is fresh.
+
+use sqlx::SqlitePool;
+
+/// Result cache TTL: a book is re-resolved only after 30 days.
+pub const SUGGESTIONS_TTL_SECS: i64 = 30 * 24 * 60 * 60;
+
+/// Debounce window for an in-flight `pending` marker. A second viewer landing
+/// within this window reads `pending` and does **not** post another task; a
+/// `pending` marker older than this is treated as a dead resolution and
+/// re-posted.
+pub const PENDING_DEBOUNCE_SECS: i64 = 15 * 60;
+
+/// Errors returned by the suggestions data layer. Single transparent `Db`
+/// variant per the `02-error-handling` boundary rule — never leak
+/// `sqlx::Error` across the module boundary.
+#[derive(Debug, thiserror::Error)]
+pub enum SuggestionsDataError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
+/// State of a per-book cache marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuggestionState {
+    /// A resolution is enqueued / in flight.
+    Pending,
+    /// Results are cached (`book_suggestions` holds 0..N rows).
+    Resolved,
+    /// Sticky negative — Hardcover matched nothing usable.
+    Empty,
+}
+
+impl SuggestionState {
+    /// Database string for this state.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SuggestionState::Pending => "pending",
+            SuggestionState::Resolved => "resolved",
+            SuggestionState::Empty => "empty",
+        }
+    }
+
+    /// Parse a database string; `None` for unrecognised values.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(Self::Pending),
+            "resolved" => Some(Self::Resolved),
+            "empty" => Some(Self::Empty),
+            _ => None,
+        }
+    }
+}
+
+/// What the read path should do for a book, derived purely from its cache
+/// marker and the current time. `serve` = return whatever rows are cached;
+/// `enqueue` = post a (re)resolution task. The RPC marks `pending` before it
+/// posts so concurrent callers can't each enqueue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheDecision {
+    pub serve: bool,
+    pub enqueue: bool,
+}
+
+/// Pure cache state machine — see the table in
+/// [`crate::suggestions`]. `marker` is the `(state, fetched_at)` pair from
+/// [`suggestion_state`] (`None` = no row yet); `now` is unix-seconds.
+pub fn decide(marker: Option<(SuggestionState, i64)>, now: i64) -> CacheDecision {
+    match marker {
+        // No marker: first viewer. Nothing to serve; kick off a resolution.
+        None => CacheDecision {
+            serve: false,
+            enqueue: true,
+        },
+        // In flight: serve nothing, and only re-post if the marker is old
+        // enough that the prior task almost certainly died.
+        Some((SuggestionState::Pending, at)) => CacheDecision {
+            serve: false,
+            enqueue: now.saturating_sub(at) > PENDING_DEBOUNCE_SECS,
+        },
+        // Resolved/empty: serve the cached rows; refresh only past the TTL.
+        Some((SuggestionState::Resolved | SuggestionState::Empty, at)) => CacheDecision {
+            serve: true,
+            enqueue: now.saturating_sub(at) > SUGGESTIONS_TTL_SECS,
+        },
+    }
+}
+
+/// A cached suggestion row as served to the API layer (cover bytes excluded —
+/// those stream through a separate endpoint). `has_cover` tells the frontend
+/// whether to point a cover `<img>` at the cover endpoint or fall back to the
+/// typographic plate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedSuggestion {
+    pub rank: i64,
+    pub hardcover_id: i64,
+    pub hardcover_slug: Option<String>,
+    pub title: String,
+    pub author: String,
+    pub list_count: i64,
+    pub has_cover: bool,
+}
+
+/// A freshly-resolved suggestion to persist. `rank` is assigned by insertion
+/// order in [`replace_suggestions`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewSuggestion {
+    pub hardcover_id: i64,
+    pub hardcover_slug: Option<String>,
+    pub title: String,
+    pub author: String,
+    pub list_count: i64,
+    pub cover_mime: Option<String>,
+    pub cover_bytes: Option<Vec<u8>>,
+}
+
+/// Read the cache marker `(state, fetched_at)` for a book, or `None` if it has
+/// never been resolved.
+pub async fn suggestion_state(
+    pool: &SqlitePool,
+    book_uuid: &str,
+) -> Result<Option<(SuggestionState, i64)>, SuggestionsDataError> {
+    let row: Option<(String, i64)> =
+        sqlx::query_as("SELECT state, fetched_at FROM book_suggestion_state WHERE book_uuid = ?")
+            .bind(book_uuid)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.and_then(|(s, at)| SuggestionState::parse(&s).map(|st| (st, at))))
+}
+
+/// Raw projection row for [`get_suggestions`]:
+/// `(rank, hardcover_id, hardcover_slug, title, author, list_count, has_cover)`.
+type SuggestionProjection = (i64, i64, Option<String>, String, String, i64, bool);
+
+/// Fetch the cached suggestion rows for a book, ordered by rank.
+pub async fn get_suggestions(
+    pool: &SqlitePool,
+    book_uuid: &str,
+) -> Result<Vec<CachedSuggestion>, SuggestionsDataError> {
+    let rows: Vec<SuggestionProjection> = sqlx::query_as(
+        // `has_cover` guards on length too, not just NOT NULL: the cover
+        // endpoint (`get_suggestion_cover`) rejects empty blobs, so a
+        // zero-length row must not advertise a cover URL that would 404.
+        // Belt + suspenders alongside the cascade's empty-bytes filter.
+        "SELECT rank, hardcover_id, hardcover_slug, title, author, list_count,
+                (cover_bytes IS NOT NULL AND length(cover_bytes) > 0) AS has_cover
+           FROM book_suggestions
+          WHERE book_uuid = ?
+          ORDER BY rank",
+    )
+    .bind(book_uuid)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(
+            |(rank, hardcover_id, hardcover_slug, title, author, list_count, has_cover)| {
+                CachedSuggestion {
+                    rank,
+                    hardcover_id,
+                    hardcover_slug,
+                    title,
+                    author,
+                    list_count,
+                    has_cover,
+                }
+            },
+        )
+        .collect())
+}
+
+/// Fetch one cached cover's `(mime, bytes)`, or `None` when the rank has no
+/// stored image. Served by the cover endpoint.
+pub async fn get_suggestion_cover(
+    pool: &SqlitePool,
+    book_uuid: &str,
+    rank: i64,
+) -> Result<Option<(String, Vec<u8>)>, SuggestionsDataError> {
+    let row: Option<(Option<String>, Option<Vec<u8>>)> = sqlx::query_as(
+        "SELECT cover_mime, cover_bytes FROM book_suggestions WHERE book_uuid = ? AND rank = ?",
+    )
+    .bind(book_uuid)
+    .bind(rank)
+    .fetch_optional(pool)
+    .await?;
+    match row {
+        Some((Some(mime), Some(bytes))) if !bytes.is_empty() => Ok(Some((mime, bytes))),
+        _ => Ok(None),
+    }
+}
+
+/// Mark a book `pending` (upsert state + reset the `fetched_at` clock). Called
+/// by the RPC immediately *before* posting a resolution task so a burst of
+/// concurrent first-viewers collapses to a single posted job.
+pub async fn mark_pending(pool: &SqlitePool, book_uuid: &str) -> Result<(), SuggestionsDataError> {
+    sqlx::query(
+        "INSERT INTO book_suggestion_state (book_uuid, state, fetched_at)
+              VALUES (?, 'pending', strftime('%s','now'))
+         ON CONFLICT(book_uuid) DO UPDATE SET
+              state      = 'pending',
+              fetched_at = strftime('%s','now')",
+    )
+    .bind(book_uuid)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Replace a book's cached suggestions and stamp its terminal marker, in one
+/// transaction. `rows` are written at ranks `0..rows.len()`; an empty `rows`
+/// slice with `state = Empty` records the sticky-negative marker.
+pub async fn replace_suggestions(
+    pool: &SqlitePool,
+    book_uuid: &str,
+    rows: &[NewSuggestion],
+    state: SuggestionState,
+) -> Result<(), SuggestionsDataError> {
+    let mut tx = pool.begin().await?;
+    sqlx::query("DELETE FROM book_suggestions WHERE book_uuid = ?")
+        .bind(book_uuid)
+        .execute(&mut *tx)
+        .await?;
+    for (rank, s) in rows.iter().enumerate() {
+        sqlx::query(
+            "INSERT INTO book_suggestions
+                 (book_uuid, rank, hardcover_id, hardcover_slug, title, author,
+                  list_count, cover_mime, cover_bytes)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(book_uuid)
+        .bind(rank as i64)
+        .bind(s.hardcover_id)
+        .bind(s.hardcover_slug.as_deref())
+        .bind(&s.title)
+        .bind(&s.author)
+        .bind(s.list_count)
+        .bind(s.cover_mime.as_deref())
+        .bind(s.cover_bytes.as_deref())
+        .execute(&mut *tx)
+        .await?;
+    }
+    sqlx::query(
+        "INSERT INTO book_suggestion_state (book_uuid, state, fetched_at)
+              VALUES (?, ?, strftime('%s','now'))
+         ON CONFLICT(book_uuid) DO UPDATE SET
+              state      = excluded.state,
+              fetched_at = excluded.fetched_at",
+    )
+    .bind(book_uuid)
+    .bind(state.as_str())
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Drop a book's cached suggestions and marker so the next view re-resolves.
+/// Used by tests and any future admin "refresh suggestions" affordance.
+pub async fn delete_suggestions(
+    pool: &SqlitePool,
+    book_uuid: &str,
+) -> Result<(), SuggestionsDataError> {
+    let mut tx = pool.begin().await?;
+    sqlx::query("DELETE FROM book_suggestions WHERE book_uuid = ?")
+        .bind(book_uuid)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("DELETE FROM book_suggestion_state WHERE book_uuid = ?")
+        .bind(book_uuid)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}

--- a/db/src/suggestions/filter.rs
+++ b/db/src/suggestions/filter.rs
@@ -1,0 +1,89 @@
+//! Pure candidate-filtering for F3.3 suggestions. Given the source book's
+//! authors/series and a list of Hardcover co-listed candidates (already ranked
+//! by co-listing count, descending), trim to the top read-alikes that are
+//! genuinely *new* discoveries: different author, different series, and an
+//! entry point (series-starter or standalone) so a reader is never dropped
+//! into the middle of a series. No I/O — exercised heavily in `tests.rs`.
+
+use std::collections::HashSet;
+
+/// A Hardcover co-listed book competing for a slot in the strip. `author` is
+/// the primary contributor; `series` / `series_position` come from Hardcover's
+/// `book_series` edge (both may be absent for a standalone).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Candidate {
+    pub hardcover_id: i64,
+    pub slug: Option<String>,
+    pub title: String,
+    pub author: String,
+    pub series: Option<String>,
+    pub series_position: Option<f64>,
+    pub list_count: i64,
+    pub cover_url: Option<String>,
+}
+
+/// Trim + lowercase for case/whitespace-insensitive name comparison.
+fn norm(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+
+/// An "entry point" is a standalone (no series) or a series-starter
+/// (`position <= 1`). A book in a series with **unknown** position is treated
+/// as *not* an entry point: we can't prove it's the first, and the roadmap
+/// prioritizes never dropping a reader mid-series over surfacing a maybe-starter.
+pub fn is_entry_point(series: Option<&str>, position: Option<f64>) -> bool {
+    match series {
+        None => true,
+        Some(name) if name.trim().is_empty() => true,
+        Some(_) => position.is_some_and(|p| p <= 1.0),
+    }
+}
+
+/// True when the candidate shares an author with the source book
+/// (case-insensitive). Such candidates are excluded — the strip is for
+/// *other* authors.
+pub fn is_same_author(candidate_author: &str, source_authors: &[String]) -> bool {
+    let c = norm(candidate_author);
+    source_authors.iter().any(|a| norm(a) == c)
+}
+
+/// True when the candidate is in the same series as the source book
+/// (case-insensitive, both must name a series).
+pub fn is_same_series(candidate_series: Option<&str>, source_series: Option<&str>) -> bool {
+    match (candidate_series, source_series) {
+        (Some(c), Some(s)) => !c.trim().is_empty() && norm(c) == norm(s),
+        _ => false,
+    }
+}
+
+/// Apply the full filter and return at most `limit` survivors, preserving the
+/// input order (callers pass candidates pre-sorted by co-listing count desc).
+/// Duplicate `hardcover_id`s are collapsed to their first occurrence.
+pub fn filter_candidates(
+    candidates: &[Candidate],
+    source_authors: &[String],
+    source_series: Option<&str>,
+    limit: usize,
+) -> Vec<Candidate> {
+    let mut seen: HashSet<i64> = HashSet::new();
+    let mut out: Vec<Candidate> = Vec::new();
+    for c in candidates {
+        if out.len() >= limit {
+            break;
+        }
+        if !seen.insert(c.hardcover_id) {
+            continue;
+        }
+        if is_same_author(&c.author, source_authors) {
+            continue;
+        }
+        if is_same_series(c.series.as_deref(), source_series) {
+            continue;
+        }
+        if !is_entry_point(c.series.as_deref(), c.series_position) {
+            continue;
+        }
+        out.push(c.clone());
+    }
+    out
+}

--- a/db/src/suggestions/hardcover.rs
+++ b/db/src/suggestions/hardcover.rs
@@ -1,0 +1,408 @@
+//! Hardcover GraphQL client for F3.3 suggestions. Composes a "readers also
+//! enjoyed" signal out of community-list co-occurrence — Hardcover has no
+//! recommendations endpoint, so we resolve the library book to a Hardcover
+//! book, collect the curated lists it sits on, and rank every other book by
+//! how many of those lists it also appears on.
+//!
+//! All queries go through [`post_graphql`] against [`HardcoverConfig`]
+//! (base URL + Bearer key + timeout), which tests point at a `wiremock`
+//! server. Schema field names were verified live against
+//! `https://api.hardcover.app/v1/graphql`.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+
+use crate::suggestions::filter::Candidate;
+
+/// Process-wide `reqwest::Client` for Hardcover GraphQL calls, built once and
+/// cloned so resolutions share one connection pool + TLS session cache.
+/// Fallible (TLS backend init); callers propagate via `?`.
+fn hardcover_client() -> reqwest::Result<reqwest::Client> {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    if let Some(c) = CLIENT.get() {
+        return Ok(c.clone());
+    }
+    let new = reqwest::Client::builder()
+        .user_agent(format!(
+            "omnibus/{} (https://github.com/sloansa/omnibus)",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()?;
+    let _ = CLIENT.set(new.clone());
+    Ok(CLIENT.get().cloned().unwrap_or(new))
+}
+
+/// Hardcover's per-query row cap (verified live: a `limit: 5000` returns 2000).
+const PAGE_SIZE: i64 = 2000;
+/// How many curated lists to sample for one book. The book may sit on
+/// thousands; richer lists (nearer 150) carry the most co-occurrence overlap,
+/// so we take the largest curated ones first and bound the work.
+const LIST_SAMPLE: i64 = 40;
+/// Hard ceiling on co-listing member rows pulled across all sampled lists.
+const MAX_MEMBER_ROWS: usize = 6000;
+/// Curated-list size band: below 5 is noise, above 150 is a dumping ground.
+const MIN_LIST_BOOKS: i64 = 5;
+const MAX_LIST_BOOKS: i64 = 150;
+/// Public list privacy flag (Hardcover `privacy_setting_id`).
+const PRIVACY_PUBLIC: i64 = 1;
+/// Depth of the candidate pool fetched for detail+filtering before trimming to
+/// the final 10 — taken deep because the same-author/same-series filter prunes
+/// hard (an author-heavy book sheds its whole top-of-list).
+pub const CANDIDATE_POOL: usize = 70;
+/// Per-request timeout. Hardcover allows up to 30s per query.
+const HARDCOVER_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Connection config for the Hardcover GraphQL API. Injectable so tests point
+/// `base_url` at a local `wiremock` server.
+#[derive(Debug, Clone)]
+pub struct HardcoverConfig {
+    /// `https://api.hardcover.app/v1/graphql` in production.
+    pub base_url: String,
+    /// Account-level Bearer token (server-wide, never per-user).
+    pub api_key: String,
+    pub timeout: Duration,
+}
+
+impl HardcoverConfig {
+    /// Build a config for the live endpoint with the given key.
+    pub fn new(api_key: String) -> Self {
+        Self {
+            base_url: "https://api.hardcover.app/v1/graphql".to_string(),
+            api_key,
+            timeout: HARDCOVER_TIMEOUT,
+        }
+    }
+}
+
+/// Errors from the Hardcover client. `Graphql` carries the joined `errors[]`
+/// messages from a 200 response that nonetheless failed (Hasura convention).
+#[derive(Debug, thiserror::Error)]
+pub enum HardcoverError {
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error("hardcover graphql error: {0}")]
+    Graphql(String),
+}
+
+/// The Hardcover book a library book resolved to, plus the fields the filter
+/// needs to exclude same-author / same-series candidates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedBook {
+    pub id: i64,
+    pub author_names: Vec<String>,
+    pub series: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlEnvelope<T> {
+    data: Option<T>,
+    #[serde(default)]
+    errors: Vec<GraphqlError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlError {
+    message: String,
+}
+
+/// POST a GraphQL operation and deserialize `data` into `T`. Returns
+/// [`HardcoverError::Graphql`] when the response carries `errors[]` or no
+/// `data`. Integer-id arrays are inlined by callers (safe — `i64`); all
+/// untrusted strings go through `variables`.
+async fn post_graphql<T: DeserializeOwned>(
+    config: &HardcoverConfig,
+    query: &str,
+    variables: serde_json::Value,
+) -> Result<T, HardcoverError> {
+    let client = hardcover_client()?;
+    let resp = client
+        .post(&config.base_url)
+        .timeout(config.timeout)
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", config.api_key),
+        )
+        .json(&serde_json::json!({ "query": query, "variables": variables }))
+        .send()
+        .await?
+        .error_for_status()?;
+    let envelope: GraphqlEnvelope<T> = resp.json().await?;
+    if !envelope.errors.is_empty() {
+        let joined = envelope
+            .errors
+            .into_iter()
+            .map(|e| e.message)
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(HardcoverError::Graphql(joined));
+    }
+    envelope
+        .data
+        .ok_or_else(|| HardcoverError::Graphql("response had no data".to_string()))
+}
+
+// ── Book resolution ──────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct EditionsData {
+    editions: Vec<EditionRow>,
+}
+#[derive(Debug, Deserialize)]
+struct EditionRow {
+    book_id: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BooksData {
+    books: Vec<BookRow>,
+}
+#[derive(Debug, Deserialize)]
+struct BookRow {
+    id: i64,
+    #[serde(default)]
+    slug: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    contributions: Vec<Contribution>,
+    #[serde(default)]
+    book_series: Vec<BookSeries>,
+    #[serde(default)]
+    image: Option<HcImage>,
+}
+#[derive(Debug, Deserialize)]
+struct Contribution {
+    #[serde(default)]
+    author: Option<HcAuthor>,
+}
+#[derive(Debug, Deserialize)]
+struct HcAuthor {
+    #[serde(default)]
+    name: Option<String>,
+}
+#[derive(Debug, Deserialize)]
+struct BookSeries {
+    #[serde(default)]
+    position: Option<f64>,
+    #[serde(default)]
+    series: Option<HcSeries>,
+}
+#[derive(Debug, Deserialize)]
+struct HcSeries {
+    #[serde(default)]
+    name: Option<String>,
+}
+#[derive(Debug, Deserialize)]
+struct HcImage {
+    #[serde(default)]
+    url: Option<String>,
+}
+
+const BOOK_FIELDS: &str = "id slug title contributions { author { name } } \
+     book_series { position series { name } } image { url }";
+
+/// Resolve a library book to a Hardcover book. ISBNs are tried first (most
+/// reliable); on a miss we fall back to an **exact** title match ordered by
+/// `users_count` so the canonical edition wins over summary/knockoff entries
+/// (which carry near-zero reads). Returns `None` when nothing resolves.
+pub async fn resolve_book(
+    config: &HardcoverConfig,
+    isbns: &[String],
+    title: &str,
+    author: Option<&str>,
+) -> Result<Option<ResolvedBook>, HardcoverError> {
+    for isbn in isbns {
+        let query = "query ($isbn: String!) { \
+             editions(where: {_or: [{isbn_13: {_eq: $isbn}}, {isbn_10: {_eq: $isbn}}]}, limit: 1) \
+             { book_id } }";
+        let data: EditionsData =
+            post_graphql(config, query, serde_json::json!({ "isbn": isbn })).await?;
+        if let Some(book_id) = data.editions.into_iter().find_map(|e| e.book_id) {
+            if let Some(resolved) = fetch_resolved_book(config, book_id).await? {
+                return Ok(Some(resolved));
+            }
+        }
+    }
+
+    // Title fallback. `_ilike` is blocked server-side, so match exact title and
+    // let `users_count desc` float the canonical edition above knockoffs.
+    let query = format!(
+        "query ($title: String!) {{ books(where: {{title: {{_eq: $title}}}}, \
+         order_by: {{users_count: desc}}, limit: 5) {{ {BOOK_FIELDS} }} }}"
+    );
+    let data: BooksData =
+        post_graphql(config, &query, serde_json::json!({ "title": title })).await?;
+    let want_author = author.map(|a| a.trim().to_lowercase());
+    let pick = data
+        .books
+        .iter()
+        .find(|b| match &want_author {
+            Some(wa) => b.contributions.iter().any(|c| {
+                c.author
+                    .as_ref()
+                    .and_then(|a| a.name.as_deref())
+                    .is_some_and(|n| n.trim().to_lowercase() == *wa)
+            }),
+            None => true,
+        })
+        .or_else(|| data.books.first());
+    Ok(pick.map(resolved_from_row))
+}
+
+fn resolved_from_row(b: &BookRow) -> ResolvedBook {
+    ResolvedBook {
+        id: b.id,
+        author_names: author_names(b),
+        series: series_name(b),
+    }
+}
+
+fn author_names(b: &BookRow) -> Vec<String> {
+    b.contributions
+        .iter()
+        .filter_map(|c| c.author.as_ref().and_then(|a| a.name.clone()))
+        .collect()
+}
+
+fn series_name(b: &BookRow) -> Option<String> {
+    b.book_series
+        .first()
+        .and_then(|bs| bs.series.as_ref().and_then(|s| s.name.clone()))
+}
+
+async fn fetch_resolved_book(
+    config: &HardcoverConfig,
+    book_id: i64,
+) -> Result<Option<ResolvedBook>, HardcoverError> {
+    let query = format!(
+        "query {{ books(where: {{id: {{_eq: {book_id}}}}}, limit: 1) {{ {BOOK_FIELDS} }} }}"
+    );
+    let data: BooksData = post_graphql(config, &query, serde_json::json!({})).await?;
+    Ok(data.books.first().map(resolved_from_row))
+}
+
+// ── List co-occurrence ───────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct ListBooksData {
+    list_books: Vec<ListBookRow>,
+}
+#[derive(Debug, Deserialize)]
+struct ListBookRow {
+    #[serde(default)]
+    list_id: Option<i64>,
+    #[serde(default)]
+    book_id: Option<i64>,
+}
+
+/// The curated, public lists (size band 5–150) a book sits on, largest first,
+/// capped at [`LIST_SAMPLE`].
+pub async fn curated_list_ids(
+    config: &HardcoverConfig,
+    book_id: i64,
+) -> Result<Vec<i64>, HardcoverError> {
+    let query = format!(
+        "query {{ list_books(where: {{book_id: {{_eq: {book_id}}}, \
+         list: {{books_count: {{_gte: {MIN_LIST_BOOKS}, _lte: {MAX_LIST_BOOKS}}}, \
+         privacy_setting_id: {{_eq: {PRIVACY_PUBLIC}}}}}}}, \
+         order_by: {{list: {{books_count: desc}}}}, limit: {LIST_SAMPLE}) {{ list_id }} }}"
+    );
+    let data: ListBooksData = post_graphql(config, &query, serde_json::json!({})).await?;
+    Ok(data
+        .list_books
+        .into_iter()
+        .filter_map(|r| r.list_id)
+        .collect())
+}
+
+/// Rank every other book by how many of `list_ids` it co-appears on. Paginates
+/// the members in [`PAGE_SIZE`] chunks up to [`MAX_MEMBER_ROWS`], excludes the
+/// source book, and returns `(book_id, count)` sorted by count desc, truncated
+/// to [`CANDIDATE_POOL`].
+pub async fn co_listed_counts(
+    config: &HardcoverConfig,
+    list_ids: &[i64],
+    exclude_book_id: i64,
+) -> Result<Vec<(i64, i64)>, HardcoverError> {
+    if list_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ids_csv = list_ids
+        .iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut counts: HashMap<i64, i64> = HashMap::new();
+    let mut offset: i64 = 0;
+    let mut pulled: usize = 0;
+    loop {
+        let query = format!(
+            "query {{ list_books(where: {{list_id: {{_in: [{ids_csv}]}}}}, \
+             order_by: {{id: asc}}, limit: {PAGE_SIZE}, offset: {offset}) {{ book_id }} }}"
+        );
+        let data: ListBooksData = post_graphql(config, &query, serde_json::json!({})).await?;
+        let n = data.list_books.len();
+        for row in data.list_books {
+            if let Some(bid) = row.book_id {
+                if bid != exclude_book_id {
+                    *counts.entry(bid).or_insert(0) += 1;
+                }
+            }
+        }
+        pulled += n;
+        if (n as i64) < PAGE_SIZE || pulled >= MAX_MEMBER_ROWS {
+            break;
+        }
+        offset += PAGE_SIZE;
+    }
+    let mut ranked: Vec<(i64, i64)> = counts.into_iter().collect();
+    // Sort by count desc, then book_id asc for a deterministic tie-break.
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    ranked.truncate(CANDIDATE_POOL);
+    Ok(ranked)
+}
+
+/// Hydrate the top co-listed `book_id`s into [`Candidate`]s, attaching each
+/// book's `list_count` from the ranking. Order follows `ranked` (count desc).
+pub async fn fetch_candidates(
+    config: &HardcoverConfig,
+    ranked: &[(i64, i64)],
+) -> Result<Vec<Candidate>, HardcoverError> {
+    if ranked.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ids_csv = ranked
+        .iter()
+        .map(|(id, _)| id.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let query =
+        format!("query {{ books(where: {{id: {{_in: [{ids_csv}]}}}}) {{ {BOOK_FIELDS} }} }}");
+    let data: BooksData = post_graphql(config, &query, serde_json::json!({})).await?;
+
+    let count_by_id: HashMap<i64, i64> = ranked.iter().copied().collect();
+    let by_id: HashMap<i64, BookRow> = data.books.into_iter().map(|b| (b.id, b)).collect();
+
+    // Walk `ranked` so output preserves the co-listing order.
+    let mut out = Vec::new();
+    for (id, _) in ranked {
+        if let Some(b) = by_id.get(id) {
+            let series = b.book_series.first();
+            out.push(Candidate {
+                hardcover_id: b.id,
+                slug: b.slug.clone(),
+                title: b.title.clone().unwrap_or_default(),
+                author: author_names(b).into_iter().next().unwrap_or_default(),
+                series: series.and_then(|s| s.series.as_ref().and_then(|s| s.name.clone())),
+                series_position: series.and_then(|s| s.position),
+                list_count: count_by_id.get(id).copied().unwrap_or(0),
+                cover_url: b.image.as_ref().and_then(|i| i.url.clone()),
+            });
+        }
+    }
+    Ok(out)
+}

--- a/db/src/suggestions/mod.rs
+++ b/db/src/suggestions/mod.rs
@@ -1,0 +1,29 @@
+//! F3.3 "Readers also enjoyed" — Hardcover community-list co-occurrence.
+//!
+//! [`hardcover`] talks to the Hardcover GraphQL API; [`filter`] holds the pure
+//! different-author / different-series / entry-point trimming; [`data`] is the
+//! cache CRUD + the [`data::decide`] de-duplication state machine; [`cascade`]
+//! orchestrates resolution and is driven by
+//! [`crate::worker::Task::ResolveSuggestions`].
+//!
+//! Caching guarantees a page refresh or a burst of concurrent viewers never
+//! re-hits Hardcover while a result is fresh: a 30-day TTL result cache, a
+//! `pending` debounce so concurrent first-viewers collapse to one posted task,
+//! and worker resource-key serialization with a cascade re-check on top.
+
+pub mod cascade;
+pub mod data;
+pub mod filter;
+pub mod hardcover;
+
+pub use cascade::{resolve, resolve_with};
+pub use data::{
+    decide, delete_suggestions, get_suggestion_cover, get_suggestions, mark_pending,
+    replace_suggestions, suggestion_state, CacheDecision, CachedSuggestion, NewSuggestion,
+    SuggestionState, SuggestionsDataError, PENDING_DEBOUNCE_SECS, SUGGESTIONS_TTL_SECS,
+};
+pub use filter::{filter_candidates, is_entry_point, is_same_author, is_same_series, Candidate};
+pub use hardcover::{HardcoverConfig, HardcoverError};
+
+#[cfg(test)]
+mod tests;

--- a/db/src/suggestions/tests.rs
+++ b/db/src/suggestions/tests.rs
@@ -1,0 +1,482 @@
+//! Tests for the F3.3 suggestions module: the pure cache state machine and
+//! filters, the cache CRUD, the Hardcover GraphQL client (against `wiremock`),
+//! and an end-to-end cascade run.
+
+use serde_json::json;
+use wiremock::matchers::{body_string_contains, method};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::author_photos::RemoteImageConfig;
+use crate::pool::init_db;
+use crate::suggestions::cascade::resolve_with;
+use crate::suggestions::data::{
+    decide, delete_suggestions, get_suggestion_cover, get_suggestions, mark_pending,
+    replace_suggestions, suggestion_state, NewSuggestion, SuggestionState, PENDING_DEBOUNCE_SECS,
+    SUGGESTIONS_TTL_SECS,
+};
+use crate::suggestions::filter::{
+    filter_candidates, is_entry_point, is_same_author, is_same_series, Candidate,
+};
+use crate::suggestions::hardcover::{
+    co_listed_counts, curated_list_ids, fetch_candidates, resolve_book, HardcoverConfig,
+};
+use crate::test_support::seed_synced_ebook;
+
+// ── decide(): the de-duplication state machine ───────────────────
+
+#[test]
+fn decide_enqueues_when_no_marker_exists() {
+    let d = decide(None, 1_000);
+    assert!(d.enqueue && !d.serve);
+}
+
+#[test]
+fn decide_does_not_repost_a_recent_pending_marker() {
+    let d = decide(
+        Some((SuggestionState::Pending, 1_000)),
+        1_000 + PENDING_DEBOUNCE_SECS - 1,
+    );
+    assert!(!d.enqueue && !d.serve);
+}
+
+#[test]
+fn decide_reposts_a_stale_pending_marker() {
+    let d = decide(
+        Some((SuggestionState::Pending, 1_000)),
+        1_000 + PENDING_DEBOUNCE_SECS + 1,
+    );
+    assert!(d.enqueue && !d.serve);
+}
+
+#[test]
+fn decide_serves_fresh_resolved_without_reposting() {
+    let d = decide(Some((SuggestionState::Resolved, 1_000)), 1_000 + 10);
+    assert!(d.serve && !d.enqueue);
+}
+
+#[test]
+fn decide_serves_and_refreshes_stale_resolved() {
+    let d = decide(
+        Some((SuggestionState::Resolved, 1_000)),
+        1_000 + SUGGESTIONS_TTL_SECS + 1,
+    );
+    assert!(d.serve && d.enqueue);
+}
+
+#[test]
+fn decide_keeps_sticky_empty_quiet_until_ttl() {
+    let fresh = decide(Some((SuggestionState::Empty, 1_000)), 1_000 + 10);
+    assert!(fresh.serve && !fresh.enqueue);
+    let stale = decide(
+        Some((SuggestionState::Empty, 1_000)),
+        1_000 + SUGGESTIONS_TTL_SECS + 1,
+    );
+    assert!(stale.serve && stale.enqueue);
+}
+
+// ── filter: entry-point / same-author / same-series / trimming ────
+
+#[test]
+fn is_entry_point_passes_standalones_and_series_starters_only() {
+    assert!(is_entry_point(None, None));
+    assert!(is_entry_point(Some(""), None));
+    assert!(is_entry_point(Some("The Empyrean"), Some(1.0)));
+    assert!(is_entry_point(Some("The Empyrean"), Some(0.5)));
+    assert!(!is_entry_point(Some("The Empyrean"), Some(2.0)));
+    // A series book with unknown position is conservatively excluded.
+    assert!(!is_entry_point(Some("The Empyrean"), None));
+}
+
+#[test]
+fn same_author_and_series_compare_case_insensitively() {
+    assert!(is_same_author(
+        "rebecca yarros",
+        &["Rebecca Yarros".to_string()]
+    ));
+    assert!(!is_same_author(
+        "Brandon Sanderson",
+        &["Rebecca Yarros".to_string()]
+    ));
+    assert!(is_same_series(Some("the empyrean"), Some("The Empyrean")));
+    assert!(!is_same_series(Some("The Empyrean"), None));
+    assert!(!is_same_series(None, None));
+}
+
+fn candidate(id: i64, author: &str, series: Option<&str>, pos: Option<f64>, lc: i64) -> Candidate {
+    Candidate {
+        hardcover_id: id,
+        slug: Some(format!("b{id}")),
+        title: format!("Title {id}"),
+        author: author.to_string(),
+        series: series.map(str::to_string),
+        series_position: pos,
+        list_count: lc,
+        cover_url: None,
+    }
+}
+
+#[test]
+fn filter_candidates_excludes_author_series_nonstarters_and_dedupes() {
+    let cands = vec![
+        candidate(1, "Author A", None, None, 9), // keep — standalone, diff author
+        candidate(1, "Author A", None, None, 9), // dup id — dropped
+        candidate(2, "Source Author", None, None, 8), // same author — dropped
+        candidate(3, "Author C", Some("Saga"), Some(3.0), 7), // mid-series — dropped
+        candidate(4, "Author D", Some("Other"), Some(1.0), 6), // keep — series starter
+        candidate(5, "Author E", Some("Trilogy"), None, 5), // unknown position — dropped
+        candidate(6, "Author F", None, None, 4), // keep — standalone
+    ];
+    let source_authors = vec!["Source Author".to_string()];
+    let out = filter_candidates(&cands, &source_authors, None, 2);
+    // Limit 2, order preserved: ids 1 and 4.
+    assert_eq!(
+        out.iter().map(|c| c.hardcover_id).collect::<Vec<_>>(),
+        vec![1, 4]
+    );
+}
+
+#[test]
+fn filter_candidates_excludes_same_series_as_source() {
+    let cands = vec![
+        candidate(1, "Author A", Some("The Empyrean"), Some(1.0), 9), // same series — dropped
+        candidate(2, "Author B", None, None, 8),                      // keep
+    ];
+    let out = filter_candidates(&cands, &[], Some("The Empyrean"), 10);
+    assert_eq!(
+        out.iter().map(|c| c.hardcover_id).collect::<Vec<_>>(),
+        vec![2]
+    );
+}
+
+// ── cache CRUD ───────────────────────────────────────────────────
+
+fn new_suggestion(id: i64, title: &str, cover: bool) -> NewSuggestion {
+    NewSuggestion {
+        hardcover_id: id,
+        hardcover_slug: Some(format!("slug-{id}")),
+        title: title.to_string(),
+        author: "Some Author".to_string(),
+        list_count: id,
+        cover_mime: cover.then(|| "image/jpeg".to_string()),
+        cover_bytes: cover.then(|| b"\xFF\xD8\xFFjpeg".to_vec()),
+    }
+}
+
+#[tokio::test]
+async fn mark_pending_sets_pending_state() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    mark_pending(&pool, "book-1").await.unwrap();
+    let (state, _) = suggestion_state(&pool, "book-1").await.unwrap().unwrap();
+    assert_eq!(state, SuggestionState::Pending);
+}
+
+#[tokio::test]
+async fn replace_suggestions_persists_rows_and_resolved_state() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let rows = vec![
+        new_suggestion(10, "First", true),
+        new_suggestion(20, "Second", false),
+    ];
+    replace_suggestions(&pool, "book-1", &rows, SuggestionState::Resolved)
+        .await
+        .unwrap();
+
+    let got = get_suggestions(&pool, "book-1").await.unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].rank, 0);
+    assert_eq!(got[0].title, "First");
+    assert!(got[0].has_cover);
+    assert_eq!(got[1].title, "Second");
+    assert!(!got[1].has_cover);
+
+    let (state, _) = suggestion_state(&pool, "book-1").await.unwrap().unwrap();
+    assert_eq!(state, SuggestionState::Resolved);
+
+    let (mime, bytes) = get_suggestion_cover(&pool, "book-1", 0)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(mime, "image/jpeg");
+    assert!(!bytes.is_empty());
+    assert!(get_suggestion_cover(&pool, "book-1", 1)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn replace_suggestions_records_sticky_empty_marker() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_suggestions(&pool, "book-1", &[], SuggestionState::Empty)
+        .await
+        .unwrap();
+    assert!(get_suggestions(&pool, "book-1").await.unwrap().is_empty());
+    let (state, _) = suggestion_state(&pool, "book-1").await.unwrap().unwrap();
+    assert_eq!(state, SuggestionState::Empty);
+}
+
+#[tokio::test]
+async fn replace_suggestions_overwrites_prior_rows() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_suggestions(
+        &pool,
+        "book-1",
+        &[new_suggestion(1, "Old", false)],
+        SuggestionState::Resolved,
+    )
+    .await
+    .unwrap();
+    replace_suggestions(
+        &pool,
+        "book-1",
+        &[new_suggestion(2, "New", false)],
+        SuggestionState::Resolved,
+    )
+    .await
+    .unwrap();
+    let got = get_suggestions(&pool, "book-1").await.unwrap();
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].title, "New");
+}
+
+#[tokio::test]
+async fn delete_suggestions_clears_rows_and_marker() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_suggestions(
+        &pool,
+        "book-1",
+        &[new_suggestion(1, "X", false)],
+        SuggestionState::Resolved,
+    )
+    .await
+    .unwrap();
+    delete_suggestions(&pool, "book-1").await.unwrap();
+    assert!(get_suggestions(&pool, "book-1").await.unwrap().is_empty());
+    assert!(suggestion_state(&pool, "book-1").await.unwrap().is_none());
+}
+
+// ── Hardcover client (wiremock) ──────────────────────────────────
+
+fn config_for(server: &MockServer) -> HardcoverConfig {
+    HardcoverConfig {
+        base_url: server.uri(),
+        api_key: "test-key".to_string(),
+        timeout: std::time::Duration::from_secs(5),
+    }
+}
+
+#[tokio::test]
+async fn resolve_book_prefers_isbn_match() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("editions(where:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "editions": [{ "book_id": 714600 }] }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("books(where: {id: {_eq:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [{
+                "id": 714600, "slug": "fourth-wing", "title": "Fourth Wing",
+                "contributions": [{ "author": { "name": "Rebecca Yarros" } }],
+                "book_series": [{ "position": 1, "series": { "name": "The Empyrean" } }],
+                "image": { "url": "https://example.com/c.jpg" }
+            }] }
+        })))
+        .mount(&server)
+        .await;
+
+    let cfg = config_for(&server);
+    let resolved = resolve_book(
+        &cfg,
+        &["9781649374042".to_string()],
+        "Fourth Wing",
+        Some("Rebecca Yarros"),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(resolved.id, 714600);
+    assert_eq!(resolved.author_names, vec!["Rebecca Yarros".to_string()]);
+    assert_eq!(resolved.series.as_deref(), Some("The Empyrean"));
+}
+
+#[tokio::test]
+async fn resolve_book_falls_back_to_title_when_no_isbn() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("title: {_eq:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [{
+                "id": 99, "slug": "x", "title": "Some Title",
+                "contributions": [{ "author": { "name": "Jane Doe" } }],
+                "book_series": [], "image": null
+            }] }
+        })))
+        .mount(&server)
+        .await;
+
+    let cfg = config_for(&server);
+    let resolved = resolve_book(&cfg, &[], "Some Title", Some("Jane Doe"))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(resolved.id, 99);
+    assert!(resolved.series.is_none());
+}
+
+#[tokio::test]
+async fn curated_list_ids_returns_list_ids() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("list_books(where: {book_id:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "list_books": [{ "list_id": 1 }, { "list_id": 2 }, { "list_id": 3 }] }
+        })))
+        .mount(&server)
+        .await;
+    let cfg = config_for(&server);
+    let ids = curated_list_ids(&cfg, 714600).await.unwrap();
+    assert_eq!(ids, vec![1, 2, 3]);
+}
+
+#[tokio::test]
+async fn co_listed_counts_ranks_by_shared_list_appearances() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("list_books(where: {list_id:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "list_books": [
+                { "book_id": 200 }, { "book_id": 200 }, { "book_id": 200 },
+                { "book_id": 201 }, { "book_id": 201 },
+                { "book_id": 714600 }, // the source book — excluded
+                { "book_id": 300 }
+            ] }
+        })))
+        .mount(&server)
+        .await;
+    let cfg = config_for(&server);
+    let ranked = co_listed_counts(&cfg, &[1, 2], 714600).await.unwrap();
+    assert_eq!(ranked, vec![(200, 3), (201, 2), (300, 1)]);
+}
+
+#[tokio::test]
+async fn fetch_candidates_preserves_rank_order_and_attaches_counts() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("books(where: {id: {_in:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [
+                { "id": 201, "slug": "b201", "title": "Beta",
+                  "contributions": [{ "author": { "name": "B" } }], "book_series": [], "image": null },
+                { "id": 200, "slug": "b200", "title": "Alpha",
+                  "contributions": [{ "author": { "name": "A" } }], "book_series": [], "image": null }
+            ] }
+        })))
+        .mount(&server)
+        .await;
+    let cfg = config_for(&server);
+    let cands = fetch_candidates(&cfg, &[(200, 5), (201, 3)]).await.unwrap();
+    assert_eq!(cands[0].hardcover_id, 200);
+    assert_eq!(cands[0].list_count, 5);
+    assert_eq!(cands[1].hardcover_id, 201);
+}
+
+// ── cascade end-to-end ───────────────────────────────────────────
+
+#[tokio::test]
+async fn resolve_with_caches_filtered_survivors_end_to_end() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_synced_ebook(&pool, "src.epub", "Test Source", "Source Author").await;
+
+    let server = MockServer::start().await;
+    let cover_url = format!("{}/c200.jpg", server.uri());
+
+    // 1. Title fallback resolves the source book.
+    Mock::given(method("POST"))
+        .and(body_string_contains("title: {_eq:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [{
+                "id": 100, "slug": "src", "title": "Test Source",
+                "contributions": [{ "author": { "name": "Source Author" } }],
+                "book_series": [], "image": null
+            }] }
+        })))
+        .mount(&server)
+        .await;
+    // 2. Curated lists.
+    Mock::given(method("POST"))
+        .and(body_string_contains("list_books(where: {book_id:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "list_books": [{ "list_id": 1 }, { "list_id": 2 }] }
+        })))
+        .mount(&server)
+        .await;
+    // 3. Co-listing members (counts: 200→3, 202→2, 201→2, 300→1).
+    Mock::given(method("POST"))
+        .and(body_string_contains("list_books(where: {list_id:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "list_books": [
+                { "book_id": 200 }, { "book_id": 200 }, { "book_id": 200 },
+                { "book_id": 202 }, { "book_id": 202 },
+                { "book_id": 201 }, { "book_id": 201 },
+                { "book_id": 300 },
+                { "book_id": 100 }
+            ] }
+        })))
+        .mount(&server)
+        .await;
+    // 4. Candidate details: 200 standalone (keep+cover), 201 same author (drop),
+    //    300 mid-series (drop), 202 series-starter (keep, no cover).
+    Mock::given(method("POST"))
+        .and(body_string_contains("books(where: {id: {_in:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [
+                { "id": 200, "slug": "alpha", "title": "Alpha",
+                  "contributions": [{ "author": { "name": "Author A" } }],
+                  "book_series": [], "image": { "url": cover_url } },
+                { "id": 201, "slug": "beta", "title": "Beta",
+                  "contributions": [{ "author": { "name": "Source Author" } }],
+                  "book_series": [], "image": null },
+                { "id": 300, "slug": "gamma", "title": "Gamma",
+                  "contributions": [{ "author": { "name": "Author C" } }],
+                  "book_series": [{ "position": 3, "series": { "name": "Saga" } }], "image": null },
+                { "id": 202, "slug": "delta", "title": "Delta",
+                  "contributions": [{ "author": { "name": "Author D" } }],
+                  "book_series": [{ "position": 1, "series": { "name": "Other" } }], "image": null }
+            ] }
+        })))
+        .mount(&server)
+        .await;
+    // 5. Cover image fetch for book 200.
+    Mock::given(method("GET"))
+        .and(body_string_contains(""))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "image/jpeg")
+                .set_body_bytes(b"\xFF\xD8\xFFcoverbytes".to_vec()),
+        )
+        .mount(&server)
+        .await;
+
+    let cfg = config_for(&server);
+    let image_cfg = RemoteImageConfig {
+        allow_private_addresses: true,
+    };
+    resolve_with(&pool, &uuid, &cfg, &image_cfg).await.unwrap();
+
+    let got = get_suggestions(&pool, &uuid).await.unwrap();
+    assert_eq!(
+        got.iter().map(|s| s.title.as_str()).collect::<Vec<_>>(),
+        vec!["Alpha", "Delta"]
+    );
+    assert_eq!(got[0].list_count, 3);
+    assert!(got[0].has_cover);
+    assert_eq!(got[1].list_count, 2);
+    assert!(!got[1].has_cover);
+
+    let (state, _) = suggestion_state(&pool, &uuid).await.unwrap().unwrap();
+    assert_eq!(state, SuggestionState::Resolved);
+}

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -101,6 +101,12 @@ impl Worker {
                 Ok(()) => TaskOutcome::Ok,
                 Err(e) => TaskOutcome::Err(e.to_string()),
             },
+            Task::ResolveSuggestions { book_uuid } => {
+                match crate::suggestions::resolve(&self.pool, &book_uuid).await {
+                    Ok(()) => TaskOutcome::Ok,
+                    Err(e) => TaskOutcome::Err(e.to_string()),
+                }
+            }
             Task::GenerateThumbs {
                 book_id,
                 last_modified_epoch,

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -85,6 +85,12 @@ pub enum Task {
     /// left by a failed post-commit FTS refresh. Keyed on a fixed resource
     /// so concurrent clicks serialize; does not consume the scan semaphore.
     RebuildFtsIndex,
+    /// Resolve and cache F3.3 "readers also enjoyed" suggestions for one book
+    /// via Hardcover list co-occurrence. Keyed on `suggestions:{book_uuid}` so
+    /// duplicate posts for one book (a burst of viewers) serialize and the
+    /// later ones no-op against the fresh cache; does not consume the scan
+    /// semaphore.
+    ResolveSuggestions { book_uuid: String },
     /// Test-only synthetic task: sleeps `latency_ms` and invokes the
     /// optional `on_run` / `on_done` hooks, with `resource` and
     /// `route_through_scan_sem` letting a test exercise the keyed mutex and
@@ -113,6 +119,7 @@ impl Task {
             Task::RefetchAuthorPhotos => Some("refetch-author-photos".into()),
             Task::BackfillChapters { library_path } => Some(format!("audiobooks:{library_path}")),
             Task::RebuildFtsIndex => Some("rebuild-fts".into()),
+            Task::ResolveSuggestions { book_uuid } => Some(format!("suggestions:{book_uuid}")),
             #[cfg(test)]
             Task::Test { resource, .. } => resource.clone(),
         }
@@ -128,6 +135,7 @@ impl Task {
             Task::RefetchAuthorPhotos => false,
             Task::BackfillChapters { .. } => false,
             Task::RebuildFtsIndex => false,
+            Task::ResolveSuggestions { .. } => false,
             #[cfg(test)]
             Task::Test {
                 route_through_scan_sem,
@@ -159,6 +167,7 @@ impl Task {
             // Reuse Scan kind for the FTS rebuild's progress display rather
             // than growing the wire-facing `TaskKind` enum for a rare admin job.
             Task::RebuildFtsIndex => TaskKind::Scan,
+            Task::ResolveSuggestions { .. } => TaskKind::ResolveSuggestions,
             #[cfg(test)]
             Task::Test { .. } => TaskKind::Scan,
         }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4319,3 +4319,64 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .bd-merge-toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
   z-index: 110; display: flex; align-items: center; gap: 12px; padding: 12px 16px;
   box-shadow: 0 6px 24px rgba(0,0,0,.35); }
+
+/* ── F3.3 "Readers also enjoyed" suggestions strip ─────────────────
+   The first 5 covers are a tight stack (each overlapping the previous by
+   ~80%); hovering the row eases them apart. "Show more" reveals the rest into
+   a plain static grid — no stacking, no hover motion. Ported from the Atrium
+   design's omnibus.css. */
+.bd-suggest-pending,
+.bd-suggest-connect { margin-top: 4px; }
+.bd-suggest-pending { padding: 16px 18px; }
+
+.bd-suggest-connect { display: flex; align-items: center; justify-content: space-between;
+  gap: 22px; padding: 22px 24px; border: 1px dashed var(--line-2); }
+.bd-suggest-connect-title { font-size: 18px; margin: 0; }
+.bd-suggest-connect-body { font-size: 13.5px; color: var(--ink-2); line-height: 1.5; margin: 6px 0 0; }
+
+.suggest-stack { display: flex; padding: 18px 0 10px; align-items: flex-start; }
+.suggest-stack > .cover-link { flex: 0 0 168px; margin-left: -134px;
+  transition: margin-left .45s cubic-bezier(.2,.7,.3,1); }
+.suggest-stack > .cover-link:first-child { margin-left: 0; }
+/* Earlier books paint on top so the strongest match leads the stack. */
+.suggest-stack > .cover-link:nth-child(1) { z-index: 5; }
+.suggest-stack > .cover-link:nth-child(2) { z-index: 4; }
+.suggest-stack > .cover-link:nth-child(3) { z-index: 3; }
+.suggest-stack > .cover-link:nth-child(4) { z-index: 2; }
+.suggest-stack > .cover-link:nth-child(5) { z-index: 1; }
+.suggest-stack:hover > .cover-link { margin-left: 18px; }
+.suggest-stack:hover > .cover-link:first-child { margin-left: 0; }
+.suggest-stack > .cover-link:hover { z-index: 10; }
+
+.suggest-static { display: flex; flex-wrap: wrap; gap: 18px; padding: 6px 0 10px; }
+.suggest-static > .cover-link { flex: 0 0 168px; }
+
+/* Per-cover caption (title/author): hidden until the stack spreads, always
+   shown in the static grid. */
+.sug-cap { opacity: 0; margin-top: 10px; transition: opacity .25s .05s; max-width: 168px; }
+.suggest-stack:hover .sug-cap,
+.suggest-stack > .cover-link:hover .sug-cap,
+.suggest-static .sug-cap { opacity: 1; }
+.sug-cap-title { font-size: 13.5px; color: var(--ink-0); font-weight: 500;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.sug-cap-author { font-size: 12px; color: var(--ink-2); margin-top: 2px;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+
+/* "on N lists" relevance badge, pinned top-right of each cover. */
+.fan-match { position: absolute; top: 8px; right: 8px; z-index: 2;
+  background: color-mix(in oklch, var(--bg-0) 70%, transparent);
+  backdrop-filter: blur(6px); padding: 2px 6px; border-radius: 999px;
+  font-size: 10px; color: var(--ink-1); }
+
+.bd-suggest-actions { display: flex; align-items: center; gap: 14px; margin-top: 8px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .suggest-stack > .cover-link { transition: none; }
+  .suggest-stack .sug-cap { opacity: 1; }
+}
+
+/* Settings → Hardcover key field status line. */
+.hardcover-status { display: flex; align-items: center; gap: 8px; margin-top: 10px;
+  font-size: 11.5px; color: var(--ink-2); }
+.hardcover-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--ink-3); flex: 0 0 8px; }
+.hardcover-dot.connected { background: oklch(0.7 0.15 150); }

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -215,6 +215,8 @@ fn kind_label(kind: TaskKind, running: bool) -> &'static str {
         (TaskKind::RefetchAuthorPhotos, false) => "Author photo refetch",
         (TaskKind::BackfillChapters, true) => "Extracting audiobook chapters",
         (TaskKind::BackfillChapters, false) => "Audiobook chapter extraction",
+        (TaskKind::ResolveSuggestions, true) => "Finding suggestions",
+        (TaskKind::ResolveSuggestions, false) => "Suggestion lookup",
         // `#[non_exhaustive]` on the shared enum means new variants
         // compile against existing client builds — render an opaque
         // fallback rather than panicking.
@@ -253,6 +255,7 @@ mod tests {
             TaskKind::ResolveAuthorPhoto,
             TaskKind::RefetchAuthorPhotos,
             TaskKind::BackfillChapters,
+            TaskKind::ResolveSuggestions,
         ] {
             assert!(!kind_label(kind, true).is_empty());
             assert!(!kind_label(kind, false).is_empty());

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -24,6 +24,7 @@ mod journals;
 mod progress;
 mod ratings;
 mod series;
+mod suggestions;
 mod tags;
 
 // auth exports exist under web, mobile, and server-only (the last only
@@ -39,6 +40,7 @@ pub use journals::*;
 pub use progress::*;
 pub use ratings::*;
 pub use series::*;
+pub use suggestions::*;
 pub use tags::*;
 
 /// Errors surfaced by the feature-gated data transport.

--- a/frontend/src/data/suggestions.rs
+++ b/frontend/src/data/suggestions.rs
@@ -1,0 +1,91 @@
+//! F3.3 suggestions fetchers + Hardcover-key read/write. Each function has a
+//! mobile REST variant (`reqwest`) and a web/SSR server-function wrapper with
+//! identical signatures across the `#[cfg]` split.
+
+use omnibus_shared::{HardcoverKeyStatus, SuggestionsResponse};
+
+#[cfg(not(feature = "mobile"))]
+use super::note_server_fn_err;
+use super::DataError;
+#[cfg(feature = "mobile")]
+use super::{drain_error, http_client, note_status, with_bearer};
+
+// ── Suggestions strip ────────────────────────────────────────────
+
+/// Web/SSR: fetch a book's "readers also enjoyed" strip via `rpc_get_suggestions`.
+#[cfg(not(feature = "mobile"))]
+pub async fn get_suggestions(
+    _server_url: &str,
+    uuid: &str,
+) -> Result<SuggestionsResponse, DataError> {
+    crate::rpc::rpc_get_suggestions(uuid.to_string())
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Mobile: GET `/api/ebooks/{uuid}/suggestions`.
+#[cfg(feature = "mobile")]
+pub async fn get_suggestions(
+    server_url: &str,
+    uuid: &str,
+) -> Result<SuggestionsResponse, DataError> {
+    let url = format!("{server_url}/api/ebooks/{uuid}/suggestions");
+    let response = with_bearer(http_client().get(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<SuggestionsResponse>().await?)
+}
+
+// ── Hardcover key (admin settings) ───────────────────────────────
+
+/// Web/SSR: read the masked Hardcover key status via `rpc_get_hardcover_key`.
+#[cfg(not(feature = "mobile"))]
+pub async fn get_hardcover_key(_server_url: &str) -> Result<HardcoverKeyStatus, DataError> {
+    crate::rpc::rpc_get_hardcover_key()
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Mobile: GET `/api/hardcover-key`.
+#[cfg(feature = "mobile")]
+pub async fn get_hardcover_key(server_url: &str) -> Result<HardcoverKeyStatus, DataError> {
+    let url = format!("{server_url}/api/hardcover-key");
+    let response = with_bearer(http_client().get(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<HardcoverKeyStatus>().await?)
+}
+
+/// Web/SSR: save (or clear, with `None`) the Hardcover key via
+/// `rpc_set_hardcover_key`. Returns the new masked status.
+#[cfg(not(feature = "mobile"))]
+pub async fn set_hardcover_key(
+    _server_url: &str,
+    key: Option<String>,
+) -> Result<HardcoverKeyStatus, DataError> {
+    crate::rpc::rpc_set_hardcover_key(key)
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Mobile: POST `/api/hardcover-key` with `{ "key": ... }`.
+#[cfg(feature = "mobile")]
+pub async fn set_hardcover_key(
+    server_url: &str,
+    key: Option<String>,
+) -> Result<HardcoverKeyStatus, DataError> {
+    let url = format!("{server_url}/api/hardcover-key");
+    let response = with_bearer(http_client().post(&url))
+        .json(&serde_json::json!({ "key": key }))
+        .send()
+        .await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<HardcoverKeyStatus>().await?)
+}

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -2,7 +2,7 @@
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
-use omnibus_shared::{EbookMetadata, Identifier};
+use omnibus_shared::{BookSuggestion, Contributor, EbookMetadata, Identifier, SuggestionsResponse};
 
 use crate::components::atrium::Cover;
 use crate::components::FormatSwitcher;
@@ -11,13 +11,17 @@ use crate::Route;
 use super::journal::BdJournalSection;
 use super::{BdInsightCell, BdMetaRow, BdSectionHead};
 
-/// Main column: public journal feed, highlights stub, from-the-same-hand fan, suggestions stub.
+/// Main column: public journal feed, highlights stub, from-the-same-hand fan,
+/// and the F3.3 "Readers also enjoyed" suggestions strip.
 #[component]
 pub(super) fn BdBodyMain(
     uuid: String,
     title: String,
     primary_author: String,
     author_books: Vec<EbookMetadata>,
+    suggestions: Option<SuggestionsResponse>,
+    server_url: String,
+    is_admin: bool,
 ) -> Element {
     rsx! {
         div { class: "bd-body-main",
@@ -50,15 +54,161 @@ pub(super) fn BdBodyMain(
                     }
                 }
             }
-            div { class: "divider" }
-            BdSectionHead {
-                kicker: format!("If you liked {title}\u{2026}"),
-                title: "Suggested for you".to_string(),
-            }
-            div { class: "bd-stub-strip card", aria_hidden: "true",
-                p { class: "bd-stub-hint mono", "Suggestions land in F3.3." }
+            BdSuggestionsStrip {
+                book_title: title,
+                suggestions,
+                server_url,
+                is_admin,
             }
         }
+    }
+}
+
+/// "Readers also enjoyed" — Hardcover read-alikes below the metadata. Renders
+/// its own divider + section head, then one of: a connect message (no key), a
+/// quiet placeholder (resolving), the cover strip (results), or an empty note.
+/// The section is always present (stable `suggestions-strip` testid); only its
+/// inner content varies by state.
+#[component]
+pub(super) fn BdSuggestionsStrip(
+    book_title: String,
+    suggestions: Option<SuggestionsResponse>,
+    server_url: String,
+    is_admin: bool,
+) -> Element {
+    rsx! {
+        div { class: "divider" }
+        BdSectionHead {
+            kicker: format!("If you liked {book_title}\u{2026}"),
+            title: "Suggested for you".to_string(),
+        }
+        div { class: "bd-suggest", "data-testid": "suggestions-strip",
+            match suggestions {
+                Some(SuggestionsResponse::Ready { items }) if !items.is_empty() => rsx! {
+                    BdSuggestionsList { items, server_url }
+                },
+                Some(SuggestionsResponse::Ready { .. }) => rsx! {
+                    div { class: "bd-suggest-pending card", "data-testid": "suggestions-empty",
+                        p { class: "mono bd-stub-hint", "No read-alikes found for this book yet." }
+                    }
+                },
+                Some(SuggestionsResponse::NotConfigured) => rsx! {
+                    SuggestionsConnectCard { is_admin }
+                },
+                // None (first paint, pre-fetch) or Pending → quiet placeholder.
+                _ => rsx! {
+                    div { class: "bd-suggest-pending card", "data-testid": "suggestions-pending",
+                        p { class: "mono bd-stub-hint", "Looking for read-alikes via Hardcover\u{2026}" }
+                    }
+                },
+            }
+        }
+    }
+}
+
+/// The cover strip itself — 5 covers stacked (hover to spread); a "show more"
+/// reveals the rest into a flat grid. Each cover links out to Hardcover.
+#[component]
+fn BdSuggestionsList(items: Vec<BookSuggestion>, server_url: String) -> Element {
+    let mut expanded = use_signal(|| false);
+    let total = items.len();
+    let collapsed_len = total.min(5);
+    let show_more = total > collapsed_len;
+    let visible = if expanded() { total } else { collapsed_len };
+    let row_class = if expanded() {
+        "suggest-static"
+    } else {
+        "suggest-stack"
+    };
+
+    rsx! {
+        div { class: "{row_class}",
+            for s in items.iter().take(visible).cloned() {
+                a {
+                    key: "{s.hardcover_id}",
+                    class: "cover-link suggest-card",
+                    href: "{s.hardcover_url}",
+                    target: "_blank",
+                    rel: "noopener noreferrer",
+                    "data-testid": "suggestion-card",
+                    Cover {
+                        book: suggestion_cover_book(&s),
+                        src_override: cover_src(&server_url, &s),
+                    }
+                    div { class: "fan-match mono", "{list_count_label(s.list_count)}" }
+                    div { class: "sug-cap",
+                        div { class: "sug-cap-title", "{s.title}" }
+                        div { class: "sug-cap-author", "{s.author}" }
+                    }
+                }
+            }
+        }
+        if show_more && !expanded() {
+            div { class: "bd-suggest-actions",
+                button {
+                    class: "btn sm",
+                    "data-testid": "suggestions-show-more",
+                    onclick: move |_| expanded.set(true),
+                    "Show {total - collapsed_len} more"
+                }
+            }
+        }
+    }
+}
+
+/// "Connect Hardcover" message shown when no API key is configured. Admins get
+/// a link to Settings; everyone else is told to ask their server admin.
+#[component]
+fn SuggestionsConnectCard(is_admin: bool) -> Element {
+    rsx! {
+        div { class: "bd-suggest-connect card", "data-testid": "suggestions-not-configured",
+            div {
+                h4 { class: "bd-suggest-connect-title", "Suggestions are powered by Hardcover" }
+                p { class: "bd-suggest-connect-body",
+                    "Add a Hardcover API key to pull read-alikes for this book."
+                }
+            }
+            if is_admin {
+                Link {
+                    to: Route::Settings {},
+                    class: "btn primary sm",
+                    "data-testid": "suggestions-connect-link",
+                    "Add Hardcover API key \u{2192}"
+                }
+            } else {
+                span { class: "mono bd-stub-hint", "Ask your server admin to connect Hardcover." }
+            }
+        }
+    }
+}
+
+/// Build a minimal [`EbookMetadata`] so the shared [`Cover`] can render a
+/// suggestion's title/author plate when no cover image is available.
+fn suggestion_cover_book(s: &BookSuggestion) -> EbookMetadata {
+    EbookMetadata {
+        title: Some(s.title.clone()),
+        creators: vec![Contributor {
+            name: s.author.clone(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// Absolute cover URL (server base + relative path), or `None` when the
+/// suggestion has no cached cover (the plate fallback then applies).
+fn cover_src(server_url: &str, s: &BookSuggestion) -> Option<String> {
+    s.cover_url
+        .as_ref()
+        .map(|path| format!("{server_url}{path}"))
+}
+
+/// "on N lists" relevance label (singular-aware).
+fn list_count_label(n: i64) -> String {
+    if n == 1 {
+        "on 1 list".to_string()
+    } else {
+        format!("on {n} lists")
     }
 }
 

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -5,7 +5,7 @@
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
-use omnibus_shared::{EbookMetadata, MergeBooksResult};
+use omnibus_shared::{EbookMetadata, MergeBooksResult, SuggestionsResponse};
 
 use crate::{data, use_server_url, Route};
 
@@ -24,6 +24,13 @@ pub fn BookDetailPage(uuid: String) -> Element {
     let server_url = use_server_url();
     let mut book: Signal<Option<EbookMetadata>> = use_signal(|| None);
     let mut author_books: Signal<Vec<EbookMetadata>> = use_signal(Vec::new);
+    // F3.3 suggestions. Starts `None` on both SSR and the first WASM paint so
+    // hydration markup matches (rule 07); the client effect below populates it.
+    let mut suggestions: Signal<Option<SuggestionsResponse>> = use_signal(|| None);
+    // Epoch guard so a poll loop left over from a previous book can't write its
+    // result onto the current book after navigation (mirrors landing's
+    // `fetch_epoch`).
+    let mut suggestions_epoch = use_signal(|| 0u64);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
     // Bumped after a merge/undo so the effect below refetches the book
@@ -104,6 +111,68 @@ pub fn BookDetailPage(uuid: String) -> Element {
         });
     }));
 
+    // F3.3 suggestions: resolved off-request by the worker and cached. Fetch
+    // for the current book; while the result is `Pending`, poll a few times on
+    // web so it appears without a manual reload. A fetch failure degrades to
+    // "no suggestions" rather than an error row.
+    let sug_url = server_url.clone();
+    use_effect(use_reactive!(|uuid| {
+        let url = sug_url.clone();
+        let uuid = uuid.clone();
+        let epoch = {
+            suggestions_epoch.with_mut(|e| *e += 1);
+            *suggestions_epoch.peek()
+        };
+        // True only while this run is still the latest — a newer book's effect
+        // bumps the epoch, so a stale poll drops its result instead of writing
+        // it onto the now-current book.
+        let is_current = move || *suggestions_epoch.peek() == epoch;
+        spawn(async move {
+            suggestions.set(None);
+            match data::get_suggestions(&url, &uuid).await {
+                Ok(resp) => {
+                    if !is_current() {
+                        return;
+                    }
+                    let pending = matches!(resp, SuggestionsResponse::Pending);
+                    suggestions.set(Some(resp));
+                    #[cfg(feature = "web")]
+                    if pending {
+                        let mut tries = 0u32;
+                        while tries < 5 {
+                            gloo_timers::future::TimeoutFuture::new(2500).await;
+                            if !is_current() {
+                                return;
+                            }
+                            tries += 1;
+                            match data::get_suggestions(&url, &uuid).await {
+                                Ok(next) => {
+                                    if !is_current() {
+                                        return;
+                                    }
+                                    let still_pending =
+                                        matches!(next, SuggestionsResponse::Pending);
+                                    suggestions.set(Some(next));
+                                    if !still_pending {
+                                        break;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                    }
+                    #[cfg(not(feature = "web"))]
+                    let _ = pending;
+                }
+                Err(_) => {
+                    if is_current() {
+                        suggestions.set(Some(SuggestionsResponse::Ready { items: Vec::new() }));
+                    }
+                }
+            }
+        });
+    }));
+
     if loading() {
         return rsx! {
             p { class: "subtitle", "Loading\u{2026}" }
@@ -146,7 +215,14 @@ pub fn BookDetailPage(uuid: String) -> Element {
     #[cfg(feature = "mobile")]
     let merge_ui: Option<Element> = merge::build_merge_ui();
 
-    let body = render_loaded(b, author_books(), merge_button);
+    let body = render_loaded(
+        b,
+        author_books(),
+        merge_button,
+        suggestions(),
+        server_url.clone(),
+        is_admin_flag,
+    );
     rsx! {
         {body}
         {merge_ui}
@@ -277,6 +353,9 @@ fn render_loaded(
     b: EbookMetadata,
     author_books: Vec<EbookMetadata>,
     merge_button: Option<Element>,
+    suggestions: Option<SuggestionsResponse>,
+    server_url: String,
+    is_admin: bool,
 ) -> Element {
     let LoadedBookView {
         title,
@@ -307,6 +386,9 @@ fn render_loaded(
                     title: title.clone(),
                     primary_author,
                     author_books,
+                    suggestions,
+                    server_url,
+                    is_admin,
                 }
                 BdRailSection {
                     b,
@@ -319,23 +401,6 @@ fn render_loaded(
             div { class: "bd-footer",
                 Link { to: Route::Landing {}, class: "btn", "Back to library" }
             }
-            BdHiddenSlots {}
-        }
-    }
-}
-
-/// Reserved hidden slot for F3.3 suggestions — anything keying off the
-/// `suggestions-slot` testid still finds it. Ratings now ship as the
-/// interactive hero rating card (`rating-stars`), so the old `ratings-slot`
-/// placeholder is gone.
-#[component]
-fn BdHiddenSlots() -> Element {
-    rsx! {
-        div {
-            class: "suggestions-slot",
-            "data-testid": "suggestions-slot",
-            aria_label: "Suggestions \u{2014} coming soon",
-            hidden: true,
         }
     }
 }

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -5,7 +5,7 @@
 //! counts via the scanner so changes can be eyeballed before saving.
 
 use dioxus::prelude::*;
-use omnibus_shared::{LibraryContents, LibrarySection, Settings};
+use omnibus_shared::{HardcoverKeyStatus, LibraryContents, LibrarySection, Settings};
 
 #[cfg(not(feature = "mobile"))]
 use crate::components::worker_status::WorkerStatusIndicator;
@@ -25,6 +25,20 @@ pub fn SettingsPage() -> Element {
     let backfill_in_flight = use_signal(|| false);
     // Bumped after a successful save to re-trigger the library-refresh effect.
     let library_refresh = use_signal(|| 0u32);
+
+    // Admin gating for the F3.3 Hardcover key card. Starts `false` so SSR and
+    // the first WASM paint agree (rule 07); the effect flips it for admins
+    // after mount. Declared unconditionally to keep hook order stable. The
+    // server-side `AdminUser` extractor on the key RPCs is the real boundary;
+    // this just keeps the card off non-admin screens.
+    let mut is_admin = use_signal(|| false);
+    use_effect(move || {
+        spawn(async move {
+            if let Ok(Some(user)) = data::current_user().await {
+                is_admin.set(user.is_admin);
+            }
+        });
+    });
 
     spawn_initial_settings_load(
         server_url.clone(),
@@ -78,6 +92,9 @@ pub fn SettingsPage() -> Element {
                 class: if status_is_error() { "settings-status error" } else { "settings-status success" },
                 if let Some(msg) = status() { "{msg}" }
             }
+        }
+        if is_admin() {
+            HardcoverKeyField {}
         }
     }
 }
@@ -273,6 +290,148 @@ fn MaintenanceActions(
                 });
             },
             "Extract Audiobook Chapters"
+        }
+    }
+}
+
+/// Admin field to set/clear the server-wide Hardcover API key (F3.3). Loads the
+/// masked status on mount; the raw key is never read back to the client.
+#[component]
+fn HardcoverKeyField() -> Element {
+    let server_url = use_server_url();
+    let mut status: Signal<Option<HardcoverKeyStatus>> = use_signal(|| None);
+    let mut key_input = use_signal(String::new);
+    let mut msg = use_signal(|| None::<String>);
+    let mut msg_is_error = use_signal(|| false);
+    let mut in_flight = use_signal(|| false);
+
+    let load_url = server_url.clone();
+    use_effect(move || {
+        let url = load_url.clone();
+        spawn(async move {
+            if let Ok(s) = data::get_hardcover_key(&url).await {
+                status.set(Some(s));
+            }
+        });
+    });
+
+    let save_url = server_url.clone();
+    let on_save = move |_| {
+        let value = key_input().trim().to_string();
+        // Empty Save is a no-op with a hint — clearing is the "Clear" button's
+        // job, so we never silently wipe the key and report "saved".
+        if value.is_empty() {
+            msg.set(Some("Enter a Hardcover key to save.".to_string()));
+            msg_is_error.set(true);
+            return;
+        }
+        let url = save_url.clone();
+        in_flight.set(true);
+        spawn(async move {
+            match data::set_hardcover_key(&url, Some(value)).await {
+                Ok(s) => {
+                    status.set(Some(s));
+                    key_input.set(String::new());
+                    msg.set(Some("Hardcover key saved.".to_string()));
+                    msg_is_error.set(false);
+                }
+                Err(_) => {
+                    msg.set(Some("Failed to save Hardcover key.".to_string()));
+                    msg_is_error.set(true);
+                }
+            }
+            in_flight.set(false);
+        });
+    };
+
+    let clear_url = server_url.clone();
+    let on_clear = move |_| {
+        let url = clear_url.clone();
+        in_flight.set(true);
+        spawn(async move {
+            match data::set_hardcover_key(&url, None).await {
+                Ok(s) => {
+                    status.set(Some(s));
+                    key_input.set(String::new());
+                    msg.set(Some("Hardcover key cleared.".to_string()));
+                    msg_is_error.set(false);
+                }
+                Err(_) => {
+                    msg.set(Some("Failed to clear Hardcover key.".to_string()));
+                    msg_is_error.set(true);
+                }
+            }
+            in_flight.set(false);
+        });
+    };
+
+    let st = status();
+    let configured = st.as_ref().map(|s| s.configured).unwrap_or(false);
+    let placeholder = st
+        .as_ref()
+        .and_then(|s| s.masked.clone())
+        .unwrap_or_else(|| "hc_live_\u{2026}".to_string());
+
+    rsx! {
+        section { class: "card", "data-testid": "hardcover-key-card",
+            h2 { "Suggestions" }
+            p { class: "subtitle", "Connect Hardcover to power \u{201c}Readers also enjoyed\u{201d}." }
+            div { class: "settings-field",
+                label { r#for: "hardcover-key", "Hardcover API Key" }
+                input {
+                    r#type: "password",
+                    id: "hardcover-key",
+                    name: "hardcover_api_key",
+                    // Server-wide secret: keep password managers / autofill /
+                    // spellcheck from storing or mangling it.
+                    autocomplete: "off",
+                    autocapitalize: "none",
+                    autocorrect: "off",
+                    spellcheck: "false",
+                    placeholder: "{placeholder}",
+                    value: "{key_input}",
+                    oninput: move |e| key_input.set(e.value()),
+                }
+            }
+            div { class: "settings-actions",
+                button {
+                    r#type: "button",
+                    class: "btn",
+                    disabled: in_flight(),
+                    "data-testid": "hardcover-save",
+                    onclick: on_save,
+                    "Save"
+                }
+                if configured {
+                    button {
+                        r#type: "button",
+                        class: "btn ghost",
+                        disabled: in_flight(),
+                        "data-testid": "hardcover-clear",
+                        onclick: on_clear,
+                        "Clear"
+                    }
+                }
+            }
+            div { class: "hardcover-status mono", "data-testid": "hardcover-status",
+                if configured {
+                    span { class: "hardcover-dot connected" }
+                    if let Some(s) = st.as_ref() {
+                        "Connected \u{00b7} {s.source} \u{00b7} {s.masked.clone().unwrap_or_default()}"
+                    }
+                } else {
+                    span { class: "hardcover-dot" }
+                    "Not connected"
+                }
+            }
+            if let Some(m) = msg() {
+                p {
+                    role: "status",
+                    "data-testid": "hardcover-key-status",
+                    class: if msg_is_error() { "settings-status error" } else { "settings-status success" },
+                    "{m}"
+                }
+            }
         }
     }
 }

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -17,11 +17,11 @@ use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
 use omnibus_shared::{
     AuthorDetail, AuthorPhotoScanResult, AuthorSummary, Bookmark, CreateBookmark, CreateHighlight,
-    CreateJournalEntry, EbookLibrary, EbookMetadata, Highlight, HighlightColor, JournalEntry,
-    LibraryContents, LibraryPage, MergeBooksResult, MetadataOverrides, PaletteResults,
-    ProgressFormat, ProgressRecord, ProgressUpdate, RatingRecord, RatingUpdate, SeriesDetail,
-    SeriesSummary, SessionReport, Settings, SortDir, SortKey, TagWeight, UpdateBookmark,
-    UpdateHighlightNote, UpdateJournalEntry, ViewFilters, WorkerStatus,
+    CreateJournalEntry, EbookLibrary, EbookMetadata, HardcoverKeyStatus, Highlight, HighlightColor,
+    JournalEntry, LibraryContents, LibraryPage, MergeBooksResult, MetadataOverrides,
+    PaletteResults, ProgressFormat, ProgressRecord, ProgressUpdate, RatingRecord, RatingUpdate,
+    SeriesDetail, SeriesSummary, SessionReport, Settings, SortDir, SortKey, SuggestionsResponse,
+    TagWeight, UpdateBookmark, UpdateHighlightNote, UpdateJournalEntry, ViewFilters, WorkerStatus,
 };
 
 // Only `validate_author_photo_url` (server-gated) and its tests reference this
@@ -29,6 +29,11 @@ use omnibus_shared::{
 // in the `mobile`/`web` client builds.
 #[cfg(feature = "server")]
 use omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN;
+
+// `BookSuggestion` is only constructed in the server-side `rpc_get_suggestions`
+// body; gate it so the web/mobile client builds don't flag an unused import.
+#[cfg(feature = "server")]
+use omnibus_shared::BookSuggestion;
 
 #[cfg(feature = "server")]
 use omnibus_db::{self as db, scanner};
@@ -422,6 +427,107 @@ pub async fn rpc_get_author(id: i64) -> Result<Option<AuthorDetail>> {
 #[post("/api/rpc/series", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_series(id: i64) -> Result<Option<SeriesDetail>> {
     Ok(db::get_series(&pool.0, id).await?)
+}
+
+/// F3.3 "Readers also enjoyed" for one book. Drives the cache de-duplication
+/// state machine: returns `NotConfigured` when no Hardcover key is set, serves
+/// the fresh/sticky cache when present, and enqueues a single background
+/// resolution (marking `pending` *before* posting) so a refresh or a burst of
+/// concurrent viewers never re-hits Hardcover. POST because it carries `uuid`.
+#[post("/api/rpc/ebook-suggestions", pool: PoolExt, worker: WorkerExt, _user: AuthUser)]
+pub async fn rpc_get_suggestions(uuid: String) -> Result<SuggestionsResponse> {
+    if db::effective_hardcover_api_key(&pool.0).await?.is_none() {
+        return Ok(SuggestionsResponse::NotConfigured);
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let decision = db::decide(db::suggestion_state(&pool.0, &uuid).await?, now);
+    if decision.enqueue {
+        // Mark pending before posting so concurrent callers can't each enqueue.
+        db::mark_pending(&pool.0, &uuid).await?;
+        worker.0.post(db::worker::Task::ResolveSuggestions {
+            book_uuid: uuid.clone(),
+        });
+    }
+    if decision.serve {
+        let items = db::get_suggestions(&pool.0, &uuid)
+            .await?
+            .into_iter()
+            .map(|c| {
+                BookSuggestion::new(
+                    &uuid,
+                    c.rank,
+                    c.hardcover_id,
+                    c.hardcover_slug,
+                    c.title,
+                    c.author,
+                    c.list_count,
+                    c.has_cover,
+                )
+            })
+            .collect();
+        Ok(SuggestionsResponse::Ready { items })
+    } else {
+        Ok(SuggestionsResponse::Pending)
+    }
+}
+
+/// Admin-only: masked status of the server-wide Hardcover key for Settings.
+/// Never returns the raw key.
+#[get("/api/rpc/hardcover-key", pool: PoolExt, _admin: AdminUser)]
+pub async fn rpc_get_hardcover_key() -> Result<HardcoverKeyStatus> {
+    read_hardcover_key_status(&pool.0).await
+}
+
+/// Admin-only: save (or clear, with `None`/blank) the Hardcover key in
+/// settings. Returns the new masked status — never echoes the raw key.
+#[post("/api/rpc/hardcover-key", pool: PoolExt, _admin: AdminUser)]
+pub async fn rpc_set_hardcover_key(key: Option<String>) -> Result<HardcoverKeyStatus> {
+    db::set_hardcover_api_key(&pool.0, key.as_deref()).await?;
+    read_hardcover_key_status(&pool.0).await
+}
+
+/// Short masked preview of a secret — never the raw value. Long keys (Hardcover
+/// tokens are JWTs) collapse to `first4…last4`.
+#[cfg(feature = "server")]
+fn mask_key(key: &str) -> String {
+    let n = key.chars().count();
+    if n <= 8 {
+        return "\u{2022}\u{2022}\u{2022}\u{2022}".to_string();
+    }
+    let first: String = key.chars().take(4).collect();
+    let last: String = key.chars().skip(n - 4).collect();
+    format!("{first}\u{2026}{last}")
+}
+
+/// Build the masked key status: settings value wins (`source = "settings"`),
+/// else the `HARDCOVER_API_KEY` env var (`source = "env"`), else unset.
+#[cfg(feature = "server")]
+async fn read_hardcover_key_status(pool: &sqlx::SqlitePool) -> Result<HardcoverKeyStatus> {
+    if let Some(k) = db::get_hardcover_api_key(pool).await? {
+        return Ok(HardcoverKeyStatus {
+            configured: true,
+            masked: Some(mask_key(&k)),
+            source: "settings".to_string(),
+        });
+    }
+    if let Ok(env_key) = std::env::var("HARDCOVER_API_KEY") {
+        let env_key = env_key.trim();
+        if !env_key.is_empty() {
+            return Ok(HardcoverKeyStatus {
+                configured: true,
+                masked: Some(mask_key(env_key)),
+                source: "env".to_string(),
+            });
+        }
+    }
+    Ok(HardcoverKeyStatus {
+        configured: false,
+        masked: None,
+        source: "none".to_string(),
+    })
 }
 
 /// Admin-triggered "Scan for picture" for an author. Clears any sticky

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -35,6 +35,7 @@ mod ratings;
 mod search;
 mod series;
 mod settings;
+mod suggestions;
 mod tags;
 
 /// Per-IP rate-limit budget for `/api/search/*` and the `/api/rpc/search-*`
@@ -291,6 +292,20 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
         .route("/api/series", get(series::get_series))
         .route("/api/series/{id}", get(series::get_series_by_id))
         .route("/api/tags", get(tags::get_tags))
+        // F3.3 suggestions — mobile-facing REST. Web hits the analogous
+        // `/api/rpc/ebook-suggestions` + `/api/rpc/hardcover-key` server fns.
+        .route(
+            "/api/ebooks/{uuid}/suggestions",
+            get(suggestions::get_suggestions),
+        )
+        .route(
+            "/api/suggestions/{uuid}/{rank}/cover",
+            get(suggestions::get_suggestion_cover),
+        )
+        .route(
+            "/api/hardcover-key",
+            get(suggestions::get_hardcover_key).post(suggestions::post_hardcover_key),
+        )
 }
 
 /// Sub-router for `/api/search/*` carrying its own per-IP rate-limit layer.

--- a/server/src/backend/suggestions.rs
+++ b/server/src/backend/suggestions.rs
@@ -1,0 +1,179 @@
+//! F3.3 suggestions REST handlers (mobile-facing) plus the admin Hardcover-key
+//! API. Web hits the analogous `/api/rpc/*` server functions.
+//!
+//! `GET /api/ebooks/{uuid}/suggestions` drives the same cache de-duplication
+//! state machine as the RPC: `NotConfigured` when no key is set, the
+//! fresh/sticky cache when present, and a single enqueued resolution otherwise.
+//! `GET /api/suggestions/{uuid}/{rank}/cover` streams cached cover bytes.
+//! `GET`/`POST /api/hardcover-key` read/write the (masked) key, admin-only.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{
+    extract::{Path, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use omnibus_db::{self as db, worker::Task};
+use omnibus_shared::{BookSuggestion, HardcoverKeyStatus, SuggestionsResponse};
+use serde::Deserialize;
+
+use super::{internal, AppState};
+use crate::auth::{AdminUser, AuthUser};
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_secs()).ok())
+        .unwrap_or(0)
+}
+
+/// Serve a book's cached "readers also enjoyed" strip. Enqueues a single
+/// background resolution (marking `pending` first) when the cache is
+/// absent/stale so a refresh or a burst of viewers never re-hits Hardcover.
+pub(super) async fn get_suggestions(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path(uuid): Path<String>,
+) -> Response {
+    match db::effective_hardcover_api_key(&state.pool).await {
+        Ok(None) => return Json(SuggestionsResponse::NotConfigured).into_response(),
+        Ok(Some(_)) => {}
+        Err(e) => return internal("read hardcover key", e),
+    }
+    let marker = match db::suggestion_state(&state.pool, &uuid).await {
+        Ok(m) => m,
+        Err(e) => return internal("read suggestion state", e),
+    };
+    let decision = db::decide(marker, now_secs());
+    if decision.enqueue {
+        if let Err(e) = db::mark_pending(&state.pool, &uuid).await {
+            return internal("mark suggestions pending", e);
+        }
+        state.worker.post(Task::ResolveSuggestions {
+            book_uuid: uuid.clone(),
+        });
+    }
+    if !decision.serve {
+        return Json(SuggestionsResponse::Pending).into_response();
+    }
+    match db::get_suggestions(&state.pool, &uuid).await {
+        Ok(rows) => {
+            let items = rows
+                .into_iter()
+                .map(|c| {
+                    BookSuggestion::new(
+                        &uuid,
+                        c.rank,
+                        c.hardcover_id,
+                        c.hardcover_slug,
+                        c.title,
+                        c.author,
+                        c.list_count,
+                        c.has_cover,
+                    )
+                })
+                .collect();
+            Json(SuggestionsResponse::Ready { items }).into_response()
+        }
+        Err(e) => internal("read suggestions", e),
+    }
+}
+
+/// Stream a cached suggestion cover's bytes; 404 on miss. Same cache semantics
+/// as `/api/covers/{uuid}`.
+pub(super) async fn get_suggestion_cover(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Path((uuid, rank)): Path<(String, i64)>,
+) -> Response {
+    match db::get_suggestion_cover(&state.pool, &uuid, rank).await {
+        Ok(Some((mime, bytes))) => (
+            [
+                (header::CONTENT_TYPE, mime.as_str()),
+                (header::CACHE_CONTROL, "private, max-age=86400"),
+                (header::VARY, "Cookie"),
+                (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+            ],
+            bytes,
+        )
+            .into_response(),
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => internal("read suggestion cover", e),
+    }
+}
+
+/// Admin-only: masked status of the server-wide Hardcover key.
+pub(super) async fn get_hardcover_key(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+) -> Response {
+    match read_status(&state.pool).await {
+        Ok(s) => Json(s).into_response(),
+        Err(e) => internal("read hardcover key", e),
+    }
+}
+
+/// Body for `POST /api/hardcover-key`. A `null`/absent/blank key clears it.
+#[derive(Debug, Deserialize)]
+pub(super) struct SetHardcoverKey {
+    #[serde(default)]
+    key: Option<String>,
+}
+
+/// Admin-only: save or clear the Hardcover key; returns the new masked status.
+pub(super) async fn post_hardcover_key(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Json(body): Json<SetHardcoverKey>,
+) -> Response {
+    if let Err(e) = db::set_hardcover_api_key(&state.pool, body.key.as_deref()).await {
+        return internal("save hardcover key", e);
+    }
+    match read_status(&state.pool).await {
+        Ok(s) => Json(s).into_response(),
+        Err(e) => internal("read hardcover key", e),
+    }
+}
+
+/// Build the masked key status: settings wins, then env, else unset.
+async fn read_status(pool: &sqlx::SqlitePool) -> Result<HardcoverKeyStatus, db::SettingsError> {
+    if let Some(k) = db::get_hardcover_api_key(pool).await? {
+        return Ok(HardcoverKeyStatus {
+            configured: true,
+            masked: Some(mask_key(&k)),
+            source: "settings".to_string(),
+        });
+    }
+    if let Ok(env_key) = std::env::var("HARDCOVER_API_KEY") {
+        let env_key = env_key.trim();
+        if !env_key.is_empty() {
+            return Ok(HardcoverKeyStatus {
+                configured: true,
+                masked: Some(mask_key(env_key)),
+                source: "env".to_string(),
+            });
+        }
+    }
+    Ok(HardcoverKeyStatus {
+        configured: false,
+        masked: None,
+        source: "none".to_string(),
+    })
+}
+
+/// Short masked preview — never the raw key.
+fn mask_key(key: &str) -> String {
+    let n = key.chars().count();
+    if n <= 8 {
+        return "\u{2022}\u{2022}\u{2022}\u{2022}".to_string();
+    }
+    let first: String = key.chars().take(4).collect();
+    let last: String = key.chars().skip(n - 4).collect();
+    format!("{first}\u{2026}{last}")
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/src/backend/suggestions/tests.rs
+++ b/server/src/backend/suggestions/tests.rs
@@ -1,0 +1,178 @@
+//! Tests for the F3.3 suggestions REST handlers.
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header::AUTHORIZATION, Request, StatusCode},
+};
+use omnibus_db::suggestions::{replace_suggestions, NewSuggestion, SuggestionState};
+use tower::ServiceExt;
+
+use crate::auth::test_support as auth_test_support;
+use crate::backend::test_support::*;
+
+fn post_json(uri: &str, token: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .method("POST")
+        .header("content-type", "application/json")
+        .header(AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+async fn body_string(res: axum::response::Response) -> String {
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+fn sample_suggestion(id: i64, title: &str, cover: bool) -> NewSuggestion {
+    NewSuggestion {
+        hardcover_id: id,
+        hardcover_slug: Some(format!("slug-{id}")),
+        title: title.to_string(),
+        author: "Read Alike".to_string(),
+        list_count: id,
+        cover_mime: cover.then(|| "image/jpeg".to_string()),
+        cover_bytes: cover.then(|| b"\xFF\xD8\xFFjpegbytes".to_vec()),
+    }
+}
+
+#[tokio::test]
+async fn api_suggestions_requires_auth() {
+    let (app, _state, _pool) = fixture().await;
+    let res = app
+        .oneshot(get_anon("/api/ebooks/some-uuid/suggestions"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_suggestions_ready_serves_cached_rows() {
+    let (app, _state, pool) = fixture().await;
+    // A configured key (settings) makes the response deterministic regardless
+    // of the ambient HARDCOVER_API_KEY env var.
+    omnibus_db::set_hardcover_api_key(&pool, Some("hc_test_key_value"))
+        .await
+        .unwrap();
+    replace_suggestions(
+        &pool,
+        "book-1",
+        &[
+            sample_suggestion(200, "Alpha", true),
+            sample_suggestion(201, "Beta", false),
+        ],
+        SuggestionState::Resolved,
+    )
+    .await
+    .unwrap();
+
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let res = app
+        .oneshot(get_with_bearer("/api/ebooks/book-1/suggestions", &token))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = body_string(res).await;
+    assert!(body.contains("\"status\":\"ready\""));
+    assert!(body.contains("Alpha"));
+    assert!(body.contains("https://hardcover.app/books/slug-200"));
+    assert!(body.contains("/api/suggestions/book-1/0/cover"));
+}
+
+#[tokio::test]
+async fn api_suggestion_cover_returns_404_on_miss() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let res = app
+        .oneshot(get_with_bearer("/api/suggestions/nope/0/cover", &token))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn api_suggestion_cover_serves_cached_bytes() {
+    let (app, _state, pool) = fixture().await;
+    replace_suggestions(
+        &pool,
+        "book-1",
+        &[sample_suggestion(200, "Alpha", true)],
+        SuggestionState::Resolved,
+    )
+    .await
+    .unwrap();
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let res = app
+        .oneshot(get_with_bearer("/api/suggestions/book-1/0/cover", &token))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.headers().get("content-type").unwrap(), "image/jpeg");
+}
+
+#[tokio::test]
+async fn api_hardcover_key_get_requires_admin() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let res = app
+        .oneshot(get_with_bearer("/api/hardcover-key", &token))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn api_hardcover_key_post_requires_admin() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let res = app
+        .oneshot(post_json(
+            "/api/hardcover-key",
+            &token,
+            serde_json::json!({ "key": "hc_secret" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn api_hardcover_key_set_then_get_returns_masked_never_raw() {
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "boss").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let raw = "hc_supersecret_jwt_value_1234";
+    let set_res = app
+        .clone()
+        .oneshot(post_json(
+            "/api/hardcover-key",
+            &token,
+            serde_json::json!({ "key": raw }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(set_res.status(), StatusCode::OK);
+    let set_body = body_string(set_res).await;
+    // The raw key must never be echoed back to the client.
+    assert!(!set_body.contains(raw));
+    assert!(set_body.contains("\"configured\":true"));
+    assert!(set_body.contains("\"source\":\"settings\""));
+
+    let get_res = app
+        .oneshot(get_with_bearer("/api/hardcover-key", &token))
+        .await
+        .unwrap();
+    assert_eq!(get_res.status(), StatusCode::OK);
+    let get_body = body_string(get_res).await;
+    assert!(!get_body.contains(raw));
+    assert!(get_body.contains("\"configured\":true"));
+    // Masked preview keeps the first/last 4 chars around an ellipsis.
+    assert!(get_body.contains("hc_s\u{2026}1234"));
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -87,6 +87,9 @@ mod server {
 
         let pool = omnibus_db::init_db(&database_url).await?;
         omnibus_db::seed_settings_from_env(&pool).await?;
+        // Seed the F3.3 Hardcover key from HARDCOVER_API_KEY only when none is
+        // saved (settings wins; env is the out-of-the-box fallback).
+        omnibus_db::seed_hardcover_key_from_env(&pool).await?;
 
         // Recovery hook: promote the named user to admin if
         // OMNIBUS_INITIAL_ADMIN is set. No-op otherwise. Logs on

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -20,6 +20,7 @@ pub mod merge;
 pub mod progress;
 pub mod ratings;
 pub mod settings;
+pub mod suggestion;
 pub mod view_prefs;
 pub mod worker;
 
@@ -38,5 +39,6 @@ pub use merge::*;
 pub use progress::*;
 pub use ratings::*;
 pub use settings::*;
+pub use suggestion::*;
 pub use view_prefs::*;
 pub use worker::*;

--- a/shared/src/suggestion.rs
+++ b/shared/src/suggestion.rs
@@ -1,0 +1,79 @@
+//! Wire types for F3.3 "Readers also enjoyed" suggestions.
+
+use serde::{Deserialize, Serialize};
+
+/// Base URL for outbound Hardcover book links (new tab).
+const HARDCOVER_BOOK_BASE: &str = "https://hardcover.app/books/";
+
+/// One suggested read-alike from Hardcover. External to the library — clicking
+/// opens `hardcover_url` in a new tab.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BookSuggestion {
+    pub hardcover_id: i64,
+    /// Outbound Hardcover book page.
+    pub hardcover_url: String,
+    pub title: String,
+    pub author: String,
+    /// Co-listing count — how many curated Hardcover lists co-shelve this book
+    /// with the source book. The relevance signal shown as "on N lists".
+    pub list_count: i64,
+    /// Relative URL to the cached cover (`/api/suggestions/:uuid/:rank/cover`),
+    /// or `None` when no cover was cached (the UI falls back to a typographic
+    /// plate). Clients combine it with their configured server base.
+    pub cover_url: Option<String>,
+}
+
+impl BookSuggestion {
+    /// Build a wire suggestion from the cached primitives, deriving the
+    /// outbound Hardcover URL (slug-based, id fallback) and the relative cover
+    /// URL (only when a cover was cached).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        book_uuid: &str,
+        rank: i64,
+        hardcover_id: i64,
+        hardcover_slug: Option<String>,
+        title: String,
+        author: String,
+        list_count: i64,
+        has_cover: bool,
+    ) -> Self {
+        let hardcover_url = match hardcover_slug {
+            Some(slug) if !slug.is_empty() => format!("{HARDCOVER_BOOK_BASE}{slug}"),
+            _ => format!("{HARDCOVER_BOOK_BASE}{hardcover_id}"),
+        };
+        let cover_url = has_cover.then(|| format!("/api/suggestions/{book_uuid}/{rank}/cover"));
+        Self {
+            hardcover_id,
+            hardcover_url,
+            title,
+            author,
+            list_count,
+            cover_url,
+        }
+    }
+}
+
+/// Response for a book's suggestions strip.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SuggestionsResponse {
+    /// No Hardcover key is configured — the UI shows a connect message.
+    NotConfigured,
+    /// A resolution is enqueued and nothing is cached yet — the UI polls.
+    Pending,
+    /// Cached results. `items` may be empty (sticky negative — Hardcover
+    /// matched nothing usable).
+    Ready { items: Vec<BookSuggestion> },
+}
+
+/// Masked status of the server-wide Hardcover key for the Settings UI. **Never
+/// carries the raw key** — only a short masked preview.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HardcoverKeyStatus {
+    pub configured: bool,
+    /// Short masked preview (e.g. `hc_l…3f9a`), or `None` when unset.
+    pub masked: Option<String>,
+    /// Where the effective key comes from: `"settings"`, `"env"`, or `"none"`.
+    pub source: String,
+}

--- a/shared/src/worker.rs
+++ b/shared/src/worker.rs
@@ -20,6 +20,7 @@ pub enum TaskKind {
     ResolveAuthorPhoto,
     RefetchAuthorPhotos,
     BackfillChapters,
+    ResolveSuggestions,
 }
 
 /// Lifecycle state of a single worker task as exposed to the UI.

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -245,9 +245,15 @@ test("renders the detail contents for the selected book", async ({ page, request
   await expect(switcher.getByTestId("action-listen")).toHaveCount(0);
 
   // F3.2 ratings ship as the interactive hero rating card; F3.3 suggestions
-  // is still a hidden placeholder slot.
+  // renders the "Readers also enjoyed" strip below the metadata. (Its inner
+  // state — connect message / pending / results — depends on whether a
+  // Hardcover key is configured and on the external API, so we only assert the
+  // section + heading are present here, not the resolved contents.)
   await expect(page.getByTestId("rating-stars")).toBeVisible();
-  await expect(page.getByTestId("suggestions-slot")).toBeAttached();
+  await expect(page.getByTestId("suggestions-strip")).toBeAttached();
+  await expect(
+    page.getByRole("heading", { name: "Suggested for you" }),
+  ).toBeVisible();
 
   // Back link still navigates to landing
   const backLink = page.getByRole("link", { name: "Back to library" });

--- a/ui_tests/playwright/tests/flows/settings.spec.ts
+++ b/ui_tests/playwright/tests/flows/settings.spec.ts
@@ -5,7 +5,11 @@ import { expectNavVisible, gotoReady } from "../utils/nav";
 
 const ebookInput = (page: Page) => page.getByLabel("Ebook Library Path");
 const audiobookInput = (page: Page) => page.getByLabel("Audiobook Library Path");
-const saveButton = (page: Page) => page.getByRole("button", { name: "Save" });
+// Scope the Save button to the library-paths form — the page now also has a
+// "Suggestions (Hardcover)" card with its own Save button (F3.3), so an
+// unscoped `name: "Save"` would match both and trip Playwright strict mode.
+const saveButton = (page: Page) =>
+  page.locator("#settings-form").getByRole("button", { name: "Save" });
 // The settings page now has two `role=status` regions — the inline form
 // status (this locator) and the worker-progress indicator above the Save
 // button (`data-testid="worker-status"`, issue #69). Target by testid so
@@ -22,6 +26,8 @@ test("renders the settings page layout", async ({ page }) => {
   await expect(settingsStatus(page)).toBeAttached();
   await expect(page.getByTestId("ebook-library-summary")).toBeAttached();
   await expect(page.getByTestId("audiobook-library-summary")).toBeAttached();
+  // F3.3 — the Hardcover suggestions key card renders on the settings page.
+  await expect(page.getByTestId("hardcover-key-card")).toBeVisible();
   await expectNavVisible(page);
 });
 


### PR DESCRIPTION
## Summary
- F3.3 backend: a per-book Hardcover "readers also enjoyed" cache resolved off-request by the F0.5 worker. 30-day TTL plus a `pending`/`empty` de-duplication state machine so a page refresh or a burst of concurrent viewers never re-hits Hardcover while a result is fresh.
- New `db/src/suggestions/`: Hardcover GraphQL client (ISBN-first resolve → curated-list co-occurrence → different-author / different-series / entry-point-only filter), cache CRUD + pure `decide` verdict, and the cascade orchestrator. Migration `0033`.
- `Task::ResolveSuggestions` worker job. `HARDCOVER_API_KEY` is stored in settings (DB) with the env var as a seed-if-unset fallback — settings wins.

## Test plan
- [ ] `just check` (fmt + clippy matrix + full test suite) green.
- [ ] db: 21 suggestions tests (decide state machine, filters, Hardcover wiremock, end-to-end cascade) + settings key-precedence tests.

## Notes
- First of 3 stacked PRs — this is the base (`-1`); `-2` adds the API surface, `-3` the UI.
- Hardcover GraphQL field names were verified live against `api.hardcover.app`.