### PR TITLE
feat: write kobo files into Author/Title folders

### DIFF
--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -28,9 +28,10 @@ and you copy it over yourself. Both are described below.
 4. When it reports success, **eject the Kobo safely**, then unplug it. The book
    appears in your library, titled from its own metadata (not the filename).
 
-Omnibus files each book under `<Author>/<Title>/` on the drive (the same tidy
-layout Calibre uses), so browsing the device over USB stays organized rather
-than a pile of files at the root.
+On this one-click write path, Omnibus files each book under `<Author>/<Title>/`
+on the drive (the same tidy layout Calibre uses), so browsing the device over
+USB stays organized rather than a pile of files at the root. (The download-then-
+copy path below hands you a single file instead — drop it wherever you like.)
 
 ## Other browsers — download, then copy
 

--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -28,6 +28,10 @@ and you copy it over yourself. Both are described below.
 4. When it reports success, **eject the Kobo safely**, then unplug it. The book
    appears in your library, titled from its own metadata (not the filename).
 
+Omnibus files each book under `<Author>/<Title>/` on the drive (the same tidy
+layout Calibre uses), so browsing the device over USB stays organized rather
+than a pile of files at the root.
+
 ## Other browsers — download, then copy
 
 1. Open the book's page in Omnibus and click **Send to Kobo**. A file named

--- a/docs/roadmap/4-1-kobo-sync.md
+++ b/docs/roadmap/4-1-kobo-sync.md
@@ -13,10 +13,13 @@ Implement the `/kobo/v1/*` protocol natively, including EPUB → KEPUB conversio
 >   the *client* machine. On Chromium (Chrome/Edge) it writes the file straight
 >   onto the mounted Kobo drive via the File System Access API (remembering the
 >   directory handle so repeat sends need no prompt); other browsers fall back to
->   a plain download the user copies over. No tokens, no protocol, no wireless
->   sync — and **no data-loss risk**, since dropping a loose file on the drive
->   root never touches `KoboReader.sqlite` or the annotation channel (the write
->   is the safe mirror of the [F4.4](4-4-kobo-annotation-import.md) USB *read*).
+>   a plain download the user copies over. The file lands under
+>   `<Author>/<Title>/<uuid>.kepub.epub` — author/title folders for a tidy
+>   Calibre-style layout, with the uuid kept as the filename so [F4.4](4-4-kobo-annotation-import.md)
+>   can still recover the book from the device's `ContentID` path. No tokens, no
+>   protocol, no wireless sync — and **no data-loss risk**, since adding a file
+>   never touches `KoboReader.sqlite` or the annotation channel (the write is the
+>   safe mirror of the [F4.4](4-4-kobo-annotation-import.md) USB *read*).
 >   User guide: [docs/kobo.md](../kobo.md). This is the KEPUB **Sub-scope** below,
 >   promoted to ship first.
 > - **Stage 2 — wireless sync (deferred).** The `/kobo/v1/*` protocol described

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -22,6 +22,10 @@ pub fn FormatSwitcher(
     formats: Vec<String>,
     uuid: String,
     #[props(default)] book_files: Vec<BookFileInfo>,
+    // Raw author + title, used to nest the Kobo write under `<Author>/<Title>/`
+    // (see [`SendToKoboButton`]). Default empty → write at the drive root.
+    #[props(default)] book_author: String,
+    #[props(default)] book_title: String,
 ) -> Element {
     let rows = prepare_rows(&formats);
     if rows.is_empty() {
@@ -46,11 +50,19 @@ pub fn FormatSwitcher(
                                 kind: row,
                                 uuid: uuid.clone(),
                                 files: files_for_format.into_iter().cloned().collect(),
+                                book_author: book_author.clone(),
+                                book_title: book_title.clone(),
                             }
                         }
                     } else {
                         rsx! {
-                            FormatRow { key: "{row.label()}", kind: row, uuid: uuid.clone() }
+                            FormatRow {
+                                key: "{row.label()}",
+                                kind: row,
+                                uuid: uuid.clone(),
+                                book_author: book_author.clone(),
+                                book_title: book_title.clone(),
+                            }
                         }
                     }
                 }
@@ -60,7 +72,12 @@ pub fn FormatSwitcher(
 }
 
 #[component]
