### PR TITLE
refactor: batch ordinal reassignment in merge (#589)

### DIFF
--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -109,6 +109,44 @@ async fn merge_books_allows_same_format_and_assigns_ordinals() {
 }
 
 #[tokio::test]
+async fn merge_books_assigns_consecutive_ordinals_for_multi_file_move() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    // Build a two-file source book by chaining a merge: a -> b leaves b
+    // holding two EPUB files (ordinals 0 and 1).
+    let a = seed_ebook(&pool, "A/One.epub", "One", "Bram Stoker").await;
+    let b = seed_ebook(&pool, "B/Two.epub", "Two", "Bram Stoker").await;
+    merge_books(&pool, &a, &b, None).await.unwrap();
+
+    // Now merge the two-file b into a single-file target c: both moved
+    // files must land at consecutive ordinals after c's own file, in one
+    // batched UPDATE per format.
+    let c = seed_ebook(&pool, "C/Three.epub", "Three", "Bram Stoker").await;
+    merge_books(&pool, &b, &c, None).await.unwrap();
+
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM books").await, 1);
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM book_files").await, 3);
+    // c's original file keeps ordinal 0; the two moved files (ordered by
+    // their prior ordinal, then filename) take 1 and 2. The file that had
+    // no label gets the source book's title ("Two"); the one already
+    // labelled "One" (from the first merge) keeps it.
+    let rows: Vec<(i64, String, String)> = sqlx::query_as(
+        "SELECT ordinal, filename, COALESCE(label, '') FROM book_files
+          WHERE book_id = (SELECT id FROM books) ORDER BY ordinal",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            (0, "Three".to_string(), String::new()),
+            (1, "Two".to_string(), "Two".to_string()),
+            (2, "One".to_string(), "One".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
 async fn merge_books_moves_progress_with_latest_wins_on_collision() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = seed_user(&pool).await;

--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -252,18 +252,48 @@ async fn assign_ordinals_after_move(
         .fetch_all(&mut **tx)
         .await?;
 
-        for (i, file_id) in moved_ids.iter().enumerate() {
-            let new_ordinal = max_existing + 1 + i as i64;
-            sqlx::query(
-                "UPDATE book_files SET ordinal = ?, label = COALESCE(label, ?)
-                  WHERE id = ?",
-            )
-            .bind(new_ordinal)
-            .bind(source_title)
-            .bind(file_id)
-            .execute(&mut **tx)
-            .await?;
+        batch_assign_ordinals(tx, &moved_ids, max_existing, source_title).await?;
+    }
+    Ok(())
+}
+
+/// Rows per chunk in `batch_assign_ordinals`. Each row costs three binds
+/// (two in the `CASE`, one in the `IN` list) plus one shared label bind, so
+/// 200 keeps a chunk comfortably under SQLite's 999-parameter cap.
+const ORDINAL_CHUNK: usize = 200;
+
+/// Assign consecutive ordinals to `moved_ids` — in the given order, starting
+/// at `max_existing + 1` — via a single `CASE`-based UPDATE per chunk,
+/// stamping `source_title` as the label on any file that still has none.
+/// Chunked so a pathologically large move can't exceed SQLite's bind cap.
+async fn batch_assign_ordinals(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    moved_ids: &[i64],
+    max_existing: i64,
+    source_title: &str,
+) -> Result<(), sqlx::Error> {
+    for (chunk_idx, chunk) in moved_ids.chunks(ORDINAL_CHUNK).enumerate() {
+        let base = max_existing + 1 + (chunk_idx * ORDINAL_CHUNK) as i64;
+        let cases = std::iter::repeat_n("WHEN ? THEN ?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE book_files SET ordinal = CASE id {cases} END,
+                    label = COALESCE(label, ?)
+              WHERE id IN ({placeholders})"
+        );
+        let mut q = sqlx::query(&sql);
+        for (i, file_id) in chunk.iter().enumerate() {
+            q = q.bind(file_id).bind(base + i as i64);
         }
+        q = q.bind(source_title);
+        for file_id in chunk {
+            q = q.bind(file_id);
+        }
+        q.execute(&mut **tx).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- `assign_ordinals_after_move` in `db/src/merge/transaction.rs` issued one `UPDATE book_files SET ordinal = ... WHERE id = ?` per moved file inside a per-format loop (O(M × K) UPDATE round-trips inside the merge transaction).
- Replaced the inner per-file loop with a new `batch_assign_ordinals` helper that sets every moved file's ordinal in a single `CASE`-based UPDATE per format. It is chunked at 200 rows (each row costs three binds — two in the `CASE`, one in the `IN` list — plus one shared label bind) to stay comfortably under SQLite's 999-parameter cap, so a pathologically large move can't overflow.
- I took the batch approach (the issue's stronger option) rather than the minimal justification-comment, matching the existing chunked `IN (...)` batch pattern used in `sync/books/removed.rs`. The exact ordinal-assignment order (`ORDER BY ordinal, filename`; consecutive values starting after the target's existing files) and the `label = COALESCE(label, source_title)` semantics are preserved unchanged.

## Test plan
- [x] cargo clippy -p omnibus-db --all-targets -- -D warnings (green)
- [x] cargo test -p omnibus-db (green — 704 tests, incl. all 15 merge tests)
- Added `merge_books_assigns_consecutive_ordinals_for_multi_file_move`: chains two merges to build a two-file source book, merges it into a single-file target, and asserts the moved files receive consecutive ordinals (0/1/2) with the correct labels — exercising the multi-row batch path that the prior single-file merge tests never hit.

## Notes
- Closes #589
- No out-of-scope changes. `move_book_files`'s `ORDINAL_OFFSET` sentinel and the outer per-format queries are unchanged.
- Assignee note: the GitHub MCP PR tools expose no assignee/label param, so this PR could not be self-assigned to Seamus or labeled programmatically.
- Reviewer: verified clippy+test green, resolves #589, no scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2pqRpyn7EDrgiYyx4pcZD

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2pqRpyn7EDrgiYyx4pcZD)_