### PR TITLE
refactor: coarsen ThumbError and FetchRemoteImageError variants

### DIFF
--- a/db/src/author_photos/remote.rs
+++ b/db/src/author_photos/remote.rs
@@ -24,12 +24,8 @@ const REMOTE_IMAGE_TIMEOUT: Duration = Duration::from_secs(15);
 /// rephrasing.
 #[derive(Debug, thiserror::Error)]
 pub enum FetchRemoteImageError {
-    /// The URL or the remote response failed a pre-persist validation gate:
-    /// bad scheme, unparseable URL, non-2xx status, non-image content-type,
-    /// SVG rejection, or over the size cap. The message carries which gate
-    /// fired — the handler maps every variant here to a 400. Kept distinct
-    /// from [`Self::BlockedAddress`] so the SSRF guard stays independently
-    /// assertable in tests.
+    /// A pre-persist validation gate failed (scheme, URL, status, content-type,
+    /// SVG, or size cap); the message names which, and the handler maps it to 400.
     #[error("{0}")]
     Validation(String),
     /// SSRF guard triggered. The supplied URL parsed cleanly, but either its

--- a/db/src/author_photos/remote.rs
+++ b/db/src/author_photos/remote.rs
@@ -24,8 +24,14 @@ const REMOTE_IMAGE_TIMEOUT: Duration = Duration::from_secs(15);
 /// rephrasing.
 #[derive(Debug, thiserror::Error)]
 pub enum FetchRemoteImageError {
-    #[error("URL must start with http:// or https://")]
-    BadScheme,
+    /// The URL or the remote response failed a pre-persist validation gate:
+    /// bad scheme, unparseable URL, non-2xx status, non-image content-type,
+    /// SVG rejection, or over the size cap. The message carries which gate
+    /// fired — the handler maps every variant here to a 400. Kept distinct
+    /// from [`Self::BlockedAddress`] so the SSRF guard stays independently
+    /// assertable in tests.
+    #[error("{0}")]
+    Validation(String),
     /// SSRF guard triggered. The supplied URL parsed cleanly, but either its
     /// host could not be resolved or one of the resolved IPs falls into a
     /// blocked range (loopback / private RFC1918 / link-local / multicast /
@@ -35,18 +41,23 @@ pub enum FetchRemoteImageError {
     /// internal-network surface area.
     #[error("URL host is not allowed: {0}")]
     BlockedAddress(String),
-    #[error("URL is not parseable")]
-    InvalidUrl,
-    #[error("remote server returned {0}")]
-    BadStatus(u16),
-    #[error("remote response content-type is not an image ({0})")]
-    NotImage(String),
-    #[error("SVG photos are not accepted")]
-    SvgRejected,
-    #[error("image exceeds {} byte cap", REMOTE_IMAGE_MAX_BYTES)]
-    TooLarge,
     #[error(transparent)]
     Http(#[from] reqwest::Error),
+}
+
+/// Validation error for a URL that doesn't parse or lacks a usable host/port.
+fn invalid_url() -> FetchRemoteImageError {
+    FetchRemoteImageError::Validation("URL is not parseable".into())
+}
+
+/// Validation error for a URL whose scheme isn't `http`/`https`.
+fn bad_scheme() -> FetchRemoteImageError {
+    FetchRemoteImageError::Validation("URL must start with http:// or https://".into())
+}
+
+/// Validation error for a download that exceeds [`REMOTE_IMAGE_MAX_BYTES`].
+fn too_large() -> FetchRemoteImageError {
+    FetchRemoteImageError::Validation(format!("image exceeds {REMOTE_IMAGE_MAX_BYTES} byte cap"))
 }
 
 /// Knobs for [`fetch_remote_image_with`]. Production code constructs
@@ -139,18 +150,13 @@ pub(super) fn is_blocked_address(addr: IpAddr) -> bool {
 /// the validated set (defeats DNS rebinding between our check and reqwest's
 /// own resolution).
 async fn validated_resolve(url: &str) -> Result<(String, Vec<SocketAddr>), FetchRemoteImageError> {
-    let parsed = reqwest::Url::parse(url).map_err(|_| FetchRemoteImageError::InvalidUrl)?;
+    let parsed = reqwest::Url::parse(url).map_err(|_| invalid_url())?;
     let scheme = parsed.scheme();
     if scheme != "http" && scheme != "https" {
-        return Err(FetchRemoteImageError::BadScheme);
+        return Err(bad_scheme());
     }
-    let host = parsed
-        .host_str()
-        .ok_or(FetchRemoteImageError::InvalidUrl)?
-        .to_string();
-    let port = parsed
-        .port_or_known_default()
-        .ok_or(FetchRemoteImageError::InvalidUrl)?;
+    let host = parsed.host_str().ok_or_else(invalid_url)?.to_string();
+    let port = parsed.port_or_known_default().ok_or_else(invalid_url)?;
 
     // Fast path: the host is already a literal IP — `lookup_host` would still
     // work, but skipping it avoids spurious DNS lookups on IP-literal URLs.
@@ -204,7 +210,7 @@ pub async fn fetch_remote_image_with(
     config: &RemoteImageConfig,
 ) -> Result<(String, Vec<u8>), FetchRemoteImageError> {
     if !(url.starts_with("http://") || url.starts_with("https://")) {
-        return Err(FetchRemoteImageError::BadScheme);
+        return Err(bad_scheme());
     }
 
     // Strict mode (the default): resolve host → validate IPs → pin the
@@ -230,7 +236,10 @@ pub async fn fetch_remote_image_with(
     let resp = client.get(url).timeout(REMOTE_IMAGE_TIMEOUT).send().await?;
     let status = resp.status();
     if !status.is_success() {
-        return Err(FetchRemoteImageError::BadStatus(status.as_u16()));
+        return Err(FetchRemoteImageError::Validation(format!(
+            "remote server returned {}",
+            status.as_u16()
+        )));
     }
     let content_type = resp
         .headers()
@@ -239,16 +248,20 @@ pub async fn fetch_remote_image_with(
         .map(std::string::ToString::to_string)
         .unwrap_or_else(|| "application/octet-stream".into());
     if !content_type.starts_with("image/") {
-        return Err(FetchRemoteImageError::NotImage(content_type));
+        return Err(FetchRemoteImageError::Validation(format!(
+            "remote response content-type is not an image ({content_type})"
+        )));
     }
     if content_type.contains("svg") {
-        return Err(FetchRemoteImageError::SvgRejected);
+        return Err(FetchRemoteImageError::Validation(
+            "SVG photos are not accepted".into(),
+        ));
     }
     // Pre-check Content-Length when the server advertises it so an
     // obviously-oversized download bails before allocating.
     if let Some(len) = resp.content_length() {
         if len > REMOTE_IMAGE_MAX_BYTES {
-            return Err(FetchRemoteImageError::TooLarge);
+            return Err(too_large());
         }
     }
     // Stream the body and abort the moment we'd cross the cap. A hostile
@@ -261,7 +274,7 @@ pub async fn fetch_remote_image_with(
     let mut stream = resp;
     while let Some(chunk) = stream.chunk().await? {
         if buf.len() as u64 + chunk.len() as u64 > REMOTE_IMAGE_MAX_BYTES {
-            return Err(FetchRemoteImageError::TooLarge);
+            return Err(too_large());
         }
         buf.extend_from_slice(&chunk);
     }

--- a/db/src/author_photos/tests.rs
+++ b/db/src/author_photos/tests.rs
@@ -393,13 +393,13 @@ async fn fetch_remote_image_blocks_ipv6_loopback_under_strict_config() {
 #[tokio::test]
 async fn fetch_remote_image_rejects_invalid_url() {
     let cfg = RemoteImageConfig::default();
-    // Garbage URL — must surface InvalidUrl, never reach the resolver.
+    // Garbage URL — must surface a validation error, never reach the resolver.
     let err = fetch_remote_image_with("http://", &cfg)
         .await
         .expect_err("must reject malformed URL");
     assert!(matches!(
         err,
-        FetchRemoteImageError::InvalidUrl | FetchRemoteImageError::BlockedAddress(_)
+        FetchRemoteImageError::Validation(_) | FetchRemoteImageError::BlockedAddress(_)
     ));
 }
 
@@ -409,7 +409,10 @@ async fn fetch_remote_image_rejects_non_http_scheme() {
     let err = fetch_remote_image_with("ftp://example.com/p.jpg", &cfg)
         .await
         .expect_err("must reject non-http(s)");
-    assert!(matches!(err, FetchRemoteImageError::BadScheme));
+    assert!(
+        matches!(&err, FetchRemoteImageError::Validation(msg) if msg.contains("http://")),
+        "expected a scheme validation error, got {err:?}",
+    );
 }
 
 #[tokio::test]
@@ -421,7 +424,7 @@ async fn fetch_remote_image_does_not_follow_redirects_to_private_ips() {
     // it re-resolves through its default resolver and the IP-range
     // guard never sees the new host — full bypass. The fix disables
     // redirect-following on the per-call client, so a 3xx surfaces
-    // as a 302 status (BadStatus) and the SSRF target is never hit.
+    // as a 302-status validation error and the SSRF target is never hit.
     //
     // The test runs under `allow_private_addresses` so the wiremock
     // server bound to loopback isn't rejected up-front — the point
@@ -442,8 +445,8 @@ async fn fetch_remote_image_does_not_follow_redirects_to_private_ips() {
         .await
         .expect_err("redirect must NOT be followed");
     assert!(
-        matches!(err, FetchRemoteImageError::BadStatus(302)),
-        "expected BadStatus(302) (redirect not followed), got {err:?}",
+        matches!(&err, FetchRemoteImageError::Validation(msg) if msg.contains("302")),
+        "expected a 302-status validation error (redirect not followed), got {err:?}",
     );
 }
 

--- a/db/src/author_photos/tests.rs
+++ b/db/src/author_photos/tests.rs
@@ -393,14 +393,16 @@ async fn fetch_remote_image_blocks_ipv6_loopback_under_strict_config() {
 #[tokio::test]
 async fn fetch_remote_image_rejects_invalid_url() {
     let cfg = RemoteImageConfig::default();
-    // Garbage URL — must surface a validation error, never reach the resolver.
+    // Garbage URL (no host) — must be rejected at validation, before any
+    // resolution. Asserting `Validation` *only* (not `BlockedAddress`) catches
+    // a regression where a malformed URL slips through to DNS resolution.
     let err = fetch_remote_image_with("http://", &cfg)
         .await
         .expect_err("must reject malformed URL");
-    assert!(matches!(
-        err,
-        FetchRemoteImageError::Validation(_) | FetchRemoteImageError::BlockedAddress(_)
-    ));
+    assert!(
+        matches!(err, FetchRemoteImageError::Validation(_)),
+        "malformed URL must be a validation error, not resolved, got {err:?}",
+    );
 }
 
 #[tokio::test]

--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -56,12 +56,10 @@ impl std::str::FromStr for ThumbSize {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ThumbError {
-    #[error("cover decode failed: {0}")]
-    Decode(String),
-    #[error("WebP encode failed: {0}")]
-    Encode(String),
-    #[error("I/O error: {0}")]
-    Io(String),
+    /// Decode, encode, or I/O failure in the thumbnail pipeline. The message
+    /// carries which step failed — no caller branches on the distinction.
+    #[error("thumbnail generation failed: {0}")]
+    Failed(String),
     #[error("no cover available for book {0}")]
     NoCover(i64),
     #[error("db error: {0}")]
@@ -144,20 +142,22 @@ fn write_thumbnail(
         let mut buf = std::io::Cursor::new(Vec::new());
         resized
             .write_to(&mut buf, ImageFormat::WebP)
-            .map_err(|e| ThumbError::Encode(e.to_string()))?;
+            .map_err(|e| ThumbError::Failed(format!("WebP encode failed: {e}")))?;
         buf.into_inner()
     };
 
     let dir = thumbs_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| ThumbError::Io(e.to_string()))?;
+    std::fs::create_dir_all(&dir).map_err(|e| ThumbError::Failed(format!("I/O error: {e}")))?;
 
     let final_path = thumb_path_for(book_id, size);
     // Per-(book,size) temp name keeps concurrent generations from clobbering
     // each other's temp files. The worker's `thumb:{book_id}` resource lock
     // already serializes per-book, so a single suffix is enough.
     let tmp_path = dir.join(format!("{book_id}_{size}.webp.tmp"));
-    std::fs::write(&tmp_path, &webp_bytes).map_err(|e| ThumbError::Io(e.to_string()))?;
-    std::fs::rename(&tmp_path, &final_path).map_err(|e| ThumbError::Io(e.to_string()))?;
+    std::fs::write(&tmp_path, &webp_bytes)
+        .map_err(|e| ThumbError::Failed(format!("I/O error: {e}")))?;
+    std::fs::rename(&tmp_path, &final_path)
+        .map_err(|e| ThumbError::Failed(format!("I/O error: {e}")))?;
 
     Ok(webp_bytes.len())
 }
@@ -172,8 +172,8 @@ pub fn generate_thumbnail(
     size: ThumbSize,
     cover_bytes: &[u8],
 ) -> Result<usize, ThumbError> {
-    let decoded =
-        image::load_from_memory(cover_bytes).map_err(|e| ThumbError::Decode(e.to_string()))?;
+    let decoded = image::load_from_memory(cover_bytes)
+        .map_err(|e| ThumbError::Failed(format!("cover decode failed: {e}")))?;
     write_thumbnail(book_id, size, &decoded)
 }
 
@@ -197,7 +197,7 @@ pub fn ensure_thumbnails_sync(
             Some(img) => img,
             None => decoded.insert(
                 image::load_from_memory(&cover_bytes)
-                    .map_err(|e| ThumbError::Decode(e.to_string()))?,
+                    .map_err(|e| ThumbError::Failed(format!("cover decode failed: {e}")))?,
             ),
         };
         write_thumbnail(book_id, size, img)?;

--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -56,8 +56,7 @@ impl std::str::FromStr for ThumbSize {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ThumbError {
-    /// Decode, encode, or I/O failure in the thumbnail pipeline. The message
-    /// carries which step failed — no caller branches on the distinction.
+    /// Decode, encode, or I/O failure in the pipeline; the message names the step.
     #[error("thumbnail generation failed: {0}")]
     Failed(String),
     #[error("no cover available for book {0}")]

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -140,7 +140,7 @@ impl Worker {
                 match tokio::task::spawn_blocking(move || {
                     crate::thumbs::ensure_thumbnails_sync(book_id, last_modified_epoch, cover)?;
                     crate::thumbs::evict_if_over_cap(cap)
-                        .map_err(|e| crate::thumbs::ThumbError::Io(e.to_string()))
+                        .map_err(|e| crate::thumbs::ThumbError::Failed(format!("I/O error: {e}")))
                 })
                 .await
                 {


### PR DESCRIPTION
## Summary
Closes #739.

Coarsens two `thiserror` enums per the "group by failure mode, let the message carry the detail" rule (`.claude/rules/02-error-handling.md`). No caller branched on the merged variants (confirmed by grepping every construction/consumption site across the workspace).

- **`ThumbError`** (`db/src/thumbs.rs`): merged `Decode`/`Encode`/`Io` → a single `Failed(String)` whose message names the failed step. Kept `NoCover` and `Db` separate.
- **`FetchRemoteImageError`** (`db/src/author_photos/remote.rs`): merged `BadScheme`/`InvalidUrl`/`BadStatus`/`NotImage`/`SvgRejected`/`TooLarge` → a single `Validation(String)`. Kept `BlockedAddress` (the SSRF guard, asserted independently in tests) and `Http` (the only variant the handler branches on → 500). HTTP-status mapping is unchanged: `Http` → 500, everything else → 400 with the `#[error]` message as the body.

Call sites, the server handler match (`server/src/backend/author_photos.rs`), the worker handler, and the SSRF/validation tests (`db/src/author_photos/tests.rs`) are updated to the coarsened shape. The `matches!(err, FetchRemoteImageError::BlockedAddress(_))` SSRF assertions are untouched; the two tests that previously matched merged variants now assert `Validation(_)` with a message-substring check to preserve precision (scheme, `302` status).

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo test -p omnibus-db author_photos` — PASS (41 passed)
- [x] `cargo test -p omnibus-db thumbs` — PASS (9 passed)
- [x] `cargo test -p omnibus author` — PASS (34 passed; handler still maps errors right)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS