### PR TITLE
refactor: hoist Hardcover key-status logic into db layer

### DIFF
--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use sqlx::{SqlitePool, Transaction};
 
-pub use omnibus_shared::{Settings, HARDCOVER_API_KEY_MAX_LEN};
+pub use omnibus_shared::{HardcoverKeyStatus, Settings, HARDCOVER_API_KEY_MAX_LEN};
 
 /// `settings` KV keys consumed by the UI/RPC layer. Kept as constants so the
 /// indexer, settings handlers, and tests all reference the same identifier.
@@ -317,6 +317,49 @@ pub async fn effective_hardcover_api_key(
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty()))
+}
+
+/// Masked status of the server-wide Hardcover key: the saved settings value
+/// wins (`source = "settings"`), then the `HARDCOVER_API_KEY` env var
+/// (`source = "env"`), else unset (`source = "none"`). Never returns the raw
+/// key — only the short masked preview from [`mask_key`]. Shared by the REST
+/// handler and the RPC server function so the fallback + masking live once.
+pub async fn hardcover_key_status(pool: &SqlitePool) -> Result<HardcoverKeyStatus, SettingsError> {
+    if let Some(k) = get_hardcover_api_key(pool).await? {
+        return Ok(HardcoverKeyStatus {
+            configured: true,
+            masked: Some(mask_key(&k)),
+            source: "settings".to_string(),
+        });
+    }
+    if let Ok(env_key) = std::env::var("HARDCOVER_API_KEY") {
+        let env_key = env_key.trim();
+        if !env_key.is_empty() {
+            return Ok(HardcoverKeyStatus {
+                configured: true,
+                masked: Some(mask_key(env_key)),
+                source: "env".to_string(),
+            });
+        }
+    }
+    Ok(HardcoverKeyStatus {
+        configured: false,
+        masked: None,
+        source: "none".to_string(),
+    })
+}
+
+/// Short masked preview of a secret — never the raw value. Keys of 8 chars or
+/// fewer collapse to a fixed bullet run; longer keys (Hardcover tokens are
+/// JWTs) render as `first4…last4`.
+fn mask_key(key: &str) -> String {
+    let n = key.chars().count();
+    if n <= 8 {
+        return "\u{2022}\u{2022}\u{2022}\u{2022}".to_string();
+    }
+    let first: String = key.chars().take(4).collect();
+    let last: String = key.chars().skip(n - 4).collect();
+    format!("{first}\u{2026}{last}")
 }
 
 /// Boot hook: seed the Hardcover key from `HARDCOVER_API_KEY` **only** when no

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -322,8 +322,8 @@ pub async fn effective_hardcover_api_key(
 /// Masked status of the server-wide Hardcover key: the saved settings value
 /// wins (`source = "settings"`), then the `HARDCOVER_API_KEY` env var
 /// (`source = "env"`), else unset (`source = "none"`). Never returns the raw
-/// key — only the short masked preview from [`mask_key`]. Shared by the REST
-/// handler and the RPC server function so the fallback + masking live once.
+/// key — only a short masked preview. Shared by the REST handler and the RPC
+/// server function so the fallback + masking live once.
 pub async fn hardcover_key_status(pool: &SqlitePool) -> Result<HardcoverKeyStatus, SettingsError> {
     if let Some(k) = get_hardcover_api_key(pool).await? {
         return Ok(HardcoverKeyStatus {

--- a/db/src/settings/tests.rs
+++ b/db/src/settings/tests.rs
@@ -216,6 +216,59 @@ async fn seed_hardcover_key_seeds_only_when_unset() {
     );
 }
 
+#[tokio::test]
+async fn hardcover_key_status_reports_settings_source_masked() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", Some("env-key"));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    set_hardcover_api_key(&pool, Some("abcdefghijkl"))
+        .await
+        .unwrap();
+
+    let status = hardcover_key_status(&pool).await.unwrap();
+    assert!(status.configured);
+    assert_eq!(status.source, "settings");
+    // Long keys collapse to first4…last4 — never the raw value.
+    assert_eq!(status.masked.as_deref(), Some("abcd\u{2026}ijkl"));
+}
+
+#[tokio::test]
+async fn hardcover_key_status_falls_back_to_env_masked() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", Some("abcdefghijkl"));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let status = hardcover_key_status(&pool).await.unwrap();
+    assert!(status.configured);
+    assert_eq!(status.source, "env");
+    assert_eq!(status.masked.as_deref(), Some("abcd\u{2026}ijkl"));
+}
+
+#[tokio::test]
+async fn hardcover_key_status_masks_short_keys_as_bullets() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    set_hardcover_api_key(&pool, Some("short")).await.unwrap();
+
+    let status = hardcover_key_status(&pool).await.unwrap();
+    assert!(status.configured);
+    assert_eq!(status.source, "settings");
+    // Keys of 8 chars or fewer never leak length beyond the fixed bullet run.
+    assert_eq!(
+        status.masked.as_deref(),
+        Some("\u{2022}\u{2022}\u{2022}\u{2022}")
+    );
+}
+
+#[tokio::test]
+async fn hardcover_key_status_is_unset_when_neither_set() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let status = hardcover_key_status(&pool).await.unwrap();
+    assert!(!status.configured);
+    assert_eq!(status.source, "none");
+    assert_eq!(status.masked, None);
+}
+
 /// F2 repoint-in-place: changing the ebook path moves the existing
 /// `scan_roots` row (keeping its id) so every book — and its durable
 /// `books.uuid` — survives the move under the new path. Nothing is deleted.

