### PR TITLE
fix: unconditional AuthorPage admin hooks for hydration parity (#626)

### DIFF
--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -19,13 +19,17 @@ pub fn AuthorPage(id: i64) -> Element {
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
-    // F5.9-lite admin gating for the Delete button. Web-only — the
-    // mobile build never renders the Delete affordance per the plan's
-    // admin-web-only v1 scope. The server-side `AdminUser` extractor
-    // on `rpc_delete_author` is the actual security boundary.
-    #[cfg(feature = "web")]
+    // F5.9-lite admin gating for the Delete button. The signal and the
+    // effect are declared unconditionally so SSR and the hydrating WASM
+    // bundle agree on hook count and order — Dioxus tracks hooks
+    // positionally, and a cfg-gated declaration would diverge the two
+    // (rule 07). The effect itself only runs on the client (Dioxus skips
+    // `use_effect` during SSR), and `data::current_user()` resolves to
+    // an `Ok(None)`-returning stub under server-only and mobile builds,
+    // so no admin surface ever leaks into the prerendered markup or the
+    // mobile UI. The server-side `AdminUser` extractor on
+    // `rpc_delete_author` is the actual security boundary.
     let mut is_admin = use_signal(|| false);
-    #[cfg(feature = "web")]
     use_effect(move || {
         spawn(async move {
             if let Ok(Some(user)) = data::current_user().await {
@@ -69,10 +73,11 @@ pub fn AuthorPage(id: i64) -> Element {
         };
     };
 
-    #[cfg(feature = "web")]
+    // `is_admin` starts at `false` and only flips to `true` after the
+    // effect above resolves against the client-side session. That keeps
+    // the first-hydration paint identical to SSR (no Delete affordance)
+    // before the client reconciles with the real admin flag.
     let is_admin_flag = is_admin();
-    #[cfg(not(feature = "web"))]
-    let is_admin_flag = false;
     render_author(a, server_url, author, is_admin_flag)
 }
 


### PR DESCRIPTION
## Summary
- `AuthorPage` gated its `is_admin` `use_signal` + populating `use_effect` on `#[cfg(feature = "web")]`. SSR (`feature = "server"`) declared fewer hooks than the WASM client's first paint, so Dioxus's positional hook tracking landed the surrounding `use_reactive!` effect at different indices across the two renders and hydration mis-adopted adjacent nodes (rule 07).
- Declared the signal and the effect unconditionally, dropped the paired `#[cfg]` split on the derived `is_admin_flag`, and relied on `data::current_user()`'s existing SSR/mobile stub (`Ok(None)`) so no admin surface leaks into the prerendered markup or the mobile UI. This mirrors the previously-landed `BookDetailPage` fix in `frontend/src/pages/book_detail/mod.rs` (F5.9-lite "Merge with…" affordance) — same rule, same pattern.
- The `Delete author` affordance itself remains gated on `#[cfg(not(feature = "mobile"))]` inside `render_author`, and the server-side `AdminUser` extractor on `rpc_delete_author` stays the security boundary.

Files touched:
- `frontend/src/pages/author.rs`

## Test plan
- [ ] `just lint` (`cargo fmt --check` + clippy across the crate/feature matrix, incl. mobile + frontend-server).
- [ ] `just test` (db + server + `frontend --features server` + shared).
- [ ] `/ui-validate` — load `/author/{id}` and confirm `mcp__Claude_Preview__preview_console_logs` shows no Dioxus hydration errors; delete affordance appears on the second paint for an admin session (present) and stays absent for a non-admin session.
- [ ] `curl -s http://127.0.0.1:$OMNIBUS_PORT/author/{id}` SSR HTML root structure matches the hydrated snapshot.

## Notes
- Local `cargo fmt --check` / clippy / test could not be run in this worktree because the agent proxy blocks fetches of the `dioxus` git dependency (`403` on `github.com/DioxusLabs/dioxus`), so the workspace cannot compile from a cold cache here. `cargo fmt` (which does not require deps) ran clean. CI is expected to catch anything the format-only local check missed.
- Fix is minimal and mirrors an established, working pattern used at `frontend/src/pages/book_detail/mod.rs` lines 51–58, so the compilation risk is low.
- No markup contracts (roles / labels / testids) changed, so Playwright specs are untouched. The `render_author` function signature is unchanged; the mobile build still passes an unused `is_admin` (allowed via the existing `#[cfg_attr(feature = "mobile", allow(unused_variables))]`).
- The issue body's cited evidence names the gated element as `modal`; the actual gated binding on the pointed-to lines is `is_admin_flag` (and its paired `is_admin` hooks upstream). The defect class is exactly what the issue describes — a `#[cfg(feature = "web")]` inside the component body creating a SSR/WASM hook-count divergence — but the specific variable name in the citation is off. Fixing the real gate (per rule 07 § "Common causes" — "Hook-order divergence") is the intent captured by the plan.

Closes #626

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMQ1M4kQQA3SmTkRCXFv61)_