### PR TITLE
chore: bump seven stale first-party dependencies (#774)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,7 +356,6 @@ dependencies = [
  "axum",
  "axum-core",
  "bytes",
- "cookie",
  "futures-util",
  "headers",
  "http",
@@ -343,6 +365,28 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -603,6 +647,15 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1369,7 +1422,7 @@ dependencies = [
  "async-tungstenite",
  "axum",
  "axum-core",
- "axum-extra",
+ "axum-extra 0.10.3",
  "base64",
  "bytes",
  "ciborium",
@@ -1389,7 +1442,7 @@ dependencies = [
  "futures",
  "futures-channel",
  "futures-util",
- "gloo-net",
+ "gloo-net 0.6.0",
  "headers",
  "http",
  "http-body",
@@ -1398,7 +1451,7 @@ dependencies = [
  "js-sys",
  "mime",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.28",
  "rustversion",
  "send_wrapper",
  "serde",
@@ -1411,7 +1464,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-layer",
  "tracing",
  "tungstenite 0.27.0",
@@ -1677,7 +1730,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
  "tracing-futures",
  "url",
@@ -1750,7 +1803,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "js-sys",
  "lazy-js-bundle",
  "rustc-hash 2.1.2",
@@ -2154,6 +2207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,13 +2610,30 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils",
+ "gloo-utils 0.2.0",
  "http",
  "js-sys",
  "pin-project",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6420f887c48417e9e86c6cf61274eb231830cccc100e49613f7952e269a1fe1"
+dependencies = [
+ "gloo-utils 0.3.0",
+ "http",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2576,10 +2652,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4202275d95a142fa209a1e35e91c250a710c5600731372cd3464a39ed01573d6"
 dependencies = [
  "js-sys",
  "serde",
@@ -3536,9 +3637,9 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.22.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca260c51a9c71f823fbfd2e6fbc8eb2ee09834b98c00763d877ca8bfa85cde3e"
+checksum = "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca"
 dependencies = [
  "byteorder",
  "data-encoding",
@@ -3551,9 +3652,9 @@ dependencies = [
 
 [[package]]
 name = "lofty_attr"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9983e64b2358522f745c1251924e3ab7252d55637e80f6a0a3de642d6a9efc"
+checksum = "458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4193,7 +4294,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "axum-extra",
+ "axum-extra 0.12.6",
  "dioxus",
  "omnibus-db",
  "omnibus-frontend",
@@ -4205,7 +4306,7 @@ dependencies = [
  "time",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "wiremock",
 ]
@@ -4227,7 +4328,7 @@ dependencies = [
  "omnibus-shared",
  "pulldown-cmark",
  "rand_core 0.6.4",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2",
@@ -4247,12 +4348,12 @@ version = "0.1.0"
 dependencies = [
  "dioxus",
  "dioxus-router",
- "gloo-net",
- "gloo-timers",
+ "gloo-net 0.7.0",
+ "gloo-timers 0.4.0",
  "js-sys",
  "omnibus-db",
  "omnibus-shared",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sqlx",
@@ -4272,7 +4373,7 @@ dependencies = [
  "dioxus-router",
  "omnibus-frontend",
  "omnibus-shared",
- "reqwest",
+ "reqwest 0.13.4",
  "serde_json",
 ]
 
@@ -4838,9 +4939,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -4901,6 +5002,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5241,7 +5343,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5249,6 +5351,45 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5355,6 +5496,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5362,6 +5504,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -5375,11 +5529,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6596,8 +6778,33 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7156,6 +7363,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "2"
 # (`macros`, `rt-multi-thread`, `sync`, `time`).
 tokio = { version = "1", default-features = false }
 tracing = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 tempfile = "3"
 
 # Pin every dioxus-* crate to the v0.7.9 monorepo tag. The `dx` CLI we ship via

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -93,12 +93,12 @@ lofty = "0.24"
 # id derivation (issue #94); it is no longer the book identity / diff key.
 uuid = { version = "1", features = ["v4", "v5"] }
 
-# F1.11 author profile photos: outbound HTTP for the Open Library resolver
-# (`db::author_photos`). `rustls` matches the rest of our async TLS
-# choices (sqlx uses `runtime-tokio-rustls`) so we don't pull in OpenSSL.
-# `json` is needed to deserialize the `/search/authors.json` response.
-# This is the only outbound HTTP in the codebase — keep it scoped to the
-# resolver module.
+# Outbound HTTP: the Open Library author-photo resolver (`db::author_photos`)
+# and the Hardcover GraphQL client (`db::suggestions::hardcover`) are the only
+# two consumers — both share this one `reqwest` dep rather than each pulling
+# their own. `rustls` matches the rest of our async TLS choices (sqlx uses
+# `runtime-tokio-rustls`) so we don't pull in OpenSSL. `json` is needed to
+# deserialize both APIs' JSON responses.
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 urlencoding = "2"
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -11,6 +11,17 @@ license.workspace = true
 
 [dependencies]
 omnibus-shared = { path = "../shared" }
+# Held back at 0.8 (latest is 0.9.0; see issue #774). The `runtime-tokio-rustls`
+# feature rename to `runtime-tokio` + `tls-rustls` is a one-line fix, but 0.9
+# also adds a new `SqlSafeStr` bound on `query()`/`query_as()` that only
+# accepts `&'static str` or an explicit `AssertSqlSafe` wrapper — a compile-time
+# "have you audited this for injection" gate. This crate builds dynamic SQL via
+# `format!` at 69+ call sites (dynamic table/column names, `IN (...)`
+# placeholder lists) that all fail to compile under 0.9 until individually
+# wrapped in `AssertSqlSafe`. Doing that safely means auditing each site to
+# confirm no user-controlled string reaches the interpolated text — real,
+# security-sensitive work that deserves its own reviewed PR, not a drive-by
+# fix bundled into a routine dependency bump. Track the migration separately.
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "process", "io-util"] }
 anyhow = "1"
@@ -66,13 +77,13 @@ ammonia = "4"
 # F3.2 journals: render user-authored markdown to HTML server-side (then
 # sanitized by `ammonia` above). Strikethrough is enabled to match the
 # composer's formatting affordances; a custom `||spoiler||` pass runs first.
-pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
+pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 
 # F2.3 audiobook metadata: read title/artist/album/duration and embedded
 # cover artwork from m4b/m4a/mp3 (and any other container lofty supports).
 # Chosen over `mp4ameta` so mp3 works through the same Tag API without an
 # ffprobe fallback.
-lofty = "0.22"
+lofty = "0.24"
 
 
 # `v4` mints the durable, content-independent `books.uuid` (F2): a fresh
@@ -83,17 +94,17 @@ lofty = "0.22"
 uuid = { version = "1", features = ["v4", "v5"] }
 
 # F1.11 author profile photos: outbound HTTP for the Open Library resolver
-# (`db::author_photos`). `rustls-tls` matches the rest of our async TLS
+# (`db::author_photos`). `rustls` matches the rest of our async TLS
 # choices (sqlx uses `runtime-tokio-rustls`) so we don't pull in OpenSSL.
 # `json` is needed to deserialize the `/search/authors.json` response.
 # This is the only outbound HTTP in the codebase — keep it scoped to the
 # resolver module.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 urlencoding = "2"
 
 # F4.3 Send-to-Kindle: SMTP delivery of the EPUB as an email attachment.
-# `rustls-tls` matches the async-TLS choice used by sqlx/reqwest so we never
-# pull in OpenSSL; `builder` provides the multipart `Message` API. Default
+# `tokio1-rustls-tls` matches the async-TLS choice used by sqlx/reqwest so we
+# never pull in OpenSSL; `builder` provides the multipart `Message` API. Default
 # features are off to drop the sync `native-tls` transport and file/sendmail
 # transports we don't use.
 lettre = { version = "0.11", default-features = false, features = [

--- a/deny.toml
+++ b/deny.toml
@@ -227,6 +227,24 @@ skip = [
     # 0.26 from sqlx-core; 1.0 from hyper-rustls (reqwest).
     # Collapses when sqlx bumps its rustls deps.
     { name = "webpki-roots", version = "0.26.11" },
+
+    # --- reqwest (issue #774 bump) ---
+    # 0.12.28 via dioxus-fullstack (git-pinned Dioxus tag); 0.13.4 is our own
+    # direct dep (workspace + db + frontend/mobile). Collapses when Dioxus
+    # bumps its own reqwest dep past 0.13.
+    { name = "reqwest", version = "0.12.28" },
+
+    # --- axum-extra (issue #774 bump) ---
+    # 0.10.3 via dioxus-server (git-pinned Dioxus tag); 0.12.6 is our own
+    # direct dep in server/Cargo.toml. Collapses when Dioxus bumps its own
+    # axum-extra dep past 0.12.
+    { name = "axum-extra", version = "0.10.3" },
+
+    # --- tower-http (issue #774 bump) ---
+    # 0.6.11 via dioxus-fullstack/dioxus-server (git-pinned Dioxus tag);
+    # 0.7.0 is our own direct dep in server/Cargo.toml. Collapses when Dioxus
+    # bumps its own tower-http dep past 0.7.
+    { name = "tower-http", version = "0.6.11" },
 ]
 
 # ---------------------------------------------------------------------------

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -7,6 +7,15 @@ The `deny.toml` `[bans]` section has matching `skip` entries for all accepted
 and blocked duplicates; `cargo deny check bans` will warn on anything outside
 this list.
 
+Note: CI's `cargo deny check bans` step runs with no explicit `--features`
+flag, so it resolves each crate's *default* feature set. `omnibus-frontend`'s
+default features are `[]` — the `web`/`mobile` features (and anything they
+pull in) are invisible to that default-resolution graph and to a bare
+`cargo tree -d`. A handful of duplicates below only show up once `web` is
+enabled (`cargo tree -d -p omnibus-frontend --features web`); those rows are
+marked "web-feature only" and have no `deny.toml` skip entry since cargo-deny
+never encounters them in its default run.
+
 ## Duplicate-family inventory
 
 | Crate | Versions | Sources | Classification | Notes |
@@ -24,6 +33,9 @@ this list.
 | `reqwest` | 0.12.28, 0.13.4 | 0.12.28 via `dioxus-fullstack` (git-pinned Dioxus tag); 0.13.4 is our own direct dep (workspace + `db` + `frontend` mobile feature) | **blocked by upstream** | Bumped to 0.13 for issue #774; the 0.12 copy remains only because `dioxus-fullstack` depends on it directly. Collapses when Dioxus bumps its own `reqwest` past 0.13. |
 | `axum-extra` | 0.10.3, 0.12.6 | 0.10.3 via `dioxus-server` (git-pinned Dioxus tag); 0.12.6 is our own direct dep in `server/Cargo.toml` | **blocked by upstream** | Bumped to 0.12 for issue #774. Collapses when Dioxus bumps its own `axum-extra` past 0.12. |
 | `tower-http` | 0.6.11, 0.7.0 | 0.6.11 via `dioxus-fullstack`/`dioxus-server` (git-pinned Dioxus tag); 0.7.0 is our own direct dep in `server/Cargo.toml` | **blocked by upstream** | Bumped to 0.7 for issue #774. Collapses when Dioxus bumps its own `tower-http` past 0.7. |
+| `gloo-net` | 0.6.0, 0.7.0 | 0.6.0 via `dioxus-fullstack` (git-pinned Dioxus tag); 0.7.0 is our own direct dep in `frontend/Cargo.toml`, gated behind the `web` feature | **blocked by upstream — web-feature only** | Bumped to 0.7 for issue #774. Not visible to `cargo deny check bans`'s default (no-`web`) run — see the scope note above. Collapses when Dioxus bumps its own `gloo-net` past 0.7. |
+| `gloo-timers` | 0.3.0, 0.4.0 | 0.3.0 via `dioxus-fullstack` (git-pinned Dioxus tag); 0.4.0 is our own direct dep in `frontend/Cargo.toml`, gated behind the `web` feature | **blocked by upstream — web-feature only** | Bumped to 0.4 for issue #774. Same scope caveat as `gloo-net` above. |
+| `gloo-utils` | 0.2.0, 0.3.0 | 0.2.0 pulled in by `gloo-net` 0.6.0 (Dioxus); 0.3.0 pulled in by our `gloo-net` 0.7.0 | **blocked by upstream — web-feature only** | Knock-on duplicate from the `gloo-net` bump above; not a dep we declare directly. Same scope caveat. |
 | `digest` | 0.10.7 (×2) | Both consumers are `sha1` (axum/tungstenite) + `blake2`/`sha2` (argon2/sqlx) | N/A — same version | `cargo tree -d` shows two entry paths to the same version (different consumers). No actual duplicate in the lockfile. |
 | `bytes`, `futures-*`, `num-traits`, `tokio`, `manganis-core` | (shown ×2 each) | Multiple downstream consumers | N/A — same version | Same pattern as `digest`: one version, multiple reverse-dependency entry points in the `cargo tree -d` output. Not true duplicates. |
 

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -1,6 +1,6 @@
 # Dependency Audit — Cargo.lock Duplicate Families
 
-Last updated: 2026-06-09 (issue #412).
+Last updated: 2026-07-07 (issue #774).
 
 Run `cargo tree -d` and inspect the output any time Dioxus or Axum are bumped.
 The `deny.toml` `[bans]` section has matching `skip` entries for all accepted
@@ -21,6 +21,9 @@ this list.
 | `convert_case` | 0.4.0, 0.8.0, 0.10.0 | 0.4 from `derive_more 0.99.20` (proc-macro path, transitive via Dioxus desktop/mobile shells); 0.8 from Dioxus proc-macro crates (`dioxus-core-macro`, `dioxus-html-internal-macro`, `dioxus-stores-macro`); 0.10 from `derive_more-impl` (pulled by `dioxus-fullstack`) | **blocked by upstream** | Pure proc-macro dependency; not in any runtime binary image. |
 | `rand` | 0.7.3, 0.8.6, 0.9.4 | 0.7 from `phf_generator 0.8.0` (build dep of `ammonia` → `html5ever` chain); 0.8 from a separate `phf_generator` path; 0.9 from `rand_core@0.9` (via tungstenite) | **blocked by upstream** | The 0.7 and 0.8 copies are build-only (`phf_codegen` / `string_cache_codegen`) and never link into the runtime binary. |
 | `webpki-roots` | 0.26.11, 1.0.7 | 0.26 from `sqlx-core`; 1.0.7 from `hyper-rustls` (reqwest) | **blocked by upstream** | sqlx-core pins 0.26; reqwest/hyper-rustls have moved to 1.x. Collapses when sqlx bumps its rustls deps. |
+| `reqwest` | 0.12.28, 0.13.4 | 0.12.28 via `dioxus-fullstack` (git-pinned Dioxus tag); 0.13.4 is our own direct dep (workspace + `db` + `frontend` mobile feature) | **blocked by upstream** | Bumped to 0.13 for issue #774; the 0.12 copy remains only because `dioxus-fullstack` depends on it directly. Collapses when Dioxus bumps its own `reqwest` past 0.13. |
+| `axum-extra` | 0.10.3, 0.12.6 | 0.10.3 via `dioxus-server` (git-pinned Dioxus tag); 0.12.6 is our own direct dep in `server/Cargo.toml` | **blocked by upstream** | Bumped to 0.12 for issue #774. Collapses when Dioxus bumps its own `axum-extra` past 0.12. |
+| `tower-http` | 0.6.11, 0.7.0 | 0.6.11 via `dioxus-fullstack`/`dioxus-server` (git-pinned Dioxus tag); 0.7.0 is our own direct dep in `server/Cargo.toml` | **blocked by upstream** | Bumped to 0.7 for issue #774. Collapses when Dioxus bumps its own `tower-http` past 0.7. |
 | `digest` | 0.10.7 (×2) | Both consumers are `sha1` (axum/tungstenite) + `blake2`/`sha2` (argon2/sqlx) | N/A — same version | `cargo tree -d` shows two entry paths to the same version (different consumers). No actual duplicate in the lockfile. |
 | `bytes`, `futures-*`, `num-traits`, `tokio`, `manganis-core` | (shown ×2 each) | Multiple downstream consumers | N/A — same version | Same pattern as `digest`: one version, multiple reverse-dependency entry points in the `cargo tree -d` output. Not true duplicates. |
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -17,8 +17,8 @@ serde_json = { workspace = true, optional = true }
 # default-members check). Version matches `omnibus-db`.
 thiserror.workspace = true
 reqwest = { workspace = true, optional = true, features = ["multipart"] }
-gloo-net = { version = "0.6", default-features = false, features = ["http", "json"], optional = true }
-gloo-timers = { version = "0.3", features = ["futures"], optional = true }
+gloo-net = { version = "0.7", default-features = false, features = ["http", "json"], optional = true }
+gloo-timers = { version = "0.4", features = ["futures"], optional = true }
 # `web-sys` is enabled only on the WASM client for `Window::local_storage()`.
 # F1.3 view-mode / sort / filter prefs are persisted there per library path.
 # F1.11: FormData/Blob/BlobPropertyBag are used by `data::upload_author_photo`
@@ -34,6 +34,8 @@ js-sys = { version = "0.3", optional = true }
 # pulled in with no default features so each consuming feature opts into
 # only what it needs — mobile gets `sync` for `watch`, server gets the
 # multi-thread runtime + macros for `#[tokio::main]`-style usage in rpc.rs.
+# Held back at 0.8 — see the rationale on `omnibus-db`'s `sqlx` dep in
+# db/Cargo.toml (issue #774). Must stay lock-stepped with `omnibus-db`.
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"], optional = true }
 tokio = { workspace = true, optional = true }
 # Server-side structured logging for #[cfg(feature = "server")] code paths

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,11 +16,13 @@ dioxus = "0.7"
 
 # Server-only deps — all optional and gated behind the `server` feature.
 axum = { version = "0.8", features = ["multipart"], optional = true }
-axum-extra = { version = "0.10", features = ["cookie"], optional = true }
-tower-http = { version = "0.6", features = ["trace", "timeout", "set-header", "fs"], optional = true }
+axum-extra = { version = "0.12", features = ["cookie"], optional = true }
+tower-http = { version = "0.7", features = ["trace", "timeout", "set-header", "fs"], optional = true }
 tower = { version = "0.5", optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+# Held back at 0.8 — see the rationale on `omnibus-db`'s `sqlx` dep in
+# db/Cargo.toml (issue #774). Must stay lock-stepped with `omnibus-db`.
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"], optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"], optional = true }
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
- Bumps six of the seven stale first-party dependencies from #774 to their latest minors:
  - `gloo-net` 0.6 → 0.7, `gloo-timers` 0.3 → 0.4 (`frontend/Cargo.toml`)
  - `pulldown-cmark` 0.12 → 0.13 (`db/Cargo.toml`)
  - `tower-http` 0.6 → 0.7 (`server/Cargo.toml`)
  - `reqwest` 0.12 → 0.13 (root workspace + `db/Cargo.toml`) — the `rustls-tls` feature flag was renamed to `rustls` in 0.13; updated at both call sites and in the accompanying comments
  - `lofty` 0.22 → 0.24 (`db/Cargo.toml`)
  - `axum-extra` 0.10 → 0.12 (`server/Cargo.toml`) — checked the 0.11→0.12 changelog; no cookie-extractor breaking changes, and the `cookie` feature we use needs no new opt-in flags
- **`sqlx` stays at 0.8** (documented as intentionally held back, per the issue's own acceptance-criteria carve-out). See "Why sqlx wasn't bumped" below — this is a bigger call than a version pin, please double check my reasoning.
- Bumping `reqwest`/`axum-extra`/`tower-http` past the versions `dioxus-fullstack`/`dioxus-server` pin internally introduces three new duplicate-family entries in `Cargo.lock` (our copy vs. the git-pinned Dioxus copy). Documented in `deny.toml`'s `[bans].skip` list and `docs/dependency-audit.md`, following the project's existing policy for this exact pattern (see `webpki-roots`, `hashbrown`, etc. in that file).

## Why sqlx wasn't bumped
sqlx 0.9.0 is out on crates.io, and the `runtime-tokio-rustls` feature rename (→ `runtime-tokio` + `tls-rustls`) would be a one-line fix. But 0.9 also adds a new `SqlSafeStr` trait bound on `sqlx::query()` / `sqlx::query_as()` that is only implemented for `&'static str` and an explicit `AssertSqlSafe` wrapper — a compile-time "have you audited this for injection" gate.

I bumped `db/Cargo.toml`'s sqlx pin locally to test the real blast radius: **69 `E0277` errors** (plus one lifetime error) in `db/src` alone, all at call sites that build dynamic SQL via `format!` (dynamic table/column names, `IN (...)` placeholder lists — e.g. `db/src/sync/books/removed.rs`, `db/src/merge/transaction.rs`, `db/src/books/list.rs`, `db/src/discovery/`, `db/src/shelves/`, and more). Every one of those would need wrapping in `AssertSqlSafe`, and doing that *correctly* means individually confirming no user-controlled string reaches the interpolated SQL text at each site — that's a real, security-sensitive audit, not a mechanical bump. I didn't think it was right to either (a) silently wrap 69+ sites in an injection-bypass assertion without auditing each one, or (b) skip auditing and hope for the best, just to make a "chore" PR compile.

I've documented the decision inline in `db/Cargo.toml` (with a pointer from `server/Cargo.toml` and `frontend/Cargo.toml`, since all three must stay lock-stepped on one sqlx version) and left it as a clearly-flagged follow-up rather than doing a rushed audit here. Happy to take this the other way if you'd rather I just do the audit in this PR — let me know.

## Test plan
- [x] Each of the six crates bumped to its latest minor; `sqlx` documented as held back with a concrete reason (compile-verified: 69+ break sites)
- [x] `cargo test -p omnibus` — 303 passed
- [x] `cargo test -p omnibus-db` — 847 + 1 + 1 passed
- [x] `cargo test -p omnibus-frontend --features server` — 223 passed
- [x] `cargo test -p omnibus-shared` — 99 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus / -p omnibus-db / -p omnibus-frontend --features server / -p omnibus-shared --all-targets -- -D warnings` (CI's exact matrix) — clean
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings` — clean
- [ ] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` — **could not run**: this sandbox lacks the GTK3/WebKitGTK system libs the `.#mobile` nix shell provides (`gdk-3.0` pkg-config not found). Confirmed this failure is pre-existing and identical on unmodified `main` (not caused by this change) — none of the bumped crates are mobile-desktop-shell deps. Please re-run in CI/nix to confirm.
- [x] `cargo audit --json --ignore RUSTSEC-2023-0071` (CI's exact invocation) — 0 vulnerabilities
- [x] `cargo deny check advisories sources bans licenses` (CI's exact invocation) — `advisories ok, bans ok, licenses ok, sources ok`

## Version
- [x] Patch — the default; add the `patch version` label or leave unlabeled

## Notes
- `Cargo.lock` changes are intentional (the version bumps plus their new transitive deps, e.g. `aws-lc-sys`/`rustls-platform-verifier` pulled in by reqwest 0.13's new default rustls crypto provider).
- Closes #774
