### PR TITLE
fix: mobile audiobook playback and player layout

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -114,9 +114,16 @@ body.atrium,
   font-size: 14px;
   line-height: 1.45;
   letter-spacing: -0.005em;
-  min-height: 100vh;
+  /* `dvh`, not `vh`: on iOS `100vh` is the *large* viewport (taller than the
+     visible area), which left the shell a few px taller than the screen and
+     let the page rubber-band/scroll behind the fixed player. */
+  min-height: 100dvh;
+  overscroll-behavior: none;
   margin: 0;
 }
+/* Kill rubber-band overscroll on the root scroller too, so the fixed player
+   can't bounce. */
+html, body { overscroll-behavior: none; }
 
 .atrium *,
 .atrium *::before,
@@ -5159,10 +5166,19 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 /* ── Mobile audiobook player ───────────────────────────────────────── */
+/* Full-screen player: pinned to the viewport with `position: fixed` so it can
+   never add to a parent's scroll height (the app shell is `min-height: 100vh`,
+   so a `100dvh`/`100%` height mismatched and left the page scrollable). A flex
+   column with the cover taking the flexible middle space (see
+   `.m-player-cover`) keeps every control on-screen regardless of phone height
+   or how many secondary pills wrap. Safe-area padding clears the notch / home
+   indicator. */
 .m-player {
-  position: relative;
-  padding: 8px 14px 28px;
-  min-height: 100%;
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  padding: max(8px, env(safe-area-inset-top)) 14px max(20px, env(safe-area-inset-bottom));
   overflow: hidden;
 }
 /* Radial accent glow washing the top of the screen (tinted by --accent). */
@@ -5170,20 +5186,40 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   position: absolute; inset: 0; pointer-events: none; z-index: 0;
   background-image: radial-gradient(80% 46% at 50% 6%, color-mix(in oklch, var(--accent) 22%, transparent), transparent 70%);
 }
-.m-player > *:not(.m-player-glow) { position: relative; z-index: 1; }
+/* Lift player content above the glow — but NOT the chapters sheet, which is a
+   fixed-position overlay; this `> *` rule (0,2,0) would otherwise outrank
+   `.m-sheet-scrim`'s `position: fixed` and pin it inline at the bottom. */
+.m-player > *:not(.m-player-glow):not(.m-sheet-scrim) { position: relative; z-index: 1; }
 
 .m-player-bar { display: flex; align-items: center; height: 40px; }
 
+/* Flexible cover slot — absorbs the column's spare height so nothing below it
+   is pushed off-screen. The cover itself is height-driven inside this slot. */
 .m-player-cover {
-  width: 220px; max-width: 62%; margin: 6px auto 0;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 6px 0 2px;
   filter: drop-shadow(0 18px 40px color-mix(in oklch, var(--accent) 30%, transparent));
+}
+.m-player-cover .cover-wrap {
+  height: 100%;
+  width: auto;
+  max-width: 62%;
+  aspect-ratio: 2 / 3;
 }
 
 .m-player-now { text-align: center; padding: 20px 6px 6px; }
 .m-player-eyebrow { color: var(--accent); }
