### PR TITLE
chore: add stylelint structural CSS guard to CI and just lint

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -13,7 +13,7 @@ The flake exposes five purpose-built shells so daily cargo work doesn't pay for 
 
 | Shell | Headline tools | When to use |
 |---|---|---|
-| `default` (slim) | rust core + sqlite + openssl + just + zellij + process-compose | Daily `cargo test`/`clippy`/`fmt`, editor, rust-analyzer — this is what direnv auto-loads via `.envrc` |
+| `default` (slim) | rust core + sqlite + openssl + just + zellij + process-compose + stylelint | Daily `cargo test`/`clippy`/`fmt`, editor, rust-analyzer, `just lint-css` — this is what direnv auto-loads via `.envrc` |
 | `web` | default + dioxus-cli + matched `wasm-bindgen` + node | `dx serve --platform web`, `just dev-up`, anything that bundles the WASM client |
 | `e2e` | web + Playwright Chromium bundle | `npx playwright test`, the `playwright` pane in the multiplexer, CI's E2E job |
 | `mobile` | default + dioxus-cli (`dx`) + Android + iOS rust-std targets + JDK 21 + Xcode/Android SDK auto-detect (+ GTK 3 / WebKitGTK on Linux) | `dx serve --platform ios`/`android`, `cargo build -p omnibus-mobile`; CI's `cargo clippy (mobile)` host-target lint |
@@ -28,6 +28,10 @@ nix develop .#mobile                  # interactive shell with Android NDK + iOS
 ```
 
 `.envrc` resolves `use flake` to `default`, so the editor stays on the slim shell at all times. `just serve` works from default because zellij + process-compose live there; each multiplexer pane internally wraps its command in the right `.#shell` (server → `.#web`, mobile → `.#mobile`, playwright → `.#e2e`), so only the panes you actually start realize their extras. `just dev-up` and `just dev-bounce` self-wrap in `.#web`, so they work straight from default too.
+
+## CSS structural lint
+
+`stylelint` lives in the slim shell so `just lint` (which runs `just lint-css`) and the `css-lint.yml` CI job both guard `frontend/assets/**.css` against structural errors — chiefly an unclosed `}`, which under CSS nesting silently reparents every following rule as a descendant of the unclosed selector and breaks layouts the Rust/web build never exercises. The ruleset ([`.stylelintrc.json`](../../.stylelintrc.json)) is parse/structural-only, so it errors on broken CSS but never nags about pre-existing style. Run `just lint-css` to check just the CSS.
 
 ## Common environment
 

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -11,7 +11,7 @@ name: CSS Lint
 on:
   pull_request:
     paths:
-      - "frontend/assets/**.css"
+      - "frontend/assets/**/*.css"
       - ".stylelintrc.json"
       - ".github/workflows/css-lint.yml"
       - "flake.nix"

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -1,0 +1,59 @@
+name: CSS Lint
+
+# Structural guard for the design-system stylesheet. A single missing `}`
+# in frontend/assets/atrium.css silently reparents every following rule as
+# a CSS-nesting descendant of the unclosed selector, so those rules stop
+# matching — a class of bug the web build never exercises and Rust CI can't
+# see. stylelint's parser turns that into an "Unclosed block" error. The
+# ruleset is deliberately parse/structural-only (see .stylelintrc.json), so
+# this never nags about pre-existing stylistic choices.
+
+on:
+  pull_request:
+    paths:
+      - "frontend/assets/**.css"
+      - ".stylelintrc.json"
+      - ".github/workflows/css-lint.yml"
+      - "flake.nix"
+      - "flake.lock"
+  push:
+    branches: [main]
+
+concurrency:
+  group: css-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  stylelint:
+    name: stylelint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # See rust.yml: id-token for the Nix installer's FlakeHub OIDC auth,
+      # actions:write for cache-nix-action's `purge: true` self-eviction.
+      id-token: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      # Distinct nix cache prefix from rust.yml/e2e.yml so the workflows
+      # don't clobber each other. The slim shell realizes stylelint only.
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-css-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-css-${{ runner.os }}-
+          purge: true
+          purge-prefixes: nix-css-${{ runner.os }}-
+          purge-last-accessed: 604800
+          purge-primary-key: never
+          gc-max-store-size-linux: 2G
+
+      - name: stylelint (structural CSS lint)
+        run: nix develop --command stylelint 'frontend/assets/**/*.css'

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-invalid-position-at-import-rule": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ cargo run -p omnibus                                        # start at http://0.
 
 # Tests & lint — aggregate targets cover the full crate matrix in one go
 just test                                                   # db + server + frontend(--features server) + shared
