### PR TITLE
fix: batch resolve_fts_rows to eliminate per-UUID N+1 (#610)

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -67,6 +67,7 @@ impl From<crate::metadata_overrides::MetadataOverridesError> for BooksError {
 // `pub(crate)` re-exports for sibling `db/` modules (`discovery`, `palette`,
 // `metadata_overrides`) that referenced these items at `crate::books::…`
 // before the split.
+pub(crate) use get::{get_books_by_ids, resolve_book_ids_bulk};
 pub(crate) use projection::{
     backfill_creator_ids, merge_overrides_into_books, parse_json_array, row_to_ebook,
     sanitize_description, BOOK_COLUMNS,

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -2,13 +2,17 @@
 //! `resolve_book_id_by_uuid` helper that the covers/thumbs/mobile routes
 //! use to translate a stable uuid to the current id.
 
+use std::collections::HashMap;
+
 use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::EbookMetadata;
 
 use crate::metadata_overrides::{apply_overrides, get_metadata_overrides};
 
-use super::projection::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
+use super::projection::{
+    backfill_creator_ids, merge_overrides_into_books, row_to_ebook, BOOK_COLUMNS,
+};
 
 /// Fetch a single book by its stable `books.id`. Returns `None` if not found.
 ///
@@ -157,6 +161,70 @@ where
     .bind(uuid)
     .fetch_optional(executor)
     .await?)
+}
+
+/// Bulk counterpart to [`resolve_book_id_by_uuid`]: map each input uuid to
+/// its current `books.id`, replicating the `merged_uuids` fallback so a
+/// merged/attached uuid still resolves to the surviving book. UUIDs that
+/// match neither table are simply absent from the returned map.
+///
+/// Emits one `SELECT` per chunk, chunked at 499 uuids because each chunk
+/// binds its uuids twice (the `books` and `merged_uuids` legs of the
+/// `UNION ALL`), keeping the bound-parameter count under SQLite's 999 limit.
+pub(crate) async fn resolve_book_ids_bulk(
+    pool: &SqlitePool,
+    uuids: &[String],
+) -> Result<HashMap<String, i64>, super::BooksError> {
+    let mut map = HashMap::with_capacity(uuids.len());
+    for chunk in uuids.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT uuid, id FROM books WHERE uuid IN ({placeholders})
+             UNION ALL
+             SELECT uuid, book_id FROM merged_uuids WHERE uuid IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String, i64)>(&sql);
+        // Bind the chunk twice — once for each `IN (...)` leg, in statement order.
+        for u in chunk.iter().chain(chunk.iter()) {
+            q = q.bind(u);
+        }
+        for (uuid, id) in q.fetch_all(pool).await? {
+            // A `books` row wins over a `merged_uuids` ledger key on the
+            // (practically impossible) collision, mirroring the `books`-first
+            // ordering of `resolve_book_id_by_uuid`'s `UNION ALL … LIMIT 1`.
+            map.entry(uuid).or_insert(id);
+        }
+    }
+    Ok(map)
+}
+
+/// Bulk-fetch merged metadata for a set of `books.id`s, applying overrides
+/// and the creator-id backfill exactly as `list_books_for_paths` does.
+/// Emits one `SELECT … WHERE b.id IN (…)` per 499-id chunk plus the two
+/// bulk override/creator passes. Return order is unspecified; callers pair
+/// rows via [`EbookMetadata::id`]. Unknown ids are simply absent.
+pub(crate) async fn get_books_by_ids(
+    pool: &SqlitePool,
+    ids: &[i64],
+) -> Result<Vec<EbookMetadata>, super::BooksError> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::with_capacity(ids.len());
+    for chunk in ids.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!("SELECT {BOOK_COLUMNS} FROM books b WHERE b.id IN ({placeholders})");
+        let mut q = sqlx::query(&sql);
+        for id in chunk {
+            q = q.bind(id);
+        }
+        for r in q.fetch_all(pool).await? {
+            out.push(row_to_ebook(&r)?);
+        }
+    }
+    merge_overrides_into_books(pool, &mut out).await?;
+    backfill_creator_ids(pool, &mut out).await?;
+    Ok(out)
 }
 
 /// Resolve any book reference (its own durable `books.uuid` or a

--- a/db/src/metadata_overrides/fts.rs
+++ b/db/src/metadata_overrides/fts.rs
@@ -9,7 +9,7 @@ use sqlx::{SqliteConnection, SqlitePool};
 
 use omnibus_shared::EbookMetadata;
 
