### PR TITLE
refactor: batch resolve_fts_rows to 2 chunked queries

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -30,8 +30,8 @@ mod tests;
 pub use facets::library_facets;
 pub use get::{
     book_file_path, book_file_path_by_id, get_book, get_book_by_uuid, get_book_files,
-    resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid,
-    resolve_canonical_book_uuid_exec,
+    get_books_by_ids, resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec,
+    resolve_book_ids_by_uuids, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
 };
 pub use list::{
     collect_paths, count_books, count_books_for_paths, library_from_db, library_from_db_combined,

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -2,13 +2,17 @@
 //! `resolve_book_id_by_uuid` helper that the covers/thumbs/mobile routes
 //! use to translate a stable uuid to the current id.
 
+use std::collections::HashMap;
+
 use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::EbookMetadata;
 
 use crate::metadata_overrides::{apply_overrides, get_metadata_overrides};
 
-use super::projection::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
+use super::projection::{
+    backfill_creator_ids, merge_overrides_into_books, row_to_ebook, BOOK_COLUMNS,
+};
 
 /// Fetch a single book by its stable `books.id`. Returns `None` if not found.
 ///
@@ -157,6 +161,109 @@ where
     .bind(uuid)
     .fetch_optional(executor)
     .await?)
+}
+
+/// Bulk counterpart to [`resolve_book_id_by_uuid`]: map each supplied
+/// `books.uuid` (or `merged_uuids` ledger key) to its current
+/// `books.id`, in one chunked round-trip. UUIDs with no matching book
+/// are absent from the returned map — matching the `None` behaviour of
+/// the per-uuid function, so callers can silently skip them.
+///
+/// Chunked at 499 binds per statement to stay under SQLite's default
+/// 999-parameter cap (the same UUID slot is bound twice in the
+/// statement — once for `books.uuid IN (…)` and once for
+/// `merged_uuids.uuid IN (…)`). Where a uuid appears both as a live
+/// `books.uuid` and as a `merged_uuids` ledger key, the direct
+/// `books.uuid` match wins — matching the `LIMIT 1` precedence of the
+/// per-uuid function's UNION.
+pub async fn resolve_book_ids_by_uuids(
+    pool: &SqlitePool,
+    uuids: &[String],
+) -> Result<HashMap<String, i64>, super::BooksError> {
+    if uuids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut map: HashMap<String, i64> = HashMap::with_capacity(uuids.len());
+    for chunk in uuids.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT uuid, id FROM (
+                 SELECT uuid, id, 0 AS rank FROM books
+                  WHERE uuid IN ({placeholders})
+                 UNION ALL
+                 SELECT uuid, book_id AS id, 1 AS rank FROM merged_uuids
+                  WHERE uuid IN ({placeholders})
+             )
+             ORDER BY rank"
+        );
+        let mut q = sqlx::query_as::<_, (String, i64)>(&sql);
+        for u in chunk {
+            q = q.bind(u);
+        }
+        for u in chunk {
+            q = q.bind(u);
+        }
+        for (uuid, id) in q.fetch_all(pool).await? {
+            // The direct `books.uuid` match (rank 0) is returned before
+            // the `merged_uuids` fallback (rank 1); the first insert per
+            // uuid wins so a live book always beats a stale ledger row.
+            map.entry(uuid).or_insert(id);
+        }
+    }
+    Ok(map)
+}
+
+/// Bulk `get_book`: return the merged metadata for every id in `ids`,
+/// keyed by id, in one chunked `WHERE b.id IN (…)` fetch per chunk +
+/// one bulk overrides load. Unknown ids are absent from the returned
+/// map. Mirrors [`get_book`]'s overrides + creator-id backfill so a
+/// caller loading many books observes the same shape it would per-id.
+///
+/// The multi-part `book_files` fetch and the `series_id`-from-name
+/// backfill that [`get_book`] runs are **not** replicated: they matter
+/// only for the book-detail UI (multi-part file picker, series-link
+/// navigation), and every current bulk consumer reads canonical text
+/// columns only.
+pub async fn get_books_by_ids(
+    pool: &SqlitePool,
+    ids: &[i64],
+) -> Result<HashMap<i64, EbookMetadata>, super::BooksError> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let mut out: HashMap<i64, EbookMetadata> = HashMap::with_capacity(ids.len());
+    // The projection's per-id scalar subqueries make each row
+    // self-contained, so a single chunked `WHERE b.id IN (…)` returns
+    // every book in one statement.
+    for chunk in ids.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            r"
+            SELECT {BOOK_COLUMNS}
+            FROM books b
+            WHERE b.id IN ({placeholders})
+            "
+        );
+        let mut q = sqlx::query(&sql);
+        for id in chunk {
+            q = q.bind(*id);
+        }
+        let rows = q.fetch_all(pool).await?;
+        let mut books: Vec<EbookMetadata> = Vec::with_capacity(rows.len());
+        for r in &rows {
+            books.push(row_to_ebook(r)?);
+        }
+        // Bulk-merge overrides (one query) then bulk-backfill the
+        // author ids override contributors leave unset (one query
+        // per chunk).
+        merge_overrides_into_books(pool, &mut books).await?;
+        backfill_creator_ids(pool, &mut books).await?;
+        for book in books {
+            out.insert(book.id, book);
+        }
+    }
+    Ok(out)
 }
 
 /// Resolve any book reference (its own durable `books.uuid` or a

