### PR TITLE
refactor: split oversized functions into named helpers

### DIFF
--- a/db/src/audiobook/stat.rs
+++ b/db/src/audiobook/stat.rs
@@ -65,6 +65,8 @@ pub fn stat_audiobook_library(
         let read = match std::fs::read_dir(&current) {
             Ok(e) => e,
             Err(e) => {
+                // A read failure on the root is fatal; on a subdir it becomes a
+                // synthetic placeholder row the diff classifier ignores.
                 if current == dir {
                     return AudiobookStatScanResult {
                         path: Some(path_str.to_string()),
@@ -72,18 +74,7 @@ pub fn stat_audiobook_library(
                         error: Some(format!("could not read directory: {e}")),
                     };
                 }
-                let relative = current
-                    .strip_prefix(dir)
-                    .unwrap_or(&current)
-                    .to_string_lossy()
-                    .to_string();
-                entries.push(AudiobookStatEntry {
-                    filename: relative,
-                    scan_key: String::new(),
-                    mtime_epoch: 0,
-                    size_bytes: 0,
-                    error: Some(e.to_string()),
-                });
+                entries.push(unreadable_subdir_entry(dir, &current, &e));
                 continue;
             }
         };
@@ -99,30 +90,9 @@ pub fn stat_audiobook_library(
             if !file_type.is_file() {
                 continue;
             }
-            let ext = entry_path
-                .extension()
-                .and_then(|s| s.to_str())
-                .map(str::to_ascii_lowercase);
-            let accepted = ext
-                .as_deref()
-                .is_some_and(|e| super::AUDIOBOOK_EXTENSIONS.contains(&e));
-            if !accepted {
-                continue;
+            if let Some(stat_entry) = stat_accepted_file(dir, &entry_path) {
+                entries.push(stat_entry);
             }
-            let relative = entry_path
-                .strip_prefix(dir)
-                .unwrap_or(&entry_path)
-                .to_string_lossy()
-                .to_string();
-            let (mtime_epoch, size_bytes) = stat_file(&entry_path);
-            let scan_key = crate::helpers::scan_key_for(&relative);
-            entries.push(AudiobookStatEntry {
-                filename: relative,
-                scan_key,
-                mtime_epoch,
-                size_bytes,
-                error: None,
-            });
         }
     }
 
@@ -133,6 +103,53 @@ pub fn stat_audiobook_library(
         entries,
         error: None,
     }
+}
+
+/// Build the empty-uuid placeholder row for a subdirectory that couldn't be
+/// read, recording the error against its scan-root-relative path.
+fn unreadable_subdir_entry(dir: &Path, current: &Path, err: &std::io::Error) -> AudiobookStatEntry {
+    let relative = current
+        .strip_prefix(dir)
+        .unwrap_or(current)
+        .to_string_lossy()
+        .to_string();
+    AudiobookStatEntry {
+        filename: relative,
+        scan_key: String::new(),
+        mtime_epoch: 0,
+        size_bytes: 0,
+        error: Some(err.to_string()),
+    }
+}
+
+/// Stat one regular file, returning a [`AudiobookStatEntry`] only when its
+/// extension is in [`super::AUDIOBOOK_EXTENSIONS`] (else `None` so the caller
+/// skips it).
+fn stat_accepted_file(dir: &Path, entry_path: &Path) -> Option<AudiobookStatEntry> {
+    let ext = entry_path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(str::to_ascii_lowercase);
+    let accepted = ext
+        .as_deref()
+        .is_some_and(|e| super::AUDIOBOOK_EXTENSIONS.contains(&e));
+    if !accepted {
+        return None;
+    }
+    let relative = entry_path
+        .strip_prefix(dir)
+        .unwrap_or(entry_path)
+        .to_string_lossy()
+        .to_string();
+    let (mtime_epoch, size_bytes) = stat_file(entry_path);
+    let scan_key = crate::helpers::scan_key_for(&relative);
+    Some(AudiobookStatEntry {
+        filename: relative,
+        scan_key,
+        mtime_epoch,
+        size_bytes,
+        error: None,
+    })
 }
 
 fn stat_file(path: &Path) -> (i64, i64) {

--- a/db/src/books/facets.rs
+++ b/db/src/books/facets.rs
@@ -23,7 +23,21 @@ pub async fn library_facets(
     }
     let ph = super::page::placeholders(library_paths.len());
 
-    let authors = facet_query(
+    Ok(FacetCounts {
+        authors: author_facets(pool, &ph, library_paths).await?,
+        series: series_facets(pool, &ph, library_paths).await?,
+        formats: format_facets(pool, &ph, library_paths).await?,
+        tags: tag_facets(pool, &ph, library_paths).await?,
+    })
+}
+
+/// Author facet counts: books-per-author over the fileless-excluded library.
+async fn author_facets(
+    pool: &SqlitePool,
+    ph: &str,
+    library_paths: &[&str],
+) -> Result<Vec<FacetCount>, sqlx::Error> {
+    facet_query(
         pool,
         &format!(
             r"
@@ -40,9 +54,16 @@ pub async fn library_facets(
         ),
         library_paths,
     )
-    .await?;
+    .await
+}
 
-    let series = facet_query(
+/// Series facet counts, excluding the empty-name series and fileless books.
+async fn series_facets(
+    pool: &SqlitePool,
+    ph: &str,
+    library_paths: &[&str],
+) -> Result<Vec<FacetCount>, sqlx::Error> {
+    facet_query(
         pool,
         &format!(
             r"
@@ -60,13 +81,19 @@ pub async fn library_facets(
         ),
         library_paths,
     )
-    .await?;
+    .await
+}
 
-    // The JOIN to `book_files` already excludes fileless books (a row with no file
-    // contributes none), so no extra EXISTS is needed here. `(book_id, format)`
-    // is unique, so COUNT(DISTINCT b.id) per lowercased format equals the
-    // number of books carrying it.
-    let formats = facet_query(
+/// Format facet counts. The JOIN to `book_files` already excludes fileless
+/// books (a row with no file contributes none), so no extra EXISTS is needed.
+/// `(book_id, format)` is unique, so COUNT(DISTINCT b.id) per lowercased format
+/// equals the number of books carrying it.
+async fn format_facets(
+    pool: &SqlitePool,
+    ph: &str,
+    library_paths: &[&str],
+) -> Result<Vec<FacetCount>, sqlx::Error> {
+    facet_query(
         pool,
         &format!(
             r"
@@ -81,9 +108,16 @@ pub async fn library_facets(
         ),
         library_paths,
     )
-    .await?;
+    .await
+}
 
-    let tags = facet_query(
+/// Tag facet counts, excluding the empty-name tag and fileless books.
+async fn tag_facets(
+    pool: &SqlitePool,
+    ph: &str,
+    library_paths: &[&str],
+) -> Result<Vec<FacetCount>, sqlx::Error> {
+    facet_query(
         pool,
         &format!(
             r"
@@ -101,14 +135,7 @@ pub async fn library_facets(
         ),
         library_paths,
     )
-    .await?;
-
-    Ok(FacetCounts {
-        authors,
-        series,
-        formats,
-        tags,
-    })
+    .await
 }
 
 /// Run one `(value, count)` facet aggregate, binding `library_paths` into its

--- a/db/src/merge/snapshot.rs
+++ b/db/src/merge/snapshot.rs
@@ -102,6 +102,24 @@ struct BookSnapshot {
     author_norm: Option<String>,
 }
 
+/// The source book's file rows plus the attach-ledger split derived from them.
+struct FileRows {
+    moved_formats: Vec<String>,
+    moved_file_ids: Vec<i64>,
+    native_formats: Vec<String>,
+    merged_uuid_rows: Vec<(String, String, String)>,
+}
+
+/// The source book's satellite link rows, stored by name for undo.
+struct LinkRows {
+    authors: Vec<(String, Option<String>, i64)>,
+    series: Vec<String>,
+    tags: Vec<String>,
+    publishers: Vec<String>,
+    languages: Vec<String>,
+    identifiers: Vec<(String, String)>,
+}
+
 /// Load the full snapshot for `book_id` inside the merge transaction.
 pub(super) async fn build_snapshot(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
@@ -118,6 +136,45 @@ pub(super) async fn build_snapshot(
     .fetch_one(&mut **tx)
     .await?;
 
+    let files = load_file_rows(tx, book_id).await?;
+    let links = load_link_rows(tx, book_id).await?;
+
+    Ok(SourceSnapshot {
+        uuid: row.uuid,
+        library_path: row.library_path,
+        path: row.path,
+        title: row.title,
+        sort: row.sort,
+        author_sort: row.author_sort,
+        series_sort: row.series_sort,
+        series_index: row.series_index,
+        pubdate: row.pubdate,
+        timestamp: row.timestamp,
+        has_cover: row.has_cover,
+        description: row.description,
+        accent_color: row.accent_color,
+        title_norm: row.title_norm,
+        author_norm: row.author_norm,
+        moved_formats: files.moved_formats,
+        moved_file_ids: files.moved_file_ids,
+        native_formats: files.native_formats,
+        authors: links.authors,
+        series: links.series,
+        tags: links.tags,
+        publishers: links.publishers,
+        languages: links.languages,
+        identifiers: links.identifiers,
+        merged_uuid_rows: files.merged_uuid_rows,
+    })
+}
+
+/// Load the source's `book_files` formats + ids and its `merged_uuids` rows,
+/// then derive `native_formats` (moved formats that aren't themselves
+/// attachments recorded in `merged_uuids`).
+async fn load_file_rows(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+) -> Result<FileRows, sqlx::Error> {
     let moved_formats: Vec<String> =
         sqlx::query_scalar("SELECT format FROM book_files WHERE book_id = ? ORDER BY format")
             .bind(book_id)
@@ -143,7 +200,20 @@ pub(super) async fn build_snapshot(
         .filter(|f| !attached_formats.contains(&f.to_uppercase()))
         .cloned()
         .collect();
+    Ok(FileRows {
+        moved_formats,
+        moved_file_ids,
+        native_formats,
+        merged_uuid_rows,
+    })
+}
 
+/// Load the source's satellite link rows (authors/series/tags/publishers/
+/// languages/identifiers) by name, for name-keyed restore on undo.
+async fn load_link_rows(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+) -> Result<LinkRows, sqlx::Error> {
     let authors: Vec<(String, Option<String>, i64)> = sqlx::query_as(
         "SELECT a.name, a.sort, l.position FROM books_authors_link l
            JOIN authors a ON a.id = l.author WHERE l.book = ? ORDER BY l.position",
@@ -182,33 +252,13 @@ pub(super) async fn build_snapshot(
             .bind(book_id)
             .fetch_all(&mut **tx)
             .await?;
-
-    Ok(SourceSnapshot {
-        uuid: row.uuid,
-        library_path: row.library_path,
-        path: row.path,
-        title: row.title,
-        sort: row.sort,
-        author_sort: row.author_sort,
-        series_sort: row.series_sort,
-        series_index: row.series_index,
-        pubdate: row.pubdate,
-        timestamp: row.timestamp,
-        has_cover: row.has_cover,
-        description: row.description,
-        accent_color: row.accent_color,
-        title_norm: row.title_norm,
-        author_norm: row.author_norm,
-        moved_formats,
-        moved_file_ids,
-        native_formats,
+    Ok(LinkRows {
         authors,
         series,
         tags,
         publishers,
         languages,
         identifiers,
-        merged_uuid_rows,
     })
 }
 

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -52,26 +52,7 @@ pub async fn undo_merge(pool: &SqlitePool, merge_log_id: i64) -> Result<String, 
     .await?;
     restore_links(&mut tx, new_id, &snap).await?;
     restore_identifiers(&mut tx, new_id, &snap).await?;
-
-    // Point pre-merge attachment uuids back at the restored row and drop
-    // the source-uuid guard so future reindexes treat the file as the
-    // source's own again.
-    for (uuid, format, library_path) in &snap.merged_uuid_rows {
-        sqlx::query(
-            "INSERT OR REPLACE INTO merged_uuids (uuid, book_id, format, library_path)
-             VALUES (?, ?, ?, ?)",
-        )
-        .bind(uuid)
-        .bind(new_id)
-        .bind(format)
-        .bind(library_path)
-        .execute(&mut *tx)
-        .await?;
-    }
-    sqlx::query("DELETE FROM merged_uuids WHERE uuid = ?")
-        .bind(&source_uuid)
-        .execute(&mut *tx)
-        .await?;
+    restore_attach_ledger(&mut tx, new_id, &source_uuid, &snap.merged_uuid_rows).await?;
 
     // The restored `books` row + links + identifiers are all written by
     // now, so the door reconstructs the FTS row from them directly.
@@ -84,9 +65,47 @@ pub async fn undo_merge(pool: &SqlitePool, merge_log_id: i64) -> Result<String, 
 
     tx.commit().await?;
 
-    // Post-commit, best-effort: the target's FTS row still carries the
-    // union (acceptable — links stayed), but rebuild it anyway so any
-    // override-driven text is current.
+    rebuild_target_fts_best_effort(pool, target_id).await?;
+
+    Ok(source_uuid)
+}
+
+/// Point the snapshot's pre-merge attachment uuids back at the restored row
+/// and drop the source-uuid guard, so future reindexes treat the source's
+/// file as its own again rather than a merged attachment of the target.
+async fn restore_attach_ledger(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    new_id: i64,
+    source_uuid: &str,
+    merged_uuid_rows: &[(String, String, String)],
+) -> Result<(), sqlx::Error> {
+    for (uuid, format, library_path) in merged_uuid_rows {
+        sqlx::query(
+            "INSERT OR REPLACE INTO merged_uuids (uuid, book_id, format, library_path)
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(uuid)
+        .bind(new_id)
+        .bind(format)
+        .bind(library_path)
+        .execute(&mut **tx)
+        .await?;
+    }
+    sqlx::query("DELETE FROM merged_uuids WHERE uuid = ?")
+        .bind(source_uuid)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Post-commit, best-effort rebuild of the merge target's FTS row. The
+/// target's row still carries the union (acceptable — links stayed), but a
+/// rebuild keeps any override-driven text current. A rebuild failure is
+/// logged and swallowed so it can't fail an already-committed undo.
+async fn rebuild_target_fts_best_effort(
+    pool: &SqlitePool,
+    target_id: i64,
+) -> Result<(), sqlx::Error> {
     let target_uuid: Option<String> = sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
         .bind(target_id)
         .fetch_optional(pool)
@@ -101,8 +120,7 @@ pub async fn undo_merge(pool: &SqlitePool, merge_log_id: i64) -> Result<String, 
             tracing::warn!(error = %e, uuid = %uuid, "undo_merge: target FTS rebuild failed");
         }
     }
-
-    Ok(source_uuid)
+    Ok(())
 }
 
 /// Recreate the source `books` row from the snapshot. The original uuid

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -55,7 +55,7 @@ pub async fn undo_merge(pool: &SqlitePool, merge_log_id: i64) -> Result<String, 
     restore_attach_ledger(&mut tx, new_id, &source_uuid, &snap.merged_uuid_rows).await?;
 
     // The restored `books` row + links + identifiers are all written by
-    // now, so the door reconstructs the FTS row from them directly.
+    // now, so the code reconstructs the FTS row from them directly.
     upsert_fts(&mut tx, new_id).await?;
 
     sqlx::query("UPDATE merge_log SET undone_at = strftime('%s','now') WHERE id = ?")

--- a/db/src/missing_files.rs
+++ b/db/src/missing_files.rs
@@ -63,8 +63,23 @@ pub async fn gc_books_missing_files(
         return Ok(0);
     }
 
+    delete_victim_rows(pool, &victims).await?;
+
+    let purged = victims.len() as u64;
+    let uuids: Vec<String> = victims.into_iter().map(|(_, uuid)| uuid).collect();
+    cleanup_victim_covers(uuids).await;
+
+    Ok(purged)
+}
+
+/// Hard-delete the `(id, uuid)` victims in one transaction: their
+/// `metadata_overrides`, `books`, and `books_fts` rows (chunked at 500 to
+/// stay under SQLite's 999-bind cap), then any taxonomy the purge orphaned.
+async fn delete_victim_rows(
+    pool: &SqlitePool,
+    victims: &[(i64, String)],
+) -> Result<(), MissingFilesError> {
     let mut tx = pool.begin().await?;
-    // Chunk at 500 to stay under SQLite's 999-bind cap on a large sweep —
     // `metadata_overrides` keys on uuid, `books` on id, so bind both per chunk.
     for chunk in victims.chunks(500) {
         let placeholders = std::iter::repeat_n("?", chunk.len())
@@ -101,9 +116,14 @@ pub async fn gc_books_missing_files(
     // taxonomy survives with it).
     crate::taxonomy::delete_orphan_taxonomy(&mut tx).await?;
     tx.commit().await?;
+    Ok(())
+}
 
-    let purged = victims.len() as u64;
-    let uuids: Vec<String> = victims.into_iter().map(|(_, uuid)| uuid).collect();
+/// Best-effort unlink of each purged book's override + scanned cover files,
+/// off the runtime via `spawn_blocking`. A `JoinError` is logged and swallowed
+/// — covers are a rebuildable cache, so a failed unlink must not fail the GC
+/// (mirrors `set_settings`).
+async fn cleanup_victim_covers(uuids: Vec<String>) {
     if let Err(join_err) = tokio::task::spawn_blocking(move || {
         for uuid in &uuids {
             delete_override_cover(uuid);
@@ -114,8 +134,6 @@ pub async fn gc_books_missing_files(
     {
         tracing::error!("gc_books_missing_files: cover cleanup spawn_blocking failed: {join_err}");
     }
-
-    Ok(purged)
 }
 
 /// One-time stamp of `is_missing_files` / `missing_files_since` for rows that

--- a/db/src/palette/authors.rs
+++ b/db/src/palette/authors.rs
@@ -9,41 +9,34 @@ use omnibus_shared::PaletteAuthorHit;
 
 use super::PaletteError;
 
-/// Run the authors arm of the palette for `like_pattern` (already escaped)
-/// scoped to `library_path`, capped to `limit`.
-pub async fn search_authors(
-    pool: &SqlitePool,
-    library_path: &str,
-    like_pattern: &str,
-    limit: i32,
-) -> Result<Vec<PaletteAuthorHit>, PaletteError> {
-    // Library scoping (`l.path = ?1`) is applied before aggregation so
-    // book_count stays library-correct (covered by `palette_scoped_to_library`
-    // and `palette_taxonomy_counts_scoped_per_library`). The join plan is
-    // locked in by `palette_taxonomy_query_plans_use_indexes`.
-    //
-    // F5.1: the count uses the effective (override-aware) creator set, not
-    // the raw `books_authors_link` rows — otherwise an author whose books
-    // were all reassigned through the metadata edit form (e.g. "Sanderson,
-    // Brandon" → "Brandon Sanderson") keeps reporting the canonical count
-    // even though `/author/:id` shows zero. Visibility still requires at
-    // least one canonical link row in this library so we don't list
-    // authors that exist only as a string inside override JSON (no
-    // navigable id), matching the rest of the palette's behavior.
-    //
-    // Issue #154: the per-author correlated `COUNT(*)` is replaced with a
-    // single-pass `effective` membership CTE (scoped to the library up
-    // front) — the UNION of (1) canonical `books_authors_link` rows whose
-    // book has no `creators` override and (2) override-extracted creator
-    // names from `json_each(mo.overrides, '$.creators')`. Each visible
-    // author's count is then a single scan of that union. UNION (not ALL)
-    // dedupes a creator repeated within one override array, matching the
-    // prior `EXISTS` semantics. The override name match stays BINARY
-    // (`= a.name`, no COLLATE) exactly as before. The empty-array clear-all
-    // case falls out: a `Some([])` override drops the book from arm (1) and
-    // yields no `json_each` rows in arm (2).
-    let rows = sqlx::query(
-        r"
+/// Authors-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
+/// `?3 = limit`.
+///
+/// Library scoping (`l.path = ?1`) is applied before aggregation so
+/// book_count stays library-correct (covered by `palette_scoped_to_library`
+/// and `palette_taxonomy_counts_scoped_per_library`). The join plan is locked
+/// in by `palette_taxonomy_query_plans_use_indexes`.
+///
+/// F5.1: the count uses the effective (override-aware) creator set, not the
+/// raw `books_authors_link` rows — otherwise an author whose books were all
+/// reassigned through the metadata edit form (e.g. "Sanderson, Brandon" →
+/// "Brandon Sanderson") keeps reporting the canonical count even though
+/// `/author/:id` shows zero. Visibility still requires at least one canonical
+/// link row in this library so we don't list authors that exist only as a
+/// string inside override JSON (no navigable id), matching the rest of the
+/// palette's behavior.
+///
+/// Issue #154: the per-author correlated `COUNT(*)` is replaced with a
+/// single-pass `effective` membership CTE (scoped to the library up front) —
+/// the UNION of (1) canonical `books_authors_link` rows whose book has no
+/// `creators` override and (2) override-extracted creator names from
+/// `json_each(mo.overrides, '$.creators')`. Each visible author's count is
+/// then a single scan of that union. UNION (not ALL) dedupes a creator
+/// repeated within one override array, matching the prior `EXISTS` semantics.
+/// The override name match stays BINARY (`= a.name`, no COLLATE) exactly as
+/// before. The empty-array clear-all case falls out: a `Some([])` override
+/// drops the book from arm (1) and yields no `json_each` rows in arm (2).
+const SEARCH_AUTHORS_SQL: &str = r"
         WITH effective AS (
           SELECT bal.author AS author_id, NULL AS author_name, bal.book AS book_id
             FROM books_authors_link bal
@@ -84,13 +77,22 @@ pub async fn search_authors(
           )
         ORDER BY book_count DESC, a.name
         LIMIT ?3
-        ",
-    )
-    .bind(library_path)
-    .bind(like_pattern)
-    .bind(limit)
-    .fetch_all(pool)
-    .await?;
+        ";
+
+/// Run the authors arm of the palette for `like_pattern` (already escaped)
+/// scoped to `library_path`, capped to `limit`.
+pub async fn search_authors(
+    pool: &SqlitePool,
+    library_path: &str,
+    like_pattern: &str,
+    limit: i32,
+) -> Result<Vec<PaletteAuthorHit>, PaletteError> {
+    let rows = sqlx::query(SEARCH_AUTHORS_SQL)
+        .bind(library_path)
+        .bind(like_pattern)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
 
     Ok(rows
         .iter()

--- a/db/src/palette/books.rs
+++ b/db/src/palette/books.rs
@@ -12,27 +12,11 @@ use crate::metadata_overrides::load_overrides_bulk;
 
 use super::PaletteError;
 
-/// Run the FTS5 books arm of the palette for `trimmed` (already-trimmed,
-/// length-capped query) scoped to `library_path`, capped to `limit`.
-///
-/// Returns the (capped) display hits alongside the *true* FTS5 match count
-/// (before the cap), computed in a single pass: the `bm25` MATCH scan runs
-/// once inside a `MATERIALIZED` CTE and the total is a scalar `COUNT(*)` over
-/// it — so the results header can show "N books" even when only `limit` ship.
-/// Returns `(vec![], 0)` when `build_fts_match` can't produce a MATCH
-/// expression for the input.
-pub async fn search_books(
-    pool: &SqlitePool,
-    library_path: &str,
-    trimmed: &str,
-    limit: i32,
-) -> Result<(Vec<PaletteBookHit>, i64), PaletteError> {
-    let Some(match_expr) = build_fts_match(trimmed) else {
-        return Ok((Vec::new(), 0));
-    };
-
-    let rows = sqlx::query(
-        r"
+/// FTS5 books-arm palette query, bound `?1 = match_expr`, `?2 = library_path`,
+/// `?3 = limit`. The `bm25` MATCH scan runs once inside a `MATERIALIZED` CTE
+/// and `total_count` is a scalar `COUNT(*)` over it, so the true (pre-cap)
+/// match total ships on every row alongside the capped result set.
+const SEARCH_BOOKS_SQL: &str = r"
         WITH matches AS MATERIALIZED (
             SELECT books_fts.rowid AS bid,
                    bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0) AS rank
@@ -61,13 +45,33 @@ pub async fn search_books(
         JOIN books b ON b.id = m.bid
         ORDER BY m.rank, b.sort, b.id
         LIMIT ?3
-        ",
-    )
-    .bind(&match_expr)
-    .bind(library_path)
-    .bind(limit)
-    .fetch_all(pool)
-    .await?;
+        ";
+
+/// Run the FTS5 books arm of the palette for `trimmed` (already-trimmed,
+/// length-capped query) scoped to `library_path`, capped to `limit`.
+///
+/// Returns the (capped) display hits alongside the *true* FTS5 match count
+/// (before the cap), computed in a single pass: the `bm25` MATCH scan runs
+/// once inside a `MATERIALIZED` CTE and the total is a scalar `COUNT(*)` over
+/// it — so the results header can show "N books" even when only `limit` ship.
+/// Returns `(vec![], 0)` when `build_fts_match` can't produce a MATCH
+/// expression for the input.
+pub async fn search_books(
+    pool: &SqlitePool,
+    library_path: &str,
+    trimmed: &str,
+    limit: i32,
+) -> Result<(Vec<PaletteBookHit>, i64), PaletteError> {
+    let Some(match_expr) = build_fts_match(trimmed) else {
+        return Ok((Vec::new(), 0));
+    };
+
+    let rows = sqlx::query(SEARCH_BOOKS_SQL)
+        .bind(&match_expr)
+        .bind(library_path)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
 
     // `total_count` is the scalar COUNT over the materialized matches, so it's
     // identical on every row; read it off the first. No rows ⇒ zero matches.
@@ -94,7 +98,21 @@ pub async fn search_books(
         });
     }
 
-    let overrides_map = load_overrides_bulk(pool, &uuids).await?;
+    apply_override_overlays(pool, &mut hits, &uuids).await?;
+
+    Ok((hits, total))
+}
+
+/// Overlay override-aware title / author / cover onto each hydrated hit, so a
+/// palette row matches what the rest of the app renders. Mirrors
+/// `apply_overrides`, including surfacing a user-uploaded cover even when the
+/// scanned book had `has_cover = 0`. `hits` and `uuids` are index-aligned.
+async fn apply_override_overlays(
+    pool: &SqlitePool,
+    hits: &mut [PaletteBookHit],
+    uuids: &[String],
+) -> Result<(), PaletteError> {
+    let overrides_map = load_overrides_bulk(pool, uuids).await?;
     for (hit, uuid) in hits.iter_mut().zip(uuids.iter()) {
         if let Some((ov, has_cover_ov)) = overrides_map.get(uuid) {
             if let Some(ref t) = ov.title {
@@ -107,13 +125,10 @@ pub async fn search_books(
                     .collect::<Vec<_>>()
                     .join(", ");
             }
-            // Mirror `apply_overrides`: surface user-uploaded covers even
-            // when the scanned book had `has_cover = 0`.
             if *has_cover_ov {
                 hit.cover_url = Some(format!("/api/covers/{}", hit.uuid));
             }
         }
     }
-
-    Ok((hits, total))
+    Ok(())
 }

--- a/db/src/palette/series.rs
+++ b/db/src/palette/series.rs
@@ -9,38 +9,29 @@ use omnibus_shared::PaletteSeriesHit;
 
 use super::PaletteError;
 
-/// Run the series arm of the palette for `like_pattern` (already escaped)
-/// scoped to `library_path`, capped to `limit`.
-pub async fn search_series(
-    pool: &SqlitePool,
-    library_path: &str,
-    like_pattern: &str,
-    limit: i32,
-) -> Result<Vec<PaletteSeriesHit>, PaletteError> {
-    // F5.1: both the count and the `author_display` line use the effective
-    // (override-aware) view, mirroring `get_series` and the palette author
-    // count. `overrides.series` (string) drives membership; if a book's
-    // first creator was renamed through the metadata edit form,
-    // `overrides.creators[0].name` drives the displayed author. Visibility
-    // still requires at least one canonical link in this library so we
-    // don't list series that exist only inside override JSON (no
-    // navigable id).
-    //
-    // Issue #154: the per-series correlated `COUNT(*)` is replaced with a
-    // single-pass `effective` membership CTE (scoped to the library up
-    // front) — the UNION of (1) canonical `books_series_link` rows whose
-    // book has no `series` override and (2) the scalar `overrides.series`
-    // string for books that do. Each visible series' count is then a single
-    // scan of that union. The override match stays BINARY
-    // (`json_extract(...) = s.name`, no COLLATE) exactly as before. The
-    // clear-all case (`Some("")`) falls out: it drops the book from arm (1)
-    // and the empty string won't equal any real series name in arm (2). The
-    // `author_display` subquery below is unchanged (not a count — out of
-    // scope for #154). UNION (not ALL) is harmless here (a book has one
-    // scalar series override) but keeps the shape uniform with the other
-    // sites.
-    let rows = sqlx::query(
-        r"
+/// Series-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
+/// `?3 = limit`.
+///
+/// F5.1: both the count and the `author_display` line use the effective
+/// (override-aware) view, mirroring `get_series` and the palette author
+/// count. `overrides.series` (string) drives membership; if a book's first
+/// creator was renamed through the metadata edit form,
+/// `overrides.creators[0].name` drives the displayed author. Visibility still
+/// requires at least one canonical link in this library so we don't list
+/// series that exist only inside override JSON (no navigable id).
+///
+/// Issue #154: the per-series correlated `COUNT(*)` is replaced with a
+/// single-pass `effective` membership CTE (scoped to the library up front) —
+/// the UNION of (1) canonical `books_series_link` rows whose book has no
+/// `series` override and (2) the scalar `overrides.series` string for books
+/// that do. Each visible series' count is then a single scan of that union.
+/// The override match stays BINARY (`json_extract(...) = s.name`, no COLLATE)
+/// exactly as before. The clear-all case (`Some("")`) falls out: it drops the
+/// book from arm (1) and the empty string won't equal any real series name in
+/// arm (2). The `author_display` subquery is unchanged (not a count — out of
+/// scope for #154). UNION (not ALL) is harmless here (a book has one scalar
+/// series override) but keeps the shape uniform with the other sites.
+const SEARCH_SERIES_SQL: &str = r"
         WITH effective AS (
           SELECT bsl.series AS series_id, NULL AS series_name, bsl.book AS book_id
             FROM books_series_link bsl
@@ -96,13 +87,22 @@ pub async fn search_series(
           )
         ORDER BY book_count DESC, s.name
         LIMIT ?3
-        ",
-    )
-    .bind(library_path)
-    .bind(like_pattern)
-    .bind(limit)
-    .fetch_all(pool)
-    .await?;
+        ";
+
+/// Run the series arm of the palette for `like_pattern` (already escaped)
+/// scoped to `library_path`, capped to `limit`.
+pub async fn search_series(
+    pool: &SqlitePool,
+    library_path: &str,
+    like_pattern: &str,
+    limit: i32,
+) -> Result<Vec<PaletteSeriesHit>, PaletteError> {
+    let rows = sqlx::query(SEARCH_SERIES_SQL)
+        .bind(library_path)
+        .bind(like_pattern)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
 
     Ok(rows
         .iter()

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -36,21 +36,33 @@ pub enum InitDbError {
 /// Initialize or open the SQLite pool at `database_url`, apply per-connection PRAGMAs, run pending
 /// migrations, and — on non-memory databases — perform a one-time legacy cover-cache directory purge.
 pub async fn init_db(database_url: &str) -> Result<SqlitePool, InitDbError> {
-    // PRAGMAs `foreign_keys`, `busy_timeout`, and `synchronous` are
-    // *per-connection* settings — they only apply to the connection that
-    // executed them, and any future connection the pool spins up would
-    // start with SQLite's defaults. Apply them inside `after_connect` so
-    // every pooled connection initializes the same way.
-    //
-    // `journal_mode = WAL` is a database-level setting that lives in the
-    // SQLite header, so it only needs to take effect once; running it on
-    // every connection is cheap (returns the current mode) and keeps the
-    // logic in one place. We still skip it for in-memory databases so the
-    // test output isn't littered with "memory" pragma results.
-    //
-    // See issue #82 for the rationale on each PRAGMA value.
     let is_memory = is_memory_url(database_url);
-    let pool = SqlitePoolOptions::new()
+    let pool = connect_pool(database_url, is_memory).await?;
+
+    MIGRATOR.run(&pool).await?;
+    run_boot_backfills(&pool).await?;
+
+    if !is_memory {
+        run_legacy_cover_purge().await;
+    }
+
+    Ok(pool)
+}
+
+/// Build the SQLite pool and register the per-connection PRAGMA setup.
+///
+/// PRAGMAs `foreign_keys`, `busy_timeout`, and `synchronous` are
+/// *per-connection* settings — they only apply to the connection that
+/// executed them, and any future connection the pool spins up would start
+/// with SQLite's defaults. Applying them inside `after_connect` makes every
+/// pooled connection initialize the same way. `journal_mode = WAL` is a
+/// database-level setting stored in the SQLite header, so it only needs to
+/// take effect once; running it on every connection is cheap (returns the
+/// current mode) and keeps the logic in one place. It's skipped for
+/// in-memory databases so test output isn't littered with pragma results.
+/// See issue #82 for the rationale on each PRAGMA value.
+async fn connect_pool(database_url: &str, is_memory: bool) -> Result<SqlitePool, sqlx::Error> {
+    SqlitePoolOptions::new()
         .max_connections(5)
         .after_connect(move |conn, _meta| {
             Box::pin(async move {
@@ -64,58 +76,47 @@ pub async fn init_db(database_url: &str) -> Result<SqlitePool, InitDbError> {
             })
         })
         .connect(database_url)
-        .await?;
-
-    MIGRATOR.run(&pool).await?;
-
-    // One-time fill of the auto-attach match key for rows indexed before
-    // migration 0016. Idempotent and a no-op once caught up.
-    crate::normalize::backfill_norm_columns(&pool).await?;
-
-    // One-time fill of the F2 `scan_key` diff key for rows indexed before
-    // migration 0026. Pure DB work (reconstructed from stored columns, no
-    // filesystem reads), idempotent, safe against in-memory test DBs.
-    crate::identity::backfill_scan_keys(&pool).await?;
-
-    // One-time fill of the F5b `series_sort` keyset column for rows indexed
-    // before migration 0028. Reconstructed from the existing series link;
-    // idempotent and a no-op once every linked book is filled.
-    crate::sort_keys::backfill_series_sort(&pool).await?;
-
-    // One-time stamp of the F10 missing-files flags for rows that were already
-    // fileless before migration 0029, starting their GC clock at boot time.
-    // Idempotent and a no-op once caught up.
-    crate::missing_files::backfill_missing_files_flags(&pool).await?;
-
-    // Issue #94: the previous `stable_uuid` implementation hashed via
-    // `DefaultHasher` and produced toolchain-dependent UUIDs. Switching to
-    // UUIDv5 changes every cover id on the next reindex, so any pre-existing
-    // `<old-uuid>.<ext>` files in the covers directory would be orphaned and
-    // never served again. Purge once on startup, then drop a sentinel so we
-    // don't keep deleting freshly-written covers on every boot. Gated on a
-    // real (non-memory) DB so that the rapid-fire test suite doesn't touch
-    // the developer's actual covers directory.
-    if !is_memory {
-        // The purge walks the covers dir and unlinks every legacy file with
-        // synchronous `std::fs`. On the worst-case first boot after the #94
-        // upgrade that directory can be large, so run it on the blocking pool
-        // rather than tying up an async runtime worker for the whole sweep.
-        // Boot still awaits completion here — this keeps the runtime's other
-        // tasks schedulable during the sweep, it does not make startup
-        // non-blocking. `JoinError` (a panic in the sweep) is logged and
-        // swallowed — the covers dir is a rebuildable cache, so a failed
-        // purge must not abort boot.
-        let dir = covers_dir();
-        if let Err(join_err) = tokio::task::spawn_blocking(move || {
-            purge_legacy_covers_once(&dir);
-        })
         .await
-        {
-            tracing::error!("issue #94: legacy cover purge spawn_blocking failed: {join_err}");
-        }
-    }
+}
 
-    Ok(pool)
+/// Run the one-time, idempotent column backfills that fill values older
+/// migrations couldn't compute. Each is a no-op once caught up and is safe
+/// against in-memory test DBs (all pure DB work, no filesystem reads).
+async fn run_boot_backfills(pool: &SqlitePool) -> Result<(), InitDbError> {
+    // Auto-attach match key for rows indexed before migration 0016.
+    crate::normalize::backfill_norm_columns(pool).await?;
+    // F2 `scan_key` diff key for rows indexed before migration 0026,
+    // reconstructed from stored columns.
+    crate::identity::backfill_scan_keys(pool).await?;
+    // F5b `series_sort` keyset column for rows indexed before migration 0028,
+    // reconstructed from the existing series link.
+    crate::sort_keys::backfill_series_sort(pool).await?;
+    // F10 missing-files flags for rows already fileless before migration 0029,
+    // starting their GC clock at boot time.
+    crate::missing_files::backfill_missing_files_flags(pool).await?;
+    Ok(())
+}
+
+/// Run the one-time issue-#94 legacy cover-cache purge on the blocking pool.
+///
+/// The previous `stable_uuid` implementation hashed via `DefaultHasher` and
+/// produced toolchain-dependent UUIDs. Switching to UUIDv5 changes every
+/// cover id on the next reindex, so any pre-existing `<old-uuid>.<ext>` files
+/// would be orphaned and never served again. `purge_legacy_covers_once`
+/// walks the covers dir with synchronous `std::fs`, which can be large on the
+/// first boot after the upgrade, so it runs on the blocking pool — boot still
+/// awaits completion, keeping other runtime tasks schedulable during the
+/// sweep. A `JoinError` (a panic in the sweep) is logged and swallowed: the
+/// covers dir is a rebuildable cache, so a failed purge must not abort boot.
+async fn run_legacy_cover_purge() {
+    let dir = covers_dir();
+    if let Err(join_err) = tokio::task::spawn_blocking(move || {
+        purge_legacy_covers_once(&dir);
+    })
+    .await
+    {
+        tracing::error!("issue #94: legacy cover purge spawn_blocking failed: {join_err}");
+    }
 }
 
 /// Returns `true` if `database_url` points at an in-memory SQLite database.

--- a/db/src/worker/exec.rs
+++ b/db/src/worker/exec.rs
@@ -6,6 +6,8 @@
 
 use std::sync::Arc;
 
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
 use omnibus_shared::ProgressState;
 
 use super::types::{lock_unpoison, Task, TaskId, TaskOutcome, Worker};
@@ -29,60 +31,31 @@ impl Worker {
         };
 
         let _scan_permit = if task.uses_scan_sem() {
-            match self.scan_sem.clone().acquire_owned().await {
+            match self
+                .acquire_permit(&self.scan_sem, id, "scan semaphore closed")
+                .await
+            {
                 Ok(p) => Some(p),
-                Err(_) => {
-                    self.write_terminal_progress(
-                        id,
-                        ProgressState::Failed {
-                            message: "scan semaphore closed".into(),
-                        },
-                    );
-                    return TaskOutcome::Err("scan semaphore closed".into());
-                }
+                Err(outcome) => return outcome,
             }
         } else {
             None
         };
 
         let _hls_permit = if task.uses_hls_sem() {
-            match self.hls_sem.clone().acquire_owned().await {
+            match self
+                .acquire_permit(&self.hls_sem, id, "hls semaphore closed")
+                .await
+            {
                 Ok(p) => Some(p),
-                Err(_) => {
-                    self.write_terminal_progress(
-                        id,
-                        ProgressState::Failed {
-                            message: "hls semaphore closed".into(),
-                        },
-                    );
-                    return TaskOutcome::Err("hls semaphore closed".into());
-                }
+                Err(outcome) => return outcome,
             }
         } else {
             None
         };
 
         let outcome = self.execute(task, id).await;
-        // Project the outcome into the wire-facing terminal state. We pull
-        // the last reported `processed` count out of the progress map so a
-        // Phase-2 in-flight progress report stays reflected in the final
-        // `Done`. Today there is no in-flight reporter so this is always 0.
-        let terminal = match &outcome {
-            TaskOutcome::Ok => {
-                let processed = lock_unpoison(&self.progress)
-                    .get(&id)
-                    .and_then(|e| match e.progress.state {
-                        ProgressState::Running { processed, .. } => Some(processed),
-                        _ => None,
-                    })
-                    .unwrap_or(0);
-                ProgressState::Done { processed }
-            }
-            TaskOutcome::Err(msg) => ProgressState::Failed {
-                message: msg.clone(),
-            },
-        };
-        self.write_terminal_progress(id, terminal);
+        self.write_terminal_progress(id, self.project_terminal(id, &outcome));
 
         // Drop the resource guard before pruning so this task no longer
         // counts as a reference to the keyed mutex when we check it. Without
@@ -96,5 +69,50 @@ impl Worker {
         }
 
         outcome
+    }
+
+    /// Acquire one owned permit from `sem`. On a closed semaphore, write the
+    /// terminal `Failed` progress with `closed_msg` and hand the caller the
+    /// matching `Err(TaskOutcome)` to return from [`run`].
+    async fn acquire_permit(
+        &self,
+        sem: &Arc<Semaphore>,
+        id: TaskId,
+        closed_msg: &str,
+    ) -> Result<OwnedSemaphorePermit, TaskOutcome> {
+        match sem.clone().acquire_owned().await {
+            Ok(p) => Ok(p),
+            Err(_) => {
+                self.write_terminal_progress(
+                    id,
+                    ProgressState::Failed {
+                        message: closed_msg.into(),
+                    },
+                );
+                Err(TaskOutcome::Err(closed_msg.into()))
+            }
+        }
+    }
+
+    /// Project a task's `outcome` into its wire-facing terminal state. On
+    /// success, the last reported `processed` count is pulled out of the
+    /// progress map so a Phase-2 in-flight report stays reflected in the final
+    /// `Done` (today there is no in-flight reporter, so this is always 0).
+    fn project_terminal(&self, id: TaskId, outcome: &TaskOutcome) -> ProgressState {
+        match outcome {
+            TaskOutcome::Ok => {
+                let processed = lock_unpoison(&self.progress)
+                    .get(&id)
+                    .and_then(|e| match e.progress.state {
+                        ProgressState::Running { processed, .. } => Some(processed),
+                        _ => None,
+                    })
+                    .unwrap_or(0);
+                ProgressState::Done { processed }
+            }
+            TaskOutcome::Err(msg) => ProgressState::Failed {
+                message: msg.clone(),
+            },
+        }
     }
 }

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -7,156 +7,82 @@ use std::sync::Arc;
 
 use super::types::{Task, TaskId, TaskOutcome, Worker};
 
+/// Map a handler's `Result` into a [`TaskOutcome`], stringifying the error.
+/// The `Ok` payload is discarded (some handlers return a path/id), so `Ok(())`
+/// and `Ok(value)` collapse to [`TaskOutcome::Ok`] identically.
+fn outcome_of<T, E: std::fmt::Display>(result: Result<T, E>) -> TaskOutcome {
+    match result {
+        Ok(_) => TaskOutcome::Ok,
+        Err(e) => TaskOutcome::Err(e.to_string()),
+    }
+}
+
 impl Worker {
     pub(super) async fn execute(self: &Arc<Self>, task: Task, id: TaskId) -> TaskOutcome {
         match task {
-            Task::Scan { library_path } => {
-                match crate::indexer::reindex_with_progress(
+            Task::Scan { library_path } => outcome_of(
+                crate::indexer::reindex_with_progress(
                     &self.pool,
                     &library_path,
                     |processed, total| {
                         self.report_progress(id, processed, Some(total));
                     },
                 )
-                .await
-                {
-                    Ok(()) => TaskOutcome::Ok,
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
-            }
+                .await,
+            ),
             Task::ScanAudiobooks { library_path } => {
-                match crate::indexer::reindex_audiobooks_with_progress(
-                    &self.pool,
-                    &library_path,
-                    |processed, total| {
-                        self.report_progress(id, processed, Some(total));
-                    },
-                )
-                .await
-                {
-                    Ok(()) => {
-                        // Post a follow-up chapter backfill task now that the
-                        // scan has populated book_file_parts rows. Same resource
-                        // key means it won't run until this task fully finishes
-                        // (including the terminal-state write in `run`), but
-                        // the post itself is instant.
-                        self.post(Task::BackfillChapters {
-                            library_path: library_path.clone(),
-                        });
-                        TaskOutcome::Ok
-                    }
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
+                self.handle_scan_audiobooks(library_path, id).await
             }
             Task::HlsTranscode {
                 book_id,
                 book_file_id,
                 library_path,
                 profile,
-            } => {
-                match crate::hls::transcode_book(
+            } => outcome_of(
+                crate::hls::transcode_book(
                     &self.pool,
                     book_id,
                     book_file_id,
                     &library_path,
                     &profile,
                 )
-                .await
-                {
-                    Ok(()) => TaskOutcome::Ok,
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
-            }
+                .await,
+            ),
             Task::ResolveAuthorPhoto { author_id } => {
-                match crate::author_photos::resolve(&self.pool, author_id).await {
-                    Ok(()) => TaskOutcome::Ok,
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
+                outcome_of(crate::author_photos::resolve(&self.pool, author_id).await)
             }
-            Task::RefetchAuthorPhotos => {
-                match crate::author_photos::refetch_all(&self.pool, |processed, total| {
+            Task::RefetchAuthorPhotos => outcome_of(
+                crate::author_photos::refetch_all(&self.pool, |processed, total| {
                     self.report_progress(id, processed, total);
                 })
-                .await
-                {
-                    Ok(()) => TaskOutcome::Ok,
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
-            }
-            Task::BackfillChapters { library_path } => {
-                match crate::indexer::backfill_chapters(
-                    &self.pool,
-                    &library_path,
-                    |processed, total| {
-                        self.report_progress(id, processed, Some(total));
-                    },
-                )
-                .await
-                {
-                    Ok(()) => TaskOutcome::Ok,
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
-            }
-            Task::RebuildFtsIndex => match crate::sync::rebuild_all_fts(&self.pool).await {
-                Ok(()) => TaskOutcome::Ok,
-                Err(e) => TaskOutcome::Err(e.to_string()),
-            },
+                .await,
+            ),
+            Task::BackfillChapters { library_path } => outcome_of(
+                crate::indexer::backfill_chapters(&self.pool, &library_path, |processed, total| {
+                    self.report_progress(id, processed, Some(total));
+                })
+                .await,
+            ),
+            Task::RebuildFtsIndex => outcome_of(crate::sync::rebuild_all_fts(&self.pool).await),
             Task::ResolveSuggestions { book_uuid } => {
-                match crate::suggestions::resolve(&self.pool, &book_uuid).await {
-                    Ok(()) => TaskOutcome::Ok,
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
+                outcome_of(crate::suggestions::resolve(&self.pool, &book_uuid).await)
             }
             Task::KepubConvert { book_id } => {
-                match crate::kepub::convert_book(&self.pool, book_id).await {
-                    Ok(_) => TaskOutcome::Ok,
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
+                outcome_of(crate::kepub::convert_book(&self.pool, book_id).await)
             }
             Task::SendToKindle {
                 book_id,
                 book_file_id,
                 recipient_email,
-            } => {
-                match crate::kindle::send(&self.pool, book_id, book_file_id, &recipient_email).await
-                {
-                    Ok(()) => TaskOutcome::Ok,
-                    Err(e) => TaskOutcome::Err(e.to_string()),
-                }
-            }
+            } => outcome_of(
+                crate::kindle::send(&self.pool, book_id, book_file_id, &recipient_email).await,
+            ),
             Task::GenerateThumbs {
                 book_id,
                 last_modified_epoch,
             } => {
-                let pool = self.pool.clone();
-                let cover = match crate::covers::get_cover(&pool, book_id).await {
-                    Ok(Some((_mime, bytes))) => bytes,
-                    Ok(None) => {
-                        return TaskOutcome::Err(format!("no cover for book {book_id}"));
-                    }
-                    Err(e) => return TaskOutcome::Err(e.to_string()),
-                };
-                let cap = crate::thumbs::cap_bytes();
-                match tokio::task::spawn_blocking(move || {
-                    crate::thumbs::ensure_thumbnails_sync(book_id, last_modified_epoch, cover)?;
-                    crate::thumbs::evict_if_over_cap(cap)
-                        .map_err(|e| crate::thumbs::ThumbError::Failed(format!("I/O error: {e}")))
-                })
-                .await
-                {
-                    Ok(Ok(())) => TaskOutcome::Ok,
-                    Ok(Err(e)) => TaskOutcome::Err(e.to_string()),
-                    Err(join_err) => {
-                        // `JoinError` covers both panics and cancellation —
-                        // distinguish so the log doesn't lie about which one.
-                        let kind = if join_err.is_panic() {
-                            "panicked"
-                        } else {
-                            "was cancelled"
-                        };
-                        TaskOutcome::Err(format!("spawn_blocking {kind}: {join_err}"))
-                    }
-                }
+                self.handle_generate_thumbs(book_id, last_modified_epoch)
+                    .await
             }
             #[cfg(test)]
             Task::Test {
@@ -165,16 +91,89 @@ impl Worker {
                 on_run,
                 on_done,
                 ..
-            } => {
-                if let Some(f) = on_run.as_ref() {
-                    f();
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(latency_ms)).await;
-                if let Some(f) = on_done.as_ref() {
-                    f();
-                }
+            } => handle_test_task(latency_ms, on_run, on_done).await,
+        }
+    }
+
+    /// Reindex an audiobook library, then (on success) post the follow-up
+    /// chapter-backfill task. The same resource key means the backfill waits
+    /// until this task fully finishes (including `run`'s terminal-state write),
+    /// but the post itself is instant.
+    async fn handle_scan_audiobooks(
+        self: &Arc<Self>,
+        library_path: String,
+        id: TaskId,
+    ) -> TaskOutcome {
+        match crate::indexer::reindex_audiobooks_with_progress(
+            &self.pool,
+            &library_path,
+            |processed, total| {
+                self.report_progress(id, processed, Some(total));
+            },
+        )
+        .await
+        {
+            Ok(()) => {
+                self.post(Task::BackfillChapters { library_path });
                 TaskOutcome::Ok
+            }
+            Err(e) => TaskOutcome::Err(e.to_string()),
+        }
+    }
+
+    /// Fetch a book's cover and (re)generate its WebP thumbnails on the
+    /// blocking pool, then evict the thumb cache if it's over the cap. A
+    /// missing cover is an error; a `JoinError` distinguishes panic from
+    /// cancellation so the log doesn't lie about which one occurred.
+    async fn handle_generate_thumbs(
+        self: &Arc<Self>,
+        book_id: i64,
+        last_modified_epoch: i64,
+    ) -> TaskOutcome {
+        let pool = self.pool.clone();
+        let cover = match crate::covers::get_cover(&pool, book_id).await {
+            Ok(Some((_mime, bytes))) => bytes,
+            Ok(None) => {
+                return TaskOutcome::Err(format!("no cover for book {book_id}"));
+            }
+            Err(e) => return TaskOutcome::Err(e.to_string()),
+        };
+        let cap = crate::thumbs::cap_bytes();
+        match tokio::task::spawn_blocking(move || {
+            crate::thumbs::ensure_thumbnails_sync(book_id, last_modified_epoch, cover)?;
+            crate::thumbs::evict_if_over_cap(cap)
+                .map_err(|e| crate::thumbs::ThumbError::Failed(format!("I/O error: {e}")))
+        })
+        .await
+        {
+            Ok(Ok(())) => TaskOutcome::Ok,
+            Ok(Err(e)) => TaskOutcome::Err(e.to_string()),
+            Err(join_err) => {
+                let kind = if join_err.is_panic() {
+                    "panicked"
+                } else {
+                    "was cancelled"
+                };
+                TaskOutcome::Err(format!("spawn_blocking {kind}: {join_err}"))
             }
         }
     }
+}
+
+/// Run the test-only synthetic task: fire the optional `on_run` hook, sleep
+/// `latency_ms`, then fire the optional `on_done` hook.
+#[cfg(test)]
+async fn handle_test_task(
+    latency_ms: u64,
+    on_run: Option<Arc<dyn Fn() + Send + Sync>>,
+    on_done: Option<Arc<dyn Fn() + Send + Sync>>,
+) -> TaskOutcome {
+    if let Some(f) = on_run.as_ref() {
+        f();
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(latency_ms)).await;
+    if let Some(f) = on_done.as_ref() {
+        f();
+    }
+    TaskOutcome::Ok
 }

--- a/frontend/src/components/search_palette/keyboard.rs
+++ b/frontend/src/components/search_palette/keyboard.rs
@@ -23,8 +23,8 @@ pub(super) struct KeyboardContext {
 pub(super) fn make_keydown_handler(ctx: KeyboardContext) -> impl FnMut(Event<KeyboardData>) {
     let KeyboardContext {
         mut open,
-        mut selected,
-        mut has_navigated,
+        selected,
+        has_navigated,
         flat_items,
         query,
         nav,
@@ -38,72 +38,89 @@ pub(super) fn make_keydown_handler(ctx: KeyboardContext) -> impl FnMut(Event<Key
             }
             Key::ArrowDown => {
                 evt.prevent_default();
-                let len = flat_items.read().len();
-                if len > 0 {
-                    // First arrow press is a "begin navigation" gesture — it
-                    // should highlight the first item, not increment past it.
-                    // Subsequent presses wrap around as usual.
-                    if !has_navigated() {
-                        selected.set(0);
-                    } else {
-                        selected.set((selected() + 1) % len);
-                    }
-                    has_navigated.set(true);
-                }
+                move_selection(selected, has_navigated, flat_items, Direction::Down);
             }
             Key::ArrowUp => {
                 evt.prevent_default();
-                let len = flat_items.read().len();
-                if len > 0 {
-                    // Symmetric with ArrowDown: first press lands on the
-                    // last item; subsequent presses walk backward.
-                    if !has_navigated() {
-                        selected.set(len - 1);
-                    } else {
-                        selected.set(if selected() == 0 {
-                            len - 1
-                        } else {
-                            selected() - 1
-                        });
-                    }
-                    has_navigated.set(true);
-                }
+                move_selection(selected, has_navigated, flat_items, Direction::Up);
             }
             Key::Enter => {
                 evt.prevent_default();
-                let items = flat_items.read();
-                if has_navigated() {
-                    // Navigate to the selected result. Books/Authors/Series go
-                    // to their detail pages; Tags fall through to /search (no
-                    // per-tag detail page exists yet).
-                    if let Some(item) = items.get(selected()) {
-                        match item {
-                            FlatItem::Book { uuid, .. } => {
-                                nav.push(Route::BookDetail { uuid: uuid.clone() });
-                            }
-                            FlatItem::Author { id, .. } => {
-                                nav.push(Route::AuthorDetail { id: *id });
-                            }
-                            FlatItem::Series { id, .. } => {
-                                nav.push(Route::SeriesDetail { id: *id });
-                            }
-                            FlatItem::Tag { name, .. } => {
-                                nav.push(Route::Search {
-                                    query: facet_query("tag", name),
-                                });
-                            }
-                        }
-                        open.0.set(false);
-                    }
-                } else {
-                    let q = query().trim().to_string();
-                    if !q.is_empty() {
-                        nav.push(Route::Search { query: q });
-                        open.0.set(false);
-                    }
-                }
+                handle_enter(open, selected, has_navigated, flat_items, query, &nav);
             }
             _ => {}
+        }
+    }
+}
+
+/// Arrow-key direction for [`move_selection`].
+#[derive(Copy, Clone)]
+enum Direction {
+    Up,
+    Down,
+}
+
+/// Move the highlight one step in `dir`, wrapping. The first arrow press is a
+/// "begin navigation" gesture: it lands on the first (Down) or last (Up) item
+/// rather than stepping past it; subsequent presses wrap around as usual.
+fn move_selection(
+    mut selected: Signal<usize>,
+    mut has_navigated: Signal<bool>,
+    flat_items: Memo<Vec<FlatItem>>,
+    dir: Direction,
+) {
+    let len = flat_items.read().len();
+    if len == 0 {
+        return;
+    }
+    let next = match (dir, has_navigated()) {
+        (Direction::Down, false) => 0,
+        (Direction::Down, true) => (selected() + 1) % len,
+        (Direction::Up, false) => len - 1,
+        (Direction::Up, true) if selected() == 0 => len - 1,
+        (Direction::Up, true) => selected() - 1,
+    };
+    selected.set(next);
+    has_navigated.set(true);
+}
+
+/// Handle Enter: open the highlighted row once the user has engaged keyboard
+/// nav (Books/Authors/Series to their detail pages; Tags fall through to
+/// `/search`), else route to the full-page `/search/:query` view.
+fn handle_enter(
+    mut open: PaletteOpen,
+    selected: Signal<usize>,
+    has_navigated: Signal<bool>,
+    flat_items: Memo<Vec<FlatItem>>,
+    query: Signal<String>,
+    nav: &dioxus_router::Navigator,
+) {
+    let items = flat_items.read();
+    if has_navigated() {
+        if let Some(item) = items.get(selected()) {
+            match item {
+                FlatItem::Book { uuid, .. } => {
+                    nav.push(Route::BookDetail { uuid: uuid.clone() });
+                }
+                FlatItem::Author { id, .. } => {
+                    nav.push(Route::AuthorDetail { id: *id });
+                }
+                FlatItem::Series { id, .. } => {
+                    nav.push(Route::SeriesDetail { id: *id });
+                }
+                FlatItem::Tag { name, .. } => {
+                    nav.push(Route::Search {
+                        query: facet_query("tag", name),
+                    });
+                }
+            }
+            open.0.set(false);
+        }
+    } else {
+        let q = query().trim().to_string();
+        if !q.is_empty() {
+            nav.push(Route::Search { query: q });
+            open.0.set(false);
         }
     }
 }

--- a/frontend/src/pages/landing/effects.rs
+++ b/frontend/src/pages/landing/effects.rs
@@ -76,17 +76,13 @@ pub(super) fn spawn_page_fetch_effect(
     )>,
     sigs: FetchSignals,
 ) {
-    let FetchSignals {
-        mut books,
-        mut next_cursor,
-        mut total,
-        mut lib_path,
-        mut lib_error,
-        mut loading,
-        loading_more: _,
-        mut error,
-        mut fetch_epoch,
-    } = sigs;
+    // `sigs` is `Copy`; the result-application signals are set inside
+    // `apply_browse_result` / `apply_search_result`. Only the fetch-lifecycle
+    // signals are driven from this body.
+    let mut next_cursor = sigs.next_cursor;
+    let mut loading = sigs.loading;
+    let mut error = sigs.error;
+    let mut fetch_epoch = sigs.fetch_epoch;
     use_effect(move || {
         let (q, sort_key, sort_dir, filters) = fetch_key();
         let epoch = {
@@ -106,47 +102,81 @@ pub(super) fn spawn_page_fetch_effect(
                 if *fetch_epoch.peek() != epoch {
                     return; // a newer fetch superseded us — drop this result
                 }
-                match result {
-                    Ok(page) => {
-                        lib_path.set(page.path);
-                        lib_error.set(None);
-                        next_cursor.set(page.next_cursor);
-                        total.set(page.total);
-                        books.set(page.books);
-                    }
-                    Err(e) => {
-                        error.set(Some(e.to_string()));
-                        // Clear the derived signals so the error state doesn't
-                        // render a stale header count.
-                        books.set(Vec::new());
-                        total.set(None);
-                        lib_error.set(None);
-                    }
-                }
+                apply_browse_result(sigs, result);
             } else {
                 // Search: capped full result set, sorted/filtered client-side.
                 let result = data::search_ebooks(&url, &q).await;
                 if *fetch_epoch.peek() != epoch {
                     return;
                 }
-                match result {
-                    Ok(lib) => {
-                        lib_path.set(lib.path);
-                        lib_error.set(lib.error);
-                        total.set(lib.total);
-                        books.set(lib.books);
-                    }
-                    Err(e) => {
-                        error.set(Some(e.to_string()));
-                        books.set(Vec::new());
-                        total.set(None);
-                        lib_error.set(None);
-                    }
-                }
+                apply_search_result(sigs, result);
             }
             loading.set(false);
         });
     });
+}
+
+/// Apply a browse (keyset page-1) fetch outcome to the page signals. On error,
+/// the derived signals are cleared so the error state doesn't render a stale
+/// header count.
+fn apply_browse_result(
+    sigs: FetchSignals,
+    result: Result<omnibus_shared::LibraryPage, data::DataError>,
+) {
+    let FetchSignals {
+        mut books,
+        mut next_cursor,
+        mut total,
+        mut lib_path,
+        mut lib_error,
+        mut error,
+        ..
+    } = sigs;
+    match result {
+        Ok(page) => {
+            lib_path.set(page.path);
+            lib_error.set(None);
+            next_cursor.set(page.next_cursor);
+            total.set(page.total);
+            books.set(page.books);
+        }
+        Err(e) => {
+            error.set(Some(e.to_string()));
+            books.set(Vec::new());
+            total.set(None);
+            lib_error.set(None);
+        }
+    }
+}
+
+/// Apply a search (capped full result set) fetch outcome to the page signals.
+/// On error, the derived signals are cleared to avoid a stale header count.
+fn apply_search_result(
+    sigs: FetchSignals,
+    result: Result<omnibus_shared::EbookLibrary, data::DataError>,
+) {
+    let FetchSignals {
+        mut books,
+        mut total,
+        mut lib_path,
+        mut lib_error,
+        mut error,
+        ..
+    } = sigs;
+    match result {
+        Ok(lib) => {
+            lib_path.set(lib.path);
+            lib_error.set(lib.error);
+            total.set(lib.total);
+            books.set(lib.books);
+        }
+        Err(e) => {
+            error.set(Some(e.to_string()));
+            books.set(Vec::new());
+            total.set(None);
+            lib_error.set(None);
+        }
+    }
 }
 
 /// Append the next page when `want_more` bumps; drops the append if a page-1 refetch supersedes it.

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -38,24 +38,17 @@ type CallbackHolder =
 /// highlights into the viewer. No-op on non-web targets.
 #[cfg(feature = "web")]
 pub(crate) fn install_reader_web_interop(uuid: String, prefs: ReaderPrefs, sigs: InteropSignals) {
-    use wasm_bindgen::prelude::*;
-
-    use super::bootstrap::{reader_bootstrap_js, BootstrapArgs};
     use super::reader_call;
-    use crate::data;
 
     let cb_holder: CallbackHolder =
         use_hook(|| std::rc::Rc::new(std::cell::RefCell::new(Vec::new())));
 
     let theme = prefs.theme;
-    let InteropSignals {
-        mut status,
-        mut loc,
-        mut selection,
-        mut highlights,
-        mut toc,
-        mut search_results,
-    } = sigs;
+    // `sigs` is `Copy`; the callbacks it feeds are wired up in
+    // `register_window_callbacks`. Only `status` (initial Loading) and
+    // `highlights` (seeded after bootstrap) are driven from this body.
+    let mut status = sigs.status;
+    let highlights = sigs.highlights;
 
     let uuid_for_mount = uuid.clone();
     let uuid_for_cb = uuid;
@@ -84,119 +77,25 @@ pub(crate) fn install_reader_web_interop(uuid: String, prefs: ReaderPrefs, sigs:
             .unwrap_or_else(|_| "\"auto\"".into());
 
         if let Some(window) = web_sys::window() {
-            let uuid_for_save = uuid_cb.clone();
-            let relocate = Closure::<dyn FnMut(String)>::new(move |json: String| {
-                if let Ok(data) = serde_json::from_str::<super::RelocateData>(&json) {
-                    if let Some(ref cfi) = data.cfi {
-                        crate::reader_progress::save(&uuid_for_save, cfi);
-                        let uuid_for_post = uuid_for_save.clone();
-                        let cfi_for_post = cfi.clone();
-                        wasm_bindgen_futures::spawn_local(async move {
-                            let body = serde_json::json!({
-                                "update": {
-                                    "book_uuid": uuid_for_post,
-                                    "format": "epub",
-                                    "epub_cfi": cfi_for_post,
-                                }
-                            });
-                            if let Ok(req) =
-                                gloo_net::http::Request::post("/api/rpc/progress").json(&body)
-                            {
-                                let _ = req.send().await;
-                            }
-                        });
-                    }
-                    loc.set(data);
-                }
-            });
-            let on_status = Closure::<dyn FnMut(String)>::new(move |state: String| {
-                status.set(match state.as_str() {
-                    "ready" => ReaderStatus::Ready,
-                    "error" => ReaderStatus::Failed,
-                    _ => ReaderStatus::Loading,
-                });
-            });
-            let _ = js_sys::Reflect::set(
-                &window,
-                &JsValue::from_str("__omnibusOnRelocate"),
-                relocate.as_ref().unchecked_ref(),
-            );
-            let on_selection = Closure::<dyn FnMut(String)>::new(move |json: String| {
-                if let Ok(data) = serde_json::from_str::<SelectionData>(&json) {
-                    selection.set(Some(data));
-                }
-            });
-            let on_toc = Closure::<dyn FnMut(String)>::new(move |json: String| {
-                if let Ok(entries) = serde_json::from_str::<Vec<TocEntry>>(&json) {
-                    toc.set(entries);
-                }
-            });
-            let on_search = Closure::<dyn FnMut(String)>::new(move |json: String| {
-                if let Ok(rs) = serde_json::from_str::<Vec<SearchResult>>(&json) {
-                    search_results.set(rs);
-                }
-            });
-            let _ = js_sys::Reflect::set(
-                &window,
-                &JsValue::from_str("__omnibusOnStatus"),
-                on_status.as_ref().unchecked_ref(),
-            );
-            let _ = js_sys::Reflect::set(
-                &window,
-                &JsValue::from_str("__omnibusOnSelection"),
-                on_selection.as_ref().unchecked_ref(),
-            );
-            let _ = js_sys::Reflect::set(
-                &window,
-                &JsValue::from_str("__omnibusOnToc"),
-                on_toc.as_ref().unchecked_ref(),
-            );
-            let _ = js_sys::Reflect::set(
-                &window,
-                &JsValue::from_str("__omnibusOnSearchResults"),
-                on_search.as_ref().unchecked_ref(),
-            );
-            *cb_holder.borrow_mut() = vec![relocate, on_status, on_selection, on_toc, on_search];
+            *cb_holder.borrow_mut() = register_window_callbacks(&window, uuid_cb.clone(), sigs);
         }
 
-        let uuid_for_fetch = uuid.clone();
-        spawn(async move {
-            let server_cfi = crate::data::get_progress(
-                "",
-                &uuid_for_fetch,
-                omnibus_shared::ProgressFormat::Epub,
-            )
-            .await
-            .ok()
-            .flatten()
-            .and_then(|r| r.epub_cfi);
-            let chosen = server_cfi.or(local_saved);
-            let cfi_arg = serde_json::to_string(&chosen).unwrap_or_else(|_| "null".into());
-            let js = reader_bootstrap_js(&BootstrapArgs {
-                url_lit: &url_lit,
-                cfi_arg: &cfi_arg,
-                font_size: size,
-                theme_lit: &theme_lit,
-                font_family_lit: &font_family_lit,
-                line_height_lit: &line_height_lit,
-                max_width_lit: &max_width_lit,
-                justify_val,
-                spread_lit: &spread_lit,
-            });
-            let _ = dioxus::document::eval(&js);
-
-            let hl_uuid = uuid_for_fetch.clone();
-            if let Ok(list) = data::list_highlights("", &hl_uuid).await {
-                for h in &list {
-                    let cfi_lit =
-                        serde_json::to_string(&h.epub_cfi_range).unwrap_or_else(|_| "\"\"".into());
-                    let color_lit = serde_json::to_string(h.color.as_str())
-                        .unwrap_or_else(|_| "\"amber\"".into());
-                    reader_call("addAnnotation", &format!("{cfi_lit}, {color_lit}"));
-                }
-                highlights.set(list);
-            }
-        });
+        let bootstrap = BootstrapLiterals {
+            url_lit,
+            theme_lit,
+            font_family_lit,
+            line_height_lit,
+            max_width_lit,
+            spread_lit,
+            font_size: size,
+            justify_val,
+        };
+        spawn(spawn_bootstrap_and_highlights(
+            uuid.clone(),
+            local_saved,
+            bootstrap,
+            highlights,
+        ));
     }));
 
     use_effect(move || {
@@ -204,6 +103,149 @@ pub(crate) fn install_reader_web_interop(uuid: String, prefs: ReaderPrefs, sigs:
             serde_json::to_string(theme.read().as_attr()).unwrap_or_else(|_| "\"dark\"".into());
         reader_call("setTheme", &attr_lit);
     });
+}
+
+/// Register the `__omnibusOn*` window callbacks that stream epub.js events
+/// (relocate/status/selection/toc/search) back into the reader signals, and
+/// return the owning `Closure`s so the caller can keep them alive past this
+/// call. The relocate callback also persists progress locally and POSTs it.
+#[cfg(feature = "web")]
+fn register_window_callbacks(
+    window: &web_sys::Window,
+    uuid_cb: String,
+    sigs: InteropSignals,
+) -> Vec<wasm_bindgen::prelude::Closure<dyn FnMut(String)>> {
+    use wasm_bindgen::prelude::*;
+
+    let InteropSignals {
+        mut status,
+        mut loc,
+        mut selection,
+        mut toc,
+        mut search_results,
+        ..
+    } = sigs;
+
+    let uuid_for_save = uuid_cb;
+    let relocate = Closure::<dyn FnMut(String)>::new(move |json: String| {
+        if let Ok(data) = serde_json::from_str::<super::RelocateData>(&json) {
+            if let Some(ref cfi) = data.cfi {
+                crate::reader_progress::save(&uuid_for_save, cfi);
+                let uuid_for_post = uuid_for_save.clone();
+                let cfi_for_post = cfi.clone();
+                wasm_bindgen_futures::spawn_local(async move {
+                    let body = serde_json::json!({
+                        "update": {
+                            "book_uuid": uuid_for_post,
+                            "format": "epub",
+                            "epub_cfi": cfi_for_post,
+                        }
+                    });
+                    if let Ok(req) = gloo_net::http::Request::post("/api/rpc/progress").json(&body)
+                    {
+                        let _ = req.send().await;
+                    }
+                });
+            }
+            loc.set(data);
+        }
+    });
+    let on_status = Closure::<dyn FnMut(String)>::new(move |state: String| {
+        status.set(match state.as_str() {
+            "ready" => ReaderStatus::Ready,
+            "error" => ReaderStatus::Failed,
+            _ => ReaderStatus::Loading,
+        });
+    });
+    let on_selection = Closure::<dyn FnMut(String)>::new(move |json: String| {
+        if let Ok(data) = serde_json::from_str::<SelectionData>(&json) {
+            selection.set(Some(data));
+        }
+    });
+    let on_toc = Closure::<dyn FnMut(String)>::new(move |json: String| {
+        if let Ok(entries) = serde_json::from_str::<Vec<TocEntry>>(&json) {
+            toc.set(entries);
+        }
+    });
+    let on_search = Closure::<dyn FnMut(String)>::new(move |json: String| {
+        if let Ok(rs) = serde_json::from_str::<Vec<SearchResult>>(&json) {
+            search_results.set(rs);
+        }
+    });
+    for (name, cb) in [
+        ("__omnibusOnRelocate", &relocate),
+        ("__omnibusOnStatus", &on_status),
+        ("__omnibusOnSelection", &on_selection),
+        ("__omnibusOnToc", &on_toc),
+        ("__omnibusOnSearchResults", &on_search),
+    ] {
+        let _ = js_sys::Reflect::set(
+            window,
+            &JsValue::from_str(name),
+            cb.as_ref().unchecked_ref(),
+        );
+    }
+    vec![relocate, on_status, on_selection, on_toc, on_search]
+}
+
+/// The pre-serialized JS literals + scalars the bootstrap IIFE needs, bundled
+/// so [`spawn_bootstrap_and_highlights`] takes one named argument.
+#[cfg(feature = "web")]
+struct BootstrapLiterals {
+    url_lit: String,
+    theme_lit: String,
+    font_family_lit: String,
+    line_height_lit: String,
+    max_width_lit: String,
+    spread_lit: String,
+    font_size: i32,
+    justify_val: bool,
+}
+
+/// Resolve the starting CFI (server progress, else local save), run the
+/// epub.js bootstrap IIFE, then seed the annotation layer from the saved
+/// highlights and publish them into the `highlights` signal.
+#[cfg(feature = "web")]
+async fn spawn_bootstrap_and_highlights(
+    uuid: String,
+    local_saved: Option<String>,
+    lits: BootstrapLiterals,
+    mut highlights: Signal<Vec<Highlight>>,
+) {
+    use super::bootstrap::{reader_bootstrap_js, BootstrapArgs};
+    use super::reader_call;
+    use crate::data;
+
+    let server_cfi = crate::data::get_progress("", &uuid, omnibus_shared::ProgressFormat::Epub)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|r| r.epub_cfi);
+    let chosen = server_cfi.or(local_saved);
+    let cfi_arg = serde_json::to_string(&chosen).unwrap_or_else(|_| "null".into());
+    let js = reader_bootstrap_js(&BootstrapArgs {
+        url_lit: &lits.url_lit,
+        cfi_arg: &cfi_arg,
+        font_size: lits.font_size,
+        theme_lit: &lits.theme_lit,
+        font_family_lit: &lits.font_family_lit,
+        line_height_lit: &lits.line_height_lit,
+        max_width_lit: &lits.max_width_lit,
+        justify_val: lits.justify_val,
+        spread_lit: &lits.spread_lit,
+    });
+    let _ = dioxus::document::eval(&js);
+
+    if let Ok(list) = data::list_highlights("", &uuid).await {
+        for h in &list {
+            let cfi_lit =
+                serde_json::to_string(&h.epub_cfi_range).unwrap_or_else(|_| "\"\"".into());
+            let color_lit =
+                serde_json::to_string(h.color.as_str()).unwrap_or_else(|_| "\"amber\"".into());
+            reader_call("addAnnotation", &format!("{cfi_lit}, {color_lit}"));
+        }
+        highlights.set(list);
+    }
 }
 
 /// Extract `file_id` from the current URL's query string (`?file_id=N`),

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -64,21 +64,35 @@ pub(super) async fn get_ebooks(
     // byte-identical to the pre-F5b full (capped) library, so existing mobile
     // clients keep working untouched.
     if q.sort.is_none() && q.dir.is_none() && q.cursor.is_none() && q.limit.is_none() {
-        return match db::library_from_db_with_total_combined(
-            &state.pool,
-            ebook.as_deref(),
-            audiobook.as_deref(),
-        )
-        .await
-        {
-            Ok((library, total)) => with_pagination_headers(Json(library).into_response(), total),
-            Err(error) => internal("read books", error),
-        };
+        return respond_full_library(&state, ebook.as_deref(), audiobook.as_deref()).await;
     }
 
-    // Paged keyset form. A cursor is decoded relative to the request's sort
-    // axis, so it's only meaningful with an explicit `sort` + `dir` — enforce
-    // that as a 400 rather than silently mis-positioning the page.
+    respond_keyset_page(&state, &q, ebook.as_deref(), audiobook.as_deref()).await
+}
+
+/// Full (capped) combined library, with `X-Total-Count` / `X-Total-Cap`
+/// headers — the pre-F5b response shape for clients that send no pagination.
+async fn respond_full_library(
+    state: &AppState,
+    ebook: Option<&str>,
+    audiobook: Option<&str>,
+) -> Response {
+    match db::library_from_db_with_total_combined(&state.pool, ebook, audiobook).await {
+        Ok((library, total)) => with_pagination_headers(Json(library).into_response(), total),
+        Err(error) => internal("read books", error),
+    }
+}
+
+/// Keyset-paginated page for an explicit `sort`/`dir`/`cursor`/`limit`. A
+/// cursor is decoded relative to the request's sort axis, so a cursor without
+/// an explicit `sort` **and** `dir`, or a malformed cursor, is a 400 rather
+/// than a silently mis-positioned page or a 500.
+async fn respond_keyset_page(
+    state: &AppState,
+    q: &EbooksQuery,
+    ebook: Option<&str>,
+    audiobook: Option<&str>,
+) -> Response {
     if q.cursor.is_some() && (q.sort.is_none() || q.dir.is_none()) {
         return (
             axum::http::StatusCode::BAD_REQUEST,
@@ -86,7 +100,6 @@ pub(super) async fn get_ebooks(
         )
             .into_response();
     }
-    // A malformed cursor is likewise a client error (400), not a 500.
     let cursor = match q.cursor.as_deref() {
         Some(c) => match db::PageCursor::decode(c) {
             Ok(p) => Some(p),
@@ -96,8 +109,8 @@ pub(super) async fn get_ebooks(
         },
         None => None,
     };
-    let path = ebook.as_ref().or(audiobook.as_ref()).cloned();
-    let paths = db::collect_paths(ebook.as_deref(), audiobook.as_deref());
+    let path = ebook.or(audiobook).map(str::to_string);
+    let paths = db::collect_paths(ebook, audiobook);
     let page = match db::list_books_page(
         &state.pool,
         &paths,

--- a/server/src/backend/overrides.rs
+++ b/server/src/backend/overrides.rs
@@ -5,6 +5,7 @@
 //! into the wire DTO. Mounted on the REST router in [`super::rest_router`].
 
 use axum::{
+    body::Bytes,
     extract::{Path, State},
     response::{IntoResponse, Response},
     Json,
@@ -127,46 +128,8 @@ pub(super) async fn post_ebook_cover(
         Err(response) => return response,
     };
 
-    // Look up the prior overrides row BEFORE touching disk. `write_override_cover`
-    // deletes any existing `override-<uuid>.*` before writing the new file, so if
-    // we wrote first and only fetched the prior row to decide on cleanup, a DB
-    // failure could orphan the user's previously-set cover (#529). Fetching first
-    // keeps the disk-write/cleanup decision race-free: only cleanup when the row
-    // is absent OR `has_cover_override` was false going in.
-    let (existing_overrides, had_prior_cover_override) =
-        match db::get_metadata_overrides(&state.pool, &uuid).await {
-            Ok(Some((ov, has_cover))) => (ov, has_cover),
-            Ok(None) => (MetadataOverrides::default(), false),
-            Err(e) => return internal("get_metadata_overrides", e),
-        };
-
-    // Write the override cover to disk. `write_override_cover` is a sync
-    // `std::fs` call — run it on the blocking pool so the axum runtime stays
-    // responsive while we hit disk (#106). `uuid` is needed again below for
-    // the overrides table update, so it's the only value we clone.
-    let uuid_for_write = uuid.clone();
-    let write_result = tokio::task::spawn_blocking(move || {
-        db::write_override_cover(&uuid_for_write, &mime, &bytes)
-    })
-    .await;
-    match write_result {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => return internal("write_override_cover", e),
-        Err(e) => return internal("spawn_blocking(write_override_cover)", e),
-    }
-
-    // Mark the overrides table with has_cover_override = 1. Preserve existing
-    // field overrides if any. If the upsert fails, only clean the file we
-    // just wrote when no prior override cover existed — otherwise the
-    // `write_override_cover` step would have deleted the user's previous
-    // valid cover, and the cleanup would compound the data loss (#516, #529).
-    if let Err(e) =
-        db::upsert_metadata_overrides(&state.pool, &uuid, &existing_overrides, true, user.id).await
-    {
-        if !had_prior_cover_override {
-            cleanup_orphan_cover(&uuid).await;
-        }
-        return internal("upsert_metadata_overrides", e);
+    if let Err(response) = persist_cover(&state, &uuid, user.id, mime, bytes).await {
+        return response;
     }
 
     // Invalidate thumb cache so next request regenerates from new cover.
@@ -180,6 +143,54 @@ pub(super) async fn post_ebook_cover(
         Ok(None) => (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
         Err(e) => internal("get_book", e),
     }
+}
+
+/// Write the new override cover to disk and mark `has_cover_override = 1`,
+/// preserving any existing field overrides. Returns the error `Response`
+/// already formed on failure so the caller can early-return.
+///
+/// The prior overrides row is read BEFORE touching disk: `write_override_cover`
+/// deletes any existing `override-<uuid>.*` before writing, so fetching first
+/// keeps the disk-write/cleanup decision race-free (#529). If the upsert fails,
+/// the just-written file is cleaned up ONLY when no prior override cover existed
+/// — otherwise the write step already replaced the user's previous valid cover
+/// and cleanup would compound the loss (#516, #529).
+async fn persist_cover(
+    state: &AppState,
+    uuid: &str,
+    user_id: i64,
+    mime: String,
+    bytes: Bytes,
+) -> Result<(), Response> {
+    let (existing_overrides, had_prior_cover_override) =
+        match db::get_metadata_overrides(&state.pool, uuid).await {
+            Ok(Some((ov, has_cover))) => (ov, has_cover),
+            Ok(None) => (MetadataOverrides::default(), false),
+            Err(e) => return Err(internal("get_metadata_overrides", e)),
+        };
+
+    // `write_override_cover` is a sync `std::fs` call — run it on the blocking
+    // pool so the axum runtime stays responsive while we hit disk (#106).
+    let uuid_for_write = uuid.to_string();
+    let write_result = tokio::task::spawn_blocking(move || {
+        db::write_override_cover(&uuid_for_write, &mime, &bytes)
+    })
+    .await;
+    match write_result {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(internal("write_override_cover", e)),
+        Err(e) => return Err(internal("spawn_blocking(write_override_cover)", e)),
+    }
+
+    if let Err(e) =
+        db::upsert_metadata_overrides(&state.pool, uuid, &existing_overrides, true, user_id).await
+    {
+        if !had_prior_cover_override {
+            cleanup_orphan_cover(uuid).await;
+        }
+        return Err(internal("upsert_metadata_overrides", e));
+    }
+    Ok(())
 }
 
 /// Best-effort delete of the on-disk override cover after a DB failure in


### PR DESCRIPTION
## Summary
Refactors the oversized functions tracked in #727 so no single function body exceeds the ~80-line soft cap (`.claude/rules/05-rust-style.md` § Function shape). Every extraction is behavior-preserving — logic was lifted into named helpers (each with a one-line `///`), large static SQL literals were hoisted to module-level `const`s, and repeated boilerplate was collapsed into small shared helpers. No `#[allow(...)]` suppressions and no `// allow:` escape hatches were needed; every offender split cleanly.

Closes #727.

### Functions split (16)
- `frontend/src/pages/reader/interop.rs` → `install_reader_web_interop` (168 → 67): extracted `register_window_callbacks` (JS callback wiring) and `spawn_bootstrap_and_highlights` (bootstrap + highlight seeding), plus a `BootstrapLiterals` bundle. Web-gated interop only; no rsx/effect body was cfg-gated (hydration rule 07 respected).
- `db/src/worker/handlers.rs` → `execute` (152 → 76): thin dispatch match; extracted `handle_scan_audiobooks` / `handle_generate_thumbs` / `handle_test_task` and an `outcome_of` result-mapper.
- `server/src/backend/overrides.rs` → `post_ebook_cover` (83 → 45): extracted `persist_cover` (disk write + overrides upsert with cleanup-on-failure).
- `db/src/merge/snapshot.rs` → `build_snapshot` (108 → 46): extracted `load_file_rows` and `load_link_rows` (returning small `FileRows` / `LinkRows` structs).
- `db/src/palette/{series,books,authors}.rs` → `search_series` / `search_books` / `search_authors` (104/96/91 → 24/46/23): hoisted each arm's static SQL to a documented module-level `const`; `search_books` also gained `apply_override_overlays`.
- `db/src/audiobook/stat.rs` → `stat_audiobook_library` (99 → 69): extracted `unreadable_subdir_entry` and `stat_accepted_file`.
- `db/src/books/facets.rs` → `library_facets` (96 → 16): extracted per-facet `author_facets` / `series_facets` / `format_facets` / `tag_facets`.
- `server/src/backend/ebooks.rs` → `get_ebooks` (90 → 21): extracted `respond_full_library` and `respond_keyset_page`.
- `frontend/src/components/search_palette/keyboard.rs` → `make_keydown_handler` (87 → 32): extracted `move_selection` (with a `Direction` enum) and `handle_enter`.
- `db/src/worker/exec.rs` → `run` (86 → 57): extracted `acquire_permit` (shared by the scan/hls semaphores) and `project_terminal`.
- `db/src/missing_files.rs` → `gc_books_missing_files` (84 → 38): extracted `delete_victim_rows` and `cleanup_victim_covers`.
- `frontend/src/pages/landing/effects.rs` → `spawn_page_fetch_effect` (82 → 49): extracted `apply_browse_result` and `apply_search_result`.
- `db/src/merge/undo.rs` → `undo_merge` (81 → 46): extracted `restore_attach_ledger` and `rebuild_target_fts_best_effort`.
- `db/src/pool.rs` → `init_db` (82 → 13): extracted `connect_pool`, `run_boot_backfills`, and `run_legacy_cover_purge`.

### Deferred
- `db/src/browse.rs` → `list_authors` is listed in #727 but is **owned by open PR #805**, so it is intentionally left untouched here to avoid a conflict. It can be swept in a follow-up once #805 lands.
- `server/src/backend/author_photos.rs` → `put_author_photo` was already refactored below the cap since the issue was filed (helper `author_exists` extracted; 35 lines). Verified, no change needed.

## Test plan
All run via `nix develop` from the workspace; all PASS.
- [x] `cargo test -p omnibus-db` — 808 passed, 0 failed
- [x] `cargo test -p omnibus` — 303 passed, 0 failed
- [x] `cargo test -p omnibus-frontend --features server` — 209 passed, 0 failed
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings` — clean (covers the web-gated reader interop)
- [x] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` (in `.#mobile`) — clean
- [x] `cargo fmt --check` — clean

## Notes
Pure refactor — no behavior, API, or schema changes. The fifth sweep in the oversized-function family (#377/#579/#590/#607). As the issue suggests, a `clippy::too_many_lines` gate might be worth adding now to stop the recurrence, but that is out of scope here.