### PR TITLE
docs: trim bloated module docs to the 5-line cap (#606)

### DIFF
--- a/db/src/audiobook.rs
+++ b/db/src/audiobook.rs
@@ -1,16 +1,8 @@
-//! Audiobook metadata extraction (server-only).
-//!
-//! Sibling to [`crate::ebook`]: walks the configured audiobook library,
-//! reads container tags (title / artist / album / duration / cover) via
-//! `lofty`, and emits rows for the DB. Multi-file audiobooks (a folder of
-//! per-chapter mp3s) are grouped by [`group::group_into_books`] into a
-//! single [`AudiobookGroup`] then fully parsed by
-//! [`parse::parse_groups`] into [`parse::IndexedAudiobook`] rows ready for
+//! Audiobook metadata extraction (server-only). Sibling to [`crate::ebook`]:
+//! walks the configured audiobook library, reads container tags via `lofty`,
+//! groups multi-file audiobooks via [`group::group_into_books`], and parses
+//! them via [`parse::parse_groups`] into rows ready for
 //! [`crate::sync::sync_audiobooks`].
-//!
-//! Covers title, primary author, album, duration in seconds, embedded
-//! artwork, per-part track ordering, and chapter extraction from Nero chpl
-//! atoms (M4B) and ID3v2 CHAP frames (MP3).
 
 use std::path::{Path, PathBuf};
 

--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -1,21 +1,8 @@
 //! Book read path. Hydrates the normalized schema into the wire
-//! `EbookMetadata` shape: scalar columns from `books`, single-valued joins
-//! via scalar subqueries, multi-valued joins via `json_group_array`. Merges
-//! `metadata_overrides` and backfills creator ids before returning.
-//!
-//! The implementation is split across focused sub-modules:
-//!
-//! * [`projection`] — shared column list, JSON row decoders, description
-//!   sanitization, the `row -> EbookMetadata` mapper, and the
-//!   `Contributor::id` backfill used after the override merge.
-//! * [`list`] — library-scoped list/count read paths plus the small
-//!   `IndexedRow` projection used by the incremental reindex diff.
-//! * [`get`] — single-book read paths (`get_book`, `get_book_by_uuid`,
-//!   `resolve_book_id_by_uuid`).
-//! * [`search`] — FTS5-backed search and its companion count helpers.
-//!
-//! Public API is re-exported here so callers (`server/`, `frontend/`, sibling
-//! `db/` modules) keep importing through `omnibus_db::books::*` unchanged.
+//! `EbookMetadata` shape, merging `metadata_overrides` and backfilling
+//! creator ids before returning. Split across the [`projection`], [`list`],
+//! [`get`], and [`search`] sub-modules (each self-documented), re-exported
+//! here as `omnibus_db::books::*`.
 
 mod facets;
 mod get;

--- a/db/src/ebook.rs
+++ b/db/src/ebook.rs
@@ -1,19 +1,8 @@
-//! EPUB metadata extraction (server-only).
-//!
-//! Walks the configured library directory, parses the OPF for each `.epub`,
-//! and produces an [`IndexedBook`] per file — metadata plus the raw cover
-//! bytes. Parse failures surface as `IndexedBook { metadata: EbookMetadata {
-//! error: Some(_), .. }, cover: None }` so one bad file does not hide the
-//! rest of the library. This output is consumed by [`crate::indexer`],
-//! which writes it to the DB.
-//!
-//! Cover sourcing: a `cover.{jpg,jpeg,png}` (or per-stem
-//! `<basename>.{jpg,jpeg,png}`) sidecar next to the epub is preferred over
-//! the embedded cover. With [`ScanOptions::materialize_sidecars`] set, the
-//! scanner extracts the embedded cover into a `<basename>.jpg`/`.png`
-//! sidecar on first encounter so subsequent scans skip the zip altogether.
-//! Materialization is best-effort: a write failure falls back to the
-//! in-memory embedded bytes for the current scan and retries on the next.
+//! EPUB metadata extraction (server-only). Walks the configured library
+//! directory, parses the OPF for each `.epub`, and produces an
+//! [`IndexedBook`] per file — metadata plus the raw cover bytes. Parse
+//! failures surface as a per-book error rather than hiding the rest of the
+//! library. Consumed by [`crate::indexer`], which writes the output to the DB.
 
 use std::path::Path;
 
@@ -65,8 +54,11 @@ pub struct ScanResult {
 /// instead of re-opening the zip.
 #[derive(Debug, Clone, Default)]
 pub struct ScanOptions {
-    /// On a successful cover extraction with no existing sidecar, write the
-    /// embedded bytes to `<basename>.{jpg|png}` next to the epub. Best-effort:
+    /// A `cover.{jpg,jpeg,png}` (or per-stem `<basename>.{jpg,jpeg,png}`)
+    /// sidecar next to the epub is always preferred over the embedded cover.
+    /// With this set, on a successful cover extraction with no existing
+    /// sidecar, write the embedded bytes to `<basename>.{jpg|png}` next to
+    /// the epub so subsequent scans skip the zip entirely. Best-effort:
     /// errors are swallowed (logged via `tracing::warn!`) so a read-only
     /// filesystem doesn't kill the scan.
     pub materialize_sidecars: bool,

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -1,34 +1,8 @@
-//! Indexer write path. `sync_books` applies a per-bucket diff
-//! (New / Changed / Removed / Backfill) atomically, then reconciles the
-//! covers directory post-commit. `replace_books` is the nuke-and-pave
-//! compatibility shim that the test suite drives.
-//!
-//! `sync_audiobooks` is the multi-file audiobook sibling: same four-bucket
-//! diff, but each "book" also writes `book_file_parts` rows (one per source
-//! audio file) so the HLS pipeline has an ordered part list.
-//!
-//! The implementation is split across focused sub-modules:
-//!
-//! * [`fts`] — the single `books_fts` choke-point (`upsert_fts` /
-//!   `delete_fts` / `rebuild_all_fts`). Every book mutation routes its
-//!   FTS maintenance through here so the standalone index can't drift.
-//! * [`books`] — the transactional orchestrator (`sync_books`), the
-//!   per-bucket helpers (`sync_removed`, `sync_changed`, `sync_new`,
-//!   `stamp_last_indexed`), `replace_books`, the per-book row writers
-//!   (`insert_book_row`, `update_book_row`), and the metadata-link
-//!   dispatch + cover side helpers (FTS is delegated to [`fts`]).
-//! * [`audiobooks`] — `sync_audiobooks` and its `AudiobookSyncPlan`
-//!   payload, plus the audiobook-specific row / parts / FTS inserts.
-//! * [`attach`] — cross-format auto-attach: lookups + writers that hang
-//!   a newly indexed file off an existing book in another format and
-//!   record it in `merged_uuids` for reindex protection.
-//! * [`authors`] — the batched author-link writer (`insert_author_links`).
-//! * [`backfill`] — the stat-only `(uuid, mtime_epoch, size_bytes)`
-//!   chunked UPDATE used to fill in the post-migration sentinels.
-//!
-//! Public API is re-exported here so callers (`server/`, `frontend/`,
-//! sibling `db/` modules) keep importing through `omnibus_db::sync::*`
-//! unchanged.
+//! Indexer write path. `sync_books` applies a per-bucket diff atomically,
+//! then reconciles the covers directory post-commit; `sync_audiobooks` is
+//! the multi-file sibling. Split across the [`fts`], [`books`],
+//! [`audiobooks`], [`attach`], [`authors`], and [`backfill`] sub-modules
+//! (each self-documented), re-exported here as `omnibus_db::sync::*`.
 
 mod attach;
 mod audiobooks;

--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -1,18 +1,8 @@
-//! Listening-position persistence — the saved `currentTime` (seconds, float)
-//! for each audiobook.
-//!
-//! Mirrors [`crate::reader_progress`] in shape: web persists to
-//! `localStorage` keyed by uuid; mobile keeps an in-memory map (resets on
-//! cold launch); server (SSR) is a no-op so the rendered markup never
-//! depends on a stored position.
-//!
-//! Also the offline / first-paint cache layer for the progress-sync endpoint
-//! (`POST /api/progress` with `format: "audio"` and
-//! `audio_position_seconds`): the listen page reads this synchronously
-//! for an instant local position, then reconciles against the server
-//! before mounting. Saves write here AND fire-and-forget POST to the
-//! server. The stored value is the raw second-offset (no JSON envelope).
-//! In-file `#[cfg]`-framing dividers retained per rule 05's nav-aid exception.
+//! Listening-position persistence — the saved `currentTime` (seconds,
+//! float) for each audiobook. Mirrors [`crate::reader_progress`] in shape
+//! (web `localStorage`, mobile in-memory map, server no-op); also the
+//! offline / first-paint cache layer the listen page reads before
+//! reconciling against the `POST /api/progress` sync endpoint.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.listening::";

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -1,27 +1,8 @@
-//! Atrium design-system primitives.
-//!
-//! The CSS lives in [`frontend/assets/atrium.css`](../../assets/atrium.css);
-//! this module exposes the Dioxus components that consume those classes.
-//! Keep the components markup-only — no business logic, no data fetching.
-//! Pages compose them.
-//!
-//! Components:
-//! - [`AtriumRoot`] — wraps the router output in a
-//!   `<div class="atrium" data-theme="dark|light|sepia">`. The Atrium token
-//!   block in `frontend/assets/atrium.css` keys off the `data-theme`
-//!   attribute on this wrapper (not on `<html>`) so the swap is declarative —
-//!   no DOM-attribute mutation from Rust.
-//! - [`Cover`] — book cover. Uses the real `/api/covers/:id` image when the
-//!   book has one and falls back to a stylized typographic template when it
-//!   doesn't. The per-book accent (from `EbookMetadata.accent`, populated
-//!   by [`omnibus_db::ebook::extract_accent`]) is wired as a `--accent`
-//!   custom property so cover-derived theming composes against the page.
-//!
-//! SSR/hydration: [`init_theme`] always seeds the context with `Theme::Dark`
-//! so the SSR-rendered markup is deterministic and matches the WASM
-//! client's first paint. A web-only [`use_effect`] reads the persisted value
-//! from `localStorage` after hydration and updates the signal, which
-//! re-renders [`AtriumRoot`] with the user's stored preference.
+//! Atrium design-system primitives: [`AtriumRoot`], [`Cover`], and the
+//! [`init_theme`] context provider. The CSS lives in
+//! [`frontend/assets/atrium.css`](../../assets/atrium.css); pages compose
+//! these markup-only components (no business logic, no data fetching)
+//! against those classes.
 
 use dioxus::prelude::*;
 use omnibus_shared::EbookMetadata;

--- a/frontend/src/components/author_photo_edit.rs
+++ b/frontend/src/components/author_photo_edit.rs
@@ -1,20 +1,8 @@
-//! Author photo edit affordance: a hover-revealed pencil button overlaid on
-//! the existing avatar that opens a modal with three actions —
-//!
-//! 1. **Paste image URL** — server fetches and validates the URL, persists
-//!    as a `manual` photo.
-//! 2. **Upload file** — multipart body to the same `PUT /api/authors/:id/photo`
-//!    endpoint used by the original admin upload path.
-//! 3. **Scan for picture** — re-runs the Open Library cascade.
-//!
-//! Used by `pages::author::AuthorPage` (hero avatar) and
-//! `pages::authors_index::AuthorsIndexPage` (per-card avatar). Both wrap
-//! their `<img>`/`<div>` inside `<AuthorPhotoEditOverlay>` so the same hover
-//! affordance shows up wherever the photo is rendered.
-//!
-//! The modal is web-only. SSR renders the wrapper but no overlay, and the
-//! mobile shell doesn't mount this component — mobile uses the discovery
-//! screens read-only for now.
+//! Author photo edit affordance: a hover-revealed pencil button
+//! ([`AuthorPhotoEditOverlay`]) that opens a modal
+//! ([`AuthorPhotoEditModal`]) offering three ways to change the photo. Used
+//! by the author hero and author-card avatars; web-only — SSR renders the
+//! wrapper with no overlay and mobile doesn't mount this component.
 
 use dioxus::prelude::*;
 
@@ -76,6 +64,11 @@ pub fn AuthorPhotoEditOverlay(
     }
 }
 
+/// Modal offering three ways to change an author's photo: paste an image
+/// URL (server fetches and validates it, persists as a `manual` photo),
+/// upload a file (multipart body to the same `PUT /api/authors/:id/photo`
+/// endpoint used by the original admin upload path), or re-scan the Open
+/// Library cascade for a picture.
 #[component]
 fn AuthorPhotoEditModal(
     author_id: i64,

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -1,13 +1,7 @@
 //! User-menu dropdown mounted in the top nav. Real wiring: Settings,
-//! Sign out, Dark/Light theme. Everything else is a stubbed `<a>`.
-//!
-//! SSR/hydration: the trigger is always rendered (empty placeholder
-//! initials in the pre-hydration phase) so the topbar markup is stable
-//! and `expectNavVisible` finds it without racing the auth ping. The
-//! App-wide [`crate::CurrentUser`] context — populated once by the boot
-//! effect in [`crate::App`] — then either fills in real initials
-//! (auth'd) or swaps the trigger for a `Log in` link (unauth). The panel
-//! only opens once we have a real user.
+//! Sign out, Dark/Light theme. Everything else is a stubbed `<a>`. See
+//! [`UserMenu`] for the SSR/hydration handling of the pre-auth trigger
+//! state.
 
 use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};
@@ -27,6 +21,14 @@ pub(crate) fn initials_for(username: &str) -> String {
 }
 
 /// Renders the user menu component (web and server targets).
+///
+/// SSR/hydration: the trigger is always rendered (empty placeholder
+/// initials in the pre-hydration phase) so the topbar markup is stable and
+/// `expectNavVisible` finds it without racing the auth ping. The App-wide
+/// [`crate::CurrentUser`] context — populated once by the boot effect in
+/// [`crate::App`] — then either fills in real initials (auth'd) or swaps
+/// the trigger for a `Log in` link (unauth). The panel only opens once we
+/// have a real user.
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
 pub fn UserMenu() -> Element {

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -1,19 +1,8 @@
-//! Feature-gated data-fetching layer.
-//!
-//! - Mobile (`feature = "mobile"`) calls the server's hand-written REST
-//!   routes (`/api/*`) via `reqwest`, picking up the base URL from the
-//!   `ServerUrl` Dioxus context. `server_url` is required at the call site.
-//! - Web (`feature = "web"`) calls the `#[get]`/`#[post]` server functions
-//!   defined in [`crate::rpc`]. No base URL needed — the server-function
-//!   client stubs use the page origin automatically. `server_url` is
-//!   ignored on the web path.
-//! - Server-only compiles (`feature = "server"` without `"web"`) reuse the
-//!   web stubs so SSR-during-fullstack-render still returns sensible data.
-//!
-//! Per-domain wrappers live in the [`auth`], [`authors`], [`books`],
-//! [`highlights`], [`journals`], [`progress`], [`series`], and [`tags`]
-//! submodules and are re-exported here so callers keep importing through
-//! `omnibus_frontend::data::*`.
+//! Feature-gated data-fetching layer: mobile calls the server's
+//! hand-written `/api/*` REST routes via `reqwest`; web and server-only
+//! compiles call the `#[get]`/`#[post]` functions in [`crate::rpc`].
+//! Per-domain wrappers live in the [`auth`], [`authors`], [`books`], and
+//! sibling submodules, re-exported here.
 
 mod auth;
 mod authors;
@@ -108,32 +97,11 @@ pub struct ServerUrl(pub String);
 
 #[cfg(feature = "mobile")]
 pub mod token_store {
-    //! In-process bearer-token store for the mobile client.
-    //!
-    //! Threading model:
-    //!
-    //! * In-memory state lives in an `RwLock<Option<String>>`. Reads/writes
-    //!   recover from poisoned locks via [`unpoison`] so a panic in one
-    //!   thread can't brick the whole app.
-    //! * Disk persistence is funnelled through a single dedicated worker
-    //!   thread fed by an `mpsc` channel. This serializes `set` and
-    //!   `clear` operations — a delayed write can never overtake a later
-    //!   clear and resurrect the token on next launch. **Persistence
-    //!   only runs in debug builds** (gated by `persistence_enabled()`,
-    //!   which returns `cfg!(debug_assertions)`) so a release build can
-    //!   never accidentally drop a long-lived credential on the
-    //!   filesystem in plaintext. Release users re-login on every cold
-    //!   start until secure storage lands.
-    //! * `set` and `clear` update the in-memory cell synchronously and
-    //!   enqueue the disk op. Async callers (`mobile_login`,
-    //!   `mobile_register`, the 401 handler in `note_status`) never block
-    //!   on flash I/O.
-    //!
-    //! **TODO:** in debug builds the token is held in process memory and
-    //! persisted to a plaintext file under the user's home directory.
-    //! Release builds skip persistence entirely. Replace with iOS Keychain /
-    //! Android Keystore via a platform-specific abstraction before flipping
-    //! persistence on for release builds.
+    //! In-process bearer-token store for the mobile client. In-memory state
+    //! lives in an `RwLock<Option<String>>` (see [`unpoison`]); disk
+    //! persistence is funnelled through a single dedicated worker thread fed
+    //! by an `mpsc` channel (see [`persistence_tx`]) so `set` / `clear`
+    //! never block on flash I/O and can't race each other.
     use std::path::{Path, PathBuf};
     use std::sync::{mpsc, LockResult, Mutex, OnceLock, RwLock};
     use tokio::sync::watch;

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -1,13 +1,6 @@
-//! Landing page (`/`) — the primary library surface.
-//!
-//! Browse (no search query) is keyset-paginated server-side (F5b): the first
-//! page carries the sidebar facets + the full-library count, and further pages
-//! are appended from a "Load more" sentinel (auto-triggered on web by an
-//! `IntersectionObserver`). Sort and filter are owned by the server — changing
-//! either refetches page 1. Search (non-empty query) keeps the pre-F5b path:
-//! the capped result set is sorted/filtered client-side (search keyset is a
-//! separate effort). View mode + sort + filters persist per library path via
-//! [`crate::view_prefs`].
+//! Landing page (`/`) — the primary library surface. See [`LandingPage`]
+//! for the browse-paginates / search-stays-client-side split. View mode +
+//! sort + filters persist per library path via [`crate::view_prefs`].
 
 use dioxus::prelude::*;
 use omnibus_shared::{EbookMetadata, ViewFilters, ViewPrefs};
@@ -305,8 +298,14 @@ fn build_handlers(sigs: &LandingSignals) -> LandingHandlers {
     }
 }
 
-/// Landing page — primary library surface. See the module doc for the
-/// browse-paginates / search-stays-client-side split.
+/// Landing page — primary library surface.
+///
+/// Browse (no search query) is keyset-paginated server-side: the first page
+/// carries the sidebar facets + the full-library count, and further pages
+/// are appended from a "Load more" sentinel (auto-triggered on web by an
+/// `IntersectionObserver`). Sort and filter are owned by the server —
+/// changing either refetches page 1. Search (non-empty query) keeps the
+/// legacy path: the capped result set is sorted/filtered client-side.
 #[component]
 pub fn LandingPage() -> Element {
     let server_url = use_server_url();

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -1,25 +1,8 @@
 //! Immersive audiobook player with direct-play and HLS fallback.
 //!
 //! Renders a full-screen "Now playing" surface: cover + title + author on the
-//! left, scrub bar + transport controls on the right.
-//!
-//! Startup sequence:
-//! 1. `GET /api/audiobooks/{uuid}/manifest` returns either
-//!    `{mode: "direct", parts}` (m4b/m4a/mp3/aac — instant) or
-//!    `{mode: "hls", playlist_url}` (everything else).
-//! 2. For direct mode, the JS shim chains per-part `<audio src>` URLs with
-//!    auto-advance on `ended`; the book's timeline is a cumulative sum of
-//!    per-part durations.
-//! 3. For HLS mode, fall back to the legacy `/status` poll + hls.js attach.
-//!    If `/status` reports `state: "failed"`, render an error overlay
-//!    instead of polling forever.
-//!
-//! Position lives in [`crate::audiobook_progress`] — localStorage on web,
-//! in-memory on mobile, no-op under SSR. Writes both there AND fire-and-
-//! forget POST `/api/rpc/progress` with `format: "audio"` +
-//! `audio_position_seconds`, so a position written on one device syncs
-//! forward on the next open. Across direct-mode parts the JS shim reports
-//! absolute (cross-part) seconds so the same shape works for both modes.
+//! left, scrub bar + transport controls on the right. See [`BookListenPage`]
+//! for the startup sequence and position-sync details.
 
 use dioxus::prelude::*;
 #[cfg(not(feature = "mobile"))]
@@ -69,6 +52,21 @@ pub(crate) use controls::AudioElement;
 pub(crate) use mini_dock::MiniDock;
 
 /// Renders the audiobook listen page for the book with the given uuid.
+///
+/// Startup sequence: `GET /api/audiobooks/{uuid}/manifest` returns either
+/// `{mode: "direct", parts}` (m4b/m4a/mp3/aac — instant) or `{mode: "hls",
+/// playlist_url}` (everything else). Direct mode chains per-part
+/// `<audio src>` URLs with auto-advance on `ended` via the JS shim, using a
+/// cumulative sum of per-part durations as the timeline; HLS mode falls back
+/// to the legacy `/status` poll + hls.js attach, rendering an error overlay
+/// if `/status` reports `state: "failed"` instead of polling forever.
+///
+/// Position lives in [`crate::audiobook_progress`] — localStorage on web,
+/// in-memory on mobile, no-op under SSR. Writes both there AND
+/// fire-and-forget POST `/api/rpc/progress` with `format: "audio"` +
+/// `audio_position_seconds`, so a position written on one device syncs
+/// forward on the next open. Across direct-mode parts the JS shim reports
+/// absolute (cross-part) seconds so the same shape works for both modes.
 #[component]
 pub fn BookListenPage(uuid: String) -> Element {
     #[cfg(feature = "mobile")]

--- a/frontend/src/rpc/mod.rs
+++ b/frontend/src/rpc/mod.rs
@@ -1,23 +1,8 @@
-//! Server functions callable from the web client.
-//!
-//! Each `#[get]`/`#[post]` function is compiled in two modes:
-//! - On the server (`feature = "server"`) the body executes, accessing the
-//!   SQLite pool via an `axum::Extension<SqlitePool>` layered onto the
-//!   Dioxus fullstack router in `server/src/main.rs`.
-//! - On the web client (`feature = "web"`) the macro generates a fetch-based
-//!   stub callable as a normal async function.
-//!
-//! Mobile does **not** use these. It talks to the hand-written `/api/*`
-//! REST routes (see `server/src/backend.rs`) via `reqwest`.
-//!
-//! These routes are distinct from the REST routes (`/api/rpc/*` vs `/api/*`)
-//! so the two clients cannot accidentally collide.
-//!
-//! The server functions themselves live in the per-domain submodules below and
-//! are re-exported here so every callsite keeps importing `crate::rpc::rpc_*`
-//! unchanged. This module owns only the cross-cutting pieces every submodule
-//! shares: the `PoolExt` / `WorkerExt` extractor aliases and the `AdminUser` /
-//! `AuthUser` authorization extractors.
+//! Server functions (`/api/rpc/*`) callable from the web client — mobile
+//! instead uses the hand-written `/api/*` REST routes (`server/src/backend.rs`).
+//! Per-domain submodules hold the functions and are re-exported here so
+//! callsites keep importing `crate::rpc::rpc_*`; this module owns only the
+//! shared `PoolExt` / `WorkerExt` / `AdminUser` / `AuthUser` pieces.
 
 mod authors;
 mod bookmarks;

--- a/server/src/auth/boot.rs
+++ b/server/src/auth/boot.rs
@@ -1,24 +1,7 @@
-//! Boot-time admin hooks.
-//!
-//! Two opt-in env-driven hooks run at server startup:
-//!
-//! * [`apply_initial_admin`] — `OMNIBUS_INITIAL_ADMIN=<username>` promotes
-//!   an existing user to admin. Recovery escape hatch ("I locked myself
-//!   out"); never creates a user.
-//! * [`seed_dev_user`] — `OMNIBUS_DEV_SEED_USER=<username>:<password>`
-//!   creates the named user (and promotes to admin) if it doesn't exist
-//!   yet. Strictly a dev convenience so Claude's `ui-validate` skill and
-//!   parallel agents can rely on a known login. **Gated on
-//!   `debug_assertions`** so release builds no-op even if the env var is
-//!   somehow set in production — relying on operational discipline alone
-//!   would be a footgun. The env var is sourced from a developer's `.env`
-//!   (gitignored, sourced by `flake.nix`). Idempotent: an existing user
-//!   is left untouched, so re-running boot won't reset a password the
-//!   developer has rotated.
-//!
-//! Successful promotions and seeds are logged at `warn` so they show up
-//! in the audit trail; misconfigurations also log at `warn` so they're
-//! visible.
+//! Boot-time admin hooks: two opt-in env-driven functions run at server
+//! startup. See [`apply_initial_admin`] (account-recovery promotion) and
+//! [`seed_dev_user`] (dev-only login seeding) for the env vars and gating
+//! each reads.
 
 use sqlx::SqlitePool;
 

--- a/server/src/auth/csrf.rs
+++ b/server/src/auth/csrf.rs
@@ -1,22 +1,8 @@
-//! CSRF origin-check middleware.
-//!
-//! Rejects state-changing cookie-authed requests whose `Origin`/`Referer`
-//! doesn't match either an allowed-origin allowlist or — when no allowlist
-//! is configured — the request's `Host`. Bearer-authed requests (mobile)
-//! are exempt because browsers don't auto-attach bearer headers cross-site.
-//! Safe methods (`GET`/`HEAD`/`OPTIONS`) always pass through.
-//!
-//! Set `OMNIBUS_PUBLIC_ORIGIN` to a comma-separated list of origins
-//! (e.g. `http://localhost:3000,https://omnibus.example.com`) when the
-//! server runs behind a reverse proxy that rewrites `Host` (the dioxus
-//! `dx serve --fullstack` dev proxy does exactly this). Without an
-//! allowlist, a proxied same-origin POST would 403 because the browser's
-//! `Origin` (`localhost:3000`) no longer matches the upstream `Host`
-//! (`127.0.0.1:<random-port>`).
-//!
-//! This is belt-and-braces on top of `SameSite=Lax`, which blocks classic
-//! cross-site form POSTs but is inconsistent across browsers and doesn't
-//! guard subdomain scenarios.
+//! CSRF origin-check middleware. Rejects state-changing cookie-authed
+//! requests whose `Origin`/`Referer` doesn't match either an allowed-origin
+//! allowlist or the request's `Host`; see [`origin_check`] for the exact
+//! rule and the `OMNIBUS_PUBLIC_ORIGIN` env var it reads. Belt-and-braces
+//! on top of `SameSite=Lax`, which is inconsistent across browsers.
 
 use axum::{
     extract::Request,
@@ -38,6 +24,17 @@ fn has_session_cookie(jar: &CookieJar) -> bool {
 }
 
 /// Reject state-changing cookie-authed requests whose `Origin`/`Referer` doesn't match the allowlist or `Host`.
+///
+/// Bearer-authed requests (mobile) are exempt because browsers don't
+/// auto-attach bearer headers cross-site; safe methods (`GET`/`HEAD`/
+/// `OPTIONS`) always pass through. Set `OMNIBUS_PUBLIC_ORIGIN` to a
+/// comma-separated list of origins (e.g.
+/// `http://localhost:3000,https://omnibus.example.com`) when the server
+/// runs behind a reverse proxy that rewrites `Host` (the dioxus
+/// `dx serve --fullstack` dev proxy does exactly this) — without an
+/// allowlist, a proxied same-origin POST would 403 because the browser's
+/// `Origin` (`localhost:3000`) no longer matches the upstream `Host`
+/// (`127.0.0.1:<random-port>`).
 pub async fn origin_check(req: Request, next: Next) -> Response {
     let method = req.method();
     if matches!(method, &Method::GET | &Method::HEAD | &Method::OPTIONS) {

--- a/server/src/auth/gate.rs
+++ b/server/src/auth/gate.rs
@@ -1,29 +1,8 @@
-//! `require_auth` — top-level middleware that gates `/api/*` routes behind a
-//! live session.
-//!
-//! Applied in `server/src/main.rs`. The middleware fast-paths two classes of
-//! request so SSR, assets, and the auth endpoints themselves keep working:
-//!
-//! * Anything that isn't a `/api/*` path (SSR HTML, WASM bundle, static
-//!   assets, Dioxus client-side routes) — passes through untouched.
-//! * Anything under `/api/auth/*` — these handle their own authentication
-//!   (`/me` uses the [`AuthUser`] extractor; `/login`/`/register` deliberately
-//!   don't require auth).
-//! * `/api/_health` — unauthenticated liveness + fingerprint probe used by
-//!   `scripts/dev-server-up.sh` to decide whether to reuse an existing
-//!   omnibus server on the port. Cannot require auth or the probe couldn't
-//!   run before a session exists.
-//!
-//! Everything else under `/api/*` — the REST routes (`/api/settings`,
-//! `/api/library`, `/api/ebooks`, `/api/covers/{uuid}`) and the
-//! Dioxus server-function endpoints (`/api/rpc/*`) — requires a valid session
-//! or returns `401 Unauthorized`.
-//!
-//! This middleware does not set per-user request extensions: handlers that
-//! need `AuthUser` should still declare it as an extractor. The middleware
-//! only gates the *boundary*; the extractor provides the typed view.
-//!
-//! [`AuthUser`]: super::AuthUser
+//! `require_auth` — top-level middleware, applied in `server/src/main.rs`,
+//! that gates `/api/*` routes behind a live session. Everything under
+//! `/api/*` other than `/api/auth/*` and `/api/_health` requires a valid
+//! session or gets `401 Unauthorized`; everything else (SSR HTML, WASM
+//! bundle, static assets) passes through untouched.
 
 use axum::{
     extract::{Request, State},
@@ -37,6 +16,15 @@ use super::extractor::extract_token;
 use crate::backend::AppState;
 
 /// Reject `/api/*` requests without a live session with `401 Unauthorized`, after exempting `/api/auth/*` and `/api/_health`.
+///
+/// `/api/auth/*` handles its own authentication (`/me` uses the
+/// [`AuthUser`](super::AuthUser) extractor; `/login`/`/register` deliberately
+/// don't require auth). `/api/_health` is an unauthenticated liveness +
+/// fingerprint probe used by `scripts/dev-server-up.sh` to decide whether to
+/// reuse an existing omnibus server on the port — it cannot require auth or
+/// the probe couldn't run before a session exists. This middleware does not
+/// set per-user request extensions: handlers that need `AuthUser` should
+/// still declare it as an extractor; this only gates the *boundary*.
 pub async fn require_auth(State(state): State<AppState>, req: Request, next: Next) -> Response {
     let path = req.uri().path();
     if !path.starts_with("/api/")

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -1,23 +1,8 @@
-//! Audiobook streaming routes: direct-play manifest + Range-served part
-//! files, with the legacy HLS pipeline retained as a fallback for
-//! non-natively-playable codecs.
-//!
-//! - `GET /api/audiobooks/{uuid}/manifest` — JSON describing how the
-//!   frontend should play this book: `direct` (per-part URLs the client
-//!   chains together) for m4b / m4a / mp3, or `hls` (playlist URL) for
-//!   anything else. See [`omnibus_db::audiobook::codec`] for the gate;
-//!   note that [`omnibus_db::hls::resolve_audiobook`] only admits books
-//!   whose top-level `book_files.format` is one of `M4B` / `M4A` / `MP3`,
-//!   so pure-AAC or pure-FLAC sources never reach this handler today.
-//! - `GET /api/audiobooks/{uuid}/parts/{ordinal}` — Range-served source
-//!   file for one part of a direct-play book.
-//! - `GET /api/audiobooks/{uuid}/playlist.m3u8` — fallback HLS manifest
-//!   built from `book_file_parts.duration_seconds`; only reachable when
-//!   the manifest endpoint returns `mode: hls`.
-//! - `GET /api/audiobooks/{uuid}/segments/{segment}` — fallback HLS
-//!   segment serve from the transcode cache.
-//! - `GET /api/audiobooks/{uuid}/status` — fallback transcode-readiness
-//!   poll (`{"ready":bool,"progress":f32}`) for the HLS path.
+//! Audiobook streaming routes: direct-play manifest (`/manifest`) + Range-
+//! served part files (`/parts/{ordinal}`), with the legacy HLS pipeline
+//! (`/playlist.m3u8`, `/segments/{segment}`, `/status`) retained as a
+//! fallback for non-natively-playable codecs. See
+//! [`get_audiobook_manifest`] for the direct-vs-HLS routing rule.
 
 use axum::{
     body::Body,
@@ -106,6 +91,11 @@ pub(super) async fn get_audiobook_playlist(
 /// `?file_id=N` to target a specific `book_files` row (for multi-file
 /// books after merge). Routes direct-playable books (m4b / m4a / mp3) to
 /// per-part HTTP Range URLs and everything else to the legacy HLS playlist.
+///
+/// See [`omnibus_db::audiobook::codec`] for the direct-vs-HLS gate; note
+/// that [`omnibus_db::hls::resolve_audiobook`] only admits books whose
+/// top-level `book_files.format` is one of `M4B` / `M4A` / `MP3`, so
+/// pure-AAC or pure-FLAC sources never reach direct mode today.
 pub(super) async fn get_audiobook_manifest(
     _user: AuthUser,
     State(state): State<AppState>,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,12 +1,8 @@
-//! Unified Dioxus fullstack entrypoint.
-//!
-//! - When built for WASM (no `server` feature), `main` calls `dioxus::launch`
-//!   to hydrate the client in the browser.
-//! - When built natively (`server` feature), `main` calls `dioxus::serve` to
-//!   run an Axum backend that serves SSR'd HTML, the WASM bundle, the
-//!   auto-registered `#[get]`/`#[post]` server functions from
-//!   [`omnibus_frontend::rpc`], and the hand-written `/api/*` REST routes
-//!   from [`omnibus::backend`] (mobile-facing).
+//! Unified Dioxus fullstack entrypoint. Built for WASM, `main` calls
+//! `dioxus::launch` to hydrate the client; built natively (`server`
+//! feature), it calls `dioxus::serve` to run an Axum backend serving SSR'd
+//! HTML, the WASM bundle, [`omnibus_frontend::rpc`] server functions, and
+//! [`omnibus::backend`]'s mobile-facing REST routes.
 
 use omnibus_frontend::App;
 

--- a/server/src/security_headers.rs
+++ b/server/src/security_headers.rs
@@ -1,75 +1,55 @@
-//! Global HTTP security response headers.
-//!
-//! Applies a single conservative set of headers to every response served by
-//! the axum router — covers SSR HTML, the Dioxus WASM bundle, server-function
-//! responses, the hand-written `/api/*` REST surface, and static assets in
-//! one place rather than depending on each handler to remember.
-//!
-//! Header rationale:
-//!
-//! * **`Content-Security-Policy`** — defense-in-depth against any XSS gap in
-//!   the user-supplied content rendered through SSR (book descriptions are
-//!   sanitized via `ammonia`, but the policy keeps an injection limited to
-//!   the page's own origin). Per-directive rationale:
-//!   * `script-src 'self' 'unsafe-inline' 'unsafe-eval'` — three relaxations,
-//!     all forced by the Dioxus web runtime; none can be tightened without
-//!     upstream changes. `'self'` loads the external WASM glue
-//!     (`/wasm/omnibus.js`). `'unsafe-inline'` is required because Dioxus
-//!     fullstack emits its hydration bootstrap (`window.dx_hydrate = …`) and
-//!     serialized state (`window.initial_dioxus_hydration_data = …`) as inline
-//!     `<script>` tags with no nonce and a per-page-variable body, so the SSR
-//!     markup cannot hydrate without it (hashes are unstable across pages;
-//!     Dioxus stamps no nonce). `'unsafe-eval'` is required because the
-//!     `dioxus-interpreter-js` runtime builds functions at runtime via the
-//!     `Function()` constructor — classic `eval`; `'wasm-unsafe-eval'` only
-//!     permits `WebAssembly.instantiate`, NOT `Function()`/`eval()`, so the
-//!     WASM panics on init under it. `'unsafe-eval'` is a superset that also
-//!     covers WASM instantiation, so `'wasm-unsafe-eval'` is not listed
-//!     separately. Net effect: `script-src` provides essentially no
-//!     script-injection protection here — an inherent cost of Dioxus web
-//!     today. The CSP's real value lives in the *other* directives:
-//!     `connect-src 'self'` blocks exfiltration to foreign origins, `'self'`
-//!     still blocks loading *external* scripts, and `object-src` / `base-uri`
-//!     / `form-action` / `frame-ancestors` are all locked down. Combined with
-//!     `ammonia` sanitizing the primary XSS source (book descriptions), an
-//!     injected script's blast radius stays bounded. Revisit only if Dioxus
-//!     drops its `Function()` use and gains nonce support.
-//!   * `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` —
-//!     `'unsafe-inline'` because Dioxus emits inline `style=""` attributes;
-//!     the Google Fonts host because `atrium.css` `@import`s the Geist /
-//!     Instrument Serif stylesheet from it. Self-hosting the fonts (a
-//!     follow-up tracked in `atrium.css`) would let both the CDN host here
-//!     and in `font-src` drop back to `'self'`.
-//!   * `font-src 'self' data: https://fonts.gstatic.com` — Google serves the
-//!     actual WOFF2 files from `fonts.gstatic.com`; without it the `@import`ed
-//!     stylesheet resolves but the glyphs fall back to system fonts.
-//!   * `img-src 'self' data: blob:` — `data:` / `blob:` cover thumbnails and
-//!     base64-embedded images.
-//!   * Tighten incrementally as the asset surface stabilizes.
-//! * **`X-Frame-Options: DENY`** — legacy clickjacking guard. `frame-ancestors
-//!   'none'` in the CSP supersedes this on modern browsers; both ship for
-//!   coverage on older clients.
-//! * **`Referrer-Policy: strict-origin-when-cross-origin`** — keeps full URLs
-//!   (which may include search queries or book ids) from leaking to other
-//!   origins, while preserving same-origin referrers used for analytics on
-//!   internal navigation.
-//! * **`X-Content-Type-Options: nosniff`** — globally suppresses MIME
-//!   sniffing. The per-handler `nosniff` on cover/thumb responses in
-//!   `backend::covers` becomes redundant once this layer is mounted, but
-//!   stays as belt-and-suspenders.
-//! * **`Strict-Transport-Security`** — only emitted when
-//!   `OMNIBUS_SECURE_COOKIES` resolves to truthy via the shared
-//!   `auth::handlers::parse_secure_cookies` reader. Sharing the parse
-//!   keeps the HSTS toggle pinned to the cookie `Secure` toggle so the
-//!   two can't drift; sending HSTS over plain HTTP is ignored by browsers
-//!   but would advertise the wrong policy on a LAN-IP dev origin where
-//!   the operator has set `OMNIBUS_SECURE_COOKIES=0`.
+//! Global HTTP security response headers, applied to every response served
+//! by the axum router (SSR HTML, WASM bundle, server-function responses,
+//! the `/api/*` REST surface, static assets) in one place rather than
+//! depending on each handler to remember. See [`DEFAULT_CSP`],
+//! [`baseline_layers`], and [`hsts_layer`] for the per-header rationale.
 
 use axum::http::{header, HeaderName, HeaderValue};
 use tower_http::set_header::SetResponseHeaderLayer;
 
 /// Conservative content-security policy that still hydrates Dioxus WASM.
-/// See module docs for the per-directive rationale.
+///
+/// Defense-in-depth against any XSS gap in the user-supplied content
+/// rendered through SSR (book descriptions are sanitized via `ammonia`, but
+/// the policy keeps an injection limited to the page's own origin).
+/// Per-directive rationale:
+///
+/// - `script-src 'self' 'unsafe-inline' 'unsafe-eval'` — three relaxations,
+///   all forced by the Dioxus web runtime; none can be tightened without
+///   upstream changes. `'self'` loads the external WASM glue
+///   (`/wasm/omnibus.js`). `'unsafe-inline'` is required because Dioxus
+///   fullstack emits its hydration bootstrap (`window.dx_hydrate = …`) and
+///   serialized state (`window.initial_dioxus_hydration_data = …`) as inline
+///   `<script>` tags with no nonce and a per-page-variable body, so the SSR
+///   markup cannot hydrate without it (hashes are unstable across pages;
+///   Dioxus stamps no nonce). `'unsafe-eval'` is required because the
+///   `dioxus-interpreter-js` runtime builds functions at runtime via the
+///   `Function()` constructor — classic `eval`; `'wasm-unsafe-eval'` only
+///   permits `WebAssembly.instantiate`, NOT `Function()`/`eval()`, so the
+///   WASM panics on init under it. `'unsafe-eval'` is a superset that also
+///   covers WASM instantiation, so `'wasm-unsafe-eval'` is not listed
+///   separately. Net effect: `script-src` provides essentially no
+///   script-injection protection here — an inherent cost of Dioxus web
+///   today. The CSP's real value lives in the *other* directives:
+///   `connect-src 'self'` blocks exfiltration to foreign origins, `'self'`
+///   still blocks loading *external* scripts, and `object-src` / `base-uri`
+///   / `form-action` / `frame-ancestors` are all locked down. Combined with
+///   `ammonia` sanitizing the primary XSS source (book descriptions), an
+///   injected script's blast radius stays bounded. Revisit only if Dioxus
+///   drops its `Function()` use and gains nonce support.
+/// - `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` —
+///   `'unsafe-inline'` because Dioxus emits inline `style=""` attributes;
+///   the Google Fonts host because `atrium.css` `@import`s the Geist /
+///   Instrument Serif stylesheet from it. Self-hosting the fonts (a
+///   follow-up tracked in `atrium.css`) would let both the CDN host here
+///   and in `font-src` drop back to `'self'`.
+/// - `font-src 'self' data: https://fonts.gstatic.com` — Google serves the
+///   actual WOFF2 files from `fonts.gstatic.com`; without it the `@import`ed
+///   stylesheet resolves but the glyphs fall back to system fonts.
+/// - `img-src 'self' data: blob:` — `data:` / `blob:` cover thumbnails and
+///   base64-embedded images.
+///
+/// Tighten incrementally as the asset surface stabilizes.
 const DEFAULT_CSP: &str = "default-src 'self'; \
 script-src 'self' 'unsafe-inline' 'unsafe-eval'; \
 style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
@@ -97,14 +77,23 @@ pub fn baseline_layers() -> [SetResponseHeaderLayer<HeaderValue>; 4] {
             header::CONTENT_SECURITY_POLICY,
             HeaderValue::from_static(DEFAULT_CSP),
         ),
+        // Legacy clickjacking guard — `frame-ancestors 'none'` in the CSP
+        // supersedes this on modern browsers; both ship for coverage on
+        // older clients.
         SetResponseHeaderLayer::overriding(
             HeaderName::from_static("x-frame-options"),
             HeaderValue::from_static("DENY"),
         ),
+        // Keeps full URLs (which may include search queries or book ids)
+        // from leaking to other origins, while preserving same-origin
+        // referrers used for analytics on internal navigation.
         SetResponseHeaderLayer::overriding(
             header::REFERRER_POLICY,
             HeaderValue::from_static("strict-origin-when-cross-origin"),
         ),
+        // Globally suppresses MIME sniffing. The per-handler `nosniff` on
+        // cover/thumb responses in `backend::covers` becomes redundant once
+        // this layer is mounted, but stays as belt-and-suspenders.
         SetResponseHeaderLayer::overriding(
             header::X_CONTENT_TYPE_OPTIONS,
             HeaderValue::from_static("nosniff"),
@@ -118,7 +107,9 @@ pub fn baseline_layers() -> [SetResponseHeaderLayer<HeaderValue>; 4] {
 /// opted into HTTPS-only cookies), `None` otherwise. The caller resolves
 /// the toggle by passing the result of `auth::handlers::parse_secure_cookies`
 /// — sharing the single parser keeps HSTS pinned to the cookie `Secure`
-/// flag so the two policies can't drift.
+/// flag so the two policies can't drift; sending HSTS over plain HTTP is
+/// ignored by browsers but would advertise the wrong policy on a LAN-IP dev
+/// origin where the operator has set `OMNIBUS_SECURE_COOKIES=0`.
 pub fn hsts_layer(secure_cookies: bool) -> Option<SetResponseHeaderLayer<HeaderValue>> {
     secure_cookies.then(|| {
         SetResponseHeaderLayer::overriding(

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,12 +1,8 @@
-//! Shared API types between the `omnibus` server and `omnibus-mobile` client.
-//!
-//! Keep this crate free of Dioxus and transport-layer dependencies so both
-//! `#[server]` functions (web) and `reqwest` calls (mobile) can depend on it
-//! without dragging in platform-specific trees.
-//!
-//! Types are organized by domain into submodules and re-exported flat from
-//! the crate root, so downstream callers keep using `omnibus_shared::Foo`
-//! regardless of where `Foo` actually lives.
+//! Shared API types between the `omnibus` server and `omnibus-mobile`
+//! client. Kept free of Dioxus and transport-layer dependencies so both
+//! `#[server]` functions (web) and `reqwest` calls (mobile) can depend on
+//! it. Types are organized by domain into submodules and re-exported flat
+//! from the crate root as `omnibus_shared::Foo`.
 
 pub mod audiobook;
 pub mod auth;


### PR DESCRIPTION
## Summary
- Trims all 19 `//!` module docs cited in #606 down to the ≤5-line cap in `.claude/rules/05-rust-style.md` § Comments & docs. No H2 headings or TODO markers remain in any module doc.
- Rationale worth keeping was relocated to `///` doc comments on the specific const/fn/struct it actually explains — nothing was silently dropped:
  - `server/src/security_headers.rs` — the full CSP per-directive writeup moved onto `DEFAULT_CSP`; the X-Frame-Options / Referrer-Policy / X-Content-Type-Options rationale became inline `//` comments in `baseline_layers`; the HSTS dev-origin caveat folded into `hsts_layer`'s doc.
  - `frontend/src/data.rs` — the mobile/web/server data-fetching split moved into a tighter module summary; the `token_store` threading-model detail was compressed, but the debug-only persistence rationale was already independently documented on `persistence_enabled` (verified, not duplicated) and the poisoned-lock recovery rationale already lived on `unpoison`.
  - `frontend/src/components/atrium.rs`, `server/src/auth/{boot,csrf,gate}.rs`, `server/src/backend/audiobooks.rs`, `frontend/src/pages/listen.rs`, and the rest similarly had their detail folded onto the relevant fn/component doc rather than deleted.
- One correction from the issue body: `frontend/src/rpc.rs` no longer exists as a single file (split into `frontend/src/rpc/` by #708, unrelated PR) — trimmed `frontend/src/rpc/mod.rs` instead, which had inherited the same bloat (20 lines) plus growth from the split.
- Two TODO removals reference already-tracked issues, so nothing new needs tracking: `atrium.rs`'s `TODO(F1.7-mobile)` is tracked by #558 (and still lives on the `persist_theme` fn's own inline comment — only the module-level mention was removed); `data.rs`'s mobile-token-persistence TODO is tracked by #90.
- Pure doc-only change — confirmed zero non-comment/non-doc line changes in the diff.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] Verified all 19 files now have ≤5-line module docs, 0 H2 headings, 0 TODOs remaining (scripted check)
- Not run: `cargo test` (doc-only change, no behavior to regress) and the mobile clippy lint (pre-existing sandbox gap unrelated to this change — no mobile files touched)

## Notes
- No migrations touched, no `Cargo.lock` changes, no markup/Playwright-relevant changes.

Closes #606
