### PR TITLE
fix: wrap issue_session's device + session inserts in a transaction (#627)

### DIFF
--- a/db/src/auth/device.rs
+++ b/db/src/auth/device.rs
@@ -1,6 +1,6 @@
 //! Devices.
 
-use sqlx::{Row, SqlitePool};
+use sqlx::{Executor, Row, Sqlite, SqlitePool};
 
 use super::{AuthError, AuthResult, Device};
 
@@ -57,14 +57,21 @@ pub fn validate_client_version(version: Option<&str>) -> AuthResult<()> {
     validate_device_field(version, MAX_CLIENT_VERSION_CHARS, "client_version")
 }
 
-/// Register a new device for a user after validating the name and client version; returns the inserted device record.
-pub async fn register_device(
-    pool: &SqlitePool,
+/// Register a new device for a user after validating the name and client version;
+/// returns the inserted device record. Executor-generic so callers issuing device
+/// + session inserts atomically (see `server::auth::handlers::issue_session`) can
+/// pass `&mut *tx` and roll back both writes on failure of the session insert.
+/// Standalone callers pass `&pool`.
+pub async fn register_device<'e, E>(
+    executor: E,
     user_id: i64,
     name: &str,
     client_kind: &str,
     client_version: Option<&str>,
-) -> AuthResult<Device> {
+) -> AuthResult<Device>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
     // Guards run *before* the INSERT so a rejected field never reaches
     // SQLite. Mirrors the placement of `validate_password` in `users`.
     validate_device_name(Some(name))?;
