### PR TITLE
refactor: split remaining oversized functions into helpers

### DIFF
--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -1,6 +1,6 @@
 //! User CRUD.
 
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use super::password::{hash_password, validate_password, validate_username};
 use super::{row_to_user, AuthError, AuthResult, User};
@@ -25,31 +25,9 @@ pub async fn create_user(pool: &SqlitePool, username: &str, password: &str) -> A
     // connection-drop implicit cleanup).
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
 
-    let user_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
-        .fetch_one(&mut *tx)
-        .await?;
-
-    let is_first = user_count == 0;
-
-    if !is_first {
-        let enabled: String =
-            sqlx::query_scalar("SELECT value FROM settings WHERE key = 'registration_enabled'")
-                .fetch_optional(&mut *tx)
-                .await?
-                .unwrap_or_else(|| "0".to_string());
-        if enabled != "1" {
-            return Err(AuthError::RegistrationDisabled);
-        }
-    }
-
-    let existing: Option<i64> =
-        sqlx::query_scalar("SELECT id FROM users WHERE username = ? COLLATE NOCASE")
-            .bind(username)
-            .fetch_optional(&mut *tx)
-            .await?;
-    if existing.is_some() {
-        return Err(AuthError::UsernameTaken);
-    }
+    // Runs on the transaction's connection so the RESERVED write lock from
+    // `BEGIN IMMEDIATE` covers the count/uniqueness checks.
+    let is_first = check_registration_preconditions(&mut tx, username).await?;
 
     let is_admin = if is_first { 1i64 } else { 0 };
     let can_upload = if is_first { 1i64 } else { 0 };
@@ -95,6 +73,46 @@ pub async fn create_user(pool: &SqlitePool, username: &str, password: &str) -> A
         can_download: can_download != 0,
         kindle_email: None,
     })
+}
+
+/// Precondition checks for [`create_user`], run inside its `BEGIN IMMEDIATE`
+/// transaction. Returns whether this is the first user (who becomes admin).
+///
+/// Errors with [`AuthError::RegistrationDisabled`] when the table is
+/// non-empty and self-registration is off, or [`AuthError::UsernameTaken`]
+/// when the (case-insensitive) username already exists. Takes the
+/// transaction connection so the caller's write lock guards these reads.
+async fn check_registration_preconditions(
+    conn: &mut SqliteConnection,
+    username: &str,
+) -> AuthResult<bool> {
+    let user_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
+        .fetch_one(&mut *conn)
+        .await?;
+
+    let is_first = user_count == 0;
+
+    if !is_first {
+        let enabled: String =
+            sqlx::query_scalar("SELECT value FROM settings WHERE key = 'registration_enabled'")
+                .fetch_optional(&mut *conn)
+                .await?
+                .unwrap_or_else(|| "0".to_string());
+        if enabled != "1" {
+            return Err(AuthError::RegistrationDisabled);
+        }
+    }
+
+    let existing: Option<i64> =
+        sqlx::query_scalar("SELECT id FROM users WHERE username = ? COLLATE NOCASE")
+            .bind(username)
+            .fetch_optional(&mut *conn)
+            .await?;
+    if existing.is_some() {
+        return Err(AuthError::UsernameTaken);
+    }
+
+    Ok(is_first)
 }
 
 /// Look up a user record by username (case-insensitive); returns `None` if no match.

--- a/db/src/ebook/stat.rs
+++ b/db/src/ebook/stat.rs
@@ -86,60 +86,12 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
                         error: Some(format!("could not read directory: {e}")),
                     };
                 }
