### PR TITLE
refactor: group over-5-prop Dioxus components into structs (#634)

### DIFF
--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -10,6 +10,13 @@ use crate::Route;
 use super::rating::BdRatingWidget;
 use super::{BdCrumb, BdCrumbItem, BdFormatBadge};
 
+/// Which formats this book has, driving the hero's CTA buttons and format badges.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct Availability {
+    pub has_ebook: bool,
+    pub has_audio: bool,
+}
+
 /// Hero section: breadcrumb, cover + format badges, title + CTAs, rating card.
 #[component]
 pub(super) fn BdHeroSection(
@@ -17,8 +24,7 @@ pub(super) fn BdHeroSection(
     title: String,
     kicker: String,
     crumbs: Vec<BdCrumbItem>,
-    has_ebook: bool,
-    has_audio: bool,
+    avail: Availability,
 ) -> Element {
     let uuid = b.unique_identifier.clone().unwrap_or_default();
     rsx! {
@@ -40,8 +46,7 @@ pub(super) fn BdHeroSection(
                     title: title.clone(),
                     kicker: kicker.clone(),
                     uuid: uuid.clone(),
-                    has_ebook,
-                    has_audio,
+                    avail,
                 }
                 aside { class: "card bd-rating-card",
                     div { class: "label", "Your rating" }
@@ -85,9 +90,12 @@ fn BdTitleCol(
     title: String,
     kicker: String,
     uuid: String,
-    has_ebook: bool,
-    has_audio: bool,
+    avail: Availability,
 ) -> Element {
+    let Availability {
+        has_ebook,
+        has_audio,
+    } = avail;
     rsx! {
         div { class: "bd-title-col",
             div { class: "label", "{kicker}" }

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -382,8 +382,10 @@ fn render_loaded(
                 title: title.clone(),
                 kicker,
                 crumbs,
-                has_ebook,
-                has_audio,
+                avail: hero::Availability {
+                    has_ebook,
+                    has_audio,
+                },
             }
             section { class: "bd-body-grid",
                 BdBodyMain {

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -10,7 +10,7 @@
 //! [`crate::view_prefs`].
 
 use dioxus::prelude::*;
-use omnibus_shared::{EbookMetadata, ViewFilters, ViewMode, ViewPrefs};
+use omnibus_shared::{EbookMetadata, ViewFilters, ViewPrefs};
 
 use crate::components::chip_editor::SuggestionItem;
 use crate::components::{RailActive, ShelvesRail};
@@ -32,8 +32,12 @@ use effects::{
     SuggestionPools,
 };
 use filtering::apply_filters;
-use sections::{LandingContent, LandingContentProps, LandingHeader};
+use sections::{
+    BooksView, LandingContent, LandingContentHandlers, LandingContentProps, LandingHeader,
+    LandingHeaderView,
+};
 use sorting::sort_books;
+use table::BookTableContext;
 
 /// Keyset page size for the browse path (F5b open question #1). A grid renders
 /// ~30–60 cards above the fold and the table more; 100 covers both without an
@@ -196,7 +200,6 @@ struct LandingViewState {
     visible_books: Vec<EbookMetadata>,
     visible_is_empty: bool,
     books_empty: bool,
-    view_mode: ViewMode,
     has_more: bool,
     is_loading_more: bool,
 }
@@ -239,7 +242,6 @@ fn derive_view_state(sigs: &LandingSignals, query: Signal<String>) -> LandingVie
         .as_ref()
         .map(|p| short_path(p))
         .unwrap_or_default();
-    let prefs_snapshot = (sigs.prefs)();
 
     LandingViewState {
         is_loading: (sigs.loading)(),
@@ -251,7 +253,6 @@ fn derive_view_state(sigs: &LandingSignals, query: Signal<String>) -> LandingVie
         visible_books,
         visible_is_empty,
         books_empty: sigs.books.read().is_empty(),
-        view_mode: prefs_snapshot.view_mode,
         has_more: (sigs.next_cursor)().is_some(),
         is_loading_more: (sigs.loading_more)(),
     }
@@ -326,34 +327,41 @@ pub fn LandingPage() -> Element {
             ShelvesRail { active: RailActive::All }
             div { class: "shelf-main",
                 LandingHeader {
-                    path_subtitle: view.path_subtitle,
-                    book_count: view.book_count,
+                    view: LandingHeaderView {
+                        path_subtitle: view.path_subtitle,
+                        book_count: view.book_count,
+                        path_missing: view.path_missing,
+                        page_error: view.page_error.clone(),
+                        lib_err: view.lib_err.clone(),
+                    },
                     prefs: prefs(),
                     on_prefs_change: on_prefs_change_header,
-                    path_missing: view.path_missing,
-                    page_error: view.page_error.clone(),
-                    lib_err: view.lib_err.clone(),
                 }
 
                 LandingContent {
                     ..LandingContentProps {
-                        is_loading: view.is_loading,
-                        visible_books: view.visible_books,
-                        visible_is_empty: view.visible_is_empty,
-                        books_empty: view.books_empty,
-                        lib_err: view.lib_err,
-                        page_error: view.page_error,
-                        view_mode: view.view_mode,
+                        books: BooksView {
+                            is_loading: view.is_loading,
+                            visible_books: view.visible_books,
+                            visible_is_empty: view.visible_is_empty,
+                            books_empty: view.books_empty,
+                            lib_err: view.lib_err,
+                            page_error: view.page_error,
+                            has_more: view.has_more,
+                            is_loading_more: view.is_loading_more,
+                        },
                         prefs: prefs(),
-                        has_more: view.has_more,
-                        is_loading_more: view.is_loading_more,
-                        server_url,
-                        is_admin: (sigs.is_admin)(),
-                        author_suggestions: sigs.pools.authors.into(),
-                        tag_suggestions: sigs.pools.tags.into(),
-                        on_prefs_change: on_prefs_change_content,
-                        on_load_more,
-                        on_clear_filters,
+                        ctx: BookTableContext {
+                            server_url,
+                            is_admin: (sigs.is_admin)(),
+                            author_suggestions: sigs.pools.authors.into(),
+                            tag_suggestions: sigs.pools.tags.into(),
+                        },
+                        handlers: LandingContentHandlers {
+                            on_prefs_change: on_prefs_change_content,
+                            on_load_more,
+                            on_clear_filters,
+                        },
                     }
                 }
             }

--- a/frontend/src/pages/landing/sections.rs
+++ b/frontend/src/pages/landing/sections.rs
@@ -6,25 +6,36 @@
 use dioxus::prelude::*;
 use omnibus_shared::{EbookMetadata, SortKey, ViewMode, ViewPrefs};
 
-use crate::components::chip_editor::SuggestionItem;
-
 use super::filters::EmptyFiltered;
 use super::grid::BookGrid;
 use super::sorting::{default_dir_for, toggle_dir};
 use super::table::{BookTable, BookTableContext};
 use super::toolbar::Toolbar;
 
+/// Header banner fields sourced from the page's derived view state.
+#[derive(Clone, PartialEq)]
+pub(super) struct LandingHeaderView {
+    pub path_subtitle: String,
+    pub book_count: usize,
+    pub path_missing: bool,
+    pub page_error: Option<String>,
+    pub lib_err: Option<String>,
+}
+
 /// Sticky `data-testid="lib-header"` header; also renders page-level + library-path errors.
 #[component]
 pub(super) fn LandingHeader(
-    path_subtitle: String,
-    book_count: usize,
+    view: LandingHeaderView,
     prefs: ViewPrefs,
     on_prefs_change: EventHandler<ViewPrefs>,
-    path_missing: bool,
-    page_error: Option<String>,
-    lib_err: Option<String>,
 ) -> Element {
+    let LandingHeaderView {
+        path_subtitle,
+        book_count,
+        path_missing,
+        page_error,
+        lib_err,
+    } = view;
     rsx! {
         header { class: "lib-header", "data-testid": "lib-header",
             div { class: "lib-header-kicker",
@@ -59,50 +70,62 @@ pub(super) fn LandingHeader(
     }
 }
 
-/// Per-render snapshot of the data the table/grid + load-more sentinel need.
-#[derive(Clone, PartialEq, Props)]
-pub(super) struct LandingContentProps {
+/// Result of the book fetch/filter pipeline: what `lib-main` should render
+/// and whether the load-more sentinel should appear.
+#[derive(Clone, PartialEq)]
+pub(super) struct BooksView {
     pub is_loading: bool,
     pub visible_books: Vec<EbookMetadata>,
     pub visible_is_empty: bool,
     pub books_empty: bool,
     pub lib_err: Option<String>,
     pub page_error: Option<String>,
-    pub view_mode: ViewMode,
-    pub prefs: ViewPrefs,
     pub has_more: bool,
     pub is_loading_more: bool,
-    pub server_url: String,
-    pub is_admin: bool,
-    pub author_suggestions: ReadSignal<Vec<SuggestionItem>>,
-    pub tag_suggestions: ReadSignal<Vec<SuggestionItem>>,
+}
+
+/// Event handlers dispatched from the sidebar/grid/table/pagination row.
+#[derive(Clone, PartialEq)]
+pub(super) struct LandingContentHandlers {
     pub on_prefs_change: EventHandler<ViewPrefs>,
     pub on_load_more: EventHandler<()>,
     pub on_clear_filters: EventHandler<()>,
+}
+
+/// Per-render snapshot of the data the table/grid + load-more sentinel need.
+#[derive(Clone, PartialEq, Props)]
+pub(super) struct LandingContentProps {
+    pub books: BooksView,
+    pub prefs: ViewPrefs,
+    pub ctx: BookTableContext,
+    pub handlers: LandingContentHandlers,
 }
 
 /// Sidebar + grid/table column with load-more sentinel; stateless, mutations route through parent handlers.
 #[component]
 pub(super) fn LandingContent(props: LandingContentProps) -> Element {
     let LandingContentProps {
+        books,
+        prefs,
+        ctx,
+        handlers,
+    } = props;
+    let BooksView {
         is_loading,
         visible_books,
         visible_is_empty,
         books_empty,
         lib_err,
         page_error,
-        view_mode,
-        prefs,
         has_more,
         is_loading_more,
-        server_url,
-        is_admin,
-        author_suggestions,
-        tag_suggestions,
+    } = books;
+    let LandingContentHandlers {
         on_prefs_change,
         on_load_more,
         on_clear_filters,
-    } = props;
+    } = handlers;
+    let view_mode = prefs.view_mode;
 
     let on_sort = {
         let prefs = prefs.clone();
@@ -130,18 +153,13 @@ pub(super) fn LandingContent(props: LandingContentProps) -> Element {
                                 books: visible_books.clone(),
                                 prefs: prefs.clone(),
                                 on_sort,
-                                ctx: BookTableContext {
-                                    server_url: server_url.clone(),
-                                    is_admin,
-                                    author_suggestions,
-                                    tag_suggestions,
-                                },
+                                ctx: ctx.clone(),
                             }
                         },
                         ViewMode::Grid => rsx! {
                             BookGrid {
                                 books: visible_books.clone(),
-                                server_url: server_url.clone(),
+                                server_url: ctx.server_url.clone(),
                             }
                         },
                     }

--- a/frontend/src/pages/listen/controls.rs
+++ b/frontend/src/pages/listen/controls.rs
@@ -7,6 +7,8 @@
 
 use dioxus::prelude::*;
 
+use super::stage::{ToolbarState, TransportCallbacks, TransportState};
+
 // --- Pure helpers extracted so they can be unit-tested without a renderer.
 
 /// CSS class for the rate button — appends `" on"` when the speed panel is open.
@@ -52,19 +54,22 @@ pub(crate) fn AudioElement() -> Element {
 
 /// Transport row: chapter-skip, ±30s seek, play/pause, rate.
 #[component]
-pub(super) fn TransportButtons(
-    play_label: String,
-    playing: bool,
-    rate_label: String,
-    rate_active: bool,
-    has_chapters: bool,
-    on_toggle: EventHandler<MouseEvent>,
-    on_skip_back: EventHandler<MouseEvent>,
-    on_skip_forward: EventHandler<MouseEvent>,
-    on_rate: EventHandler<MouseEvent>,
-    on_chapter_prev: EventHandler<MouseEvent>,
-    on_chapter_next: EventHandler<MouseEvent>,
-) -> Element {
+pub(super) fn TransportButtons(state: TransportState, callbacks: TransportCallbacks) -> Element {
+    let TransportState {
+        play_label,
+        playing,
+        rate_label,
+        rate_active,
+        has_chapters,
+    } = state;
+    let TransportCallbacks {
+        on_toggle,
+        on_skip_back,
+        on_skip_forward,
+        on_rate,
+        on_chapter_prev,
+        on_chapter_next,
+    } = callbacks;
     let rate_class = rate_btn_class(rate_active);
 
     rsx! {
@@ -179,15 +184,16 @@ mod tests {
 /// highlighted state. The panels themselves are visual shells until
 /// their backing infrastructure ships (PRs 3–5).
 #[component]
-pub(super) fn Toolbar(
-    sleep_active: bool,
-    sleep_label: String,
-    bookmarks_active: bool,
-    chapters_active: bool,
-    on_sleep: EventHandler<MouseEvent>,
-    on_bookmark: EventHandler<MouseEvent>,
-    on_chapters: EventHandler<MouseEvent>,
-) -> Element {
+pub(super) fn Toolbar(state: ToolbarState) -> Element {
+    let ToolbarState {
+        sleep_active,
+        sleep_label,
+        bookmarks_active,
+        chapters_active,
+        on_sleep,
+        on_bookmark,
+        on_chapters,
+    } = state;
     let sleep_cls = toolbar_btn_class(sleep_active);
     let bm_class = toolbar_btn_class(bookmarks_active);
     let ch_class = toolbar_btn_class(chapters_active);

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -16,7 +16,9 @@ use super::overlays::{FailedOverlay, PreparingOverlay};
 use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep_timer};
 use super::sleep_panel::SleepPanel;
 use super::speed_panel::SpeedPanel;
-use super::stage::{PlaybackPosition, PlayerCallbacks, PlayerStage, ToolbarState, TransportState};
+use super::stage::{
+    PlaybackPosition, PlayerCallbacks, PlayerContent, PlayerStage, ToolbarState, TransportState,
+};
 use crate::Nav;
 
 /// Derive the current chapter index from `elapsed` and a sorted chapter list.
@@ -279,14 +281,18 @@ pub(super) fn ReadyPlayer(
             }
 
             PlayerStage {
-                book: book.clone(),
-                title,
-                author,
+                content: PlayerContent {
+                    book: book.clone(),
+                    title,
+                    author,
+                    chapters: chs.clone(),
+                },
                 position: PlaybackPosition {
                     elapsed: elapsed_now,
                     duration: dur,
                     remaining,
                     scrub_max,
+                    current_chapter_index: ch_idx,
                 },
                 transport: TransportState {
                     play_label,
@@ -338,8 +344,6 @@ pub(super) fn ReadyPlayer(
                         }
                     }),
                 },
-                chapters: chs.clone(),
-                current_chapter_index: ch_idx,
             }
 
             if speed_panel_open() {

--- a/frontend/src/pages/listen/stage.rs
+++ b/frontend/src/pages/listen/stage.rs
@@ -84,13 +84,24 @@ mod tests {
     }
 }
 
-/// Scrubber timing — elapsed plus the derived totals (duration, remaining, slider max).
+/// Scrubber timing — elapsed plus the derived totals (duration, remaining,
+/// slider max) — and the chapter index derived from `elapsed`.
 #[derive(Clone, PartialEq)]
 pub(super) struct PlaybackPosition {
     pub elapsed: f64,
     pub duration: f64,
     pub remaining: f64,
     pub scrub_max: f64,
+    pub current_chapter_index: usize,
+}
+
+/// Static per-book display content: title, author, and the full chapter list.
+#[derive(Clone, PartialEq)]
+pub(super) struct PlayerContent {
+    pub book: EbookMetadata,
+    pub title: String,
+    pub author: String,
+    pub chapters: Vec<ChapterInfo>,
 }
 
 /// Play/skip/rate button labels and on/off state shared by the transport row.
@@ -116,6 +127,17 @@ pub(super) struct PlayerCallbacks {
     pub on_chapter_seek: EventHandler<f64>,
 }
 
+/// The subset of [`PlayerCallbacks`] the transport row itself dispatches.
+#[derive(Clone, PartialEq)]
+pub(super) struct TransportCallbacks {
+    pub on_toggle: EventHandler<MouseEvent>,
+    pub on_skip_back: EventHandler<MouseEvent>,
+    pub on_skip_forward: EventHandler<MouseEvent>,
+    pub on_rate: EventHandler<MouseEvent>,
+    pub on_chapter_prev: EventHandler<MouseEvent>,
+    pub on_chapter_next: EventHandler<MouseEvent>,
+}
+
 /// Toolbar row (sleep/bookmark/chapters) — per-button highlight state plus toggle handlers.
 #[derive(Clone, PartialEq)]
 pub(super) struct ToolbarState {
@@ -130,19 +152,21 @@ pub(super) struct ToolbarState {
 
 #[component]
 pub(super) fn PlayerStage(
-    book: EbookMetadata,
-    title: String,
-    author: String,
+    content: PlayerContent,
     position: PlaybackPosition,
     transport: TransportState,
     callbacks: PlayerCallbacks,
     toolbar: ToolbarState,
-    chapters: Vec<ChapterInfo>,
-    current_chapter_index: usize,
 ) -> Element {
+    let PlayerContent {
+        book,
+        title,
+        author,
+        chapters,
+    } = content;
     let ch_count = chapters.len();
-    let kicker = kicker_text(ch_count, current_chapter_index);
-    let chapter_sub = chapter_sub_text(&chapters, current_chapter_index);
+    let kicker = kicker_text(ch_count, position.current_chapter_index);
+    let chapter_sub = chapter_sub_text(&chapters, position.current_chapter_index);
 
     rsx! {
         div { class: "lp-stage",
@@ -164,33 +188,23 @@ pub(super) fn PlayerStage(
                     elapsed: position.elapsed,
                     duration: position.duration,
                     remaining: position.remaining,
-                    current_chapter_index,
+                    current_chapter_index: position.current_chapter_index,
                     on_seek: callbacks.on_chapter_seek,
                 }
 
                 TransportButtons {
-                    play_label: transport.play_label,
-                    playing: transport.playing,
-                    rate_label: transport.rate_label,
-                    rate_active: transport.rate_active,
-                    has_chapters: transport.has_chapters,
-                    on_toggle: callbacks.on_toggle,
-                    on_skip_back: callbacks.on_skip_back,
-                    on_skip_forward: callbacks.on_skip_forward,
-                    on_rate: callbacks.on_rate,
-                    on_chapter_prev: callbacks.on_chapter_prev,
-                    on_chapter_next: callbacks.on_chapter_next,
+                    state: transport,
+                    callbacks: TransportCallbacks {
+                        on_toggle: callbacks.on_toggle,
+                        on_skip_back: callbacks.on_skip_back,
+                        on_skip_forward: callbacks.on_skip_forward,
+                        on_rate: callbacks.on_rate,
+                        on_chapter_prev: callbacks.on_chapter_prev,
+                        on_chapter_next: callbacks.on_chapter_next,
+                    },
                 }
 
-                Toolbar {
-                    sleep_active: toolbar.sleep_active,
-                    sleep_label: toolbar.sleep_label,
-                    bookmarks_active: toolbar.bookmarks_active,
-                    chapters_active: toolbar.chapters_active,
-                    on_sleep: toolbar.on_sleep,
-                    on_bookmark: toolbar.on_bookmark,
-                    on_chapters: toolbar.on_chapters,
-                }
+                Toolbar { state: toolbar }
             }
         }
     }

--- a/frontend/src/pages/listen/stage.rs
+++ b/frontend/src/pages/listen/stage.rs
@@ -85,7 +85,7 @@ mod tests {
 }
 
 /// Scrubber timing — elapsed plus the derived totals (duration, remaining,
-/// slider max) — and the chapter index derived from `elapsed`.
+/// slider max) — and the current chapter index.
 #[derive(Clone, PartialEq)]
 pub(super) struct PlaybackPosition {
     pub elapsed: f64,
@@ -95,7 +95,7 @@ pub(super) struct PlaybackPosition {
     pub current_chapter_index: usize,
 }
 
-/// Static per-book display content: title, author, and the full chapter list.
+/// Static per-book display content: the book itself, title, author, and the full chapter list.
 #[derive(Clone, PartialEq)]
 pub(super) struct PlayerContent {
     pub book: EbookMetadata,


### PR DESCRIPTION
## Summary

Resolves #634: seven Dioxus components across `frontend/src/pages/landing/sections.rs`, `frontend/src/pages/listen/controls.rs`, `frontend/src/pages/listen/stage.rs`, and `frontend/src/pages/book_detail/hero.rs` took more than 5 props. Groups related props into named structs, mirroring the `PlaybackSignals`/`ToolbarState`/`TransportState` pattern already used in `listen/stage.rs` and `listen/ready_player.rs` (from the merged #599):

- **`LandingHeader`** (7 → 3 params): `path_subtitle`/`book_count`/`path_missing`/`page_error`/`lib_err` collapse into a new `LandingHeaderView`.
- **`LandingContentProps`** (18 → 5 fields): grouped into `BooksView` (loading/pagination/error state), the existing `BookTableContext` (`server_url`/`is_admin`/suggestion pools — reused as-is from `landing/table`, previously duplicated here as flat fields), and a new `LandingContentHandlers`. Also drops the `view_mode` field, which duplicated `prefs.view_mode`.
- **`TransportButtons`** (11 → 2 params): now takes the existing `TransportState` plus a new `TransportCallbacks` (the callback subset of `PlayerCallbacks` it actually dispatches).
- **`Toolbar`** (listen page, 7 → 1 param): now takes the existing `ToolbarState` directly instead of re-flattening it into 7 props, eliminating a duplicate shape.
- **`PlayerStage`** (9 → 5 params): `book`/`title`/`author`/`chapters` collapse into a new `PlayerContent`; `current_chapter_index` joins `PlaybackPosition` (both describe "where we are" in the timeline). Its body now passes `transport`/`toolbar` straight through to `TransportButtons`/`Toolbar` instead of destructuring and re-listing every field.
- **`BdHeroSection`/`BdTitleCol`** (6 → 5 params each): `has_ebook`/`has_audio` (duplicated across both components) collapse into a new `Availability`.

Mechanical, behavior-preserving: no rsx markup changed, no new Playwright surface required.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 1 passed
- [x] `cargo test -p omnibus` — 235 passed
- [x] `cargo test -p omnibus-frontend --features server` — 185 passed
- [x] `cargo test -p omnibus-shared` — 74 passed

## Notes
- `PlayerCallbacks.on_seek` stays unused by `PlayerStage` — that was already the case on `main` before this change and is out of scope here.
- No `Cargo.lock` change, no migration, no markup/testid changes.
- All 7 cited components now have ≤5 params/fields.

Closes #634
