### PR TITLE
refactor: prefer &str params and drop redundant clones

### DIFF
--- a/db/src/shelves/read.rs
+++ b/db/src/shelves/read.rs
@@ -69,7 +69,7 @@ pub async fn list_visible_shelves(
     let mut manual_ids = Vec::new();
     for r in &rows {
         let id: i64 = r.try_get("id")?;
-        let kind = parse_kind(r.try_get("kind")?)?;
+        let kind = parse_kind(&r.try_get::<String, _>("kind")?)?;
         match kind {
             ShelfKind::Smart => smart_ids.push(id),
             ShelfKind::Manual => manual_ids.push(id),
@@ -79,7 +79,7 @@ pub async fn list_visible_shelves(
             owner_user_id: r.try_get("owner_user_id")?,
             kind,
             name: r.try_get("name")?,
-            visibility: parse_visibility(r.try_get("visibility")?)?,
+            visibility: parse_visibility(&r.try_get::<String, _>("visibility")?)?,
             accent: r.try_get("accent")?,
             match_mode: r.try_get("match_mode")?,
         });
@@ -125,7 +125,7 @@ pub async fn get_shelf(pool: &SqlitePool, id: i64) -> Result<Option<Shelf>, Shel
     };
 
     let owner_user_id: i64 = r.try_get("owner_user_id")?;
-    let kind = parse_kind(r.try_get("kind")?)?;
+    let kind = parse_kind(&r.try_get::<String, _>("kind")?)?;
     let match_mode = r
         .try_get::<Option<String>, _>("match_mode")?
         .as_deref()
@@ -153,7 +153,7 @@ pub async fn get_shelf(pool: &SqlitePool, id: i64) -> Result<Option<Shelf>, Shel
         kind,
         name: r.try_get("name")?,
         description: r.try_get("description")?,
-        visibility: parse_visibility(r.try_get("visibility")?)?,
+        visibility: parse_visibility(&r.try_get::<String, _>("visibility")?)?,
         accent: r.try_get("accent")?,
         match_mode,
         rules,
@@ -404,12 +404,12 @@ fn order_by_sql(sort: SortKey, dir: SortDir) -> String {
     }
 }
 
