### PR TITLE
refactor: merge split sqlx/omnibus_shared import blocks in db

### DIFF
--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -4,9 +4,8 @@
 
 use std::collections::HashMap;
 
-use sqlx::{Row, Sqlite, SqlitePool, Transaction};
-
 use omnibus_shared::EbookMetadata;
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
 use crate::metadata_overrides::{apply_overrides, get_metadata_overrides};
 

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -7,9 +7,8 @@
 //! multi-thousand-author library doesn't pay an O(rows × books) cost.
 //! Single-tenant today — no per-user ACL filtering.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::{AuthorSummary, SeriesSummary};
+use sqlx::{Row, SqlitePool};
 
 /// Errors returned by the browse index queries.
 #[derive(Debug, thiserror::Error)]

--- a/db/src/discovery/authors.rs
+++ b/db/src/discovery/authors.rs
@@ -3,9 +3,8 @@
 //! canonical `books_authors_link` so the form-edited creator list drives
 //! both the shelf contents and the per-card creator names.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::{AuthorDetail, EbookMetadata};
+use sqlx::{Row, SqlitePool};
 
 use crate::books::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
 use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -5,9 +5,8 @@
 
 use std::collections::HashMap;
 
-use sqlx::{Executor, SqlitePool};
-
 use omnibus_shared::{EbookMetadata, MetadataOverrides};
+use sqlx::{Executor, SqlitePool};
 
 use crate::books::resolve_book_id_by_uuid_exec;
 use crate::sync::upsert_fts;

--- a/db/src/palette/mod.rs
+++ b/db/src/palette/mod.rs
@@ -4,9 +4,8 @@
 //! use scoped `LIKE` substring matches against the name columns. Bounded
 //! per category and scoped to `library_path`.
 
-use sqlx::SqlitePool;
-
 use omnibus_shared::PaletteResults;
+use sqlx::SqlitePool;
 
 use crate::helpers::cap_query_len;
 

--- a/db/src/shelves/read.rs
+++ b/db/src/shelves/read.rs
@@ -3,12 +3,11 @@
 
 use std::collections::HashMap;
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::{
     EbookMetadata, MatchMode, RuleField, RuleOp, RulePreview, Shelf, ShelfKind, ShelfPage,
     ShelfRule, ShelfSummary, SortDir, SortKey, Visibility,
 };
+use sqlx::{Row, SqlitePool};
 
 use super::rules::{membership_predicate, Bind};
 use super::ShelfError;

--- a/db/src/sort_keys.rs
+++ b/db/src/sort_keys.rs
@@ -10,9 +10,8 @@
 //! `metadata_overrides` is a read layer and is deliberately ignored, so a
 //! book's sort position tracks its scanned series, not an override.
 
-use sqlx::SqlitePool;
-
 use omnibus_shared::EbookMetadata;
+use sqlx::SqlitePool;
 
 /// Errors returned by [`backfill_series_sort`].
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Summary
Refs #772 (partial: 7 of ~26 files; a dedicated follow-up sweep will close it, kept out of this PR to stay conflict-free with concurrent db PRs).

Rule `05-rust-style` § Mechanics prescribes three import blocks (`std`, external crates alphabetical, `crate::`), each blank-line separated. Seven files in `db/src` instead split the external block in two — a lone `use sqlx::...;` block separated by a blank line from `use omnibus_shared::...;`, with `sqlx` placed first. This merges each file's `sqlx` + `omnibus_shared` imports into a single alphabetically-sorted external-crate block (`omnibus_shared` before `sqlx`, since `o` < `s`).

Mechanical, import-ordering only — no behavior change.

Files touched:
- `db/src/browse.rs`
- `db/src/sort_keys.rs`
- `db/src/discovery/authors.rs`
- `db/src/palette/mod.rs`
- `db/src/books/get.rs`
- `db/src/metadata_overrides/upsert.rs`
- `db/src/shelves/read.rs`

## Test plan
- [x] `cargo fmt --check` — PASS (rustfmt still clean)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS

## Notes
- Scope is deliberately limited to these 7 files. The issue's broader "grep the rest of `db/src` and fix all instances" sweep is intentionally deferred to a follow-up to avoid merge conflicts with concurrent PRs currently touching other files in `db/src`.