### PR TITLE
refactor: split four oversized db/ functions under the 80-line cap (#579)

### DIFF
--- a/db/src/audiobook/parse.rs
+++ b/db/src/audiobook/parse.rs
@@ -194,10 +194,52 @@ fn parse_one_group(group: super::AudiobookGroup, library_root: &Path) -> Indexed
     }
 }
 
+/// Read lofty tags + duration for a single audiobook part at `path`. A
+/// lofty failure logs a WARN and falls back to default metadata with a
+/// zero duration and a max sort_track, so one corrupt file doesn't drop
+/// the whole group.
+fn read_part_tags(path: &Path) -> (AudiobookMetadata, u32) {
+    match lofty::read_from_path(path) {
+        Ok(tagged) => {
+            let dur = Some(tagged.properties().duration().as_secs_f64())
+                .filter(|d| d.is_finite() && *d > 0.0);
+            let tag = tagged.primary_tag().or_else(|| tagged.first_tag());
+            let mut m = AudiobookMetadata {
+                duration_seconds: dur,
+                ..Default::default()
+            };
+            let track = if let Some(t) = tag {
+                m.title = t
+                    .title()
+                    .map(|c| c.trim().to_string())
+                    .filter(|s| !s.is_empty());
+                m.artist = t
+                    .artist()
+                    .map(|c| c.trim().to_string())
+                    .filter(|s| !s.is_empty());
+                m.album = t
+                    .album()
+                    .map(|c| c.trim().to_string())
+                    .filter(|s| !s.is_empty());
+                t.track().unwrap_or(999_999)
+            } else {
+                999_999
+            };
+            (m, track)
+        }
+        Err(e) => {
+            tracing::warn!(
+                file = %path.display(),
+                error = %e,
+                "audiobook part: failed to read tags"
+            );
+            (AudiobookMetadata::default(), 999_999u32)
+        }
+    }
+}
+
 /// Read lofty tags + duration for every part of `group` and, in the
