### PR TITLE
test: add Playwright coverage for Hardcover-key and suggestions-strip flows (#664)

### DIFF
--- a/ui_tests/playwright/tests/flows/settings.spec.ts
+++ b/ui_tests/playwright/tests/flows/settings.spec.ts
@@ -15,6 +15,14 @@ const saveButton = (page: Page) =>
 // button (`data-testid="worker-status"`, issue #69). Target by testid so
 // the assertions stay specific to the form's "Settings saved." line.
 const settingsStatus = (page: Page) => page.getByTestId("settings-status");
+// F3.3 Hardcover-key card controls — testid-scoped since the card has its
+// own "Save"/"Clear" buttons that would otherwise collide with the
+// library-paths form's "Save" button (see `saveButton` above).
+const hardcoverKeyInput = (page: Page) => page.getByLabel("Hardcover API Key");
+const hardcoverSaveButton = (page: Page) => page.getByTestId("hardcover-save");
+const hardcoverClearButton = (page: Page) => page.getByTestId("hardcover-clear");
+const hardcoverStatus = (page: Page) => page.getByTestId("hardcover-status");
+const hardcoverMessage = (page: Page) => page.getByTestId("hardcover-key-status");
 
 test("renders the settings page layout", async ({ page }) => {
   await page.goto("/settings");
@@ -91,4 +99,81 @@ test("shows an error status when saving settings fails", async ({ page }) => {
 
   await expect(settingsStatus(page)).toHaveText("Failed to save settings.");
   await expect(settingsStatus(page)).toHaveClass(/error/);
+});
+
+// ---------------------------------------------------------------------------
+// Action — F3.3 Hardcover key save/clear
+// ---------------------------------------------------------------------------
+
+test("saves a Hardcover key, shows a connected status, then clears it", async ({ page }) => {
+  await gotoReady(page, "/settings");
+
+  const key = `hc_test_${Date.now()}`;
+
+  await hardcoverKeyInput(page).fill(key);
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/rpc/hardcover-key",
+      expectedBody: { key },
+      expectedStatus: 200,
+    },
+    async () => hardcoverSaveButton(page).click(),
+  );
+
+  await expect(hardcoverMessage(page)).toHaveText("Hardcover key saved.");
+  await expect(hardcoverMessage(page)).toHaveClass(/success/);
+  await expect(hardcoverStatus(page)).toContainText("Connected");
+  // The raw key is never echoed back to the client.
+  await expect(hardcoverKeyInput(page)).toHaveValue("");
+  await expect(hardcoverClearButton(page)).toBeVisible();
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/rpc/hardcover-key",
+      expectedBody: { key: null },
+      expectedStatus: 200,
+    },
+    async () => hardcoverClearButton(page).click(),
+  );
+
+  await expect(hardcoverMessage(page)).toHaveText("Hardcover key cleared.");
+  await expect(hardcoverMessage(page)).toHaveClass(/success/);
+  await expect(hardcoverStatus(page)).toContainText("Not connected");
+  await expect(hardcoverClearButton(page)).toHaveCount(0);
+});
+
+test("shows an error status when saving the Hardcover key fails", async ({ page }) => {
+  await gotoReady(page, "/settings");
+
+  // Only fail the write — the mount-time GET status fetch must still pass
+  // through, otherwise the card never renders the fields under test.
+  await page.route("**/api/rpc/hardcover-key", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ status: 500, contentType: "text/plain", body: "forced failure" });
+    }
+    return route.continue();
+  });
+
+  const key = `hc_test_error_${Date.now()}`;
+  await hardcoverKeyInput(page).fill(key);
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/rpc/hardcover-key",
+      expectedBody: { key },
+      expectedStatus: 500,
+    },
+    async () => hardcoverSaveButton(page).click(),
+  );
+
+  await expect(hardcoverMessage(page)).toHaveText("Failed to save Hardcover key.");
+  await expect(hardcoverMessage(page)).toHaveClass(/error/);
+  // The failed save must not clear the admin's typed-in draft.
+  await expect(hardcoverKeyInput(page)).toHaveValue(key);
 });

