### PR TITLE
feat: edit highlight notes from the reader drawer

### DIFF
--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -1,6 +1,6 @@
 //! Highlights & notes drawer for the reader. Lists every highlight for the
 //! open book, filterable by palette color. Clicking a row navigates to the
-//! highlight's CFI; rows also expose copy and delete actions.
+//! highlight's CFI; rows also expose note, copy, and delete actions.
 
 use dioxus::prelude::*;
 
@@ -38,6 +38,7 @@ fn copy_text(text: &str) {
 pub(super) fn HighlightsDrawer(
     highlights: Signal<Vec<Highlight>>,
     on_quote: EventHandler<Highlight>,
+    on_edit_note: EventHandler<Highlight>,
     on_close: EventHandler<()>,
 ) -> Element {
     let mut filter = use_signal(|| None::<HighlightColor>);
@@ -89,7 +90,13 @@ pub(super) fn HighlightsDrawer(
                     div { class: "rd-drawer-empty", "No highlights yet." }
                 } else {
                     for h in shown.iter() {
-                        HighlightRow { key: "{h.id}", highlight: h.clone(), highlights, on_quote }
+                        HighlightRow {
+                            key: "{h.id}",
+                            highlight: h.clone(),
+                            highlights,
+                            on_quote,
+                            on_edit_note,
+                        }
                     }
                 }
             }
@@ -102,6 +109,7 @@ fn HighlightRow(
     highlight: Highlight,
     highlights: Signal<Vec<Highlight>>,
     on_quote: EventHandler<Highlight>,
+    on_edit_note: EventHandler<Highlight>,
 ) -> Element {
     let color = highlight.color.as_str();
     let quote = highlight
@@ -114,6 +122,13 @@ fn HighlightRow(
     // Legacy highlights created before the text column have nothing to copy;
     // disable the action rather than offer a silent no-op.
     let has_text = highlight.text.is_some();
+    // The note button both adds a first note and edits an existing one; its
+    // label reflects which so the affordance reads correctly either way.
+    let note_label = if highlight.note.is_some() {
+        "Edit note"
+    } else {
+        "Add note"
+    };
     let id = highlight.id;
 
     let on_delete = move |_| {
@@ -147,6 +162,16 @@ fn HighlightRow(
                 div { class: "rd-hl-note", "{n}" }
             }
             div { class: "rd-hl-actions",
+                button {
+                    class: "rd-act sm",
+                    r#type: "button",
+                    "data-testid": "highlight-note",
+                    onclick: {
+                        let h = highlight.clone();
+                        move |_| on_edit_note.call(h.clone())
+                    },
+                    "{note_label}"
+                }
                 button {
                     class: "rd-act sm",
                     r#type: "button",

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -528,6 +528,12 @@ fn ReaderLayout(
                         quote_target.set(Some(h));
                         show_highlights.set(false);
                     },
+                    on_edit_note: move |h: Highlight| {
+                        let mut note_target = note_target;
+                        let mut show_highlights = show_highlights;
+                        note_target.set(Some(h));
+                        show_highlights.set(false);
+                    },
                     on_close: move |_| {
                         let mut show_highlights = show_highlights;
                         show_highlights.set(false);

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -17,6 +17,9 @@ const TARGET = FIXTURE_BOOKS.find((b) => b.slug === "alpha")!;
 // A separate book for the highlight action test so seeding/deleting highlights
 // doesn't pollute the empty-state assertions on TARGET (tests run in parallel).
 const HL_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "beta")!;
+// A third book for the note-editing test so its persisted highlight never
+// collides with the seed/delete cycle on HL_BOOK.
+const NOTE_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "gamma")!;
 
 test("renders the reader layout", async ({ page, request }) => {
   // Deep-link straight to the immersive reader by the book's stable uuid,
@@ -136,6 +139,65 @@ test("seeds a highlight and deletes it from the highlights drawer", async ({
     async () => row.getByTestId("highlight-delete").click(),
   );
   await expect(page.getByText(quote)).toHaveCount(0);
+});
+
+test("adds a note to an existing highlight from the drawer", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, NOTE_BOOK.title);
+
+  // Seed a note-less highlight so the drawer offers the "Add note" affordance.
+  const quote = `note passage ${Date.now()}`;
+  const created = await request.post("/api/highlights", {
+    data: {
+      book_uuid: uuid,
+      epub_cfi_range: "epubcfi(/6/4!/4/2,/1:0,/1:40)",
+      color: "green",
+      text: quote,
+    },
+  });
+  expect(created.status(), "seed highlight").toBe(200);
+
+  await gotoReady(page, `/read/${uuid}`);
+  await expect(page.getByTestId("reader-viewer")).toBeVisible();
+
+  // Open the drawer; the seeded highlight shows an "Add note" button.
+  await page.getByTestId("reader-highlights").click();
+  await expect(page.getByTestId("reader-highlights-drawer")).toBeVisible();
+  const row = page
+    .getByTestId("reader-highlight-row")
+    .filter({ hasText: quote });
+  await expect(row).toHaveCount(1);
+  await expect(row.getByTestId("highlight-note")).toHaveText("Add note");
+
+  // The note button opens the shared composer over the drawer.
+  await row.getByTestId("highlight-note").click();
+  await expect(page.getByTestId("reader-note-composer")).toBeVisible();
+
+  const note = `a thought worth keeping ${Date.now()}`;
+  await page.getByTestId("reader-note-input").fill(note);
+
+  // Saving persists via the update-note RPC and closes the composer.
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: /\/api\/rpc\/highlights\/update-note(?:\?|$)/,
+      expectedStatus: 200,
+    },
+    async () => page.getByTestId("reader-note-save").click(),
+  );
+  await expect(page.getByTestId("reader-note-composer")).toHaveCount(0);
+
+  // Reopen the drawer: the note now renders on the row, and the button flips
+  // to "Edit note" to reflect the persisted note.
+  await page.getByTestId("reader-highlights").click();
+  const savedRow = page
+    .getByTestId("reader-highlight-row")
+    .filter({ hasText: quote });
+  await expect(savedRow.getByText(note)).toBeVisible();
+  await expect(savedRow.getByTestId("highlight-note")).toHaveText("Edit note");
 });
 
 test("opens the reader from the book detail Read action", async ({ page, request }) => {


### PR DESCRIPTION
## Summary
- Reader Highlights & notes drawer rows now expose an **Add note / Edit note** action that opens the existing markdown note composer for that highlight.
- The `highlights.note` column, `update-note` RPC/REST, and the composer already existed — this only adds the drawer entry point via a new `on_edit_note` handler, mirroring the sibling quote flow.

## Test plan
- [x] `cargo fmt` + `cargo clippy -p omnibus-frontend --features server` clean
- [x] New E2E `adds a note to an existing highlight from the drawer` passes: seed → Add note → composer → save → `update-note` 200 → note renders → button flips to "Edit note"
- [x] Rest of `reader.spec.ts` passes (the one drawer empty-state failure was pre-existing shared-DB pollution from `journal.spec.ts`, unrelated to this change)