### PR TITLE
test: cover untested thiserror variants across db enums

### DIFF
--- a/db/src/audiobook/tests.rs
+++ b/db/src/audiobook/tests.rs
@@ -128,6 +128,27 @@ fn audiobook_error_unsupported_variant_renders_format_token() {
 }
 
 #[test]
+fn build_indexed_book_surfaces_tag_error_for_undecodable_audio() {
+    // `build_indexed_book` propagates the lofty decode/container failure via
+    // `?` as `AudiobookError::Tag` — the direct-propagation counterpart to
+    // `parse_audiobook_targets`, which instead folds the same failure into an
+    // `error` metadata row. Feeding a file with an audio extension but junk
+    // bytes drives `lofty::read_from_path` to error, which `#[from]` maps to
+    // `Tag`.
+    let dir = make_test_dir("tag_err");
+    let f = dir.join("garbage.m4b");
+    fs::write(&f, b"this is not a valid m4b container").unwrap();
+    let err =
+        build_indexed_book(&f, "garbage.m4b".into()).expect_err("undecodable audio must not parse");
+    fs::remove_dir_all(&dir).unwrap();
+    assert!(matches!(err, AudiobookError::Tag(_)), "got {err:?}");
+    assert!(
+        err.to_string().starts_with("tag decode failed"),
+        "got {err}"
+    );
+}
+
+#[test]
 fn duration_to_hm_splits_finite_seconds_into_hours_and_minutes() {
     assert_eq!(duration_to_hm(3661.0), (1, 1));
     assert_eq!(duration_to_hm(0.0), (0, 0));

--- a/db/src/author_photos/tests.rs
+++ b/db/src/author_photos/tests.rs
@@ -513,19 +513,25 @@ async fn fetch_remote_image_rejects_svg_content_type() {
 }
 
 #[tokio::test]
-async fn fetch_remote_image_rejects_body_exceeding_size_cap() {
-    // A body larger than `REMOTE_IMAGE_MAX_BYTES` must abort mid-stream (the
-    // per-chunk cap that bounds memory even when the server lies about, or
-    // omits, `Content-Length`), surfacing as a `Validation` error naming the
-    // byte cap. The content-type is a valid image so the size gate — not the
-    // type gate — is what fires.
+async fn fetch_remote_image_rejects_oversized_content_length() {
+    // An advertised `Content-Length` past `REMOTE_IMAGE_MAX_BYTES` must bail on
+    // the pre-check (remote.rs `resp.content_length()`) — before the streaming
+    // read — so an obviously-oversized download aborts up front. This is the
+    // gate that actually fires here: the streamed body path is the belt-and-
+    // braces fallback for servers that omit or lie about Content-Length.
+    //
+    // hyper refuses to emit a Content-Length that disagrees with the body it
+    // sends (it panics on the mismatch), so a fabricated huge header over a
+    // tiny body isn't possible over wiremock — the body must genuinely exceed
+    // the cap by one byte, which is what makes the honest Content-Length
+    // oversized. `+ 1` keeps the allocation to the minimum that trips the gate.
     let server = MockServer::start().await;
-    let oversized_body = vec![0xFFu8; (super::remote::REMOTE_IMAGE_MAX_BYTES as usize) + 1024];
+    let body = vec![0xFFu8; (super::remote::REMOTE_IMAGE_MAX_BYTES as usize) + 1];
     Mock::given(method("GET"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "image/jpeg")
-                .set_body_bytes(oversized_body),
+                .set_body_bytes(body),
         )
         .mount(&server)
         .await;
@@ -534,7 +540,7 @@ async fn fetch_remote_image_rejects_body_exceeding_size_cap() {
     };
     let err = fetch_remote_image_with(&format!("{}/big.jpg", server.uri()), &cfg)
         .await
-        .expect_err("oversized body must be rejected");
+        .expect_err("oversized Content-Length must be rejected");
     assert!(
         matches!(&err, FetchRemoteImageError::Validation(msg) if msg.contains("cap")),
         "got {err:?}",

--- a/db/src/author_photos/tests.rs
+++ b/db/src/author_photos/tests.rs
@@ -453,6 +453,95 @@ async fn fetch_remote_image_does_not_follow_redirects_to_private_ips() {
 }
 
 #[tokio::test]
+async fn fetch_remote_image_rejects_non_image_content_type() {
+    // Post-fetch validation gate: a 200 whose content-type isn't `image/*`
+    // (e.g. an HTML error page served with 200) must be rejected as a
+    // `Validation` error naming the content-type, never persisted as a photo.
+    // Runs under the test config so the loopback wiremock host isn't blocked
+    // up-front — the point is the content-type gate, not the SSRF guard.
+    let server = MockServer::start().await;
+    // `set_body_bytes` (unlike `set_body_string`) doesn't stamp its own
+    // content-type, so the explicit `insert_header` is what reqwest observes.
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html")
+                .set_body_bytes(b"<html>not an image</html>".to_vec()),
+        )
+        .mount(&server)
+        .await;
+    let cfg = RemoteImageConfig {
+        allow_private_addresses: true,
+    };
+    let err = fetch_remote_image_with(&format!("{}/x.jpg", server.uri()), &cfg)
+        .await
+        .expect_err("non-image content-type must be rejected");
+    assert!(
+        matches!(&err, FetchRemoteImageError::Validation(msg) if msg.contains("not an image")),
+        "got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn fetch_remote_image_rejects_svg_content_type() {
+    // SVG is an image type but is refused outright (it can carry scripts), so
+    // a `content-type: image/svg+xml` response — which passes the `image/`
+    // prefix check — must still be rejected by the dedicated SVG gate as a
+    // `Validation` error.
+    let server = MockServer::start().await;
+    // `set_body_bytes` keeps our `image/svg+xml` header intact (a string body
+    // would force `text/plain` and hit the not-an-image gate instead), so the
+    // response passes the `image/` prefix check and reaches the SVG gate.
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "image/svg+xml")
+                .set_body_bytes(b"<svg/>".to_vec()),
+        )
+        .mount(&server)
+        .await;
+    let cfg = RemoteImageConfig {
+        allow_private_addresses: true,
+    };
+    let err = fetch_remote_image_with(&format!("{}/x.svg", server.uri()), &cfg)
+        .await
+        .expect_err("SVG content-type must be rejected");
+    assert!(
+        matches!(&err, FetchRemoteImageError::Validation(msg) if msg.contains("SVG")),
+        "got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn fetch_remote_image_rejects_body_exceeding_size_cap() {
+    // A body larger than `REMOTE_IMAGE_MAX_BYTES` must abort mid-stream (the
+    // per-chunk cap that bounds memory even when the server lies about, or
+    // omits, `Content-Length`), surfacing as a `Validation` error naming the
+    // byte cap. The content-type is a valid image so the size gate — not the
+    // type gate — is what fires.
+    let server = MockServer::start().await;
+    let oversized_body = vec![0xFFu8; (super::remote::REMOTE_IMAGE_MAX_BYTES as usize) + 1024];
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "image/jpeg")
+                .set_body_bytes(oversized_body),
+        )
+        .mount(&server)
+        .await;
+    let cfg = RemoteImageConfig {
+        allow_private_addresses: true,
+    };
+    let err = fetch_remote_image_with(&format!("{}/big.jpg", server.uri()), &cfg)
+        .await
+        .expect_err("oversized body must be rejected");
+    assert!(
+        matches!(&err, FetchRemoteImageError::Validation(msg) if msg.contains("cap")),
+        "got {err:?}",
+    );
+}
+
+#[tokio::test]
 async fn fetch_remote_image_allows_loopback_under_test_config() {
     // The test-only escape hatch must actually flip the guard off so
     // the existing wiremock-backed integration tests can keep working.

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -2074,3 +2074,26 @@ async fn get_book_uuid_by_scan_key_returns_none_for_unknown_key() {
         .unwrap()
         .is_none());
 }
+
+// ---------- BooksError variants ----------
+
+#[test]
+fn books_error_maps_overrides_serialization_to_overrides_json_variant() {
+    // The `From<MetadataOverridesError>` bridge (the only site that mints
+    // `BooksError::OverridesJson`) must route a corrupt-overrides-JSON
+    // deserialization failure to `OverridesJson`, carrying the underlying
+    // `serde_json::Error` and its message — never collapsing it into `Db`.
+    let json_err =
+        serde_json::from_str::<MetadataOverrides>("{ not valid json").expect_err("must not parse");
+    let src = crate::metadata_overrides::MetadataOverridesError::Serialization(json_err);
+    let err: BooksError = src.into();
+    assert!(
+        matches!(err, BooksError::OverridesJson(_)),
+        "Serialization must map to OverridesJson, got {err:?}"
+    );
+    assert!(
+        err.to_string()
+            .starts_with("overrides deserialization failed"),
+        "got {err}"
+    );
+}

--- a/db/src/kepub/tests.rs
+++ b/db/src/kepub/tests.rs
@@ -219,6 +219,45 @@ async fn convert_book_errors_when_kepubify_binary_absent() {
     assert!(matches!(err, KepubError::Io(_)), "got {err:?}");
 }
 
+#[tokio::test]
+async fn convert_book_returns_non_zero_when_kepubify_exits_non_zero() {
+    // A kepubify run that exits non-zero (unsupported EPUB, internal error)
+    // must surface as `KepubError::NonZero` carrying the exit status and the
+    // captured stderr, so the caller can log it and fall back to plain EPUB —
+    // never a torn cache file. A fake binary that prints to stderr and exits 3
+    // drives the exit-code branch in `run_kepubify`.
+    let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
+    let lib = tempfile::tempdir().unwrap();
+    let book_id = seed_epub_book(&pool, lib.path()).await;
+
+    let cache = tempfile::tempdir().unwrap();
+    let bin_dir = tempfile::tempdir().unwrap();
+    let script = bin_dir.path().join("kepubify");
+    write_failing_kepubify(&script);
+    let _env = EnvVarGuard::set_os("OMNIBUS_DATA_DIR", Some(cache.path().as_os_str()))
+        .also_set_os("OMNIBUS_KEPUBIFY_PATH", Some(script.as_os_str()));
+
+    let err = convert_book(&pool, book_id).await.unwrap_err();
+    assert!(
+        matches!(&err, KepubError::NonZero { stderr, .. } if stderr.contains("boom")),
+        "got {err:?}"
+    );
+    // No cache file left behind on failure.
+    assert!(!kepub_path(book_id).exists());
+}
+
+/// Write a fake `kepubify` at `path` that answers `--version` (so detection
+/// passes) but for any real invocation writes to stderr and exits non-zero,
+/// driving the `NonZero` branch in `run_kepubify`.
+fn write_failing_kepubify(path: &Path) {
+    let script = "#!/bin/sh\n\
+         if [ \"$1\" = \"--version\" ]; then echo 'kepubify 0-fake'; exit 0; fi\n\
+         echo 'boom: conversion failed' 1>&2\n\
+         exit 3\n";
+    std::fs::write(path, script).unwrap();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
 /// Number of lines the fake kepubify appended to `counter` (== run count).
 fn run_count(counter: &Path) -> usize {
     std::fs::read_to_string(counter)

--- a/db/src/kindle/tests.rs
+++ b/db/src/kindle/tests.rs
@@ -83,3 +83,29 @@ fn build_epub_email_rejects_malformed_address() {
     .unwrap_err();
     assert!(matches!(err, KindleError::Address(_)));
 }
+
+#[test]
+fn kindle_error_timeout_reports_the_overall_send_cap() {
+    // `deliver` maps a `tokio::time::timeout` elapse to `Timeout` (a unit
+    // variant) so a hung relay surfaces a bounded failure instead of hanging
+    // the worker forever. Its rendered message must name the overall cap so an
+    // admin can tell it apart from a per-command `Smtp` error.
+    let err = KindleError::Timeout;
+    assert_eq!(err.to_string(), "SMTP delivery timed out after 90s");
+}
+
+#[test]
+fn kindle_error_build_wraps_lettre_message_error() {
+    // The MIME builders (`build_epub_email` / `send_test`) surface a lettre
+    // message-assembly failure through `#[from] lettre::error::Error` as
+    // `KindleError::Build`. Feeding a real lettre error through the `From`
+    // bridge asserts that mapping (and its `{0}` message) without needing a
+    // live SMTP relay.
+    let src = lettre::error::Error::MissingFrom;
+    let err: KindleError = src.into();
+    assert!(matches!(err, KindleError::Build(_)), "got {err:?}");
+    assert!(
+        err.to_string().starts_with("failed to build the email"),
+        "got {err}"
+    );
+}

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -631,6 +631,35 @@ async fn undo_merge_rejects_double_undo() {
 }
 
 #[tokio::test]
+async fn undo_merge_returns_snapshot_error_when_source_metadata_is_corrupt() {
+    // `undo_merge` replays `merge_log.source_metadata` via
+    // `serde_json::from_str`; a row whose snapshot JSON is corrupt (truncated
+    // by a bad manual edit or a partial write) must surface as
+    // `MergeError::Snapshot` — the `#[from] serde_json::Error` variant — not
+    // as a panic or a `Db` error. Overwrite a real log entry's snapshot with
+    // malformed JSON to drive the decode failure.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let target = seed_ebook(&pool, "A/Dracula.epub", "Dracula", "Bram Stoker").await;
+    let source = seed_audiobook(&pool, "B/Drakula.m4b", "Drakula", "Bram Stoker").await;
+    let out = merge_books(&pool, &source, &target, None).await.unwrap();
+
+    sqlx::query("UPDATE merge_log SET source_metadata = ? WHERE id = ?")
+        .bind("{ this is not valid json")
+        .bind(out.merge_log_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let err = undo_merge(&pool, out.merge_log_id).await.unwrap_err();
+    assert!(matches!(err, MergeError::Snapshot(_)), "got {err:?}");
+    assert!(
+        err.to_string()
+            .starts_with("merge snapshot encode/decode failed"),
+        "got {err}"
+    );
+}
+
+#[tokio::test]
 async fn merge_moves_highlights_to_target() {
     // F1 merge fix: highlights are now in the re-parent set, so a manual
     // merge no longer loses the source book's highlights.

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -182,6 +182,34 @@ async fn get_metadata_overrides_returns_none_when_absent() {
     assert!(result.is_none());
 }
 #[tokio::test]
+async fn get_metadata_overrides_returns_serialization_error_for_corrupt_blob() {
+    // The write path serializes valid JSON, but a row can still hold a corrupt
+    // `overrides` blob (a hand-edited DB, or a schema predating a field). When
+    // the read decodes it via `serde_json::from_str`, the failure must surface
+    // as `MetadataOverridesError::Serialization` — the `#[from] serde_json`
+    // variant — not a `Db` error. Insert malformed JSON directly to bypass the
+    // serialize-on-write and drive the decode failure.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO metadata_overrides (book_uuid, overrides) VALUES (?, ?)")
+        .bind("corrupt-uuid")
+        .bind("{ not valid json")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let err = get_metadata_overrides(&pool, "corrupt-uuid")
+        .await
+        .expect_err("corrupt overrides JSON must not decode");
+    assert!(
+        matches!(err, MetadataOverridesError::Serialization(_)),
+        "got {err:?}"
+    );
+    assert!(
+        err.to_string().starts_with("JSON (de)serialization failed"),
+        "got {err}"
+    );
+}
+#[tokio::test]
 async fn delete_metadata_overrides_removes_row() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")

--- a/db/src/pool/tests.rs
+++ b/db/src/pool/tests.rs
@@ -18,56 +18,30 @@ async fn init_db_returns_migrate_error_when_applied_checksum_is_tampered() {
     // migration against the checksum recorded in `_sqlx_migrations`. A row
     // whose stored checksum no longer matches (an edited-after-apply migration,
     // per rule 06) must fail startup — the typed wrapper surfaces it as
-    // `InitDbError::Migrate`, not a panic or a leaked `MigrateError`. Seed an
-    // on-disk DB with a tampered version-1 checksum, then run `init_db` on it.
-    let tmp = std::env::temp_dir().join(format!(
-        "omnibus-migrate-tamper-{}-{}.db",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    let _ = std::fs::remove_file(&tmp);
-    let url = format!("sqlite://{}?mode=rwc", tmp.display());
+    // `InitDbError::Migrate`, not a panic or a leaked `MigrateError`.
+    //
+    // First `init_db` lets sqlx create and populate `_sqlx_migrations` itself
+    // (no hand-recreation of its internal schema, which would rot across sqlx
+    // versions); then we tamper version 1's checksum in place and re-open. The
+    // tempdir auto-removes the DB plus its WAL/`-shm` sidecars on drop.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("omnibus.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
 
-    // Pre-create the migrations table with sqlx's exact DDL (CREATE TABLE IF
-    // NOT EXISTS, so the migrator reuses it) and record version 1 as applied
-    // with a deliberately wrong checksum (48 zero bytes ≠ the real SHA-384).
-    let pool = SqlitePool::connect(&url).await.unwrap();
-    sqlx::query(
-        "CREATE TABLE IF NOT EXISTS _sqlx_migrations (
-            version BIGINT PRIMARY KEY,
-            description TEXT NOT NULL,
-            installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            success BOOLEAN NOT NULL,
-            checksum BLOB NOT NULL,
-            execution_time BIGINT NOT NULL
-        )",
-    )
-    .execute(&pool)
-    .await
-    .unwrap();
-    sqlx::query(
-        "INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time)
-         VALUES (?, ?, ?, ?, ?)",
-    )
-    .bind(1_i64)
-    .bind("tampered")
-    .bind(true)
-    .bind(vec![0u8; 48])
-    .bind(0_i64)
-    .execute(&pool)
-    .await
-    .unwrap();
+    let pool = init_db(&url).await.expect("initial init_db should succeed");
+    sqlx::query("UPDATE _sqlx_migrations SET checksum = zeroblob(48) WHERE version = 1")
+        .execute(&pool)
+        .await
+        .unwrap();
     drop(pool);
 
     let err = init_db(&url)
         .await
         .expect_err("a tampered migration checksum must fail startup");
-    let is_migrate = matches!(err, InitDbError::Migrate(_));
-    let _ = std::fs::remove_file(&tmp);
-    assert!(is_migrate, "expected InitDbError::Migrate, got {err:?}");
+    assert!(
+        matches!(err, InitDbError::Migrate(_)),
+        "expected InitDbError::Migrate, got {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/db/src/pool/tests.rs
+++ b/db/src/pool/tests.rs
@@ -13,6 +13,64 @@ async fn init_db_returns_db_error_when_url_is_invalid() {
 }
 
 #[tokio::test]
+async fn init_db_returns_migrate_error_when_applied_checksum_is_tampered() {
+    // sqlx checksums every migration and, at startup, compares each embedded
+    // migration against the checksum recorded in `_sqlx_migrations`. A row
+    // whose stored checksum no longer matches (an edited-after-apply migration,
+    // per rule 06) must fail startup — the typed wrapper surfaces it as
+    // `InitDbError::Migrate`, not a panic or a leaked `MigrateError`. Seed an
+    // on-disk DB with a tampered version-1 checksum, then run `init_db` on it.
+    let tmp = std::env::temp_dir().join(format!(
+        "omnibus-migrate-tamper-{}-{}.db",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_file(&tmp);
+    let url = format!("sqlite://{}?mode=rwc", tmp.display());
+
+    // Pre-create the migrations table with sqlx's exact DDL (CREATE TABLE IF
+    // NOT EXISTS, so the migrator reuses it) and record version 1 as applied
+    // with a deliberately wrong checksum (48 zero bytes ≠ the real SHA-384).
+    let pool = SqlitePool::connect(&url).await.unwrap();
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS _sqlx_migrations (
+            version BIGINT PRIMARY KEY,
+            description TEXT NOT NULL,
+            installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            success BOOLEAN NOT NULL,
+            checksum BLOB NOT NULL,
+            execution_time BIGINT NOT NULL
+        )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(1_i64)
+    .bind("tampered")
+    .bind(true)
+    .bind(vec![0u8; 48])
+    .bind(0_i64)
+    .execute(&pool)
+    .await
+    .unwrap();
+    drop(pool);
+
+    let err = init_db(&url)
+        .await
+        .expect_err("a tampered migration checksum must fail startup");
+    let is_migrate = matches!(err, InitDbError::Migrate(_));
+    let _ = std::fs::remove_file(&tmp);
+    assert!(is_migrate, "expected InitDbError::Migrate, got {err:?}");
+}
+
+#[tokio::test]
 async fn migrator_records_applied_versions() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let versions: Vec<i64> =

--- a/db/src/suggestions/tests.rs
+++ b/db/src/suggestions/tests.rs
@@ -343,6 +343,31 @@ async fn curated_list_ids_returns_list_ids() {
 }
 
 #[tokio::test]
+async fn post_graphql_surfaces_graphql_error_envelope() {
+    // Hasura returns HTTP 200 even for a failed operation, carrying the
+    // failure in an `errors[]` array. `post_graphql` must join those messages
+    // into `HardcoverError::Graphql` rather than treating the 200 as success
+    // or trying to decode the (absent) `data`. Driven through `curated_list_ids`
+    // since `post_graphql` is private.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "errors": [{ "message": "field 'list_books' not found" }]
+        })))
+        .mount(&server)
+        .await;
+    let cfg = config_for(&server);
+    let err = curated_list_ids(&cfg, 714600)
+        .await
+        .expect_err("an errors[] envelope must not decode as success");
+    assert!(
+        matches!(&err, crate::suggestions::hardcover::HardcoverError::Graphql(msg)
+            if msg.contains("field 'list_books' not found")),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn co_listed_counts_ranks_by_shared_list_appearances() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))

--- a/db/src/thumbs/tests.rs
+++ b/db/src/thumbs/tests.rs
@@ -113,3 +113,32 @@ fn evict_if_over_cap_removes_oldest_files() {
     let remaining: Vec<_> = std::fs::read_dir(tmp.path()).unwrap().flatten().collect();
     assert_eq!(remaining.len(), 2, "should have evicted 1 oldest file");
 }
+
+// ---------- ThumbError variants ----------
+
+#[test]
+fn generate_thumbnail_returns_failed_when_bytes_are_not_a_decodable_image() {
+    // The decode step (`image::load_from_memory`) is the pipeline's first
+    // fallible stage; garbage bytes that aren't any known image format must
+    // surface as `ThumbError::Failed` with a message naming the decode step,
+    // rather than panicking. `Failed` is the coarse variant folding the
+    // former Decode/Encode/I-O cases, so the decode failure exercises it.
+    let _guard = EnvVarGuard::set("OMNIBUS_THUMBS_DIR", None);
+    let err = generate_thumbnail(7, ThumbSize::Sm, b"definitely not an image")
+        .expect_err("undecodable bytes must not produce a thumbnail");
+    assert!(
+        matches!(err, ThumbError::Failed(ref msg) if msg.contains("decode")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn thumb_error_no_cover_renders_book_id_in_message() {
+    // `NoCover` carries the book id so a caller (and the download handler)
+    // can render "no cover available for book N". Constructed directly: it is
+    // a coarse, caller-branchable variant whose message contract is asserted
+    // here even though the current pipeline reaches the missing-cover case
+    // before minting it.
+    let err = ThumbError::NoCover(451);
+    assert_eq!(err.to_string(), "no cover available for book 451");
+}


### PR DESCRIPTION
## Summary
Adds one unit test per previously-uncovered `thiserror` variant across ten `db`-crate enums, per `.claude/rules/03-unit-testing.md` ("one test per `thiserror` variant"). Each test constructs or triggers the variant and asserts the resulting error matches (variant + rendered message). All tests are added to the existing sibling `<mod>/tests.rs` files — no production code changed.

Variant → test file:
- `BooksError::OverridesJson` → `db/src/books/tests.rs` (the `From<MetadataOverridesError::Serialization>` bridge — the only mint site).
- `KindleError::Timeout`, `KindleError::Build` → `db/src/kindle/tests.rs`.
- `AudiobookError::Tag` → `db/src/audiobook/tests.rs` (`build_indexed_book` on undecodable audio).
- `ThumbError::Failed` (decode path) + `ThumbError::NoCover` → `db/src/thumbs/tests.rs`.
- `MergeError::Snapshot` → `db/src/merge/tests.rs` (corrupt `merge_log.source_metadata`, then `undo_merge`).
- `FetchRemoteImageError` NotImage / SvgRejected / TooLarge (all `Validation`) → `db/src/author_photos/tests.rs` (wiremock).
- `MetadataOverridesError::Serialization` → `db/src/metadata_overrides/tests.rs` (corrupt overrides blob).
- `KepubError::NonZero` → `db/src/kepub/tests.rs` (fake kepubify exiting non-zero).
- `HardcoverError::Graphql` → `db/src/suggestions/tests.rs` (wiremock `errors[]` envelope).
- `InitDbError::Migrate` → `db/src/pool/tests.rs` (tampered `_sqlx_migrations` checksum → `VersionMismatch`).

Closes #769

## Test plan
- [x] `cargo test -p omnibus-db` — PASS (822 lib + 2 integration; 14 new tests included; 0 failed).
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (clean).
- [x] `cargo fmt --check` — PASS (clean).

## Notes
- The issue's evidence table for `ThumbError` is stale: `Decode`/`Encode` have been consolidated into a single coarse `Failed(String)` variant (matching rule 05's coarse-variant guidance), and there is no separate `NoCover` line at the cited offset. Covered `Failed` via a decode failure (`generate_thumbnail` on garbage bytes).
- `ThumbError::NoCover(i64)` is defined but never constructed anywhere in the repo — it is effectively dead. It is still `pub` and caller-branchable, so its message contract is asserted by constructing it directly (same pattern as the existing `AudiobookError::Unsupported` test); no production change was needed.
- `Timeout` (a unit variant) and `Build`/`OverridesJson` (whose only mint site is a `From` bridge) are covered by constructing the source error and exercising the exact conversion/`Display`, rather than standing up a live SMTP relay.