-fn parse_kind(s: String) -> Result<ShelfKind, ShelfError> {
-    ShelfKind::from_str(&s).ok_or_else(|| ShelfError::InvalidRule(format!("unknown kind {s:?}")))
+fn parse_kind(s: &str) -> Result<ShelfKind, ShelfError> {
+    ShelfKind::from_str(s).ok_or_else(|| ShelfError::InvalidRule(format!("unknown kind {s:?}")))
 }
 
-fn parse_visibility(s: String) -> Result<Visibility, ShelfError> {
-    Visibility::from_str(&s)
+fn parse_visibility(s: &str) -> Result<Visibility, ShelfError> {
+    Visibility::from_str(s)
         .ok_or_else(|| ShelfError::InvalidRule(format!("unknown visibility {s:?}")))
 }
 

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -25,20 +25,13 @@ pub use books::{replace_books, sync_books, sync_books_with_progress, SyncPlan};
 pub use fts::rebuild_all_fts;
 pub(crate) use fts::{delete_fts, upsert_fts};
 
-/// Push a post-commit cover triple (`uuid`, mime, bytes) onto `covers` when
-/// the freshly-indexed book carries an embedded cover.
-///
-/// Covers are reconciled to disk after the write transaction commits, so
-/// each bucket accumulates `(uuid, mime, bytes)` triples as it writes. The
-/// source cover is borrowed from the indexed book, hence the two clones;
-/// `uuid` is passed by value because callers hand over either an owned
-/// freshly-minted uuid or a `to_string()` of a borrowed one.
+/// Push a post-commit cover triple onto `covers`, allocating only when the book actually has a cover.
 pub(crate) fn push_cover(
     covers: &mut Vec<(String, String, Vec<u8>)>,
-    uuid: String,
+    uuid: &str,
     cover: &Option<(String, Vec<u8>)>,
 ) {
     if let Some((mime, bytes)) = cover {
-        covers.push((uuid, mime.clone(), bytes.clone()));
+        covers.push((uuid.to_string(), mime.clone(), bytes.clone()));
     }
 }

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -24,3 +24,21 @@ pub use books::{replace_books, sync_books, sync_books_with_progress, SyncPlan};
 // admin endpoint that repair the whole index.
 pub use fts::rebuild_all_fts;
 pub(crate) use fts::{delete_fts, upsert_fts};
+
+/// Push a post-commit cover triple (`uuid`, mime, bytes) onto `covers` when
+/// the freshly-indexed book carries an embedded cover.
+///
+/// Covers are reconciled to disk after the write transaction commits, so
+/// each bucket accumulates `(uuid, mime, bytes)` triples as it writes. The
+/// source cover is borrowed from the indexed book, hence the two clones;
+/// `uuid` is passed by value because callers hand over either an owned
+/// freshly-minted uuid or a `to_string()` of a borrowed one.
+pub(crate) fn push_cover(
+    covers: &mut Vec<(String, String, Vec<u8>)>,
+    uuid: String,
+    cover: &Option<(String, Vec<u8>)>,
+) {
+    if let Some((mime, bytes)) = cover {
+        covers.push((uuid, mime.clone(), bytes.clone()));
+    }
+}

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -290,7 +290,7 @@ async fn rewrite_audiobook_in_place(
     insert_chapters(tx, book_file_id, &b.chapters, &b.parts).await?;
     insert_audiobook_author_link(tx, book_id, b.creator_name.as_deref()).await?;
     upsert_fts(tx, book_id).await?;
-    super::push_cover(covers, uuid.to_string(), &b.cover);
+    super::push_cover(covers, uuid, &b.cover);
     Ok(())
 }
 
@@ -363,7 +363,7 @@ async fn insert_new_audiobook(
     insert_chapters(tx, inserted.book_file_id, &b.chapters, &b.parts).await?;
     insert_audiobook_author_link(tx, inserted.book_id, b.creator_name.as_deref()).await?;
     upsert_fts(tx, inserted.book_id).await?;
-    super::push_cover(covers, inserted.uuid, &b.cover);
+    super::push_cover(covers, &inserted.uuid, &b.cover);
     Ok(())
 }
 

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -290,9 +290,7 @@ async fn rewrite_audiobook_in_place(
     insert_chapters(tx, book_file_id, &b.chapters, &b.parts).await?;
     insert_audiobook_author_link(tx, book_id, b.creator_name.as_deref()).await?;
     upsert_fts(tx, book_id).await?;
-    if let Some((mime, bytes)) = &b.cover {
-        covers.push((uuid.to_string(), mime.clone(), bytes.clone()));
-    }
+    super::push_cover(covers, uuid.to_string(), &b.cover);
     Ok(())
 }
 
@@ -365,9 +363,7 @@ async fn insert_new_audiobook(
     insert_chapters(tx, inserted.book_file_id, &b.chapters, &b.parts).await?;
     insert_audiobook_author_link(tx, inserted.book_id, b.creator_name.as_deref()).await?;
     upsert_fts(tx, inserted.book_id).await?;
-    if let Some((mime, bytes)) = &b.cover {
-        covers.push((inserted.uuid, mime.clone(), bytes.clone()));
-    }
+    super::push_cover(covers, inserted.uuid, &b.cover);
     Ok(())
 }
 

--- a/db/src/sync/books/changed.rs
+++ b/db/src/sync/books/changed.rs
@@ -123,7 +123,7 @@ async fn sync_changed_one(
         insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
         // Source the FTS row from the rows we just wrote via the door.
         upsert_fts(tx, inserted.book_id).await?;
-        super::super::push_cover(changed_covers, inserted.uuid, &b.cover);
+        super::super::push_cover(changed_covers, &inserted.uuid, &b.cover);
         return Ok(());
     };
 

--- a/db/src/sync/books/changed.rs
+++ b/db/src/sync/books/changed.rs
@@ -123,9 +123,7 @@ async fn sync_changed_one(
         insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
         // Source the FTS row from the rows we just wrote via the door.
         upsert_fts(tx, inserted.book_id).await?;
-        if let Some((mime, bytes)) = &b.cover {
-            changed_covers.push((inserted.uuid, mime.clone(), bytes.clone()));
-        }
+        super::super::push_cover(changed_covers, inserted.uuid, &b.cover);
         return Ok(());
     };
 

--- a/db/src/sync/books/new.rs
+++ b/db/src/sync/books/new.rs
@@ -78,9 +78,7 @@ pub(super) async fn sync_new(
         let inserted = insert_book_row(tx, library_id, library_path, b).await?;
         insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
         upsert_fts(tx, inserted.book_id).await?;
-        if let Some((mime, bytes)) = &b.cover {
-            new_covers.push((inserted.uuid, mime.clone(), bytes.clone()));
-        }
+        super::super::push_cover(&mut new_covers, inserted.uuid, &b.cover);
         on_book_written();
     }
     Ok(new_covers)

--- a/db/src/sync/books/new.rs
+++ b/db/src/sync/books/new.rs
@@ -78,7 +78,7 @@ pub(super) async fn sync_new(
         let inserted = insert_book_row(tx, library_id, library_path, b).await?;
         insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
         upsert_fts(tx, inserted.book_id).await?;
-        super::super::push_cover(&mut new_covers, inserted.uuid, &b.cover);
+        super::super::push_cover(&mut new_covers, &inserted.uuid, &b.cover);
         on_book_written();
     }
     Ok(new_covers)

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -40,7 +40,7 @@ pub(super) async fn rewrite_book_in_place(
     insert_book_file_row(tx, book_id, b).await?;
     insert_metadata_links(tx, book_id, &b.metadata).await?;
     upsert_fts(tx, book_id).await?;
-    super::super::push_cover(covers, uuid.to_string(), &b.cover);
+    super::super::push_cover(covers, uuid, &b.cover);
     Ok(())
 }
 

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -40,9 +40,7 @@ pub(super) async fn rewrite_book_in_place(
     insert_book_file_row(tx, book_id, b).await?;
     insert_metadata_links(tx, book_id, &b.metadata).await?;
     upsert_fts(tx, book_id).await?;
-    if let Some((mime, bytes)) = &b.cover {
-        covers.push((uuid.to_string(), mime.clone(), bytes.clone()));
-    }
+    super::super::push_cover(covers, uuid.to_string(), &b.cover);
     Ok(())
 }
 

--- a/frontend/src/components/merge_dialog.rs
+++ b/frontend/src/components/merge_dialog.rs
@@ -253,7 +253,7 @@ fn render_search_pane(
             "Find the other copy of this book. Its files, tags, highlights and reading "
             "progress move onto the entry you\u{2019}re viewing \u{2014} and the duplicate disappears."
         }
-        {render_target_rail(target.clone(), target_title.clone())}
+        {render_target_rail(target.clone(), &target_title)}
         div { class: "mg-search",
             svg {
                 class: "mg-search-icon",
@@ -316,7 +316,7 @@ async fn async_sleep_ms(ms: u32) {
 
 /// Pinned "this is the keeper" context shown above the search field: the
 /// current book's cover + title + author/series, with a "stays" note.
-fn render_target_rail(target: EbookMetadata, title: String) -> Element {
+fn render_target_rail(target: EbookMetadata, title: &str) -> Element {
     let author = target
         .creators
         .first()

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -96,7 +96,7 @@ pub(super) async fn get_ebooks(
         },
         None => None,
     };
-    let path = ebook.clone().or_else(|| audiobook.clone());
+    let path = ebook.as_ref().or(audiobook.as_ref()).cloned();
     let paths = db::collect_paths(ebook.as_deref(), audiobook.as_deref());
     let page = match db::list_books_page(
         &state.pool,


### PR DESCRIPTION
## Summary
Closes #736. Idiomatic-borrowing cleanup — no behavior change.

- `db/src/shelves/read.rs`: `parse_kind` / `parse_visibility` now take `&str` (bodies only read); the four call sites pass a borrow.
- `frontend/src/components/merge_dialog.rs`: `render_target_rail`'s `title` is now `&str`; the call site drops its `.clone()` and borrows instead.
- `server/src/backend/ebooks.rs`: `let path = ebook.clone().or_else(|| audiobook.clone());` became `ebook.as_ref().or(audiobook.as_ref()).cloned()` — clones at most once (the selected value) instead of eagerly cloning `ebook` even when it's `Some`.
- `db/src/sync.rs`: added a shared `push_cover(covers, uuid, &cover)` helper and routed the five identical `covers.push((uuid, mime.clone(), bytes.clone()))` sites (`sync/audiobooks.rs` ×2, `sync/books/{changed,new,shared}.rs`) through it. The `maybe_adopt_cover` return site in `sync/attach/mod.rs` is a genuinely different shape (returns `Ok(Some(...))`, uuid from a DB query) and was deliberately left as-is, matching the issue's "if a review confirms identical shape" caveat.

Not changed: `frontend/src/data/authors.rs::set_author_photo_url`. The flagged `#[cfg(mobile)]` variant shares a single caller with its non-mobile sibling, and the non-mobile variant forwards the value into the `#[post]` server function `rpc_set_author_photo_url(id, url: String)` — a wire contract that must stay owned `String`. Switching to `&str` would force a new `url.to_string()` in the web path (adding an allocation, the opposite of the cleanup), so leaving it by-value is the lower-cost choice. Noted here rather than silently applied.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo test -p omnibus-db sync` — 72 passed, 0 failed
- [x] `cargo test -p omnibus-db shelves` — 36 passed, 0 failed
- [x] `cargo test -p omnibus` — 303 passed, 0 failed
- [x] `cargo test -p omnibus-frontend --features server` — 207 passed, 0 failed
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean