### PR TITLE
docs: add missing /// rustdoc to twelve frontend pub items (#636)

### DIFF
--- a/frontend/src/components/bottom_nav.rs
+++ b/frontend/src/components/bottom_nav.rs
@@ -9,6 +9,7 @@ use dioxus_router::Link;
 
 use crate::Route;
 
+/// Renders the bottom navigation bar component.
 #[component]
 pub fn BottomNav() -> Element {
     rsx! {

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -31,6 +31,7 @@ impl SuggestionItem {
     }
 }
 
+/// Props for the [`ChipEditor`] component.
 #[derive(Props, PartialEq, Clone)]
 pub struct ChipEditorProps {
     /// The chip list. Shared with the consumer so the parent can read

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -13,6 +13,8 @@ use omnibus_shared::BookFileInfo;
 #[cfg(not(feature = "mobile"))]
 use crate::Route;
 
+/// Renders the format switcher, letting the reader pick which available
+/// format of a book to open.
 #[component]
 pub fn FormatSwitcher(
     formats: Vec<String>,

--- a/frontend/src/components/top_nav.rs
+++ b/frontend/src/components/top_nav.rs
@@ -11,6 +11,7 @@ use crate::components::search_palette::SearchPaletteHost;
 use crate::components::user_menu::UserMenu;
 use crate::Route;
 
+/// Renders the top navigation bar component.
 #[component]
 pub fn TopNav() -> Element {
     let route = use_route::<Route>();

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -26,6 +26,7 @@ pub(crate) fn initials_for(username: &str) -> String {
     trimmed.chars().take(2).collect::<String>().to_uppercase()
 }
 
+/// Renders the user menu component (web and server targets).
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
 pub fn UserMenu() -> Element {

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -10,6 +10,7 @@ use dioxus_router::{use_navigator, Link};
 use crate::components::auth::{AuthShell, Banner, BannerKind, Field, StrengthMeter, StrengthScore};
 use crate::{use_server_url, Route};
 
+/// Renders the login page.
 #[component]
 pub fn LoginPage() -> Element {
     let mut username = use_signal(String::new);
@@ -143,6 +144,7 @@ pub fn LoginPage() -> Element {
     }
 }
 
+/// Renders the register page.
 #[component]
 pub fn RegisterPage() -> Element {
     let username = use_signal(String::new);

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -12,6 +12,7 @@ use crate::components::atrium::Cover;
 use crate::components::author_photo_edit::AuthorPhotoEditOverlay;
 use crate::{data, use_server_url, Route};
 
+/// Renders the author discovery page.
 #[component]
 pub fn AuthorPage(id: i64) -> Element {
     let server_url = use_server_url();

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -68,6 +68,7 @@ pub(crate) use controls::AudioElement;
 #[cfg(not(feature = "mobile"))]
 pub(crate) use mini_dock::MiniDock;
 
+/// Renders the audiobook listen page for the book with the given uuid.
 #[component]
 pub fn BookListenPage(uuid: String) -> Element {
     #[cfg(feature = "mobile")]

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -12,6 +12,7 @@ use omnibus_shared::{
 
 use crate::{data, use_server_url, Route};
 
+/// Renders the full-page search results for the given query.
 #[component]
 pub fn SearchPage(query: String) -> Element {
     let server_url = use_server_url();

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -8,6 +8,7 @@ use omnibus_shared::SeriesDetail;
 use crate::components::atrium::Cover;
 use crate::{data, use_server_url, Route};
 
+/// Renders the series discovery page.
 #[component]
 pub fn SeriesPage(id: i64) -> Element {
     let server_url = use_server_url();

--- a/frontend/src/pages/tag_cloud.rs
+++ b/frontend/src/pages/tag_cloud.rs
@@ -7,6 +7,7 @@ use omnibus_shared::TagWeight;
 
 use crate::{data, use_server_url, Route};
 
+/// Renders the tag cloud page.
 #[component]
 pub fn TagCloudPage() -> Element {
     let server_url = use_server_url();


### PR DESCRIPTION
## Summary
- Adds the required one-line `///` rustdoc summary to twelve `pub` page and component items in `omnibus-frontend` that were missing it, per `.claude/rules/05-rust-style.md` § &#34;Function `///`&#34;.
- Items documented: `LoginPage`, `RegisterPage` (auth.rs), `AuthorPage`, `BookListenPage`, `SearchPage`, `SeriesPage`, `TagCloudPage`, `BottomNav`, `ChipEditorProps` (struct-level), `FormatSwitcher`, `TopNav`, `UserMenu` (web/server variant).
- Doc-only: no behavior, markup, or test changes. Nothing was feature-gated, so SSR/WASM hydration is unaffected.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-frontend --features server` — 191 passed
- [x] `cargo doc -p omnibus-frontend --no-deps` — none of the twelve items produce warnings

## Notes
- No `Cargo.lock` change.
- `cargo doc` still emits 16 pre-existing intra-doc-link warnings in `frontend/src/routes.rs` (module `//!` links to private items like `crate::ScreenLayout`). These predate this change and are out of scope; flagging for a possible follow-up but not fixing here per the one-issue scope.
- Followed the Sniffer remedy exactly. `ChipEditorProps` got a struct-level doc that links to its `[ChipEditor]` component; `FormatSwitcher` got a second sentence describing its purpose per the issue&#39;s suggestion.

## Reviewer notes
Independent adversarial review of `origin/main...origin/docs/636-frontend-rustdoc` (checks re-run in a clean worktree):

- **Citations confirmed (12/12):** all named items now carry a one-line `///` summary — `LoginPage`, `RegisterPage`, `AuthorPage`, `BookListenPage`, `SearchPage`, `SeriesPage`, `TagCloudPage`, `BottomNav`, `ChipEditorProps` (struct-level), `FormatSwitcher`, `TopNav`, `UserMenu` (web/server variant). No item was missed.
- **Scope:** diff is 13 insertions across 11 files, all under `frontend/src/`, doc-comment lines only — no behavior/markup/test changes, no feature-gated rsx, no touched files outside the issue's area.
- **`cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`:** re-run, PASS (clean).
- **`cargo test -p omnibus-frontend --features server`:** re-run, 191 passed / 0 failed.
- **`cargo doc -p omnibus-frontend --no-deps`:** builds; the 16 warnings are byte-for-byte identical on `origin/main` (verified `generated 16 warnings` on both branches) and are module-level intra-doc-link issues in unchanged files — none reference the 12 documented items. Not introduced by this PR.
- **Migrations:** no file under `db/migrations/` modified.

Verdict: doc-only change fully resolves #636; no regressions.


---
_Generated by [Claude Code](https://claude.ai/code/session_012cbxKchuBhYPYoMKbLXyDi)_