### PR TITLE
feat: send to kobo writes KEPUB directly to a plugged-in device over USB

### DIFF
--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -1,29 +1,44 @@
 # Send a book to your Kobo
 
 Omnibus can hand a book to a Kobo e-reader as a **KEPUB** — Kobo's own EPUB
-variant, which gets noticeably faster page turns than a plain EPUB. Today this
-is a **manual, wired transfer**: you download the KEPUB from Omnibus and copy it
-onto the Kobo over USB.
+variant, which gets noticeably faster page turns than a plain EPUB. It's a
+**wired transfer**: your Kobo plugs into the computer running the browser (never
+the Omnibus server), and the book copies onto it over USB.
+
+On **Chrome or Edge**, Omnibus writes the file straight onto the plugged-in
+device in one click. On other browsers (Firefox, Safari), it downloads the KEPUB
+and you copy it over yourself. Both are described below.
 
 > [!TIP]
 > This transfer is completely safe for your device. Copying a file over USB
 > **cannot delete or change anything already on your Kobo** — not your books,
-> not your highlights, not your notes. (That is *not* true of wireless "sync",
-> which is a different feature Omnibus does not yet offer — see the note at the
-> bottom.)
+> not your highlights, not your notes. Omnibus only ever *adds* a book file; it
+> never touches the device's internal database. (That is *not* true of wireless
+> "sync", which is a different feature Omnibus does not yet offer — see the note
+> at the bottom.)
 
-## Steps
+## Chrome / Edge — one-click write
+
+1. Connect your Kobo with a USB cable and tap **Connect** on the device. It
+   appears as a USB drive.
+2. Open the book's page in Omnibus and click **Send to Kobo**.
+3. The first time, your browser asks you to pick a folder — choose the **Kobo
+   drive** and allow saving. Omnibus remembers it, so later sends write silently
+   with no prompt.
+4. When it reports success, **eject the Kobo safely**, then unplug it. The book
+   appears in your library, titled from its own metadata (not the filename).
+
+## Other browsers — download, then copy
 
 1. Open the book's page in Omnibus and click **Send to Kobo**. A file named
    `<id>.kepub.epub` downloads to your computer.
-2. Connect your Kobo to the computer with a USB cable and tap **Connect** on the
-   device. It appears as a USB drive.
+2. Connect your Kobo with a USB cable and tap **Connect** on the device. It
+   appears as a USB drive.
 3. Copy the downloaded `.kepub.epub` file onto the Kobo drive. You can drop it at
    the top level or into any folder — the Kobo scans the whole drive.
-4. **Eject the Kobo safely**, then unplug it. The book appears in your library,
-   titled from its own metadata (not the filename).
+4. **Eject the Kobo safely**, then unplug it. The book appears in your library.
 
-That's it. Open the book on the Kobo and you'll get the faster KEPUB page turns.
+Either way, open the book on the Kobo and you'll get the faster KEPUB page turns.
 
 ## What this does and doesn't do
 

--- a/docs/roadmap/4-1-kobo-sync.md
+++ b/docs/roadmap/4-1-kobo-sync.md
@@ -9,9 +9,14 @@ Implement the `/kobo/v1/*` protocol natively, including EPUB → KEPUB conversio
 > wireless protocol's annotation-loss hazard (see [Risks](#risks)):
 >
 > - **Stage 1 — wired KEPUB sideload (shipped).** A **Send to Kobo** button on
->   each book downloads the book as KEPUB (via kepubify) to copy onto the device
->   over USB. No tokens, no protocol, no wireless sync — and **no data-loss
->   risk**, since a USB file copy never touches the device's annotation channel.
+>   each book delivers the book as KEPUB (via kepubify) to a device plugged into
+>   the *client* machine. On Chromium (Chrome/Edge) it writes the file straight
+>   onto the mounted Kobo drive via the File System Access API (remembering the
+>   directory handle so repeat sends need no prompt); other browsers fall back to
+>   a plain download the user copies over. No tokens, no protocol, no wireless
+>   sync — and **no data-loss risk**, since dropping a loose file on the drive
+>   root never touches `KoboReader.sqlite` or the annotation channel (the write
+>   is the safe mirror of the [F4.4](4-4-kobo-annotation-import.md) USB *read*).
 >   User guide: [docs/kobo.md](../kobo.md). This is the KEPUB **Sub-scope** below,
 >   promoted to ship first.
 > - **Stage 2 — wireless sync (deferred).** The `/kobo/v1/*` protocol described

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3750,14 +3750,14 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 
 /* F4.3 Send-to-Kindle result toast — fixed bottom-center, mirrors
    .bd-merge-toast so action feedback is consistent across the book page. */
-.kindle-toast {
+.kindle-toast, .kobo-toast {
   position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
   z-index: 110; display: flex; align-items: center; gap: 12px; padding: 12px 16px;
   box-shadow: 0 6px 24px rgba(0,0,0,.35);
 }
-.kindle-toast-msg { font-size: 0.9rem; }
-.kindle-toast-msg.success { color: #34d399; }
-.kindle-toast-msg.error { color: #f87171; }
+.kindle-toast-msg, .kobo-toast-msg { font-size: 0.9rem; }
+.kindle-toast-msg.success, .kobo-toast-msg.success { color: #34d399; }
+.kindle-toast-msg.error, .kobo-toast-msg.error { color: #f87171; }
 
 .library-card { margin-top: 1.25rem; }
 .library-card h2, .library-title {

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -297,8 +297,12 @@ pub fn SendToKoboButton(
 
 /// Map the JS write flow's status string to the toast `(is_error, message)`
 /// pair, or `None` when the user cancelled the picker (no toast at all). Pure,
-/// so it's unit-tested without a browser.
+/// so it's unit-tested without a browser. Only *called* on web (the SSR/native
+/// stub of `write_kepub_to_kobo` never runs it), so the non-web lib build sees
+/// it as dead outside its tests — allow that rather than gate it off `web` and
+/// lose the server-feature test coverage.
 #[cfg(not(feature = "mobile"))]
+#[cfg_attr(not(feature = "web"), allow(dead_code))]
 fn kobo_outcome(status: &str, message: Option<String>) -> Option<(bool, String)> {
     match status {
         "ok" => Some((

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -191,23 +191,15 @@ fn read_book_action(_uuid: &str) -> Element {
     }
 }
 
-/// F4.1 "Send to Kobo" CTA: downloads the book as KEPUB (`GET
-/// /api/ebooks/:uuid/kepub`) for USB sideload onto a Kobo. Web/SSR renders a
-/// plain download `<a>` — a full-navigation download carries the session
-/// cookie, so it authenticates like the reader's file fetch. Mobile renders a
-/// disabled placeholder (the copy-over-USB flow is desktop-only).
+/// F4.1 "Send to Kobo" CTA. Web/SSR renders the interactive
+/// [`SendToKoboButton`]; mobile renders a disabled placeholder (the copy-over-
+/// USB flow is desktop-only). The cfg gate lives at the helper definition (rule
+/// 07: keep cfg out of rsx bodies), and SSR + first WASM paint emit the same
+/// enabled button so hydration holds.
 #[cfg(not(feature = "mobile"))]
 fn send_to_kobo_action(uuid: &str) -> Element {
-    let href = format!("/api/ebooks/{uuid}/kepub");
     rsx! {
-        a {
-            href: "{href}",
-            download: "",
-            class: "btn",
-            title: "Download as KEPUB to copy onto a Kobo over USB",
-            "data-testid": "action-kobo",
-            "Send to Kobo"
-        }
+        SendToKoboButton { uuid: uuid.to_string() }
     }
 }
 
@@ -223,6 +215,203 @@ fn send_to_kobo_action(_uuid: &str) -> Element {
         }
     }
 }
+
+/// Interactive "Send to Kobo" button. When the browser supports the File System
+/// Access API (Chrome/Edge), clicking writes the book's KEPUB straight onto a
+/// plugged-in Kobo: the device mounts as a USB drive on the *client* machine
+/// (never the server), so the write happens in the browser. The chosen
+/// directory handle is remembered in IndexedDB, so after the first pick a click
+/// writes silently. Browsers without the API fall back to a plain download.
+/// Shows "Sending…" in-place and raises a toast on the terminal outcome —
+/// success/download auto-dismisses, errors stay until dismissed. `class` /
+/// `testid` default to the per-format-row styling; the hero CTA overrides them.
+#[cfg(not(feature = "mobile"))]
+#[component]
+pub fn SendToKoboButton(
+    uuid: String,
+    #[props(default = "btn".to_string())] class: String,
+    #[props(default = "action-kobo".to_string())] testid: String,
+) -> Element {
+    let mut in_flight = use_signal(|| false);
+    // (is_error, message) — None until a send completes / the toast is dismissed.
+    let mut result = use_signal(|| None::<(bool, String)>);
+
+    rsx! {
+        button {
+            class: "{class}",
+            r#type: "button",
+            disabled: in_flight(),
+            title: "Write the KEPUB onto a plugged-in Kobo (Chrome/Edge), or download it to copy over",
+            "data-testid": "{testid}",
+            onclick: move |_| {
+                let uuid = uuid.clone();
+                in_flight.set(true);
+                result.set(None);
+                spawn(async move {
+                    let outcome = write_kepub_to_kobo(&uuid).await;
+                    in_flight.set(false);
+                    // `None` = the user cancelled the directory picker; stay quiet.
+                    if let Some((is_error, message)) = outcome {
+                        result.set(Some((is_error, message)));
+                        if !is_error {
+                            async_sleep_ms(5000).await;
+                            result.set(None);
+                        }
+                    }
+                });
+            },
+            if in_flight() { "Sending\u{2026}" } else { "Send to Kobo" }
+        }
+        if let Some((is_error, message)) = result() {
+            div { class: "kobo-toast card", role: "status",
+                span {
+                    "data-testid": "kobo-send-status",
+                    class: if is_error { "kobo-toast-msg error" } else { "kobo-toast-msg success" },
+                    "{message}"
+                }
+                button {
+                    class: "btn ghost sm",
+                    "data-testid": "kobo-toast-dismiss",
+                    aria_label: "Dismiss",
+                    onclick: move |_| result.set(None),
+                    "\u{00d7}"
+                }
+            }
+        }
+    }
+}
+
+/// Map the JS write flow's status string to the toast `(is_error, message)`
+/// pair, or `None` when the user cancelled the picker (no toast at all). Pure,
+/// so it's unit-tested without a browser.
+#[cfg(not(feature = "mobile"))]
+fn kobo_outcome(status: &str, message: Option<String>) -> Option<(bool, String)> {
+    match status {
+        "ok" => Some((
+            false,
+            "Sent to your Kobo \u{2014} eject it safely before unplugging.".to_string(),
+        )),
+        "downloaded" => Some((
+            false,
+            "Your browser can\u{2019}t write to the device, so the KEPUB downloaded instead \u{2014} drag it onto your Kobo.".to_string(),
+        )),
+        "cancelled" => None,
+        _ => Some((
+            true,
+            format!(
+                "Send to Kobo failed: {}",
+                message.unwrap_or_else(|| "unknown error".to_string())
+            ),
+        )),
+    }
+}
+
+/// Outcome pushed back from [`KOBO_WRITE_JS`] over the eval channel.
+#[cfg(all(not(feature = "mobile"), feature = "web"))]
+#[derive(serde::Deserialize)]
+struct KoboWriteOutcome {
+    status: String,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Run the File System Access write flow and map its result to a toast pair.
+/// Same-origin `fetch` carries the session cookie, so the KEPUB endpoint
+/// authenticates like any other in-page request. Web-only; the SSR stub below
+/// never runs (the click handler only fires in the browser) but must compile.
+#[cfg(all(not(feature = "mobile"), feature = "web"))]
+async fn write_kepub_to_kobo(uuid: &str) -> Option<(bool, String)> {
+    // Interpolate the uuid as a JS string literal so it can't break out of the
+    // script (it's a UUIDv4 in practice, but quote defensively).
+    let uuid_lit = serde_json::to_string(uuid).unwrap_or_else(|_| "\"\"".to_string());
+    let js = KOBO_WRITE_JS.replace("__UUID__", &uuid_lit);
+    let mut eval = dioxus::document::eval(&js);
+    match eval.recv::<KoboWriteOutcome>().await {
+        Ok(out) => kobo_outcome(&out.status, out.message),
+        Err(_) => Some((true, "Send to Kobo failed.".to_string())),
+    }
+}
+
+#[cfg(all(not(feature = "mobile"), not(feature = "web"), feature = "server"))]
+async fn write_kepub_to_kobo(_uuid: &str) -> Option<(bool, String)> {
+    None
+}
+
+/// Browser-side write flow. Reuses a remembered Kobo directory handle
+/// (persisted in IndexedDB) or prompts for one once, fetches the KEPUB, and
+/// writes it to the device's drive root — Kobo imports loose files there, so
+/// this never touches the device's `KoboReader.sqlite` master DB. Falls back to
+/// a plain download when the File System Access API is absent (Firefox/Safari).
+/// `__UUID__` is substituted with a quoted JS string literal before eval.
+#[cfg(all(not(feature = "mobile"), feature = "web"))]
+const KOBO_WRITE_JS: &str = r#"
+const uuid = __UUID__;
+const idb = () => new Promise((res, rej) => {
+  const r = indexedDB.open('omnibus-kobo', 1);
+  r.onupgradeneeded = () => r.result.createObjectStore('handles');
+  r.onsuccess = () => res(r.result);
+  r.onerror = () => rej(r.error);
+});
+const openDir = async () => {
+  try {
+    const db = await idb();
+    return await new Promise((res, rej) => {
+      const rq = db.transaction('handles', 'readonly').objectStore('handles').get('dir');
+      rq.onsuccess = () => res(rq.result || null);
+      rq.onerror = () => rej(rq.error);
+    });
+  } catch (_) { return null; }
+};
+const saveDir = async (h) => {
+  try {
+    const db = await idb();
+    await new Promise((res, rej) => {
+      const tx = db.transaction('handles', 'readwrite');
+      tx.objectStore('handles').put(h, 'dir');
+      tx.oncomplete = () => res();
+      tx.onerror = () => rej(tx.error);
+    });
+  } catch (_) {}
+};
+await (async () => {
+  try {
+    if (!window.showDirectoryPicker) {
+      const a = document.createElement('a');
+      a.href = `/api/ebooks/${uuid}/kepub`;
+      a.download = '';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      dioxus.send({ status: 'downloaded' });
+      return;
+    }
+    let dir = await openDir();
+    if (dir) {
+      let perm = await dir.queryPermission({ mode: 'readwrite' });
+      if (perm !== 'granted') perm = await dir.requestPermission({ mode: 'readwrite' });
+      if (perm !== 'granted') dir = null;
+    }
+    if (!dir) {
+      dir = await window.showDirectoryPicker({ id: 'omnibus-kobo', mode: 'readwrite', startIn: 'desktop' });
+      await saveDir(dir);
+    }
+    const resp = await fetch(`/api/ebooks/${uuid}/kepub`, { credentials: 'include' });
+    if (!resp.ok) { dioxus.send({ status: 'error', message: `download failed (${resp.status})` }); return; }
+    const cd = resp.headers.get('content-disposition') || '';
+    const m = /filename="?([^"]+)"?/.exec(cd);
+    const filename = (m && m[1]) || `${uuid}.kepub.epub`;
+    const blob = await resp.blob();
+    const fh = await dir.getFileHandle(filename, { create: true });
+    const w = await fh.createWritable();
+    await w.write(blob);
+    await w.close();
+    dioxus.send({ status: 'ok', filename: filename });
+  } catch (e) {
+    if (e && e.name === 'AbortError') { dioxus.send({ status: 'cancelled' }); return; }
+    dioxus.send({ status: 'error', message: (e && e.message) || String(e) });
+  }
+})();
+"#;
 
 /// "Send to Kindle" CTA (F4.3). Web/SSR renders the interactive
 /// [`SendToKindleButton`]; mobile renders a disabled placeholder. The cfg gate
@@ -540,6 +729,44 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].label(), "CbZ");
         assert!(matches!(rows[0], FormatKind::Other(_)));
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_outcome_reports_success_for_device_write() {
+        let (is_error, msg) = super::kobo_outcome("ok", None).unwrap();
+        assert!(!is_error);
+        assert!(msg.contains("Sent to your Kobo"));
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_outcome_reports_download_fallback_for_unsupported_browser() {
+        let (is_error, msg) = super::kobo_outcome("downloaded", None).unwrap();
+        assert!(!is_error);
+        assert!(msg.contains("downloaded instead"));
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_outcome_stays_silent_when_picker_cancelled() {
+        assert!(super::kobo_outcome("cancelled", None).is_none());
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_outcome_surfaces_error_message_when_present() {
+        let (is_error, msg) = super::kobo_outcome("error", Some("disk full".into())).unwrap();
+        assert!(is_error);
+        assert_eq!(msg, "Send to Kobo failed: disk full");
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_outcome_falls_back_to_unknown_error_without_message() {
+        let (is_error, msg) = super::kobo_outcome("error", None).unwrap();
+        assert!(is_error);
+        assert_eq!(msg, "Send to Kobo failed: unknown error");
     }
 
     #[test]

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -235,6 +235,10 @@ pub fn SendToKoboButton(
     let mut in_flight = use_signal(|| false);
     // (is_error, message) — None until a send completes / the toast is dismissed.
     let mut result = use_signal(|| None::<(bool, String)>);
+    // Monotonic id of the latest send. A superseded task must not touch shared
+    // state — otherwise an earlier send's auto-dismiss sleep can clear (or hide
+    // the error of) a newer send's toast.
+    let mut send_seq = use_signal(|| 0u64);
 
     rsx! {
         button {
@@ -245,17 +249,27 @@ pub fn SendToKoboButton(
             "data-testid": "{testid}",
             onclick: move |_| {
                 let uuid = uuid.clone();
+                let seq = *send_seq.peek() + 1;
+                send_seq.set(seq);
                 in_flight.set(true);
                 result.set(None);
                 spawn(async move {
                     let outcome = write_kepub_to_kobo(&uuid).await;
+                    // A newer send has superseded this one — leave all shared
+                    // state to it.
+                    if *send_seq.peek() != seq {
+                        return;
+                    }
                     in_flight.set(false);
                     // `None` = the user cancelled the directory picker; stay quiet.
                     if let Some((is_error, message)) = outcome {
                         result.set(Some((is_error, message)));
                         if !is_error {
                             async_sleep_ms(5000).await;
-                            result.set(None);
+                            // Only clear if we're still the latest send.
+                            if *send_seq.peek() == seq {
+                                result.set(None);
+                            }
                         }
                     }
                 });

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -36,6 +36,8 @@ mod format_switcher;
 pub use format_switcher::FormatSwitcher;
 #[cfg(not(feature = "mobile"))]
 pub use format_switcher::SendToKindleButton;
+#[cfg(not(feature = "mobile"))]
+pub use format_switcher::SendToKoboButton;
 
 // Reusable add/remove chip editor with a substring-match suggestion
 // dropdown. See `chip_editor.rs` for the full API.

--- a/frontend/src/pages/book_detail/export_menu.rs
+++ b/frontend/src/pages/book_detail/export_menu.rs
@@ -5,7 +5,7 @@
 
 use dioxus::prelude::*;
 
-use crate::components::SendToKindleButton;
+use crate::components::{SendToKindleButton, SendToKoboButton};
 
 /// The "Export" trigger + dropdown panel. Renders the download links for
 /// whichever formats the book has, the interactive Send-to-Kindle button,
@@ -100,18 +100,16 @@ fn BdExportPanel(uuid: String, has_ebook: bool, has_audio: bool, open: Signal<bo
                     testid: "hero-send-kindle".to_string(),
                 }
             }
-            // Send-to-Kobo downloads the book as KEPUB; the endpoint converts
-            // the EPUB (falling back to plain EPUB when kepubify is absent), so
-            // it only applies to books with an ebook. Plain anchor for a real
-            // browser download, same as the EPUB row above.
+            // Send-to-Kobo writes the KEPUB straight onto a plugged-in Kobo
+            // (Chrome/Edge), or downloads it to copy over. Only applies to books
+            // with an ebook, since the endpoint converts the EPUB. Reuses the
+            // interactive button (same menu-stays-open + own-toast model as
+            // Send-to-Kindle above).
             if has_ebook {
-                a {
-                    class: "bd-export-item",
-                    "data-testid": "export-send-kobo",
-                    href: "/api/ebooks/{uuid}/kepub",
-                    download: "",
-                    onclick: move |_| open.set(false),
-                    span { class: "bd-export-item-label", "Send to Kobo" }
+                SendToKoboButton {
+                    uuid: uuid.clone(),
+                    class: "bd-export-item".to_string(),
+                    testid: "hero-send-kobo".to_string(),
                 }
             }
         }

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -262,11 +262,13 @@ test("renders the detail contents for the selected book", async ({ page, request
   const heroKindleBtn = exportPanel.getByTestId("hero-send-kindle");
   await expect(heroKindleBtn).toBeVisible();
   await expect(heroKindleBtn).toBeEnabled();
-  // Send-to-Kobo is a KEPUB download link (same endpoint as the per-format
-  // action-kobo), enabled because the book has an EPUB.
-  const koboExport = exportPanel.getByTestId("export-send-kobo");
-  await expect(koboExport).toHaveAttribute("href", /\/api\/ebooks\/.+\/kepub$/);
-  await expect(koboExport).toHaveAttribute("download");
+  // Send-to-Kobo is the interactive button (writes the KEPUB onto a plugged-in
+  // Kobo on Chromium, or downloads it to copy over elsewhere); enabled because
+  // the book has an EPUB. Its own testid keeps it distinct from the per-format
+  // action-kobo above.
+  const koboExport = exportPanel.getByTestId("hero-send-kobo");
+  await expect(koboExport).toBeVisible();
+  await expect(koboExport).toBeEnabled();
   // The audiobook download only appears for books with an audio file; the
   // ebook-only seed must not render it. Close the menu again via the scrim.
   // The scrim fills the viewport, so click a corner clear of the panel
@@ -299,22 +301,34 @@ test("renders the detail contents for the selected book", async ({ page, request
   await expect(page.getByTestId("ebook-table")).toBeVisible();
 });
 
-// Action — Send to Kobo (F4.1 KEPUB download)
+// Action — Send to Kobo (F4.1 KEPUB direct write / download fallback)
 // ---------------------------------------------------------------------------
 
-test("Send to Kobo downloads the book with a uuid-named file", async ({ page, request }) => {
+test("Send to Kobo delivers the book with a uuid-named file", async ({ page, request }) => {
   const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+
+  // Force the download fallback path: without the File System Access API the
+  // button fetches the KEPUB and triggers a normal browser download. The native
+  // directory picker can't be driven headlessly (and isn't present in every
+  // Chromium build), so nulling `showDirectoryPicker` makes the path
+  // deterministic in CI. Must run before navigation so it applies to the page.
+  await page.addInitScript(() => {
+    Object.defineProperty(window, "showDirectoryPicker", {
+      configurable: true,
+      value: undefined,
+    });
+  });
   await gotoReady(page, `/books/${uuid}`);
 
   const epubRow = page.getByTestId("format-switcher").getByTestId("format-row-epub");
   const koboBtn = epubRow.getByTestId("action-kobo");
   await expect(koboBtn).toBeVisible();
-  await expect(koboBtn).toHaveAttribute("href", new RegExp(`/api/ebooks/${uuid}/kepub$`));
+  await expect(koboBtn).toBeEnabled();
 
-  // Clicking downloads the file (the `download` attribute keeps the page put).
-  // The filename stem is the canonical book uuid; the extension is
-  // `.kepub.epub` when kepubify converts, or `.epub` on fallback — assert the
-  // uuid-embedded contract that F4.4's USB import relies on, tolerant of both.
+  // Clicking downloads the file (the fallback anchor keeps the page put). The
+  // filename stem is the canonical book uuid; the extension is `.kepub.epub`
+  // when kepubify converts, or `.epub` on fallback — assert the uuid-embedded
+  // contract that F4.4's USB import relies on, tolerant of both.
   const [download] = await Promise.all([
     page.waitForEvent("download"),
     koboBtn.click(),


### PR DESCRIPTION
## Summary
- **Send to Kobo** now writes the KEPUB straight onto a plugged-in Kobo on Chrome/Edge via the File System Access API — the device mounts on the *client* machine, so the write happens in-browser. The chosen directory handle is remembered in IndexedDB, so repeat sends are silent. Firefox/Safari fall back to the existing download-and-copy.
- Frontend-only; reuses the existing `GET /api/ebooks/:uuid/kepub` route. Wires the interactive button into both the per-format row and the hero Export menu.
- Only ever drops a loose file at the drive root — never touches the device's `KoboReader.sqlite` — so there is no data-loss risk (the safe mirror of the F4.4 USB *read*).

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 5 new `kobo_outcome` unit tests pass
- [x] clippy clean on wasm32 (web) + mobile; `cargo fmt --check` + `just lint-css` pass
- [ ] E2E `book_detail.spec.ts` updated to the new button contract — runs in CI (`run_ui_tests`)

## Version
- [x] **Patch** — the default.

## Notes
- The native picker / USB write can't be driven headlessly, so the E2E forces the deterministic download-fallback path; the write path is covered by the unit-tested outcome mapping.