-use crate::books::resolve_book_id_by_uuid;
+use crate::books::{get_books_by_ids, resolve_book_id_by_uuid, resolve_book_ids_bulk};
 use crate::sync::upsert_fts;
 
 use super::upsert::MetadataOverridesError;
@@ -99,21 +99,21 @@ pub(crate) async fn rebuild_fts_for_books_batch(
 }
 
 /// Resolve UUIDs to `(book_id, merged metadata)`, skipping any uuid with
-/// no live book row. Uses [`resolve_book_id_by_uuid`] so merged/attached
-/// uuids resolve to the surviving book.
+/// no live book row. Two chunked bulk queries regardless of batch size —
+/// [`resolve_book_ids_bulk`] (uuid→id, with the merged/attached fallback)
+/// then [`get_books_by_ids`] — joined in memory, replacing the former
+/// two-query-per-uuid loop.
 async fn resolve_fts_rows(
     pool: &SqlitePool,
     book_uuids: &[String],
 ) -> Result<Vec<(i64, EbookMetadata)>, MetadataOverridesError> {
-    let mut rows: Vec<(i64, EbookMetadata)> = Vec::with_capacity(book_uuids.len());
-    for uuid in book_uuids {
-        let Some(book_id) = resolve_book_id_by_uuid(pool, uuid).await? else {
-            continue;
-        };
-        let Some(merged) = crate::books::get_book(pool, book_id).await? else {
-            continue;
-        };
-        rows.push((book_id, merged));
-    }
-    Ok(rows)
+    // De-dupe ids so a canonical uuid and one of its merged uuids appearing
+    // together in the batch write the same FTS row only once.
+    let id_map = resolve_book_ids_bulk(pool, book_uuids).await?;
+    let mut ids: Vec<i64> = id_map.into_values().collect();
+    ids.sort_unstable();
+    ids.dedup();
+
+    let books = get_books_by_ids(pool, &ids).await?;
+    Ok(books.into_iter().map(|b| (b.id, b)).collect())
 }

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -501,6 +501,102 @@ async fn upsert_overrides_materializes_series_link_for_new_series() {
     );
 }
 
