### PR TITLE
fix: enforce SESSION_BATCH_CAP on rpc_record_sessions

### DIFF
--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -34,6 +34,12 @@ use omnibus_shared::{
 #[cfg(feature = "server")]
 use omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN;
 
+// `check_session_batch_size` is server-gated (called only from the server-side
+// body of `rpc_record_sessions`), so keep the import `server`-gated too — the
+// client build would otherwise flag it unused.
+#[cfg(feature = "server")]
+use omnibus_shared::SESSION_BATCH_CAP;
+
 // `BookSuggestion` is only constructed in the server-side `rpc_get_suggestions`
 // body; gate it so the web/mobile client builds don't flag an unused import.
 #[cfg(feature = "server")]
@@ -756,15 +762,36 @@ pub async fn rpc_get_progress(
     Ok(db::progress::get_progress(&pool.0, user.id, &uuid, format).await?)
 }
 
+/// Reject batches larger than `SESSION_BATCH_CAP` before any per-record work.
+/// Mirrors the 422 the mobile REST route emits from
+/// `server::backend::progress::post_sessions`: an authenticated client should
+/// not be able to hold the write path open with an unbounded insert loop.
+///
+/// Kept as a small server-gated helper so a unit test can exercise the
+/// over-cap rejection without spinning up the dioxus server-fn router — the
+/// same pattern as `validate_author_photo_url` above.
+#[cfg(feature = "server")]
+fn check_session_batch_size(len: usize) -> std::result::Result<(), ServerFnError> {
+    if len > SESSION_BATCH_CAP {
+        return Err(ServerFnError::new(format!(
+            "batch too large: {} records exceeds maximum of {}",
+            len, SESSION_BATCH_CAP
+        )));
+    }
+    Ok(())
+}
+
 /// Persist a batch of reading- or listening-session reports and return the
-/// inserted count. Validates every report up-front before any insert; the
-/// inserts then run sequentially (not in a single transaction), so a DB
-/// error mid-batch commits the rows that already succeeded and propagates
-/// the error to the caller — the count of committed rows is then lost.
-/// Reports whose `book_uuid` is unknown are silently dropped (counted out)
-/// rather than failing the batch.
+/// inserted count. Rejects batches larger than `SESSION_BATCH_CAP` (matching
+/// the mobile REST cap) before any DB work. Validates every remaining report
+/// up-front before any insert; the inserts then run sequentially (not in a
+/// single transaction), so a DB error mid-batch commits the rows that already
+/// succeeded and propagates the error to the caller — the count of committed
+/// rows is then lost. Reports whose `book_uuid` is unknown are silently
+/// dropped (counted out) rather than failing the batch.
 #[post("/api/rpc/progress/sessions", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_record_sessions(reports: Vec<SessionReport>) -> Result<u64> {
+    check_session_batch_size(reports.len())?;
     for r in &reports {
         if let Err(msg) = r.validate() {
             return Err(ServerFnError::new(msg).into());
@@ -1184,7 +1211,10 @@ pub async fn rpc_preview_shelf_rule(
 // suite as `cargo test -p omnibus-frontend --features server`.
 #[cfg(all(test, feature = "server"))]
 mod tests {
-    use super::{validate_author_photo_url, AUTHOR_PHOTO_URL_MAX_LEN};
+    use super::{
+        check_session_batch_size, validate_author_photo_url, AUTHOR_PHOTO_URL_MAX_LEN,
+        SESSION_BATCH_CAP,
+    };
 
     // `rpc_save_settings`'s validation wiring is covered by the REST
     // boundary test `api_post_settings_returns_422_when_*_path_exceeds_max_len`
@@ -1218,6 +1248,29 @@ mod tests {
         assert!(
             err.to_string().contains("required"),
             "error message should say required: {err}"
+        );
+    }
+
+    #[test]
+    fn check_session_batch_size_accepts_at_cap() {
+        // At-cap batches must pass — the REST handler treats `> cap` (not
+        // `>= cap`) as the rejection condition, and the RPC path has to
+        // match so a client near the limit doesn't see divergent errors
+        // between web and mobile.
+        assert!(check_session_batch_size(SESSION_BATCH_CAP).is_ok());
+    }
+
+    #[test]
+    fn check_session_batch_size_rejects_over_cap_with_cap_in_message() {
+        let err = check_session_batch_size(SESSION_BATCH_CAP + 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&SESSION_BATCH_CAP.to_string()),
+            "error message should name the cap: {msg}"
+        );
+        assert!(
+            msg.contains(&(SESSION_BATCH_CAP + 1).to_string()),
+            "error message should name the offending length: {msg}"
         );
     }
 }

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -10,7 +10,7 @@ use axum::{
     Json,
 };
 use omnibus_db::{self as db, progress::ProgressError};
-use omnibus_shared::{ProgressFormat, ProgressUpdate, SessionReport};
+use omnibus_shared::{ProgressFormat, ProgressUpdate, SessionReport, SESSION_BATCH_CAP};
 use serde::Deserialize;
 
 use super::{internal, AppState};
@@ -61,16 +61,15 @@ pub(super) async fn get_progress(
     }
 }
 
-/// Hard cap on `SessionReport`s per `post_sessions` batch.
-pub(super) const MAX_SESSION_BATCH: usize = 500;
-
 /// Append a batch of session reports. Mobile posts these on reconnect; web
 /// posts best-effort on unmount. Each report is validated at the API
 /// boundary (negative durations / inverted time ranges → 400); unknown
 /// book uuids are silently skipped inside the db layer (best-effort
 /// telemetry). `recorded` reflects the **inserted** row count so callers
 /// can tell which queued reports actually persisted. Batches larger than
-/// `MAX_SESSION_BATCH` are rejected with 422 before any DB work.
+/// `SESSION_BATCH_CAP` are rejected with 422 before any DB work — the
+/// same cap the web RPC path in `omnibus_frontend::rpc::rpc_record_sessions`
+/// enforces, so both clients see the same wire contract.
 ///
 /// The entire batch runs inside a single transaction — a DB error mid-loop
 /// rolls back all previously inserted rows so the client can safely retry
@@ -80,11 +79,11 @@ pub(super) async fn post_sessions(
     State(state): State<AppState>,
     Json(reports): Json<Vec<SessionReport>>,
 ) -> Response {
-    if reports.len() > MAX_SESSION_BATCH {
+    if reports.len() > SESSION_BATCH_CAP {
         let msg = format!(
             "batch too large: {} records exceeds maximum of {}",
             reports.len(),
-            MAX_SESSION_BATCH
+            SESSION_BATCH_CAP
         );
         return (axum::http::StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
     }

--- a/server/src/backend/progress/tests.rs
+++ b/server/src/backend/progress/tests.rs
@@ -3,7 +3,7 @@ use axum::{
     body::{to_bytes, Body},
     http::{header::AUTHORIZATION, Request, StatusCode},
 };
-use omnibus_shared::ProgressRecord;
+use omnibus_shared::{ProgressRecord, SESSION_BATCH_CAP};
 use tower::ServiceExt;
 
 use super::*;
@@ -300,7 +300,7 @@ async fn api_post_sessions_batch_of_two_records_both() {
 
 #[tokio::test]
 async fn post_sessions_rejects_oversized_batch() {
-    // Batches larger than MAX_SESSION_BATCH must be rejected with 422
+    // Batches larger than SESSION_BATCH_CAP must be rejected with 422
     // before any DB work — the global 1 MiB body limit permits thousands
     // of compact reports, so the per-batch cap is the real defense
     // against a client holding the WAL write lock open.
@@ -308,7 +308,7 @@ async fn post_sessions_rejects_oversized_batch() {
     let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
     let user = auth_test_support::create_user(&pool, "alice").await;
     let token = auth_test_support::bearer_token(&pool, user.id).await;
-    let reports: Vec<_> = (0..=MAX_SESSION_BATCH)
+    let reports: Vec<_> = (0..=SESSION_BATCH_CAP)
         .map(|_| {
             serde_json::json!({
                 "book_uuid": uuid,

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -10,6 +10,15 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 mod tests;
 
+/// Hard cap on `SessionReport`s per batch, enforced identically by the mobile
+/// REST route (`POST /api/progress/sessions`) and the web RPC path
+/// (`rpc_record_sessions`). Both handlers reject over-cap batches before any
+/// DB work so an authenticated client cannot hold the write transaction open
+/// with an unbounded per-record insert loop. Kept as a compile-time constant
+/// rather than an env var: changing it needs a coordinated server + client
+/// bump, not a per-deploy tweak.
+pub const SESSION_BATCH_CAP: usize = 500;
+
 /// Discriminator for the format-specific payload variant in [`ProgressUpdate`]
 /// / [`ProgressRecord`] / [`SessionReport`]. Serializes as a plain
 /// lowercase string (`"epub"` / `"audio"`) so the wire shape stays compact.


### PR DESCRIPTION
## Summary
- Hoist the session-batch cap (`500`) out of `server::backend::progress` and into `omnibus_shared` as `pub const SESSION_BATCH_CAP: usize = 500;`, with a `///` comment on why it's compile-time (coordinated server + client bump, not a per-deploy tweak).
- `server::backend::progress::post_sessions` now imports `SESSION_BATCH_CAP` from `omnibus_shared` and its 422 message references the new name.
- `frontend::rpc::rpc_record_sessions` (the web RPC path that previously lacked a batch cap) now short-circuits with a `ServerFnError` before any per-record validation or DB work, matching the tone of the REST 422. The check lives in a small server-gated `check_session_batch_size` helper (mirroring the existing `validate_author_photo_url` pattern) so a unit test can exercise the over-cap rejection without spinning up the dioxus server-fn router.

## Test plan
- [ ] `just lint` (`cargo fmt --check` + clippy across the crate/feature matrix)
- [ ] `cargo test -p omnibus-shared` — exercises the shared constant via existing `SessionReport` tests
- [ ] `cargo test -p omnibus post_sessions_rejects_oversized_batch` — 422 path on the mobile REST route
- [ ] `cargo test -p omnibus-frontend --features server check_session_batch_size` — over-cap and at-cap paths for the web RPC

## Notes
> [!NOTE]
> Local `cargo test` / `cargo clippy` couldn't run in this session: the sandbox has no populated cargo registry / git cache and github.com fetches through the agent proxy return 403 for the pinned dioxus git rev, so all deps failed to resolve. `cargo fmt --check` passed cleanly. Everything else has to be verified by CI.

- The 422 message wording (`"batch too large: N records exceeds maximum of CAP"`) is kept verbatim across REST and RPC so log-scraping and client-side error surfacing stay consistent.
- The REST-side test constant was renamed from `MAX_SESSION_BATCH` to `SESSION_BATCH_CAP` in the same commit; nothing else referenced the old name.
- Deliberately kept the RPC handler on non-transactional inserts (the pre-existing behavior noted in the doc comment) — that's a separate defect from the cap gap, out of scope for this PR.

Closes #609

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review

**Verdict: approved-with-notes** — resolves #609 cleanly; only cosmetic nits.

- Acceptance criteria met: `SESSION_BATCH_CAP` is defined once in `omnibus_shared::progress` (flat re-exported via `pub use progress::*` from `shared/src/lib.rs`), imported by both `server::backend::progress` and `frontend::rpc` without copy-paste; the `check_session_batch_size` guard runs as the **first** line of `rpc_record_sessions`'s body, so it fires strictly before the per-item `validate()` loop and any DB work. `MAX_SESSION_BATCH` grep on the branch returns zero hits — the rename is complete.
- Scope is tight: only the four cited files (`shared/src/progress.rs`, `server/src/backend/progress.rs`, `server/src/backend/progress/tests.rs`, `frontend/src/rpc.rs`) touched, no `Cargo.lock` churn, no migrations.
- 422 wording is kept verbatim across REST and RPC (`"batch too large: N records exceeds maximum of CAP"`), so log-scraping stays consistent. The REST handler still uses `>` (not `>=`), and the RPC helper matches — the new `check_session_batch_size_accepts_at_cap` test pins that boundary, avoiding an off-by-one divergence between the two clients.
- Style nit (non-blocking): `check_session_batch_size` returns `std::result::Result<(), ServerFnError>`, while the sibling `validate_author_photo_url` uses the shorter `Result<&str, ServerFnError>` alias from `dioxus::prelude`. Both compile; consistent style would drop the `std::result::` prefix.
- Style nit (non-blocking): the new `#[cfg(feature = "server")] use omnibus_shared::SESSION_BATCH_CAP;` line was inserted between `AUTHOR_PHOTO_URL_MAX_LEN` and `BookSuggestion`, which breaks strict alphabetical order (A → S → B). The surrounding block is grouped by "server-gated single symbol imports" more than by alpha order, so this is a very minor smell.
- Out-of-scope callout is honest: the RPC path's non-transactional insert loop (a DB error mid-batch commits already-persisted rows and loses the count) is documented in the updated doc comment and explicitly deferred — that's a separate defect from the cap gap and belongs in its own change.
