### PR TITLE
refactor: cap epub_cfi, shelf description, and shelf rule value lengths (#735)

### DIFF
--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -7,6 +7,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::highlight::CreateHighlight;
+
 #[cfg(test)]
 mod tests;
 
@@ -17,6 +19,11 @@ mod tests;
 /// to bound per-request DB work and SQLite write-lock hold time. Not
 /// runtime-configurable; change here to move the cap.
 pub const SESSION_BATCH_CAP: usize = 500;
+
+/// Maximum length (in chars) of an `epub_cfi` position string. Defined in
+/// terms of `CreateHighlight::EPUB_CFI_RANGE_MAX_LEN` — both hold the same
+/// kind of value — so the two ceilings can't drift apart.
+pub const EPUB_CFI_MAX_LEN: usize = CreateHighlight::EPUB_CFI_RANGE_MAX_LEN;
 
 /// Discriminator for the format-specific payload variant in [`ProgressUpdate`]
 /// / [`ProgressRecord`] / [`SessionReport`]. Serializes as a plain
@@ -62,6 +69,11 @@ impl ProgressUpdate {
                     .unwrap_or(true)
                 {
                     return Err("epub_cfi is required for format=epub".into());
+                }
+                if let Some(cfi) = &self.epub_cfi {
+                    if cfi.chars().count() > EPUB_CFI_MAX_LEN {
+                        return Err(format!("epub_cfi exceeds {EPUB_CFI_MAX_LEN} characters"));
+                    }
                 }
                 if self.audio_position_seconds.is_some() {
                     return Err("audio_position_seconds must not be set for format=epub".into());

--- a/shared/src/progress/tests.rs
+++ b/shared/src/progress/tests.rs
@@ -29,6 +29,33 @@ fn progress_update_rejects_cross_format_cfi_on_audio() {
 }
 
 #[test]
+fn progress_update_rejects_overlong_epub_cfi() {
+    let u = ProgressUpdate {
+        book_uuid: "x".into(),
+        format: ProgressFormat::Epub,
+        epub_cfi: Some("a".repeat(EPUB_CFI_MAX_LEN + 1)),
+        audio_position_seconds: None,
+    };
+    let err = u
+        .validate()
+        .expect_err("over-cap epub_cfi must be rejected");
+    assert!(err.contains("epub_cfi"), "got: {err}");
+}
+
+#[test]
+fn progress_update_accepts_epub_cfi_at_cap() {
+    // Multibyte char: chars().count() == EPUB_CFI_MAX_LEN but len() (bytes)
+    // is double that, so a regression to a byte-length check would fail this.
+    let u = ProgressUpdate {
+        book_uuid: "x".into(),
+        format: ProgressFormat::Epub,
+        epub_cfi: Some("é".repeat(EPUB_CFI_MAX_LEN)),
+        audio_position_seconds: None,
+    };
+    assert!(u.validate().is_ok());
+}
+
+#[test]
 fn session_report_rejects_inverted_time_range() {
     let r = SessionReport {
         book_uuid: "x".into(),

--- a/shared/src/shelves.rs
+++ b/shared/src/shelves.rs
@@ -12,6 +12,13 @@ use crate::EbookMetadata;
 /// Max length of a shelf name (matches the create-modal input expectation).
 pub const SHELF_NAME_MAX_LEN: usize = 120;
 
+/// Max length of a shelf description.
+pub const SHELF_DESCRIPTION_MAX_LEN: usize = 2048;
+
+/// Max length of a smart-rule condition value. Rule values are short strings
+/// (a tag/author/series name, a rating, a date window), never free text.
+pub const SHELF_RULE_VALUE_MAX_LEN: usize = 512;
+
 /// Kind of shelf, fixed at creation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -177,6 +184,11 @@ impl ShelfRule {
         if self.value.trim().is_empty() {
             return Err("condition value is required".into());
         }
+        if self.value.chars().count() > SHELF_RULE_VALUE_MAX_LEN {
+            return Err(format!(
+                "condition value must be ≤ {SHELF_RULE_VALUE_MAX_LEN} characters"
+            ));
+        }
         Ok(())
     }
 }
@@ -232,6 +244,7 @@ impl CreateShelfRequest {
     /// into a 400/422.
     pub fn validate(&self) -> Result<(), String> {
         validate_name(&self.name)?;
+        validate_description(&self.description)?;
         match self.kind {
             ShelfKind::Smart => {
                 if self.match_mode.is_none() {
@@ -279,6 +292,7 @@ impl UpdateShelfRequest {
         if let Some(name) = &self.name {
             validate_name(name)?;
         }
+        validate_description(&self.description)?;
         if let Some(rules) = &self.rules {
             for r in rules {
                 r.validate()?;
@@ -319,6 +333,18 @@ fn validate_name(name: &str) -> Result<(), String> {
         return Err(format!(
             "shelf name must be ≤ {SHELF_NAME_MAX_LEN} characters"
         ));
+    }
+    Ok(())
+}
+
+/// Reject an over-long shelf description. `None` is always permitted.
+fn validate_description(description: &Option<String>) -> Result<(), String> {
+    if let Some(description) = description {
+        if description.chars().count() > SHELF_DESCRIPTION_MAX_LEN {
+            return Err(format!(
+                "shelf description must be ≤ {SHELF_DESCRIPTION_MAX_LEN} characters"
+            ));
+        }
     }
     Ok(())
 }

--- a/shared/src/shelves/tests.rs
+++ b/shared/src/shelves/tests.rs
@@ -75,6 +75,69 @@ fn rule_validate_rejects_bad_op_and_empty_value() {
 }
 
 #[test]
+fn rule_validate_rejects_overlong_value_and_accepts_value_at_cap() {
+    let overlong = ShelfRule {
+        field: RuleField::Tag,
+        op: RuleOp::Is,
+        value: "a".repeat(SHELF_RULE_VALUE_MAX_LEN + 1),
+    };
+    assert!(overlong.validate().is_err());
+
+    // Multibyte char: chars().count() == cap but len() (bytes) is double
+    // that, so a regression to a byte-length check would fail this.
+    let at_cap = ShelfRule {
+        field: RuleField::Tag,
+        op: RuleOp::Is,
+        value: "é".repeat(SHELF_RULE_VALUE_MAX_LEN),
+    };
+    assert!(at_cap.validate().is_ok());
+}
+
+#[test]
+fn create_validate_rejects_overlong_description_and_accepts_description_at_cap() {
+    let base = CreateShelfRequest {
+        kind: ShelfKind::Manual,
+        name: "Best of 2026".into(),
+        description: None,
+        visibility: Visibility::Private,
+        match_mode: None,
+        rules: vec![],
+        book_uuids: vec![],
+    };
+
+    let overlong = CreateShelfRequest {
+        description: Some("a".repeat(SHELF_DESCRIPTION_MAX_LEN + 1)),
+        ..base.clone()
+    };
+    assert!(overlong.validate().is_err());
+
+    // Multibyte char: chars().count() == cap but len() (bytes) is double
+    // that, so a regression to a byte-length check would fail this.
+    let at_cap = CreateShelfRequest {
+        description: Some("é".repeat(SHELF_DESCRIPTION_MAX_LEN)),
+        ..base.clone()
+    };
+    assert!(at_cap.validate().is_ok());
+}
+
+#[test]
+fn update_validate_rejects_overlong_description() {
+    let overlong = UpdateShelfRequest {
+        description: Some("a".repeat(SHELF_DESCRIPTION_MAX_LEN + 1)),
+        ..Default::default()
+    };
+    assert!(overlong.validate().is_err());
+
+    // Multibyte char: chars().count() == cap but len() (bytes) is double
+    // that, so a regression to a byte-length check would fail this.
+    let at_cap = UpdateShelfRequest {
+        description: Some("é".repeat(SHELF_DESCRIPTION_MAX_LEN)),
+        ..Default::default()
+    };
+    assert!(at_cap.validate().is_ok());
+}
+
+#[test]
 fn create_validate_enforces_smart_invariants() {
     let smart = CreateShelfRequest {
         kind: ShelfKind::Smart,


### PR DESCRIPTION
## Summary
- `ProgressUpdate::epub_cfi`, `CreateShelfRequest`/`UpdateShelfRequest::description`, and `ShelfRule::value` accepted unbounded strings (up to the existing 1 MiB request-body cap), inconsistent with `CreateHighlight::EPUB_CFI_RANGE_MAX_LEN` already capping the same kind of value. Same pattern as the closed issues in this family (#294, #517, #638, #639, #659, #501).
- Adds `EPUB_CFI_MAX_LEN` (4096, matching `CreateHighlight::EPUB_CFI_RANGE_MAX_LEN`), `SHELF_DESCRIPTION_MAX_LEN` (2048), and `SHELF_RULE_VALUE_MAX_LEN` (512), enforced inside each type's existing `validate()` method in `shared/`.
- All checks use `.chars().count()`, not `.len()`, per the byte-vs-char-count precedent from #240.
- No `db/`/`server/`/`frontend/` or migration changes needed — validation happens entirely in the `shared` crate before the DB call.

## Test plan
- [x] Added a rejects-over-cap + accepts-at-cap test pair for each of the three fields (`shared/src/progress/tests.rs`, `shared/src/shelves/tests.rs`)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-shared --all-targets --all-features -- -D warnings`
- [x] `cargo test -p omnibus-shared` (92 passed)
- [x] `cargo clippy` (workspace default-members)
- [x] `cargo test -p omnibus-db`, `cargo test -p omnibus`, `cargo test -p omnibus-frontend --features server`

## Version
- [ ] **Minor**
- [x] **Patch** — the default
- [ ] **No release**

## Notes
- Followed the issue's own suggested approach as-is; no deviation needed.

Closes #735