### PR TITLE
refactor: group oversized Dioxus component prop lists into structs

### DIFF
--- a/frontend/src/components/auth/banner.rs
+++ b/frontend/src/components/auth/banner.rs
@@ -46,22 +46,44 @@ impl BannerKind {
     }
 }
 
-/// Top-of-form callout. Use [`BannerKind`] to pick severity; `title` is
-/// required, `message` and `action` are optional.
+/// Props for the [`Banner`] component. Use [`BannerKind`] to pick
+/// severity; `title` is required, `message` and `action` are optional.
 ///
 /// `dismissible` renders an inline dismiss button — purely visual here;
 /// callers are responsible for hiding the banner in response to the
 /// click. (The primitive stays stateless so the same component works
 /// under SSR.)
+#[derive(Props, Clone, PartialEq)]
+pub struct BannerProps {
+    /// Severity tier — drives color, icon, and ARIA role.
+    pub kind: BannerKind,
+    /// Bold headline copy (required).
+    pub title: String,
+    /// Optional supporting line under the title.
+    #[props(default)]
+    pub message: Option<String>,
+    /// Optional action slot rendered under the message.
+    #[props(default)]
+    pub action: Option<Element>,
+    /// When true, renders an inline dismiss button (visual only).
+    #[props(default = false)]
+    pub dismissible: bool,
+    /// Fired when the dismiss button is clicked.
+    #[props(default)]
+    pub on_dismiss: Option<EventHandler<MouseEvent>>,
+}
+
+/// Top-of-form callout. See [`BannerProps`] for the field contract.
 #[component]
-pub fn Banner(
-    kind: BannerKind,
-    title: String,
-    #[props(default)] message: Option<String>,
-    #[props(default)] action: Option<Element>,
-    #[props(default = false)] dismissible: bool,
-    #[props(default)] on_dismiss: Option<EventHandler<MouseEvent>>,
-) -> Element {
+pub fn Banner(props: BannerProps) -> Element {
+    let BannerProps {
+        kind,
+        title,
+        message,
+        action,
+        dismissible,
+        on_dismiss,
+    } = props;
     let kind_class = kind.class_suffix();
     let wrapper_class = format!("auth-banner auth-banner-{kind_class}");
     let icon = kind.icon();

--- a/frontend/src/components/auth/banner.rs
+++ b/frontend/src/components/auth/banner.rs
@@ -73,7 +73,7 @@ pub struct BannerProps {
     pub on_dismiss: Option<EventHandler<MouseEvent>>,
 }
 
-/// Top-of-form callout. See [`BannerProps`] for the field contract.
+/// Top-of-form callout. See [`BannerProps`] for the banner contract.
 #[component]
 pub fn Banner(props: BannerProps) -> Element {
     let BannerProps {

--- a/frontend/src/components/auth/field.rs
+++ b/frontend/src/components/auth/field.rs
@@ -6,7 +6,7 @@
 
 use dioxus::prelude::*;
 
-/// Form field with shared label / hint / error / success states.
+/// Props for the [`Field`] component.
 ///
 /// The outer element is a `<div>`, and the visible label is a real
 /// `<label for={input_id}>`. **The error / hint message is rendered as a
@@ -18,34 +18,50 @@ use dioxus::prelude::*;
 /// Callers pass any input element (`input`, `select`, `textarea`) as
 /// `children` and the matching `input_id` so the `<label>` can bind via
 /// `for=`.
-///
-/// Props:
-/// - `label` — visible label text.
-/// - `input_id` — the `id` set on the inner input element; drives the
-///   label's `for=` binding so screen readers and Playwright's
-///   `getByLabel` resolve the input by label text alone.
-/// - `hint` — supporting copy under the input (hidden when an error is shown).
-/// - `error` — when present, switches the field to its error visual and
-///   shows the message under the input as `role="alert"`.
-/// - `success` — when true, switches the field to its success visual
-///   (green accent + check mark).
-/// - `action` — optional slot rendered visually at the top-right of the
-///   field (e.g. a "Forgot?" link). Lives **after** the input in DOM order
-///   and is positioned by CSS, so tabbing through the form goes
-///   label → input → action → next field rather than label → action →
-///   input (the latter pulls focus to the action between fields and traps
-///   typed characters that the user thought were going into the input).
-/// - `children` — the input element.
+#[derive(Props, Clone, PartialEq)]
+pub struct FieldProps {
+    /// Visible label text.
+    pub label: String,
+    /// The `id` set on the inner input element; drives the label's
+    /// `for=` binding so screen readers and Playwright's `getByLabel`
+    /// resolve the input by label text alone.
+    pub input_id: String,
+    /// Supporting copy under the input (hidden when an error is shown).
+    #[props(default)]
+    pub hint: Option<String>,
+    /// When present, switches the field to its error visual and shows
+    /// the message under the input as `role="alert"`.
+    #[props(default)]
+    pub error: Option<String>,
+    /// When true, switches the field to its success visual (green accent
+    /// + check mark).
+    #[props(default = false)]
+    pub success: bool,
+    /// Optional slot rendered visually at the top-right of the field
+    /// (e.g. a "Forgot?" link). Lives **after** the input in DOM order
+    /// and is positioned by CSS, so tabbing through the form goes
+    /// label → input → action → next field rather than label → action →
+    /// input (the latter pulls focus to the action between fields and
+    /// traps typed characters the user meant for the input).
+    #[props(default)]
+    pub action: Option<Element>,
+    /// The input element.
+    pub children: Element,
+}
+
+/// Form field with shared label / hint / error / success states. See
+/// [`FieldProps`] for the field contract.
 #[component]
-pub fn Field(
-    label: String,
-    input_id: String,
-    #[props(default)] hint: Option<String>,
-    #[props(default)] error: Option<String>,
-    #[props(default = false)] success: bool,
-    #[props(default)] action: Option<Element>,
-    children: Element,
-) -> Element {
+pub fn Field(props: FieldProps) -> Element {
+    let FieldProps {
+        label,
+        input_id,
+        hint,
+        error,
+        success,
+        action,
+        children,
+    } = props;
     let state_class = field_state_class(error.as_deref(), success);
     let wrapper_class = format!("auth-field {state_class}");
 

--- a/frontend/src/pages/auth/login.rs
+++ b/frontend/src/pages/auth/login.rs
@@ -212,18 +212,38 @@ pub fn LoginPage() -> Element {
     out
 }
 
+/// Props for the [`LoginForm`] component.
+#[derive(Props, Clone, PartialEq)]
+struct LoginFormProps {
+    /// Username input value, shared with the parent.
+    username: Signal<String>,
+    /// Password input value, shared with the parent.
+    password: Signal<String>,
+    /// Current submission error, if any.
+    error: Signal<Option<String>>,
+    /// True while a login request is in flight.
+    submitting: Signal<bool>,
+    /// "Keep me signed in" checkbox state.
+    keep_signed_in: Signal<bool>,
+    /// Fired on form submit (click).
+    on_submit: EventHandler<FormEvent>,
+    /// Fired on Enter keydown in either input.
+    on_keydown: EventHandler<Event<KeyboardData>>,
+}
+
 /// Login form body — inputs write the parent's signals through,
 /// submission delegates via `on_submit`/`on_keydown`.
 #[component]
-fn LoginForm(
-    username: Signal<String>,
-    password: Signal<String>,
-    error: Signal<Option<String>>,
-    submitting: Signal<bool>,
-    mut keep_signed_in: Signal<bool>,
-    on_submit: EventHandler<FormEvent>,
-    on_keydown: EventHandler<Event<KeyboardData>>,
-) -> Element {
+fn LoginForm(props: LoginFormProps) -> Element {
+    let LoginFormProps {
+        username,
+        password,
+        error,
+        submitting,
+        mut keep_signed_in,
+        on_submit,
+        on_keydown,
+    } = props;
     rsx! {
         form { class: "auth-form-inner",
             onsubmit: on_submit,

--- a/frontend/src/pages/auth/login.rs
+++ b/frontend/src/pages/auth/login.rs
@@ -225,7 +225,7 @@ struct LoginFormProps {
     submitting: Signal<bool>,
     /// "Keep me signed in" checkbox state.
     keep_signed_in: Signal<bool>,
-    /// Fired on form submit (click).
+    /// Fired on form submission (submit-button click or Enter).
     on_submit: EventHandler<FormEvent>,
     /// Fired on Enter keydown in either input.
     on_keydown: EventHandler<Event<KeyboardData>>,

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -10,18 +10,39 @@ use omnibus_shared::EbookMetadata;
 use crate::components::atrium::Cover;
 use crate::Route;
 
+/// Props for [`MobileLanding`] — the already-derived view state handed
+/// down from [`super::LandingPage`].
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct MobileLandingProps {
+    /// Total book count shown in the "N books" label.
+    pub book_count: usize,
+    /// The page of books to render as cover cells.
+    pub books: Vec<EbookMetadata>,
+    /// True while the first page is still loading.
+    pub is_loading: bool,
+    /// True when more pages remain to load.
+    pub has_more: bool,
+    /// True while a "Load more" fetch is in flight.
+    pub is_loading_more: bool,
+    /// Fired when the "Load more" button is pressed.
+    pub on_load_more: EventHandler<()>,
+    /// Base server URL used to build thumbnail `src`/`srcset`.
+    pub server_url: String,
+}
+
 /// Mobile landing surface. Fed the already-derived view state from
 /// [`super::LandingPage`] so the data path stays shared across targets.
 #[component]
-pub(super) fn MobileLanding(
-    book_count: usize,
-    books: Vec<EbookMetadata>,
-    is_loading: bool,
-    has_more: bool,
-    is_loading_more: bool,
-    on_load_more: EventHandler<()>,
-    server_url: String,
-) -> Element {
+pub(super) fn MobileLanding(props: MobileLandingProps) -> Element {
+    let MobileLandingProps {
+        book_count,
+        books,
+        is_loading,
+        has_more,
+        is_loading_more,
+        on_load_more,
+        server_url,
+    } = props;
     rsx! {
         div { class: "m-lib", "data-testid": "mobile-landing",
             header { class: "m-lib-head",

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -330,6 +330,23 @@ pub(super) fn EditableCell(
     }
 }
 
+/// Props for the [`AuthorsCell`] component.
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct AuthorsCellProps {
+    /// Gates edit affordances — only admins can open the chip editor.
+    pub is_admin: bool,
+    /// Which field (if any) the row is currently editing.
+    pub editing: Signal<Option<EditField>>,
+    /// The in-progress author chip list shared with the row.
+    pub authors_draft: Signal<Vec<String>>,
+    /// Comma-joined author names shown in display mode.
+    pub authors_text: String,
+    /// Library-wide author pool surfaced in the dropdown.
+    pub suggestions: ReadSignal<Vec<SuggestionItem>>,
+    /// Fired with the new full author list on every add/remove.
+    pub on_change: EventHandler<Vec<String>>,
+}
+
 /// Inline-editable Authors cell. Unlike [`EditableCell`] (which hosts
 /// a single-line text input), the Authors cell renders the full
 /// [`ChipEditor`] *inside* the `<td>` when the row's editing signal
@@ -340,14 +357,15 @@ pub(super) fn EditableCell(
 /// Click: swaps to chip editor (auto-focused) with the library-wide
 /// author pool surfaced in the dropdown. Escape exits edit mode.
 #[component]
-pub(super) fn AuthorsCell(
-    is_admin: bool,
-    editing: Signal<Option<EditField>>,
-    authors_draft: Signal<Vec<String>>,
-    authors_text: String,
-    suggestions: ReadSignal<Vec<SuggestionItem>>,
-    on_change: EventHandler<Vec<String>>,
-) -> Element {
+pub(super) fn AuthorsCell(props: AuthorsCellProps) -> Element {
+    let AuthorsCellProps {
+        is_admin,
+        editing,
+        authors_draft,
+        authors_text,
+        suggestions,
+        on_change,
+    } = props;
     let mut editing = editing;
     let is_editing = editing() == Some(EditField::Authors);
     let active_class = if is_editing {

--- a/frontend/src/pages/listen/chapter_map.rs
+++ b/frontend/src/pages/listen/chapter_map.rs
@@ -82,16 +82,34 @@ mod tests {
     }
 }
 
+/// Props for the [`ChapterMap`] component.
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct ChapterMapProps {
+    /// Ordered chapter markers; empty falls back to a single-segment bar.
+    pub chapters: Vec<ChapterInfo>,
+    /// Seconds elapsed in the whole book.
+    pub elapsed: f64,
+    /// Total book duration in seconds.
+    pub duration: f64,
+    /// Seconds remaining in the whole book.
+    pub remaining: f64,
+    /// Index of the currently-playing chapter.
+    pub current_chapter_index: usize,
+    /// Fired with the target time in seconds when a segment is clicked.
+    pub on_seek: EventHandler<f64>,
+}
+
 /// The chapter progress map component.
 #[component]
-pub(super) fn ChapterMap(
-    chapters: Vec<ChapterInfo>,
-    elapsed: f64,
-    duration: f64,
-    remaining: f64,
-    current_chapter_index: usize,
-    on_seek: EventHandler<f64>,
-) -> Element {
+pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
+    let ChapterMapProps {
+        chapters,
+        elapsed,
+        duration,
+        remaining,
+        current_chapter_index,
+        on_seek,
+    } = props;
     if chapters.is_empty() {
         let fill_pct = no_chapter_fill_pct(elapsed, duration);
         return rsx! {

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -480,17 +480,35 @@ fn render_player(p: PlayerProps) -> Element {
     }
 }
 
+/// Props for the [`ChaptersSheet`] component.
+#[derive(Props, Clone, PartialEq)]
+struct ChaptersSheetProps {
+    /// Ordered chapter markers rendered as sheet rows.
+    chapters: Vec<ChapterInfo>,
+    /// Index of the currently-playing chapter.
+    current_index: usize,
+    /// Seconds elapsed in the whole book (drives the current row's bar).
+    elapsed: f64,
+    /// Formatted total-duration label shown in the sheet header.
+    total_label: String,
+    /// Fired with the target time in seconds when a row is tapped.
+    on_seek: EventHandler<f64>,
+    /// Fired when the scrim or a row dismisses the sheet.
+    on_close: EventHandler<MouseEvent>,
+}
+
 /// Bottom-sheet chapter list. Current row is accent-highlighted with a mini
 /// progress bar; done rows show a check, upcoming rows show their duration.
 #[component]
-fn ChaptersSheet(
-    chapters: Vec<ChapterInfo>,
-    current_index: usize,
-    elapsed: f64,
-    total_label: String,
-    on_seek: EventHandler<f64>,
-    on_close: EventHandler<MouseEvent>,
-) -> Element {
+fn ChaptersSheet(props: ChaptersSheetProps) -> Element {
+    let ChaptersSheetProps {
+        chapters,
+        current_index,
+        elapsed,
+        total_label,
+        on_seek,
+        on_close,
+    } = props;
     let count = chapters.len();
     rsx! {
         div { class: "m-sheet-scrim", "data-testid": "mobile-chapters-sheet", onclick: move |e| on_close.call(e),

--- a/frontend/src/pages/metadata_edit/fields.rs
+++ b/frontend/src/pages/metadata_edit/fields.rs
@@ -108,16 +108,37 @@ pub(super) fn MeField(
     }
 }
 
+/// Props for the [`MeArea`] component.
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct MeAreaProps {
+    /// Field label; also slugified into the textarea's `id`.
+    pub label: String,
+    /// The textarea's bound value signal.
+    pub value: Signal<String>,
+    /// Fired with the new text on every input.
+    pub on_change: EventHandler<String>,
+    /// Visible row count for the textarea.
+    #[props(default = 4)]
+    pub rows: i32,
+    /// When true, applies the "edited" accent + badge.
+    #[props(default)]
+    pub edited: bool,
+    /// Optional hint copy shown beside the label.
+    #[props(default)]
+    pub hint: String,
+}
+
 /// Multi-line textarea field.
 #[component]
-pub(super) fn MeArea(
-    label: String,
-    value: Signal<String>,
-    on_change: EventHandler<String>,
-    #[props(default = 4)] rows: i32,
-    #[props(default)] edited: bool,
-    #[props(default)] hint: String,
-) -> Element {
+pub(super) fn MeArea(props: MeAreaProps) -> Element {
+    let MeAreaProps {
+        label,
+        value,
+        on_change,
+        rows,
+        edited,
+        hint,
+    } = props;
     let border_class = if edited { " me-input-edited" } else { "" };
     let field_id = label_to_id(&label);
 


### PR DESCRIPTION
## Summary
- Closes #764.
- Eight Dioxus components exceeded the ~5-prop threshold. Each now takes a single `props: XxxProps` argument backed by a `#[derive(Props, Clone, PartialEq)]` struct, dropping every raw parameter list to 1. Call sites are unchanged: Dioxus flattens a component's single Props-struct fields back into the rsx call namespace (the same pattern `ChipEditor`/`ChipEditorProps` already uses), so the flattened field-name call syntax keeps working.
- Components grouped: `Field` (7→`FieldProps`), `Banner` (6→`BannerProps`) in `components/auth/`; `LoginForm` (7→`LoginFormProps`) in `pages/auth/login.rs`; `MobileLanding` (7→`MobileLandingProps`) in `pages/landing/mobile.rs`; `ChapterMap` (6→`ChapterMapProps`) in `pages/listen/chapter_map.rs`; `ChaptersSheet` (6→`ChaptersSheetProps`) in `pages/listen/mobile.rs`; `AuthorsCell` (6→`AuthorsCellProps`) in `pages/landing/table/cells.rs`; `MeArea` (6→`MeAreaProps`) in `pages/metadata_edit/fields.rs`.
- No behavior or visual change: only the function-signature shape changed; each struct carries the same field names, `#[props(default...)]` attributes, and doc comments. No new `#[allow(clippy::too_many_arguments)]`, and no `#[cfg(feature = ...)]` gating was introduced into any component body (hydration parity preserved).

> Note: the issue lists `frontend/src/pages/auth.rs → LoginForm`; that file has since been split into `pages/auth/`, so `LoginForm` now lives in `pages/auth/login.rs`. Only `LoginForm` was touched there — `RegisterForm` (a separate issue) is untouched.

## Test plan
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (209 passed, 0 failed)
- [x] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` — PASS (validates the mobile-only components + mobile login branch)
- [x] `cargo fmt --check` — PASS

## Notes
- Approach avoids call-site churn entirely, so files outside the eight components (e.g. `server_connect.rs`, `register.rs`, `landing.rs`, `listen/stage.rs`, `table/row.rs`, `metadata_edit/form_grid.rs`) that call `Field`/`Banner`/`MobileLanding`/`ChapterMap`/`AuthorsCell`/`MeArea` were not modified.