### PR TITLE
feat: match "From the same hand" section to Atrium design

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1041,30 +1041,8 @@ body.atrium,
 }
 .spoiler.revealed { filter: none; cursor: auto; background: transparent; }
 
-/* "From the same hand" horizontal cover scroll */
-.bd-author-books-row {
-  display: flex;
-  gap: 16px;
-  overflow-x: auto;
-  padding: 4px 0 12px;
-  scroll-snap-type: x proximity;
-  -webkit-overflow-scrolling: touch;
-}
-.bd-author-book-tile {
-  flex: 0 0 140px;
-  scroll-snap-align: start;
-  display: block;
-  text-decoration: none;
-  cursor: pointer;
-}
-.bd-author-book-tile:hover .cover-wrap {
-  transform: translateY(-4px) scale(1.01);
-  filter: drop-shadow(0 22px 26px color-mix(in oklch, black 55%, transparent))
-          drop-shadow(0 2px 0 color-mix(in oklch, black 30%, transparent));
-}
-.bd-author-books-empty {
-  padding: 22px 24px;
-}
+/* "From the same hand" — the author-lead card + spreading cover stack live in
+   the F3.3 suggestions block below (they reuse `.suggest-stack` / `.sug-cap`). */
 
 /* Body — rail */
 .bd-rail {
@@ -4466,6 +4444,65 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   .suggest-stack > .cover-link { transition: none; }
   .suggest-stack .sug-cap { opacity: 1; }
 }
+
+/* ── "From the same hand" — author-lead card + spreading cover stack ───
+   Reuses the `.suggest-stack` mechanics above: the first child is a solid
+   author card (portrait + name + count) instead of a cover, and up to four
+   sibling covers spread out from behind it on row hover. Ported from the
+   Atrium design's omnibus.css. */
+.bd-same-hand-hint { font-size: 11px; color: var(--ink-3); margin: -6px 0 10px; }
+.bd-same-hand-empty { display: flex; gap: 20px; align-items: stretch; }
+.bd-same-hand-note {
+  flex: 1; display: grid; place-items: center; padding: 20px 24px;
+  border-radius: 12px; border: 1px dashed var(--line-2);
+  color: var(--ink-3); font-size: 14px; text-align: center;
+}
+
+.author-lead { flex: 0 0 168px; }
+.author-lead-card {
+  height: 252px;                       /* = a 168px cover at 2/3 */
+  display: flex; flex-direction: column; align-items: center; text-align: center;
+  gap: 13px; padding: 22px 15px 16px;
+  background: linear-gradient(180deg, var(--bg-1), color-mix(in oklch, var(--bg-1) 88%, var(--bg-0)));
+  border: 1px solid var(--line-2); border-radius: 8px;
+  box-shadow: 0 18px 22px color-mix(in oklch, black 42%, transparent),
+              0 2px 0 color-mix(in oklch, black 22%, transparent);
+}
+.author-portrait {
+  position: relative; width: 94px; height: 94px; border-radius: 999px;
+  display: grid; place-items: center; cursor: pointer; overflow: hidden; flex: 0 0 auto;
+  background: radial-gradient(120% 120% at 32% 22%,
+    color-mix(in oklch, var(--accent) 30%, var(--bg-2)), var(--bg-2));
+  border: 1px solid color-mix(in oklch, var(--accent) 50%, var(--line-2));
+  color: var(--ink-0); transition: transform .25s cubic-bezier(.2,.7,.2,1), box-shadow .25s;
+}
+.author-portrait .glyph { font-family: var(--serif); font-style: italic; font-size: 46px; line-height: 1; }
+.author-portrait:hover { transform: translateY(-2px) scale(1.03);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 42%, transparent); }
+.author-portrait .hint {
+  position: absolute; left: 0; right: 0; bottom: 0; padding: 6px 0 5px;
+  font-family: var(--mono); font-size: 8.5px; letter-spacing: .08em; text-transform: uppercase;
+  background: color-mix(in oklch, var(--accent) 85%, black 6%); color: #fff;
+  opacity: 0; transform: translateY(100%); transition: transform .22s, opacity .22s;
+}
+.author-portrait:hover .hint { opacity: 1; transform: translateY(0); }
+.author-lead-name {
+  display: inline-block; font-family: var(--serif); font-size: 17px; line-height: 1.14;
+  color: var(--ink-0); cursor: pointer; text-wrap: balance;
+}
+.author-lead-name:hover { color: var(--accent); }
+.author-lead-count {
+  margin-top: 5px; font-family: var(--mono); font-size: 10px; letter-spacing: .05em;
+  text-transform: uppercase; color: var(--ink-3);
+}
+.author-lead-more {
+  margin-top: auto; font-size: 11px; color: var(--ink-2); cursor: pointer;
+  border-top: 1px solid var(--line-2); padding-top: 10px; width: 100%;
+}
+.author-lead-more:hover { color: var(--accent); }
+.sh-title { font-size: 13.5px; color: var(--ink-0); font-weight: 500;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.sh-sub { font-size: 12px; color: var(--ink-2); margin-top: 2px; }
 
 /* Settings → Hardcover key field status line. */
 .hardcover-status { display: flex; align-items: center; gap: 8px; margin-top: 10px;

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -64,11 +64,7 @@ pub(super) fn BdSameHand(
     } else {
         format!("More by {primary_author}")
     };
-    let last_name = primary_author
-        .split_whitespace()
-        .last()
-        .unwrap_or(&primary_author)
-        .to_string();
+    let author_label = same_hand_author_label(&primary_author);
     let author_route = author_id.map(|id| Route::AuthorDetail { id });
     let action = author_route.clone().map(|route| {
         rsx! {
@@ -82,7 +78,7 @@ pub(super) fn BdSameHand(
             div { class: "bd-same-hand-empty", "data-testid": "from-same-hand-empty",
                 AuthorLead { author: primary_author.clone(), owned, rest, author_route: author_route.clone() }
                 div { class: "bd-same-hand-note",
-                    "This is the only book by {last_name} in your library so far."
+                    "This is the only book by {author_label} in your library so far."
                 }
             }
         } else {
@@ -124,6 +120,13 @@ fn AuthorLead(author: String, owned: usize, rest: usize, author_route: Option<Ro
         .map(|c| c.to_uppercase().to_string())
         .unwrap_or_default();
     let books_word = if owned == 1 { "book" } else { "books" };
+    // Guard the tooltip against a missing author name so it never renders the
+    // malformed "Open 's author page".
+    let portrait_title = if author.trim().is_empty() {
+        "Open author page".to_string()
+    } else {
+        format!("Open {author}'s author page")
+    };
     rsx! {
         div { class: "cover-link author-lead",
             div { class: "author-lead-card",
@@ -131,7 +134,7 @@ fn AuthorLead(author: String, owned: usize, rest: usize, author_route: Option<Ro
                     Link {
                         to: route.clone(),
                         class: "author-portrait",
-                        title: "Open {author}'s author page",
+                        title: "{portrait_title}",
                         span { class: "glyph", "{initial}" }
                         span { class: "hint", "Author page \u{2192}" }
                     }
@@ -162,6 +165,15 @@ fn same_hand_title(b: &EbookMetadata) -> String {
     match b.title.as_deref() {
         Some(t) if !t.trim().is_empty() => t.to_string(),
         _ => b.filename.clone(),
+    }
+}
+
+/// Author surname for the empty-state note, falling back to a generic label
+/// when the author name is unknown so the sentence stays well-formed.
+fn same_hand_author_label(primary_author: &str) -> String {
+    match primary_author.split_whitespace().last() {
+        Some(last) => last.to_string(),
+        None => "this author".to_string(),
     }
 }
 
@@ -471,5 +483,62 @@ mod tests {
             bd_identifier_key(&split_scheme),
             bd_identifier_key(&split_value)
         );
+    }
+
+    #[test]
+    fn same_hand_title_prefers_title_over_filename() {
+        let b = EbookMetadata {
+            title: Some("Piranesi".into()),
+            filename: "piranesi.epub".into(),
+            ..Default::default()
+        };
+        assert_eq!(same_hand_title(&b), "Piranesi");
+    }
+
+    #[test]
+    fn same_hand_title_falls_back_to_filename_when_title_blank() {
+        // `None`, empty, and whitespace-only titles all fall back so a tile
+        // never renders a blank caption.
+        for title in [None, Some("".into()), Some("   ".into())] {
+            let b = EbookMetadata {
+                title,
+                filename: "dune.epub".into(),
+                ..Default::default()
+            };
+            assert_eq!(same_hand_title(&b), "dune.epub");
+        }
+    }
+
+    #[test]
+    fn same_hand_year_extracts_four_digit_prefix() {
+        let b = EbookMetadata {
+            published: Some("2020-09-15".into()),
+            ..Default::default()
+        };
+        assert_eq!(same_hand_year(&b), Some("2020".to_string()));
+    }
+
+    #[test]
+    fn same_hand_year_is_none_when_missing_or_too_short() {
+        let missing = EbookMetadata::default();
+        assert_eq!(same_hand_year(&missing), None);
+        let short = EbookMetadata {
+            published: Some("20".into()),
+            ..Default::default()
+        };
+        // `get(0..4)` returns `None` for a string shorter than four bytes.
+        assert_eq!(same_hand_year(&short), None);
+    }
+
+    #[test]
+    fn same_hand_author_label_uses_surname_when_present() {
+        assert_eq!(same_hand_author_label("Ada Lovelace"), "Lovelace");
+        assert_eq!(same_hand_author_label("Homer"), "Homer");
+    }
+
+    #[test]
+    fn same_hand_author_label_falls_back_when_author_blank() {
+        assert_eq!(same_hand_author_label(""), "this author");
+        assert_eq!(same_hand_author_label("   "), "this author");
     }
 }

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -18,6 +18,7 @@ pub(super) fn BdBodyMain(
     uuid: String,
     title: String,
     primary_author: String,
+    author_id: Option<i64>,
     author_books: Vec<EbookMetadata>,
     suggestions: Option<SuggestionsResponse>,
     server_url: String,
@@ -33,27 +34,7 @@ pub(super) fn BdBodyMain(
                 p { class: "bd-stub-hint", "Highlights land in F3.2." }
             }
             div { class: "divider" }
-            BdSectionHead {
-                kicker: if primary_author.is_empty() { "More to read".to_string() } else { format!("More by {primary_author}") },
-                title: "From the same hand".to_string(),
-            }
-            if author_books.is_empty() {
-                div { class: "bd-author-books-empty card", "data-testid": "from-same-hand-empty",
-                    p { class: "mono", "No other books by this author in your library." }
-                }
-            } else {
-                div { class: "bd-author-books-row", "data-testid": "from-same-hand",
-                    for ab in author_books.iter() {
-                        Link {
-                            key: "{ab.id}",
-                            to: Route::BookDetail { uuid: ab.unique_identifier.clone().unwrap_or_default() },
-                            class: "bd-author-book-tile",
-                            "data-testid": "from-same-hand-tile",
-                            Cover { book: ab.clone() }
-                        }
-                    }
-                }
-            }
+            BdSameHand { primary_author, author_id, author_books }
             BdSuggestionsStrip {
                 book_title: title,
                 suggestions,
@@ -62,6 +43,135 @@ pub(super) fn BdBodyMain(
             }
         }
     }
+}
+
+/// "From the same hand" — an author-lead card heading a spreading cover stack
+/// of up to four other books by the same author (Atrium `SameHandSection`).
+/// Reuses the `.suggest-stack` / `.sug-cap` mechanics: the lead card sits first
+/// and the covers fan out from behind it on hover. When the author has no other
+/// books in the library, the lead card is paired with a short note instead.
+#[component]
+pub(super) fn BdSameHand(
+    primary_author: String,
+    author_id: Option<i64>,
+    author_books: Vec<EbookMetadata>,
+) -> Element {
+    let owned = author_books.len() + 1;
+    let shown = author_books.len().min(4);
+    let rest = author_books.len() - shown;
+    let kicker = if primary_author.is_empty() {
+        "More to read".to_string()
+    } else {
+        format!("More by {primary_author}")
+    };
+    let last_name = primary_author
+        .split_whitespace()
+        .last()
+        .unwrap_or(&primary_author)
+        .to_string();
+    let author_route = author_id.map(|id| Route::AuthorDetail { id });
+    let action = author_route.clone().map(|route| {
+        rsx! {
+            Link { to: route, class: "btn ghost sm", "Author page \u{2192}" }
+        }
+    });
+
+    rsx! {
+        BdSectionHead { kicker, title: "From the same hand".to_string(), action }
+        if author_books.is_empty() {
+            div { class: "bd-same-hand-empty", "data-testid": "from-same-hand-empty",
+                AuthorLead { author: primary_author.clone(), owned, rest, author_route: author_route.clone() }
+                div { class: "bd-same-hand-note",
+                    "This is the only book by {last_name} in your library so far."
+                }
+            }
+        } else {
+            p { class: "mono bd-same-hand-hint",
+                "Hover the row to spread \u{00b7} click a cover to open the book, the portrait to open the author"
+            }
+            div { class: "suggest-stack", "data-testid": "from-same-hand",
+                AuthorLead { author: primary_author.clone(), owned, rest, author_route: author_route.clone() }
+                for ab in author_books.iter().take(4) {
+                    Link {
+                        key: "{ab.id}",
+                        to: Route::BookDetail { uuid: ab.unique_identifier.clone().unwrap_or_default() },
+                        class: "cover-link",
+                        "data-testid": "from-same-hand-tile",
+                        title: "Open {same_hand_title(ab)}",
+                        Cover { book: ab.clone() }
+                        div { class: "sug-cap",
+                            div { class: "sh-title", "{same_hand_title(ab)}" }
+                            if let Some(year) = same_hand_year(ab) {
+                                div { class: "sh-sub", "{year}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Author "lead" card that heads the same-hand stack: portrait glyph, name, and
+/// owned-count, with an optional "+N more" footer. When `author_route` is
+/// `Some`, the portrait/name/footer are author-page links; otherwise they render
+/// as plain text (a book whose author carries no resolvable id).
+#[component]
+fn AuthorLead(author: String, owned: usize, rest: usize, author_route: Option<Route>) -> Element {
+    let initial = author
+        .chars()
+        .next()
+        .map(|c| c.to_uppercase().to_string())
+        .unwrap_or_default();
+    let books_word = if owned == 1 { "book" } else { "books" };
+    rsx! {
+        div { class: "cover-link author-lead",
+            div { class: "author-lead-card",
+                if let Some(route) = author_route.clone() {
+                    Link {
+                        to: route.clone(),
+                        class: "author-portrait",
+                        title: "Open {author}'s author page",
+                        span { class: "glyph", "{initial}" }
+                        span { class: "hint", "Author page \u{2192}" }
+                    }
+                    div {
+                        Link { to: route.clone(), class: "author-lead-name", "{author}" }
+                        div { class: "author-lead-count", "{owned} {books_word} in your library" }
+                    }
+                    if rest > 0 {
+                        Link { to: route.clone(), class: "author-lead-more", "+{rest} more \u{2192}" }
+                    }
+                } else {
+                    div { class: "author-portrait",
+                        span { class: "glyph", "{initial}" }
+                    }
+                    div {
+                        div { class: "author-lead-name", "{author}" }
+                        div { class: "author-lead-count", "{owned} {books_word} in your library" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Display title for a same-hand tile — the book title, falling back to the
+/// on-disk filename (mirrors the shared `Cover` plate fallback).
+fn same_hand_title(b: &EbookMetadata) -> String {
+    match b.title.as_deref() {
+        Some(t) if !t.trim().is_empty() => t.to_string(),
+        _ => b.filename.clone(),
+    }
+}
+
+/// Four-digit publication year for the tile subline, or `None` when absent.
+fn same_hand_year(b: &EbookMetadata) -> Option<String> {
+    b.published
+        .as_deref()
+        .and_then(|p| p.get(0..4))
+        .filter(|y| !y.is_empty())
+        .map(str::to_string)
 }
 
 /// "Readers also enjoyed" — Hardcover read-alikes below the metadata. Renders

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -291,6 +291,7 @@ fn build_crumbs(
 struct LoadedBookView {
     title: String,
     primary_author: String,
+    author_id: Option<i64>,
     authors_line: String,
     kicker: String,
     series: Option<String>,
@@ -308,6 +309,7 @@ fn derive_loaded_view(b: &EbookMetadata) -> LoadedBookView {
         .first()
         .map(|c| c.name.clone())
         .unwrap_or_default();
+    let author_id = b.creators.first().and_then(|c| c.id);
     let authors_line = b
         .creators
         .iter()
@@ -339,6 +341,7 @@ fn derive_loaded_view(b: &EbookMetadata) -> LoadedBookView {
     LoadedBookView {
         title,
         primary_author,
+        author_id,
         authors_line,
         kicker,
         series,
@@ -361,6 +364,7 @@ fn render_loaded(
     let LoadedBookView {
         title,
         primary_author,
+        author_id,
         authors_line,
         kicker,
         series,
@@ -386,6 +390,7 @@ fn render_loaded(
                     uuid: uuid.clone(),
                     title: title.clone(),
                     primary_author,
+                    author_id,
                     author_books,
                     suggestions,
                     server_url,
@@ -447,10 +452,16 @@ pub(super) fn BdCrumb(items: Vec<BdCrumbItem>) -> Element {
     }
 }
 
-/// Body section heading row — kicker label + serif title. The kicker stacks
-/// above the title (mirrors `screens/_shared.jsx#SectionHead`).
+/// Body section heading row — kicker label + serif title, with an optional
+/// right-aligned `action` slot (mirrors `screens/_shared.jsx#SectionHead`). The
+/// kicker stacks above the title; the action floats opposite via the flex
+/// `space-between` on `.bd-section-head`.
 #[component]
-pub(super) fn BdSectionHead(kicker: String, title: String) -> Element {
+pub(super) fn BdSectionHead(
+    kicker: String,
+    title: String,
+    #[props(default)] action: Option<Element>,
+) -> Element {
     rsx! {
         div { class: "bd-section-head",
             div { class: "bd-section-head-text",
@@ -459,6 +470,7 @@ pub(super) fn BdSectionHead(kicker: String, title: String) -> Element {
                 }
                 h3 { class: "bd-section-title", "{title}" }
             }
+            {action}
         }
     }
 }

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -138,7 +138,12 @@ test("From the same hand row renders other books by the same author", async ({
   ).toHaveCount(0);
 
   // Clicking any sibling tile must navigate to its /books/:uuid page —
-  // tiles are router Links that swap the route param in place.
+  // tiles are router Links that swap the route param in place. The Atrium
+  // stack overlaps the tiles behind the author-lead card and only spreads
+  // them apart on row hover, so hover first to settle the layout before
+  // clicking — otherwise the tile's centre sits under the lead card and the
+  // click is intercepted (matches the "Hover the row to spread" affordance).
+  await row.hover();
   await tiles.first().click();
   await expect(page).toHaveURL(/\/books\/[0-9a-fA-F-]{36}$/);
   await expect(page).not.toHaveURL(new RegExp(`/books/${uuid}$`));


### PR DESCRIPTION
## Summary
- Replace the flat cover-scroll row with the Atrium `SameHandSection`: an author-lead card (portrait glyph, author name, owned-count, "+N more") heads a spreading stack of up to four sibling covers with title/year captions, plus a "Author page →" section action.
- Redesign the empty state to pair the author-lead card with "This is the only book by {LastName} in your library so far."
- Add an optional `action` slot to `BdSectionHead` and thread the author id down for the author-page links.
- Port the `author-lead*` / `sh-*` CSS, reuse the existing `suggest-stack` / `sug-cap` mechanics, and drop the now-dead `bd-author-books-*` rules.

## Test plan
- [ ] `cargo fmt --check` + `clippy` clean; 185 frontend tests pass (`cargo test -p omnibus-frontend --features server`).
- [ ] Verified in a hydrated browser — populated (multi-book author): lead card + up to 4 sibling tiles with year captions, current book excluded; single-book author: empty-state note.
- [ ] Existing `book_detail` Playwright testid contract (`from-same-hand` / `-tile` / `-empty`) unchanged.

## Notes
- Tile subline shows year only — `EbookMetadata` carries no page count (design showed `{year} · {pages}p`).