### PR TITLE
perf(db): add book_uuid-first indexes on five user-data tables

### DIFF
--- a/db/migrations/0036_idx_user_data_book_uuid.sql
+++ b/db/migrations/0036_idx_user_data_book_uuid.sql
@@ -1,0 +1,16 @@
+-- Book-uuid-first indexes for the five older user-data tables.
+--
+-- `gc_books_missing_files` (db/src/missing_files.rs) probes each of these
+-- tables with `NOT EXISTS (SELECT 1 FROM <t> WHERE book_uuid = b.uuid)`
+-- on every reindex cycle. Their existing `(user_id, book_uuid)` indexes
+-- can't serve the probe — SQLite skips a multi-column index when the
+-- leading column (`user_id`) isn't in the predicate — so each subquery
+-- degrades to a full-table scan. `merge/transaction.rs::move_progress_and_history`
+-- runs `UPDATE`/`DELETE ... WHERE book_uuid = ?` on the same tables and
+-- pays the same cost. `user_ratings` already ships this fix (0031); the
+-- five older siblings never got it.
+CREATE INDEX IF NOT EXISTS idx_reading_progress_book_uuid   ON reading_progress(book_uuid);
+CREATE INDEX IF NOT EXISTS idx_bookmarks_book_uuid          ON bookmarks(book_uuid);
+CREATE INDEX IF NOT EXISTS idx_reading_sessions_book_uuid   ON reading_sessions(book_uuid);
+CREATE INDEX IF NOT EXISTS idx_listening_sessions_book_uuid ON listening_sessions(book_uuid);
+CREATE INDEX IF NOT EXISTS idx_highlights_book_uuid         ON highlights(book_uuid);

--- a/db/src/missing_files/tests.rs
+++ b/db/src/missing_files/tests.rs
@@ -653,3 +653,39 @@ async fn gc_purges_orphan_author_when_its_last_book_is_deleted() {
         .unwrap();
     assert_eq!(after, 0, "the purged book's now-bookless author is GC'd");
 }
