### PR TITLE
perf: batch N+1 query loops in cold-path db functions

### DIFF
--- a/db/src/identity.rs
+++ b/db/src/identity.rs
@@ -71,24 +71,43 @@ async fn backfill_books_scan_keys(pool: &SqlitePool) -> Result<(), sqlx::Error> 
         return Ok(());
     }
 
+    // A book with two native formats would appear twice; the first
+    // reconstruction wins (any native file locates the same book).
     let mut seen = std::collections::HashSet::new();
+    let updates: Vec<(i64, String)> = rows
+        .into_iter()
+        .filter(|(id, ..)| seen.insert(*id))
+        .map(|(id, path, filename, format, part_count)| {
+            (
+                id,
+                reconstruct_scan_key(&path, &filename, &format, part_count),
+            )
+        })
+        .collect();
+
     let mut tx = pool.begin().await?;
-    for (id, path, filename, format, part_count) in rows {
-        // A book with two native formats would appear twice; the first
-        // reconstruction wins (any native file locates the same book).
-        if !seen.insert(id) {
-            continue;
+    for chunk in updates.chunks(SCAN_KEY_UPDATE_CHUNK) {
+        let values = std::iter::repeat_n("(?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE books SET scan_key = v.column2
+               FROM (VALUES {values}) AS v
+              WHERE books.id = v.column1"
+        );
+        let mut q = sqlx::query(&sql);
+        for (id, scan_key) in chunk {
+            q = q.bind(id).bind(scan_key);
         }
-        let scan_key = reconstruct_scan_key(&path, &filename, &format, part_count);
-        sqlx::query("UPDATE books SET scan_key = ? WHERE id = ?")
-            .bind(&scan_key)
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
+        q.execute(&mut *tx).await?;
     }
     tx.commit().await?;
     Ok(())
 }
+
+/// Rows per chunk for the `scan_key` backfill UPDATEs. Two binds per row keeps
+/// a chunk well under SQLite's 999-parameter cap.
+const SCAN_KEY_UPDATE_CHUNK: usize = 400;
 
 /// Fill `merged_uuids.scan_key` from the attached file's `book_files` row
 /// (its location-override `path` + stem), so an attached file survives a
@@ -107,14 +126,31 @@ async fn backfill_merged_scan_keys(pool: &SqlitePool) -> Result<(), sqlx::Error>
         return Ok(());
     }
 
+    let updates: Vec<(String, String)> = rows
+        .into_iter()
+        .map(|(uuid, path, filename, format, part_count)| {
+            (
+                uuid,
+                reconstruct_scan_key(&path, &filename, &format, part_count),
+            )
+        })
+        .collect();
+
     let mut tx = pool.begin().await?;
