### PR TITLE
refactor: merge remaining split sqlx/omnibus_shared imports in db (#772)

### DIFF
--- a/db/src/books/facets.rs
+++ b/db/src/books/facets.rs
@@ -6,9 +6,8 @@
 //! mirroring the former client-side `facet_counts`, which tallied the full
 //! hydrated list regardless of the active filter selection.
 
-use sqlx::SqlitePool;
-
 use omnibus_shared::{FacetCount, FacetCounts};
+use sqlx::SqlitePool;
 
 /// Per-facet book counts for `library_paths`, ordered by count descending then
 /// value ascending (the order the sidebar renders). Empty `library_paths`

--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -1,9 +1,8 @@
 //! Library-scoped list/count read paths plus the small `IndexedRow`
 //! projection used by the incremental reindex diff.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::{EbookLibrary, EbookMetadata};
+use sqlx::{Row, SqlitePool};
 
 use super::projection::{
     backfill_creator_ids, merge_overrides_into_books, row_to_ebook, BOOK_COLUMNS,

--- a/db/src/books/page/tests.rs
+++ b/db/src/books/page/tests.rs
@@ -2,9 +2,8 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use sqlx::SqlitePool;
-
 use omnibus_shared::{SortDir, SortKey, ViewFilters};
+use sqlx::SqlitePool;
 
 use super::*;
 use crate::pool::init_db;

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -4,9 +4,8 @@
 //! `crate::books`, plus the discovery read paths (`get_author`,
 //! `get_series`) via `pub(crate)` re-exports.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::{Contributor, EbookMetadata, Identifier};
+use sqlx::{Row, SqlitePool};
 
 use crate::helpers::format_series_index;
 use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};

--- a/db/src/books/search.rs
+++ b/db/src/books/search.rs
@@ -3,9 +3,8 @@
 //! results hydrate into the same `EbookMetadata` shape `list_books` /
 //! `get_book` return.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::EbookMetadata;
+use sqlx::{Row, SqlitePool};
 
 use crate::helpers::{build_fts_match, cap_query_len};
 

--- a/db/src/discovery/series.rs
+++ b/db/src/discovery/series.rs
@@ -4,9 +4,8 @@
 //! set so books moved into or out of a series via the edit form surface
 //! here too.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::{EbookMetadata, SeriesDetail};
+use sqlx::{Row, SqlitePool};
 
 use crate::books::{backfill_creator_ids, row_to_ebook, BOOK_COLUMNS};
 use crate::metadata_overrides::{apply_overrides, load_overrides_bulk};

--- a/db/src/discovery/tags.rs
+++ b/db/src/discovery/tags.rs
@@ -3,9 +3,8 @@
 //! a book are reflected here; visibility still requires a canonical
 //! `books_tags_link` row so override-only tags never surface.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::TagWeight;
+use sqlx::{Row, SqlitePool};
 
 use super::DiscoveryError;
 

--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -2,9 +2,8 @@
 //! to the target, snapshot the source into `merge_log`, and delete the
 //! source row — all-or-nothing.
 
-use sqlx::{SqlitePool, Transaction};
-
 use omnibus_shared::MetadataOverrides;
+use sqlx::{SqlitePool, Transaction};
 
 use crate::covers::{find_cover_file, write_cover_file};
 use crate::sync::delete_fts;

--- a/db/src/metadata_overrides/fts.rs
+++ b/db/src/metadata_overrides/fts.rs
@@ -4,9 +4,8 @@
 //! patch in one transaction. Called best-effort by the upsert/merge paths;
 //! the delete path restores canonical FTS in its own transaction instead.
 
-use sqlx::{Sqlite, SqliteConnection, SqlitePool, Transaction};
-
 use omnibus_shared::EbookMetadata;
+use sqlx::{Sqlite, SqliteConnection, SqlitePool, Transaction};
 
 use crate::books::{get_books_by_ids, resolve_book_id_by_uuid, resolve_book_ids_bulk};
 use crate::sync::upsert_fts;

--- a/db/src/metadata_overrides/links.rs
+++ b/db/src/metadata_overrides/links.rs
@@ -4,9 +4,8 @@
 //! read time via `apply_overrides` and doesn't yet need a sibling helper
 //! here.
 
-use sqlx::SqliteConnection;
-
 use omnibus_shared::MetadataOverrides;
+use sqlx::SqliteConnection;
 
 /// When an override sets a series name, ensure a `series` row and
 /// `books_series_link` exist so the browse index and detail-page breadcrumb

--- a/db/src/palette/authors.rs
+++ b/db/src/palette/authors.rs
@@ -3,9 +3,8 @@
 //! still requires at least one canonical link so override-only authors
 //! (no navigable id) don't appear.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::PaletteAuthorHit;
+use sqlx::{Row, SqlitePool};
 
 use super::PaletteError;
 

--- a/db/src/palette/books.rs
+++ b/db/src/palette/books.rs
@@ -2,9 +2,8 @@
 //! matches with override-aware overlays applied after hydration so the
 //! palette row matches what the rest of the app renders.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::PaletteBookHit;
+use sqlx::{Row, SqlitePool};
 
 use crate::books::parse_json_array;
 use crate::helpers::build_fts_match;

--- a/db/src/palette/series.rs
+++ b/db/src/palette/series.rs
@@ -3,9 +3,8 @@
 //! first book's effective creators. Visibility still requires at least
 //! one canonical link in this library.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::PaletteSeriesHit;
+use sqlx::{Row, SqlitePool};
 
 use super::PaletteError;
 

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -3,9 +3,8 @@
 //! still requires at least one canonical link so override-only tags
 //! (no navigable id) don't appear.
 
-use sqlx::{Row, SqlitePool};
-
 use omnibus_shared::PaletteTagHit;
+use sqlx::{Row, SqlitePool};
 
 use super::PaletteError;
 

--- a/db/src/shelves/write.rs
+++ b/db/src/shelves/write.rs
@@ -5,9 +5,8 @@
 //! still points at the surviving book. Name collisions per owner surface as
 //! [`ShelfError::NameTaken`].
 
-use sqlx::{Sqlite, SqlitePool, Transaction};
-
 use omnibus_shared::{CreateShelfRequest, Shelf, ShelfKind, ShelfRule, UpdateShelfRequest};
+use sqlx::{Sqlite, SqlitePool, Transaction};
 
 use super::read::get_shelf;
 use super::ShelfError;

--- a/db/src/sync/authors.rs
+++ b/db/src/sync/authors.rs
@@ -3,9 +3,8 @@
 //! blocklist, upserts surviving names into `authors`, and writes the
 //! per-book join rows in a constant handful of statements.
 
-use sqlx::Transaction;
-
 use omnibus_shared::EbookMetadata;
+use sqlx::Transaction;
 
 /// Batch-insert author join rows from the merged `creators` list. The OPF
 /// parser appends `<dc:contributor>` entries onto `creators` in source

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -4,9 +4,8 @@
 //! the rewrite-in-place and cross-format attach paths, and the
 //! post-commit cover materialization + missing-files marker helper.
 
-use sqlx::Transaction;
-
 use omnibus_shared::EbookMetadata;
+use sqlx::Transaction;
 
 use crate::covers::write_cover_file;
 use crate::helpers::{


### PR DESCRIPTION
## Summary
- `.claude/rules/05-rust-style.md` § Mechanics requires three import blocks (`std`, external crates, `crate::`), each alphabetical within. A recurring pattern in `db/src` instead split the external-crate block in two: a lone `use sqlx::...;` block separated by a blank line from `use omnibus_shared::...;`, with `sqlx` placed first (wrong order too, since `omnibus_shared` < `sqlx` alphabetically).
- PR #805 already fixed the 7 files originally cited in #772, but explicitly deferred the rest of the sweep to avoid conflicting with concurrent `db/src` PRs at the time.
- This PR finishes that sweep: merges the split blocks in the remaining 17 files across `db/src` (`books/`, `discovery/`, `merge/`, `metadata_overrides/`, `palette/`, `shelves/`, `sync/`).
- Verified via a full grep-based scan of `db/src`, `server/src`, and `frontend/src` afterward — no instances of the split-block pattern remain anywhere in the workspace.
- Mechanical, import-ordering only — no behavior change.

Files touched:
- `db/src/books/facets.rs`
- `db/src/books/list.rs`
- `db/src/books/page/tests.rs`
- `db/src/books/projection.rs`
- `db/src/books/search.rs`
- `db/src/discovery/series.rs`
- `db/src/discovery/tags.rs`
- `db/src/merge/transaction.rs`
- `db/src/metadata_overrides/fts.rs`
- `db/src/metadata_overrides/links.rs`
- `db/src/palette/authors.rs`
- `db/src/palette/books.rs`
- `db/src/palette/series.rs`
- `db/src/palette/tags.rs`
- `db/src/shelves/write.rs`
- `db/src/sync/authors.rs`
- `db/src/sync/books/shared.rs`

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 847 + 1 + 1 passed
- [x] Full grep sweep of `db/src`, `server/src`, `frontend/src` for the `sqlx`-block-then-`omnibus_shared`-block pattern — zero remaining instances

## Version
- [x] Patch — the default; add the `patch version` label or leave unlabeled

## Notes
- No behavior change; each edit is a no-op reorder of two adjacent `use` lines into one alphabetized block.

Closes #772


---
_Generated by [Claude Code](https://claude.ai/code/session_01Txm31mRsFv2aP9AkmQeZhM)_