### PR TITLE
fix: authenticate mobile cover thumbnails via thumb_url (?token=)

### DIFF
--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -187,10 +187,15 @@ fn thumb_srcs(
     server_url: &str,
 ) -> (Option<String>, Option<String>) {
     if book.cover_url.is_some() {
-        let base = format!("{server_url}/api/thumbs/{uuid}");
+        // `thumb_url` server-prefixes and, on mobile, appends the `?token=`
+        // the WebView's `<img>` fetch needs — the native reqwest bearer path
+        // doesn't cover image loads (see `contexts::media_url`).
+        let sm = crate::thumb_url(server_url, uuid, "sm");
+        let md = crate::thumb_url(server_url, uuid, "md");
+        let lg = crate::thumb_url(server_url, uuid, "lg");
         (
-            Some(format!("{base}/md")),
-            Some(format!("{base}/sm 160w, {base}/md 320w, {base}/lg 640w")),
+            Some(md.clone()),
+            Some(format!("{sm} 160w, {md} 320w, {lg} 640w")),
         )
     } else {
         (None, None)

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -187,9 +187,7 @@ fn thumb_srcs(
     server_url: &str,
 ) -> (Option<String>, Option<String>) {
     if book.cover_url.is_some() {
-        // `thumb_url` server-prefixes and, on mobile, appends the `?token=`
-        // the WebView's `<img>` fetch needs — the native reqwest bearer path
-        // doesn't cover image loads (see `contexts::media_url`).
+        // `thumb_url` appends the mobile `?token=` an `<img>` fetch needs (see `contexts::media_url`).
         let sm = crate::thumb_url(server_url, uuid, "sm");
         let md = crate::thumb_url(server_url, uuid, "md");
         let lg = crate::thumb_url(server_url, uuid, "lg");

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -124,9 +124,7 @@ fn thumb_srcs(
     server_url: &str,
 ) -> (Option<String>, Option<String>) {
     if book.cover_url.is_some() {
-        // `thumb_url` server-prefixes and, on mobile, appends the `?token=`
-        // the WebView's `<img>` fetch needs — the native reqwest bearer path
-        // doesn't cover image loads (see `contexts::media_url`).
+        // `thumb_url` appends the mobile `?token=` an `<img>` fetch needs (see `contexts::media_url`).
         let sm = crate::thumb_url(server_url, uuid, "sm");
         let md = crate::thumb_url(server_url, uuid, "md");
         let lg = crate::thumb_url(server_url, uuid, "lg");

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -124,10 +124,15 @@ fn thumb_srcs(
     server_url: &str,
 ) -> (Option<String>, Option<String>) {
     if book.cover_url.is_some() {
-        let base = format!("{server_url}/api/thumbs/{uuid}");
+        // `thumb_url` server-prefixes and, on mobile, appends the `?token=`
+        // the WebView's `<img>` fetch needs — the native reqwest bearer path
+        // doesn't cover image loads (see `contexts::media_url`).
+        let sm = crate::thumb_url(server_url, uuid, "sm");
+        let md = crate::thumb_url(server_url, uuid, "md");
+        let lg = crate::thumb_url(server_url, uuid, "lg");
         (
-            Some(format!("{base}/md")),
-            Some(format!("{base}/sm 160w, {base}/md 320w, {base}/lg 640w")),
+            Some(md.clone()),
+            Some(format!("{sm} 160w, {md} 320w, {lg} 640w")),
         )
     } else {
         (None, None)


### PR DESCRIPTION
## Summary
Follow-up to #720 (mobile designs) × #719 (`?token=` on `<img>` fetches). The new mobile library grid and book-detail hero inlined their own thumbnail URLs (`{server}/api/thumbs/{uuid}/…`), bypassing the `thumb_url` helper #719 added — so `<img>` fetches carried no auth and covers rendered as broken-image placeholders on device.

- Route both mobile thumbnail builders through `crate::thumb_url`, matching `grid.rs`/`shelf_detail.rs`; on mobile it appends the session `?token=`, on web it's a no-op (path unchanged).

## Test plan
- [x] `just lint` + `just test` green.
- [x] On-device (iPhone 17 sim): mobile library grid now renders real cover art instead of broken-image placeholders.