+
+/// The GC's five `NOT EXISTS ... WHERE book_uuid = b.uuid` subqueries need a
+/// `book_uuid`-first index on each table — the pre-existing
+/// `(user_id, book_uuid)` composites can't serve the probe because SQLite
+/// skips a multi-column index when the leading column isn't in the predicate.
+/// Assert every table's plan uses its `idx_<table>_book_uuid` covering index
+/// (a `SEARCH` — a `SCAN` would mean the migration was lost or the index name
+/// drifted). Same shape as the GC's per-table subquery.
+#[tokio::test]
+async fn user_data_book_uuid_probes_use_the_book_uuid_first_index() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let cases = [
+        ("reading_progress", "idx_reading_progress_book_uuid"),
+        ("bookmarks", "idx_bookmarks_book_uuid"),
+        ("reading_sessions", "idx_reading_sessions_book_uuid"),
+        ("listening_sessions", "idx_listening_sessions_book_uuid"),
+        ("highlights", "idx_highlights_book_uuid"),
+    ];
+    for (table, index) in cases {
+        let sql = format!("EXPLAIN QUERY PLAN SELECT 1 FROM {table} WHERE book_uuid = ?");
+        let plan: Vec<(i64, i64, i64, String)> = sqlx::query_as(&sql)
+            .bind("any-uuid")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        let text = plan
+            .iter()
+            .map(|(_, _, _, s)| s.as_str())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            text.contains(&format!("SEARCH {table}")) && text.contains(index),
+            "expected {table} probe to SEARCH via {index}, got: {text}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `gc_books_missing_files` (`db/src/missing_files.rs`) runs five `NOT EXISTS (SELECT 1 FROM  WHERE book_uuid = b.uuid)` subqueries on every reindex cycle. All five tables (`reading_progress`, `bookmarks`, `reading_sessions`, `listening_sessions`, `highlights`) carry a `(user_id, book_uuid)` composite from migration 0013/0027 — but SQLite can&#39;t use a multi-column index when the leading column (`user_id`) is absent from the predicate, so each subquery degrades to a full-table scan. `merge/transaction.rs::move_progress_and_history` runs `UPDATE`/`DELETE ... WHERE book_uuid = ?` on the same five tables and pays the same cost. `user_ratings` already shipped this fix (migration 0031 → `idx_user_ratings_book`); the five older siblings never got it.
- Adds migration `0036_idx_user_data_book_uuid.sql` with `CREATE INDEX IF NOT EXISTS idx_<table>_book_uuid ON <table>(book_uuid)` on each of the five tables. No prod-code changes — SQLite&#39;s planner picks up the new indexes on the next reindex tick.
- Adds `user_data_book_uuid_probes_use_the_book_uuid_first_index` in `db/src/missing_files/tests.rs` — runs `EXPLAIN QUERY PLAN` for each `NOT EXISTS ... WHERE book_uuid = ?` shape and asserts every plan is a `SEARCH ... USING COVERING INDEX idx_<table>_book_uuid` (a `SCAN` would mean the migration was lost or an index name drifted).

## Test plan
- [ ] `just test` — the new plan-shape assertion runs under `cargo test -p omnibus-db missing_files::` against `sqlite::memory:` (all existing migrations + 0036).
- [ ] Confirmed locally by replaying every migration under `db/migrations/*.sql` through Python&#39;s `sqlite3` (SQLite 3.45.1): before 0036, all five probes were `SCAN <table> USING COVERING INDEX `; after 0036, all five flip to `SEARCH <table> USING COVERING INDEX idx_<table>_book_uuid (book_uuid=?)`.

## Notes
- **Migration number.** Origin `main` is at `0034_shelves.sql`. Open PR #670 already claims `0035_idx_merged_uuids.sql`, so this PR uses `0036` to avoid a checksum-mismatch collision on merge. If #670 lands after this one, its 0035 slots in before ours cleanly; if it lands first, no gap. Per rule 06 no already-applied migration is edited.
- **CI validates the compile.** The sandbox&#39;s HTTPS proxy returns 403 on `github.com/DioxusLabs/dioxus`, so `cargo` couldn&#39;t resolve the workspace here — `cargo fmt --all -- --check` passed, `cargo clippy` / `cargo test` were skipped locally. CI is the source of truth.
- **No changes to `gc_books_missing_files` or `move_progress_and_history` themselves** — the fix is purely additional indexes.

Closes #630

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review

Verdict: **approved**.

- **Resolves #630.** All five tables named in the issue (`reading_progress`, `bookmarks`, `reading_sessions`, `listening_sessions`, `highlights`) receive a `book_uuid`-first `CREATE INDEX IF NOT EXISTS`. Matches the issue's suggested SQL verbatim.
- **Migration hygiene (rule 06).** Diff is `db/migrations/0036_idx_user_data_book_uuid.sql` (new) + `db/src/missing_files/tests.rs` (append only). No previously-applied migration file was touched. `0036` slots in after `0034_shelves.sql` on main; `0035` is reserved for PR #670 as noted.
- **EXPLAIN QUERY PLAN reproduced.** Replayed every migration from `origin/main` through Python `sqlite3`, then applied 0036 from the branch:
  - Before 0036 — all five probes: `SCAN <table> USING COVERING INDEX <existing composite>` (full-scan because the composite's leading column `user_id` isn't in the predicate).
  - After 0036 — all five probes: `SEARCH <table> USING COVERING INDEX idx_<table>_book_uuid (book_uuid=?)` — exactly what the new test asserts.
- **Test placement & style (rule 03).** Appended to the existing sibling `db/src/missing_files/tests.rs` (declared by `#[cfg(test)] mod tests;` in `missing_files.rs`). Uses `init_db("sqlite::memory:")`. Name `user_data_book_uuid_probes_use_the_book_uuid_first_index` is sentence-style per convention. No duplicate `tests` module was created.
- **Scope.** No prod-code changes; DDL + a plan-shape test. No scope creep.
- **PR hygiene.** Conventional-commit title `perf(db): …` (appropriate for indexing); branch `refactor/630-user-data-book-uuid-indexes`; `Closes #630`; assignee `seamus-sloan`.
- **Naming nit (non-blocking).** The pre-existing `user_ratings` index in migration 0031 is `idx_user_ratings_book` (no `_uuid` suffix). The PR uses the more explicit `idx_<table>_book_uuid` — which is what the issue's suggested SQL prescribed, so the drift is deliberate and matches the acceptance criteria. Worth mentioning only for future consistency reads.
