### PR TITLE
refactor: batch ebook sync_new + sync_removed DB queries

### DIFF
--- a/db/src/sync/books/new.rs
+++ b/db/src/sync/books/new.rs
@@ -3,14 +3,15 @@
 //! same-scan_key fileless row in place to preserve `books.uuid`, and tries the
 //! cross-format auto-attach heuristic before minting a fresh row.
 
+use std::collections::HashMap;
+
 use sqlx::Transaction;
 
 use crate::helpers::scan_key_for;
 
 use super::super::fts::upsert_fts;
 use super::shared::{
-    existing_by_scan_key, insert_book_row, insert_metadata_links, rewrite_book_in_place,
-    try_attach_new_ebook,
+    insert_book_row, insert_metadata_links, rewrite_book_in_place, try_attach_new_ebook,
 };
 
 /// Insert a batch of New entries: canonical `books` + `book_files` row,
@@ -22,8 +23,42 @@ pub(super) async fn sync_new(
     new_books: &[crate::ebook::IndexedBook],
     mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, sqlx::Error> {
+    if new_books.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Pre-compute the `scan_key` (relative path, F2) for every New entry so we
+    // can batch the "does a `books` row with this scan_key already exist?"
+    // lookup — a fileless book whose file returned, or the same file marked
+    // New by `replace_books` after being marked missing in the same call. The
+    // per-book loop below only consults the in-memory `id_map`; the attach
+    // heuristic still runs per-book because it's not a scan_key lookup.
+    let all_scan_keys: Vec<String> = new_books
+        .iter()
+        .map(|b| scan_key_for(&b.metadata.filename))
+        .collect();
+
+    // One batch SELECT per chunk (chunked at 499 to stay under SQLite's
+    // 999-parameter cap: 1 bind for library_id + up to 499 scan_key binds).
+    // Mirrors the same-scan_key pre-fetch in `sync_changed`.
+    let mut id_map: HashMap<String, (i64, String)> = HashMap::new();
+    for chunk in all_scan_keys.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let id_sql = format!(
+            "SELECT scan_key, id, uuid FROM books
+              WHERE library_id = ? AND scan_key IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String, i64, String)>(&id_sql).bind(library_id);
+        for sk in chunk {
+            q = q.bind(sk);
+        }
+        for (sk, id, uuid) in q.fetch_all(&mut **tx).await? {
+            id_map.insert(sk, (id, uuid));
+        }
+    }
+
     let mut new_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
-    for b in new_books {
+    for (b, scan_key) in new_books.iter().zip(all_scan_keys.iter()) {
         // A row with this exact scan_key (relative path) already exists — a
         // fileless book whose file returned, or the same file marked New by
         // `replace_books` after being marked missing in the same call. This is the
@@ -31,8 +66,7 @@ pub(super) async fn sync_new(
         // `books.uuid`) — checked before the cross-format attach heuristic,
         // which would otherwise mis-bind the returning file to the fileless row as
         // an attachment.
-        let scan_key = scan_key_for(&b.metadata.filename);
-        if let Some((book_id, uuid)) = existing_by_scan_key(tx, library_id, &scan_key).await? {
+        if let Some((book_id, uuid)) = id_map.get(scan_key).map(|(id, u)| (*id, u.clone())) {
             rewrite_book_in_place(tx, book_id, &uuid, b, &mut new_covers).await?;
             on_book_written();
             continue;

--- a/db/src/sync/books/removed.rs
+++ b/db/src/sync/books/removed.rs
@@ -1,13 +1,13 @@
 //! Removed bucket: every uuid whose file disappeared keeps its `books` row.
-//! `mark_book_files_missing` drops only the `book_files` row and flags the book
-//! missing for F10 GC — its metadata, taxonomy links, and FTS row stay, so the
-//! book remains in browse/search; the grid and facets hide it via their own
-//! `EXISTS book_files` filter. Idempotent — a re-run on an already-fileless row
-//! deletes zero `book_files`.
+//! One chunked DELETE drops only the `book_files` rows, and one chunked UPDATE
+//! flags each book missing for F10 GC — its metadata, taxonomy links, and FTS
+//! row stay, so the book remains in browse/search; the grid and facets hide it
+//! via their own `EXISTS book_files` filter. Idempotent — a re-run on an
+//! already-fileless row deletes zero `book_files` and the flag UPDATE no-ops
+//! (the `is_missing_files = 0` guard preserves the original
+//! `missing_files_since`).
 
 use sqlx::Transaction;
-
-use super::shared::mark_book_files_missing;
 
 /// Mark a batch of removed books' files missing (F2). The file is gone, but the
 /// `books` row — its metadata, taxonomy links, FTS row, and every soft-ref
@@ -15,7 +15,8 @@ use super::shared::mark_book_files_missing;
 /// chapters cascading), so the book stays in author/series/tag browse and
 /// search while the grid/facets hide it via their `EXISTS book_files` filter. A
 /// returning file re-attaches via the Changed path, preserving the uuid.
-/// Idempotent: a re-run on an already-fileless row deletes zero `book_files`.
+/// Idempotent: a re-run on an already-fileless row deletes zero `book_files`
+/// and the flag UPDATE is a no-op via the `is_missing_files = 0` guard.
 pub(super) async fn sync_removed(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
@@ -32,8 +33,11 @@ pub(super) async fn sync_removed(
             .collect::<Vec<_>>()
             .join(", ");
 
-        // Resolve the affected ids, then drop their file rows — keeping each
-        // `books` row (and its links/FTS) as a fileless book.
+        // Resolve the affected ids, then batch-drop their file rows and flag
+        // the rows missing — keeping each `books` row (and its links/FTS) as a
+        // fileless book. Two chunked statements replace the old per-book
+        // `mark_book_files_missing` fan-out (which fired 2 DML per removed
+        // book).
         let id_sql =
             format!("SELECT id FROM books WHERE library_id = ? AND uuid IN ({placeholders})");
         let mut q = sqlx::query_scalar::<_, i64>(&id_sql).bind(library_id);
@@ -42,9 +46,41 @@ pub(super) async fn sync_removed(
         }
         let ids = q.fetch_all(&mut **tx).await?;
         missing += ids.len();
-        for id in ids {
-            mark_book_files_missing(tx, id).await?;
+        if ids.is_empty() {
+            continue;
         }
+
+        let id_placeholders = std::iter::repeat_n("?", ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        // One DELETE per chunk: `book_file_parts` + `file_chapters` cascade
+        // off the `book_files` row, so a single sweep drops everything the
+        // file owned.
+        let delete_sql = format!("DELETE FROM book_files WHERE book_id IN ({id_placeholders})");
+        let mut delete_q = sqlx::query(&delete_sql);
+        for id in &ids {
+            delete_q = delete_q.bind(id);
+        }
+        delete_q.execute(&mut **tx).await?;
+
+        // One UPDATE per chunk: set the F10 missing flag + start the retention
+        // clock. The `is_missing_files = 0` guard preserves the original
+        // `missing_files_since` on a re-run; the `is_missing_files_override = 0`
+        // guard leaves intentionally-fileless rows (wishlist) unflagged so
+        // reads keep showing them.
+        let update_sql = format!(
+            "UPDATE books
+                SET is_missing_files = 1, missing_files_since = unixepoch()
+              WHERE id IN ({id_placeholders})
+                AND is_missing_files = 0
+                AND is_missing_files_override = 0"
+        );
+        let mut update_q = sqlx::query(&update_sql);
+        for id in &ids {
+            update_q = update_q.bind(id);
+        }
+        update_q.execute(&mut **tx).await?;
     }
     if missing > 0 {
         // These rows are flagged missing (F10); `missing_files::gc_books_missing_files`

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -23,23 +23,6 @@ use super::super::authors::insert_author_links;
 use super::super::fts::upsert_fts;
 use super::wipe_per_book_link_rows;
 
-/// Resolve an existing `books` row (id + uuid) under `library_id` by its
-/// `scan_key`. Used by the New path to re-attach to a fileless / same-path row
-/// instead of inserting a colliding one.
-pub(super) async fn existing_by_scan_key(
-    tx: &mut Transaction<'_, sqlx::Sqlite>,
-    library_id: i64,
-    scan_key: &str,
-) -> Result<Option<(i64, String)>, sqlx::Error> {
-    sqlx::query_as::<_, (i64, String)>(
-        "SELECT id, uuid FROM books WHERE library_id = ? AND scan_key = ?",
-    )
-    .bind(library_id)
-    .bind(scan_key)
-    .fetch_optional(&mut **tx)
-    .await
-}
-
 /// Rewrite an existing book in place from a freshly-parsed entry: refresh
 /// the `books` scalars, wipe + re-insert this format's `book_files` and the
 /// per-book links, and refresh FTS — preserving `books.id`/`books.uuid`.

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -633,6 +633,154 @@ async fn sync_empty_plan_with_full_removed_clears_library() {
 
     assert!(list_books(&pool, "/lib").await.unwrap().is_empty());
 }
+
+/// A single Removed bucket exceeding SQLite's 999-bind cap must succeed after
+/// batching: `sync_removed` chunks the id-resolution SELECT *and* the batched
+/// DELETE + UPDATE that replaced the per-book `mark_book_files_missing` fan-out.
+/// 1000 uuids exercises both the chunk boundary (500 + 500) and the batched-DML
+/// path so a regression back to the per-book loop would still pass but the
+/// bind-cap failure below would surface immediately.
+#[tokio::test]
+async fn sync_books_with_removed_above_bind_cap_succeeds() {
+    let _covers = CoversTempDir::new("book_remove_chunk");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    // 1000 books forces the chunked path through two chunks (500 + 500) and
+    // pushes an un-chunked `IN (?, ?, ...)` past the 999-bind cap.
+    const N: usize = 1000;
+    let new_books: Vec<_> = (0..N)
+        .map(|i| indexed(&format!("book{i:04}.epub"), Some("t"), &[], &[], None, None))
+        .collect();
+    replace_books(&pool, "/lib", new_books).await.unwrap();
+    assert_eq!(list_books(&pool, "/lib").await.unwrap().len(), N);
+
+    let all_uuids: Vec<String> = sqlx::query_scalar("SELECT uuid FROM books")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+    // Wholesale remove all 1000 in a single plan.
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            removed_uuids: all_uuids,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("wholesale removal of >500 books must not exceed bind cap");
+
+    // Every row is retained as fileless (books row + FTS survive), grid hides
+    // them.
+    assert!(
+        list_books(&pool, "/lib").await.unwrap().is_empty(),
+        "every book is hidden from the grid (fileless) after wholesale removal"
+    );
+    let books_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let files_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM book_files")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let flagged: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books WHERE is_missing_files = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(books_total, N as i64, "books rows retained as fileless");
+    assert_eq!(files_total, 0, "every book_files row was dropped");
+    assert_eq!(
+        flagged, N as i64,
+        "every row was flagged missing by the batched UPDATE"
+    );
+}
+
+/// The batched New path pre-fetches a `HashMap` of `(scan_key -> (id, uuid))`
+/// before entering the per-book loop. When a mix of returning-file (fileless)
+/// entries and truly-new entries lands in one plan, the returning files must
+/// re-attach to their existing rows (preserving `books.uuid`) and the new files
+/// must mint fresh rows — all resolved off the in-memory map with no per-book
+/// SELECT.
+#[tokio::test]
+async fn sync_new_batch_pre_fetch_re_attaches_returning_and_inserts_fresh() {
+    let _covers = CoversTempDir::new("new_batch_prefetch");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    // Seed 3 books, then mark them all fileless so the next sync sees their
+    // scan_keys as candidates for re-attach.
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed("a.epub", Some("A"), &["X"], &[], None, None),
+            indexed("b.epub", Some("B"), &["Y"], &[], None, None),
+            indexed("c.epub", Some("C"), &["Z"], &[], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+    let uuid_a = crate::test_support::uuid_by_scan_key(&pool, "a.epub").await;
+    let uuid_b = crate::test_support::uuid_by_scan_key(&pool, "b.epub").await;
+    let uuid_c = crate::test_support::uuid_by_scan_key(&pool, "c.epub").await;
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            removed_uuids: vec![uuid_a.clone(), uuid_b.clone(), uuid_c.clone()],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // One plan: 2 returning files (a.epub, c.epub) + 1 brand-new (d.epub). The
+    // batched scan_key SELECT resolves a.epub + c.epub to their existing rows;
+    // d.epub falls through the map lookup, tries the attach heuristic, then
+    // inserts.
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            new_books: vec![
+                indexed("a.epub", Some("A"), &["X"], &[], None, None),
+                indexed("c.epub", Some("C"), &["Z"], &[], None, None),
+                indexed("d.epub", Some("D"), &["W"], &[], None, None),
+            ],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let visible = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(
+        visible.len(),
+        3,
+        "two re-attached rows + one new row are visible; b.epub stays fileless"
+    );
+    assert_eq!(
+        crate::test_support::uuid_by_scan_key(&pool, "a.epub").await,
+        uuid_a,
+        "returning a.epub keeps its durable uuid (re-attached, not re-minted)"
+    );
+    assert_eq!(
+        crate::test_support::uuid_by_scan_key(&pool, "c.epub").await,
+        uuid_c,
+        "returning c.epub keeps its durable uuid (re-attached, not re-minted)"
+    );
+    // The fileless row (b.epub) survives with its uuid; the new row (d.epub)
+    // has a fresh uuid.
+    assert_eq!(
+        crate::test_support::uuid_by_scan_key(&pool, "b.epub").await,
+        uuid_b,
+        "fileless b.epub retains its scan_key + uuid across the sync"
+    );
+    let uuid_d = crate::test_support::uuid_by_scan_key(&pool, "d.epub").await;
+    assert!(![uuid_a, uuid_b, uuid_c].contains(&uuid_d));
+}
+
 #[tokio::test]
 async fn reindex_replaces_library_atomically() {
     let _covers = CoversTempDir::new("atomic");


### PR DESCRIPTION
## Summary

Extends the `sync_changed` batching pattern (#442) to the two remaining
unbatched ebook sync buckets, so a large import / rescan no longer
issues 1–2 DB queries per book.

- **`sync_new`** — pre-fetch a `HashMap` via one
  chunked SELECT before the per-book loop; the loop consults the
  in-memory map instead of calling `existing_by_scan_key` per book.
  The cross-format attach heuristic stays per-book per the issue
  Notes ("start with the simple `existing_by_scan_key` batch before
  tackling the attachment flow"). Removes the now-unused
  `existing_by_scan_key` helper.
- **`sync_removed`** — replaces the per-id
  `mark_book_files_missing` fan-out (2 DML per removed book) with one
  chunked `DELETE FROM book_files WHERE book_id IN (...)` + one
  chunked `UPDATE books SET is_missing_files = 1, ... WHERE id IN
  (...)`, chunked at 500 to stay under SQLite's 999-bind cap. The
  UPDATE preserves the original guards (`is_missing_files = 0 AND
  is_missing_files_override = 0`) so idempotent re-runs and
  wishlist-fileless rows behave identically.
- `mark_book_files_missing` is kept in `shared.rs` because
  `sync_audiobooks_removed` still calls it (per issue scope — only the
  ebook path is called out).

## Tests

Two new tests in `db/src/sync/tests.rs`:

- `sync_books_with_removed_above_bind_cap_succeeds` — 1000-book wholesale
  removal (mirrors `sync_audiobooks_with_removed_above_bind_cap_succeeds`)
  that would blow SQLite's 999-bind cap if the DELETE/UPDATE weren't
  chunked; asserts every row is retained as fileless with the missing
  flag set.
- `sync_new_batch_pre_fetch_re_attaches_returning_and_inserts_fresh` —
  mixed plan (2 returning fileless entries + 1 brand-new entry) that
  exercises the pre-fetched `id_map` path and the fall-through to
  insert; asserts durable uuids survive the re-attach.

## Verification

- fmt: `cargo fmt -p omnibus-db --check` clean.
- clippy / tests: **not runnable in the sandbox** — the workspace
  resolve fetches the Dioxus git dep (`https://github.com/DioxusLabs/dioxus?tag=v0.7.9`)
  which the agent's egress proxy 403s. CI is the source of truth.
- The changes are limited to the `db` crate (no callers outside sync);
  `sync_audiobooks_removed` still uses the preserved
  `mark_book_files_missing`.

## Test plan

- [ ] CI green (`just test` covers the two new tests + the existing sync suite).
- [ ] Local `cargo test -p omnibus-db sync` passes.

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review

**Verdict: approved-with-notes.** The diff resolves #631 exactly on the terms the issue prescribes.

**Confirmed:**
- `sync_new`: one chunked `SELECT scan_key, id, uuid ... WHERE library_id = ? AND scan_key IN (...)` pre-fills a `HashMap<String, (i64, String)>` before the per-book loop; the loop consults `id_map.get(scan_key)` and issues no scan_key SELECT of its own. Mirrors `changed.rs` (same 499 chunk size for `1 + 499 = 500` binds, well under 999).
- `sync_removed`: per-id `mark_book_files_missing` fan-out replaced by one chunked `DELETE FROM book_files WHERE book_id IN (...)` + one chunked `UPDATE books SET is_missing_files = 1, missing_files_since = unixepoch() WHERE id IN (...) AND is_missing_files = 0 AND is_missing_files_override = 0`. **Both idempotency guards preserved verbatim** (the risk the review was watching for).
- `existing_by_scan_key` deletion is clean — `git grep` on the branch returns zero hits; the only remaining reference in the shared module is `mark_book_files_missing`, deliberately retained for `sync_audiobooks_removed` (audiobook path is out of scope per the issue).
- `try_attach_new_ebook` correctly kept per-book — the issue Notes explicitly deferred that heuristic.
- Chunk sizing: `new.rs` uses 499 (1 library_id + 499 scan_keys = 500 binds); `removed.rs` uses 500 for the SELECT (501 binds) and up to 500 for the derived DELETE/UPDATE. All under 999.
- Scope: touches only the four cited files. No migrations touched. Branch name / commit title / `Closes #631` all conform.

**Notes (non-blocking):**
- `sync_new_batch_pre_fetch_re_attaches_returning_and_inserts_fresh` proves semantic correctness of the mixed plan but does **not** actively prove batching happened — a regression back to per-book `existing_by_scan_key` would still pass this test. Only `sync_books_with_removed_above_bind_cap_succeeds` gates the batched Removed path against regression (via the 999-bind cap). Consider a query-count assertion or 1000-scan_key New-bucket variant if you want symmetric regression coverage for `sync_new`.
- Import ordering in `new.rs` uses 4 groups (std / sqlx / crate / super) rather than the 3-block canonical form in rule 05, but this mirrors the sibling `changed.rs`, so it's consistent with the codebase.
- CI still in-progress at review time (clippy + test, bundle running; rustfmt + audit green). PR author flagged clippy/test unrunnable in sandbox — CI is the source of truth.