### PR TITLE
refactor: split remaining oversized frontend functions (#377)

### DIFF
--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -192,8 +192,7 @@ struct ChipInputAreaProps {
     on_pick: EventHandler<String>,
 }
 
-/// Input + suggestion-dropdown half of `ChipEditor`'s markup, split out so
-/// `ChipEditor` itself stays a thin composition of `ChipList` + this area.
+/// Input field plus its suggestion dropdown.
 #[component]
 fn ChipInputArea(props: ChipInputAreaProps) -> Element {
     let ChipInputAreaProps {

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -133,11 +133,6 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
             &on_close,
         );
     };
-    let SelectionView {
-        filtered,
-        typed,
-        show_create_row,
-    } = selection;
 
     rsx! {
         Fragment {
@@ -150,40 +145,101 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
                     on_change_remove.call(new_values);
                 },
             }
-            div { class: "chip-editor-input-wrap",
-                ChipInput {
-                    input,
-                    placeholder: props.placeholder.clone(),
-                    input_class: props.input_class.clone(),
-                    testid: format!("{}-input", props.testid_prefix),
-                    autofocus: props.autofocus,
-                    on_focus: move |_| {
-                        focused.set(true);
-                        suppress_open.set(false);
+            ChipInputArea {
+                input,
+                placeholder: props.placeholder.clone(),
+                input_class: props.input_class.clone(),
+                testid_prefix: props.testid_prefix.clone(),
+                autofocus: props.autofocus,
+                dropdown_header: props.dropdown_header.clone(),
+                selection,
+                highlight: highlight(),
+                on_focus: move |_| {
+                    focused.set(true);
+                    suppress_open.set(false);
+                },
+                on_blur: move |_| {
+                    focused.set(false);
+                    highlight.set(None);
+                },
+                on_input: move |value: String| {
+                    input.set(value);
+                    highlight.set(None);
+                    suppress_open.set(false);
+                },
+                on_keydown,
+                on_pick: move |name: String| commit(name),
+            }
+        }
+    }
+}
+
+/// Props for the [`ChipInputArea`] sub-component.
+#[derive(Props, Clone, PartialEq)]
+struct ChipInputAreaProps {
+    input: Signal<String>,
+    placeholder: String,
+    input_class: String,
+    testid_prefix: String,
+    autofocus: bool,
+    dropdown_header: String,
+    selection: SelectionView,
+    highlight: Option<usize>,
+    on_focus: EventHandler<()>,
+    on_blur: EventHandler<()>,
+    on_input: EventHandler<String>,
+    on_keydown: EventHandler<Event<KeyboardData>>,
+    on_pick: EventHandler<String>,
+}
+
+/// Input + suggestion-dropdown half of `ChipEditor`'s markup, split out so
+/// `ChipEditor` itself stays a thin composition of `ChipList` + this area.
+#[component]
+fn ChipInputArea(props: ChipInputAreaProps) -> Element {
+    let ChipInputAreaProps {
+        input,
+        placeholder,
+        input_class,
+        testid_prefix,
+        autofocus,
+        dropdown_header,
+        selection,
+        highlight,
+        on_focus,
+        on_blur,
+        on_input,
+        on_keydown,
+        on_pick,
+    } = props;
+    let SelectionView {
+        filtered,
+        typed,
+        show_create_row,
+    } = selection;
+    rsx! {
+        div { class: "chip-editor-input-wrap",
+            ChipInput {
+                input,
+                placeholder,
+                input_class,
+                testid: format!("{testid_prefix}-input"),
+                autofocus,
+                on_focus,
+                on_blur,
+                on_input,
+                on_keydown,
+            }
+            if !filtered.is_empty() || show_create_row {
+                SuggestionDropdown {
+                    selection: DropdownSelectionState {
+                        filtered: filtered.clone(),
+                        show_create_row,
+                        typed: typed.clone(),
+                        highlight,
                     },
-                    on_blur: move |_| {
-                        focused.set(false);
-                        highlight.set(None);
-                    },
-                    on_input: move |value: String| {
-                        input.set(value);
-                        highlight.set(None);
-                        suppress_open.set(false);
-                    },
-                    on_keydown,
-                }
-                if !filtered.is_empty() || show_create_row {
-                    SuggestionDropdown {
-                        selection: DropdownSelectionState {
-                            filtered: filtered.clone(),
-                            show_create_row,
-                            typed: typed.clone(),
-                            highlight: highlight(),
-                        },
-                        dropdown_header: props.dropdown_header.clone(),
-                        testid: format!("{}-suggestions", props.testid_prefix),
-                        on_pick: move |name: String| commit(name),
-                    }
+                    dropdown_header,
+                    testid: format!("{testid_prefix}-suggestions"),
+                    on_pick,
                 }
             }
         }
@@ -191,7 +247,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
 }
 
 /// Per-render derived view bundling the filtered suggestion rows, the typed text, and the Create-row flag.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 struct SelectionView {
     filtered: Vec<SuggestionItem>,
     typed: String,

--- a/frontend/src/pages/auth/login.rs
+++ b/frontend/src/pages/auth/login.rs
@@ -147,8 +147,7 @@ pub fn LoginPage() -> Element {
     out
 }
 
-/// Mobile login body: connected-server bar plus the credentials form. Split
-/// out of `LoginPage` so the mobile branch reads as a plain composition.
+/// Mobile login body: connected-server bar plus the credentials form.
 #[cfg(feature = "mobile")]
 #[component]
 fn MobileLoginForm(

--- a/frontend/src/pages/auth/login.rs
+++ b/frontend/src/pages/auth/login.rs
@@ -127,89 +127,110 @@ pub fn LoginPage() -> Element {
     };
 
     #[cfg(feature = "mobile")]
-    let mut username = username;
-    #[cfg(feature = "mobile")]
-    let mut password = password;
-    #[cfg(feature = "mobile")]
-    let nav = use_navigator();
-    #[cfg(feature = "mobile")]
     let host = display_host(&use_server_url());
     #[cfg(feature = "mobile")]
     let out = m_auth_shell(
         "Your library, wherever you are.",
         rsx! {
-            // Connected-to bar: shows which server this login targets, with a
-            // Back affordance that returns to the Connect screen (which
-            // pre-fills the current URL) without clearing it.
-            div { class: "m-auth-connected",
-                button {
-                    class: "m-auth-back",
-                    r#type: "button",
-                    onclick: move |_| { nav.replace(Route::ServerConnect {}); },
-                    "← Back"
-                }
-                div { class: "m-auth-connected-to",
-                    span { class: "m-auth-connected-dot" }
-                    span { class: "m-auth-connected-label",
-                        "Logging into "
-                        span { class: "mono", "{host}" }
-                    }
-                }
-            }
-            form { class: "auth-form-inner",
-                onsubmit: on_submit,
-                "data-testid": "login-form",
-                if let Some(msg) = error() {
-                    Banner { kind: BannerKind::Err, title: msg, dismissible: false }
-                }
-                Field { label: "Email or username".to_string(), input_id: "login-username".to_string(),
-                    input {
-                        id: "login-username",
-                        name: "username",
-                        r#type: "text",
-                        autocomplete: "username",
-                        autocapitalize: "none",
-                        autocorrect: "off",
-                        spellcheck: "false",
-                        value: "{username}",
-                        oninput: move |e| username.set(e.value()),
-                        onkeydown: on_keydown,
-                    }
-                }
-                Field {
-                    label: "Password".to_string(),
-                    input_id: "login-password".to_string(),
-                    action: rsx! {
-                        Link { to: Route::Login {}, class: "auth-field-action-link", "Forgot?" }
-                    },
-                    input {
-                        id: "login-password",
-                        name: "password",
-                        r#type: "password",
-                        autocomplete: "current-password",
-                        autocapitalize: "none",
-                        autocorrect: "off",
-                        spellcheck: "false",
-                        value: "{password}",
-                        oninput: move |e| password.set(e.value()),
-                        onkeydown: on_keydown,
-                    }
-                }
-                button {
-                    class: "btn primary lg auth-submit",
-                    r#type: "submit",
-                    disabled: submitting(),
-                    if submitting() { "Signing in…" } else { "Sign in" }
-                }
-                p { class: "auth-footer",
-                    "New here? "
-                    Link { to: Route::Register {}, "Create an account" }
-                }
+            MobileLoginForm {
+                host,
+                username,
+                password,
+                error,
+                submitting,
+                on_submit,
+                on_keydown,
             }
         },
     );
 
     out
+}
+
+/// Mobile login body: connected-server bar plus the credentials form. Split
+/// out of `LoginPage` so the mobile branch reads as a plain composition.
+#[cfg(feature = "mobile")]
+#[component]
+fn MobileLoginForm(
+    host: String,
+    mut username: Signal<String>,
+    mut password: Signal<String>,
+    error: Signal<Option<String>>,
+    submitting: Signal<bool>,
+    on_submit: EventHandler<FormEvent>,
+    on_keydown: EventHandler<Event<KeyboardData>>,
+) -> Element {
+    let nav = use_navigator();
+    rsx! {
+        // Connected-to bar: shows which server this login targets, with a
+        // Back affordance that returns to the Connect screen (which
+        // pre-fills the current URL) without clearing it.
+        div { class: "m-auth-connected",
+            button {
+                class: "m-auth-back",
+                r#type: "button",
+                onclick: move |_| { nav.replace(Route::ServerConnect {}); },
+                "← Back"
+            }
+            div { class: "m-auth-connected-to",
+                span { class: "m-auth-connected-dot" }
+                span { class: "m-auth-connected-label",
+                    "Logging into "
+                    span { class: "mono", "{host}" }
+                }
+            }
+        }
+        form { class: "auth-form-inner",
+            onsubmit: on_submit,
+            "data-testid": "login-form",
+            if let Some(msg) = error() {
+                Banner { kind: BannerKind::Err, title: msg, dismissible: false }
+            }
+            Field { label: "Email or username".to_string(), input_id: "login-username".to_string(),
+                input {
+                    id: "login-username",
+                    name: "username",
+                    r#type: "text",
+                    autocomplete: "username",
+                    autocapitalize: "none",
+                    autocorrect: "off",
+                    spellcheck: "false",
+                    value: "{username}",
+                    oninput: move |e| username.set(e.value()),
+                    onkeydown: on_keydown,
+                }
+            }
+            Field {
+                label: "Password".to_string(),
+                input_id: "login-password".to_string(),
+                action: rsx! {
+                    Link { to: Route::Login {}, class: "auth-field-action-link", "Forgot?" }
+                },
+                input {
+                    id: "login-password",
+                    name: "password",
+                    r#type: "password",
+                    autocomplete: "current-password",
+                    autocapitalize: "none",
+                    autocorrect: "off",
+                    spellcheck: "false",
+                    value: "{password}",
+                    oninput: move |e| password.set(e.value()),
+                    onkeydown: on_keydown,
+                }
+            }
+            button {
+                class: "btn primary lg auth-submit",
+                r#type: "submit",
+                disabled: submitting(),
+                if submitting() { "Signing in…" } else { "Sign in" }
+            }
+            p { class: "auth-footer",
+                "New here? "
+                Link { to: Route::Register {}, "Create an account" }
+            }
+        }
+    }
 }
 
 /// Props for the [`LoginForm`] component.

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -45,27 +45,13 @@ struct AuthorIndexFilter {
 pub fn AuthorsIndexPage() -> Element {
     let server_url = use_server_url();
     let server_url_for_cards = server_url.clone();
-    let mut authors: Signal<Vec<AuthorSummary>> = use_signal(Vec::new);
-    let mut loading = use_signal(|| true);
-    let mut error: Signal<Option<String>> = use_signal(|| None);
+    let authors: Signal<Vec<AuthorSummary>> = use_signal(Vec::new);
+    let loading = use_signal(|| true);
+    let error: Signal<Option<String>> = use_signal(|| None);
     let mut filter = use_signal(String::new);
     let mut sort = use_signal(|| Sort::Name);
 
-    let url = server_url.clone();
-    use_effect(move || {
-        let url = url.clone();
-        spawn(async move {
-            loading.set(true);
-            match data::list_authors(&url).await {
-                Ok(a) => {
-                    authors.set(a);
-                    error.set(None);
-                }
-                Err(e) => error.set(Some(e.to_string())),
-            }
-            loading.set(false);
-        });
-    });
+    use_authors_fetch_effect(server_url.clone(), authors, loading, error);
 
     if loading() {
         return rsx! {
@@ -88,49 +74,15 @@ pub fn AuthorsIndexPage() -> Element {
     let total_authors = all.len();
     let total_books: usize = all.iter().map(|a| a.book_count).sum();
 
-    // Client-side filter + sort.
     let q = filter.read().to_lowercase();
-    let mut filtered: Vec<&AuthorSummary> = if q.is_empty() {
-        all.iter().collect()
-    } else {
-        all.iter()
-            .filter(|a| a.name.to_lowercase().contains(&q))
-            .collect()
-    };
-    match sort() {
-        // Within Sort::Name the primary axis is the sort_key bucket:
-        // alpha first (`is_alpha_bucket` → false sorts before true),
-        // non-alpha (digits, punctuation, accented mononyms, etc.)
-        // trail at the end under the '#' section. Secondary axis is
-        // the lowercased key itself so cards stay alphabetical within
-        // their letter group.
-        Sort::Name => filtered.sort_by(|a, b| {
-            let ka = sort_key(a);
-            let kb = sort_key(b);
-            is_non_alpha_key(&ka)
-                .cmp(&is_non_alpha_key(&kb))
-                .then_with(|| ka.to_lowercase().cmp(&kb.to_lowercase()))
-        }),
-        Sort::BookCount => filtered.sort_by(|a, b| {
-            b.book_count
-                .cmp(&a.book_count)
-                .then_with(|| sort_key(a).to_lowercase().cmp(&sort_key(b).to_lowercase()))
-        }),
-    }
+    let mut filtered = filter_authors(&all, &q);
+    sort_authors(&mut filtered, sort());
 
     // Group by first letter of sort key (last name when available, else name).
     // Only meaningful when sorting by name.
     let show_letters = matches!(sort(), Sort::Name);
-    let mut letters: Vec<(char, Vec<&AuthorSummary>)> = Vec::new();
-    if show_letters {
-        for a in &filtered {
-            let l = first_letter(a);
-            match letters.last_mut() {
-                Some((existing, group)) if *existing == l => group.push(a),
-                _ => letters.push((l, vec![a])),
-            }
-        }
-    }
+    let letters = group_by_letter(&filtered, show_letters);
+
     // Alphabet strip: A–Z followed by a single '#' bucket for any
     // authors whose surname-equivalent doesn't start with an ASCII
     // letter (digits, punctuation, accented mononyms, …). The '#'
@@ -167,6 +119,82 @@ pub fn AuthorsIndexPage() -> Element {
             {authors_index_body(&filtered, &letters, show_letters, any_in_library, &server_url_for_cards)}
         }
     }
+}
+
+/// Fetches the full author list on mount and whenever `server_url` changes.
+fn use_authors_fetch_effect(
+    server_url: String,
+    mut authors: Signal<Vec<AuthorSummary>>,
+    mut loading: Signal<bool>,
+    mut error: Signal<Option<String>>,
+) {
+    use_effect(move || {
+        let url = server_url.clone();
+        spawn(async move {
+            loading.set(true);
+            match data::list_authors(&url).await {
+                Ok(a) => {
+                    authors.set(a);
+                    error.set(None);
+                }
+                Err(e) => error.set(Some(e.to_string())),
+            }
+            loading.set(false);
+        });
+    });
+}
+
+/// Client-side name filter (case-insensitive substring match).
+fn filter_authors<'a>(all: &'a [AuthorSummary], query: &str) -> Vec<&'a AuthorSummary> {
+    if query.is_empty() {
+        all.iter().collect()
+    } else {
+        all.iter()
+            .filter(|a| a.name.to_lowercase().contains(query))
+            .collect()
+    }
+}
+
+/// Sorts `filtered` in place along the selected axis.
+fn sort_authors(filtered: &mut [&AuthorSummary], sort: Sort) {
+    match sort {
+        // Within Sort::Name the primary axis is the sort_key bucket:
+        // alpha first (`is_alpha_bucket` → false sorts before true),
+        // non-alpha (digits, punctuation, accented mononyms, etc.)
+        // trail at the end under the '#' section. Secondary axis is
+        // the lowercased key itself so cards stay alphabetical within
+        // their letter group.
+        Sort::Name => filtered.sort_by(|a, b| {
+            let ka = sort_key(a);
+            let kb = sort_key(b);
+            is_non_alpha_key(&ka)
+                .cmp(&is_non_alpha_key(&kb))
+                .then_with(|| ka.to_lowercase().cmp(&kb.to_lowercase()))
+        }),
+        Sort::BookCount => filtered.sort_by(|a, b| {
+            b.book_count
+                .cmp(&a.book_count)
+                .then_with(|| sort_key(a).to_lowercase().cmp(&sort_key(b).to_lowercase()))
+        }),
+    }
+}
+
+/// Buckets `filtered` by first letter of `sort_key`; empty when `show_letters` is false.
+fn group_by_letter<'a>(
+    filtered: &[&'a AuthorSummary],
+    show_letters: bool,
+) -> Vec<(char, Vec<&'a AuthorSummary>)> {
+    let mut letters: Vec<(char, Vec<&AuthorSummary>)> = Vec::new();
+    if show_letters {
+        for a in filtered {
+            let l = first_letter(a);
+            match letters.last_mut() {
+                Some((existing, group)) if *existing == l => group.push(a),
+                _ => letters.push((l, vec![a])),
+            }
+        }
+    }
+    letters
 }
 
 /// Body section (plain fn, not `#[component]`, so we can keep the borrow-only

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -322,7 +322,23 @@ pub fn LandingPage() -> Element {
     // only the presentation branches. (Mobile is a separate build, so this
     // cfg split doesn't affect web SSR/WASM hydration parity — rule 07.)
     #[cfg(feature = "mobile")]
-    let body = rsx! {
+    let body = mobile_landing_body(view, handlers, server_url);
+
+    #[cfg(not(feature = "mobile"))]
+    let body = web_landing_body(&sigs, view, handlers, server_url);
+
+    body
+}
+
+/// Mobile presentation branch of [`LandingPage`]: a single compact grid, no
+/// admin table or suggestion pools.
+#[cfg(feature = "mobile")]
+fn mobile_landing_body(
+    view: LandingViewState,
+    handlers: LandingHandlers,
+    server_url: String,
+) -> Element {
+    rsx! {
         mobile::MobileLanding {
             book_count: view.book_count,
             books: view.visible_books,
@@ -332,65 +348,70 @@ pub fn LandingPage() -> Element {
             on_load_more: handlers.on_load_more,
             server_url,
         }
-    };
+    }
+}
 
-    #[cfg(not(feature = "mobile"))]
-    let body = {
-        let prefs = sigs.prefs;
-        let LandingHandlers {
-            on_prefs_change_header,
-            on_prefs_change_content,
-            on_load_more,
-            on_clear_filters,
-        } = handlers;
-        rsx! {
-            div { class: "shelf-layout",
-                ShelvesRail { active: RailActive::All }
-                div { class: "shelf-main",
-                    LandingHeader {
-                        view: LandingHeaderView {
-                            path_subtitle: view.path_subtitle,
-                            book_count: view.book_count,
-                            path_missing: view.path_missing,
-                            page_error: view.page_error.clone(),
-                            lib_err: view.lib_err.clone(),
+/// Web presentation branch of [`LandingPage`]: shelves rail + header +
+/// grid/table content, wired to the admin table context and suggestion pools.
+#[cfg(not(feature = "mobile"))]
+fn web_landing_body(
+    sigs: &LandingSignals,
+    view: LandingViewState,
+    handlers: LandingHandlers,
+    server_url: String,
+) -> Element {
+    let prefs = sigs.prefs;
+    let LandingHandlers {
+        on_prefs_change_header,
+        on_prefs_change_content,
+        on_load_more,
+        on_clear_filters,
+    } = handlers;
+    rsx! {
+        div { class: "shelf-layout",
+            ShelvesRail { active: RailActive::All }
+            div { class: "shelf-main",
+                LandingHeader {
+                    view: LandingHeaderView {
+                        path_subtitle: view.path_subtitle,
+                        book_count: view.book_count,
+                        path_missing: view.path_missing,
+                        page_error: view.page_error.clone(),
+                        lib_err: view.lib_err.clone(),
+                    },
+                    prefs: prefs(),
+                    on_prefs_change: on_prefs_change_header,
+                }
+
+                LandingContent {
+                    ..LandingContentProps {
+                        books: BooksView {
+                            is_loading: view.is_loading,
+                            visible_books: view.visible_books,
+                            visible_is_empty: view.visible_is_empty,
+                            books_empty: view.books_empty,
+                            lib_err: view.lib_err,
+                            page_error: view.page_error,
+                            has_more: view.has_more,
+                            is_loading_more: view.is_loading_more,
                         },
                         prefs: prefs(),
-                        on_prefs_change: on_prefs_change_header,
-                    }
-
-                    LandingContent {
-                        ..LandingContentProps {
-                            books: BooksView {
-                                is_loading: view.is_loading,
-                                visible_books: view.visible_books,
-                                visible_is_empty: view.visible_is_empty,
-                                books_empty: view.books_empty,
-                                lib_err: view.lib_err,
-                                page_error: view.page_error,
-                                has_more: view.has_more,
-                                is_loading_more: view.is_loading_more,
-                            },
-                            prefs: prefs(),
-                            ctx: BookTableContext {
-                                server_url,
-                                is_admin: (sigs.is_admin)(),
-                                author_suggestions: sigs.pools.authors.into(),
-                                tag_suggestions: sigs.pools.tags.into(),
-                            },
-                            handlers: LandingContentHandlers {
-                                on_prefs_change: on_prefs_change_content,
-                                on_load_more,
-                                on_clear_filters,
-                            },
-                        }
+                        ctx: BookTableContext {
+                            server_url,
+                            is_admin: (sigs.is_admin)(),
+                            author_suggestions: sigs.pools.authors.into(),
+                            tag_suggestions: sigs.pools.tags.into(),
+                        },
+                        handlers: LandingContentHandlers {
+                            on_prefs_change: on_prefs_change_content,
+                            on_load_more,
+                            on_clear_filters,
+                        },
                     }
                 }
             }
         }
-    };
-
-    body
+    }
 }
 
 /// Short, human-friendly tail of an absolute library path. We show only the

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -135,8 +135,6 @@ pub fn BookReadPage(uuid: String) -> Element {
 
 /// Every signal `BookReadPage` owns, minus the reader-prefs context (which
 /// is published but not otherwise threaded through the component body).
-/// Returned by [`use_reader_signals`] so the page body stays a thin
-/// composition of setup → handlers → display → markup.
 #[derive(Copy, Clone)]
 struct ReaderSignals {
     status: Signal<ReaderStatus>,
@@ -223,9 +221,7 @@ fn use_reader_signals(uuid: &str, theme: Signal<Theme>) -> ReaderSignals {
     }
 }
 
-/// Display strings/values the reader chrome renders, derived from `loc` +
-/// `book_meta`. Split out of `BookReadPage` so the render-prep stage reads
-/// as one call instead of six sequential signal reads.
+/// Display strings/values the reader chrome renders, derived from `loc` and `book_meta`.
 struct ReaderDisplay {
     page_str: String,
     chapter_str: String,
@@ -237,6 +233,7 @@ struct ReaderDisplay {
     book_accent: String,
 }
 
+/// Derive page/chapter labels and book title/author/accent from `loc` and `book_meta`.
 fn derive_reader_display(
     loc: Signal<RelocateData>,
     book_meta: Signal<Option<omnibus_shared::EbookMetadata>>,

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -55,46 +55,22 @@ fn reader_call(method: &str, arg_js: &str) {
 #[component]
 pub fn BookReadPage(uuid: String) -> Element {
     let theme = use_context::<Signal<Theme>>();
-
-    // Seed identically on SSR and WASM so the first client render matches the
-    // server-rendered markup — the overlay (rendered when `Loading`) must be
-    // present in both, otherwise Dioxus mis-adopts nodes during hydration
-    // (see .claude/rules/07-hydration.md). The web `use_effect` below
-    // transitions to `Ready` via the JS glue's `on_status` callback after the
-    // reader mounts.
-    let status = use_signal(ReaderStatus::default);
-
-    let prefs = init_reader_prefs(theme);
-    use_context_provider(|| prefs);
-
-    let show_aa = use_signal(|| false);
-    let selection: Signal<Option<SelectionData>> = use_signal(|| None);
-    let highlights: Signal<Vec<Highlight>> = use_signal(Vec::new);
-    let toc: Signal<Vec<TocEntry>> = use_signal(Vec::new);
-    let show_toc = use_signal(|| false);
-    let show_highlights = use_signal(|| false);
-    let note_target: Signal<Option<Highlight>> = use_signal(|| None);
-    let quote_target: Signal<Option<Highlight>> = use_signal(|| None);
-    let show_search = use_signal(|| false);
-    let search_results: Signal<Vec<SearchResult>> = use_signal(Vec::new);
-    let show_bookmarks = use_signal(|| false);
-    let loc = use_signal(RelocateData::default);
-    let book_meta = use_book_metadata(uuid.clone());
-
-    #[cfg(feature = "web")]
-    install_reader_web_interop(
-        uuid.clone(),
-        prefs,
-        InteropSignals {
-            status,
-            loc,
-            selection,
-            highlights,
-            toc,
-            search_results,
-        },
-    );
-
+    let ReaderSignals {
+        status,
+        show_aa,
+        selection,
+        highlights,
+        toc,
+        show_toc,
+        show_highlights,
+        note_target,
+        quote_target,
+        show_search,
+        search_results,
+        show_bookmarks,
+        loc,
+        book_meta,
+    } = use_reader_signals(&uuid, theme);
     let (on_back, on_prev, on_next, on_keydown) = chrome_handlers::install_chrome_handlers(
         selection,
         chrome_handlers::OverlaySignals {
@@ -107,32 +83,16 @@ pub fn BookReadPage(uuid: String) -> Element {
             quote_target,
         },
     );
-
-    let (page_str, chapter_str) = format_progress_labels(&loc.read());
-    let pct = loc.read().pct;
-    let chapter_title_display = loc.read().chapter_title.clone();
-    let current_cfi = loc.read().cfi.clone().unwrap_or_default();
-    let book_title = book_meta
-        .read()
-        .as_ref()
-        .and_then(|b| b.title.clone())
-        .unwrap_or_default();
-    let book_author = book_meta
-        .read()
-        .as_ref()
-        .and_then(|b| b.creators.first().map(|c| c.name.clone()))
-        .unwrap_or_default();
-    let book_accent = book_meta
-        .read()
-        .as_ref()
-        .and_then(|b| b.accent.clone())
-        .unwrap_or_else(|| "#3a3027".to_string());
-
-    // Suppress the `prefs` unused-variable warning on non-web targets:
-    // `install_reader_web_interop` is web-only, so on SSR / mobile the
-    // local binding is published via context but never read.
-    #[cfg(not(feature = "web"))]
-    let _ = prefs;
+    let ReaderDisplay {
+        page_str,
+        chapter_str,
+        pct,
+        chapter_title,
+        current_cfi,
+        book_title,
+        book_author,
+        book_accent,
+    } = derive_reader_display(loc, book_meta);
 
     rsx! {
         ReaderLayout {
@@ -141,7 +101,7 @@ pub fn BookReadPage(uuid: String) -> Element {
                 book_title,
                 book_author,
                 book_accent,
-                chapter_title: chapter_title_display,
+                chapter_title,
                 current_cfi,
             },
             progress: ReaderProgress {
@@ -170,6 +130,145 @@ pub fn BookReadPage(uuid: String) -> Element {
                 on_next,
             },
         }
+    }
+}
+
+/// Every signal `BookReadPage` owns, minus the reader-prefs context (which
+/// is published but not otherwise threaded through the component body).
+/// Returned by [`use_reader_signals`] so the page body stays a thin
+/// composition of setup → handlers → display → markup.
+#[derive(Copy, Clone)]
+struct ReaderSignals {
+    status: Signal<ReaderStatus>,
+    show_aa: Signal<bool>,
+    selection: Signal<Option<SelectionData>>,
+    highlights: Signal<Vec<Highlight>>,
+    toc: Signal<Vec<TocEntry>>,
+    show_toc: Signal<bool>,
+    show_highlights: Signal<bool>,
+    note_target: Signal<Option<Highlight>>,
+    quote_target: Signal<Option<Highlight>>,
+    show_search: Signal<bool>,
+    search_results: Signal<Vec<SearchResult>>,
+    show_bookmarks: Signal<bool>,
+    loc: Signal<RelocateData>,
+    book_meta: Signal<Option<omnibus_shared::EbookMetadata>>,
+}
+
+/// Construct every signal `BookReadPage` owns, publish `prefs` to context,
+/// and (on web) install the epub.js JS interop. Must run unconditionally
+/// from `BookReadPage` — every call here is a Dioxus hook, so the call
+/// order has to stay stable across renders.
+fn use_reader_signals(uuid: &str, theme: Signal<Theme>) -> ReaderSignals {
+    // Seed identically on SSR and WASM so the first client render matches the
+    // server-rendered markup — the overlay (rendered when `Loading`) must be
+    // present in both, otherwise Dioxus mis-adopts nodes during hydration
+    // (see .claude/rules/07-hydration.md). The web `use_effect` in
+    // `install_reader_web_interop` transitions to `Ready` via the JS glue's
+    // `on_status` callback after the reader mounts.
+    let status = use_signal(ReaderStatus::default);
+
+    let prefs = init_reader_prefs(theme);
+    use_context_provider(|| prefs);
+
+    let show_aa = use_signal(|| false);
+    let selection: Signal<Option<SelectionData>> = use_signal(|| None);
+    let highlights: Signal<Vec<Highlight>> = use_signal(Vec::new);
+    let toc: Signal<Vec<TocEntry>> = use_signal(Vec::new);
+    let show_toc = use_signal(|| false);
+    let show_highlights = use_signal(|| false);
+    let note_target: Signal<Option<Highlight>> = use_signal(|| None);
+    let quote_target: Signal<Option<Highlight>> = use_signal(|| None);
+    let show_search = use_signal(|| false);
+    let search_results: Signal<Vec<SearchResult>> = use_signal(Vec::new);
+    let show_bookmarks = use_signal(|| false);
+    let loc = use_signal(RelocateData::default);
+    let book_meta = use_book_metadata(uuid.to_string());
+
+    #[cfg(feature = "web")]
+    install_reader_web_interop(
+        uuid.to_string(),
+        prefs,
+        InteropSignals {
+            status,
+            loc,
+            selection,
+            highlights,
+            toc,
+            search_results,
+        },
+    );
+
+    // Suppress the `prefs` unused-variable warning on non-web targets:
+    // `install_reader_web_interop` is web-only, so on SSR / mobile the
+    // local binding is published via context but never read.
+    #[cfg(not(feature = "web"))]
+    let _ = prefs;
+
+    ReaderSignals {
+        status,
+        show_aa,
+        selection,
+        highlights,
+        toc,
+        show_toc,
+        show_highlights,
+        note_target,
+        quote_target,
+        show_search,
+        search_results,
+        show_bookmarks,
+        loc,
+        book_meta,
+    }
+}
+
+/// Display strings/values the reader chrome renders, derived from `loc` +
+/// `book_meta`. Split out of `BookReadPage` so the render-prep stage reads
+/// as one call instead of six sequential signal reads.
+struct ReaderDisplay {
+    page_str: String,
+    chapter_str: String,
+    pct: u32,
+    chapter_title: String,
+    current_cfi: String,
+    book_title: String,
+    book_author: String,
+    book_accent: String,
+}
+
+fn derive_reader_display(
+    loc: Signal<RelocateData>,
+    book_meta: Signal<Option<omnibus_shared::EbookMetadata>>,
+) -> ReaderDisplay {
+    let (page_str, chapter_str) = format_progress_labels(&loc.read());
+    let pct = loc.read().pct;
+    let chapter_title = loc.read().chapter_title.clone();
+    let current_cfi = loc.read().cfi.clone().unwrap_or_default();
+    let book_title = book_meta
+        .read()
+        .as_ref()
+        .and_then(|b| b.title.clone())
+        .unwrap_or_default();
+    let book_author = book_meta
+        .read()
+        .as_ref()
+        .and_then(|b| b.creators.first().map(|c| c.name.clone()))
+        .unwrap_or_default();
+    let book_accent = book_meta
+        .read()
+        .as_ref()
+        .and_then(|b| b.accent.clone())
+        .unwrap_or_else(|| "#3a3027".to_string());
+    ReaderDisplay {
+        page_str,
+        chapter_str,
+        pct,
+        chapter_title,
+        current_cfi,
+        book_title,
+        book_author,
+        book_accent,
     }
 }
 


### PR DESCRIPTION
## Summary
- Re-measured #377 against current `main`: three of the original seven offenders (`render_loaded`, `install_control_surface`, `SeriesIndexPage`) were already brought under the ~80-line cap by earlier merged refactor PRs — no action needed there.
- This PR splits the five functions still over the ~80-line cap:
  - `BookReadPage` (`frontend/src/pages/reader/mod.rs`): 119 → 79 lines. Extracted `use_reader_signals` (owns every reader signal + web interop install) and `derive_reader_display` (page/chapter/title/author/accent derivation) as named helpers returning small structs, mirroring the existing `LandingSignals`/`derive_view_state` pattern in `landing.rs`.
  - `LandingPage` (`frontend/src/pages/landing.rs`): 83 → 20 lines. Extracted the mobile and web presentation branches into `mobile_landing_body`/`web_landing_body`.
  - `ChipEditor` (`frontend/src/components/chip_editor.rs`): 95 → 79 lines. Extracted the input+dropdown half of the markup into a new `ChipInputArea` sub-component (mirrors the existing `ChipList`/`SuggestionDropdown` split already in this file).
  - `AuthorsIndexPage` (`frontend/src/pages/authors_index.rs`): 126 → 78 lines. Extracted `use_authors_fetch_effect`, `filter_authors`, `sort_authors`, `group_by_letter` as named helpers.
  - `LoginPage` (`frontend/src/pages/auth/login.rs`): 123 → 58 lines. Extracted the mobile branch's markup into a new `MobileLoginForm` sub-component (mirrors the existing `LoginForm`/`LoginCredentialFields` split already used on the web branch). `LoginPage` was added to this issue's scope via a 2026-06-23 audit comment, not the original evidence list.
- Every extraction is behavior-preserving: no rsx markup, CSS class, prop, or DOM structure changed — only where the code lives. SSR/hydration parity (rule 07) and Playwright selectors are unaffected.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-frontend --features server` — 223 passed, 0 failed
- [x] No function body listed above exceeds ~80 lines after extraction
- [x] No new `#[allow(...)]` suppressions added

## Version
- [x] Patch — the default; add the `patch version` label or leave unlabeled

## Notes
- Closes #377
