### PR TITLE
fix: dispatch Docker build after creating a release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@
 - Every merge to `main` cuts a release. By default it's a patch bump
   (`vX.Y.Z` → `vX.Y.(Z+1)`); add the `minor version` label for a minor bump
   (`vX.Y.Z` → `vX.(Y+1).0`). If both labels are applied, `minor version` wins.
+- To skip the release, add the `no release` label. Unlabeled PRs that only
+  touch docs (`*.md`, `docs/`) or CI (`.github/`) skip automatically.
 
 <!--
 Use the following for callouts:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@
 
 ## Notes
 - 
-- Apply at most one release label when the PR is targeting `main`:
-  - `patch version` bumps `vX.Y.Z` to `vX.Y.(Z+1)`
-  - `minor version` bumps `vX.Y.Z` to `vX.(Y+1).0`
+- Every merge to `main` cuts a release. By default it's a patch bump
+  (`vX.Y.Z` → `vX.Y.(Z+1)`); add the `minor version` label for a minor bump
+  (`vX.Y.Z` → `vX.(Y+1).0`). If both labels are applied, `minor version` wins.
 
 <!--
 Use the following for callouts:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,8 +17,10 @@ on:
 
 concurrency:
   # Key on the tag being built so parallel dispatches for distinct tags don't
-  # cancel each other, and a re-dispatch of the same tag coalesces.
-  group: docker-${{ inputs.tag || github.ref }}
+  # cancel each other, and a re-dispatch of the same tag coalesces. Use
+  # github.ref_name (the bare `vX.Y.Z`) so the dispatch and release-event paths
+  # produce the same key — github.ref would be `refs/tags/vX.Y.Z` on a release.
+  group: docker-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,24 @@
 name: Docker
 
 # Build + push the fullstack image to Docker Hub (sesloan/omnibus).
-# Triggered only by published GitHub releases.
+# Dispatched by the Release workflow (workflow_dispatch with the release tag);
+# `release: published` is a fallback for releases created by a human/PAT — a
+# release made by the Release workflow's GITHUB_TOKEN can't fire that event.
 # Needs repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (Read/Write token).
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build (e.g. v1.2.3)"
+        required: true
+        type: string
 
 concurrency:
-  group: docker-${{ github.ref }}
+  # Key on the tag being built so parallel dispatches for distinct tags don't
+  # cancel each other, and a re-dispatch of the same tag coalesces.
+  group: docker-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -24,7 +34,11 @@ jobs:
     name: build and push
     runs-on: ubuntu-latest
     steps:
+      # On dispatch, check out the release tag; on a release event, github.ref
+      # is already the tag ref.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -35,7 +49,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # release → 1.2.3/1.2/1/latest (latest=auto, semver only).
+      # → 1.2.3/1.2/1/latest (latest=auto, semver only). The semver source is
+      # the dispatch input tag, falling back to github.ref_name (the tag on a
+      # release event).
       - name: Derive image metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -44,9 +60,9 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.tag || github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }}
