### PR TITLE
refactor: split oversized Dioxus component bodies

### DIFF
--- a/frontend/src/components/search_palette/overlay.rs
+++ b/frontend/src/components/search_palette/overlay.rs
@@ -113,53 +113,17 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
                 onclick: move |evt| evt.stop_propagation(),
                 onkeydown: on_keydown,
 
-                // Input row
-                div { class: "sp-input-wrap",
-                    svg {
-                        class: "sp-input-icon",
-                        width: "18",
-                        height: "18",
-                        view_box: "0 0 24 24",
-                        fill: "none",
-                        stroke: "currentColor",
-                        stroke_width: "2",
-                        stroke_linecap: "round",
-                        stroke_linejoin: "round",
-                        circle { cx: "11", cy: "11", r: "8" }
-                        line { x1: "21", y1: "21", x2: "16.65", y2: "16.65" }
-                    }
-                    input {
-                        class: "sp-input",
-                        "data-testid": "sp-input",
-                        r#type: "text",
-                        placeholder: "Search books, authors, series, tags…",
-                        autofocus: true,
-                        // `autofocus` only fires on initial page load.
-                        // `onmounted` programmatically focuses the input
-                        // when the overlay is dynamically rendered (⌘K).
-                        // Uses `requestAnimationFrame` so the browser has
-                        // finished layout before we `.focus()` — without
-                        // that delay the focus call lands on an element
-                        // that isn't yet painted and the caret never
-                        // appears (this is the timing reason prior
-                        // attempts with `set_focus(true)`/`spawn` failed).
-                        onmounted: move |evt: MountedEvent| {
-                            focus_palette_input(&evt);
-                        },
-                        value: "{query}",
-                        oninput: move |evt| {
-                            let v = evt.value();
-                            query.set(v.clone());
-                            spawn_search(v);
-                            // Typing reverts to "Enter goes to /search" until
-                            // the user re-engages arrow-key navigation.
-                            has_navigated.set(false);
-                            selected.set(0);
-                        },
-                    }
-                    if is_loading {
-                        span { class: "sp-spinner", "…" }
-                    }
+                SpInputRow {
+                    query,
+                    is_loading,
+                    on_input: move |v: String| {
+                        query.set(v.clone());
+                        spawn_search(v);
+                        // Typing reverts to "Enter goes to /search" until
+                        // the user re-engages arrow-key navigation.
+                        has_navigated.set(false);
+                        selected.set(0);
+                    },
                 }
 
                 // Meta line
@@ -179,6 +143,53 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
 
                 // Footer
                 SpFooter {}
+            }
+        }
+    }
+}
+
+/// Search-icon + autofocused query input, with the debounce/RPC dispatch
+/// delegated to `on_input` and the loading spinner shown while a search runs.
+#[component]
+fn SpInputRow(query: Signal<String>, is_loading: bool, on_input: EventHandler<String>) -> Element {
+    rsx! {
+        div { class: "sp-input-wrap",
+            svg {
+                class: "sp-input-icon",
+                width: "18",
+                height: "18",
+                view_box: "0 0 24 24",
+                fill: "none",
+                stroke: "currentColor",
+                stroke_width: "2",
+                stroke_linecap: "round",
+                stroke_linejoin: "round",
+                circle { cx: "11", cy: "11", r: "8" }
+                line { x1: "21", y1: "21", x2: "16.65", y2: "16.65" }
+            }
+            input {
+                class: "sp-input",
+                "data-testid": "sp-input",
+                r#type: "text",
+                placeholder: "Search books, authors, series, tags…",
+                autofocus: true,
+                // `autofocus` only fires on initial page load.
+                // `onmounted` programmatically focuses the input
+                // when the overlay is dynamically rendered (⌘K).
+                // Uses `requestAnimationFrame` so the browser has
+                // finished layout before we `.focus()` — without
+                // that delay the focus call lands on an element
+                // that isn't yet painted and the caret never
+                // appears (this is the timing reason prior
+                // attempts with `set_focus(true)`/`spawn` failed).
+                onmounted: move |evt: MountedEvent| {
+                    focus_palette_input(&evt);
+                },
+                value: "{query}",
+                oninput: move |evt| on_input.call(evt.value()),
+            }
+            if is_loading {
+                span { class: "sp-spinner", "…" }
             }
         }
     }

--- a/frontend/src/pages/add_books.rs
+++ b/frontend/src/pages/add_books.rs
@@ -13,119 +13,43 @@ use dioxus_router::use_navigator;
 use crate::data::{self, EbookUploadMeta};
 use crate::{use_server_url, Route};
 
+/// The editable-metadata + staged-upload signals threaded through the page's
+/// handlers and confirm form. `Copy` so the async handlers can capture them.
+#[derive(Copy, Clone, PartialEq)]
+struct UploadState {
+    filename: Signal<String>,
+    file_bytes: Signal<Option<Vec<u8>>>,
+    title: Signal<String>,
+    author: Signal<String>,
+    series: Signal<String>,
+    series_index: Signal<String>,
+    inspected: Signal<bool>,
+    busy: Signal<bool>,
+    status: Signal<Option<String>>,
+    status_is_error: Signal<bool>,
+}
+
 /// Upload form: pick an EPUB, confirm/correct the auto-extracted metadata, file it.
 #[component]
 pub fn AddBooksPage() -> Element {
     let server_url = use_server_url();
     let nav = use_navigator();
 
-    let mut filename = use_signal(String::new);
-    let mut file_bytes: Signal<Option<Vec<u8>>> = use_signal(|| None);
-    let mut title = use_signal(String::new);
-    let mut author = use_signal(String::new);
-    let mut series = use_signal(String::new);
-    let mut series_index = use_signal(String::new);
-    let mut inspected = use_signal(|| false);
-    let mut busy = use_signal(|| false);
-    let mut status: Signal<Option<String>> = use_signal(|| None);
-    let mut status_is_error = use_signal(|| false);
-
-    // File select → read bytes → inspect → pre-fill the editable fields.
-    let on_file = {
-        let server_url = server_url.clone();
-        move |evt: Event<FormData>| {
-            let Some(file) = evt.files().into_iter().next() else {
-                return;
-            };
-            let name = file.name();
-            let server_url = server_url.clone();
-            busy.set(true);
-            status.set(Some(format!("Reading {name}\u{2026}")));
-            status_is_error.set(false);
-            spawn(async move {
-                match file.read_bytes().await {
-                    Ok(bytes) => {
-                        let bytes = bytes.to_vec();
-                        match data::inspect_ebook(&server_url, name.clone(), &bytes).await {
-                            Ok(insp) => {
-                                title.set(insp.title.unwrap_or_default());
-                                author.set(insp.author.unwrap_or_default());
-                                series.set(insp.series.unwrap_or_default());
-                                series_index.set(insp.series_index.unwrap_or_default());
-                                filename.set(name);
-                                file_bytes.set(Some(bytes));
-                                inspected.set(true);
-                                status.set(Some(
-                                    "Review the details, then add to your library.".into(),
-                                ));
-                                status_is_error.set(false);
-                            }
-                            Err(e) => {
-                                // Clear any previously staged upload so stale bytes
-                                // can't be submitted after a new file fails inspect.
-                                inspected.set(false);
-                                file_bytes.set(None);
-                                filename.set(String::new());
-                                status.set(Some(format!("Could not read that EPUB: {e}")));
-                                status_is_error.set(true);
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        inspected.set(false);
-                        file_bytes.set(None);
-                        filename.set(String::new());
-                        status.set(Some(format!("Could not read that file: {e}")));
-                        status_is_error.set(true);
-                    }
-                }
-                busy.set(false);
-            });
-        }
+    let state = UploadState {
+        filename: use_signal(String::new),
+        file_bytes: use_signal(|| None),
+        title: use_signal(String::new),
+        author: use_signal(String::new),
+        series: use_signal(String::new),
+        series_index: use_signal(String::new),
+        inspected: use_signal(|| false),
+        busy: use_signal(|| false),
+        status: use_signal(|| None),
+        status_is_error: use_signal(|| false),
     };
 
-    // Confirm → file the book → redirect to its detail page.
-    let on_submit = {
-        let server_url = server_url.clone();
-        move |evt: FormEvent| {
-            evt.prevent_default();
-            let server_url = server_url.clone();
-            let confirmed_title = title().trim().to_string();
-            let confirmed_author = author().trim().to_string();
-            if confirmed_title.is_empty() || confirmed_author.is_empty() {
-                status.set(Some("Title and author are required.".into()));
-                status_is_error.set(true);
-                return;
-            }
-            let Some(bytes) = file_bytes() else {
-                status.set(Some("Choose an EPUB file first.".into()));
-                status_is_error.set(true);
-                return;
-            };
-            let name = filename();
-            let meta = EbookUploadMeta {
-                title: confirmed_title,
-                author: confirmed_author,
-                series: series().trim().to_string(),
-                series_index: series_index().trim().to_string(),
-            };
-            busy.set(true);
-            status.set(Some("Adding to your library\u{2026}".into()));
-            status_is_error.set(false);
-            spawn(async move {
-                match data::upload_ebook(&server_url, name, bytes, meta).await {
-                    Ok(result) => {
-                        nav.push(Route::BookDetail { uuid: result.uuid });
-                    }
-                    Err(e) => {
-                        status.set(Some(format!("Upload failed: {e}")));
-                        status_is_error.set(true);
-                        busy.set(false);
-                    }
-                }
-            });
-        }
-    };
+    let on_file = make_on_file(server_url.clone(), state);
+    let on_submit = make_on_submit(server_url, state, nav);
 
     rsx! {
         section { class: "card",
@@ -134,147 +58,300 @@ pub fn AddBooksPage() -> Element {
                 "Upload an EPUB and Omnibus will file it into your library."
             }
 
-            // Type toggle — ebook active, audiobook stubbed until audio ingest lands.
-            div {
-                class: "add-books-types",
-                role: "group",
-                aria_label: "Upload type",
-                button {
-                    r#type: "button",
-                    class: "btn",
-                    aria_pressed: "true",
-                    "data-testid": "add-books-type-ebook",
-                    "Ebook"
-                }
-                button {
-                    r#type: "button",
-                    class: "btn ghost",
-                    disabled: true,
-                    aria_disabled: "true",
-                    title: "Audiobook upload is coming soon",
-                    "data-testid": "add-books-type-audiobook",
-                    "Audiobook (coming soon)"
-                }
+            UploadTypeToggle {}
+
+            FileDropZone {
+                filename: state.filename,
+                busy: state.busy,
+                on_file: EventHandler::new(on_file),
             }
 
-            div { class: "settings-field",
-                span { class: "settings-label", "EPUB file" }
-                div {
-                    class: if filename().is_empty() { "file-drop-zone" } else { "file-drop-zone has-file" },
-                    div { class: "file-drop-content",
-                        if filename().is_empty() {
-                            svg {
-                                class: "file-drop-icon",
-                                width: "28", height: "28",
-                                view_box: "0 0 24 24",
-                                fill: "none",
-                                stroke: "currentColor",
-                                stroke_width: "1.5",
-                                stroke_linecap: "round",
-                                stroke_linejoin: "round",
-                                path { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" }
-                                polyline { points: "17 8 12 3 7 8" }
-                                line { x1: "12", y1: "3", x2: "12", y2: "15" }
-                            }
-                            span { class: "file-drop-prompt",
-                                "Drop an EPUB here or "
-                                strong { "choose a file" }
-                            }
-                        } else {
-                            svg {
-                                class: "file-drop-icon file-drop-icon--ok",
-                                width: "28", height: "28",
-                                view_box: "0 0 24 24",
-                                fill: "none",
-                                stroke: "currentColor",
-                                stroke_width: "1.5",
-                                stroke_linecap: "round",
-                                stroke_linejoin: "round",
-                                polyline { points: "20 6 9 17 4 12" }
-                            }
-                            span { class: "file-drop-filename", "{filename()}" }
-                            span { class: "file-drop-change", "Click to change" }
-                        }
-                    }
-                    input {
-                        id: "add-books-file",
-                        r#type: "file",
-                        accept: ".epub,application/epub+zip",
-                        "data-testid": "add-books-file-input",
-                        aria_label: "EPUB file",
-                        class: "file-drop-input",
-                        disabled: busy(),
-                        onchange: on_file,
-                    }
-                }
+            if (state.inspected)() {
+                ConfirmForm { state, on_submit: EventHandler::new(on_submit) }
             }
 
-            if inspected() {
-                form {
-                    id: "add-books-form",
-                    class: "settings-form",
-                    onsubmit: on_submit,
-
-                    div { class: "settings-field",
-                        label { r#for: "add-books-title", "Title" }
-                        input {
-                            id: "add-books-title",
-                            r#type: "text",
-                            value: "{title}",
-                            disabled: busy(),
-                            oninput: move |e| title.set(e.value()),
-                        }
-                    }
-                    div { class: "settings-field",
-                        label { r#for: "add-books-author", "Author" }
-                        input {
-                            id: "add-books-author",
-                            r#type: "text",
-                            value: "{author}",
-                            disabled: busy(),
-                            oninput: move |e| author.set(e.value()),
-                        }
-                    }
-                    div { class: "settings-field",
-                        label { r#for: "add-books-series", "Series" }
-                        input {
-                            id: "add-books-series",
-                            r#type: "text",
-                            value: "{series}",
-                            disabled: busy(),
-                            oninput: move |e| series.set(e.value()),
-                        }
-                    }
-                    div { class: "settings-field",
-                        label { r#for: "add-books-series-index", "Series index" }
-                        input {
-                            id: "add-books-series-index",
-                            r#type: "text",
-                            value: "{series_index}",
-                            disabled: busy(),
-                            oninput: move |e| series_index.set(e.value()),
-                        }
-                    }
-
-                    div { class: "settings-actions",
-                        button {
-                            r#type: "submit",
-                            class: "btn",
-                            disabled: busy(),
-                            "data-testid": "add-books-submit",
-                            "Add to library"
-                        }
-                    }
-                }
-            }
-
-            if let Some(msg) = status() {
+            if let Some(msg) = (state.status)() {
                 p {
                     id: "add-books-status",
                     "data-testid": "add-books-status",
                     role: "status",
-                    class: if status_is_error() { "settings-status error" } else { "settings-status success" },
+                    class: if (state.status_is_error)() { "settings-status error" } else { "settings-status success" },
                     "{msg}"
+                }
+            }
+        }
+    }
+}
+
+/// Build the file-select handler: read bytes → inspect → pre-fill the fields.
+fn make_on_file(server_url: String, state: UploadState) -> impl FnMut(Event<FormData>) {
+    let mut filename = state.filename;
+    let mut file_bytes = state.file_bytes;
+    let mut title = state.title;
+    let mut author = state.author;
+    let mut series = state.series;
+    let mut series_index = state.series_index;
+    let mut inspected = state.inspected;
+    let mut busy = state.busy;
+    let mut status = state.status;
+    let mut status_is_error = state.status_is_error;
+    move |evt: Event<FormData>| {
+        let Some(file) = evt.files().into_iter().next() else {
+            return;
+        };
+        let name = file.name();
+        let server_url = server_url.clone();
+        busy.set(true);
+        status.set(Some(format!("Reading {name}\u{2026}")));
+        status_is_error.set(false);
+        spawn(async move {
+            match file.read_bytes().await {
+                Ok(bytes) => {
+                    let bytes = bytes.to_vec();
+                    match data::inspect_ebook(&server_url, name.clone(), &bytes).await {
+                        Ok(insp) => {
+                            title.set(insp.title.unwrap_or_default());
+                            author.set(insp.author.unwrap_or_default());
+                            series.set(insp.series.unwrap_or_default());
+                            series_index.set(insp.series_index.unwrap_or_default());
+                            filename.set(name);
+                            file_bytes.set(Some(bytes));
+                            inspected.set(true);
+                            status
+                                .set(Some("Review the details, then add to your library.".into()));
+                            status_is_error.set(false);
+                        }
+                        Err(e) => {
+                            // Clear any previously staged upload so stale bytes
+                            // can't be submitted after a new file fails inspect.
+                            inspected.set(false);
+                            file_bytes.set(None);
+                            filename.set(String::new());
+                            status.set(Some(format!("Could not read that EPUB: {e}")));
+                            status_is_error.set(true);
+                        }
+                    }
+                }
+                Err(e) => {
+                    inspected.set(false);
+                    file_bytes.set(None);
+                    filename.set(String::new());
+                    status.set(Some(format!("Could not read that file: {e}")));
+                    status_is_error.set(true);
+                }
+            }
+            busy.set(false);
+        });
+    }
+}
+
+/// Build the confirm handler: validate → file the book → redirect to it.
+fn make_on_submit(
+    server_url: String,
+    state: UploadState,
+    nav: dioxus_router::Navigator,
+) -> impl FnMut(FormEvent) {
+    let title = state.title;
+    let author = state.author;
+    let series = state.series;
+    let series_index = state.series_index;
+    let file_bytes = state.file_bytes;
+    let filename = state.filename;
+    let mut busy = state.busy;
+    let mut status = state.status;
+    let mut status_is_error = state.status_is_error;
+    move |evt: FormEvent| {
+        evt.prevent_default();
+        let server_url = server_url.clone();
+        let confirmed_title = title().trim().to_string();
+        let confirmed_author = author().trim().to_string();
+        if confirmed_title.is_empty() || confirmed_author.is_empty() {
+            status.set(Some("Title and author are required.".into()));
+            status_is_error.set(true);
+            return;
+        }
+        let Some(bytes) = file_bytes() else {
+            status.set(Some("Choose an EPUB file first.".into()));
+            status_is_error.set(true);
+            return;
+        };
+        let name = filename();
+        let meta = EbookUploadMeta {
+            title: confirmed_title,
+            author: confirmed_author,
+            series: series().trim().to_string(),
+            series_index: series_index().trim().to_string(),
+        };
+        busy.set(true);
+        status.set(Some("Adding to your library\u{2026}".into()));
+        status_is_error.set(false);
+        spawn(async move {
+            match data::upload_ebook(&server_url, name, bytes, meta).await {
+                Ok(result) => {
+                    nav.push(Route::BookDetail { uuid: result.uuid });
+                }
+                Err(e) => {
+                    status.set(Some(format!("Upload failed: {e}")));
+                    status_is_error.set(true);
+                    busy.set(false);
+                }
+            }
+        });
+    }
+}
+
+/// Ebook / audiobook type toggle (audiobook stubbed until audio ingest lands).
+#[component]
+fn UploadTypeToggle() -> Element {
+    rsx! {
+        div {
+            class: "add-books-types",
+            role: "group",
+            aria_label: "Upload type",
+            button {
+                r#type: "button",
+                class: "btn",
+                aria_pressed: "true",
+                "data-testid": "add-books-type-ebook",
+                "Ebook"
+            }
+            button {
+                r#type: "button",
+                class: "btn ghost",
+                disabled: true,
+                aria_disabled: "true",
+                title: "Audiobook upload is coming soon",
+                "data-testid": "add-books-type-audiobook",
+                "Audiobook (coming soon)"
+            }
+        }
+    }
+}
+
+/// File-picker drop zone: prompt icon when empty, filename + checkmark once chosen.
+#[component]
+fn FileDropZone(
+    filename: Signal<String>,
+    busy: Signal<bool>,
+    on_file: EventHandler<Event<FormData>>,
+) -> Element {
+    rsx! {
+        div { class: "settings-field",
+            span { class: "settings-label", "EPUB file" }
+            div {
+                class: if filename().is_empty() { "file-drop-zone" } else { "file-drop-zone has-file" },
+                div { class: "file-drop-content",
+                    if filename().is_empty() {
+                        svg {
+                            class: "file-drop-icon",
+                            width: "28", height: "28",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.5",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            path { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" }
+                            polyline { points: "17 8 12 3 7 8" }
+                            line { x1: "12", y1: "3", x2: "12", y2: "15" }
+                        }
+                        span { class: "file-drop-prompt",
+                            "Drop an EPUB here or "
+                            strong { "choose a file" }
+                        }
+                    } else {
+                        svg {
+                            class: "file-drop-icon file-drop-icon--ok",
+                            width: "28", height: "28",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.5",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            polyline { points: "20 6 9 17 4 12" }
+                        }
+                        span { class: "file-drop-filename", "{filename()}" }
+                        span { class: "file-drop-change", "Click to change" }
+                    }
+                }
+                input {
+                    id: "add-books-file",
+                    r#type: "file",
+                    accept: ".epub,application/epub+zip",
+                    "data-testid": "add-books-file-input",
+                    aria_label: "EPUB file",
+                    class: "file-drop-input",
+                    disabled: busy(),
+                    onchange: move |evt| on_file.call(evt),
+                }
+            }
+        }
+    }
+}
+
+/// Editable title/author/series confirm form shown after a successful inspect.
+#[component]
+fn ConfirmForm(state: UploadState, on_submit: EventHandler<FormEvent>) -> Element {
+    let mut title = state.title;
+    let mut author = state.author;
+    let mut series = state.series;
+    let mut series_index = state.series_index;
+    let busy = state.busy;
+    rsx! {
+        form {
+            id: "add-books-form",
+            class: "settings-form",
+            onsubmit: move |evt| on_submit.call(evt),
+
+            div { class: "settings-field",
+                label { r#for: "add-books-title", "Title" }
+                input {
+                    id: "add-books-title",
+                    r#type: "text",
+                    value: "{title}",
+                    disabled: busy(),
+                    oninput: move |e| title.set(e.value()),
+                }
+            }
+            div { class: "settings-field",
+                label { r#for: "add-books-author", "Author" }
+                input {
+                    id: "add-books-author",
+                    r#type: "text",
+                    value: "{author}",
+                    disabled: busy(),
+                    oninput: move |e| author.set(e.value()),
+                }
+            }
+            div { class: "settings-field",
+                label { r#for: "add-books-series", "Series" }
+                input {
+                    id: "add-books-series",
+                    r#type: "text",
+                    value: "{series}",
+                    disabled: busy(),
+                    oninput: move |e| series.set(e.value()),
+                }
+            }
+            div { class: "settings-field",
+                label { r#for: "add-books-series-index", "Series index" }
+                input {
+                    id: "add-books-series-index",
+                    r#type: "text",
+                    value: "{series_index}",
+                    disabled: busy(),
+                    oninput: move |e| series_index.set(e.value()),
+                }
+            }
+
+            div { class: "settings-actions",
+                button {
+                    r#type: "submit",
+                    class: "btn",
+                    disabled: busy(),
+                    "data-testid": "add-books-submit",
+                    "Add to library"
                 }
             }
         }

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -13,7 +13,7 @@ use super::bookmarks::use_bookmarks;
 use super::bookmarks_drawer::BookmarksDrawer;
 use super::chapters_drawer::ChaptersDrawer;
 use super::overlays::{FailedOverlay, PreparingOverlay};
-use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep_timer};
+use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep_timer, SleepChoice};
 use super::sleep_panel::SleepPanel;
 use super::speed_panel::SpeedPanel;
 use super::stage::{
@@ -161,15 +161,13 @@ pub(super) fn ReadyPlayer(
     playback_failed: Signal<bool>,
     chapters: Signal<Vec<ChapterInfo>>,
 ) -> Element {
-    let duration = signals.duration;
     let elapsed = signals.elapsed;
-    let playing = signals.playing;
     let rate = signals.rate;
     let hls_ready = signals.hls_ready;
-    let mut speed_panel_open = use_signal(|| false);
-    let mut sleep_panel_open = use_signal(|| false);
-    let mut bookmarks_open = use_signal(|| false);
-    let mut chapters_open = use_signal(|| false);
+    let speed_panel_open = use_signal(|| false);
+    let sleep_panel_open = use_signal(|| false);
+    let bookmarks_open = use_signal(|| false);
+    let chapters_open = use_signal(|| false);
 
     // Sleep timer + bookmark state. Both are custom hooks declared
     // unconditionally so SSR/WASM hook order matches (rule 07); their web
@@ -183,6 +181,135 @@ pub(super) fn ReadyPlayer(
         let elapsed_now = elapsed();
         chapter_index_for_elapsed(&chs, elapsed_now)
     });
+
+    let panes = OverlayPanes {
+        speed_panel_open,
+        sleep_panel_open,
+        bookmarks_open,
+        chapters_open,
+    };
+
+    // `seek` is shared by the stage's chapter list and the chapters/bookmarks
+    // drawers, so it's built once here and handed to both children.
+    let on_chapter_seek = move |_secs: f64| {
+        #[cfg(feature = "web")]
+        super::helpers::audio_call("seek", &_secs.to_string());
+    };
+
+    // Sleep + bookmark actions are lifted here so `PlayerOverlays` can stay a
+    // pure passthrough — `SleepController` isn't `PartialEq`, so it can't be a
+    // component prop, but these `EventHandler`s can.
+    let on_sleep_select = move |secs: i32| sleep.select_seconds(secs);
+    let on_sleep_end_of_chapter = move |_: ()| {
+        let chs_now = chapters.peek().clone();
+        let idx = current_chapter_index();
+        if let Some(secs) = end_of_chapter_seconds(&chs_now, idx, *elapsed.peek()) {
+            sleep.select_end_of_chapter(secs);
+        }
+    };
+    let on_sleep_toggle_fade = move |_: ()| sleep.toggle_fade();
+    let on_bookmark_add = move |_: ()| {
+        let chs_now = chapters.peek().clone();
+        bookmarks.create(*elapsed.peek(), &chs_now);
+    };
+
+    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    let author = book
+        .creators
+        .first()
+        .map(|c| c.name.clone())
+        .unwrap_or_else(|| "Unknown Author".to_string());
+    let ready = hls_ready();
+    let failed = playback_failed();
+
+    let accent_style = book
+        .accent
+        .as_deref()
+        .map(|a| format!("--accent: {a};"))
+        .unwrap_or_default();
+
+    let chs = chapters();
+    let ch_idx = current_chapter_index();
+
+    // Reactive sleep-timer reads — re-render the toolbar label + panel live.
+    let sleep_remaining = (sleep.remaining)();
+    let sleep_active = matches!(sleep_remaining, Some(s) if s > 0);
+    let sleep_display = SleepDisplay {
+        remaining: sleep_remaining,
+        choice: (sleep.choice)(),
+        fade: (sleep.fade)(),
+        has_chapters: !chs.is_empty(),
+    };
+    let bookmark_toast = (bookmarks.toast)();
+
+    rsx! {
+        div { class: "lp-root", style: "{accent_style}",
+            div { class: "lp-backdrop" }
+
+            Nav {}
+
+            if failed {
+                FailedOverlay {}
+            } else if !ready {
+                PreparingOverlay {}
+            }
+
+            PlayerStageBinding {
+                book: book.clone(),
+                title,
+                author,
+                signals,
+                panes,
+                chapters,
+                current_chapter_index,
+                sleep_active: sleep_active || sleep_panel_open(),
+                sleep_label: sleep_toolbar_label(sleep_remaining),
+                on_chapter_seek: EventHandler::new(on_chapter_seek),
+            }
+
+            PlayerOverlays {
+                panes,
+                uuid: uuid.clone(),
+                rate,
+                sleep_display,
+                bookmarks,
+                bookmark_toast,
+                chapters: chs.clone(),
+                current_chapter_index: ch_idx,
+                elapsed: elapsed(),
+                on_chapter_seek: EventHandler::new(on_chapter_seek),
+                on_sleep_select: EventHandler::new(on_sleep_select),
+                on_sleep_end_of_chapter: EventHandler::new(on_sleep_end_of_chapter),
+                on_sleep_toggle_fade: EventHandler::new(on_sleep_toggle_fade),
+                on_bookmark_add: EventHandler::new(on_bookmark_add),
+            }
+        }
+    }
+}
+
+/// Assemble the transport + toolbar handlers and derived display values, then
+/// render [`PlayerStage`]. Owns the play/skip/seek/rate/chapter callbacks and
+/// the mutually-exclusive toolbar toggles.
+#[component]
+pub(super) fn PlayerStageBinding(
+    book: EbookMetadata,
+    title: String,
+    author: String,
+    signals: PlaybackSignals,
+    panes: OverlayPanes,
+    chapters: Signal<Vec<ChapterInfo>>,
+    current_chapter_index: Memo<usize>,
+    sleep_active: bool,
+    sleep_label: String,
+    on_chapter_seek: EventHandler<f64>,
+) -> Element {
+    let duration = signals.duration;
+    let elapsed = signals.elapsed;
+    let playing = signals.playing;
+    let mut speed_panel_open = panes.speed_panel_open;
+    let mut sleep_panel_open = panes.sleep_panel_open;
+    let mut bookmarks_open = panes.bookmarks_open;
+    let mut chapters_open = panes.chapters_open;
 
     let on_toggle = super::helpers::on_toggle_playback();
     let on_skip_back = super::helpers::on_skip_back_30();
@@ -202,7 +329,6 @@ pub(super) fn ReadyPlayer(
             chapters_open.set(false);
         }
     };
-
     let on_chapter_prev = move |_: MouseEvent| {
         let chs = chapters();
         let idx = current_chapter_index();
@@ -211,7 +337,6 @@ pub(super) fn ReadyPlayer(
             super::helpers::audio_call("seek", &_target.to_string());
         }
     };
-
     let on_chapter_next = move |_: MouseEvent| {
         let chs = chapters();
         let idx = current_chapter_index();
@@ -221,175 +346,166 @@ pub(super) fn ReadyPlayer(
         }
     };
 
-    let on_chapter_seek = move |_secs: f64| {
-        #[cfg(feature = "web")]
-        super::helpers::audio_call("seek", &_secs.to_string());
-    };
-
-    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
-    let author = book
-        .creators
-        .first()
-        .map(|c| c.name.clone())
-        .unwrap_or_else(|| "Unknown Author".to_string());
     let dur = duration();
     let elapsed_now = elapsed();
-    let remaining = (dur - elapsed_now).max(0.0);
-    let scrub_max = scrub_max(dur);
-    let rate_label = format!("{:.2}\u{00d7}", rate());
-    let play_label = if playing() { "Pause" } else { "Play" }.to_string();
-    let ready = hls_ready();
-    let failed = playback_failed();
-
-    let accent_style = book
-        .accent
-        .as_deref()
-        .map(|a| format!("--accent: {a};"))
-        .unwrap_or_default();
-
     let chs = chapters();
-    let ch_idx = current_chapter_index();
-
-    // Reactive sleep-timer reads — re-render the toolbar label + panel live.
-    let sleep_remaining = (sleep.remaining)();
-    let sleep_choice = (sleep.choice)();
-    let sleep_fade = (sleep.fade)();
-    let sleep_active = matches!(sleep_remaining, Some(s) if s > 0);
-    let sleep_btn_label = sleep_toolbar_label(sleep_remaining);
-    let has_chapters = !chs.is_empty();
-    let bookmark_toast = (bookmarks.toast)();
 
     rsx! {
-        div { class: "lp-root", style: "{accent_style}",
-            div { class: "lp-backdrop" }
+        PlayerStage {
+            content: PlayerContent {
+                book: book.clone(),
+                title,
+                author,
+                chapters: chs.clone(),
+            },
+            position: PlaybackPosition {
+                elapsed: elapsed_now,
+                duration: dur,
+                remaining: (dur - elapsed_now).max(0.0),
+                scrub_max: scrub_max(dur),
+                current_chapter_index: current_chapter_index(),
+            },
+            transport: TransportState {
+                play_label: if playing() { "Pause" } else { "Play" }.to_string(),
+                playing: playing(),
+                rate_label: format!("{:.2}\u{00d7}", (signals.rate)()),
+                rate_active: speed_panel_open(),
+                has_chapters: !chs.is_empty(),
+            },
+            callbacks: PlayerCallbacks {
+                on_seek: EventHandler::new(on_seek),
+                on_toggle: EventHandler::new(on_toggle),
+                on_skip_back: EventHandler::new(on_skip_back),
+                on_skip_forward: EventHandler::new(on_skip_forward),
+                on_rate: EventHandler::new(on_rate),
+                on_chapter_prev: EventHandler::new(on_chapter_prev),
+                on_chapter_next: EventHandler::new(on_chapter_next),
+                on_chapter_seek,
+            },
+            toolbar: ToolbarState {
+                sleep_active,
+                sleep_label,
+                bookmarks_active: bookmarks_open(),
+                chapters_active: chapters_open(),
+                on_sleep: EventHandler::new(move |_| {
+                    let cur = *sleep_panel_open.peek();
+                    sleep_panel_open.set(!cur);
+                    if !cur {
+                        speed_panel_open.set(false);
+                        bookmarks_open.set(false);
+                        chapters_open.set(false);
+                    }
+                }),
+                on_bookmark: EventHandler::new(move |_| {
+                    let cur = *bookmarks_open.peek();
+                    bookmarks_open.set(!cur);
+                    if !cur {
+                        speed_panel_open.set(false);
+                        sleep_panel_open.set(false);
+                        chapters_open.set(false);
+                    }
+                }),
+                on_chapters: EventHandler::new(move |_| {
+                    let cur = *chapters_open.peek();
+                    chapters_open.set(!cur);
+                    if !cur {
+                        speed_panel_open.set(false);
+                        sleep_panel_open.set(false);
+                        bookmarks_open.set(false);
+                    }
+                }),
+            },
+        }
+    }
+}
 
-            Nav {}
+/// Open/closed state for the four toolbar-driven panes.
+#[derive(Copy, Clone, PartialEq)]
+pub(super) struct OverlayPanes {
+    pub speed_panel_open: Signal<bool>,
+    pub sleep_panel_open: Signal<bool>,
+    pub bookmarks_open: Signal<bool>,
+    pub chapters_open: Signal<bool>,
+}
 
-            if failed {
-                FailedOverlay {}
-            } else if !ready {
-                PreparingOverlay {}
-            }
+/// Reactive sleep-timer values rendered by the sleep panel.
+#[derive(Copy, Clone, PartialEq)]
+pub(super) struct SleepDisplay {
+    pub remaining: Option<i32>,
+    pub choice: SleepChoice,
+    pub fade: bool,
+    pub has_chapters: bool,
+}
 
-            PlayerStage {
-                content: PlayerContent {
-                    book: book.clone(),
-                    title,
-                    author,
-                    chapters: chs.clone(),
-                },
-                position: PlaybackPosition {
-                    elapsed: elapsed_now,
-                    duration: dur,
-                    remaining,
-                    scrub_max,
-                    current_chapter_index: ch_idx,
-                },
-                transport: TransportState {
-                    play_label,
-                    playing: playing(),
-                    rate_label,
-                    rate_active: speed_panel_open(),
-                    has_chapters: !chs.is_empty(),
-                },
-                callbacks: PlayerCallbacks {
-                    on_seek: EventHandler::new(on_seek),
-                    on_toggle: EventHandler::new(on_toggle),
-                    on_skip_back: EventHandler::new(on_skip_back),
-                    on_skip_forward: EventHandler::new(on_skip_forward),
-                    on_rate: EventHandler::new(on_rate),
-                    on_chapter_prev: EventHandler::new(on_chapter_prev),
-                    on_chapter_next: EventHandler::new(on_chapter_next),
-                    on_chapter_seek: EventHandler::new(on_chapter_seek),
-                },
-                toolbar: ToolbarState {
-                    sleep_active: sleep_active || sleep_panel_open(),
-                    sleep_label: sleep_btn_label,
-                    bookmarks_active: bookmarks_open(),
-                    chapters_active: chapters_open(),
-                    on_sleep: EventHandler::new(move |_| {
-                        let cur = *sleep_panel_open.peek();
-                        sleep_panel_open.set(!cur);
-                        if !cur {
-                            speed_panel_open.set(false);
-                            bookmarks_open.set(false);
-                            chapters_open.set(false);
-                        }
-                    }),
-                    on_bookmark: EventHandler::new(move |_| {
-                        let cur = *bookmarks_open.peek();
-                        bookmarks_open.set(!cur);
-                        if !cur {
-                            speed_panel_open.set(false);
-                            sleep_panel_open.set(false);
-                            chapters_open.set(false);
-                        }
-                    }),
-                    on_chapters: EventHandler::new(move |_| {
-                        let cur = *chapters_open.peek();
-                        chapters_open.set(!cur);
-                        if !cur {
-                            speed_panel_open.set(false);
-                            sleep_panel_open.set(false);
-                            bookmarks_open.set(false);
-                        }
-                    }),
-                },
+/// The four toolbar-toggled surfaces plus the bookmark-saved toast. Each
+/// renders only when its backing open-signal (or toast option) is set. Sleep
+/// mutations arrive as `EventHandler`s so the non-`PartialEq` `SleepController`
+/// stays out of props.
+#[component]
+pub(super) fn PlayerOverlays(
+    panes: OverlayPanes,
+    uuid: String,
+    rate: Signal<f64>,
+    sleep_display: SleepDisplay,
+    bookmarks: super::bookmarks::BookmarksController,
+    bookmark_toast: Option<super::bookmarks::BookmarkToast>,
+    chapters: Vec<ChapterInfo>,
+    current_chapter_index: usize,
+    elapsed: f64,
+    on_chapter_seek: EventHandler<f64>,
+    on_sleep_select: EventHandler<i32>,
+    on_sleep_end_of_chapter: EventHandler<()>,
+    on_sleep_toggle_fade: EventHandler<()>,
+    on_bookmark_add: EventHandler<()>,
+) -> Element {
+    let mut speed_panel_open = panes.speed_panel_open;
+    let mut sleep_panel_open = panes.sleep_panel_open;
+    let mut bookmarks_open = panes.bookmarks_open;
+    let mut chapters_open = panes.chapters_open;
+    rsx! {
+        if speed_panel_open() {
+            SpeedPanel {
+                rate,
+                uuid: uuid.clone(),
+                on_close: move |_| speed_panel_open.set(false),
             }
+        }
+        if sleep_panel_open() {
+            SleepPanel {
+                remaining: sleep_display.remaining,
+                choice: sleep_display.choice,
+                fade: sleep_display.fade,
+                has_chapters: sleep_display.has_chapters,
+                on_select: move |secs: i32| on_sleep_select.call(secs),
+                on_end_of_chapter: move |_| on_sleep_end_of_chapter.call(()),
+                on_toggle_fade: move |_| on_sleep_toggle_fade.call(()),
+                on_close: move |_| sleep_panel_open.set(false),
+            }
+        }
+        if bookmarks_open() {
+            BookmarksDrawer {
+                controller: bookmarks,
+                chapters: chapters.clone(),
+                on_seek: on_chapter_seek,
+                on_add: move |_| on_bookmark_add.call(()),
+                on_close: move |_| bookmarks_open.set(false),
+            }
+        }
 
-            if speed_panel_open() {
-                SpeedPanel {
-                    rate,
-                    uuid: uuid.clone(),
-                    on_close: move |_| speed_panel_open.set(false),
-                }
+        if let Some(toast) = bookmark_toast {
+            div { class: "lp-toast", "data-testid": "bookmark-toast",
+                span { class: "lp-toast-icon", "\u{2691}" }
+                span { class: "lp-toast-text", "Bookmark saved" }
+                span { class: "lp-toast-meta", "{toast.time_label} \u{00b7} {toast.chapter_label}" }
             }
-            if sleep_panel_open() {
-                SleepPanel {
-                    remaining: sleep_remaining,
-                    choice: sleep_choice,
-                    fade: sleep_fade,
-                    has_chapters,
-                    on_select: move |secs: i32| sleep.select_seconds(secs),
-                    on_end_of_chapter: move |_| {
-                        let chs_now = chapters.peek().clone();
-                        let idx = current_chapter_index();
-                        if let Some(secs) = end_of_chapter_seconds(&chs_now, idx, *elapsed.peek()) {
-                            sleep.select_end_of_chapter(secs);
-                        }
-                    },
-                    on_toggle_fade: move |_| sleep.toggle_fade(),
-                    on_close: move |_| sleep_panel_open.set(false),
-                }
-            }
-            if bookmarks_open() {
-                BookmarksDrawer {
-                    controller: bookmarks,
-                    chapters: chs.clone(),
-                    on_seek: EventHandler::new(on_chapter_seek),
-                    on_add: EventHandler::new(move |_| {
-                        let chs_now = chapters.peek().clone();
-                        bookmarks.create(*elapsed.peek(), &chs_now);
-                    }),
-                    on_close: move |_| bookmarks_open.set(false),
-                }
-            }
-
-            if let Some(toast) = bookmark_toast {
-                div { class: "lp-toast", "data-testid": "bookmark-toast",
-                    span { class: "lp-toast-icon", "\u{2691}" }
-                    span { class: "lp-toast-text", "Bookmark saved" }
-                    span { class: "lp-toast-meta", "{toast.time_label} \u{00b7} {toast.chapter_label}" }
-                }
-            }
-            if chapters_open() {
-                ChaptersDrawer {
-                    chapters: chs.clone(),
-                    current_chapter_index: ch_idx,
-                    elapsed: elapsed_now,
-                    on_seek: EventHandler::new(on_chapter_seek),
-                    on_close: move |_| chapters_open.set(false),
-                }
+        }
+        if chapters_open() {
+            ChaptersDrawer {
+                chapters: chapters.clone(),
+                current_chapter_index,
+                elapsed,
+                on_seek: on_chapter_seek,
+                on_close: move |_| chapters_open.set(false),
             }
         }
     }

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -39,151 +39,178 @@ pub(super) fn FormGrid(
     fields: FormFields,
     suggestions: FormSuggestions,
 ) -> Element {
+    rsx! {
+        div { class: "me-form",
+            FieldGrid { orig, fields, suggestions }
+            TagsSection { tags: fields.tags, tag_suggestions: suggestions.tags }
+            SeriesSection { orig, series: fields.series, series_index: fields.series_index }
+        }
+    }
+}
+
+/// Main field grid: title, sort/filename, publisher, published, language,
+/// the author chip row, and the description textarea.
+#[component]
+fn FieldGrid(
+    orig: Signal<EbookMetadata>,
+    fields: FormFields,
+    suggestions: FormSuggestions,
+) -> Element {
     let mut title = fields.title;
     let mut description = fields.description;
     let mut publisher = fields.publisher;
     let mut published = fields.published;
     let mut language = fields.language;
-    let mut series = fields.series;
-    let mut series_index = fields.series_index;
     let authors = fields.authors;
-    let tags = fields.tags;
     let sort_by = fields.sort_by;
     let filename = fields.filename;
     let author_suggestions = suggestions.authors;
-    let tag_suggestions = suggestions.tags;
 
     rsx! {
-        div { class: "me-form",
-            div { class: "me-field-grid",
+        div { class: "me-field-grid",
 
-                // Title — spans 2 cols, big serif
-                MeField {
-                    label: "Title",
-                    value: title,
-                    on_change: move |v: String| title.set(v),
-                    w: 2,
-                    big: true,
-                    serif: true,
-                    edited: title() != orig().title.clone().unwrap_or_default(),
+            // Title — spans 2 cols, big serif
+            MeField {
+                label: "Title",
+                value: title,
+                on_change: move |v: String| title.set(v),
+                w: 2,
+                big: true,
+                serif: true,
+                edited: title() != orig().title.clone().unwrap_or_default(),
+            }
+
+            // File-as / sort name (mono, read-only for now)
+            MeField {
+                label: "Sort by",
+                value: sort_by,
+                on_change: move |_: String| {},
+                mono: true,
+                locked: true,
+                hint: "from file-as",
+            }
+
+            // Filename (mono, read-only)
+            MeField {
+                label: "Filename",
+                value: filename,
+                on_change: move |_: String| {},
+                mono: true,
+                locked: true,
+            }
+
+            // Publisher
+            MeField {
+                label: "Publisher",
+                value: publisher,
+                on_change: move |v: String| publisher.set(v),
+                w: 2,
+                edited: publisher() != orig().publisher.clone().unwrap_or_default(),
+            }
+
+            // Published date
+            MeField {
+                label: "Published",
+                value: published,
+                on_change: move |v: String| published.set(v),
+                mono: true,
+                edited: published() != orig().published.clone().unwrap_or_default(),
+            }
+
+            // Language
+            MeField {
+                label: "Language",
+                value: language,
+                on_change: move |v: String| language.set(v),
+                edited: language() != orig().language.clone().unwrap_or_default(),
+            }
+
+            // Authors — chip row spanning 4 cols
+            div { class: "me-field-full",
+                MeLabel {
+                    text: "Author(s)",
+                    edited: {
+                        let orig_authors: Vec<String> = orig().creators.iter().map(|c| c.name.clone()).collect();
+                        authors() != orig_authors
+                    },
+                    hint: "primary author first",
                 }
-
-                // File-as / sort name (mono, read-only for now)
-                MeField {
-                    label: "Sort by",
-                    value: sort_by,
-                    on_change: move |_: String| {},
-                    mono: true,
-                    locked: true,
-                    hint: "from file-as",
-                }
-
-                // Filename (mono, read-only)
-                MeField {
-                    label: "Filename",
-                    value: filename,
-                    on_change: move |_: String| {},
-                    mono: true,
-                    locked: true,
-                }
-
-                // Publisher
-                MeField {
-                    label: "Publisher",
-                    value: publisher,
-                    on_change: move |v: String| publisher.set(v),
-                    w: 2,
-                    edited: publisher() != orig().publisher.clone().unwrap_or_default(),
-                }
-
-                // Published date
-                MeField {
-                    label: "Published",
-                    value: published,
-                    on_change: move |v: String| published.set(v),
-                    mono: true,
-                    edited: published() != orig().published.clone().unwrap_or_default(),
-                }
-
-                // Language
-                MeField {
-                    label: "Language",
-                    value: language,
-                    on_change: move |v: String| language.set(v),
-                    edited: language() != orig().language.clone().unwrap_or_default(),
-                }
-
-                // Authors — chip row spanning 4 cols
-                div { class: "me-field-full",
-                    MeLabel {
-                        text: "Author(s)",
-                        edited: {
-                            let orig_authors: Vec<String> = orig().creators.iter().map(|c| c.name.clone()).collect();
-                            authors() != orig_authors
-                        },
-                        hint: "primary author first",
-                    }
-                    div { class: "me-chip-row",
-                        ChipEditor {
-                            values: authors,
-                            placeholder: "+ add author\u{2026}".to_string(),
-                            on_change: move |_| {},
-                            suggestions: author_suggestions,
-                            show_avatar: true,
-                            aria_remove_prefix: "Remove".to_string(),
-                            testid_prefix: "me-authors".to_string(),
-                        }
+                div { class: "me-chip-row",
+                    ChipEditor {
+                        values: authors,
+                        placeholder: "+ add author\u{2026}".to_string(),
+                        on_change: move |_| {},
+                        suggestions: author_suggestions,
+                        show_avatar: true,
+                        aria_remove_prefix: "Remove".to_string(),
+                        testid_prefix: "me-authors".to_string(),
                     }
                 }
-
-                // Description — textarea spanning 2 cols
-                MeArea {
-                    label: "Description",
-                    value: description,
-                    on_change: move |v: String| description.set(v),
-                    rows: 5,
-                    edited: description() != orig().description.clone().unwrap_or_default(),
-                    hint: "plain text or HTML",
-                }
             }
 
-            // ── Tags section ───────────────────────────────
-            div { class: "divider" }
-            div { class: "me-tags-header",
-                div { class: "label", "Tags" }
+            // Description — textarea spanning 2 cols
+            MeArea {
+                label: "Description",
+                value: description,
+                on_change: move |v: String| description.set(v),
+                rows: 5,
+                edited: description() != orig().description.clone().unwrap_or_default(),
+                hint: "plain text or HTML",
             }
-            div { class: "me-tag-chips",
-                ChipEditor {
-                    values: tags,
-                    placeholder: "+ add tag\u{2026}".to_string(),
-                    on_change: move |_| {},
-                    suggestions: tag_suggestions,
-                    show_avatar: false,
-                    input_class: "me-tag-input".to_string(),
-                    aria_remove_prefix: "Remove tag".to_string(),
-                    testid_prefix: "me-tags".to_string(),
-                }
-            }
+        }
+    }
+}
 
-            // ── Series section ─────────────────────────────
-            div { class: "divider" }
-            div { class: "label", "Series & position" }
-            div { class: "me-series-grid",
-                MeField {
-                    label: "Series",
-                    value: series,
-                    on_change: move |v: String| series.set(v),
-                    placeholder: "not part of a series",
-                    edited: series() != orig().series.clone().unwrap_or_default(),
-                }
-                MeField {
-                    label: "Book #",
-                    value: series_index,
-                    on_change: move |v: String| series_index.set(v),
-                    mono: true,
-                    placeholder: "\u{2014}",
-                    edited: series_index() != orig().series_index.clone().unwrap_or_default(),
-                }
+/// Divider + tag chip editor for the metadata form's tags section.
+#[component]
+fn TagsSection(tags: Signal<Vec<String>>, tag_suggestions: Signal<Vec<SuggestionItem>>) -> Element {
+    rsx! {
+        div { class: "divider" }
+        div { class: "me-tags-header",
+            div { class: "label", "Tags" }
+        }
+        div { class: "me-tag-chips",
+            ChipEditor {
+                values: tags,
+                placeholder: "+ add tag\u{2026}".to_string(),
+                on_change: move |_| {},
+                suggestions: tag_suggestions,
+                show_avatar: false,
+                input_class: "me-tag-input".to_string(),
+                aria_remove_prefix: "Remove tag".to_string(),
+                testid_prefix: "me-tags".to_string(),
+            }
+        }
+    }
+}
+
+/// Divider + series name and book-number fields for the metadata form.
+#[component]
+fn SeriesSection(
+    orig: Signal<EbookMetadata>,
+    series: Signal<String>,
+    series_index: Signal<String>,
+) -> Element {
+    let mut series = series;
+    let mut series_index = series_index;
+    rsx! {
+        div { class: "divider" }
+        div { class: "label", "Series & position" }
+        div { class: "me-series-grid",
+            MeField {
+                label: "Series",
+                value: series,
+                on_change: move |v: String| series.set(v),
+                placeholder: "not part of a series",
+                edited: series() != orig().series.clone().unwrap_or_default(),
+            }
+            MeField {
+                label: "Book #",
+                value: series_index,
+                on_change: move |v: String| series_index.set(v),
+                mono: true,
+                placeholder: "\u{2014}",
+                edited: series_index() != orig().series_index.clone().unwrap_or_default(),
             }
         }
     }

--- a/frontend/src/pages/reader/aa_panel.rs
+++ b/frontend/src/pages/reader/aa_panel.rs
@@ -14,182 +14,238 @@ use super::typography::{LineSpacing, Margins, Spread, Typeface};
 /// text size, line spacing, margins, and justify toggle.
 #[component]
 pub(crate) fn ReaderAaPanel(on_close: EventHandler<MouseEvent>) -> Element {
-    let prefs = use_context::<ReaderPrefs>();
-    let theme = *prefs.theme.read();
-    let typeface = *prefs.typeface.read();
-    let line_spacing = *prefs.line_spacing.read();
-    let margins = *prefs.margins.read();
-    let justify = *prefs.justify.read();
-    let spread = *prefs.spread.read();
-    let font_pct = prefs.font_pct();
     rsx! {
         div { class: "rd-scrim", onclick: on_close }
         div {
             class: "rd-aa-panel",
             onclick: move |evt: MouseEvent| evt.stop_propagation(),
 
-            div { class: "rd-aa-row",
-                div { class: "rd-aa-label", "Theme" }
-                div {
-                    class: "rd-seg",
-                    button {
-                        class: if theme == Theme::Dark { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_theme(Theme::Dark),
-                        "Dark"
-                    }
-                    button {
-                        class: if theme == Theme::Light { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_theme(Theme::Light),
-                        "Light"
-                    }
-                    button {
-                        class: if theme == Theme::Sepia { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_theme(Theme::Sepia),
-                        "Sepia"
-                    }
-                }
-            }
+            ThemeRow {}
+            TypefaceRow {}
+            TextSizeRow {}
+            LineSpacingRow {}
+            MarginsRow {}
+            PageViewRow {}
+            JustifyRow {}
+        }
+    }
+}
 
-            div { class: "rd-aa-row",
-                div { class: "rd-aa-label", "Typeface" }
-                div {
-                    style: "display:flex; gap:6px;",
-                    button {
-                        class: if typeface == Typeface::Editorial { "rd-typeface-chip on" } else { "rd-typeface-chip" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_typeface(Typeface::Editorial),
-                        span { class: "preview", style: "font-family:'Instrument Serif',serif;", "Aa" }
-                        span { class: "name", "Editorial" }
-                    }
-                    button {
-                        class: if typeface == Typeface::Classic { "rd-typeface-chip on" } else { "rd-typeface-chip" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_typeface(Typeface::Classic),
-                        span { class: "preview", style: "font-family:'EB Garamond',serif;", "Aa" }
-                        span { class: "name", "Classic" }
-                    }
-                    button {
-                        class: if typeface == Typeface::Modern { "rd-typeface-chip on" } else { "rd-typeface-chip" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_typeface(Typeface::Modern),
-                        span { class: "preview", style: "font-family:Georgia,serif;", "Aa" }
-                        span { class: "name", "Modern" }
-                    }
-                }
-            }
-
-            div { class: "rd-aa-row",
-                div { class: "rd-aa-label", "Text size" }
-                div {
-                    style: "display:flex; align-items:center; gap:12px;",
-                    button {
-                        class: "rd-tool",
-                        r#type: "button",
-                        "aria-label": "Decrease font size",
-                        "data-testid": "reader-font-decrease",
-                        onclick: move |_| prefs.decrease_font(),
-                        style: "font-family:var(--serif); font-size:13px; color:var(--ink-2); min-width:24px; height:24px; padding:0;",
-                        "A"
-                    }
-                    div {
-                        class: "rd-size-track",
-                        div { class: "rd-size-fill", style: "width:{font_pct}%;" }
-                        div { class: "rd-size-thumb", style: "left:{font_pct}%;" }
-                    }
-                    button {
-                        class: "rd-tool",
-                        r#type: "button",
-                        "aria-label": "Increase font size",
-                        "data-testid": "reader-font-increase",
-                        onclick: move |_| prefs.increase_font(),
-                        style: "font-family:var(--serif); font-size:24px; color:var(--ink-1); min-width:24px; height:24px; padding:0;",
-                        "A"
-                    }
-                }
-            }
-
-            div { class: "rd-aa-row",
-                div { class: "rd-aa-label", "Line spacing" }
-                div {
-                    class: "rd-seg",
-                    button {
-                        class: if line_spacing == LineSpacing::Tight { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_line_spacing(LineSpacing::Tight),
-                        "Tight"
-                    }
-                    button {
-                        class: if line_spacing == LineSpacing::Cozy { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_line_spacing(LineSpacing::Cozy),
-                        "Cozy"
-                    }
-                    button {
-                        class: if line_spacing == LineSpacing::Airy { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_line_spacing(LineSpacing::Airy),
-                        "Airy"
-                    }
-                }
-            }
-
-            div { class: "rd-aa-row",
-                div { class: "rd-aa-label", "Margins" }
-                div {
-                    class: "rd-seg",
-                    button {
-                        class: if margins == Margins::Narrow { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_margins(Margins::Narrow),
-                        "Narrow"
-                    }
-                    button {
-                        class: if margins == Margins::Normal { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_margins(Margins::Normal),
-                        "Normal"
-                    }
-                    button {
-                        class: if margins == Margins::Wide { "on" } else { "" },
-                        r#type: "button",
-                        onclick: move |_| prefs.set_margins(Margins::Wide),
-                        "Wide"
-                    }
-                }
-            }
-
-            div { class: "rd-aa-row",
-                div { class: "rd-aa-label", "Page view" }
-                div {
-                    class: "rd-seg",
-                    button {
-                        class: if spread == Spread::Single { "on" } else { "" },
-                        r#type: "button",
-                        "data-testid": "reader-spread-single",
-                        onclick: move |_| prefs.set_spread(Spread::Single),
-                        "Single"
-                    }
-                    button {
-                        class: if spread == Spread::Double { "on" } else { "" },
-                        r#type: "button",
-                        "data-testid": "reader-spread-double",
-                        onclick: move |_| prefs.set_spread(Spread::Double),
-                        "Two-page"
-                    }
-                }
-            }
-
+/// Theme segmented control (Dark / Light / Sepia).
+#[component]
+fn ThemeRow() -> Element {
+    let prefs = use_context::<ReaderPrefs>();
+    let theme = *prefs.theme.read();
+    rsx! {
+        div { class: "rd-aa-row",
+            div { class: "rd-aa-label", "Theme" }
             div {
-                class: "rd-toggle-row",
-                span { style: "font-size:13px; color:var(--ink-1);", "Justify text" }
-                div {
-                    class: if justify { "rd-toggle-track on" } else { "rd-toggle-track" },
-                    onclick: move |_| prefs.toggle_justify(),
-                    div { class: "rd-toggle-knob" }
+                class: "rd-seg",
+                button {
+                    class: if theme == Theme::Dark { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_theme(Theme::Dark),
+                    "Dark"
                 }
+                button {
+                    class: if theme == Theme::Light { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_theme(Theme::Light),
+                    "Light"
+                }
+                button {
+                    class: if theme == Theme::Sepia { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_theme(Theme::Sepia),
+                    "Sepia"
+                }
+            }
+        }
+    }
+}
+
+/// Typeface chip row (Editorial / Classic / Modern).
+#[component]
+fn TypefaceRow() -> Element {
+    let prefs = use_context::<ReaderPrefs>();
+    let typeface = *prefs.typeface.read();
+    rsx! {
+        div { class: "rd-aa-row",
+            div { class: "rd-aa-label", "Typeface" }
+            div {
+                style: "display:flex; gap:6px;",
+                button {
+                    class: if typeface == Typeface::Editorial { "rd-typeface-chip on" } else { "rd-typeface-chip" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_typeface(Typeface::Editorial),
+                    span { class: "preview", style: "font-family:'Instrument Serif',serif;", "Aa" }
+                    span { class: "name", "Editorial" }
+                }
+                button {
+                    class: if typeface == Typeface::Classic { "rd-typeface-chip on" } else { "rd-typeface-chip" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_typeface(Typeface::Classic),
+                    span { class: "preview", style: "font-family:'EB Garamond',serif;", "Aa" }
+                    span { class: "name", "Classic" }
+                }
+                button {
+                    class: if typeface == Typeface::Modern { "rd-typeface-chip on" } else { "rd-typeface-chip" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_typeface(Typeface::Modern),
+                    span { class: "preview", style: "font-family:Georgia,serif;", "Aa" }
+                    span { class: "name", "Modern" }
+                }
+            }
+        }
+    }
+}
+
+/// Text-size stepper with a fill track showing the current font percentage.
+#[component]
+fn TextSizeRow() -> Element {
+    let prefs = use_context::<ReaderPrefs>();
+    let font_pct = prefs.font_pct();
+    rsx! {
+        div { class: "rd-aa-row",
+            div { class: "rd-aa-label", "Text size" }
+            div {
+                style: "display:flex; align-items:center; gap:12px;",
+                button {
+                    class: "rd-tool",
+                    r#type: "button",
+                    "aria-label": "Decrease font size",
+                    "data-testid": "reader-font-decrease",
+                    onclick: move |_| prefs.decrease_font(),
+                    style: "font-family:var(--serif); font-size:13px; color:var(--ink-2); min-width:24px; height:24px; padding:0;",
+                    "A"
+                }
+                div {
+                    class: "rd-size-track",
+                    div { class: "rd-size-fill", style: "width:{font_pct}%;" }
+                    div { class: "rd-size-thumb", style: "left:{font_pct}%;" }
+                }
+                button {
+                    class: "rd-tool",
+                    r#type: "button",
+                    "aria-label": "Increase font size",
+                    "data-testid": "reader-font-increase",
+                    onclick: move |_| prefs.increase_font(),
+                    style: "font-family:var(--serif); font-size:24px; color:var(--ink-1); min-width:24px; height:24px; padding:0;",
+                    "A"
+                }
+            }
+        }
+    }
+}
+
+/// Line-spacing segmented control (Tight / Cozy / Airy).
+#[component]
+fn LineSpacingRow() -> Element {
+    let prefs = use_context::<ReaderPrefs>();
+    let line_spacing = *prefs.line_spacing.read();
+    rsx! {
+        div { class: "rd-aa-row",
+            div { class: "rd-aa-label", "Line spacing" }
+            div {
+                class: "rd-seg",
+                button {
+                    class: if line_spacing == LineSpacing::Tight { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_line_spacing(LineSpacing::Tight),
+                    "Tight"
+                }
+                button {
+                    class: if line_spacing == LineSpacing::Cozy { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_line_spacing(LineSpacing::Cozy),
+                    "Cozy"
+                }
+                button {
+                    class: if line_spacing == LineSpacing::Airy { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_line_spacing(LineSpacing::Airy),
+                    "Airy"
+                }
+            }
+        }
+    }
+}
+
+/// Margins segmented control (Narrow / Normal / Wide).
+#[component]
+fn MarginsRow() -> Element {
+    let prefs = use_context::<ReaderPrefs>();
+    let margins = *prefs.margins.read();
+    rsx! {
+        div { class: "rd-aa-row",
+            div { class: "rd-aa-label", "Margins" }
+            div {
+                class: "rd-seg",
+                button {
+                    class: if margins == Margins::Narrow { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_margins(Margins::Narrow),
+                    "Narrow"
+                }
+                button {
+                    class: if margins == Margins::Normal { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_margins(Margins::Normal),
+                    "Normal"
+                }
+                button {
+                    class: if margins == Margins::Wide { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_margins(Margins::Wide),
+                    "Wide"
+                }
+            }
+        }
+    }
+}
+
+/// Page-view segmented control (Single / Two-page spread).
+#[component]
+fn PageViewRow() -> Element {
+    let prefs = use_context::<ReaderPrefs>();
+    let spread = *prefs.spread.read();
+    rsx! {
+        div { class: "rd-aa-row",
+            div { class: "rd-aa-label", "Page view" }
+            div {
+                class: "rd-seg",
+                button {
+                    class: if spread == Spread::Single { "on" } else { "" },
+                    r#type: "button",
+                    "data-testid": "reader-spread-single",
+                    onclick: move |_| prefs.set_spread(Spread::Single),
+                    "Single"
+                }
+                button {
+                    class: if spread == Spread::Double { "on" } else { "" },
+                    r#type: "button",
+                    "data-testid": "reader-spread-double",
+                    onclick: move |_| prefs.set_spread(Spread::Double),
+                    "Two-page"
+                }
+            }
+        }
+    }
+}
+
+/// Justify-text toggle switch.
+#[component]
+fn JustifyRow() -> Element {
+    let prefs = use_context::<ReaderPrefs>();
+    let justify = *prefs.justify.read();
+    rsx! {
+        div {
+            class: "rd-toggle-row",
+            span { style: "font-size:13px; color:var(--ink-1);", "Justify text" }
+            div {
+                class: if justify { "rd-toggle-track on" } else { "rd-toggle-track" },
+                onclick: move |_| prefs.toggle_justify(),
+                div { class: "rd-toggle-knob" }
             }
         }
     }

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -240,19 +240,6 @@ fn ReaderLayout(
         pct,
         status,
     } = progress;
-    let ReaderPanelSignals {
-        show_aa,
-        selection,
-        highlights,
-        toc,
-        show_toc,
-        show_highlights,
-        note_target,
-        quote_target,
-        show_search,
-        search_results,
-        show_bookmarks,
-    } = panels;
     let ReaderNavHandlers {
         on_keydown,
         on_back,
@@ -260,27 +247,11 @@ fn ReaderLayout(
         on_next,
     } = nav;
 
-    let highlight_count = highlights.read().len();
-
-    // Close every overlay (panel, drawer, composer) — `Fn` + `Copy` so each
-    // toggle handler can call it before opening its own surface, keeping the
-    // chrome mutually exclusive.
-    let close_overlays = move || {
-        let mut a = show_aa;
-        a.set(false);
-        let mut b = show_toc;
-        b.set(false);
-        let mut c = show_search;
-        c.set(false);
-        let mut d = show_highlights;
-        d.set(false);
-        let mut e = show_bookmarks;
-        e.set(false);
-        let mut f = note_target;
-        f.set(None);
-        let mut g = quote_target;
-        g.set(None);
-    };
+    let show_aa = panels.show_aa;
+    let selection = panels.selection;
+    let highlights = panels.highlights;
+    let note_target = panels.note_target;
+    let quote_target = panels.quote_target;
 
     rsx! {
         document::Script { src: JSZIP_JS }
@@ -295,46 +266,11 @@ fn ReaderLayout(
 
             div { class: "rd-wash" }
 
-            ReaderTopChrome {
+            ReaderTopBar {
                 book_title: book_title.clone(),
                 chapter_title: chapter_title.clone(),
-                show_aa: show_aa(),
-                toc_active: show_toc(),
-                search_active: show_search(),
-                highlights_active: show_highlights(),
-                bookmarks_active: show_bookmarks(),
-                highlight_count,
+                panels,
                 on_back,
-                on_toggle_aa: move |_| {
-                    let cur = show_aa();
-                    close_overlays();
-                    let mut s = show_aa;
-                    s.set(!cur);
-                },
-                on_toggle_toc: move |_| {
-                    let cur = show_toc();
-                    close_overlays();
-                    let mut s = show_toc;
-                    s.set(!cur);
-                },
-                on_toggle_search: move |_| {
-                    let cur = show_search();
-                    close_overlays();
-                    let mut s = show_search;
-                    s.set(!cur);
-                },
-                on_toggle_highlights: move |_| {
-                    let cur = show_highlights();
-                    close_overlays();
-                    let mut s = show_highlights;
-                    s.set(!cur);
-                },
-                on_toggle_bookmarks: move |_| {
-                    let cur = show_bookmarks();
-                    close_overlays();
-                    let mut s = show_bookmarks;
-                    s.set(!cur);
-                },
             }
 
             ReaderViewerStage { status }
@@ -358,202 +294,354 @@ fn ReaderLayout(
                 }
             }
 
-            if let Some(sel) = selection.read().as_ref() {
-                {
-                    let uuid_pop = uuid.clone();
-                    rsx! {
-                        SelectionPopover {
-                            sel_rect_x: sel.rect.x,
-                            sel_rect_y: sel.rect.y,
-                            sel_rect_width: sel.rect.width,
-                            sel_cfi: sel.cfi_range.clone(),
-                            sel_text: sel.text.clone(),
-                            on_dismiss: move |_| {
-                                let mut selection = selection;
-                                selection.set(None);
-                            },
-                            on_highlight: {
-                                let uuid_pop = uuid_pop.clone();
-                                move |(cfi, color, text): (String, HighlightColor, String)| {
-                                    let mut selection = selection;
-                                    selection.set(None);
-                                    spawn_create_highlight(
-                                        uuid_pop.clone(), cfi, color, text,
-                                        highlights, note_target, quote_target, PostCreate::None,
-                                    );
-                                }
-                            },
-                            on_note: {
-                                let uuid_pop = uuid_pop.clone();
-                                move |(cfi, text): (String, String)| {
-                                    let mut selection = selection;
-                                    selection.set(None);
-                                    spawn_create_highlight(
-                                        uuid_pop.clone(), cfi, HighlightColor::Amber, text,
-                                        highlights, note_target, quote_target, PostCreate::Note,
-                                    );
-                                }
-                            },
-                            on_quote: {
-                                let uuid_pop = uuid_pop.clone();
-                                move |(cfi, text): (String, String)| {
-                                    let mut selection = selection;
-                                    selection.set(None);
-                                    spawn_create_highlight(
-                                        uuid_pop.clone(), cfi, HighlightColor::Amber, text,
-                                        highlights, note_target, quote_target, PostCreate::Quote,
-                                    );
-                                }
-                            },
-                            on_copy: move |text: String| {
-                                #[cfg(feature = "web")]
-                                {
-                                    let lit = serde_json::to_string(&text)
-                                        .unwrap_or_else(|_| "\"\"".into());
-                                    reader_call("copyText", &lit);
-                                }
-                                let _ = &text;
-                                let mut selection = selection;
-                                selection.set(None);
-                            },
-                            on_share: move |text: String| {
-                                #[cfg(feature = "web")]
-                                {
-                                    let lit = serde_json::to_string(&text)
-                                        .unwrap_or_else(|_| "\"\"".into());
-                                    reader_call("shareText", &lit);
-                                }
-                                let _ = &text;
-                                let mut selection = selection;
-                                selection.set(None);
-                            },
-                        }
-                    }
-                }
+            ReaderSelectionPopover {
+                uuid: uuid.clone(),
+                selection,
+                highlights,
+                note_target,
+                quote_target,
             }
 
-            if show_toc() {
-                TocDrawer {
-                    entries: toc.read().clone(),
-                    current_title: chapter_title.clone(),
-                    on_navigate: move |href: String| {
-                        #[cfg(feature = "web")]
-                        {
-                            let lit = serde_json::to_string(&href).unwrap_or_else(|_| "\"\"".into());
-                            reader_call("display", &lit);
-                        }
-                        let _ = &href;
-                        let mut show_toc = show_toc;
-                        show_toc.set(false);
-                    },
-                    on_close: move |_| {
-                        let mut show_toc = show_toc;
-                        show_toc.set(false);
-                    },
-                }
-            }
-
-            if show_highlights() {
-                HighlightsDrawer {
-                    highlights,
-                    on_quote: move |h: Highlight| {
-                        let mut quote_target = quote_target;
-                        let mut show_highlights = show_highlights;
-                        quote_target.set(Some(h));
-                        show_highlights.set(false);
-                    },
-                    on_edit_note: move |h: Highlight| {
-                        let mut note_target = note_target;
-                        let mut show_highlights = show_highlights;
-                        note_target.set(Some(h));
-                        show_highlights.set(false);
-                    },
-                    on_close: move |_| {
-                        let mut show_highlights = show_highlights;
-                        show_highlights.set(false);
-                    },
-                }
-            }
-
-            if show_search() {
-                SearchPanel {
-                    results: search_results,
-                    on_query: move |q: String| {
-                        #[cfg(feature = "web")]
-                        {
-                            let lit = serde_json::to_string(&q).unwrap_or_else(|_| "\"\"".into());
-                            reader_call("search", &lit);
-                        }
-                        let _ = &q;
-                    },
-                    on_navigate: move |cfi: String| {
-                        #[cfg(feature = "web")]
-                        {
-                            let lit = serde_json::to_string(&cfi).unwrap_or_else(|_| "\"\"".into());
-                            reader_call("display", &lit);
-                        }
-                        let _ = &cfi;
-                        let mut show_search = show_search;
-                        show_search.set(false);
-                    },
-                    on_close: move |_| {
-                        let mut show_search = show_search;
-                        show_search.set(false);
-                    },
-                }
-            }
-
-            if show_bookmarks() {
-                ReaderBookmarksDrawer {
+            ReaderOverlays {
+                meta: OverlayMeta {
                     uuid: uuid.clone(),
+                    book_title: book_title.clone(),
+                    book_author: book_author.clone(),
+                    book_accent: book_accent.clone(),
+                    chapter_title: chapter_title.clone(),
                     current_cfi: current_cfi.clone(),
-                    current_label: chapter_title.clone(),
-                    on_navigate: move |cfi: String| {
-                        #[cfg(feature = "web")]
-                        {
-                            let lit = serde_json::to_string(&cfi).unwrap_or_else(|_| "\"\"".into());
-                            reader_call("display", &lit);
-                        }
-                        let _ = &cfi;
-                        let mut show_bookmarks = show_bookmarks;
-                        show_bookmarks.set(false);
-                    },
-                    on_close: move |_| {
-                        let mut show_bookmarks = show_bookmarks;
-                        show_bookmarks.set(false);
-                    },
-                }
+                },
+                panels,
             }
+        }
+    }
+}
 
-            if let Some(h) = quote_target.read().clone() {
-                QuotePanel {
-                    quote_text: h.text.clone().unwrap_or_default(),
-                    author: book_author.clone(),
-                    subtitle: book_title.clone(),
-                    accent: book_accent.clone(),
-                    on_close: move |_| {
-                        let mut quote_target = quote_target;
-                        quote_target.set(None);
-                    },
+/// Selection popover: highlight / note / quote / copy / share actions for the
+/// current text selection. Renders nothing when there is no selection.
+#[component]
+fn ReaderSelectionPopover(
+    uuid: String,
+    selection: Signal<Option<SelectionData>>,
+    highlights: Signal<Vec<Highlight>>,
+    note_target: Signal<Option<Highlight>>,
+    quote_target: Signal<Option<Highlight>>,
+) -> Element {
+    let Some(sel) = selection.read().as_ref().cloned() else {
+        return rsx! {};
+    };
+    rsx! {
+        SelectionPopover {
+            sel_rect_x: sel.rect.x,
+            sel_rect_y: sel.rect.y,
+            sel_rect_width: sel.rect.width,
+            sel_cfi: sel.cfi_range.clone(),
+            sel_text: sel.text.clone(),
+            on_dismiss: move |_| {
+                let mut selection = selection;
+                selection.set(None);
+            },
+            on_highlight: {
+                let uuid = uuid.clone();
+                move |(cfi, color, text): (String, HighlightColor, String)| {
+                    let mut selection = selection;
+                    selection.set(None);
+                    spawn_create_highlight(
+                        uuid.clone(), cfi, color, text,
+                        highlights, note_target, quote_target, PostCreate::None,
+                    );
                 }
-            }
+            },
+            on_note: {
+                let uuid = uuid.clone();
+                move |(cfi, text): (String, String)| {
+                    let mut selection = selection;
+                    selection.set(None);
+                    spawn_create_highlight(
+                        uuid.clone(), cfi, HighlightColor::Amber, text,
+                        highlights, note_target, quote_target, PostCreate::Note,
+                    );
+                }
+            },
+            on_quote: {
+                let uuid = uuid.clone();
+                move |(cfi, text): (String, String)| {
+                    let mut selection = selection;
+                    selection.set(None);
+                    spawn_create_highlight(
+                        uuid.clone(), cfi, HighlightColor::Amber, text,
+                        highlights, note_target, quote_target, PostCreate::Quote,
+                    );
+                }
+            },
+            on_copy: move |text: String| {
+                #[cfg(feature = "web")]
+                {
+                    let lit = serde_json::to_string(&text)
+                        .unwrap_or_else(|_| "\"\"".into());
+                    reader_call("copyText", &lit);
+                }
+                let _ = &text;
+                let mut selection = selection;
+                selection.set(None);
+            },
+            on_share: move |text: String| {
+                #[cfg(feature = "web")]
+                {
+                    let lit = serde_json::to_string(&text)
+                        .unwrap_or_else(|_| "\"\"".into());
+                    reader_call("shareText", &lit);
+                }
+                let _ = &text;
+                let mut selection = selection;
+                selection.set(None);
+            },
+        }
+    }
+}
 
-            if let Some(h) = note_target.read().clone() {
-                NoteComposer {
-                    highlight: h,
-                    on_saved: move |(id, note): (i64, Option<String>)| {
-                        let mut highlights = highlights;
-                        let idx = highlights.read().iter().position(|x| x.id == id);
-                        if let Some(i) = idx {
-                            highlights.write()[i].note = note;
-                        }
-                    },
-                    on_close: move |_| {
-                        let mut note_target = note_target;
-                        note_target.set(None);
-                    },
-                }
+/// Book identity + display strings the overlay drawers render.
+#[derive(Clone, PartialEq)]
+pub(super) struct OverlayMeta {
+    pub uuid: String,
+    pub book_title: String,
+    pub book_author: String,
+    pub book_accent: String,
+    pub chapter_title: String,
+    pub current_cfi: String,
+}
+
+/// The toggleable reader overlays: contents, highlights, search, bookmarks
+/// drawers plus the quote panel and note composer. Each renders only when its
+/// backing signal is set.
+#[component]
+fn ReaderOverlays(meta: OverlayMeta, panels: ReaderPanelSignals) -> Element {
+    let OverlayMeta {
+        uuid,
+        book_title,
+        book_author,
+        book_accent,
+        chapter_title,
+        current_cfi,
+    } = meta;
+    let ReaderPanelSignals {
+        highlights,
+        toc,
+        show_toc,
+        show_highlights,
+        note_target,
+        quote_target,
+        show_search,
+        search_results,
+        show_bookmarks,
+        ..
+    } = panels;
+
+    rsx! {
+        if show_toc() {
+            TocDrawer {
+                entries: toc.read().clone(),
+                current_title: chapter_title.clone(),
+                on_navigate: move |href: String| {
+                    #[cfg(feature = "web")]
+                    {
+                        let lit = serde_json::to_string(&href).unwrap_or_else(|_| "\"\"".into());
+                        reader_call("display", &lit);
+                    }
+                    let _ = &href;
+                    let mut show_toc = show_toc;
+                    show_toc.set(false);
+                },
+                on_close: move |_| {
+                    let mut show_toc = show_toc;
+                    show_toc.set(false);
+                },
             }
+        }
+
+        if show_highlights() {
+            HighlightsDrawer {
+                highlights,
+                on_quote: move |h: Highlight| {
+                    let mut quote_target = quote_target;
+                    let mut show_highlights = show_highlights;
+                    quote_target.set(Some(h));
+                    show_highlights.set(false);
+                },
+                on_edit_note: move |h: Highlight| {
+                    let mut note_target = note_target;
+                    let mut show_highlights = show_highlights;
+                    note_target.set(Some(h));
+                    show_highlights.set(false);
+                },
+                on_close: move |_| {
+                    let mut show_highlights = show_highlights;
+                    show_highlights.set(false);
+                },
+            }
+        }
+
+        if show_search() {
+            SearchPanel {
+                results: search_results,
+                on_query: move |q: String| {
+                    #[cfg(feature = "web")]
+                    {
+                        let lit = serde_json::to_string(&q).unwrap_or_else(|_| "\"\"".into());
+                        reader_call("search", &lit);
+                    }
+                    let _ = &q;
+                },
+                on_navigate: move |cfi: String| {
+                    #[cfg(feature = "web")]
+                    {
+                        let lit = serde_json::to_string(&cfi).unwrap_or_else(|_| "\"\"".into());
+                        reader_call("display", &lit);
+                    }
+                    let _ = &cfi;
+                    let mut show_search = show_search;
+                    show_search.set(false);
+                },
+                on_close: move |_| {
+                    let mut show_search = show_search;
+                    show_search.set(false);
+                },
+            }
+        }
+
+        if show_bookmarks() {
+            ReaderBookmarksDrawer {
+                uuid: uuid.clone(),
+                current_cfi: current_cfi.clone(),
+                current_label: chapter_title.clone(),
+                on_navigate: move |cfi: String| {
+                    #[cfg(feature = "web")]
+                    {
+                        let lit = serde_json::to_string(&cfi).unwrap_or_else(|_| "\"\"".into());
+                        reader_call("display", &lit);
+                    }
+                    let _ = &cfi;
+                    let mut show_bookmarks = show_bookmarks;
+                    show_bookmarks.set(false);
+                },
+                on_close: move |_| {
+                    let mut show_bookmarks = show_bookmarks;
+                    show_bookmarks.set(false);
+                },
+            }
+        }
+
+        if let Some(h) = quote_target.read().clone() {
+            QuotePanel {
+                quote_text: h.text.clone().unwrap_or_default(),
+                author: book_author.clone(),
+                subtitle: book_title.clone(),
+                accent: book_accent.clone(),
+                on_close: move |_| {
+                    let mut quote_target = quote_target;
+                    quote_target.set(None);
+                },
+            }
+        }
+
+        if let Some(h) = note_target.read().clone() {
+            NoteComposer {
+                highlight: h,
+                on_saved: move |(id, note): (i64, Option<String>)| {
+                    let mut highlights = highlights;
+                    let idx = highlights.read().iter().position(|x| x.id == id);
+                    if let Some(i) = idx {
+                        highlights.write()[i].note = note;
+                    }
+                },
+                on_close: move |_| {
+                    let mut note_target = note_target;
+                    note_target.set(None);
+                },
+            }
+        }
+    }
+}
+
+/// Owns the mutually-exclusive overlay toggles and renders [`ReaderTopChrome`].
+/// Each tool closes every other surface before opening its own.
+#[component]
+fn ReaderTopBar(
+    book_title: String,
+    chapter_title: String,
+    panels: ReaderPanelSignals,
+    on_back: EventHandler<MouseEvent>,
+) -> Element {
+    let show_aa = panels.show_aa;
+    let show_toc = panels.show_toc;
+    let show_search = panels.show_search;
+    let show_highlights = panels.show_highlights;
+    let show_bookmarks = panels.show_bookmarks;
+    let note_target = panels.note_target;
+    let quote_target = panels.quote_target;
+    let highlight_count = panels.highlights.read().len();
+
+    // Close every overlay (panel, drawer, composer) — `Fn` + `Copy` so each
+    // toggle handler can call it before opening its own surface, keeping the
+    // chrome mutually exclusive.
+    let close_overlays = move || {
+        let mut a = show_aa;
+        a.set(false);
+        let mut b = show_toc;
+        b.set(false);
+        let mut c = show_search;
+        c.set(false);
+        let mut d = show_highlights;
+        d.set(false);
+        let mut e = show_bookmarks;
+        e.set(false);
+        let mut f = note_target;
+        f.set(None);
+        let mut g = quote_target;
+        g.set(None);
+    };
+
+    rsx! {
+        ReaderTopChrome {
+            book_title,
+            chapter_title,
+            show_aa: show_aa(),
+            toc_active: show_toc(),
+            search_active: show_search(),
+            highlights_active: show_highlights(),
+            bookmarks_active: show_bookmarks(),
+            highlight_count,
+            on_back,
+            on_toggle_aa: move |_| {
+                let cur = show_aa();
+                close_overlays();
+                let mut s = show_aa;
+                s.set(!cur);
+            },
+            on_toggle_toc: move |_| {
+                let cur = show_toc();
+                close_overlays();
+                let mut s = show_toc;
+                s.set(!cur);
+            },
+            on_toggle_search: move |_| {
+                let cur = show_search();
+                close_overlays();
+                let mut s = show_search;
+                s.set(!cur);
+            },
+            on_toggle_highlights: move |_| {
+                let cur = show_highlights();
+                close_overlays();
+                let mut s = show_highlights;
+                s.set(!cur);
+            },
+            on_toggle_bookmarks: move |_| {
+                let cur = show_bookmarks();
+                close_overlays();
+                let mut s = show_bookmarks;
+                s.set(!cur);
+            },
         }
     }
 }

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -439,20 +439,82 @@ fn HardcoverKeyField() -> Element {
 #[component]
 fn SmtpConfigField() -> Element {
     let server_url = use_server_url();
-    let mut status: Signal<Option<SmtpConfigStatus>> = use_signal(|| None);
-    let mut host = use_signal(String::new);
-    let mut port = use_signal(|| "587".to_string());
-    let mut username = use_signal(String::new);
-    let mut from_email = use_signal(String::new);
-    let mut password = use_signal(String::new);
-    let mut security = use_signal(|| SmtpSecurity::Starttls);
-    let mut msg = use_signal(|| None::<String>);
-    let mut msg_is_error = use_signal(|| false);
-    let mut in_flight = use_signal(|| false);
+    let fields = SmtpFields {
+        host: use_signal(String::new),
+        port: use_signal(|| "587".to_string()),
+        username: use_signal(String::new),
+        from_email: use_signal(String::new),
+        password: use_signal(String::new),
+        security: use_signal(|| SmtpSecurity::Starttls),
+    };
+    let io = SmtpIo {
+        status: use_signal(|| None),
+        msg: use_signal(|| None),
+        msg_is_error: use_signal(|| false),
+        in_flight: use_signal(|| false),
+    };
 
-    let load_url = server_url.clone();
+    spawn_smtp_config_load(server_url.clone(), fields, io.status);
+
+    let on_save = make_smtp_save(server_url.clone(), fields, io);
+    let on_clear = make_smtp_clear(server_url.clone(), fields, io);
+    let on_test = make_smtp_test(server_url, io);
+
+    let st = (io.status)();
+    let configured = st.as_ref().map(|s| s.configured).unwrap_or(false);
+
+    rsx! {
+        section { class: "card", "data-testid": "smtp-card",
+            h2 { "Email delivery (SMTP)" }
+            p { class: "subtitle", "Configure the relay used by Send-to-Kindle." }
+            SmtpConnectionFields { fields, configured }
+            SmtpTestActions {
+                configured,
+                in_flight: io.in_flight,
+                status: st,
+                msg: io.msg,
+                msg_is_error: io.msg_is_error,
+                on_save: EventHandler::new(on_save),
+                on_test: EventHandler::new(on_test),
+                on_clear: EventHandler::new(on_clear),
+            }
+        }
+    }
+}
+
+/// Editable SMTP connection signals threaded into the connection fields.
+#[derive(Copy, Clone, PartialEq)]
+struct SmtpFields {
+    host: Signal<String>,
+    port: Signal<String>,
+    username: Signal<String>,
+    from_email: Signal<String>,
+    password: Signal<String>,
+    security: Signal<SmtpSecurity>,
+}
+
+/// Loaded status + save/test message + in-flight signals for the SMTP card.
+#[derive(Copy, Clone, PartialEq)]
+struct SmtpIo {
+    status: Signal<Option<SmtpConfigStatus>>,
+    msg: Signal<Option<String>>,
+    msg_is_error: Signal<bool>,
+    in_flight: Signal<bool>,
+}
+
+/// Load the masked SMTP config on mount and seed the editable fields.
+fn spawn_smtp_config_load(
+    server_url: String,
+    fields: SmtpFields,
+    mut status: Signal<Option<SmtpConfigStatus>>,
+) {
+    let mut host = fields.host;
+    let mut port = fields.port;
+    let mut username = fields.username;
+    let mut from_email = fields.from_email;
+    let mut security = fields.security;
     use_effect(move || {
-        let url = load_url.clone();
+        let url = server_url.clone();
         spawn(async move {
             if let Ok(s) = data::get_smtp_config(&url).await {
                 if let Some(h) = s.host.clone() {
@@ -472,9 +534,21 @@ fn SmtpConfigField() -> Element {
             }
         });
     });
+}
 
-    let save_url = server_url.clone();
-    let on_save = move |_| {
+/// Build the Save handler: validate the port, then POST the config update.
+fn make_smtp_save(server_url: String, fields: SmtpFields, io: SmtpIo) -> impl FnMut(MouseEvent) {
+    let host = fields.host;
+    let port = fields.port;
+    let username = fields.username;
+    let from_email = fields.from_email;
+    let mut password = fields.password;
+    let security = fields.security;
+    let mut status = io.status;
+    let mut msg = io.msg;
+    let mut msg_is_error = io.msg_is_error;
+    let mut in_flight = io.in_flight;
+    move |_| {
         let host_val = host().trim().to_string();
         // `parse::<u16>()` accepts 0, but 0 is not a usable port — reject it
         // so the UI matches the "1 and 65535" message (and the DB validator).
@@ -499,7 +573,7 @@ fn SmtpConfigField() -> Element {
             security: security(),
             password: password_val,
         };
-        let url = save_url.clone();
+        let url = server_url.clone();
         in_flight.set(true);
         spawn(async move {
             match data::set_smtp_config(&url, update).await {
@@ -516,11 +590,23 @@ fn SmtpConfigField() -> Element {
             }
             in_flight.set(false);
         });
-    };
+    }
+}
 
-    let clear_url = server_url.clone();
-    let on_clear = move |_| {
-        let url = clear_url.clone();
+/// Build the Clear handler: wipe the stored config and reset the fields.
+fn make_smtp_clear(server_url: String, fields: SmtpFields, io: SmtpIo) -> impl FnMut(MouseEvent) {
+    let mut host = fields.host;
+    let mut port = fields.port;
+    let mut username = fields.username;
+    let mut from_email = fields.from_email;
+    let mut password = fields.password;
+    let mut security = fields.security;
+    let mut status = io.status;
+    let mut msg = io.msg;
+    let mut msg_is_error = io.msg_is_error;
+    let mut in_flight = io.in_flight;
+    move |_| {
+        let url = server_url.clone();
         in_flight.set(true);
         spawn(async move {
             match data::clear_smtp_config(&url).await {
@@ -542,11 +628,16 @@ fn SmtpConfigField() -> Element {
             }
             in_flight.set(false);
         });
-    };
+    }
+}
 
-    let test_url = server_url;
-    let on_test = move |_| {
-        let url = test_url.clone();
+/// Build the Send-Test handler: fire a test email via the configured relay.
+fn make_smtp_test(server_url: String, io: SmtpIo) -> impl FnMut(MouseEvent) {
+    let mut msg = io.msg;
+    let mut msg_is_error = io.msg_is_error;
+    let mut in_flight = io.in_flight;
+    move |_| {
+        let url = server_url.clone();
         in_flight.set(true);
         spawn(async move {
             match data::send_smtp_test(&url).await {
@@ -564,133 +655,153 @@ fn SmtpConfigField() -> Element {
             }
             in_flight.set(false);
         });
-    };
+    }
+}
 
-    let st = status();
-    let configured = st.as_ref().map(|s| s.configured).unwrap_or(false);
-
+/// Host / port / security / username / password / from-email inputs.
+#[component]
+fn SmtpConnectionFields(fields: SmtpFields, configured: bool) -> Element {
+    let mut host = fields.host;
+    let mut port = fields.port;
+    let mut username = fields.username;
+    let mut from_email = fields.from_email;
+    let mut password = fields.password;
+    let mut security = fields.security;
     rsx! {
-        section { class: "card", "data-testid": "smtp-card",
-            h2 { "Email delivery (SMTP)" }
-            p { class: "subtitle", "Configure the relay used by Send-to-Kindle." }
-            div { class: "settings-field",
-                label { r#for: "smtp-host", "SMTP Host" }
-                input {
-                    r#type: "text",
-                    id: "smtp-host",
-                    name: "smtp_host",
-                    autocomplete: "off",
-                    placeholder: "smtp.example.com",
-                    value: "{host}",
-                    oninput: move |e| host.set(e.value()),
-                }
+        div { class: "settings-field",
+            label { r#for: "smtp-host", "SMTP Host" }
+            input {
+                r#type: "text",
+                id: "smtp-host",
+                name: "smtp_host",
+                autocomplete: "off",
+                placeholder: "smtp.example.com",
+                value: "{host}",
+                oninput: move |e| host.set(e.value()),
             }
-            div { class: "settings-field",
-                label { r#for: "smtp-port", "Port" }
-                input {
-                    r#type: "number",
-                    id: "smtp-port",
-                    name: "smtp_port",
-                    value: "{port}",
-                    oninput: move |e| port.set(e.value()),
-                }
+        }
+        div { class: "settings-field",
+            label { r#for: "smtp-port", "Port" }
+            input {
+                r#type: "number",
+                id: "smtp-port",
+                name: "smtp_port",
+                value: "{port}",
+                oninput: move |e| port.set(e.value()),
             }
-            div { class: "settings-field",
-                label { r#for: "smtp-security", "Security" }
-                select {
-                    id: "smtp-security",
-                    name: "smtp_security",
-                    "data-testid": "smtp-security",
-                    value: "{security().as_str()}",
-                    onchange: move |e| security.set(SmtpSecurity::from_str_or_default(&e.value())),
-                    option { value: "starttls", "STARTTLS (587)" }
-                    option { value: "tls", "TLS (465)" }
-                }
+        }
+        div { class: "settings-field",
+            label { r#for: "smtp-security", "Security" }
+            select {
+                id: "smtp-security",
+                name: "smtp_security",
+                "data-testid": "smtp-security",
+                value: "{security().as_str()}",
+                onchange: move |e| security.set(SmtpSecurity::from_str_or_default(&e.value())),
+                option { value: "starttls", "STARTTLS (587)" }
+                option { value: "tls", "TLS (465)" }
             }
-            div { class: "settings-field",
-                label { r#for: "smtp-username", "Username" }
-                input {
-                    r#type: "text",
-                    id: "smtp-username",
-                    name: "smtp_username",
-                    autocomplete: "off",
-                    value: "{username}",
-                    oninput: move |e| username.set(e.value()),
-                }
+        }
+        div { class: "settings-field",
+            label { r#for: "smtp-username", "Username" }
+            input {
+                r#type: "text",
+                id: "smtp-username",
+                name: "smtp_username",
+                autocomplete: "off",
+                value: "{username}",
+                oninput: move |e| username.set(e.value()),
             }
-            div { class: "settings-field",
-                label { r#for: "smtp-password", "Password" }
-                input {
-                    r#type: "password",
-                    id: "smtp-password",
-                    name: "smtp_password",
-                    autocomplete: "off",
-                    autocapitalize: "none",
-                    autocorrect: "off",
-                    spellcheck: "false",
-                    placeholder: if configured { "\u{2022}\u{2022}\u{2022}\u{2022} (unchanged)" } else { "" },
-                    value: "{password}",
-                    oninput: move |e| password.set(e.value()),
-                }
+        }
+        div { class: "settings-field",
+            label { r#for: "smtp-password", "Password" }
+            input {
+                r#type: "password",
+                id: "smtp-password",
+                name: "smtp_password",
+                autocomplete: "off",
+                autocapitalize: "none",
+                autocorrect: "off",
+                spellcheck: "false",
+                placeholder: if configured { "\u{2022}\u{2022}\u{2022}\u{2022} (unchanged)" } else { "" },
+                value: "{password}",
+                oninput: move |e| password.set(e.value()),
             }
-            div { class: "settings-field",
-                label { r#for: "smtp-from", "From Email" }
-                input {
-                    r#type: "email",
-                    id: "smtp-from",
-                    name: "smtp_from_email",
-                    autocomplete: "off",
-                    placeholder: "library@example.com",
-                    value: "{from_email}",
-                    oninput: move |e| from_email.set(e.value()),
-                }
+        }
+        div { class: "settings-field",
+            label { r#for: "smtp-from", "From Email" }
+            input {
+                r#type: "email",
+                id: "smtp-from",
+                name: "smtp_from_email",
+                autocomplete: "off",
+                placeholder: "library@example.com",
+                value: "{from_email}",
+                oninput: move |e| from_email.set(e.value()),
             }
-            div { class: "settings-actions",
+        }
+    }
+}
+
+/// Save / send-test / clear buttons, the configured-state line, and the
+/// save/test status message.
+#[component]
+fn SmtpTestActions(
+    configured: bool,
+    in_flight: Signal<bool>,
+    status: Option<SmtpConfigStatus>,
+    msg: Signal<Option<String>>,
+    msg_is_error: Signal<bool>,
+    on_save: EventHandler<MouseEvent>,
+    on_test: EventHandler<MouseEvent>,
+    on_clear: EventHandler<MouseEvent>,
+) -> Element {
+    rsx! {
+        div { class: "settings-actions",
+            button {
+                r#type: "button",
+                class: "btn",
+                disabled: in_flight(),
+                "data-testid": "smtp-save",
+                onclick: move |e| on_save.call(e),
+                "Save"
+            }
+            if configured {
                 button {
                     r#type: "button",
-                    class: "btn",
+                    class: "btn ghost",
                     disabled: in_flight(),
-                    "data-testid": "smtp-save",
-                    onclick: on_save,
-                    "Save"
+                    "data-testid": "smtp-test",
+                    onclick: move |e| on_test.call(e),
+                    "Send Test"
                 }
-                if configured {
-                    button {
-                        r#type: "button",
-                        class: "btn ghost",
-                        disabled: in_flight(),
-                        "data-testid": "smtp-test",
-                        onclick: on_test,
-                        "Send Test"
-                    }
-                    button {
-                        r#type: "button",
-                        class: "btn ghost",
-                        disabled: in_flight(),
-                        "data-testid": "smtp-clear",
-                        onclick: on_clear,
-                        "Clear"
-                    }
+                button {
+                    r#type: "button",
+                    class: "btn ghost",
+                    disabled: in_flight(),
+                    "data-testid": "smtp-clear",
+                    onclick: move |e| on_clear.call(e),
+                    "Clear"
                 }
             }
-            div { class: "hardcover-status mono", "data-testid": "smtp-status",
-                if configured {
-                    span { class: "hardcover-dot connected" }
-                    if let Some(s) = st.as_ref() {
-                        "Configured \u{00b7} {s.source}"
-                    }
-                } else {
-                    span { class: "hardcover-dot" }
-                    "Not configured"
+        }
+        div { class: "hardcover-status mono", "data-testid": "smtp-status",
+            if configured {
+                span { class: "hardcover-dot connected" }
+                if let Some(s) = status.as_ref() {
+                    "Configured \u{00b7} {s.source}"
                 }
+            } else {
+                span { class: "hardcover-dot" }
+                "Not configured"
             }
-            if let Some(m) = msg() {
-                p {
-                    role: "status",
-                    "data-testid": "smtp-config-status",
-                    class: if msg_is_error() { "settings-status error" } else { "settings-status success" },
-                    "{m}"
-                }
+        }
+        if let Some(m) = msg() {
+            p {
+                role: "status",
+                "data-testid": "smtp-config-status",
+                class: if msg_is_error() { "settings-status error" } else { "settings-status success" },
+                "{m}"
             }
         }
     }


### PR DESCRIPTION
## Summary
Closes #763.

Splits the 7 oversized Dioxus `#[component]` bodies flagged in the issue so no single component body exceeds ~150 lines. Each split follows a natural seam (signal/handler setup vs. render sections, or grouped render sub-sections) and is pure refactor — no visual or behavior change, and no new `#[cfg(feature = ...)]` gating is introduced into any component body (rule 07 hydration parity preserved).

Per component (all measured body length now well under ~150):
- `frontend/src/pages/reader/mod.rs` — `ReaderLayout` (324 → 91). Extracted `ReaderTopBar` (owns the mutually-exclusive overlay toggles + `close_overlays`), `ReaderSelectionPopover`, and `ReaderOverlays` (the toc/highlights/search/bookmarks drawers + quote/note surfaces). Left the 25-prop count (#570) untouched — out of scope here.
- `frontend/src/pages/add_books.rs` — `AddBooksPage` (265 → 51). Grouped page signals into `UploadState`; extracted the two async handlers into `make_on_file` / `make_on_submit` builders and the markup into `UploadTypeToggle` / `FileDropZone` / `ConfirmForm`.
- `frontend/src/pages/settings.rs` — `SmtpConfigField` (258 → 44). Grouped signals into `SmtpFields` / `SmtpIo`; extracted `spawn_smtp_config_load` + `make_smtp_save` / `make_smtp_clear` / `make_smtp_test` handler builders and `SmtpConnectionFields` / `SmtpTestActions` sub-components.
- `frontend/src/pages/listen/ready_player.rs` — `ReadyPlayer` (249 → 126). Extracted `PlayerStageBinding` (transport + toolbar handlers and the `PlayerStage` render) and `PlayerOverlays` (speed/sleep/bookmarks/chapters panes + toast). Sleep mutations are passed as `EventHandler`s since `SleepController` isn't `PartialEq`.
- `frontend/src/pages/reader/aa_panel.rs` — `ReaderAaPanel` (181 → 17). Split into one sub-component per settings row (`ThemeRow`, `TypefaceRow`, `TextSizeRow`, `LineSpacingRow`, `MarginsRow`, `PageViewRow`, `JustifyRow`), each reading the `ReaderPrefs` context directly.
- `frontend/src/components/search_palette/overlay.rs` — `SpOverlay` (167 → 131). Extracted the search-icon + query input into `SpInputRow`.
- `frontend/src/pages/metadata_edit/form_grid.rs` — `FormGrid` (154 → 9). Split into `FieldGrid` / `TagsSection` / `SeriesSection`.

Also stripped the roadmap-phase angle for #440 in `reader/mod.rs`: verified its `//!` module-doc header carries no roadmap-phase reference (e.g. "F2.4") — it is already a plain ≤5-line description, so no change was needed there.

## Test plan
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (209 passed)
- [x] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` — PASS (CI mobile job / target-specific dead code)
- [x] `cargo fmt --check` — PASS

## Notes
- No new tests added: this is a pure extraction with identical rendered output, covered transitively by the existing 209 frontend tests. Extracted helpers/sub-components each carry a one-line `///`.
- `settings.rs` (~827) and `reader/mod.rs` (~805) now sit just over the ~800-line file soft-cap. Splitting them into new module files is a larger structural change than this body-length issue scopes (and would touch beyond the 7 files here), so it's left for a follow-up.