+/// The batch FTS rebuild resolves and rewrites more than one uuid in a
+/// single call — exercising the bulk uuid→id resolve + `IN (…)` book fetch
+/// that replaced the former two-query-per-uuid loop. Overrides written
+/// straight to the table leave `books_fts` stale (no per-save rebuild), so
+/// only the batch rebuild can make search reflect both overridden titles.
+#[tokio::test]
+async fn rebuild_fts_for_books_batch_rewrites_multiple_uuids() {
+    let _covers = CoversTempDir::new("fts_batch_multi");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed(
+                "one.epub",
+                Some("AlphaScanned"),
+                &["Author A"],
+                &[],
+                None,
+                None,
+            ),
+            indexed(
+                "two.epub",
+                Some("BetaScanned"),
+                &["Author B"],
+                &[],
+                None,
+                None,
+            ),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let uuid_of = |title: &str| {
+        books
+            .iter()
+            .find(|b| b.title.as_deref() == Some(title))
+            .and_then(|b| b.unique_identifier.clone())
+            .expect("seeded book should exist")
+    };
+    let uuid_a = uuid_of("AlphaScanned");
+    let uuid_b = uuid_of("BetaScanned");
+
+    // Write overrides straight to the table so `books_fts` stays stale; this
+    // isolates the batch rebuild's bulk resolve from the per-save rebuild
+    // that `upsert_metadata_overrides` would otherwise trigger.
+    for (uuid, title) in [(&uuid_a, "AlphaRenamed"), (&uuid_b, "BetaRenamed")] {
+        let json = serde_json::to_string(&MetadataOverrides {
+            title: Some(title.to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        sqlx::query("INSERT INTO metadata_overrides (book_uuid, overrides) VALUES (?, ?)")
+            .bind(uuid)
+            .bind(&json)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    // Sanity: FTS still matches the scanned titles (no rebuild yet).
+    assert!(search_books(&pool, "/lib", "AlphaRenamed")
+        .await
+        .unwrap()
+        .is_empty());
+
+    rebuild_fts_for_books_batch(&pool, &[uuid_a, uuid_b])
+        .await
+        .unwrap();
+
+    // Both overridden titles are now searchable; neither scanned title is.
+    assert_eq!(
+        search_books(&pool, "/lib", "AlphaRenamed").await.unwrap()[0]
+            .title
+            .as_deref(),
+        Some("AlphaRenamed")
+    );
+    assert_eq!(
+        search_books(&pool, "/lib", "BetaRenamed").await.unwrap()[0]
+            .title
+            .as_deref(),
+        Some("BetaRenamed")
+    );
+    assert!(search_books(&pool, "/lib", "AlphaScanned")
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(search_books(&pool, "/lib", "BetaScanned")
+        .await
+        .unwrap()
+        .is_empty());
+}
+
 /// The override row and the `books_series_link` row must land
 /// atomically: after `upsert_metadata_overrides` commits, a direct
 /// SELECT on `books_series_link` must already reflect the new series.


### PR DESCRIPTION
## Summary
- `resolve_fts_rows` (in `db/src/metadata_overrides/fts.rs`) resolved each UUID with two sequential queries — `resolve_book_id_by_uuid` + `get_book` — so a batch FTS rebuild (author delete, multi-book override/author-photo save) issued 2N round-trips before any write began.
- Replaced the loop with two chunked bulk queries joined in memory:
  1. `resolve_book_ids_bulk` — one `SELECT` per **499**-uuid chunk over `books` `UNION ALL` `merged_uuids`, replicating `resolve_book_id_by_uuid`&#39;s merged/attached fallback. Chunked at 499 (not 500) because each chunk binds its uuids twice (once per `IN (…)` leg), keeping the parameter count under SQLite&#39;s 999 limit.
  2. `get_books_by_ids` — one `SELECT … WHERE b.id IN (…)` per 499-id chunk plus the shared bulk override / creator-id passes, mirroring `list_books_for_paths`.
- Behaviour preserved: unknown UUIDs are silently skipped and merged UUIDs route to the surviving book. Resolved ids are additionally de-duped so a canonical uuid and one of its merged uuids appearing in the same batch write that FTS row once (a tiny improvement over the old loop, which would have written it twice).
- Both helpers live next to `resolve_book_id_by_uuid` / `get_book` in `db/src/books/get.rs` as `pub(crate)`, re-exported through `crate::books`. This is a better home than the issue&#39;s suggested `db/src/identity.rs`: the single-item `resolve_book_id_by_uuid` (which the issue cites as living in `identity.rs`) actually lives in `books/get.rs`, so co-locating the bulk sibling there keeps the merged-uuid fallback logic in one place. `identity.rs` only holds the `scan_key` backfill.

## Test plan
- [x] cargo clippy -p omnibus-db --all-targets -- -D warnings (green)
- [x] cargo test -p omnibus-db (green — 704 lib tests + integration)
- New test `rebuild_fts_for_books_batch_rewrites_multiple_uuids` in `db/src/metadata_overrides/tests.rs`: seeds two books, writes overrides straight to the table (leaving `books_fts` stale so the per-save rebuild path is bypassed), then asserts a single `rebuild_fts_for_books_batch` call over both UUIDs makes search reflect both overridden titles and drop both scanned titles — exercising the &gt;1-UUID bulk resolve.
- Existing FTS/override tests continue to pass unchanged.

## Notes
- Closes #610
- The `merged_uuids`/`books` namespaces don&#39;t collide in practice (minted UUIDv4s vs. legacy stable-uuid ledger keys), but `resolve_book_ids_bulk` prefers the `books` row via `entry().or_insert` to mirror the `books`-first ordering of `resolve_book_id_by_uuid`&#39;s `UNION ALL … LIMIT 1`, so behaviour is identical even in the impossible-collision case.
- `get_books_by_ids` matches `list_books_for_paths` semantics (overrides + creator-id backfill), which is all the FTS overlay needs — it does not run `get_book`&#39;s per-book `backfill_series_id_by_name` or the multipart `book_files` fetch, since `overlay_overrides` only consumes title/authors/series-name/tags/description. Keeping those out avoids reintroducing per-book queries.
- Assignee note: the GitHub MCP PR tools expose no assignee/label param, so this PR could not be self-assigned to Seamus or labeled programmatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2pqRpyn7EDrgiYyx4pcZD)_

---
Reviewer: verified clippy + test green (704 passing incl. the new batch test), resolves #610 (N+1 replaced by two 499-chunked bulk queries within SQLite bind limits, merged-uuid fallback + silent-skip preserved), no scope creep, no migrations touched.