### PR TITLE
fix: cap author photo URL length in REST handler

### DIFF
--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -262,6 +262,15 @@ pub(super) async fn put_author_photo_url(
     if url.is_empty() {
         return (axum::http::StatusCode::BAD_REQUEST, "url is required").into_response();
     }
+    // Cap before handing the string to the fetch pipeline so a multi-megabyte
+    // URL can't allocate/parse unbounded. 2048 matches the RPC path (#456).
+    if url.len() > 2048 {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            "url must be 2048 characters or fewer",
+        )
+            .into_response();
+    }
 
     let (advertised_mime, bytes) =
         match db::author_photos::fetch_remote_image_with(url, state.remote_image_config()).await {

--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -263,11 +263,14 @@ pub(super) async fn put_author_photo_url(
         return (axum::http::StatusCode::BAD_REQUEST, "url is required").into_response();
     }
     // Cap before handing the string to the fetch pipeline so a multi-megabyte
-    // URL can't allocate/parse unbounded. 2048 matches the RPC path (#456).
-    if url.len() > 2048 {
+    // URL can't allocate/parse unbounded. Shares the RPC path's cap (#456).
+    if url.len() > omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN {
         return (
             axum::http::StatusCode::BAD_REQUEST,
-            "url must be 2048 characters or fewer",
+            format!(
+                "url must be {} bytes or fewer",
+                omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN
+            ),
         )
             .into_response();
     }

--- a/server/src/backend/author_photos/tests.rs
+++ b/server/src/backend/author_photos/tests.rs
@@ -303,6 +303,31 @@ async fn api_put_author_photo_url_rejects_empty_url() {
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
 
+#[tokio::test]
+async fn api_put_author_photo_url_rejects_overlong_url() {
+    let (app, _state, pool) = fixture().await;
+    let id = seed_author(&pool, "Ada Lovelace").await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    // 2049 chars — one over the 2048 cap. Rejected with 400 before any
+    // outbound fetch fires, so the (unreachable) host never matters.
+    let overlong = format!(
+        "http://example.com/{}",
+        "a".repeat(2049 - "http://example.com/".len())
+    );
+    assert_eq!(overlong.len(), 2049);
+    let res = app
+        .oneshot(put_photo_url(
+            &format!("/api/authors/{id}/photo/url"),
+            &token,
+            &overlong,
+        ))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
 /// SSRF regression: the default `AppState` (built by `fixture()`) must
 /// reject IP-literal URLs that point at the loopback / cloud-metadata /
 /// RFC1918 address space *before* any TCP connect.

--- a/server/src/backend/author_photos/tests.rs
+++ b/server/src/backend/author_photos/tests.rs
@@ -310,13 +310,13 @@ async fn api_put_author_photo_url_rejects_overlong_url() {
     let admin = auth_test_support::create_admin(&pool, "admin").await;
     let token = auth_test_support::bearer_token(&pool, admin.id).await;
 
-    // 2049 chars — one over the 2048 cap. Rejected with 400 before any
-    // outbound fetch fires, so the (unreachable) host never matters.
-    let overlong = format!(
-        "http://example.com/{}",
-        "a".repeat(2049 - "http://example.com/".len())
-    );
-    assert_eq!(overlong.len(), 2049);
+    // One byte over the shared cap. The length guard rejects with 400
+    // before any outbound fetch fires; the loopback host keeps the test
+    // hermetic (and blocked by the SSRF guard) even if that guard regresses.
+    let cap = omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN;
+    let prefix = "http://127.0.0.1/";
+    let overlong = format!("{prefix}{}", "a".repeat(cap + 1 - prefix.len()));
+    assert_eq!(overlong.len(), cap + 1);
     let res = app
         .oneshot(put_photo_url(
             &format!("/api/authors/{id}/photo/url"),


### PR DESCRIPTION
## Summary
- Closes #639
- `PUT /api/authors/{id}/photo/url` (`put_author_photo_url`) previously validated only that the URL was non-empty, then handed it straight to the SSRF-guarded fetch pipeline with no upper-bound length gate — an admin could send a multi-megabyte URL that allocates and parses unbounded.
- Adds a `url.len() > 2048` guard immediately after the existing `is_empty()` check, returning `400 Bad Request` via the same `(StatusCode::BAD_REQUEST, msg)` tuple the empty-URL guard uses. 2048 matches the cap already applied to the RPC path in #456.

## Test plan
- [x] `cargo test -p omnibus author` — 34 passed, including the new `api_put_author_photo_url_rejects_overlong_url` (asserts a 2049-char URL is rejected with 400; authorizes an admin via `create_admin` + `bearer_token`, same as the sibling `..._rejects_empty_url` test).
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean.
- [x] `cargo fmt` — clean.

## Notes
- Issue #456 already fixed the Dioxus RPC path (`rpc_set_author_photo_url`); this handler is the separate REST endpoint that was missed.