### PR TITLE
refactor: drop section-divider comments from production frontend code

### DIFF
--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -3,6 +3,8 @@
 //! (web `localStorage`, mobile in-memory map, server no-op); also the
 //! offline / first-paint cache layer the listen page reads before
 //! reconciling against the `POST /api/progress` sync endpoint.
+//! Kept flat: each `load`/`save` impl is a mutually-exclusive `#[cfg]` variant
+//! of the same signature, so per-target submodules would only add indirection.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.listening::";
@@ -29,10 +31,7 @@ pub fn save_rate(uuid: &str, rate: f64) {
     save_rate_impl(uuid, rate);
 }
 
-// -----------------------------------------------------------------------------
-// Web — localStorage
-// -----------------------------------------------------------------------------
-
+// Web — localStorage.
 #[cfg(feature = "web")]
 fn storage_key(uuid: &str) -> String {
     format!("{STORAGE_PREFIX}{uuid}")
@@ -85,10 +84,7 @@ fn save_rate_impl(uuid: &str, rate: f64) {
     let _ = storage.set_item(&rate_key(uuid), &format!("{rate}"));
 }
 
-// -----------------------------------------------------------------------------
 // Mobile — process-local map; resets on cold launch.
-// -----------------------------------------------------------------------------
-
 #[cfg(feature = "mobile")]
 mod mobile_store {
     use std::collections::HashMap;
@@ -160,10 +156,7 @@ fn save_rate_impl(uuid: &str, rate: f64) {
     mobile_store::set_rate(uuid, rate);
 }
 
-// -----------------------------------------------------------------------------
 // SSR / server-only build — no persistence.
-// -----------------------------------------------------------------------------
-
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 fn load_impl(_uuid: &str) -> Option<f64> {
     None
@@ -180,10 +173,7 @@ fn load_rate_impl(_uuid: &str) -> Option<f64> {
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 fn save_rate_impl(_uuid: &str, _rate: f64) {}
 
-// -----------------------------------------------------------------------------
 // Tests — only the in-memory mobile store can be exercised without a browser.
-// -----------------------------------------------------------------------------
-
 #[cfg(all(test, feature = "mobile"))]
 mod tests {
     use super::*;

--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -1,10 +1,8 @@
 //! Listening-position persistence — the saved `currentTime` (seconds,
 //! float) for each audiobook. Mirrors [`crate::reader_progress`] in shape
-//! (web `localStorage`, mobile in-memory map, server no-op); also the
-//! offline / first-paint cache layer the listen page reads before
-//! reconciling against the `POST /api/progress` sync endpoint.
-//! Kept flat: each `load`/`save` impl is a mutually-exclusive `#[cfg]` variant
-//! of the same signature, so per-target submodules would only add indirection.
+//! (web `localStorage`, mobile in-memory map, server no-op) and caches the
+//! first-paint position the listen page reconciles against `POST /api/progress`.
+//! Kept flat: each impl is a `#[cfg]` variant of one signature (no submodules).
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.listening::";

--- a/frontend/src/data/journals.rs
+++ b/frontend/src/data/journals.rs
@@ -12,7 +12,7 @@ use super::DataError;
 #[cfg(feature = "mobile")]
 use super::{drain_error, http_client, note_status, with_bearer};
 
-// --- Mobile (REST) -------------------------------------------------------
+// Mobile (REST).
 
 /// POST `/api/journals` — create a journal entry.
 #[cfg(feature = "mobile")]
@@ -93,7 +93,7 @@ pub async fn preview_journal_markdown(
     Ok(response.json::<String>().await?)
 }
 
-// --- Web / SSR (RPC) -----------------------------------------------------
+// Web / SSR (RPC).
 
 /// Web/SSR `create_journal_entry` — proxies to `rpc_create_journal_entry`.
 #[cfg(not(feature = "mobile"))]

--- a/frontend/src/data/shelves.rs
+++ b/frontend/src/data/shelves.rs
@@ -14,7 +14,7 @@ use super::DataError;
 #[cfg(feature = "mobile")]
 use super::{drain_error, http_client, note_status, with_bearer};
 
-// --- mobile (REST) ---------------------------------------------------------
+// Mobile (REST).
 
 /// GET `/api/shelves` — the caller's visible shelves.
 #[cfg(feature = "mobile")]
@@ -174,7 +174,7 @@ pub async fn preview_shelf_rule(
     Ok(response.json::<RulePreview>().await?)
 }
 
-// --- web / SSR (RPC server functions) --------------------------------------
+// Web / SSR (RPC server functions).
 
 #[cfg(not(feature = "mobile"))]
 pub async fn list_shelves(_server_url: &str) -> Result<Vec<ShelfSummary>, DataError> {

--- a/frontend/src/data/uploads.rs
+++ b/frontend/src/data/uploads.rs
@@ -22,7 +22,7 @@ pub struct EbookUploadMeta {
     pub series_index: String,
 }
 
-// --- Web (gloo-net + FormData) ---------------------------------------------
+// Web (gloo-net + FormData).
 
 /// Build a one-shot `Blob` from raw bytes with the given MIME type.
 #[cfg(feature = "web")]
@@ -120,7 +120,7 @@ pub async fn upload_ebook(
         .map_err(|e| DataError::Other(e.to_string()))
 }
 
-// --- Mobile (reqwest multipart) --------------------------------------------
+// Mobile (reqwest multipart).
 
 #[cfg(feature = "mobile")]
 pub async fn inspect_ebook(
@@ -176,7 +176,7 @@ pub async fn upload_ebook(
     Ok(response.json::<UploadCommitResult>().await?)
 }
 
-// --- Fallback stub (SSR / no platform feature) -----------------------------
+// Fallback stub (SSR / no platform feature).
 
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 pub async fn inspect_ebook(

--- a/frontend/src/pages/landing/sorting.rs
+++ b/frontend/src/pages/landing/sorting.rs
@@ -255,8 +255,7 @@ mod tests {
         books.iter().map(|b| b.id).collect()
     }
 
-    // --- row_slug ---
-
+    // row_slug cases.
     #[test]
     fn row_slug_lowercases_and_strips_extension() {
         assert_eq!(row_slug("Alpha.epub"), "alpha");
@@ -278,8 +277,7 @@ mod tests {
         assert_eq!(row_slug("plain"), "plain");
     }
 
-    // --- sort_books ---
-
+    // sort_books cases.
     fn sample() -> Vec<EbookMetadata> {
         vec![
             book(BookSpec {

--- a/frontend/src/pages/listen/bootstrap.rs
+++ b/frontend/src/pages/listen/bootstrap.rs
@@ -17,15 +17,12 @@ use crate::data;
 /// closure that registers them.
 type JsCallbackHolder = std::rc::Rc<std::cell::RefCell<Vec<Closure<dyn FnMut(f64)>>>>;
 
-// ---------------------------------------------------------------------------
-// Pure helpers — extracted so they can be tested without a browser.
-// Everything else in this module is a JS interop seam:
-//   * `register_js_callbacks` — writes closures into `window.*` properties.
-//   * `inject_hls_script` / `install_control_surface` — call `eval()`.
-//   * `run_manifest_init` — async manifest fetch + `/status` poll loop.
-// Those three functions cannot be unit-tested without a WASM runtime.
-// The logic below is the Rust-side decision surface that *can* be tested.
-// ---------------------------------------------------------------------------
+// The functions below are the Rust-side decision surface, extracted so they
+// can be unit-tested without a browser. Everything else in this module is a JS
+// interop seam that needs a WASM runtime: `register_js_callbacks` writes
+// closures into `window.*` properties, `inject_hls_script` /
+// `install_control_surface` call `eval()`, and `run_manifest_init` runs the
+// async manifest fetch + `/status` poll loop.
 
 /// Select the resume position: prefer the server-authoritative value when
 /// available, fall back to the locally cached initial position.

--- a/frontend/src/pages/listen/bootstrap.rs
+++ b/frontend/src/pages/listen/bootstrap.rs
@@ -17,12 +17,8 @@ use crate::data;
 /// closure that registers them.
 type JsCallbackHolder = std::rc::Rc<std::cell::RefCell<Vec<Closure<dyn FnMut(f64)>>>>;
 
-// The functions below are the Rust-side decision surface, extracted so they
-// can be unit-tested without a browser. Everything else in this module is a JS
-// interop seam that needs a WASM runtime: `register_js_callbacks` writes
-// closures into `window.*` properties, `inject_hls_script` /
-// `install_control_surface` call `eval()`, and `run_manifest_init` runs the
-// async manifest fetch + `/status` poll loop.
+// Below: the pure Rust decision surface, extracted so it can be unit-tested.
+// The rest of the module is JS/WASM interop (`eval`, `window.*` callbacks).
 
 /// Select the resume position: prefer the server-authoritative value when
 /// available, fall back to the locally cached initial position.

--- a/frontend/src/pages/listen/controls.rs
+++ b/frontend/src/pages/listen/controls.rs
@@ -9,7 +9,7 @@ use dioxus::prelude::*;
 
 use super::stage::{ToolbarState, TransportCallbacks, TransportState};
 
-// --- Pure helpers extracted so they can be unit-tested without a renderer.
+// Pure helpers extracted so they can be unit-tested without a renderer.
 
 /// CSS class for the rate button — appends `" on"` when the speed panel is open.
 pub(super) fn rate_btn_class(active: bool) -> &'static str {

--- a/frontend/src/reader_progress.rs
+++ b/frontend/src/reader_progress.rs
@@ -2,7 +2,8 @@
 //! per-UUID in `localStorage`, mobile keeps an in-memory map, SSR is a
 //! no-op. Offline / first-paint cache for the progress-sync endpoint:
 //! reader reads sync, saves write here AND fire-and-forget POST.
-//! In-file `#[cfg]`-framing dividers retained per rule 05's nav-aid exception.
+//! Kept flat: each `load`/`save` impl is a mutually-exclusive `#[cfg]` variant
+//! of the same signature, so per-target submodules would only add indirection.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.reading::";
@@ -19,10 +20,7 @@ pub fn save(uuid: &str, cfi: &str) {
     save_impl(uuid, cfi);
 }
 
-// -----------------------------------------------------------------------------
-// Web — localStorage
-// -----------------------------------------------------------------------------
-
+// Web — localStorage.
 #[cfg(feature = "web")]
 fn storage_key(uuid: &str) -> String {
     format!("{STORAGE_PREFIX}{uuid}")
@@ -47,10 +45,7 @@ fn save_impl(uuid: &str, cfi: &str) {
     let _ = storage.set_item(&storage_key(uuid), cfi);
 }
 
-// -----------------------------------------------------------------------------
 // Mobile — process-local map; resets on cold launch.
-// -----------------------------------------------------------------------------
-
 #[cfg(feature = "mobile")]
 mod mobile_store {
     use std::collections::HashMap;
@@ -93,10 +88,7 @@ fn save_impl(uuid: &str, cfi: &str) {
     mobile_store::set(uuid, cfi.to_string());
 }
 
-// -----------------------------------------------------------------------------
 // SSR / server-only build — no persistence.
-// -----------------------------------------------------------------------------
-
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 fn load_impl(_uuid: &str) -> Option<String> {
     None
@@ -105,10 +97,7 @@ fn load_impl(_uuid: &str) -> Option<String> {
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 fn save_impl(_uuid: &str, _cfi: &str) {}
 
-// -----------------------------------------------------------------------------
 // Tests — only the in-memory mobile store can be exercised without a browser.
-// -----------------------------------------------------------------------------
-
 #[cfg(all(test, feature = "mobile"))]
 mod tests {
     use super::*;
@@ -145,13 +134,11 @@ mod tests {
     }
 }
 
-// -----------------------------------------------------------------------------
 // SSR / server-only tests — exercise the no-persistence path that compiles
 // under the `server` feature (the default `cargo test -p omnibus-frontend
 // --features server`). The `web`/`mobile` impls live behind their own cfgs and
 // are unreachable here, so these assertions pin the documented SSR contract:
 // every load returns `None` and `save` is an inert no-op.
-// -----------------------------------------------------------------------------
 #[cfg(all(test, not(any(feature = "web", feature = "mobile"))))]
 mod ssr_tests {
     use super::*;

--- a/frontend/src/reader_progress.rs
+++ b/frontend/src/reader_progress.rs
@@ -1,9 +1,8 @@
 //! Reading-position persistence — saved EPUB CFI per book. Web stores
 //! per-UUID in `localStorage`, mobile keeps an in-memory map, SSR is a
-//! no-op. Offline / first-paint cache for the progress-sync endpoint:
-//! reader reads sync, saves write here AND fire-and-forget POST.
-//! Kept flat: each `load`/`save` impl is a mutually-exclusive `#[cfg]` variant
-//! of the same signature, so per-target submodules would only add indirection.
+//! no-op. Offline / first-paint cache for the progress-sync endpoint.
+//! Kept flat: each impl is a `#[cfg]` variant of one signature, so
+//! per-target submodules would only add indirection.
 
 #[cfg(feature = "web")]
 const STORAGE_PREFIX: &str = "omn.reading::";

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -1,9 +1,8 @@
 //! Per-library view-preference persistence for [`ViewPrefs`]. Web stores
 //! per library-path in `localStorage`, mobile keeps an in-memory map, SSR
 //! returns defaults so first-hydration markup matches the WASM client.
-//! Shape lives in `omnibus-shared` so a future server endpoint can reuse it.
-//! Kept flat: each `load`/`save` impl is a mutually-exclusive `#[cfg]` variant
-//! of the same signature, so per-target submodules would only add indirection.
+//! Shape lives in `omnibus-shared`. Kept flat: each impl is a `#[cfg]`
+//! variant of one signature, so per-target submodules would only indirect.
 
 use omnibus_shared::ViewPrefs;
 

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -2,7 +2,8 @@
 //! per library-path in `localStorage`, mobile keeps an in-memory map, SSR
 //! returns defaults so first-hydration markup matches the WASM client.
 //! Shape lives in `omnibus-shared` so a future server endpoint can reuse it.
-//! In-file `#[cfg]`-framing dividers retained per rule 05's nav-aid exception.
+//! Kept flat: each `load`/`save` impl is a mutually-exclusive `#[cfg]` variant
+//! of the same signature, so per-target submodules would only add indirection.
 
 use omnibus_shared::ViewPrefs;
 
@@ -22,10 +23,7 @@ pub fn save(library_path: &str, prefs: &ViewPrefs) {
     save_impl(library_path, prefs);
 }
 
-// -----------------------------------------------------------------------------
-// Web — localStorage
-// -----------------------------------------------------------------------------
-
+// Web — localStorage.
 #[cfg(feature = "web")]
 fn storage_key(library_path: &str) -> String {
     format!("{STORAGE_PREFIX}{library_path}")
@@ -59,10 +57,7 @@ fn save_impl(library_path: &str, prefs: &ViewPrefs) {
     let _ = storage.set_item(&storage_key(library_path), &raw);
 }
 
-// -----------------------------------------------------------------------------
 // Mobile — process-local map; resets on cold launch.
-// -----------------------------------------------------------------------------
-
 #[cfg(feature = "mobile")]
 mod mobile_store {
     use omnibus_shared::ViewPrefs;
@@ -110,10 +105,7 @@ fn save_impl(library_path: &str, prefs: &ViewPrefs) {
     mobile_store::set(library_path, prefs.clone());
 }
 
-// -----------------------------------------------------------------------------
 // SSR / server-only build — no persistence; defaults always.
-// -----------------------------------------------------------------------------
-
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 fn load_impl(_library_path: &str) -> ViewPrefs {
     ViewPrefs::default()
@@ -122,10 +114,7 @@ fn load_impl(_library_path: &str) -> ViewPrefs {
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 fn save_impl(_library_path: &str, _prefs: &ViewPrefs) {}
 
-// -----------------------------------------------------------------------------
 // Tests — only the in-memory mobile store can be exercised without a browser.
-// -----------------------------------------------------------------------------
-
 #[cfg(all(test, feature = "mobile"))]
 mod tests {
     use super::*;
@@ -162,13 +151,11 @@ mod tests {
     }
 }
 
-// -----------------------------------------------------------------------------
 // SSR / server-only tests — exercise the no-persistence path that compiles
 // under the `server` feature (the default `cargo test -p omnibus-frontend
 // --features server`). The `web`/`mobile` impls live behind their own cfgs and
 // are unreachable here, so these assertions pin the documented SSR contract:
 // every call returns defaults and `save` is an inert no-op.
-// -----------------------------------------------------------------------------
 #[cfg(all(test, not(any(feature = "web", feature = "mobile"))))]
 mod ssr_tests {
     use super::*;


### PR DESCRIPTION
## Summary
- Closes #553. Removes the 60+ decorative `// ---` / `// ===` section-divider comments from **production** `frontend/` code, replacing them with concise inline notes. The frontend crate is now divider-free (production and test modules).
- **Stacked on #830** (`refactor/825-split-oversized-frontend-files`) — this PR targets that branch, not `main`. Much of the original divider footprint was already eliminated by #830's file splits (`rpc.rs` → `rpc/`, `data.rs` → `data/`, `pages/auth.rs` → `pages/auth/`), so the remaining work was concentrated in files that stay intentionally flat.
- Applied the least-invasive resolution per the issue's acceptance criteria:
  - **`view_prefs.rs`, `reader_progress.rs`, `audiobook_progress.rs`** (the web/mobile/SSR triads) and the cfg-gated `data/{journals,shelves,uploads}.rs` transports — kept flat and dropped the banners. Each section is a mutually-exclusive `#[cfg]` variant of the *same* public signature, so splitting into per-target submodules would only add indirection. The module `//!` now states this explicitly.
  - **`pages/listen/{bootstrap,controls}.rs`** and the `pages/landing/sorting.rs` test groupings — converted decorative banners to plain prose comments, preserving the explanatory content.
- No behavior change: comment-only edits (66 deletions / 25 insertions across 9 files). The two cited server files (`server/src/backend/{author_photos,overrides}.rs`) had no production dividers left, so they were untouched.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — PASS (223 passed, 0 failed)
- [x] `cargo test -p omnibus` — PASS (303 passed, 0 failed)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --features server --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` (mobile shell) — PASS (exercises the `#[cfg(feature = "mobile")]` branches touched)
- [x] `cargo fmt --check` — PASS

## Notes
- Comment-only refactor; no runtime, API, or schema changes.
- Issue #728 will later stack on this branch and also edits `pages/auth.rs`.