### PR TITLE
test: add direct round-trip tests for parsing helpers

### DIFF
--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -311,18 +311,37 @@ mod tests {
         out
     }
 
+    // The OCF spec requires the archive to open with an uncompressed
+    // `mimetype` entry holding exactly `application/epub+zip` (no trailing
+    // newline). `build_zip` stores every entry, and `doc_from_opf` lists this
+    // first, so the fixtures are spec-complete rather than leaning on the
+    // `epub` crate's tolerance for a missing mimetype.
+    const MIMETYPE: &[u8] = b"application/epub+zip";
+
     const CONTAINER_XML: &[u8] = br##"<?xml version="1.0"?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
   <rootfiles><rootfile full-path="content.opf" media-type="application/oebps-package+xml"/></rootfiles>
 </container>"##;
 
+    // Minimal EPUB3 navigation document the OPF manifest references. Included
+    // so the manifest points at a real resource instead of a dangling href.
+    const NAV_XHTML: &[u8] = br##"<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+  <head><title>Contents</title></head>
+  <body>
+    <nav epub:type="toc"><ol><li><a href="content.opf">Start</a></li></ol></nav>
+  </body>
+</html>"##;
+
     /// Parse an in-memory EPUB whose sole OPF is `opf`. The manifest/spine are
     /// required by the parser, so every fixture below wraps its `<metadata>`
-    /// in [`opf_package`].
+    /// in [`opf_package`]. The `mimetype` entry comes first per the OCF spec.
     fn doc_from_opf(opf: &str) -> EpubDoc<Cursor<Vec<u8>>> {
         let zip = build_zip(&[
+            ("mimetype", MIMETYPE),
             ("META-INF/container.xml", CONTAINER_XML),
             ("content.opf", opf.as_bytes()),
+            ("nav.xhtml", NAV_XHTML),
         ]);
         EpubDoc::from_reader(Cursor::new(zip)).expect("parse in-memory epub")
     }

--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -213,8 +213,330 @@ fn all<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>, key: &str) -> Vec<Str
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
+    use epub::doc::{EpubDoc, MetadataRefinement};
+
+    use super::{
+        collect_contributors, collect_identifiers, collect_series, first, lookup_refinement,
+    };
     use crate::ebook::scan_ebook_library;
     use crate::ebook::test_support::*;
