### PR TITLE
docs: prompt for a version bump label in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,11 +5,11 @@
 - [ ] 
 
 ## Version
-Every merge to `main` cuts a release. Pick the version update this PR should
-trigger and apply the matching label:
+By default a merge to `main` cuts a patch release. Pick the version update this
+PR should trigger; labels override the default:
 - [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
-- [ ] **Patch** — add the `patch version` label, or leave unlabeled to default
-  to a patch bump (`vX.Y.Z` → `vX.Y.(Z+1)`).
+- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
+  (`vX.Y.Z` → `vX.Y.(Z+1)`).
 - [ ] **No release** — add the `no release` label to skip cutting a release.
 
 If both `minor version` and `patch version` are applied, `minor version` wins.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,13 +4,20 @@
 ## Test plan
 - [ ] 
 
+## Version
+Every merge to `main` cuts a release. Pick the version update this PR should
+trigger and apply the matching label:
+- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
+- [ ] **Patch** — add the `patch version` label, or leave unlabeled to default
+  to a patch bump (`vX.Y.Z` → `vX.Y.(Z+1)`).
+- [ ] **No release** — add the `no release` label to skip cutting a release.
+
+If both `minor version` and `patch version` are applied, `minor version` wins.
+Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
+release automatically.
+
 ## Notes
 - 
-- Every merge to `main` cuts a release. By default it's a patch bump
-  (`vX.Y.Z` → `vX.Y.(Z+1)`); add the `minor version` label for a minor bump
-  (`vX.Y.Z` → `vX.(Y+1).0`). If both labels are applied, `minor version` wins.
-- To skip the release, add the `no release` label. Unlabeled PRs that only
-  touch docs (`*.md`, `docs/`) or CI (`.github/`) skip automatically.
 
 <!--
 Use the following for callouts:


### PR DESCRIPTION
Add a Version section that asks the author to pick minor / patch / no
release and apply the matching label, mirroring the labels release.yml
reads. Keeps minor-wins and docs/CI auto-skip guidance.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014K7Qy3EK2SSUmoJw7WeG4q