### PR TITLE
refactor: group BookSuggestion::new args to drop too_many_arguments

### DIFF
--- a/frontend/src/rpc.rs
+++ b/frontend/src/rpc.rs
@@ -39,10 +39,11 @@ use omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN;
 #[cfg(feature = "server")]
 use omnibus_shared::SESSION_BATCH_CAP;
 
-// `BookSuggestion` is only constructed in the server-side `rpc_get_suggestions`
-// body; gate it so the web/mobile client builds don't flag an unused import.
+// `BookSuggestion` / `RawSuggestion` are only used in the server-side
+// `rpc_get_suggestions` body; gate them so the web/mobile client builds don't
+// flag an unused import.
 #[cfg(feature = "server")]
-use omnibus_shared::BookSuggestion;
+use omnibus_shared::{BookSuggestion, RawSuggestion};
 
 #[cfg(feature = "server")]
 use omnibus_db::{self as db, scanner};
@@ -468,11 +469,13 @@ pub async fn rpc_get_suggestions(uuid: String) -> Result<SuggestionsResponse> {
                 BookSuggestion::new(
                     &uuid,
                     c.rank,
-                    c.hardcover_id,
-                    c.hardcover_slug,
-                    c.title,
-                    c.author,
-                    c.list_count,
+                    RawSuggestion {
+                        hardcover_id: c.hardcover_id,
+                        hardcover_slug: c.hardcover_slug,
+                        title: c.title,
+                        author: c.author,
+                        list_count: c.list_count,
+                    },
                     c.has_cover,
                 )
             })

--- a/server/src/backend/suggestions.rs
+++ b/server/src/backend/suggestions.rs
@@ -16,7 +16,7 @@ use axum::{
     Json,
 };
 use omnibus_db::{self as db, worker::Task};
-use omnibus_shared::{BookSuggestion, HardcoverKeyStatus, SuggestionsResponse};
+use omnibus_shared::{BookSuggestion, HardcoverKeyStatus, RawSuggestion, SuggestionsResponse};
 use serde::Deserialize;
 
 use super::{internal, AppState};
@@ -67,11 +67,13 @@ pub(super) async fn get_suggestions(
                     BookSuggestion::new(
                         &uuid,
                         c.rank,
-                        c.hardcover_id,
-                        c.hardcover_slug,
-                        c.title,
-                        c.author,
-                        c.list_count,
+                        RawSuggestion {
+                            hardcover_id: c.hardcover_id,
+                            hardcover_slug: c.hardcover_slug,
+                            title: c.title,
+                            author: c.author,
+                            list_count: c.list_count,
+                        },
                         c.has_cover,
                     )
                 })

--- a/shared/src/suggestion.rs
+++ b/shared/src/suggestion.rs
@@ -23,9 +23,7 @@ pub struct BookSuggestion {
     pub cover_url: Option<String>,
 }
 
-/// The Hardcover-sourced fields of one cached suggestion, grouped so
-/// [`BookSuggestion::new`] can derive the wire type from a single value rather
-/// than a long positional argument list.
+/// The Hardcover-sourced fields of one cached suggestion, grouped as the input to [`BookSuggestion::new`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RawSuggestion {
     pub hardcover_id: i64,

--- a/shared/src/suggestion.rs
+++ b/shared/src/suggestion.rs
@@ -23,21 +23,30 @@ pub struct BookSuggestion {
     pub cover_url: Option<String>,
 }
 
+/// The Hardcover-sourced fields of one cached suggestion, grouped so
+/// [`BookSuggestion::new`] can derive the wire type from a single value rather
+/// than a long positional argument list.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RawSuggestion {
+    pub hardcover_id: i64,
+    pub hardcover_slug: Option<String>,
+    pub title: String,
+    pub author: String,
+    pub list_count: i64,
+}
+
 impl BookSuggestion {
-    /// Build a wire suggestion from the cached primitives, deriving the
+    /// Build a wire suggestion from a book's cached primitives, deriving the
     /// outbound Hardcover URL (slug-based, id fallback) and the relative cover
     /// URL (only when a cover was cached).
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        book_uuid: &str,
-        rank: i64,
-        hardcover_id: i64,
-        hardcover_slug: Option<String>,
-        title: String,
-        author: String,
-        list_count: i64,
-        has_cover: bool,
-    ) -> Self {
+    pub fn new(book_uuid: &str, rank: i64, raw: RawSuggestion, has_cover: bool) -> Self {
+        let RawSuggestion {
+            hardcover_id,
+            hardcover_slug,
+            title,
+            author,
+            list_count,
+        } = raw;
         let hardcover_url = match hardcover_slug {
             Some(slug) if !slug.is_empty() => format!("{HARDCOVER_BOOK_BASE}{slug}"),
             _ => format!("{HARDCOVER_BOOK_BASE}{hardcover_id}"),
@@ -77,3 +86,6 @@ pub struct HardcoverKeyStatus {
     /// Where the effective key comes from: `"settings"`, `"env"`, or `"none"`.
     pub source: String,
 }
+
+#[cfg(test)]
+mod tests;

--- a/shared/src/suggestion/tests.rs
+++ b/shared/src/suggestion/tests.rs
@@ -1,0 +1,46 @@
+//! URL-derivation tests for `BookSuggestion::new`.
+
+use super::*;
+
+/// A `RawSuggestion` with a non-empty slug and the given id, other fields fixed.
+fn raw(hardcover_id: i64, hardcover_slug: Option<String>) -> RawSuggestion {
+    RawSuggestion {
+        hardcover_id,
+        hardcover_slug,
+        title: "Dune".into(),
+        author: "Frank Herbert".into(),
+        list_count: 7,
+    }
+}
+
+#[test]
+fn new_uses_slug_url_and_derives_cover_url_when_cover_cached() {
+    let s = BookSuggestion::new("book-1", 2, raw(42, Some("dune".into())), true);
+    assert_eq!(s.hardcover_id, 42);
+    assert_eq!(s.hardcover_url, "https://hardcover.app/books/dune");
+    assert_eq!(s.title, "Dune");
+    assert_eq!(s.author, "Frank Herbert");
+    assert_eq!(s.list_count, 7);
+    assert_eq!(
+        s.cover_url.as_deref(),
+        Some("/api/suggestions/book-1/2/cover")
+    );
+}
+
+#[test]
+fn new_falls_back_to_id_url_when_slug_is_none() {
+    let s = BookSuggestion::new("book-1", 0, raw(99, None), false);
+    assert_eq!(s.hardcover_url, "https://hardcover.app/books/99");
+}
+
+#[test]
+fn new_falls_back_to_id_url_when_slug_is_empty() {
+    let s = BookSuggestion::new("book-1", 0, raw(99, Some(String::new())), false);
+    assert_eq!(s.hardcover_url, "https://hardcover.app/books/99");
+}
+
+#[test]
+fn new_omits_cover_url_when_no_cover_cached() {
+    let s = BookSuggestion::new("book-1", 3, raw(42, Some("dune".into())), false);
+    assert_eq!(s.cover_url, None);
+}

--- a/shared/src/suggestion/tests.rs
+++ b/shared/src/suggestion/tests.rs
@@ -2,7 +2,8 @@
 
 use super::*;
 
-/// A `RawSuggestion` with a non-empty slug and the given id, other fields fixed.
+/// A `RawSuggestion` with the given id and slug (`None`/empty exercises the
+/// id-fallback branch); title, author, and list_count are fixed.
 fn raw(hardcover_id: i64, hardcover_slug: Option<String>) -> RawSuggestion {
     RawSuggestion {
         hardcover_id,


### PR DESCRIPTION
## Summary
- Closes #666.
- Groups the five Hardcover-sourced fields of `BookSuggestion::new` (`hardcover_id`, `hardcover_slug`, `title`, `author`, `list_count`) into a new `shared::RawSuggestion` struct, so the constructor now takes 4 params — `new(book_uuid: &str, rank: i64, raw: RawSuggestion, has_cover: bool)`.
- Removes the `#[allow(clippy::too_many_arguments)]` suppression.
- Updates both call sites (`server/src/backend/suggestions.rs`, `frontend/src/rpc.rs`) to build a `RawSuggestion` literal from the cached row.
- Adds `shared/src/suggestion/tests.rs` covering the URL derivation (slug URL, id fallback for `None`/empty slug) and cover-URL on/off branches.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p omnibus-shared` — 84 passed (incl. 4 new `suggestion::tests`)
- [x] `cargo test -p omnibus suggestions` — 8 passed
- [x] `cargo test -p omnibus-frontend --features server` — 191 passed
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — clean (confirms the removed allow doesn't reintroduce the lint)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean