### PR TITLE
perf(db): index merged_uuids on (library_path, scan_key) and (library_path, format)

### DIFF
--- a/db/migrations/0035_idx_merged_uuids.sql
+++ b/db/migrations/0035_idx_merged_uuids.sql
@@ -1,0 +1,14 @@
+-- Indexes for the two hot reindex/list queries against `merged_uuids`.
+--
+-- Every scanned file lands in `find_attachment_by_scan_key` /
+-- `record_attachment` (both filter on `library_path = ? AND scan_key = ?`),
+-- and multiformat listings hit `list_merged_rows_for_formats` (filter on
+-- `library_path = ? AND format IN (...)`). Migration 0026 added
+-- `scan_key` without an index and migration 0016 (the table itself) never
+-- indexed `(library_path, format)` either, so both codepaths were doing
+-- full table scans that grow with total attachment count.
+CREATE INDEX IF NOT EXISTS idx_merged_uuids_library_scan
+    ON merged_uuids(library_path, scan_key);
+
+CREATE INDEX IF NOT EXISTS idx_merged_uuids_library_format
+    ON merged_uuids(library_path, format);

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -395,6 +395,62 @@ async fn known_uuid_reattaches_even_when_titles_no_longer_match() {
     );
 }
 
+/// The attach-ledger scan_key lookup (shared by `find_attachment_by_scan_key`
+/// and `record_attachment`, fired once per file per reindex) must ride
+/// `idx_merged_uuids_library_scan`, not scan. Guards against regressing to
+/// the un-indexed form the table shipped with in migration 0026.
+#[tokio::test]
+async fn merged_uuids_library_scan_lookup_uses_index() {
+    use sqlx::Row;
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let plan: String = sqlx::query(
+        "EXPLAIN QUERY PLAN
+         SELECT uuid, book_id, format FROM merged_uuids
+          WHERE library_path = ? AND scan_key = ?",
+    )
+    .bind("/audio")
+    .bind("Stoker/Dracula.m4b")
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .iter()
+    .map(|r| r.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(
+        plan.contains("idx_merged_uuids_library_scan"),
+        "scan_key lookup should use idx_merged_uuids_library_scan, got plan:\n{plan}"
+    );
+}
+
+/// The multiformat listing query in `list_merged_rows_for_formats` must
+/// ride `idx_merged_uuids_library_format`, not scan the whole ledger.
+#[tokio::test]
+async fn merged_uuids_library_format_listing_uses_index() {
+    use sqlx::Row;
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let plan: String = sqlx::query(
+        "EXPLAIN QUERY PLAN
+         SELECT mu.uuid FROM merged_uuids mu
+          WHERE mu.library_path = ? AND mu.format IN (?, ?, ?)",
+    )
+    .bind("/audio")
+    .bind("M4B")
+    .bind("M4A")
+    .bind("MP3")
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .iter()
+    .map(|r| r.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(
+        plan.contains("idx_merged_uuids_library_format"),
+        "format listing should use idx_merged_uuids_library_format, got plan:\n{plan}"
+    );
+}
+
 #[tokio::test]
 async fn attachment_survives_a_scan_root_repoint() {
     // F2: an attached file is matched by its repoint-stable


### PR DESCRIPTION
## Summary
- Add migration `0035_idx_merged_uuids.sql` creating `idx_merged_uuids_library_scan (library_path, scan_key)` and `idx_merged_uuids_library_format (library_path, format)`, so the three hot `merged_uuids` WHERE clauses (`find_attachment_by_scan_key`, `record_attachment`&#39;s SELECT, and `list_merged_rows_for_formats`) stop full-scanning the ledger on every reindex / multiformat listing.
- Add two `EXPLAIN QUERY PLAN` guard tests in `db/src/sync/attach/tests.rs` (mirroring the sessions index guards from migration 0012&#39;s `prune_idle_delete_uses_last_used_index`) so a future refactor can&#39;t silently regress to a scan.

## Test plan
- [ ] `cargo test -p omnibus-db` — including new tests `merged_uuids_library_scan_lookup_uses_index` and `merged_uuids_library_format_listing_uses_index`.
- [ ] `just lint`
- [ ] `just dev-bounce` after merge (per rule 06) so a running dev server picks up the new migration.

## Notes
- Migration number: latest existing file is `0034_shelves.sql`, so this lands as `0035_...`. The issue body cited &#34;0018&#34; and the stage-A plan cited &#34;0019&#34; — both stale relative to `ls db/migrations/`. Rule 06 forbids editing an applied migration, so this is a new forward-only file.
- `IF NOT EXISTS` on both indexes so a fresh DB and an upgraded DB converge (rule 06 § forward-only).
- No production code changes — SQLite&#39;s planner picks up the new indexes automatically. Verified locally against an in-memory build of the full migration chain (Python `sqlite3`): all three query plans read `SEARCH merged_uuids USING INDEX idx_merged_uuids_library_scan|_format`.

&gt; [!WARNING]
&gt; Verification of `cargo test` / `just lint` **could not be run in the worker sandbox**: cargo attempted to fetch the `dioxus` git dependency (`https://github.com/DioxusLabs/dioxus?tag=v0.7.9`) and the agent egress proxy returned 403 for that host (organization policy). All other checks — migration SQL applied cleanly against `sqlite::memory:`, EXPLAIN QUERY PLAN confirmed on every WHERE clause — passed locally. Please run `just check` (or CI) before merging.

Closes #628

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review
- **Verdict:** approved. Diff is minimal and precisely targets #628 — one new forward-only migration + two guard tests, no production code touched.
- **Acceptance criteria:** both indexes present with the names the issue specified; migration number `0035` is correct (next after `0034_shelves.sql` on `origin/main`); `IF NOT EXISTS` and forward-only per rule 06.
- **EXPLAIN QUERY PLAN reproduced:** replayed the full migration chain against `sqlite::memory:` via `python3 sqlite3`; all three cited WHERE clauses (`find_attachment_by_scan_key`, `record_attachment`&#39;s SELECT, `list_merged_rows_for_formats`) now report `SEARCH merged_uuids USING INDEX idx_merged_uuids_library_scan` / `_format` instead of `SCAN merged_uuids`.
- **Migration hygiene:** no files under `db/migrations/` other than the new `0035_...` are touched (`git diff --stat` = 2 files, migration + tests).
- **Tests:** placed in the sibling `db/src/sync/attach/tests.rs` per rule 03; names follow `fn_under_test_does_X_when_Y`; both use `init_db("sqlite::memory:")`. Guard-style assertions are the right shape for schema-level regressions.
- **Env caveat (reviewer):** cargo test could not be exercised in the review worktree either — same dioxus 403 the worker flagged. Not treated as a review failure; CI is the source of truth.