### PR TITLE
refactor: cap journals/shelves list queries and fix shelves N+1 (#733)

### DIFF
--- a/db/src/journals/mod.rs
+++ b/db/src/journals/mod.rs
@@ -24,6 +24,12 @@ const SELECT_ENTRY: &str = "SELECT je.id, je.book_uuid, je.user_id AS author_id,
    FROM journal_entries je
    JOIN users u ON u.id = je.user_id";
 
+/// Hard cap on how many entries `list_journal_entries` returns for a single
+/// book. Matches `LIST_BOOKMARKS_LIMIT`/`LIST_HIGHLIGHTS_LIMIT` — a
+/// defensive ceiling so a book with a pathological entry count can't produce
+/// an unbounded REST response.
+pub const LIST_JOURNAL_ENTRIES_LIMIT: i64 = 1_000;
+
 #[derive(Debug, thiserror::Error)]
 pub enum JournalError {
     #[error("book not found")]
@@ -84,9 +90,10 @@ pub async fn list_journal_entries(
         return Ok(vec![]);
     };
     let rows = sqlx::query(&format!(
-        "{SELECT_ENTRY} WHERE je.book_uuid = ? ORDER BY je.created_at DESC, je.id DESC"
+        "{SELECT_ENTRY} WHERE je.book_uuid = ? ORDER BY je.created_at DESC, je.id DESC LIMIT ?"
     ))
     .bind(&canonical)
+    .bind(LIST_JOURNAL_ENTRIES_LIMIT)
     .fetch_all(pool)
     .await?;
     rows.iter().map(row_to_entry).collect()

--- a/db/src/journals/tests.rs
+++ b/db/src/journals/tests.rs
@@ -235,6 +235,42 @@ async fn create_resolves_merged_uuid_to_surviving_book() {
     );
 }
 
+/// Bulk-insert `count` entry rows for `book_uuid` without going through
+/// `create_journal_entry` — too slow at over-cap row counts.
+async fn seed_entries_raw(pool: &SqlitePool, user_id: i64, book_uuid: &str, count: i64) {
+    sqlx::query(
+        r#"
+        WITH RECURSIVE n(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
+        )
+        INSERT INTO journal_entries (user_id, book_uuid, body_md, created_at)
+        SELECT ?, ?, 'entry ' || i, i FROM n
+        "#,
+    )
+    .bind(count)
+    .bind(user_id)
+    .bind(book_uuid)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn list_journal_entries_caps_response_at_hard_limit() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+    let over_cap = LIST_JOURNAL_ENTRIES_LIMIT + 500;
+    seed_entries_raw(&pool, user, &uuid, over_cap).await;
+
+    let list = list_journal_entries(&pool, &uuid).await.unwrap();
+    assert_eq!(
+        list.len() as i64,
+        LIST_JOURNAL_ENTRIES_LIMIT,
+        "list_journal_entries must not return more than LIST_JOURNAL_ENTRIES_LIMIT rows",
+    );
+}
+
 #[tokio::test]
 async fn create_propagates_db_error_when_pool_is_closed() {
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/shelves.rs
+++ b/db/src/shelves.rs
@@ -15,7 +15,7 @@ mod write;
 #[cfg(test)]
 mod tests;
 
-pub use read::{get_shelf, list_visible_shelves, preview_rule, shelf_page};
+pub use read::{get_shelf, list_visible_shelves, preview_rule, shelf_page, LIST_SHELVES_LIMIT};
 pub use write::{add_books, create_shelf, delete_shelf, remove_book, update_shelf};
 
 /// Errors from the shelves data layer.

--- a/db/src/shelves/read.rs
+++ b/db/src/shelves/read.rs
@@ -1,6 +1,8 @@
 //! Shelf read paths: visibility-scoped listing, single-shelf detail, the
 //! member book page, and the create-modal rule preview.
 
+use std::collections::HashMap;
+
 use sqlx::{Row, SqlitePool};
 
 use omnibus_shared::{
@@ -22,8 +24,19 @@ const FILE_EXISTS: &str = "EXISTS (SELECT 1 FROM book_files bf WHERE bf.book_id 
 /// Cover count in the create-modal live preview.
 const PREVIEW_SAMPLE: i64 = 12;
 
+/// Hard cap on how many shelves `list_visible_shelves` returns for a single
+/// viewer. Matches `LIST_BOOKMARKS_LIMIT`/`LIST_HIGHLIGHTS_LIMIT` — a
+/// defensive ceiling so a user with a pathological shelf count can't produce
+/// an unbounded REST response.
+pub const LIST_SHELVES_LIMIT: i64 = 500;
+
 /// Every shelf `viewer_id` can see: own + public, or all when `is_admin`.
-/// Each row carries its live book count (smart = rule match, manual = row count).
+/// Each row carries its live book count (smart = rule match, manual = row
+/// count). Rule loads and manual counts are batched across the whole visible
+/// set (one `WHERE id IN (...)` / `GROUP BY` query each) rather than issued
+/// per row; smart-shelf counts still run one query per shelf since each
+/// shelf's membership predicate is unique and can't be folded into a single
+/// `GROUP BY`.
 pub async fn list_visible_shelves(
     pool: &SqlitePool,
     viewer_id: i64,
@@ -33,33 +46,65 @@ pub async fn list_visible_shelves(
         "SELECT id, owner_user_id, kind, name, visibility, accent, match_mode
            FROM shelves
           WHERE owner_user_id = ? OR visibility = 'public' OR ?
-          ORDER BY position, id",
+          ORDER BY position, id
+          LIMIT ?",
     )
     .bind(viewer_id)
     .bind(is_admin)
+    .bind(LIST_SHELVES_LIMIT)
     .fetch_all(pool)
     .await?;
 
-    let mut out = Vec::with_capacity(rows.len());
+    struct VisibleShelfRow {
+        id: i64,
+        owner_user_id: i64,
+        kind: ShelfKind,
+        name: String,
+        visibility: Visibility,
+        accent: Option<String>,
+        match_mode: Option<String>,
+    }
+    let mut parsed = Vec::with_capacity(rows.len());
+    let mut smart_ids = Vec::new();
+    let mut manual_ids = Vec::new();
     for r in &rows {
         let id: i64 = r.try_get("id")?;
-        let owner_user_id: i64 = r.try_get("owner_user_id")?;
         let kind = parse_kind(r.try_get("kind")?)?;
-        let book_count = match kind {
-            ShelfKind::Smart => {
-                let mode = parse_mode(r.try_get("match_mode")?);
-                let rules = load_rules(pool, id).await?;
-                count_smart(pool, owner_user_id, mode, &rules).await?
-            }
-            ShelfKind::Manual => count_manual(pool, id).await?,
-        };
-        out.push(ShelfSummary {
+        match kind {
+            ShelfKind::Smart => smart_ids.push(id),
+            ShelfKind::Manual => manual_ids.push(id),
+        }
+        parsed.push(VisibleShelfRow {
             id,
-            owner_user_id,
+            owner_user_id: r.try_get("owner_user_id")?,
             kind,
             name: r.try_get("name")?,
             visibility: parse_visibility(r.try_get("visibility")?)?,
             accent: r.try_get("accent")?,
+            match_mode: r.try_get("match_mode")?,
+        });
+    }
+
+    let mut rules_by_shelf = load_rules_batch(pool, &smart_ids).await?;
+    let manual_counts = count_manual_batch(pool, &manual_ids).await?;
+
+    let mut out = Vec::with_capacity(parsed.len());
+    for row in parsed {
+        let book_count = match row.kind {
+            ShelfKind::Smart => {
+                let mode = parse_mode(row.match_mode);
+                let rules = rules_by_shelf.remove(&row.id).unwrap_or_default();
+                count_smart(pool, row.owner_user_id, mode, &rules).await?
+            }
+            ShelfKind::Manual => manual_counts.get(&row.id).copied().unwrap_or(0),
+        };
+        out.push(ShelfSummary {
+            id: row.id,
+            owner_user_id: row.owner_user_id,
+            kind: row.kind,
+            name: row.name,
+            visibility: row.visibility,
+            accent: row.accent,
             book_count,
         });
     }
@@ -181,19 +226,78 @@ async fn load_rules(pool: &SqlitePool, shelf_id: i64) -> Result<Vec<ShelfRule>, 
     .bind(shelf_id)
     .fetch_all(pool)
     .await?;
-    let mut out = Vec::with_capacity(rows.len());
+    rows.iter().map(row_to_rule).collect()
+}
+
+/// Load rules for every shelf id in `shelf_ids` in one query, grouped by
+/// shelf id in stored order — avoids the per-row `load_rules` call
+/// `list_visible_shelves` used to make for each smart shelf.
+async fn load_rules_batch(
+    pool: &SqlitePool,
+    shelf_ids: &[i64],
+) -> Result<HashMap<i64, Vec<ShelfRule>>, ShelfError> {
+    let mut out: HashMap<i64, Vec<ShelfRule>> = HashMap::new();
+    if shelf_ids.is_empty() {
+        return Ok(out);
+    }
+    let placeholders = shelf_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT shelf_id, field, op, value FROM shelf_rules \
+         WHERE shelf_id IN ({placeholders}) ORDER BY shelf_id, position, id"
+    );
+    let mut q = sqlx::query(&sql);
+    for id in shelf_ids {
+        q = q.bind(id);
+    }
+    let rows = q.fetch_all(pool).await?;
     for r in &rows {
-        let field: String = r.try_get("field")?;
-        let op: String = r.try_get("op")?;
-        out.push(ShelfRule {
-            field: RuleField::from_str(&field)
-                .ok_or_else(|| ShelfError::InvalidRule(format!("unknown field {field:?}")))?,
-            op: RuleOp::from_str(&op)
-                .ok_or_else(|| ShelfError::InvalidRule(format!("unknown op {op:?}")))?,
-            value: r.try_get("value")?,
-        });
+        let shelf_id: i64 = r.try_get("shelf_id")?;
+        out.entry(shelf_id).or_default().push(row_to_rule(r)?);
     }
     Ok(out)
+}
+
+/// Count manual-shelf membership for every shelf id in `shelf_ids` in one
+/// `GROUP BY` query — avoids the per-row `count_manual` call
+/// `list_visible_shelves` used to make for each manual shelf. A shelf with
+/// zero books has no row in `shelf_books` and so is absent from the map;
+/// callers default missing ids to 0.
+async fn count_manual_batch(
+    pool: &SqlitePool,
+    shelf_ids: &[i64],
+) -> Result<HashMap<i64, i64>, ShelfError> {
+    let mut out = HashMap::new();
+    if shelf_ids.is_empty() {
+        return Ok(out);
+    }
+    let placeholders = shelf_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT shelf_id, COUNT(*) AS cnt FROM shelf_books \
+         WHERE shelf_id IN ({placeholders}) GROUP BY shelf_id"
+    );
+    let mut q = sqlx::query(&sql);
+    for id in shelf_ids {
+        q = q.bind(id);
+    }
+    let rows = q.fetch_all(pool).await?;
+    for r in &rows {
+        out.insert(r.try_get("shelf_id")?, r.try_get("cnt")?);
+    }
+    Ok(out)
+}
+
+/// Parse one `shelf_rules` row (`field`, `op`, `value` columns) into a
+/// [`ShelfRule`]. Shared by [`load_rules`] and [`load_rules_batch`].
+fn row_to_rule(r: &sqlx::sqlite::SqliteRow) -> Result<ShelfRule, ShelfError> {
+    let field: String = r.try_get("field")?;
+    let op: String = r.try_get("op")?;
+    Ok(ShelfRule {
+        field: RuleField::from_str(&field)
+            .ok_or_else(|| ShelfError::InvalidRule(format!("unknown field {field:?}")))?,
+        op: RuleOp::from_str(&op)
+            .ok_or_else(|| ShelfError::InvalidRule(format!("unknown op {op:?}")))?,
+        value: r.try_get("value")?,
+    })
 }
 
 async fn count_smart(

--- a/db/src/shelves/read.rs
+++ b/db/src/shelves/read.rs
@@ -33,8 +33,8 @@ pub const LIST_SHELVES_LIMIT: i64 = 500;
 /// Every shelf `viewer_id` can see: own + public, or all when `is_admin`.
 /// Each row carries its live book count (smart = rule match, manual = row
 /// count). Rule loads and manual counts are batched across the whole visible
-/// set (one `WHERE id IN (...)` / `GROUP BY` query each) rather than issued
-/// per row; smart-shelf counts still run one query per shelf since each
+/// set (one `WHERE shelf_id IN (...)` / `GROUP BY` query each) rather than
+/// issued per row; smart-shelf counts still run one query per shelf since each
 /// shelf's membership predicate is unique and can't be folded into a single
 /// `GROUP BY`.
 pub async fn list_visible_shelves(
@@ -229,9 +229,11 @@ async fn load_rules(pool: &SqlitePool, shelf_id: i64) -> Result<Vec<ShelfRule>, 
     rows.iter().map(row_to_rule).collect()
 }
 
-/// Load rules for every shelf id in `shelf_ids` in one query, grouped by
-/// shelf id in stored order — avoids the per-row `load_rules` call
-/// `list_visible_shelves` used to make for each smart shelf.
+/// Load rules for every shelf id in `shelf_ids` in one query, keyed by shelf
+/// id in the returned map. Each shelf's own `Vec<ShelfRule>` preserves stored
+/// order (`ORDER BY ... position, id`); the map itself has no iteration
+/// order. Avoids the per-row `load_rules` call `list_visible_shelves` used to
+/// make for each smart shelf.
 async fn load_rules_batch(
     pool: &SqlitePool,
     shelf_ids: &[i64],

--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -422,6 +422,85 @@ async fn list_visible_scopes_by_owner_public_and_admin() {
     );
 }
 
+/// Bulk-insert `count` manual shelf rows owned by `owner_id` without going
+/// through `create_shelf` — too slow at over-cap row counts.
+async fn seed_shelves_raw(pool: &sqlx::SqlitePool, owner_id: i64, count: i64) {
+    sqlx::query(
+        r#"
+        WITH RECURSIVE n(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
+        )
+        INSERT INTO shelves (owner_user_id, kind, name, position)
+        SELECT ?, 'manual', 'Shelf ' || i, i FROM n
+        "#,
+    )
+    .bind(count)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn list_visible_shelves_caps_response_at_hard_limit() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let owner = make_user(&pool, "owner", false).await;
+    let over_cap = LIST_SHELVES_LIMIT + 50;
+    seed_shelves_raw(&pool, owner, over_cap).await;
+
+    let list = list_visible_shelves(&pool, owner, false).await.unwrap();
+    assert_eq!(
+        list.len() as i64,
+        LIST_SHELVES_LIMIT,
+        "list_visible_shelves must not return more than LIST_SHELVES_LIMIT rows",
+    );
+}
+
+#[tokio::test]
+async fn list_visible_shelves_reports_correct_per_shelf_counts_when_batched() {
+    // Exercises the batched rule-load / manual-count path with more than one
+    // shelf of each kind, so a shelf_id mix-up in the batching would surface
+    // as a wrong count on the wrong shelf.
+    let (pool, _covers) = seed_discovery_fixture().await;
+    let owner = make_user(&pool, "owner", false).await;
+
+    let fiction = create_shelf(
+        &pool,
+        owner,
+        &smart_req("Fiction", MatchMode::Any, vec![tag_rule("fiction")]),
+    )
+    .await
+    .unwrap();
+    let empty_smart = create_shelf(
+        &pool,
+        owner,
+        &smart_req("No matches", MatchMode::Any, vec![tag_rule("no-such-tag")]),
+    )
+    .await
+    .unwrap();
+
+    let book_a = uuid_by_title(&pool, "Saga: Book One").await;
+    let manual_with_book =
+        create_shelf(&pool, owner, &manual_req("Manual with book", vec![book_a]))
+            .await
+            .unwrap();
+    let manual_empty = create_shelf(&pool, owner, &manual_req("Manual empty", vec![]))
+        .await
+        .unwrap();
+
+    let shelves = list_visible_shelves(&pool, owner, false).await.unwrap();
+    let count_for = |id: i64| shelves.iter().find(|s| s.id == id).unwrap().book_count;
+
+    assert_eq!(count_for(fiction.id), 2, "two books tagged fiction");
+    assert_eq!(count_for(empty_smart.id), 0, "no book matches the tag");
+    assert_eq!(count_for(manual_with_book.id), 1);
+    assert_eq!(
+        count_for(manual_empty.id),
+        0,
+        "an empty manual shelf has no shelf_books row and must default to 0"
+    );
+}
+
 #[tokio::test]
 async fn duplicate_name_for_same_owner_is_name_taken() {
     let pool = init_db("sqlite::memory:").await.unwrap();


### PR DESCRIPTION
## Summary
- `list_journal_entries` gets a hard `LIST_JOURNAL_ENTRIES_LIMIT` (1,000), matching the `LIST_BOOKMARKS_LIMIT`/`LIST_HIGHLIGHTS_LIMIT` convention from #640.
- `list_visible_shelves` gets a hard `LIST_SHELVES_LIMIT` (500).
- `list_visible_shelves`'s N+1 read pattern is fixed: rule loads for every smart shelf are batched into one `WHERE shelf_id IN (...)` query, and manual-shelf counts are batched into one `GROUP BY shelf_id` query, instead of a `load_rules`/`count_smart`/`count_manual` pair issued per row.

**Deviation from the issue's suggested approach:** the issue's suggested-approach note says to batch "manual/smart counts via one GROUP BY query." `count_smart` is left as one call per smart shelf — each smart shelf's membership predicate is a distinct `WHERE` clause built from its own rules/match_mode/owner, so it can't be folded into a single `GROUP BY` the way manual counts (a plain `COUNT(*) ... GROUP BY shelf_id` over `shelf_books`) can without emulating per-shelf predicates via a large `CASE`/`UNION` — not worth the added complexity for the win. The batched rule loads + batched manual counts still eliminate the dominant part of the N+1 (down from ~2-3 queries per shelf to ~1 query per smart shelf plus 3 fixed queries).

## Test plan
- [x] `cargo test -p omnibus-db` passes (792 tests), including new cap-enforcement tests for both functions and a batching-correctness test (`list_visible_shelves_reports_correct_per_shelf_counts_when_batched`) that would catch a shelf-id mix-up in the batched maps
- [x] `cargo test -p omnibus` passes (293 tests)
- [x] `cargo test -p omnibus-frontend --features server` passes (202 tests)
- [x] `cargo clippy --all-targets --all-features` (db) and `cargo clippy` (default members) — clean
- [x] `cargo fmt --check` — clean

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- No migration needed — both fixes are query-shape changes only.
- No REST/RPC response contract changes beyond the caps themselves (no truncation-signaling header exists for bookmarks/highlights either, so none was added here — matches precedent).

Closes #733