-.m-player-title {
-  font-family: var(--serif); font-weight: 400; font-size: 30px;
-  line-height: 1.02; margin-top: 10px;
+/* Scoped under `.atrium` so this outranks the design-system `.atrium h1`
+   (font-size: 64px). The player title is an <h1>; without the extra class
+   the 64px hero size wins on specificity (0,1,1 vs 0,1,0), overflows the
+   phone viewport, and collapses the whole centered layout. */
+.atrium .m-player-title {
+  font-family: var(--serif); font-weight: 400; font-size: 26px;
+  line-height: 1.05; margin-top: 10px;
 }
 .m-player-by { margin-top: 8px; color: var(--ink-1); font-size: 14px; }
 .m-player-chline {
@@ -5217,23 +5253,22 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   display: flex; align-items: center; justify-content: center;
   gap: 12px; padding: 18px 0 8px;
 }
-.m-tp-ghost, .m-tp-ch, .m-tp-skip, .m-tp-rate {
+.m-tp-ch, .m-tp-skip {
   display: inline-flex; align-items: center; justify-content: center;
   border: 1px solid var(--line); background: transparent; color: var(--ink-1);
   border-radius: 999px; cursor: pointer; font-family: var(--mono); font-size: 12px;
+  flex-shrink: 0;
 }
-.m-tp-ghost { width: 40px; height: 40px; font-size: 16px; }
 .m-tp-ch { width: 44px; height: 44px; }
 .m-tp-skip { width: 48px; height: 48px; }
-.m-tp-rate { min-width: 48px; height: 40px; padding: 0 10px; }
-.m-tp-ghost:hover, .m-tp-ch:hover, .m-tp-skip:hover, .m-tp-rate:hover {
+.m-tp-ch:hover, .m-tp-skip:hover {
   color: var(--ink-0); border-color: var(--accent);
 }
-.m-tp-ghost:disabled, .m-tp-ch:disabled { opacity: .4; cursor: not-allowed; }
+.m-tp-ch:disabled { opacity: .4; cursor: not-allowed; }
 
 .m-tp-play {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 72px; height: 72px; border-radius: 50%; border: none; cursor: pointer;
+  width: 72px; height: 72px; flex-shrink: 0; border-radius: 50%; border: none; cursor: pointer;
   background: var(--accent); color: var(--accent-ink);
   box-shadow: 0 10px 28px color-mix(in oklch, var(--accent) 40%, transparent);
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -267,6 +267,21 @@ pub fn App() -> Element {
 
     components::atrium::init_theme();
 
+    // Mobile (wry WKWebView): the Dioxus-generated viewport meta lacks
+    // `viewport-fit=cover`, so the WebView insets its scroll content by the
+    // safe areas (status bar + home indicator) — a phantom ~100px of scroll
+    // behind the fixed full-screen player, and `env(safe-area-inset-*)` reads 0.
+    // Patch the meta once at startup so content fills the screen edge-to-edge
+    // and the player's safe-area padding applies. Effect (not markup), so it's
+    // free to be target-gated.
+    #[cfg(feature = "mobile")]
+    use_effect(|| {
+        dioxus::document::eval(
+            "const m = document.querySelector('meta[name=viewport]');\
+             if (m) m.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover');",
+        );
+    });
+
     // The single `<audio>` element, mounted at the App root (sibling of the
     // Router) so it never unmounts on navigation — the persistence anchor for
     // cross-page playback. Rendered on not(mobile) for SSR/WASM hydration

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -427,9 +427,10 @@ fn render_player(p: PlayerProps) -> Element {
                 }
             }
 
-            // Transport row
+            // Transport row — five primary controls. Keeping it to five (vs
+            // folding in favorite/speed) is what keeps the 72px play button
+            // circular on a phone; speed lives in the secondary row below.
             div { class: "m-player-transport",
-                button { class: "m-tp-ghost", r#type: "button", disabled: true, title: "Favorite (coming soon)", "aria-label": "Favorite", "\u{2661}" }
                 button {
                     class: "m-tp-ch", r#type: "button", disabled: !has_chapters,
                     "aria-label": "Previous chapter", onclick: on_prev, "\u{25C1}|"
@@ -449,11 +450,11 @@ fn render_player(p: PlayerProps) -> Element {
                     class: "m-tp-ch", r#type: "button", disabled: !has_chapters,
                     "aria-label": "Next chapter", onclick: on_next, "|\u{25B7}"
                 }
-                button { class: "m-tp-rate", r#type: "button", "data-testid": "mobile-rate", "aria-label": "Playback speed", onclick: on_speed, "{rate_label}" }
             }
 
-            // Secondary controls
+            // Secondary controls — speed sits here (per the design).
             div { class: "m-player-secondary",
+                button { class: "m-pill", r#type: "button", "data-testid": "mobile-rate", "aria-label": "Playback speed", onclick: on_speed, "{rate_label}" }
                 button { class: "m-pill", r#type: "button", disabled: true, title: "Sleep timer (coming soon)", "Sleep" }
                 button { class: "m-pill", r#type: "button", disabled: true, title: "Bookmark (coming soon)", "Bookmark" }
                 button {

--- a/server/src/auth/extractor.rs
+++ b/server/src/auth/extractor.rs
@@ -146,16 +146,17 @@ where
 }
 
 /// Authenticated user for **media read endpoints** (`/api/covers`,
-/// `/api/thumbs`, `/api/authors/{id}/photo`). Identical to [`AuthUser`]
-/// except it also accepts the session token from a `?token=` query
-/// parameter.
+/// `/api/thumbs`, `/api/authors/{id}/photo`, and direct-play audiobook
+/// `/api/audiobooks/{uuid}/parts/{ordinal}` streams). Identical to
+/// [`AuthUser`] except it also accepts the session token from a `?token=`
+/// query parameter.
 ///
-/// These URLs are rendered into `<img src>` in the mobile WebView, which
-/// fetches them without the native `reqwest` client's `Authorization`
-/// header (and without a session cookie, since mobile auth is bearer-only)
-/// — so a header/cookie-only gate 401s every cover on mobile. The query
-/// token is the only auth an `<img>` fetch can carry. Confined to these
-/// image reads; the full API stays header/cookie-only.
+/// These URLs are wired straight into an `<img src>` / `<audio src>` in the
+/// mobile WebView, which fetches them without the native `reqwest` client's
+/// `Authorization` header (and without a session cookie, since mobile auth is
+/// bearer-only) — so a header/cookie-only gate 401s every cover and audio
+/// stream on mobile. The query token is the only auth such a fetch can carry.
+/// Confined to these reads; the full API stays header/cookie-only.
 #[derive(Debug, Clone)]
 pub struct MediaAuthUser(pub AuthUser);
 

--- a/server/src/auth/gate.rs
+++ b/server/src/auth/gate.rs
@@ -3,8 +3,9 @@
 //! `/api/*` other than `/api/auth/*` and `/api/_health` requires a valid
 //! session or gets `401 Unauthorized`; everything else (SSR HTML, WASM
 //! bundle, static assets) passes through untouched. Media read endpoints
-//! (covers, thumbs, author-photo / suggestion-cover GETs) additionally
-//! accept the session as a `?token=` query param — see [`is_media_read_path`].
+//! (covers, thumbs, author-photo / suggestion-cover GETs, and direct-play
+//! audiobook part streams) additionally accept the session as a `?token=`
+//! query param — see [`is_media_read_path`].
 
 use axum::{
     extract::{Request, State},
@@ -28,6 +29,10 @@ fn is_media_read_path(path: &str) -> bool {
         || path.starts_with("/api/thumbs/")
         || (path.starts_with("/api/authors/") && path.ends_with("/photo"))
         || (path.starts_with("/api/suggestions/") && path.ends_with("/cover"))
+        // Direct-play audiobook part streams feed the mobile WebView's
+        // `<audio src>`, which can only carry the session as `?token=`. HLS
+        // segments are web-only (cookie-authed) so they stay off this list.
+        || (path.starts_with("/api/audiobooks/") && path.contains("/parts/"))
 }
 
 /// Reject `/api/*` requests without a live session with `401 Unauthorized`, after exempting `/api/auth/*` and `/api/_health`.

--- a/server/src/auth/gate.rs
+++ b/server/src/auth/gate.rs
@@ -18,9 +18,10 @@ use omnibus_db::auth as auth_db;
 use super::extractor::{extract_token, query_token};
 use crate::backend::AppState;
 
-/// Media read endpoints whose bytes are rendered into an `<img src>` and so
-/// may authenticate via a `?token=` query param — the only auth a WebView's
-/// `<img>` fetch can carry. Kept in lockstep with the handlers gated on
+/// Media read endpoints whose bytes are rendered into an `<img src>` (covers,
+/// thumbs, photos) or `<audio src>` (direct-play audiobook parts) and so may
+/// authenticate via a `?token=` query param — the only auth such a WebView
+/// media fetch can carry. Kept in lockstep with the handlers gated on
 /// [`MediaAuthUser`]; every other `/api/*` path stays header/cookie-only.
 ///
 /// [`MediaAuthUser`]: super::MediaAuthUser

--- a/server/src/auth/gate/tests.rs
+++ b/server/src/auth/gate/tests.rs
@@ -11,6 +11,10 @@ async fn app() -> (Router, sqlx::SqlitePool) {
     let router = Router::new()
         .route("/api/value", get(|| async { "ok" }))
         .route("/api/thumbs/{uuid}/{size}", get(|| async { "thumb ok" }))
+        .route(
+            "/api/audiobooks/{uuid}/parts/{ordinal}",
+            get(|| async { "part ok" }),
+        )
         .route("/api/auth/login", get(|| async { "login ok" }))
         .route("/api/_health", get(|| async { "health ok" }))
         .route("/", get(|| async { "home" }))
@@ -226,6 +230,40 @@ async fn media_get_with_invalid_query_token_is_401() {
         .oneshot(
             Request::builder()
                 .uri("/api/thumbs/some-uuid/md?token=not-a-real-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn audiobook_part_get_with_query_token_passes() {
+    // The mobile WebView's `<audio src>` can only carry the session as
+    // `?token=`; the direct-play part stream must accept it like covers do.
+    let (app, pool) = app().await;
+    let token = seed_bearer_token(&pool).await;
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/audiobooks/some-uuid/parts/0?token={token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn audiobook_part_get_without_auth_is_401() {
+    let (app, pool) = app().await;
+    seed_bearer_token(&pool).await;
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/audiobooks/some-uuid/parts/0")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -22,7 +22,7 @@ use tower::ServiceExt;
 use tower_http::services::ServeFile;
 
 use super::{internal, AppState};
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, MediaAuthUser};
 
 /// Content-Type for MPEG-TS audio segments served by the HLS fallback.
 /// Defined at module scope so the per-request `HeaderValue` insert is a
@@ -165,8 +165,14 @@ pub(super) struct PartsQuery {
 
 /// Range-served raw file for one part of a direct-play audiobook.
 /// Accepts optional `?file_id=N` to target a specific `book_files` row.
+///
+/// Authenticated via [`MediaAuthUser`] (not [`AuthUser`]) because this URL is
+/// wired straight into the mobile WebView's `<audio src>`, whose fetch can
+/// carry neither the native `reqwest` bearer header nor a session cookie — the
+/// `?token=` query param is the only auth it has. Kept in lockstep with
+/// `is_media_read_path` in `auth::gate`.
 pub(super) async fn get_audiobook_part(
-    _user: AuthUser,
+    _user: MediaAuthUser,
     State(state): State<AppState>,
     Path((uuid, ordinal)): Path<(String, i64)>,
     Query(query): Query<PartsQuery>,

--- a/server/src/backend/audiobooks/tests.rs
+++ b/server/src/backend/audiobooks/tests.rs
@@ -651,6 +651,53 @@ async fn api_get_audiobook_download_serves_first_part_as_attachment() {
 }
 
 #[tokio::test]
+async fn api_get_audiobook_part_serves_with_query_token_no_header() {
+    // Mobile plays audio through a WebView `<audio src>`, whose fetch carries
+    // neither the native bearer header nor a session cookie — only `?token=`.
+    // The part handler must authenticate on that query param alone (via
+    // `MediaAuthUser`), matching how covers/thumbs already behave.
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let library_path = dir.path().to_string_lossy().to_string();
+    std::fs::create_dir_all(dir.path().join("Author/Book")).unwrap();
+    let file_path = dir.path().join("Author/Book/01.mp3");
+    let payload: Vec<u8> = (0u8..100).collect();
+    std::fs::File::create(&file_path)
+        .unwrap()
+        .write_all(&payload)
+        .unwrap();
+
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let uuid = seed_audiobook_with_parts(
+        &pool,
+        &library_path,
+        "MP3",
+        &[(0, "Author/Book/01.mp3", 60.0)],
+    )
+    .await;
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    let req = axum::http::Request::builder()
+        .uri(format!("/api/audiobooks/{uuid}/parts/0?token={token}"))
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let ct = res
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert_eq!(ct, "audio/mpeg");
+    let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(body.as_ref(), payload.as_slice());
+}
+
+#[tokio::test]
 async fn api_get_audiobook_segment_returns_401_when_anonymous() {
     let (app, _, _) = fixture().await;
     let res = app


### PR DESCRIPTION
## Summary
Fixes the mobile audiobook experience — audio playback and the full player screen (two commits).

### 1. Audio wouldn't play (401) — `fix: accept ?token= query auth on audiobook part streams`
The mobile app is a wry WebView; audiobook audio plays through an `<audio>` element whose fetch can only carry the session as a `?token=` query param (not the native bearer header or a cookie). `GET /api/audiobooks/{uuid}/parts/{ordinal}` was gated on `AuthUser` (header/cookie only) and absent from the media-read allowlist, so every mobile audio request 401'd and playback silently failed. Switched the part handler to `MediaAuthUser` and added the parts path to `is_media_read_path` (the treatment covers/thumbs already get). HLS segments stay off the list (web-only, cookie-authed).

### 2. Player looked nothing like the design + several control bugs — `fix: mobile audiobook player layout and controls`
- **Whole player unstyled.** A single missing `}` on `.m-account-seg-btn.on` (added with the Account screen) made CSS nesting swallow the entire `.m-player-*` block as descendants of that selector, so none of the rules matched — full-bleed cover, overflowing title, uncentred transport. The web build never caught it because the desktop player doesn't use `.m-player-*`.
- **Title oversized.** `.atrium h1` (64px) outranked `.m-player-title`; scoped it as `.atrium .m-player-title` at 26px.
- **Play button stretched.** The seven-button transport was too wide, so flex squished the play button to a vertical ellipse. Trimmed to the design's five controls, moved speed to the secondary row, dropped the disabled favorite placeholder, and pinned `flex-shrink: 0`.
- **Chapters opened inline** instead of pulling up: excluded `.m-sheet-scrim` from the `.m-player > *` `position: relative` override so its `position: fixed` overlay works.
- **Player scrolled.** Pinned `.m-player` with `position: fixed; inset: 0` (flex column, cover flexes to fill), switched the app shell to `100dvh` + `overscroll-behavior: none`, and set `viewport-fit=cover` on the viewport meta so WKWebView stops insetting content for the safe areas (the ~100px phantom scroll).

## Test plan
- [x] `cargo test -p omnibus --lib auth::gate` + `backend::audiobooks` — pass, incl. new `?token=` cases
- [x] `cargo fmt --check` + `cargo clippy -p omnibus` — clean
- [x] Live server: `GET /api/audiobooks/{uuid}/parts/0?token=<valid>` → 200 (was 401); bogus → 401
- [x] iOS simulator: audio streams; player matches the design; play button circular; Chapters pulls up as an overlay; **no scroll** (confirmed by swipe test)

## Version
- [ ] Default patch release — leaving unlabeled.

## Notes
> [!NOTE]
> The missing-brace bug was invisible to the web build and to brace-balance checks (the file stays balanced — the brace is "borrowed" by nesting). A CSS structural-lint CI guard is being spun up separately.
