### PR TITLE
chore: bump sha2 to 0.11, document argon2/rand_core holds (#523)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -457,7 +457,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -473,6 +473,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -719,6 +728,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-serialize"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1024,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1118,7 +1151,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1191,10 +1224,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1660,10 +1704,10 @@ version = "0.7.9"
 source = "git+https://github.com/DioxusLabs/dioxus?tag=v0.7.9#3e43ffa6cf1488d5388c888eb5f2494a006ae6de"
 dependencies = [
  "base16",
- "digest",
+ "digest 0.10.7",
  "proc-macro2",
  "quote",
- "sha2",
+ "sha2 0.10.9",
  "slab",
  "syn 2.0.117",
 ]
@@ -2888,7 +2932,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2983,6 +3027,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3844,7 +3897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4331,7 +4384,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
@@ -5442,8 +5495,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -5784,8 +5837,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5801,8 +5854,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5846,7 +5910,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6041,7 +6105,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -6079,7 +6143,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -6101,7 +6165,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -6122,7 +6186,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6159,7 +6223,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -8120,7 +8184,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle 0.6.2",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -35,25 +35,26 @@ tracing.workspace = true
 
 # Auth (F0.3). Argon2id password hashing, CSPRNG token generation, SHA-256
 # of the raw token for at-rest storage, base64url for wire-format tokens.
-# getrandom is used directly for CSPRNG token/key generation (it is already
-# a transitive dep via sqlx/argon2) to avoid pulling in the pre-1.0 rand 0.8
-# crate for this security-critical path. rand_core is pinned to 0.6 (same
-# version already in the lock via password-hash) with `getrandom` enabled so
+# getrandom is used directly (via `getrandom::fill`) for CSPRNG token/key
+# generation in token.rs / session_key.rs — it is already a transitive dep
+# via sqlx/argon2, so using it directly avoids pulling in the pre-1.0 rand
+# crate for this security-critical path. rand_core carries `getrandom` so
 # that OsRng is available for SaltString::generate in password.rs.
 #
-# Why the version mix isn't uniformly "latest":
-# * argon2 0.5 is the latest *stable* release; 0.6 is only available as
-#   pre-release (0.6.0-rc.*) and we don't ship release candidates of
-#   password-hashing code. 0.5.3 has no open advisories.
-# * rand_core stays at 0.6 because argon2 0.5's transitive `password-hash`
-#   pulls 0.6, and our direct dep only exists to flip on the `getrandom`
-#   feature on that *same* 0.6 instance — a 0.9 direct bump would be dead
-#   weight (separate version, doesn't reach argon2's OsRng). Lock-stepped
-#   with the argon2 bump above.
-argon2 = "0.5"
+# held at 0.5: argon2 0.6 has never shipped a *stable* release — the latest
+#   published version is a release candidate (0.6.0-rc.*), and we don't ship
+#   an RC of password-hashing code. 0.5.3 has no open advisories. Revisit
+#   when 0.6.0 final lands; the bump then also pulls password-hash 0.6 (and
+#   rand_core 0.9), which is why rand_core is lock-stepped below.
+argon2 = "0.5" # held at 0.5: no stable 0.6 upstream (latest is 0.6.0-rc.*)
 getrandom = "0.3"
-rand_core = { version = "0.6", features = ["getrandom"] }
-sha2 = "0.10"
+# held at 0.6: rand_core exists here only to flip on the `getrandom` feature
+#   on the *same* 0.6 instance argon2 0.5's transitive `password-hash` 0.5
+#   pulls in, so OsRng reaches SaltString::generate. A 0.9 direct bump would
+#   be dead weight (a separate version that never reaches argon2's OsRng)
+#   until argon2 0.6 stabilizes and moves password-hash to rand_core 0.9.
+rand_core = { version = "0.6", features = ["getrandom"] } # held at 0.6: tied to argon2 0.5's password-hash
+sha2 = "0.11"
 base64 = "0.22"
 
 # F1.2 thumbnail pipeline: decode EPUB covers (JPEG/PNG/WebP) and re-encode

--- a/db/src/auth/password/tests.rs
+++ b/db/src/auth/password/tests.rs
@@ -8,14 +8,8 @@ fn hash_password_and_verify_password_round_trips_a_matching_credential() {
     assert!(!verify_password("wrong password entirely", &phc).unwrap());
 }
 
-/// Forward-compatibility guard for the crypto-crate staleness bumps
-/// (issue #523). This is a real Argon2id PHC string captured from an
-/// earlier `argon2` release — the exact byte-format already sitting in
-/// deployed `users.password_hash` columns. It must keep validating
-/// verbatim through whatever `argon2` / `password-hash` versions this
-/// crate pins, so any future bump that would silently reject stored
-/// hashes fails here instead of locking every existing account out at
-/// login. The plaintext is `correct horse battery staple`.
+/// Compatibility guard: ensures previously stored Argon2id PHC hashes still verify after dependency bumps.
+/// This PHC string was captured from a deployed database row.
 const KNOWN_STORED_PHC: &str =
     "$argon2id$v=19$m=19456,t=2,p=1$hfViri/PktpsaVGThRVdQg$FuImGjf9eL7k2PhxMjxBJSlSRgXCSKi1/KrKELG4DuA";
 

--- a/db/src/auth/password/tests.rs
+++ b/db/src/auth/password/tests.rs
@@ -8,6 +8,36 @@ fn hash_password_and_verify_password_round_trips_a_matching_credential() {
     assert!(!verify_password("wrong password entirely", &phc).unwrap());
 }
 
+/// Forward-compatibility guard for the crypto-crate staleness bumps
+/// (issue #523). This is a real Argon2id PHC string captured from an
+/// earlier `argon2` release — the exact byte-format already sitting in
+/// deployed `users.password_hash` columns. It must keep validating
+/// verbatim through whatever `argon2` / `password-hash` versions this
+/// crate pins, so any future bump that would silently reject stored
+/// hashes fails here instead of locking every existing account out at
+/// login. The plaintext is `correct horse battery staple`.
+const KNOWN_STORED_PHC: &str =
+    "$argon2id$v=19$m=19456,t=2,p=1$hfViri/PktpsaVGThRVdQg$FuImGjf9eL7k2PhxMjxBJSlSRgXCSKi1/KrKELG4DuA";
+
+#[test]
+fn verify_password_accepts_a_hash_produced_by_an_earlier_argon2_version() {
+    // Round-trip against a hash minted before the bump: PHC format is
+    // designed for forward compatibility, but confirm it rather than
+    // assume it (issue #523 acceptance criteria).
+    assert!(verify_password("correct horse battery staple", KNOWN_STORED_PHC).unwrap());
+    assert!(!verify_password("wrong password entirely", KNOWN_STORED_PHC).unwrap());
+}
+
+#[test]
+fn stored_phc_string_still_parses_through_the_password_hash_crate() {
+    // The `verify_password` path parses via `PasswordHash::new`; assert the
+    // parse itself accepts the stored format and recovers the tuning
+    // parameters, so a `password-hash` bump that changed the grammar is
+    // caught at the parse boundary, not only at verify.
+    let parsed = PasswordHash::new(KNOWN_STORED_PHC).unwrap();
+    assert_eq!(parsed.algorithm.as_str(), "argon2id");
+}
+
 #[test]
 fn verify_password_returns_crypto_error_for_malformed_phc_string() {
     let err = verify_password("any-password", "not-a-valid-phc-string").unwrap_err();


### PR DESCRIPTION
## Summary
Closes #523. Closes the pre-1.0 / major-version gap on the `db` crate's security-critical crypto crates, one at a time, verifying auth round-trips after each:

- **`sha2` 0.10 → 0.11** — session-token SHA-256 hashing (`db/src/auth/token.rs`). Stable 0.11.0 exists; bumped. `db`'s direct `sha2` is now 0.11.0 (the 0.10.9 that remains is internal to `sqlx-core`, not our code).
- **`argon2` — held at 0.5** (documented in `db/Cargo.toml`). There is **no stable 0.6 upstream**: the latest published version is a release candidate (`0.6.0-rc.*`), and we don't ship an RC of password-hashing code (`cargo update -p argon2 --precise 0.6.0` → "no matching package"). 0.5.3 has no open advisories. Per the AC, a documented hold-back is explicitly allowed here (mirrors how #774 held `sqlx`).
- **`rand_core` — held at 0.6** (documented). It exists here only to flip on the `getrandom` feature on the *same* 0.6 instance argon2 0.5's transitive `password-hash` 0.5 pulls in, so `OsRng` reaches `SaltString::generate`. A 0.9 direct bump would be dead weight until argon2 0.6 stabilizes and moves `password-hash` to `rand_core` 0.9. Lock-stepped with the argon2 hold.
- **`getrandom` — already at 0.3** (done by an earlier PR); the token/key RNG already uses the 0.3 `getrandom::fill` API. Left untouched.

Stacked on #829 (`chore/774-bump-first-party-deps`) — this PR targets that branch, not `main`.

**Old-hash compatibility (AC):** added two tests in `db/src/auth/password/tests.rs` that pin a real pre-bump Argon2id PHC string (the exact byte-format sitting in deployed `users.password_hash` columns) and assert it still (a) validates through `verify_password` and (b) parses through `PasswordHash::new`. Any future crypto bump that would silently reject stored hashes now fails here instead of locking existing accounts out at login.

## Test plan
All run from the workspace via `nix develop`:

- [x] `cargo test -p omnibus-db` — **PASS** (849 passed, 0 failed; incl. the 2 new old-hash tests + the token/session SHA-256 round-trips)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — **PASS** (exit 0, no warnings)
- [x] `cargo fmt` — **PASS** (no changes)
- [x] `cargo deny check advisories sources bans` (in `.#audit`) — **PASS** (`advisories ok, bans ok, sources ok`)
- [x] `cargo audit` (in `.#audit`) — one finding, **pre-existing and unrelated**: `RUSTSEC-2026-0097` against `rand 0.7.3`, reachable only as a build-dependency via `wry → dioxus-desktop` (mobile/desktop stack). It is present identically on the base branch's `Cargo.lock` and this PR's `Cargo.lock` diff touches no `rand` entry, so it is not introduced by these bumps. `cargo deny` already ignores it (`deny.toml`) and evaluates the server graph where `rand 0.7.3` isn't present.

## Notes
- Touched only the four crates named in #523 — no changes to any crate #774 bumped.
- `Cargo.lock` now carries both `sha2` 0.10.9 (sqlx-internal) and 0.11.0 (our direct dep); Cargo permits the two majors to coexist. Same for `digest` (0.10.7 + 0.11.3).
- No production code changes were needed for the `sha2` bump — the `Digest`/`Sha256` API is unchanged 0.10 → 0.11.