### PR TITLE
refactor: batch audiobook sync New/Removed buckets to eliminate N+1 queries

### DIFF
--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -107,8 +107,8 @@ pub async fn sync_audiobooks_with_progress(
     Ok(())
 }
 
-/// Apply the Removed bucket (F2): resolve affected ids and, via
-/// `books::mark_book_files_missing`, drop the `book_files` rows (parts/chapters
+/// Apply the Removed bucket (F2): resolve affected ids and, in a pair of
+/// chunked batch statements, drop the `book_files` rows (parts/chapters
 /// cascade) and flag each book missing — but **retain** the `books` row, its
 /// links, FTS, and soft-ref user data, so the book stays in browse/search (the
 /// grid hides it via `EXISTS book_files`) and a returning group re-attaches via
@@ -140,9 +140,7 @@ async fn sync_audiobooks_removed(
         }
         let ids = q.fetch_all(&mut **tx).await?;
         missing += ids.len();
-        for id in ids {
-            super::books::mark_book_files_missing(tx, id).await?;
-        }
+        batch_mark_audiobooks_files_missing(tx, &ids).await?;
     }
     if missing > 0 {
         tracing::info!(
@@ -156,6 +154,47 @@ async fn sync_audiobooks_removed(
     // entry instead (the target book survives, possibly fileless).
     // `remove_attached_files` already chunks internally.
     attach::remove_attached_files(tx, removed_uuids).await?;
+    Ok(())
+}
+
+/// Drop `book_files` and flag `books` missing for a resolved id batch in two
+/// chunked statements — the batched replacement for the per-book
+/// `mark_book_files_missing` loop. Chunks at 500 ids per statement to stay
+/// under SQLite's 999-bind cap. Idempotent: the `is_missing_files = 0` guard
+/// on the UPDATE preserves the original `missing_files_since` on a re-run, and
+/// the `is_missing_files_override = 0` guard leaves intentionally-fileless
+/// rows (wishlist) un-flagged.
+async fn batch_mark_audiobooks_files_missing(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    ids: &[i64],
+) -> Result<(), sqlx::Error> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    for chunk in ids.chunks(500) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let delete_sql = format!("DELETE FROM book_files WHERE book_id IN ({placeholders})");
+        let mut q = sqlx::query(&delete_sql);
+        for id in chunk {
+            q = q.bind(id);
+        }
+        q.execute(&mut **tx).await?;
+
+        let update_sql = format!(
+            "UPDATE books
+                SET is_missing_files = 1, missing_files_since = unixepoch()
+              WHERE id IN ({placeholders})
+                AND is_missing_files = 0
+                AND is_missing_files_override = 0"
+        );
+        let mut q = sqlx::query(&update_sql);
+        for id in chunk {
+            q = q.bind(id);
+        }
+        q.execute(&mut **tx).await?;
+    }
     Ok(())
 }
 
