### PR TITLE
feat: smart-shelf rules match by name + contains/starts-with ops

### DIFF
--- a/db/src/shelves/rules.rs
+++ b/db/src/shelves/rules.rs
@@ -2,8 +2,10 @@
 //!
 //! Each [`ShelfRule`] becomes an `EXISTS`/comparison fragment over the `books b`
 //! alias; the rule set combines with `OR` (match any) or `AND` (match all).
-//! Owner-scoped fields (`rating`) bind the shelf owner's id. `status` is not
-//! supported yet (the schema records no read-completion signal).
+//! Text fields (tag/author/series/format) match by **name**, case-insensitively
+//! — equality via `COLLATE NOCASE`, substring/prefix via `LIKE` (`contains` /
+//! `starts with`). Owner-scoped fields (`rating`) bind the shelf owner's id.
+//! `status` is not supported yet (the schema records no read-completion signal).
 
 use omnibus_shared::{MatchMode, RuleField, RuleOp, ShelfRule};
 
@@ -55,47 +57,37 @@ pub(super) fn membership_predicate(
 
 /// Translate one condition into `(sql, binds)`.
 fn condition_sql(rule: &ShelfRule, owner_id: i64) -> Result<(String, Vec<Bind>), ShelfError> {
+    // Central op gate: the SQL arms below only handle ops the field accepts.
+    if !rule.field.accepts(rule.op) {
+        return Err(unsupported(rule));
+    }
     let v = rule.value.trim();
     match rule.field {
-        RuleField::Tag => {
-            let exists = "SELECT 1 FROM books_tags_link btl JOIN tags t ON t.id = btl.tag \
-                          WHERE btl.book = b.id AND t.name = ? COLLATE NOCASE";
-            let sql = match rule.op {
-                RuleOp::Is => format!("EXISTS ({exists})"),
-                RuleOp::IsNot => format!("NOT EXISTS ({exists})"),
-                _ => return Err(unsupported(rule)),
-            };
-            Ok((sql, vec![Bind::Text(v.to_string())]))
-        }
-        RuleField::Author => {
-            expect_op(rule, RuleOp::Is)?;
-            Ok((
-                "EXISTS (SELECT 1 FROM books_authors_link bal \
-                 WHERE bal.book = b.id AND bal.author = ?)"
-                    .into(),
-                vec![Bind::Int(parse_id(v)?)],
-            ))
-        }
-        RuleField::Series => {
-            expect_op(rule, RuleOp::Is)?;
-            Ok((
-                "EXISTS (SELECT 1 FROM books_series_link bsl \
-                 WHERE bsl.book = b.id AND bsl.series = ?)"
-                    .into(),
-                vec![Bind::Int(parse_id(v)?)],
-            ))
-        }
-        RuleField::Format => {
-            expect_op(rule, RuleOp::Includes)?;
-            // `book_files.format` is COLLATE NOCASE, so a lowercase chip
-            // (`"epub"`) matches the stored `"EPUB"`.
-            Ok((
-                "EXISTS (SELECT 1 FROM book_files bf \
-                 WHERE bf.book_id = b.id AND bf.format = ? COLLATE NOCASE)"
-                    .into(),
-                vec![Bind::Text(v.to_string())],
-            ))
-        }
+        // Text fields resolve against the normalized taxonomy `name` columns
+        // (all `COLLATE NOCASE`), so the user types a name, not an id.
+        RuleField::Tag => text_condition(
+            rule,
+            "SELECT 1 FROM books_tags_link btl JOIN tags t ON t.id = btl.tag \
+             WHERE btl.book = b.id AND ",
+            "t.name",
+        ),
+        RuleField::Author => text_condition(
+            rule,
+            "SELECT 1 FROM books_authors_link bal JOIN authors a ON a.id = bal.author \
+             WHERE bal.book = b.id AND ",
+            "a.name",
+        ),
+        RuleField::Series => text_condition(
+            rule,
+            "SELECT 1 FROM books_series_link bsl JOIN series s ON s.id = bsl.series \
+             WHERE bsl.book = b.id AND ",
+            "s.name",
+        ),
+        RuleField::Format => text_condition(
+            rule,
+            "SELECT 1 FROM book_files bf WHERE bf.book_id = b.id AND ",
+            "bf.format",
+        ),
         RuleField::Rating => {
             let cmp = match rule.op {
                 RuleOp::Is => "=",
@@ -164,13 +156,64 @@ fn date_condition(rule: &ShelfRule, v: &str) -> Result<(String, Vec<Bind>), Shel
     }
 }
 
-/// Error unless `rule.op` equals `want`.
-fn expect_op(rule: &ShelfRule, want: RuleOp) -> Result<(), ShelfError> {
-    if rule.op == want {
-        Ok(())
+/// Build a case-insensitive `EXISTS`/`NOT EXISTS` text predicate for a joined
+/// name column.
+///
+/// `inner` is the subquery up to (but not including) the column comparison, e.g.
+/// `"SELECT 1 FROM books_tags_link btl JOIN tags t ON t.id = btl.tag WHERE
+/// btl.book = b.id AND "`; `col` is the compared column (`"t.name"`). Equality
+/// (`is`/`is_not`/`includes`) uses `COLLATE NOCASE`; `contains`/`starts_with`
+/// use `LIKE` (case-insensitive for ASCII) with metacharacters escaped so user
+/// text matches literally.
+fn text_condition(
+    rule: &ShelfRule,
+    inner: &str,
+    col: &str,
+) -> Result<(String, Vec<Bind>), ShelfError> {
+    let v = rule.value.trim();
+    let (cmp, bind, negate) = match rule.op {
+        RuleOp::Is | RuleOp::Includes => (
+            format!("{col} = ? COLLATE NOCASE"),
+            Bind::Text(v.into()),
+            false,
+        ),
+        RuleOp::IsNot => (
+            format!("{col} = ? COLLATE NOCASE"),
+            Bind::Text(v.into()),
+            true,
+        ),
+        RuleOp::Contains => (
+            format!("{col} LIKE ? ESCAPE '\\'"),
+            Bind::Text(format!("%{}%", like_escape(v))),
+            false,
+        ),
+        RuleOp::StartsWith => (
+            format!("{col} LIKE ? ESCAPE '\\'"),
+            Bind::Text(format!("{}%", like_escape(v))),
+            false,
+        ),
+        _ => return Err(unsupported(rule)),
+    };
+    let exists = format!("EXISTS ({inner}{cmp})");
+    let sql = if negate {
+        format!("NOT {exists}")
     } else {
-        Err(unsupported(rule))
+        exists
+    };
+    Ok((sql, vec![bind]))
+}
+
+/// Escape `LIKE` metacharacters (`\`, `%`, `_`) so user text matches literally.
+/// Pairs with the `ESCAPE '\'` clause in [`text_condition`].
+fn like_escape(v: &str) -> String {
+    let mut out = String::with_capacity(v.len());
+    for c in v.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(c);
     }
+    out
 }
 
 fn parse_id(v: &str) -> Result<i64, ShelfError> {
@@ -337,11 +380,81 @@ mod rule_tests {
 
     #[test]
     fn bad_op_for_field_is_rejected() {
+        // `gte` is numeric-only; author is a text field, so it must be rejected.
         assert!(membership_predicate(
-            &[rule(RuleField::Author, RuleOp::IsNot, "3")],
+            &[rule(RuleField::Author, RuleOp::Gte, "3")],
             MatchMode::Any,
             1
         )
         .is_err());
+    }
+
+    #[test]
+    fn author_matches_by_name_not_id() {
+        // Regression: `is` on author/series used to bind a numeric id, so a
+        // typed name failed to parse. It now joins the taxonomy `name` column.
+        let p = membership_predicate(
+            &[rule(RuleField::Author, RuleOp::Is, "Ursula K. Le Guin")],
+            MatchMode::Any,
+            1,
+        )
+        .unwrap();
+        assert!(
+            p.sql.contains("a.name = ? COLLATE NOCASE"),
+            "sql was {}",
+            p.sql
+        );
+        assert_eq!(p.binds, vec![Bind::Text("Ursula K. Le Guin".into())]);
+    }
+
+    #[test]
+    fn series_is_not_negates_the_exists() {
+        let p = membership_predicate(
+            &[rule(RuleField::Series, RuleOp::IsNot, "Foundation")],
+            MatchMode::Any,
+            1,
+        )
+        .unwrap();
+        assert!(p.sql.starts_with("(NOT EXISTS"), "sql was {}", p.sql);
+        assert!(p.sql.contains("s.name = ? COLLATE NOCASE"));
+    }
+
+    #[test]
+    fn contains_and_starts_with_build_like_patterns() {
+        let c = membership_predicate(
+            &[rule(RuleField::Tag, RuleOp::Contains, "sci")],
+            MatchMode::Any,
+            1,
+        )
+        .unwrap();
+        assert!(
+            c.sql.contains("t.name LIKE ? ESCAPE '\\'"),
+            "sql was {}",
+            c.sql
+        );
+        assert_eq!(c.binds, vec![Bind::Text("%sci%".into())]);
+
+        let s = membership_predicate(
+            &[rule(RuleField::Author, RuleOp::StartsWith, "Le")],
+            MatchMode::Any,
+            1,
+        )
+        .unwrap();
+        assert!(s.sql.contains("a.name LIKE ? ESCAPE '\\'"));
+        assert_eq!(s.binds, vec![Bind::Text("Le%".into())]);
+    }
+
+    #[test]
+    fn like_escape_neutralizes_wildcards() {
+        // A user searching for a literal `%` or `_` must not get wildcard
+        // behavior; the escaped pattern is wrapped for `contains`.
+        assert_eq!(like_escape("100%_off\\x"), "100\\%\\_off\\\\x");
+        let p = membership_predicate(
+            &[rule(RuleField::Tag, RuleOp::Contains, "50%")],
+            MatchMode::Any,
+            1,
+        )
+        .unwrap();
+        assert_eq!(p.binds, vec![Bind::Text("%50\\%%".into())]);
     }
 }

--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -85,6 +85,50 @@ async fn create_smart_shelf_membership_matches_tag_rule() {
 }
 
 #[tokio::test]
+async fn smart_shelf_matches_author_by_name_case_insensitively() {
+    let (pool, _covers) = seed_discovery_fixture().await;
+    let owner = make_user(&pool, "owner", false).await;
+
+    // "Ada Lovelace" authored 3 of the 4 fixture books. A lowercase value must
+    // still match — regression: `author is` used to demand a numeric id, so a
+    // typed name (any case) matched nothing.
+    let rule = ShelfRule {
+        field: RuleField::Author,
+        op: RuleOp::Is,
+        value: "ada lovelace".into(),
+    };
+    let shelf = create_shelf(
+        &pool,
+        owner,
+        &smart_req("By Ada", MatchMode::Any, vec![rule]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(shelf.book_count, 3);
+}
+
+#[tokio::test]
+async fn smart_shelf_matches_series_starts_with() {
+    let (pool, _covers) = seed_discovery_fixture().await;
+    let owner = make_user(&pool, "owner", false).await;
+
+    // Series "Saga" holds two books; a `starts with` prefix matches both.
+    let rule = ShelfRule {
+        field: RuleField::Series,
+        op: RuleOp::StartsWith,
+        value: "Sag".into(),
+    };
+    let shelf = create_shelf(
+        &pool,
+        owner,
+        &smart_req("Saga-ish", MatchMode::Any, vec![rule]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(shelf.book_count, 2);
+}
+
+#[tokio::test]
 async fn smart_shelf_updates_when_a_qualifying_book_appears() {
     let (pool, _covers) = seed_discovery_fixture().await;
     let owner = make_user(&pool, "owner", false).await;

--- a/frontend/src/components/create_shelf_modal.rs
+++ b/frontend/src/components/create_shelf_modal.rs
@@ -30,6 +30,8 @@ const FIELDS: &[(RuleField, &str)] = &[
 const OPS: &[(RuleOp, &str)] = &[
     (RuleOp::Is, "is"),
     (RuleOp::IsNot, "is not"),
+    (RuleOp::Contains, "contains"),
+    (RuleOp::StartsWith, "starts with"),
     (RuleOp::Gte, "is at least"),
     (RuleOp::Includes, "includes"),
     (RuleOp::InLast, "in the last"),
@@ -538,12 +540,13 @@ fn condition_value_input(
         };
     }
 
-    // Rating / Year are numeric; the rest are free text (author/series accept
-    // a numeric id in v1).
+    // Rating / Year are numeric; the rest are free text matched by name
+    // (case-insensitive), so author/series take the name the user sees.
     let (input_type, placeholder) = match draft.field {
         RuleField::Rating => ("number", "4"),
         RuleField::Year => ("number", "2024"),
-        RuleField::Author | RuleField::Series => ("number", "id"),
+        RuleField::Author => ("text", "author name"),
+        RuleField::Series => ("text", "series name"),
         _ => ("text", "value"),
     };
     let step = if matches!(draft.field, RuleField::Rating) {

--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -527,6 +527,8 @@ fn op_label(op: RuleOp) -> &'static str {
     match op {
         RuleOp::Is => "is",
         RuleOp::IsNot => "is not",
+        RuleOp::Contains => "contains",
+        RuleOp::StartsWith => "starts with",
         RuleOp::Gte => "is at least",
         RuleOp::Includes => "includes",
         RuleOp::InLast => "in the last",

--- a/shared/src/shelves.rs
+++ b/shared/src/shelves.rs
@@ -61,6 +61,10 @@ pub enum RuleField {
 pub enum RuleOp {
     Is,
     IsNot,
+    /// case-insensitive substring match — text fields.
+    Contains,
+    /// case-insensitive prefix match — text fields.
+    StartsWith,
     /// "is at least" (≥) — rating / year.
     Gte,
     /// membership test — format.
@@ -110,6 +114,8 @@ wire_enum!(
     RuleOp,
     RuleOp::Is => "is",
     RuleOp::IsNot => "is_not",
+    RuleOp::Contains => "contains",
+    RuleOp::StartsWith => "starts_with",
     RuleOp::Gte => "gte",
     RuleOp::Includes => "includes",
     RuleOp::InLast => "in_last",
@@ -124,11 +130,10 @@ impl RuleField {
         use RuleField::*;
         use RuleOp::*;
         let ok: &[RuleOp] = match self {
-            Tag => &[Is, IsNot],
-            Author | Series => &[Is],
+            Tag | Author | Series => &[Is, IsNot, Contains, StartsWith],
             Rating => &[Is, Gte],
             Status => &[Is],
-            Format => &[Includes],
+            Format => &[Includes, Contains, StartsWith],
             Year => &[Is, Gte],
             DateAdded | DateUpdated => &[InLast, Between, Before, After],
         };
@@ -146,9 +151,11 @@ impl RuleField {
     }
 }
 
-/// One smart-shelf condition. `value` interpretation is per-field (see the
-/// migration comment): author/series → id; tag/status/format → string;
-/// year/rating → int; date fields → ISO date, `START..END`, or `30d`/`3m`/`1y`.
+/// One smart-shelf condition. `value` interpretation is per-field:
+/// tag/author/series/status/format → name (case-insensitive); year/rating → int;
+/// date fields → ISO date, `START..END`, or `30d`/`3m`/`1y`. (Migration `0034`'s
+/// comment predates the author/series id→name switch and is frozen once applied;
+/// this doc is the source of truth.)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShelfRule {
     pub field: RuleField,

--- a/shared/src/shelves.rs
+++ b/shared/src/shelves.rs
@@ -152,10 +152,11 @@ impl RuleField {
 }
 
 /// One smart-shelf condition. `value` interpretation is per-field:
-/// tag/author/series/status/format → name (case-insensitive); year/rating → int;
-/// date fields → ISO date, `START..END`, or `30d`/`3m`/`1y`. (Migration `0034`'s
-/// comment predates the author/series id→name switch and is frozen once applied;
-/// this doc is the source of truth.)
+/// tag/author/series/format → name (case-insensitive); year/rating → int;
+/// date fields → ISO date, `START..END`, or `30d`/`3m`/`1y`. (`status` is
+/// reserved but not yet supported — the rule engine rejects it.) Migration
+/// `0034`'s comment predates the author/series id→name switch and is frozen once
+/// applied; this doc is the source of truth.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShelfRule {
     pub field: RuleField,

--- a/shared/src/shelves/tests.rs
+++ b/shared/src/shelves/tests.rs
@@ -18,6 +18,8 @@ fn wire_tokens_round_trip_for_every_enum() {
     for op in [
         RuleOp::Is,
         RuleOp::IsNot,
+        RuleOp::Contains,
+        RuleOp::StartsWith,
         RuleOp::Gte,
         RuleOp::Includes,
         RuleOp::InLast,
@@ -38,7 +40,12 @@ fn accepts_gates_ops_per_field() {
     assert!(RuleField::Tag.accepts(RuleOp::IsNot));
     assert!(!RuleField::Tag.accepts(RuleOp::Gte));
     assert!(RuleField::Format.accepts(RuleOp::Includes));
-    assert!(!RuleField::Author.accepts(RuleOp::IsNot));
+    // Author/series are name-based text fields: they take the same text ops as
+    // tag (is / is not / contains / starts with) but not the numeric ones.
+    assert!(RuleField::Author.accepts(RuleOp::IsNot));
+    assert!(RuleField::Author.accepts(RuleOp::Contains));
+    assert!(RuleField::Series.accepts(RuleOp::StartsWith));
+    assert!(!RuleField::Author.accepts(RuleOp::Gte));
     assert!(RuleField::DateAdded.accepts(RuleOp::Between));
     assert!(!RuleField::DateAdded.accepts(RuleOp::Is));
 }
@@ -47,7 +54,7 @@ fn accepts_gates_ops_per_field() {
 fn rule_validate_rejects_bad_op_and_empty_value() {
     let bad_op = ShelfRule {
         field: RuleField::Author,
-        op: RuleOp::IsNot,
+        op: RuleOp::Gte,
         value: "5".into(),
     };
     assert!(bad_op.validate().is_err());


### PR DESCRIPTION
## Summary
- Smart-shelf **Author/Series** conditions matched a numeric taxonomy id, so a typed name never matched. They now resolve against `authors.name` / `series.name` with `COLLATE NOCASE`, and the modal inputs became name text fields.
- Added **`contains`** and **`starts with`** operators (escaped `LIKE`) for the text fields (tag / author / series / format).
- Every text comparison is now **case-insensitive** (`MP3` == `mp3`) — equality via `COLLATE NOCASE`, substring/prefix via `LIKE`.

## Test plan
- [x] `just check` — fmt + clippy across all crates (incl. mobile + frontend `--features server`) + full test matrix, green
- [x] db shelf tests (28) incl. new: author-by-name case-insensitive → 3 books, series `starts with` → 2 books, `LIKE` escaping of `%`/`_`, `is not` negation
- [x] shared shelf tests (6): new op wire-token round-trip + `accepts()` gating
- [x] UI: create a smart shelf with `Author is <name>` / `Tag contains <x>` and confirm live preview counts

## Notes
- Migration `0034_shelves.sql` is already applied, so its `author/series → id` value-interpretation comment is left **frozen** (rule 06 — never edit an applied migration); the `ShelfRule` doc in `shared/src/shelves.rs` is now the source of truth.
- Behavior change: any pre-existing smart shelf that stored a numeric author/series id will stop matching and needs recreating with the name. The modal only ever offered a number input for these, so this is the intended correction.