### PR TITLE
feat: recolor highlights from the reader drawer

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4440,6 +4440,17 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   font-family: var(--serif); font-style: italic; font-size: 16px; line-height: 1.42; }
 .rd-hl-note { display: flex; gap: 7px; font-size: 12.5px; color: var(--ink-2);
   line-height: 1.45; }
+/* Per-row recolor: pick a new palette color for an existing highlight. */
+.rd-hl-swatches { display: flex; gap: 6px; margin-top: 2px; }
+.rd-hl-swatch { width: 16px; height: 16px; border-radius: 50%; cursor: pointer;
+  padding: 0; border: 2px solid transparent; transition: transform .12s; }
+.rd-hl-swatch:hover { transform: scale(1.15); }
+.rd-hl-swatch.on { border-color: var(--ink-0); }
+.rd-hl-swatch[data-color="amber"]  { background: var(--hl-amber); }
+.rd-hl-swatch[data-color="green"]  { background: var(--hl-green); }
+.rd-hl-swatch[data-color="blue"]   { background: var(--hl-blue); }
+.rd-hl-swatch[data-color="rose"]   { background: var(--hl-rose); }
+.rd-hl-swatch[data-color="violet"] { background: var(--hl-violet); }
 .rd-hl-actions { display: flex; gap: 2px; }
 
 /* Note composer (centered card over a scrim). */

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -53,6 +53,10 @@ fn reannotate(cfi: &str, color: HighlightColor) {
 /// Recolor a highlight to `next`: optimistically repaint the viewer + the row
 /// signal, persist via `update_highlight_color`, and roll both back to `prev`
 /// if the write fails. Mirrors the create/delete optimistic pattern.
+///
+/// A no-op when `next == prev` (clicking the already-selected swatch). The
+/// rollback is gated on the row still showing `next`, so a late failure from
+/// one request can't clobber a newer recolor that already succeeded.
 fn spawn_recolor(
     mut highlights: Signal<Vec<Highlight>>,
     id: i64,
@@ -60,6 +64,9 @@ fn spawn_recolor(
     next: HighlightColor,
     prev: HighlightColor,
 ) {
+    if next == prev {
+        return;
+    }
     reannotate(&cfi, next);
     // Bind the index first so the read guard drops before `write()` — a live
     // `read()` temporary across `write()` is a runtime borrow panic.
@@ -72,10 +79,18 @@ fn spawn_recolor(
             .await
             .is_err()
         {
-            reannotate(&cfi, prev);
-            let idx = highlights.read().iter().position(|h| h.id == id);
-            if let Some(i) = idx {
-                highlights.write()[i].color = prev;
+            // Only revert if this request's optimistic color is still current;
+            // if a later recolor superseded it, leave that newer value alone.
+            let still_ours = highlights
+                .read()
+                .iter()
+                .any(|h| h.id == id && h.color == next);
+            if still_ours {
+                reannotate(&cfi, prev);
+                let idx = highlights.read().iter().position(|h| h.id == id);
+                if let Some(i) = idx {
+                    highlights.write()[i].color = prev;
+                }
             }
         }
     });

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -1,6 +1,7 @@
 //! Highlights & notes drawer for the reader. Lists every highlight for the
 //! open book, filterable by palette color. Clicking a row navigates to the
-//! highlight's CFI; rows also expose note, copy, and delete actions.
+//! highlight's CFI; rows expose a recolor swatch strip plus note, quote,
+//! copy, and delete actions.
 
 use dioxus::prelude::*;
 
@@ -32,6 +33,52 @@ fn copy_text(text: &str) {
         let lit = serde_json::to_string(text).unwrap_or_else(|_| "\"\"".into());
         super::reader_call("copyText", &lit);
     }
+}
+
+/// Repaint a highlight's annotation in place: drop the old swatch and re-add
+/// it at the same CFI in `color` (web only). Used when recoloring so the
+/// viewer reflects the new color without a full reload.
+#[cfg_attr(not(feature = "web"), allow(unused_variables))]
+fn reannotate(cfi: &str, color: HighlightColor) {
+    #[cfg(feature = "web")]
+    {
+        let cfi_lit = serde_json::to_string(cfi).unwrap_or_else(|_| "\"\"".into());
+        super::reader_call("removeAnnotation", &cfi_lit);
+        let color_lit =
+            serde_json::to_string(color.as_str()).unwrap_or_else(|_| "\"amber\"".into());
+        super::reader_call("addAnnotation", &format!("{cfi_lit}, {color_lit}"));
+    }
+}
+
+/// Recolor a highlight to `next`: optimistically repaint the viewer + the row
+/// signal, persist via `update_highlight_color`, and roll both back to `prev`
+/// if the write fails. Mirrors the create/delete optimistic pattern.
+fn spawn_recolor(
+    mut highlights: Signal<Vec<Highlight>>,
+    id: i64,
+    cfi: String,
+    next: HighlightColor,
+    prev: HighlightColor,
+) {
+    reannotate(&cfi, next);
+    // Bind the index first so the read guard drops before `write()` — a live
+    // `read()` temporary across `write()` is a runtime borrow panic.
+    let idx = highlights.read().iter().position(|h| h.id == id);
+    if let Some(i) = idx {
+        highlights.write()[i].color = next;
+    }
+    spawn(async move {
+        if crate::data::update_highlight_color("", id, next)
+            .await
+            .is_err()
+        {
+            reannotate(&cfi, prev);
+            let idx = highlights.read().iter().position(|h| h.id == id);
+            if let Some(i) = idx {
+                highlights.write()[i].color = prev;
+            }
+        }
+    });
 }
 
 #[component]
@@ -147,6 +194,9 @@ fn HighlightRow(
         });
     };
 
