### PR TITLE
chore: automate release labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,9 @@
 
 ## Notes
 - 
+- Apply at most one release label when the PR is targeting `main`:
+  - `patch version` bumps `vX.Y.Z` to `vX.Y.(Z+1)`
+  - `minor version` bumps `vX.Y.Z` to `vX.(Y+1).0`
 
 <!--
 Use the following for callouts:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,15 +1,11 @@
 name: Docker
 
 # Build + push the fullstack image to Docker Hub (sesloan/omnibus).
-# Triggers: release → version tags + latest; daily cron + manual → nightly.
+# Triggered only by published GitHub releases.
 # Needs repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (Read/Write token).
 on:
   release:
     types: [published]
-  schedule:
-    # 15:00 UTC = 11am EDT (10am EST). Cron is UTC-only — no DST.
-    - cron: "0 15 * * *"
-  workflow_dispatch:
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -39,7 +35,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # release → 1.2.3/1.2/1/latest (latest=auto, semver only); cron/manual → nightly.
+      # release → 1.2.3/1.2/1/latest (latest=auto, semver only).
       - name: Derive image metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -51,8 +47,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=schedule,pattern=nightly
-            type=raw,value=nightly,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -60,7 +54,6 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          # Re-pull base images each run so the nightly picks up upstream fixes.
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,11 @@ on:
   pull_request_target:
     types: [closed]
 
+# Serialize on the base branch so runs queue and compute tags sequentially.
+# A per-PR group would let two labeled PRs merging together read the same
+# latest release and race to the same tag; the loser would silently skip.
 concurrency:
-  group: release-${{ github.event.pull_request.number }}
+  group: release-${{ github.event.pull_request.base.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -23,10 +26,16 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Determine next version
-        id: version
+      - name: Create GitHub release
         uses: actions/github-script@v7
+        env:
+          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
         with:
+          # Compute the next tag and create the release in one retry loop.
+          # The base-branch concurrency group serializes runs, but a burst of
+          # merges can still make GitHub cancel intermediate pending runs; if a
+          # computed tag already exists we re-read the latest release and bump
+          # again rather than silently skipping, so no version is ever dropped.
           script: |
             const labels = context.payload.pull_request.labels.map(({ name }) => name);
             const hasPatch = labels.includes("patch version");
@@ -38,81 +47,82 @@ jobs:
               );
               return;
             }
