### PR TITLE
fix: decode GIF covers, store covers with true extension

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -57,10 +57,12 @@ rand_core = { version = "0.6", features = ["getrandom"] } # held at 0.6: tied to
 sha2 = "0.11"
 base64 = "0.22"
 
-# F1.2 thumbnail pipeline: decode EPUB covers (JPEG/PNG/WebP) and re-encode
-# as WebP at multiple sizes. Only the three listed formats are enabled to keep
-# compile times and binary size down.
-image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+# F1.2 thumbnail pipeline: decode EPUB covers (JPEG/PNG/WebP/GIF) and re-encode
+# as WebP at multiple sizes. Only the listed formats are enabled to keep
+# compile times and binary size down. `gif` is enabled so a cover whose bytes
+# are actually a GIF (even when mislabelled `image/jpeg`) decodes to its first
+# frame instead of failing `The image format Gif is not supported` (#828).
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "gif"] }
 
 # HTML sanitization for EPUB description fields (issue #62) and F3.2 journal
 # entries. OPF `<dc:description>` is often HTML; journal bodies are

--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -75,6 +75,19 @@ impl ImageFormat {
         }
     }
 
+    /// Map the format `image::guess_format` sniffed from the bytes onto our
+    /// local set, or `None` for a codec we don't cache (SVG isn't a raster
+    /// format `image` sniffs, and anything else falls back to the mime).
+    fn from_guessed(guessed: image::ImageFormat) -> Option<Self> {
+        match guessed {
+            image::ImageFormat::Jpeg => Some(ImageFormat::Jpeg),
+            image::ImageFormat::Png => Some(ImageFormat::Png),
+            image::ImageFormat::Gif => Some(ImageFormat::Gif),
+            image::ImageFormat::WebP => Some(ImageFormat::Webp),
+            _ => None,
+        }
+    }
+
     pub(crate) fn from_ext(ext: &str) -> Self {
         match ext.to_ascii_lowercase().as_str() {
             "jpg" | "jpeg" => ImageFormat::Jpeg,
@@ -106,8 +119,15 @@ pub(crate) fn cover_path_for(uuid: &str, ext: &str) -> PathBuf {
 pub(crate) fn write_cover_file(uuid: &str, mime: &str, bytes: &[u8]) -> std::io::Result<()> {
     let dir = covers_dir();
     std::fs::create_dir_all(&dir)?;
-    let ext = ImageFormat::from_mime(mime).to_ext();
-    std::fs::write(cover_path_for(uuid, ext), bytes)
+    // Trust the bytes over the caller-supplied mime: a cover mislabelled
+    // `image/jpeg` whose bytes are really a GIF must land as `<uuid>.gif`,
+    // not `<uuid>.jpg` (#828). Fall back to the mime only when the sniff
+    // fails or yields a format outside our local set (e.g. SVG).
+    let fmt = image::guess_format(bytes)
+        .ok()
+        .and_then(ImageFormat::from_guessed)
+        .unwrap_or_else(|| ImageFormat::from_mime(mime));
+    std::fs::write(cover_path_for(uuid, fmt.to_ext()), bytes)
 }
 
 pub(crate) fn find_cover_file(uuid: &str) -> Option<(String, Vec<u8>)> {

--- a/db/src/covers/tests.rs
+++ b/db/src/covers/tests.rs
@@ -180,3 +180,42 @@ async fn cover_returns_none_for_missing_book_id() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     assert!(get_cover(&pool, 999_999).await.unwrap().is_none());
 }
+
+/// A minimal but valid 1x1 GIF87a: header + logical-screen descriptor + a
+/// 2-colour global table + one image descriptor and a single-pixel LZW frame.
+/// Enough for `image` to sniff the format and decode a first frame (#828).
+const GIF_1X1: &[u8] = &[
+    0x47, 0x49, 0x46, 0x38, 0x37, 0x61, // "GIF87a"
+    0x01, 0x00, 0x01, 0x00, // 1x1 logical screen
+    0x80, 0x00, 0x00, // GCT flag, 2 colours, no bg/aspect
+    0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, // palette: black, white
+    0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, // image descriptor
+    0x02, 0x02, 0x44, 0x01, 0x00, // LZW min code size + 1-pixel data block
+    0x3B, // trailer
+];
+
+/// A cover whose bytes are really a GIF must be written as `<uuid>.gif` even
+/// when the caller hands us `image/jpeg` — the extension is sniffed from the
+/// bytes, not trusted from the mime (#828). This is the root cause of covers
+/// landing as `<uuid>.jpg` and later failing to decode.
+#[tokio::test]
+async fn write_cover_file_stores_gif_when_bytes_are_gif_despite_jpeg_mime() {
+    let _covers = CoversTempDir::new("gif_extension");
+    let uuid = "gif-book";
+
+    write_cover_file(uuid, "image/jpeg", GIF_1X1).unwrap();
+
+    // The `.gif` path exists with the GIF bytes; no `.jpg` was written.
+    assert_eq!(std::fs::read(cover_path_for(uuid, "gif")).unwrap(), GIF_1X1);
+    assert!(std::fs::read(cover_path_for(uuid, "jpg")).is_err());
+}
+
+/// The `gif` codec is compiled into the `image` crate, so GIF cover bytes
+/// decode via `load_from_memory` instead of erroring with "The image format
+/// Gif is not supported" — the fatal failure reported in #828.
+#[test]
+fn gif_cover_bytes_decode_via_load_from_memory() {
+    let img =
+        image::load_from_memory(GIF_1X1).expect("GIF must decode once the gif codec is enabled");
+    assert_eq!((img.width(), img.height()), (1, 1));
+}


### PR DESCRIPTION
## Summary
Closes #828.

Some EPUB covers ship bytes that are actually a **GIF** while the OPF (or upload) labels them `image/jpeg`. Two independent root causes made these covers fatal:

1. **No GIF codec compiled in.** `db/Cargo.toml` enabled only `["jpeg", "png", "webp"]` on the `image` crate, so `image::load_from_memory` in `db/src/thumbs.rs` (which sniffs the format from the *bytes*) hit `The image format Gif is not supported` and the whole thumbnail generation failed — no cover rendered.
2. **The stored extension trusted the caller's mime, not the bytes.** `write_cover_file` in `db/src/covers.rs` derived the on-disk extension from `ImageFormat::from_mime(mime)`, so GIF bytes labelled `image/jpeg` were written as `<uuid>.jpg`. Even with the codec enabled, a GIF-in-a-`.jpg` is misleading and defeats format-by-extension probes.

### Fix (surgical, `db` crate only)
- **Enable the GIF codec:** add `"gif"` to the `image` crate's `features`. `load_from_memory` sniffs the format from the bytes, so GIF-bytes-in-a-`.jpg` now decode; a GIF decodes to its first frame, which is fine for a cover thumbnail.
- **Store the true extension:** `write_cover_file` now sniffs the real format via `image::guess_format(bytes)` and maps `image::ImageFormat::{Jpeg,Png,Gif,WebP}` onto the local `ImageFormat`, falling back to the mime-derived format only when the sniff fails or returns a codec outside our local set (e.g. SVG). A GIF is no longer written as `<uuid>.jpg`.

The serving path and the frontend are intentionally left untouched — those robustness items are tracked separately in #832.

> [!NOTE]
> Stacked on #834 (`chore/523-bump-security-crates`), which itself stacks on #829. This PR targets `chore/523-bump-security-crates`, not `main`. `db/Cargo.toml` / `Cargo.lock` already reflect the #774 + #523 dependency bumps.

## Test plan
Added to `db/src/covers/tests.rs`:
- `write_cover_file_stores_gif_when_bytes_are_gif_despite_jpeg_mime` — GIF magic bytes (`GIF87a`) passed with mime `image/jpeg` land as `<uuid>.gif`, and no `<uuid>.jpg` is written.
- `gif_cover_bytes_decode_via_load_from_memory` — a valid 1x1 GIF decodes via `image::load_from_memory` without the "format Gif is not supported" error, proving the codec is compiled in.

Commands (run in the nix shell from the workspace):
- [x] `cargo test -p omnibus-db` — **PASS** (851 unit + 2 integration; new GIF tests green)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — **PASS** (clean)
- [x] `cargo fmt --check -p omnibus-db` — **PASS**
- [x] `cargo deny check advisories sources bans` — **PASS** (`advisories ok, bans ok, sources ok`). The gif codec added `gif 0.14.2` and pulled no new advisory. `cargo audit` still surfaces the pre-existing `RUSTSEC-2026-0097` (`rand 0.7.3`), which is unrelated (build-dep-only via `wry → dioxus-desktop`) and already allow-listed in `deny.toml`.

## Notes
- The GIF decodes to its first frame — animated GIF covers are collapsed to a static thumbnail, which is the desired behaviour for a cover.
- `guess_format` sniffs raster magic bytes only; SVG covers (not a raster format) correctly fall through to the mime-derived extension, so no regression for `image/svg+xml`.