-just lint                                                   # cargo fmt --check + clippy (incl. mobile + frontend-server)
+just lint                                                   # cargo fmt --check + clippy (incl. mobile + frontend-server) + stylelint
+just lint-css                                               # structural CSS lint only (stylelint; catches unclosed rules in frontend/assets)
 just check                                                  # lint then test
 # …or per-crate (note: `cargo test --workspace` SKIPS frontend rpc/page tests
 #  and mobile — the rpc/page tests need --features server to compile the

--- a/Justfile
+++ b/Justfile
@@ -50,9 +50,17 @@ test:
         cargo test -p omnibus-frontend --features server && \
         cargo test -p omnibus-shared'
 
+# Structural CSS lint — stylelint over frontend/assets, scoped to parse /
+# structural errors only (unclosed rules, misplaced @import), not style.
+# An unclosed `}` silently reparents later rules under CSS nesting, so a
+# missing brace must fail the build. stylelint is Nix-pinned in slimPackages.
+lint-css:
+    nix develop --command stylelint 'frontend/assets/**/*.css'
+
 # Format check + clippy, including the crate/feature combos a bare
-# `cargo clippy` (default-members, default features) misses.
-lint:
+# `cargo clippy` (default-members, default features) misses. Depends on
+# `lint-css` so the CSS structural guard rides the same gate as fmt/clippy.
+lint: lint-css
     nix develop --command bash -ec '\
         cargo fmt --check && \
         cargo clippy --all-targets && \

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,11 @@
           # are fetched from one cache instead of each worktree's target/
           # rebuilding (and incrementally re-caching) the same dependency tree.
           pkgs.sccache
+          # Structural CSS linter for `just lint-css` / the css-lint CI job.
+          # Lives in slim (not webExtras) because it's a lint tool that runs
+          # in the same `just lint` shell as fmt/clippy; the nixpkgs build is
+          # self-contained (bundles its own node), so this adds no npm project.
+          pkgs.stylelint
         ];
 
         # Web-build extras: dioxus-cli + matched wasm-bindgen + node + ffmpeg.


### PR DESCRIPTION
## Summary
- Adds a **CSS structural-lint guard** so a malformed stylesheet fails the build instead of shipping silently.
- Motivation: a single missing `}` in `frontend/assets/atrium.css` (an unclosed `.m-account-seg-btn.on { … }` rule) let CSS nesting swallow the entire downstream `.m-player-*` block as descendants of that selector. Those rules then never matched, breaking the mobile audiobook player layout. It went undetected because the web build doesn't use `.m-player-*` and there was no CSS linting in CI.
- Tool: **stylelint 16**, Nix-pinned in `slimPackages` (nixpkgs build is self-contained — bundles its own node, so no npm project / `node_modules` / lockfile is introduced).
- Ruleset ([`.stylelintrc.json`](.stylelintrc.json)) is deliberately **parse/structural-only**: an unclosed block is a `CssSyntaxError` the parser raises regardless of rules, plus `no-invalid-position-at-import-rule`. No stylistic rules, so it never nags about pre-existing style and `atrium.css` is **not** reformatted.

### Wiring
- `flake.nix` — `pkgs.stylelint` added to `slimPackages` (it's a linter; belongs in the same shell as fmt/clippy).
- `justfile` — new `just lint-css`; `just lint` now depends on it, so the guard rides the standard `just lint` / `just check` gate.
- `.github/workflows/css-lint.yml` — new CI job, runs on PRs touching `frontend/assets/**.css` (+ `.stylelintrc.json`, the workflow, and the flake), mirroring the repo's Nix-install + cache pattern.
- Docs (rule 99): `CLAUDE.md` Quick-commands and `.claude/rules/01-dev-environment.md` (shell table + a short "CSS structural lint" section).

## Test plan
- [x] `just lint-css` on healthy `atrium.css` → **exit 0**, zero output (no stylistic noise).
- [x] **Proved it catches the regression**: deleted one closing `}` in `atrium.css`, then `just lint-css`:
  ```
  frontend/assets/atrium.css
    1540:1  ✖  Unclosed block  CssSyntaxError
  ✖ 1 problem (1 error, 0 warnings)
  → exit 2 (build fails)
  ```
- [x] Restored the brace → `just lint-css` **exit 0** again (braces balanced 1323/1323). No changes left in `atrium.css`.
- [x] `nix eval .#devShells.<sys>.default` evaluates cleanly with the added package.

## Notes
- Docs-and-CI-only change plus a flake tooling addition; no Rust/runtime code touched.
- The `css-lint.yml` job uses a distinct Nix cache prefix (`nix-css-`) so it doesn't clobber the `rust`/`e2e` workflow caches, and realizes only the slim shell + stylelint.