### PR TITLE
fix: enforce SESSION_BATCH_CAP on rpc_record_sessions to match REST path (#609)

### DIFF
--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -34,6 +34,11 @@ use omnibus_shared::{
 #[cfg(feature = "server")]
 use omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN;
 
+// Only the server-side body of `rpc_record_sessions` (and its test) reference
+// this cap. Gate the import to keep the `web`/`mobile` client builds clean.
+#[cfg(feature = "server")]
+use omnibus_shared::SESSION_BATCH_CAP;
+
 // `BookSuggestion` is only constructed in the server-side `rpc_get_suggestions`
 // body; gate it so the web/mobile client builds don't flag an unused import.
 #[cfg(feature = "server")]
@@ -756,15 +761,38 @@ pub async fn rpc_get_progress(
     Ok(db::progress::get_progress(&pool.0, user.id, &uuid, format).await?)
 }
 
+/// Reject over-cap session batches at the RPC boundary, mirroring the mobile
+/// REST route's 422 rejection in `server::backend::progress::post_sessions`.
+/// Extracted so the length check can be covered by a unit test that doesn't
+/// spin up the fullstack server-function router.
+///
+/// Only the server-side body of `rpc_record_sessions` calls this, so it is
+/// `server`-gated like `validate_author_photo_url` — otherwise it is dead
+/// code in the `mobile`/`web` client builds (caught by clippy).
+#[cfg(feature = "server")]
+fn check_session_batch_cap(reports: &[SessionReport]) -> Result<(), ServerFnError> {
+    if reports.len() > SESSION_BATCH_CAP {
+        return Err(ServerFnError::new(format!(
+            "batch too large: {} records exceeds maximum of {}",
+            reports.len(),
+            SESSION_BATCH_CAP
+        )));
+    }
+    Ok(())
+}
+
 /// Persist a batch of reading- or listening-session reports and return the
-/// inserted count. Validates every report up-front before any insert; the
-/// inserts then run sequentially (not in a single transaction), so a DB
-/// error mid-batch commits the rows that already succeeded and propagates
-/// the error to the caller — the count of committed rows is then lost.
-/// Reports whose `book_uuid` is unknown are silently dropped (counted out)
-/// rather than failing the batch.
+/// inserted count. Batches larger than `SESSION_BATCH_CAP` are rejected up
+/// front (mirroring the mobile REST route in `server::backend::progress`).
+/// Validates every report before any insert; the inserts then run
+/// sequentially (not in a single transaction), so a DB error mid-batch
+/// commits the rows that already succeeded and propagates the error to the
+/// caller — the count of committed rows is then lost. Reports whose
+/// `book_uuid` is unknown are silently dropped (counted out) rather than
+/// failing the batch.
 #[post("/api/rpc/progress/sessions", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_record_sessions(reports: Vec<SessionReport>) -> Result<u64> {
+    check_session_batch_cap(&reports)?;
     for r in &reports {
         if let Err(msg) = r.validate() {
             return Err(ServerFnError::new(msg).into());
@@ -1184,7 +1212,22 @@ pub async fn rpc_preview_shelf_rule(
 // suite as `cargo test -p omnibus-frontend --features server`.
 #[cfg(all(test, feature = "server"))]
 mod tests {
-    use super::{validate_author_photo_url, AUTHOR_PHOTO_URL_MAX_LEN};
+    use super::{
+        check_session_batch_cap, validate_author_photo_url, AUTHOR_PHOTO_URL_MAX_LEN,
+        SESSION_BATCH_CAP,
+    };
+    use omnibus_shared::{ProgressFormat, SessionReport};
+
+    fn dummy_report() -> SessionReport {
+        SessionReport {
+            book_uuid: "uuid".into(),
+            format: ProgressFormat::Epub,
+            started_at: 0,
+            ended_at: 1,
+            progress_units: 1,
+            device_id: None,
+        }
+    }
 
     // `rpc_save_settings`'s validation wiring is covered by the REST
     // boundary test `api_post_settings_returns_422_when_*_path_exceeds_max_len`
@@ -1218,6 +1261,32 @@ mod tests {
         assert!(
             err.to_string().contains("required"),
             "error message should say required: {err}"
+        );
+    }
+
+    #[test]
+    fn check_session_batch_cap_accepts_batch_at_cap() {
+        // Boundary: exactly at the cap must be accepted so a client packing
+        // batches to the documented maximum isn't rejected off-by-one.
+        let reports = vec![dummy_report(); SESSION_BATCH_CAP];
+        assert!(check_session_batch_cap(&reports).is_ok());
+    }
+
+    #[test]
+    fn check_session_batch_cap_rejects_batch_over_cap() {
+        // Mirrors the mobile REST path's 422 rejection in
+        // `server::backend::progress::post_sessions` — the web RPC path
+        // must not permit an unbounded per-record write loop.
+        let reports = vec![dummy_report(); SESSION_BATCH_CAP + 1];
+        let err = check_session_batch_cap(&reports).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&SESSION_BATCH_CAP.to_string()),
+            "error message should name the cap: {msg}"
+        );
+        assert!(
+            msg.contains(&(SESSION_BATCH_CAP + 1).to_string()),
+            "error message should name the batch length: {msg}"
         );
     }
 }

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -10,7 +10,7 @@ use axum::{
     Json,
 };
 use omnibus_db::{self as db, progress::ProgressError};
-use omnibus_shared::{ProgressFormat, ProgressUpdate, SessionReport};
+use omnibus_shared::{ProgressFormat, ProgressUpdate, SessionReport, SESSION_BATCH_CAP};
 use serde::Deserialize;
 
 use super::{internal, AppState};
@@ -61,16 +61,15 @@ pub(super) async fn get_progress(
     }
 }
 
-/// Hard cap on `SessionReport`s per `post_sessions` batch.
-pub(super) const MAX_SESSION_BATCH: usize = 500;
-
 /// Append a batch of session reports. Mobile posts these on reconnect; web
 /// posts best-effort on unmount. Each report is validated at the API
 /// boundary (negative durations / inverted time ranges → 400); unknown
 /// book uuids are silently skipped inside the db layer (best-effort
 /// telemetry). `recorded` reflects the **inserted** row count so callers
 /// can tell which queued reports actually persisted. Batches larger than
-/// `MAX_SESSION_BATCH` are rejected with 422 before any DB work.
+/// `SESSION_BATCH_CAP` (defined in `omnibus_shared` so the web RPC path
+/// in `omnibus_frontend::rpc::rpc_record_sessions` enforces the same
+/// bound) are rejected with 422 before any DB work.
 ///
 /// The entire batch runs inside a single transaction — a DB error mid-loop
 /// rolls back all previously inserted rows so the client can safely retry
@@ -80,11 +79,11 @@ pub(super) async fn post_sessions(
     State(state): State<AppState>,
     Json(reports): Json<Vec<SessionReport>>,
 ) -> Response {
-    if reports.len() > MAX_SESSION_BATCH {
+    if reports.len() > SESSION_BATCH_CAP {
         let msg = format!(
             "batch too large: {} records exceeds maximum of {}",
             reports.len(),
-            MAX_SESSION_BATCH
+            SESSION_BATCH_CAP
         );
         return (axum::http::StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
     }

--- a/server/src/backend/progress/tests.rs
+++ b/server/src/backend/progress/tests.rs
@@ -300,7 +300,7 @@ async fn api_post_sessions_batch_of_two_records_both() {
 
 #[tokio::test]
 async fn post_sessions_rejects_oversized_batch() {
-    // Batches larger than MAX_SESSION_BATCH must be rejected with 422
+    // Batches larger than SESSION_BATCH_CAP must be rejected with 422
     // before any DB work — the global 1 MiB body limit permits thousands
     // of compact reports, so the per-batch cap is the real defense
     // against a client holding the WAL write lock open.
@@ -308,7 +308,7 @@ async fn post_sessions_rejects_oversized_batch() {
     let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
     let user = auth_test_support::create_user(&pool, "alice").await;
     let token = auth_test_support::bearer_token(&pool, user.id).await;
-    let reports: Vec<_> = (0..=MAX_SESSION_BATCH)
+    let reports: Vec<_> = (0..=SESSION_BATCH_CAP)
         .map(|_| {
             serde_json::json!({
                 "book_uuid": uuid,

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -10,6 +10,15 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 mod tests;
 
+/// Maximum number of `SessionReport`s accepted per session-batch upload.
+///
+/// Enforced at both API boundaries — the mobile REST route
+/// `POST /api/progress/sessions` and the web RPC `rpc_record_sessions` —
+/// so no authenticated client can drive an unbounded per-record write
+/// loop under a single transaction and hold the SQLite write lock longer
+/// than intended. Not runtime-configurable; change here to move the cap.
+pub const SESSION_BATCH_CAP: usize = 500;
+
 /// Discriminator for the format-specific payload variant in [`ProgressUpdate`]
 /// / [`ProgressRecord`] / [`SessionReport`]. Serializes as a plain
 /// lowercase string (`"epub"` / `"audio"`) so the wire shape stays compact.

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -14,9 +14,8 @@ mod tests;
 ///
 /// Enforced at both API boundaries — the mobile REST route
 /// `POST /api/progress/sessions` and the web RPC `rpc_record_sessions` —
-/// so no authenticated client can drive an unbounded per-record write
-/// loop under a single transaction and hold the SQLite write lock longer
-/// than intended. Not runtime-configurable; change here to move the cap.
+/// to bound per-request DB work and SQLite write-lock hold time. Not
+/// runtime-configurable; change here to move the cap.
 pub const SESSION_BATCH_CAP: usize = 500;
 
 /// Discriminator for the format-specific payload variant in [`ProgressUpdate`]


### PR DESCRIPTION
## Summary
- Hoist the session-batch cap out of `server::backend::progress` into `omnibus_shared::SESSION_BATCH_CAP` (500) with a `///` doc explaining the invariant, so both the mobile REST route and the web RPC reference one value with no `frontend`→`server` import.
- Add a `check_session_batch_cap` helper in `frontend::rpc` (server-gated, like `validate_author_photo_url`) and call it at the top of `rpc_record_sessions` — mirrors the REST path's rejection, returning a `ServerFnError` carrying both the observed length and the cap so the web client sees the same message the mobile client gets in the 422 body.
- Update the existing REST test and doc comment to reference the new constant name; add two unit tests for the helper (boundary at cap accepts, over-cap rejects and names both numbers in the error).

## Test plan
- [x] `cargo test -p omnibus-shared` — 80 pass
- [x] `cargo test -p omnibus progress::` — 11 pass (includes the renamed `post_sessions_rejects_oversized_batch`)
- [x] `cargo test -p omnibus-frontend --features server tests::` — 191 pass (includes the two new `check_session_batch_cap_*` cases)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p omnibus-shared -p omnibus -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets -- -D warnings` — clean (import stays gated so `web` build has no unused-import warning)
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — clean

## Notes
- I chose to keep the extracted helper `server`-gated (matching the neighbouring `validate_author_photo_url`) rather than making it `pub(crate)` on all targets — the check is only reachable through the server-side body, and the existing frontend tests file only runs under `--features server`.
- The disk on this worktree ran out of space partway through the first frontend test run; I cleared `target/debug/incremental` in this worktree only (other agents' worktrees left untouched) and everything compiled cleanly afterwards.

Closes #609

---
_Generated by [Claude Code](https://claude.ai/code/session_011jT4GRngsgD6b1zhkZztTN)_