### PR TITLE
fix: wrap single-book FTS rebuild in a transaction

### DIFF
--- a/db/src/metadata_overrides/fts.rs
+++ b/db/src/metadata_overrides/fts.rs
@@ -5,7 +5,7 @@
 //! overridable columns with the merged values. Called best-effort from
 //! the upsert/merge/delete paths.
 
-use sqlx::{SqliteConnection, SqlitePool};
+use sqlx::{Sqlite, SqliteConnection, SqlitePool, Transaction};
 
 use omnibus_shared::EbookMetadata;
 
@@ -24,6 +24,11 @@ use super::upsert::MetadataOverridesError;
 /// `Ok(())` if the uuid has no matching book — overrides for an unknown
 /// uuid would only happen if a book row was deleted out from under us,
 /// in which case there is no FTS row to maintain.
+///
+/// The canonical-write + override-overlay pair runs inside a single
+/// transaction via [`rebuild_fts_row_tx`], so a failure in the overlay
+/// rolls back the canonical write instead of leaving the FTS row with
+/// unmerged data — matching [`rebuild_fts_for_books_batch`].
 pub(crate) async fn rebuild_fts_for_book(
     pool: &SqlitePool,
     book_uuid: &str,
@@ -34,9 +39,24 @@ pub(crate) async fn rebuild_fts_for_book(
     let Some(merged) = crate::books::get_book(pool, book_id).await? else {
         return Ok(());
     };
-    let mut conn = pool.acquire().await?;
-    upsert_fts(&mut conn, book_id).await?;
-    overlay_overrides(&mut conn, book_id, &merged).await?;
+    let mut tx = pool.begin().await?;
+    rebuild_fts_row_tx(&mut tx, book_id, &merged).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Write the canonical `books_fts` row then overlay the override-merged
+/// columns, both against an open transaction so the pair commits (or rolls
+/// back) atomically. The single write implementation shared by the
+/// single-book ([`rebuild_fts_for_book`]) and batch
+/// ([`rebuild_fts_for_books_batch`]) paths.
+pub(crate) async fn rebuild_fts_row_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    book_id: i64,
+    merged: &EbookMetadata,
+) -> Result<(), sqlx::Error> {
+    upsert_fts(tx, book_id).await?;
+    overlay_overrides(tx, book_id, merged).await?;
     Ok(())
 }
 
@@ -91,8 +111,7 @@ pub(crate) async fn rebuild_fts_for_books_batch(
     }
     let mut tx = pool.begin().await?;
     for (book_id, merged) in &rows {
-        upsert_fts(&mut tx, *book_id).await?;
-        overlay_overrides(&mut tx, *book_id, merged).await?;
+        rebuild_fts_row_tx(&mut tx, *book_id, merged).await?;
     }
     tx.commit().await?;
     Ok(())

--- a/db/src/metadata_overrides/fts.rs
+++ b/db/src/metadata_overrides/fts.rs
@@ -1,9 +1,8 @@
 //! Rebuild the `books_fts` row after an override write so search matches
-//! what the UI displays (merged canonical + override metadata). Thin
-//! wrappers over the [`crate::sync::upsert_fts`] choke-point: the door
-//! writes the canonical row, then [`overlay_overrides`] patches the
-//! overridable columns with the merged values. Called best-effort from
-//! the upsert/merge/delete paths.
+//! the UI (merged canonical + override metadata). Wraps the
+//! [`crate::sync::upsert_fts`] choke-point plus an [`overlay_overrides`]
+//! patch in one transaction. Called best-effort by the upsert/merge paths;
+//! the delete path restores canonical FTS in its own transaction instead.
 
 use sqlx::{Sqlite, SqliteConnection, SqlitePool, Transaction};
 

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -300,6 +300,65 @@ async fn upsert_metadata_overrides_rebuilds_fts_for_palette() {
     let palette = search_palette(&pool, "/lib", "Edited").await.unwrap();
     assert_eq!(palette.books.len(), 1);
 }
+/// The single-book rebuild overlays *every* override-driven FTS column,
+/// not just the title. A tag (`subjects`) override must land in the
+/// `books_fts.tags` column via `overlay_overrides` — which now runs in the
+/// same transaction as the canonical `upsert_fts` write. Asserting the
+/// stored `books_fts.tags` value directly (rather than via `search_books`,
+/// which deliberately filters the `tags` column out of its MATCH) guards
+/// that the overlay half of the transactional rebuild committed: a partial
+/// rebuild that persisted only the canonical `upsert_fts` row would leave
+/// the scanned tag here instead of the overridden one.
+#[tokio::test]
+async fn upsert_metadata_overrides_rebuilds_fts_tags_column() {
+    let _covers = CoversTempDir::new("fts_override_tag");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed(
+            "t.epub",
+            Some("A Book"),
+            &["Author"],
+            &["scannedtag"],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let uuid = books[0].unique_identifier.clone().unwrap();
+    let book_id = books[0].id;
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            subjects: Some(vec!["overriddentag".into()]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let tags: String = sqlx::query_scalar("SELECT tags FROM books_fts WHERE rowid = ?")
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        tags, "overriddentag",
+        "overlay_overrides must have committed the overridden tag into books_fts.tags"
+    );
+}
 /// Bug #1 follow-on: deleting the override should restore the FTS row
 /// to the canonical scanned values.
 #[tokio::test]

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -180,12 +180,18 @@ pub async fn get_metadata_overrides(
 /// Delete overrides for a book UUID (revert to scanned values).
 ///
 /// The row DELETE and the `books_fts` restore run inside one
-/// `BEGIN IMMEDIATE` transaction, so a failure in the FTS rebuild rolls
-/// back the DELETE instead of leaving the overrides gone while search
-/// still matches the deleted override text. With the override row removed,
-/// the canonical [`upsert_fts`] write inside the transaction *is* the
+/// `BEGIN IMMEDIATE` transaction. With the override row removed, the
+/// canonical [`upsert_fts`] write inside the transaction *is* the
 /// revert-to-scanned state — no override overlay is needed, and it reads
 /// the same canonical taxonomy the scan-time index writes.
+///
+/// Unlike [`upsert_metadata_overrides`] / [`merge_metadata_overrides`]
+/// (whose post-commit FTS rebuild is best-effort), the FTS restore here is
+/// **not** best-effort: a failure in the restore aborts the whole call and
+/// rolls the DELETE back, so the overrides can never be dropped while
+/// search still matches the deleted override text. Callers must treat this
+/// as fallible — the delete can fail (surfacing as a 500 at the handler)
+/// even when the row existed, leaving the override intact.
 pub async fn delete_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -9,6 +9,9 @@ use sqlx::{Executor, SqlitePool};
 
 use omnibus_shared::{EbookMetadata, MetadataOverrides};
 
+use crate::books::resolve_book_id_by_uuid_exec;
+use crate::sync::upsert_fts;
+
 use super::fts::rebuild_fts_for_book;
 use super::links::materialize_series_link;
 
@@ -176,21 +179,28 @@ pub async fn get_metadata_overrides(
 
 /// Delete overrides for a book UUID (revert to scanned values).
 ///
-/// Also rebuilds the book's `books_fts` row so that search reverts to
-/// matching the canonical scanned metadata, mirroring
-/// [`upsert_metadata_overrides`].
+/// The row DELETE and the `books_fts` restore run inside one
+/// `BEGIN IMMEDIATE` transaction, so a failure in the FTS rebuild rolls
+/// back the DELETE instead of leaving the overrides gone while search
+/// still matches the deleted override text. With the override row removed,
+/// the canonical [`upsert_fts`] write inside the transaction *is* the
+/// revert-to-scanned state — no override overlay is needed, and it reads
+/// the same canonical taxonomy the scan-time index writes.
 pub async fn delete_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
 ) -> Result<(), MetadataOverridesError> {
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     sqlx::query("DELETE FROM metadata_overrides WHERE book_uuid = ?")
         .bind(book_uuid)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
-    // Best-effort FTS rebuild — same rationale as `upsert_metadata_overrides`.
-    if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
-        tracing::warn!(book_uuid, error = %e, "books_fts rebuild after override delete failed");
+    // Resolve inside the transaction so the id read agrees with the DELETE.
+    // A uuid with no live book has no FTS row to restore.
+    if let Some(book_id) = resolve_book_id_by_uuid_exec(&mut *tx, book_uuid).await? {
+        upsert_fts(&mut tx, book_id).await?;
     }
+    tx.commit().await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- `rebuild_fts_for_book` (the single-book path in `db/src/metadata_overrides/fts.rs`) previously ran `upsert_fts` (canonical DELETE+INSERT) and `overlay_overrides` (override UPDATE) as two separate autocommit writes on a bare acquired connection. A failure in the overlay after the canonical write committed left the `books_fts` row with unmerged canonical data. It now wraps both writes in one transaction.
- Extracted a transaction-aware helper `rebuild_fts_row_tx(&mut Transaction, book_id, merged)` that is the single write implementation shared by BOTH the single-book path and the batch path (`rebuild_fts_for_books_batch`), so the two can no longer drift.
- `delete_metadata_overrides` (`db/src/metadata_overrides/upsert.rs`) now runs the override DELETE and the FTS restore inside one `BEGIN IMMEDIATE` transaction, so a failed rebuild rolls back the DELETE instead of leaving the overrides gone while search still matches the deleted override text.
- Behavior-preserving consistency/atomicity fix; no public signature changes.

Closes #637

## Test plan
- [x] `cargo fmt -p omnibus-db` — clean
- [x] `cargo test -p omnibus-db metadata_overrides` — 15 passed, 0 failed (incl. new `upsert_metadata_overrides_rebuilds_fts_tags_column`)
- [x] `cargo test -p omnibus-db fts` — 31 passed, 0 failed
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean

## Notes
- Added `upsert_metadata_overrides_rebuilds_fts_tags_column`, which asserts `books_fts.tags` directly (not via `search_books`, whose MATCH deliberately excludes the `tags` column) to prove the overlay half of the transactional rebuild commits.
- The delete path restores canonical FTS via `upsert_fts` alone inside the tx: once the override row is deleted, the merged state *is* canonical, and `upsert_fts` reads the same canonical taxonomy the scan-time index writes — so no override overlay is needed, and it avoids a cross-connection read that couldn't observe the uncommitted DELETE. The existing `delete_metadata_overrides_restores_fts` / `delete_overrides_reverts_to_scanned` tests cover this.