### PR TITLE
feat: responsive mobile ereader chrome (F6.2)

### DIFF
--- a/docs/roadmap/6-2-mobile-epub-reader.md
+++ b/docs/roadmap/6-2-mobile-epub-reader.md
@@ -6,7 +6,25 @@ Read epubs inside the native mobile app, reusing the F2.1 progress model and the
 
 ## Objective
 
-Let a user read any epub inside the native `mobile/` app. The crate is Dioxus Native (Blitz) — a Rust HTML/CSS renderer with **no** JavaScript engine — so the F2.2 web reader's `epub.js` cannot run there directly. We need a reader path that fits the Blitz runtime while keeping reading position canonical as an EPUB CFI so it round-trips through F2.1 across web and mobile.
+Let a user read any epub inside the native `mobile/` app, reusing the shared
+reader UI and keeping reading position canonical as an EPUB CFI so it
+round-trips through F2.1 across web and mobile.
+
+## Status
+
+- **Mobile reader chrome (shipped).** The reader is one shared Dioxus
+  component; the native shell renders the same tree in a WebView. A
+  phone-width breakpoint in `frontend/assets/atrium.css` (`@media
+  (max-width: 600px)`, the "Reader on phone widths" block) adapts the desktop
+  chrome to the mobile handoff: slim top/bottom bars, no gutter page-turn
+  buttons, full-width drawers (contents / search / highlights / bookmarks /
+  quote card), a bottom-sheet selection popover, and a top-sheet Aa panel.
+  Covered by the phone-viewport tests in
+  `ui_tests/playwright/tests/flows/reader.spec.ts`.
+- **Native epub streaming (remaining).** Wiring `epub.js` to actually stream
+  and paginate a book on-device — a `document::eval` bridge in place of the
+  web build's `wasm-bindgen` interop, plus a bearer-authed fetch of
+  `GET /api/ebooks/:uuid/file` — is the open work below.
 
 ## User / business value
 

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4520,8 +4520,12 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
  * same tree in a WebView, so this breakpoint is what the phone app sees.
  * Adapts the desktop chrome/overlays to the mobile handoff: slim bars, no
  * gutter buttons, full-width drawers, a bottom-sheet selection popover, and