@@ -261,6 +300,11 @@ async fn rewrite_audiobook_in_place(
 /// Apply the New bucket: for each entry try cross-format attach first,
 /// otherwise insert a fresh `books` + `book_files` + parts + chapters +
 /// author-link + FTS row. Returns the post-commit cover triples.
+///
+/// Pre-fetches every candidate `scan_key` in one chunked batch query so the
+/// per-book loop can look up existing rows in memory instead of firing a
+/// `SELECT` per book — mirrors the batched lookup at the top of
+/// [`sync_audiobooks_changed`].
 async fn sync_audiobooks_new(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
@@ -269,17 +313,35 @@ async fn sync_audiobooks_new(
     mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, SyncError> {
     let mut new_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
+    if new_books.is_empty() {
+        return Ok(new_covers);
+    }
+    // Pre-fetch existing (id, uuid) for every candidate scan_key in one
+    // chunked batch (499 keys + library_id keeps us under SQLite's 999-bind
+    // cap) — a fileless book whose group returned, or a `replace_books` re-add,
+    // takes the rewrite-in-place branch below before the cross-format attach
+    // heuristic runs, preserving `books.uuid`.
+    let all_scan_keys: Vec<String> = new_books.iter().map(|b| b.scan_key.clone()).collect();
+    let mut id_map: HashMap<String, (i64, String)> = HashMap::new();
+    for chunk in all_scan_keys.chunks(499) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT scan_key, id, uuid FROM books
+              WHERE library_id = ? AND scan_key IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String, i64, String)>(&sql).bind(library_id);
+        for sk in chunk {
+            q = q.bind(sk);
+        }
+        for (sk, id, uuid) in q.fetch_all(&mut **tx).await? {
+            id_map.insert(sk, (id, uuid));
+        }
+    }
+
     for b in new_books {
-        // Same-scan_key row (a fileless book whose group returned, or a
-        // `replace_books` re-add) → rewrite in place, *before* the
-        // cross-format attach heuristic, preserving `books.uuid`.
-        let existing: Option<(i64, String)> =
-            sqlx::query_as("SELECT id, uuid FROM books WHERE library_id = ? AND scan_key = ?")
-                .bind(library_id)
-                .bind(&b.scan_key)
-                .fetch_optional(&mut **tx)
-                .await?;
-        if let Some((book_id, uuid)) = existing {
+        if let Some((book_id, uuid)) = id_map.get(&b.scan_key).map(|(id, u)| (*id, u.clone())) {
             rewrite_audiobook_in_place(tx, book_id, &uuid, b, &mut new_covers).await?;
             on_book_written();
             continue;

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -1459,6 +1459,83 @@ async fn sync_audiobooks_with_removed_above_bind_cap_succeeds() {
         books_total, fts_count,
         "every fileless audiobook keeps its books + FTS row"
     );
+
+    // The Removed bucket must flag every affected row as
+    // `is_missing_files = 1` so `missing_files::gc_books_missing_files` can
+    // eventually purge long-missing, user-data-free books. Regression guard on
+    // the batched `DELETE ... IN (…)` / `UPDATE ... IN (…)` pair replacing
+    // the pre-batch per-book `mark_book_files_missing` loop.
+    let missing_flagged: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM books WHERE is_missing_files = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        missing_flagged, N as i64,
+        "the batched Removed pass must flag every audiobook `is_missing_files = 1`"
+    );
+}
+
+/// F2 acceptance for the audiobook path: removing a group makes its book
+/// fileless (grid hides it, but the row + durable `books.uuid` survive), and
+/// when the same group returns via the New bucket it re-attaches to that row.
+/// Regression guard on the batched `sync_audiobooks_new` scan_key pre-fetch —
+/// a fileless book whose group returns must still take the rewrite-in-place
+/// branch and preserve the uuid, not mint a fresh one.
+#[tokio::test]
+async fn sync_audiobooks_new_relinks_returning_group_to_same_uuid_after_fileless_gap() {
+    let _covers = CoversTempDir::new("ab_fileless_relink");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![indexed_audiobook("Author/Book.m4b", "Book", Some("Author"))],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let uuid1 = crate::test_support::uuid_by_scan_key(&pool, "Author/Book.m4b").await;
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            removed_uuids: vec![uuid1.clone()],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        list_books(&pool, "/lib").await.unwrap().is_empty(),
+        "fileless audiobook is hidden from the library grid"
+    );
+    assert_eq!(
+        crate::test_support::uuid_by_scan_key(&pool, "Author/Book.m4b").await,
+        uuid1,
+        "fileless audiobook retains its scan_key and durable uuid"
+    );
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![indexed_audiobook("Author/Book.m4b", "Book", Some("Author"))],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let after = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(after.len(), 1);
+    assert_eq!(
+        after[0].unique_identifier.as_deref(),
+        Some(uuid1.as_str()),
+        "returning audiobook group relinks to the same uuid (no orphaned user data)"
+    );
 }
 
 // Audiobook parts + chapters: row contents and edge cases.


### PR DESCRIPTION
## Summary

Closes #632.

Mirror the Changed-bucket batching pattern into the New and Removed buckets of the audiobook sync path (`db/src/sync/audiobooks.rs`). Both buckets used to fire 1–2 DB queries per book while `sync_audiobooks_changed` was already batched.

### `sync_audiobooks_new`
Pre-fetches every candidate `scan_key` in one chunked `SELECT scan_key, id, uuid FROM books WHERE library_id = ? AND scan_key IN (…)` (499 keys per chunk under SQLite's 999-bind cap) into a `HashMap` before the per-book loop, replacing the per-book `SELECT id, uuid FROM books WHERE library_id = ? AND scan_key = ?` `fetch_optional`. The rewrite-in-place branch (fileless-returning + `replace_books` re-add) now looks up in memory; the cross-format attach heuristic path is unchanged.

### `sync_audiobooks_removed`
Introduces `batch_mark_audiobooks_files_missing` — one chunked `DELETE FROM book_files WHERE book_id IN (…)` plus one chunked `UPDATE books SET is_missing_files = 1, missing_files_since = unixepoch() WHERE id IN (…) AND is_missing_files = 0 AND is_missing_files_override = 0` per 500 ids, replacing the per-book `mark_book_files_missing(tx, id)` loop. Same fileless-book semantics (F2), same idempotency guards, one round-trip per chunk instead of two per book.

## Tests

- Extended `sync_audiobooks_with_removed_above_bind_cap_succeeds` (the existing 1000-audiobook wholesale-removal test) to assert every affected row is flagged `is_missing_files = 1` after the batched Removed pass — regression guard on the new `DELETE ... IN (…)` / `UPDATE ... IN (…)` pair.
- Added `sync_audiobooks_new_relinks_returning_group_to_same_uuid_after_fileless_gap`, the audiobook counterpart of the existing ebook F2 relink test, guarding the batched New scan_key lookup against regressing the fileless-then-returning cycle (returning group must relink to the same `books.uuid`, not mint a fresh one).

## Test plan

- [ ] `just test` (CI) — new tests pass; existing audiobook sync tests continue to pass.
- [ ] `just lint` (CI) — `cargo fmt --check` + clippy across the matrix.

## Verification note

Local `cargo test -p omnibus-db` could not be run in this sandbox: the git-sourced `dioxus` dep (`https://github.com/DioxusLabs/dioxus?tag=v0.7.9`) is denied by the egress proxy (403), which blocks any workspace-wide cargo resolution because the workspace `[patch.crates-io]` applies even to the DB crate. `cargo fmt -p omnibus-db --check` is clean. CI is the source of truth here.


---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review

**Verdict: approved**

Scope is precisely the two files the issue calls out (`db/src/sync/audiobooks.rs`, `db/src/sync/tests.rs`); no scope creep, no migrations touched, no unrelated churn.

- **Acceptance A (New bucket batched).** `sync_audiobooks_new` now pre-fetches `(id, uuid)` for every candidate `scan_key` into a `HashMap` via one chunked `SELECT scan_key, id, uuid FROM books WHERE library_id = ? AND scan_key IN (…)` before the per-book loop; the previous per-book `fetch_optional` is gone. The rewrite-in-place branch (fileless-returning + `replace_books` re-add — preserves `books.uuid`) runs *before* the cross-format attach heuristic, exactly as before. Chunk cap 499 + 1 library_id bind = 500 binds, well under 999.
- **Acceptance B (Removed bucket batched).** `batch_mark_audiobooks_files_missing` replaces the per-book `mark_book_files_missing(tx, id)` loop with one chunked `DELETE FROM book_files WHERE book_id IN (…)` + one chunked `UPDATE books SET is_missing_files = 1, missing_files_since = unixepoch() WHERE id IN (…) AND is_missing_files = 0 AND is_missing_files_override = 0` per 500 ids. Both idempotency guards (`is_missing_files = 0`, `is_missing_files_override = 0`) preserved — a re-run keeps the original `missing_files_since` and leaves wishlist rows untouched. Chunk cap 500 binds, under 999.
- **Idempotency / F2 semantics.** Fileless-book invariant intact: `books` row + `merged_uuids` + FTS survive; only `book_files` is dropped. The rewrite-in-place branch in `sync_audiobooks_new` still keys off `(library_id, scan_key)` and reuses the existing `books.id` + `uuid`, so a returning group re-attaches instead of minting a new uuid.
- **Test rigor.** The extended `sync_audiobooks_with_removed_above_bind_cap_succeeds` now asserts `COUNT(*) WHERE is_missing_files = 1 == N` after the batched Removed pass — would fail if the batched `UPDATE ... IN (…)` regressed to a no-op or lost the flag. The new `sync_audiobooks_new_relinks_returning_group_to_same_uuid_after_fileless_gap` walks the full new → remove (fileless, uuid retained) → re-add cycle and asserts the returning group relinks to the *same* `uuid1` — would fail if the batched pre-fetch skipped the rewrite-in-place branch and let `try_attach_new_audiobook` / `insert_new_audiobook` mint a fresh uuid.
- **Rule 05 line cap.** `db/src/sync/audiobooks.rs` is 783 lines (verified against the PR branch tip), under the ~800-line soft cap.
- **Housekeeping.** Conventional-commit title (`refactor:`), branch matches `refactor/632-…`, PR body opens with `Closes #632`. rustfmt + cargo audit + copilot review all green; `clippy + test` and `bundle` still running at review time — CI is the source of truth per the PR body's verification note (git-sourced `dioxus` dep is proxy-denied locally).

No changes requested.
