### PR TITLE
refactor: extract shared multipart image-validation pipeline (#766)

### DIFF
--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -28,6 +28,7 @@ mod covers;
 mod ebooks;
 mod health;
 mod highlights;
+mod image_upload;
 mod journals;
 mod kindle;
 mod overrides;

--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -16,6 +16,7 @@ use omnibus_shared::detect_image_format;
 use serde::Deserialize;
 use sqlx::SqlitePool;
 
+use super::image_upload::extract_validated_image;
 use super::{internal, AppState};
 use crate::auth::{AdminUser, MediaAuthUser};
 
@@ -86,66 +87,9 @@ pub(super) async fn put_author_photo(
         return (axum::http::StatusCode::NOT_FOUND, "author not found").into_response();
     }
 
-    let (mime, bytes) = loop {
-        match multipart.next_field().await {
-            Ok(Some(field)) => {
-                let name = field.name().unwrap_or("").to_string();
-                if name != "photo" {
-                    continue;
-                }
-                let content_type = field
-                    .content_type()
-                    .unwrap_or("application/octet-stream")
-                    .to_string();
-                if !content_type.starts_with("image/") {
-                    return (
-                        axum::http::StatusCode::BAD_REQUEST,
-                        "photo must be an image",
-                    )
-                        .into_response();
-                }
-                if content_type.contains("svg") {
-                    return (
-                        axum::http::StatusCode::BAD_REQUEST,
-                        "SVG photos are not accepted",
-                    )
-                        .into_response();
-                }
-                match field.bytes().await {
-                    Ok(b) => {
-                        if b.len() > 10 * 1024 * 1024 {
-                            return (
-                                axum::http::StatusCode::BAD_REQUEST,
-                                "photo must be under 10 MB",
-                            )
-                                .into_response();
-                        }
-                        // Bind the detected MIME directly: a `None` here means the
-                        // bytes carry no recognisable image header, so surface a
-                        // 415 rather than `.unwrap()`-panicking the task (#210).
-                        match detect_image_format(&b) {
-                            Some(mime) => break (mime, b),
-                            None => {
-                                return (
-                                    axum::http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                                    "Could not detect image format",
-                                )
-                                    .into_response();
-                            }
-                        }
-                    }
-                    Err(e) => return internal("read photo field", e),
-                }
-            }
-            Ok(None) => {
-                return (
-                    axum::http::StatusCode::BAD_REQUEST,
-                    "missing 'photo' field in multipart body",
-                )
-                    .into_response()
-            }
-            Err(e) => return internal("parse multipart", e),
-        }
+    let (mime, bytes) = match extract_validated_image(&mut multipart, "photo").await {
+        Ok(pair) => pair,
+        Err(response) => return response,
     };
 
     if let Err(e) = db::upsert_author_photo(

--- a/server/src/backend/image_upload.rs
+++ b/server/src/backend/image_upload.rs
@@ -1,0 +1,92 @@
+//! Shared multipart image-upload validation: content-type check, SVG
+//! rejection, size cap, and magic-byte sniff. Used by the cover-upload
+//! (`overrides::post_ebook_cover`) and author-photo-upload
+//! (`author_photos::put_author_photo`) handlers so the two pipelines can't
+//! drift out of sync.
+
+use axum::body::Bytes;
+use axum::response::{IntoResponse, Response};
+use omnibus_shared::detect_image_format;
+
+use super::internal;
+
+const MAX_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+
+/// Reads the `field_name` field out of `multipart`, validating content-type,
+/// rejecting SVG, capping size at 10 MiB, and sniffing magic bytes. Returns
+/// the detected MIME + bytes on success, or the exact error `Response` the
+/// caller should return on failure.
+pub(super) async fn extract_validated_image(
+    multipart: &mut axum::extract::Multipart,
+    field_name: &str,
+) -> Result<(String, Bytes), Response> {
+    loop {
+        match multipart.next_field().await {
+            Ok(Some(field)) => {
+                let name = field.name().unwrap_or("").to_string();
+                if name != field_name {
+                    continue;
+                }
+                let content_type = field
+                    .content_type()
+                    .unwrap_or("application/octet-stream")
+                    .to_string();
+                if !content_type.starts_with("image/") {
+                    return Err((
+                        axum::http::StatusCode::BAD_REQUEST,
+                        format!("{field_name} must be an image"),
+                    )
+                        .into_response());
+                }
+                // Reject SVG — contains executable content and can XSS when
+                // opened directly in a browser tab.
+                if content_type.contains("svg") {
+                    return Err((
+                        axum::http::StatusCode::BAD_REQUEST,
+                        format!("SVG {field_name}s are not accepted"),
+                    )
+                        .into_response());
+                }
+                match field.bytes().await {
+                    Ok(b) => {
+                        if b.len() > MAX_IMAGE_BYTES {
+                            return Err((
+                                axum::http::StatusCode::BAD_REQUEST,
+                                format!("{field_name} must be under 10 MB"),
+                            )
+                                .into_response());
+                        }
+                        // Validate magic bytes — don't trust Content-Type alone.
+                        // Bind the detected MIME directly: a `None` here means the
+                        // bytes carry no recognisable image header, so surface a
+                        // 415 rather than `.unwrap()`-panicking the task (#210).
+                        match detect_image_format(&b) {
+                            // Use the detected MIME so the stored extension matches
+                            // actual content, not the (untrusted) client header.
+                            Some(mime) => return Ok((mime, b)),
+                            None => {
+                                return Err((
+                                    axum::http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                                    "Could not detect image format",
+                                )
+                                    .into_response());
+                            }
+                        }
+                    }
+                    Err(e) => return Err(internal("read image field", e)),
+                }
+            }
+            Ok(None) => {
+                return Err((
+                    axum::http::StatusCode::BAD_REQUEST,
+                    format!("missing '{field_name}' field in multipart body"),
+                )
+                    .into_response())
+            }
+            Err(e) => return Err(internal("parse multipart", e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/src/backend/image_upload/tests.rs
+++ b/server/src/backend/image_upload/tests.rs
@@ -1,0 +1,118 @@
+//! Tests for the shared multipart image-validation helper.
+
+use axum::body::{to_bytes, Body};
+use axum::extract::{DefaultBodyLimit, FromRequest, Multipart};
+use axum::http::{Request, StatusCode};
+
+use super::*;
+
+const PNG_MAGIC: &[u8] = &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+/// Builds a single-field `multipart/form-data` body and parses it back into
+/// the `Multipart` extractor, mirroring what axum does for a real request.
+async fn multipart_with_field(field_name: &str, content_type: &str, bytes: &[u8]) -> Multipart {
+    const BOUNDARY: &str = "test-boundary";
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"{field_name}\"\r\nContent-Type: {content_type}\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(bytes);
+    body.extend_from_slice(format!("\r\n--{BOUNDARY}--\r\n").as_bytes());
+
+    let mut request = Request::builder()
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={BOUNDARY}"),
+        )
+        .body(Body::from(body))
+        .expect("request should build");
+    // The production router raises axum's 2 MiB `DefaultBodyLimit` for these
+    // routes (see `backend.rs`); disable it here too so this test exercises
+    // `extract_validated_image`'s own 10 MiB cap, not axum's unrelated default.
+    DefaultBodyLimit::disable().apply(&mut request);
+    Multipart::from_request(request, &())
+        .await
+        .expect("multipart body should parse")
+}
+
+async fn empty_multipart() -> Multipart {
+    const BOUNDARY: &str = "test-boundary";
+    let request = Request::builder()
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={BOUNDARY}"),
+        )
+        .body(Body::from(format!("--{BOUNDARY}--\r\n")))
+        .expect("request should build");
+    Multipart::from_request(request, &())
+        .await
+        .expect("multipart body should parse")
+}
+
+#[tokio::test]
+async fn extract_validated_image_returns_detected_mime_and_bytes_for_a_valid_png() {
+    let mut multipart = multipart_with_field("cover", "image/png", PNG_MAGIC).await;
+    let (mime, bytes) = extract_validated_image(&mut multipart, "cover")
+        .await
+        .expect("valid png should be accepted");
+    assert_eq!(mime, "image/png");
+    assert_eq!(&bytes[..], PNG_MAGIC);
+}
+
+#[tokio::test]
+async fn extract_validated_image_returns_400_when_field_is_missing() {
+    let mut multipart = empty_multipart().await;
+    let response = extract_validated_image(&mut multipart, "cover")
+        .await
+        .expect_err("missing field should error");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body, "missing 'cover' field in multipart body");
+}
+
+#[tokio::test]
+async fn extract_validated_image_returns_400_for_non_image_content_type() {
+    let mut multipart = multipart_with_field("photo", "text/plain", b"not an image").await;
+    let response = extract_validated_image(&mut multipart, "photo")
+        .await
+        .expect_err("non-image content-type should error");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body, "photo must be an image");
+}
+
+#[tokio::test]
+async fn extract_validated_image_rejects_svg_content_type() {
+    let mut multipart =
+        multipart_with_field("cover", "image/svg+xml", b"<svg xmlns=\"...\"/>").await;
+    let response = extract_validated_image(&mut multipart, "cover")
+        .await
+        .expect_err("svg should be rejected");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body, "SVG covers are not accepted");
+}
+
+#[tokio::test]
+async fn extract_validated_image_rejects_oversized_uploads() {
+    let oversized = vec![0u8; MAX_IMAGE_BYTES + 1];
+    let mut multipart = multipart_with_field("cover", "image/png", &oversized).await;
+    let response = extract_validated_image(&mut multipart, "cover")
+        .await
+        .expect_err("oversized upload should error");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body, "cover must be under 10 MB");
+}
+
+#[tokio::test]
+async fn extract_validated_image_returns_415_for_unrecognized_magic_bytes() {
+    let mut multipart = multipart_with_field("photo", "image/png", b"not-a-real-png").await;
+    let response = extract_validated_image(&mut multipart, "photo")
+        .await
+        .expect_err("unrecognized magic bytes should error");
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}

--- a/server/src/backend/overrides.rs
+++ b/server/src/backend/overrides.rs
@@ -10,8 +10,9 @@ use axum::{
     Json,
 };
 use omnibus_db::{self as db};
-use omnibus_shared::{detect_image_format, MetadataOverrides};
+use omnibus_shared::MetadataOverrides;
 
+use super::image_upload::extract_validated_image;
 use super::{internal, AppState};
 use crate::auth::AuthUser;
 
@@ -121,71 +122,9 @@ pub(super) async fn post_ebook_cover(
     };
 
     // Extract the cover field from the multipart body.
-    let (mime, bytes) = loop {
-        match multipart.next_field().await {
-            Ok(Some(field)) => {
-                let name = field.name().unwrap_or("").to_string();
-                if name != "cover" {
-                    continue;
-                }
-                let content_type = field
-                    .content_type()
-                    .unwrap_or("application/octet-stream")
-                    .to_string();
-                if !content_type.starts_with("image/") {
-                    return (
-                        axum::http::StatusCode::BAD_REQUEST,
-                        "cover must be an image",
-                    )
-                        .into_response();
-                }
-                // Reject SVG — contains executable content and can XSS when
-                // opened directly in a browser tab.
-                if content_type.contains("svg") {
-                    return (
-                        axum::http::StatusCode::BAD_REQUEST,
-                        "SVG covers are not accepted",
-                    )
-                        .into_response();
-                }
-                match field.bytes().await {
-                    Ok(b) => {
-                        if b.len() > 10 * 1024 * 1024 {
-                            return (
-                                axum::http::StatusCode::BAD_REQUEST,
-                                "cover must be under 10 MB",
-                            )
-                                .into_response();
-                        }
-                        // Validate magic bytes — don't trust Content-Type alone.
-                        // Bind the detected MIME directly: a `None` here means the
-                        // bytes carry no recognisable image header, so surface a
-                        // 415 rather than `.unwrap()`-panicking the task (#210).
-                        match detect_image_format(&b) {
-                            // Use the detected MIME so the stored extension matches
-                            // actual content, not the (untrusted) client header.
-                            Some(mime) => break (mime, b),
-                            None => {
-                                return (
-                                    axum::http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                                    "Could not detect image format",
-                                )
-                                    .into_response();
-                            }
-                        }
-                    }
-                    Err(e) => return internal("read cover field", e),
-                }
-            }
-            Ok(None) => {
-                return (
-                    axum::http::StatusCode::BAD_REQUEST,
-                    "missing 'cover' field in multipart body",
-                )
-                    .into_response()
-            }
-            Err(e) => return internal("parse multipart", e),
-        }
+    let (mime, bytes) = match extract_validated_image(&mut multipart, "cover").await {
+        Ok(pair) => pair,
+        Err(response) => return response,
     };
 
     // Look up the prior overrides row BEFORE touching disk. `write_override_cover`


### PR DESCRIPTION
## Summary
- Two REST handlers (`post_ebook_cover` in `server/src/backend/overrides.rs` and `put_author_photo` in `server/src/backend/author_photos.rs`) each hand-rolled the same staged multipart image-validation pipeline: content-type check → SVG reject → 10 MiB size cap → magic-byte sniff.
- Extracted the pipeline into a new `extract_validated_image(multipart, field_name)` helper in `server/src/backend/image_upload.rs`, called from both handlers. Behavior is unchanged — same status codes, same user-facing messages (parameterized by field name: `"cover"` vs `"photo"`), same 10 MiB cap, same SVG rejection, same magic-byte sniff via `detect_image_format`.
- Internal-only tracing context strings for the two `field.bytes()`-read-error paths were consolidated from `"read cover field"`/`"read photo field"` to a single `"read image field"` — this only affects the server log line on a 500, not any externally observable response.

## Test plan
- [x] Added `server/src/backend/image_upload/tests.rs` — unit tests for the new helper covering: valid PNG accepted, missing field (400), non-image content-type (400), SVG rejected (400), oversized upload (400), unrecognized magic bytes (415).
- [x] Existing `server/src/backend/overrides/tests.rs` and `server/src/backend/author_photos/tests.rs` pass unchanged.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` clean.
- [x] `cargo test -p omnibus` — full suite (303 tests) passes.

## Version
- [x] **Patch** — the default; internal refactor, no behavior change, no release-note-worthy feature.

## Notes
- Closes #766.
- No migrations, no API/behavior changes, no Playwright-relevant markup touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FejFgWsFa7Kcxo9ADRnxvS)_