### PR TITLE
test: harden normalize + audiobook chapter parsers

### DIFF
--- a/db/src/audiobook/chapters.rs
+++ b/db/src/audiobook/chapters.rs
@@ -55,10 +55,13 @@ fn find_child_box(
     parent_size: u64,
     target: &[u8; 4],
 ) -> Option<BoxInfo> {
-    let end = parent_offset + parent_size;
+    // Adversarial size fields are attacker-controlled u64s, so every offset
+    // arithmetic uses checked ops: a box claiming a length that overflows or
+    // underruns its own header bails out rather than panicking mid-scan.
+    let end = parent_offset.checked_add(parent_size)?;
     let mut pos = parent_offset;
 
-    while pos + 8 <= end {
+    while pos.checked_add(8)? <= end {
         file.seek(SeekFrom::Start(pos)).ok()?;
         let mut header = [0u8; 8];
         file.read_exact(&mut header).ok()?;
@@ -71,20 +74,27 @@ fn find_child_box(
             let mut ext = [0u8; 8];
             file.read_exact(&mut ext).ok()?;
             let ext_size = u64::from_be_bytes(ext);
-            (ext_size, pos + 16)
+            (ext_size, pos.checked_add(16)?)
         } else if size == 0 {
             // Box extends to end of file
-            (end - pos, pos + 8)
+            (end.checked_sub(pos)?, pos.checked_add(8)?)
         } else {
-            (size, pos + 8)
+            (size, pos.checked_add(8)?)
         };
 
-        if box_size < 8 {
+        // Reject a box whose declared size doesn't cover its own header
+        // (guards the `box_size - header_len` subtraction below) or that
+        // runs past the parent region.
+        let header_len = data_offset.checked_sub(pos)?;
+        if box_size < header_len {
+            return None;
+        }
+        if pos.checked_add(box_size)? > end {
             return None;
         }
 
         if box_type == target {
-            let data_size = box_size - (data_offset - pos);
+            let data_size = box_size - header_len;
             return Some(BoxInfo {
                 data_offset,
                 data_size,

--- a/db/src/audiobook/chapters.rs
+++ b/db/src/audiobook/chapters.rs
@@ -101,7 +101,7 @@ fn find_child_box(
             });
         }
 
-        pos += box_size;
+        pos = pos.checked_add(box_size)?;
     }
     None
 }

--- a/db/src/audiobook/chapters/tests.rs
+++ b/db/src/audiobook/chapters/tests.rs
@@ -250,3 +250,178 @@ fn extract_id3v2_4_chap_uses_syncsafe_sizes() {
     assert_eq!(result[1].start_ms, 120_000);
     assert_eq!(result[1].end_ms, 300_000);
 }
+
+// --- Adversarial / truncated input ---------------------------------------
+//
+// The MP4 box-tree and ID3v2 CHAP parsers run on arbitrary user-supplied
+// files during indexing; a panic (or hang) here aborts the whole library
+// scan. These tests never assert a specific parse — only that the parser
+// terminates *gracefully* (returns, no panic, no hang) on hostile bytes.
+
+/// Write raw bytes to a temp file and return it (kept alive by the caller).
+fn temp_with_bytes(bytes: &[u8]) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(bytes).unwrap();
+    file.flush().unwrap();
+    file
+}
+
+/// A well-formed MP4 byte stream (ftyp + moov/udta/chpl) as a flat buffer,
+/// so tests can truncate it at arbitrary offsets.
+fn valid_mp4_bytes() -> Vec<u8> {
+    let chapters: &[(u64, &str)] = &[(0, "Intro"), (3_000_000_000, "One")];
+    let mut chpl_body = Vec::new();
+    chpl_body.extend_from_slice(&[0u8; 4]); // version 0 + flags
+    chpl_body.extend_from_slice(&(chapters.len() as u32).to_be_bytes());
+    for (start, title) in chapters {
+        chpl_body.extend_from_slice(&start.to_be_bytes());
+        chpl_body.push(title.len() as u8);
+        chpl_body.extend_from_slice(title.as_bytes());
+    }
+    let chpl = box_with(b"chpl", &chpl_body);
+    let udta = box_with(b"udta", &chpl);
+    let moov = box_with(b"moov", &udta);
+
+    let mut ftyp_body = Vec::new();
+    ftyp_body.extend_from_slice(b"M4B ");
+    ftyp_body.extend_from_slice(&0u32.to_be_bytes());
+    let ftyp = box_with(b"ftyp", &ftyp_body);
+
+    let mut out = ftyp;
+    out.extend_from_slice(&moov);
+    out
+}
+
+/// Wrap a body in an MP4 box header (`size(4 BE) + type(4) + body`).
+fn box_with(box_type: &[u8; 4], body: &[u8]) -> Vec<u8> {
+    let size = (8 + body.len()) as u32;
+    let mut out = Vec::with_capacity(size as usize);
+    out.extend_from_slice(&size.to_be_bytes());
+    out.extend_from_slice(box_type);
+    out.extend_from_slice(body);
+    out
+}
+
+#[test]
+fn extract_mp4_chapters_handles_truncation_at_every_offset_without_panicking() {
+    let full = valid_mp4_bytes();
+    // Cut the byte stream at every prefix length; each must return gracefully.
+    for cut in 0..=full.len() {
+        let file = temp_with_bytes(&full[..cut]);
+        // Must not panic; result is whatever the parser salvages (often empty).
+        let _ = extract_chapters(file.path(), "M4B");
+    }
+}
+
+#[test]
+fn extract_mp4_chapters_handles_oversized_box_length_field() {
+    // A top-level box whose declared 32-bit size vastly exceeds the buffer.
+    let mut data = Vec::new();
+    data.extend_from_slice(&u32::MAX.to_be_bytes());
+    data.extend_from_slice(b"moov");
+    data.extend_from_slice(&[0u8; 4]); // a few trailing bytes, far short of the claim
+    let file = temp_with_bytes(&data);
+    assert!(extract_chapters(file.path(), "M4B").is_empty());
+}
+
+#[test]
+fn extract_mp4_chapters_handles_extended_size_overflow_and_underrun() {
+    // size == 1 selects the 64-bit extended-size path. u64::MAX would overflow
+    // `pos + box_size`; a value of 8 underruns the 16-byte extended header.
+    for ext in [u64::MAX, 8, 0] {
+        let mut data = Vec::new();
+        data.extend_from_slice(&1u32.to_be_bytes()); // size == 1 → extended
+        data.extend_from_slice(b"moov");
+        data.extend_from_slice(&ext.to_be_bytes());
+        data.extend_from_slice(&[0u8; 8]);
+        let file = temp_with_bytes(&data);
+        // No panic on the checked add/sub; salvages nothing.
+        assert!(extract_chapters(file.path(), "M4B").is_empty());
+    }
+}
+
+#[test]
+fn extract_mp4_chapters_handles_chpl_count_larger_than_payload() {
+    // chpl claims 10_000 entries but carries none — reads must not run away.
+    let mut chpl_body = Vec::new();
+    chpl_body.extend_from_slice(&[0u8; 4]); // version 0 + flags
+    chpl_body.extend_from_slice(&10_000u32.to_be_bytes());
+    let chpl = box_with(b"chpl", &chpl_body);
+    let udta = box_with(b"udta", &chpl);
+    let moov = box_with(b"moov", &udta);
+    let file = temp_with_bytes(&moov);
+    assert!(extract_chapters(file.path(), "M4B").is_empty());
+}
+
+#[test]
+fn extract_mp4_chapters_handles_empty_input() {
+    let file = temp_with_bytes(&[]);
+    assert!(extract_chapters(file.path(), "M4B").is_empty());
+}
+
+#[test]
+fn extract_id3_chapters_handles_truncation_at_every_offset_without_panicking() {
+    for major in [3u8, 4u8] {
+        let full =
+            make_id3v2_chap_fixture(major, &[(0, 60_000, "Intro"), (60_000, 180_000, "One")]);
+        for cut in 0..=full.len() {
+            let file = temp_with_bytes(&full[..cut]);
+            let _ = extract_chapters(file.path(), "MP3");
+        }
+    }
+}
+
+#[test]
+fn extract_id3_chapters_handles_oversized_tag_and_frame_sizes() {
+    // Valid ID3 header, but the tag-size and CHAP frame-size claim far more
+    // bytes than the buffer holds. Both major versions exercise the two
+    // frame-size decoders (plain BE u32 for v2.3, syncsafe for v2.4).
+    for major in [3u8, 4u8] {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"ID3");
+        data.push(major);
+        data.push(0); // revision
+        data.push(0); // flags
+        data.extend_from_slice(&[0x7F, 0x7F, 0x7F, 0x7F]); // huge syncsafe tag size
+        data.extend_from_slice(b"CHAP");
+        data.extend_from_slice(&[0x7F, 0x7F, 0x7F, 0x7F]); // huge frame size
+        data.extend_from_slice(&[0u8; 2]); // frame flags
+        data.extend_from_slice(b"short"); // far fewer bytes than claimed
+        let file = temp_with_bytes(&data);
+        assert!(extract_chapters(file.path(), "MP3").is_empty());
+    }
+}
+
+#[test]
+fn extract_id3_chapters_handles_chap_body_truncated_after_element_id() {
+    // A CHAP frame whose body ends right after the null-terminated element id,
+    // before the four required u32 time/offset fields — must not index-panic.
+    let mut chap_body = Vec::new();
+    chap_body.extend_from_slice(b"ch0\0"); // element id, then nothing
+    let mut frame = Vec::new();
+    frame.extend_from_slice(b"CHAP");
+    frame.extend_from_slice(&(chap_body.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&[0u8; 2]); // flags
+    frame.extend_from_slice(&chap_body);
+
+    let mut data = Vec::new();
+    data.extend_from_slice(b"ID3");
+    data.push(3); // v2.3 → plain BE frame sizes
+    data.push(0);
+    data.push(0);
+    let tag_size = frame.len() as u32;
+    data.push(((tag_size >> 21) & 0x7F) as u8);
+    data.push(((tag_size >> 14) & 0x7F) as u8);
+    data.push(((tag_size >> 7) & 0x7F) as u8);
+    data.push((tag_size & 0x7F) as u8);
+    data.extend_from_slice(&frame);
+    let file = temp_with_bytes(&data);
+    // The malformed CHAP body yields no chapter; overall result is empty.
+    assert!(extract_chapters(file.path(), "MP3").is_empty());
+}
+
+#[test]
+fn extract_id3_chapters_handles_empty_input() {
+    let file = temp_with_bytes(&[]);
+    assert!(extract_chapters(file.path(), "MP3").is_empty());
+}

--- a/db/src/normalize/tests.rs
+++ b/db/src/normalize/tests.rs
@@ -44,6 +44,90 @@ fn normalize_author_swaps_single_comma_last_first() {
     );
 }
 
+/// Varied-Unicode inputs that stress every branch of the folder: accents,
+/// mixed scripts, emoji, article prefixes, whitespace runs, empty/blank,
+/// comma forms (author swap), CJK, RTL, and a very long string. Shared by
+/// the idempotence and no-panic tests below.
+fn tricky_inputs() -> Vec<String> {
+    let mut v: Vec<String> = [
+        "",
+        "   ",
+        "\t\n  \r",
+        "---",
+        "!!! ??? ...",
+        "Dracula",
+        "  DRACULA!  ",
+        "The Hitch-Hiker's Guide",
+        "A Tale of Two Cities",
+        "An Anthology",
+        "The",
+        "Dune:  Messiah",
+        "multiple     internal     spaces",
+        "Çítåtelka",
+        "Mémoires d'outre-tombe",
+        "Ĳsselmeer œuvre æsthetic ﬁ ﬂ",
+        "Stoker, Bram",
+        "Smith, John, Jr.",
+        "café ☕ résumé 📚 naïve",
+        "🎉🎊✨",
+        "Война и мир",
+        "戦争と平和",
+        "مرحبا بالعالم",
+        "ᚠᚢᚦᚨᚱᚲ",
+        "ﬀ ﬁ ﬂ ﬃ ﬄ",                         // ligatures that deunicode expands
+        "①②③ ⅣⅤⅥ",                           // enclosed / roman numerals
+        "\u{200B}zero\u{200B}width\u{200B}", // zero-width spaces
+        "  ,  ",                             // comma with only blanks around it
+        ",leading comma",
+        "trailing comma,",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    // A very long input to exercise the capacity/allocation path.
+    v.push("Tomás Ërník ".repeat(5_000));
+    v
+}
+
+#[test]
+fn normalize_title_is_idempotent_over_varied_unicode() {
+    for input in tricky_inputs() {
+        let once = normalize_title(&input);
+        // Re-normalizing the output must be a fixed point: applying the
+        // folder a second time yields exactly the first result.
+        let twice = once.as_deref().and_then(normalize_title);
+        assert_eq!(twice, once, "title not idempotent for {input:?}");
+    }
+}
+
+#[test]
+fn normalize_author_is_idempotent_over_varied_unicode() {
+    for input in tricky_inputs() {
+        let once = normalize_author(&input);
+        let twice = once.as_deref().and_then(normalize_author);
+        assert_eq!(twice, once, "author not idempotent for {input:?}");
+    }
+}
+
+#[test]
+fn normalize_never_panics_over_varied_unicode() {
+    // The folder runs on arbitrary scanned metadata; a panic here would
+    // abort a library scan. Assert it always returns without panicking and
+    // that any surviving key is non-empty and free of leading/trailing/
+    // doubled ASCII spaces (the folder's invariant).
+    for input in tricky_inputs() {
+        for key in [normalize_title(&input), normalize_author(&input)]
+            .into_iter()
+            .flatten()
+        {
+            assert!(!key.is_empty(), "empty key survived for {input:?}");
+            assert!(!key.starts_with(' '), "leading space for {input:?}");
+            assert!(!key.ends_with(' '), "trailing space for {input:?}");
+            assert!(!key.contains("  "), "doubled space for {input:?}");
+        }
+    }
+}
+
 #[tokio::test]
 async fn backfill_norm_columns_propagates_db_error_when_pool_is_closed() {
     let pool = init_db("sqlite::memory:").await.unwrap();


### PR DESCRIPTION
## Summary
Part of #770 — the deferred property/edge-test items that the main #770 PR intentionally left out (flagged there as lower-priority "needs human judgment" additions). No new dependencies — all tests are plain `#[test]` (no `proptest`/`cargo-fuzz`).

**`db/src/normalize.rs`** (`normalize_title`/`normalize_author`) — its own doc warns "a false positive silently corrupts a book," yet only hand-picked examples were tested. Added to the existing sibling `db/src/normalize/tests.rs`:
- **Idempotence** — `normalize(normalize(s)) == normalize(s)` for both title and author over a shared table of tricky inputs (accents, mixed scripts/CJK/RTL, emoji, ligatures, article prefixes, whitespace runs, empty/blank, comma forms, zero-width spaces, a very long string).
- **No-panic** — the folder never panics over that same input set, and any surviving key upholds its invariant (non-empty, no leading/trailing/doubled ASCII space).

**`db/src/audiobook/chapters.rs`** — the hand-rolled MP4 box-tree and ID3v2 CHAP parsers run on arbitrary user files during indexing, where a panic aborts the whole library scan. Added to the sibling `db/src/audiobook/chapters/tests.rs`:
- Truncation at **every** byte offset of a valid MP4 and of both ID3v2.3/.4 fixtures.
- Adversarial/oversized length fields (a box/frame claiming more bytes than the buffer holds; 64-bit extended-size overflow and header underrun; a `chpl` count larger than the payload; a CHAP body truncated after its element id).
- Empty input on both paths.

These assert the parser terminates *gracefully* (error/empty, no panic, no hang) — not a specific parse.

### Production fix (in scope — hardening these parsers)
The truncation/adversarial tests surfaced a **real panic**: a crafted M4B with a 64-bit extended-size box (`size == 1`, `ext_size == u64::MAX`) overflows the offset arithmetic in `find_child_box` — `attempt to add with overflow at chapters.rs:61` — aborting the scan. Verified by running the new tests against the unpatched code. Minimal fix: `find_child_box` now uses checked add/sub on the attacker-controlled `u64` size fields, rejects a box whose declared size can't cover its own header (fixes an underflow on the extended-size path) or that overruns its parent region, and bails to `None` instead of panicking. Well-formed files are unaffected — all six pre-existing happy-path fixtures still pass.

## Test plan
- [x] `cargo test -p omnibus-db` → **PASS** (820 lib + 2 integration, 0 failures)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` → **PASS**
- [x] `cargo fmt --check` → **PASS**
- [x] Confirmed the production fix is load-bearing: the new MP4 extended-size test panics against the unpatched parser (`attempt to add with overflow`), passes after the fix.

## Notes
Scoped to the two parser families flagged in #770's "property/fuzz-test pass" section. `Closes` is intentionally omitted — the main #770 PR closes the issue; this lands the deferred half.