### PR TITLE
fix: bump crossbeam-epoch to clear RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

The `cargo audit` CI gate is failing on **RUSTSEC-2026-0204** — `crossbeam-epoch 0.9.18` has an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid. It's a transitive dependency, so the fix is a lockfile-only bump to the patched **0.9.20**.

## Change

- `Cargo.lock`: `crossbeam-epoch 0.9.18 → 0.9.20` (via `cargo update -p crossbeam-epoch`).

## Verification

`cargo audit --ignore RUSTSEC-2023-0071` now reports **0 vulnerabilities** (exit 0); only the pre-existing unmaintained/unsound *warnings* remain, which don't fail the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)