### PR TITLE
fix: guard scanner removal pass against incomplete/empty enumeration (#819)

### DIFF
--- a/db/src/audiobook/stat.rs
+++ b/db/src/audiobook/stat.rs
@@ -100,7 +100,18 @@ pub fn stat_audiobook_library(
                 continue;
             }
         };
-        for entry in read.flatten() {
+        // Explicit iteration (not `.flatten()`): an `Err` mid-enumeration is
+        // a partial `readdir` and must flag the walk `incomplete`, or the
+        // #819 removal guard would treat a partial view as complete. Mirrors
+        // the ebook walker.
+        for entry in read {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => {
+                    incomplete = true;
+                    continue;
+                }
+            };
             let Ok(file_type) = entry.file_type() else {
                 continue;
             };

--- a/db/src/audiobook/stat.rs
+++ b/db/src/audiobook/stat.rs
@@ -28,6 +28,15 @@ pub struct AudiobookStatScanResult {
     pub path: Option<String>,
     pub entries: Vec<AudiobookStatEntry>,
     pub error: Option<String>,
+    /// True when a subdir `read_dir` failed, so `entries` is a partial
+    /// enumeration. Mirrors [`crate::ebook::StatScanResult::incomplete`];
+    /// the audiobook reindex must not run its removal pass on it.
+    pub incomplete: bool,
+    /// True when the walk saw any regular file of any extension. Mirrors
+    /// [`crate::ebook::StatScanResult::saw_any_file`] — distinguishes a
+    /// totally-empty populated root (distrust) from a shared root with no
+    /// audio files (trust).
+    pub saw_any_file: bool,
 }
 
 /// Walk `path`, stat every file with an extension in
@@ -47,6 +56,8 @@ pub fn stat_audiobook_library(
             path: None,
             entries: vec![],
             error: None,
+            incomplete: false,
+            saw_any_file: false,
         };
     };
 
@@ -56,10 +67,18 @@ pub fn stat_audiobook_library(
             path: Some(path_str.to_string()),
             entries: vec![],
             error: Some(format!("path not found: {path_str}")),
+            incomplete: false,
+            saw_any_file: false,
         };
     }
 
     let mut entries: Vec<AudiobookStatEntry> = Vec::new();
+    // Set when any subdir read fails — partial enumeration; see the
+    // ebook walker for the rationale.
+    let mut incomplete = false;
+    // Set for any regular file of any extension — the "root isn't empty"
+    // signal (see the ebook walker).
+    let mut saw_any_file = false;
     let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
     while let Some(current) = stack.pop() {
         let read = match std::fs::read_dir(&current) {
@@ -72,8 +91,11 @@ pub fn stat_audiobook_library(
                         path: Some(path_str.to_string()),
                         entries: vec![],
                         error: Some(format!("could not read directory: {e}")),
+                        incomplete: true,
+                        saw_any_file: false,
                     };
                 }
+                incomplete = true;
                 entries.push(unreadable_subdir_entry(dir, &current, &e));
                 continue;
             }
@@ -90,6 +112,7 @@ pub fn stat_audiobook_library(
             if !file_type.is_file() {
                 continue;
             }
+            saw_any_file = true;
             if let Some(stat_entry) = stat_accepted_file(dir, &entry_path) {
                 entries.push(stat_entry);
             }
@@ -102,6 +125,8 @@ pub fn stat_audiobook_library(
         path: Some(path_str.to_string()),
         entries,
         error: None,
+        incomplete,
+        saw_any_file,
     }
 }
 

--- a/db/src/ebook/stat.rs
+++ b/db/src/ebook/stat.rs
@@ -42,6 +42,18 @@ pub struct StatScanResult {
     pub path: Option<String>,
     pub entries: Vec<StatEntry>,
     pub error: Option<String>,
+    /// True when the walk could not fully enumerate the tree — a subdir
+    /// `read_dir` failed (EACCES, transient I/O), so `entries` is a
+    /// **partial** view. The indexer must not run its removal pass on a
+    /// partial enumeration, or it flags every un-enumerated book missing
+    /// (see `crate::indexer::reindex`).
+    pub incomplete: bool,
+    /// True when the walk saw **any** regular file, of any extension. A
+    /// populated root that reads *totally* empty (no files at all) is the
+    /// boot-race / unmounted-NFS signature the indexer distrusts — as
+    /// opposed to a shared root that legitimately has files of another
+    /// format but no `.epub` (which stays trustworthy).
+    pub saw_any_file: bool,
 }
 
 /// Phase A: walk the library and `stat` every `.epub` without opening the
@@ -60,6 +72,8 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
             path: None,
             entries: vec![],
             error: None,
+            incomplete: false,
+            saw_any_file: false,
         };
     };
 
@@ -69,10 +83,20 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
             path: Some(path_str.to_string()),
             entries: vec![],
             error: Some(format!("path not found: {path_str}")),
+            incomplete: false,
+            saw_any_file: false,
         };
     }
 
     let mut entries: Vec<StatEntry> = Vec::new();
+    // Set when any subdir read fails: the enumeration is partial, so the
+    // indexer must skip its removal pass rather than flag the missing
+    // subtree as gone.
+    let mut incomplete = false;
+    // Set when the walk sees any regular file at all (any extension) — a
+    // totally-empty read of a populated library is the transient-fault
+    // signature the indexer distrusts.
+    let mut saw_any_file = false;
     let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
     while let Some(current) = stack.pop() {
         let read = match std::fs::read_dir(&current) {
@@ -84,14 +108,17 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
                         path: Some(path_str.to_string()),
                         entries: vec![],
                         error: Some(format!("could not read directory: {e}")),
+                        incomplete: true,
+                        saw_any_file: false,
                     };
                 }
+                incomplete = true;
                 entries.push(unreadable_subdir_entry(dir, &current, &e));
                 continue;
             }
         };
         for entry in read.flatten() {
-            push_dir_entry(dir, &entry, &mut stack, &mut entries);
+            push_dir_entry(dir, &entry, &mut stack, &mut entries, &mut saw_any_file);
         }
     }
 
@@ -101,6 +128,8 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
         path: Some(path_str.to_string()),
         entries,
         error: None,
+        incomplete,
+        saw_any_file,
     }
 }
 
