### PR TITLE
fix: index merged_uuids on (library_path, scan_key) and (library_path, format) (#628)

### DIFF
--- a/db/migrations/0035_idx_merged_uuids.sql
+++ b/db/migrations/0035_idx_merged_uuids.sql
@@ -1,0 +1,26 @@
+-- Secondary indexes for the `merged_uuids` hot lookups.
+--
+-- Migration 0026 added `scan_key` to `merged_uuids` and made the
+-- `(library_path, scan_key)` pair the reindex diff key for cross-format
+-- attachments, but shipped no accompanying index. The only pre-existing
+-- indexes are the `uuid` PK and `idx_merged_uuids_book (book_id)`, so every
+-- `find_attachment_by_scan_key` / `record_attachment` call in
+-- `db/src/sync/attach/mod.rs` scans the whole ledger, and
+-- `list_merged_rows_for_formats` in `db/src/books/list.rs` scans it once per
+-- library-scoped landing/browse query.
+--
+-- These indexes let the planner seek both patterns directly:
+--   * `(library_path, scan_key)` — index-time attach lookup, keyed once per
+--     scanned file on every reindex cycle
+--   * `(library_path, format)` — landing/browse projection joining
+--     `merged_uuids -> book_files` for the format-filtered rail
+--
+-- Forward-only, pure secondary indexes — no backfill, no table recreate,
+-- so a fresh DB and an upgraded DB converge on the same schema.
+-- `IF NOT EXISTS` keeps the migration idempotent against any hand-created
+-- index of the same name.
+CREATE INDEX IF NOT EXISTS idx_merged_uuids_library_scan
+    ON merged_uuids(library_path, scan_key);
+
+CREATE INDEX IF NOT EXISTS idx_merged_uuids_library_format
+    ON merged_uuids(library_path, format);

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -462,3 +462,81 @@ async fn attachment_survives_a_scan_root_repoint() {
         "no duplicate ledger row"
     );
 }
+
+/// The reindex-hot lookup keyed on `(library_path, scan_key)` must seek the
+/// composite index, not scan the ledger. Guards migration 0035.
+#[tokio::test]
+async fn find_attachment_by_scan_key_uses_library_scan_index() {
+    use sqlx::Row;
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let plan: String = sqlx::query(
+        "EXPLAIN QUERY PLAN
+         SELECT uuid, book_id, format FROM merged_uuids
+          WHERE library_path = ? AND scan_key = ?",
+    )
+    .bind("/audio")
+    .bind("Stoker/Dracula.m4b")
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .iter()
+    .map(|r| r.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(
+        plan.contains("idx_merged_uuids_library_scan"),
+        "attach lookup should use idx_merged_uuids_library_scan, got plan:\n{plan}"
+    );
+}
+
+/// The landing/browse projection filtering merged rows by
+/// `(library_path, format)` must seek the composite index, not scan.
+/// Guards migration 0035.
+#[tokio::test]
+async fn list_merged_rows_for_formats_uses_library_format_index() {
+    use sqlx::Row;
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let plan: String = sqlx::query(
+        "EXPLAIN QUERY PLAN
+         SELECT mu.uuid
+           FROM merged_uuids mu
+           JOIN book_files bf ON bf.book_id = mu.book_id AND bf.format = mu.format
+          WHERE mu.library_path = ?
+            AND mu.format IN (?, ?, ?)",
+    )
+    .bind("/audio")
+    .bind("M4B")
+    .bind("M4A")
+    .bind("MP3")
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .iter()
+    .map(|r| r.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(
+        plan.contains("idx_merged_uuids_library_format"),
+        "merged-rows projection should use idx_merged_uuids_library_format, got plan:\n{plan}"
+    );
+}
+
+/// End-to-end confirmation that the new indexes are non-destructive: the
+/// attach ledger still returns the expected row after the index migration.
+#[tokio::test]
+async fn find_attachment_by_scan_key_returns_expected_row_after_indexes() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;
+    seed_audiobook(&pool, "Stoker/Dracula.m4b", "Dracula", "Bram Stoker").await;
+
+    let row: (String, i64, String) = sqlx::query_as(
+        "SELECT uuid, book_id, format FROM merged_uuids
+          WHERE library_path = ? AND scan_key = ?",
+    )
+    .bind("/audio")
+    .bind("Stoker/Dracula.m4b")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.2, "M4B");
+}

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -523,20 +523,18 @@ async fn list_merged_rows_for_formats_uses_library_format_index() {
 
 /// End-to-end confirmation that the new indexes are non-destructive: the
 /// attach ledger still returns the expected row after the index migration.
+/// Calls `super::find_attachment_by_scan_key` directly (rather than a raw
+/// `SELECT`) so any future query change in the helper is caught by the test.
 #[tokio::test]
 async fn find_attachment_by_scan_key_returns_expected_row_after_indexes() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;
     seed_audiobook(&pool, "Stoker/Dracula.m4b", "Dracula", "Bram Stoker").await;
 
-    let row: (String, i64, String) = sqlx::query_as(
-        "SELECT uuid, book_id, format FROM merged_uuids
-          WHERE library_path = ? AND scan_key = ?",
-    )
-    .bind("/audio")
-    .bind("Stoker/Dracula.m4b")
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(row.2, "M4B");
+    let mut tx = pool.begin().await.unwrap();
+    let hit = super::find_attachment_by_scan_key(&mut tx, "/audio", "Stoker/Dracula.m4b")
+        .await
+        .unwrap()
+        .expect("attach ledger row for the seeded audiobook must exist");
+    assert_eq!(hit.2, "M4B", "format column should match the audiobook seed");
 }

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -536,5 +536,8 @@ async fn find_attachment_by_scan_key_returns_expected_row_after_indexes() {
         .await
         .unwrap()
         .expect("attach ledger row for the seeded audiobook must exist");
-    assert_eq!(hit.2, "M4B", "format column should match the audiobook seed");
+    assert_eq!(
+        hit.2, "M4B",
+        "format column should match the audiobook seed"
+    );
 }