-    for (uuid, path, filename, format, part_count) in rows {
-        let scan_key = reconstruct_scan_key(&path, &filename, &format, part_count);
-        sqlx::query("UPDATE merged_uuids SET scan_key = ? WHERE uuid = ?")
-            .bind(&scan_key)
-            .bind(&uuid)
-            .execute(&mut *tx)
-            .await?;
+    for chunk in updates.chunks(SCAN_KEY_UPDATE_CHUNK) {
+        let values = std::iter::repeat_n("(?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE merged_uuids SET scan_key = v.column2
+               FROM (VALUES {values}) AS v
+              WHERE merged_uuids.uuid = v.column1"
+        );
+        let mut q = sqlx::query(&sql);
+        for (uuid, scan_key) in chunk {
+            q = q.bind(uuid).bind(scan_key);
+        }
+        q.execute(&mut *tx).await?;
     }
     tx.commit().await?;
     Ok(())

--- a/db/src/identity/tests.rs
+++ b/db/src/identity/tests.rs
@@ -67,6 +67,75 @@ async fn backfill_fills_null_scan_keys_once_and_is_idempotent() {
 }
 
 #[tokio::test]
+async fn backfill_fills_multiple_books_and_a_merged_attachment_in_one_pass() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'Lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    // Two native books with NULL scan_keys …
+    for (uuid, path, title) in [("bk-1", "A1", "T1"), ("bk-2", "A2", "T2")] {
+        sqlx::query(
+            "INSERT INTO books (uuid, scan_key, library_id, path, title) VALUES (?, NULL, 1, ?, ?)",
+        )
+        .bind(uuid)
+        .bind(path)
+        .bind(title)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    let bk1_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = 'bk-1'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch)
+         VALUES ((SELECT id FROM books WHERE uuid='bk-1'), 'EPUB', 'T1', 10, 100),
+                ((SELECT id FROM books WHERE uuid='bk-2'), 'EPUB', 'T2', 10, 100),
+                ((SELECT id FROM books WHERE uuid='bk-1'), 'M4B',  'T1', 20, 200)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    // … and an attachment row (the M4B on bk-1) with a NULL scan_key.
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('att-1', ?, 'M4B', '/lib', NULL)",
+    )
+    .bind(bk1_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    backfill_scan_keys(&pool).await.unwrap();
+
+    // Both books get their *native* (non-attached) format's key; bk-1's native
+    // format is EPUB (M4B is the attachment), so it must resolve to the EPUB key.
+    let keys: Vec<(String, Option<String>)> =
+        sqlx::query_as("SELECT uuid, scan_key FROM books ORDER BY uuid")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        keys,
+        vec![
+            ("bk-1".to_string(), Some("A1/T1.epub".to_string())),
+            ("bk-2".to_string(), Some("A2/T2.epub".to_string())),
+        ]
+    );
+    // The merged key reconstructs from the attached file's *own* `book_files`
+    // location override (`COALESCE(bf.path, '')`), which is NULL here, so the
+    // key is the bare leaf — no parent path.
+    let att: Option<String> =
+        sqlx::query_scalar("SELECT scan_key FROM merged_uuids WHERE uuid = 'att-1'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(att.as_deref(), Some("T1.m4b"));
+}
+
+#[tokio::test]
 async fn backfill_scan_keys_propagates_db_error_when_pool_is_closed() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     pool.close().await;

