### PR TITLE
feat: unify machine timestamps on INTEGER unix-seconds (F11)

### DIFF
--- a/.claude/rules/06-migrations.md
+++ b/.claude/rules/06-migrations.md
@@ -13,7 +13,7 @@ works in production.
 
 1. **Name it `NNNN_short_description.sql`.** Take the next zero-padded
    number after the highest existing file (latest is
-   `0018_multiformat_book_files.sql`). The number is the version
+   `0038_unify_timestamps_to_unix_seconds.sql`). The number is the version
    `_sqlx_migrations` records; renumbering or renaming an applied file
    breaks the applied-version bookkeeping.
 2. **Never edit an applied migration.** Once a file has run anywhere

--- a/db/migrations/0038_unify_timestamps_to_unix_seconds.sql
+++ b/db/migrations/0038_unify_timestamps_to_unix_seconds.sql
@@ -1,0 +1,114 @@
+-- F11 — unify machine timestamps on INTEGER unix-seconds.
+--
+-- Five tables still stored a "machine" timestamp as TEXT (`datetime('now')`)
+-- or DATETIME (`CURRENT_TIMESTAMP`) while every table since the auth migration
+-- uses INTEGER `strftime('%s','now')`. The divergence blocks a uniform
+-- `GROUP BY date(col,'unixepoch')` across books and the session/stats tables
+-- (F3.4) and forces per-call string parsing (`covers::get_last_modified_epoch`).
+-- This converts all five to INTEGER unix-seconds; the in-DDL
+-- `CAST(strftime('%s', col) AS INTEGER)` is the backfill (every prior writer
+-- used `datetime('now')`/`CURRENT_TIMESTAMP`, both 'YYYY-MM-DD HH:MM:SS' UTC
+-- that `strftime('%s', …)` parses exactly). Forward-only per rule 06.
+--
+-- `books.pubdate` is a genuinely partial *human* date and stays TEXT.
+--
+-- foreign_keys is ON (init_db sets it) and this runs inside the migrator's
+-- implicit transaction, where `PRAGMA foreign_keys` is a no-op. A table
+-- *recreate* of `books` would therefore fire ON DELETE CASCADE during the
+-- implicit DROP-TABLE delete and wipe every child row (book_files, link
+-- tables, book_identifiers, merge_log). So `books` is converted **in place**
+-- via ADD/UPDATE/DROP/RENAME — no row delete, no cascade. The trade-off is
+-- that `books.timestamp`/`last_modified` lose their column DEFAULT (SQLite
+-- rejects a non-constant `ADD COLUMN` default on a populated table), so the
+-- two book writers now set `strftime('%s','now')` explicitly. The four other
+-- tables are child/standalone (nothing FK-references them), so they recreate
+-- cleanly and keep the ideal `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`.
+
+-- books.timestamp + last_modified: TEXT -> INTEGER, in place.
+-- DROP COLUMN refuses an indexed column, so drop the four dependent indexes
+-- first and recreate them against the converted columns afterward.
+DROP INDEX idx_books_timestamp;
+DROP INDEX idx_books_last_modified;
+DROP INDEX idx_books_library_timestamp;
+DROP INDEX idx_books_library_last_modified;
+
+ALTER TABLE books ADD COLUMN timestamp_epoch     INTEGER;
+ALTER TABLE books ADD COLUMN last_modified_epoch INTEGER;
+UPDATE books SET
+    timestamp_epoch     = CAST(strftime('%s', timestamp)     AS INTEGER),
+    last_modified_epoch = CAST(strftime('%s', last_modified) AS INTEGER);
+ALTER TABLE books DROP COLUMN timestamp;
+ALTER TABLE books DROP COLUMN last_modified;
+ALTER TABLE books RENAME COLUMN timestamp_epoch     TO timestamp;
+ALTER TABLE books RENAME COLUMN last_modified_epoch TO last_modified;
+
+CREATE INDEX idx_books_last_modified ON books(last_modified);
+CREATE INDEX idx_books_timestamp     ON books(timestamp);
+CREATE INDEX idx_books_library_last_modified ON books (library_id, last_modified, id);
+CREATE INDEX idx_books_library_timestamp     ON books (library_id, timestamp, id);
+
+-- metadata_overrides.updated_at: TEXT -> INTEGER (recreate; nothing FK-refs it).
+CREATE TABLE metadata_overrides_new (
+    book_uuid          TEXT    NOT NULL PRIMARY KEY,
+    overrides          TEXT    NOT NULL DEFAULT '{}',
+    has_cover_override INTEGER NOT NULL DEFAULT 0,
+    updated_by         INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    updated_at         INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+INSERT INTO metadata_overrides_new
+    SELECT book_uuid, overrides, has_cover_override, updated_by,
+           CAST(strftime('%s', updated_at) AS INTEGER)
+      FROM metadata_overrides;
+DROP TABLE metadata_overrides;
+ALTER TABLE metadata_overrides_new RENAME TO metadata_overrides;
+CREATE INDEX idx_metadata_overrides_updated ON metadata_overrides(updated_at);
+
+-- author_photos.fetched_at: TEXT -> INTEGER (recreate; preserve both CHECKs).
+CREATE TABLE author_photos_new (
+    author_id   INTEGER PRIMARY KEY REFERENCES authors(id) ON DELETE CASCADE,
+    source      TEXT NOT NULL CHECK (source IN ('manual', 'openlibrary', 'letter')),
+    url         TEXT,
+    bytes       BLOB,
+    mime        TEXT,
+    fetched_at  INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+    CHECK (
+        (source =  'letter' AND bytes IS NULL     AND mime IS NULL)
+     OR (source <> 'letter' AND bytes IS NOT NULL AND mime IS NOT NULL)
+    )
+);
+INSERT INTO author_photos_new
+    SELECT author_id, source, url, bytes, mime,
+           CAST(strftime('%s', fetched_at) AS INTEGER)
+      FROM author_photos;
+DROP TABLE author_photos;
+ALTER TABLE author_photos_new RENAME TO author_photos;
+
+-- merge_log.merged_at + undone_at: TEXT -> INTEGER (recreate; child of books).
+CREATE TABLE merge_log_new (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    target_book_id  INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    source_uuid     TEXT    NOT NULL,
+    source_metadata TEXT    NOT NULL,
+    merged_by       INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    merged_at       INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+    undone_at       INTEGER
+);
+INSERT INTO merge_log_new
+    SELECT id, target_book_id, source_uuid, source_metadata, merged_by,
+           CAST(strftime('%s', merged_at) AS INTEGER),
+           CASE WHEN undone_at IS NULL THEN NULL
+                ELSE CAST(strftime('%s', undone_at) AS INTEGER) END
+      FROM merge_log;
+DROP TABLE merge_log;
+ALTER TABLE merge_log_new RENAME TO merge_log;
+CREATE INDEX idx_merge_log_target ON merge_log(target_book_id);
+
+-- ignored_authors.ignored_at: DATETIME/CURRENT_TIMESTAMP -> INTEGER (recreate).
+CREATE TABLE ignored_authors_new (
+    name       TEXT    NOT NULL PRIMARY KEY COLLATE NOCASE,
+    ignored_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+INSERT INTO ignored_authors_new
+    SELECT name, CAST(strftime('%s', ignored_at) AS INTEGER) FROM ignored_authors;
+DROP TABLE ignored_authors;
+ALTER TABLE ignored_authors_new RENAME TO ignored_authors;

--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -75,15 +75,15 @@ pub async fn get_author_photo(
     }
 }
 
-/// Look up just the cascade-state metadata (source + fetched_at) for an
-/// author. Used by the resolver to decide whether to skip resolution — a
+/// Look up just the cascade-state metadata (source + `fetched_at` unix-seconds)
+/// for an author. Used by the resolver to decide whether to skip resolution — a
 /// `'letter'` row prevents re-querying Open Library until an admin clears it
 /// via `delete_author_photo`.
 pub async fn author_photo_status(
     pool: &SqlitePool,
     author_id: i64,
-) -> Result<Option<(AuthorPhotoSource, String)>, AuthorPhotosDataError> {
-    let row: Option<(String, String)> =
+) -> Result<Option<(AuthorPhotoSource, i64)>, AuthorPhotosDataError> {
+    let row: Option<(String, i64)> =
         sqlx::query_as("SELECT source, fetched_at FROM author_photos WHERE author_id = ?")
             .bind(author_id)
             .fetch_optional(pool)
@@ -104,7 +104,7 @@ pub async fn upsert_author_photo(
 ) -> Result<(), AuthorPhotosDataError> {
     sqlx::query(
         "INSERT INTO author_photos (author_id, source, url, mime, bytes, fetched_at)
-              VALUES (?, ?, ?, ?, ?, datetime('now'))
+              VALUES (?, ?, ?, ?, ?, strftime('%s','now'))
          ON CONFLICT(author_id) DO UPDATE SET
               source     = excluded.source,
               url        = excluded.url,

--- a/db/src/books/page.rs
+++ b/db/src/books/page.rs
@@ -210,14 +210,27 @@ fn build_page_sql(
 }
 
 /// The `(primary, secondary)` `books` sort columns for each axis. `primary`
-/// is always a `TEXT` column; `secondary` (the in-series index) is `Some`
-/// only for [`SortKey::Series`].
+/// always yields `TEXT`; `secondary` (the in-series index) is `Some` only for
+/// [`SortKey::Series`].
+///
+/// The two time axes read INTEGER unix-seconds (migration 0038) but format
+/// them to fixed-width ISO here, for the same reason the projection does: the
+/// cursor round-trips the primary value as `Option<String>` and compares it
+/// lexicographically, which stays chronologically correct on ISO text. (The
+/// trade-off is that ordering by the expression can't use the raw-column
+/// keyset index — acceptable at a self-hosted library's scale.)
 fn axis_sort_columns(sort: SortKey) -> (&'static str, Option<&'static str>) {
     match sort {
         SortKey::Title => ("b.sort", None),
         SortKey::Author => ("b.author_sort", None),
-        SortKey::LastUpdated => ("b.last_modified", None),
-        SortKey::NewestAdded => ("b.timestamp", None),
+        SortKey::LastUpdated => (
+            "strftime('%Y-%m-%dT%H:%M:%SZ', b.last_modified, 'unixepoch')",
+            None,
+        ),
+        SortKey::NewestAdded => (
+            "strftime('%Y-%m-%dT%H:%M:%SZ', b.timestamp, 'unixepoch')",
+            None,
+        ),
         SortKey::Series => ("b.series_sort", Some("b.series_index")),
     }
 }

--- a/db/src/books/page/tests.rs
+++ b/db/src/books/page/tests.rs
@@ -167,6 +167,65 @@ async fn list_books_page_handles_null_sort_rows_at_first_page_boundary() {
 }
 
 #[tokio::test]
+async fn newest_added_orders_by_epoch_and_paginates_via_cursor() {
+    // `books.timestamp` is INTEGER unix-seconds (migration 0038); the axis
+    // formats it to fixed-width ISO so the keyset cursor round-trips it as text
+    // and still sorts chronologically. Distinct epochs + one-at-a-time paging
+    // exercise both the ordering and the cursor across page boundaries.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = insert_lib(&pool, "/lib").await;
+    let a = insert_book(&pool, lib, "A", Some("A"), None, None).await;
+    let b = insert_book(&pool, lib, "B", Some("B"), None, None).await;
+    let c = insert_book(&pool, lib, "C", Some("C"), None, None).await;
+    for (id, day) in [(a, "2020-01-01"), (b, "2022-06-15"), (c, "2024-12-31")] {
+        sqlx::query("UPDATE books SET timestamp = strftime('%s', ? || ' 00:00:00') WHERE id = ?")
+            .bind(day)
+            .bind(id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+    let f = ViewFilters::default();
+
+    // Newest first: c, b, a.
+    let page = list_books_page(
+        &pool,
+        &["/lib"],
+        SortKey::NewestAdded,
+        SortDir::Desc,
+        &f,
+        None,
+        50,
+    )
+    .await
+    .unwrap();
+    assert_eq!(ids(&page), vec![c, b, a]);
+
+    // Paging one at a time reproduces the same order with no gaps/dupes.
+    let mut seen = Vec::new();
+    let mut cursor: Option<PageCursor> = None;
+    loop {
+        let p = list_books_page(
+            &pool,
+            &["/lib"],
+            SortKey::NewestAdded,
+            SortDir::Desc,
+            &f,
+            cursor.as_ref(),
+            1,
+        )
+        .await
+        .unwrap();
+        seen.extend(ids(&p));
+        match p.next {
+            Some(n) => cursor = Some(n),
+            None => break,
+        }
+    }
+    assert_eq!(seen, vec![c, b, a]);
+}
+
+#[tokio::test]
 async fn list_books_page_breaks_sort_ties_by_id_deterministically() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let lib = insert_lib(&pool, "/lib").await;

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -37,7 +37,14 @@ pub const MAX_BOOKS_RETURNED: i64 = 50_000;
 pub(crate) const BOOK_COLUMNS: &str = r"
     b.id, b.uuid,
     b.title, b.description, b.series_index, b.has_cover,
-    b.pubdate, b.last_modified, b.timestamp, b.accent_color,
+    b.pubdate,
+    -- `last_modified`/`timestamp` are INTEGER unix-seconds (migration 0038);
+    -- format back to fixed-width ISO so the wire `EbookMetadata.modified` /
+    -- `added_at` stay `Option<String>` and the landing lexicographic sort
+    -- keeps working (ISO sorts identically to chronological).
+    strftime('%Y-%m-%dT%H:%M:%SZ', b.last_modified, 'unixepoch') AS last_modified,
+    strftime('%Y-%m-%dT%H:%M:%SZ', b.timestamp,     'unixepoch') AS timestamp,
+    b.accent_color,
 
     (SELECT json_object('filename', bf.filename, 'format', bf.format)
        FROM book_files bf

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -22,6 +22,39 @@ use omnibus_shared::{Contributor, EbookMetadata, Identifier, MetadataOverrides};
 // companion count helper so callers can detect truncation.
 
 #[tokio::test]
+async fn get_book_formats_machine_timestamps_as_fixed_width_iso() {
+    // Migration 0038 stores `timestamp`/`last_modified` as INTEGER epochs; the
+    // projection formats them back to fixed-width ISO so the wire
+    // `added_at`/`modified` stay `Option<String>` and sort lexicographically.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, timestamp, last_modified) \
+         VALUES ('bk', 'b', 1, '/lib/bk', 'Book', \
+                 strftime('%s','2024-01-02 03:04:05'), strftime('%s','2020-06-15 12:00:00')) \
+         RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch) \
+         VALUES (?, 'EPUB', 'b', 1, 1)",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(book.added_at.as_deref(), Some("2024-01-02T03:04:05Z"));
+    assert_eq!(book.modified.as_deref(), Some("2020-06-15T12:00:00Z"));
+}
+
+#[tokio::test]
 async fn library_from_db_returns_empty_for_none_path() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let lib = library_from_db(&pool, None).await.unwrap();

--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -236,18 +236,18 @@ pub async fn get_cover(
     Ok(result)
 }
 
-/// Return `strftime('%s', last_modified)` as epoch seconds for `book_id`,
-/// or `None` if the book does not exist.
+/// Return `books.last_modified` (INTEGER unix-seconds since migration 0038) for
+/// `book_id`, or `None` if the book does not exist.
 pub async fn get_last_modified_epoch(
     pool: &SqlitePool,
     book_id: i64,
 ) -> Result<Option<i64>, CoversError> {
-    Ok(sqlx::query_scalar(
-        "SELECT CAST(strftime('%s', last_modified) AS INTEGER) FROM books WHERE id = ?",
+    Ok(
+        sqlx::query_scalar("SELECT last_modified FROM books WHERE id = ?")
+            .bind(book_id)
+            .fetch_optional(pool)
+            .await?,
     )
-    .bind(book_id)
-    .fetch_optional(pool)
-    .await?)
 }
 
 #[cfg(test)]

--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -237,17 +237,22 @@ pub async fn get_cover(
 }
 
 /// Return `books.last_modified` (INTEGER unix-seconds since migration 0038) for
-/// `book_id`, or `None` if the book does not exist.
+/// `book_id`, or `None` if the book does not exist. `last_modified` is nullable
+/// after the in-place 0038 conversion, so a row that somehow lacks one falls
+/// back to now — a bare `i64` decode of a NULL would error and 500 the thumbs
+/// endpoint; falling back keeps it serving and regenerates the stale thumbnail.
 pub async fn get_last_modified_epoch(
     pool: &SqlitePool,
     book_id: i64,
 ) -> Result<Option<i64>, CoversError> {
-    Ok(
-        sqlx::query_scalar("SELECT last_modified FROM books WHERE id = ?")
-            .bind(book_id)
-            .fetch_optional(pool)
-            .await?,
+    // `strftime` returns TEXT and a SELECT has no column affinity to coerce it,
+    // so CAST the fallback back to INTEGER for the `i64` decode.
+    Ok(sqlx::query_scalar(
+        "SELECT CAST(COALESCE(last_modified, strftime('%s','now')) AS INTEGER) FROM books WHERE id = ?",
     )
+    .bind(book_id)
+    .fetch_optional(pool)
+    .await?)
 }
 
 #[cfg(test)]

--- a/db/src/covers/tests.rs
+++ b/db/src/covers/tests.rs
@@ -7,6 +7,29 @@ use crate::test_support::{indexed, CoversTempDir};
 use omnibus_shared::MetadataOverrides;
 
 #[tokio::test]
+async fn get_last_modified_epoch_falls_back_to_now_when_column_null() {
+    // `books.last_modified` is nullable after 0038's in-place conversion; a bare
+    // `i64` decode of a NULL would error and 500 `/api/thumbs/*`. The COALESCE
+    // keeps it serving (and regenerates the stale thumb).
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, last_modified) \
+         VALUES ('bk', 'b', 1, '/lib/bk', 'Book', NULL) RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let got = get_last_modified_epoch(&pool, id).await.unwrap();
+    assert!(matches!(got, Some(e) if e > 1_700_000_000), "got {got:?}");
+    // A missing book still yields None rather than a fabricated epoch.
+    assert_eq!(get_last_modified_epoch(&pool, 99_999).await.unwrap(), None);
+}
+
+#[tokio::test]
 async fn cover_returns_none_when_file_missing() {
     let _covers = CoversTempDir::new("missing");
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/merge/snapshot.rs
+++ b/db/src/merge/snapshot.rs
@@ -1,8 +1,31 @@
 //! The JSON snapshot of a merge's source book, stored in
 //! `merge_log.source_metadata` and replayed by `undo_merge`.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use sqlx::Transaction;
+
+/// Deserialize `timestamp` from either the current INTEGER unix-seconds or the
+/// TEXT form persisted by pre-0038 snapshots. A numeric string parses to its
+/// epoch; a non-numeric ISO string (`'YYYY-MM-DD HH:MM:SS'`) can't be converted
+/// without a date library, so it degrades to `None` — `recreate_source_row`
+/// then falls back to now, an acceptable loss for a book merged before the
+/// migration and undone after it.
+fn de_epoch_flexible<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Flexible {
+        Int(i64),
+        Text(String),
+    }
+    Ok(match Option::<Flexible>::deserialize(deserializer)? {
+        Some(Flexible::Int(n)) => Some(n),
+        Some(Flexible::Text(s)) => s.trim().parse::<i64>().ok(),
+        None => None,
+    })
+}
 
 /// Everything needed to recreate the absorbed `books` row and its
 /// satellite rows on undo. Link rows are stored **by name** — the
@@ -20,7 +43,11 @@ pub(super) struct SourceSnapshot {
     pub series_sort: Option<String>,
     pub series_index: Option<f64>,
     pub pubdate: Option<String>,
-    pub timestamp: Option<String>,
+    /// `books.timestamp` (INTEGER unix-seconds since migration 0038). A
+    /// custom deserializer also accepts the string form that pre-0038
+    /// snapshots persisted, so old `merge_log` JSON still replays.
+    #[serde(default, deserialize_with = "de_epoch_flexible")]
+    pub timestamp: Option<i64>,
     pub has_cover: i64,
     pub description: Option<String>,
     pub accent_color: Option<String>,
@@ -67,7 +94,7 @@ struct BookSnapshot {
     series_sort: Option<String>,
     series_index: Option<f64>,
     pubdate: Option<String>,
-    timestamp: Option<String>,
+    timestamp: Option<i64>,
     has_cover: i64,
     description: Option<String>,
     accent_color: Option<String>,
@@ -183,4 +210,30 @@ pub(super) async fn build_snapshot(
         identifiers,
         merged_uuid_rows,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct Wrap {
+        #[serde(default, deserialize_with = "de_epoch_flexible")]
+        timestamp: Option<i64>,
+    }
+
+    #[test]
+    fn de_epoch_flexible_accepts_int_numeric_string_and_degrades_iso() {
+        let ts = |json: &str| serde_json::from_str::<Wrap>(json).unwrap().timestamp;
+        // Current form: a JSON integer.
+        assert_eq!(ts(r#"{"timestamp":1704164645}"#), Some(1_704_164_645));
+        // Legacy numeric string (some serializers emitted epochs as strings).
+        assert_eq!(ts(r#"{"timestamp":"1704164645"}"#), Some(1_704_164_645));
+        // Legacy ISO string can't convert without a date lib -> None (undo
+        // then falls back to now).
+        assert_eq!(ts(r#"{"timestamp":"2024-01-02 03:04:05"}"#), None);
+        // Null / missing -> None.
+        assert_eq!(ts(r#"{"timestamp":null}"#), None);
+        assert_eq!(ts(r#"{}"#), None);
+    }
 }

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -370,6 +370,44 @@ async fn undo_merge_restores_source_book_and_moves_file_back() {
 }
 
 #[tokio::test]
+async fn undo_merge_stamps_now_when_snapshot_timestamp_is_unparseable() {
+    // A pre-0038 merge snapshot stored `timestamp` as an ISO string, which
+    // `de_epoch_flexible` can't convert to an epoch (-> None). The recreate must
+    // fall back to now rather than leaving the restored row's date-added NULL.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let target = seed_ebook(&pool, "A/Dracula.epub", "Dracula", "Bram Stoker").await;
+    let source = seed_audiobook(&pool, "B/Drakula.m4b", "Drakula", "Bram Stoker").await;
+    let out = merge_books(&pool, &source, &target, None).await.unwrap();
+
+    // Rewrite the persisted snapshot to the legacy string form.
+    let json: String = sqlx::query_scalar("SELECT source_metadata FROM merge_log WHERE id = ?")
+        .bind(out.merge_log_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let mut snap: serde_json::Value = serde_json::from_str(&json).unwrap();
+    snap["timestamp"] = serde_json::json!("2024-01-02 03:04:05");
+    sqlx::query("UPDATE merge_log SET source_metadata = ? WHERE id = ?")
+        .bind(snap.to_string())
+        .bind(out.merge_log_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    undo_merge(&pool, out.merge_log_id).await.unwrap();
+
+    let ts: Option<i64> = sqlx::query_scalar("SELECT timestamp FROM books WHERE uuid = ?")
+        .bind(&source)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(
+        matches!(ts, Some(e) if e > 1_700_000_000),
+        "restored timestamp should fall back to now, got {ts:?}"
+    );
+}
+
+#[tokio::test]
 async fn undo_merge_with_deleted_file_restores_fileless_book() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let target = seed_ebook(&pool, "A/Dracula.epub", "Dracula", "Bram Stoker").await;

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -361,7 +361,7 @@ async fn undo_merge_restores_source_book_and_moves_file_back() {
     );
     // Guard cleared; log marked undone; FTS has both rows again.
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM merged_uuids").await, 0);
-    let undone: Option<String> = sqlx::query_scalar("SELECT undone_at FROM merge_log")
+    let undone: Option<i64> = sqlx::query_scalar("SELECT undone_at FROM merge_log")
         .fetch_one(&pool)
         .await
         .unwrap();

--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -505,12 +505,12 @@ async fn merge_overrides(
     sqlx::query(
         "INSERT INTO metadata_overrides
             (book_uuid, overrides, has_cover_override, updated_by, updated_at)
-         VALUES (?, ?, ?, ?, datetime('now'))
+         VALUES (?, ?, ?, ?, strftime('%s','now'))
          ON CONFLICT(book_uuid) DO UPDATE SET
            overrides = excluded.overrides,
            has_cover_override = excluded.has_cover_override,
            updated_by = excluded.updated_by,
-           updated_at = datetime('now')",
+           updated_at = strftime('%s','now')",
     )
     .bind(target_uuid)
     .bind(serde_json::to_string(&merged)?)

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -123,16 +123,18 @@ async fn recreate_source_row(
                 sqlx::Error::Protocol(format!("unexpected settings validation error: {msg}")),
             ),
         })?;
-    // `timestamp` is restored from the snapshot (epoch, migration 0038);
-    // `last_modified` is stamped now, set explicitly because the in-place
-    // 0038 conversion dropped the `books` column default. The `pubdate`
-    // COALESCE fallback is pre-existing and unrelated to F11.
+    // `timestamp` is restored from the snapshot, falling back to now when a
+    // pre-0038 snapshot's timestamp couldn't be parsed to an epoch
+    // (`de_epoch_flexible` -> None) — the `books` column is nullable since the
+    // in-place 0038 conversion dropped its default, so without the COALESCE the
+    // restored row would carry a NULL date-added. `last_modified` is stamped
+    // now for the same reason. The `pubdate` COALESCE is pre-existing.
     let id: i64 = sqlx::query_scalar(
         "INSERT INTO books
             (uuid, library_id, path, title, sort, author_sort, series_sort, series_index, pubdate,
              timestamp, last_modified, has_cover, description, accent_color, title_norm, author_norm)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')),
-                 ?, strftime('%s','now'), ?, ?, ?, ?, ?)
+                 COALESCE(?, strftime('%s','now')), strftime('%s','now'), ?, ?, ?, ?, ?)
          RETURNING id",
     )
     .bind(&snap.uuid)

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -26,7 +26,7 @@ use super::MergeError;
 pub async fn undo_merge(pool: &SqlitePool, merge_log_id: i64) -> Result<String, MergeError> {
     let mut tx = pool.begin().await?;
 
-    let row: Option<(i64, String, String, Option<String>)> = sqlx::query_as(
+    let row: Option<(i64, String, String, Option<i64>)> = sqlx::query_as(
         "SELECT target_book_id, source_uuid, source_metadata, undone_at
            FROM merge_log WHERE id = ?",
     )
@@ -77,7 +77,7 @@ pub async fn undo_merge(pool: &SqlitePool, merge_log_id: i64) -> Result<String, 
     // now, so the door reconstructs the FTS row from them directly.
     upsert_fts(&mut tx, new_id).await?;
 
-    sqlx::query("UPDATE merge_log SET undone_at = datetime('now') WHERE id = ?")
+    sqlx::query("UPDATE merge_log SET undone_at = strftime('%s','now') WHERE id = ?")
         .bind(merge_log_id)
         .execute(&mut *tx)
         .await?;
@@ -123,11 +123,16 @@ async fn recreate_source_row(
                 sqlx::Error::Protocol(format!("unexpected settings validation error: {msg}")),
             ),
         })?;
+    // `timestamp` is restored from the snapshot (epoch, migration 0038);
+    // `last_modified` is stamped now, set explicitly because the in-place
+    // 0038 conversion dropped the `books` column default. The `pubdate`
+    // COALESCE fallback is pre-existing and unrelated to F11.
     let id: i64 = sqlx::query_scalar(
         "INSERT INTO books
             (uuid, library_id, path, title, sort, author_sort, series_sort, series_index, pubdate,
-             timestamp, has_cover, description, accent_color, title_norm, author_norm)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?)
+             timestamp, last_modified, has_cover, description, accent_color, title_norm, author_norm)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')),
+                 ?, strftime('%s','now'), ?, ?, ?, ?, ?)
          RETURNING id",
     )
     .bind(&snap.uuid)
@@ -139,7 +144,7 @@ async fn recreate_source_row(
     .bind(&snap.series_sort)
     .bind(snap.series_index)
     .bind(&snap.pubdate)
-    .bind(&snap.timestamp)
+    .bind(snap.timestamp)
     .bind(snap.has_cover)
     .bind(&snap.description)
     .bind(&snap.accent_color)

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -53,12 +53,12 @@ where
 {
     sqlx::query(
         "INSERT INTO metadata_overrides (book_uuid, overrides, has_cover_override, updated_by, updated_at)
-         VALUES (?, ?, ?, ?, datetime('now'))
+         VALUES (?, ?, ?, ?, strftime('%s','now'))
          ON CONFLICT(book_uuid) DO UPDATE SET
            overrides = excluded.overrides,
            has_cover_override = excluded.has_cover_override,
            updated_by = excluded.updated_by,
-           updated_at = datetime('now')",
+           updated_at = strftime('%s','now')",
     )
     .bind(book_uuid)
     .bind(overrides_json)

--- a/db/src/pool/tests.rs
+++ b/db/src/pool/tests.rs
@@ -140,6 +140,110 @@ async fn migration_0021_drops_redundant_and_dead_schema_objects() {
 }
 
 #[tokio::test]
+async fn migration_0038_stores_machine_timestamps_as_integer_unix_seconds() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    // Minimum FK graph, then one row per table 0038 migrated. All rely on the
+    // (now epoch) column defaults except `books`, whose in-place conversion
+    // dropped its default — so its two columns are set explicitly.
+    sqlx::query(
+        "INSERT INTO users (id, username, password_hash, is_admin) VALUES (1, 'u', 'h', 1)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title, timestamp, last_modified) \
+         VALUES ('bk', 1, '/lib/bk', 'Book', strftime('%s','now'), strftime('%s','now'))",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO authors (id, name) VALUES (1, 'Ada')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO metadata_overrides (book_uuid, overrides, updated_by) VALUES ('bk', '{}', 1)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO author_photos (author_id, source, url, bytes, mime) \
+         VALUES (1, 'openlibrary', 'http://x', X'00', 'image/png')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO merge_log (target_book_id, source_uuid, source_metadata) \
+         VALUES ((SELECT id FROM books WHERE uuid='bk'), 'src', '{}')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO ignored_authors (name) VALUES ('Bob')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Every migrated machine-timestamp column is INTEGER-typed and a plausible
+    // "now" (> 2023-11-14). `typeof` proves the storage class, not just affinity.
+    for (sql, label) in [
+        (
+            "SELECT typeof(timestamp) || ':' || (timestamp > 1700000000) FROM books",
+            "books.timestamp",
+        ),
+        (
+            "SELECT typeof(last_modified) || ':' || (last_modified > 1700000000) FROM books",
+            "books.last_modified",
+        ),
+        (
+            "SELECT typeof(updated_at) || ':' || (updated_at > 1700000000) FROM metadata_overrides",
+            "metadata_overrides.updated_at",
+        ),
+        (
+            "SELECT typeof(fetched_at) || ':' || (fetched_at > 1700000000) FROM author_photos",
+            "author_photos.fetched_at",
+        ),
+        (
+            "SELECT typeof(merged_at) || ':' || (merged_at > 1700000000) FROM merge_log",
+            "merge_log.merged_at",
+        ),
+        (
+            "SELECT typeof(ignored_at) || ':' || (ignored_at > 1700000000) FROM ignored_authors",
+            "ignored_authors.ignored_at",
+        ),
+    ] {
+        let got: String = sqlx::query_scalar(sql).fetch_one(&pool).await.unwrap();
+        assert_eq!(
+            got, "integer:1",
+            "{label} must be INTEGER unix-seconds, got {got}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn migration_0038_text_datetime_converts_to_exact_unix_seconds() {
+    // The in-DDL backfill relies on this exact conversion of the old
+    // `datetime('now')` / `CURRENT_TIMESTAMP` TEXT form. Locking it here is the
+    // parsing case rule 03 requires; it would fail on the pre-0038 schema where
+    // these columns stayed TEXT and sorted lexicographically.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let epoch: i64 =
+        sqlx::query_scalar("SELECT CAST(strftime('%s','2024-01-02 03:04:05') AS INTEGER)")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(epoch, 1_704_164_645);
+}
+
+#[tokio::test]
 async fn migrator_is_idempotent_on_rerun() {
     let tmp = std::env::temp_dir().join(format!(
         "omnibus-migrate-{}-{}.db",

--- a/db/src/shelves/rules.rs
+++ b/db/src/shelves/rules.rs
@@ -120,7 +120,10 @@ fn condition_sql(rule: &ShelfRule, owner_id: i64) -> Result<(String, Vec<Bind>),
     }
 }
 
-/// Date-field conditions over `books.timestamp` / `books.last_modified`.
+/// Date-field conditions over `books.timestamp` / `books.last_modified`, which
+/// are INTEGER unix-seconds (migration 0038): the relative-window comparison
+/// stays numeric via `strftime('%s', …)`, and the absolute-date comparisons
+/// render the column back to a calendar date with the `'unixepoch'` modifier.
 fn date_condition(rule: &ShelfRule, v: &str) -> Result<(String, Vec<Bind>), ShelfError> {
     let col = match rule.field {
         RuleField::DateAdded => "b.timestamp",
@@ -129,7 +132,7 @@ fn date_condition(rule: &ShelfRule, v: &str) -> Result<(String, Vec<Bind>), Shel
     };
     match rule.op {
         RuleOp::InLast => Ok((
-            format!("{col} >= datetime('now', ?)"),
+            format!("{col} >= CAST(strftime('%s', 'now', ?) AS INTEGER)"),
             vec![Bind::Text(parse_relative_window(v)?)],
         )),
         RuleOp::Between => {
@@ -137,7 +140,7 @@ fn date_condition(rule: &ShelfRule, v: &str) -> Result<(String, Vec<Bind>), Shel
                 ShelfError::InvalidRule(format!("range must be START..END, got {v:?}"))
             })?;
             Ok((
-                format!("date({col}) BETWEEN ? AND ?"),
+                format!("date({col}, 'unixepoch') BETWEEN ? AND ?"),
                 vec![
                     Bind::Text(validate_date(start)?),
                     Bind::Text(validate_date(end)?),
@@ -145,11 +148,11 @@ fn date_condition(rule: &ShelfRule, v: &str) -> Result<(String, Vec<Bind>), Shel
             ))
         }
         RuleOp::Before => Ok((
-            format!("date({col}) < ?"),
+            format!("date({col}, 'unixepoch') < ?"),
             vec![Bind::Text(validate_date(v)?)],
         )),
         RuleOp::After => Ok((
-            format!("date({col}) > ?"),
+            format!("date({col}, 'unixepoch') > ?"),
             vec![Bind::Text(validate_date(v)?)],
         )),
         _ => Err(unsupported(rule)),

--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -85,6 +85,86 @@ async fn create_smart_shelf_membership_matches_tag_rule() {
 }
 
 #[tokio::test]
+async fn smart_shelf_date_added_rules_match_epoch_column() {
+    // `books.timestamp` is INTEGER unix-seconds (migration 0038); the date-rule
+    // SQL must compare it as an epoch (`date(col,'unixepoch')`, numeric
+    // `strftime('%s',…)`) rather than as a TEXT date, or every match silently
+    // returns nothing.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 2).await;
+    let owner = make_user(&pool, "owner", false).await;
+    sqlx::query(
+        "UPDATE books SET timestamp = strftime('%s','2024-06-15 00:00:00') \
+                 WHERE id = (SELECT MIN(id) FROM books)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE books SET timestamp = strftime('%s','2020-01-01 00:00:00') \
+                 WHERE id = (SELECT MAX(id) FROM books)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let date_rule = |op, value: &str| ShelfRule {
+        field: RuleField::DateAdded,
+        op,
+        value: value.into(),
+    };
+
+    // `After` an absolute date → only the 2024 book.
+    let after = create_shelf(
+        &pool,
+        owner,
+        &smart_req(
+            "After",
+            MatchMode::Any,
+            vec![date_rule(RuleOp::After, "2024-01-01")],
+        ),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        after.book_count, 1,
+        "only the 2024-added book is after 2024-01-01"
+    );
+
+    // `Between` a calendar window → the same single book.
+    let between = create_shelf(
+        &pool,
+        owner,
+        &smart_req(
+            "June",
+            MatchMode::Any,
+            vec![date_rule(RuleOp::Between, "2024-06-01..2024-06-30")],
+        ),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        between.book_count, 1,
+        "only the mid-June book is in the window"
+    );
+
+    // `InLast 1d` exercises the numeric epoch comparison — both books are years
+    // old, so it must match none (a TEXT/INTEGER mismatch here would misbehave).
+    let recent = create_shelf(
+        &pool,
+        owner,
+        &smart_req(
+            "Recent",
+            MatchMode::Any,
+            vec![date_rule(RuleOp::InLast, "1d")],
+        ),
+    )
+    .await
+    .unwrap();
+    assert_eq!(recent.book_count, 0, "no book was added in the last day");
+}
+
+#[tokio::test]
 async fn smart_shelf_matches_author_by_name_case_insensitively() {
     let (pool, _covers) = seed_discovery_fixture().await;
     let owner = make_user(&pool, "owner", false).await;

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -531,10 +531,13 @@ async fn insert_audiobook_row(
     let uuid = mint_uuid();
 
     let book_id = sqlx::query_scalar::<_, i64>(
+        // `timestamp`/`last_modified` set explicitly — migration 0038 dropped
+        // their column default when converting `books` in place to INTEGER.
         "INSERT INTO books \
             (uuid, scan_key, library_id, path, title, sort, author_sort, has_cover, description, \
-             accent_color, title_norm, author_norm) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+             accent_color, title_norm, author_norm, timestamp, last_modified) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, \
+                 strftime('%s','now'), strftime('%s','now')) \
          RETURNING id",
     )
     .bind(&uuid)
@@ -758,7 +761,7 @@ async fn update_audiobook_row(
         "UPDATE books SET \
             path = ?, title = ?, sort = ?, author_sort = ?, has_cover = ?, \
             description = ?, accent_color = ?, title_norm = ?, author_norm = ?, \
-            last_modified = datetime('now') \
+            last_modified = strftime('%s','now') \
          WHERE id = ?",
     )
     .bind(&book_path)

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -223,7 +223,7 @@ async fn update_book_row(
             path = ?, title = ?, sort = ?, author_sort = ?, series_sort = ?, series_index = ?,
             pubdate = ?, has_cover = ?, description = ?, accent_color = ?,
             title_norm = ?, author_norm = ?,
-            last_modified = datetime('now')
+            last_modified = strftime('%s','now')
          WHERE id = ?",
     )
     .bind(&book_path)
@@ -280,10 +280,15 @@ pub(super) async fn insert_book_row(
     let has_cover = i64::from(b.cover.is_some());
 
     let book_id = sqlx::query_scalar::<_, i64>(
+        // `timestamp`/`last_modified` are set explicitly: migration 0038
+        // converted them in place to INTEGER and (unlike a recreate) could not
+        // carry the old `DEFAULT (strftime('%s','now'))` forward.
         "INSERT INTO books
             (uuid, scan_key, library_id, path, title, sort, author_sort, series_sort, series_index,
-             pubdate, has_cover, description, accent_color, title_norm, author_norm)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             pubdate, has_cover, description, accent_color, title_norm, author_norm,
+             timestamp, last_modified)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                 strftime('%s','now'), strftime('%s','now'))
          RETURNING id",
     )
     .bind(&uuid)

--- a/docs/design/db-review-f11-timestamp-unification.md
+++ b/docs/design/db-review-f11-timestamp-unification.md
@@ -1,6 +1,27 @@
 # Unify machine timestamps on INTEGER unix-seconds (F11)
 
-**Status: Proposed — deferred from db.md F11, awaiting decision.**
+**Status: Implemented** as `db/migrations/0038_unify_timestamps_to_unix_seconds.sql`
+(**Option A** — wire stays `String`).
+
+> **Implementation note — `books` converted in place, not recreated.** The D2
+> migration mechanism below (table-recreate of `books`) is **unsafe in this
+> repo**: `init_db` sets `PRAGMA foreign_keys=ON` per connection, sqlx runs each
+> migration inside a transaction where `foreign_keys` can't be toggled (and
+> sqlx-sqlite ignores `-- no-transaction`), so a recreate's implicit
+> `DROP TABLE books` fires `ON DELETE CASCADE` and wipes `book_files`, the link
+> tables, `book_identifiers`, and `merge_log`. `books` is therefore converted
+> **in place** (`ADD` nullable INTEGER cols → backfill `CAST(strftime('%s', …))`
+> → `DROP` old → `RENAME`), which — because SQLite rejects a non-constant
+> `ADD COLUMN` default on a populated table — leaves `books.timestamp` /
+> `last_modified` as nullable INTEGER **without** a column default. The two book
+> writers (`sync/books/shared.rs`, `sync/audiobooks.rs`) now set
+> `strftime('%s','now')` explicitly. The four other tables are child/standalone,
+> so they recreate cleanly and keep `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`
+> as sketched. Two sites the doc predates were also updated: the keyset cursor
+> (`books/page.rs`) and the smart-shelf date rules (`shelves/rules.rs`) now read
+> the columns as epochs.
+
+**Original proposal (deferred from db.md F11) follows.**
 
 Source: `docs/review/db.md` → *"Three inconsistent time representations"*. This
 doc exists to make the one blocking decision tractable — the **wire/serde shape


### PR DESCRIPTION
## Summary
- Migration `0038` converts the five laggard TEXT/DATETIME machine-timestamp columns — `books.timestamp`/`last_modified`, `metadata_overrides.updated_at`, `author_photos.fetched_at`, `merge_log.merged_at`/`undone_at`, `ignored_authors.ignored_at` — to INTEGER unix-seconds so date arithmetic (`GROUP BY date(col,'unixepoch')`) is uniform across books and the session/stats tables (F11).
- `books` is converted **in place** (`ADD`/backfill/`DROP`/`RENAME`), not recreated: the migrator runs with `foreign_keys=ON` inside a transaction where a recreate's implicit `DROP TABLE` would cascade-wipe `book_files`, link tables, `book_identifiers`, and `merge_log`. In-place drops the column default (SQLite forbids a non-constant `ADD COLUMN` default), so the two book writers set `strftime('%s','now')` explicitly; the four child/standalone tables recreate cleanly with the default intact.
- Option A — wire unchanged: the projection and keyset-sort axis format the epoch back to fixed-width ISO, so `EbookMetadata` and the frontend are untouched. Smart-shelf date rules and the merge snapshot now read the columns as epochs (with a serde shim so pre-`0038` snapshots still replay).

## Test plan
- [x] Full matrix green: db 754, server 268, frontend(`--features server`) 191, shared 87 — plus 6 new tests (migration type + exact-conversion, projection ISO output, `NewestAdded` keyset ordering, shelf date-rule matching, snapshot deserializer).
- [x] Migration validated end-to-end on a seeded DB: children survive, every column converts to correct epochs, FK/integrity checks clean, CHECK constraints and indexes preserved.
- [x] `cargo fmt --check` + `cargo clippy` clean.

## Notes
- Forward-only and irreversible once prod rows convert (second-resolution epoch is all `datetime('now')` ever carried, so no precision lost). Wire stays `String`, so a later flip to `i64` remains an additive frontend-only change.