### PR TITLE
fix: strip non-checkbox <input> from journal markdown sanitizer

### DIFF
--- a/db/src/journals/markdown.rs
+++ b/db/src/journals/markdown.rs
@@ -52,6 +52,8 @@ fn sanitize(html: &str) -> String {
 /// Runs on already-sanitized HTML, so the only attributes an `<input>` can
 /// carry are the allowlisted `checked`/`disabled`/`type="checkbox"`/`class`,
 /// none of which contain `>`; scanning to the next `>` therefore bounds the tag.
+/// Attribute presence is matched on real name boundaries (not raw substrings),
+/// so a lookalike like `aria-disabled` can't sneak an interactive input through.
 fn drop_non_checkbox_inputs(html: &str) -> String {
     let mut out = String::with_capacity(html.len());
     let mut rest = html;
@@ -63,13 +65,42 @@ fn drop_non_checkbox_inputs(html: &str) -> String {
             return out;
         };
         let tag = &tag_rest[..end];
-        if tag.contains("type=\"checkbox\"") && tag.contains("disabled") {
+        if has_attr_value(tag, "type", "checkbox") && has_bool_attr(tag, "disabled") {
             out.push_str(tag);
         }
         rest = &tag_rest[end..];
     }
     out.push_str(rest);
     out
+}
+
+/// Whether `tag` carries a standalone boolean attribute `name` — matched on
+/// name boundaries so `aria-disabled` / `notdisabled` don't count, and tolerant
+/// of both the bare form and a serializer's `name=""` (ammonia emits the latter).
+fn has_bool_attr(tag: &str, name: &str) -> bool {
+    tag.match_indices(name).any(|(i, _)| {
+        let preceded_by_space = tag[..i]
+            .chars()
+            .next_back()
+            .is_some_and(char::is_whitespace);
+        let boundary = tag[i + name.len()..]
+            .chars()
+            .next()
+            .is_none_or(|c| c.is_whitespace() || matches!(c, '=' | '>' | '/'));
+        preceded_by_space && boundary
+    })
+}
+
+/// Whether `tag` carries `name="value"` as a real attribute (name preceded by
+/// whitespace), not a substring of a longer name like `data-type="checkbox"`.
+fn has_attr_value(tag: &str, name: &str, value: &str) -> bool {
+    let needle = format!("{name}=\"{value}\"");
+    tag.match_indices(needle.as_str()).any(|(i, _)| {
+        tag[..i]
+            .chars()
+            .next_back()
+            .is_some_and(char::is_whitespace)
+    })
 }
 
 /// Rewrite `||text||` spoiler markers in the markdown **source** into inline
@@ -172,11 +203,38 @@ mod tests {
 
     #[test]
     fn strips_button_and_bare_inputs_entirely() {
-        // Non-checkbox inputs of any flavour, including an attribute-less one,
-        // must not survive — each degrades to a bare `<input>` under ammonia.
-        for body in ["<input type=\"button\">", "<input>"] {
+        // Non-checkbox inputs of any flavour, including an attribute-less one and
+        // an *interactive* (non-disabled) checkbox, must not survive — each
+        // degrades to a bare/enabled `<input>` under ammonia. Only the disabled
+        // task-list checkbox is allowed through.
+        for body in [
+            "<input type=\"button\">",
+            "<input>",
+            "<input type=\"checkbox\">",
+        ] {
             let html = render(body);
             assert!(!html.contains("<input"), "no input from {body:?}: {html}");
+        }
+    }
+
+    #[test]
+    fn drop_non_checkbox_inputs_matches_real_attribute_tokens() {
+        // A genuine disabled task-list checkbox survives.
+        assert!(
+            drop_non_checkbox_inputs("<input disabled=\"\" type=\"checkbox\">").contains("<input"),
+            "real task-list checkbox kept"
+        );
+        // Lookalike attribute names must not satisfy the `disabled` check, so an
+        // interactive checkbox cannot slip through on a substring match.
+        for tag in [
+            "<input aria-disabled=\"true\" type=\"checkbox\">",
+            "<input data-disabled=\"\" type=\"checkbox\">",
+            "<input notdisabled=\"\" type=\"checkbox\">",
+        ] {
+            assert!(
+                !drop_non_checkbox_inputs(tag).contains("<input"),
+                "lookalike disabled attr rejected: {tag}"
+            );
         }
     }
 

--- a/db/src/journals/markdown.rs
+++ b/db/src/journals/markdown.rs
@@ -28,18 +28,48 @@ pub fn render(md: &str) -> String {
 /// (the only inline element the spoiler pass introduces) and the read-only
 /// task-list checkbox pulldown-cmark emits for `- [ ]` items.
 fn sanitize(html: &str) -> String {
-    ammonia::Builder::default()
+    let cleaned = ammonia::Builder::default()
         .add_tags(["span", "input"])
         .add_allowed_classes("span", ["spoiler"])
         // Task-list checkboxes only — `disabled`/`checked` are valueless flags;
         // `type` is pinned to `checkbox` via the value allowlist (kept out of
-        // the generic attribute set, which would otherwise permit any value),
-        // so no interactive or arbitrary `<input>` survives.
+        // the generic attribute set, which would otherwise permit any value).
         .add_tag_attributes("input", ["checked", "disabled"])
         .add_tag_attribute_values("input", "type", ["checkbox"])
         .add_allowed_classes("input", ["task-list-item-checkbox"])
         .clean(html)
-        .to_string()
+        .to_string();
+    drop_non_checkbox_inputs(&cleaned)
+}
+
+/// Remove every `<input>` that isn't a disabled task-list checkbox.
+///
+/// `ammonia` strips *disallowed attributes* but keeps an *allowed tag*, so a
+/// hand-authored `<input type="text">` degrades to a bare `<input>` — which the
+/// browser renders as a text field — and would otherwise survive. We only ever
+/// emit `<input>` for task-list checkboxes (`<input disabled type="checkbox">`),
+/// so any tag missing either marker is user-authored and dropped wholesale.
+/// Runs on already-sanitized HTML, so the only attributes an `<input>` can
+/// carry are the allowlisted `checked`/`disabled`/`type="checkbox"`/`class`,
+/// none of which contain `>`; scanning to the next `>` therefore bounds the tag.
+fn drop_non_checkbox_inputs(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+    while let Some(start) = rest.find("<input") {
+        out.push_str(&rest[..start]);
+        let tag_rest = &rest[start..];
+        let Some(end) = tag_rest.find('>').map(|i| i + 1) else {
+            // No closing `>` — malformed; drop the remainder rather than emit it.
+            return out;
+        };
+        let tag = &tag_rest[..end];
+        if tag.contains("type=\"checkbox\"") && tag.contains("disabled") {
+            out.push_str(tag);
+        }
+        rest = &tag_rest[end..];
+    }
+    out.push_str(rest);
+    out
 }
 
 /// Rewrite `||text||` spoiler markers in the markdown **source** into inline
@@ -130,15 +160,24 @@ mod tests {
     }
 
     #[test]
-    fn task_list_input_type_is_pinned_to_checkbox() {
-        // A hand-authored non-checkbox input must not survive even though the
-        // `input` tag is now allowlisted for task lists.
+    fn strips_non_checkbox_input_element_entirely() {
+        // ammonia would keep the allowlisted `input` tag while stripping its
+        // disallowed attributes, leaving a bare `<input>` (a text field by
+        // default). The whole element — not just its attributes — must go.
         let html = render("<input type=\"text\" value=\"x\">");
-        assert!(
-            !html.contains("type=\"text\""),
-            "non-checkbox dropped: {html}"
-        );
-        assert!(!html.contains("value="), "input value dropped: {html}");
+        assert!(!html.contains("<input"), "input element removed: {html}");
+        assert!(!html.contains("type=\"text\""), "type dropped: {html}");
+        assert!(!html.contains("value="), "value dropped: {html}");
+    }
+
+    #[test]
+    fn strips_button_and_bare_inputs_entirely() {
+        // Non-checkbox inputs of any flavour, including an attribute-less one,
+        // must not survive — each degrades to a bare `<input>` under ammonia.
+        for body in ["<input type=\"button\">", "<input>"] {
+            let html = render(body);
+            assert!(!html.contains("<input"), "no input from {body:?}: {html}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ammonia strips disallowed *attributes* but keeps an allowed *tag*, so a hand-authored `<input type="text">` degraded to a bare `<input>` (a text field by default) and survived journal sanitization — reproduced against `main`.
- Add a post-sanitization `drop_non_checkbox_inputs` pass that removes any `<input>` lacking both `type="checkbox"` and `disabled`; task-list checkboxes still render.
- Runs on already-sanitized HTML where `<input>` attributes are allowlist-constrained (none contain `>`), so scanning to the next `>` safely bounds each tag; a malformed unterminated tag is dropped rather than emitted.

## Test plan
- [x] `cargo test -p omnibus-db` — 11/11 markdown tests pass, incl. new `strips_non_checkbox_input_element_entirely` and `strips_button_and_bare_inputs_entirely`; `renders_task_list_checkboxes` still green.
- [x] `cargo clippy -p omnibus-db` — clean, no warnings.
- [x] `cargo fmt --check` — clean.

## Notes
- Fix against `main`; independent of the reader highlight-note branch (#655).