+            type=semver,pattern={{major}},value=${{ inputs.tag || github.ref_name }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,11 @@ permissions:
 jobs:
   create-release:
     name: create release
+    # Every merge to main cuts a release: unlabeled merges default to a patch
+    # bump; the 'minor version' label opts into a minor bump instead.
     if: >
       github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'main' &&
-      (
-        contains(github.event.pull_request.labels.*.name, 'patch version') ||
-        contains(github.event.pull_request.labels.*.name, 'minor version')
-      )
+      github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub release
@@ -40,19 +38,10 @@ jobs:
           # again rather than silently skipping, so no version is ever dropped.
           script: |
             const labels = context.payload.pull_request.labels.map(({ name }) => name);
-            const hasPatch = labels.includes("patch version");
+            // 'minor version' opts into a minor bump and wins if both labels are
+            // present; every other case (patch label, or no label at all) is a
+            // patch bump.
             const hasMinor = labels.includes("minor version");
-
-            if (hasPatch && hasMinor) {
-              core.setFailed(
-                "PR has both 'patch version' and 'minor version' labels. Apply exactly one release label.",
-              );
-              return;
-            }
-            if (!hasPatch && !hasMinor) {
-              core.setFailed("No supported release label found on the merged PR.");
-              return;
-            }
 
             const label = hasMinor ? "minor version" : "patch version";
             const target = process.env.TARGET_SHA;
@@ -124,7 +113,7 @@ jobs:
                   core.info(`Dispatched Docker build for ${tag}.`);
                 } catch (error) {
                   core.setFailed(
-                    `Release ${tag} was created but dispatching the Docker build failed: ${error.message}. ` +
+                    `Release ${tag} was created but dispatching the Docker build failed: ${error.message || String(error)}. ` +
                       `Re-run the Docker workflow manually with tag ${tag}.`,
                   );
                 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ permissions:
   contents: write
   # Needed to dispatch the Docker workflow after the release is created.
   actions: write
+  # Needed to list the merged PR's changed files for the docs/CI skip check.
+  pull-requests: read
 
 jobs:
   create-release:
@@ -38,11 +40,42 @@ jobs:
           # again rather than silently skipping, so no version is ever dropped.
           script: |
             const labels = context.payload.pull_request.labels.map(({ name }) => name);
+            const hasMinor = labels.includes("minor version");
+            const hasPatch = labels.includes("patch version");
+
+            // Explicit opt-out wins over everything.
+            if (labels.includes("no release")) {
+              core.info("PR is labeled 'no release'; skipping release.");
+              return;
+            }
+
+            // Unlabeled merges default to a release, but docs-only / CI-only
+            // changes don't warrant a version bump. An explicit version label
+            // overrides this (the author opted in).
+            if (!hasMinor && !hasPatch) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+              });
+              const onlyDocsOrCi =
+                files.length > 0 &&
+                files.every(({ filename }) =>
+                  filename.endsWith(".md") ||
+                  filename.startsWith("docs/") ||
+                  filename.startsWith(".github/"),
+                );
+              if (onlyDocsOrCi) {
+                core.info(
+                  "PR only touches docs/CI and has no version label; skipping release.",
+                );
+                return;
+              }
+            }
+
             // 'minor version' opts into a minor bump and wins if both labels are
             // present; every other case (patch label, or no label at all) is a
             // patch bump.
-            const hasMinor = labels.includes("minor version");
-
             const label = hasMinor ? "minor version" : "patch version";
             const target = process.env.TARGET_SHA;
             const maxAttempts = 5;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ concurrency:
 
 permissions:
   contents: write
+  # Needed to dispatch the Docker workflow after the release is created.
+  actions: write
 
 jobs:
   create-release:
@@ -106,6 +108,26 @@ jobs:
                   body: `Automated ${label} release from #${context.payload.pull_request.number}.`,
                 });
                 core.info(`Created release ${tag}.`);
+
+                // A release created with GITHUB_TOKEN can't fire the Docker
+                // workflow's `release: published` trigger (GitHub blocks
+                // token-triggered workflow chaining), so dispatch it directly.
+                // workflow_dispatch is exempt from that block.
+                try {
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: "docker.yml",
+                    ref: context.payload.pull_request.base.ref,
+                    inputs: { tag },
+                  });
+                  core.info(`Dispatched Docker build for ${tag}.`);
+                } catch (error) {
+                  core.setFailed(
+                    `Release ${tag} was created but dispatching the Docker build failed: ${error.message}. ` +
+                      `Re-run the Docker workflow manually with tag ${tag}.`,
+                  );
+                }
                 return;
               } catch (error) {
                 // 422 = tag/release already exists: another run won the race.


### PR DESCRIPTION
## Summary
Fixes the release → Docker chain broken after #694. The `Release` workflow creates the GitHub release with the automatic `GITHUB_TOKEN`, and GitHub deliberately does **not** fire event-triggered workflows (like Docker's `release: published`) from a `GITHUB_TOKEN`-created event — to prevent recursive runs. Result: `v0.1.0` was created but no Docker image was built.

`workflow_dispatch` and `repository_dispatch` are the two exceptions that *do* run from `GITHUB_TOKEN`, so:

- **release.yml** — after creating the release, directly dispatches the Docker workflow via `createWorkflowDispatch` with the new tag as input. Adds `actions: write` permission for the dispatch. If the dispatch fails, the job fails loudly with instructions to re-run Docker manually.
- **docker.yml** — adds a `workflow_dispatch` trigger with a required `tag` input; checks out that tag and derives the semver image tags from it (`value=${{ inputs.tag || github.ref_name }}`, so the `release: published` fallback path still works for a human/PAT-created release). Concurrency now keys on the tag.

## Test plan
- [ ] Merge with a `patch version` label → `Release` creates `vX.Y.Z` and the `Docker` run appears (event=`workflow_dispatch`) and pushes the image.
- [ ] Manually re-run `Docker` via the Actions UI with `tag=v0.1.0` to backfill the image that didn't build.

## Notes
- `v0.1.0` already exists but its image never built — after this merges, dispatch `Docker` manually with `tag=v0.1.0` to backfill it.