--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -490,7 +490,7 @@ pub async fn rpc_get_suggestions(uuid: String) -> Result<SuggestionsResponse> {
 /// Never returns the raw key.
 #[get("/api/rpc/hardcover-key", pool: PoolExt, _admin: AdminUser)]
 pub async fn rpc_get_hardcover_key() -> Result<HardcoverKeyStatus> {
-    read_hardcover_key_status(&pool.0).await
+    Ok(db::hardcover_key_status(&pool.0).await?)
 }
 
 /// Admin-only: save (or clear, with `None`/blank) the Hardcover key in
@@ -502,51 +502,10 @@ pub async fn rpc_get_hardcover_key() -> Result<HardcoverKeyStatus> {
 #[post("/api/rpc/hardcover-key", pool: PoolExt, _admin: AdminUser)]
 pub async fn rpc_set_hardcover_key(key: Option<String>) -> Result<HardcoverKeyStatus> {
     match db::set_hardcover_api_key(&pool.0, key.as_deref()).await {
-        Ok(()) => read_hardcover_key_status(&pool.0).await,
+        Ok(()) => Ok(db::hardcover_key_status(&pool.0).await?),
         Err(db::SettingsError::Validation(msg)) => Err(ServerFnError::new(msg).into()),
         Err(e) => Err(ServerFnError::new(e.to_string()).into()),
     }
-}
-
-/// Short masked preview of a secret — never the raw value. Long keys (Hardcover
-/// tokens are JWTs) collapse to `first4…last4`.
-#[cfg(feature = "server")]
-fn mask_key(key: &str) -> String {
-    let n = key.chars().count();
-    if n <= 8 {
-        return "\u{2022}\u{2022}\u{2022}\u{2022}".to_string();
-    }
-    let first: String = key.chars().take(4).collect();
-    let last: String = key.chars().skip(n - 4).collect();
-    format!("{first}\u{2026}{last}")
-}
-
-/// Build the masked key status: settings value wins (`source = "settings"`),
-/// else the `HARDCOVER_API_KEY` env var (`source = "env"`), else unset.
-#[cfg(feature = "server")]
-async fn read_hardcover_key_status(pool: &sqlx::SqlitePool) -> Result<HardcoverKeyStatus> {
-    if let Some(k) = db::get_hardcover_api_key(pool).await? {
-        return Ok(HardcoverKeyStatus {
-            configured: true,
-            masked: Some(mask_key(&k)),
-            source: "settings".to_string(),
-        });
-    }
-    if let Ok(env_key) = std::env::var("HARDCOVER_API_KEY") {
-        let env_key = env_key.trim();
-        if !env_key.is_empty() {
-            return Ok(HardcoverKeyStatus {
-                configured: true,
-                masked: Some(mask_key(env_key)),
-                source: "env".to_string(),
-            });
-        }
-    }
-    Ok(HardcoverKeyStatus {
-        configured: false,
-        masked: None,
-        source: "none".to_string(),
-    })
 }
 
 /// Admin-triggered "Scan for picture" for an author. Clears any sticky

--- a/server/src/backend/suggestions.rs
+++ b/server/src/backend/suggestions.rs
@@ -16,7 +16,7 @@ use axum::{
     Json,
 };
 use omnibus_db::{self as db, worker::Task};
-use omnibus_shared::{BookSuggestion, HardcoverKeyStatus, RawSuggestion, SuggestionsResponse};
+use omnibus_shared::{BookSuggestion, RawSuggestion, SuggestionsResponse};
 use serde::Deserialize;
 
 use super::{internal, AppState};
@@ -112,7 +112,7 @@ pub(super) async fn get_hardcover_key(
     _admin: AdminUser,
     State(state): State<AppState>,
 ) -> Response {
-    match read_status(&state.pool).await {
+    match db::hardcover_key_status(&state.pool).await {
         Ok(s) => Json(s).into_response(),
         Err(e) => internal("read hardcover key", e),
     }
@@ -140,47 +140,10 @@ pub(super) async fn post_hardcover_key(
         }
         Err(e) => return internal("save hardcover key", e),
     }
-    match read_status(&state.pool).await {
+    match db::hardcover_key_status(&state.pool).await {
         Ok(s) => Json(s).into_response(),
         Err(e) => internal("read hardcover key", e),
     }
-}
-
-/// Build the masked key status: settings wins, then env, else unset.
-async fn read_status(pool: &sqlx::SqlitePool) -> Result<HardcoverKeyStatus, db::SettingsError> {
-    if let Some(k) = db::get_hardcover_api_key(pool).await? {
-        return Ok(HardcoverKeyStatus {
-            configured: true,
-            masked: Some(mask_key(&k)),
-            source: "settings".to_string(),
-        });
-    }
-    if let Ok(env_key) = std::env::var("HARDCOVER_API_KEY") {
-        let env_key = env_key.trim();
-        if !env_key.is_empty() {
-            return Ok(HardcoverKeyStatus {
-                configured: true,
-                masked: Some(mask_key(env_key)),
-                source: "env".to_string(),
-            });
-        }
-    }
-    Ok(HardcoverKeyStatus {
-        configured: false,
-        masked: None,
-        source: "none".to_string(),
-    })
-}
-
-/// Short masked preview — never the raw key.
-fn mask_key(key: &str) -> String {
-    let n = key.chars().count();
-    if n <= 8 {
-        return "\u{2022}\u{2022}\u{2022}\u{2022}".to_string();
-    }
-    let first: String = key.chars().take(4).collect();
-    let last: String = key.chars().skip(n - 4).collect();
-    format!("{first}\u{2026}{last}")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Closes #667.
- The masked-key-preview + settings-then-env fallback logic for the Hardcover API key was duplicated byte-for-byte between the REST handler (`server/src/backend/suggestions.rs`) and the RPC server function (`frontend/src/rpc.rs`).
- Hoisted it into a single `db::settings::hardcover_key_status(pool) -> Result<HardcoverKeyStatus, SettingsError>` (re-exported as `db::hardcover_key_status`), with `mask_key` now a private helper in the db layer.
- Both call sites are now one-line delegations; their local `read_status` / `read_hardcover_key_status` / `mask_key` copies are deleted.
- `HardcoverKeyStatus` already lived in `shared/`, so no type moved — the db `settings` module simply imports it (it already imported other `omnibus_shared` items).

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo test -p omnibus-db settings` — 23 passed (incl. 4 new `hardcover_key_status_*` cases covering settings/env source, long-key `first4…last4` masking, short-key bullet masking, and unset)
- [x] `cargo test -p omnibus suggestions` — 8 passed (REST, incl. `api_hardcover_key_set_then_get_returns_masked_never_raw`)
- [x] `cargo test -p omnibus-frontend --features server` — 191 passed (RPC)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean

## Notes
- Pure refactor: REST and RPC endpoints return the same JSON as before.