@@ -126,12 +155,15 @@ fn unreadable_subdir_entry(base: &Path, current: &Path, err: &std::io::Error) ->
 
 /// Process one `read_dir` entry: push subdirectories onto `stack` for the
 /// walk, and append a stat row for each `.epub` file. Non-epub files and
-/// entries whose `file_type()` can't be read are skipped.
+/// entries whose `file_type()` can't be read are skipped. `saw_any_file` is
+/// set for every regular file regardless of extension (the "root isn't
+/// empty" signal, see the caller).
 fn push_dir_entry(
     base: &Path,
     entry: &std::fs::DirEntry,
     stack: &mut Vec<PathBuf>,
     entries: &mut Vec<StatEntry>,
+    saw_any_file: &mut bool,
 ) {
     let Ok(file_type) = entry.file_type() else {
         return;
@@ -144,6 +176,7 @@ fn push_dir_entry(
     if !file_type.is_file() {
         return;
     }
+    *saw_any_file = true;
     let is_epub = entry_path
         .extension()
         .and_then(|s| s.to_str())

--- a/db/src/ebook/stat.rs
+++ b/db/src/ebook/stat.rs
@@ -117,8 +117,16 @@ pub fn stat_ebook_library(path: Option<&str>, library_path_key: &str) -> StatSca
                 continue;
             }
         };
-        for entry in read.flatten() {
-            push_dir_entry(dir, &entry, &mut stack, &mut entries, &mut saw_any_file);
+        // Iterate the ReadDir results explicitly rather than `.flatten()`:
+        // an `Err` mid-enumeration is a partial `readdir` (an I/O fault
+        // after the dir opened), so it must flag the walk `incomplete` — a
+        // `.flatten()` here would silently drop the bad entry and leave the
+        // enumeration looking complete, defeating the #819 removal guard.
+        for entry in read {
+            match entry {
+                Ok(e) => push_dir_entry(dir, &e, &mut stack, &mut entries, &mut saw_any_file),
+                Err(_) => incomplete = true,
+            }
         }
     }
 

--- a/db/src/ebook/stat/tests.rs
+++ b/db/src/ebook/stat/tests.rs
@@ -1,4 +1,5 @@
 use crate::ebook::scan_ebook_library;
+use crate::ebook::stat::stat_ebook_library;
 use crate::ebook::test_support::*;
 
 #[test]
@@ -106,5 +107,80 @@ fn scan_continues_past_unreadable_subdirectory() {
     assert!(
         msg.len() > "could not read directory".len(),
         "error message should include the io detail, got {msg:?}",
+    );
+}
+
+#[test]
+fn stat_marks_result_complete_on_a_healthy_tree() {
+    let dir = make_test_dir("stat_complete");
+    std::fs::write(dir.join("a.epub"), b"not a zip").unwrap();
+    let out = stat_ebook_library(Some(dir.to_str().unwrap()), dir.to_str().unwrap());
+    std::fs::remove_dir_all(&dir).unwrap();
+    assert!(out.error.is_none());
+    assert!(
+        !out.incomplete,
+        "a fully-readable tree must report a complete enumeration"
+    );
+    assert!(out.saw_any_file, "a tree with a file must set saw_any_file");
+}
+
+#[test]
+fn stat_sets_saw_any_file_for_non_epub_files_only() {
+    // A root that holds files of another format (no .epub) must still report
+    // `saw_any_file` — the #819 guard uses this to keep a shared root
+    // trustworthy even when this format's diff is empty.
+    let dir = make_test_dir("stat_saw_other");
+    std::fs::write(dir.join("cover.jpg"), b"ignore").unwrap();
+    let out = stat_ebook_library(Some(dir.to_str().unwrap()), dir.to_str().unwrap());
+    std::fs::remove_dir_all(&dir).unwrap();
+    assert!(out.entries.is_empty(), "no .epub means no stat entries");
+    assert!(
+        out.saw_any_file,
+        "a non-epub file must still set saw_any_file"
+    );
+}
+
+#[test]
+fn stat_leaves_saw_any_file_false_on_a_truly_empty_root() {
+    let dir = make_test_dir("stat_empty");
+    let out = stat_ebook_library(Some(dir.to_str().unwrap()), dir.to_str().unwrap());
+    std::fs::remove_dir_all(&dir).unwrap();
+    assert!(
+        !out.saw_any_file,
+        "a truly-empty root must leave saw_any_file false"
+    );
+}
+
+// An unreadable subdir makes the enumeration partial — the `incomplete`
+// flag is the signal the indexer uses to skip its removal pass (#819).
+#[cfg(unix)]
+#[test]
+fn stat_flags_incomplete_when_a_subdirectory_is_unreadable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = make_test_dir("stat_incomplete");
+    std::fs::write(dir.join("good.epub"), b"not a zip").unwrap();
+    let locked = dir.join("locked");
+    std::fs::create_dir_all(&locked).unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+    if std::fs::read_dir(&locked).is_ok() {
+        // Running as root (CI container) — perms don't bite; skip.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+        return;
+    }
+
+    let out = stat_ebook_library(Some(dir.to_str().unwrap()), dir.to_str().unwrap());
+
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::remove_dir_all(&dir).unwrap();
+
+    assert!(
+        out.error.is_none(),
+        "a subdir fault is not a fatal root error"
+    );
+    assert!(
+        out.incomplete,
+        "an unreadable subdir must flag the enumeration incomplete"
     );
 }

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -41,6 +41,79 @@ impl From<crate::settings::SettingsError> for IndexerError {
 /// thrashing the disk for users who leave the app open all day.
 pub const REFRESH_AFTER_SECS: i64 = 60 * 60;
 
+/// Circuit-breaker threshold (issue #819): abort the removal pass when a
+/// single scan would flag more than this fraction of a previously-populated
+/// library missing. A legitimate bulk delete this large is rare; a scan
+/// that would erase a fifth of the library is far more likely a transient
+/// mount/permission fault, so we halt and serve the existing index rather
+/// than commit the wipe.
+pub const MASS_MISSING_FRACTION: f64 = 0.20;
+
+/// A scan that flags at most this many books missing is always allowed
+/// through, regardless of [`MASS_MISSING_FRACTION`]. Without a floor, the
+/// circuit-breaker would trip on ordinary small-library edits (deleting 1
+/// of 3 books is 33%). Only libraries larger than this can trip the
+/// percentage guard.
+pub const MASS_MISSING_MIN_ABSOLUTE: usize = 10;
+
+/// Error raised when the removal pass would flag an implausible share of the
+/// library missing. Surfaced (not swallowed) so the worker logs it and the
+/// existing index is left intact — the underlying files are almost certainly
+/// still on disk behind a transient fault.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "reindex aborted: {removed} of {total} books ({percent:.0}%) would be flagged missing — \
+     refusing to erode the library on a likely-transient scan fault (issue #819)"
+)]
+pub struct MassMissingError {
+    pub removed: usize,
+    pub total: usize,
+    pub percent: f64,
+}
+
+/// Decide whether a scan's enumeration can be trusted to drive the removal
+/// pass. Untrustworthy when the walk was `incomplete` (a subdir read
+/// failed), or when the root read **totally empty** (`saw_any_file ==
+/// false`) while the DB still holds file-backed books under it — the
+/// boot-race / unmounted-NFS case where an empty read would otherwise mark
+/// the whole library missing.
+///
+/// `saw_any_file` counts files of *any* extension, so a shared root that
+/// legitimately holds files of another format but none of this library's
+/// (e.g. EPUBs under an audiobook reindex) stays trustworthy — only a truly
+/// empty directory trips the guard.
+///
+/// A genuinely empty library (`db_has_files == false`) is trustworthy: the
+/// first-ever scan of an empty root, or a library the user really did clear,
+/// must still be indexable.
+fn enumeration_is_trustworthy(incomplete: bool, saw_any_file: bool, db_has_files: bool) -> bool {
+    if incomplete {
+        return false;
+    }
+    // A previously-populated root that now reads totally empty is the
+    // transient fault, not a real mass-delete — distrust it. Equivalently:
+    // trust when the walk saw a file, or when the DB has nothing to lose.
+    saw_any_file || !db_has_files
+}
+
+/// Trip the circuit-breaker when `removed` exceeds both the absolute floor
+/// and [`MASS_MISSING_FRACTION`] of the file-backed library. Returns the
+/// typed error to surface; `Ok(())` when the removal is within bounds.
+fn check_mass_missing(removed: usize, db_file_backed: usize) -> Result<(), MassMissingError> {
+    if removed <= MASS_MISSING_MIN_ABSOLUTE || db_file_backed == 0 {
+        return Ok(());
+    }
+    let fraction = removed as f64 / db_file_backed as f64;
+    if fraction > MASS_MISSING_FRACTION {
+        return Err(MassMissingError {
+            removed,
+            total: db_file_backed,
+            percent: fraction * 100.0,
+        });
+    }
+    Ok(())
+}
+
 /// True when a refresh should be kicked off: no state at all, or state
 /// older than [`REFRESH_AFTER_SECS`].
 ///
