### PR TITLE
chore: add dioxus-cli (dx) to the mobile dev shell

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -16,7 +16,7 @@ The flake exposes five purpose-built shells so daily cargo work doesn't pay for 
 | `default` (slim) | rust core + sqlite + openssl + just + zellij + process-compose | Daily `cargo test`/`clippy`/`fmt`, editor, rust-analyzer — this is what direnv auto-loads via `.envrc` |
 | `web` | default + dioxus-cli + matched `wasm-bindgen` + node | `dx serve --platform web`, `just dev-up`, anything that bundles the WASM client |
 | `e2e` | web + Playwright Chromium bundle | `npx playwright test`, the `playwright` pane in the multiplexer, CI's E2E job |
-| `mobile` | default + Android + iOS rust-std targets + JDK 21 + Xcode/Android SDK auto-detect (+ GTK 3 / WebKitGTK on Linux) | `dx serve --platform ios`/`android`, `cargo build -p omnibus-mobile`; CI's `cargo clippy (mobile)` host-target lint |
+| `mobile` | default + dioxus-cli (`dx`) + Android + iOS rust-std targets + JDK 21 + Xcode/Android SDK auto-detect (+ GTK 3 / WebKitGTK on Linux) | `dx serve --platform ios`/`android`, `cargo build -p omnibus-mobile`; CI's `cargo clippy (mobile)` host-target lint |
 | `audit` | default + cargo-audit + cargo-deny | Local `cargo audit` / `cargo deny`, mirrors CI's security job |
 
 One-shot pattern for any non-default shell:

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,11 @@
         # glib/cairo/pango/gdk-pixbuf/atk into PKG_CONFIG_PATH transitively.
         mobileExtras = [
           pkgs.jdk21
+          # `dx` for native iOS/Android serve. Mobile is Dioxus Native (no
+          # wasm target), so unlike `webExtras` this needs the CLI but not a
+          # matched `wasm-bindgen` — `dx serve --platform ios/android` never
+          # invokes wasm-bindgen/binaryen.
+          pkgs-unstable.dioxus-cli
         ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
           pkgs.glib
           pkgs.gtk3


### PR DESCRIPTION
## Summary
- The `.#mobile` dev shell pulled in the iOS/Android Rust targets + JDK but never `dioxus-cli`, so `dx serve --platform ios/android` failed with `dx: not found`. This broke the documented mobile commands and the `just serve` / `just serve-pc` iOS+Android panes (both invoke `.#mobile`).
- Add `pkgs-unstable.dioxus-cli` to `mobileExtras`. Mobile is Dioxus Native (no wasm target), so it needs the CLI but not a matched `wasm-bindgen`/`binaryen` the way `webExtras` does.
- Sync the `mobile` shell row in the dev-environment rule to list `dioxus-cli (dx)`.

## Test plan
- [x] `nix flake check` — all checks pass (mobile derivation evaluates cleanly).
- [x] `nix develop .#mobile --command dx --version` → `dioxus 0.7.9`.
- [x] iOS and Android both launch via `dx serve --platform ios/android --package omnibus-mobile`.

## Notes
- Dev-shell tooling only — no change to the built artifact, hence the `no release` label.