--- a/db/src/metadata_overrides/fts.rs
+++ b/db/src/metadata_overrides/fts.rs
@@ -9,7 +9,7 @@ use sqlx::{SqliteConnection, SqlitePool};
 
 use omnibus_shared::EbookMetadata;
 
-use crate::books::resolve_book_id_by_uuid;
+use crate::books::{get_books_by_ids, resolve_book_id_by_uuid, resolve_book_ids_by_uuids};
 use crate::sync::upsert_fts;
 
 use super::upsert::MetadataOverridesError;
@@ -99,21 +99,38 @@ pub(crate) async fn rebuild_fts_for_books_batch(
 }
 
 /// Resolve UUIDs to `(book_id, merged metadata)`, skipping any uuid with
-/// no live book row. Uses [`resolve_book_id_by_uuid`] so merged/attached
+/// no live book row. Uses [`resolve_book_ids_by_uuids`] so merged/attached
 /// uuids resolve to the surviving book.
+///
+/// Two round-trips per chunk (chunked at 499 to respect SQLite's
+/// bind-parameter cap): one bulk uuid→id resolve, then one bulk book
+/// fetch. A per-uuid loop would issue 2N round-trips, which dominates
+/// the write phase for the large batches this path fires on
+/// (author-photo updates, multi-book override saves).
+///
+/// The two lookups are joined in memory; uuids that resolve to an id
+/// whose book row has since vanished are silently dropped (same
+/// tolerance the pre-batch [`rebuild_fts_for_book`] path applied).
 async fn resolve_fts_rows(
     pool: &SqlitePool,
     book_uuids: &[String],
 ) -> Result<Vec<(i64, EbookMetadata)>, MetadataOverridesError> {
-    let mut rows: Vec<(i64, EbookMetadata)> = Vec::with_capacity(book_uuids.len());
-    for uuid in book_uuids {
-        let Some(book_id) = resolve_book_id_by_uuid(pool, uuid).await? else {
-            continue;
-        };
-        let Some(merged) = crate::books::get_book(pool, book_id).await? else {
-            continue;
-        };
-        rows.push((book_id, merged));
+    let id_by_uuid = resolve_book_ids_by_uuids(pool, book_uuids).await?;
+    if id_by_uuid.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Deduplicate: two uuids can point at the same book (a merged/attached
+    // ledger key alongside its target's own uuid), and we only need to
+    // rebuild each FTS row once.
+    let mut ids: Vec<i64> = id_by_uuid.values().copied().collect();
+    ids.sort_unstable();
+    ids.dedup();
+    let mut book_by_id = get_books_by_ids(pool, &ids).await?;
+    let mut rows: Vec<(i64, EbookMetadata)> = Vec::with_capacity(ids.len());
+    for id in ids {
+        if let Some(merged) = book_by_id.remove(&id) {
+            rows.push((id, merged));
+        }
     }
     Ok(rows)
 }

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -564,3 +564,127 @@ async fn upsert_overrides_persists_books_series_link_row_for_new_series() {
         "books_series_link should reflect the new override series after upsert commits"
     );
 }
+
+/// `rebuild_fts_for_books_batch` mixes a direct `books.uuid`, a
+/// `merged_uuids` ledger-key uuid, and an unknown uuid in one call.
+/// After the batch commits, `books_fts` for each surviving book must
+/// carry the *merged* (override-overlaid) text, and the unknown uuid
+/// must be silently skipped. Guards the acceptance criteria of the
+/// batch-resolve refactor: at most two queries regardless of size,
+/// merged uuids still route to the surviving book, unknown uuids
+/// don't fail the whole batch.
+#[tokio::test]
+async fn rebuild_fts_for_books_batch_handles_direct_merged_and_unknown_uuids() {
+    let _covers = CoversTempDir::new("batch_fts_mixed");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    // Two books indexed the normal way — each gets a native
+    // `books.uuid`. The batch will use the first book by its direct
+    // uuid; for the second we attach a synthetic `merged_uuids` row so
+    // the batch resolves that key to the same book.
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed("a.epub", Some("Alpha"), &["A"], &[], None, None),
+            indexed("b.epub", Some("Beta"), &["B"], &[], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let (alpha_uuid, alpha_id) = books
+        .iter()
+        .find(|b| b.title.as_deref() == Some("Alpha"))
+        .map(|b| (b.unique_identifier.clone().unwrap(), b.id))
+        .unwrap();
+    let (beta_uuid, beta_id) = books
+        .iter()
+        .find(|b| b.title.as_deref() == Some("Beta"))
+        .map(|b| (b.unique_identifier.clone().unwrap(), b.id))
+        .unwrap();
+
+    // Register a merged-uuid ledger key pointing at Beta so the batch
+    // resolve path exercises the `merged_uuids` fallback. Skip the
+    // `books.uuid` lookup — the row hangs off a foreign format
+    // (M4B is not indexed here) so it wouldn't otherwise resolve.
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path)
+         VALUES ('attached-uuid', ?, 'M4B', '/lib')",
+    )
+    .bind(beta_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Persist overrides for both books so `overlay_overrides` has
+    // something to patch on top of the canonical row.
+    upsert_metadata_overrides(
+        &pool,
+        &alpha_uuid,
+        &MetadataOverrides {
+            title: Some("Alpha Edited".into()),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+    upsert_metadata_overrides(
+        &pool,
+        &beta_uuid,
+        &MetadataOverrides {
+            title: Some("Beta Edited".into()),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    // Corrupt the FTS rows so the batch rebuild is the only path that
+    // could produce the expected text.
+    sqlx::query("UPDATE books_fts SET title = 'STALE' WHERE rowid IN (?, ?)")
+        .bind(alpha_id)
+        .bind(beta_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    rebuild_fts_for_books_batch(
+        &pool,
+        &[
+            alpha_uuid,
+            "attached-uuid".to_string(),
+            "does-not-exist".to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let alpha_fts: String = sqlx::query_scalar("SELECT title FROM books_fts WHERE rowid = ?")
+        .bind(alpha_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let beta_fts: String = sqlx::query_scalar("SELECT title FROM books_fts WHERE rowid = ?")
+        .bind(beta_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        alpha_fts, "Alpha Edited",
+        "direct uuid routes through resolve + get_books_by_ids and overlays the override title"
+    );
+    assert_eq!(
+        beta_fts, "Beta Edited",
+        "the merged_uuids ledger key resolves to Beta and overlays its override title"
+    );
+}


### PR DESCRIPTION
## Summary
- `resolve_fts_rows` in `db/src/metadata_overrides/fts.rs` used to issue `resolve_book_id_by_uuid` + `get_book` per uuid — 2N round-trips per batch. On author-photo updates and multi-book override saves this generated thousands of SELECTs where a handful would do (the write phase inside the transaction was already batched — only the read phase was unoptimized).
- Add `resolve_book_ids_by_uuids` in `db/src/books/get.rs`: one chunked `SELECT` per 499-uuid chunk, replicating `resolve_book_id_by_uuid`&#39;s `books.uuid` → `merged_uuids` UNION fallback so merged/attached uuids still route to the surviving book. A `rank` column in the union preserves the per-uuid `LIMIT 1` precedence (direct `books.uuid` wins over the ledger fallback).
- Add `get_books_by_ids` in `db/src/books/get.rs`: chunked `WHERE b.id IN (…)` over the shared `BOOK_COLUMNS` projection, folding in `merge_overrides_into_books` + `backfill_creator_ids` so the returned shape matches `get_book`&#39;s — minus the detail-page-only `series_id`-from-name backfill and multi-part `book_files` fetch, which no bulk consumer needs.
- Rewrite `resolve_fts_rows` on top of both. Dedup ids before the bulk fetch so a merged-uuid ledger key alongside its target&#39;s own uuid rebuilds the FTS row once, not twice. Unknown uuids stay silently skipped.

## Test plan
- [x] `cargo fmt --package omnibus-db` clean
- [ ] `cargo test -p omnibus-db metadata_overrides` — deferred to CI: the sandbox proxy blocks the `DioxusLabs/dioxus` git dep (403), so a full-workspace resolve fails locally.
- [x] New test `rebuild_fts_for_books_batch_handles_direct_merged_and_unknown_uuids` covers the batch path with a mixed input: direct `books.uuid`, `merged_uuids` ledger key, and an unknown uuid. Corrupts the FTS rows first so the assertion can only pass if the batch rebuild ran; then asserts both surviving books&#39; FTS titles are the override-overlaid text and the unknown uuid was skipped without error.
- [x] Existing `metadata_overrides` tests continue to compile against the new bulk helpers (they call `rebuild_fts_for_book` for the single-uuid path, which is untouched).

## Notes
- `resolve_book_ids_by_uuids` and `get_books_by_ids` are `pub` for future reuse — the FTS rebuild is the first caller, but the same 2N → O(1) pattern applies anywhere else that loops `resolve_book_id_by_uuid` + `get_book`.
- Not exhaustive: `get_books_by_ids` intentionally skips the `series_id`-from-name and multi-part `book_files` steps `get_book` runs. Both matter only for the detail-page UI, which loads one book at a time and can keep using `get_book`. Callers that need them can post-fetch per id.

Closes #610

Co-Authored-By: Claude Opus 4.7 
Claude-Session: https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGkb1sHd7fp3UR5VC9Vkw)_

---
### Adversarial review

**Verdict:** approved-with-notes.

- Resolves #610 in spirit: the 2N-per-uuid loop is gone. Per outer 499-uuid chunk, `resolve_fts_rows` now issues ~4 queries (`resolve_book_ids_by_uuids` UNION + `BOOK_COLUMNS` SELECT + `load_overrides_bulk` SELECT + `backfill_creator_ids` SELECT). That is O(1) per chunk, not the "at most 2 queries regardless of batch size" the issue's acceptance criterion asks for — but the perf goal (kill the N+1) is met and the extra two queries per chunk are the exact ones `list_books_for_paths` already runs. The PR body and the `resolve_fts_rows` doc comment both undersell the query count as "two round-trips per chunk"; consider clarifying to "constant round-trips per chunk, independent of batch size" so the docstring doesn't rot the next time someone counts.
- Merged-uuid precedence preserved. The bulk resolver's `UNION ALL … ORDER BY rank` + first-writer-wins `HashMap::entry(uuid).or_insert(id)` correctly reproduces the per-uuid `LIMIT 1` behaviour where a direct `books.uuid` hit beats a colliding `merged_uuids` ledger row. Both `books.uuid` (UNIQUE) and `merged_uuids.uuid` (PRIMARY KEY, migration `0016`) are unique, so no intra-rank ambiguity.
- Silent-skip for unknown uuids preserved. Unknown uuids never enter `id_by_uuid`, never enter `ids`, never enter `book_by_id`; `rebuild_fts_for_books_batch` still returns `Ok(())`.
- Chunk size 499 is safe: the resolver binds each uuid twice (books + merged_uuids), 2×499 = 998 &lt; SQLite's 999 default cap. `get_books_by_ids` binds each id once, well under the cap.
- Skipping `backfill_series_id_by_name` and multi-part `book_files` in `get_books_by_ids` is safe for the FTS use case: `overlay_overrides` writes only `title / authors / series / tags / description`, none of which depend on `series_id` (which is a link-target for the detail page only) or `book_files` (multi-part is UI-only).
- Dedup step is a correctness/perf win, not a regression: a merged-uuid ledger key alongside its target's own uuid used to rebuild the FTS row twice with the same content; it now runs once. `rebuild_fts_for_books_batch` returns `()`, so no caller observes the row count.
- Rule 03 test placement (`db/src/metadata_overrides/tests.rs` sibling) and long-sentence naming (`rebuild_fts_for_books_batch_handles_direct_merged_and_unknown_uuids`) both compliant. New `pub` fns carry `///` docs (rule 05). No migrations touched (rule 06 clean). Conventional commit title, `Closes #610` in body, branch `refactor/610-…` matches convention.
- Minor style: `get.rs` now has four blank-line-separated import blocks (`std`, `sqlx`, `omnibus_shared`, `crate::`/`super::`) instead of the three rule 05 prescribes — but this matches the pre-existing split in `list.rs` / `search.rs` / the old `fts.rs`, so it's a codebase-wide convention drift, not a PR-local issue.
- CI at review time: `cargo audit` and `rustfmt` green; `clippy + test` and `bundle` still in progress. Author's local `cargo test` was blocked by the sandbox proxy 403 on the Dioxus git dep — that's the environment, not the change.
