### PR TITLE
fix: cap Hardcover API key length across settings/RPC/REST

### DIFF
--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use sqlx::{SqlitePool, Transaction};
 
-pub use omnibus_shared::Settings;
+pub use omnibus_shared::{Settings, HARDCOVER_API_KEY_MAX_LEN};
 
 /// `settings` KV keys consumed by the UI/RPC layer. Kept as constants so the
 /// indexer, settings handlers, and tests all reference the same identifier.
@@ -22,6 +22,12 @@ const HARDCOVER_API_KEY_KEY: &str = "hardcover_api_key";
 /// Errors returned by the settings data layer.
 #[derive(Debug, thiserror::Error)]
 pub enum SettingsError {
+    /// A caller-supplied value failed a boundary check (length caps, format,
+    /// etc.). Grouped as a single variant with the detail in the message so
+    /// this stays consistent with the coarse-variant guidance in the error
+    /// rule — callers surface it as a 4xx, not a 500.
+    #[error("{0}")]
+    Validation(String),
     #[error(transparent)]
     Db(#[from] sqlx::Error),
 }
@@ -269,12 +275,20 @@ pub async fn get_hardcover_api_key(pool: &SqlitePool) -> Result<Option<String>, 
 }
 
 /// Persist (or clear, when `None`/blank) the Hardcover API key in `settings`.