@@ -111,6 +184,13 @@ pub struct ReindexDiff {
 /// with each `filename` to fill `ParseTarget.absolute` so Phase B can
 /// open files directly without re-walking.
 ///
+/// `enumeration_trustworthy` gates the **Removed** bucket only: when the
+/// caller could not fully enumerate the tree (a subdir read failed, or a
+/// once-populated root read empty) it passes `false`, and `diff_library`
+/// leaves `removed` empty so a partial scan can never flag a book missing.
+/// The New / Changed / Backfill buckets are unaffected — an incomplete
+/// scan still safely indexes the files it *did* see.
+///
 /// # Bucket semantics
 ///
 /// - **Unchanged** — on disk, in DB, `(mtime_epoch, size_bytes)` matches.
@@ -122,6 +202,7 @@ pub struct ReindexDiff {
 ///   row is dropped so the book becomes a **fileless book** (the `books`
 ///   row + its soft-ref user data are retained, not deleted); a returning
 ///   file re-attaches via Changed. An already-fileless book is left alone.
+///   Only populated when `enumeration_trustworthy` is `true`.
 /// - **Backfill** — in DB, in disk, DB has the migration default
 ///   `(mtime_epoch=0, size_bytes=0)`. Treated as the sentinel for "fs
 ///   metadata never observed" (post-migration), so the writer only
@@ -132,6 +213,7 @@ pub fn diff_library(
     disk: &[ebook::StatEntry],
     db: &[books::IndexedRow],
     library_root: &Path,
+    enumeration_trustworthy: bool,
 ) -> ReindexDiff {
     use std::collections::HashMap;
 
@@ -184,16 +266,22 @@ pub fn diff_library(
         }
     }
 
-    for row in db {
-        if row.scan_key.is_empty() {
-            continue;
-        }
-        if !disk_by_key.contains_key(row.scan_key.as_str()) {
-            // A file-backed book whose file is gone becomes a fileless
-            // book (the row + its soft-ref user data are retained, not
-            // deleted). An already-fileless book is left untouched.
-            if row.has_file {
-                out.removed.push(row.uuid.clone());
+    // The removal pass runs only on a fully-trusted enumeration. On a
+    // partial scan (unreadable subdir, or a once-populated root now
+    // reading empty) we leave `removed` empty so no book is flagged
+    // missing and no `merged_uuids` row is eroded (issue #819).
+    if enumeration_trustworthy {
+        for row in db {
+            if row.scan_key.is_empty() {
+                continue;
+            }
+            if !disk_by_key.contains_key(row.scan_key.as_str()) {
+                // A file-backed book whose file is gone becomes a fileless
+                // book (the row + its soft-ref user data are retained, not
+                // deleted). An already-fileless book is left untouched.
+                if row.has_file {
+                    out.removed.push(row.uuid.clone());
+                }
             }
         }
     }
@@ -254,7 +342,21 @@ pub async fn reindex_with_progress(
         books::list_merged_rows_for_formats(pool, library_path, ebook::EBOOK_FORMATS).await?,
     );
     let library_root: PathBuf = PathBuf::from(library_path);
-    let diff = diff_library(&stat.entries, &db_rows, &library_root);
+    let db_file_backed = db_rows.iter().filter(|r| r.has_file).count();
+    let trustworthy =
+        enumeration_is_trustworthy(stat.incomplete, stat.saw_any_file, db_file_backed > 0);
+    if !trustworthy {
+        tracing::warn!(
+            library_path,
+            incomplete = stat.incomplete,
+            saw_any_file = stat.saw_any_file,
+            db_file_backed,
+            "reindex: enumeration incomplete or a populated root read empty — \
+             skipping the removal pass; no books marked missing (issue #819)"
+        );
+    }
+    let diff = diff_library(&stat.entries, &db_rows, &library_root, trustworthy);
+    check_mass_missing(diff.removed.len(), db_file_backed)?;
 
     // Parse Phase B only for the buckets that need it.
     let new_targets = diff.new.clone();
@@ -308,12 +410,23 @@ pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow
     reindex_audiobooks_with_progress(pool, library_path, |_, _| {}).await
 }
 
+/// Enumeration-trust signals lifted out of Phase A so the caller can gate
+/// the removal pass without re-reading the filesystem (issue #819).
+struct EnumerationSignals {
+    /// A subdir `read_dir` failed — partial view.
+    incomplete: bool,
+    /// The walk saw at least one regular file (of any extension).
+    saw_any_file: bool,
+}
+
 /// Phase A of [`reindex_audiobooks_with_progress`]: stat every audio file
 /// under `library_path`, then group the per-file entries into one
-/// [`audiobook::AudiobookGroup`] per book (folder-based grouping).
+/// [`audiobook::AudiobookGroup`] per book (folder-based grouping). The
+/// [`EnumerationSignals`] ride alongside so the caller can suppress the
+/// removal pass on a partial or empty scan (issue #819).
 async fn stat_and_group_audiobooks(
     library_path: &str,
-) -> anyhow::Result<Vec<audiobook::AudiobookGroup>> {
+) -> anyhow::Result<(Vec<audiobook::AudiobookGroup>, EnumerationSignals)> {
     let path_for_scan = library_path.to_owned();
     let library_key = library_path.to_owned();
     let stat = tokio::task::spawn_blocking(move || {
@@ -324,12 +437,16 @@ async fn stat_and_group_audiobooks(
         anyhow::bail!("audiobook scan of {library_path} failed: {msg}");
     }
 
+    let signals = EnumerationSignals {
+        incomplete: stat.incomplete,
+        saw_any_file: stat.saw_any_file,
+    };
     let entries = stat.entries;
     let library_key2 = library_path.to_owned();
     let groups =
         tokio::task::spawn_blocking(move || audiobook::group_into_books(entries, &library_key2))
             .await?;
-    Ok(groups)
+    Ok((groups, signals))
 }
 
 /// Project audiobook groups to the ebook [`ebook::StatEntry`] shape so
@@ -358,7 +475,7 @@ pub async fn reindex_audiobooks_with_progress(
     library_path: &str,
     on_progress: impl FnMut(u32, u32),
 ) -> anyhow::Result<()> {
-    let groups = stat_and_group_audiobooks(library_path).await?;
+    let (groups, signals) = stat_and_group_audiobooks(library_path).await?;
 
     // Diff groups against DB rows (project groups to the ebook StatEntry shape
     // so diff_library can be reused verbatim). Scope to audiobook formats so a
@@ -375,7 +492,21 @@ pub async fn reindex_audiobooks_with_progress(
     );
     let library_root: PathBuf = PathBuf::from(library_path);
     let groups_as_stat = project_groups_to_stat(&groups);
-    let diff = diff_library(&groups_as_stat, &db_rows, &library_root);
+    let db_file_backed = db_rows.iter().filter(|r| r.has_file).count();
+    let trustworthy =
+        enumeration_is_trustworthy(signals.incomplete, signals.saw_any_file, db_file_backed > 0);
+    if !trustworthy {
+        tracing::warn!(
+            library_path,
+            incomplete = signals.incomplete,
+            saw_any_file = signals.saw_any_file,
+            db_file_backed,
+            "reindex_audiobooks: enumeration incomplete or a populated root read empty — \
+             skipping the removal pass; no books marked missing (issue #819)"
+        );
+    }
+    let diff = diff_library(&groups_as_stat, &db_rows, &library_root, trustworthy);
+    check_mass_missing(diff.removed.len(), db_file_backed)?;
 
     // Phase B: parse only the New and Changed groups.
     let groups_by_group_path: std::collections::HashMap<String, audiobook::AudiobookGroup> = groups

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -1,13 +1,14 @@
 //! Unit tests for the `indexer` module — `diff_library` classifiers,
-//! `is_stale` window logic, `reindex` preservation-on-failure, and the
-//! shared-path cross-format deletion guard.
+//! `is_stale` window logic, `reindex` preservation-on-failure, the
+//! incomplete-enumeration data-loss guard (#819), and the shared-path
+//! cross-format deletion guard.
 
 use super::*;
 use crate::books::{list_books, IndexedRow};
 use crate::ebook::StatEntry;
 use crate::pool::init_db;
-use crate::sync::replace_books;
-use crate::test_support::{indexed, CoversTempDir};
+use crate::sync::{replace_books, sync_books, SyncPlan};
+use crate::test_support::{count_rows, indexed, make_test_dir, CoversTempDir};
 
 /// Seed a `scan_roots` row for `path` with an explicit `last_indexed`
 /// epoch-seconds value. There's no public writer for `last_indexed`
@@ -67,7 +68,7 @@ fn fileless_row(scan_key: &str) -> IndexedRow {
 fn diff_classifies_new_file_as_new() {
     let disk = vec![entry("a.epub", "uuid-a", 100, 1000)];
     let db: Vec<IndexedRow> = vec![];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert_eq!(d.new.len(), 1);
     assert_eq!(d.new[0].filename, "a.epub");
     assert_eq!(d.new[0].mtime_epoch, 100);
@@ -82,7 +83,7 @@ fn diff_classifies_new_file_as_new() {
 fn diff_classifies_missing_file_as_removed() {
     let disk: Vec<StatEntry> = vec![];
     let db = vec![row("uuid-a", 100, 1000)];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert_eq!(d.removed, vec!["uuid-a".to_string()]);
     assert!(d.new.is_empty());
     assert!(d.changed.is_empty());
@@ -93,7 +94,7 @@ fn diff_classifies_missing_file_as_removed() {
 fn diff_classifies_matching_stat_as_unchanged() {
     let disk = vec![entry("a.epub", "uuid-a", 100, 1000)];
     let db = vec![row("uuid-a", 100, 1000)];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert_eq!(d.unchanged, vec!["uuid-a".to_string()]);
     assert!(d.new.is_empty());
     assert!(d.changed.is_empty());
@@ -105,7 +106,7 @@ fn diff_classifies_matching_stat_as_unchanged() {
 fn diff_classifies_mtime_drift_as_changed() {
     let disk = vec![entry("a.epub", "uuid-a", 200, 1000)];
     let db = vec![row("uuid-a", 100, 1000)];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert_eq!(d.changed.len(), 1);
     assert_eq!(d.changed[0].mtime_epoch, 200);
     assert!(d.unchanged.is_empty());
@@ -115,7 +116,7 @@ fn diff_classifies_mtime_drift_as_changed() {
 fn diff_classifies_size_drift_as_changed() {
     let disk = vec![entry("a.epub", "uuid-a", 100, 2000)];
     let db = vec![row("uuid-a", 100, 1000)];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert_eq!(d.changed.len(), 1);
     assert_eq!(d.changed[0].size_bytes, 2000);
 }
@@ -127,7 +128,7 @@ fn diff_routes_zero_zero_sentinel_to_backfill_not_changed() {
     // re-parse on the first post-migration reindex.
     let disk = vec![entry("a.epub", "uuid-a", 100, 1000)];
     let db = vec![row("uuid-a", 0, 0)];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert_eq!(d.backfill, vec![("uuid-a".into(), 100, 1000)]);
     assert!(d.changed.is_empty());
     assert!(d.new.is_empty());
@@ -148,7 +149,7 @@ fn diff_handles_mixed_buckets_in_one_call() {
         row("uuid-bf", 0, 0),
         row("uuid-gone", 50, 200),
     ];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert_eq!(d.unchanged, vec!["uuid-keep".to_string()]);
     assert_eq!(d.changed.len(), 1);
     assert_eq!(d.changed[0].filename, "edit.epub");
@@ -173,7 +174,7 @@ fn diff_ignores_empty_uuid_placeholders_from_stat_walk() {
         },
     ];
     let db: Vec<IndexedRow> = vec![];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert_eq!(d.new.len(), 1);
     assert_eq!(d.new[0].filename, "good.epub");
 }
@@ -185,7 +186,7 @@ fn diff_routes_returning_file_for_a_fileless_book_through_changed() {
     // (which would mint a fresh uuid and orphan its soft-ref user data).
     let disk = vec![entry("a.epub", "a.epub", 100, 1000)];
     let db = vec![fileless_row("a.epub")];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert!(d.new.is_empty(), "a fileless match is not New");
     assert_eq!(d.changed.len(), 1);
     assert_eq!(d.changed[0].filename, "a.epub");
@@ -197,7 +198,7 @@ fn diff_leaves_a_still_missing_fileless_book_untouched() {
     // A fileless book whose file is still gone stays fileless — not re-Removed.
     let disk: Vec<StatEntry> = vec![];
     let db = vec![fileless_row("a.epub")];
-    let d = diff_library(&disk, &db, Path::new("/lib"));
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
     assert!(d.removed.is_empty());
     assert!(d.new.is_empty());
     assert!(d.changed.is_empty());
@@ -206,8 +207,130 @@ fn diff_leaves_a_still_missing_fileless_book_untouched() {
 #[test]
 fn diff_builds_absolute_paths_for_parse_targets() {
     let disk = vec![entry("sub/a.epub", "uuid-a", 100, 1000)];
-    let d = diff_library(&disk, &[], Path::new("/srv/library"));
+    let d = diff_library(&disk, &[], Path::new("/srv/library"), true);
     assert_eq!(d.new[0].absolute, Path::new("/srv/library/sub/a.epub"));
+}
+
+#[test]
+fn diff_suppresses_removed_bucket_when_enumeration_is_untrustworthy() {
+    // #819: on a partial/empty enumeration the caller passes
+    // `enumeration_trustworthy = false`, and the Removed bucket must stay
+    // empty — nothing is flagged missing even though the disk set is empty.
+    let disk: Vec<StatEntry> = vec![];
+    let db = vec![row("uuid-a", 100, 1000), row("uuid-b", 200, 2000)];
+    let d = diff_library(&disk, &db, Path::new("/lib"), false);
+    assert!(
+        d.removed.is_empty(),
+        "an untrusted enumeration must not remove anything, got {:?}",
+        d.removed
+    );
+    assert!(d.new.is_empty());
+    assert!(d.changed.is_empty());
+}
+
+#[test]
+fn diff_still_indexes_new_files_when_enumeration_is_untrustworthy() {
+    // Distrust gates only the Removed bucket — a partial scan still safely
+    // indexes the files it did see (New/Changed/Backfill unaffected).
+    let disk = vec![entry("new.epub", "uuid-new", 100, 1000)];
+    let db = vec![row("uuid-old", 50, 500)];
+    let d = diff_library(&disk, &db, Path::new("/lib"), false);
+    assert_eq!(d.new.len(), 1, "new files still index on an untrusted scan");
+    assert_eq!(d.new[0].filename, "new.epub");
+    assert!(
+        d.removed.is_empty(),
+        "the un-enumerated old book is not removed"
+    );
+}
+
+#[test]
+fn diff_isolates_an_unreadable_file_from_its_siblings_in_the_same_root() {
+    // Acceptance (b): a single file the walker couldn't stat is still
+    // enumerated (read_dir listed it) — its `stat_file` degraded to (0, 0),
+    // so the diff re-parses it in place via Changed (harmless, preserves the
+    // id). Critically, it must NOT knock any sibling in the same root into
+    // Removed; the readable sibling stays Unchanged.
+    let disk = vec![
+        entry("good.epub", "uuid-good", 100, 1000),
+        entry("bad.epub", "uuid-bad", 0, 0),
+    ];
+    let db = vec![row("uuid-good", 100, 1000), row("uuid-bad", 100, 1000)];
+    let d = diff_library(&disk, &db, Path::new("/lib"), true);
+    assert_eq!(
+        d.unchanged,
+        vec!["uuid-good".to_string()],
+        "the readable sibling stays Unchanged"
+    );
+    assert_eq!(
+        d.changed.len(),
+        1,
+        "the unreadable file re-parses in place, not removed"
+    );
+    assert_eq!(d.changed[0].filename, "bad.epub");
+    assert!(
+        d.removed.is_empty(),
+        "an unreadable file must not remove any sibling, got {:?}",
+        d.removed
+    );
+}
+
+#[test]
+fn enumeration_trustworthy_true_for_healthy_populated_scan() {
+    // Complete walk, files present (saw_any_file), DB has files — normal case.
+    assert!(enumeration_is_trustworthy(false, true, true));
+}
+
+#[test]
+fn enumeration_untrustworthy_when_incomplete() {
+    // A subdir read failed — partial view, distrust regardless of the rest.
+    assert!(!enumeration_is_trustworthy(true, true, true));
+}
+
+#[test]
+fn enumeration_untrustworthy_when_populated_root_reads_totally_empty() {
+    // The boot-race / unmounted-NFS case: the walk saw NO file of any
+    // extension but the DB still holds file-backed books. Distrust so the
+    // removal pass is skipped.
+    assert!(!enumeration_is_trustworthy(false, false, true));
+}
+
+#[test]
+fn enumeration_trustworthy_when_root_has_files_of_another_format() {
+    // #328 shared-path: the root has files (saw_any_file), just none of this
+    // library's format. That is a legitimate empty diff, not a fault — trust
+    // it so the cross-format removal still works.
+    assert!(enumeration_is_trustworthy(false, true, true));
+}
+
+#[test]
+fn enumeration_trustworthy_when_empty_root_matches_empty_db() {
+    // A genuinely empty library (or first-ever scan) must stay indexable —
+    // an empty read is only suspicious when the DB disagrees.
+    assert!(enumeration_is_trustworthy(false, false, false));
+}
+
+#[test]
+fn check_mass_missing_allows_removals_within_the_threshold() {
+    // 20 of 100 (20%) is at the boundary, not over it — allowed.
+    assert!(check_mass_missing(20, 100).is_ok());
+    // 21 of 100 (21%) trips the breaker.
+    assert!(check_mass_missing(21, 100).is_err());
+}
+
+#[test]
+fn check_mass_missing_allows_small_absolute_removals_regardless_of_percent() {
+    // Deleting the only book in a 1-book library is 100% but under the
+    // absolute floor, so it must not trip the breaker.
+    assert!(check_mass_missing(1, 1).is_ok());
+    assert!(check_mass_missing(MASS_MISSING_MIN_ABSOLUTE, MASS_MISSING_MIN_ABSOLUTE).is_ok());
+}
+
+#[test]
+fn check_mass_missing_reports_counts_and_percent_in_the_error() {
+    let err = check_mass_missing(50, 100).unwrap_err();
+    assert_eq!(err.removed, 50);
+    assert_eq!(err.total, 100);
+    assert!((err.percent - 50.0).abs() < f64::EPSILON);
 }
 
 #[test]
@@ -355,10 +478,13 @@ async fn reindex_audiobooks_does_not_delete_ebook_rows_when_libraries_share_a_pa
     let _covers = CoversTempDir::new("reindex-audio-shared");
     let pool = init_db("sqlite::memory:").await.unwrap();
 
-    // The audiobook reindex needs a real (but empty) directory to
-    // scan — `stat_audiobook_library` returns an error otherwise.
+    // A real shared dir holding a real EPUB but no audio files — the exact
+    // configuration the bug reproduces on. The EPUB file keeps the walk
+    // non-empty so the #819 guard trusts the (audio-empty) enumeration and
+    // still runs the removal pass for the absent M4B.
     let shared = crate::test_support::make_test_dir("reindex-audio-shared-lib");
     let shared_path = shared.to_string_lossy().into_owned();
+    std::fs::write(shared.join("dracula.epub"), b"not a zip").unwrap();
 
     // Pre-seed one EPUB row and one audiobook row at the same
     // library_path — the exact configuration the bug reproduces on.
@@ -383,10 +509,10 @@ async fn reindex_audiobooks_does_not_delete_ebook_rows_when_libraries_share_a_pa
         "test precondition: two books (EPUB + M4B) seeded at the shared path"
     );
 
-    // Run the audiobook reindex against the empty directory. The
-    // audiobook row should be classified as Removed (and deleted);
-    // the EPUB row must survive because its format is outside the
-    // audiobook allow-list.
+    // Run the audiobook reindex. No .m4b files are on disk, but the EPUB
+    // keeps the enumeration non-empty (trustworthy), so the audiobook row is
+    // classified Removed; the EPUB row survives because its format is
+    // outside the audiobook allow-list.
     reindex_audiobooks(&pool, &shared_path).await.unwrap();
 
     let after = list_books(&pool, &shared_path).await.unwrap();
@@ -413,6 +539,10 @@ async fn reindex_ebooks_does_not_delete_audiobook_rows_when_libraries_share_a_pa
 
     let shared = crate::test_support::make_test_dir("reindex-ebook-shared-lib");
     let shared_path = shared.to_string_lossy().into_owned();
+    // A real (non-epub) audio file keeps the ebook walk non-empty so the
+    // #819 guard trusts the (epub-empty) enumeration and still removes the
+    // absent EPUB row.
+    std::fs::write(shared.join("AudioTitle.m4b"), b"not audio").unwrap();
 
     replace_books(
         &pool,
@@ -435,9 +565,9 @@ async fn reindex_ebooks_does_not_delete_audiobook_rows_when_libraries_share_a_pa
         "test precondition: two books (EPUB + M4B) seeded at the shared path"
     );
 
-    // Run the ebook reindex against the empty directory. The EPUB
-    // row should be classified as Removed (and deleted); the M4B
-    // row must survive because its format is outside the ebook
+    // Run the ebook reindex. No .epub files are on disk, but the .m4b keeps
+    // the enumeration non-empty (trustworthy), so the EPUB row is classified
+    // Removed; the M4B row survives because its format is outside the ebook
     // allow-list.
     reindex(&pool, &shared_path).await.unwrap();
 
@@ -590,4 +720,231 @@ async fn backfill_chapters_is_idempotent_after_all_books_have_chapters() {
         progress_calls, 0,
         "on_progress must not be called when all books already have chapters"
     );
+}
+
+// ---------- #819: incomplete-enumeration data-loss guard ----------
+
+/// Read a book's `is_missing_files` flag by its `scan_key` (the relative
+/// path). Returns `None` if no such book row exists.
+async fn is_missing_by_scan_key(pool: &SqlitePool, scan_key: &str) -> Option<i64> {
+    sqlx::query_scalar("SELECT is_missing_files FROM books WHERE scan_key = ?")
+        .bind(scan_key)
+        .fetch_optional(pool)
+        .await
+        .unwrap()
+}
+
+/// Index one EPUB through the real `sync_books` write path at `library_path`
+/// (a real on-disk dir), writing a matching stub file so a later `reindex`
+/// re-finds it. `filename` is the library-relative path.
+async fn seed_ebook_at(pool: &SqlitePool, library_path: &str, filename: &str, title: &str) {
+    let abs = std::path::Path::new(library_path).join(filename);
+    if let Some(parent) = abs.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&abs, b"not a zip").unwrap();
+    let (mtime, size) = {
+        let meta = std::fs::metadata(&abs).unwrap();
+        (
+            meta.modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0),
+            meta.len() as i64,
+        )
+    };
+    // Seed the row with the real stat so the reindex classifies it Unchanged
+    // (not Changed) on a healthy pass.
+    let mut book = indexed(filename, Some(title), &["Author"], &[], None, None);
+    book.mtime_epoch = mtime;
+    book.size_bytes = size;
+    sync_books(
+        pool,
+        library_path,
+        SyncPlan {
+            new_books: vec![book],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// Drop all permissions on `dir` so `read_dir` fails with EACCES. Returns
+/// `false` when the platform ignores the perm change (e.g. running as root
+/// in a CI container), so the caller can skip the assertion rather than
+/// report a false negative.
+#[cfg(unix)]
+fn make_unreadable(dir: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+    std::fs::read_dir(dir).is_err()
+}
+
+#[cfg(unix)]
+fn restore_readable(dir: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o755));
+}
+
+/// Acceptance (a): a scan against a transiently-empty root leaves every
+/// book's `is_missing_files` flag untouched. Reproduces the boot-race /
+/// unmounted-NFS incident: the DB has file-backed books, but the root reads
+/// empty this pass. Nothing may be flagged missing.
+#[tokio::test]
+async fn reindex_against_transiently_empty_root_leaves_is_missing_unchanged() {
+    let _covers = CoversTempDir::new("empty-root-guard");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = make_test_dir("empty-root-guard-lib");
+    let lib_path = lib.to_string_lossy().into_owned();
+
+    seed_ebook_at(&pool, &lib_path, "a.epub", "Dracula").await;
+    seed_ebook_at(&pool, &lib_path, "b.epub", "Frankenstein").await;
+
+    // Simulate the mount vanishing: delete the files so the root reads
+    // empty, but the DB still holds two file-backed books.
+    std::fs::remove_file(lib.join("a.epub")).unwrap();
+    std::fs::remove_file(lib.join("b.epub")).unwrap();
+
+    reindex(&pool, &lib_path).await.unwrap();
+
+    // Neither book was flagged missing — the empty read was distrusted.
+    assert_eq!(
+        is_missing_by_scan_key(&pool, "a.epub").await,
+        Some(0),
+        "a book under a transiently-empty root must not be flagged missing"
+    );
+    assert_eq!(is_missing_by_scan_key(&pool, "b.epub").await, Some(0));
+    // Both `book_files` rows survive.
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM book_files").await,
+        2,
+        "book_files must survive a transiently-empty scan"
+    );
+
+    let _ = std::fs::remove_dir_all(&lib);
+}
+
+/// Acceptance (a) + "merged_uuids sacred": an EACCES fault mid-scan must
+/// leave both `is_missing_files` and `merged_uuids` unchanged — no curation
+/// record is eroded as a side effect of a partial scan.
+#[cfg(unix)]
+#[tokio::test]
+async fn reindex_with_unreadable_subdir_preserves_missing_flags_and_merged_uuids() {
+    let _covers = CoversTempDir::new("eacces-guard");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = make_test_dir("eacces-guard-lib");
+    let lib_path = lib.to_string_lossy().into_owned();
+
+    // A readable book at the top, and two under a subdir we'll lock. One of
+    // the locked pair is merged into the readable one, so its EPUB-format
+    // `merged_uuids` row is the curation record we must protect.
+    seed_ebook_at(&pool, &lib_path, "top.epub", "Top").await;
+    seed_ebook_at(&pool, &lib_path, "locked/source.epub", "Source").await;
+    seed_ebook_at(&pool, &lib_path, "locked/other.epub", "Other").await;
+
+    let target = crate::test_support::uuid_by_scan_key(&pool, "top.epub").await;
+    let source = crate::test_support::uuid_by_scan_key(&pool, "locked/source.epub").await;
+    crate::merge_books(&pool, &source, &target, None)
+        .await
+        .unwrap();
+
+    let merged_before = count_rows(&pool, "SELECT COUNT(*) FROM merged_uuids").await;
+    assert!(
+        merged_before >= 1,
+        "test precondition: the merge must record a merged_uuids row"
+    );
+
+    let locked = lib.join("locked");
+    if !make_unreadable(&locked) {
+        let _ = std::fs::remove_dir_all(&lib);
+        return; // running as root — perms don't bite; skip
+    }
+
+    let result = reindex(&pool, &lib_path).await;
+
+    restore_readable(&locked);
+
+    result.expect("a partial scan must still succeed (it just skips removal)");
+
+    // The un-enumerated books under `locked/` were NOT flagged missing.
+    assert_eq!(
+        is_missing_by_scan_key(&pool, "locked/other.epub").await,
+        Some(0),
+        "a book under an unreadable subdir must not be flagged missing"
+    );
+    // The merge's curation record survives untouched.
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM merged_uuids").await,
+        merged_before,
+        "a scan must never erode merged_uuids"
+    );
+
+    let _ = std::fs::remove_dir_all(&lib);
+}
+
+/// Acceptance (c): forcing a full rescan (`last_indexed = 0`) while some
+/// files are unreadable must not wipe `book_files` or resurrect merged-away
+/// books. Even with the refresh window bypassed, the partial enumeration is
+/// distrusted so the removal pass never runs.
+#[cfg(unix)]
+#[tokio::test]
+async fn forced_full_rescan_with_unreadable_files_does_not_wipe_or_resurrect() {
+    let _covers = CoversTempDir::new("forced-rescan-guard");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = make_test_dir("forced-rescan-guard-lib");
+    let lib_path = lib.to_string_lossy().into_owned();
+
+    seed_ebook_at(&pool, &lib_path, "keep.epub", "Keep").await;
+    seed_ebook_at(&pool, &lib_path, "locked/source.epub", "Source").await;
+
+    let target = crate::test_support::uuid_by_scan_key(&pool, "keep.epub").await;
+    let source = crate::test_support::uuid_by_scan_key(&pool, "locked/source.epub").await;
+    crate::merge_books(&pool, &source, &target, None)
+        .await
+        .unwrap();
+
+    let books_before = count_rows(&pool, "SELECT COUNT(*) FROM books").await;
+    let files_before = count_rows(&pool, "SELECT COUNT(*) FROM book_files").await;
+    let merged_before = count_rows(&pool, "SELECT COUNT(*) FROM merged_uuids").await;
+
+    // Force a full rescan by resetting last_indexed to the epoch.
+    sqlx::query("UPDATE scan_roots SET last_indexed = 0 WHERE path = ?")
+        .bind(&lib_path)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let locked = lib.join("locked");
+    if !make_unreadable(&locked) {
+        let _ = std::fs::remove_dir_all(&lib);
+        return; // running as root — skip
+    }
+
+    let result = reindex(&pool, &lib_path).await;
+
+    restore_readable(&locked);
+    result.expect("forced rescan under a partial fault must still succeed");
+
+    // Nothing wiped: the same book, file, and merge counts as before.
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM books").await,
+        books_before,
+        "a forced rescan under a fault must not delete book rows"
+    );
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM book_files").await,
+        files_before,
+        "a forced rescan under a fault must not drop book_files"
+    );
+    // The merged-away book did not resurrect (merged_uuids intact, book count
+    // unchanged — no duplicate reappeared).
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM merged_uuids").await,
+        merged_before,
+        "the merge must survive a forced rescan under a fault"
+    );
+
+    let _ = std::fs::remove_dir_all(&lib);
 }

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -779,7 +779,14 @@ async fn seed_ebook_at(pool: &SqlitePool, library_path: &str, filename: &str, ti
 fn make_unreadable(dir: &std::path::Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o000)).unwrap();
-    std::fs::read_dir(dir).is_err()
+    if std::fs::read_dir(dir).is_err() {
+        return true;
+    }
+    // The platform ignored the perm change (e.g. running as root). Restore
+    // read access before bailing so the caller's temp-dir cleanup doesn't
+    // trip over a 0o000 directory.
+    restore_readable(dir);
+    false
 }
 
 #[cfg(unix)]

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -501,7 +501,7 @@ async fn reindex_diff_classifies_merged_source_file_as_unchanged() {
         size_bytes: ab.total_size_bytes,
         error: None,
     }];
-    let diff = diff_library(&disk, &db_rows, std::path::Path::new("/audio"));
+    let diff = diff_library(&disk, &db_rows, std::path::Path::new("/audio"), true);
     // The merged row's identity in the diff is `merged_uuids.uuid` = the
     // source book's (now-deleted) uuid, which equals `source`.
     assert_eq!(diff.unchanged, vec![source]);

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -149,7 +149,7 @@ async fn reindex_diff_classifies_attached_file_as_unchanged() {
         size_bytes: ab.total_size_bytes,
         error: None,
     }];
-    let diff = diff_library(&disk, &db_rows, std::path::Path::new("/audio"));
+    let diff = diff_library(&disk, &db_rows, std::path::Path::new("/audio"), true);
     // The merged row's identity is `merged_uuids.uuid` = the attach ledger
     // key (stable_uuid of the audiobook's group path), unchanged by F2.
     assert_eq!(


### PR DESCRIPTION
## Summary

Closes #819.

On a scan that could not fully enumerate a library root — an unreadable subdir (EACCES), a partial `readdir`, or a previously-populated root that read empty (unmounted NFS / boot-order race) — the scanner still ran its removal pass and flagged every not-yet-seen book `is_missing_files = 1`, dropping `book_files` **and** eroding `merged_uuids` (which resurrected merged-away books as duplicates on the next scan). A single unreadable/absent file became a full-library "everything is missing" event.

This makes the removal pass refuse to run on an untrustworthy enumeration and adds a circuit-breaker as a backstop:

- **Stat walkers** (`db/src/ebook/stat.rs`, `db/src/audiobook/stat.rs`) now report two signals: `incomplete` (a subdir `read_dir` failed → partial view) and `saw_any_file` (the walk saw at least one regular file of *any* extension).
- **`diff_library`** gains an `enumeration_trustworthy` parameter. When `false`, the **Removed** bucket stays empty — nothing is flagged missing and no `merged_uuids`/curation row is eroded. New / Changed / Backfill are unaffected, so a partial scan still safely indexes the files it *did* see.
- **`reindex` / `reindex_audiobooks`** distrust an enumeration that is `incomplete`, or that read totally empty (`!saw_any_file`) while the DB still holds file-backed books. A shared root that legitimately holds files of another format but none of this library's stays **trusted**, so the existing #328 cross-format removal keeps working. Untrusted scans log a warning and mark nothing missing.
- **Circuit-breaker** (`MassMissingError`): even on a trusted enumeration, if the removal would flag more than `MASS_MISSING_FRACTION` (20%) of the file-backed library missing — above a `MASS_MISSING_MIN_ABSOLUTE` (10-book) floor so small libraries aren't tripped by ordinary edits — it halts with a surfaced error instead of committing the wipe.
- Individual unreadable files never abort enumeration of the rest: a file the walker can't stat degrades to the `(0,0)` sentinel and re-parses in place; siblings are untouched.

Tests (all `sqlite::memory:`, sibling `tests.rs`) cover the three acceptance criteria — (a) an EACCES / transiently-empty root leaves `is_missing_files` and `merged_uuids` unchanged, (b) a single unreadable file doesn't affect siblings in the same root, (c) a forced full rescan (`last_indexed = 0`) under a fault neither wipes `book_files` nor resurrects merged-away books — plus the pure classifier, the trust decision, the circuit-breaker, and the `incomplete` / `saw_any_file` stat flags.

## Test plan
- [x] `cargo test -p omnibus-db` → **PASS** (865 lib + 1 + 1 integration; 0 failed)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` → **PASS** (clean)
- [x] `cargo fmt --check` → **PASS**
- [x] `cargo build -p omnibus` → **PASS** (downstream server crate compiles)

## Notes
- The circuit-breaker and the trust guard are layered: distrust handles transient faults (nothing removed at all), while the breaker is a backstop against a *trusted-but-implausible* mass delete.
- No schema/migration change, no new env vars or dependencies; the `StatScanResult` / `AudiobookStatScanResult` structs gained two public fields, constructed only within `db`.