### PR TITLE
feat: book-detail suggestions strip + settings key field

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4319,3 +4319,64 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .bd-merge-toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
   z-index: 110; display: flex; align-items: center; gap: 12px; padding: 12px 16px;
   box-shadow: 0 6px 24px rgba(0,0,0,.35); }
+
+/* ── F3.3 "Readers also enjoyed" suggestions strip ─────────────────
+   The first 5 covers are a tight stack (each overlapping the previous by
+   ~80%); hovering the row eases them apart. "Show more" reveals the rest into
+   a plain static grid — no stacking, no hover motion. Ported from the Atrium
+   design's omnibus.css. */
+.bd-suggest-pending,
+.bd-suggest-connect { margin-top: 4px; }
+.bd-suggest-pending { padding: 16px 18px; }
+
+.bd-suggest-connect { display: flex; align-items: center; justify-content: space-between;
+  gap: 22px; padding: 22px 24px; border: 1px dashed var(--line-2); }
+.bd-suggest-connect-title { font-size: 18px; margin: 0; }
+.bd-suggest-connect-body { font-size: 13.5px; color: var(--ink-2); line-height: 1.5; margin: 6px 0 0; }
+
+.suggest-stack { display: flex; padding: 18px 0 10px; align-items: flex-start; }
+.suggest-stack > .cover-link { flex: 0 0 168px; margin-left: -134px;
+  transition: margin-left .45s cubic-bezier(.2,.7,.3,1); }
+.suggest-stack > .cover-link:first-child { margin-left: 0; }
+/* Earlier books paint on top so the strongest match leads the stack. */
+.suggest-stack > .cover-link:nth-child(1) { z-index: 5; }
+.suggest-stack > .cover-link:nth-child(2) { z-index: 4; }
+.suggest-stack > .cover-link:nth-child(3) { z-index: 3; }
+.suggest-stack > .cover-link:nth-child(4) { z-index: 2; }
+.suggest-stack > .cover-link:nth-child(5) { z-index: 1; }
+.suggest-stack:hover > .cover-link { margin-left: 18px; }
+.suggest-stack:hover > .cover-link:first-child { margin-left: 0; }
+.suggest-stack > .cover-link:hover { z-index: 10; }
+
+.suggest-static { display: flex; flex-wrap: wrap; gap: 18px; padding: 6px 0 10px; }
+.suggest-static > .cover-link { flex: 0 0 168px; }
+
+/* Per-cover caption (title/author): hidden until the stack spreads, always
+   shown in the static grid. */
+.sug-cap { opacity: 0; margin-top: 10px; transition: opacity .25s .05s; max-width: 168px; }
+.suggest-stack:hover .sug-cap,
+.suggest-stack > .cover-link:hover .sug-cap,
+.suggest-static .sug-cap { opacity: 1; }
+.sug-cap-title { font-size: 13.5px; color: var(--ink-0); font-weight: 500;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.sug-cap-author { font-size: 12px; color: var(--ink-2); margin-top: 2px;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+
+/* "on N lists" relevance badge, pinned top-right of each cover. */
+.fan-match { position: absolute; top: 8px; right: 8px; z-index: 2;
+  background: color-mix(in oklch, var(--bg-0) 70%, transparent);
+  backdrop-filter: blur(6px); padding: 2px 6px; border-radius: 999px;
+  font-size: 10px; color: var(--ink-1); }
+
+.bd-suggest-actions { display: flex; align-items: center; gap: 14px; margin-top: 8px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .suggest-stack > .cover-link { transition: none; }
+  .suggest-stack .sug-cap { opacity: 1; }
+}
+
+/* Settings → Hardcover key field status line. */
+.hardcover-status { display: flex; align-items: center; gap: 8px; margin-top: 10px;
+  font-size: 11.5px; color: var(--ink-2); }
+.hardcover-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--ink-3); flex: 0 0 8px; }
+.hardcover-dot.connected { background: oklch(0.7 0.15 150); }

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -24,6 +24,7 @@ mod journals;
 mod progress;
 mod ratings;
 mod series;
+mod suggestions;
 mod tags;
 
 // auth exports exist under web, mobile, and server-only (the last only
@@ -39,6 +40,7 @@ pub use journals::*;
 pub use progress::*;
 pub use ratings::*;
 pub use series::*;
+pub use suggestions::*;
 pub use tags::*;
 
 /// Errors surfaced by the feature-gated data transport.

--- a/frontend/src/data/suggestions.rs
+++ b/frontend/src/data/suggestions.rs
@@ -1,0 +1,91 @@
+//! F3.3 suggestions fetchers + Hardcover-key read/write. Each function has a
+//! mobile REST variant (`reqwest`) and a web/SSR server-function wrapper with
+//! identical signatures across the `#[cfg]` split.
+
+use omnibus_shared::{HardcoverKeyStatus, SuggestionsResponse};
+
+#[cfg(not(feature = "mobile"))]
+use super::note_server_fn_err;
+use super::DataError;
+#[cfg(feature = "mobile")]
+use super::{drain_error, http_client, note_status, with_bearer};
+
+// ── Suggestions strip ────────────────────────────────────────────
+
+/// Web/SSR: fetch a book's "readers also enjoyed" strip via `rpc_get_suggestions`.
+#[cfg(not(feature = "mobile"))]
+pub async fn get_suggestions(
+    _server_url: &str,
+    uuid: &str,
+) -> Result<SuggestionsResponse, DataError> {
+    crate::rpc::rpc_get_suggestions(uuid.to_string())
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Mobile: GET `/api/ebooks/{uuid}/suggestions`.
+#[cfg(feature = "mobile")]
+pub async fn get_suggestions(
+    server_url: &str,
+    uuid: &str,
+) -> Result<SuggestionsResponse, DataError> {
+    let url = format!("{server_url}/api/ebooks/{uuid}/suggestions");
+    let response = with_bearer(http_client().get(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<SuggestionsResponse>().await?)
+}
+
+// ── Hardcover key (admin settings) ───────────────────────────────
+
+/// Web/SSR: read the masked Hardcover key status via `rpc_get_hardcover_key`.
+#[cfg(not(feature = "mobile"))]
+pub async fn get_hardcover_key(_server_url: &str) -> Result<HardcoverKeyStatus, DataError> {
+    crate::rpc::rpc_get_hardcover_key()
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Mobile: GET `/api/hardcover-key`.
+#[cfg(feature = "mobile")]
+pub async fn get_hardcover_key(server_url: &str) -> Result<HardcoverKeyStatus, DataError> {
+    let url = format!("{server_url}/api/hardcover-key");
+    let response = with_bearer(http_client().get(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<HardcoverKeyStatus>().await?)
+}
+
+/// Web/SSR: save (or clear, with `None`) the Hardcover key via
+/// `rpc_set_hardcover_key`. Returns the new masked status.
+#[cfg(not(feature = "mobile"))]
+pub async fn set_hardcover_key(
+    _server_url: &str,
+    key: Option<String>,
+) -> Result<HardcoverKeyStatus, DataError> {
+    crate::rpc::rpc_set_hardcover_key(key)
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Mobile: POST `/api/hardcover-key` with `{ "key": ... }`.
+#[cfg(feature = "mobile")]
+pub async fn set_hardcover_key(
+    server_url: &str,
+    key: Option<String>,
+) -> Result<HardcoverKeyStatus, DataError> {
+    let url = format!("{server_url}/api/hardcover-key");
+    let response = with_bearer(http_client().post(&url))
+        .json(&serde_json::json!({ "key": key }))
+        .send()
+        .await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<HardcoverKeyStatus>().await?)
+}

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -2,7 +2,7 @@
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
-use omnibus_shared::{EbookMetadata, Identifier};
+use omnibus_shared::{BookSuggestion, Contributor, EbookMetadata, Identifier, SuggestionsResponse};
 
 use crate::components::atrium::Cover;
 use crate::components::FormatSwitcher;
@@ -11,13 +11,17 @@ use crate::Route;
 use super::journal::BdJournalSection;
 use super::{BdInsightCell, BdMetaRow, BdSectionHead};
 
-/// Main column: public journal feed, highlights stub, from-the-same-hand fan, suggestions stub.
+/// Main column: public journal feed, highlights stub, from-the-same-hand fan,
+/// and the F3.3 "Readers also enjoyed" suggestions strip.
 #[component]
 pub(super) fn BdBodyMain(
     uuid: String,
     title: String,
     primary_author: String,
     author_books: Vec<EbookMetadata>,
+    suggestions: Option<SuggestionsResponse>,
+    server_url: String,
+    is_admin: bool,
 ) -> Element {
     rsx! {
         div { class: "bd-body-main",
@@ -50,15 +54,161 @@ pub(super) fn BdBodyMain(
                     }
                 }
             }
-            div { class: "divider" }
-            BdSectionHead {
-                kicker: format!("If you liked {title}\u{2026}"),
-                title: "Suggested for you".to_string(),
-            }
-            div { class: "bd-stub-strip card", aria_hidden: "true",
-                p { class: "bd-stub-hint mono", "Suggestions land in F3.3." }
+            BdSuggestionsStrip {
+                book_title: title,
+                suggestions,
+                server_url,
+                is_admin,
             }
         }
+    }
+}
+
+/// "Readers also enjoyed" — Hardcover read-alikes below the metadata. Renders
+/// its own divider + section head, then one of: a connect message (no key), a
+/// quiet placeholder (resolving), the cover strip (results), or an empty note.
+/// The section is always present (stable `suggestions-strip` testid); only its
+/// inner content varies by state.
+#[component]
+pub(super) fn BdSuggestionsStrip(
+    book_title: String,
+    suggestions: Option<SuggestionsResponse>,
+    server_url: String,
+    is_admin: bool,
+) -> Element {
+    rsx! {
+        div { class: "divider" }
+        BdSectionHead {
+            kicker: format!("If you liked {book_title}\u{2026}"),
+            title: "Suggested for you".to_string(),
+        }
+        div { class: "bd-suggest", "data-testid": "suggestions-strip",
+            match suggestions {
+                Some(SuggestionsResponse::Ready { items }) if !items.is_empty() => rsx! {
+                    BdSuggestionsList { items, server_url }
+                },
+                Some(SuggestionsResponse::Ready { .. }) => rsx! {
+                    div { class: "bd-suggest-pending card", "data-testid": "suggestions-empty",
+                        p { class: "mono bd-stub-hint", "No read-alikes found for this book yet." }
+                    }
+                },
+                Some(SuggestionsResponse::NotConfigured) => rsx! {
+                    SuggestionsConnectCard { is_admin }
+                },
+                // None (first paint, pre-fetch) or Pending → quiet placeholder.
+                _ => rsx! {
+                    div { class: "bd-suggest-pending card", "data-testid": "suggestions-pending",
+                        p { class: "mono bd-stub-hint", "Looking for read-alikes via Hardcover\u{2026}" }
+                    }
+                },
+            }
+        }
+    }
+}
+
+/// The cover strip itself — 5 covers stacked (hover to spread); a "show more"
+/// reveals the rest into a flat grid. Each cover links out to Hardcover.
+#[component]
+fn BdSuggestionsList(items: Vec<BookSuggestion>, server_url: String) -> Element {
+    let mut expanded = use_signal(|| false);
+    let total = items.len();
+    let collapsed_len = total.min(5);
+    let show_more = total > collapsed_len;
+    let visible = if expanded() { total } else { collapsed_len };
+    let row_class = if expanded() {
+        "suggest-static"
+    } else {
+        "suggest-stack"
+    };
+
+    rsx! {
+        div { class: "{row_class}",
+            for s in items.iter().take(visible).cloned() {
+                a {
+                    key: "{s.hardcover_id}",
+                    class: "cover-link suggest-card",
+                    href: "{s.hardcover_url}",
+                    target: "_blank",
+                    rel: "noopener noreferrer",
+                    "data-testid": "suggestion-card",
+                    Cover {
+                        book: suggestion_cover_book(&s),
+                        src_override: cover_src(&server_url, &s),
+                    }
+                    div { class: "fan-match mono", "{list_count_label(s.list_count)}" }
+                    div { class: "sug-cap",
+                        div { class: "sug-cap-title", "{s.title}" }
+                        div { class: "sug-cap-author", "{s.author}" }
+                    }
+                }
+            }
+        }
+        if show_more && !expanded() {
+            div { class: "bd-suggest-actions",
+                button {
+                    class: "btn sm",
+                    "data-testid": "suggestions-show-more",
+                    onclick: move |_| expanded.set(true),
+                    "Show {total - collapsed_len} more"
+                }
+            }
+        }
+    }
+}
+
+/// "Connect Hardcover" message shown when no API key is configured. Admins get
+/// a link to Settings; everyone else is told to ask their server admin.
+#[component]
+fn SuggestionsConnectCard(is_admin: bool) -> Element {
+    rsx! {
+        div { class: "bd-suggest-connect card", "data-testid": "suggestions-not-configured",
+            div {
+                h4 { class: "bd-suggest-connect-title", "Suggestions are powered by Hardcover" }
+                p { class: "bd-suggest-connect-body",
+                    "Add a Hardcover API key to pull read-alikes for this book."
+                }
+            }
+            if is_admin {
+                Link {
+                    to: Route::Settings {},
+                    class: "btn primary sm",
+                    "data-testid": "suggestions-connect-link",
+                    "Add Hardcover API key \u{2192}"
+                }
+            } else {
+                span { class: "mono bd-stub-hint", "Ask your server admin to connect Hardcover." }
+            }
+        }
+    }
+}
+
+/// Build a minimal [`EbookMetadata`] so the shared [`Cover`] can render a
+/// suggestion's title/author plate when no cover image is available.
+fn suggestion_cover_book(s: &BookSuggestion) -> EbookMetadata {
+    EbookMetadata {
+        title: Some(s.title.clone()),
+        creators: vec![Contributor {
+            name: s.author.clone(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// Absolute cover URL (server base + relative path), or `None` when the
+/// suggestion has no cached cover (the plate fallback then applies).
+fn cover_src(server_url: &str, s: &BookSuggestion) -> Option<String> {
+    s.cover_url
+        .as_ref()
+        .map(|path| format!("{server_url}{path}"))
+}
+
+/// "on N lists" relevance label (singular-aware).
+fn list_count_label(n: i64) -> String {
+    if n == 1 {
+        "on 1 list".to_string()
+    } else {
+        format!("on {n} lists")
     }
 }
 

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -5,7 +5,7 @@
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
-use omnibus_shared::{EbookMetadata, MergeBooksResult};
+use omnibus_shared::{EbookMetadata, MergeBooksResult, SuggestionsResponse};
 
 use crate::{data, use_server_url, Route};
 
@@ -24,6 +24,13 @@ pub fn BookDetailPage(uuid: String) -> Element {
     let server_url = use_server_url();
     let mut book: Signal<Option<EbookMetadata>> = use_signal(|| None);
     let mut author_books: Signal<Vec<EbookMetadata>> = use_signal(Vec::new);
+    // F3.3 suggestions. Starts `None` on both SSR and the first WASM paint so
+    // hydration markup matches (rule 07); the client effect below populates it.
+    let mut suggestions: Signal<Option<SuggestionsResponse>> = use_signal(|| None);
+    // Epoch guard so a poll loop left over from a previous book can't write its
+    // result onto the current book after navigation (mirrors landing's
+    // `fetch_epoch`).
+    let mut suggestions_epoch = use_signal(|| 0u64);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
     // Bumped after a merge/undo so the effect below refetches the book
@@ -104,6 +111,68 @@ pub fn BookDetailPage(uuid: String) -> Element {
         });
     }));
 
+    // F3.3 suggestions: resolved off-request by the worker and cached. Fetch
+    // for the current book; while the result is `Pending`, poll a few times on
+    // web so it appears without a manual reload. A fetch failure degrades to
+    // "no suggestions" rather than an error row.
+    let sug_url = server_url.clone();
+    use_effect(use_reactive!(|uuid| {
+        let url = sug_url.clone();
+        let uuid = uuid.clone();
+        let epoch = {
+            suggestions_epoch.with_mut(|e| *e += 1);
+            *suggestions_epoch.peek()
+        };
+        // True only while this run is still the latest — a newer book's effect
+        // bumps the epoch, so a stale poll drops its result instead of writing
+        // it onto the now-current book.
+        let is_current = move || *suggestions_epoch.peek() == epoch;
+        spawn(async move {
+            suggestions.set(None);
+            match data::get_suggestions(&url, &uuid).await {
+                Ok(resp) => {
+                    if !is_current() {
+                        return;
+                    }
+                    let pending = matches!(resp, SuggestionsResponse::Pending);
+                    suggestions.set(Some(resp));
+                    #[cfg(feature = "web")]
+                    if pending {
+                        let mut tries = 0u32;
+                        while tries < 5 {
+                            gloo_timers::future::TimeoutFuture::new(2500).await;
+                            if !is_current() {
+                                return;
+                            }
+                            tries += 1;
+                            match data::get_suggestions(&url, &uuid).await {
+                                Ok(next) => {
+                                    if !is_current() {
+                                        return;
+                                    }
+                                    let still_pending =
+                                        matches!(next, SuggestionsResponse::Pending);
+                                    suggestions.set(Some(next));
+                                    if !still_pending {
+                                        break;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                    }
+                    #[cfg(not(feature = "web"))]
+                    let _ = pending;
+                }
+                Err(_) => {
+                    if is_current() {
+                        suggestions.set(Some(SuggestionsResponse::Ready { items: Vec::new() }));
+                    }
+                }
+            }
+        });
+    }));
+
     if loading() {
         return rsx! {
             p { class: "subtitle", "Loading\u{2026}" }
@@ -146,7 +215,14 @@ pub fn BookDetailPage(uuid: String) -> Element {
     #[cfg(feature = "mobile")]
     let merge_ui: Option<Element> = merge::build_merge_ui();
 
-    let body = render_loaded(b, author_books(), merge_button);
+    let body = render_loaded(
+        b,
+        author_books(),
+        merge_button,
+        suggestions(),
+        server_url.clone(),
+        is_admin_flag,
+    );
     rsx! {
         {body}
         {merge_ui}
@@ -277,6 +353,9 @@ fn render_loaded(
     b: EbookMetadata,
     author_books: Vec<EbookMetadata>,
     merge_button: Option<Element>,
+    suggestions: Option<SuggestionsResponse>,
+    server_url: String,
+    is_admin: bool,
 ) -> Element {
     let LoadedBookView {
         title,
@@ -307,6 +386,9 @@ fn render_loaded(
                     title: title.clone(),
                     primary_author,
                     author_books,
+                    suggestions,
+                    server_url,
+                    is_admin,
                 }
                 BdRailSection {
                     b,
@@ -319,23 +401,6 @@ fn render_loaded(
             div { class: "bd-footer",
                 Link { to: Route::Landing {}, class: "btn", "Back to library" }
             }
-            BdHiddenSlots {}
-        }
-    }
-}
-
-/// Reserved hidden slot for F3.3 suggestions — anything keying off the
-/// `suggestions-slot` testid still finds it. Ratings now ship as the
-/// interactive hero rating card (`rating-stars`), so the old `ratings-slot`
-/// placeholder is gone.
-#[component]
-fn BdHiddenSlots() -> Element {
-    rsx! {
-        div {
-            class: "suggestions-slot",
-            "data-testid": "suggestions-slot",
-            aria_label: "Suggestions \u{2014} coming soon",
-            hidden: true,
         }
     }
 }

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -5,7 +5,7 @@
 //! counts via the scanner so changes can be eyeballed before saving.
 
 use dioxus::prelude::*;
-use omnibus_shared::{LibraryContents, LibrarySection, Settings};
+use omnibus_shared::{HardcoverKeyStatus, LibraryContents, LibrarySection, Settings};
 
 #[cfg(not(feature = "mobile"))]
 use crate::components::worker_status::WorkerStatusIndicator;
@@ -25,6 +25,20 @@ pub fn SettingsPage() -> Element {
     let backfill_in_flight = use_signal(|| false);
     // Bumped after a successful save to re-trigger the library-refresh effect.
     let library_refresh = use_signal(|| 0u32);
+
+    // Admin gating for the F3.3 Hardcover key card. Starts `false` so SSR and
+    // the first WASM paint agree (rule 07); the effect flips it for admins
+    // after mount. Declared unconditionally to keep hook order stable. The
+    // server-side `AdminUser` extractor on the key RPCs is the real boundary;
+    // this just keeps the card off non-admin screens.
+    let mut is_admin = use_signal(|| false);
+    use_effect(move || {
+        spawn(async move {
+            if let Ok(Some(user)) = data::current_user().await {
+                is_admin.set(user.is_admin);
+            }
+        });
+    });
 
     spawn_initial_settings_load(
         server_url.clone(),
@@ -78,6 +92,9 @@ pub fn SettingsPage() -> Element {
                 class: if status_is_error() { "settings-status error" } else { "settings-status success" },
                 if let Some(msg) = status() { "{msg}" }
             }
+        }
+        if is_admin() {
+            HardcoverKeyField {}
         }
     }
 }
@@ -273,6 +290,148 @@ fn MaintenanceActions(
                 });
             },
             "Extract Audiobook Chapters"
+        }
+    }
+}
+
+/// Admin field to set/clear the server-wide Hardcover API key (F3.3). Loads the
+/// masked status on mount; the raw key is never read back to the client.
+#[component]
+fn HardcoverKeyField() -> Element {
+    let server_url = use_server_url();
+    let mut status: Signal<Option<HardcoverKeyStatus>> = use_signal(|| None);
+    let mut key_input = use_signal(String::new);
+    let mut msg = use_signal(|| None::<String>);
+    let mut msg_is_error = use_signal(|| false);
+    let mut in_flight = use_signal(|| false);
+
+    let load_url = server_url.clone();
+    use_effect(move || {
+        let url = load_url.clone();
+        spawn(async move {
+            if let Ok(s) = data::get_hardcover_key(&url).await {
+                status.set(Some(s));
+            }
+        });
+    });
+
+    let save_url = server_url.clone();
+    let on_save = move |_| {
+        let value = key_input().trim().to_string();
+        // Empty Save is a no-op with a hint — clearing is the "Clear" button's
+        // job, so we never silently wipe the key and report "saved".
+        if value.is_empty() {
+            msg.set(Some("Enter a Hardcover key to save.".to_string()));
+            msg_is_error.set(true);
+            return;
+        }
+        let url = save_url.clone();
+        in_flight.set(true);
+        spawn(async move {
+            match data::set_hardcover_key(&url, Some(value)).await {
+                Ok(s) => {
+                    status.set(Some(s));
+                    key_input.set(String::new());
+                    msg.set(Some("Hardcover key saved.".to_string()));
+                    msg_is_error.set(false);
+                }
+                Err(_) => {
+                    msg.set(Some("Failed to save Hardcover key.".to_string()));
+                    msg_is_error.set(true);
+                }
+            }
+            in_flight.set(false);
+        });
+    };
+
+    let clear_url = server_url.clone();
+    let on_clear = move |_| {
+        let url = clear_url.clone();
+        in_flight.set(true);
+        spawn(async move {
+            match data::set_hardcover_key(&url, None).await {
+                Ok(s) => {
+                    status.set(Some(s));
+                    key_input.set(String::new());
+                    msg.set(Some("Hardcover key cleared.".to_string()));
+                    msg_is_error.set(false);
+                }
+                Err(_) => {
+                    msg.set(Some("Failed to clear Hardcover key.".to_string()));
+                    msg_is_error.set(true);
+                }
+            }
+            in_flight.set(false);
+        });
+    };
+
+    let st = status();
+    let configured = st.as_ref().map(|s| s.configured).unwrap_or(false);
+    let placeholder = st
+        .as_ref()
+        .and_then(|s| s.masked.clone())
+        .unwrap_or_else(|| "hc_live_\u{2026}".to_string());
+
+    rsx! {
+        section { class: "card", "data-testid": "hardcover-key-card",
+            h2 { "Suggestions" }
+            p { class: "subtitle", "Connect Hardcover to power \u{201c}Readers also enjoyed\u{201d}." }
+            div { class: "settings-field",
+                label { r#for: "hardcover-key", "Hardcover API Key" }
+                input {
+                    r#type: "password",
+                    id: "hardcover-key",
+                    name: "hardcover_api_key",
+                    // Server-wide secret: keep password managers / autofill /
+                    // spellcheck from storing or mangling it.
+                    autocomplete: "off",
+                    autocapitalize: "none",
+                    autocorrect: "off",
+                    spellcheck: "false",
+                    placeholder: "{placeholder}",
+                    value: "{key_input}",
+                    oninput: move |e| key_input.set(e.value()),
+                }
+            }
+            div { class: "settings-actions",
+                button {
+                    r#type: "button",
+                    class: "btn",
+                    disabled: in_flight(),
+                    "data-testid": "hardcover-save",
+                    onclick: on_save,
+                    "Save"
+                }
+                if configured {
+                    button {
+                        r#type: "button",
+                        class: "btn ghost",
+                        disabled: in_flight(),
+                        "data-testid": "hardcover-clear",
+                        onclick: on_clear,
+                        "Clear"
+                    }
+                }
+            }
+            div { class: "hardcover-status mono", "data-testid": "hardcover-status",
+                if configured {
+                    span { class: "hardcover-dot connected" }
+                    if let Some(s) = st.as_ref() {
+                        "Connected \u{00b7} {s.source} \u{00b7} {s.masked.clone().unwrap_or_default()}"
+                    }
+                } else {
+                    span { class: "hardcover-dot" }
+                    "Not connected"
+                }
+            }
+            if let Some(m) = msg() {
+                p {
+                    role: "status",
+                    "data-testid": "hardcover-key-status",
+                    class: if msg_is_error() { "settings-status error" } else { "settings-status success" },
+                    "{m}"
+                }
+            }
         }
     }
 }

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -245,9 +245,15 @@ test("renders the detail contents for the selected book", async ({ page, request
   await expect(switcher.getByTestId("action-listen")).toHaveCount(0);
 
   // F3.2 ratings ship as the interactive hero rating card; F3.3 suggestions
-  // is still a hidden placeholder slot.
+  // renders the "Readers also enjoyed" strip below the metadata. (Its inner
+  // state — connect message / pending / results — depends on whether a
+  // Hardcover key is configured and on the external API, so we only assert the
+  // section + heading are present here, not the resolved contents.)
   await expect(page.getByTestId("rating-stars")).toBeVisible();
-  await expect(page.getByTestId("suggestions-slot")).toBeAttached();
+  await expect(page.getByTestId("suggestions-strip")).toBeAttached();
+  await expect(
+    page.getByRole("heading", { name: "Suggested for you" }),
+  ).toBeVisible();
 
   // Back link still navigates to landing
   const backLink = page.getByRole("link", { name: "Back to library" });

--- a/ui_tests/playwright/tests/flows/settings.spec.ts
+++ b/ui_tests/playwright/tests/flows/settings.spec.ts
@@ -5,7 +5,11 @@ import { expectNavVisible, gotoReady } from "../utils/nav";
 
 const ebookInput = (page: Page) => page.getByLabel("Ebook Library Path");
 const audiobookInput = (page: Page) => page.getByLabel("Audiobook Library Path");
-const saveButton = (page: Page) => page.getByRole("button", { name: "Save" });
+// Scope the Save button to the library-paths form — the page now also has a
+// "Suggestions (Hardcover)" card with its own Save button (F3.3), so an
+// unscoped `name: "Save"` would match both and trip Playwright strict mode.
+const saveButton = (page: Page) =>
+  page.locator("#settings-form").getByRole("button", { name: "Save" });
 // The settings page now has two `role=status` regions — the inline form
 // status (this locator) and the worker-progress indicator above the Save
 // button (`data-testid="worker-status"`, issue #69). Target by testid so
@@ -22,6 +26,8 @@ test("renders the settings page layout", async ({ page }) => {
   await expect(settingsStatus(page)).toBeAttached();
   await expect(page.getByTestId("ebook-library-summary")).toBeAttached();
   await expect(page.getByTestId("audiobook-library-summary")).toBeAttached();
+  // F3.3 — the Hardcover suggestions key card renders on the settings page.
+  await expect(page.getByTestId("hardcover-key-card")).toBeVisible();
   await expectNavVisible(page);
 });
 


### PR DESCRIPTION
## Summary
- The "Readers also enjoyed" strip on the book-detail page: 5 covers stacked (hover to spread) → "show more" reveals the rest as a static grid, an "on N lists" relevance badge, and covers that link out to Hardcover in a new tab. Connect / resolving / empty states included.
- Settings → Suggestions card to set or clear the Hardcover key (masked, admin-only). `suggest-*` styles ported from the Atrium design.
- Feature-gated data layer (web RPC / mobile REST). First paint is state-stable for SSR/WASM hydration; a bounded client poll surfaces results without a manual reload.

## Test plan
- [ ] `cargo test -p omnibus-frontend --features server` — 185 tests green.
- [ ] CI E2E (Playwright) runs on this PR; `book_detail.spec.ts` updated to assert the new section.
- [ ] Manual: book-detail strip renders; Settings key round-trips and the raw key never reaches the client.

## Notes
- Head of the 3-PR stack; base `u/sloan/suggestions-2` (#649).