+
+    // --- In-memory OPF harness ---------------------------------------------
+    //
+    // The `collect_*`/`first` helpers only read `doc.metadata`, but `EpubDoc`
+    // (and the `MetadataItem`s it holds) can't be constructed directly — the
+    // `id` field is private and the only constructors want a real zip. So we
+    // wrap a hand-built OPF in the smallest valid EPUB container and let the
+    // real parser produce the `metadata` vec, exercising the exact
+    // refinement/attribute branches disk fixtures would. `MetadataRefinement`
+    // *is* fully public, so `lookup_refinement` is tested on it directly.
+
+    /// IEEE CRC32 over `bytes` — the checksum each stored ZIP entry needs.
+    fn crc32(bytes: &[u8]) -> u32 {
+        let mut crc: u32 = 0xFFFF_FFFF;
+        for &b in bytes {
+            crc ^= b as u32;
+            for _ in 0..8 {
+                let mask = (crc & 1).wrapping_neg();
+                crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+            }
+        }
+        !crc
+    }
+
+    /// Assemble an uncompressed (stored) ZIP from `(name, bytes)` entries.
+    /// Stored entries keep the writer trivial — no deflate, just headers,
+    /// CRCs, and a central directory — and `EpubDoc` reads them fine.
+    fn build_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut out: Vec<u8> = Vec::new();
+        let mut central: Vec<u8> = Vec::new();
+
+        for (name, data) in entries {
+            let offset = out.len() as u32;
+            let crc = crc32(data);
+            let name_len = name.len() as u16;
+            let size = data.len() as u32;
+
+            // Local file header + the (stored) file data.
+            out.extend_from_slice(&0x0403_4b50u32.to_le_bytes());
+            out.extend_from_slice(&20u16.to_le_bytes()); // version needed
+            out.extend_from_slice(&0u16.to_le_bytes()); // flags
+            out.extend_from_slice(&0u16.to_le_bytes()); // method: stored
+            out.extend_from_slice(&0u16.to_le_bytes()); // mod time
+            out.extend_from_slice(&0u16.to_le_bytes()); // mod date
+            out.extend_from_slice(&crc.to_le_bytes());
+            out.extend_from_slice(&size.to_le_bytes()); // compressed size
+            out.extend_from_slice(&size.to_le_bytes()); // uncompressed size
+            out.extend_from_slice(&name_len.to_le_bytes());
+            out.extend_from_slice(&0u16.to_le_bytes()); // extra len
+            out.extend_from_slice(name.as_bytes());
+            out.extend_from_slice(data);
+
+            // Matching central-directory record, accumulated for the tail.
+            central.extend_from_slice(&0x0201_4b50u32.to_le_bytes());
+            central.extend_from_slice(&20u16.to_le_bytes()); // version made by
+            central.extend_from_slice(&20u16.to_le_bytes()); // version needed
+            central.extend_from_slice(&0u16.to_le_bytes()); // flags
+            central.extend_from_slice(&0u16.to_le_bytes()); // method
+            central.extend_from_slice(&0u16.to_le_bytes()); // mod time
+            central.extend_from_slice(&0u16.to_le_bytes()); // mod date
+            central.extend_from_slice(&crc.to_le_bytes());
+            central.extend_from_slice(&size.to_le_bytes());
+            central.extend_from_slice(&size.to_le_bytes());
+            central.extend_from_slice(&name_len.to_le_bytes());
+            central.extend_from_slice(&0u16.to_le_bytes()); // extra
+            central.extend_from_slice(&0u16.to_le_bytes()); // comment
+            central.extend_from_slice(&0u16.to_le_bytes()); // disk start
+            central.extend_from_slice(&0u16.to_le_bytes()); // internal attrs
+            central.extend_from_slice(&0u32.to_le_bytes()); // external attrs
+            central.extend_from_slice(&offset.to_le_bytes());
+            central.extend_from_slice(name.as_bytes());
+        }
+
+        let cd_offset = out.len() as u32;
+        let cd_size = central.len() as u32;
+        out.extend_from_slice(&central);
+
+        // End-of-central-directory record.
+        out.extend_from_slice(&0x0605_4b50u32.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes()); // this disk
+        out.extend_from_slice(&0u16.to_le_bytes()); // cd start disk
+        out.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+        out.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+        out.extend_from_slice(&cd_size.to_le_bytes());
+        out.extend_from_slice(&cd_offset.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes()); // comment len
+        out
+    }
+
+    const CONTAINER_XML: &[u8] = br##"<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile full-path="content.opf" media-type="application/oebps-package+xml"/></rootfiles>
+</container>"##;
+
+    /// Parse an in-memory EPUB whose sole OPF is `opf`. The manifest/spine are
+    /// required by the parser, so every fixture below wraps its `<metadata>`
+    /// in [`opf_package`].
+    fn doc_from_opf(opf: &str) -> EpubDoc<Cursor<Vec<u8>>> {
+        let zip = build_zip(&[
+            ("META-INF/container.xml", CONTAINER_XML),
+            ("content.opf", opf.as_bytes()),
+        ]);
+        EpubDoc::from_reader(Cursor::new(zip)).expect("parse in-memory epub")
+    }
+
+    /// Wrap a `<metadata>` body in a full OPF package at the given version
+    /// (`"3.0"` selects the EPUB3 refinement branch; `"2.0"` the legacy branch
+    /// where `opf:*` attributes on `<dc:*>` become refinements).
+    fn opf_package(version: &str, metadata_body: &str) -> String {
+        format!(
+            r##"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="{version}" unique-identifier="pub-id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+{metadata_body}
+  </metadata>
+  <manifest><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml"/></manifest>
+  <spine><itemref idref="nav"/></spine>
+</package>"##
+        )
+    }
+
+    // --- lookup_refinement -------------------------------------------------
+
+    #[test]
+    fn lookup_refinement_returns_value_for_matching_property() {
+        let refs = vec![
+            MetadataRefinement {
+                property: "file-as".into(),
+                value: "Le Guin, Ursula K.".into(),
+                lang: None,
+                scheme: None,
+            },
+            MetadataRefinement {
+                property: "role".into(),
+                value: "aut".into(),
+                lang: None,
+                scheme: None,
+            },
+        ];
+        assert_eq!(lookup_refinement(&refs, "role"), Some("aut".to_string()));
+    }
+
+    #[test]
+    fn lookup_refinement_returns_none_when_property_absent() {
+        let refs = vec![MetadataRefinement {
+            property: "role".into(),
+            value: "aut".into(),
+            lang: None,
+            scheme: None,
+        }];
+        assert_eq!(lookup_refinement(&refs, "file-as"), None);
+        assert_eq!(lookup_refinement(&[], "role"), None);
+    }
+
+    #[test]
+    fn lookup_refinement_returns_first_match_when_duplicated() {
+        let refs = vec![
+            MetadataRefinement {
+                property: "scheme".into(),
+                value: "uuid".into(),
+                lang: None,
+                scheme: None,
+            },
+            MetadataRefinement {
+                property: "scheme".into(),
+                value: "isbn".into(),
+                lang: None,
+                scheme: None,
+            },
+        ];
+        assert_eq!(lookup_refinement(&refs, "scheme"), Some("uuid".to_string()));
+    }
+
+    // --- collect_contributors ----------------------------------------------
+
+    #[test]
+    fn collect_contributors_reads_role_and_file_as_from_epub3_refinements() {
+        let doc = doc_from_opf(&opf_package(
+            "3.0",
+            r##"    <dc:creator id="aut">Ursula K. Le Guin</dc:creator>
+    <meta refines="#aut" property="role">aut</meta>
+    <meta refines="#aut" property="file-as">Le Guin, Ursula K.</meta>"##,
+        ));
+        let creators = collect_contributors(&doc, "creator");
+        assert_eq!(creators.len(), 1);
+        assert_eq!(creators[0].name, "Ursula K. Le Guin");
+        assert_eq!(creators[0].role.as_deref(), Some("aut"));
+        assert_eq!(creators[0].file_as.as_deref(), Some("Le Guin, Ursula K."));
+    }
+
+    #[test]
+    fn collect_contributors_reads_role_and_file_as_from_legacy_opf_attributes() {
+        // Legacy EPUB2: `opf:role` / `opf:file-as` ride as attributes on the
+        // `<dc:creator>` element rather than separate `<meta refines>` nodes.
+        let doc = doc_from_opf(&opf_package(
+            "2.0",
+            r##"    <dc:creator opf:role="aut" opf:file-as="Le Guin, Ursula K.">Ursula K. Le Guin</dc:creator>"##,
+        ));
+        let creators = collect_contributors(&doc, "creator");
+        assert_eq!(creators.len(), 1);
+        assert_eq!(creators[0].name, "Ursula K. Le Guin");
+        assert_eq!(creators[0].role.as_deref(), Some("aut"));
+        assert_eq!(creators[0].file_as.as_deref(), Some("Le Guin, Ursula K."));
+    }
+
+    #[test]
+    fn collect_contributors_filters_by_key_and_skips_blank_names() {
+        // Only the requested property is returned, and whitespace-only names
+        // are dropped. `contributor` is selected here to prove keying works
+        // for the second role the pipeline merges in.
+        let doc = doc_from_opf(&opf_package(
+            "3.0",
+            r##"    <dc:creator>Primary Author</dc:creator>
+    <dc:contributor>   </dc:contributor>
+    <dc:contributor>Jane Editor</dc:contributor>"##,
+        ));
+        let contributors = collect_contributors(&doc, "contributor");
+        assert_eq!(contributors.len(), 1);
+        assert_eq!(contributors[0].name, "Jane Editor");
+        assert!(contributors[0].role.is_none());
+        assert!(contributors[0].file_as.is_none());
+    }
+
+    // --- collect_series ----------------------------------------------------
+
+    #[test]
+    fn collect_series_reads_epub3_belongs_to_collection_with_group_position() {
+        let doc = doc_from_opf(&opf_package(
+            "3.0",
+            r##"    <meta property="belongs-to-collection" id="c1">Earthsea</meta>
+    <meta refines="#c1" property="group-position">2</meta>"##,
+        ));
+        let (series, index) = collect_series(&doc);
+        assert_eq!(series.as_deref(), Some("Earthsea"));
+        assert_eq!(index.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn collect_series_falls_back_to_legacy_calibre_series_meta() {
+        // No `belongs-to-collection`, so the Calibre `<meta name="...">` keys
+        // supply both the name and the index.
+        let doc = doc_from_opf(&opf_package(
+            "2.0",
+            r##"    <meta name="calibre:series" content="Earthsea"/>
+    <meta name="calibre:series_index" content="2.0"/>"##,
+        ));
+        let (series, index) = collect_series(&doc);
+        assert_eq!(series.as_deref(), Some("Earthsea"));
+        assert_eq!(index.as_deref(), Some("2.0"));
+    }
+
+    #[test]
+    fn collect_series_returns_none_when_no_series_metadata_present() {
+        let doc = doc_from_opf(&opf_package(
+            "3.0",
+            r##"    <dc:title>Standalone</dc:title>"##,
+        ));
+        let (series, index) = collect_series(&doc);
+        assert_eq!(series, None);
+        assert_eq!(index, None);
+    }
+
+    // --- collect_identifiers -----------------------------------------------
+
+    #[test]
+    fn collect_identifiers_reads_scheme_from_epub3_refinement() {
+        let doc = doc_from_opf(&opf_package(
+            "3.0",
+            r##"    <dc:identifier id="pub-id">urn:uuid:abc</dc:identifier>
+    <meta refines="#pub-id" property="scheme">uuid</meta>"##,
+        ));
+        let ids = collect_identifiers(&doc);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].value, "urn:uuid:abc");
+        assert_eq!(ids[0].scheme.as_deref(), Some("uuid"));
+    }
+
+    #[test]
+    fn collect_identifiers_reads_scheme_from_legacy_opf_scheme_attribute() {
+        // Legacy EPUB2 carries the scheme as an `opf:scheme` attribute, which
+        // the parser surfaces as a `scheme` refinement.
+        let doc = doc_from_opf(&opf_package(
+            "2.0",
+            r##"    <dc:identifier id="pub-id" opf:scheme="ISBN">9780000000000</dc:identifier>"##,
+        ));
+        let ids = collect_identifiers(&doc);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].value, "9780000000000");
+        assert_eq!(ids[0].scheme.as_deref(), Some("ISBN"));
+    }
+
+    #[test]
+    fn collect_identifiers_leaves_scheme_none_when_unspecified_and_skips_blanks() {
+        let doc = doc_from_opf(&opf_package(
+            "3.0",
+            r##"    <dc:identifier>plain-id</dc:identifier>
+    <dc:identifier>   </dc:identifier>"##,
+        ));
+        let ids = collect_identifiers(&doc);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].value, "plain-id");
+        assert!(ids[0].scheme.is_none());
+    }
+
+    // --- first (shared refinement-adjacent reader) -------------------------
+
+    #[test]
+    fn first_returns_trimmed_value_for_present_key_and_none_otherwise() {
+        let doc = doc_from_opf(&opf_package(
+            "3.0",
+            r##"    <dc:title>  Earthsea  </dc:title>"##,
+        ));
+        assert_eq!(first(&doc, "title").as_deref(), Some("Earthsea"));
+        assert_eq!(first(&doc, "publisher"), None);
+    }
 
     #[test]
     fn scan_records_parse_errors_per_file() {

--- a/frontend/src/pages/reader/typography.rs
+++ b/frontend/src/pages/reader/typography.rs
@@ -2,7 +2,7 @@
 //! are cross-book, per-user reader prefs (typeface, line spacing, margins);
 //! the reader page reads them on mount and writes them on every change.
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Typeface {
     Editorial,
     Classic,
@@ -40,7 +40,7 @@ impl Typeface {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum LineSpacing {
     Tight,
     Cozy,
@@ -75,7 +75,7 @@ impl LineSpacing {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Margins {
     Narrow,
     Normal,
@@ -113,7 +113,7 @@ impl Margins {
 /// Single-page vs two-page spread. Maps to epub.js `rendition.spread(...)`:
 /// `"none"` forces a single column, `"auto"` lets epub.js pair pages when the
 /// viewport is wide enough.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Spread {
     Single,
     Double,
@@ -161,4 +161,55 @@ pub(crate) fn save_reader_pref(key: &str, value: &str) {
 #[cfg(feature = "web")]
 pub(crate) fn load_reader_pref(key: &str) -> Option<String> {
     local_storage().and_then(|s| s.get_item(key).ok().flatten())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The storage token is the persistence contract: a `to_storage` arm that
+    // drifts out of lockstep with its `from_storage` arm silently loses a
+    // saved preference on the next reader mount. These round-trips pin every
+    // variant of every enum so that drift fails here, not in a browser.
+
+    #[test]
+    fn typeface_round_trips_through_storage_for_every_variant() {
+        for variant in [Typeface::Editorial, Typeface::Classic, Typeface::Modern] {
+            assert_eq!(Typeface::from_storage(variant.to_storage()), Some(variant));
+        }
+    }
+
+    #[test]
+    fn line_spacing_round_trips_through_storage_for_every_variant() {
+        for variant in [LineSpacing::Tight, LineSpacing::Cozy, LineSpacing::Airy] {
+            assert_eq!(
+                LineSpacing::from_storage(variant.to_storage()),
+                Some(variant)
+            );
+        }
+    }
+
+    #[test]
+    fn margins_round_trips_through_storage_for_every_variant() {
+        for variant in [Margins::Narrow, Margins::Normal, Margins::Wide] {
+            assert_eq!(Margins::from_storage(variant.to_storage()), Some(variant));
+        }
+    }
+
+    #[test]
+    fn spread_round_trips_through_storage_for_every_variant() {
+        for variant in [Spread::Single, Spread::Double] {
+            assert_eq!(Spread::from_storage(variant.to_storage()), Some(variant));
+        }
+    }
+
+    #[test]
+    fn from_storage_returns_none_for_unrecognized_token() {
+        // One per enum: an unknown stored value must fall through to `None`
+        // so the caller can drop to its default rather than mis-restore.
+        assert_eq!(Typeface::from_storage("nonsense"), None);
+        assert_eq!(LineSpacing::from_storage(""), None);
+        assert_eq!(Margins::from_storage("NARROW"), None);
+        assert_eq!(Spread::from_storage("triple"), None);
+    }
 }


### PR DESCRIPTION
## Summary
- Closes #770.
- **`db/src/ebook/parse.rs`** — added direct unit tests for `collect_contributors`, `collect_series`, `collect_identifiers`, and `lookup_refinement`, each covering the EPUB3-refined-metadata path and the legacy-Calibre/EPUB2-attribute fallback path **separately**. Tests feed minimal in-memory OPF XML (wrapped in a tiny hand-built stored ZIP so the real `epub` parser produces the `metadata` vec) rather than routing through the whole EPUB-file pipeline. `lookup_refinement` is exercised directly against hand-built `MetadataRefinement` values (found / not-found / first-of-duplicates). Added to the existing `#[cfg(test)] mod tests` — no restructuring of `parse.rs` into a directory module.
- **`frontend/src/pages/reader/typography.rs`** — added an inline `#[cfg(test)] mod tests` with a `from_storage(to_storage(x)) == Some(x)` round-trip covering **every** variant of all four enums (`Typeface`, `LineSpacing`, `Margins`, `Spread`), plus a `from_storage` unknown-token → `None` case per enum. Added `Debug` to the four enum derives so `assert_eq!` can report mismatches (they already derived `Clone, Copy, PartialEq, Eq`).
- **`shared/src/view_prefs.rs`** — **not modified.** AC #3 (`SortKey::as_wire`/`from_wire` round-trip) is already fully covered by the pre-existing `sort_key_from_wire_round_trips_every_variant` in `shared/src/view_prefs/tests.rs`, which asserts `from_wire(as_wire()) == Some(key)` across all five variants. Adding a second inline module would duplicate that test and collide with the existing `mod tests;` sibling declaration, so it was left as-is.

The optional lower-priority property/fuzz items from the issue — `db/src/normalize.rs` (`normalize_title`/`normalize_author` idempotence) and `db/src/audiobook/chapters.rs` (truncated/adversarial MP4 + ID3v2 CHAP buffers) — are intentionally **deferred to a separate follow-up PR**, as the issue suggests for the mechanical round-trip scope.

## Test plan
- [x] `cargo test -p omnibus-db` — PASS (821 passed, incl. 13 new `ebook::parse::tests`)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (214 passed, incl. 5 new `typography::tests`)
- [x] `cargo test -p omnibus-shared` — PASS (99 passed)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS (also ran `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean)
- [x] `cargo fmt --check` — PASS

## Version
- [x] **No release** — tests-only change (plus a `Debug` derive); add the `no release` label.

## Notes
- No runtime behavior change: additions are `#[cfg(test)]` test code plus a `#[derive(Debug)]` on four reader-preference enums.