### PR TITLE
fix: guard use_book_metadata against stale reader navigation (#711)

### DIFF
--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -60,17 +60,28 @@ pub(crate) fn format_progress_labels(loc: &RelocateData) -> (String, String) {
 
 /// Drop the previous book's title and kick off a fresh `get_ebook` fetch
 /// whenever `uuid` changes. SPA navigations between books would otherwise
-/// flash the previous title while the request is in flight.
+/// flash the previous title while the request is in flight, and an epoch
+/// guard keeps a slower, superseded fetch from overwriting a newer one.
 pub(crate) fn use_book_metadata(uuid: String) -> Signal<Option<EbookMetadata>> {
     let mut book_meta: Signal<Option<EbookMetadata>> = use_signal(|| None);
     let server_url = use_server_url();
+    // Epoch guard so a fetch for a previously-viewed book can't overwrite
+    // `book_meta` after a newer navigation has already superseded it
+    // (mirrors book_detail's `suggestions_epoch`).
+    let mut fetch_epoch = use_signal(|| 0u64);
     use_effect(use_reactive!(|uuid| {
         book_meta.set(None);
         let url = server_url.clone();
         let uuid = uuid.clone();
+        let epoch = {
+            fetch_epoch.with_mut(|e| *e += 1);
+            *fetch_epoch.peek()
+        };
         spawn(async move {
             if let Ok(Some(b)) = data::get_ebook(&url, &uuid).await {
-                book_meta.set(Some(b));
+                if *fetch_epoch.peek() == epoch {
+                    book_meta.set(Some(b));
+                }
             }
         });
     }));


### PR DESCRIPTION
## Summary
- `use_book_metadata` (`frontend/src/pages/reader/signals.rs`) spawned a `get_ebook` fetch on every `uuid` change with no guard against out-of-order completion. Fast reader navigation (book A → book B) could let A's fetch resolve after B's and overwrite `book_meta` with the wrong book's metadata.
- Added an epoch guard: bump a `fetch_epoch` signal at the start of each effect run, capture the epoch, and only write `book_meta` if the epoch is still current when the fetch resolves. This mirrors the existing `suggestions_epoch` pattern in `frontend/src/pages/book_detail/mod.rs`.
- Closes #711

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (191 passed)

## Notes
- No new unit test was added for the epoch-guard race itself: the identical `suggestions_epoch` pattern in `book_detail/mod.rs` has no isolated unit test either, since exercising the out-of-order-completion race requires a full async Dioxus runtime harness that doesn't exist in this crate yet. The existing `signals::tests` module (pure-function coverage for `format_progress_labels` / `ReaderStatus`) is unaffected and still passes.
- Behavior-only change, no markup/prop signature changes — no Playwright updates needed.
