### PR TITLE
fix: use web_sys BlobPropertyBag::set_type in place of deprecated type_

### DIFF
--- a/frontend/src/data/uploads.rs
+++ b/frontend/src/data/uploads.rs
@@ -30,8 +30,8 @@ fn ebook_blob(bytes: &[u8]) -> Result<web_sys::Blob, DataError> {
     let u8 = js_sys::Uint8Array::from(bytes);
     let parts = js_sys::Array::new();
     parts.push(&u8);
-    let mut opts = web_sys::BlobPropertyBag::new();
-    opts.type_("application/epub+zip");
+    let opts = web_sys::BlobPropertyBag::new();
+    opts.set_type("application/epub+zip");
     web_sys::Blob::new_with_u8_array_sequence_and_options(&parts, &opts)
         .map_err(|e| DataError::Other(format!("Blob::new: {e:?}")))
 }


### PR DESCRIPTION
## Summary
- Swap the deprecated `web_sys::BlobPropertyBag::type_` for `set_type` in the "add your own books" web upload path; `set_type` takes `&self`, so the now-unused `mut` on the binding is dropped too.
- Pre-existing warning (unrelated to Send-to-Kobo) that fails wasm clippy under `-D warnings`.

## Test plan
- [x] `nix develop .#web --command cargo clippy -p omnibus-frontend --features web --target wasm32-unknown-unknown -- -D warnings` — clean.

## Version
- [x] **Patch** — default.

## Notes
- N/A