### PR TITLE
fix: batch New/Removed ebook sync buckets to match Changed (#631)

### DIFF
--- a/db/src/sync/books/changed.rs
+++ b/db/src/sync/books/changed.rs
@@ -13,7 +13,8 @@ use crate::helpers::scan_key_for;
 use super::super::attach;
 use super::super::fts::upsert_fts;
 use super::shared::{
-    attach_ebook_file, insert_book_row, insert_metadata_links, rewrite_book_in_place,
+    attach_ebook_file, existing_by_scan_keys, insert_book_row, insert_metadata_links,
+    rewrite_book_in_place,
 };
 
 /// Apply Changed entries: wipe-and-rewrite the per-book link rows for each,
@@ -44,23 +45,10 @@ pub(super) async fn sync_changed(
         .map(|b| scan_key_for(&b.metadata.filename))
         .collect();
 
-    // One batch SELECT per chunk (chunked at 499 to stay under SQLite's
-    // 999-parameter cap: 1 bind for library_id + up to 499 scan_key binds).
-    let mut id_map: HashMap<String, (i64, String)> = HashMap::new();
-    for chunk in all_scan_keys.chunks(499) {
-        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let id_sql = format!(
-            "SELECT scan_key, id, uuid FROM books
-              WHERE library_id = ? AND scan_key IN ({placeholders})"
-        );
-        let mut q = sqlx::query_as::<_, (String, i64, String)>(&id_sql).bind(library_id);
-        for sk in chunk {
-            q = q.bind(sk);
-        }
-        for (sk, id, uuid) in q.fetch_all(&mut **tx).await? {
-            id_map.insert(sk, (id, uuid));
-        }
-    }
+    // One batch SELECT per chunk resolves every scan_key to its (id, uuid)
+    // before the loop — no SELECT per changed book.
+    let id_map: HashMap<String, (i64, String)> =
+        existing_by_scan_keys(tx, library_id, &all_scan_keys).await?;
 
     // Wipe-and-rewrite the per-book link rows for each Changed entry,
     // then UPDATE the `books` row and re-insert FTS. This preserves

--- a/db/src/sync/books/new.rs
+++ b/db/src/sync/books/new.rs
@@ -9,7 +9,7 @@ use crate::helpers::scan_key_for;
 
 use super::super::fts::upsert_fts;
 use super::shared::{
-    existing_by_scan_key, insert_book_row, insert_metadata_links, rewrite_book_in_place,
+    existing_by_scan_keys, insert_book_row, insert_metadata_links, rewrite_book_in_place,
     try_attach_new_ebook,
 };
 
@@ -22,8 +22,23 @@ pub(super) async fn sync_new(
     new_books: &[crate::ebook::IndexedBook],
     mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, sqlx::Error> {
+    if new_books.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Batch-resolve the "does a row with this exact scan_key already exist?"
+    // check in one query per chunk before the loop, mirroring the Changed
+    // bucket's `id_map`. The per-book loop then looks up in memory — no SELECT
+    // per new book — and only the cross-format attach heuristic (which needs
+    // the target's own state) stays inside the loop.
+    let all_scan_keys: Vec<String> = new_books
+        .iter()
+        .map(|b| scan_key_for(&b.metadata.filename))
+        .collect();
+    let existing = existing_by_scan_keys(tx, library_id, &all_scan_keys).await?;
+
     let mut new_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
-    for b in new_books {
+    for (b, scan_key) in new_books.iter().zip(all_scan_keys.iter()) {
         // A row with this exact scan_key (relative path) already exists — a
         // fileless book whose file returned, or the same file marked New by
         // `replace_books` after being marked missing in the same call. This is the
@@ -31,9 +46,8 @@ pub(super) async fn sync_new(
         // `books.uuid`) — checked before the cross-format attach heuristic,
         // which would otherwise mis-bind the returning file to the fileless row as
         // an attachment.
-        let scan_key = scan_key_for(&b.metadata.filename);
-        if let Some((book_id, uuid)) = existing_by_scan_key(tx, library_id, &scan_key).await? {
-            rewrite_book_in_place(tx, book_id, &uuid, b, &mut new_covers).await?;
+        if let Some((book_id, uuid)) = existing.get(scan_key) {
+            rewrite_book_in_place(tx, *book_id, uuid, b, &mut new_covers).await?;
             on_book_written();
             continue;
         }

--- a/db/src/sync/books/removed.rs
+++ b/db/src/sync/books/removed.rs
@@ -1,13 +1,13 @@
 //! Removed bucket: every uuid whose file disappeared keeps its `books` row.
-//! `mark_book_files_missing` drops only the `book_files` row and flags the book
-//! missing for F10 GC — its metadata, taxonomy links, and FTS row stay, so the
-//! book remains in browse/search; the grid and facets hide it via their own
-//! `EXISTS book_files` filter. Idempotent — a re-run on an already-fileless row
-//! deletes zero `book_files`.
+//! Only the `book_files` row is dropped and the book is flagged missing for F10
+//! GC — its metadata, taxonomy links, and FTS row stay, so the book remains in
+//! browse/search; the grid and facets hide it via their own `EXISTS book_files`
+//! filter. Idempotent — a re-run on an already-fileless row deletes zero
+//! `book_files`.
 
 use sqlx::Transaction;
 
-use super::shared::mark_book_files_missing;
+use super::shared::mark_book_files_missing_batch;
 
 /// Mark a batch of removed books' files missing (F2). The file is gone, but the
 /// `books` row — its metadata, taxonomy links, FTS row, and every soft-ref
@@ -16,6 +16,10 @@ use super::shared::mark_book_files_missing;
 /// search while the grid/facets hide it via their `EXISTS book_files` filter. A
 /// returning file re-attaches via the Changed path, preserving the uuid.
 /// Idempotent: a re-run on an already-fileless row deletes zero `book_files`.
+///
+/// Resolves every affected `books.id` in chunked `uuid IN (...)` SELECTs, then
+/// drops their file rows + flags them missing in batched DML — no per-book
+/// fan-out (mirrors the Changed bucket's batched id lookup).
 pub(super) async fn sync_removed(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
@@ -24,32 +28,31 @@ pub(super) async fn sync_removed(
     if removed_uuids.is_empty() {
         return Ok(());
     }
-    let mut missing = 0usize;
     // library_id + 1 bind per uuid; chunk at 500 to stay under SQLite's
     // 999-param cap when a whole library (or any large diff) is removed.
+    let mut ids: Vec<i64> = Vec::new();
     for chunk in removed_uuids.chunks(500) {
         let placeholders = std::iter::repeat_n("?", chunk.len())
             .collect::<Vec<_>>()
             .join(", ");
-
-        // Resolve the affected ids, then drop their file rows — keeping each
-        // `books` row (and its links/FTS) as a fileless book.
         let id_sql =
             format!("SELECT id FROM books WHERE library_id = ? AND uuid IN ({placeholders})");
         let mut q = sqlx::query_scalar::<_, i64>(&id_sql).bind(library_id);
         for uuid in chunk {
             q = q.bind(uuid);
         }
-        let ids = q.fetch_all(&mut **tx).await?;
-        missing += ids.len();
-        for id in ids {
-            mark_book_files_missing(tx, id).await?;
-        }
+        ids.extend(q.fetch_all(&mut **tx).await?);
     }
-    if missing > 0 {
+
+    mark_book_files_missing_batch(tx, &ids).await?;
+
+    if !ids.is_empty() {
         // These rows are flagged missing (F10); `missing_files::gc_books_missing_files`
         // purges the long-missing, user-data-free ones on a later reindex.
-        tracing::info!(missing, "sync: retained removed books as fileless books");
+        tracing::info!(
+            missing = ids.len(),
+            "sync: retained removed books as fileless books"
+        );
     }
     Ok(())
 }

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -4,6 +4,8 @@
 //! the rewrite-in-place and cross-format attach paths, and the
 //! post-commit cover materialization + missing-files marker helper.
 
+use std::collections::HashMap;
+
 use sqlx::Transaction;
 
 use omnibus_shared::EbookMetadata;
@@ -23,21 +25,32 @@ use super::super::authors::insert_author_links;
 use super::super::fts::upsert_fts;
 use super::wipe_per_book_link_rows;
 
-/// Resolve an existing `books` row (id + uuid) under `library_id` by its
-/// `scan_key`. Used by the New path to re-attach to a fileless / same-path row
-/// instead of inserting a colliding one.
-pub(super) async fn existing_by_scan_key(
+/// Batch-resolve existing `books` rows (id + uuid) under `library_id` for a
+/// set of `scan_key`s, returning a `scan_key -> (id, uuid)` map. Used by the
+/// New and Changed paths to re-attach to a fileless / same-path row instead of
+/// firing one SELECT per candidate. Chunked at 499 to stay under SQLite's
+/// 999-parameter cap (1 bind for `library_id` + up to 499 scan_key binds).
+pub(super) async fn existing_by_scan_keys(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
-    scan_key: &str,
-) -> Result<Option<(i64, String)>, sqlx::Error> {
-    sqlx::query_as::<_, (i64, String)>(
-        "SELECT id, uuid FROM books WHERE library_id = ? AND scan_key = ?",
-    )
-    .bind(library_id)
-    .bind(scan_key)
-    .fetch_optional(&mut **tx)
-    .await
+    scan_keys: &[String],
+) -> Result<HashMap<String, (i64, String)>, sqlx::Error> {
+    let mut map: HashMap<String, (i64, String)> = HashMap::new();
+    for chunk in scan_keys.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let id_sql = format!(
+            "SELECT scan_key, id, uuid FROM books
+              WHERE library_id = ? AND scan_key IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String, i64, String)>(&id_sql).bind(library_id);
+        for sk in chunk {
+            q = q.bind(sk);
+        }
+        for (sk, id, uuid) in q.fetch_all(&mut **tx).await? {
+            map.insert(sk, (id, uuid));
+        }
+    }
+    Ok(map)
 }
 
 /// Rewrite an existing book in place from a freshly-parsed entry: refresh
@@ -205,6 +218,45 @@ pub(in crate::sync) async fn mark_book_files_missing(
     .bind(book_id)
     .execute(&mut **tx)
     .await?;
+    Ok(())
+}
+
+/// Batched [`mark_book_files_missing`] for the Removed bucket: drop the
+/// `book_files` rows (parts/chapters cascade) and flag the books missing in two
+/// chunked DML passes instead of two statements per book. The `IN (...)` lists
+/// are chunked at 999 to stay under SQLite's bound-parameter cap. The `UPDATE`
+/// keeps the same `is_missing_files = 0 AND is_missing_files_override = 0`
+/// guards as the per-book path — idempotent re-runs preserve the original
+/// `missing_files_since`, and intentionally-fileless (wishlist) rows stay
+/// un-flagged.
+pub(in crate::sync) async fn mark_book_files_missing_batch(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_ids: &[i64],
+) -> Result<(), sqlx::Error> {
+    for chunk in book_ids.chunks(999) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let delete_sql = format!("DELETE FROM book_files WHERE book_id IN ({placeholders})");
+        let mut delete_q = sqlx::query(&delete_sql);
+        for id in chunk {
+            delete_q = delete_q.bind(id);
+        }
+        delete_q.execute(&mut **tx).await?;
+
+        let update_sql = format!(
+            "UPDATE books
+                SET is_missing_files = 1, missing_files_since = unixepoch()
+              WHERE id IN ({placeholders})
+                AND is_missing_files = 0 AND is_missing_files_override = 0"
+        );
+        let mut update_q = sqlx::query(&update_sql);
+        for id in chunk {
+            update_q = update_q.bind(id);
+        }
+        update_q.execute(&mut **tx).await?;
+    }
     Ok(())
 }
 

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -422,6 +422,229 @@ async fn removed_file_goes_fileless_then_returning_file_relinks_same_uuid() {
         "returning file relinks to the same uuid (no orphaned user data)"
     );
 }
+/// Removing a whole library in one plan exceeds SQLite's 999-bind cap, so
+/// `sync_removed` must chunk both the `uuid IN (...)` id resolution and the
+/// batched `DELETE`/`UPDATE` that replace the old per-book
+/// `mark_book_files_missing` loop. Seeding 1000 books via `replace_books` also
+/// drives `sync_new`'s batched `existing_by_scan_keys` lookup above the cap.
+#[tokio::test]
+async fn sync_removed_above_bind_cap_flags_every_book_missing_in_batched_dml() {
+    let _covers = CoversTempDir::new("ebook_remove_chunk");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    // 1000 > 999: one un-chunked IN(?, ?, ...) would bind library_id + 1000
+    // uuids and fail at runtime with "too many SQL variables".
+    const N: usize = 1000;
+    let books: Vec<_> = (0..N)
+        .map(|i| {
+            indexed(
+                &format!("book{i:04}.epub"),
+                Some(&format!("Book {i}")),
+                &[],
+                &[],
+                None,
+                None,
+            )
+        })
+        .collect();
+    replace_books(&pool, "/lib", books).await.unwrap();
+    assert_eq!(list_books(&pool, "/lib").await.unwrap().len(), N);
+
+    let all_uuids: Vec<String> = sqlx::query_scalar("SELECT uuid FROM books")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            removed_uuids: all_uuids,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("wholesale removal of >999 books must not exceed the bind cap");
+
+    assert!(
+        list_books(&pool, "/lib").await.unwrap().is_empty(),
+        "every book is fileless (hidden from the grid) after wholesale removal"
+    );
+    let books_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let files_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM book_files")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let flagged: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books WHERE is_missing_files = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        books_total as usize, N,
+        "every books row retained as fileless"
+    );
+    assert_eq!(
+        files_total, 0,
+        "batched DELETE dropped every book_files row"
+    );
+    assert_eq!(
+        flagged as usize, N,
+        "batched UPDATE flagged every book missing (F10)"
+    );
+}
+/// The batched Removed path is idempotent: a second removal of already-fileless
+/// rows deletes zero `book_files` and — via the `is_missing_files = 0` guard on
+/// the batched `UPDATE` — preserves each row's original `missing_files_since`.
+#[tokio::test]
+async fn sync_removed_batched_is_idempotent_and_preserves_missing_since() {
+    let _covers = CoversTempDir::new("ebook_remove_idempotent");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed("a.epub", Some("A"), &[], &[], None, None),
+            indexed("b.epub", Some("B"), &[], &[], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+    let uuids: Vec<String> = sqlx::query_scalar("SELECT uuid FROM books")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            removed_uuids: uuids.clone(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let since_first: Vec<i64> =
+        sqlx::query_scalar("SELECT missing_files_since FROM books ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        since_first.len(),
+        2,
+        "both rows flagged with a retention stamp"
+    );
+
+    // Re-run the same removal — the guarded UPDATE must not restamp.
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            removed_uuids: uuids,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let since_second: Vec<i64> =
+        sqlx::query_scalar("SELECT missing_files_since FROM books ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        since_first, since_second,
+        "idempotent re-run preserves the original missing_files_since"
+    );
+    let files_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM book_files")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(files_total, 0, "no file rows to drop on the second pass");
+}
+/// `sync_new` batch-resolves the same-scan_key check before the loop, so many
+/// returning files relink to their original `books.uuid` in one pass — the
+/// in-memory `existing_by_scan_keys` map, not a SELECT per book, drives the
+/// re-attach.
+#[tokio::test]
+async fn sync_new_batched_relink_preserves_uuids_for_many_fileless_rows() {
+    let _covers = CoversTempDir::new("ebook_new_relink");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    const N: usize = 6;
+    let seed: Vec<_> = (0..N)
+        .map(|i| {
+            indexed(
+                &format!("book{i}.epub"),
+                Some(&format!("Book {i}")),
+                &[],
+                &[],
+                None,
+                None,
+            )
+        })
+        .collect();
+    replace_books(&pool, "/lib", seed).await.unwrap();
+    // `scan_key` is the library-relative path; for these flat files it equals
+    // the `list_books` filename we compare against below.
+    let uuids_before: std::collections::HashMap<String, String> = list_indexed_rows(&pool, "/lib")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| (r.scan_key.clone(), r.uuid.clone()))
+        .collect();
+
+    // All files vanish, then all return in a single New batch.
+    let all_uuids: Vec<String> = uuids_before.values().cloned().collect();
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            removed_uuids: all_uuids,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let returning: Vec<_> = (0..N)
+        .map(|i| {
+            indexed(
+                &format!("book{i}.epub"),
+                Some(&format!("Book {i}")),
+                &[],
+                &[],
+                None,
+                None,
+            )
+        })
+        .collect();
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            new_books: returning,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let after = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(
+        after.len(),
+        N,
+        "every returning file relinks (no duplicate rows)"
+    );
+    for b in &after {
+        assert_eq!(
+            b.unique_identifier.as_deref(),
+            uuids_before.get(&b.filename).map(String::as_str),
+            "returning file {} relinks to its original uuid",
+            b.filename
+        );
+    }
+}
 /// One sync covering all four mutating branches at once. Unchanged
 /// ids stay put; Changed id stays put; New gets a fresh id;
 /// Removed disappears.


### PR DESCRIPTION
## Summary
- The New and Removed ebook sync buckets fired 1–2 DB queries per book inside per-book loops — the same N+1 pattern `#442` already fixed for the Changed bucket, left un-applied to the other two. On an initial import or large rescan those buckets can hold thousands of entries.
- **`sync_new`**: pre-resolves the "does a row with this exact scan_key already exist?" check for every candidate in one chunked query (`existing_by_scan_keys`) before the loop, then looks up in memory — no SELECT per new book. The cross-format auto-attach heuristic (which needs the target book's own state) stays inside the loop, as suggested.
- **`sync_removed`**: resolves affected `books.id` in chunked `uuid IN (...)` SELECTs, then drops the `book_files` rows and flags the books missing in a batched, chunked `DELETE` + `UPDATE` (`mark_book_files_missing_batch`) instead of two statements per book. The `UPDATE` keeps the `is_missing_files = 0 AND is_missing_files_override = 0` guards, so idempotency (preserving the original `missing_files_since`) and wishlist (`_override`) behavior are unchanged.
- **Better-than-suggested / dedup**: extracted the batch scan_key→(id,uuid) lookup into a shared `existing_by_scan_keys` helper and pointed the Changed bucket at it too, removing the duplicated inline batch-query block so all three buckets share one chunked lookup.

## Test plan
- [x] cargo clippy -p omnibus-db --all-targets -- -D warnings (green)
- [x] cargo test -p omnibus-db (green — 706 passed)
- New tests in `db/src/sync/tests.rs`:
  - `sync_removed_above_bind_cap_flags_every_book_missing_in_batched_dml` — 1000-book wholesale removal exercises the chunked id resolution + batched DELETE/UPDATE (and drives `sync_new`'s batched lookup above the 999-bind cap via the `replace_books` seed); asserts every row retained, zero `book_files`, all flagged missing.
  - `sync_removed_batched_is_idempotent_and_preserves_missing_since` — a second removal deletes zero file rows and does not restamp `missing_files_since`.
  - `sync_new_batched_relink_preserves_uuids_for_many_fileless_rows` — many returning files relink to their original `books.uuid` in one New pass.

## Notes
- Closes #631
- Out of scope, noticed but not fixed: `sync_audiobooks_removed` (`db/src/sync/audiobooks.rs`) still loops the per-book `mark_book_files_missing`; the issue scoped this ticket to the ebook buckets. It could now reuse `mark_book_files_missing_batch` in a follow-up.
- Assignee note: the GitHub MCP PR tools expose no assignee/label param, so this PR could not be self-assigned to Seamus or labeled programmatically.
- Reviewer: verified clippy+test green (706 passed, incl. 3 new batched-path tests), resolves #631, no scope creep, no Cargo.toml/lock or migration edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2pqRpyn7EDrgiYyx4pcZD)_