### PR TITLE
refactor: derive is_admin/current_user from CurrentUser context (#730)

### DIFF
--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -100,8 +100,9 @@ pub fn use_current_user() -> CurrentUser {
 /// Derive `is_admin` from the app-wide [`CurrentUser`] context instead of an
 /// independent per-mount `/api/auth/me` fetch. Starts `false` so SSR and the
 /// first WASM paint agree (rule 07); only the web build wires the effect
-/// that flips it once the context resolves an admin user. Mobile/SSR stay at
-/// the default since `CurrentUser` isn't provided there.
+/// that flips it once the context resolves an admin user. Mobile stays at
+/// the default since `CurrentUser` isn't provided there; SSR has the context
+/// but it stays unresolved until the web client's boot effect runs post-mount.
 #[cfg_attr(not(feature = "web"), allow(unused_mut))]
 pub fn use_is_admin() -> Signal<bool> {
     let mut is_admin = use_signal(|| false);

--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -97,6 +97,42 @@ pub fn use_current_user() -> CurrentUser {
     use_context::<CurrentUser>()
 }
 
+/// Derive `is_admin` from the app-wide [`CurrentUser`] context instead of an
+/// independent per-mount `/api/auth/me` fetch. Starts `false` so SSR and the
+/// first WASM paint agree (rule 07); only the web build wires the effect
+/// that flips it once the context resolves an admin user. Mobile/SSR stay at
+/// the default since `CurrentUser` isn't provided there.
+#[cfg_attr(not(feature = "web"), allow(unused_mut))]
+pub fn use_is_admin() -> Signal<bool> {
+    let mut is_admin = use_signal(|| false);
+    #[cfg(feature = "web")]
+    {
+        let user_ctx = use_current_user().0;
+        use_effect(move || {
+            is_admin.set(matches!(user_ctx(), Some(Some(ref u)) if u.is_admin));
+        });
+    }
+    is_admin
+}
+
+/// Derive the resolved current user from the app-wide [`CurrentUser`]
+/// context instead of an independent per-mount `/api/auth/me` fetch,
+/// flattening "not yet resolved" and "unauthenticated" alike to `None`.
+/// Starts `None` so SSR and the first WASM paint agree (rule 07); only the
+/// web build wires the effect that fills it in once the context resolves.
+#[cfg_attr(not(feature = "web"), allow(unused_mut))]
+pub fn use_current_user_summary() -> Signal<Option<omnibus_shared::UserSummary>> {
+    let mut current = use_signal(|| None);
+    #[cfg(feature = "web")]
+    {
+        let user_ctx = use_current_user().0;
+        use_effect(move || {
+            current.set(user_ctx().flatten());
+        });
+    }
+    current
+}
+
 /// App-wide audiobook playback state. Owned by [`crate::App`] via
 /// `use_context_provider` so the full listen player and the persistent
 /// mini-dock share one set of signals. Playback survives route changes

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -20,24 +20,13 @@ pub fn AuthorPage(id: i64) -> Element {
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
 
-    // F5.9-lite admin gating for the Delete button. The signal and the
-    // effect are declared unconditionally so SSR and the hydrating WASM
-    // bundle agree on hook count and order — Dioxus tracks hooks
-    // positionally, and a cfg-gated declaration would diverge the two
-    // (rule 07). The effect itself only runs on the client (Dioxus skips
-    // `use_effect` during SSR), and `data::current_user()` resolves to
-    // an `Ok(None)`-returning stub under server-only and mobile builds,
-    // so no admin surface ever leaks into the prerendered markup or the
-    // mobile UI. The server-side `AdminUser` extractor on
-    // `rpc_delete_author` is the actual security boundary.
-    let mut is_admin = use_signal(|| false);
-    use_effect(move || {
-        spawn(async move {
-            if let Ok(Some(user)) = data::current_user().await {
-                is_admin.set(user.is_admin);
-            }
-        });
-    });
+    // F5.9-lite admin gating for the Delete button — derived from the
+    // app-wide `CurrentUser` context (`crate::use_is_admin`) instead of an
+    // independent per-mount `/api/auth/me` fetch. Mobile/SSR stay at the
+    // `false` default since the context is web-only; the server-side
+    // `AdminUser` extractor on `rpc_delete_author` is the actual security
+    // boundary.
+    let is_admin = crate::use_is_admin();
 
     // See `BookDetailPage` for why `id` needs `use_reactive!`.
     let url = server_url.clone();

--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -19,17 +19,12 @@ use super::BdSectionHead;
 pub(super) fn BdJournalSection(uuid: String) -> Element {
     let server_url = use_server_url();
     let mut entries = use_signal(Vec::<JournalEntry>::new);
-    let mut current_user = use_signal(|| None::<UserSummary>);
+    // Derived from the app-wide `CurrentUser` context (`crate::use_current_user_summary`)
+    // instead of an independent per-mount `/api/auth/me` fetch. Mobile/SSR
+    // stay at the `None` default since the context is web-only.
+    let current_user = crate::use_current_user_summary();
     // Bumped after any mutation to refetch the server-authoritative feed.
     let reload = use_signal(|| 0u32);
-
-    use_effect(move || {
-        spawn(async move {
-            if let Ok(u) = data::current_user().await {
-                current_user.set(u);
-            }
-        });
-    });
 
     let load_url = server_url.clone();
     use_effect(use_reactive!(|uuid| {

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -50,24 +50,13 @@ pub fn BookDetailPage(uuid: String) -> Element {
     // (signals read inside `use_effect` re-arm it).
     let refresh = use_signal(|| 0u32);
 
-    // Admin gating for the "Merge with…" affordance. The signal and the
-    // effect are declared unconditionally so SSR and the hydrating WASM
-    // bundle agree on hook count and order — Dioxus tracks hooks
-    // positionally, and a cfg-gated declaration would diverge the two.
-    // The effect itself only runs on the client (Dioxus skips `use_effect`
-    // during SSR), and `data::current_user()` resolves to an
-    // `Ok(None)`-returning stub under server-only builds, so no admin
-    // surface ever leaks into the prerendered markup. Mobile renders no
-    // admin surfaces; the server-side `AdminUser` extractor on
-    // `rpc_merge_books` is the actual security boundary.
-    let mut is_admin = use_signal(|| false);
-    use_effect(move || {
-        spawn(async move {
-            if let Ok(Some(user)) = data::current_user().await {
-                is_admin.set(user.is_admin);
-            }
-        });
-    });
+    // Admin gating for the "Merge with…" affordance — derived from the
+    // app-wide `CurrentUser` context (`crate::use_is_admin`) instead of an
+    // independent per-mount `/api/auth/me` fetch. Mobile/SSR stay at the
+    // `false` default since the context is web-only; the server-side
+    // `AdminUser` extractor on `rpc_merge_books` is the actual security
+    // boundary.
+    let is_admin = crate::use_is_admin();
 
     // Merge dialog state. Declared unconditionally per rule 07 so the hook
     // count is identical on every target — mobile compiles the signals but

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -96,7 +96,7 @@ fn setup_landing_signals(server_url: &str, query: Signal<String>) -> LandingSign
     // if a newer fetch (sort/dir/filter/query change) superseded it mid-flight
     // — otherwise it would splice an old result stream onto the new list.
     let fetch_epoch = use_signal(|| 0u64);
-    let is_admin = setup_admin_signal();
+    let is_admin = crate::use_is_admin();
     // Suggestion pools for the inline Authors chip editor and the
     // (future-reserved) Tags pool, each carrying the dropdown book-count.
     let pools = SuggestionPools {
@@ -131,23 +131,6 @@ fn setup_landing_signals(server_url: &str, query: Signal<String>) -> LandingSign
         is_admin,
         pools,
     }
-}
-
-/// Wire `is_admin` to the current-user context on web; SSR/mobile leave it
-/// at its `false` default so the first paint matches.
-fn setup_admin_signal() -> Signal<bool> {
-    // F5.9-lite: admin-only inline-edit affordances on the power-user table.
-    // Reads from the App-wide `CurrentUser` context — no per-mount round-trip.
-    #[cfg_attr(not(feature = "web"), allow(unused_mut))]
-    let mut is_admin = use_signal(|| false);
-    #[cfg(feature = "web")]
-    {
-        let user_ctx = crate::use_current_user().0;
-        use_effect(move || {
-            is_admin.set(matches!(user_ctx(), Some(Some(ref u)) if u.is_admin));
-        });
-    }
-    is_admin
 }
 
 /// Arm every reactive side-effect the landing page needs: admin-gated

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -29,19 +29,12 @@ pub fn SettingsPage() -> Element {
     // Bumped after a successful save to re-trigger the library-refresh effect.
     let library_refresh = use_signal(|| 0u32);
 
-    // Admin gating for the F3.3 Hardcover key card. Starts `false` so SSR and
-    // the first WASM paint agree (rule 07); the effect flips it for admins
-    // after mount. Declared unconditionally to keep hook order stable. The
-    // server-side `AdminUser` extractor on the key RPCs is the real boundary;
-    // this just keeps the card off non-admin screens.
-    let mut is_admin = use_signal(|| false);
-    use_effect(move || {
-        spawn(async move {
-            if let Ok(Some(user)) = data::current_user().await {
-                is_admin.set(user.is_admin);
-            }
-        });
-    });
+    // Admin gating for the F3.3 Hardcover key card — derived from the
+    // app-wide `CurrentUser` context (`crate::use_is_admin`) instead of an
+    // independent per-mount `/api/auth/me` fetch. The server-side `AdminUser`
+    // extractor on the key RPCs is the real boundary; this just keeps the
+    // card off non-admin screens.
+    let is_admin = crate::use_is_admin();
 
     spawn_initial_settings_load(
         server_url.clone(),


### PR DESCRIPTION
## Summary
- `frontend/src/pages/book_detail/mod.rs`, `author.rs`, `settings.rs`, and `book_detail/journal.rs` each fired their own `/api/auth/me` round-trip on every mount (`use_signal` + `use_effect` + `spawn(async move { data::current_user().await })`) purely to derive an `is_admin` flag or the current user — duplicating the app-wide `CurrentUser` context `landing.rs` already reads for the same purpose.
- Extracted `landing.rs`'s own `setup_admin_signal` into two shared, reusable hooks in `frontend/src/contexts.rs`:
  - `use_is_admin() -> Signal<bool>` — derives the admin flag from the `CurrentUser` context.
  - `use_current_user_summary() -> Signal<Option<UserSummary>>` — derives the resolved user, flattening "not yet resolved" and "unauthenticated" to `None` alike (needed by `book_detail/journal.rs`, which reads more than just `is_admin`).
- Pointed all five call sites — `landing.rs` (now calling the shared helper instead of its private one), `book_detail/mod.rs`, `author.rs`, `settings.rs`, and `book_detail/journal.rs` — at the new hooks, removing five duplicated `use_signal`/`use_effect`/`spawn` blocks.
- No behavior change: both hooks start at the same `false`/`None` default `landing.rs`'s original pattern used, so SSR and first-paint parity (rule 07) is preserved, and mobile/SSR builds stay at the default exactly as before (`data::current_user()` was already a `Ok(None)`-returning stub on those targets, and the `CurrentUser` context is web-only, so behavior is identical — just without the redundant per-mount fetch on web).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings`
- [x] `cargo clippy` (workspace default-members)
- [x] `cargo test -p omnibus-frontend --features server` (202 passed)
- [x] No markup/rsx changes — confirmed via diff (pure logic refactor), so no Playwright spec updates needed.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- `book_detail/journal.rs`'s `current_user` needs the full `UserSummary` (not just `is_admin`) for the composer's ownership check, hence the second hook rather than reusing `use_is_admin` everywhere.

Closes #730


---
_Generated by [Claude Code](https://claude.ai/code/session_015E1sMYdo16jwq58MxGVvU2)_