- * a full-width quote card. */
-@media (max-width: 600px) {
+ * a full-width quote card. The reader renders bare (no `.app-shell`, no tab
+ * bar), so these plain selectors only ever match its own chrome. This is the
+ * single reader-responsive block — keep new phone rules here rather than a
+ * second `@media` later in the file, whose equal specificity would win the
+ * cascade and silently override these. */
+@media (max-width: 480px) {
   .rd-top, .rd-bottom { padding: 0 14px; gap: 8px; }
   .rd-title-book { font-size: 15px; }
   .rd-title-sep { margin: 0 6px; }
@@ -5458,15 +5462,4 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 @media (max-width: 560px) {
   /* Metadata edit: single-column fields at phone width. */
   .me-field-grid { grid-template-columns: 1fr; }
-}
-
-/* ── Immersive reader: full-width drawers/panels on a phone ────────
-   The reader renders bare (no `.app-shell`, no tab bar), so these plain
-   selectors apply only to its own chrome. The 380–432px fixed panels
-   overflow a phone; cap them to the viewport. */
-@media (max-width: 480px) {
-  .rd-drawer { width: min(380px, 100vw); }
-  .rd-quote-drawer { width: 100vw; }
-  .rd-aa-panel { width: min(320px, calc(100vw - 24px)); right: 12px; }
-  .rd-note-composer { width: min(360px, calc(100vw - 24px)); }
 }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4515,6 +4515,54 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .rd-quote-ratios { display: flex; gap: 6px; }
 .rd-quote-actions { display: flex; gap: 8px; margin-top: 22px; }
 
+/* ── Reader on phone widths (F6.2 mobile ereader) ──────────────────
+ * The reader is one shared component; the native mobile shell renders the
+ * same tree in a WebView, so this breakpoint is what the phone app sees.
+ * Adapts the desktop chrome/overlays to the mobile handoff: slim bars, no
+ * gutter buttons, full-width drawers, a bottom-sheet selection popover, and
+ * a full-width quote card. */
+@media (max-width: 600px) {
+  .rd-top, .rd-bottom { padding: 0 14px; gap: 8px; }
+  .rd-title-book { font-size: 15px; }
+  .rd-title-sep { margin: 0 6px; }
+  .rd-tool { min-width: 32px; padding: 0 6px; }
+  /* Page + progress on the left already carry the position; the centred
+     "Ch. N of M" only crowds a narrow bar (the handoff bottom row is just
+     position on the left, time-left on the right). */
+  .rd-bottom > div { display: none; }
+  /* Mobile turns pages by swipe/tap; the circular gutter buttons would sit
+     over the prose on a phone-width column. */
+  .rd-turn { display: none; }
+
+  /* Drawers (contents / search / highlights / bookmarks / quote card) span
+     the full width instead of a 380–432px side panel. */
+  .rd-drawer, .rd-quote-drawer { width: auto; left: 0; right: 0; }
+
+  /* The Aa display panel drops the tool-anchored caret and becomes a sheet
+     pinned below the top bar. */
+  .rd-aa-panel { left: 12px; right: 12px; width: auto; top: 64px; }
+  .rd-aa-panel::before { display: none; }
+
+  /* Note composer keeps a margin off the viewport edges. */
+  .rd-note-composer { width: min(360px, calc(100vw - 32px)); }
+
+  /* Selection popover → bottom sheet ("highlight a passage" handoff). The
+     caret rect drives inline top/left, so the sheet position needs
+     !important to win over them. */
+  .rd-selection-popover {
+    top: auto !important; bottom: 66px !important;
+    left: 16px !important; right: 16px !important;
+    padding: 14px 12px; border-radius: 16px;
+    background: color-mix(in oklch, var(--bg-1) 96%, transparent);
+    box-shadow: 0 24px 48px -16px rgba(0,0,0,.5); }
+  /* Swatches on one centred row, then a full-width rule, then the actions —
+     the divider's 100% width forces the wrap between the two groups. */
+  .rd-swatch-row { flex-wrap: wrap; justify-content: center; row-gap: 12px; }
+  .rd-swatch { width: 30px; height: 30px; }
+  .rd-pop-div { width: 100%; height: 1px; align-self: auto; margin: 2px 4px; }
+  .rd-act { height: 36px; }
+}
+
 /* ── F5.10 merge dialog (book detail) — "Merge duplicates" redesign ──
  * Wide modal: pinned keeper rail + search + result rows with covers.
  * Three-zone flex column (head / scrolling body / foot). Replaces the

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -211,3 +211,53 @@ test("opens the reader from the book detail Read action", async ({ page, request
   await expect(page).toHaveURL(new RegExp(`/read/${uuid}$`));
   await expect(page.getByTestId("reader-viewer")).toBeVisible();
 });
+
+// The reader is one shared component: the native mobile shell renders the
+// same tree in a WebView, so the phone-width layout (F6.2 mobile ereader) is
+// verified here at a phone viewport. Chrome is SSR markup, robust to the
+// epub.js render not painting headlessly.
+test.describe("mobile reader (phone viewport)", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("renders the mobile reader layout", async ({ page, request }) => {
+    const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+    await gotoReady(page, `/read/${uuid}`);
+
+    // Same chrome contract as desktop — the viewer and top tools stay present.
+    await expect(page.getByTestId("reader-viewer")).toBeVisible();
+    await expect(page.getByTestId("reader-back")).toBeVisible();
+    await expect(page.getByTestId("reader-toc")).toBeVisible();
+
+    // The circular page-turn gutters are suppressed on phone widths (mobile
+    // turns pages by swipe/tap; the buttons would sit over the prose).
+    await expect(page.getByTestId("reader-prev")).toBeHidden();
+    await expect(page.getByTestId("reader-next")).toBeHidden();
+  });
+
+  test("drawers and the display panel span the full width", async ({
+    page,
+    request,
+  }) => {
+    const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+    await gotoReady(page, `/read/${uuid}`);
+    await expect(page.getByTestId("reader-viewer")).toBeVisible();
+
+    // Contents drawer stretches edge to edge instead of a 380px side panel.
+    await page.getByTestId("reader-toc").click();
+    const drawer = page.getByTestId("reader-toc-drawer");
+    await expect(drawer).toBeVisible();
+    const drawerBox = await drawer.boundingBox();
+    expect(drawerBox, "toc drawer box").not.toBeNull();
+    expect(drawerBox!.width).toBeGreaterThan(370);
+    await page.keyboard.press("Escape");
+    await expect(drawer).toHaveCount(0);
+
+    // The Aa display panel becomes a sheet pinned under the top bar, not a
+    // 320px tool-anchored popover.
+    await page.getByTestId("reader-aa").click();
+    await expect(page.getByTestId("reader-font-increase")).toBeVisible();
+    const aaBox = await page.locator(".rd-aa-panel").boundingBox();
+    expect(aaBox, "aa panel box").not.toBeNull();
+    expect(aaBox!.width).toBeGreaterThan(340);
+  });
+});


### PR DESCRIPTION
Adapt the shared reader to the mobile design handoff. The reader is one
Dioxus component and the native shell renders the same tree in a WebView,
so a phone-width breakpoint in atrium.css is what the mobile app sees.

- Slim top/bottom bars; drop the centred chapter counter on a narrow bar.
- Hide the circular page-turn gutters (mobile turns pages by swipe/tap).
- Full-width drawers (contents / search / highlights / bookmarks / quote)
  instead of a 380-432px side panel.
- Selection popover becomes a bottom sheet; Aa panel becomes a top sheet
  without its tool-anchored caret; note composer keeps a viewport margin.

Add phone-viewport coverage to reader.spec.ts (gutters hidden, drawers and
Aa panel span full width) and record the delivery + remaining native
epub streaming work in the F6.2 roadmap doc.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MCM5spSVhKLeDZWM9vSRgt