### PR TITLE
fix: stop leaking raw DB/internal error text on the RPC surface (#761)

### DIFF
--- a/frontend/src/rpc/account.rs
+++ b/frontend/src/rpc/account.rs
@@ -8,7 +8,7 @@ use dioxus::prelude::*;
 use omnibus_db::{self as db, auth::AuthError};
 
 #[cfg(feature = "server")]
-use super::{AuthUser, PoolExt};
+use super::{internal_error, AuthUser, PoolExt};
 
 /// Set (or clear, with `None`/blank) the authenticated user's Kindle email.
 /// Rejects a malformed address with a validation `ServerFnError`.
@@ -17,6 +17,6 @@ pub async fn rpc_set_kindle_email(email: Option<String>) -> Result<()> {
     match db::auth::set_kindle_email(&pool.0, user.id, email.as_deref()).await {
         Ok(()) => Ok(()),
         Err(AuthError::Validation(msg)) => Err(ServerFnError::new(msg).into()),
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("set_kindle_email", e).into()),
     }
 }

--- a/frontend/src/rpc/authors.rs
+++ b/frontend/src/rpc/authors.rs
@@ -20,7 +20,7 @@ use omnibus_shared::AUTHOR_PHOTO_URL_MAX_LEN;
 use omnibus_shared::detect_image_format;
 
 #[cfg(feature = "server")]
-use super::{AdminUser, AuthUser, PoolExt, WorkerExt};
+use super::{internal_error, AdminUser, AuthUser, PoolExt, WorkerExt};
 
 /// Fetch a single author and all their books. POST for the same reason as
 /// `rpc_get_ebook` — needs `id` in the body.
@@ -114,14 +114,14 @@ pub async fn rpc_set_author_photo_url(id: i64, url: String) -> Result<()> {
             .bind(id)
             .fetch_one(&pool.0)
             .await
-            .map_err(|e| ServerFnError::new(format!("author exists check: {e}")))?
+            .map_err(|e| internal_error("author_exists_check", e))?
             != 0;
     if !author_exists {
         return Err(ServerFnError::new("author not found").into());
     }
     let (_mime_hint, bytes) = db::author_photos::fetch_remote_image(trimmed)
         .await
-        .map_err(|e| ServerFnError::new(e.to_string()))?;
+        .map_err(|e| internal_error("fetch_remote_image", e))?;
     let mime = detect_image_format(&bytes)
         .ok_or_else(|| ServerFnError::new("file at URL does not appear to be a valid image"))?;
     db::upsert_author_photo(
@@ -133,7 +133,7 @@ pub async fn rpc_set_author_photo_url(id: i64, url: String) -> Result<()> {
         Some(&bytes),
     )
     .await
-    .map_err(|e| ServerFnError::new(format!("upsert_author_photo: {e}")))?;
+    .map_err(|e| internal_error("upsert_author_photo", e))?;
     Ok(())
 }
 

--- a/frontend/src/rpc/bookmarks.rs
+++ b/frontend/src/rpc/bookmarks.rs
@@ -9,20 +9,7 @@ use omnibus_shared::{Bookmark, CreateBookmark, UpdateBookmark};
 use omnibus_db as db;
 
 #[cfg(feature = "server")]
-use super::{AuthUser, PoolExt};
-
-/// Log a bookmark DB error server-side and return a generic client error so
-/// raw `sqlx` text (which can carry SQL / schema details) never reaches the
-/// authed client — mirrors the REST `internal(...)` helper.
-#[cfg(feature = "server")]
-fn bookmark_db_error<E, R>(op: &str, e: E) -> R
-where
-    E: std::fmt::Display,
-    R: From<ServerFnError>,
-{
-    tracing::error!(op = op, error = %e, "rpc bookmark db error");
-    ServerFnError::new("internal server error").into()
-}
+use super::{internal_error, AuthUser, PoolExt};
 
 /// Create a bookmark on a book. Mobile uses the analogous REST route in
 /// `server::backend::bookmarks`; the rest of this family follows the same
@@ -45,7 +32,7 @@ pub async fn rpc_create_bookmark(input: CreateBookmark) -> Result<Bookmark> {
             tracing::error!(error = %e, "rpc_create_bookmark: inserted row could not be re-read");
             Err(ServerFnError::new("internal server error").into())
         }
-        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(bookmark_db_error("create", e)),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(internal_error("create", e).into()),
     }
 }
 
@@ -56,8 +43,8 @@ pub async fn rpc_create_bookmark(input: CreateBookmark) -> Result<Bookmark> {
 pub async fn rpc_list_bookmarks(book_uuid: String) -> Result<Vec<Bookmark>> {
     match db::bookmarks::list_bookmarks(&pool.0, user.id, &book_uuid).await {
         Ok(list) => Ok(list),
-        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(bookmark_db_error("list", e)),
-        Err(e) => Err(bookmark_db_error("list", e)),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(internal_error("list", e).into()),
+        Err(e) => Err(internal_error("list", e).into()),
     }
 }
 
@@ -75,8 +62,8 @@ pub async fn rpc_update_bookmark(id: i64, body: UpdateBookmark) -> Result<()> {
         Err(db::bookmarks::BookmarkError::NotFound) => {
             Err(ServerFnError::new("bookmark not found").into())
         }
-        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(bookmark_db_error("update", e)),
-        Err(e) => Err(bookmark_db_error("update", e)),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(internal_error("update", e).into()),
+        Err(e) => Err(internal_error("update", e).into()),
     }
 }
 
@@ -90,7 +77,7 @@ pub async fn rpc_delete_bookmark(id: i64) -> Result<()> {
         Err(db::bookmarks::BookmarkError::NotFound) => {
             Err(ServerFnError::new("bookmark not found").into())
         }
-        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(bookmark_db_error("delete", e)),
-        Err(e) => Err(bookmark_db_error("delete", e)),
+        Err(db::bookmarks::BookmarkError::Sqlx(e)) => Err(internal_error("delete", e).into()),
+        Err(e) => Err(internal_error("delete", e).into()),
     }
 }

--- a/frontend/src/rpc/highlights.rs
+++ b/frontend/src/rpc/highlights.rs
@@ -8,7 +8,7 @@ use omnibus_shared::{CreateHighlight, Highlight, HighlightColor, UpdateHighlight
 use omnibus_db as db;
 
 #[cfg(feature = "server")]
-use super::{AuthUser, PoolExt};
+use super::{internal_error, AuthUser, PoolExt};
 
 /// Create a highlight on a book. Mobile uses the analogous REST route in
 /// `server::backend::highlights`; the rest of this family of RPCs follows
@@ -27,7 +27,7 @@ pub async fn rpc_create_highlight(input: CreateHighlight) -> Result<Highlight> {
             Err(ServerFnError::new("highlight not found").into())
         }
         Err(db::highlights::HighlightError::Sqlx(e)) => {
-            Err(ServerFnError::new(e.to_string()).into())
+            Err(internal_error("create_highlight", e).into())
         }
     }
 }
@@ -40,9 +40,9 @@ pub async fn rpc_list_highlights(book_uuid: String) -> Result<Vec<Highlight>> {
     match db::highlights::list_highlights(&pool.0, user.id, &book_uuid).await {
         Ok(list) => Ok(list),
         Err(db::highlights::HighlightError::Sqlx(e)) => {
-            Err(ServerFnError::new(e.to_string()).into())
+            Err(internal_error("list_highlights", e).into())
         }
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("list_highlights", e).into()),
     }
 }
 
@@ -58,9 +58,9 @@ pub async fn rpc_update_highlight_color(id: i64, color: HighlightColor) -> Resul
             Err(ServerFnError::new("highlight not found").into())
         }
         Err(db::highlights::HighlightError::Sqlx(e)) => {
-            Err(ServerFnError::new(e.to_string()).into())
+            Err(internal_error("update_highlight_color", e).into())
         }
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("update_highlight_color", e).into()),
     }
 }
 
@@ -79,9 +79,9 @@ pub async fn rpc_update_highlight_note(id: i64, body: UpdateHighlightNote) -> Re
             Err(ServerFnError::new("highlight not found").into())
         }
         Err(db::highlights::HighlightError::Sqlx(e)) => {
-            Err(ServerFnError::new(e.to_string()).into())
+            Err(internal_error("update_highlight_note", e).into())
         }
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("update_highlight_note", e).into()),
     }
 }
 
@@ -96,8 +96,8 @@ pub async fn rpc_delete_highlight(id: i64) -> Result<()> {
             Err(ServerFnError::new("highlight not found").into())
         }
         Err(db::highlights::HighlightError::Sqlx(e)) => {
-            Err(ServerFnError::new(e.to_string()).into())
+            Err(internal_error("delete_highlight", e).into())
         }
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("delete_highlight", e).into()),
     }
 }

--- a/frontend/src/rpc/journals.rs
+++ b/frontend/src/rpc/journals.rs
@@ -8,7 +8,7 @@ use omnibus_shared::{CreateJournalEntry, JournalEntry, UpdateJournalEntry};
 use omnibus_db as db;
 
 #[cfg(feature = "server")]
-use super::{AuthUser, PoolExt};
+use super::{internal_error, AuthUser, PoolExt};
 
 /// Create a public journal entry on a book. Mobile uses the analogous REST
 /// route in `server::backend::journals`; the rest of this family follows the
@@ -26,7 +26,9 @@ pub async fn rpc_create_journal_entry(input: CreateJournalEntry) -> Result<Journ
         Err(db::journals::JournalError::NotFound) => {
             Err(ServerFnError::new("journal entry not found").into())
         }
-        Err(db::journals::JournalError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(db::journals::JournalError::Sqlx(e)) => {
+            Err(internal_error("create_journal_entry", e).into())
+        }
     }
 }
 
@@ -37,7 +39,7 @@ pub async fn rpc_create_journal_entry(input: CreateJournalEntry) -> Result<Journ
 pub async fn rpc_list_journal_entries(book_uuid: String) -> Result<Vec<JournalEntry>> {
     match db::journals::list_journal_entries(&pool.0, &book_uuid).await {
         Ok(list) => Ok(list),
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("list_journal_entries", e).into()),
     }
 }
 
@@ -54,7 +56,7 @@ pub async fn rpc_update_journal_entry(id: i64, input: UpdateJournalEntry) -> Res
         Err(db::journals::JournalError::NotFound) => {
             Err(ServerFnError::new("journal entry not found").into())
         }
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("update_journal_entry", e).into()),
     }
 }
 
@@ -68,7 +70,7 @@ pub async fn rpc_delete_journal_entry(id: i64) -> Result<()> {
         Err(db::journals::JournalError::NotFound) => {
             Err(ServerFnError::new("journal entry not found").into())
         }
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("delete_journal_entry", e).into()),
     }
 }
 

--- a/frontend/src/rpc/kindle.rs
+++ b/frontend/src/rpc/kindle.rs
@@ -17,7 +17,7 @@ use omnibus_shared::ProgressState;
 use omnibus_db as db;
 
 #[cfg(feature = "server")]
-use super::{AuthUser, PoolExt, WorkerExt};
+use super::{internal_error, AuthUser, PoolExt, WorkerExt};
 
 /// Enqueue a send of the EPUB for `book_uuid` (optionally a specific `file_id`
 /// for multi-EPUB books) to the authenticated user's Kindle address, returning
@@ -29,7 +29,7 @@ use super::{AuthUser, PoolExt, WorkerExt};
 pub async fn rpc_send_to_kindle(book_uuid: String, file_id: Option<i64>) -> Result<u64> {
     let recipient = db::auth::get_kindle_email(&pool.0, user.id)
         .await
-        .map_err(|e| ServerFnError::new(e.to_string()))?;
+        .map_err(|e| internal_error("get_kindle_email", e))?;
     let Some(recipient) = recipient else {
         return Err(ServerFnError::new(
             "add your Kindle email on your account page before sending",

--- a/frontend/src/rpc/mod.rs
+++ b/frontend/src/rpc/mod.rs
@@ -50,6 +50,23 @@ type WorkerExt = dioxus::fullstack::axum::Extension<std::sync::Arc<omnibus_db::w
 #[cfg(feature = "server")]
 pub use server_auth::{AdminUser, AuthUser};
 
+/// Log an internal RPC failure server-side and return a generic client-facing
+/// `ServerFnError`, so raw `sqlx`/transport error text (which can carry SQL,
+/// schema, or network details) never reaches the client — mirrors the REST
+/// `server::backend::internal` helper for the `/api/rpc/*` surface. Returns
+/// the concrete `ServerFnError` (rather than a generic `Into`-bound `Result`
+/// error) so it composes with both `Err(internal_error(...).into())` match
+/// arms and `.map_err(|e| internal_error(...))?` chains without the compiler
+/// needing to disambiguate two different `From` conversions at once.
+#[cfg(feature = "server")]
+pub(crate) fn internal_error<E>(op: &'static str, e: E) -> dioxus::fullstack::ServerFnError
+where
+    E: std::fmt::Display,
+{
+    tracing::error!(op = op, error = %e, "rpc internal error");
+    dioxus::fullstack::ServerFnError::new("internal server error")
+}
+
 /// Server-side per-route authorization extractors used by the `#[get]` /
 /// `#[post]` macros in the submodules. These are deliberately scoped to this
 /// module instead of imported from `crate::omnibus::auth` — the `frontend`

--- a/frontend/src/rpc/progress.rs
+++ b/frontend/src/rpc/progress.rs
@@ -13,7 +13,7 @@ use omnibus_db as db;
 use omnibus_shared::SESSION_BATCH_CAP;
 
 #[cfg(feature = "server")]
-use super::{AuthUser, PoolExt};
+use super::{internal_error, AuthUser, PoolExt};
 
 /// Progress-sync save. Mobile uses the analogous REST route in
 /// `server::backend::progress`. POST because Dioxus `#[get]` server
@@ -29,7 +29,7 @@ pub async fn rpc_save_progress(update: ProgressUpdate) -> Result<ProgressRecord>
         Err(db::progress::ProgressError::BookNotFound) => {
             Err(ServerFnError::new("book not found").into())
         }
-        Err(db::progress::ProgressError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(db::progress::ProgressError::Sqlx(e)) => Err(internal_error("save_progress", e).into()),
     }
 }
 
@@ -41,7 +41,10 @@ pub async fn rpc_get_progress(
     uuid: String,
     format: ProgressFormat,
 ) -> Result<Option<ProgressRecord>> {
-    Ok(db::progress::get_progress(&pool.0, user.id, &uuid, format).await?)
+    match db::progress::get_progress(&pool.0, user.id, &uuid, format).await {
+        Ok(rec) => Ok(rec),
+        Err(e) => Err(internal_error("get_progress", e).into()),
+    }
 }
 
 /// Reject over-cap session batches at the RPC boundary, mirroring the mobile
@@ -83,7 +86,10 @@ pub async fn rpc_record_sessions(reports: Vec<SessionReport>) -> Result<u64> {
     }
     let mut inserted = 0u64;
     for r in &reports {
-        if db::progress::record_session(&pool.0, user.id, r).await? {
+        let recorded = db::progress::record_session(&pool.0, user.id, r)
+            .await
+            .map_err(|e| internal_error("record_session", e))?;
+        if recorded {
             inserted += 1;
         }
     }

--- a/frontend/src/rpc/ratings.rs
+++ b/frontend/src/rpc/ratings.rs
@@ -8,7 +8,7 @@ use omnibus_shared::{RatingRecord, RatingUpdate};
 use omnibus_db as db;
 
 #[cfg(feature = "server")]
-use super::{AuthUser, PoolExt};
+use super::{internal_error, AuthUser, PoolExt};
 
 /// Set (or change) the current user's star rating for a book. Mobile uses the
 /// analogous REST route in `server::backend::ratings`. POST carries the
@@ -23,7 +23,7 @@ pub async fn rpc_set_rating(update: RatingUpdate) -> Result<RatingRecord> {
         Err(db::ratings::RatingError::BookNotFound) => {
             Err(ServerFnError::new("book not found").into())
         }
-        Err(db::ratings::RatingError::Sqlx(e)) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(db::ratings::RatingError::Sqlx(e)) => Err(internal_error("set_rating", e).into()),
     }
 }
 
@@ -31,12 +31,18 @@ pub async fn rpc_set_rating(update: RatingUpdate) -> Result<RatingRecord> {
 /// book is unknown or the user has not rated it yet.
 #[post("/api/rpc/ratings/get", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_get_rating(uuid: String) -> Result<Option<RatingRecord>> {
-    Ok(db::ratings::get_rating(&pool.0, user.id, &uuid).await?)
+    match db::ratings::get_rating(&pool.0, user.id, &uuid).await {
+        Ok(rec) => Ok(rec),
+        Err(e) => Err(internal_error("get_rating", e).into()),
+    }
 }
 
 /// Clear (un-rate) the current user's rating for a book. A no-op when no
 /// rating exists, so it always succeeds for a known or unknown uuid.
 #[post("/api/rpc/ratings/clear", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_clear_rating(uuid: String) -> Result<()> {
-    Ok(db::ratings::delete_rating(&pool.0, user.id, &uuid).await?)
+    match db::ratings::delete_rating(&pool.0, user.id, &uuid).await {
+        Ok(()) => Ok(()),
+        Err(e) => Err(internal_error("clear_rating", e).into()),
+    }
 }

--- a/frontend/src/rpc/settings.rs
+++ b/frontend/src/rpc/settings.rs
@@ -11,7 +11,7 @@ use omnibus_shared::{
 use omnibus_db::{self as db, scanner};
 
 #[cfg(feature = "server")]
-use super::{AdminUser, AuthUser, PoolExt, WorkerExt};
+use super::{internal_error, AdminUser, AuthUser, PoolExt, WorkerExt};
 
 /// Fetch the current server settings row. Admin-only.
 #[get("/api/rpc/settings", pool: PoolExt, _admin: AdminUser)]
@@ -101,7 +101,7 @@ pub async fn rpc_set_hardcover_key(key: Option<String>) -> Result<HardcoverKeySt
     match db::set_hardcover_api_key(&pool.0, key.as_deref()).await {
         Ok(()) => Ok(db::hardcover_key_status(&pool.0).await?),
         Err(db::SettingsError::Validation(msg)) => Err(ServerFnError::new(msg).into()),
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("set_hardcover_key", e).into()),
     }
 }
 
@@ -120,7 +120,7 @@ pub async fn rpc_set_smtp_config(update: SmtpConfigUpdate) -> Result<SmtpConfigS
     match db::set_smtp_config(&pool.0, &update).await {
         Ok(()) => Ok(db::smtp_status(&pool.0).await?),
         Err(db::SettingsError::Validation(msg)) => Err(ServerFnError::new(msg).into()),
-        Err(e) => Err(ServerFnError::new(e.to_string()).into()),
+        Err(e) => Err(internal_error("set_smtp_config", e).into()),
     }
 }
 
@@ -139,7 +139,7 @@ pub async fn rpc_clear_smtp_config() -> Result<SmtpConfigStatus> {
 pub async fn rpc_send_smtp_test() -> Result<()> {
     let email = db::auth::get_kindle_email(&pool.0, admin.0.id)
         .await
-        .map_err(|e| ServerFnError::new(e.to_string()))?;
+        .map_err(|e| internal_error("get_kindle_email", e))?;
     let Some(email) = email else {
         return Err(ServerFnError::new(
             "set your Kindle email on your account page first, then send a test",
@@ -148,7 +148,7 @@ pub async fn rpc_send_smtp_test() -> Result<()> {
     };
     db::kindle::send_test(&pool.0, &email)
         .await
-        .map_err(|e| ServerFnError::new(e.to_string()))?;
+        .map_err(|e| internal_error("send_smtp_test", e))?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- The Dioxus server-fn (`/api/rpc/*`) surface stringified raw `sqlx`/internal error `Display` text straight into `ServerFnError`, so the browser could see SQL/schema/transport details on core reading/annotation flows (journals, highlights, ratings, progress) plus account/authors/settings/kindle. `server/src/backend.rs` already has this discipline on the REST/mobile surface via a shared `internal()` helper; the RPC surface had no equivalent.
- Added `rpc::internal_error()` (mirrors `server::backend::internal`) that logs the real error server-side via `tracing::error!` and returns a fixed `"internal server error"` message to the client. Applied it to every cited leak site in the issue, plus the equivalent `?`-propagated leaks in the same modules (same error types, same functions) that the issue's own evidence list missed because it was grepped for explicit `.to_string()` calls rather than bare `?`.
- `frontend/src/rpc/bookmarks.rs` had already independently fixed this exact pattern with a private, file-local helper — hoisted it into the shared `rpc::internal_error` (used by 9 modules now) instead of leaving 9 near-duplicate copies.
- Left `frontend/src/rpc/books.rs:84` (`PageCursor::decode`) unchanged: on inspection, `CursorError::Malformed`'s `Display` is a fixed, safe `"malformed pagination cursor"` string carrying no internal detail — it already satisfies the acceptance criteria's own carve-out ("errors that are legitimately meant for the user... continue to surface their specific message").

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` clean
- [x] `cargo clippy --workspace --exclude omnibus-mobile -- -D warnings` clean
- [x] `cargo test -p omnibus-frontend --features server` — 202 passed
- [x] `cargo test -p omnibus` — 297 passed
- [x] `cargo test -p omnibus-db` — passed
- [x] `cargo test -p omnibus-shared` — 92 passed

## Version
- [x] **Patch** — default, unlabeled

## Notes
- Out of scope, flagged for a follow-up issue: `frontend/src/rpc/books.rs`, `authors.rs` (aside from the one function touched here), and `settings.rs` have additional `?`-based calls (e.g. `db::get_settings(...).await?`, `db::list_authors(...).await?`) that funnel through the same blanket `CapturedError: From<E: Into<anyhow::Error>>` conversion and could leak in the same way. They weren't named in #761's evidence or severity discussion (which calls out journals/highlights/ratings/progress specifically), so left untouched here to keep this PR bounded to the cited scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_018P4LFLXa7sMVeVc1CxmXbR)_