### PR TITLE
fix: unconditional rsx for journal composer/edit (#660)

### DIFF
--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -4,8 +4,9 @@
 //! composer with a live-formatting markdown editor (see `journal_editor.js`),
 //! and owner-only edit/delete. Entries and the current user load post-mount so
 //! SSR and the first hydration paint match (rule 07). Markdown bodies are
-//! rendered + sanitized server-side; the click-to-reveal spoiler handler is
-//! wired by a post-mount effect, never in the rsx body.
+//! rendered + sanitized server-side; the click-to-reveal spoiler handler and
+//! the live-editor progressive enhancement are both wired by post-mount
+//! effects (`editor_enhance`), never in the rsx body.
 
 use dioxus::prelude::*;
 use omnibus_shared::{
@@ -263,54 +264,28 @@ fn BdJournalComposer(uuid: String, server_url: String, reload: Signal<u32>) -> E
                     dangerous_inner_html: "{preview_html}",
                 }
             } else {
-                {
-                    // Web: a live-formatting contenteditable whose markdown is
-                    // mirrored into the hidden textarea (which keeps the `body`
-                    // signal — and therefore publish/validate/preview —
-                    // unchanged). Non-web (SSR page tests / native mobile) has
-                    // no eval, so it falls back to the plain textarea.
-                    #[cfg(feature = "web")]
-                    {
-                        rsx! {
-                            textarea {
-                                id: "journal-composer-mirror",
-                                class: "bd-journal-mirror",
-                                "data-testid": "journal-body",
-                                "aria-hidden": "true",
-                                tabindex: "-1",
-                                value: "{body}",
-                                oninput: move |e| body.set(e.value()),
-                            }
-                            div {
-                                id: "journal-composer-editor",
-                                class: "me-textarea bd-journal-editor",
-                                "data-testid": "journal-editor",
-                                contenteditable: "true",
-                                role: "textbox",
-                                "aria-multiline": "true",
-                                "aria-label": "Journal entry",
-                                "data-placeholder": "What are you thinking about this book? Markdown supported.",
-                                onmounted: move |_| editor_attach(
-                                    "journal-composer-editor",
-                                    "journal-composer-mirror",
-                                ),
-                            }
-                        }
-                    }
-                    #[cfg(not(feature = "web"))]
-                    {
-                        rsx! {
-                            textarea {
-                                id: "journal-composer-body",
-                                class: "me-textarea bd-journal-textarea",
-                                "data-testid": "journal-body",
-                                rows: "5",
-                                placeholder: "What are you thinking about this book? Markdown supported.",
-                                value: "{body}",
-                                oninput: move |e| body.set(e.value()),
-                            }
-                        }
-                    }
+                // One rsx body on every target (rule 07): the plain textarea
+                // is what SSR emits AND what WASM's first hydration paint
+                // renders. On web the `onmounted` handler progressively
+                // enhances it into a live-formatting contenteditable overlay
+                // (see `editor_enhance`); on non-web the enhance dispatch is a
+                // no-op, so mobile keeps the plain textarea.
+                textarea {
+                    id: "journal-composer-body",
+                    class: "me-textarea bd-journal-textarea",
+                    "data-testid": "journal-body",
+                    rows: "5",
+                    placeholder: "What are you thinking about this book? Markdown supported.",
+                    "aria-label": "Journal entry",
+                    value: "{body}",
+                    oninput: move |e| body.set(e.value()),
+                    onmounted: move |_| editor_enhance(
+                        "journal-composer-editor",
+                        "journal-composer-body",
+                        "journal-editor",
+                        "Journal entry",
+                        "What are you thinking about this book? Markdown supported.",
+                    ),
                 }
             }
             div { class: "bd-journal-composer-foot",
@@ -482,50 +457,24 @@ fn BdJournalEntryCard(
                 div { class: "bd-journal-toolbar-row",
                     BdJournalToolbar { target_id: format!("journal-edit-editor-{entry_id}") }
                 }
-                {
-                    // Same live-editor-on-web / textarea-on-non-web split as the
-                    // composer, keyed per entry id so multiple open editors
-                    // don't collide.
-                    #[cfg(feature = "web")]
-                    {
-                        rsx! {
-                            textarea {
-                                id: "journal-edit-mirror-{entry_id}",
-                                class: "bd-journal-mirror",
-                                "data-testid": "journal-edit-body",
-                                "aria-hidden": "true",
-                                tabindex: "-1",
-                                value: "{edit_body}",
-                                oninput: move |e| edit_body.set(e.value()),
-                            }
-                            div {
-                                id: "journal-edit-editor-{entry_id}",
-                                class: "me-textarea bd-journal-editor",
-                                "data-testid": "journal-edit-editor",
-                                contenteditable: "true",
-                                role: "textbox",
-                                "aria-multiline": "true",
-                                "aria-label": "Edit journal entry",
-                                onmounted: move |_| editor_attach(
-                                    &format!("journal-edit-editor-{entry_id}"),
-                                    &format!("journal-edit-mirror-{entry_id}"),
-                                ),
-                            }
-                        }
-                    }
-                    #[cfg(not(feature = "web"))]
-                    {
-                        rsx! {
-                            textarea {
-                                id: "journal-edit-body-{entry_id}",
-                                class: "me-textarea bd-journal-textarea",
-                                "data-testid": "journal-edit-body",
-                                rows: "5",
-                                value: "{edit_body}",
-                                oninput: move |e| edit_body.set(e.value()),
-                            }
-                        }
-                    }
+                // One rsx body on every target (rule 07); web progressively
+                // enhances into the live editor via `onmounted`. Ids are keyed
+                // per entry so multiple open editors don't collide.
+                textarea {
+                    id: "journal-edit-body-{entry_id}",
+                    class: "me-textarea bd-journal-textarea",
+                    "data-testid": "journal-edit-body",
+                    rows: "5",
+                    "aria-label": "Edit journal entry",
+                    value: "{edit_body}",
+                    oninput: move |e| edit_body.set(e.value()),
+                    onmounted: move |_| editor_enhance(
+                        &format!("journal-edit-editor-{entry_id}"),
+                        &format!("journal-edit-body-{entry_id}"),
+                        "journal-edit-editor",
+                        "Edit journal entry",
+                        "",
+                    ),
                 }
                 div { class: "bd-journal-entry-foot",
                     if let Some(msg) = error() {

--- a/frontend/src/pages/book_detail/journal_editor.js
+++ b/frontend/src/pages/book_detail/journal_editor.js
@@ -11,7 +11,10 @@
 // `body` signal they always did — this is purely an editing-surface upgrade.
 //
 // Loaded once (idempotent guard) and driven from Dioxus via the eval channel:
-// the trailing `await dioxus.recv()` block dispatches attach / command / insert.
+// the trailing `await dioxus.recv()` block dispatches enhance / command / insert.
+// `enhance` is the web progressive-enhancement entry point — rsx renders a plain
+// textarea on every target so SSR and the first hydration paint match (rule 07),
+// and this JS creates the contenteditable overlay after mount.
 
 if (!window.OmnibusJournalEditor) {
   window.OmnibusJournalEditor = (function () {
@@ -208,7 +211,36 @@ if (!window.OmnibusJournalEditor) {
 
     const insert = (editorId, text) => command(editorId, "insert", text, "");
 
-    return { attach, command, insert };
+    // Progressive-enhancement: called from the plain textarea's `onmounted` on
+    // every mount. On web, this drops a sibling contenteditable overlay next
+    // to the mirror textarea and hands off to `attach`. Any stale editor div
+    // left over from a previous mount (e.g. show_preview toggled the textarea
+    // out and back in) is removed first, so we always end up with a fresh
+    // overlay wired to the current mirror.
+    function enhance(mirrorId, editorId, editorTestId, ariaLabel, placeholder) {
+      const mirror = byId(mirrorId);
+      if (!mirror) return;
+      const stale = byId(editorId);
+      if (stale) stale.remove();
+      const editor = document.createElement("div");
+      editor.id = editorId;
+      editor.className = "me-textarea bd-journal-editor";
+      if (editorTestId) editor.setAttribute("data-testid", editorTestId);
+      editor.setAttribute("contenteditable", "true");
+      editor.setAttribute("role", "textbox");
+      editor.setAttribute("aria-multiline", "true");
+      if (ariaLabel) editor.setAttribute("aria-label", ariaLabel);
+      if (placeholder) editor.setAttribute("data-placeholder", placeholder);
+      mirror.parentNode.insertBefore(editor, mirror);
+      // Inline style, not a class swap — keeps Dioxus's class attribute
+      // reconciliation from ever un-hiding the mirror on re-render.
+      mirror.style.display = "none";
+      mirror.setAttribute("aria-hidden", "true");
+      mirror.setAttribute("tabindex", "-1");
+      attach(editorId, mirrorId);
+    }
+
+    return { attach, command, insert, enhance };
   })();
 }
 
@@ -216,7 +248,11 @@ if (!window.OmnibusJournalEditor) {
 const __omn = await dioxus.recv();
 const __E = window.OmnibusJournalEditor;
 if (__E && __omn) {
-  if (__omn.action === "attach") __E.attach(__omn.editorId, __omn.mirrorId);
-  else if (__omn.action === "command") __E.command(__omn.editorId, __omn.op, __omn.a, __omn.b);
-  else if (__omn.action === "insert") __E.insert(__omn.editorId, __omn.text);
+  if (__omn.action === "enhance") {
+    __E.enhance(__omn.mirrorId, __omn.editorId, __omn.op, __omn.a, __omn.b);
+  } else if (__omn.action === "command") {
+    __E.command(__omn.editorId, __omn.op, __omn.a, __omn.b);
+  } else if (__omn.action === "insert") {
+    __E.insert(__omn.editorId, __omn.text);
+  }
 }

--- a/frontend/src/pages/book_detail/journal_editor.rs
+++ b/frontend/src/pages/book_detail/journal_editor.rs
@@ -2,10 +2,11 @@
 //!
 //! Bridges the Dioxus components to the hand-rolled `contenteditable` editor in
 //! the co-located `journal_editor.js`: it ships the JS module over the eval
-//! channel, exposes `attach` / `command` / `insert` actions, renders the
+//! channel, exposes `enhance` / `command` / `insert` actions, renders the
 //! formatting toolbar, and builds the insert-from-highlights blockquote. The
-//! editor itself is web-only — non-web targets fall back to a plain textarea, so
-//! the eval helpers are no-ops there.
+//! rsx renders a plain textarea on every target (so SSR and the first WASM
+//! paint match, per rule 07); web progressively enhances it into a
+//! contenteditable overlay from a post-mount `editor_enhance` call.
 
 use dioxus::prelude::*;
 
@@ -18,9 +19,9 @@ const JOURNAL_EDITOR_JS: &str = include_str!("journal_editor.js");
 
 /// Send one action to the live editor over the eval channel. Web-only — the
 /// eval (and `serde_json`) are unavailable on SSR/native, so this is a no-op
-/// there. The contenteditable surface itself is also web-gated (see the write
-/// surface), so non-web targets fall back to a plain textarea and never reach
-/// the JS.
+/// there. The rsx renders a plain textarea on every target; non-web keeps that
+/// textarea (the enhance dispatch here is a no-op), so mobile / SSR never
+/// materialize the contenteditable overlay.
 #[cfg(feature = "web")]
 fn editor_dispatch(action: &str, editor_id: &str, mirror_id: &str, op: &str, a: &str, b: &str) {
     let eval = dioxus::document::eval(JOURNAL_EDITOR_JS);
@@ -41,12 +42,34 @@ fn editor_dispatch(
 ) {
 }
 
-/// Attach the live editor to the contenteditable `editor_id`, mirroring its
-/// markdown into the hidden textarea `mirror_id`. Web-only: it's called from the
-/// contenteditable's `onmounted`, which only exists on the web write surface.
-#[cfg(feature = "web")]
-pub(crate) fn editor_attach(editor_id: &str, mirror_id: &str) {
-    editor_dispatch("attach", editor_id, mirror_id, "", "", "");
+/// Progressively enhance a plain `<textarea id=mirror_id>` (rendered by rsx on
+/// every target) into a live-editor pair: JS creates the `<div id=editor_id
+/// contenteditable>` overlay, hides the textarea, and wires the pair together.
+/// Called from the textarea's `onmounted` on every target — a no-op on non-web
+/// where the eval channel is stubbed, so mobile falls back to the plain
+/// textarea automatically.
+///
+/// `editor_testid` becomes the overlay div's `data-testid` (Playwright targets
+/// it). `aria_label` / `placeholder` are copied onto the overlay so
+/// accessibility and empty-state hints match the composer/edit contexts.
+pub(crate) fn editor_enhance(
+    editor_id: &str,
+    mirror_id: &str,
+    editor_testid: &str,
+    aria_label: &str,
+    placeholder: &str,
+) {
+    // op/a/b slots on the shared dispatch payload carry the enhance-specific
+    // extras (testid / aria-label / placeholder) so the JS action can build the
+    // overlay without a bespoke channel.
+    editor_dispatch(
+        "enhance",
+        editor_id,
+        mirror_id,
+        editor_testid,
+        aria_label,
+        placeholder,
+    );
 }
 
 /// Run a toolbar formatting command (`wrap` / `prefix` / `link`) on the live


### PR DESCRIPTION
## Summary
- `BdJournalComposer` and `BdJournalEntryCard` in `frontend/src/pages/book_detail/journal.rs` gated two structurally different rsx subtrees on `#[cfg(feature = "web")]` — the classic hydration-mismatch anti-pattern rule 07 (`.claude/rules/07-hydration.md`) explicitly forbids. Under `--features server` the composer rendered a single ``; under `--features web` it rendered a `mirror` + `contenteditable` pair with different ids and testids, so SSR and the first WASM paint disagreed and Dioxus mis-adopted nodes by position.
- Both components now render one unconditional rsx body on every target — the plain-textarea shape (ids `journal-composer-body` / `journal-edit-body-{entry_id}`, testids `journal-body` / `journal-edit-body`) — and progressively enhance on web via a post-mount `editor_enhance` call. The JS side gains a small `enhance` action (in `frontend/src/pages/book_detail/journal_editor.js`) that creates the sibling `contenteditable` overlay with the appropriate `data-testid`/`aria-label`/`data-placeholder`, hides the textarea via inline style (so Dioxus's class attribute reconciliation never un-hides it), and hands off to the existing `attach`. `editor_enhance` is a no-op dispatch on non-web, so mobile / SSR keep the plain textarea automatically.
- The Playwright contract is preserved end-to-end: `data-testid=journal-body` still lives on the (now-mirrored) textarea, and `data-testid=journal-editor` / `journal-edit-editor` still identify the contenteditable overlay after enhancement. `ui_tests/playwright/tests/flows/journal.spec.ts` needs no changes.

## Test plan
- [ ] `just lint` and `just test` in a proper dev shell (blocked here — see Notes).
- [ ] Load `/books/{uuid}` via `ui-validate`; open the composer, confirm `mcp__Claude_Preview__preview_console_logs` shows no Dioxus hydration errors and the SSR curl + hydrated snapshot agree at the composer's root-level structure.
- [ ] Exercise `ui_tests/playwright/tests/flows/journal.spec.ts` (layout, toolbar wrap, insert-from-highlights, publish/edit/delete, preview + spoiler, publish-500 error) — the testids and network contracts are unchanged.

## Notes
- **Toolchain blocked in this sandbox.** `cargo check -p omnibus-frontend --features server` cannot resolve the `dioxus` git dependency because the agent-proxy egress policy denies HTTPS to `github.com/DioxusLabs/dioxus` (`GET /git/DioxusLabs/dioxus/info/refs` returns 403 through the proxy, and `~/.cargo/git/db/dioxus-…` has no packed objects). `just lint`/`just test`/`cargo clippy` therefore did not run locally — please rely on CI. `node --check journal_editor.js` passes.
- **Progressive-enhancement idempotence.** The new `enhance` action always removes any stale editor overlay before re-inserting one, so the `show_preview` write→preview→write round-trip (which unmounts and re-mounts the textarea while leaving the JS-inserted editor as an orphan sibling) ends up with the fresh mirror + fresh overlay wired together, seeded from the current `body` signal via the existing `attach` seed logic. `attach` itself remains idempotent via its `data-omnibus-live` attribute guard.
- **Removed dead code.** `editor_attach` in `frontend/src/pages/book_detail/journal_editor.rs` had no remaining callers after the rsx split was collapsed and has been deleted; the JS `attach` is still used internally by `enhance`.
- **Docstring refresh.** Updated the module `//!` on `journal.rs` and `journal_editor.rs`, plus the `editor_dispatch` rustdoc, to reflect that the plain textarea is the unconditional SSR shape and enhancement is a post-mount concern — keeping rule 98 (skill/citation freshness) satisfied for the files this PR touches.

Closes #660

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review

Verdict: **approved**. The fix cleanly resolves #660 by eliminating both `#[cfg(feature = "web")]` rsx forks in `journal.rs` and shifting the live-editor split to a post-mount JS-side progressive enhancement, exactly matching the reference patterns cited in rule 07 (`frontend/src/view_prefs.rs` cfg'ing the impl, `book_detail/mod.rs:28-30` reconciling in an effect).

- **Rule 07 invariant met.** `grep 'cfg(feature = "web")\|cfg(not(feature = "web"))' frontend/src/pages/book_detail/journal.rs` returns a single hit — the pre-existing spoiler `use_effect` body at line 55, which correctly gates the eval (not the rsx). Both `BdJournalComposer` and `BdJournalEntryCard` now emit one unconditional `<textarea>` shape.
- **Testid contract preserved.** `journal-body` and `journal-edit-body` remain on the SSR-rendered textareas; `journal-editor` and `journal-edit-editor` are set on the JS-inserted overlay via `editor.setAttribute("data-testid", editorTestId)` — so `ui_tests/playwright/tests/flows/journal.spec.ts` needs no changes (confirmed unchanged in this diff).
- **Hook order stable.** `use_effect` calls and both `onmounted` handlers are declared unconditionally in the rsx across all targets; no hook count divergence between SSR and WASM.
- **Payload wiring correct.** Rust `editor_dispatch("enhance", editor_id, mirror_id, editor_testid, aria_label, placeholder)` → JS `enhance(__omn.mirrorId, __omn.editorId, __omn.op, __omn.a, __omn.b)` → `enhance(mirrorId, editorId, editorTestId, ariaLabel, placeholder)` — the argument order threads through consistently on both the composer (`"journal-editor"`, `"Journal entry"`, placeholder) and edit-card (`"journal-edit-editor"`, `"Edit journal entry"`, `""`) call sites.
- **Idempotency verified.** `enhance` looks up any prior `<div id=editorId>` and calls `.remove()` before inserting the fresh overlay, then `attach`'s `data-omnibus-live` guard prevents duplicate event wiring — so the write→preview→write toggle ends with exactly one overlay wired to the current mirror. Hiding the mirror via inline `style.display = "none"` (not a class swap) is a deliberate choice to survive Dioxus's class-attribute reconciliation on re-render, and the rationale is documented in-file.
- **Scope discipline.** Diff is exactly the three files named in the PR body; no migrations, no drive-by refactors, `editor_attach` cleanly deleted along with its sole caller. Conventional-commit title, correct branch, `Closes #660` present. `node --check journal_editor.js` passes.

Runtime SSR/hydration verification (curl parity + `preview_console_logs` clean) and the `cargo test`/`just lint` matrix are deferred to CI + reviewer per the PR's own Notes — the dioxus git-dep 403 through the agent proxy is a sandbox limitation, not a review failure.