### PR TITLE
fix: add missing key: attributes to rsx list renders (#729, #765)

### DIFF
--- a/frontend/src/components/create_shelf_modal.rs
+++ b/frontend/src/components/create_shelf_modal.rs
@@ -371,7 +371,10 @@ fn render_preview(preview: &Option<RulePreview>, server_url: &str) -> Element {
             }
             div { class: "shelf-preview-grid",
                 for book in p.sample.iter().cloned() {
-                    {sample_cover(book, server_url)}
+                    div {
+                        key: "{book.unique_identifier.clone().unwrap_or_default()}",
+                        {sample_cover(book, server_url)}
+                    }
                 }
             }
         },
@@ -472,7 +475,7 @@ fn ConditionRow(
                 value: field.as_str(),
                 onchange: on_field,
                 for (f, label) in FIELDS.iter() {
-                    option { value: f.as_str(), "{label}" }
+                    option { key: "{f.as_str()}", value: f.as_str(), "{label}" }
                 }
             }
             select {
@@ -481,7 +484,7 @@ fn ConditionRow(
                 value: op.as_str(),
                 onchange: on_op,
                 for (o, label) in OPS.iter().filter(|(o, _)| field.accepts(*o)) {
-                    option { value: o.as_str(), "{label}" }
+                    option { key: "{o.as_str()}", value: o.as_str(), "{label}" }
                 }
             }
             {condition_value_input(&draft, on_val, on_val2, on_unit)}
@@ -613,7 +616,10 @@ fn PickerBody(picked: Signal<Vec<String>>, server_url: String) -> Element {
             }
             div { class: "shelf-picker-grid",
                 for book in filtered.iter().map(|b| (*b).clone()) {
-                    {picker_tile(book, &server_url, picked, &mut picked)}
+                    div {
+                        key: "{book.unique_identifier.clone().unwrap_or_default()}",
+                        {picker_tile(book, &server_url, picked, &mut picked)}
+                    }
                 }
             }
         }

