### PR TITLE
test: deterministically gate poisoned-completions worker test (CI flake)

### DIFF
--- a/db/src/worker/tests.rs
+++ b/db/src/worker/tests.rs
@@ -640,15 +640,39 @@ async fn poisoned_completions_lock_recovers_instead_of_panicking() {
         "completions mutex should be poisoned after the panic"
     );
 
+    // Gate the task inside `on_run` so it cannot finish — and therefore
+    // cannot prune its `completions` slot — until `await_completion` has
+    // taken the receiver out of the map. Otherwise the 0-latency task can
+    // complete and prune first, and `await_completion` documents that an
+    // already-pruned id returns `Err("unknown task id")`: a timing race that
+    // flakes under CI load.
+    let gate = Arc::new(std::sync::Barrier::new(2));
+    let gate_task = gate.clone();
     let id = w.post(Task::Test {
         tag: "after-poison",
         latency_ms: 0,
         resource: None,
         route_through_scan_sem: false,
-        on_run: None,
+        on_run: Some(Arc::new(move || {
+            gate_task.wait();
+        })),
         on_done: None,
     });
-    match w.await_completion(id).await {
+
+    // `await_completion` removes the receiver from the map on its first poll,
+    // before its first `.await`; releasing the gate only after that yield
+    // guarantees the awaiter is holding the receiver and observes the outcome
+    // the task then publishes, instead of racing the prune. The barrier wait
+    // runs on the blocking pool so it never pins a runtime worker thread.
+    let (outcome, ()) = tokio::join!(w.await_completion(id), async {
+        tokio::task::yield_now().await;
+        tokio::task::spawn_blocking(move || {
+            gate.wait();
+        })
+        .await
+        .unwrap();
+    });
+    match outcome {
         TaskOutcome::Ok => {}
         other => panic!("expected Ok after poison recovery, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

`db::worker::tests::poisoned_completions_lock_recovers_instead_of_panicking` is a flaky test on `main`. It posts a **0-latency** `Task::Test` and then `await_completion(id)`, expecting `TaskOutcome::Ok`. But a 0-latency task can run to completion and drop its `completions`-map slot (via `CompletionsPruneGuard`) *before* `await_completion` takes the receiver out of the map. `await_completion` documents that an already-pruned id returns `Err("unknown task id")`, so under CI load the test intermittently fails with:

```
expected Ok after poison recovery, got Err("unknown task id")
```

This surfaced on the `clippy + test` job of an unrelated frontend PR (#709) — the failing test lives in `omnibus-db` and is not caused by that PR. Because every PR runs the full test matrix, this flake can red-flag any PR at random.

The fix is test-only: gate the task inside its `on_run` hook on a `std::sync::Barrier` and release it only after `await_completion` has been polled once. `await_completion` removes the receiver from the map on its first poll (before its first `.await`), so releasing the gate after a `yield_now` guarantees the awaiter is holding the receiver before the task publishes its outcome — the prune then becomes a no-op and `Ok` is always observed. No production code changes; the poison-recovery behaviour under test is unchanged.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db --lib worker::` — 18 passed, 0 failed
- [x] Ran `poisoned_completions_lock_recovers_instead_of_panicking` 40× in a loop — 40/40 pass (was racy at 0-latency before the gate)

## Notes
- Test-only change to `db/src/worker/tests.rs` (+21/−2). No `Cargo.lock`, migration, dependency, or production change.
- The sibling `poisoned_progress_lock_*` tests were already deterministic (they poll `progress_snapshot()` with a deadline rather than `await_completion`) and are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_012cbxKchuBhYPYoMKbLXyDi)_