### PR DESCRIPTION
## Summary
- Adds `db/migrations/0035_idx_merged_uuids.sql` with two composite indexes so the reindex-hot lookups on `merged_uuids` stop degrading to full table scans as the ledger grows:
  - `idx_merged_uuids_library_scan (library_path, scan_key)` — used by `find_attachment_by_scan_key` and `record_attachment` in `db/src/sync/attach/mod.rs`, called once per file on every reindex cycle.
  - `idx_merged_uuids_library_format (library_path, format)` — used by `list_merged_rows_for_formats` in `db/src/books/list.rs`, hit once per landing/browse query.
- Migration 0026 introduced the `(library_path, scan_key)` key but shipped no accompanying index; the ledger only had the `uuid` PK and `idx_merged_uuids_book (book_id)`. Both new indexes are pure secondary (no backfill, no table recreate), `IF NOT EXISTS` for idempotency, so a fresh DB and an upgraded DB converge on the same schema.
- Extends `db/src/sync/attach/tests.rs` with three tests:
  - `find_attachment_by_scan_key_uses_library_scan_index` — `EXPLAIN QUERY PLAN` asserts the planner seeks `idx_merged_uuids_library_scan`.
  - `list_merged_rows_for_formats_uses_library_format_index` — `EXPLAIN QUERY PLAN` asserts the planner seeks `idx_merged_uuids_library_format`.
  - `find_attachment_by_scan_key_returns_expected_row_after_indexes` — smoke check the ledger still returns the expected row after the migration.

Files touched:
- `db/migrations/0035_idx_merged_uuids.sql` (new)
- `db/src/sync/attach/tests.rs`

## Test plan
- [ ] `just test` — the new tests assert planner index use via `EXPLAIN QUERY PLAN` (same shape as the existing `prune_idle_delete_uses_last_used_index` in `db/src/auth/session/tests.rs`).
- [ ] `just dev-bounce` after the migration lands (required by rule 06-migrations).

## Notes
> [!IMPORTANT]
> This worktree cannot run `cargo test` / `cargo clippy` because the sandbox proxy blocks the git fetch for the `dioxus` workspace dependency (`https://github.com/DioxusLabs/dioxus` returns 403 through the agent proxy), and no cached copy of the git dep exists. Verification I was able to run locally:
> - `cargo fmt --check --package omnibus-db` — clean.
> - Simulated the full migration chain (0001..0035) against `sqlite::memory:` via Python's `sqlite3` module: all 35 files apply cleanly, both new indexes exist, and `EXPLAIN QUERY PLAN` for all three hot-path queries reports `SEARCH ... USING INDEX idx_merged_uuids_library_scan` / `idx_merged_uuids_library_format`. Same syntax/planner that the sqlx-embedded migrator runs.
>
> Please re-run `just check` on a machine with Nix + full deps before merging.

- Rule 06-migrations.md notes "latest is `0018_multiformat_book_files.sql`" — that citation is stale (actual latest before this PR was `0034_shelves.sql`). Left untouched to keep this PR scoped to the index fix.

Closes #628

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMQ1M4kQQA3SmTkRCXFv61)_