### PR TITLE
chore: strip roadmap-phase and issue refs from module docs

### DIFF
--- a/db/src/discovery/series.rs
+++ b/db/src/discovery/series.rs
@@ -15,11 +15,8 @@ use super::{DiscoveryError, MAX_DISCOVERY_BOOKS};
 
 /// Fetch a series by ID with its books, ordered by series index. Returns
 /// `None` if the series ID doesn't exist. The nested `books` vec is
-/// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped.
-///
-/// Currently returns results across all users (single-tenant). When F4.x
-/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
-/// to books accessible to that user.
+/// capped at [`MAX_DISCOVERY_BOOKS`]; `book_count` is uncapped. Results
+/// span all users (single-tenant).
 pub async fn get_series(
     pool: &SqlitePool,
     series_id: i64,


### PR DESCRIPTION
## Summary
- Closes #440.
- The style guide (`.claude/rules/05-rust-style.md`) forbids roadmap-phase labels (`F2.x`, `F4.x`, …) and GitHub issue numbers (`#NNN`) in `//!` / `///` doc comments — they rot. This strips the remaining offender.
- Trimmed the `///` on `get_series` in `db/src/discovery/series.rs`: dropped the "When F4.x per-user ACL lands…" forward-ref so the doc describes only current behavior (results span all users / single-tenant).
- The other files named in the issue (`db/src/progress.rs`, `db/src/audiobook.rs`, `server/src/backend/audiobooks.rs`, `frontend/src/pages/listen.rs`, `frontend/src/audiobook_progress.rs`) had already had their doc-comment refs cleaned in prior work — no doc-comment matches remained, so they are untouched here.
- The `#338` reference in `server/src/backend/audiobooks.rs` is a plain inline `//` code comment explaining *why* a status discriminator exists (not a doc comment), so it is intentionally left as-is per the issue's scope (doc comments only).
- `frontend/src/pages/reader/mod.rs` (the `F2.4` `//!` ref) is handled separately in PR #763 and is deliberately excluded here.

## Test plan
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo fmt --check` — PASS
- [x] `grep -rnE 'F[0-9]+\.[0-9a-z]|#[0-9]{2,}'` across the target files — no `//!`/`///` doc-comment matches remain (only the intentional inline `//` comment in `audiobooks.rs`)

## Notes
- Doc-comment-only change; no code behavior changes.