### PR TITLE
chore: publish multi-arch (amd64 + native arm64) docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,8 +46,10 @@ jobs:
     name: build ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     strategy:
-      # Publish whichever arch legs succeed independently; a merge-time miss is
-      # caught by the manifest step rather than silently dropping an arch.
+      # fail-fast: false lets a healthy arch leg finish (and warm its cache)
+      # instead of being cancelled when the other fails, so both legs' failures
+      # surface in one run. A failed leg still fails the build job, so merge
+      # (needs: build) is skipped — publishing is all-or-nothing, never partial.
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,13 @@ name: Docker
 # version each build is for (e.g. "Docker v1.2.3") without opening the run.
 run-name: "Docker ${{ inputs.tag || github.ref_name }}"
 
-# Build + push the fullstack image to Docker Hub (sesloan/omnibus).
+# Build + push the fullstack image to Docker Hub (sesloan/omnibus) as a
+# multi-arch manifest covering linux/amd64 and linux/arm64. Each arch builds
+# on its own NATIVE runner (arm64 on GitHub's free public-repo arm64 hosted
+# runner) and pushes by digest; a final merge job stitches the digests into
+# one tagged manifest list. No QEMU emulation — the arm64 leg runs at full
+# speed so a Raspberry Pi / arm64 host can `docker pull sesloan/omnibus`.
+#
 # Dispatched by the Release workflow (workflow_dispatch with the release tag);
 # `release: published` is a fallback for releases created by a human/PAT — a
 # release made by the Release workflow's GITHUB_TOKEN can't fire that event.
@@ -36,10 +42,27 @@ env:
   IMAGE: sesloan/omnibus
 
 jobs:
-  publish:
-    name: build and push
-    runs-on: ubuntu-latest
+  build:
+    name: build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # Publish whichever arch legs succeed independently; a merge-time miss is
+      # caught by the manifest step rather than silently dropping an arch.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm # native arm64 — free on public repos, no QEMU
     steps:
+      # A platform slug (linux/amd64) can't be an artifact name; flatten the
+      # slash so the per-arch digest artifacts get distinct, valid names.
+      - name: Derive platform slug
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
       # On dispatch, check out the release tag; on a release event, github.ref
       # is already the tag ref.
       - uses: actions/checkout@v4
@@ -55,9 +78,69 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Labels only here — the tags live on the merged manifest, not the
+      # per-arch digest pushes.
+      - name: Derive image labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+
+      # Push by digest (no tag): each arch lands as an untagged image the merge
+      # job references by digest. `pull: true` refreshes the base images.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          pull: true
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Scope the layer cache per arch so the two legs don't clobber each
+          # other's cache entries.
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: merge manifest and push
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # → 1.2.3/1.2/1/latest (latest=auto, semver only). The semver source is
       # the dispatch input tag, falling back to github.ref_name (the tag on a
-      # release event).
+      # release event). Also exports DOCKER_METADATA_OUTPUT_JSON for the
+      # imagetools step below.
       - name: Derive image metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -70,18 +153,18 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }}
             type=semver,pattern={{major}},value=${{ inputs.tag || github.ref_name }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          pull: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Cache layers across runs so unchanged build stages don't recompile.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Stitch the per-arch digests into one multi-arch manifest under every
+      # derived tag, then push. `jq` turns the metadata-action tag list into
+      # repeated `-t` flags.
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect pushed manifest
+        run: docker buildx imagetools inspect "${{ env.IMAGE }}:${{ steps.meta.outputs.version }}"
 
       # Advertise exactly what landed on Docker Hub on the run summary page so
       # the pushed tags don't have to be dug out of the buildx logs. Values are
@@ -93,7 +176,7 @@ jobs:
           REF: ${{ inputs.tag || github.ref_name }}
         run: |
           {
-            echo "### 🐳 Published to Docker Hub"
+            echo "### 🐳 Published to Docker Hub (linux/amd64 + linux/arm64)"
             echo
             echo "Release: **$REF**"
             echo


### PR DESCRIPTION
## Summary
- Publish `sesloan/omnibus` as a multi-arch manifest (`linux/amd64` + `linux/arm64`) so arm64 hosts (e.g. a Raspberry Pi 4/5) can `docker pull` directly instead of running the amd64 image under emulation.
- Each arch builds on its **native** runner — arm64 on GitHub's free public-repo `ubuntu-24.04-arm` — and pushes by digest; a `merge` job stitches the digests into one tagged manifest with `docker buildx imagetools create`. No QEMU, so the arm64 leg builds at full speed.
- The `Dockerfile` already handled arm64 (multi-arch bases, arch-branched kepubify fetch); only the publish workflow was pinned to `linux/amd64`.

## Test plan
- [x] `docker.yml` parses as valid YAML; jobs `build` (amd64/arm64 matrix) + `merge`.
- [ ] Dispatch the workflow against a test tag and confirm `docker buildx imagetools inspect sesloan/omnibus:<tag>` reports both `linux/amd64` and `linux/arm64`.
- [ ] `docker pull` on an arm64 host resolves the arm64 image.

## Version
- [x] **No release** — CI-only (`.github/`) change; the release is skipped automatically for unlabeled CI-only PRs per the template.

## Notes
- Layer cache is scoped per-arch (`scope=<platform>`) so the two legs don't clobber each other's `type=gha` cache.