### PR TITLE
fix: add length caps to progress epub_cfi, shelf description, and rule value (#735)

### DIFF
--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -18,6 +18,11 @@ mod tests;
 /// runtime-configurable; change here to move the cap.
 pub const SESSION_BATCH_CAP: usize = 500;
 
+/// Maximum length (in chars) of `ProgressUpdate::epub_cfi`. Matches
+/// `CreateHighlight::EPUB_CFI_RANGE_MAX_LEN` — both store the same kind of
+/// value.
+pub const EPUB_CFI_MAX_LEN: usize = 4096;
+
 /// Discriminator for the format-specific payload variant in [`ProgressUpdate`]
 /// / [`ProgressRecord`] / [`SessionReport`]. Serializes as a plain
 /// lowercase string (`"epub"` / `"audio"`) so the wire shape stays compact.
@@ -62,6 +67,11 @@ impl ProgressUpdate {
                     .unwrap_or(true)
                 {
                     return Err("epub_cfi is required for format=epub".into());
+                }
+                if let Some(cfi) = &self.epub_cfi {
+                    if cfi.chars().count() > EPUB_CFI_MAX_LEN {
+                        return Err(format!("epub_cfi exceeds {EPUB_CFI_MAX_LEN} characters"));
+                    }
                 }
                 if self.audio_position_seconds.is_some() {
                     return Err("audio_position_seconds must not be set for format=epub".into());

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -7,6 +7,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::highlight::CreateHighlight;
+
 #[cfg(test)]
 mod tests;
 
@@ -18,10 +20,10 @@ mod tests;
 /// runtime-configurable; change here to move the cap.
 pub const SESSION_BATCH_CAP: usize = 500;
 
-/// Maximum length (in chars) of `ProgressUpdate::epub_cfi`. Matches
-/// `CreateHighlight::EPUB_CFI_RANGE_MAX_LEN` — both store the same kind of
-/// value.
-pub const EPUB_CFI_MAX_LEN: usize = 4096;
+/// Maximum length (in chars) of `ProgressUpdate::epub_cfi`. Aliased to
+/// `CreateHighlight::EPUB_CFI_RANGE_MAX_LEN` so both write paths for the same
+/// kind of value can't drift apart.
+pub const EPUB_CFI_MAX_LEN: usize = CreateHighlight::EPUB_CFI_RANGE_MAX_LEN;
 
 /// Discriminator for the format-specific payload variant in [`ProgressUpdate`]
 /// / [`ProgressRecord`] / [`SessionReport`]. Serializes as a plain

--- a/shared/src/progress/tests.rs
+++ b/shared/src/progress/tests.rs
@@ -43,6 +43,31 @@ fn session_report_rejects_inverted_time_range() {
 }
 
 #[test]
+fn progress_update_rejects_epub_cfi_over_max_len() {
+    let u = ProgressUpdate {
+        book_uuid: "x".into(),
+        format: ProgressFormat::Epub,
+        epub_cfi: Some("a".repeat(EPUB_CFI_MAX_LEN + 1)),
+        audio_position_seconds: None,
+    };
+    let err = u
+        .validate()
+        .expect_err("over-max epub_cfi must be rejected");
+    assert!(err.contains("epub_cfi"), "got: {err}");
+}
+
+#[test]
+fn progress_update_accepts_epub_cfi_at_max_len() {
+    let u = ProgressUpdate {
+        book_uuid: "x".into(),
+        format: ProgressFormat::Epub,
+        epub_cfi: Some("a".repeat(EPUB_CFI_MAX_LEN)),
+        audio_position_seconds: None,
+    };
+    assert!(u.validate().is_ok());
+}
+
+#[test]
 fn session_report_rejects_negative_progress_units() {
     let r = SessionReport {
         book_uuid: "x".into(),

--- a/shared/src/shelves.rs
+++ b/shared/src/shelves.rs
@@ -12,6 +12,13 @@ use crate::EbookMetadata;
 /// Max length of a shelf name (matches the create-modal input expectation).
 pub const SHELF_NAME_MAX_LEN: usize = 120;
 
+/// Max length of a shelf description.
+pub const SHELF_DESCRIPTION_MAX_LEN: usize = 2048;
+
+/// Max length of a smart-shelf rule's `value` (a tag/author/year/date token,
+/// never a long free-text field).
+pub const SHELF_RULE_VALUE_MAX_LEN: usize = 512;
+
 /// Kind of shelf, fixed at creation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -177,6 +184,11 @@ impl ShelfRule {
         if self.value.trim().is_empty() {
             return Err("condition value is required".into());
         }
+        if self.value.chars().count() > SHELF_RULE_VALUE_MAX_LEN {
+            return Err(format!(
+                "condition value must be ≤ {SHELF_RULE_VALUE_MAX_LEN} characters"
+            ));
+        }
         Ok(())
     }
 }
@@ -232,6 +244,7 @@ impl CreateShelfRequest {
     /// into a 400/422.
     pub fn validate(&self) -> Result<(), String> {
         validate_name(&self.name)?;
+        validate_description(&self.description)?;
         match self.kind {
             ShelfKind::Smart => {
                 if self.match_mode.is_none() {
@@ -279,6 +292,7 @@ impl UpdateShelfRequest {
         if let Some(name) = &self.name {
             validate_name(name)?;
         }
+        validate_description(&self.description)?;
         if let Some(rules) = &self.rules {
             for r in rules {
                 r.validate()?;
@@ -319,6 +333,18 @@ fn validate_name(name: &str) -> Result<(), String> {
         return Err(format!(
             "shelf name must be ≤ {SHELF_NAME_MAX_LEN} characters"
         ));
+    }
+    Ok(())
+}
+
+/// Reject an over-long shelf description. `None` is always permitted.
+fn validate_description(description: &Option<String>) -> Result<(), String> {
+    if let Some(description) = description {
+        if description.chars().count() > SHELF_DESCRIPTION_MAX_LEN {
+            return Err(format!(
+                "shelf description must be ≤ {SHELF_DESCRIPTION_MAX_LEN} characters"
+            ));
+        }
     }
     Ok(())
 }

--- a/shared/src/shelves/tests.rs
+++ b/shared/src/shelves/tests.rs
@@ -189,3 +189,12 @@ fn update_validate_rejects_overlong_description() {
     };
     assert!(update.validate().is_err());
 }
+
+#[test]
+fn update_validate_accepts_description_at_max_len() {
+    let update = UpdateShelfRequest {
+        description: Some("x".repeat(SHELF_DESCRIPTION_MAX_LEN)),
+        ..Default::default()
+    };
+    assert!(update.validate().is_ok());
+}

--- a/shared/src/shelves/tests.rs
+++ b/shared/src/shelves/tests.rs
@@ -75,6 +75,23 @@ fn rule_validate_rejects_bad_op_and_empty_value() {
 }
 
 #[test]
+fn rule_validate_rejects_overlong_value_and_accepts_at_max() {
+    let too_long = ShelfRule {
+        field: RuleField::Tag,
+        op: RuleOp::Is,
+        value: "x".repeat(SHELF_RULE_VALUE_MAX_LEN + 1),
+    };
+    assert!(too_long.validate().is_err());
+
+    let at_max = ShelfRule {
+        field: RuleField::Tag,
+        op: RuleOp::Is,
+        value: "x".repeat(SHELF_RULE_VALUE_MAX_LEN),
+    };
+    assert!(at_max.validate().is_ok());
+}
+
+#[test]
 fn create_validate_enforces_smart_invariants() {
     let smart = CreateShelfRequest {
         kind: ShelfKind::Smart,
@@ -142,4 +159,33 @@ fn create_validate_rejects_blank_and_overlong_names() {
         ..base.clone()
     };
     assert!(long.validate().is_err());
+}
+
+#[test]
+fn create_validate_rejects_overlong_description_and_accepts_at_max() {
+    let base = CreateShelfRequest {
+        kind: ShelfKind::Manual,
+        name: "Best of 2026".into(),
+        description: Some("x".repeat(SHELF_DESCRIPTION_MAX_LEN + 1)),
+        visibility: Visibility::Private,
+        match_mode: None,
+        rules: vec![],
+        book_uuids: vec![],
+    };
+    assert!(base.validate().is_err());
+
+    let at_max = CreateShelfRequest {
+        description: Some("x".repeat(SHELF_DESCRIPTION_MAX_LEN)),
+        ..base.clone()
+    };
+    assert!(at_max.validate().is_ok());
+}
+
+#[test]
+fn update_validate_rejects_overlong_description() {
+    let update = UpdateShelfRequest {
+        description: Some("x".repeat(SHELF_DESCRIPTION_MAX_LEN + 1)),
+        ..Default::default()
+    };
+    assert!(update.validate().is_err());
 }


### PR DESCRIPTION
## Summary
- Three string fields landed in the DB with no per-field length cap, in the same family of gaps this project has repeatedly found and fixed elsewhere (#294, #517, #638, #639, #659, #501).
- `ProgressUpdate::validate` (`shared/src/progress.rs`) now caps `epub_cfi` at `EPUB_CFI_MAX_LEN` (4096 chars), matching `CreateHighlight::EPUB_CFI_RANGE_MAX_LEN` — both store the same kind of value.
- `CreateShelfRequest`/`UpdateShelfRequest::validate` (`shared/src/shelves.rs`) now cap `description` at `SHELF_DESCRIPTION_MAX_LEN` (2048 chars) via a new `validate_description` helper mirroring the existing `validate_name`.
- `ShelfRule::validate` now caps `value` at `SHELF_RULE_VALUE_MAX_LEN` (512 chars) — rule values are short tokens (tag/author/year/date), never long free text.
- All caps measured with `.chars().count()` (Unicode scalar values), not `.len()`, per the issue's note about #240's byte-vs-character-count bug.

## Test plan
- [x] `cargo test -p omnibus-shared` — added one rejects-over-cap + one accepts-at-cap test per field (epub_cfi, shelf description via both Create/Update, rule value)
- [x] `cargo test -p omnibus-db`, `cargo test -p omnibus-frontend --features server`, `cargo test -p omnibus` all pass unchanged
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

## Version
- [ ] Minor
- [x] Patch — the default; leaving unlabeled
- [ ] No release

## Notes
- Pure validation addition in `shared/`; no migration, no wire-shape change, no behavior change for any value under the new caps.

Closes #735


---
_Generated by [Claude Code](https://claude.ai/code/session_01DetkTD7LxDETLig66tachR)_