+    let cur_color = highlight.color;
+    let recolor_cfi = highlight.epub_cfi_range.clone();
+
     let nav_cfi = highlight.epub_cfi_range.clone();
 
     rsx! {
@@ -160,6 +210,23 @@ fn HighlightRow(
             }
             if let Some(n) = note {
                 div { class: "rd-hl-note", "{n}" }
+            }
+            div { class: "rd-hl-swatches", "data-testid": "reader-highlight-swatches",
+                for (swatch_color, swatch_name) in PALETTE {
+                    button {
+                        key: "{swatch_name}",
+                        class: if swatch_color == cur_color { "rd-hl-swatch on" } else { "rd-hl-swatch" },
+                        r#type: "button",
+                        "data-color": "{swatch_name}",
+                        "data-testid": "reader-highlight-recolor-{swatch_name}",
+                        "aria-label": "Recolor {swatch_name}",
+                        "aria-pressed": if swatch_color == cur_color { "true" } else { "false" },
+                        onclick: {
+                            let recolor_cfi = recolor_cfi.clone();
+                            move |_| spawn_recolor(highlights, id, recolor_cfi.clone(), swatch_color, cur_color)
+                        },
+                    }
+                }
             }
             div { class: "rd-hl-actions",
                 button {

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -20,6 +20,9 @@ const HL_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "beta")!;
 // A third book for the note-editing test so its persisted highlight never
 // collides with the seed/delete cycle on HL_BOOK.
 const NOTE_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "gamma")!;
+// A fourth book for the recolor test so its seeded highlight is isolated from
+// the other highlight specs running in parallel.
+const RECOLOR_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "pioneers-3")!;
 
 test("renders the reader layout", async ({ page, request }) => {
   // Deep-link straight to the immersive reader by the book's stable uuid,
@@ -198,6 +201,60 @@ test("adds a note to an existing highlight from the drawer", async ({
     .filter({ hasText: quote });
   await expect(savedRow.getByText(note)).toBeVisible();
   await expect(savedRow.getByTestId("highlight-note")).toHaveText("Edit note");
+});
+
+test("recolors an existing highlight from the drawer", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, RECOLOR_BOOK.title);
+
+  // Seed an amber highlight so the drawer offers its recolor swatches.
+  const quote = `recolor passage ${Date.now()}`;
+  const created = await request.post("/api/highlights", {
+    data: {
+      book_uuid: uuid,
+      epub_cfi_range: "epubcfi(/6/4!/4/2,/1:0,/1:40)",
+      color: "amber",
+      text: quote,
+    },
+  });
+  expect(created.status(), "seed highlight").toBe(200);
+
+  await gotoReady(page, `/read/${uuid}`);
+  await expect(page.getByTestId("reader-viewer")).toBeVisible();
+
+  await page.getByTestId("reader-highlights").click();
+  await expect(page.getByTestId("reader-highlights-drawer")).toBeVisible();
+  const row = page
+    .getByTestId("reader-highlight-row")
+    .filter({ hasText: quote });
+  await expect(row).toHaveCount(1);
+
+  // Amber is the current color; green is not yet selected.
+  await expect(
+    row.getByTestId("reader-highlight-recolor-amber"),
+  ).toHaveAttribute("aria-pressed", "true");
+  await expect(
+    row.getByTestId("reader-highlight-recolor-green"),
+  ).toHaveAttribute("aria-pressed", "false");
+
+  // Picking green fires the update-color RPC and moves the selected swatch.
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: /\/api\/rpc\/highlights\/update-color(?:\?|$)/,
+      expectedStatus: 200,
+    },
+    async () => row.getByTestId("reader-highlight-recolor-green").click(),
+  );
+  await expect(
+    row.getByTestId("reader-highlight-recolor-green"),
+  ).toHaveAttribute("aria-pressed", "true");
+  await expect(
+    row.getByTestId("reader-highlight-recolor-amber"),
+  ).toHaveAttribute("aria-pressed", "false");
 });
 
 test("opens the reader from the book detail Read action", async ({ page, request }) => {


### PR DESCRIPTION
## Summary

The highlight color-change stack already existed end-to-end — `PATCH /api/highlights/{id}/color`, the `update-color` RPC, `db::highlights::update_highlight_color`, and the `update_highlight_color` client fn for both web and mobile — but **no UI ever called it**. Once a highlight was created, its color was permanent. This wires that dormant capability into the highlights drawer.

## Changes

- **`frontend/src/pages/reader/highlights_drawer.rs`** — each highlight row now carries a 5-color palette swatch strip. Picking a new color:
  - optimistically repaints the epub.js annotation in place (`removeAnnotation` + `addAnnotation`) and updates the row signal,
  - persists via the existing `update_highlight_color`,
  - rolls both the annotation and the signal back if the write fails (mirrors the established create/delete optimistic pattern).
  - The current color is ringed and exposed via `aria-pressed`.
- **`frontend/assets/atrium.css`** — `.rd-hl-swatch` styling, reusing the existing `--hl-*` palette tokens.
- **`ui_tests/playwright/tests/flows/reader.spec.ts`** — a test that seeds an amber highlight, picks green, asserts the `update-color` RPC fires, and checks the selected swatch moves.

## Verification

- `cargo check --features server` ✅, `cargo check --features mobile` ✅, `cargo clippy --features server` ✅ (0 warnings), `cargo fmt` clean.
- Playwright can't run in the authoring environment (no dev server), so the E2E test is verified by structure/convention rather than a live run.

## Scope note

Recolor is surfaced in the **drawer**. Tapping a highlight *in the text* to edit it (the epub.js click callback is currently `undefined`) is a natural follow-up that needs additional glue/interop plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCM5spSVhKLeDZWM9vSRgt)_