-
-            let latestRelease;
-            try {
-              const response = await github.rest.repos.getLatestRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              });
-              latestRelease = response.data;
-            } catch (error) {
-              if (error.status === 404) {
-                core.setFailed(
-                  "No published release exists yet. Create the initial major release manually before using version labels.",
-                );
-                return;
-              }
-              throw error;
-            }
-
-            const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(latestRelease.tag_name);
-            if (!match) {
-              core.setFailed(
-                `Latest release tag '${latestRelease.tag_name}' is not in vMAJOR.MINOR.PATCH format.`,
-              );
-              return;
-            }
-
-            const major = Number(match[1]);
-            let minor = Number(match[2]);
-            let patch = Number(match[3]);
-
-            if (hasMinor) {
-              minor += 1;
-              patch = 0;
-            } else if (hasPatch) {
-              patch += 1;
-            } else {
+            if (!hasPatch && !hasMinor) {
               core.setFailed("No supported release label found on the merged PR.");
               return;
             }
 
-            const tag = `v${major}.${minor}.${patch}`;
-            core.setOutput("tag", tag);
-            core.setOutput("label", hasMinor ? "minor version" : "patch version");
-
-      - name: Create GitHub release
-        uses: actions/github-script@v7
-        env:
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-          RELEASE_LABEL: ${{ steps.version.outputs.label }}
-          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
-        with:
-          script: |
-            const tag = process.env.RELEASE_TAG;
+            const label = hasMinor ? "minor version" : "patch version";
             const target = process.env.TARGET_SHA;
+            const maxAttempts = 5;
 
-            try {
-              await github.rest.repos.getReleaseByTag({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag,
-              });
-              core.info(`Release ${tag} already exists. Skipping creation.`);
-              return;
-            } catch (error) {
-              if (error.status !== 404) {
+            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+              let latestRelease;
+              try {
+                const response = await github.rest.repos.getLatestRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                });
+                latestRelease = response.data;
+              } catch (error) {
+                if (error.status === 404) {
+                  core.setFailed(
+                    "No published release exists yet. Create the initial major release manually before using version labels.",
+                  );
+                  return;
+                }
+                throw error;
+              }
+
+              const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(latestRelease.tag_name);
+              if (!match) {
+                core.setFailed(
+                  `Latest release tag '${latestRelease.tag_name}' is not in vMAJOR.MINOR.PATCH format.`,
+                );
+                return;
+              }
+
+              const major = Number(match[1]);
+              let minor = Number(match[2]);
+              let patch = Number(match[3]);
+
+              if (hasMinor) {
+                minor += 1;
+                patch = 0;
+              } else {
+                patch += 1;
+              }
+
+              const tag = `v${major}.${minor}.${patch}`;
+
+              try {
+                await github.rest.repos.createRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag_name: tag,
+                  target_commitish: target,
+                  name: tag,
+                  generate_release_notes: true,
+                  body: `Automated ${label} release from #${context.payload.pull_request.number}.`,
+                });
+                core.info(`Created release ${tag}.`);
+                return;
+              } catch (error) {
+                // 422 = tag/release already exists: another run won the race.
+                // Re-read the latest release and bump again from it.
+                const alreadyExists =
+                  error.status === 422 &&
+                  (error.response?.data?.errors || []).some(
+                    (e) => e.code === "already_exists",
+                  );
+                if (alreadyExists && attempt < maxAttempts) {
+                  core.info(`Tag ${tag} already exists; recomputing (attempt ${attempt}).`);
+                  continue;
+                }
                 throw error;
               }
             }
 
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              target_commitish: target,
-              name: tag,
-              generate_release_notes: true,
-              body: `Automated ${process.env.RELEASE_LABEL} release from #${context.payload.pull_request.number}.`,
-            });
+            core.setFailed(
+              `Could not create a release after ${maxAttempts} attempts due to repeated tag collisions.`,
+            );

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release
+
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: release-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: create release
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'patch version') ||
+        contains(github.event.pull_request.labels.*.name, 'minor version')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine next version
+        id: version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(({ name }) => name);
+            const hasPatch = labels.includes("patch version");
+            const hasMinor = labels.includes("minor version");
+
+            if (hasPatch && hasMinor) {
+              core.setFailed(
+                "PR has both 'patch version' and 'minor version' labels. Apply exactly one release label.",
+              );
+              return;
+            }
+
+            let latestRelease;
+            try {
+              const response = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              latestRelease = response.data;
+            } catch (error) {
+              if (error.status === 404) {
+                core.setFailed(
+                  "No published release exists yet. Create the initial major release manually before using version labels.",
+                );
+                return;
+              }
+              throw error;
+            }
+
+            const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(latestRelease.tag_name);
+            if (!match) {
+              core.setFailed(
+                `Latest release tag '${latestRelease.tag_name}' is not in vMAJOR.MINOR.PATCH format.`,
+              );
+              return;
+            }
+
+            const major = Number(match[1]);
+            let minor = Number(match[2]);
+            let patch = Number(match[3]);
+
+            if (hasMinor) {
+              minor += 1;
+              patch = 0;
+            } else if (hasPatch) {
+              patch += 1;
+            } else {
+              core.setFailed("No supported release label found on the merged PR.");
+              return;
+            }
+
+            const tag = `v${major}.${minor}.${patch}`;
+            core.setOutput("tag", tag);
+            core.setOutput("label", hasMinor ? "minor version" : "patch version");
+
+      - name: Create GitHub release
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_LABEL: ${{ steps.version.outputs.label }}
+          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+        with:
+          script: |
+            const tag = process.env.RELEASE_TAG;
+            const target = process.env.TARGET_SHA;
+
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              core.info(`Release ${tag} already exists. Skipping creation.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              target_commitish: target,
+              name: tag,
+              generate_release_notes: true,
+              body: `Automated ${process.env.RELEASE_LABEL} release from #${context.payload.pull_request.number}.`,
+            });


### PR DESCRIPTION
## Summary
- Adds `patch version` and `minor version` labels to PRs
- PRs tagged with `patch version` will create a new release when merged into `main` (i.e. `v1.0.1` --> `v1.0.2`)
- PRs tagged with `minor version` will create a new release when merged into `main` (i.e. (v1.0.2` --> `v1.1.0`)
- Docker publishing now runs **only** on published GitHub releases. The nightly `schedule` cron and `workflow_dispatch` triggers (and the `nightly` image tag) are intentionally removed — releases are now the sole publish path.

## Test plan
- [ ] 

## Notes
- 

<!--
Use the following for callouts:

>[!NOTE]
> Blue message!

>[!WARNING]
> Yello message!

>[!IMPORTANT]
> Purple message!

>[!CAUTION]
> Red message!

>[!TIP]
> Green message!
-->
