### PR TITLE
fix: wrap shelves write-path in a transaction, batch N+1 inserts (#732)

### DIFF
--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -578,6 +578,102 @@ async fn preview_rule_reports_matched_and_total() {
 }
 
 #[tokio::test]
+async fn create_manual_shelf_batches_book_inserts_across_the_chunk_boundary() {
+    // 250 uuids forces `insert_books` through two chunks (200 + 50); this
+    // must not lose, duplicate, or misorder any row at the boundary.
+    const N: i64 = 250;
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, N).await;
+    let owner = make_user(&pool, "owner", false).await;
+
+    let uuids: Vec<String> = (1..=N).map(|i| format!("uuid-{i}")).collect();
+    let shelf = create_shelf(&pool, owner, &manual_req("Big", uuids.clone()))
+        .await
+        .unwrap();
+    assert_eq!(shelf.book_count, N);
+
+    let page = shelf_page(&pool, &shelf, SortKey::Title, SortDir::Asc)
+        .await
+        .unwrap();
+    let titles: Vec<_> = page.books.iter().filter_map(|b| b.title.clone()).collect();
+    let expected: Vec<_> = (1..=N).map(|i| format!("Title {i}")).collect();
+    assert_eq!(
+        titles, expected,
+        "insertion order (== position) survives the 200-row chunk boundary"
+    );
+}
+
+#[tokio::test]
+async fn create_smart_shelf_batches_rule_inserts_across_the_chunk_boundary() {
+    // 250 rules forces `insert_rules` through two chunks (199 + 51); this
+    // must not lose, duplicate, or misorder any rule at the boundary.
+    const N: usize = 250;
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let owner = make_user(&pool, "owner", false).await;
+
+    let rules: Vec<ShelfRule> = (0..N).map(|i| tag_rule(&format!("tag-{i}"))).collect();
+    let shelf = create_shelf(
+        &pool,
+        owner,
+        &smart_req("Many rules", MatchMode::Any, rules),
+    )
+    .await
+    .unwrap();
+
+    let values: Vec<String> =
+        sqlx::query_scalar("SELECT value FROM shelf_rules WHERE shelf_id = ? ORDER BY position")
+            .bind(shelf.id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    let expected: Vec<_> = (0..N).map(|i| format!("tag-{i}")).collect();
+    assert_eq!(
+        values, expected,
+        "rule order (== position) survives the 199-row chunk boundary"
+    );
+}
+
+#[tokio::test]
+async fn update_shelf_rolls_back_rule_replacement_when_rename_collides() {
+    // The rule replacement and the shelf-row rename share one transaction:
+    // if the rename fails (name already taken), the just-inserted new rules
+    // must roll back too, leaving the shelf's original rules intact.
+    let (pool, _covers) = seed_discovery_fixture().await;
+    let owner = make_user(&pool, "owner", false).await;
+    create_shelf(&pool, owner, &manual_req("Existing", vec![]))
+        .await
+        .unwrap();
+    let target = create_shelf(
+        &pool,
+        owner,
+        &smart_req("Target", MatchMode::Any, vec![tag_rule("fiction")]),
+    )
+    .await
+    .unwrap();
+
+    let err = update_shelf(
+        &pool,
+        target.id,
+        &UpdateShelfRequest {
+            name: Some("Existing".into()),
+            rules: Some(vec![tag_rule("mystery")]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, ShelfError::NameTaken));
+
+    let reloaded = get_shelf(&pool, target.id).await.unwrap().unwrap();
+    assert_eq!(reloaded.name, "Target", "the rename did not apply");
+    assert_eq!(
+        reloaded.rules,
+        vec![tag_rule("fiction")],
+        "the rule replacement was rolled back along with the failed rename"
+    );
+}
+
+#[tokio::test]
 async fn can_view_and_can_edit_enforce_visibility() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let owner = make_user(&pool, "owner", false).await;

--- a/db/src/shelves/write.rs
+++ b/db/src/shelves/write.rs
@@ -140,7 +140,8 @@ pub async fn delete_shelf(pool: &SqlitePool, id: i64) -> Result<(), ShelfError> 
 
 /// Append books to a hand-picked shelf. Each uuid is resolved to canonical
 /// first; an unknown uuid fails the whole call. Already-present books are
-/// silently kept (INSERT OR IGNORE). The whole batch lands in one transaction.
+/// silently kept (INSERT OR IGNORE). The batch insert itself lands in one
+/// transaction, so a mid-batch failure can't leave a partial set of rows.
 pub async fn add_books(
     pool: &SqlitePool,
     shelf_id: i64,
@@ -194,7 +195,8 @@ async fn insert_books(
     added_by: i64,
     start_pos: i64,
 ) -> Result<(), ShelfError> {
-    for (chunk_idx, chunk) in uuids.chunks(200).enumerate() {
+    const CHUNK_SIZE: usize = 200;
+    for (chunk_idx, chunk) in uuids.chunks(CHUNK_SIZE).enumerate() {
         let rows = std::iter::repeat_n("(?, ?, ?, ?)", chunk.len())
             .collect::<Vec<_>>()
             .join(", ");
@@ -202,7 +204,7 @@ async fn insert_books(
             "INSERT OR IGNORE INTO shelf_books (shelf_id, book_uuid, position, added_by_user_id)
              VALUES {rows}"
         );
-        let base = start_pos + (chunk_idx * 200) as i64;
+        let base = start_pos + (chunk_idx * CHUNK_SIZE) as i64;
         let mut q = sqlx::query(&sql);
         for (i, uuid) in chunk.iter().enumerate() {
             q = q
@@ -224,13 +226,14 @@ async fn insert_rules(
     shelf_id: i64,
     rules: &[ShelfRule],
 ) -> Result<(), ShelfError> {
-    for (chunk_idx, chunk) in rules.chunks(199).enumerate() {
+    const CHUNK_SIZE: usize = 199;
+    for (chunk_idx, chunk) in rules.chunks(CHUNK_SIZE).enumerate() {
         let rows = std::iter::repeat_n("(?, ?, ?, ?, ?)", chunk.len())
             .collect::<Vec<_>>()
             .join(", ");
         let sql =
             format!("INSERT INTO shelf_rules (shelf_id, field, op, value, position) VALUES {rows}");
-        let base = (chunk_idx * 199) as i64;
+        let base = (chunk_idx * CHUNK_SIZE) as i64;
         let mut q = sqlx::query(&sql);
         for (i, rule) in chunk.iter().enumerate() {
             q = q

--- a/db/src/shelves/write.rs
+++ b/db/src/shelves/write.rs
@@ -5,9 +5,9 @@
 //! still points at the surviving book. Name collisions per owner surface as
 //! [`ShelfError::NameTaken`].
 
-use sqlx::SqlitePool;
+use sqlx::{Sqlite, SqlitePool, Transaction};
 
-use omnibus_shared::{CreateShelfRequest, Shelf, ShelfKind, UpdateShelfRequest};
+use omnibus_shared::{CreateShelfRequest, Shelf, ShelfKind, ShelfRule, UpdateShelfRequest};
 
 use super::read::get_shelf;
 use super::ShelfError;
@@ -20,6 +20,9 @@ const ACCENTS: [&str; 6] = [
 
 /// Create a shelf owned by `owner_id` and return its full detail. Manual book
 /// uuids are resolved up front so a bad uuid fails before the shelf row exists.
+/// The shelf row, its rule set, and its membership all land in one
+/// transaction so a mid-write failure can't leave a shelf with a partial rule
+/// set or partial membership.
 pub async fn create_shelf(
     pool: &SqlitePool,
     owner_id: i64,
@@ -28,6 +31,8 @@ pub async fn create_shelf(
     let resolved = resolve_all(pool, &req.book_uuids).await?;
     let accent = pick_accent(pool, owner_id).await?;
     let position = next_shelf_position(pool, owner_id).await?;
+
+    let mut tx = pool.begin().await?;
 
     let id: i64 = sqlx::query_scalar::<_, i64>(
         "INSERT INTO shelves
@@ -42,20 +47,27 @@ pub async fn create_shelf(
     .bind(req.match_mode.map(|m| m.as_str()))
     .bind(&accent)
     .bind(position)
-    .fetch_one(pool)
+    .fetch_one(&mut *tx)
     .await
     .map_err(map_unique)?;
 
     if req.kind == ShelfKind::Smart {
-        replace_rules(pool, id, req).await?;
+        insert_rules(&mut tx, id, &req.rules).await?;
     }
-    insert_books(pool, id, &resolved, owner_id, 0).await?;
+    insert_books(&mut tx, id, &resolved, owner_id, 0).await?;
+
+    tx.commit().await?;
 
     get_shelf(pool, id).await?.ok_or(ShelfError::NotFound)
 }
 
 /// Apply a partial update. `None` fields are untouched; `rules` (when present)
 /// replaces the whole rule set. Returns the updated shelf.
+///
+/// The rule replacement runs *before* the shelf-row `UPDATE` within the same
+/// transaction: both share one commit, so a rename that collides with an
+/// existing name (`ShelfError::NameTaken`) rolls the rule replacement back
+/// too, instead of leaving the new rules committed under the old name.
 pub async fn update_shelf(
     pool: &SqlitePool,
     id: i64,
@@ -80,6 +92,17 @@ pub async fn update_shelf(
         }
         _ => {}
     }
+
+    let mut tx = pool.begin().await?;
+
+    if let Some(rules) = &req.rules {
+        sqlx::query("DELETE FROM shelf_rules WHERE shelf_id = ?")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+        insert_rules(&mut tx, id, rules).await?;
+    }
+
     sqlx::query(
         "UPDATE shelves SET
             name        = COALESCE(?, name),
@@ -94,19 +117,11 @@ pub async fn update_shelf(
     .bind(req.visibility.map(|v| v.as_str()))
     .bind(req.match_mode.map(|m| m.as_str()))
     .bind(id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await
     .map_err(map_unique)?;
 
-    if let Some(rules) = &req.rules {
-        sqlx::query("DELETE FROM shelf_rules WHERE shelf_id = ?")
-            .bind(id)
-            .execute(pool)
-            .await?;
-        for (i, rule) in rules.iter().enumerate() {
-            insert_rule(pool, id, rule, i as i64).await?;
-        }
-    }
+    tx.commit().await?;
 
     get_shelf(pool, id).await?.ok_or(ShelfError::NotFound)
 }
@@ -125,7 +140,7 @@ pub async fn delete_shelf(pool: &SqlitePool, id: i64) -> Result<(), ShelfError> 
 
 /// Append books to a hand-picked shelf. Each uuid is resolved to canonical
 /// first; an unknown uuid fails the whole call. Already-present books are
-/// silently kept (INSERT OR IGNORE).
+/// silently kept (INSERT OR IGNORE). The whole batch lands in one transaction.
 pub async fn add_books(
     pool: &SqlitePool,
     shelf_id: i64,
@@ -134,7 +149,11 @@ pub async fn add_books(
 ) -> Result<(), ShelfError> {
     let resolved = resolve_all(pool, uuids).await?;
     let start = next_book_position(pool, shelf_id).await?;
-    insert_books(pool, shelf_id, &resolved, added_by, start).await
+
+    let mut tx = pool.begin().await?;
+    insert_books(&mut tx, shelf_id, &resolved, added_by, start).await?;
+    tx.commit().await?;
+    Ok(())
 }
 
 /// Remove a book from a hand-picked shelf. A no-op when it isn't on the shelf.
@@ -165,55 +184,64 @@ async fn resolve_all(pool: &SqlitePool, uuids: &[String]) -> Result<Vec<String>,
     Ok(out)
 }
 
+/// Batch-insert `shelf_books` rows in a single transaction. Chunked at 200
+/// rows (4 binds/row keeps each statement under SQLite's 999 bind-parameter
+/// cap) instead of one round-trip per book.
 async fn insert_books(
-    pool: &SqlitePool,
+    tx: &mut Transaction<'_, Sqlite>,
     shelf_id: i64,
     uuids: &[String],
     added_by: i64,
     start_pos: i64,
 ) -> Result<(), ShelfError> {
-    for (i, uuid) in uuids.iter().enumerate() {
-        sqlx::query(
+    for (chunk_idx, chunk) in uuids.chunks(200).enumerate() {
+        let rows = std::iter::repeat_n("(?, ?, ?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
             "INSERT OR IGNORE INTO shelf_books (shelf_id, book_uuid, position, added_by_user_id)
-             VALUES (?, ?, ?, ?)",
-        )
-        .bind(shelf_id)
-        .bind(uuid)
-        .bind(start_pos + i as i64)
-        .bind(added_by)
-        .execute(pool)
-        .await?;
+             VALUES {rows}"
+        );
+        let base = start_pos + (chunk_idx * 200) as i64;
+        let mut q = sqlx::query(&sql);
+        for (i, uuid) in chunk.iter().enumerate() {
+            q = q
+                .bind(shelf_id)
+                .bind(uuid)
+                .bind(base + i as i64)
+                .bind(added_by);
+        }
+        q.execute(&mut **tx).await?;
     }
     Ok(())
 }
 
-async fn replace_rules(
-    pool: &SqlitePool,
+/// Batch-insert `shelf_rules` rows in rule order, in a single transaction.
+/// Chunked at 199 rows (5 binds/row keeps each statement under SQLite's 999
+/// bind-parameter cap) instead of one round-trip per rule.
+async fn insert_rules(
+    tx: &mut Transaction<'_, Sqlite>,
     shelf_id: i64,
-    req: &CreateShelfRequest,
+    rules: &[ShelfRule],
 ) -> Result<(), ShelfError> {
-    for (i, rule) in req.rules.iter().enumerate() {
-        insert_rule(pool, shelf_id, rule, i as i64).await?;
+    for (chunk_idx, chunk) in rules.chunks(199).enumerate() {
+        let rows = std::iter::repeat_n("(?, ?, ?, ?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql =
+            format!("INSERT INTO shelf_rules (shelf_id, field, op, value, position) VALUES {rows}");
+        let base = (chunk_idx * 199) as i64;
+        let mut q = sqlx::query(&sql);
+        for (i, rule) in chunk.iter().enumerate() {
+            q = q
+                .bind(shelf_id)
+                .bind(rule.field.as_str())
+                .bind(rule.op.as_str())
+                .bind(&rule.value)
+                .bind(base + i as i64);
+        }
+        q.execute(&mut **tx).await?;
     }
-    Ok(())
-}
-
-async fn insert_rule(
-    pool: &SqlitePool,
-    shelf_id: i64,
-    rule: &omnibus_shared::ShelfRule,
-    position: i64,
-) -> Result<(), ShelfError> {
-    sqlx::query(
-        "INSERT INTO shelf_rules (shelf_id, field, op, value, position) VALUES (?, ?, ?, ?, ?)",
-    )
-    .bind(shelf_id)
-    .bind(rule.field.as_str())
-    .bind(rule.op.as_str())
-    .bind(&rule.value)
-    .bind(position)
-    .execute(pool)
-    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- `create_shelf`, `update_shelf`, and `add_books` in `db/src/shelves/write.rs` issued their per-book/per-rule inserts directly against the pool in loops with no shared transaction. A crash or DB error partway through left a shelf with a partial rule set or partial membership, with no rollback.
- Wraps each function's multi-step writes in a single `sqlx::Transaction`.
- Replaces the per-row `INSERT` loops with chunked multi-row `INSERT ... VALUES` statements (200 rows/chunk for `shelf_books`, 199 for `shelf_rules` — both under SQLite's 999 bind-parameter cap), mirroring the pattern in `db/src/sync/*`.
- Reorders `update_shelf`'s rule replacement ahead of the shelf-row rename so a rename collision (`NameTaken`) rolls the rule replacement back too, instead of leaving new rules committed under the old name — this also makes the transaction's atomicity guarantee independently testable (see test plan).

Closes #732

## Test plan
- [x] `cargo test -p omnibus-db` (792 passed)
- [x] New test `update_shelf_rolls_back_rule_replacement_when_rename_collides` asserts a simulated mid-write failure (a rename that collides with an existing shelf name) leaves the shelf's original rules intact instead of a partial rule swap
- [x] New tests `create_manual_shelf_batches_book_inserts_across_the_chunk_boundary` / `create_smart_shelf_batches_rule_inserts_across_the_chunk_boundary` assert 250-row batches land correctly across the chunk boundary (200/199-row chunks)
- [x] `cargo clippy -p omnibus-db --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- Companion read-side N+1 issue (`list_visible_shelves`'s `load_rules`/`count_smart`/`count_manual` per shelf row) is tracked separately in #733 and intentionally out of scope here.
- No migration changes; no API/behavior changes visible to callers other than the atomicity fix itself.