--- a/frontend/src/components/create_shelf_modal.rs
+++ b/frontend/src/components/create_shelf_modal.rs
@@ -372,7 +372,7 @@ fn render_preview(preview: &Option<RulePreview>, server_url: &str) -> Element {
             div { class: "shelf-preview-grid",
                 for book in p.sample.iter().cloned() {
                     div {
-                        key: "{book.unique_identifier.clone().unwrap_or_default()}",
+                        key: "{book.id}",
                         {sample_cover(book, server_url)}
                     }
                 }
@@ -617,7 +617,7 @@ fn PickerBody(picked: Signal<Vec<String>>, server_url: String) -> Element {
             div { class: "shelf-picker-grid",
                 for book in filtered.iter().map(|b| (*b).clone()) {
                     div {
-                        key: "{book.unique_identifier.clone().unwrap_or_default()}",
+                        key: "{book.id}",
                         {picker_tile(book, &server_url, picked, &mut picked)}
                     }
                 }

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -338,6 +338,7 @@ fn LetterNav(
                     if has {
                         rsx! {
                             a {
+                                key: "{l}",
                                 class: "idx-letter idx-letter-on",
                                 href: "#letter-{frag}",
                                 "data-testid": "authors-letter-{frag}",
@@ -346,7 +347,7 @@ fn LetterNav(
                         }
                     } else {
                         rsx! {
-                            span { class: "idx-letter", "{l}" }
+                            span { key: "{l}", class: "idx-letter", "{l}" }
                         }
                     }
                 }

--- a/frontend/src/pages/book_detail/journal_editor.rs
+++ b/frontend/src/pages/book_detail/journal_editor.rs
@@ -182,6 +182,7 @@ pub(crate) fn BdJournalToolbar(target_id: String) -> Element {
         div { class: "bd-journal-toolbar", "data-testid": "journal-toolbar", role: "toolbar",
             for btn in BUTTONS.iter() {
                 button {
+                    key: "{btn.title}",
                     r#type: "button",
                     class: "btn ghost sm bd-journal-tool",
                     title: "{btn.title}",

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -481,19 +481,21 @@ pub(super) fn BdCrumb(items: Vec<BdCrumbItem>) -> Element {
     rsx! {
         nav { class: "bd-crumb", "aria-label": "breadcrumb",
             for (i, item) in items.iter().cloned().enumerate() {
-                if i > 0 {
-                    span { class: "bd-crumb-sep", "\u{203a}" }
-                }
-                if i == last_idx {
-                    span { class: "bd-crumb-curr", "{item.text}" }
-                } else if let Some(route) = item.target.clone() {
-                    Link {
-                        to: route,
-                        class: if i == 0 { "bd-crumb-home" } else { "bd-crumb-step" },
-                        "{item.text}"
+                Fragment { key: "{i}-{item.text}",
+                    if i > 0 {
+                        span { class: "bd-crumb-sep", "\u{203a}" }
                     }
-                } else {
-                    span { class: "bd-crumb-step", "{item.text}" }
+                    if i == last_idx {
+                        span { class: "bd-crumb-curr", "{item.text}" }
+                    } else if let Some(route) = item.target.clone() {
+                        Link {
+                            to: route,
+                            class: if i == 0 { "bd-crumb-home" } else { "bd-crumb-step" },
+                            "{item.text}"
+                        }
+                    } else {
+                        span { class: "bd-crumb-step", "{item.text}" }
+                    }
                 }
             }
         }

--- a/frontend/src/pages/listen/chapter_map.rs
+++ b/frontend/src/pages/listen/chapter_map.rs
@@ -144,6 +144,7 @@ pub(super) fn ChapterMap(
 
                         rsx! {
                             div {
+                                key: "{ch.ordinal}",
                                 class: "{class_name}",
                                 style: "flex: {flex_val};",
                                 title: "{title}",

--- a/frontend/src/pages/reader/toc_drawer.rs
+++ b/frontend/src/pages/reader/toc_drawer.rs
@@ -53,6 +53,7 @@ pub(super) fn TocDrawer(
                             let indent = format!("padding-left:{}px;", 14 + entry.level * 16);
                             rsx! {
                                 button {
+                                    key: "{entry.href}",
                                     class: "{row_class}",
                                     style: "{indent}",
                                     r#type: "button",

--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -160,7 +160,7 @@ fn member_grid(
         div { class: "lib-grid shelf-grid", "data-testid": "shelf-grid", role: "list",
             for book in books.iter().cloned() {
                 div {
-                    key: "{book.unique_identifier.clone().unwrap_or_default()}",
+                    key: "{book.id}",
                     {member_tile(book, server_url)}
                 }
             }
@@ -412,7 +412,7 @@ fn AddBooksModal(shelf_id: i64, on_close: EventHandler<()>, on_added: EventHandl
                     div { class: "shelf-picker-grid",
                         for book in filtered.iter().map(|b| (*b).clone()) {
                             div {
-                                key: "{book.unique_identifier.clone().unwrap_or_default()}",
+                                key: "{book.id}",
                                 {add_picker_tile(book, &server_url, picked)}
                             }
                         }

--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -106,8 +106,8 @@ pub fn ShelfDetailPage(id: i64) -> Element {
 
                 if is_smart {
                     div { class: "shelf-rule-summary",
-                        for rule in current.rules.iter() {
-                            span { class: "shelf-rule-chip", "{rule_text(rule)}" }
+                        for (i, rule) in current.rules.iter().enumerate() {
+                            span { key: "{i}", class: "shelf-rule-chip", "{rule_text(rule)}" }
                         }
                     }
                     div { class: "shelf-sort-row",
@@ -159,7 +159,10 @@ fn member_grid(
     rsx! {
         div { class: "lib-grid shelf-grid", "data-testid": "shelf-grid", role: "list",
             for book in books.iter().cloned() {
-                {member_tile(book, server_url)}
+                div {
+                    key: "{book.unique_identifier.clone().unwrap_or_default()}",
+                    {member_tile(book, server_url)}
+                }
             }
             if !is_smart {
                 {
@@ -408,7 +411,10 @@ fn AddBooksModal(shelf_id: i64, on_close: EventHandler<()>, on_added: EventHandl
                     }
                     div { class: "shelf-picker-grid",
                         for book in filtered.iter().map(|b| (*b).clone()) {
-                            {add_picker_tile(book, &server_url, picked)}
+                            div {
+                                key: "{book.unique_identifier.clone().unwrap_or_default()}",
+                                {add_picker_tile(book, &server_url, picked)}
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- The "missing `key:` attribute" family of rsx list-render sweeps continues: #729 found 8 sites, #765 found 4 more (not covered by #729). Missing `key:` risks Dioxus misapplying component/element state across list-item reorders or filters.
- Added a stable `key:` to all 12 cited sites:
  - `frontend/src/pages/shelf_detail.rs` — smart-shelf rule chips (keyed on index), member-grid tiles and the add-books picker grid (keyed on book uuid, via a keyed wrapper `div` around the existing helper fn — `key:` can't attach to a plain fn-call expression)
  - `frontend/src/components/create_shelf_modal.rs` — sample-cover preview grid + picker tiles (same wrapper-div pattern, keyed on uuid), and the field/op `<option>` lists in the condition-row selects (keyed on the field/op wire string)
  - `frontend/src/pages/reader/toc_drawer.rs` — TOC rows, keyed on `entry.href`
  - `frontend/src/pages/authors_index.rs` — A–Z jump-strip letters, keyed on the letter
  - `frontend/src/pages/book_detail/journal_editor.rs` — static toolbar buttons, keyed on `btn.title`
  - `frontend/src/pages/listen/chapter_map.rs` — chapter segments, keyed on `ch.ordinal`
  - `frontend/src/pages/book_detail/mod.rs` (`BdCrumb`) — each loop iteration renders a variable number of sibling elements (an optional separator span plus one of three content branches), so the whole iteration body is wrapped in a keyed `Fragment` rather than keying a single element — the correct Dioxus pattern for a multi-node loop body.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` — 202 passed
- [x] `cargo clippy` (default-members) — clean
- Independently re-verified by an adversarial review pass (separate agent, re-ran the diff and all three commands above from a clean checkout).
- Not run: Playwright (no local browser/server harness in this session) — the change is markup-only (`key:` attributes), doesn't alter DOM structure/selectors/testids other than adding one wrapping `div` around 4 already-existing per-book tile helpers, so existing shelf/reader-TOC/chapter-map specs should be unaffected.

## Version
- [x] **Patch** — default, unlabeled

## Notes
- Pre-existing, unrelated flakiness observed in `cargo test -p omnibus`: `backend::uploads::tests::inspect_allows_non_admin_with_can_upload` fails intermittently (~1 in 3 runs) under the full parallel suite, but passes in isolation. Reproduced the same intermittent failure on a clean `origin/main` checkout with this branch's changes stashed, so it's unrelated to this diff (which touches only `frontend/src/pages` and `frontend/src/components`) — flagging per project convention rather than silently fixing.

Closes #729
Closes #765
