### PR TITLE
docs: trim bloated //! module docs in suggestions/journal files (#665)

### DIFF
--- a/db/src/suggestions/cascade.rs
+++ b/db/src/suggestions/cascade.rs
@@ -1,13 +1,7 @@
-//! Resolution orchestration for F3.3 suggestions. Mirrors
-//! `author_photos::cascade`: a single `resolve` entry point the worker drives,
-//! plus a `resolve_with` that takes injectable configs for tests.
-//!
-//! Flow: resolve the library book to a Hardcover book (ISBN-first, title
-//! fallback) → collect its curated lists → rank co-listed books → filter to
-//! different-author / different-series / entry-point survivors → fetch cover
-//! bytes → cache the top 10. A clean miss writes the sticky `empty` marker; a
-//! transient network error leaves the marker untouched so the debounce window
-//! re-posts later.
+//! Resolution orchestration for F3.3 suggestions, mirroring
+//! `author_photos::cascade`: a single [`resolve`] entry point the worker drives
+//! (via [`crate::worker::Task::ResolveSuggestions`]) plus a [`resolve_with`]
+//! that takes injectable Hardcover + image configs for tests.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -52,6 +46,13 @@ pub async fn resolve(pool: &SqlitePool, book_uuid: &str) -> anyhow::Result<()> {
 
 /// [`resolve`] with injectable Hardcover + remote-image configs (tests point
 /// these at a local `wiremock` server).
+///
+/// Flow: resolve the library book to a Hardcover book (ISBN-first, title
+/// fallback) → collect its curated lists → rank co-listed books → filter to
+/// different-author / different-series / entry-point survivors → fetch cover
+/// bytes → cache the top 10. A clean miss writes the sticky `empty` marker; a
+/// transient network error leaves the marker untouched so the debounce window
+/// re-posts later.
 pub async fn resolve_with(
     pool: &SqlitePool,
     book_uuid: &str,

--- a/db/src/suggestions/data.rs
+++ b/db/src/suggestions/data.rs
@@ -1,11 +1,8 @@
-//! Cache CRUD + de-duplication state machine for F3.3 suggestions.
-//!
-//! Two tables back this (migration 0033): `book_suggestion_state` holds one
-//! marker per source book (the TTL clock + `pending`/`resolved`/`empty`
-//! state), and `book_suggestions` holds 0..N cached result rows. The pure
-//! [`decide`] function turns the marker into a "serve cached? enqueue a
-//! refetch?" verdict — the single place that guarantees a page refresh or a
-//! burst of concurrent viewers never re-hits Hardcover while a result is fresh.
+//! Cache CRUD + the pure [`decide`] de-duplication state machine for F3.3
+//! suggestions. Two tables back this (migration 0033): `book_suggestion_state`
+//! holds one TTL/`pending`/`resolved`/`empty` marker per source book, and
+//! `book_suggestions` holds its 0..N cached result rows. Read by [`cascade`]
+//! and the suggestions RPC/REST handlers.
 
 use sqlx::SqlitePool;
 
@@ -69,9 +66,13 @@ pub struct CacheDecision {
     pub enqueue: bool,
 }
 
-/// Pure cache state machine — see the table in
-/// [`crate::suggestions`]. `marker` is the `(state, fetched_at)` pair from
+/// Pure cache state machine. `marker` is the `(state, fetched_at)` pair from
 /// [`suggestion_state`] (`None` = no row yet); `now` is unix-seconds.
+///
+/// This is the single place that guarantees a page refresh or a burst of
+/// concurrent viewers never re-hits Hardcover while a result is fresh: a 30-day
+/// TTL result cache, plus a `pending` debounce so concurrent first-viewers
+/// collapse to one posted resolution task.
 pub fn decide(marker: Option<(SuggestionState, i64)>, now: i64) -> CacheDecision {
     match marker {
         // No marker: first viewer. Nothing to serve; kick off a resolution.

--- a/db/src/suggestions/filter.rs
+++ b/db/src/suggestions/filter.rs
@@ -1,9 +1,8 @@
 //! Pure candidate-filtering for F3.3 suggestions. Given the source book's
-//! authors/series and a list of Hardcover co-listed candidates (already ranked
-//! by co-listing count, descending), trim to the top read-alikes that are
-//! genuinely *new* discoveries: different author, different series, and an
-//! entry point (series-starter or standalone) so a reader is never dropped
-//! into the middle of a series. No I/O — exercised heavily in `tests.rs`.
+//! authors/series and Hardcover co-listed candidates (already ranked by
+//! co-listing count, descending), trim to the top read-alikes that are genuine
+//! *new* discoveries: different author, different series, and an entry point
+//! (series-starter or standalone). No I/O; called by [`crate::suggestions::cascade`].
 
 use std::collections::HashSet;
 

--- a/db/src/suggestions/hardcover.rs
+++ b/db/src/suggestions/hardcover.rs
@@ -1,13 +1,8 @@
-//! Hardcover GraphQL client for F3.3 suggestions. Composes a "readers also
-//! enjoyed" signal out of community-list co-occurrence — Hardcover has no
+//! Hardcover GraphQL client for F3.3 suggestions. Hardcover has no
 //! recommendations endpoint, so we resolve the library book to a Hardcover
 //! book, collect the curated lists it sits on, and rank every other book by
-//! how many of those lists it also appears on.
-//!
-//! All queries go through [`post_graphql`] against [`HardcoverConfig`]
-//! (base URL + Bearer key + timeout), which tests point at a `wiremock`
-//! server. Schema field names were verified live against
-//! `https://api.hardcover.app/v1/graphql`.
+//! how many of those lists it shares. All queries go through [`post_graphql`]
+//! against [`HardcoverConfig`] (base URL + Bearer key + timeout).
 
 use std::collections::HashMap;
 use std::sync::OnceLock;

--- a/db/src/suggestions/mod.rs
+++ b/db/src/suggestions/mod.rs
@@ -1,15 +1,8 @@
-//! F3.3 "Readers also enjoyed" — Hardcover community-list co-occurrence.
-//!
-//! [`hardcover`] talks to the Hardcover GraphQL API; [`filter`] holds the pure
-//! different-author / different-series / entry-point trimming; [`data`] is the
-//! cache CRUD + the [`data::decide`] de-duplication state machine; [`cascade`]
-//! orchestrates resolution and is driven by
+//! Hardcover community-list co-occurrence suggestions ("Readers also enjoyed").
+//! [`hardcover`] is the GraphQL client, [`filter`] the pure ranking/trim logic,
+//! [`data`] the cache CRUD + [`data::decide`] de-dup state machine, and
+//! [`cascade`] the resolution orchestrator driven by
 //! [`crate::worker::Task::ResolveSuggestions`].
-//!
-//! Caching guarantees a page refresh or a burst of concurrent viewers never
-//! re-hits Hardcover while a result is fresh: a 30-day TTL result cache, a
-//! `pending` debounce so concurrent first-viewers collapse to one posted task,
-//! and worker resource-key serialization with a cascade re-check on top.
 
 pub mod cascade;
 pub mod data;

--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -1,9 +1,8 @@
-//! Public reading-journal section for the book-detail page.
-//!
-//! Renders every reader's entries plus an owner-only composer with a live
-//! markdown editor (see `journal_editor.js`). Entries, the current user, and
-//! the write surface all attach post-mount so SSR and first-hydration paint
-//! stay identical (rule 07); bodies are sanitized server-side.
+//! Public reading-journal section for the book-detail page. Renders every
+//! reader's entries plus an owner-only composer with a live markdown editor
+//! (see `journal_editor.js`). Entries, the current user, and the write surface
+//! all attach post-mount so SSR and first-hydration paint stay identical
+//! (rule 07); bodies are sanitized server-side.
 
 use dioxus::prelude::*;
 use omnibus_shared::{

--- a/frontend/src/pages/book_detail/journal_editor.rs
+++ b/frontend/src/pages/book_detail/journal_editor.rs
@@ -1,9 +1,8 @@
-//! Live markdown editor glue for the journal composer.
-//!
-//! Ships the co-located `journal_editor.js` over Dioxus's eval channel and
-//! exposes `enhance` / `command` / `insert` actions plus the formatting
-//! toolbar. Web-only — non-web targets keep the plain SSR textarea (rule 07)
-//! and every eval helper is a no-op.
+//! Live markdown editor glue for the journal composer. Ships the co-located
+//! `journal_editor.js` over Dioxus's eval channel and exposes
+//! `enhance` / `command` / `insert` actions plus the formatting toolbar.
+//! Web-only — non-web targets keep the plain SSR textarea (rule 07) and every
+//! eval helper is a no-op.
 
 use dioxus::prelude::*;
 

--- a/server/src/backend/suggestions.rs
+++ b/server/src/backend/suggestions.rs
@@ -1,11 +1,8 @@
 //! F3.3 suggestions REST handlers (mobile-facing) plus the admin Hardcover-key
-//! API. Web hits the analogous `/api/rpc/*` server functions.
-//!
-//! `GET /api/ebooks/{uuid}/suggestions` drives the same cache de-duplication
-//! state machine as the RPC: `NotConfigured` when no key is set, the
-//! fresh/sticky cache when present, and a single enqueued resolution otherwise.
-//! `GET /api/suggestions/{uuid}/{rank}/cover` streams cached cover bytes.
-//! `GET`/`POST /api/hardcover-key` read/write the (masked) key, admin-only.
+//! API; web hits the analogous `/api/rpc/*` server functions. Serves the
+//! cache-backed "readers also enjoyed" strip (`GET .../suggestions`), streams
+//! cached cover bytes (`GET .../cover`), and reads/writes the masked
+//! account-level key (`GET`/`POST /api/hardcover-key`, admin-only).
 
 use std::time::{SystemTime, UNIX_EPOCH};
 


### PR DESCRIPTION
## Summary

Trims the eight F3.2/F3.3 module docs flagged in #665 to the ≤5-line cap (rule 05 § Comments &amp; docs). Genuinely-useful rationale is relocated onto the specific item it describes rather than deleted, per the issue&#39;s acceptance criteria:

- `db/src/suggestions/mod.rs` (12→5): the cache state-machine / TTL / debounce walkthrough moves onto `data::decide` as a `///` block.
- `db/src/suggestions/cascade.rs` (10→4): the resolution-flow walkthrough (resolve → lists → rank → filter → cover → cache) moves onto `resolve_with`, the function that actually performs it.
- `db/src/suggestions/data.rs` (8→5), `filter.rs` (6→5), `hardcover.rs` (10→5), `server/src/backend/suggestions.rs` (8→5), `frontend/src/pages/book_detail/journal.rs` (6→5), `frontend/src/pages/book_detail/journal_editor.rs` (6→5): collapsed to one tight paragraph, dropping the blank-line-separated second paragraph and any embedded per-endpoint enumeration.

Also fixes a dangling intra-doc reference: `data::decide` previously said &#34;see the table in [`crate::suggestions`]&#34;, but no such table existed in the module doc — replaced with the inline caching guarantee.

Mechanical, behavior-preserving, docs only.

## Test plan

- `cargo fmt` — clean.
- `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean; `cargo test -p omnibus-db` — pass.
- `cargo clippy -p omnibus --all-targets -- -D warnings` — clean.
- `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean.
- `cargo doc -p omnibus-frontend --no-deps` — the 16 doc warnings it emits are all pre-existing private-item intra-doc links in files I did not touch (`chip_editor.rs`, `data.rs`, `contexts.rs`, `routes.rs`, `atrium.rs`, `auth/mod.rs`); none reference the two journal files I edited, and my edits introduce no new intra-doc links.

## Notes

- No `Cargo.lock` change.
- The two `frontend/book_detail/journal*.rs` files had already been partially trimmed on `main` (6 lines each with a blank-line second paragraph); this brings them fully under the single-paragraph ≤5-line cap.
- Deviation from the suggested remedy: none of substance. Dropped the `hardcover.rs` &#34;schema verified live against api.hardcover.app&#34; and `wiremock` asides rather than relocating them (low-value implementation trivia); the remedy only called out the `mod.rs` walkthrough for relocation.
- Scope: docs only; no behavior, markup, or Playwright contracts touched. No unrelated debt fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cbxKchuBhYPYoMKbLXyDi

---
_Generated by [Claude Code](https://claude.ai/code/session_012cbxKchuBhYPYoMKbLXyDi)_

---

## Reviewer notes

Independent adversarial review against `origin/main...origin/docs/665-trim-module-docs` (8 files, +47/−63, docs-only).

**Citations confirmed.** All eight `//!` blocks named in #665 are now ≤5 lines with no embedded H2 headings or TODO markers. Relocations are genuine, not deletions: the `mod.rs` cache/TTL/debounce walkthrough now lives on `data::decide` as a `///`, and the `cascade.rs` resolve→lists→rank→filter→cover→cache flow now lives on `resolve_with` (the fn that performs it). Only comment lines changed in every file — behavior-preserving.

**Checks re-run** (crate-scoped, in a clean throwaway worktree of the branch tip `278500d`):
- `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean.
- `cargo test -p omnibus-db` — pass.
- `cargo clippy -p omnibus --all-targets -- -D warnings` — clean.
- `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean.

**No edited migration.** Nothing under `db/migrations/` was touched.

**No scope creep.** Changes are confined to the eight cited files; no behavior, markup, or test contracts altered.

**Caveat (non-blocking).** The new `data.rs` module doc introduces a fresh unresolved intra-doc link — line 4, `` [`cascade`] `` resolves to "no item named `cascade` in scope" under `cargo doc`. `filter.rs` in this same PR correctly uses the fully-qualified `` [`crate::suggestions::cascade`] ``; `data.rs` should match. This is a rustdoc warning only — it is not gated by the required `-D warnings` clippy checks (which pass), and the `db` crate already carries ~35 pre-existing broken-intra-doc-link warnings, so it does not block the merge. Worth a one-line follow-up fix given the PR's stated goal of doc hygiene and its claim to have *fixed* a dangling link.