### PR TITLE
refactor: group ReaderLayout props into structs

### DIFF
--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -173,9 +173,7 @@ pub fn BookReadPage(uuid: String) -> Element {
     }
 }
 
-/// Book identity + display strings the reader chrome renders (title bar,
-/// quote/note panels, bookmark labels). Rebuilt each render from the parent's
-/// metadata reads; `PartialEq` lets Dioxus skip the layout when unchanged.
+/// Book identity + display strings the reader chrome renders.
 #[derive(Clone, PartialEq)]
 pub(super) struct ReaderMeta {
     pub uuid: String,
@@ -195,9 +193,7 @@ pub(super) struct ReaderProgress {
     pub status: ReaderStatus,
 }
 
-/// Every overlay/panel signal the reader chrome toggles or renders from
-/// (Aa panel, selection popover, TOC/highlights/search/bookmarks drawers,
-/// note + quote composers). All `Copy` signals, so the struct is `Copy`.
+/// Overlay/panel signals the reader chrome toggles or renders from.
 #[derive(Copy, Clone, PartialEq)]
 pub(super) struct ReaderPanelSignals {
     pub show_aa: Signal<bool>,
@@ -213,8 +209,7 @@ pub(super) struct ReaderPanelSignals {
     pub show_bookmarks: Signal<bool>,
 }
 
-/// Navigation + keyboard handlers built by `install_chrome_handlers` and
-/// threaded into the top bar, page-turn gutters, and surface keydown.
+/// Navigation + keyboard handlers for the top bar, page-turn gutters, and surface keydown.
 #[derive(Copy, Clone, PartialEq)]
 pub(super) struct ReaderNavHandlers {
     pub on_keydown: EventHandler<KeyboardEvent>,

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -136,64 +136,135 @@ pub fn BookReadPage(uuid: String) -> Element {
 
     rsx! {
         ReaderLayout {
-            uuid: uuid.clone(),
-            book_title,
-            book_author,
-            book_accent,
-            chapter_title: chapter_title_display,
-            current_cfi,
-            page_str,
-            chapter_str,
-            pct,
-            status: status(),
-            show_aa,
-            selection,
-            highlights,
-            toc,
-            show_toc,
-            show_highlights,
-            note_target,
-            quote_target,
-            show_search,
-            search_results,
-            show_bookmarks,
-            on_keydown,
-            on_back,
-            on_prev,
-            on_next,
+            meta: ReaderMeta {
+                uuid: uuid.clone(),
+                book_title,
+                book_author,
+                book_accent,
+                chapter_title: chapter_title_display,
+                current_cfi,
+            },
+            progress: ReaderProgress {
+                page_str,
+                chapter_str,
+                pct,
+                status: status(),
+            },
+            panels: ReaderPanelSignals {
+                show_aa,
+                selection,
+                highlights,
+                toc,
+                show_toc,
+                show_highlights,
+                note_target,
+                quote_target,
+                show_search,
+                search_results,
+                show_bookmarks,
+            },
+            nav: ReaderNavHandlers {
+                on_keydown,
+                on_back,
+                on_prev,
+                on_next,
+            },
         }
     }
+}
+
+/// Book identity + display strings the reader chrome renders (title bar,
+/// quote/note panels, bookmark labels). Rebuilt each render from the parent's
+/// metadata reads; `PartialEq` lets Dioxus skip the layout when unchanged.
+#[derive(Clone, PartialEq)]
+pub(super) struct ReaderMeta {
+    pub uuid: String,
+    pub book_title: String,
+    pub book_author: String,
+    pub book_accent: String,
+    pub chapter_title: String,
+    pub current_cfi: String,
+}
+
+/// Bottom-bar progress labels and the load-status overlay state.
+#[derive(Clone, PartialEq)]
+pub(super) struct ReaderProgress {
+    pub page_str: String,
+    pub chapter_str: String,
+    pub pct: u32,
+    pub status: ReaderStatus,
+}
+
+/// Every overlay/panel signal the reader chrome toggles or renders from
+/// (Aa panel, selection popover, TOC/highlights/search/bookmarks drawers,
+/// note + quote composers). All `Copy` signals, so the struct is `Copy`.
+#[derive(Copy, Clone, PartialEq)]
+pub(super) struct ReaderPanelSignals {
+    pub show_aa: Signal<bool>,
+    pub selection: Signal<Option<SelectionData>>,
+    pub highlights: Signal<Vec<Highlight>>,
+    pub toc: Signal<Vec<TocEntry>>,
+    pub show_toc: Signal<bool>,
+    pub show_highlights: Signal<bool>,
+    pub note_target: Signal<Option<Highlight>>,
+    pub quote_target: Signal<Option<Highlight>>,
+    pub show_search: Signal<bool>,
+    pub search_results: Signal<Vec<SearchResult>>,
+    pub show_bookmarks: Signal<bool>,
+}
+
+/// Navigation + keyboard handlers built by `install_chrome_handlers` and
+/// threaded into the top bar, page-turn gutters, and surface keydown.
+#[derive(Copy, Clone, PartialEq)]
+pub(super) struct ReaderNavHandlers {
+    pub on_keydown: EventHandler<KeyboardEvent>,
+    pub on_back: EventHandler<MouseEvent>,
+    pub on_prev: EventHandler<MouseEvent>,
+    pub on_next: EventHandler<MouseEvent>,
 }
 
 /// Reader chrome + panels (top bar, viewer stage, gutters, status bar, Aa panel, selection popover).
 #[component]
 fn ReaderLayout(
-    uuid: String,
-    book_title: String,
-    book_author: String,
-    book_accent: String,
-    chapter_title: String,
-    current_cfi: String,
-    page_str: String,
-    chapter_str: String,
-    pct: u32,
-    status: ReaderStatus,
-    show_aa: Signal<bool>,
-    selection: Signal<Option<SelectionData>>,
-    highlights: Signal<Vec<Highlight>>,
-    toc: Signal<Vec<TocEntry>>,
-    show_toc: Signal<bool>,
-    show_highlights: Signal<bool>,
-    note_target: Signal<Option<Highlight>>,
-    quote_target: Signal<Option<Highlight>>,
-    show_search: Signal<bool>,
-    search_results: Signal<Vec<SearchResult>>,
-    show_bookmarks: Signal<bool>,
-    on_keydown: EventHandler<KeyboardEvent>,
-    on_back: EventHandler<MouseEvent>,
-    on_prev: EventHandler<MouseEvent>,
-    on_next: EventHandler<MouseEvent>,
+    meta: ReaderMeta,
+    progress: ReaderProgress,
+    panels: ReaderPanelSignals,
+    nav: ReaderNavHandlers,
 ) -> Element {
+    let ReaderMeta {
+        uuid,
+        book_title,
+        book_author,
+        book_accent,
+        chapter_title,
+        current_cfi,
+    } = meta;
+    let ReaderProgress {
+        page_str,
+        chapter_str,
+        pct,
+        status,
+    } = progress;
+    let ReaderPanelSignals {
+        show_aa,
+        selection,
+        highlights,
+        toc,
+        show_toc,
+        show_highlights,
+        note_target,
+        quote_target,
+        show_search,
+        search_results,
+        show_bookmarks,
+    } = panels;
+    let ReaderNavHandlers {
+        on_keydown,
+        on_back,
+        on_prev,
+        on_next,
+    } = nav;
+
     let highlight_count = highlights.read().len();
 
     // Close every overlay (panel, drawer, composer) — `Fn` + `Copy` so each


### PR DESCRIPTION
## Summary
- Groups `ReaderLayout`'s 24 props (in `frontend/src/pages/reader/mod.rs`) into four cohesive structs by concern, following the module's existing `OverlaySignals` / `InteropSignals` grouping pattern:
  - `ReaderMeta` — book identity + display strings (`uuid`, `book_title`, `book_author`, `book_accent`, `chapter_title`, `current_cfi`).
  - `ReaderProgress` — bottom-bar labels + load-status overlay (`page_str`, `chapter_str`, `pct`, `status`).
  - `ReaderPanelSignals` — the 11 overlay/panel `Signal`s (Aa panel, selection popover, TOC/highlights/search/bookmarks drawers, note + quote composers).
  - `ReaderNavHandlers` — the 4 nav/keydown `EventHandler`s from `install_chrome_handlers`.
- `ReaderLayout` now takes 4 props instead of 24; the body destructures each struct back into the same local bindings, so the rsx (markup + behavior) is byte-identical.
- No `#[allow(clippy::too_many_arguments)]` is added or needed — the `#[component]` macro already bundles a component's args into a generated `Props` struct, so the lint never fires here; clippy is clean without any suppression.

Closes #570

## Test plan
- [x] `nix develop --command bash -c 'cargo fmt --check'` — PASS (clean)
- [x] `nix develop --command bash -c 'cargo test -p omnibus-frontend --features server'` — PASS (207 passed; 0 failed)
- [x] `nix develop --command bash -c 'cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings'` — PASS (clean, no suppression)

## Notes
- Pure API-shape refactor: no markup, styling, or behavior changes, so no Playwright/markup-contract updates are required. Hydration parity is preserved (rule 07) — the rsx emitted on every target is unchanged.
- The grouping structs derive `Clone, PartialEq` (`Copy` too for the signal/handler structs); `PartialEq` preserves Dioxus's per-render memoization exactly as the individual props did before.