@@ -78,7 +85,7 @@ pub async fn register_device(
     .bind(name)
     .bind(client_kind)
     .bind(client_version)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await?;
     Ok(Device {
         id: row.get("id"),

--- a/db/src/auth/device.rs
+++ b/db/src/auth/device.rs
@@ -57,11 +57,12 @@ pub fn validate_client_version(version: Option<&str>) -> AuthResult<()> {
     validate_device_field(version, MAX_CLIENT_VERSION_CHARS, "client_version")
 }
 
-/// Register a new device for a user after validating the name and client version;
-/// returns the inserted device record. Executor-generic so callers issuing device
-/// + session inserts atomically (see `server::auth::handlers::issue_session`) can
-/// pass `&mut *tx` and roll back both writes on failure of the session insert.
-/// Standalone callers pass `&pool`.
+/// Register a new device for a user after validating name and client version.
+///
+/// Executor-generic so `server::auth::handlers::issue_session` can pair this
+/// with `create_session` inside one `sqlx::Transaction` — passing `&mut *tx`
+/// rolls back the device insert on failure of the session insert. Standalone
+/// callers pass `&pool`.
 pub async fn register_device<'e, E>(
     executor: E,
     user_id: i64,

--- a/db/src/auth/device/tests.rs
+++ b/db/src/auth/device/tests.rs
@@ -7,6 +7,7 @@
 use super::*;
 use crate::auth::test_support::pool;
 use crate::auth::users::create_user;
+use crate::auth::{create_session, SessionKind};
 
 #[tokio::test]
 async fn device_register_and_list() {
@@ -104,4 +105,51 @@ async fn register_device_rejects_control_char_in_client_version() {
             if m.contains("invalid client_version") && m.contains("control characters")),
         "expected Validation about client_version control chars, got {err:?}",
     );
+}
+
+#[tokio::test]
+async fn register_device_rolls_back_when_session_insert_fails_inside_same_tx() {
+    // Reproduces the failure-after-register path in
+    // `server::auth::handlers::issue_session` (issue #627): both writes must be
+    // atomic so a broken `create_session` never leaves an orphan `devices` row.
+    // We force `create_session` to fail by giving it a `device_id` that
+    // doesn't exist — SQLite's foreign_keys=ON pragma rejects the INSERT and
+    // dropping the transaction without a commit issues a ROLLBACK.
+    let p = pool().await;
+    let u = create_user(&p, "alice", "correct horse battery staple")
+        .await
+        .unwrap();
+    let mut tx = p.begin().await.expect("begin tx");
+    let device = register_device(&mut *tx, u.id, "Phone", "ios", None)
+        .await
+        .expect("register_device inside tx should succeed");
+    // Force the same-tx `create_session` to fail via a bogus FK. Passing
+    // `device.id + 1_000_000` guarantees no matching `devices` row exists,
+    // so the sessions.device_id FK check aborts the INSERT.
+    let sess_err = create_session(
+        &mut *tx,
+        u.id,
+        Some(device.id + 1_000_000),
+        SessionKind::Cookie,
+        3600,
+    )
+    .await
+    .expect_err("create_session must fail on unknown device_id FK");
+    assert!(
+        matches!(sess_err, AuthError::Internal(_)),
+        "sqlx FK failure should surface as AuthError::Internal, got {sess_err:?}",
+    );
+    // Drop the transaction without committing — sqlx's Transaction Drop
+    // issues a ROLLBACK, so the device INSERT above must not survive.
+    drop(tx);
+    let devices = list_devices_for_user(&p, u.id).await.unwrap();
+    assert!(
+        devices.is_empty(),
+        "rolled-back transaction must not leave orphan device rows, got {devices:?}",
+    );
+    let session_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sessions")
+        .fetch_one(&p)
+        .await
+        .unwrap();
+    assert_eq!(session_count, 0, "no sessions row should exist either");
 }

--- a/db/src/auth/session.rs
+++ b/db/src/auth/session.rs
@@ -1,6 +1,6 @@
 //! Sessions.
 
-use sqlx::{Row, SqlitePool};
+use sqlx::{Executor, Row, Sqlite, SqlitePool};
 
 use super::token::{generate_token, hash_token, parse_session_token};
 use super::{now_unix, AuthError, AuthResult, NewSession, Session, SessionKind, User};
@@ -15,14 +15,21 @@ const SESSION_TOUCH_THRESHOLD_SECS: i64 = 5 * 60;
 /// (cookie absolute TTL is 30 days; bearer is 90).
 pub(crate) const SESSION_IDLE_TIMEOUT_SECS: i64 = 7 * 24 * 60 * 60;
 
-/// Create a new session for `user_id`, returning the session record and the raw (unhashed) token.
-pub async fn create_session(
-    pool: &SqlitePool,
+/// Create a new session for `user_id`, returning the session record and the raw
+/// (unhashed) token. Executor-generic so `server::auth::handlers::issue_session`
+/// can pair this with `register_device` inside a single `sqlx::Transaction` — an
+/// error here rolls back the device INSERT and prevents an orphan `devices` row.
+/// Standalone callers (e.g. cookie-only refresh paths) pass `&pool`.
+pub async fn create_session<'e, E>(
+    executor: E,
     user_id: i64,
     device_id: Option<i64>,
     kind: SessionKind,
     ttl_secs: i64,
-) -> AuthResult<NewSession> {
+) -> AuthResult<NewSession>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
     let raw = generate_token()?;
     let hash = hash_token(&raw);
     let now = now_unix();
@@ -38,7 +45,7 @@ pub async fn create_session(
     .bind(device_id)
     .bind(kind.as_str())
     .bind(expires)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await?;
 
     let session = Session {

--- a/db/src/auth/session.rs
+++ b/db/src/auth/session.rs
@@ -15,10 +15,11 @@ const SESSION_TOUCH_THRESHOLD_SECS: i64 = 5 * 60;
 /// (cookie absolute TTL is 30 days; bearer is 90).
 pub(crate) const SESSION_IDLE_TIMEOUT_SECS: i64 = 7 * 24 * 60 * 60;
 
-/// Create a new session for `user_id`, returning the session record and the raw
-/// (unhashed) token. Executor-generic so `server::auth::handlers::issue_session`
-/// can pair this with `register_device` inside a single `sqlx::Transaction` — an
-/// error here rolls back the device INSERT and prevents an orphan `devices` row.
+/// Create a new session for `user_id`, returning the session record and the raw (unhashed) token.
+///
+/// Executor-generic so `server::auth::handlers::issue_session` can pair this
+/// with `register_device` inside a single `sqlx::Transaction` — an error here
+/// rolls back the device insert and prevents an orphan `devices` row.
 /// Standalone callers (e.g. cookie-only refresh paths) pass `&pool`.
 pub async fn create_session<'e, E>(
     executor: E,

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -212,14 +212,8 @@ async fn issue_session(
     let device_id = if let (Some(name), Some(kind_str)) =
         (device_name.as_deref(), client_kind.as_deref())
     {
-        match auth_db::register_device(
-            &mut *tx,
-            user.id,
-            name,
-            kind_str,
-            client_version.as_deref(),
-        )
-        .await
+        match auth_db::register_device(&mut *tx, user.id, name, kind_str, client_version.as_deref())
+            .await
         {
             Ok(d) => Some(d.id),
             Err(e) => return auth_error_to_response(e),

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -194,11 +194,32 @@ async fn issue_session(
 ) -> Response {
     let bearer = want_bearer(client_kind.as_deref());
 
-    let device_id = if let (Some(name), Some(kind)) =
+    let (kind, ttl) = if bearer {
+        (SessionKind::Bearer, BEARER_TTL_SECS)
+    } else {
+        (SessionKind::Cookie, COOKIE_TTL_SECS)
+    };
+
+    // Wrap `register_device` and `create_session` in one transaction so a
+    // failure of the session INSERT rolls back the device INSERT rather than
+    // leaving an orphan `devices` row (issue #627). Any `?`/early return
+    // below drops `tx` before `commit`; sqlx's Drop issues a ROLLBACK.
+    let mut tx = match state.pool().begin().await {
+        Ok(tx) => tx,
+        Err(e) => return internal(e),
+    };
+
+    let device_id = if let (Some(name), Some(kind_str)) =
         (device_name.as_deref(), client_kind.as_deref())
     {
-        match auth_db::register_device(state.pool(), user.id, name, kind, client_version.as_deref())
-            .await
+        match auth_db::register_device(
+            &mut *tx,
+            user.id,
+            name,
+            kind_str,
+            client_version.as_deref(),
+        )
+        .await
         {
             Ok(d) => Some(d.id),
             Err(e) => return auth_error_to_response(e),
@@ -207,16 +228,14 @@ async fn issue_session(
         None
     };
 
-    let (kind, ttl) = if bearer {
-        (SessionKind::Bearer, BEARER_TTL_SECS)
-    } else {
-        (SessionKind::Cookie, COOKIE_TTL_SECS)
-    };
-
-    let issued = match auth_db::create_session(state.pool(), user.id, device_id, kind, ttl).await {
+    let issued = match auth_db::create_session(&mut *tx, user.id, device_id, kind, ttl).await {
         Ok(s) => s,
         Err(e) => return auth_error_to_response(e),
     };
+
+    if let Err(e) = tx.commit().await {
+        return internal(e);
+    }
 
     let body = LoginResponse {
         user: user_summary(&user),


### PR DESCRIPTION
## Summary
- `server::auth::handlers::issue_session` used to call `auth_db::register_device` and `auth_db::create_session` as two sequential bare-pool operations. If `create_session` failed after `register_device` succeeded, the device row stayed committed with no matching session — the `devices` table grew orphan rows on any transient failure during login/registration.
- Wrap both writes in one `sqlx::Transaction`: begin at the top of `issue_session`, thread `&mut *tx` through both DB calls, commit only after both succeed. Any `?`/early-return before `commit` drops the transaction and sqlx's Drop issues a ROLLBACK, so a broken `create_session` reverts the `register_device` insert.
- Promote `auth_db::register_device` and `auth_db::create_session` from `&SqlitePool` to `impl sqlx::Executor<'_, Database = Sqlite>` — the same pool-or-transaction generic pattern already used by `books::resolve_book_id_by_uuid_exec` and `metadata_overrides::upsert_overrides_row`. `&SqlitePool` still implements `Executor`, so every pre-existing caller (test_support, extractor/gate tests, handlers/tests, session lookups) compiles unchanged.

## Test plan
- [x] Added `register_device_rolls_back_when_session_insert_fails_inside_same_tx` in `db/src/auth/device/tests.rs` — drives the failure-after-register path by forcing the session INSERT to fail via a bogus `device_id` FK inside the shared transaction, then asserts both `devices` and `sessions` are empty after the transaction is dropped.
- [ ] `just lint` (see Notes — could not run locally in this sandbox; CI will validate)
- [ ] `just test` (see Notes — could not run locally in this sandbox; CI will validate)

## Notes
> [!IMPORTANT]
> `just lint` / `just test` could not be executed in this worker's sandbox: the workspace pulls `dioxus` from a git dep (`https://github.com/DioxusLabs/dioxus` @ v0.7.9), and the git proxy in this environment returns 403 for that repo, so `cargo check -p omnibus-db` cannot resolve the workspace lockfile. The changes are mechanical (signature widening + transaction wrap) and follow the existing `_exec` pattern already in the db crate; CI has access to the full dep graph and will run the full matrix.

- Rule 02 (boundary rule): the two DB functions still return `AuthResult`, so no `sqlx::Error` leaks across the module boundary — the FK-failure test asserts the surfaced error is `AuthError::Internal(_)`.
- Rule 05 / 03 (test placement): the new test lives beside its module in `db/src/auth/device/tests.rs`.
- No migration, no new env var, no new dependency, no markup change → no docs/skills/Playwright updates required.

Closes #627

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review

**Verdict: needs-rework — CI is red on two mechanical style checks.**

- **Atomicity (correct).** `pool().begin()` runs before either write; `&mut *tx` is threaded through both `register_device` and `create_session`; `tx.commit()` gates the success path; every error path returns without commit, so sqlx's `Transaction::Drop` issues ROLLBACK. No intervening bare-pool write between begin and commit.
- **Scope (clean).** Diff is exactly the two DB-fn signature widenings, the handler wire-up, and the new test — 4 files, 103/22 lines.
- **Signature safety (verified).** `&SqlitePool` implements `Executor<'_, Database = Sqlite>`, so all pre-existing callers in `server/src/auth/{extractor,gate,handlers,test_support}` and `db/src/auth/session*` continue to compile unchanged with `&p` / `&pool`.
- **Test rigor (good).** FK-fail path is real: `sessions.device_id REFERENCES devices(id)` (migration `0004_auth.sql`) plus `PRAGMA foreign_keys = ON` in `db::pool::init_db` guarantee the bogus `device.id + 1_000_000` INSERT aborts. Test asserts both `devices` and `sessions` are empty after drop, and pins the error type to `AuthError::Internal(_)`. Placement in `db/src/auth/device/tests.rs` and long-sentence name match Rule 03.
- **Rule 02 / migration hygiene / conventional commit (all clean).** DB fns return `AuthResult`; no `sqlx::Error` crosses the module boundary. No `db/migrations/` files touched. Commit title `fix:`, branch `fix/627-issue-session-transaction`, `Closes #627` present.
- **BLOCKERS — CI failing on two mechanical issues that must be fixed before merge:**
  1. `rustfmt` (job 84679051929): `cargo fmt --all --check` wants the `auth_db::register_device(&mut *tx, user.id, name, kind_str, client_version.as_deref())` call collapsed to one line before `.await`. Run `cargo fmt` in `server/src/auth/handlers.rs`.
  2. `clippy` (job 84679051918): `-D clippy::doc-lazy-continuation` on `db/src/auth/device.rs:63-64` — the `///` doc block for `register_device` starts wrapped lines with `+ session inserts...` and `Standalone callers...`, which clippy reads as unindented list items. Either indent those continuation lines by two spaces or restructure the doc comment (e.g. one-line summary + blank `///` + prose).

Both are style-only fixes; the core atomicity change is correct and minimal.