-/// same sweep, lift the first readable embedded cover. A per-part lofty
-/// failure logs a WARN and emits a [`PartWork`] with empty metadata and
-/// `duration = 0` so one corrupt file doesn't drop the whole group.
+/// same sweep, lift the first readable embedded cover.
 fn extract_tags_and_metadata(
     group: &super::AudiobookGroup,
     library_root: &Path,
@@ -209,44 +251,7 @@ fn extract_tags_and_metadata(
     for stat_entry in &group.parts {
         let absolute = library_root.join(&stat_entry.filename);
 
-        // Read track number separately via lofty for sort ordering.
-        let (meta_result, track_num) = match lofty::read_from_path(&absolute) {
-            Ok(tagged) => {
-                let dur = Some(tagged.properties().duration().as_secs_f64())
-                    .filter(|d| d.is_finite() && *d > 0.0);
-                let tag = tagged.primary_tag().or_else(|| tagged.first_tag());
-                let mut m = AudiobookMetadata {
-                    duration_seconds: dur,
-                    ..Default::default()
-                };
-                let track = if let Some(t) = tag {
-                    m.title = t
-                        .title()
-                        .map(|c| c.trim().to_string())
-                        .filter(|s| !s.is_empty());
-                    m.artist = t
-                        .artist()
-                        .map(|c| c.trim().to_string())
-                        .filter(|s| !s.is_empty());
-                    m.album = t
-                        .album()
-                        .map(|c| c.trim().to_string())
-                        .filter(|s| !s.is_empty());
-                    t.track().unwrap_or(999_999)
-                } else {
-                    999_999
-                };
-                (Ok(m), track)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    file = %absolute.display(),
-                    error = %e,
-                    "audiobook part: failed to read tags"
-                );
-                (Err(e), 999_999u32)
-            }
-        };
+        let (meta, track_num) = read_part_tags(&absolute);
 
         // Fetch embedded cover from the very first readable part.
         if !first_cover_fetched {
@@ -264,13 +269,7 @@ fn extract_tags_and_metadata(
             }
         }
 
-        let (meta, duration) = match meta_result {
-            Ok(m) => {
-                let d = m.duration_seconds.unwrap_or(0.0);
-                (m, d)
-            }
-            Err(_) => (AudiobookMetadata::default(), 0.0),
-        };
+        let duration = meta.duration_seconds.unwrap_or(0.0);
 
         parts_work.push(PartWork {
             sort_track: track_num,

--- a/db/src/audiobook/parse.rs
+++ b/db/src/audiobook/parse.rs
@@ -196,8 +196,8 @@ fn parse_one_group(group: super::AudiobookGroup, library_root: &Path) -> Indexed
 
 /// Read lofty tags + duration for a single audiobook part at `path`. A
 /// lofty failure logs a WARN and falls back to default metadata with a
-/// zero duration and a max sort_track, so one corrupt file doesn't drop
-/// the whole group.
+/// zero duration and a large sort_track sentinel (`999_999`, sorting last),
+/// so one corrupt file doesn't drop the whole group.
 fn read_part_tags(path: &Path) -> (AudiobookMetadata, u32) {
     match lofty::read_from_path(path) {
         Ok(tagged) => {

--- a/db/src/books/page.rs
+++ b/db/src/books/page.rs
@@ -127,6 +127,45 @@ pub async fn list_books_page(
     }
     let limit = limit.clamp(1, MAX_BOOKS_RETURNED);
 
+    let (sql, mut binds) = build_page_sql(sort, dir, library_paths, filters, cursor);
+    // Fetch one beyond the page so a full page can advertise a `next` cursor
+    // without a trailing empty round-trip.
+    binds.push(SqlVal::Int(limit + 1));
+
+    let mut q = sqlx::query(&sql);
+    for v in &binds {
+        q = match v {
+            SqlVal::Text(s) => q.bind(s.as_str()),
+            SqlVal::Real(r) => q.bind(*r),
+            SqlVal::Int(i) => q.bind(*i),
+        };
+    }
+    let rows = q.fetch_all(pool).await?;
+
+    let take = rows.len().min(limit as usize);
+    let next = (rows.len() as i64 > limit).then(|| cursor_from_row(&rows[take - 1]));
+
+    let mut books = Vec::with_capacity(take);
+    for r in &rows[..take] {
+        books.push(row_to_ebook(r)?);
+    }
+    merge_overrides_into_books(pool, &mut books).await?;
+    backfill_creator_ids(pool, &mut books).await?;
+
+    Ok(BookPage { books, next })
+}
+
+/// Build the paginated `SELECT` and its positional binds for `sort`/`dir`
+/// over `library_paths`, filtered by `filters` and seeked past `cursor`.
+/// Split out of [`list_books_page`] so the SQL-construction stage is
+/// independently testable from the fetch/decode stage.
+fn build_page_sql(
+    sort: SortKey,
+    dir: SortDir,
+    library_paths: &[&str],
+    filters: &ViewFilters,
+    cursor: Option<&PageCursor>,
+) -> (String, Vec<SqlVal>) {
     let (primary, secondary) = axis_sort_columns(sort);
     let dir_sql = match dir {
         SortDir::Asc => "ASC",
@@ -167,31 +206,7 @@ pub async fn list_books_page(
          LIMIT ?
         "
     );
-    // Fetch one beyond the page so a full page can advertise a `next` cursor
-    // without a trailing empty round-trip.
-    binds.push(SqlVal::Int(limit + 1));
-
-    let mut q = sqlx::query(&sql);
-    for v in &binds {
-        q = match v {
-            SqlVal::Text(s) => q.bind(s.as_str()),
-            SqlVal::Real(r) => q.bind(*r),
-            SqlVal::Int(i) => q.bind(*i),
-        };
-    }
-    let rows = q.fetch_all(pool).await?;
-
-    let take = rows.len().min(limit as usize);
-    let next = (rows.len() as i64 > limit).then(|| cursor_from_row(&rows[take - 1]));
-
-    let mut books = Vec::with_capacity(take);
-    for r in &rows[..take] {
-        books.push(row_to_ebook(r)?);
-    }
-    merge_overrides_into_books(pool, &mut books).await?;
-    backfill_creator_ids(pool, &mut books).await?;
-
-    Ok(BookPage { books, next })
+    (sql, binds)
 }
 
 /// The `(primary, secondary)` `books` sort columns for each axis. `primary`

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -308,16 +308,12 @@ pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow
     reindex_audiobooks_with_progress(pool, library_path, |_, _| {}).await
 }
 
-/// [`reindex_audiobooks`] variant that calls `on_progress(processed,
-/// total)` after each per-book write inside `sync_audiobooks`. Used by
-/// [`crate::worker::Worker`] to report determinate `processed / total`
-/// counts to the UI indicator.
-pub async fn reindex_audiobooks_with_progress(
-    pool: &SqlitePool,
+/// Phase A of [`reindex_audiobooks_with_progress`]: stat every audio file
+/// under `library_path`, then group the per-file entries into one
+/// [`audiobook::AudiobookGroup`] per book (folder-based grouping).
+async fn stat_and_group_audiobooks(
     library_path: &str,
-    on_progress: impl FnMut(u32, u32),
-) -> anyhow::Result<()> {
-    // Phase A: stat every audio file.
+) -> anyhow::Result<Vec<audiobook::AudiobookGroup>> {
     let path_for_scan = library_path.to_owned();
     let library_key = library_path.to_owned();
     let stat = tokio::task::spawn_blocking(move || {
@@ -328,12 +324,41 @@ pub async fn reindex_audiobooks_with_progress(
         anyhow::bail!("audiobook scan of {library_path} failed: {msg}");
     }
 
-    // Phase A.5: group per-file entries into one AudiobookGroup per book.
     let entries = stat.entries;
     let library_key2 = library_path.to_owned();
     let groups =
         tokio::task::spawn_blocking(move || audiobook::group_into_books(entries, &library_key2))
             .await?;
+    Ok(groups)
+}
+
+/// Project audiobook groups to the ebook [`ebook::StatEntry`] shape so
+/// `diff_library` can be reused verbatim across both library kinds. Skips
+/// attachment-only groups (empty `scan_key`).
+fn project_groups_to_stat(groups: &[audiobook::AudiobookGroup]) -> Vec<ebook::StatEntry> {
+    groups
+        .iter()
+        .filter(|g| !g.scan_key.is_empty())
+        .map(|g| ebook::StatEntry {
+            filename: g.group_path.clone(),
+            scan_key: g.scan_key.clone(),
+            mtime_epoch: g.max_mtime_epoch,
+            size_bytes: g.total_size_bytes,
+            error: None,
+        })
+        .collect()
+}
+
+/// [`reindex_audiobooks`] variant that calls `on_progress(processed,
+/// total)` after each per-book write inside `sync_audiobooks`. Used by
+/// [`crate::worker::Worker`] to report determinate `processed / total`
+/// counts to the UI indicator.
+pub async fn reindex_audiobooks_with_progress(
+    pool: &SqlitePool,
+    library_path: &str,
+    on_progress: impl FnMut(u32, u32),
+) -> anyhow::Result<()> {
+    let groups = stat_and_group_audiobooks(library_path).await?;
 
     // Diff groups against DB rows (project groups to the ebook StatEntry shape
     // so diff_library can be reused verbatim). Scope to audiobook formats so a
@@ -349,17 +374,7 @@ pub async fn reindex_audiobooks_with_progress(
             .await?,
     );
     let library_root: PathBuf = PathBuf::from(library_path);
-    let groups_as_stat: Vec<ebook::StatEntry> = groups
-        .iter()
-        .filter(|g| !g.scan_key.is_empty())
-        .map(|g| ebook::StatEntry {
-            filename: g.group_path.clone(),
-            scan_key: g.scan_key.clone(),
-            mtime_epoch: g.max_mtime_epoch,
-            size_bytes: g.total_size_bytes,
-            error: None,
-        })
-        .collect();
+    let groups_as_stat = project_groups_to_stat(&groups);
     let diff = diff_library(&groups_as_stat, &db_rows, &library_root);
 
     // Phase B: parse only the New and Changed groups.
@@ -415,13 +430,13 @@ pub async fn reindex_audiobooks_with_progress(
 /// per book, and all chapter inserts are committed in batches of 250 books
 /// to avoid per-book WAL flushes (mirrors the sync/audiobooks.rs backfill
 /// pattern).
-pub(crate) async fn backfill_chapters(
+/// Query the first-part filename (ordinal=0) and format for every book
+/// under `library_path` that needs chapter backfill (no `file_chapters`
+/// rows yet).
+async fn fetch_backfill_candidates(
     pool: &SqlitePool,
     library_path: &str,
-    mut on_progress: impl FnMut(u32, u32),
-) -> anyhow::Result<()> {
-    // One query: the first-part filename (ordinal=0) and format for every
-    // book that needs chapters.
+) -> anyhow::Result<Vec<(i64, String, String)>> {
     let rows: Vec<(i64, String, String)> = sqlx::query_as(
         "SELECT bf.id, bfp.filename, bf.format \
          FROM book_files bf \
@@ -437,21 +452,16 @@ pub(crate) async fn backfill_chapters(
     .bind(library_path)
     .fetch_all(pool)
     .await?;
+    Ok(rows)
+}
 
-    if rows.is_empty() {
-        return Ok(());
-    }
-
-    let total = u32::try_from(rows.len()).unwrap_or(u32::MAX);
-    tracing::info!(
-        count = total,
-        "backfilling chapters for existing audiobooks"
-    );
-
-    // Bulk-fetch all parts for the backfill set, then group by book_file_id —
-    // avoids N per-book SELECT round-trips. Chunk at 500 to stay well under
-    // SQLite's 999 bind-parameter limit.
-    let book_file_ids: Vec<i64> = rows.iter().map(|(id, _, _)| *id).collect();
+/// Bulk-fetch all `book_file_parts` rows for `book_file_ids` and group them
+/// by `book_file_id` — avoids N per-book SELECT round-trips. Chunked at 500
+/// to stay well under SQLite's 999 bind-parameter limit.
+async fn bulk_fetch_parts(
+    pool: &SqlitePool,
+    book_file_ids: &[i64],
+) -> anyhow::Result<std::collections::HashMap<i64, Vec<crate::audiobook::AudiobookPart>>> {
     let mut all_parts_rows: Vec<(i64, i64, String, i64, i64, f64)> = Vec::new();
     for chunk in book_file_ids.chunks(500) {
         let placeholders = std::iter::repeat_n("?", chunk.len())
@@ -469,7 +479,6 @@ pub(crate) async fn backfill_chapters(
         all_parts_rows.extend(parts_query.fetch_all(pool).await?);
     }
 
-    // Group parts by book_file_id.
     let mut parts_by_id: std::collections::HashMap<i64, Vec<crate::audiobook::AudiobookPart>> =
         std::collections::HashMap::new();
     for (book_file_id, ordinal, filename, size_bytes, mtime_epoch, duration_seconds) in
@@ -486,6 +495,27 @@ pub(crate) async fn backfill_chapters(
                 duration_seconds,
             });
     }
+    Ok(parts_by_id)
+}
+
+pub(crate) async fn backfill_chapters(
+    pool: &SqlitePool,
+    library_path: &str,
+    mut on_progress: impl FnMut(u32, u32),
+) -> anyhow::Result<()> {
+    let rows = fetch_backfill_candidates(pool, library_path).await?;
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let total = u32::try_from(rows.len()).unwrap_or(u32::MAX);
+    tracing::info!(
+        count = total,
+        "backfilling chapters for existing audiobooks"
+    );
+
+    let book_file_ids: Vec<i64> = rows.iter().map(|(id, _, _)| *id).collect();
+    let parts_by_id = bulk_fetch_parts(pool, &book_file_ids).await?;
 
     // Process books in batches of 250 to bound transaction size (mirrors the
     // sync/audiobooks.rs backfill pattern).


### PR DESCRIPTION
## Summary
Extracts named helpers from the four `db/` functions cited in #579 that exceeded the ~80-line soft cap (`.claude/rules/05-rust-style.md` § Function shape). Mechanical, behavior-preserving split; no schema/migration/API changes.

- `db/src/books/page.rs` — `list_books_page` (87 → 44 lines): extracted `build_page_sql(sort, dir, library_paths, filters, cursor)` for the SQL-construction stage.
- `db/src/indexer.rs` — `reindex_audiobooks_with_progress` (86 → 60 lines): extracted `stat_and_group_audiobooks(library_path)` (Phase A stat + grouping) and `project_groups_to_stat(groups)` (the `StatEntry` projection).
- `db/src/audiobook/parse.rs` — `extract_tags_and_metadata` (89 → 43 lines): extracted `read_part_tags(path)` for the per-part lofty read + tag extraction.
- `db/src/indexer.rs` — `backfill_chapters` (110 → 57 lines): extracted `fetch_backfill_candidates(pool, library_path)` (the backfill-candidates query) and `bulk_fetch_parts(pool, book_file_ids)` (the bulk parts fetch + group-by).

All six new helpers carry a one-line `///` doc summary per the issue's acceptance criteria.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 742 passed, 0 failed (unchanged from baseline)
- [x] `cargo build -p omnibus -p omnibus-shared` and `cargo clippy -p omnibus -p omnibus-shared -p omnibus-frontend --all-targets -- -D warnings` — clean (confirms no downstream breakage; all four touched functions keep their existing signatures)

## Notes
- Scope confined to the three files cited in #579; no unrelated debt fixed.
- No `Cargo.lock` change, no migration touched.
- `db/src/sync/books.rs:178–191` was also cited in #442 (a separate, unrelated N+1 issue) but investigation found that fix already landed on `main` in an earlier refactor — out of scope here, and #442 will be reported stale separately.
- Deviation from the issue's suggested approach: none of substance — followed the four-helper split exactly as outlined (`build_page_sql`, `stat_and_group_audiobooks` + `project_groups_to_stat`, `read_part_tags`, `fetch_backfill_candidates` + `bulk_fetch_parts`).

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