--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -83,6 +83,8 @@ async fn rewire_merged_uuid_refs(
             .bind(source_id)
             .fetch_optional(&mut **tx)
             .await?;
+    // Bounded by a book's native format count (typically 1-2), so this stays
+    // a per-format loop rather than a batched multi-row insert.
     for fmt in &snapshot.native_formats {
         sqlx::query(
             "INSERT OR REPLACE INTO merged_uuids (uuid, book_id, format, library_path, scan_key)

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -174,12 +174,12 @@ async fn move_files_back(
         // Batch the format lookup, then assign per-format ordinals in Rust in
         // the original `file_ids` order (files that vanished since the merge
         // are absent from the map and skipped, leaving the book fileless).
-        let formats = fetch_file_formats(tx, target_id, file_ids).await?;
+        let formats_by_file = fetch_file_formats(tx, target_id, file_ids).await?;
         let mut per_format: std::collections::HashMap<String, i64> =
             std::collections::HashMap::new();
         let mut assignments: Vec<(i64, i64)> = Vec::with_capacity(file_ids.len());
         for &fid in file_ids {
-            let Some(fmt) = formats.get(&fid) else {
+            let Some(fmt) = formats_by_file.get(&fid) else {
                 continue;
             };
             let ordinal = per_format.entry(fmt.to_uppercase()).or_insert(0);

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -171,30 +171,22 @@ async fn move_files_back(
     formats: &[String],
 ) -> Result<(), sqlx::Error> {
     if !file_ids.is_empty() {
-        // Fetch format for each file so we can assign per-format ordinals.
+        // Batch the format lookup, then assign per-format ordinals in Rust in
+        // the original `file_ids` order (files that vanished since the merge
+        // are absent from the map and skipped, leaving the book fileless).
+        let formats = fetch_file_formats(tx, target_id, file_ids).await?;
         let mut per_format: std::collections::HashMap<String, i64> =
             std::collections::HashMap::new();
+        let mut assignments: Vec<(i64, i64)> = Vec::with_capacity(file_ids.len());
         for &fid in file_ids {
-            let fmt: Option<String> =
-                sqlx::query_scalar("SELECT format FROM book_files WHERE id = ? AND book_id = ?")
-                    .bind(fid)
-                    .bind(target_id)
-                    .fetch_optional(&mut **tx)
-                    .await?;
-            let Some(fmt) = fmt else { continue };
+            let Some(fmt) = formats.get(&fid) else {
+                continue;
+            };
             let ordinal = per_format.entry(fmt.to_uppercase()).or_insert(0);
-            sqlx::query(
-                "UPDATE book_files SET book_id = ?1, ordinal = ?2, label = NULL
-                  WHERE id = ?3 AND book_id = ?4",
-            )
-            .bind(new_source_id)
-            .bind(*ordinal)
-            .bind(fid)
-            .bind(target_id)
-            .execute(&mut **tx)
-            .await?;
+            assignments.push((fid, *ordinal));
             *ordinal += 1;
         }
+        reparent_files_with_ordinals(tx, new_source_id, target_id, &assignments).await?;
     } else {
         // Legacy snapshot without file IDs — move by format.
         for fmt in formats {
@@ -209,6 +201,143 @@ async fn move_files_back(
     Ok(())
 }
 
+/// Rows per chunk for [`fetch_file_formats`] / [`reparent_files_with_ordinals`].
+/// The SELECT binds one id per row (+1 for `target_id`); the UPDATE binds three
+/// (two in the `CASE`, one in the `IN` list). 200 keeps either chunk under
+/// SQLite's 999-parameter cap.
+const MOVE_BACK_CHUNK: usize = 200;
+
+/// Batch-fetch the `format` for each of `file_ids` still owned by `target_id`,
+/// keyed by file id. Files that vanished since the merge are simply absent.
+async fn fetch_file_formats(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    target_id: i64,
+    file_ids: &[i64],
+) -> Result<std::collections::HashMap<i64, String>, sqlx::Error> {
+    let mut out = std::collections::HashMap::with_capacity(file_ids.len());
+    for chunk in file_ids.chunks(MOVE_BACK_CHUNK) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT id, format FROM book_files
+              WHERE book_id = ? AND id IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (i64, String)>(&sql).bind(target_id);
+        for fid in chunk {
+            q = q.bind(fid);
+        }
+        for (id, fmt) in q.fetch_all(&mut **tx).await? {
+            out.insert(id, fmt);
+        }
+    }
+    Ok(out)
+}
+
+/// Re-parent each `(file_id, ordinal)` onto `new_source_id`, clearing its
+/// label, via one `CASE`-based UPDATE per chunk. Equivalent to a per-row
+/// `UPDATE … SET book_id, ordinal, label = NULL WHERE id = ? AND book_id = ?`
+/// but in a single statement per chunk.
+async fn reparent_files_with_ordinals(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    new_source_id: i64,
+    target_id: i64,
+    assignments: &[(i64, i64)],
+) -> Result<(), sqlx::Error> {
+    for chunk in assignments.chunks(MOVE_BACK_CHUNK) {
+        let cases = std::iter::repeat_n("WHEN ? THEN ?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE book_files
+                SET book_id = ?, ordinal = CASE id {cases} END, label = NULL
+              WHERE book_id = ? AND id IN ({placeholders})"
+        );
+        let mut q = sqlx::query(&sql).bind(new_source_id);
+        for (fid, ordinal) in chunk {
+            q = q.bind(fid).bind(ordinal);
+        }
+        q = q.bind(target_id);
+        for (fid, _) in chunk {
+            q = q.bind(fid);
+        }
+        q.execute(&mut **tx).await?;
+    }
+    Ok(())
+}
+
+/// Restore the source's author links by name in two batched statements
+/// (mirroring the sync writer): one `INSERT ... ON CONFLICT` upsert that keeps
+/// each name's first non-null sort, then one `INSERT OR IGNORE ... SELECT ...
+/// JOIN authors` that resolves ids by name. A name repeated in the snapshot
+/// keeps its first (lowest) position — identical to the old per-row
+/// `INSERT OR IGNORE` loop, since `books_authors_link` is keyed `(book,
+/// author)`.
+async fn restore_author_links(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    authors: &[(String, Option<String>, i64)],
+) -> Result<(), sqlx::Error> {
+    if authors.is_empty() {
+        return Ok(());
+    }
+
+    // Distinct names in first-seen order, each mapped to its first non-null
+    // sort — matching the old per-row `COALESCE(authors.sort, excluded.sort)`.
+    let mut order: Vec<&str> = Vec::new();
+    let mut sort_for: std::collections::HashMap<&str, Option<&str>> =
+        std::collections::HashMap::new();
+    for (name, sort, _) in authors {
+        match sort_for.get_mut(name.as_str()) {
+            Some(slot) if slot.is_none() => *slot = sort.as_deref(),
+            Some(_) => {}
+            None => {
+                order.push(name);
+                sort_for.insert(name, sort.as_deref());
+            }
+        }
+    }
+
+    let author_rows = std::iter::repeat_n("(?, ?)", order.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let upsert_sql = format!(
+        "INSERT INTO authors (name, sort) VALUES {author_rows} \
+         ON CONFLICT(name) DO UPDATE SET sort = COALESCE(authors.sort, excluded.sort)"
+    );
+    let mut q = sqlx::query(&upsert_sql);
+    for name in &order {
+        q = q.bind(*name).bind(sort_for[*name]);
+    }
+    q.execute(&mut **tx).await?;
+
+    // Link rows deduped by name, keeping the first (lowest) position.
+    let mut linked: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let link_entries: Vec<(&str, i64)> = authors
+        .iter()
+        .filter(|(name, _, _)| linked.insert(name))
+        .map(|(name, _, pos)| (name.as_str(), *pos))
+        .collect();
+    let link_rows = std::iter::repeat_n("(?, ?)", link_entries.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let link_sql = format!(
+        "INSERT OR IGNORE INTO books_authors_link (book, author, position) \
+         SELECT ?, a.id, v.column2 \
+         FROM (VALUES {link_rows}) AS v \
+         JOIN authors a ON a.name = v.column1"
+    );
+    let mut q = sqlx::query(&link_sql).bind(book_id);
+    for (name, pos) in &link_entries {
+        q = q.bind(*name).bind(*pos);
+    }
+    q.execute(&mut **tx).await?;
+    Ok(())
+}
+
 /// Restore the source's link rows by **name** — taxonomy ids may have
 /// been garbage-collected between merge and undo. The unioned copies on
 /// the target are left in place.
@@ -217,25 +346,12 @@ async fn restore_links(
     book_id: i64,
     snap: &SourceSnapshot,
 ) -> Result<(), sqlx::Error> {
-    for (name, sort, position) in &snap.authors {
-        sqlx::query(
-            "INSERT INTO authors (name, sort) VALUES (?, ?)
-             ON CONFLICT(name) DO UPDATE SET sort = COALESCE(authors.sort, excluded.sort)",
-        )
-        .bind(name)
-        .bind(sort)
-        .execute(&mut **tx)
-        .await?;
-        sqlx::query(
-            "INSERT OR IGNORE INTO books_authors_link (book, author, position)
-             SELECT ?, a.id, ? FROM authors a WHERE a.name = ?",
-        )
-        .bind(book_id)
-        .bind(position)
-        .bind(name)
-        .execute(&mut **tx)
-        .await?;
-    }
+    restore_author_links(tx, book_id, &snap.authors).await?;
+    // Series/tags/publishers/languages go through the per-name
+    // `resolve_or_insert_*` taxonomy helpers (INSERT OR IGNORE + SELECT id per
+    // name). A snapshot restores at most a handful of each on a rare admin
+    // undo, and batching would mean a new batch resolver in `taxonomy.rs`; the
+    // per-name loop is the accepted tradeoff here.
     for name in &snap.series {
         let id = resolve_or_insert_series(tx, name).await?;
         sqlx::query("INSERT OR IGNORE INTO books_series_link (book, series) VALUES (?, ?)")

--- a/db/src/normalize.rs
+++ b/db/src/normalize.rs
@@ -71,22 +71,44 @@ pub async fn backfill_norm_columns(pool: &SqlitePool) -> Result<(), NormalizeErr
         return Ok(());
     }
 
+    // `title_norm` lands as '' (not NULL) when nothing survives normalization,
+    // so the `IS NULL` guard above stays idempotent. Empty strings never
+    // match: the attach lookup only binds non-empty keys. `author_norm` stays
+    // genuinely nullable (no fallback).
+    let updates: Vec<(i64, String, Option<String>)> = rows
+        .into_iter()
+        .map(|(id, title, author)| {
+            (
+                id,
+                normalize_title(&title).unwrap_or_default(),
+                author.as_deref().and_then(normalize_author),
+            )
+        })
+        .collect();
+
     let mut tx = pool.begin().await?;
-    for (id, title, author) in rows {
-        // `title_norm` lands as '' (not NULL) when nothing survives
-        // normalization, so the IS NULL guard above stays idempotent.
-        // Empty strings never match: the attach lookup only binds
-        // non-empty keys.
-        sqlx::query("UPDATE books SET title_norm = ?, author_norm = ? WHERE id = ?")
-            .bind(normalize_title(&title).unwrap_or_default())
-            .bind(author.as_deref().and_then(normalize_author))
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
+    for chunk in updates.chunks(NORM_UPDATE_CHUNK) {
+        let values = std::iter::repeat_n("(?, ?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE books SET title_norm = v.column2, author_norm = v.column3
+               FROM (VALUES {values}) AS v
+              WHERE books.id = v.column1"
+        );
+        let mut q = sqlx::query(&sql);
+        for (id, title_norm, author_norm) in chunk {
+            q = q.bind(id).bind(title_norm).bind(author_norm);
+        }
+        q.execute(&mut *tx).await?;
     }
     tx.commit().await?;
     Ok(())
 }
+
+/// Rows per chunk for the norm-column backfill UPDATE. Three binds per row
+/// keeps a chunk under SQLite's 999-parameter cap.
+const NORM_UPDATE_CHUNK: usize = 300;
 
 #[cfg(test)]
 mod tests;

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -217,15 +217,15 @@ pub(crate) async fn prune_orphan_libraries(
         .map(|(id, _)| id)
         .collect();
 
-    if !orphan_ids.is_empty() {
-        // One batched conditional delete: an orphan row goes only if it has no
-        // books. A root that still owns books is left in place (never-prune)
-        // so the FK cascade on `books.library_id` is never triggered. The
-        // `NOT EXISTS` filter keeps that guard per-row inside the set delete,
-        // so a book-owning orphan in the id list survives untouched. Scan
-        // roots are bounded to a handful, so the id list never approaches
-        // SQLite's bind cap.
-        let placeholders = std::iter::repeat_n("?", orphan_ids.len())
+    // One batched conditional delete per chunk: an orphan row goes only if it
+    // has no books. A root that still owns books is left in place (never-prune)
+    // so the FK cascade on `books.library_id` is never triggered. The
+    // `NOT EXISTS` filter keeps that guard per-row inside the set delete, so a
+    // book-owning orphan in the id list survives untouched. Chunked at 499 ids
+    // so a pathologically large scan-root table can't exceed SQLite's
+    // 999-parameter cap.
+    for chunk in orphan_ids.chunks(499) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(
@@ -234,7 +234,7 @@ pub(crate) async fn prune_orphan_libraries(
                 AND NOT EXISTS (SELECT 1 FROM books WHERE library_id = scan_roots.id)"
         );
         let mut q = sqlx::query(&sql);
-        for id in &orphan_ids {
+        for id in chunk {
             q = q.bind(id);
         }
         q.execute(&mut **tx).await?;

--- a/db/src/settings.rs
+++ b/db/src/settings.rs
@@ -207,7 +207,7 @@ pub(crate) async fn prune_orphan_libraries(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     keep: &[Option<&str>],
 ) -> Result<Vec<String>, SettingsError> {
-    let childless_orphans: Vec<i64> = sqlx::query_as("SELECT id, path FROM scan_roots")
+    let orphan_ids: Vec<i64> = sqlx::query_as("SELECT id, path FROM scan_roots")
         .fetch_all(&mut **tx)
         .await?
         .into_iter()
@@ -217,17 +217,27 @@ pub(crate) async fn prune_orphan_libraries(
         .map(|(id, _)| id)
         .collect();
 
-    for id in childless_orphans {
-        // Conditional delete: the row goes only if it has no books. A root
-        // that still owns books is left in place (never-prune) so the FK
-        // cascade on `books.library_id` is never triggered.
-        sqlx::query(
-            "DELETE FROM scan_roots WHERE id = ?
-              AND NOT EXISTS (SELECT 1 FROM books WHERE library_id = scan_roots.id)",
-        )
-        .bind(id)
-        .execute(&mut **tx)
-        .await?;
+    if !orphan_ids.is_empty() {
+        // One batched conditional delete: an orphan row goes only if it has no
+        // books. A root that still owns books is left in place (never-prune)
+        // so the FK cascade on `books.library_id` is never triggered. The
+        // `NOT EXISTS` filter keeps that guard per-row inside the set delete,
+        // so a book-owning orphan in the id list survives untouched. Scan
+        // roots are bounded to a handful, so the id list never approaches
+        // SQLite's bind cap.
+        let placeholders = std::iter::repeat_n("?", orphan_ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "DELETE FROM scan_roots
+              WHERE id IN ({placeholders})
+                AND NOT EXISTS (SELECT 1 FROM books WHERE library_id = scan_roots.id)"
+        );
+        let mut q = sqlx::query(&sql);
+        for id in &orphan_ids {
+            q = q.bind(id);
+        }
+        q.execute(&mut **tx).await?;
     }
 
     Ok(Vec::new())

--- a/db/src/suggestions/data.rs
+++ b/db/src/suggestions/data.rs
@@ -228,25 +228,7 @@ pub async fn replace_suggestions(
         .bind(book_uuid)
         .execute(&mut *tx)
         .await?;
-    for (rank, s) in rows.iter().enumerate() {
-        sqlx::query(
-            "INSERT INTO book_suggestions
-                 (book_uuid, rank, hardcover_id, hardcover_slug, title, author,
-                  list_count, cover_mime, cover_bytes)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind(book_uuid)
-        .bind(rank as i64)
-        .bind(s.hardcover_id)
-        .bind(s.hardcover_slug.as_deref())
-        .bind(&s.title)
-        .bind(&s.author)
-        .bind(s.list_count)
-        .bind(s.cover_mime.as_deref())
-        .bind(s.cover_bytes.as_deref())
-        .execute(&mut *tx)
-        .await?;
-    }
+    insert_suggestion_rows(&mut tx, book_uuid, rows).await?;
     sqlx::query(
         "INSERT INTO book_suggestion_state (book_uuid, state, fetched_at)
               VALUES (?, ?, strftime('%s','now'))
@@ -259,6 +241,47 @@ pub async fn replace_suggestions(
     .execute(&mut *tx)
     .await?;
     tx.commit().await?;
+    Ok(())
+}
+
+/// Rows per chunk in [`insert_suggestion_rows`]. Nine binds per row keeps a
+/// 100-row chunk (900 binds) comfortably under SQLite's 999-parameter cap.
+const SUGGESTION_INSERT_CHUNK: usize = 100;
+
+/// Bulk-insert `rows` at ranks `0..rows.len()` via one multi-row
+/// `INSERT ... VALUES (..),(..),..` per chunk, preserving insertion order as
+/// the rank. Chunked so a large result set can't exceed SQLite's bind cap.
+async fn insert_suggestion_rows(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    book_uuid: &str,
+    rows: &[NewSuggestion],
+) -> Result<(), SuggestionsDataError> {
+    for (chunk_idx, chunk) in rows.chunks(SUGGESTION_INSERT_CHUNK).enumerate() {
+        let base = chunk_idx * SUGGESTION_INSERT_CHUNK;
+        let values = std::iter::repeat_n("(?, ?, ?, ?, ?, ?, ?, ?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "INSERT INTO book_suggestions
+                 (book_uuid, rank, hardcover_id, hardcover_slug, title, author,
+                  list_count, cover_mime, cover_bytes)
+             VALUES {values}"
+        );
+        let mut q = sqlx::query(&sql);
+        for (i, s) in chunk.iter().enumerate() {
+            q = q
+                .bind(book_uuid)
+                .bind((base + i) as i64)
+                .bind(s.hardcover_id)
+                .bind(s.hardcover_slug.as_deref())
+                .bind(&s.title)
+                .bind(&s.author)
+                .bind(s.list_count)
+                .bind(s.cover_mime.as_deref())
+                .bind(s.cover_bytes.as_deref());
+        }
+        q.execute(&mut **tx).await?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
Closes #734. Collapses per-row query loops in cold-path (`db/`) functions into batched statements, matching the chunked pattern already used across `db/src/sync/`.

Batched:
- **`suggestions/data.rs` `replace_suggestions`** — per-suggestion `INSERT` loop → one multi-row `INSERT ... VALUES` per chunk (100 rows × 9 binds, under SQLite's 999-param cap), via a new `insert_suggestion_rows` helper. Rank is still insertion order.
- **`settings.rs` `prune_orphan_libraries`** — one conditional `DELETE` per candidate id → a single `DELETE ... WHERE id IN (...) AND NOT EXISTS (...)`. The per-row never-prune guard (a book-owning orphan survives) is kept inside the set delete via `NOT EXISTS`.
- **`identity.rs` `backfill_books_scan_keys` + `backfill_merged_scan_keys`** — per-row `UPDATE` loops → chunked `UPDATE ... FROM (VALUES ...)` (mirroring `backfill_audiobook_stats`). scan_key is reconstructed in Rust; the "first native format wins" dedup is preserved.
- **`normalize.rs` `backfill_norm_columns`** — per-row `UPDATE` loop → chunked `UPDATE ... FROM (VALUES ...)`. `title_norm` still lands as `''` (empty), `author_norm` stays nullable.
- **`merge/undo.rs` `move_files_back`** — per-file `SELECT format` + `UPDATE` → one batched format fetch + a `CASE`-based UPDATE per chunk (mirroring `batch_assign_ordinals`). Per-format ordinals, the `book_id = target_id` guard, and skip-if-vanished (fileless restore) are all preserved.
- **`merge/undo.rs` `restore_links`** (authors only) — per-author upsert + link → two batched statements (`INSERT ... ON CONFLICT` + `INSERT OR IGNORE ... SELECT ... JOIN authors`), mirroring the sync author writer. First-seen sort and first (lowest) position for a repeated name are preserved.

Left as-is with a one-line comment (accepted per the issue's AC):
- **`merge/undo.rs` `restore_links`** — the series/tags/publishers/languages loops go through the per-name `resolve_or_insert_*` taxonomy helpers; batching would require a new batch resolver in `taxonomy.rs`, not worth it for a rare admin undo restoring a handful of each.
- **`merge/transaction.rs` `rewire_merged_uuid_refs`** — bounded by a book's native format count (typically 1-2).

Behavior is preserved exactly (same rows, same order where it matters); confirmed by the existing per-site tests (`prune_orphan_libraries_keeps_non_empty_roots_and_drops_childless`, `replace_suggestions_*`, `undo_merge_*`, `backfill_*`), all of which pass unchanged. Added one test (`identity`) exercising the multi-row batched path across both the books and `merged_uuids` backfills.

## Test plan
- [x] `nix develop --command bash -c 'cargo fmt'` — clean
- [x] `nix develop --command bash -c 'cargo clippy -p omnibus-db --all-targets -- -D warnings'` — clean
- [x] `nix develop --command bash -c 'cargo test -p omnibus-db'` — **800 passed; 0 failed** (+1 new test)