--- a/ui_tests/playwright/tests/flows/suggestions.spec.ts
+++ b/ui_tests/playwright/tests/flows/suggestions.spec.ts
@@ -52,6 +52,30 @@ async function mockSuggestionsResponse(page: Page, body: unknown): Promise<void>
   );
 }
 
+/**
+ * Navigate to a book's detail page and wait for the suggestions strip's
+ * POST /api/rpc/ebook-suggestions to resolve (it's a POST per Dioxus server
+ * function convention, and the handler enqueues a cascade resolution as a
+ * side effect — not a side-effect-free read), so the page has settled into
+ * whichever mocked state before assertions run.
+ *
+ * This deliberately doesn't reuse `expectMutation`: that helper's request
+ * wait is tuned for a click-triggered mutation on an already-hydrated page,
+ * but this request fires from the page's own mount effect right after WASM
+ * hydration — which, on a fresh navigation, can take meaningfully longer
+ * than a warm in-page action.
+ */
+async function gotoBookAwaitingSuggestions(page: Page, uuid: string): Promise<void> {
+  const requestPromise = page.waitForRequest(
+    (r) => r.method() === "POST" && r.url().includes("/api/rpc/ebook-suggestions"),
+    { timeout: 30_000 },
+  );
+  await gotoReady(page, `/books/${uuid}`);
+  const request = await requestPromise;
+  const response = await request.response();
+  expect(response?.status()).toBe(200);
+}
+
 // ---------------------------------------------------------------------------
 // State — not configured (no Hardcover key)
 // ---------------------------------------------------------------------------