-                // Sub-dir unreadable: record a placeholder with an empty
-                // uuid so the legacy wrapper can lift it into an error
-                // row. Carry the io::Error string so callers can
-                // distinguish "permission denied" from "no such file" —
-                // the incremental indexer ignores empty-uuid entries.
-                let relative = current
-                    .strip_prefix(dir)
-                    .unwrap_or(&current)
-                    .to_string_lossy()
-                    .to_string();
-                entries.push(StatEntry {
-                    filename: relative,
-                    scan_key: String::new(),
-                    mtime_epoch: 0,
-                    size_bytes: 0,
-                    error: Some(e.to_string()),
-                });
+                entries.push(unreadable_subdir_entry(dir, &current, &e));
                 continue;
             }
         };
         for entry in read.flatten() {
-            let Ok(file_type) = entry.file_type() else {
-                continue;
-            };
-            let entry_path = entry.path();
-            if file_type.is_dir() {
-                stack.push(entry_path);
-                continue;
-            }
-            if !file_type.is_file() {
-                continue;
-            }
-            let is_epub = entry_path
-                .extension()
-                .and_then(|s| s.to_str())
-                .map(|s| s.eq_ignore_ascii_case("epub"))
-                .unwrap_or(false);
-            if !is_epub {
-                continue;
-            }
-            let relative = entry_path
-                .strip_prefix(dir)
-                .unwrap_or(&entry_path)
-                .to_string_lossy()
-                .to_string();
-            let (mtime_epoch, size_bytes) = stat_file(&entry_path);
-            let scan_key = crate::helpers::scan_key_for(&relative);
-            entries.push(StatEntry {
-                filename: relative,
-                scan_key,
-                mtime_epoch,
-                size_bytes,
-                error: None,
-            });
+            push_dir_entry(dir, &entry, &mut stack, &mut entries);
         }
     }
 
@@ -150,6 +102,70 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
         entries,
         error: None,
     }
