### PR TITLE
fix: cap session-report batches on rpc_record_sessions (#609)

### DIFF
--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -34,6 +34,11 @@ use omnibus_shared::{
 #[cfg(feature = "server")]
 use omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN;
 
+// Only `validate_session_batch` (server-gated) and its tests reference this
+// cap; same reason for the `server` gate as `AUTHOR_PHOTO_URL_MAX_LEN` above.
+#[cfg(feature = "server")]
+use omnibus_shared::SESSION_BATCH_CAP;
+
 // `BookSuggestion` is only constructed in the server-side `rpc_get_suggestions`
 // body; gate it so the web/mobile client builds don't flag an unused import.
 #[cfg(feature = "server")]
@@ -756,20 +761,43 @@ pub async fn rpc_get_progress(
     Ok(db::progress::get_progress(&pool.0, user.id, &uuid, format).await?)
 }
 
+/// Reject a batch that exceeds `SESSION_BATCH_CAP` with the same
+/// message shape the REST twin (`server::backend::progress::post_sessions`)
+/// uses. Extracted so it can be exercised directly from unit tests
+/// without spinning up the fullstack server-fn stack.
+///
+/// Only the server-side body of `rpc_record_sessions` calls this, so it
+/// is `server`-gated like `validate_author_photo_url` above — otherwise
+/// it is dead code in the `mobile`/`web` client builds (caught by clippy).
+#[cfg(feature = "server")]
+fn validate_session_batch(reports: &[SessionReport]) -> Result<(), ServerFnError> {
+    if reports.len() > SESSION_BATCH_CAP {
+        return Err(ServerFnError::new(format!(
+            "batch too large: {} records exceeds maximum of {}",
+            reports.len(),
+            SESSION_BATCH_CAP
+        )));
+    }
+    for r in reports {
+        if let Err(msg) = r.validate() {
+            return Err(ServerFnError::new(msg));
+        }
+    }
+    Ok(())
+}
+
 /// Persist a batch of reading- or listening-session reports and return the
 /// inserted count. Validates every report up-front before any insert; the
 /// inserts then run sequentially (not in a single transaction), so a DB
 /// error mid-batch commits the rows that already succeeded and propagates
 /// the error to the caller — the count of committed rows is then lost.
 /// Reports whose `book_uuid` is unknown are silently dropped (counted out)
-/// rather than failing the batch.
+/// rather than failing the batch. Batches larger than `SESSION_BATCH_CAP`
+/// (defined in `omnibus_shared`) are rejected before any DB work — twins
+/// the REST cap in `server::backend::progress::post_sessions`.
 #[post("/api/rpc/progress/sessions", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_record_sessions(reports: Vec<SessionReport>) -> Result<u64> {
-    for r in &reports {
-        if let Err(msg) = r.validate() {
-            return Err(ServerFnError::new(msg).into());
-        }
-    }
+    validate_session_batch(&reports)?;
     let mut inserted = 0u64;
     for r in &reports {
         if db::progress::record_session(&pool.0, user.id, r).await? {
@@ -1184,7 +1212,22 @@ pub async fn rpc_preview_shelf_rule(
 // suite as `cargo test -p omnibus-frontend --features server`.
 #[cfg(all(test, feature = "server"))]
 mod tests {
-    use super::{validate_author_photo_url, AUTHOR_PHOTO_URL_MAX_LEN};
+    use super::{
+        validate_author_photo_url, validate_session_batch, AUTHOR_PHOTO_URL_MAX_LEN,
+        SESSION_BATCH_CAP,
+    };
+    use omnibus_shared::{ProgressFormat, SessionReport};
+
+    fn session_report(book_uuid: &str) -> SessionReport {
+        SessionReport {
+            book_uuid: book_uuid.to_string(),
+            format: ProgressFormat::Epub,
+            started_at: 100,
+            ended_at: 460,
+            progress_units: 360,
+            device_id: None,
+        }
+    }
 
     // `rpc_save_settings`'s validation wiring is covered by the REST
     // boundary test `api_post_settings_returns_422_when_*_path_exceeds_max_len`
@@ -1218,6 +1261,49 @@ mod tests {
         assert!(
             err.to_string().contains("required"),
             "error message should say required: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_session_batch_rejects_batch_larger_than_cap() {
+        // Web-RPC twin of the REST cap enforced in
+        // `server::backend::progress::post_sessions`: an authenticated web
+        // caller must not be able to smuggle an unbounded batch into the
+        // sequential write loop just because the cap check only lived on
+        // the REST path.
+        let reports: Vec<_> = (0..=SESSION_BATCH_CAP)
+            .map(|_| session_report("book-uuid"))
+            .collect();
+        let err = validate_session_batch(&reports).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("batch too large") && msg.contains(&SESSION_BATCH_CAP.to_string()),
+            "error message should name the cap: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_session_batch_accepts_batch_at_cap() {
+        let reports: Vec<_> = (0..SESSION_BATCH_CAP)
+            .map(|_| session_report("book-uuid"))
+            .collect();
+        assert!(validate_session_batch(&reports).is_ok());
+    }
+
+    #[test]
+    fn validate_session_batch_propagates_per_item_validation_error() {
+        // Per-item validation must still fire when the batch is under the
+        // cap — regression guard for the pre-fix branch where the batch
+        // check accidentally replaced the item loop.
+        let mut reports = vec![session_report("book-uuid")];
+        reports.push(SessionReport {
+            book_uuid: String::new(),
+            ..session_report("book-uuid")
+        });
+        let err = validate_session_batch(&reports).unwrap_err();
+        assert!(
+            err.to_string().contains("book_uuid"),
+            "error message should surface the per-item validator: {err}"
         );
     }
 }

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -10,7 +10,7 @@ use axum::{
     Json,
 };
 use omnibus_db::{self as db, progress::ProgressError};
-use omnibus_shared::{ProgressFormat, ProgressUpdate, SessionReport};
+use omnibus_shared::{ProgressFormat, ProgressUpdate, SessionReport, SESSION_BATCH_CAP};
 use serde::Deserialize;
 
 use super::{internal, AppState};
@@ -61,16 +61,15 @@ pub(super) async fn get_progress(
     }
 }
 
-/// Hard cap on `SessionReport`s per `post_sessions` batch.
-pub(super) const MAX_SESSION_BATCH: usize = 500;
-
 /// Append a batch of session reports. Mobile posts these on reconnect; web
 /// posts best-effort on unmount. Each report is validated at the API
 /// boundary (negative durations / inverted time ranges → 400); unknown
 /// book uuids are silently skipped inside the db layer (best-effort
 /// telemetry). `recorded` reflects the **inserted** row count so callers
 /// can tell which queued reports actually persisted. Batches larger than
-/// `MAX_SESSION_BATCH` are rejected with 422 before any DB work.
+/// `SESSION_BATCH_CAP` (defined in `omnibus_shared`) are rejected with
+/// 422 before any DB work; the twin cap on the web RPC path lives in
+/// `frontend::rpc::rpc_record_sessions`.
 ///
 /// The entire batch runs inside a single transaction — a DB error mid-loop
 /// rolls back all previously inserted rows so the client can safely retry
@@ -80,11 +79,11 @@ pub(super) async fn post_sessions(
     State(state): State<AppState>,
     Json(reports): Json<Vec<SessionReport>>,
 ) -> Response {
-    if reports.len() > MAX_SESSION_BATCH {
+    if reports.len() > SESSION_BATCH_CAP {
         let msg = format!(
             "batch too large: {} records exceeds maximum of {}",
             reports.len(),
-            MAX_SESSION_BATCH
+            SESSION_BATCH_CAP
         );
         return (axum::http::StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
     }

--- a/server/src/backend/progress/tests.rs
+++ b/server/src/backend/progress/tests.rs
@@ -3,7 +3,7 @@ use axum::{
     body::{to_bytes, Body},
     http::{header::AUTHORIZATION, Request, StatusCode},
 };
-use omnibus_shared::ProgressRecord;
+use omnibus_shared::{ProgressRecord, SESSION_BATCH_CAP};
 use tower::ServiceExt;
 
 use super::*;
@@ -300,7 +300,7 @@ async fn api_post_sessions_batch_of_two_records_both() {
 
 #[tokio::test]
 async fn post_sessions_rejects_oversized_batch() {
-    // Batches larger than MAX_SESSION_BATCH must be rejected with 422
+    // Batches larger than SESSION_BATCH_CAP must be rejected with 422
     // before any DB work — the global 1 MiB body limit permits thousands
     // of compact reports, so the per-batch cap is the real defense
     // against a client holding the WAL write lock open.
@@ -308,7 +308,7 @@ async fn post_sessions_rejects_oversized_batch() {
     let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
     let user = auth_test_support::create_user(&pool, "alice").await;
     let token = auth_test_support::bearer_token(&pool, user.id).await;
-    let reports: Vec<_> = (0..=MAX_SESSION_BATCH)
+    let reports: Vec<_> = (0..=SESSION_BATCH_CAP)
         .map(|_| {
             serde_json::json!({
                 "book_uuid": uuid,

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -10,6 +10,13 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 mod tests;
 
+/// Hard cap on `SessionReport`s per batch, enforced by both the REST
+/// `POST /api/progress/sessions` handler and the web
+/// `rpc_record_sessions` server function. The batch runs inside a
+/// single write transaction, so bounding it here keeps the SQLite WAL
+/// write lock from being held open by a client-side loop.
+pub const SESSION_BATCH_CAP: usize = 500;
+
 /// Discriminator for the format-specific payload variant in [`ProgressUpdate`]
 /// / [`ProgressRecord`] / [`SessionReport`]. Serializes as a plain
 /// lowercase string (`"epub"` / `"audio"`) so the wire shape stays compact.

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -12,9 +12,14 @@ mod tests;
 
 /// Hard cap on `SessionReport`s per batch, enforced by both the REST
 /// `POST /api/progress/sessions` handler and the web
-/// `rpc_record_sessions` server function. The batch runs inside a
-/// single write transaction, so bounding it here keeps the SQLite WAL
-/// write lock from being held open by a client-side loop.
+/// `rpc_record_sessions` server function. The two paths differ in how
+/// they write: REST commits the whole batch inside one SQLite write
+/// transaction, so an unbounded batch would hold the WAL write lock
+/// for the entire loop; the RPC path calls
+/// `db::progress::record_session` sequentially — one transaction per
+/// report — so an unbounded batch instead lets a client drive an
+/// arbitrary-length write storm. Capping the batch here bounds both
+/// failure modes at the API boundary.
 pub const SESSION_BATCH_CAP: usize = 500;
 
 /// Discriminator for the format-specific payload variant in [`ProgressUpdate`]


### PR DESCRIPTION
## Summary
- Hoist `MAX_SESSION_BATCH` from `server::backend::progress` into `omnibus_shared` as `pub const SESSION_BATCH_CAP: usize = 500` so both the REST twin and the web RPC reference one source of truth.
- Add the same length check to `frontend::rpc::rpc_record_sessions` that `post_sessions` has been enforcing — an authenticated web caller can no longer smuggle an unbounded batch into the sequential write loop and pin the SQLite WAL write lock.
- Extract `validate_session_batch(&[SessionReport]) -> Result<(), ServerFnError>` so the length + per-item checks can be exercised directly from `#[cfg(all(test, feature = "server"))]` tests (mirrors the pre-existing `validate_author_photo_url` pattern — the fullstack server-fn body can't be reached without spinning up the whole stack).

## Files touched
- `shared/src/progress.rs` — add `SESSION_BATCH_CAP` with `///` cap docs.
- `server/src/backend/progress.rs` — replace the local `pub(super) const MAX_SESSION_BATCH` with the shared name; update the `post_sessions` docstring to point at the web twin.
- `server/src/backend/progress/tests.rs` — import the shared name, rename the reference in `post_sessions_rejects_oversized_batch`.
- `frontend/src/rpc.rs` — `server`-gated `use omnibus_shared::SESSION_BATCH_CAP` + `validate_session_batch`; `rpc_record_sessions` now short-circuits via the helper; three new tests in the `mod tests` block (over-cap rejection, at-cap accept, per-item validator still fires under the cap).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default members: server, shared, frontend)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-shared`
- [x] `cargo test -p omnibus-db`
- [x] `cargo test -p omnibus`
- [x] `cargo test -p omnibus-frontend --features server` — three new `validate_session_batch_*` tests pass, existing `post_sessions_rejects_oversized_batch` still green.

## Notes
- Skipped `cargo clippy -p omnibus-mobile` and `cargo clippy --all-features` in this sandbox: mobile needs GTK-3 that isn't available here, and `--all-features` on `omnibus-frontend` combines the mutually incompatible `mobile` + `web` features (pre-existing on `origin/main`, not introduced by this change). Neither is touched by this fix.
- `SESSION_BATCH_CAP` stays a compile-time constant — no `.env.example` change needed, per the acceptance criteria on the issue.

Closes #609


---
_Generated by [Claude Code](https://claude.ai/code/session_01YMQ1M4kQQA3SmTkRCXFv61)_