### PR TITLE
chore: advertise the release version in Release + Docker workflow runs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,9 @@
 name: Docker
 
+# The run title carries the release tag so the Actions list shows which
+# version each build is for (e.g. "Docker v1.2.3") without opening the run.
+run-name: "Docker ${{ inputs.tag || github.ref_name }}"
+
 # Build + push the fullstack image to Docker Hub (sesloan/omnibus).
 # Dispatched by the Release workflow (workflow_dispatch with the release tag);
 # `release: published` is a fallback for releases created by a human/PAT — a
@@ -78,3 +82,22 @@ jobs:
           # Cache layers across runs so unchanged build stages don't recompile.
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Advertise exactly what landed on Docker Hub on the run summary page so
+      # the pushed tags don't have to be dug out of the buildx logs. Values are
+      # passed via env (not inlined into the script) to avoid shell injection
+      # from the dispatch-supplied tag.
+      - name: Summarize published image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          REF: ${{ inputs.tag || github.ref_name }}
+        run: |
+          {
+            echo "### 🐳 Published to Docker Hub"
+            echo
+            echo "Release: **$REF**"
+            echo
+            echo '```'
+            echo "$TAGS"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Release
 
+# Name the run after the PR that triggered it so the Actions list shows which
+# merge each release run belongs to; the minted version is written to the run's
+# step summary (the tag is computed at runtime, so it can't be templated here).
+run-name: "Release for PR #${{ github.event.pull_request.number }}"
+
 on:
   pull_request_target:
     types: [closed]
@@ -46,6 +51,12 @@ jobs:
             // Explicit opt-out wins over everything.
             if (labels.includes("no release")) {
               core.info("PR is labeled 'no release'; skipping release.");
+              await core.summary
+                .addRaw(
+                  `⏭️ **No release cut** — PR #${context.payload.pull_request.number} is labeled \`no release\`.`,
+                  true,
+                )
+                .write();
               return;
             }
 
@@ -69,6 +80,12 @@ jobs:
                 core.info(
                   "PR only touches docs/CI and has no version label; skipping release.",
                 );
+                await core.summary
+                  .addRaw(
+                    `⏭️ **No release cut** — PR #${context.payload.pull_request.number} only touches docs/CI and carries no version label.`,
+                    true,
+                  )
+                  .write();
                 return;
               }
             }
@@ -120,7 +137,7 @@ jobs:
               const tag = `v${major}.${minor}.${patch}`;
 
               try {
-                await github.rest.repos.createRelease({
+                const { data: release } = await github.rest.repos.createRelease({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   tag_name: tag,
@@ -130,6 +147,13 @@ jobs:
                   body: `Automated ${label} release from #${context.payload.pull_request.number}.`,
                 });
                 core.info(`Created release ${tag}.`);
+                await core.summary
+                  .addHeading(`🚀 Released ${tag}`, 3)
+                  .addRaw(
+                    `**${label}** bump from #${context.payload.pull_request.number} → [${tag}](${release.html_url})`,
+                    true,
+                  )
+                  .write();
 
                 // A release created with GITHUB_TOKEN can't fire the Docker
                 // workflow's `release: published` trigger (GitHub blocks


### PR DESCRIPTION
## Summary
- Surface the release version where it's visible from the **Actions tab**, instead of only in a buried `core.info` log line and on the Releases page. Looking at a Docker run, you previously couldn't tell which release it was building.
- `docker.yml`: add a top-level `run-name` so each Docker run is titled with the tag (e.g. `Docker v1.2.3`); add a `Summarize published image` step that writes the exact pushed image tags to the run's step summary.
- `release.yml`: add a `run-name` naming the triggering PR; write the minted version (with a link to the release) to the run's step summary on the success path, and the reason on the `no release` / docs-only skip paths.

## Test plan
- [x] `ruby -ryaml` parses all four workflow files; `node --check` on the extracted `release.yml` github-script confirms the embedded JS is syntactically valid.
- [ ] Post-merge: the next version-bumping PR's Release run shows `🚀 Released vX.Y.Z` on its summary, and the dispatched Docker run is titled `Docker vX.Y.Z` with the pushed tags in its summary. Only exercisable once a release-cutting PR merges *after* this one — `pull_request_target` runs the base-branch copy of the workflow, so these changes take effect for subsequent merges.

## Notes
- CI-only change (`.github/` only), so per the PR template it **auto-skips the release** — no version label needed.
- `run-name` can't carry the computed tag for `release.yml` (the bump is computed at runtime from the latest release), so that path advertises the version via the step summary instead. `docker.yml` receives the tag as a dispatch input, so its `run-name` shows the version directly.
- The image-tag values are passed into the summary step via `env:` (not inlined into the `run:` script) to avoid shell injection from a dispatch-supplied tag.
