### PR TITLE
fix: add test coverage for AuthError::Crypto on login path (#762)

### DIFF
--- a/db/src/auth/login/tests.rs
+++ b/db/src/auth/login/tests.rs
@@ -84,3 +84,22 @@ async fn login_unknown_user_returns_invalid_credentials() {
         .unwrap_err();
     assert!(matches!(err, AuthError::InvalidCredentials));
 }
+
+#[tokio::test]
+async fn login_corrupted_password_hash_returns_crypto_error() {
+    // Regression: a corrupted `password_hash` column (e.g. disk
+    // corruption, a bad migration) must surface as a deliberate
+    // `Crypto` error rather than panicking or silently granting access.
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    sqlx::query("UPDATE users SET password_hash = ? WHERE id = ?")
+        .bind("not-a-valid-phc-string")
+        .bind(u.id)
+        .execute(&p)
+        .await
+        .unwrap();
+    let err = verify_login(&p, "alice", "hunter2-real-long")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthError::Crypto(_)));
+}

--- a/db/src/auth/password/tests.rs
+++ b/db/src/auth/password/tests.rs
@@ -9,6 +9,12 @@ fn password_roundtrips() {
 }
 
 #[test]
+fn verify_password_returns_crypto_error_for_malformed_phc_string() {
+    let err = verify_password("any-password", "not-a-valid-phc-string").unwrap_err();
+    assert!(matches!(err, AuthError::Crypto(_)));
+}
+
+#[test]
 fn password_policy_rejects_short() {
     let err = validate_password("short").unwrap_err();
     assert!(

--- a/server/src/auth/handlers/tests.rs
+++ b/server/src/auth/handlers/tests.rs
@@ -347,6 +347,34 @@ async fn login_unknown_user_returns_401() {
 }
 
 #[tokio::test]
+async fn login_corrupted_password_hash_returns_500() {
+    // Regression: `AuthError::Crypto` (raised when the stored
+    // `password_hash` isn't a valid PHC string) is mapped to a generic
+    // 500 by `auth_error_to_response`, same as `Internal`. Locks in that
+    // a corrupted row surfaces as a deliberate internal error rather than
+    // a panic or a silent auth bypass.
+    let (app, pool) = app().await;
+    let user = db::auth::create_user(&pool, "alice", "correct horse battery staple")
+        .await
+        .unwrap();
+    sqlx::query("UPDATE users SET password_hash = ? WHERE id = ?")
+        .bind("not-a-valid-phc-string")
+        .bind(user.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let res = app
+        .oneshot(json_req(
+            "/api/auth/login",
+            "POST",
+            json!({"username": "alice", "password": "correct horse battery staple"}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
 async fn logout_revokes_session_and_next_me_is_401() {
     let (app, pool) = app().await;
     db::auth::create_user(&pool, "alice", "correct horse battery staple")


### PR DESCRIPTION
## Summary
- `AuthError::Crypto` (`db/src/auth.rs`) was reachable from the live login path (a corrupted/malformed `password_hash` column causes `verify_password`'s `PasswordHash::new(phc)?` to fail) but had zero test coverage.
- Added a test asserting `verify_password` returns `Err(AuthError::Crypto(_))` for a malformed PHC string (`db/src/auth/password/tests.rs`).
- Added a DB-layer regression test that seeds a real user, corrupts their stored `password_hash`, and asserts `verify_login` returns `Err(AuthError::Crypto(_))` (`db/src/auth/login/tests.rs`).
- Added a handler-level regression test that does the same corruption and asserts `POST /api/auth/login` returns `500` (`server/src/auth/handlers/tests.rs`) — locking in the existing `server/src/auth/handlers.rs` mapping of `Crypto` to a generic 500 end-to-end, per Copilot review feedback distinguishing DB-layer vs HTTP-layer coverage.
- Test-only change; no production code or migrations touched.

## Test plan
- [x] `db/src/auth/password/tests.rs` asserts `verify_password` returns `Err(AuthError::Crypto(_))` for a malformed PHC string
- [x] `db/src/auth/login/tests.rs` asserts a login attempt against a user with a corrupted `password_hash` column returns `Err(AuthError::Crypto(_))`
- [x] `server/src/auth/handlers/tests.rs` asserts `POST /api/auth/login` against a corrupted `password_hash` returns `500`
- [x] `cargo test -p omnibus-db` (797 passed)
- [x] `cargo test -p omnibus` (297 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings`

## Version
- [x] **Patch** — the default

## Notes
- Test-only; the 500-mapping for a corrupted hash is left as-is (matches the issue's suggested approach — locking in current behavior rather than changing it), now covered at both the DB and HTTP layers.

Closes #762