### PR TITLE
perf: covering indexes for devices/bookmarks/highlights ORDER BY (#641)

### DIFF
--- a/db/migrations/0035_covering_indexes_devices_bookmarks_highlights.sql
+++ b/db/migrations/0035_covering_indexes_devices_bookmarks_highlights.sql
@@ -1,0 +1,31 @@
+-- Covering indexes for three filter-then-sort read paths.
+--
+-- Each query seeks a leading equality column and orders by a trailing
+-- column, but the pre-existing indexes cover only the filter — so SQLite
+-- matches the rows then does an in-memory temp-B-tree sort. Extending each
+-- index to include the ORDER BY column lets the planner walk the index in
+-- output order and drop the sort entirely.
+--
+--   * devices    — list_devices_for_user (db/src/auth/device.rs):
+--       WHERE user_id = ? ORDER BY last_seen_at DESC
+--       had only idx_devices_user (user_id) from 0004.
+--   * bookmarks  — list_bookmarks (db/src/bookmarks/mod.rs):
+--       WHERE user_id = ? AND book_uuid = ? ORDER BY created_at ASC
+--       had only bookmarks_user_book_idx (user_id, book_uuid) from 0027.
+--   * highlights — list_highlights (db/src/highlights/mod.rs):
+--       WHERE h.user_id = ? AND h.book_uuid = ? ORDER BY h.created_at ASC
+--       had only idx_highlights_user_book (user_id, book_uuid) from 0027.
+--
+-- The row counts are small in typical usage, so this is a forward-looking
+-- cleanup rather than a hot-path fix. Forward-only, pure secondary indexes:
+-- populated on CREATE with no backfill and no table recreate, so a fresh DB
+-- built from 0001..0035 and an upgraded DB converge on the same schema.
+-- `IF NOT EXISTS` keeps each CREATE idempotent against a hand-made index of
+-- the same name. The now partially-redundant filter-only indexes are left in
+-- place deliberately — dropping them is a separate change.
+CREATE INDEX IF NOT EXISTS idx_devices_user_last_seen
+    ON devices(user_id, last_seen_at DESC);
+CREATE INDEX IF NOT EXISTS idx_bookmarks_user_book_created
+    ON bookmarks(user_id, book_uuid, created_at);
+CREATE INDEX IF NOT EXISTS idx_highlights_user_book_created
+    ON highlights(user_id, book_uuid, created_at);

--- a/db/src/auth/device/tests.rs
+++ b/db/src/auth/device/tests.rs
@@ -105,3 +105,50 @@ async fn register_device_rejects_control_char_in_client_version() {
         "expected Validation about client_version control chars, got {err:?}",
     );
 }
