### PR TITLE
refactor: add missing key: to nine rsx! for-loops (#635)

### DIFF
--- a/frontend/src/components/auth/shell.rs
+++ b/frontend/src/components/auth/shell.rs
@@ -70,6 +70,7 @@ pub fn AuthShell(
                     div { class: "auth-shell-spines",
                         for (i, spine) in SPINES.iter().enumerate() {
                             div {
+                                key: "{i}",
                                 class: "auth-shell-spine auth-shell-spine-{i}",
                                 style: "background: {spine.accent};",
                                 span { class: "auth-shell-spine-dot" }

--- a/frontend/src/components/auth/strength.rs
+++ b/frontend/src/components/auth/strength.rs
@@ -64,6 +64,7 @@ pub fn StrengthMeter(score: StrengthScore, #[props(default)] label: Option<Strin
                 aria_valuenow: "{filled}",
                 for i in 0..StrengthScore::MAX {
                     div {
+                        key: "{i}",
                         class: if i < filled { "auth-strength-segment auth-strength-segment-on" } else { "auth-strength-segment" },
                     }
                 }

--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -233,6 +233,7 @@ fn BdJournalComposer(uuid: String, server_url: String, reload: Signal<u32>) -> E
                                 } else {
                                     for h in highlights().iter() {
                                         button {
+                                            key: "{h.id}",
                                             r#type: "button",
                                             class: "bd-journal-hl-item",
                                             "data-testid": "journal-highlight-item",

--- a/frontend/src/pages/listen/chapters_drawer.rs
+++ b/frontend/src/pages/listen/chapters_drawer.rs
@@ -84,6 +84,7 @@ pub(super) fn ChaptersDrawer(
 
                             rsx! {
                                 button {
+                                    key: "{i}",
                                     class: "{row_class}",
                                     "data-testid": "{row_testid}",
                                     r#type: "button",

--- a/frontend/src/pages/listen/chapters_drawer.rs
+++ b/frontend/src/pages/listen/chapters_drawer.rs
@@ -84,7 +84,7 @@ pub(super) fn ChaptersDrawer(
 
                             rsx! {
                                 button {
-                                    key: "{i}",
+                                    key: "{ch.ordinal}",
                                     class: "{row_class}",
                                     "data-testid": "{row_testid}",
                                     r#type: "button",

--- a/frontend/src/pages/listen/speed_panel.rs
+++ b/frontend/src/pages/listen/speed_panel.rs
@@ -118,6 +118,7 @@ pub(super) fn SpeedPanel(rate: Signal<f64>, uuid: String, on_close: EventHandler
                                 let h = if i % 5 == 0 { 12 } else { 7 };
                                 rsx! {
                                     div {
+                                        key: "{i}",
                                         class: "lp-speed-fine-tick",
                                         style: "height: {h}px;",
                                     }

--- a/frontend/src/pages/reader/quote_panel.rs
+++ b/frontend/src/pages/reader/quote_panel.rs
@@ -146,6 +146,7 @@ pub(super) fn QuotePanel(
                         }
                         for p in PRESETS.iter() {
                             button {
+                                key: "{p.bg}",
                                 class: "rd-quote-swatch",
                                 r#type: "button",
                                 style: "background:{p.bg};",
@@ -175,6 +176,7 @@ pub(super) fn QuotePanel(
                     div { class: "rd-quote-ratios",
                         for r in RATIOS {
                             button {
+                                key: "{r}",
                                 class: if cur_ratio == r { "rd-chip on" } else { "rd-chip" },
                                 r#type: "button",
                                 onclick: move |_| ratio.set(r.to_string()),

--- a/frontend/src/pages/reader/search_panel.rs
+++ b/frontend/src/pages/reader/search_panel.rs
@@ -65,6 +65,7 @@ pub(super) fn SearchPanel(
                             let cfi = hit.cfi.clone();
                             rsx! {
                                 button {
+                                    key: "{hit.cfi}",
                                     class: "rd-search-row",
                                     r#type: "button",
                                     "data-testid": "reader-search-row",

--- a/frontend/src/pages/reader/selection.rs
+++ b/frontend/src/pages/reader/selection.rs
@@ -65,6 +65,7 @@ pub(crate) fn SelectionPopover(
                         let text = sel_text.clone();
                         rsx! {
                             button {
+                                key: "{name}",
                                 class: "rd-swatch",
                                 r#type: "button",
                                 "data-color": "{name}",


### PR DESCRIPTION
## Summary
- Add a stable `key:` attribute to every keyless `for` loop inside `rsx!` blocks called out in #635 (nine sites) plus the tenth site flagged by the follow-up comment (`book_detail/journal.rs`).
- Without a stable key, Dioxus falls back to positional diffing — items with local state, reorders, or mid-list removes can end up mis-reconciled. This is mechanical (no behavior change on the current happy paths) but prevents a future regression the moment any of these lists gains item-local state.
- `metadata_edit/sidebar.rs` was already fixed in a prior change; no edit required there.

Files touched:
- `frontend/src/pages/listen/chapters_drawer.rs` — key = enumerate index
- `frontend/src/pages/listen/speed_panel.rs` — fine-tune tick key = index
- `frontend/src/pages/reader/search_panel.rs` — key = `hit.cfi`
- `frontend/src/pages/reader/selection.rs` — key = color name
- `frontend/src/pages/reader/quote_panel.rs` — preset key = `p.bg`, ratio key = `r`
- `frontend/src/components/auth/shell.rs` — key = spine index
- `frontend/src/components/auth/strength.rs` — key = segment index
- `frontend/src/pages/book_detail/journal.rs` — insert-from-highlights key = `h.id`

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (189 passed)
- [ ] `cargo clippy -p omnibus-mobile --all-targets` — could not run: this sandbox lacks the `.#mobile` nix shell (GTK3/gdk-3.0 system libs). The change is a mechanical `key:` addition to non-mobile-gated components, so mobile-specific regressions are not plausible; CI's `cargo clippy (mobile)` job will confirm.
- [ ] `cargo test -p omnibus-db`, `-p omnibus`, `-p omnibus-shared` — skipped as no DB / server / shared code was touched.

## Notes
- No pre-existing warnings on `main` surfaced by the affected crate.
- `metadata_edit/sidebar.rs:48` from the issue's evidence list already had `key: "{ident.scheme:?}-{ident.value}"` on `main`, so it needed no change; the PR closes the remaining nine sites (eight from the body + one flagged in the comment thread).

Closes #635

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMQ1M4kQQA3SmTkRCXFv61)_