-fn FormatRow(kind: FormatKind, uuid: String) -> Element {
+fn FormatRow(
+    kind: FormatKind,
+    uuid: String,
+    #[props(default)] book_author: String,
+    #[props(default)] book_title: String,
+) -> Element {
     let label = kind.label();
     let testid = format!("format-row-{}", label.to_ascii_lowercase());
     rsx! {
@@ -78,7 +95,7 @@ fn FormatRow(kind: FormatKind, uuid: String) -> Element {
                         // hydration parity — keep cfg gates out of rsx).
                         {read_book_action(&uuid)}
                         {send_to_kindle_action(&uuid, None)}
-                        {send_to_kobo_action(&uuid)}
+                        {send_to_kobo_action(&uuid, &book_author, &book_title)}
                     },
                     FormatKind::M4b | FormatKind::Mp3 => rsx! {
                         // F2.3: web routes into the immersive player; mobile
@@ -98,7 +115,13 @@ fn FormatRow(kind: FormatKind, uuid: String) -> Element {
 /// Expandable row for formats with multiple files (after merge). Shows the
 /// format badge with a file count, and sub-rows for each file.
 #[component]
-fn MultiFileRow(kind: FormatKind, uuid: String, files: Vec<BookFileInfo>) -> Element {
+fn MultiFileRow(
+    kind: FormatKind,
+    uuid: String,
+    files: Vec<BookFileInfo>,
+    #[props(default)] book_author: String,
+    #[props(default)] book_title: String,
+) -> Element {
     let label = kind.label();
     let testid = format!("format-row-{}", label.to_ascii_lowercase());
     let count = files.len();
@@ -116,7 +139,7 @@ fn MultiFileRow(kind: FormatKind, uuid: String, files: Vec<BookFileInfo>) -> Ele
             // (lowest-ordinal) EPUB, so a multi-EPUB book still gets the CTA
             // here. Per-file KEPUB is a deferred follow-up.
             if kind == FormatKind::Epub {
-                div { class: "format-actions", {send_to_kobo_action(&uuid)} }
+                div { class: "format-actions", {send_to_kobo_action(&uuid, &book_author, &book_title)} }
             }
         }
         for file in &files {
@@ -197,14 +220,18 @@ fn read_book_action(_uuid: &str) -> Element {
 /// 07: keep cfg out of rsx bodies), and SSR + first WASM paint emit the same
 /// enabled button so hydration holds.
 #[cfg(not(feature = "mobile"))]
-fn send_to_kobo_action(uuid: &str) -> Element {
+fn send_to_kobo_action(uuid: &str, book_author: &str, book_title: &str) -> Element {
     rsx! {
-        SendToKoboButton { uuid: uuid.to_string() }
+        SendToKoboButton {
+            uuid: uuid.to_string(),
+            book_author: book_author.to_string(),
+            book_title: book_title.to_string(),
+        }
     }
 }
 
 #[cfg(feature = "mobile")]
-fn send_to_kobo_action(_uuid: &str) -> Element {
+fn send_to_kobo_action(_uuid: &str, _book_author: &str, _book_title: &str) -> Element {
     rsx! {
         button {
             class: "btn",
@@ -229,6 +256,11 @@ fn send_to_kobo_action(_uuid: &str) -> Element {
 #[component]
 pub fn SendToKoboButton(
     uuid: String,
+    // Raw book author + title — nest the written file under
+    // `<Author>/<Title>/` so it lands in the same folder layout Calibre and the
+    // Kobo use, instead of a bare uuid file at the drive root. Empty → root.
+    #[props(default)] book_author: String,
+    #[props(default)] book_title: String,
     #[props(default = "btn".to_string())] class: String,
     #[props(default = "action-kobo".to_string())] testid: String,
 ) -> Element {
@@ -249,12 +281,13 @@ pub fn SendToKoboButton(
             "data-testid": "{testid}",
             onclick: move |_| {
                 let uuid = uuid.clone();
+                let subdir = kobo_subdir(&book_author, &book_title);
                 let seq = *send_seq.peek() + 1;
                 send_seq.set(seq);
                 in_flight.set(true);
                 result.set(None);
                 spawn(async move {
-                    let outcome = write_kepub_to_kobo(&uuid).await;
+                    let outcome = write_kepub_to_kobo(&uuid, subdir.as_deref()).await;
                     // A newer send has superseded this one — leave all shared
                     // state to it.
                     if *send_seq.peek() != seq {
@@ -293,6 +326,42 @@ pub fn SendToKoboButton(
             }
         }
     }
+}
+
+/// Sanitize one path component for a Kobo's FAT/exFAT filesystem: replace the
+/// characters illegal on Windows/FAT (and control chars) with spaces, collapse
+/// whitespace, and strip stray leading/trailing dots and spaces. `None` when
+/// nothing usable survives. Pure — unit-tested without a browser.
+#[cfg(not(feature = "mobile"))]
+fn kobo_path_segment(raw: &str) -> Option<String> {
+    let cleaned: String = raw
+        .chars()
+        .map(|c| match c {
+            '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' => ' ',
+            c if c.is_control() => ' ',
+            c => c,
+        })
+        .collect();
+    let collapsed = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    // FAT caps a component at 255 bytes; stay well under and cut on a char
+    // boundary, then re-trim in case the cut left a trailing dot/space.
+    let capped: String = collapsed.chars().take(120).collect();
+    let trimmed = capped.trim_matches(|c| c == '.' || c == ' ');
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Build the `<Author>/<Title>` subfolder a Kobo write nests the file under, or
+/// `None` (write at the drive root) when neither segment survives sanitization.
+/// Segments join with `/`; the JS write flow splits on it to create each
+/// directory. The file *inside* keeps the uuid name so a future USB annotation
+/// import can still map the device's `ContentID` back to the book.
+#[cfg(not(feature = "mobile"))]
+fn kobo_subdir(book_author: &str, book_title: &str) -> Option<String> {
+    let segs: Vec<String> = [book_author, book_title]
+        .iter()
+        .filter_map(|s| kobo_path_segment(s))
+        .collect();
+    (!segs.is_empty()).then(|| segs.join("/"))
 }
 
 /// Map the JS write flow's status string to the toast `(is_error, message)`
@@ -338,11 +407,16 @@ struct KoboWriteOutcome {
 /// authenticates like any other in-page request. Web-only; the SSR stub below
 /// never runs (the click handler only fires in the browser) but must compile.
 #[cfg(all(not(feature = "mobile"), feature = "web"))]
-async fn write_kepub_to_kobo(uuid: &str) -> Option<(bool, String)> {
-    // Interpolate the uuid as a JS string literal so it can't break out of the
-    // script (it's a UUIDv4 in practice, but quote defensively).
+async fn write_kepub_to_kobo(uuid: &str, subdir: Option<&str>) -> Option<(bool, String)> {
+    // Interpolate as JS string literals so neither can break out of the script
+    // (the uuid is a UUIDv4 and the subdir is already sanitized, but quote
+    // defensively).
     let uuid_lit = serde_json::to_string(uuid).unwrap_or_else(|_| "\"\"".to_string());
-    let js = KOBO_WRITE_JS.replace("__UUID__", &uuid_lit);
+    let subdir_lit =
+        serde_json::to_string(subdir.unwrap_or("")).unwrap_or_else(|_| "\"\"".to_string());
+    let js = KOBO_WRITE_JS
+        .replace("__UUID__", &uuid_lit)
+        .replace("__SUBDIR__", &subdir_lit);
     let mut eval = dioxus::document::eval(&js);
     match eval.recv::<KoboWriteOutcome>().await {
         Ok(out) => kobo_outcome(&out.status, out.message),
@@ -351,19 +425,21 @@ async fn write_kepub_to_kobo(uuid: &str) -> Option<(bool, String)> {
 }
 
 #[cfg(all(not(feature = "mobile"), not(feature = "web"), feature = "server"))]
-async fn write_kepub_to_kobo(_uuid: &str) -> Option<(bool, String)> {
+async fn write_kepub_to_kobo(_uuid: &str, _subdir: Option<&str>) -> Option<(bool, String)> {
     None
 }
 
 /// Browser-side write flow. Reuses a remembered Kobo directory handle
 /// (persisted in IndexedDB) or prompts for one once, fetches the KEPUB, and
-/// writes it to the device's drive root — Kobo imports loose files there, so
-/// this never touches the device's `KoboReader.sqlite` master DB. Falls back to
-/// a plain download when the File System Access API is absent (Firefox/Safari).
-/// `__UUID__` is substituted with a quoted JS string literal before eval.
+/// writes it under `<Author>/<Title>/` on the device (creating the folders) —
+/// Kobo imports files anywhere on the drive, so this never touches the device's
+/// `KoboReader.sqlite` master DB. Falls back to a plain download when the File
+/// System Access API is absent (Firefox/Safari). `__UUID__` and `__SUBDIR__`
+/// are substituted with quoted JS string literals before eval.
 #[cfg(all(not(feature = "mobile"), feature = "web"))]
 const KOBO_WRITE_JS: &str = r#"
 const uuid = __UUID__;
+const subdir = __SUBDIR__;
 const idb = () => new Promise((res, rej) => {
   const r = indexedDB.open('omnibus-kobo', 1);
   r.onupgradeneeded = () => r.result.createObjectStore('handles');
@@ -419,7 +495,16 @@ await (async () => {
     const m = /filename="?([^"]+)"?/.exec(cd);
     const filename = (m && m[1]) || `${uuid}.kepub.epub`;
     const blob = await resp.blob();
-    const fh = await dir.getFileHandle(filename, { create: true });
+    // Nest under <Author>/<Title>/ (each segment pre-sanitized server-side),
+    // creating folders as needed, so the file lands in the same layout Calibre
+    // and the Kobo use instead of a bare uuid file at the drive root.
+    let target = dir;
+    if (subdir) {
+      for (const seg of subdir.split('/')) {
+        if (seg) target = await target.getDirectoryHandle(seg, { create: true });
+      }
+    }
+    const fh = await target.getFileHandle(filename, { create: true });
     const w = await fh.createWritable();
     await w.write(blob);
     await w.close();
@@ -785,6 +870,66 @@ mod tests {
         let (is_error, msg) = super::kobo_outcome("error", None).unwrap();
         assert!(is_error);
         assert_eq!(msg, "Send to Kobo failed: unknown error");
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_path_segment_replaces_illegal_chars_and_collapses_space() {
+        assert_eq!(
+            super::kobo_path_segment("AC/DC: Back \"in\"  Black?").as_deref(),
+            Some("AC DC Back in Black"),
+        );
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_path_segment_strips_leading_trailing_dots_and_spaces() {
+        assert_eq!(
+            super::kobo_path_segment("  .Hidden Title. ").as_deref(),
+            Some("Hidden Title"),
+        );
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_path_segment_returns_none_when_nothing_usable_remains() {
+        assert_eq!(super::kobo_path_segment("   ///  ").as_deref(), None);
+        assert_eq!(super::kobo_path_segment("").as_deref(), None);
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_path_segment_caps_length_on_a_char_boundary() {
+        let seg = super::kobo_path_segment(&"é".repeat(200)).unwrap();
+        assert_eq!(seg.chars().count(), 120);
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_subdir_joins_author_and_title() {
+        assert_eq!(
+            super::kobo_subdir("Ada Lovelace", "Notes on the Engine").as_deref(),
+            Some("Ada Lovelace/Notes on the Engine"),
+        );
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_subdir_uses_only_the_surviving_segment() {
+        assert_eq!(
+            super::kobo_subdir("", "Just a Title").as_deref(),
+            Some("Just a Title"),
+        );
+        assert_eq!(
+            super::kobo_subdir("Author Only", "   ").as_deref(),
+            Some("Author Only"),
+        );
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_subdir_is_none_when_both_segments_are_empty() {
+        assert_eq!(super::kobo_subdir("  ", "").as_deref(), None);
     }
 
     #[test]

--- a/frontend/src/components/format_switcher.rs
+++ b/frontend/src/components/format_switcher.rs
@@ -328,10 +328,22 @@ pub fn SendToKoboButton(
     }
 }
 
+/// True when `name`'s base (the part before any extension) is a Windows
+/// reserved device name (case-insensitive) — `CON`, `PRN`, `AUX`, `NUL`,
+/// `COM1`–`COM9`, `LPT1`–`LPT9`. Creating a folder or file with one of these
+/// names fails on Windows even though FAT itself allows it.
+#[cfg(not(feature = "mobile"))]
+fn is_windows_reserved_name(name: &str) -> bool {
+    let base = name.split('.').next().unwrap_or(name).to_ascii_uppercase();
+    matches!(base.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || matches!(base.strip_prefix("COM").or_else(|| base.strip_prefix("LPT")), Some(d) if matches!(d, "1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"))
+}
+
 /// Sanitize one path component for a Kobo's FAT/exFAT filesystem: replace the
 /// characters illegal on Windows/FAT (and control chars) with spaces, collapse
-/// whitespace, and strip stray leading/trailing dots and spaces. `None` when
-/// nothing usable survives. Pure — unit-tested without a browser.
+/// whitespace, strip stray leading/trailing dots and spaces, and defuse Windows
+/// reserved device names. `None` when nothing usable survives. Pure —
+/// unit-tested without a browser.
 #[cfg(not(feature = "mobile"))]
 fn kobo_path_segment(raw: &str) -> Option<String> {
     let cleaned: String = raw
@@ -347,7 +359,15 @@ fn kobo_path_segment(raw: &str) -> Option<String> {
     // boundary, then re-trim in case the cut left a trailing dot/space.
     let capped: String = collapsed.chars().take(120).collect();
     let trimmed = capped.trim_matches(|c| c == '.' || c == ' ');
-    (!trimmed.is_empty()).then(|| trimmed.to_string())
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Underscore-prefix a reserved device name so the OS accepts it.
+    if is_windows_reserved_name(trimmed) {
+        Some(format!("_{trimmed}"))
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 /// Build the `<Author>/<Title>` subfolder a Kobo write nests the file under, or
@@ -495,9 +515,10 @@ await (async () => {
     const m = /filename="?([^"]+)"?/.exec(cd);
     const filename = (m && m[1]) || `${uuid}.kepub.epub`;
     const blob = await resp.blob();
-    // Nest under <Author>/<Title>/ (each segment pre-sanitized server-side),
-    // creating folders as needed, so the file lands in the same layout Calibre
-    // and the Kobo use instead of a bare uuid file at the drive root.
+    // Nest under <Author>/<Title>/ (each segment sanitized in the Rust caller
+    // before interpolation), creating folders as needed, so the file lands in
+    // the same layout Calibre and the Kobo use instead of a bare uuid file at
+    // the drive root.
     let target = dir;
     if (subdir) {
       for (const seg of subdir.split('/')) {
@@ -930,6 +951,32 @@ mod tests {
     #[test]
     fn kobo_subdir_is_none_when_both_segments_are_empty() {
         assert_eq!(super::kobo_subdir("  ", "").as_deref(), None);
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_path_segment_defuses_windows_reserved_names() {
+        // Case-insensitive, and ignoring an extension after a dot.
+        assert_eq!(super::kobo_path_segment("CON").as_deref(), Some("_CON"));
+        assert_eq!(super::kobo_path_segment("nul").as_deref(), Some("_nul"));
+        assert_eq!(super::kobo_path_segment("Aux").as_deref(), Some("_Aux"));
+        assert_eq!(super::kobo_path_segment("COM4").as_deref(), Some("_COM4"));
+        assert_eq!(
+            super::kobo_path_segment("lpt9.txt").as_deref(),
+            Some("_lpt9.txt")
+        );
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn kobo_path_segment_leaves_non_reserved_lookalikes_alone() {
+        // COM0/LPT0 aren't reserved; and a reserved word as a substring is fine.
+        assert_eq!(super::kobo_path_segment("COM0").as_deref(), Some("COM0"));
+        assert_eq!(
+            super::kobo_path_segment("Console").as_deref(),
+            Some("Console")
+        );
+        assert_eq!(super::kobo_path_segment("Conan").as_deref(), Some("Conan"));
     }
 
     #[test]

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -387,6 +387,10 @@ pub(super) fn BdRailSection(
                     formats: b.formats.clone(),
                     uuid: uuid.clone(),
                     book_files: b.book_files.clone(),
+                    // Author + title drive the Send-to-Kobo `<Author>/<Title>/`
+                    // folder layout on the device.
+                    book_author: b.creators.first().map(|c| c.name.clone()).unwrap_or_default(),
+                    book_title: title.clone(),
                 }
                 Link {
                     to: Route::MetadataEdit { uuid: uuid.clone() },

--- a/frontend/src/pages/book_detail/export_menu.rs
+++ b/frontend/src/pages/book_detail/export_menu.rs
@@ -11,7 +11,13 @@ use crate::components::{SendToKindleButton, SendToKoboButton};
 /// whichever formats the book has, the interactive Send-to-Kindle button,
 /// and the Send-to-Kobo KEPUB download.
 #[component]
-pub(super) fn BdExportMenu(uuid: String, has_ebook: bool, has_audio: bool) -> Element {
+pub(super) fn BdExportMenu(
+    uuid: String,
+    has_ebook: bool,
+    has_audio: bool,
+    #[props(default)] book_author: String,
+    #[props(default)] book_title: String,
+) -> Element {
     let mut open = use_signal(|| false);
     rsx! {
         div { class: "bd-export",
@@ -34,7 +40,7 @@ pub(super) fn BdExportMenu(uuid: String, has_ebook: bool, has_audio: bool) -> El
                     "data-testid": "hero-export-scrim",
                     onclick: move |_| open.set(false),
                 }
-                BdExportPanel { uuid, has_ebook, has_audio, open }
+                BdExportPanel { uuid, has_ebook, has_audio, book_author, book_title, open }
             }
         }
     }
@@ -47,7 +53,14 @@ pub(super) fn BdExportMenu(uuid: String, has_ebook: bool, has_audio: bool) -> El
 /// this is a scrim-dismissed popover with plain links/buttons, not an ARIA
 /// menu with roving-tabindex / arrow-key navigation.
 #[component]
-fn BdExportPanel(uuid: String, has_ebook: bool, has_audio: bool, open: Signal<bool>) -> Element {
+fn BdExportPanel(
+    uuid: String,
+    has_ebook: bool,
+    has_audio: bool,
+    book_author: String,
+    book_title: String,
+    open: Signal<bool>,
+) -> Element {
     let mut open = open;
     let on_keydown = move |evt: Event<KeyboardData>| {
         if evt.key() == Key::Escape {
@@ -108,6 +121,8 @@ fn BdExportPanel(uuid: String, has_ebook: bool, has_audio: bool, open: Signal<bo
             if has_ebook {
                 SendToKoboButton {
                     uuid: uuid.clone(),
+                    book_author: book_author.clone(),
+                    book_title: book_title.clone(),
                     class: "bd-export-item".to_string(),
                     testid: "hero-send-kobo".to_string(),
                 }

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -137,7 +137,13 @@ fn BdTitleCol(
             if let Some(desc) = b.description.as_deref() {
                 div { class: "bd-desc", "data-testid": "book-description", dangerous_inner_html: "{desc}" }
             }
-            BdCtaRow { uuid: uuid.clone(), has_ebook, has_audio }
+            BdCtaRow {
+                uuid: uuid.clone(),
+                has_ebook,
+                has_audio,
+                book_author: b.creators.first().map(|c| c.name.clone()).unwrap_or_default(),
+                book_title: title.clone(),
+            }
             div { class: "bd-progress-meta", aria_hidden: "true",
                 div { class: "bd-progress-line",
                     span { class: "mono", "Not started" }
@@ -159,7 +165,13 @@ fn BdTitleCol(
 /// CTA button row: primary read/listen action, secondary listen, and the
 /// "Export" dropdown that collects the per-device send/download actions.
 #[component]
-fn BdCtaRow(uuid: String, has_ebook: bool, has_audio: bool) -> Element {
+fn BdCtaRow(
+    uuid: String,
+    has_ebook: bool,
+    has_audio: bool,
+    #[props(default)] book_author: String,
+    #[props(default)] book_title: String,
+) -> Element {
     rsx! {
         div { class: "bd-cta-row",
             if has_ebook {
@@ -202,7 +214,14 @@ fn BdCtaRow(uuid: String, has_ebook: bool, has_audio: bool) -> Element {
             }
             // Download + Send-to-Kindle/Kobo live behind one "Export" menu so
             // the CTA row stays a single primary action plus this dropdown.
-            BdExportMenu { uuid: uuid.clone(), has_ebook, has_audio }
+            // Author + title feed the Send-to-Kobo `<Author>/<Title>/` layout.
+            BdExportMenu {
+                uuid: uuid.clone(),
+                has_ebook,
+                has_audio,
+                book_author: book_author.clone(),
+                book_title: book_title.clone(),
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Send to Kobo** now writes the file to `<Author>/<Title>/<uuid>.kepub.epub` on the device instead of a bare uuid file at the drive root — the same tidy layout Calibre uses, so browsing the Kobo over USB stays organized.
- The uuid stays as the *filename* on purpose: the planned [F4.4](docs/roadmap/4-4-kobo-annotation-import.md) highlight-import can still recover the book from the device's `ContentID` path.
- Author + title are threaded from the book-detail page into the write flow; each path segment is sanitized in tested Rust (`kobo_path_segment` / `kobo_subdir`) for FAT/exFAT safety, and the JS creates the folders. Missing metadata → falls back to the drive root.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 7 new `kobo_path_segment`/`kobo_subdir` unit tests (illegal chars, dot/space trim, length cap, segment join, empty→root)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` (server), wasm32, and mobile all clean; `cargo fmt --check` passes
- [ ] E2E unchanged: the folder nesting is on the File-System-Access write path, which the `book_detail` spec forces off (download fallback), so the existing filename contract still holds — runs in CI (`run_ui_tests`)

## Version
- [x] **Patch** — the default.

## Notes
- The download fallback (Firefox/Safari) is a browser download and can't create folders — unchanged.