### PR TITLE
fix: disable iOS autocapitalize/autocorrect on login + register fields

### DIFF
--- a/.claude/rules/05-rust-style.md
+++ b/.claude/rules/05-rust-style.md
@@ -23,6 +23,11 @@ covered by [04-playwright.md](04-playwright.md).
   needs to be split (see below). Section-marker comments
   (`// --- Removed`) are tolerated *only* when a function can't be split
   further and still needs nav aids.
+- **Keep comments terse — one line wins.** State the *why* and stop;
+  don't restate what the code or attribute names already say, and don't
+  leave PR-narration (the play-by-play of what a change does, worked
+  examples, before/after) in the source — that belongs in the PR body,
+  not a multi-line block above a one-line tweak.
 
 ## Function shape
 

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -89,6 +89,13 @@ pub fn LoginPage() -> Element {
                         name: "username",
                         r#type: "text",
                         autocomplete: "username",
+                        // iOS soft keyboards default to autocapitalize=sentences
+                        // + autocorrect on; either mangles a typed credential
+                        // before `oninput` fires. Usernames are case-folded in
+                        // the DB, but keep parity with the password field.
+                        autocapitalize: "none",
+                        autocorrect: "off",
+                        spellcheck: "false",
                         value: "{username}",
                         oninput: move |e| username.set(e.value()),
                         onkeydown: on_keydown,
@@ -112,6 +119,12 @@ pub fn LoginPage() -> Element {
                         name: "password",
                         r#type: "password",
                         autocomplete: "current-password",
+                        // Without these, an iOS soft keyboard capitalizes the
+                        // first char (e.g. `omnibus-dev` → `Omnibus-dev`) and
+                        // the case-sensitive hash check 401s.
+                        autocapitalize: "none",
+                        autocorrect: "off",
+                        spellcheck: "false",
                         value: "{password}",
                         oninput: move |e| password.set(e.value()),
                         onkeydown: on_keydown,
@@ -281,6 +294,9 @@ fn RegisterForm(
                     name: "username",
                     r#type: "text",
                     autocomplete: "username",
+                    autocapitalize: "none",
+                    autocorrect: "off",
+                    spellcheck: "false",
                     value: "{username}",
                     aria_invalid: "{username_invalid}",
                     oninput: move |e| {
@@ -299,6 +315,9 @@ fn RegisterForm(
                     name: "password",
                     r#type: "password",
                     autocomplete: "new-password",
+                    autocapitalize: "none",
+                    autocorrect: "off",
+                    spellcheck: "false",
                     value: "{password}",
                     aria_invalid: "{password_invalid}",
                     onkeydown: on_keydown,

--- a/frontend/src/pages/auth.rs
+++ b/frontend/src/pages/auth.rs
@@ -89,10 +89,6 @@ pub fn LoginPage() -> Element {
                         name: "username",
                         r#type: "text",
                         autocomplete: "username",
-                        // iOS soft keyboards default to autocapitalize=sentences
-                        // + autocorrect on; either mangles a typed credential
-                        // before `oninput` fires. Usernames are case-folded in
-                        // the DB, but keep parity with the password field.
                         autocapitalize: "none",
                         autocorrect: "off",
                         spellcheck: "false",
@@ -119,9 +115,7 @@ pub fn LoginPage() -> Element {
                         name: "password",
                         r#type: "password",
                         autocomplete: "current-password",
-                        // Without these, an iOS soft keyboard capitalizes the
-                        // first char (e.g. `omnibus-dev` → `Omnibus-dev`) and
-                        // the case-sensitive hash check 401s.
+                        // iOS soft keyboards capitalize the first char, 401ing a case-sensitive password.
                         autocapitalize: "none",
                         autocorrect: "off",
                         spellcheck: "false",


### PR DESCRIPTION
## Summary
- On iOS, the login/register inputs let the soft keyboard auto-capitalize the first character (`omnibus-dev` → `Omnibus-dev`). The username survives (DB is `COLLATE NOCASE`) but the case-sensitive password hash 401s — the account then locks after repeated attempts.
- Add `autocapitalize="none"` + `autocorrect="off"` + `spellcheck="false"` to all four login/register username/password inputs, matching the existing pattern already used on the Settings → Hardcover API key field.
- Markup is unconditional (identical SSR/web/mobile), so it's hydration-safe.

## Test plan
- [x] Reproduced at the API: `{"password":"Omnibus-dev"}` → 401, `{"password":"omnibus-dev"}` → 200.
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets` and `cargo clippy -p omnibus-mobile --all-targets` both clean.
- [x] Confirmed on the iOS simulator: login now succeeds with the on-screen keyboard.