+}
+
+/// Build the empty-`scan_key` placeholder for an unreadable subdirectory.
+///
+/// Carries the io::Error string so callers can distinguish "permission
+/// denied" from "no such file" — the legacy wrapper lifts these into error
+/// rows and the incremental indexer ignores empty-`scan_key` entries.
+fn unreadable_subdir_entry(base: &Path, current: &Path, err: &std::io::Error) -> StatEntry {
+    let relative = current
+        .strip_prefix(base)
+        .unwrap_or(current)
+        .to_string_lossy()
+        .to_string();
+    StatEntry {
+        filename: relative,
+        scan_key: String::new(),
+        mtime_epoch: 0,
+        size_bytes: 0,
+        error: Some(err.to_string()),
+    }
+}
+
+/// Process one `read_dir` entry: push subdirectories onto `stack` for the
+/// walk, and append a stat row for each `.epub` file. Non-epub files and
+/// entries whose `file_type()` can't be read are skipped.
+fn push_dir_entry(
+    base: &Path,
+    entry: &std::fs::DirEntry,
+    stack: &mut Vec<PathBuf>,
+    entries: &mut Vec<StatEntry>,
+) {
+    let Ok(file_type) = entry.file_type() else {
+        return;
+    };
+    let entry_path = entry.path();
+    if file_type.is_dir() {
+        stack.push(entry_path);
+        return;
+    }
+    if !file_type.is_file() {
+        return;
+    }
+    let is_epub = entry_path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.eq_ignore_ascii_case("epub"))
+        .unwrap_or(false);
+    if !is_epub {
+        return;
+    }
+    let relative = entry_path
+        .strip_prefix(base)
+        .unwrap_or(&entry_path)
+        .to_string_lossy()
+        .to_string();
+    let (mtime_epoch, size_bytes) = stat_file(&entry_path);
+    let scan_key = crate::helpers::scan_key_for(&relative);
+    entries.push(StatEntry {
+        filename: relative,
+        scan_key,
+        mtime_epoch,
+        size_bytes,
+        error: None,
+    });
 }
 
 /// `entry.metadata()` + `modified()` → epoch seconds. Anything we can't

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -293,9 +293,11 @@ fn use_mobile_viewport_fix() {}
 #[component]
 pub fn App() -> Element {
     use_context_provider(|| SearchQuery(Signal::new(String::new())));
-    // Per rule 07, hook calls in App() are unconditional — feature gates
-    // live inside the helper bodies so the call sequence is identical on
-    // every target.
+    // Hook calls in App() are unconditional — the feature gates live inside
+    // the helper bodies (mobile compiles them to no-op stubs). This keeps
+    // rule 07's SSR-vs-WASM hydration parity within the not(mobile) build,
+    // where the helpers are real hooks; true hook-count parity across mobile
+    // isn't claimed (the stubs run no hooks).
     use_palette_setup();
     use_user_and_playback_contexts();
     use_current_user_boot();

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -209,6 +209,86 @@ fn use_user_and_playback_contexts() {
 #[cfg(feature = "mobile")]
 fn use_user_and_playback_contexts() {}
 
+/// Install the app-root playback shim and the single boot-time `/me` fetch.
+///
+/// Web only: installs the `window.OmnibusAudio` shim (so the `<audio>` element
+/// and playback signals outlive navigation for the persistent mini-dock) and
+/// runs one `current_user()` fetch, then subscribes to `web_auth_state` so a
+/// fresh login refills the cache and a 401 clears it without a hard reload.
+/// Called unconditionally from [`App`]; the cfg lives here so the call site
+/// stays gate-free.
+#[cfg(feature = "web")]
+fn use_current_user_boot() {
+    // App-root audiobook playback driver: installs the `window.OmnibusAudio`
+    // shim and reacts to the playback context's `uuid` signal.
+    pages::install_audio_bootstrap(use_playback());
+
+    let mut slot = use_context::<CurrentUser>().0;
+    use_future(move || async move {
+        // Initial fetch on mount. Only an explicit `Ok(_)` updates
+        // state — transient errors (network blip, rate-limit 429)
+        // leave the signal at `None` so callers keep showing the
+        // pre-resolve placeholder.
+        if let Ok(resolved) = data::current_user().await {
+            slot.set(Some(resolved));
+        }
+
+        // React to subsequent auth-state transitions. `current_user`
+        // itself pings `web_auth_state` on every call (true on 200,
+        // false on 401), so the very first transition we observe
+        // here is usually `true -> true` from the initial fetch
+        // above — skip same-value updates to avoid a redundant
+        // refetch loop.
+        let mut rx = data::web_auth_state::subscribe();
+        let mut last = *rx.borrow_and_update();
+        while rx.changed().await.is_ok() {
+            let now = *rx.borrow_and_update();
+            if now == last {
+                continue;
+            }
+            last = now;
+            if now {
+                // Fresh login (channel flipped false -> true): refetch
+                // so the avatar / admin gates update without a reload.
+                if let Ok(resolved) = data::current_user().await {
+                    slot.set(Some(resolved));
+                }
+            } else {
+                // 401 observed elsewhere: flip to unauthenticated
+                // immediately. ScreenLayout already drives the
+                // /login redirect off the same channel.
+                slot.set(Some(None));
+            }
+        }
+    });
+}
+
+/// Non-web stub: no playback shim, no `/me` boot fetch.
+#[cfg(not(feature = "web"))]
+fn use_current_user_boot() {}
+
+/// Patch the viewport meta on mobile so content fills the screen edge-to-edge.
+///
+/// Mobile (wry WKWebView) only: the Dioxus-generated viewport meta lacks
+/// `viewport-fit=cover`, so the WebView insets its scroll content by the safe
+/// areas (status bar + home indicator) — a phantom ~100px of scroll behind the
+/// fixed full-screen player, and `env(safe-area-inset-*)` reads 0. The patch is
+/// an effect (not markup), so it's free to be target-gated. Non-mobile is a
+/// no-op stub; called unconditionally from [`App`].
+#[cfg(feature = "mobile")]
+fn use_mobile_viewport_fix() {
+    use_effect(|| {
+        dioxus::document::eval(
+            "const m = document.querySelector('meta[name=viewport]');\
+             if (m) m.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover');",
+        );
+    });
+}
+
+/// Non-mobile stub: the viewport meta is already correct.
+#[cfg(not(feature = "mobile"))]
+fn use_mobile_viewport_fix() {}
+
 /// Root app component. Renders global styles and the router.
 #[component]
 pub fn App() -> Element {
@@ -218,76 +298,11 @@ pub fn App() -> Element {
     // every target.
     use_palette_setup();
     use_user_and_playback_contexts();
-
-    // Single boot-time `/me` fetch (replaces the per-component effects in
-    // user_menu / landing / author). Also subscribes to `web_auth_state`
-    // so a fresh login refills the cache and a 401 clears it without
-    // requiring a hard reload.
-    // App-root audiobook playback driver: installs the `window.OmnibusAudio`
-    // shim and reacts to the playback context's `uuid` signal. Mounted here
-    // (not in the route) so the `<audio>` element and signals outlive
-    // navigation, enabling the persistent mini-dock.
-    #[cfg(feature = "web")]
-    pages::install_audio_bootstrap(use_playback());
-
-    #[cfg(feature = "web")]
-    {
-        let mut slot = use_context::<CurrentUser>().0;
-        use_future(move || async move {
-            // Initial fetch on mount. Only an explicit `Ok(_)` updates
-            // state — transient errors (network blip, rate-limit 429)
-            // leave the signal at `None` so callers keep showing the
-            // pre-resolve placeholder.
-            if let Ok(resolved) = data::current_user().await {
-                slot.set(Some(resolved));
-            }
-
-            // React to subsequent auth-state transitions. `current_user`
-            // itself pings `web_auth_state` on every call (true on 200,
-            // false on 401), so the very first transition we observe
-            // here is usually `true -> true` from the initial fetch
-            // above — skip same-value updates to avoid a redundant
-            // refetch loop.
-            let mut rx = data::web_auth_state::subscribe();
-            let mut last = *rx.borrow_and_update();
-            while rx.changed().await.is_ok() {
-                let now = *rx.borrow_and_update();
-                if now == last {
-                    continue;
-                }
-                last = now;
-                if now {
-                    // Fresh login (channel flipped false -> true): refetch
-                    // so the avatar / admin gates update without a reload.
-                    if let Ok(resolved) = data::current_user().await {
-                        slot.set(Some(resolved));
-                    }
-                } else {
-                    // 401 observed elsewhere: flip to unauthenticated
-                    // immediately. ScreenLayout already drives the
-                    // /login redirect off the same channel.
-                    slot.set(Some(None));
-                }
-            }
-        });
-    }
+    use_current_user_boot();
 
     components::atrium::init_theme();
 
-    // Mobile (wry WKWebView): the Dioxus-generated viewport meta lacks
-    // `viewport-fit=cover`, so the WebView insets its scroll content by the
-    // safe areas (status bar + home indicator) — a phantom ~100px of scroll
-    // behind the fixed full-screen player, and `env(safe-area-inset-*)` reads 0.
-    // Patch the meta once at startup so content fills the screen edge-to-edge
-    // and the player's safe-area padding applies. Effect (not markup), so it's
-    // free to be target-gated.
-    #[cfg(feature = "mobile")]
-    use_effect(|| {
-        dioxus::document::eval(
-            "const m = document.querySelector('meta[name=viewport]');\
-             if (m) m.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover');",
-        );
-    });
+    use_mobile_viewport_fix();
 
     // The single `<audio>` element, mounted at the App root (sibling of the
     // Router) so it never unmounts on navigation — the persistence anchor for

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -60,42 +60,24 @@ pub fn BookDetailPage(uuid: String) -> Element {
 
     // Merge dialog state. Declared unconditionally per rule 07 so the hook
     // count is identical on every target — mobile compiles the signals but
-    // never reads them (the rsx that consumes them is still cfg-gated below
-    // and `build_merge_*` are stubbed to `None` on mobile).
+    // `render_book_shell` stubs the builders that read them.
     let merge_open = use_signal(|| false);
     let merge_result: Signal<Option<MergeBooksResult>> = use_signal(|| None);
     let undo_error: Signal<Option<String>> = use_signal(|| None);
-    // Mobile's merge builders are `None`-returning stubs that take no args,
-    // so the three signals above would otherwise be unused on that target.
-    #[cfg(feature = "mobile")]
-    let _ = (merge_open, merge_result, undo_error);
 
-    let url = server_url.clone();
-    use_effect(use_reactive!(|uuid| {
-        let _ = refresh();
-        fetch_book_and_author_books(
-            url.clone(),
-            uuid.clone(),
+    use_book_data_effects(
+        uuid.clone(),
+        server_url.clone(),
+        BookDataSignals {
             book,
             author_books,
             loading,
             error,
-        );
-    }));
-
-    // F3.3 suggestions: resolved off-request by the worker and cached. Fetch
-    // for the current book; while the result is `Pending`, poll a few times on
-    // web so it appears without a manual reload. A fetch failure degrades to
-    // "no suggestions" rather than an error row.
-    let sug_url = server_url.clone();
-    use_effect(use_reactive!(|uuid| {
-        poll_suggestions_until_resolved(
-            sug_url.clone(),
-            uuid.clone(),
+            refresh,
             suggestions_epoch,
             suggestions,
-        );
-    }));
+        },
+    );
 
     if loading() {
         return rsx! {
@@ -115,6 +97,92 @@ pub fn BookDetailPage(uuid: String) -> Element {
         };
     };
 
+    render_book_shell(
+        b,
+        MergeSignals {
+            open: merge_open,
+            result: merge_result,
+            undo_error,
+            refresh,
+        },
+        author_books(),
+        suggestions(),
+        is_admin,
+        server_url,
+    )
+}
+
+/// The book-page data signals written by the fetch effects. `Copy` (Dioxus
+/// signals), so the group is passed by value.
+#[derive(Clone, Copy)]
+struct BookDataSignals {
+    book: Signal<Option<EbookMetadata>>,
+    author_books: Signal<Vec<EbookMetadata>>,
+    loading: Signal<bool>,
+    error: Signal<Option<String>>,
+    refresh: Signal<u32>,
+    suggestions_epoch: Signal<u64>,
+    suggestions: Signal<Option<SuggestionsResponse>>,
+}
+
+/// Install the two `uuid`-reactive fetch effects: the book + author-books load
+/// (also re-armed by `refresh` after a merge/undo) and the F3.3 suggestions
+/// poll. Called unconditionally from [`BookDetailPage`] so the hook sequence
+/// stays fixed; both effects re-run when `uuid` changes.
+fn use_book_data_effects(uuid: String, server_url: String, sig: BookDataSignals) {
+    let url = server_url.clone();
+    let refresh = sig.refresh;
+    use_effect(use_reactive!(|uuid| {
+        // Read `refresh` so a merge/undo bump re-arms this effect.
+        let _ = refresh();
+        fetch_book_and_author_books(
+            url.clone(),
+            uuid.clone(),
+            sig.book,
+            sig.author_books,
+            sig.loading,
+            sig.error,
+        );
+    }));
+
+    // F3.3 suggestions: resolved off-request by the worker and cached. Fetch
+    // for the current book; while the result is `Pending`, poll a few times on
+    // web so it appears without a manual reload. A fetch failure degrades to
+    // "no suggestions" rather than an error row.
+    let sug_url = server_url.clone();
+    use_effect(use_reactive!(|uuid| {
+        poll_suggestions_until_resolved(
+            sug_url.clone(),
+            uuid.clone(),
+            sig.suggestions_epoch,
+            sig.suggestions,
+        );
+    }));
+}
+
+/// Merge-dialog signals threaded from [`BookDetailPage`] into the loaded-book
+/// renderer. `Copy` (Dioxus signals), so passing them by value is cheap and
+/// keeps the callee free of extra hook calls.
+#[derive(Clone, Copy)]
+struct MergeSignals {
+    open: Signal<bool>,
+    result: Signal<Option<MergeBooksResult>>,
+    undo_error: Signal<Option<String>>,
+    refresh: Signal<u32>,
+}
+
+/// Assemble the loaded-book view: derive the admin flag, build the (web-only)
+/// merge button + dialog, and compose them with [`render_loaded`]. Kept a plain
+/// fn so the platform `cfg` gates live here instead of the component body
+/// (rule 07 — no new gates inside `BookDetailPage`).
+fn render_book_shell(
+    b: EbookMetadata,
+    merge: MergeSignals,
+    author_books: Vec<EbookMetadata>,
+    suggestions: Option<SuggestionsResponse>,
+    is_admin: Signal<bool>,
+    server_url: String,
+) -> Element {
     // `is_admin` starts at `false` and only flips to `true` on the web
     // client after `current_user()` resolves an admin user, so this read
     // returns `false` during SSR and for non-admins on every platform.
@@ -123,28 +191,40 @@ pub fn BookDetailPage(uuid: String) -> Element {
     // Rail "Merge with…" button (admin, web only) — threaded down as a
     // prebuilt Element so the rail component stays platform-agnostic.
     #[cfg(not(feature = "mobile"))]
-    let merge_button: Option<Element> = merge::build_merge_button(is_admin_flag, merge_open);
+    let merge_button: Option<Element> = merge::build_merge_button(is_admin_flag, merge.open);
     #[cfg(feature = "mobile")]
     let merge_button: Option<Element> = merge::build_merge_button(is_admin_flag);
 
     #[cfg(not(feature = "mobile"))]
     let merge_ui: Option<Element> = merge::build_merge_ui(
-        merge_open,
-        merge_result,
-        undo_error,
-        refresh,
+        merge.open,
+        merge.result,
+        merge.undo_error,
+        merge.refresh,
         server_url.clone(),
         b.clone(),
     );
     #[cfg(feature = "mobile")]
-    let merge_ui: Option<Element> = merge::build_merge_ui();
+    let merge_ui: Option<Element> = {
+        // Mobile's builders take no args; read every field so the signals
+        // (declared unconditionally in `BookDetailPage` for hook parity)
+        // aren't flagged as never-read on this target.
+        let MergeSignals {
+            open,
+            result,
+            undo_error,
+            refresh,
+        } = merge;
+        let _ = (open, result, undo_error, refresh);
+        merge::build_merge_ui()
+    };
 
     let body = render_loaded(
         b,
-        author_books(),
+        author_books,
         merge_button,
-        suggestions(),
-        server_url.clone(),
+        suggestions,
+        server_url,
         is_admin_flag,
     );
     rsx! {

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -197,10 +197,7 @@ fn empty_results(r: &PaletteResults, q: &str) -> Element {
     }
 }
 
-/// Non-empty section order plus whether the query matched a tag name. A tag-name
-/// match leads with Tags (the second design artboard); otherwise the canonical
-/// type order. Empty sections are filtered out. The bool is threaded on to the
-/// section renderers so they can annotate a tag-driven result set.
+/// Non-empty section order (tags-first on a tag-name match) plus that match flag.
 fn section_order(r: &PaletteResults, q: &str) -> (Vec<Section>, bool) {
     let q_lower = q.to_lowercase();
     let tag_match = r

--- a/frontend/src/pages/search.rs
+++ b/frontend/src/pages/search.rs
@@ -133,47 +133,10 @@ fn SearchResults(results: PaletteResults, query: String) -> Element {
     let total = r.total_count();
 
     if total == 0 {
-        return rsx! {
-            div { class: "search-head",
-                div {
-                    div { class: "label", "Search results" }
-                    h1 { class: "search-title",
-                        "No results for \u{201c}"
-                        {highlight(&q, &q)}
-                        "\u{201d}"
-                    }
-                }
-            }
-            p { class: "subtitle", "data-testid": "search-result-count",
-                "0 results \u{00b7} fts5 \u{00b7} {r.duration_ms}ms"
-            }
-        };
+        return empty_results(&r, &q);
     }
 
-    // A query that lands inside tag names leads with the Tags group (the
-    // second design artboard); otherwise the canonical type order.
-    let q_lower = q.to_lowercase();
-    let tag_match = r
-        .tags
-        .iter()
-        .any(|t| t.name.to_lowercase().contains(&q_lower));
-    let canonical = [
-        Section::Books,
-        Section::Authors,
-        Section::Series,
-        Section::Tags,
-    ];
-    let tags_first = [
-        Section::Tags,
-        Section::Books,
-        Section::Authors,
-        Section::Series,
-    ];
-    let order: Vec<Section> = if tag_match { tags_first } else { canonical }
-        .into_iter()
-        .filter(|s| s.count(&r) > 0)
-        .collect();
-
+    let (order, tag_match) = section_order(&r, &q);
     let result_word = if total == 1 { "result" } else { "results" };
 
     rsx! {
@@ -213,6 +176,54 @@ fn SearchResults(results: PaletteResults, query: String) -> Element {
             {on_this_page(&order, &r, tag_match, &q)}
         }
     }
+}
+
+/// Empty-state header + zero-count summary for a query with no hits.
+fn empty_results(r: &PaletteResults, q: &str) -> Element {
+    rsx! {
+        div { class: "search-head",
+            div {
+                div { class: "label", "Search results" }
+                h1 { class: "search-title",
+                    "No results for \u{201c}"
+                    {highlight(q, q)}
+                    "\u{201d}"
+                }
+            }
+        }
+        p { class: "subtitle", "data-testid": "search-result-count",
+            "0 results \u{00b7} fts5 \u{00b7} {r.duration_ms}ms"
+        }
+    }
+}
+
+/// Non-empty section order plus whether the query matched a tag name. A tag-name
+/// match leads with Tags (the second design artboard); otherwise the canonical
+/// type order. Empty sections are filtered out. The bool is threaded on to the
+/// section renderers so they can annotate a tag-driven result set.
+fn section_order(r: &PaletteResults, q: &str) -> (Vec<Section>, bool) {
+    let q_lower = q.to_lowercase();
+    let tag_match = r
+        .tags
+        .iter()
+        .any(|t| t.name.to_lowercase().contains(&q_lower));
+    let canonical = [
+        Section::Books,
+        Section::Authors,
+        Section::Series,
+        Section::Tags,
+    ];
+    let tags_first = [
+        Section::Tags,
+        Section::Books,
+        Section::Authors,
+        Section::Series,
+    ];
+    let order: Vec<Section> = if tag_match { tags_first } else { canonical }
+        .into_iter()
+        .filter(|s| s.count(r) > 0)
+        .collect();
+    (order, tag_match)
 }
 
 // ── Section renderers ────────────────────────────────────────────────────

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -3,7 +3,7 @@
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
-use omnibus_shared::SeriesDetail;
+use omnibus_shared::{EbookMetadata, SeriesDetail};
 
 use crate::components::atrium::Cover;
 use crate::{data, use_server_url, Route};
@@ -72,6 +72,27 @@ fn render_series(s: SeriesDetail) -> Element {
         .find_map(|b| b.creators.first().map(|c| (c.name.clone(), c.id)))
         .unwrap_or_default();
 
+    rsx! {
+        div { class: "disc-page", style: "--accent: {accent}",
+            {series_header(&s, &primary_author, primary_author_id)}
+            div { class: "disc-body",
+                div { class: "series-cards",
+                    for book in s.books.iter() {
+                        {series_book_row(book)}
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Series page header: breadcrumb (with an optional linked author crumb) and
+/// the italic-first-word hero title.
+fn series_header(
+    s: &SeriesDetail,
+    primary_author: &str,
+    primary_author_id: Option<i64>,
+) -> Element {
     // Split series name for italic styling on key word.
     let title_parts: Vec<&str> = s.name.splitn(2, ' ').collect();
     let title_first = title_parts.first().copied().unwrap_or("");
@@ -80,76 +101,71 @@ fn render_series(s: SeriesDetail) -> Element {
     } else {
         ""
     };
-
     rsx! {
-        div { class: "disc-page", style: "--accent: {accent}",
-            // Header
-            div { class: "disc-series-header",
-                nav { class: "breadcrumb", aria_label: "breadcrumb",
-                    Link { to: Route::Landing {}, "Library" }
-                    span { class: "breadcrumb-sep", " › " }
-                    if !primary_author.is_empty() {
-                        if let Some(author_id) = primary_author_id {
-                            Link {
-                                to: Route::AuthorDetail { id: author_id },
-                                "data-testid": "series-crumb-author",
-                                "{primary_author}"
-                            }
-                        } else {
-                            span { "data-testid": "series-crumb-author", "{primary_author}" }
+        div { class: "disc-series-header",
+            nav { class: "breadcrumb", aria_label: "breadcrumb",
+                Link { to: Route::Landing {}, "Library" }
+                span { class: "breadcrumb-sep", " › " }
+                if !primary_author.is_empty() {
+                    if let Some(author_id) = primary_author_id {
+                        Link {
+                            to: Route::AuthorDetail { id: author_id },
+                            "data-testid": "series-crumb-author",
+                            "{primary_author}"
                         }
-                        span { class: "breadcrumb-sep", " › " }
+                    } else {
+                        span { "data-testid": "series-crumb-author", "{primary_author}" }
                     }
-                    span { "{s.name}" }
+                    span { class: "breadcrumb-sep", " › " }
                 }
-                div { class: "disc-series-head-row",
-                    div {
-                        span { class: "label", "Series · {s.book_count} in library" }
-                        h1 { class: "disc-hero-title",
-                            em { "{title_first}" }
-                            if !title_rest.is_empty() {
-                                " {title_rest}"
-                            }
+                span { "{s.name}" }
+            }
+            div { class: "disc-series-head-row",
+                div {
+                    span { class: "label", "Series · {s.book_count} in library" }
+                    h1 { class: "disc-hero-title",
+                        em { "{title_first}" }
+                        if !title_rest.is_empty() {
+                            " {title_rest}"
                         }
                     }
                 }
             }
+        }
+    }
+}
 
-            // Body: card grid of books
-            div { class: "disc-body",
-                div { class: "series-cards",
-                    for book in s.books.iter() {
-                        article {
-                            key: "{book.id}",
-                            class: "card series-card",
-                            div { class: "series-card-cover",
-                                Link {
-                                    to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
-                                    Cover { book: book.clone() }
-                                }
-                            }
-                            div { class: "series-card-info",
-                                span { class: "label",
-                                    if let Some(ref idx) = book.series_index {
-                                        "Book #{idx}"
-                                    }
-                                    if let Some(ref year) = book.published {
-                                        " · {year}"
-                                    }
-                                }
-                                h3 { class: "series-card-title",
-                                    Link {
-                                        to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
-                                        "{book.title.as_deref().unwrap_or(&book.filename)}"
-                                    }
-                                }
-                                if let Some(ref desc) = book.description {
-                                    div { class: "series-card-desc",
-                                        dangerous_inner_html: "{desc}"
-                                    }
-                                }
-                            }
-                        }
+/// One book card in the series grid: cover, index/year label, title link, and
+/// an optional description.
+fn series_book_row(book: &EbookMetadata) -> Element {
+    rsx! {
+        article {
+            key: "{book.id}",
+            class: "card series-card",
+            div { class: "series-card-cover",
+                Link {
+                    to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
+                    Cover { book: book.clone() }
+                }
+            }
+            div { class: "series-card-info",
+                span { class: "label",
+                    if let Some(ref idx) = book.series_index {
+                        "Book #{idx}"
+                    }
+                    if let Some(ref year) = book.published {
+                        " · {year}"
+                    }
+                }
+                h3 { class: "series-card-title",
+                    Link {
+                        to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
+                        "{book.title.as_deref().unwrap_or(&book.filename)}"
+                    }
+                }
+                if let Some(ref desc) = book.description {
+                    div { class: "series-card-desc",
+                        dangerous_inner_html: "{desc}"
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Closes #607.

Resolves the six functions from the issue's Evidence table that exceeded the ~80-line soft cap (rule `05-rust-style.md` § Function shape). **All six were measured and confirmed still over the cap** at the start of this change — none had been quietly brought under cap by earlier PRs (#584 extracted some hook-ordering helpers from `App`/`BookDetailPage`, but both bodies were still 94 and 117 lines respectively). No function was skipped.

Behavior is unchanged throughout — each change is a pure extraction of existing logic into named helpers/sub-components (each with a one-line `///`).

| File | Function | Before → After (body lines) | Extraction |
|---|---|---|---|
| `db/src/auth/users.rs` | `create_user` | 84 → 62 | `check_registration_preconditions(&mut tx, username)` for the count / `registration_enabled` / username-taken checks. Helper takes the transaction connection so the `BEGIN IMMEDIATE` write lock still guards the reads. |
| `db/src/ebook/stat.rs` | `stat_ebook_library` | 96 → 48 | `unreadable_subdir_entry(...)` (placeholder row) + `push_dir_entry(...)` (per-entry processing). The walk structure stays in the outer fn. |
| `frontend/src/pages/series.rs` | `render_series` | 100 → 29 | `series_header(...)` + `series_book_row(...)` plain-fn sub-components (no `#[component]` needed on a plain fn). |
| `frontend/src/lib.rs` | `App` | 94 → 29 | `use_current_user_boot()` (web `/me` boot fetch + audio shim) and `use_mobile_viewport_fix()` (mobile viewport patch), each with a stub on the other target — the #584 "cfg-in-the-helper, unconditional call site" pattern. |
| `frontend/src/pages/search.rs` | `SearchResults` | 86 → 49 | `empty_results(...)` (zero-hit header) + `section_order(...)` (order derivation + tag-match flag). |
| `frontend/src/pages/book_detail/mod.rs` | `BookDetailPage` | 117 → 76 | `use_book_data_effects(...)` (the two uuid-reactive fetch effects) + `render_book_shell(...)` (loaded-book assembly incl. the pre-existing cfg-gated merge UI), threading signal groups via `Copy` structs. |

Hydration (rule 07): no new `#[cfg(feature)]` gating was introduced into any component body. Existing platform gates in `App` / `BookDetailPage` were moved *out* of the component into plain helpers (cfg allowed there); the rsx and hook sequence stay identical across SSR / WASM / mobile.

## Test plan
- [x] `cargo test -p omnibus-db` — **PASS** (808 tests)
- [x] `cargo test -p omnibus-frontend --features server` — **PASS** (209 tests)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — **PASS**
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — **PASS**
- [x] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` (`.#mobile`) — **PASS** (catches dead-code on the native target)
- [x] `cargo fmt --check` — **PASS**

## Version
- [x] **Patch** — default (internal refactor, no behavior change).

## Notes
- `create_user`'s helper receives `&mut tx` (deref-coerced to `&mut SqliteConnection`), not a `&SqlitePool`, so the `BEGIN IMMEDIATE` RESERVED write lock still covers the precondition reads.
- The mobile `render_book_shell` branch destructures and reads every `MergeSignals` field so the unconditionally-declared signals (hook-parity, rule 07) aren't flagged as never-read by the native-target dead-code lint — mirrors the pre-existing `let _ = (...)` suppression this replaced. No new `#[allow(...)]` was added.