+/// Rejects values whose trimmed length exceeds [`HARDCOVER_API_KEY_MAX_LEN`]
+/// with [`SettingsError::Validation`] before the write, so an admin can't
+/// paste an unbounded payload into the settings KV.
 pub async fn set_hardcover_api_key(
     pool: &SqlitePool,
     key: Option<&str>,
 ) -> Result<(), SettingsError> {
     match key.map(str::trim).filter(|s| !s.is_empty()) {
         Some(v) => {
+            if v.len() > HARDCOVER_API_KEY_MAX_LEN {
+                return Err(SettingsError::Validation(format!(
+                    "hardcover_api_key must be {HARDCOVER_API_KEY_MAX_LEN} bytes or fewer"
+                )));
+            }
             sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
                 .bind(HARDCOVER_API_KEY_KEY)
                 .bind(v)

--- a/db/src/settings/tests.rs
+++ b/db/src/settings/tests.rs
@@ -114,6 +114,39 @@ async fn seed_settings_from_env_is_noop_when_vars_unset() {
 // ── Hardcover API key (F3.3) — settings wins, env seeds-if-unset ──
 
 #[tokio::test]
+async fn set_hardcover_api_key_accepts_value_at_max_len() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let at_limit = "a".repeat(HARDCOVER_API_KEY_MAX_LEN);
+    set_hardcover_api_key(&pool, Some(&at_limit)).await.unwrap();
+    assert_eq!(
+        get_hardcover_api_key(&pool).await.unwrap().as_deref(),
+        Some(at_limit.as_str())
+    );
+}
+
+#[tokio::test]
+async fn set_hardcover_api_key_rejects_value_over_max_len() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let over_limit = "a".repeat(HARDCOVER_API_KEY_MAX_LEN + 1);
+    let err = set_hardcover_api_key(&pool, Some(&over_limit))
+        .await
+        .unwrap_err();
+    match err {
+        SettingsError::Validation(msg) => {
+            assert!(
+                msg.contains(&HARDCOVER_API_KEY_MAX_LEN.to_string()),
+                "error should name the cap: {msg}"
+            );
+        }
+        other => panic!("expected SettingsError::Validation, got {other:?}"),
+    }
+    // 4xx-style rejection short-circuits before the write, so the row stays unset.
+    assert_eq!(get_hardcover_api_key(&pool).await.unwrap(), None);
+}
+
+#[tokio::test]
 async fn hardcover_key_set_get_and_clear_roundtrips() {
     let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -487,8 +487,22 @@ pub async fn rpc_get_hardcover_key() -> Result<HardcoverKeyStatus> {
 
 /// Admin-only: save (or clear, with `None`/blank) the Hardcover key in
 /// settings. Returns the new masked status — never echoes the raw key.
+/// Rejects values whose trimmed length exceeds
+/// `HARDCOVER_API_KEY_MAX_LEN` at the API boundary so an admin can't
+/// persist an unbounded payload — mirrors the same guard `db::set_hardcover_api_key`
+/// enforces as defence in depth.
 #[post("/api/rpc/hardcover-key", pool: PoolExt, _admin: AdminUser)]
 pub async fn rpc_set_hardcover_key(key: Option<String>) -> Result<HardcoverKeyStatus> {
+    if let Some(k) = key.as_deref() {
+        let trimmed = k.trim();
+        if trimmed.len() > omnibus_shared::HARDCOVER_API_KEY_MAX_LEN {
+            return Err(ServerFnError::new(format!(
+                "hardcover_api_key must be {} bytes or fewer",
+                omnibus_shared::HARDCOVER_API_KEY_MAX_LEN
+            ))
+            .into());
+        }
+    }
     db::set_hardcover_api_key(&pool.0, key.as_deref()).await?;
     read_hardcover_key_status(&pool.0).await
 }

--- a/server/src/backend/suggestions.rs
+++ b/server/src/backend/suggestions.rs
@@ -16,7 +16,9 @@ use axum::{
     Json,
 };
 use omnibus_db::{self as db, worker::Task};
-use omnibus_shared::{BookSuggestion, HardcoverKeyStatus, SuggestionsResponse};
+use omnibus_shared::{
+    BookSuggestion, HardcoverKeyStatus, SuggestionsResponse, HARDCOVER_API_KEY_MAX_LEN,
+};
 use serde::Deserialize;
 
 use super::{internal, AppState};
@@ -124,11 +126,25 @@ pub(super) struct SetHardcoverKey {
 }
 
 /// Admin-only: save or clear the Hardcover key; returns the new masked status.
+/// Rejects values whose trimmed length exceeds `HARDCOVER_API_KEY_MAX_LEN`
+/// with 422 at the API boundary so an admin can't persist an unbounded
+/// payload — `db::set_hardcover_api_key` enforces the same cap as defence
+/// in depth.
 pub(super) async fn post_hardcover_key(
     _admin: AdminUser,
     State(state): State<AppState>,
     Json(body): Json<SetHardcoverKey>,
 ) -> Response {
+    if let Some(k) = body.key.as_deref() {
+        let trimmed = k.trim();
+        if trimmed.len() > HARDCOVER_API_KEY_MAX_LEN {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                format!("hardcover_api_key must be {HARDCOVER_API_KEY_MAX_LEN} bytes or fewer"),
+            )
+                .into_response();
+        }
+    }
     if let Err(e) = db::set_hardcover_api_key(&state.pool, body.key.as_deref()).await {
         return internal("save hardcover key", e);
     }

--- a/server/src/backend/suggestions/tests.rs
+++ b/server/src/backend/suggestions/tests.rs
@@ -143,6 +143,35 @@ async fn api_hardcover_key_post_requires_admin() {
 }
 
 #[tokio::test]
+async fn api_hardcover_key_post_returns_422_when_key_exceeds_max_len() {
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "boss").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let over_limit = "a".repeat(omnibus_shared::HARDCOVER_API_KEY_MAX_LEN + 1);
+    let res = app
+        .oneshot(post_json(
+            "/api/hardcover-key",
+            &token,
+            serde_json::json!({ "key": over_limit }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = body_string(res).await;
+    assert!(
+        body.contains(&omnibus_shared::HARDCOVER_API_KEY_MAX_LEN.to_string()),
+        "error body should name the cap: {body}"
+    );
+
+    // 422 must short-circuit before the write reaches the settings table.
+    assert_eq!(
+        omnibus_db::get_hardcover_api_key(&pool).await.unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
 async fn api_hardcover_key_set_then_get_returns_masked_never_raw() {
     let (app, _state, pool) = fixture().await;
     let admin = auth_test_support::create_admin(&pool, "boss").await;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -28,6 +28,11 @@ pub mod worker;
 /// Maximum byte length of an author photo source URL.
 pub const AUTHOR_PHOTO_URL_MAX_LEN: usize = 2048;
 
+/// Maximum byte length of a stored Hardcover API key. Sized generously for a
+/// Hardcover Bearer token (a JWT that comfortably fits in ~1–2 KiB) so the
+/// admin-writable settings surface doesn't accept unbounded input.
+pub const HARDCOVER_API_KEY_MAX_LEN: usize = 2048;
+
 pub use audiobook::*;
 pub use auth::*;
 pub use bookmark::*;


### PR DESCRIPTION
## Summary
- Add `HARDCOVER_API_KEY_MAX_LEN = 2048` in `omnibus-shared` (alongside `AUTHOR_PHOTO_URL_MAX_LEN`) and enforce it on all three F3.3 Hardcover-key write paths — `db::set_hardcover_api_key`, the `#[post("/api/rpc/hardcover-key")]` server function, and `POST /api/hardcover-key` REST — so an admin can't paste an unbounded value into the settings KV.
- Add a `SettingsError::Validation(String)` variant to the db-side `SettingsError` enum. The db call now short-circuits with `Validation` before the write; the API-boundary gates return `ServerFnError` (RPC) and `422 UNPROCESSABLE_ENTITY` (REST), matching how `Settings::validate()` failures propagate on the sibling library-paths save path.

## Test plan
- [ ] `db/src/settings/tests.rs`: `set_hardcover_api_key_accepts_value_at_max_len` and `set_hardcover_api_key_rejects_value_over_max_len` exercise the new cap on the db layer.
- [ ] `server/src/backend/suggestions/tests.rs`: `api_hardcover_key_post_returns_422_when_key_exceeds_max_len` exercises the REST 422 path and confirms the write short-circuits before touching the settings KV.
- [ ] `cargo test -p omnibus-db --lib settings::` and `cargo test -p omnibus --test '*' ` (via CI — see Notes).
- [ ] `just lint` / `just test` in CI.

## Notes
- Frozen-variant coverage: the RPC path is covered transitively per the existing `frontend/src/rpc.rs` tests-module note about `rpc_save_settings` — a direct call-through would only re-test the shared validator without spinning up the fullstack router, so the REST + db tests are the observable coverage.
- Local verification limits: `nix` isn't available in this sandbox, and the cargo git-source for `dioxus` (github.com/DioxusLabs/dioxus @ v0.7.9) is blocked by the agent proxy (403), so I couldn't run `cargo fmt --check` / `cargo test` end-to-end against the whole workspace. `cargo fmt --check` did run and is clean on the touched files. CI (which uses `nix develop`) is authoritative.
- No `Cargo.lock` changes.
- No schema / migration changes.
- Kept strictly in scope — did not audit-swap other admin-writable settings for similar caps; note-only if any other unbounded knob shows up.

Closes #659

Co-Authored-By: Claude Opus 4.7 
Claude-Session: https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review

**Verdict: approved.**

- Diff resolves #659 exactly: `HARDCOVER_API_KEY_MAX_LEN = 2048` lives in `omnibus-shared` with a `///` doc; `db::set_hardcover_api_key` short-circuits with the new `SettingsError::Validation(String)` variant **before** the `INSERT OR REPLACE` (verified in the diff — the length check sits inside the `Some(v)` arm above the `sqlx::query`); both RPC (`ServerFnError`) and REST (`422 UNPROCESSABLE_ENTITY`) gate the API boundary as defence-in-depth.
- Rule 02 conformance: coarse `Validation(String)` variant (matches `PasswordInvalid` pattern), `#[error(transparent)] #[from]` still wraps `sqlx::Error`, no raw `sqlx::Error` leaked. `?` propagates cleanly.
- Rule 03 conformance: tests in sibling `db/src/settings/tests.rs` and `server/src/backend/suggestions/tests.rs`, sentence-style names (`set_hardcover_api_key_accepts_value_at_max_len`, `..._rejects_value_over_max_len`, `api_hardcover_key_post_returns_422_when_key_exceeds_max_len`), happy at-limit + over-limit + short-circuit-before-write assertions. RPC path left transitive per rule 03's "thin wrappers" guidance — correct call.
- Scope discipline: six files touched, all necessary. No migrations, no `Cargo.lock`, no unrelated cleanup, no drive-by audit of other admin-writable settings.
- Conventional-commit title (`fix:`), branch `fix/659-hardcover-key-length-cap`, `Closes #659` all present.
- Minor observation (non-blocking): the REST handler routes all `db::set_hardcover_api_key` errors through `internal(...)` (500). If future callers hit the DB `Validation` branch without the REST-boundary guard firing first, that would surface as 500 rather than 422 — currently unreachable because the REST guard uses the same cap, but a `match` on `SettingsError::Validation → 422` would make the defence-in-depth explicit at the handler.
- Caveat: local `cargo check -p omnibus-shared` blocked by the agent proxy 403 on the `dioxus` git dep (worker noted the same). CI is authoritative.