### PR TITLE
refactor: split oversized journal/suggestions functions (#662)

### DIFF
--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -124,20 +124,23 @@ pub(super) fn BdJournalSection(uuid: String) -> Element {
 /// optional reading-progress slider, and a spoiler-syntax hint.
 #[component]
 fn BdJournalComposer(uuid: String, server_url: String, reload: Signal<u32>) -> Element {
-    let mut reload = reload;
     let mut open = use_signal(|| false);
-    let mut body = use_signal(String::new);
-    let mut show_preview = use_signal(|| false);
-    let mut preview_html = use_signal(String::new);
-    let mut track_progress = use_signal(|| false);
-    let mut progress = use_signal(|| 50i64);
-    let mut saving = use_signal(|| false);
-    let mut error = use_signal(|| None::<String>);
+    let body = use_signal(String::new);
+    let show_preview = use_signal(|| false);
+    let preview_html = use_signal(String::new);
+    let track_progress = use_signal(|| false);
+    let progress = use_signal(|| 50i64);
+    let saving = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
     // Saved highlights for this book, loaded lazily the first time the
-    // insert-from-highlights popover is opened.
-    let mut highlights = use_signal(Vec::<Highlight>::new);
-    let mut highlights_open = use_signal(|| false);
-    let mut highlights_loaded = use_signal(|| false);
+    // insert-from-highlights popover is opened. Owned here rather than by
+    // BdJournalHighlightsPopover so the cache survives that component's
+    // subtree unmounting when the Write/Preview tab toggles.
+    let highlights = BdJournalHighlightsState {
+        list: use_signal(Vec::<Highlight>::new),
+        open: use_signal(|| false),
+        loaded: use_signal(|| false),
+    };
 
     if !open() {
         return rsx! {
@@ -152,231 +155,375 @@ fn BdJournalComposer(uuid: String, server_url: String, reload: Signal<u32>) -> E
         };
     }
 
+    let foot_state = BdJournalComposerFootState {
+        body,
+        track_progress,
+        progress,
+        saving,
+        error,
+        open,
+        show_preview,
+    };
+
     rsx! {
         div { class: "card bd-journal-composer", "data-testid": "journal-composer",
-            div { class: "bd-journal-composer-tabs",
-                button {
-                    r#type: "button",
-                    class: if show_preview() { "btn ghost sm" } else { "btn ghost sm bd-tab-active" },
-                    onclick: move |_| show_preview.set(false),
-                    "Write"
-                }
-                button {
-                    r#type: "button",
-                    class: if show_preview() { "btn ghost sm bd-tab-active" } else { "btn ghost sm" },
-                    "data-testid": "journal-preview-toggle",
-                    onclick: {
-                        let url = server_url.clone();
-                        move |_| {
-                            let url = url.clone();
-                            let md = body();
-                            // Clear any prior preview so a failed fetch can't leave stale HTML on screen.
-                            preview_html.set(String::new());
-                            show_preview.set(true);
-                            spawn(async move {
-                                match data::preview_journal_markdown(&url, md).await {
-                                    Ok(html) => {
-                                        preview_html.set(html);
-                                        error.set(None);
-                                    }
-                                    Err(e) => error.set(Some(format!("Preview failed: {e}"))),
-                                }
-                            });
+            BdJournalComposerTabs {
+                show_preview,
+                body,
+                preview_html,
+                server_url: server_url.clone(),
+                error,
+            }
+            BdJournalComposerBody {
+                uuid: uuid.clone(),
+                server_url: server_url.clone(),
+                show_preview,
+                preview_html,
+                body,
+                highlights,
+            }
+            BdJournalComposerFoot { uuid, server_url, state: foot_state, reload }
+        }
+    }
+}
+
+/// Write/Preview tab row + spoiler-syntax hint. "Preview" fetches the
+/// server-rendered markdown before switching views.
+#[component]
+fn BdJournalComposerTabs(
+    mut show_preview: Signal<bool>,
+    body: Signal<String>,
+    mut preview_html: Signal<String>,
+    server_url: String,
+    mut error: Signal<Option<String>>,
+) -> Element {
+    rsx! {
+        div { class: "bd-journal-composer-tabs",
+            button {
+                r#type: "button",
+                class: if show_preview() { "btn ghost sm" } else { "btn ghost sm bd-tab-active" },
+                onclick: move |_| show_preview.set(false),
+                "Write"
+            }
+            button {
+                r#type: "button",
+                class: if show_preview() { "btn ghost sm bd-tab-active" } else { "btn ghost sm" },
+                "data-testid": "journal-preview-toggle",
+                onclick: move |_| {
+                    let url = server_url.clone();
+                    let md = body();
+                    // Clear any prior preview so a failed fetch can't leave stale HTML on screen.
+                    preview_html.set(String::new());
+                    show_preview.set(true);
+                    spawn(async move {
+                        match data::preview_journal_markdown(&url, md).await {
+                            Ok(html) => {
+                                preview_html.set(html);
+                                error.set(None);
+                            }
+                            Err(e) => error.set(Some(format!("Preview failed: {e}"))),
                         }
-                    },
-                    "Preview"
-                }
-                span { class: "bd-journal-foot-spacer" }
-                span {
-                    class: "mono bd-journal-spoiler-help",
-                    "data-testid": "journal-spoiler-help",
-                    title: "Hide spoilers with ||double pipes|| \u{2014} they appear blurred until clicked.",
-                    "Spoilers? Wrap text in ||double pipes||"
+                    });
+                },
+                "Preview"
+            }
+            span { class: "bd-journal-foot-spacer" }
+            span {
+                class: "mono bd-journal-spoiler-help",
+                "data-testid": "journal-spoiler-help",
+                title: "Hide spoilers with ||double pipes|| \u{2014} they appear blurred until clicked.",
+                "Spoilers? Wrap text in ||double pipes||"
+            }
+        }
+    }
+}
+
+/// Write/preview toggle body: the formatting toolbar + insert-from-highlights
+/// popover while writing, or the rendered markdown preview while previewing.
+#[component]
+fn BdJournalComposerBody(
+    uuid: String,
+    server_url: String,
+    show_preview: Signal<bool>,
+    preview_html: Signal<String>,
+    body: Signal<String>,
+    highlights: BdJournalHighlightsState,
+) -> Element {
+    let mut body = body;
+    // Matches the editable div's id below; bound once so the toolbar and
+    // popover always target the same live editor instance.
+    let editor_id = "journal-composer-editor";
+    rsx! {
+        if !show_preview() {
+            div { class: "bd-journal-toolbar-row",
+                BdJournalToolbar { target_id: editor_id.to_string() }
+                BdJournalHighlightsPopover {
+                    uuid: uuid.clone(),
+                    server_url: server_url.clone(),
+                    state: highlights,
                 }
             }
-            if !show_preview() {
-                div { class: "bd-journal-toolbar-row",
-                    BdJournalToolbar { target_id: "journal-composer-editor".to_string() }
-                    div { class: "bd-journal-hl-wrap",
-                        button {
-                            r#type: "button",
-                            class: if highlights_open() { "btn ghost sm bd-tab-active" } else { "btn ghost sm" },
-                            "data-testid": "journal-insert-highlight",
-                            onclick: {
-                                let url = server_url.clone();
-                                let uuid = uuid.clone();
-                                move |_| {
-                                    let opening = !highlights_open();
-                                    highlights_open.set(opening);
-                                    if opening && !highlights_loaded() {
-                                        highlights_loaded.set(true);
-                                        let url = url.clone();
-                                        let uuid = uuid.clone();
-                                        spawn(async move {
-                                            if let Ok(list) = data::list_highlights(&url, &uuid).await {
-                                                highlights.set(
-                                                    list.into_iter().filter(|h| h.text.is_some()).collect(),
-                                                );
-                                            }
-                                        });
-                                    }
-                                }
-                            },
-                            "From highlights"
+        }
+        if show_preview() {
+            div {
+                class: "bd-journal-preview",
+                "data-testid": "journal-preview",
+                dangerous_inner_html: "{preview_html}",
+            }
+        } else {
+            // Rule 07 (hydration parity): render one rsx body on every
+            // target. SSR + first-hydration paint show the plain textarea
+            // as the write surface; a sibling contenteditable div rides
+            // along, hidden by CSS until post-mount JS flips the wrapper's
+            // `data-omnibus-enhanced` marker (see `editor_enhance`). The
+            // textarea keeps carrying the `body` signal even after
+            // enhancement — the JS mirrors the editor's markdown back into
+            // its `value`, so publish/validate/preview are unchanged.
+            div { class: "bd-journal-editor-wrap",
+                textarea {
+                    id: "journal-composer-body",
+                    class: "me-textarea bd-journal-textarea",
+                    "data-testid": "journal-body",
+                    rows: "5",
+                    placeholder: "What are you thinking about this book? Markdown supported.",
+                    value: "{body}",
+                    oninput: move |e| body.set(e.value()),
+                    onmounted: move |_| editor_enhance("journal-composer-body", editor_id),
+                }
+                div {
+                    id: "{editor_id}",
+                    class: "me-textarea bd-journal-editor",
+                    "data-testid": "journal-editor",
+                    contenteditable: "true",
+                    role: "textbox",
+                    "aria-multiline": "true",
+                    "aria-label": "Journal entry",
+                    "data-placeholder": "What are you thinking about this book? Markdown supported.",
+                }
+            }
+        }
+    }
+}
+
+/// Saved-highlights cache for the insert-from-highlights popover. Owned by
+/// the composer (see `BdJournalComposer`), not by the popover itself, so it
+/// survives the popover's host subtree unmounting when the Write/Preview tab
+/// toggles or the composer is closed and reopened.
+#[derive(Clone, Copy, PartialEq, Props)]
+struct BdJournalHighlightsState {
+    list: Signal<Vec<Highlight>>,
+    open: Signal<bool>,
+    loaded: Signal<bool>,
+}
+
+/// "Insert from highlights" popover: lazily loads this book's saved
+/// highlights the first time it's opened, and inserts the chosen passage's
+/// text as a blockquote into the composer's editor.
+#[component]
+fn BdJournalHighlightsPopover(
+    uuid: String,
+    server_url: String,
+    state: BdJournalHighlightsState,
+) -> Element {
+    // Matches `BdJournalComposerBody`'s editable div id — this popover is
+    // only ever mounted for the composer's editor, never the entry-card one.
+    const TARGET_ID: &str = "journal-composer-editor";
+    let BdJournalHighlightsState {
+        list: mut highlights,
+        open: mut highlights_open,
+        loaded: mut highlights_loaded,
+    } = state;
+
+    rsx! {
+        div { class: "bd-journal-hl-wrap",
+            button {
+                r#type: "button",
+                class: if highlights_open() { "btn ghost sm bd-tab-active" } else { "btn ghost sm" },
+                "data-testid": "journal-insert-highlight",
+                onclick: move |_| {
+                    let opening = !highlights_open();
+                    highlights_open.set(opening);
+                    if opening && !highlights_loaded() {
+                        highlights_loaded.set(true);
+                        let url = server_url.clone();
+                        let uuid = uuid.clone();
+                        spawn(async move {
+                            if let Ok(list) = data::list_highlights(&url, &uuid).await {
+                                highlights.set(
+                                    list.into_iter().filter(|h| h.text.is_some()).collect(),
+                                );
+                            }
+                        });
+                    }
+                },
+                "From highlights"
+            }
+            if highlights_open() {
+                div {
+                    class: "card bd-journal-hl-pop",
+                    "data-testid": "journal-highlights-pop",
+                    div { class: "label bd-journal-hl-head", "From your highlights" }
+                    if highlights().is_empty() {
+                        p { class: "mono bd-journal-hl-empty",
+                            "No saved highlights for this book yet."
                         }
-                        if highlights_open() {
-                            div {
-                                class: "card bd-journal-hl-pop",
-                                "data-testid": "journal-highlights-pop",
-                                div { class: "label bd-journal-hl-head", "From your highlights" }
-                                if highlights().is_empty() {
-                                    p { class: "mono bd-journal-hl-empty",
-                                        "No saved highlights for this book yet."
+                    } else {
+                        for h in highlights().iter() {
+                            button {
+                                key: "{h.id}",
+                                r#type: "button",
+                                class: "bd-journal-hl-item",
+                                "data-testid": "journal-highlight-item",
+                                onmousedown: move |e| e.prevent_default(),
+                                onclick: {
+                                    let text = h.text.clone().unwrap_or_default();
+                                    move |_| {
+                                        editor_insert(TARGET_ID, &highlight_blockquote(&text));
+                                        highlights_open.set(false);
                                     }
-                                } else {
-                                    for h in highlights().iter() {
-                                        button {
-                                            key: "{h.id}",
-                                            r#type: "button",
-                                            class: "bd-journal-hl-item",
-                                            "data-testid": "journal-highlight-item",
-                                            onmousedown: move |e| e.prevent_default(),
-                                            onclick: {
-                                                let text = h.text.clone().unwrap_or_default();
-                                                move |_| {
-                                                    editor_insert(
-                                                        "journal-composer-editor",
-                                                        &highlight_blockquote(&text),
-                                                    );
-                                                    highlights_open.set(false);
-                                                }
-                                            },
-                                            "{h.text.clone().unwrap_or_default()}"
-                                        }
-                                    }
-                                }
+                                },
+                                "{h.text.clone().unwrap_or_default()}"
                             }
                         }
                     }
                 }
             }
-            if show_preview() {
-                div {
-                    class: "bd-journal-preview",
-                    "data-testid": "journal-preview",
-                    dangerous_inner_html: "{preview_html}",
+        }
+    }
+}
+
+/// Signals shared by the composer's footer (progress toggle, save state, and
+/// the cancel/publish buttons). Grouped per the &gt;5-prop convention (#634).
+#[derive(Clone, Copy, PartialEq, Props)]
+struct BdJournalComposerFootState {
+    body: Signal<String>,
+    track_progress: Signal<bool>,
+    progress: Signal<i64>,
+    saving: Signal<bool>,
+    error: Signal<Option<String>>,
+    open: Signal<bool>,
+    show_preview: Signal<bool>,
+}
+
+/// Submit the composer's draft as a new journal entry; on success, reset the
+/// composer back to its collapsed state and bump `reload` so the feed
+/// refetches. Mirrors `fetch_and_poll_suggestions` in `mod.rs`: async
+/// mutation logic lives in a named fn, not inlined in the render body.
+async fn publish_journal_entry(
+    url: String,
+    input: CreateJournalEntry,
+    mut state: BdJournalComposerFootState,
+    mut reload: Signal<u32>,
+) {
+    match data::create_journal_entry(&url, input).await {
+        Ok(_) => {
+            state.body.set(String::new());
+            state.show_preview.set(false);
+            state.track_progress.set(false);
+            state.open.set(false);
+            reload.set(reload() + 1);
+        }
+        Err(e) => state.error.set(Some(e.to_string())),
+    }
+    state.saving.set(false);
+}
+
+/// Progress toggle/slider, error row, and cancel/publish buttons.
+#[component]
+fn BdJournalComposerFoot(
+    uuid: String,
+    server_url: String,
+    state: BdJournalComposerFootState,
+    mut reload: Signal<u32>,
+) -> Element {
+    let BdJournalComposerFootState {
+        mut body,
+        mut track_progress,
+        mut progress,
+        mut saving,
+        mut error,
+        mut open,
+        mut show_preview,
+    } = state;
+
+    rsx! {
+        div { class: "bd-journal-composer-foot",
+            label { class: "bd-journal-progress",
+                input {
+                    r#type: "checkbox",
+                    checked: track_progress(),
+                    oninput: move |e| track_progress.set(e.value() == "true"),
                 }
-            } else {
-                // Rule 07 (hydration parity): render one rsx body on every
-                // target. SSR + first-hydration paint show the plain textarea
-                // as the write surface; a sibling contenteditable div rides
-                // along, hidden by CSS until post-mount JS flips the wrapper's
-                // `data-omnibus-enhanced` marker (see `editor_enhance`). The
-                // textarea keeps carrying the `body` signal even after
-                // enhancement — the JS mirrors the editor's markdown back into
-                // its `value`, so publish/validate/preview are unchanged.
-                div { class: "bd-journal-editor-wrap",
-                    textarea {
-                        id: "journal-composer-body",
-                        class: "me-textarea bd-journal-textarea",
-                        "data-testid": "journal-body",
-                        rows: "5",
-                        placeholder: "What are you thinking about this book? Markdown supported.",
-                        value: "{body}",
-                        oninput: move |e| body.set(e.value()),
-                        onmounted: move |_| editor_enhance(
-                            "journal-composer-body",
-                            "journal-composer-editor",
-                        ),
+                span { class: "label", "Progress" }
+                if track_progress() {
+                    input {
+                        r#type: "range",
+                        min: "0",
+                        max: "100",
+                        value: "{progress}",
+                        "data-testid": "journal-progress",
+                        oninput: move |e| {
+                            if let Ok(v) = e.value().parse::<i64>() {
+                                progress.set(v);
+                            }
+                        },
                     }
-                    div {
-                        id: "journal-composer-editor",
-                        class: "me-textarea bd-journal-editor",
-                        "data-testid": "journal-editor",
-                        contenteditable: "true",
-                        role: "textbox",
-                        "aria-multiline": "true",
-                        "aria-label": "Journal entry",
-                        "data-placeholder": "What are you thinking about this book? Markdown supported.",
-                    }
+                    span { class: "mono bd-journal-progress-val", "{progress}%" }
                 }
             }
-            div { class: "bd-journal-composer-foot",
-                label { class: "bd-journal-progress",
-                    input {
-                        r#type: "checkbox",
-                        checked: track_progress(),
-                        oninput: move |e| track_progress.set(e.value() == "true"),
-                    }
-                    span { class: "label", "Progress" }
-                    if track_progress() {
-                        input {
-                            r#type: "range",
-                            min: "0",
-                            max: "100",
-                            value: "{progress}",
-                            "data-testid": "journal-progress",
-                            oninput: move |e| {
-                                if let Ok(v) = e.value().parse::<i64>() {
-                                    progress.set(v);
-                                }
-                            },
-                        }
-                        span { class: "mono bd-journal-progress-val", "{progress}%" }
-                    }
-                }
-                span { class: "bd-journal-foot-spacer" }
-                if let Some(msg) = error() {
-                    span { class: "mono bd-journal-error", role: "alert", "{msg}" }
-                }
-                button {
-                    r#type: "button",
-                    class: "btn ghost sm",
-                    onclick: move |_| {
-                        open.set(false);
-                        body.set(String::new());
-                        show_preview.set(false);
-                        error.set(None);
-                    },
-                    "Cancel"
-                }
-                button {
-                    r#type: "button",
-                    class: "btn primary sm",
-                    "data-testid": "journal-publish",
-                    disabled: saving() || body().trim().is_empty(),
-                    onclick: {
-                        let url = server_url.clone();
-                        let uuid = uuid.clone();
-                        move |_| {
-                            let url = url.clone();
-                            let input = CreateJournalEntry {
-                                book_uuid: uuid.clone(),
-                                body_md: body(),
-                                progress: if track_progress() { Some(progress() as u8) } else { None },
-                            };
-                            saving.set(true);
-                            error.set(None);
-                            spawn(async move {
-                                match data::create_journal_entry(&url, input).await {
-                                    Ok(_) => {
-                                        body.set(String::new());
-                                        show_preview.set(false);
-                                        track_progress.set(false);
-                                        open.set(false);
-                                        reload.set(reload() + 1);
-                                    }
-                                    Err(e) => error.set(Some(e.to_string())),
-                                }
-                                saving.set(false);
-                            });
-                        }
-                    },
-                    if saving() { "Publishing\u{2026}" } else { "Publish entry" }
-                }
+            span { class: "bd-journal-foot-spacer" }
+            if let Some(msg) = error() {
+                span { class: "mono bd-journal-error", role: "alert", "{msg}" }
+            }
+            button {
+                r#type: "button",
+                class: "btn ghost sm",
+                onclick: move |_| {
+                    open.set(false);
+                    body.set(String::new());
+                    show_preview.set(false);
+                    error.set(None);
+                },
+                "Cancel"
+            }
+            button {
+                r#type: "button",
+                class: "btn primary sm",
+                "data-testid": "journal-publish",
+                disabled: saving() || body().trim().is_empty(),
+                onclick: move |_| {
+                    let url = server_url.clone();
+                    let uuid = uuid.clone();
+                    let input = CreateJournalEntry {
+                        book_uuid: uuid,
+                        body_md: body(),
+                        progress: if track_progress() { Some(progress() as u8) } else { None },
+                    };
+                    saving.set(true);
+                    error.set(None);
+                    spawn(publish_journal_entry(url, input, state, reload));
+                },
+                if saving() { "Publishing\u{2026}" } else { "Publish entry" }
             }
         }
     }
+}
+
+/// Delete a journal entry and bump `reload` on success; on failure, surface
+/// the error. Either way, `saving` is cleared afterward so the card's
+/// actions don't stay disabled if the post-delete refetch silently fails.
+async fn delete_journal_entry_and_reload(
+    url: String,
+    entry_id: i64,
+    mut saving: Signal<bool>,
+    mut error: Signal<Option<String>>,
+    mut reload: Signal<u32>,
+) {
+    match data::delete_journal_entry(&url, entry_id).await {
+        Ok(()) => reload.set(reload() + 1),
+        Err(e) => error.set(Some(e.to_string())),
+    }
+    saving.set(false);
 }
 
 /// One journal entry card: author monogram + byline + date/progress, rendered
@@ -388,7 +535,6 @@ fn BdJournalEntryCard(
     server_url: String,
     reload: Signal<u32>,
 ) -> Element {
-    let mut reload = reload;
     let mut editing = use_signal(|| false);
     let mut edit_body = use_signal(|| entry.body_md.clone());
     let mut saving = use_signal(|| false);
@@ -450,15 +596,9 @@ fn BdJournalEntryCard(
                                     let url = url.clone();
                                     saving.set(true);
                                     error.set(None);
-                                    spawn(async move {
-                                        match data::delete_journal_entry(&url, entry_id).await {
-                                            Ok(()) => reload.set(reload() + 1),
-                                            Err(e) => {
-                                                error.set(Some(e.to_string()));
-                                                saving.set(false);
-                                            }
-                                        }
-                                    });
+                                    spawn(delete_journal_entry_and_reload(
+                                        url, entry_id, saving, error, reload,
+                                    ));
                                 }
                             },
                             "Delete"
@@ -467,78 +607,17 @@ fn BdJournalEntryCard(
                 }
             }
             if editing() {
-                div { class: "bd-journal-toolbar-row",
-                    BdJournalToolbar { target_id: format!("journal-edit-editor-{entry_id}") }
-                }
-                // Rule 07 (hydration parity): single rsx body on every target,
-                // keyed per entry id so multiple open editors don't collide.
-                // Same progressive-enhancement pattern as the composer.
-                div { class: "bd-journal-editor-wrap",
-                    textarea {
-                        id: "journal-edit-body-{entry_id}",
-                        class: "me-textarea bd-journal-textarea",
-                        "data-testid": "journal-edit-body",
-                        rows: "5",
-                        value: "{edit_body}",
-                        oninput: move |e| edit_body.set(e.value()),
-                        onmounted: move |_| editor_enhance(
-                            &format!("journal-edit-body-{entry_id}"),
-                            &format!("journal-edit-editor-{entry_id}"),
-                        ),
-                    }
-                    div {
-                        id: "journal-edit-editor-{entry_id}",
-                        class: "me-textarea bd-journal-editor",
-                        "data-testid": "journal-edit-editor",
-                        contenteditable: "true",
-                        role: "textbox",
-                        "aria-multiline": "true",
-                        "aria-label": "Edit journal entry",
-                    }
-                }
-                div { class: "bd-journal-entry-foot",
-                    if let Some(msg) = error() {
-                        span { class: "mono bd-journal-error", role: "alert", "{msg}" }
-                    }
-                    span { class: "bd-journal-foot-spacer" }
-                    button {
-                        r#type: "button",
-                        class: "btn ghost sm",
-                        onclick: move |_| editing.set(false),
-                        "Cancel"
-                    }
-                    button {
-                        r#type: "button",
-                        class: "btn primary sm",
-                        "data-testid": "journal-edit-save",
-                        disabled: saving() || edit_body().trim().is_empty(),
-                        onclick: {
-                            let url = server_url.clone();
-                            move |_| {
-                                let url = url.clone();
-                                let input = UpdateJournalEntry {
-                                    body_md: edit_body(),
-                                    progress: entry_progress,
-                                };
-                                saving.set(true);
-                                error.set(None);
-                                spawn(async move {
-                                    match data::update_journal_entry(&url, entry_id, input).await {
-                                        Ok(_) => {
-                                            editing.set(false);
-                                            saving.set(false);
-                                            reload.set(reload() + 1);
-                                        }
-                                        Err(e) => {
-                                            error.set(Some(e.to_string()));
-                                            saving.set(false);
-                                        }
-                                    }
-                                });
-                            }
-                        },
-                        if saving() { "Saving\u{2026}" } else { "Save" }
-                    }
+                BdJournalEntryEditForm {
+                    entry_id,
+                    entry_progress,
+                    server_url: server_url.clone(),
+                    state: BdJournalEntryEditState {
+                        edit_body,
+                        saving,
+                        error,
+                        editing,
+                        reload,
+                    },
                 }
             } else {
                 div {
@@ -550,6 +629,110 @@ fn BdJournalEntryCard(
                         span { class: "mono bd-journal-error", role: "alert", "{msg}" }
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Signals the edit form mutates: the draft body, save state, the error row,
+/// the `editing` toggle it closes on cancel/save, and the feed's `reload`
+/// counter. Grouped per the &gt;5-prop convention (#634).
+#[derive(Clone, Copy, PartialEq, Props)]
+struct BdJournalEntryEditState {
+    edit_body: Signal<String>,
+    saving: Signal<bool>,
+    error: Signal<Option<String>>,
+    editing: Signal<bool>,
+    reload: Signal<u32>,
+}
+
+/// Edit-mode body for a journal entry: formatting toolbar, live editor, and
+/// the cancel/save row. Keyed per `entry_id` so multiple open editors on the
+/// same page don't collide (element ids, JS eval targets).
+#[component]
+fn BdJournalEntryEditForm(
+    entry_id: i64,
+    entry_progress: Option<u8>,
+    server_url: String,
+    state: BdJournalEntryEditState,
+) -> Element {
+    let BdJournalEntryEditState {
+        mut edit_body,
+        mut saving,
+        mut error,
+        mut editing,
+        mut reload,
+    } = state;
+
+    rsx! {
+        div { class: "bd-journal-toolbar-row",
+            BdJournalToolbar { target_id: format!("journal-edit-editor-{entry_id}") }
+        }
+        // Rule 07 (hydration parity): single rsx body on every target,
+        // keyed per entry id so multiple open editors don't collide.
+        // Same progressive-enhancement pattern as the composer.
+        div { class: "bd-journal-editor-wrap",
+            textarea {
+                id: "journal-edit-body-{entry_id}",
+                class: "me-textarea bd-journal-textarea",
+                "data-testid": "journal-edit-body",
+                rows: "5",
+                value: "{edit_body}",
+                oninput: move |e| edit_body.set(e.value()),
+                onmounted: move |_| editor_enhance(
+                    &format!("journal-edit-body-{entry_id}"),
+                    &format!("journal-edit-editor-{entry_id}"),
+                ),
+            }
+            div {
+                id: "journal-edit-editor-{entry_id}",
+                class: "me-textarea bd-journal-editor",
+                "data-testid": "journal-edit-editor",
+                contenteditable: "true",
+                role: "textbox",
+                "aria-multiline": "true",
+                "aria-label": "Edit journal entry",
+            }
+        }
+        div { class: "bd-journal-entry-foot",
+            if let Some(msg) = error() {
+                span { class: "mono bd-journal-error", role: "alert", "{msg}" }
+            }
+            span { class: "bd-journal-foot-spacer" }
+            button {
+                r#type: "button",
+                class: "btn ghost sm",
+                onclick: move |_| editing.set(false),
+                "Cancel"
+            }
+            button {
+                r#type: "button",
+                class: "btn primary sm",
+                "data-testid": "journal-edit-save",
+                disabled: saving() || edit_body().trim().is_empty(),
+                onclick: move |_| {
+                    let url = server_url.clone();
+                    let input = UpdateJournalEntry {
+                        body_md: edit_body(),
+                        progress: entry_progress,
+                    };
+                    saving.set(true);
+                    error.set(None);
+                    spawn(async move {
+                        match data::update_journal_entry(&url, entry_id, input).await {
+                            Ok(_) => {
+                                editing.set(false);
+                                saving.set(false);
+                                reload.set(reload() + 1);
+                            }
+                            Err(e) => {
+                                error.set(Some(e.to_string()));
+                                saving.set(false);
+                            }
+                        }
+                    });
+                },
+                if saving() { "Saving\u{2026}" } else { "Save" }
             }
         }
     }

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -27,7 +27,7 @@ pub fn BookDetailPage(uuid: String) -> Element {
     let mut author_books: Signal<Vec<EbookMetadata>> = use_signal(Vec::new);
     // F3.3 suggestions. Starts `None` on both SSR and the first WASM paint so
     // hydration markup matches (rule 07); the client effect below populates it.
-    let mut suggestions: Signal<Option<SuggestionsResponse>> = use_signal(|| None);
+    let suggestions: Signal<Option<SuggestionsResponse>> = use_signal(|| None);
     // Epoch guard so a poll loop left over from a previous book can't write its
     // result onto the current book after navigation (mirrors landing's
     // `fetch_epoch`).
@@ -113,9 +113,7 @@ pub fn BookDetailPage(uuid: String) -> Element {
     }));
 
     // F3.3 suggestions: resolved off-request by the worker and cached. Fetch
-    // for the current book; while the result is `Pending`, poll a few times on
-    // web so it appears without a manual reload. A fetch failure degrades to
-    // "no suggestions" rather than an error row.
+    // for the current book, polling while pending; see `fetch_and_poll_suggestions`.
     let sug_url = server_url.clone();
     use_effect(use_reactive!(|uuid| {
         let url = sug_url.clone();
@@ -124,54 +122,13 @@ pub fn BookDetailPage(uuid: String) -> Element {
             suggestions_epoch.with_mut(|e| *e += 1);
             *suggestions_epoch.peek()
         };
-        // True only while this run is still the latest — a newer book's effect
-        // bumps the epoch, so a stale poll drops its result instead of writing
-        // it onto the now-current book.
-        let is_current = move || *suggestions_epoch.peek() == epoch;
-        spawn(async move {
-            suggestions.set(None);
-            match data::get_suggestions(&url, &uuid).await {
-                Ok(resp) => {
-                    if !is_current() {
-                        return;
-                    }
-                    let pending = matches!(resp, SuggestionsResponse::Pending);
-                    suggestions.set(Some(resp));
-                    #[cfg(feature = "web")]
-                    if pending {
-                        let mut tries = 0u32;
-                        while tries < 5 {
-                            gloo_timers::future::TimeoutFuture::new(2500).await;
-                            if !is_current() {
-                                return;
-                            }
-                            tries += 1;
-                            match data::get_suggestions(&url, &uuid).await {
-                                Ok(next) => {
-                                    if !is_current() {
-                                        return;
-                                    }
-                                    let still_pending =
-                                        matches!(next, SuggestionsResponse::Pending);
-                                    suggestions.set(Some(next));
-                                    if !still_pending {
-                                        break;
-                                    }
-                                }
-                                Err(_) => break,
-                            }
-                        }
-                    }
-                    #[cfg(not(feature = "web"))]
-                    let _ = pending;
-                }
-                Err(_) => {
-                    if is_current() {
-                        suggestions.set(Some(SuggestionsResponse::Ready { items: Vec::new() }));
-                    }
-                }
-            }
-        });
+        spawn(fetch_and_poll_suggestions(
+            url,
+            uuid,
+            epoch,
+            suggestions_epoch,
+            suggestions,
+        ));
     }));
 
     if loading() {
@@ -227,6 +184,74 @@ pub fn BookDetailPage(uuid: String) -> Element {
     rsx! {
         {body}
         {merge_ui}
+    }
+}
+
+/// Fetch suggestions for `uuid` and, on web, poll while the result is
+/// `Pending`. A fetch failure degrades to "no suggestions" rather than an
+/// error row. `epoch`/`suggestions_epoch` guard against a stale poll (left
+/// over from a previously viewed book) writing onto the current book after
+/// navigation.
+async fn fetch_and_poll_suggestions(
+    url: String,
+    uuid: String,
+    epoch: u64,
+    suggestions_epoch: Signal<u64>,
+    mut suggestions: Signal<Option<SuggestionsResponse>>,
+) {
+    // True only while this run is still the latest.
+    let is_current = move || *suggestions_epoch.peek() == epoch;
+    suggestions.set(None);
+    match data::get_suggestions(&url, &uuid).await {
+        Ok(resp) => {
+            if !is_current() {
+                return;
+            }
+            #[cfg(feature = "web")]
+            let pending = matches!(resp, SuggestionsResponse::Pending);
+            suggestions.set(Some(resp));
+            #[cfg(feature = "web")]
+            if pending {
+                poll_suggestions_until_resolved(url, uuid, is_current, suggestions).await;
+            }
+        }
+        Err(_) => {
+            if is_current() {
+                suggestions.set(Some(SuggestionsResponse::Ready { items: Vec::new() }));
+            }
+        }
+    }
+}
+
+/// Re-poll `get_suggestions` a few times while it keeps returning `Pending`.
+/// Web-only — non-web targets never see a `Pending` state worth polling for.
+#[cfg(feature = "web")]
+async fn poll_suggestions_until_resolved(
+    url: String,
+    uuid: String,
+    is_current: impl Fn() -> bool,
+    mut suggestions: Signal<Option<SuggestionsResponse>>,
+) {
+    let mut tries = 0u32;
+    while tries < 5 {
+        gloo_timers::future::TimeoutFuture::new(2500).await;
+        if !is_current() {
+            return;
+        }
+        tries += 1;
+        match data::get_suggestions(&url, &uuid).await {
+            Ok(next) => {
+                if !is_current() {
+                    return;
+                }
+                let still_pending = matches!(next, SuggestionsResponse::Pending);
+                suggestions.set(Some(next));
+                if !still_pending {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- `BookDetailPage`'s F3.3 suggestions-poll effect is extracted into `fetch_and_poll_suggestions` / `poll_suggestions_until_resolved` (`frontend/src/pages/book_detail/mod.rs`).
- `BdJournalComposer` (was ~254 lines) is split into `BdJournalComposerTabs`, `BdJournalComposerBody`, `BdJournalHighlightsPopover`, and `BdJournalComposerFoot` (78 lines, under the ~80-line cap), with the publish-and-reset logic pulled into a named `publish_journal_entry` fn (mirroring the `mod.rs` extraction).
- `BdJournalEntryCard`'s edit-mode branch is split into `BdJournalEntryEditForm`; the delete-handler logic is pulled into a named `delete_journal_entry_and_reload` fn. `BdJournalEntryCard` itself is down to ~105 lines (from 172) — still over the ~80-line soft cap; the head/byline/actions block is a natural next extraction, left for a follow-up rather than growing this PR further.
- New multi-signal props are grouped into `Props` structs (`BdJournalComposerFootState`, `BdJournalHighlightsState`, `BdJournalEntryEditState`) per the `>5`-prop convention from #634.

## Review fixes
An 8-angle adversarial review caught a real regression before merge: the saved-highlights cache (`highlights`/`highlights_open`/`highlights_loaded`) had moved from `BdJournalComposer`'s own hooks into the new `BdJournalHighlightsPopover` child component — which only mounts while `!show_preview`, so toggling to Preview and back (or closing/reopening the composer) would silently reset the popover and re-fetch. Fixed by keeping that state owned by `BdJournalComposer` (via `BdJournalHighlightsState`) and passing it down, so it survives the popover subtree unmounting. Also fixed: `BdJournalComposerBody` was receiving `show_preview`/`preview_html` as read snapshots instead of `Signal` handles (coarser reactivity than necessary), and the highlights-popover's editor target id was cloned per rendered highlight instead of being a `const`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default members)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo check -p omnibus-frontend --features web --target wasm32-unknown-unknown` (the `web`-gated poll helper only compiles under this target)
- [x] `cargo test -p omnibus-db`, `-p omnibus`, `-p omnibus-frontend --features server` (191 passed), `-p omnibus-shared`
- [ ] `cargo clippy -p omnibus-mobile --all-targets` — not run; this container has no GTK3/WebKitGTK dev libraries (`gdk-3.0.pc` missing) to link `omnibus-mobile`, and the mobile crate isn't touched by this diff, so this is a pre-existing environment gap, not a regression.

## Notes
- Out of scope, left as follow-ups rather than expanding this PR: a shared `async_sleep_ms` helper already exists (`worker_status.rs`, `search_palette/overlay.rs`, `merge_dialog.rs`) that `poll_suggestions_until_resolved`'s inline `gloo_timers` sleep could adopt; and `BdJournalEntryCard`'s remaining ~105 lines could be trimmed further by extracting its head/byline/actions row the same way the edit form was extracted.
- No migrations touched. No Playwright test-id/id/aria strings changed — verified byte-for-byte against `ui_tests/playwright/tests/flows/journal.spec.ts`.

Closes #662
