### PR TITLE
test: cover SortKey round-trip and db::palette arms

### DIFF
--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -1073,3 +1073,251 @@ async fn palette_totals_report_uncapped_counts() {
         "books + authors + tags (no series)"
     );
 }
+
+// ── per-arm helpers (direct coverage) ────────────────────────────
+// The arm functions below are normally reached only through
+// `search_palette`; these exercise them directly with an already-escaped
+// `%pattern%` (the caller escapes LIKE metacharacters before calling).
+
+#[tokio::test]
+async fn search_authors_returns_matching_author_with_scoped_count() {
+    let _covers = CoversTempDir::new("arm_search_authors");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed("a.epub", Some("Babel"), &["R. F. Kuang"], &[], None, None),
+            indexed(
+                "b.epub",
+                Some("Yellowface"),
+                &["R. F. Kuang"],
+                &[],
+                None,
+                None,
+            ),
+            indexed("c.epub", Some("Other"), &["Someone Else"], &[], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let hits = search_authors(&pool, "/lib", "%kuang%", LIMIT)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1, "only the Kuang author matches");
+    assert_eq!(hits[0].name, "R. F. Kuang");
+    assert_eq!(hits[0].book_count, 2);
+    assert_eq!(hits[0].lead_book_title.as_deref(), Some("Babel"));
+}
+
+#[tokio::test]
+async fn search_authors_respects_limit() {
+    let _covers = CoversTempDir::new("arm_search_authors_limit");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let books: Vec<_> = (0..4)
+        .map(|i| {
+            indexed(
+                &format!("m{i}.epub"),
+                Some(&format!("Book {i}")),
+                &[&format!("Match Author {i}")],
+                &[],
+                None,
+                None,
+            )
+        })
+        .collect();
+    replace_books(&pool, "/lib", books).await.unwrap();
+
+    let hits = search_authors(&pool, "/lib", "%match%", 2).await.unwrap();
+    assert_eq!(hits.len(), 2, "arm caps at the supplied limit");
+}
+
+#[tokio::test]
+async fn count_authors_counts_visible_matches_uncapped() {
+    let _covers = CoversTempDir::new("arm_count_authors");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let books: Vec<_> = (0..7)
+        .map(|i| {
+            indexed(
+                &format!("m{i}.epub"),
+                Some(&format!("Book {i}")),
+                &[&format!("Match Author {i}")],
+                &[],
+                None,
+                None,
+            )
+        })
+        .collect();
+    replace_books(&pool, "/lib", books).await.unwrap();
+
+    // Uncapped: counts all 7 matching authors regardless of the display cap.
+    let total = count_authors(&pool, "/lib", "%match%").await.unwrap();
+    assert_eq!(total, 7);
+    // A non-matching pattern counts zero.
+    assert_eq!(count_authors(&pool, "/lib", "%zzznope%").await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn count_authors_is_scoped_to_library() {
+    let _covers = CoversTempDir::new("arm_count_authors_scoped");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed("a.epub", Some("A"), &["Tolkien"], &[], None, None)],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed("b.epub", Some("B"), &["Tolkien"], &[], None, None)],
+    )
+    .await
+    .unwrap();
+
+    // Same author name in both libraries, but the count is per-library.
+    assert_eq!(
+        count_authors(&pool, "/lib-a", "%tolkien%").await.unwrap(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn search_series_returns_matching_series_with_author_display() {
+    let _covers = CoversTempDir::new("arm_search_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed(
+                "a.epub",
+                Some("Book One"),
+                &["Author X"],
+                &[],
+                Some(("Poppy War", "1")),
+                None,
+            ),
+            indexed(
+                "b.epub",
+                Some("Book Two"),
+                &["Author X"],
+                &[],
+                Some(("Poppy War", "2")),
+                None,
+            ),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let hits = search_series(&pool, "/lib", "%poppy%", LIMIT)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "Poppy War");
+    assert_eq!(hits[0].book_count, 2);
+    assert_eq!(hits[0].author_display.as_deref(), Some("Author X"));
+    assert_eq!(hits[0].lead_book_title.as_deref(), Some("Book One"));
+}
+
+#[tokio::test]
+async fn count_series_counts_visible_matches_scoped() {
+    let _covers = CoversTempDir::new("arm_count_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed(
+                "a.epub",
+                Some("A"),
+                &["X"],
+                &[],
+                Some(("Match Alpha", "1")),
+                None,
+            ),
+            indexed(
+                "b.epub",
+                Some("B"),
+                &["X"],
+                &[],
+                Some(("Match Beta", "1")),
+                None,
+            ),
+            indexed(
+                "c.epub",
+                Some("C"),
+                &["X"],
+                &[],
+                Some(("Unrelated", "1")),
+                None,
+            ),
+        ],
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(count_series(&pool, "/lib", "%match%").await.unwrap(), 2);
+    assert_eq!(count_series(&pool, "/lib", "%zzznope%").await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn search_tags_returns_matching_tag_with_scoped_count() {
+    let _covers = CoversTempDir::new("arm_search_tags");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed(
+                "a.epub",
+                Some("A"),
+                &["Author"],
+                &["Dark academia"],
+                None,
+                None,
+            ),
+            indexed(
+                "b.epub",
+                Some("B"),
+                &["Author"],
+                &["Dark academia"],
+                None,
+                None,
+            ),
+            indexed("c.epub", Some("C"), &["Author"], &["Cozy"], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let hits = search_tags(&pool, "/lib", "%academia%", LIMIT)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "Dark academia");
+    assert_eq!(hits[0].book_count, 2);
+}
+
+#[tokio::test]
+async fn count_tags_counts_visible_matches_scoped() {
+    let _covers = CoversTempDir::new("arm_count_tags");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![
+            indexed("a.epub", Some("A"), &["X"], &["match-one"], None, None),
+            indexed("b.epub", Some("B"), &["X"], &["match-two"], None, None),
+            indexed("c.epub", Some("C"), &["X"], &["other"], None, None),
+        ],
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(count_tags(&pool, "/lib", "%match-%").await.unwrap(), 2);
+    assert_eq!(count_tags(&pool, "/lib", "%zzznope%").await.unwrap(), 0);
+}

--- a/shared/src/view_prefs.rs
+++ b/shared/src/view_prefs.rs
@@ -6,6 +6,9 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// Which list view to render on the library page.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]

--- a/shared/src/view_prefs/tests.rs
+++ b/shared/src/view_prefs/tests.rs
@@ -1,0 +1,94 @@
+//! Unit tests for library-view preference wire round-trips: the
+//! `SortKey`/`SortDir` string↔enum tokens (which must stay in lockstep
+//! with their serde renames) and the `ViewFilters::is_empty` predicate.
+
+use super::*;
+
+/// Every `SortKey` variant, so a round-trip test can't silently skip one
+/// a future variant would add.
+const ALL_SORT_KEYS: [SortKey; 5] = [
+    SortKey::Title,
+    SortKey::Author,
+    SortKey::Series,
+    SortKey::LastUpdated,
+    SortKey::NewestAdded,
+];
+
+#[test]
+fn sort_key_from_wire_round_trips_every_variant() {
+    for key in ALL_SORT_KEYS {
+        assert_eq!(
+            SortKey::from_wire(key.as_wire()),
+            Some(key),
+            "as_wire/from_wire must round-trip {key:?}"
+        );
+    }
+}
+
+#[test]
+fn sort_key_as_wire_uses_snake_case_tokens() {
+    // The wire tokens are the single source of truth and are documented to
+    // match the serde `snake_case` rename, so the REST `?sort=` string and
+    // a serialized `SortKey` agree. Pin the exact tokens here.
+    assert_eq!(SortKey::Title.as_wire(), "title");
+    assert_eq!(SortKey::Author.as_wire(), "author");
+    assert_eq!(SortKey::Series.as_wire(), "series");
+    assert_eq!(SortKey::LastUpdated.as_wire(), "last_updated");
+    assert_eq!(SortKey::NewestAdded.as_wire(), "newest_added");
+}
+
+#[test]
+fn sort_key_from_wire_returns_none_for_unrecognized_token() {
+    assert_eq!(SortKey::from_wire("nonsense"), None);
+    assert_eq!(SortKey::from_wire(""), None);
+    // Case-sensitive: the wire token is lowercase snake_case.
+    assert_eq!(SortKey::from_wire("Title"), None);
+    // Wrong separator: hyphen, not underscore.
+    assert_eq!(SortKey::from_wire("last-updated"), None);
+}
+
+#[test]
+fn sort_key_default_is_title() {
+    assert_eq!(SortKey::default(), SortKey::Title);
+    assert_eq!(SortKey::default().as_wire(), "title");
+}
+
+#[test]
+fn sort_dir_as_wire_uses_lowercase_tokens() {
+    // Documented to match the serde `lowercase` rename for the `?dir=` query.
+    assert_eq!(SortDir::Asc.as_wire(), "asc");
+    assert_eq!(SortDir::Desc.as_wire(), "desc");
+}
+
+#[test]
+fn view_filters_is_empty_true_for_default() {
+    assert!(ViewFilters::default().is_empty());
+}
+
+#[test]
+fn view_filters_is_empty_false_when_any_facet_has_a_value() {
+    // One case per facet: any single populated group flips the predicate.
+    let with_author = ViewFilters {
+        authors: vec!["Tolkien".into()],
+        ..Default::default()
+    };
+    assert!(!with_author.is_empty());
+
+    let with_series = ViewFilters {
+        series: vec!["Poppy War".into()],
+        ..Default::default()
+    };
+    assert!(!with_series.is_empty());
+
+    let with_format = ViewFilters {
+        formats: vec!["epub".into()],
+        ..Default::default()
+    };
+    assert!(!with_format.is_empty());
+
+    let with_tag = ViewFilters {
+        tags: vec!["horror".into()],
+        ..Default::default()
+    };
+    assert!(!with_tag.is_empty());
+}

--- a/shared/src/view_prefs/tests.rs
+++ b/shared/src/view_prefs/tests.rs
@@ -4,8 +4,11 @@
 
 use super::*;
 
-/// Every `SortKey` variant, so a round-trip test can't silently skip one
-/// a future variant would add.
+/// Hand-maintained list of every `SortKey` variant — keep it in sync when
+/// a new variant is added, or the round-trip test below will silently skip
+/// the new one. (A `SortKey::ALL` const or an exhaustive `match` in
+/// `as_wire` would make this automatic; the tests just mirror the current
+/// shape.)
 const ALL_SORT_KEYS: [SortKey; 5] = [
     SortKey::Title,
     SortKey::Author,


### PR DESCRIPTION
## Summary
- Closes #737.
- Adds a new sibling `shared/src/view_prefs/tests.rs` covering `SortKey::as_wire`/`from_wire` round-trip for every variant, the `None` fallback for an unrecognized/mis-cased/wrong-separator wire token, the default, and the `SortDir::as_wire` + `ViewFilters::is_empty` gaps the sweep flagged. Kept within the shared crate's existing `serde`/`thiserror` deps (no `serde_json`): the round-trip is asserted via `as_wire`/`from_wire` and the wire tokens are pinned to their documented serde `snake_case`/`lowercase` renames.
- Adds direct happy-path tests in `db/src/palette/tests.rs` for the six per-arm helpers (`search_authors`/`count_authors`, `search_series`/`count_series`, `search_tags`/`count_tags`) that were previously exercised only indirectly through `search_palette` — matching, library scoping, override-aware/uncapped counts, and the `limit` cap.
- Test-only: no production logic changed (the arm helpers were already reachable via `use super::*` in the test module).

## Test plan
- [x] `cargo fmt` / `cargo fmt --check` — clean
- [x] `cargo test -p omnibus-shared` — 99 passed (6 new `view_prefs::tests::*`)
- [x] `cargo test -p omnibus-db palette` — 30 passed (8 new arm-function tests)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — clean
- 14 new tests total.