### PR TITLE
chore: lint the web Cargo feature in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,14 +92,8 @@ jobs:
       - name: Clippy frontend
         run: nix develop --command cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings
 
-      # The `server`-feature step above never compiles the `#[cfg(feature =
-      # "web")]` half of the frontend, so web-only warnings (e.g. a
-      # `#[warn(deprecated)]` web-sys call) slip past `-D warnings`. Lint the
-      # `web` feature explicitly against `wasm32-unknown-unknown` — the target
-      # it actually ships to via `dx serve --platform web`. The wasm rust-std
-      # lives in the slim shell (see flake.nix `rustCore`), so this needs the
-      # default `nix develop`, not the heavier `.#web` shell: clippy is a
-      # type-check, not a bundle, so no dioxus-cli / wasm-bindgen is required.
+      # Lint the `web` feature on wasm32 so web-only (`#[cfg(feature = "web")]`)
+      # deprecations/warnings are caught — the `server` step above never sees them.
       - name: Clippy frontend (web)
         run: nix develop --command cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,6 +92,17 @@ jobs:
       - name: Clippy frontend
         run: nix develop --command cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings
 
+      # The `server`-feature step above never compiles the `#[cfg(feature =
+      # "web")]` half of the frontend, so web-only warnings (e.g. a
+      # `#[warn(deprecated)]` web-sys call) slip past `-D warnings`. Lint the
+      # `web` feature explicitly against `wasm32-unknown-unknown` — the target
+      # it actually ships to via `dx serve --platform web`. The wasm rust-std
+      # lives in the slim shell (see flake.nix `rustCore`), so this needs the
+      # default `nix develop`, not the heavier `.#web` shell: clippy is a
+      # type-check, not a bundle, so no dioxus-cli / wasm-bindgen is required.
+      - name: Clippy frontend (web)
+        run: nix develop --command cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings
+
       - name: Clippy shared
         run: nix develop --command cargo clippy -p omnibus-shared --all-targets -- -D warnings
 


### PR DESCRIPTION
## Summary
- Closes #771.
- Adds a `Clippy frontend (web)` step to `.github/workflows/rust.yml` that lints `omnibus-frontend --features web` at the same `-D warnings` level as the existing per-crate steps. CI previously only linted the frontend with `--features server`, so `#[cfg(feature = "web")]` code was never compiled under the `-D warnings` gate — a real blind spot that let a default-level `#[warn(deprecated)]` warning reach `main`.
- The step runs in the **default** `nix develop` shell (not the heavier `.#web` shell) against `--target wasm32-unknown-unknown` — the target the `web` feature actually ships to via `dx serve --platform web`. The wasm `rust-std` is bundled in the slim shell (`flake.nix` `rustCore`) precisely so a WASM-target type-check needs no dioxus-cli / wasm-bindgen.
- The deprecation the issue flagged (`web_sys::BlobPropertyBag::type_` → `set_type()` in `frontend/src/data/uploads.rs`) is **already fixed on `main`** — no `.type_(` call remains anywhere in `frontend/src/` (both `uploads.rs` and `authors.rs` already use `set_type`). No source change was needed; this PR delivers the missing CI guard that would have caught it and will catch future web-only regressions.

## Test plan
- [x] `nix develop --command cargo fmt` — clean, no changes.
- [x] Ran the exact new CI command locally — clean: `nix develop --command cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings` → `Finished` with **0 warnings**, exit 0.
- [x] Reproduce-then-confirm: temporarily reintroduced the deprecated `opts.type_(...)` call and re-ran the same command — it failed with `error: use of deprecated method 'web_sys::BlobPropertyBag::type_': Use 'set_type()' instead` (`-D deprecated` implied by `-D warnings`), proving the step catches the exact class of warning the issue describes. Reverted immediately.
- [x] YAML validated (parses cleanly); the new step mirrors the existing `Clippy frontend` step's shell / nix / `-D warnings` shape.
- This CI step will exercise the `web` feature on this very PR.