+
+/// `list_devices_for_user` must satisfy its `ORDER BY last_seen_at DESC`
+/// from `idx_devices_user_last_seen` (migration 0035) rather than a temp
+/// B-tree sort. Rows + ANALYZE are seeded first: the older
+/// `idx_devices_user (user_id)` shares the leading column, so on an empty
+/// table costs tie and the planner may keep the sort — only with realistic
+/// per-user row counts does the covering index's saved sort win. Structural
+/// check; pins the index name and the absence of a temp B-tree, not
+/// SQLite's exact plan wording.
+#[tokio::test]
+async fn list_devices_uses_covering_index_for_order_by() {
+    use sqlx::Row;
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    for i in 0..64 {
+        sqlx::query(
+            "INSERT INTO devices (user_id, name, client_kind, last_seen_at) VALUES (?, ?, 'ios', ?)",
+        )
+        .bind(u.id)
+        .bind(format!("Device {i}"))
+        .bind(i)
+        .execute(&p)
+        .await
+        .unwrap();
+    }
+    sqlx::query("ANALYZE").execute(&p).await.unwrap();
+    let plan: String = sqlx::query(
+        "EXPLAIN QUERY PLAN SELECT id, user_id, name, client_kind, client_version, \
+         created_at, last_seen_at FROM devices WHERE user_id = ? ORDER BY last_seen_at DESC",
+    )
+    .bind(u.id)
+    .fetch_all(&p)
+    .await
+    .unwrap()
+    .iter()
+    .map(|r| r.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(
+        plan.contains("idx_devices_user_last_seen"),
+        "device listing should use idx_devices_user_last_seen, got plan:\n{plan}"
+    );
+    assert!(
+        !plan.contains("TEMP B-TREE"),
+        "device listing should sort from the index, not a temp B-tree, got plan:\n{plan}"
+    );
+}

--- a/db/src/bookmarks/tests.rs
+++ b/db/src/bookmarks/tests.rs
@@ -176,3 +176,52 @@ async fn delete_bookmark_returns_not_found_for_other_user() {
     let err = delete_bookmark(&pool, bob, b.id).await.unwrap_err();
     assert!(matches!(err, BookmarkError::NotFound));
 }
+
+/// `list_bookmarks` must satisfy its `ORDER BY created_at ASC` from
+/// `idx_bookmarks_user_book_created` (migration 0035) rather than a temp
+/// B-tree sort. Rows + ANALYZE are seeded first: the older
+/// `bookmarks_user_book_idx` shares the (user_id, book_uuid) prefix, so on
+/// an empty table costs tie and the planner may keep the sort — only with
+/// realistic per-key row counts does the covering index's saved sort win.
+/// Structural check; pins the index name and the absence of a temp B-tree,
+/// not SQLite's exact plan wording.
+#[tokio::test]
+async fn list_bookmarks_uses_covering_index_for_order_by() {
+    use sqlx::Row;
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    for i in 0..64 {
+        sqlx::query(
+            "INSERT INTO bookmarks (user_id, book_uuid, position, created_at) \
+             VALUES (?, 'uuid', ?, ?)",
+        )
+        .bind(user)
+        .bind(i.to_string())
+        .bind(i)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    sqlx::query("ANALYZE").execute(&pool).await.unwrap();
+    let plan: String = sqlx::query(
+        "EXPLAIN QUERY PLAN SELECT id, book_uuid, position, title, created_at \
+         FROM bookmarks WHERE user_id = ? AND book_uuid = ? ORDER BY created_at ASC",
+    )
+    .bind(user)
+    .bind("uuid")
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .iter()
+    .map(|r| r.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(
+        plan.contains("idx_bookmarks_user_book_created"),
+        "list_bookmarks should use idx_bookmarks_user_book_created, got plan:\n{plan}"
+    );
+    assert!(
+        !plan.contains("TEMP B-TREE"),
+        "list_bookmarks should sort from the index, not a temp B-tree, got plan:\n{plan}"
+    );
+}

--- a/db/src/highlights/tests.rs
+++ b/db/src/highlights/tests.rs
@@ -246,3 +246,53 @@ async fn delete_highlight_returns_not_found_for_other_user() {
     let err = delete_highlight(&pool, bob, h.id).await.unwrap_err();
     assert!(matches!(err, HighlightError::NotFound));
 }
+
+/// `list_highlights` must satisfy its `ORDER BY created_at ASC` from
+/// `idx_highlights_user_book_created` (migration 0035) rather than a temp
+/// B-tree sort. Rows + ANALYZE are seeded first: the older
+/// `idx_highlights_user_book` shares the (user_id, book_uuid) prefix, so on
+/// an empty table costs tie and the planner may keep the sort — only with
+/// realistic per-key row counts does the covering index's saved sort win.
+/// Structural check; pins the index name and the absence of a temp B-tree,
+/// not SQLite's exact plan wording.
+#[tokio::test]
+async fn list_highlights_uses_covering_index_for_order_by() {
+    use sqlx::Row;
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    for i in 0..64 {
+        sqlx::query(
+            "INSERT INTO highlights (user_id, book_uuid, epub_cfi_range, color, created_at) \
+             VALUES (?, 'uuid', ?, 'amber', ?)",
+        )
+        .bind(user)
+        .bind(format!("epubcfi(/6/{i})"))
+        .bind(i)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    sqlx::query("ANALYZE").execute(&pool).await.unwrap();
+    let plan: String = sqlx::query(
+        "EXPLAIN QUERY PLAN SELECT h.id, h.book_uuid, h.epub_cfi_range, h.color, h.note, \
+         h.text, h.created_at FROM highlights h \
+         WHERE h.user_id = ? AND h.book_uuid = ? ORDER BY h.created_at ASC",
+    )
+    .bind(user)
+    .bind("uuid")
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .iter()
+    .map(|r| r.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(
+        plan.contains("idx_highlights_user_book_created"),
+        "list_highlights should use idx_highlights_user_book_created, got plan:\n{plan}"
+    );
+    assert!(
+        !plan.contains("TEMP B-TREE"),
+        "list_highlights should sort from the index, not a temp B-tree, got plan:\n{plan}"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds migration `0035_covering_indexes_devices_bookmarks_highlights.sql` with three composite covering indexes, one per cited filter-then-sort query. Each leads with the `WHERE` equality column(s) and trails with the `ORDER BY` key, so SQLite walks the index in output order instead of matching rows and then doing an in-memory temp-B-tree sort:
  - `idx_devices_user_last_seen (user_id, last_seen_at DESC)` — `list_devices_for_user` (`db/src/auth/device.rs`)
  - `idx_bookmarks_user_book_created (user_id, book_uuid, created_at)` — `list_bookmarks` (`db/src/bookmarks/mod.rs`)
  - `idx_highlights_user_book_created (user_id, book_uuid, created_at)` — `list_highlights` (`db/src/highlights/mod.rs`)
- Forward-only, pure secondary indexes: populated on `CREATE`, no backfill, no table recreate; `IF NOT EXISTS` keeps each idempotent. No production code change required.
- The older filter-only indexes (`idx_devices_user`, `bookmarks_user_book_idx`, `idx_highlights_user_book`) share the leading prefix and are left in place — dropping the now partially-redundant ones is deliberately out of scope (a separate change), matching the precedent set by migration 0025.
- Kept to a standalone 0035 rather than bundling with #630&#39;s `book_uuid`-first indexes (as the issue floated) so this lands independently and doesn&#39;t couple to another in-flight change.

## Test plan
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` (green)
- [x] `cargo test -p omnibus-db` (green — 706 passed, up from 703)
- New EXPLAIN QUERY PLAN tests, one per query, assert the plan uses the covering index **and** contains no `TEMP B-TREE`:
  - `auth::device::tests::list_devices_uses_covering_index_for_order_by`
  - `bookmarks::tests::list_bookmarks_uses_covering_index_for_order_by`
  - `highlights::tests::list_highlights_uses_covering_index_for_order_by`
  - Each seeds rows + `ANALYZE` before asserting: the older filter-only index shares the `WHERE` prefix, so on an empty table the planner ties and may keep the sort; the covering index only wins once there are realistic per-key row counts — which is also the only regime where the sort cost (and thus this index) actually matters.

## Notes
- Closes #641
- Out-of-scope debt noticed but not fixed: the older prefix-only indexes are now redundant with these covering indexes and could be dropped in a follow-up (the SELECT-list columns are non-trivial, so making them true covering indexes would require adding the projected columns — not done here to keep scope tight).
- Verified only against `omnibus-db` under a trimmed workspace (the workspace pins Dioxus as a git dep that this environment cannot fetch, so `server`/`frontend`/`mobile` cannot compile here). The change is entirely within `db/` and all call sites are in `db/`, so this is fully exercised; `Cargo.toml`/`Cargo.lock` were not touched.
- Assignee note: the GitHub MCP PR tools expose no assignee/label param, so this PR could not be self-assigned to Seamus or labeled programmatically.
- Reviewer: verified clippy+test green (706 passed), resolves #641, no scope creep, migration 0035 added (no applied migration edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2pqRpyn7EDrgiYyx4pcZD)_