### PR TITLE
test: rename 8 tests to name the function under test

### DIFF
--- a/db/src/auth/password/tests.rs
+++ b/db/src/auth/password/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn password_roundtrips() {
+fn hash_password_and_verify_password_round_trip_matching_credential() {
     let phc = hash_password("correct horse battery staple").unwrap();
     assert!(phc.starts_with("$argon2id$"));
     assert!(verify_password("correct horse battery staple", &phc).unwrap());

--- a/db/src/auth/password/tests.rs
+++ b/db/src/auth/password/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn hash_password_and_verify_password_round_trip_matching_credential() {
+fn hash_password_and_verify_password_round_trips_a_matching_credential() {
     let phc = hash_password("correct horse battery staple").unwrap();
     assert!(phc.starts_with("$argon2id$"));
     assert!(verify_password("correct horse battery staple", &phc).unwrap());

--- a/db/src/auth/session/tests.rs
+++ b/db/src/auth/session/tests.rs
@@ -4,7 +4,7 @@ use crate::auth::token::SESSION_COOKIE_NAME;
 use crate::auth::users::create_user;
 
 #[tokio::test]
-async fn session_roundtrip() {
+async fn create_session_and_lookup_session_round_trip_a_cookie_session() {
     let p = pool().await;
     let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
     let ns = create_session(&p, u.id, None, SessionKind::Cookie, 3600)

--- a/db/src/auth/session/tests.rs
+++ b/db/src/auth/session/tests.rs
@@ -4,7 +4,7 @@ use crate::auth::token::SESSION_COOKIE_NAME;
 use crate::auth::users::create_user;
 
 #[tokio::test]
-async fn create_session_and_lookup_session_round_trip_a_cookie_session() {
+async fn create_session_and_lookup_session_round_trips_a_cookie_session() {
     let p = pool().await;
     let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
     let ns = create_session(&p, u.id, None, SessionKind::Cookie, 3600)

--- a/db/src/journals/markdown.rs
+++ b/db/src/journals/markdown.rs
@@ -149,7 +149,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_strikethrough() {
+    fn render_emits_del_for_strikethrough() {
         let html = render("~~gone~~");
         assert!(html.contains("<del>gone</del>"), "got: {html}");
     }

--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -225,7 +225,7 @@ mod ssr_tests {
     }
 
     #[test]
-    fn save_is_a_noop() {
+    fn save_is_a_noop_under_ssr() {
         save("book-a", 100.0);
         assert_eq!(load("book-a"), None);
     }

--- a/shared/src/image_format.rs
+++ b/shared/src/image_format.rs
@@ -31,7 +31,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn detects_jpeg() {
+    fn detect_image_format_recognizes_jpeg_magic_bytes() {
         assert_eq!(
             detect_image_format(&[0xFF, 0xD8, 0xFF, 0xE0]),
             Some("image/jpeg".into())
@@ -39,18 +39,18 @@ mod tests {
     }
 
     #[test]
-    fn detects_png() {
+    fn detect_image_format_recognizes_png_magic_bytes() {
         let png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         assert_eq!(detect_image_format(&png), Some("image/png".into()));
     }
 
     #[test]
-    fn detects_gif() {
+    fn detect_image_format_recognizes_gif_magic_bytes() {
         assert_eq!(detect_image_format(b"GIF89a..."), Some("image/gif".into()));
     }
 
     #[test]
-    fn detects_webp() {
+    fn detect_image_format_recognizes_webp_magic_bytes() {
         // "RIFF" + 4-byte length + "WEBP".
         let webp = b"RIFF\x00\x00\x00\x00WEBPVP8 ";
         assert_eq!(detect_image_format(webp), Some("image/webp".into()));


### PR DESCRIPTION
## Summary
- Rename 8 tests whose names elided the function under test to the `fn_under_test_does_X_when_Y` sentence-style convention (`.claude/rules/03-unit-testing.md` § Naming). Rename-only — no assertions or logic changed.
- Closes #738

Renames:
- `password_roundtrips` → `hash_password_and_verify_password_round_trip_matching_credential` (`db/src/auth/password/tests.rs`)
- `session_roundtrip` → `create_session_and_lookup_session_round_trip_a_cookie_session` (`db/src/auth/session/tests.rs`)
- `renders_strikethrough` → `render_emits_del_for_strikethrough` (`db/src/journals/markdown.rs`)
- `save_is_a_noop` → `save_is_a_noop_under_ssr` (`frontend/src/audiobook_progress.rs`)
- `detects_jpeg` → `detect_image_format_recognizes_jpeg_magic_bytes` (`shared/src/image_format.rs`)
- `detects_png` → `detect_image_format_recognizes_png_magic_bytes` (`shared/src/image_format.rs`)
- `detects_gif` → `detect_image_format_recognizes_gif_magic_bytes` (`shared/src/image_format.rs`)
- `detects_webp` → `detect_image_format_recognizes_webp_magic_bytes` (`shared/src/image_format.rs`)

## Test plan
- [x] `cargo fmt` — clean, no diffs
- [x] `cargo test -p omnibus-db auth` — PASS (161 passed; both renamed auth tests run)
- [x] `cargo test -p omnibus-db journals && cargo test -p omnibus-shared image_format && cargo test -p omnibus-frontend --features server audiobook_progress` — PASS (journals 24, image_format 7, audiobook_progress 3; all renamed tests run)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (no warnings)