### PR TITLE
chore(security): triage RUSTSEC advisories in deny.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,24 @@ ignore = [
     { id = "RUSTSEC-2024-0420", reason = "gtk-rs GTK3 binding unmaintained — Linux-only Dioxus desktop dep (wry/tao); awaiting upstream migration to GTK4" },
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — transitive via Dioxus mobile/desktop crates; awaiting upstream migration" },
     { id = "RUSTSEC-2025-0057", reason = "fxhash unmaintained — transitive via Dioxus mobile/desktop crates; awaiting upstream migration" },
+
+    # ---- Unsound (informational) advisories in the Dioxus desktop/mobile
+    # GTK/WebKit tree. Like the unmaintained notices above these are NOT
+    # vulnerabilities (cargo-audit's --json gate counts 0 vulnerabilities);
+    # they flag `unsafe` blocks upstream can misuse. Both are confined to the
+    # mobile/desktop native shell and neither is reachable from the shipped
+    # `omnibus` server. Fixing them requires an upstream Dioxus bump we don't
+    # control (both crates are pinned deep under the git-pinned wry/gtk tree).
+    # Triaged 2026-07-06 (issue #773). Revisit when Dioxus upgrades wry/gtk.
+    #
+    # NB: RUSTSEC-2026-0186 (memmap2 unchecked pointer offset) is the third
+    # advisory from that triage. It was NOT ignored — it was the one path
+    # reachable from the default (non-mobile) build (memmap2 → subsecond →
+    # dioxus-core), so it was fixed for real by bumping memmap2 0.9.10 → 0.9.11
+    # (`cargo update -p memmap2`; patched in >= 0.9.11), which needs no change
+    # to the Dioxus pin. See Cargo.lock.
+    { id = "RUSTSEC-2024-0429", reason = "glib 0.18.5 VariantStrIter unsoundness — mobile/desktop only via wry→gtk→glib (patched in glib 0.20, forced by upstream gtk-rs 0.18 pin under wry); not reachable in the server build" },
+    { id = "RUSTSEC-2026-0097", reason = "rand 0.7.3 thread_rng unsoundness — build-dependency only via phf_generator 0.8 (ammonia/html5ever codegen under wry); never links into any runtime binary, unsound path (custom logger reseed) not exercised in a build script" },
 ]
 
 # ---------------------------------------------------------------------------

--- a/deny.toml
+++ b/deny.toml
@@ -64,7 +64,7 @@ ignore = [
     # (`cargo update -p memmap2`; patched in >= 0.9.11), which needs no change
     # to the Dioxus pin. See Cargo.lock.
     { id = "RUSTSEC-2024-0429", reason = "glib 0.18.5 VariantStrIter unsoundness — mobile/desktop only via wry→gtk→glib (patched in glib 0.20, forced by upstream gtk-rs 0.18 pin under wry); not reachable in the server build" },
-    { id = "RUSTSEC-2026-0097", reason = "rand 0.7.3 thread_rng unsoundness — build-dependency only via phf_generator 0.8 (ammonia/html5ever codegen under wry); never links into any runtime binary, unsound path (custom logger reseed) not exercised in a build script" },
+    { id = "RUSTSEC-2026-0097", reason = "rand 0.7.3 unsoundness — aliased mutable reference when a custom `log` logger calls rand::rng()/thread_rng() and ThreadRng reseeds mid-log; build-dependency only via phf_generator 0.8 (ammonia/html5ever codegen under wry), never links into any runtime binary and that logger-reseed path is not exercised in a build script" },
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #773. Triages the three previously-undocumented RUSTSEC advisories `cargo audit` surfaces:

- **RUSTSEC-2026-0186** (`memmap2 0.9.10`, unsound) — **fixed by bump to `0.9.11`** (`cargo update -p memmap2`; patched in `>= 0.9.11`). This was the one path reachable from the **default non-mobile build** (`memmap2` → `subsecond` → `dioxus-core`), so it was resolved for real rather than ignored. Needs no change to the Dioxus git pin; `cargo audit` no longer reports it.
- **RUSTSEC-2024-0429** (`glib 0.18.5`, unsound) — **ignored (documented)**. Mobile/desktop-only via `wry → gtk → glib`; patched only in `glib 0.20`, forced by the upstream gtk-rs 0.18 pin under `wry`. Not reachable from the server build; not fixable without an upstream Dioxus bump.
- **RUSTSEC-2026-0097** (`rand 0.7.3`, unsound) — **ignored (documented)**. Build-dependency only via `phf_generator 0.8` (ammonia/html5ever codegen under `wry`); never links into any runtime binary, and the unsound path (custom-logger reseed) is not exercised in a build script.

Both ignores are dated (2026-07-06, issue #773) and mirror the existing GTK/mobile ignore style in `deny.toml`. No new advisories introduced.

## Test plan
- [x] `nix develop .#audit --command bash -c 'cargo deny check advisories'` → `advisories ok` (0 errors)
- [x] Full CI set `cargo deny check advisories sources bans licenses` → `advisories ok, bans ok, licenses ok, sources ok`
- [x] `cargo audit --json` → `vulnerabilities.count = 0`; `memmap2` advisory gone; only the two ignored mobile-only unsound warnings remain
- [x] `cargo build -p omnibus` (server, the crate reaching memmap2 via subsecond) builds clean with memmap2 0.9.11

## Notes
- `no release` intent: touches only `deny.toml` + `Cargo.lock`; add the `no release` label if a release should be skipped.