### PR TITLE
fix: reject over-length search queries at the handler

### DIFF
--- a/server/src/backend/search.rs
+++ b/server/src/backend/search.rs
@@ -7,6 +7,7 @@
 
 use axum::{
     extract::{Query, State},
+    http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
@@ -16,9 +17,21 @@ use serde::Deserialize;
 use super::{internal, with_pagination_headers, AppState};
 use crate::auth::AuthUser;
 
+/// Handler-level cap on the raw `?q=` length, in bytes. Rejects abusive
+/// input at the boundary before it reaches the db layer, which applies its
+/// own finer char-count trim (`cap_query_len`) as a fallback.
+const MAX_SEARCH_QUERY_LEN: usize = 1024;
+
 #[derive(Deserialize)]
 pub(super) struct SearchQuery {
     q: String,
+}
+
+/// Reject an over-length query with 400 so the allocation never reaches the
+/// db layer. Returns `Some(response)` when `q` exceeds [`MAX_SEARCH_QUERY_LEN`].
+fn reject_if_over_length(q: &str) -> Option<Response> {
+    (q.len() > MAX_SEARCH_QUERY_LEN)
+        .then(|| (StatusCode::BAD_REQUEST, "query too long").into_response())
 }
 
 pub(super) async fn get_search(
@@ -26,6 +39,9 @@ pub(super) async fn get_search(
     State(state): State<AppState>,
     Query(params): Query<SearchQuery>,
 ) -> Response {
+    if let Some(rejection) = reject_if_over_length(&params.q) {
+        return rejection;
+    }
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,
         Err(error) => return internal("read settings", error),
@@ -63,6 +79,9 @@ pub(super) async fn get_search_palette(
     State(state): State<AppState>,
     Query(params): Query<SearchQuery>,
 ) -> Response {
+    if let Some(rejection) = reject_if_over_length(&params.q) {
+        return rejection;
+    }
     let settings = match db::get_settings(&state.pool).await {
         Ok(s) => s,
         Err(error) => return internal("read settings", error),

--- a/server/src/backend/search.rs
+++ b/server/src/backend/search.rs
@@ -17,8 +17,8 @@ use serde::Deserialize;
 use super::{internal, with_pagination_headers, AppState};
 use crate::auth::AuthUser;
 
-/// Handler-level cap on the raw `?q=` length, in bytes. Rejects abusive
-/// input at the boundary before it reaches the db layer, which applies its
+/// Handler-level cap on the decoded `q` parameter length, in bytes. Rejects
+/// abusive input before the search db calls; the db layer still applies its
 /// own finer char-count trim (`cap_query_len`) as a fallback.
 const MAX_SEARCH_QUERY_LEN: usize = 1024;
 
@@ -27,8 +27,9 @@ pub(super) struct SearchQuery {
     q: String,
 }
 
-/// Reject an over-length query with 400 so the allocation never reaches the
-/// db layer. Returns `Some(response)` when `q` exceeds [`MAX_SEARCH_QUERY_LEN`].
+/// Reject an over-length query with 400 so oversized input is never forwarded
+/// into the search db calls. Returns `Some(response)` when `q` exceeds
+/// [`MAX_SEARCH_QUERY_LEN`].
 fn reject_if_over_length(q: &str) -> Option<Response> {
     (q.len() > MAX_SEARCH_QUERY_LEN)
         .then(|| (StatusCode::BAD_REQUEST, "query too long").into_response())

--- a/server/src/backend/search/tests.rs
+++ b/server/src/backend/search/tests.rs
@@ -132,8 +132,9 @@ async fn api_search_rejects_missing_q_param() {
 
 #[tokio::test]
 async fn api_search_rejects_over_length_q_with_400() {
-    // Issue #638: the handler caps raw `?q=` length at MAX_SEARCH_QUERY_LEN
-    // bytes and rejects longer input with 400 before any db call.
+    // Issue #638: the handler caps the decoded `q` length at
+    // MAX_SEARCH_QUERY_LEN bytes and rejects longer input with 400 before any
+    // search db call.
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;
     let token = auth_test_support::bearer_token(&pool, user.id).await;
@@ -179,7 +180,7 @@ async fn api_search_palette_returns_empty_when_path_not_configured() {
 #[tokio::test]
 async fn api_search_palette_rejects_over_length_q_with_400() {
     // Issue #638: the palette handler shares the same MAX_SEARCH_QUERY_LEN
-    // cap, rejecting over-length input with 400 before any db call.
+    // cap, rejecting over-length input with 400 before any search db call.
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;
     let token = auth_test_support::bearer_token(&pool, user.id).await;

--- a/server/src/backend/search/tests.rs
+++ b/server/src/backend/search/tests.rs
@@ -131,6 +131,25 @@ async fn api_search_rejects_missing_q_param() {
 }
 
 #[tokio::test]
+async fn api_search_rejects_over_length_q_with_400() {
+    // Issue #638: the handler caps raw `?q=` length at MAX_SEARCH_QUERY_LEN
+    // bytes and rejects longer input with 400 before any db call.
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let oversized = "a".repeat(MAX_SEARCH_QUERY_LEN + 1);
+    let response = app
+        .oneshot(get_with_bearer(
+            &format!("/api/search?q={oversized}"),
+            &token,
+        ))
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn api_search_returns_401_when_anonymous() {
     let (app, _, _) = fixture().await;
     let res = app.oneshot(get_anon("/api/search?q=hello")).await.unwrap();
@@ -155,6 +174,25 @@ async fn api_search_palette_returns_empty_when_path_not_configured() {
     let results: omnibus_shared::PaletteResults = serde_json::from_slice(&bytes).unwrap();
     assert!(results.books.is_empty());
     assert!(results.authors.is_empty());
+}
+
+#[tokio::test]
+async fn api_search_palette_rejects_over_length_q_with_400() {
+    // Issue #638: the palette handler shares the same MAX_SEARCH_QUERY_LEN
+    // cap, rejecting over-length input with 400 before any db call.
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let oversized = "a".repeat(MAX_SEARCH_QUERY_LEN + 1);
+    let response = app
+        .oneshot(get_with_bearer(
+            &format!("/api/search/palette?q={oversized}"),
+            &token,
+        ))
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Closes #638
- Both `get_search` and `get_search_palette` now reject requests where the raw `?q=` length exceeds `MAX_SEARCH_QUERY_LEN` (1024 bytes) with `400 Bad Request`, before any call into the db layer.
- Matches the existing handler-boundary validation pattern (`(StatusCode::BAD_REQUEST, msg).into_response()`, as in `highlights.rs`); the shared `reject_if_over_length` helper keeps both handlers in sync.
- The db-layer `cap_query_len` (256-char trim) is left in place as a belt-and-suspenders fallback.

## Test plan
- [x] `cargo test -p omnibus search` — 11 passed, incl. new `api_search_rejects_over_length_q_with_400` and `api_search_palette_rejects_over_length_q_with_400`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — clean

## Notes
- Handler cap (1024 bytes) is intentionally coarser than the db layer's 256-char trim: it rejects abusive input at the boundary, while the db trim still normalizes ordinary queries.