### PR TITLE
fix: batch audiobook sync New/Removed bucket queries (#632)

### DIFF
--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -125,13 +125,14 @@ async fn sync_audiobooks_removed(
     let mut missing = 0usize;
     // Chunk at 500 to stay under SQLite's 999-param cap when a whole library
     // (or any large diff) is removed — same convention as `sync_removed` in
-    // `books.rs`.
+    // `books/removed.rs`.
     for chunk in removed_uuids.chunks(500) {
         let placeholders = std::iter::repeat_n("?", chunk.len())
             .collect::<Vec<_>>()
             .join(", ");
-        // Resolve affected ids and drop their file rows — retaining each
-        // `books` row (and its links/FTS) as a fileless book (F2).
+        // Resolve affected ids once, then drop their file rows and flag them
+        // missing with a single batched DELETE + UPDATE keyed on the id list —
+        // retaining each `books` row (and its links/FTS) as a fileless book (F2).
         let id_sql =
             format!("SELECT id FROM books WHERE library_id = ? AND uuid IN ({placeholders})");
         let mut q = sqlx::query_scalar::<_, i64>(&id_sql).bind(library_id);
@@ -139,10 +140,11 @@ async fn sync_audiobooks_removed(
             q = q.bind(uuid);
         }
         let ids = q.fetch_all(&mut **tx).await?;
-        missing += ids.len();
-        for id in ids {
-            super::books::mark_book_files_missing(tx, id).await?;
+        if ids.is_empty() {
+            continue;
         }
+        missing += ids.len();
+        mark_book_files_missing_batch(tx, &ids).await?;
     }
     if missing > 0 {
         tracing::info!(
@@ -156,6 +158,42 @@ async fn sync_audiobooks_removed(
     // entry instead (the target book survives, possibly fileless).
     // `remove_attached_files` already chunks internally.
     attach::remove_attached_files(tx, removed_uuids).await?;
+    Ok(())
+}
+
+/// Batched form of `books::mark_book_files_missing` for the Removed bucket: one
+/// IN-list DELETE of the `book_files` rows (parts/chapters cascade) and one
+/// guarded UPDATE flagging the now-fileless `books` rows missing (F2), instead
+/// of two statements per book. The UPDATE keeps `mark_book_files_missing`'s
+/// guards — `is_missing_files = 0` preserves the original `missing_files_since`
+/// on a re-run, and `is_missing_files_override = 0` leaves intentionally-fileless
+/// rows (wishlist) un-flagged. `ids` must be non-empty and within the SQLite
+/// 999-param cap (the caller chunks at 500).
+async fn mark_book_files_missing_batch(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    ids: &[i64],
+) -> Result<(), SyncError> {
+    let placeholders = std::iter::repeat_n("?", ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let del_sql = format!("DELETE FROM book_files WHERE book_id IN ({placeholders})");
+    let mut del_q = sqlx::query(&del_sql);
+    for id in ids {
+        del_q = del_q.bind(id);
+    }
+    del_q.execute(&mut **tx).await?;
+
+    let upd_sql = format!(
+        "UPDATE books
+            SET is_missing_files = 1, missing_files_since = unixepoch()
+          WHERE id IN ({placeholders}) AND is_missing_files = 0 AND is_missing_files_override = 0"
+    );
+    let mut upd_q = sqlx::query(&upd_sql);
+    for id in ids {
+        upd_q = upd_q.bind(id);
+    }
+    upd_q.execute(&mut **tx).await?;
     Ok(())
 }
 
@@ -269,17 +307,35 @@ async fn sync_audiobooks_new(
     mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, SyncError> {
     let mut new_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
+    if new_books.is_empty() {
+        return Ok(new_covers);
+    }
+    // Pre-fetch every same-scan_key `books` row in one batch (chunked at 499 to
+    // stay under SQLite's 999-param cap), keyed on the F2 `scan_key` — mirrors
+    // `sync_audiobooks_changed`. New entries carry distinct scan_keys, so each
+    // maps at most one existing row and the map never goes stale mid-loop.
+    let all_scan_keys: Vec<String> = new_books.iter().map(|b| b.scan_key.clone()).collect();
+    let mut id_map: HashMap<String, (i64, String)> = HashMap::new();
+    for chunk in all_scan_keys.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let id_sql = format!(
+            "SELECT scan_key, id, uuid FROM books
+              WHERE library_id = ? AND scan_key IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String, i64, String)>(&id_sql).bind(library_id);
+        for sk in chunk {
+            q = q.bind(sk);
+        }
+        for (sk, id, uuid) in q.fetch_all(&mut **tx).await? {
+            id_map.insert(sk, (id, uuid));
+        }
+    }
+
     for b in new_books {
         // Same-scan_key row (a fileless book whose group returned, or a
         // `replace_books` re-add) → rewrite in place, *before* the
         // cross-format attach heuristic, preserving `books.uuid`.
-        let existing: Option<(i64, String)> =
-            sqlx::query_as("SELECT id, uuid FROM books WHERE library_id = ? AND scan_key = ?")
-                .bind(library_id)
-                .bind(&b.scan_key)
-                .fetch_optional(&mut **tx)
-                .await?;
-        if let Some((book_id, uuid)) = existing {
+        if let Some((book_id, uuid)) = id_map.get(&b.scan_key).map(|(id, u)| (*id, u.clone())) {
             rewrite_audiobook_in_place(tx, book_id, &uuid, b, &mut new_covers).await?;
             on_book_written();
             continue;

--- a/db/src/sync/books/mod.rs
+++ b/db/src/sync/books/mod.rs
@@ -17,9 +17,7 @@ mod new;
 mod removed;
 mod shared;
 
-pub(super) use shared::{
-    clear_missing_files_flag, materialize_new_covers,
-};
+pub(super) use shared::{clear_missing_files_flag, materialize_new_covers};
 
 use backfill::stamp_last_indexed;
 use changed::sync_changed;

--- a/db/src/sync/books/mod.rs
+++ b/db/src/sync/books/mod.rs
@@ -18,7 +18,7 @@ mod removed;
 mod shared;
 
 pub(super) use shared::{
-    clear_missing_files_flag, mark_book_files_missing, materialize_new_covers,
+    clear_missing_files_flag, materialize_new_covers,
 };
 
 use backfill::stamp_last_indexed;

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -1461,6 +1461,88 @@ async fn sync_audiobooks_with_removed_above_bind_cap_succeeds() {
     );
 }
 
+/// F2 for audiobooks: removing a group makes its book fileless (hidden from the
+/// grid, `books` row + durable uuid retained); when the same group returns via
+/// the New bucket it re-attaches to that row, preserving the uuid. Exercises the
+/// batched scan_key pre-fetch map in `sync_audiobooks_new` driving the
+/// rewrite-in-place branch instead of a per-book `SELECT`.
+#[tokio::test]
+async fn sync_audiobooks_removed_group_goes_fileless_then_returning_group_relinks_same_uuid() {
+    let _covers = CoversTempDir::new("ab_fileless_relink");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![indexed_audiobook("Author/Book.m4b", "Book", Some("Author"))],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let uuid1 = crate::test_support::uuid_by_scan_key(&pool, "Author/Book.m4b").await;
+
+    // Group gone → fileless: hidden from the grid, row + uuid survive.
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            removed_uuids: vec![uuid1.clone()],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        list_books(&pool, "/lib").await.unwrap().is_empty(),
+        "fileless audiobook is hidden from the library grid"
+    );
+    assert_eq!(
+        crate::test_support::uuid_by_scan_key(&pool, "Author/Book.m4b").await,
+        uuid1,
+        "fileless audiobook retains its scan_key and durable uuid"
+    );
+
+    // Group returns via New → the batched map resolves the same-scan_key row and
+    // rewrites in place, preserving the uuid.
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![indexed_audiobook("Author/Book.m4b", "Book", Some("Author"))],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let after = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(after.len(), 1);
+    assert_eq!(
+        after[0].unique_identifier.as_deref(),
+        Some(uuid1.as_str()),
+        "returning group relinks to the same uuid via the batched New path"
+    );
+    // Exactly one books row + one book_files row — the batched pre-fetch must not
+    // mint a duplicate for the returning group.
+    let books_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let files_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM book_files")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        books_total, 1,
+        "no duplicate books row for the returning group"
+    );
+    assert_eq!(
+        files_total, 1,
+        "returning group re-creates exactly one file row"
+    );
+}
+
 // Audiobook parts + chapters: row contents and edge cases.
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `sync_audiobooks_new` fired a per-book `SELECT id, uuid FROM books WHERE library_id = ? AND scan_key = ?` and `sync_audiobooks_removed` called `mark_book_files_missing` (a DELETE + UPDATE) once per removed book — the same N+1 the already-batched Changed bucket had eliminated.
- **New**: now pre-fetches every same-`scan_key` row in one chunked (499-param) query keyed by `scan_key`, mirroring `sync_audiobooks_changed`, then the per-book loop reads the resulting map. New entries carry distinct scan_keys, so the map never goes stale mid-loop.
- **Removed**: resolves affected ids per 500-uuid chunk (unchanged), then replaces the per-id `mark_book_files_missing` loop with a single IN-list DELETE of `book_files` plus one guarded UPDATE flagging the now-fileless rows missing (`mark_book_files_missing_batch`). The UPDATE keeps the original guards (`is_missing_files = 0` preserves `missing_files_since` on a re-run; `is_missing_files_override = 0` leaves wishlist rows un-flagged), so behavior is byte-for-byte the same as the per-book helper.
- No public signatures changed; both bucket functions stay private to the module.

## Test plan
- [x] cargo clippy -p omnibus-db --all-targets -- -D warnings (green)
- [x] cargo test -p omnibus-db (green — 704 passed)
- New test `sync_audiobooks_removed_group_goes_fileless_then_returning_group_relinks_same_uuid` covers the batched New rewrite-in-place path (removed → fileless → returning group relinks the same uuid, with no duplicate `books`/`book_files` row). The existing `sync_audiobooks_with_removed_above_bind_cap_succeeds` (1000 books) already exercises the chunked Removed path and the &gt;499 chunked New scan_key map.

## Notes
- Closes #632
- Out-of-scope debt noticed but not fixed: the ebook `sync_new` (`db/src/sync/books/new.rs`) still calls `existing_by_scan_key` per book, and the ebook `sync_removed` (`db/src/sync/books/removed.rs`) still loops `mark_book_files_missing` per id — the exact ebook counterparts of what this PR batches for audiobooks. Left untouched to keep this PR scoped to #632.
- Assignee note: the GitHub MCP PR tools expose no assignee/label param, so this PR could not be self-assigned to Seamus or labeled programmatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2pqRpyn7EDrgiYyx4pcZD)_

---
Reviewer: verified clippy + test green (704 + new test), resolves #632, batching stays within the 999 bind cap (New 499+1, Removed 500), guards preserved byte-for-byte, no migration edits, no Cargo changes. The `books/mod.rs` edit is just dropping the now-unused `mark_book_files_missing` re-export (books/removed.rs still imports it from `shared` directly). Approve.