@@ -59,7 +83,7 @@ async function mockSuggestionsResponse(page: Page, body: unknown): Promise<void>
 test("shows a connect prompt when no Hardcover key is configured", async ({ page, request }) => {
   const uuid = await fetchBookUuidByTitle(request, TARGET.title);
   await mockSuggestionsResponse(page, { status: "not_configured" });
-  await gotoReady(page, `/books/${uuid}`);
+  await gotoBookAwaitingSuggestions(page, uuid);
 
   const strip = page.getByTestId("suggestions-strip");
   await expect(strip).toBeVisible();
@@ -80,7 +104,7 @@ test("shows a connect prompt when no Hardcover key is configured", async ({ page
 test("shows a pending placeholder while a resolution is enqueued", async ({ page, request }) => {
   const uuid = await fetchBookUuidByTitle(request, TARGET.title);
   await mockSuggestionsResponse(page, { status: "pending" });
-  await gotoReady(page, `/books/${uuid}`);
+  await gotoBookAwaitingSuggestions(page, uuid);
 
   await expect(page.getByTestId("suggestions-pending")).toBeVisible();
   await expect(page.getByText("Looking for read-alikes via Hardcover…")).toBeVisible();
@@ -93,7 +117,7 @@ test("shows a pending placeholder while a resolution is enqueued", async ({ page
 test("shows an empty note when the cache resolved with no matches", async ({ page, request }) => {
   const uuid = await fetchBookUuidByTitle(request, TARGET.title);
   await mockSuggestionsResponse(page, { status: "ready", items: [] });
-  await gotoReady(page, `/books/${uuid}`);
+  await gotoBookAwaitingSuggestions(page, uuid);
 
   await expect(page.getByTestId("suggestions-empty")).toBeVisible();
   await expect(page.getByText("No read-alikes found for this book yet.")).toBeVisible();
@@ -110,7 +134,7 @@ test("renders cached suggestions and expands the collapsed stack via show more",
   const uuid = await fetchBookUuidByTitle(request, TARGET.title);
   const items = Array.from({ length: 7 }, (_, i) => mockSuggestion(i));
   await mockSuggestionsResponse(page, { status: "ready", items });
-  await gotoReady(page, `/books/${uuid}`);
+  await gotoBookAwaitingSuggestions(page, uuid);
 
   const strip = page.getByTestId("suggestions-strip");
   const cards = strip.getByTestId("suggestion-card");

--- a/ui_tests/playwright/tests/flows/suggestions.spec.ts
+++ b/ui_tests/playwright/tests/flows/suggestions.spec.ts
@@ -1,0 +1,137 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { fetchBookUuidByTitle } from "../utils/ebooks";
+import { gotoReady } from "../utils/nav";
+import { fixturesDir, seedLibrary } from "../utils/seed";
+
+// F3.3 "Readers also enjoyed" strip on the book-detail page. The strip's
+// state depends on whether a Hardcover key is configured server-wide and on
+// the outcome of a real Hardcover API call — neither of which this suite can
+// control deterministically (no `HARDCOVER_API_KEY` in CI, and the key is
+// shared global state other specs, e.g. `settings.spec.ts`, also mutate). So
+// every test here mocks `POST /api/rpc/ebook-suggestions` via `page.route`
+// rather than seeding real `book_suggestions` rows — the frontend calls a
+// plain interceptable server function (see `rpc_get_suggestions` in
+// `frontend/src/rpc/books.rs`), so this reproduces every UI state exactly
+// without a new DB seeding seam or any cross-spec state race.
+test.beforeAll(async ({ request }) => {
+  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
+});
+
+const TARGET = FIXTURE_BOOKS.find((b) => b.slug === "alpha")!;
+
+interface MockSuggestion {
+  hardcover_id: number;
+  hardcover_url: string;
+  title: string;
+  author: string;
+  list_count: number;
+  cover_url: string | null;
+}
+
+function mockSuggestion(rank: number): MockSuggestion {
+  return {
+    hardcover_id: 1000 + rank,
+    hardcover_url: `https://hardcover.app/books/mock-${rank}`,
+    title: `Suggested Book ${rank}`,
+    author: `Suggested Author ${rank}`,
+    list_count: rank + 1,
+    cover_url: null,
+  };
+}
+
+/** Intercept the suggestions fetch and reply with a fixed `SuggestionsResponse`. */
+async function mockSuggestionsResponse(page: Page, body: unknown): Promise<void> {
+  await page.route("**/api/rpc/ebook-suggestions", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// State — not configured (no Hardcover key)
+// ---------------------------------------------------------------------------
+
+test("shows a connect prompt when no Hardcover key is configured", async ({ page, request }) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await mockSuggestionsResponse(page, { status: "not_configured" });
+  await gotoReady(page, `/books/${uuid}`);
+
+  const strip = page.getByTestId("suggestions-strip");
+  await expect(strip).toBeVisible();
+  await expect(page.getByTestId("suggestions-not-configured")).toBeVisible();
+  await expect(
+    page.getByText("Add a Hardcover API key to pull read-alikes for this book."),
+  ).toBeVisible();
+  // The seeded dev user is an admin, so the connect card links to Settings.
+  const connectLink = page.getByTestId("suggestions-connect-link");
+  await expect(connectLink).toBeVisible();
+  await expect(connectLink).toHaveAttribute("href", "/settings");
+});
+
+// ---------------------------------------------------------------------------
+// State — pending (resolution enqueued, nothing cached yet)
+// ---------------------------------------------------------------------------
+
+test("shows a pending placeholder while a resolution is enqueued", async ({ page, request }) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await mockSuggestionsResponse(page, { status: "pending" });
+  await gotoReady(page, `/books/${uuid}`);
+
+  await expect(page.getByTestId("suggestions-pending")).toBeVisible();
+  await expect(page.getByText("Looking for read-alikes via Hardcover…")).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// State — ready, no matches (sticky negative)
+// ---------------------------------------------------------------------------
+
+test("shows an empty note when the cache resolved with no matches", async ({ page, request }) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await mockSuggestionsResponse(page, { status: "ready", items: [] });
+  await gotoReady(page, `/books/${uuid}`);
+
+  await expect(page.getByTestId("suggestions-empty")).toBeVisible();
+  await expect(page.getByText("No read-alikes found for this book yet.")).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// State — ready, with results (collapsed stack + "show more" + outbound link)
+// ---------------------------------------------------------------------------
+
+test("renders cached suggestions and expands the collapsed stack via show more", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  const items = Array.from({ length: 7 }, (_, i) => mockSuggestion(i));
+  await mockSuggestionsResponse(page, { status: "ready", items });
+  await gotoReady(page, `/books/${uuid}`);
+
+  const strip = page.getByTestId("suggestions-strip");
+  const cards = strip.getByTestId("suggestion-card");
+
+  // Collapsed stack caps at 5 even though 7 items are cached.
+  await expect(cards).toHaveCount(5);
+  await expect(cards.first()).toContainText(items[0]!.title);
+  await expect(cards.first()).toContainText(items[0]!.author);
+  await expect(cards.first()).toContainText("on 1 list");
+
+  // Each card is an outbound link to the Hardcover book page, opened in a
+  // new tab without leaking a `window.opener` reference.
+  await expect(cards.first()).toHaveAttribute("href", items[0]!.hardcover_url);
+  await expect(cards.first()).toHaveAttribute("target", "_blank");
+  await expect(cards.first()).toHaveAttribute("rel", "noopener noreferrer");
+
+  const showMore = page.getByTestId("suggestions-show-more");
+  await expect(showMore).toHaveText("Show 2 more");
+  await showMore.click();
+
+  await expect(cards).toHaveCount(7);
+  await expect(cards.last()).toContainText(items[6]!.title);
+  await expect(showMore).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- Adds the Playwright action-test coverage that #664 flagged as missing for two F3.3 surfaces.
- `settings.spec.ts`: two new tests — save a Hardcover API key and clear it via `expectMutation` against `POST /api/rpc/hardcover-key`, asserting the "Connected"/"Not connected" status text and that the raw key is never echoed back; and a forced-500 error-path test (via `page.route`) asserting the failure message renders and the typed draft isn't cleared.
- `suggestions.spec.ts` (new file): covers all four states of the "Readers also enjoyed" strip on book-detail — not-configured (connect-to-Settings prompt), pending, ready-with-no-matches, and ready-with-items (collapsed-to-5 stack, "show more" expansion to 7, and outbound Hardcover link attributes `href`/`target`/`rel`).

**Design decision — mock over seed:** rather than adding a server-side seam to pre-populate `book_suggestions`/`book_suggestion_state` rows (which the issue's own note flagged as an open question), the suggestions spec mocks `POST /api/rpc/ebook-suggestions` via `page.route`. That endpoint is a plain interceptable Dioxus server function (`rpc_get_suggestions` in `frontend/src/rpc/books.rs`), so mocking reproduces every `SuggestionsResponse` variant exactly, with no `HARDCOVER_API_KEY` dependency in CI and no shared-state race against `settings.spec.ts`'s real key mutations. All testids referenced (`suggestions-strip`, `suggestions-not-configured`, `suggestions-pending`, `suggestions-empty`, `suggestion-card`, `suggestions-show-more`, `suggestions-connect-link`, `hardcover-save`, `hardcover-clear`, `hardcover-status`, `hardcover-key-status`) were verified against the actual markup in `frontend/src/pages/book_detail/body.rs` and `frontend/src/pages/settings.rs`.

No production code changed — test-only addition.

## Test plan
- [x] Brought up a real `dx serve --fullstack` dev server and ran the affected specs in a real browser: `settings.spec.ts` (5/5 pass), `suggestions.spec.ts` (4/4 pass), full `book_detail.spec.ts` (11/11 pass, unaffected).
- [x] `npx tsc --noEmit` clean on the changed files (3 pre-existing, unrelated `noUncheckedIndexedAccess` errors in other spec files were not touched).
- [ ] CI (`playwright` shards) — pending on this push.

## Notes
- No Rust touched, so `cargo fmt`/`clippy`/`test` are out of scope for this change.
- No migrations, no `Cargo.lock` changes, no markup changes.

Closes #664
