### PR TITLE
feat: name the mobile app "Omnibus" and enable background audio

### DIFF
--- a/mobile/Dioxus.toml
+++ b/mobile/Dioxus.toml
@@ -1,5 +1,11 @@
 [application]
-name = "omnibus-mobile"
+name = "Omnibus"
+
+[background]
+# Keep audiobook playback alive when the app is backgrounded or the screen is
+# locked. dx maps this to iOS UIBackgroundModes "audio" and Android
+# FOREGROUND_SERVICE_MEDIA_PLAYBACK.
+audio = true
 
 [android]
 uses_cleartext_traffic = true

--- a/mobile/Dioxus.toml
+++ b/mobile/Dioxus.toml
@@ -2,9 +2,6 @@
 name = "Omnibus"
 
 [background]
-# Keep audiobook playback alive when the app is backgrounded or the screen is
-# locked. dx maps this to iOS UIBackgroundModes "audio" and Android
-# FOREGROUND_SERVICE_MEDIA_PLAYBACK.
 audio = true
 
 [android]


### PR DESCRIPTION
## Summary
- Set the mobile app display name to **Omnibus** (was `omnibus-mobile`, which rendered as "OmnibusMobile" on the home screen) via `[application] name`.
- Enable **background audio** with `[background] audio = true` so audiobook playback keeps running when the app is backgrounded or the screen is locked. dx maps this to iOS `UIBackgroundModes "audio"` and Android `FOREGROUND_SERVICE_MEDIA_PLAYBACK`.

## Test plan
- [x] `mobile/Dioxus.toml` parses (config-only change; verified via `just --list`).
- [ ] On a mobile build, the home-screen label reads "Omnibus" and audiobook playback continues in the background. (Not built in this PR — declarative config.)

## Version
- [ ] **No release** — mobile-only config, no web code path changes (`no release` label applied).

## Notes
- Renaming the app changes the built bundle name (`OmnibusMobile.app` → `Omnibus.app`). This affects the default `.app` path in the `just ios-icon` recipe on the separate draft PR #782 — reconcile there when that PR is finalized on-device.
- Depends on nothing; independent of the web branding PR #781 and the icon/install draft #782.
