### PR TITLE
refactor: group props into structs for 15 over-threshold Dioxus components

### DIFF
--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -31,14 +31,66 @@ impl SuggestionItem {
     }
 }
 
-/// Props for the [`ChipEditor`] component.
+/// Presentational options for [`ChipEditor`] — everything that shapes how the
+/// chips, input, and dropdown look, split out of [`ChipEditorProps`] so the
+/// component's props stay small (the values/suggestions/handlers stay on the
+/// props; the knobs live here). Every field defaults, so a consumer can pass
+/// `ChipEditorOptions::default()` and override only what differs.
+#[derive(Clone, PartialEq)]
+pub struct ChipEditorOptions {
+    /// Placeholder shown inside the chip-input.
+    pub placeholder: String,
+    /// When true, each chip is prefixed with an uppercase-initials
+    /// avatar. Used by author chips (`me-avatar`); off for tags.
+    pub show_avatar: bool,
+    /// CSS class for the inline `<input>`. Defaults to `me-chip-input`
+    /// (the author/landing-row style); tag rows pass `me-tag-input`.
+    pub input_class: String,
+    /// Prefix for the per-chip Remove button's `aria-label`, e.g.
+    /// "Remove" → "Remove Ada Lovelace" or "Remove tag" → "Remove tag
+    /// fiction".
+    pub aria_remove_prefix: String,
+    /// Per-instance testid prefix so multiple ChipEditors on one page
+    /// don't collide. The `<input>` gets `<prefix>-input` and the
+    /// suggestions `<ul>` gets `<prefix>-suggestions`. Suggestion
+    /// `<li>`s use `role="option"` with the suggestion as accessible
+    /// name (no per-row testid) so Playwright resolves them via
+    /// `getByRole("option", { name })`.
+    pub testid_prefix: String,
+    /// When `true`, the inline `<input>` receives `autofocus` so the
+    /// dropdown surfaces on first paint. Used by the landing-page
+    /// Authors cell so admins don't have to click twice (once to
+    /// enter edit mode, once to focus the input). Off by default to
+    /// keep the metadata-edit page from stealing focus from the page's
+    /// other fields on mount.
+    pub autofocus: bool,
+    /// Optional uppercase mini-header rendered at the top of the
+    /// suggestion dropdown — "ADD AUTHOR" / "ADD TAG". Empty string (the
+    /// default) suppresses the header entirely.
+    pub dropdown_header: String,
+}
+
+impl Default for ChipEditorOptions {
+    fn default() -> Self {
+        Self {
+            placeholder: String::new(),
+            show_avatar: false,
+            input_class: "me-chip-input".to_string(),
+            aria_remove_prefix: "Remove".to_string(),
+            testid_prefix: "chip-editor".to_string(),
+            autofocus: false,
+            dropdown_header: String::new(),
+        }
+    }
+}
+
+/// Props for the [`ChipEditor`] component. The data + behavioral props live
+/// here; presentational knobs are grouped in [`ChipEditorOptions`].
 #[derive(Props, PartialEq, Clone)]
 pub struct ChipEditorProps {
     /// The chip list. Shared with the consumer so the parent can read
     /// it for dirty-detection / persistence.
     pub values: Signal<Vec<String>>,
-    /// Placeholder shown inside the chip-input.
-    pub placeholder: String,
     /// Fired after every chip add or remove with the new full list, so
     /// the consumer can persist on change (e.g. POST overrides) without
     /// having to re-subscribe to the signal.
@@ -51,45 +103,14 @@ pub struct ChipEditorProps {
     /// the wrapping `ReadSignal`; an empty signal suppresses the
     /// dropdown entirely.
     pub suggestions: ReadSignal<Vec<SuggestionItem>>,
-    /// When true, each chip is prefixed with an uppercase-initials
-    /// avatar. Used by author chips (`me-avatar`); off for tags.
-    #[props(default = false)]
-    pub show_avatar: bool,
-    /// CSS class for the inline `<input>`. Defaults to `me-chip-input`
-    /// (the author/landing-row style); tag rows pass `me-tag-input`.
-    #[props(default = "me-chip-input".to_string())]
-    pub input_class: String,
-    /// Prefix for the per-chip Remove button's `aria-label`, e.g.
-    /// "Remove" → "Remove Ada Lovelace" or "Remove tag" → "Remove tag
-    /// fiction".
-    #[props(default = "Remove".to_string())]
-    pub aria_remove_prefix: String,
-    /// Per-instance testid prefix so multiple ChipEditors on one page
-    /// don't collide. The `<input>` gets `<prefix>-input` and the
-    /// suggestions `<ul>` gets `<prefix>-suggestions`. Suggestion
-    /// `<li>`s use `role="option"` with the suggestion as accessible
-    /// name (no per-row testid) so Playwright resolves them via
-    /// `getByRole("option", { name })`.
-    #[props(default = "chip-editor".to_string())]
-    pub testid_prefix: String,
-    /// When `true`, the inline `<input>` receives `autofocus` so the
-    /// dropdown surfaces on first paint. Used by the landing-page
-    /// Authors cell so admins don't have to click twice (once to
-    /// enter edit mode, once to focus the input). Off by default to
-    /// keep the metadata-edit page from stealing focus from the page's
-    /// other fields on mount.
-    #[props(default = false)]
-    pub autofocus: bool,
-    /// Optional uppercase mini-header rendered at the top of the
-    /// suggestion dropdown — "ADD AUTHOR" / "ADD TAG". Empty string (the
-    /// default) suppresses the header entirely.
-    #[props(default)]
-    pub dropdown_header: String,
     /// Fired when the user presses Escape inside the input. Useful for
     /// host components that want to exit a wrapping edit mode in
     /// addition to clearing the dropdown highlight. Default no-op.
     #[props(default)]
     pub on_close: EventHandler<()>,
+    /// Presentational knobs (placeholder, avatar, testids, …).
+    #[props(default)]
+    pub options: ChipEditorOptions,
 }
 
 /// Add/remove chip editor with autocomplete dropdown.
@@ -103,7 +124,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
     // re-surface the pool; any keystroke / fresh focus clears it.
     let mut input = use_signal(String::new);
     let mut highlight = use_signal::<Option<usize>>(|| None);
-    let mut focused = use_signal(|| props.autofocus);
+    let mut focused = use_signal(|| props.options.autofocus);
     let mut suppress_open = use_signal(|| false);
 
     let selection = compute_selection(&props, input(), focused(), suppress_open());
@@ -138,8 +159,8 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
         Fragment {
             ChipList {
                 values: values_sig,
-                show_avatar: props.show_avatar,
-                aria_remove_prefix: props.aria_remove_prefix.clone(),
+                show_avatar: props.options.show_avatar,
+                aria_remove_prefix: props.options.aria_remove_prefix.clone(),
                 on_remove: move |new_values: Vec<String>| {
                     values_sig.set(new_values.clone());
                     on_change_remove.call(new_values);
@@ -147,11 +168,11 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
             }
             ChipInputArea {
                 input,
-                placeholder: props.placeholder.clone(),
-                input_class: props.input_class.clone(),
-                testid_prefix: props.testid_prefix.clone(),
-                autofocus: props.autofocus,
-                dropdown_header: props.dropdown_header.clone(),
+                placeholder: props.options.placeholder.clone(),
+                input_class: props.options.input_class.clone(),
+                testid_prefix: props.options.testid_prefix.clone(),
+                autofocus: props.options.autofocus,
+                dropdown_header: props.options.dropdown_header.clone(),
                 selection,
                 highlight: highlight(),
                 on_focus: move |_| {
@@ -401,9 +422,9 @@ fn dispatch_keydown(
     }
 }
 
-/// Inline `<input>` for the chip editor — owns nothing, forwards every event to the parent's handlers.
-#[component]
-fn ChipInput(
+/// Props for the [`ChipInput`] sub-component.
+#[derive(Props, Clone, PartialEq)]
+struct ChipInputProps {
     input: Signal<String>,
     placeholder: String,
     input_class: String,
@@ -413,7 +434,22 @@ fn ChipInput(
     on_blur: EventHandler<()>,
     on_input: EventHandler<String>,
     on_keydown: EventHandler<Event<KeyboardData>>,
-) -> Element {
+}
+
+/// Inline `<input>` for the chip editor — owns nothing, forwards every event to the parent's handlers.
+#[component]
+fn ChipInput(props: ChipInputProps) -> Element {
+    let ChipInputProps {
+        input,
+        placeholder,
+        input_class,
+        testid,
+        autofocus,
+        on_focus,
+        on_blur,
+        on_input,
+        on_keydown,
+    } = props;
     rsx! {
         input {
             class: "{input_class}",

--- a/frontend/src/pages/auth/register.rs
+++ b/frontend/src/pages/auth/register.rs
@@ -13,6 +13,18 @@ use crate::{use_server_url, Route};
 use super::m_auth_shell;
 use super::submit_register;
 
+/// Form-input signals shared across the register form body and its fields:
+/// the two inputs, the routed error, the in-flight flag, and the terms
+/// checkbox. Grouped so [`RegisterForm`] stays under the prop cap.
+#[derive(Clone, Copy, PartialEq)]
+struct RegisterFormState {
+    username: Signal<String>,
+    password: Signal<String>,
+    error: Signal<Option<RegisterError>>,
+    submitting: Signal<bool>,
+    terms_ack: Signal<bool>,
+}
+
 /// Renders the register page.
 #[component]
 pub fn RegisterPage() -> Element {
@@ -56,11 +68,13 @@ pub fn RegisterPage() -> Element {
     // (`RegisterForm`), only the surrounding shell differs.
     let form = rsx! {
         RegisterForm {
-            username,
-            password,
-            error,
-            submitting,
-            terms_ack,
+            state: RegisterFormState {
+                username,
+                password,
+                error,
+                submitting,
+                terms_ack,
+            },
             on_submit_now: move |_| submit_now.call(()),
         }
     };
@@ -135,14 +149,14 @@ fn register_submit_handlers(
 
 /// Register form body — inputs write the parent's signals through, submission delegates via `on_submit_now`.
 #[component]
-fn RegisterForm(
-    username: Signal<String>,
-    password: Signal<String>,
-    error: Signal<Option<RegisterError>>,
-    submitting: Signal<bool>,
-    mut terms_ack: Signal<bool>,
-    on_submit_now: EventHandler<()>,
-) -> Element {
+fn RegisterForm(state: RegisterFormState, on_submit_now: EventHandler<()>) -> Element {
+    let RegisterFormState {
+        username,
+        password,
+        error,
+        submitting,
+        mut terms_ack,
+    } = state;
     let (on_submit, on_keydown) = register_submit_handlers(submitting, error, on_submit_now);
 
     let err = error();

--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -14,6 +14,43 @@ use crate::{data, use_server_url};
 use super::journal_editor::*;
 use super::BdSectionHead;
 
+/// Draft-composer signals owned by [`BdJournalComposer`] and threaded into
+/// its footer. Grouped so the composer sub-components stay under the prop cap.
+#[derive(Clone, Copy, PartialEq)]
+struct JournalComposerState {
+    open: Signal<bool>,
+    body: Signal<String>,
+    track_progress: Signal<bool>,
+    progress: Signal<i64>,
+    saving: Signal<bool>,
+    error: Signal<Option<String>>,
+    show_preview: Signal<bool>,
+}
+
+/// Per-entry inline-edit signals shared by the entry card, its header action
+/// row, and the edit form. Grouped so those components stay under the prop cap.
+#[derive(Clone, Copy, PartialEq)]
+struct JournalEntryEditState {
+    editing: Signal<bool>,
+    edit_body: Signal<String>,
+    saving: Signal<bool>,
+    error: Signal<Option<String>>,
+    reload: Signal<u32>,
+}
+
+/// Presentational fields for a journal entry card header (author identity,
+/// meta line, and the data an owner's Edit action needs to seed the form).
+#[derive(Clone, PartialEq)]
+struct JournalEntryHeaderView {
+    author_name: String,
+    initial: String,
+    is_owner: bool,
+    meta_line: String,
+    entry_id: i64,
+    body_for_edit: String,
+    server_url: String,
+}
+
 /// Public reading-journal section: header, composer, and the entry feed.
 #[component]
 pub(super) fn BdJournalSection(uuid: String) -> Element {
@@ -178,13 +215,15 @@ fn BdJournalComposer(uuid: String, server_url: String, reload: Signal<u32>) -> E
                 uuid,
                 server_url,
                 reload,
-                open,
-                body,
-                track_progress,
-                progress,
-                saving,
-                error,
-                show_preview,
+                state: JournalComposerState {
+                    open,
+                    body,
+                    track_progress,
+                    progress,
+                    saving,
+                    error,
+                    show_preview,
+                },
             }
         }
     }
@@ -415,14 +454,17 @@ fn BdJournalComposerFoot(
     uuid: String,
     server_url: String,
     reload: Signal<u32>,
-    open: Signal<bool>,
-    body: Signal<String>,
-    track_progress: Signal<bool>,
-    progress: Signal<i64>,
-    saving: Signal<bool>,
-    error: Signal<Option<String>>,
-    show_preview: Signal<bool>,
+    state: JournalComposerState,
 ) -> Element {
+    let JournalComposerState {
+        open,
+        body,
+        mut track_progress,
+        progress,
+        saving,
+        error,
+        show_preview,
+    } = state;
     let mut reload = reload;
     let mut open = open;
     let mut body = body;
@@ -487,20 +529,23 @@ fn BdJournalComposerFoot(
 /// editing — the Edit/Delete action row. Delete removes the entry and
 /// reloads the feed; Edit seeds the edit-form body and opens it.
 #[component]
-fn BdJournalEntryHeader(
-    author_name: String,
-    initial: String,
-    is_owner: bool,
-    meta_line: String,
-    entry_id: i64,
-    body_for_edit: String,
-    server_url: String,
-    editing: Signal<bool>,
-    edit_body: Signal<String>,
-    saving: Signal<bool>,
-    error: Signal<Option<String>>,
-    reload: Signal<u32>,
-) -> Element {
+fn BdJournalEntryHeader(view: JournalEntryHeaderView, edit: JournalEntryEditState) -> Element {
+    let JournalEntryHeaderView {
+        author_name,
+        initial,
+        is_owner,
+        meta_line,
+        entry_id,
+        body_for_edit,
+        server_url,
+    } = view;
+    let JournalEntryEditState {
+        editing,
+        edit_body,
+        saving,
+        error,
+        reload,
+    } = edit;
     let mut editing = editing;
     let mut edit_body = edit_body;
     let mut saving = saving;
@@ -566,10 +611,15 @@ fn BdJournalEntryCard(
     server_url: String,
     reload: Signal<u32>,
 ) -> Element {
-    let editing = use_signal(|| false);
-    let edit_body = use_signal(|| entry.body_md.clone());
-    let saving = use_signal(|| false);
-    let error = use_signal(|| None::<String>);
+    let edit = JournalEntryEditState {
+        editing: use_signal(|| false),
+        edit_body: use_signal(|| entry.body_md.clone()),
+        saving: use_signal(|| false),
+        error: use_signal(|| None::<String>),
+        reload,
+    };
+    let editing = edit.editing;
+    let error = edit.error;
 
     let is_owner = current_user
         .as_ref()
@@ -592,29 +642,23 @@ fn BdJournalEntryCard(
     rsx! {
         article { class: "card bd-journal-entry", "data-testid": "journal-entry",
             BdJournalEntryHeader {
-                author_name: entry.author_name.clone(),
-                initial,
-                is_owner,
-                meta_line,
-                entry_id,
-                body_for_edit: entry.body_md.clone(),
-                server_url: server_url.clone(),
-                editing,
-                edit_body,
-                saving,
-                error,
-                reload,
+                view: JournalEntryHeaderView {
+                    author_name: entry.author_name.clone(),
+                    initial,
+                    is_owner,
+                    meta_line,
+                    entry_id,
+                    body_for_edit: entry.body_md.clone(),
+                    server_url: server_url.clone(),
+                },
+                edit,
             }
             if editing() {
                 BdJournalEntryEditForm {
                     entry_id,
                     entry_progress,
                     server_url: server_url.clone(),
-                    edit_body,
-                    saving,
-                    error,
-                    editing,
-                    reload,
+                    edit,
                 }
             } else {
                 div {
@@ -675,12 +719,15 @@ fn BdJournalEntryEditForm(
     entry_id: i64,
     entry_progress: Option<u8>,
     server_url: String,
-    edit_body: Signal<String>,
-    saving: Signal<bool>,
-    error: Signal<Option<String>>,
-    editing: Signal<bool>,
-    reload: Signal<u32>,
+    edit: JournalEntryEditState,
 ) -> Element {
+    let JournalEntryEditState {
+        editing,
+        edit_body,
+        saving,
+        error,
+        reload,
+    } = edit;
     let mut saving = saving;
     let mut error = error;
     let mut editing = editing;

--- a/frontend/src/pages/book_detail/rating.rs
+++ b/frontend/src/pages/book_detail/rating.rs
@@ -10,6 +10,17 @@ use omnibus_shared::{RatingRecord, RatingUpdate};
 
 use crate::{data, use_server_url};
 
+/// Live rating signals shared between [`BdRatingWidget`] and each
+/// [`BdStarHalf`] click target: the persisted record, hover preview, failed
+/// flag, and the monotonic op counter. Grouped to keep the half under the cap.
+#[derive(Clone, Copy, PartialEq)]
+struct RatingState {
+    current: Signal<Option<RatingRecord>>,
+    hover: Signal<Option<f32>>,
+    failed: Signal<bool>,
+    op_seq: Signal<u64>,
+}
+
 /// Clickable 0.5–5.0 star rating bound to the current user and `uuid`.
 #[component]
 pub(super) fn BdRatingWidget(uuid: String) -> Element {
@@ -23,6 +34,12 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
     // Monotonic write counter: a save only applies its result if it's still the
     // latest, so an out-of-order (slow) response can't clobber a newer click.
     let op_seq = use_signal(|| 0u64);
+    let state = RatingState {
+        current,
+        hover,
+        failed,
+        op_seq,
+    };
 
     let load_url = server_url.clone();
     use_effect(use_reactive!(|uuid| {
@@ -81,20 +98,14 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
                                 side: "left",
                                 uuid: uuid.clone(),
                                 server_url: server_url.clone(),
-                                current,
-                                hover,
-                                failed,
-                                op_seq,
+                                state,
                             }
                             BdStarHalf {
                                 value: slot,
                                 side: "right",
                                 uuid: uuid.clone(),
                                 server_url: server_url.clone(),
-                                current,
-                                hover,
-                                failed,
-                                op_seq,
+                                state,
                             }
                         }
                     }
@@ -118,11 +129,14 @@ fn BdStarHalf(
     side: &'static str,
     uuid: String,
     server_url: String,
-    current: Signal<Option<RatingRecord>>,
-    hover: Signal<Option<f32>>,
-    failed: Signal<bool>,
-    op_seq: Signal<u64>,
+    state: RatingState,
 ) -> Element {
+    let RatingState {
+        current,
+        mut hover,
+        failed,
+        op_seq,
+    } = state;
     rsx! {
         button {
             r#type: "button",

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -9,8 +9,32 @@ use omnibus_shared::{Contributor, EbookMetadata, MetadataOverrides};
 
 use super::super::filtering::format_badge_label;
 use super::EditField;
-use crate::components::chip_editor::{ChipEditor, SuggestionItem};
+use crate::components::chip_editor::{ChipEditor, ChipEditorOptions, SuggestionItem};
 use crate::data;
+
+/// Shared edit context for a scalar cell wrapper: admin gating, the row's
+/// current editing signal, and the per-field save callback. Grouped so the
+/// title/series/scalar wrappers stay under the prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct CellEditCtx {
+    pub is_admin: bool,
+    pub editing: Signal<Option<EditField>>,
+    pub save_field: EventHandler<(EditField, String)>,
+}
+
+/// Per-row context threaded from `EbookRow` through `EbookRowMarkup` into
+/// `EbookRowCells`: admin gating, editing state, the authors chip draft +
+/// suggestion pool, and the two save callbacks. Grouped so the row markup
+/// components stay under the prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct RowContext {
+    pub is_admin: bool,
+    pub editing: Signal<Option<EditField>>,
+    pub authors_draft: Signal<Vec<String>>,
+    pub author_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    pub save_field: EventHandler<(EditField, String)>,
+    pub save_authors: EventHandler<Vec<String>>,
+}
 
 /// Build the common per-cell save callback. Empty strings clear the
 /// override (None — the scanned value re-surfaces); non-empty strings
@@ -92,13 +116,12 @@ pub(super) fn build_save_authors(
 /// Title cell wrapper — pre-wires the title field's [`EditableCell`] props
 /// and routes its `on_save` through the shared row save callback.
 #[component]
-pub(super) fn RowTitleCell(
-    title: String,
-    error: Option<String>,
-    is_admin: bool,
-    editing: Signal<Option<EditField>>,
-    save_field: EventHandler<(EditField, String)>,
-) -> Element {
+pub(super) fn RowTitleCell(title: String, error: Option<String>, ctx: CellEditCtx) -> Element {
+    let CellEditCtx {
+        is_admin,
+        editing,
+        save_field,
+    } = ctx;
     rsx! {
         EditableCell {
             col_class: "ebook-col-title".to_string(),
@@ -117,13 +140,12 @@ pub(super) fn RowTitleCell(
 /// Series cell wrapper — display shows "Name #Index" (F1.3), edit input
 /// seeds with just the series name (the index lives on the full edit page).
 #[component]
-pub(super) fn RowSeriesCell(
-    series_line: String,
-    series_text: String,
-    is_admin: bool,
-    editing: Signal<Option<EditField>>,
-    save_field: EventHandler<(EditField, String)>,
-) -> Element {
+pub(super) fn RowSeriesCell(series_line: String, series_text: String, ctx: CellEditCtx) -> Element {
+    let CellEditCtx {
+        is_admin,
+        editing,
+        save_field,
+    } = ctx;
     rsx! {
         EditableCell {
             col_class: "ebook-col-series".to_string(),
@@ -150,10 +172,13 @@ pub(super) fn RowScalarCell(
     field: EditField,
     value: String,
     placeholder: String,
-    is_admin: bool,
-    editing: Signal<Option<EditField>>,
-    save_field: EventHandler<(EditField, String)>,
+    ctx: CellEditCtx,
 ) -> Element {
+    let CellEditCtx {
+        is_admin,
+        editing,
+        save_field,
+    } = ctx;
     rsx! {
         EditableCell {
             col_class,
@@ -214,17 +239,13 @@ pub(super) fn EbookRowFormatsCell(formats: Vec<String>) -> Element {
     }
 }
 
-/// Inline-editable text cell used by `EbookRow`. Renders a span of text by
-/// default; in admin mode, a click swaps to a text input that commits via the
-/// `on_save` prop on Enter or blur and cancels on Escape. The input's `onclick`
-/// stops propagation so the row-level navigate handler doesn't fire while the
-/// user is editing.
-#[component]
-pub(super) fn EditableCell(
-    col_class: String,
-    cell_testid: String,
-    field: EditField,
-    display_value: String,
+/// Props for the [`EditableCell`] component.
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct EditableCellProps {
+    pub col_class: String,
+    pub cell_testid: String,
+    pub field: EditField,
+    pub display_value: String,
     /// Separate value used to seed the input when edit mode opens.
     /// Some cells render a richer display string than the underlying
     /// scalar override — Series shows "Pioneers #1" but only "Pioneers"
@@ -232,13 +253,33 @@ pub(super) fn EditableCell(
     /// input seeds (and the blur-comparison runs against) the editable
     /// scalar, not the rendered text. Defaults to `display_value`.
     #[props(default)]
-    edit_value: Option<String>,
-    is_admin: bool,
-    editing: Signal<Option<EditField>>,
-    placeholder: String,
-    on_save: EventHandler<String>,
-    error: Option<String>,
-) -> Element {
+    pub edit_value: Option<String>,
+    pub is_admin: bool,
+    pub editing: Signal<Option<EditField>>,
+    pub placeholder: String,
+    pub on_save: EventHandler<String>,
+    pub error: Option<String>,
+}
+
+/// Inline-editable text cell used by `EbookRow`. Renders a span of text by
+/// default; in admin mode, a click swaps to a text input that commits via the
+/// `on_save` prop on Enter or blur and cancels on Escape. The input's `onclick`
+/// stops propagation so the row-level navigate handler doesn't fire while the
+/// user is editing.
+#[component]
+pub(super) fn EditableCell(props: EditableCellProps) -> Element {
+    let EditableCellProps {
+        col_class,
+        cell_testid,
+        field,
+        display_value,
+        edit_value,
+        is_admin,
+        editing,
+        placeholder,
+        on_save,
+        error,
+    } = props;
     let mut editing = editing;
     let mut draft = use_signal(String::new);
     let is_editing = editing() == Some(field);
@@ -393,14 +434,17 @@ pub(super) fn AuthorsCell(props: AuthorsCellProps) -> Element {
                 div { class: "ebook-cell-chip-host",
                     ChipEditor {
                         values: authors_draft,
-                        placeholder: "+ add author\u{2026}".to_string(),
                         on_change,
                         suggestions,
-                        show_avatar: false,
-                        aria_remove_prefix: "Remove".to_string(),
-                        testid_prefix: "ebook-cell-author".to_string(),
-                        autofocus: true,
-                        dropdown_header: "ADD AUTHOR".to_string(),
+                        options: ChipEditorOptions {
+                            placeholder: "+ add author\u{2026}".to_string(),
+                            show_avatar: false,
+                            aria_remove_prefix: "Remove".to_string(),
+                            testid_prefix: "ebook-cell-author".to_string(),
+                            autofocus: true,
+                            dropdown_header: "ADD AUTHOR".to_string(),
+                            ..ChipEditorOptions::default()
+                        },
                         on_close: move |_| {
                             editing.set(None);
                         },

--- a/frontend/src/pages/landing/table/row.rs
+++ b/frontend/src/pages/landing/table/row.rs
@@ -10,11 +10,10 @@ use omnibus_shared::EbookMetadata;
 
 use super::super::sorting::{contributor_names, row_slug};
 use super::cells::{
-    build_save_authors, build_save_field, AuthorsCell, EbookRowCoverCell, EbookRowFormatsCell,
-    RowScalarCell, RowSeriesCell, RowTitleCell,
+    build_save_authors, build_save_field, AuthorsCell, CellEditCtx, EbookRowCoverCell,
+    EbookRowFormatsCell, RowContext, RowScalarCell, RowSeriesCell, RowTitleCell,
 };
 use super::{BookTableContext, EditField};
-use crate::components::chip_editor::SuggestionItem;
 use crate::Route;
 
 /// One row in the power-user table for `book`.
@@ -33,17 +32,17 @@ pub(super) fn EbookRow(book: EbookMetadata, ctx: BookTableContext) -> Element {
     let save_authors = build_save_authors(uuid.clone(), server_url.clone(), book_state);
     let display = derive_row_display(&book_state.read(), &server_url, &uuid);
 
+    let ctx = RowContext {
+        is_admin,
+        editing,
+        authors_draft,
+        author_suggestions,
+        save_field: EventHandler::new(save_field),
+        save_authors: EventHandler::new(save_authors),
+    };
+
     rsx! {
-        EbookRowMarkup {
-            display,
-            uuid,
-            is_admin,
-            editing,
-            authors_draft,
-            author_suggestions,
-            save_field,
-            save_authors,
-        }
+        EbookRowMarkup { display, uuid, ctx }
     }
 }
 
@@ -152,16 +151,8 @@ fn derive_row_display(book: &EbookMetadata, server_url: &str, uuid: &str) -> Row
 /// so the parent stays a thin state-setup shell. All inputs are already
 /// derived; this component does no signal seeding of its own.
 #[component]
-fn EbookRowMarkup(
-    display: RowDisplay,
-    uuid: String,
-    is_admin: bool,
-    editing: Signal<Option<EditField>>,
-    authors_draft: Signal<Vec<String>>,
-    author_suggestions: ReadSignal<Vec<SuggestionItem>>,
-    save_field: EventHandler<(EditField, String)>,
-    save_authors: EventHandler<Vec<String>>,
-) -> Element {
+fn EbookRowMarkup(display: RowDisplay, uuid: String, ctx: RowContext) -> Element {
+    let editing = ctx.editing;
     let nav = use_navigator();
     let uuid_click = uuid.clone();
     let uuid_key = uuid;
@@ -199,15 +190,7 @@ fn EbookRowMarkup(
                     nav.push(Route::BookDetail { uuid: uuid_key.clone() });
                 }
             },
-            EbookRowCells {
-                display,
-                is_admin,
-                editing,
-                authors_draft,
-                author_suggestions,
-                save_field,
-                save_authors,
-            }
+            EbookRowCells { display, ctx }
         }
     }
 }
@@ -216,15 +199,22 @@ fn EbookRowMarkup(
 /// [`EbookRowMarkup`] so the row-level event handlers and the per-cell
 /// wiring live in separate functions.
 #[component]
-fn EbookRowCells(
-    display: RowDisplay,
-    is_admin: bool,
-    editing: Signal<Option<EditField>>,
-    authors_draft: Signal<Vec<String>>,
-    author_suggestions: ReadSignal<Vec<SuggestionItem>>,
-    save_field: EventHandler<(EditField, String)>,
-    save_authors: EventHandler<Vec<String>>,
-) -> Element {
+fn EbookRowCells(display: RowDisplay, ctx: RowContext) -> Element {
+    let RowContext {
+        is_admin,
+        editing,
+        authors_draft,
+        author_suggestions,
+        save_field,
+        save_authors,
+    } = ctx;
+    // Cloned per scalar cell so each wrapper owns its own copy of the shared
+    // admin/editing/save context.
+    let cell_ctx = CellEditCtx {
+        is_admin,
+        editing,
+        save_field,
+    };
     let RowDisplay {
         book,
         row_testid: _,
@@ -245,13 +235,7 @@ fn EbookRowCells(
 
     rsx! {
         EbookRowCoverCell { thumb_src, thumb_srcset, has_cover, alt_title: cover_alt }
-        RowTitleCell {
-            title,
-            error: book.error,
-            is_admin,
-            editing,
-            save_field,
-        }
+        RowTitleCell { title, error: book.error, ctx: cell_ctx.clone() }
         AuthorsCell {
             is_admin,
             editing,
@@ -260,16 +244,14 @@ fn EbookRowCells(
             suggestions: author_suggestions,
             on_change: move |names: Vec<String>| save_authors.call(names),
         }
-        RowSeriesCell { series_line, series_text, is_admin, editing, save_field }
+        RowSeriesCell { series_line, series_text, ctx: cell_ctx.clone() }
         RowScalarCell {
             col_class: "ebook-col-publisher".to_string(),
             cell_testid: "ebook-cell-publisher".to_string(),
             field: EditField::Publisher,
             value: publisher,
             placeholder: "Publisher".to_string(),
-            is_admin,
-            editing,
-            save_field,
+            ctx: cell_ctx.clone(),
         }
         RowScalarCell {
             col_class: "ebook-col-published".to_string(),
@@ -277,9 +259,7 @@ fn EbookRowCells(
             field: EditField::Published,
             value: published,
             placeholder: "YYYY-MM-DD".to_string(),
-            is_admin,
-            editing,
-            save_field,
+            ctx: cell_ctx.clone(),
         }
         EbookRowFormatsCell { formats: book.formats }
         td { class: "ebook-col-updated", "data-testid": "ebook-cell-updated", "{updated}" }
@@ -290,9 +270,7 @@ fn EbookRowCells(
             field: EditField::Language,
             value: language,
             placeholder: "en".to_string(),
-            is_admin,
-            editing,
-            save_field,
+            ctx: cell_ctx,
         }
     }
 }

--- a/frontend/src/pages/metadata_edit/fields.rs
+++ b/frontend/src/pages/metadata_edit/fields.rs
@@ -60,21 +60,58 @@ pub(super) fn label_to_id(label: &str) -> String {
     )
 }
 
+/// Props for the [`MeField`] component.
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct MeFieldProps {
+    /// Field label; also slugified into the input's `id` and used as the
+    /// fallback placeholder.
+    pub label: String,
+    /// The input's bound value signal.
+    pub value: Signal<String>,
+    /// Fired with the new text on every input.
+    pub on_change: EventHandler<String>,
+    /// Grid width in columns (`2` spans two columns; anything else is one).
+    #[props(default)]
+    pub w: i32,
+    /// Big serif display styling (title field).
+    #[props(default)]
+    pub big: bool,
+    /// Serif input styling.
+    #[props(default)]
+    pub serif: bool,
+    /// Monospace input styling.
+    #[props(default)]
+    pub mono: bool,
+    /// When true, applies the "edited" accent + badge.
+    #[props(default)]
+    pub edited: bool,
+    /// Renders the input read-only + disabled.
+    #[props(default)]
+    pub locked: bool,
+    /// Optional hint copy shown beside the label.
+    #[props(default)]
+    pub hint: String,
+    /// Overrides the placeholder (defaults to the label when empty).
+    #[props(default)]
+    pub placeholder: String,
+}
+
 /// Single-line input field in the form grid.
 #[component]
-pub(super) fn MeField(
-    label: String,
-    value: Signal<String>,
-    on_change: EventHandler<String>,
-    #[props(default)] w: i32,
-    #[props(default)] big: bool,
-    #[props(default)] serif: bool,
-    #[props(default)] mono: bool,
-    #[props(default)] edited: bool,
-    #[props(default)] locked: bool,
-    #[props(default)] hint: String,
-    #[props(default)] placeholder: String,
-) -> Element {
+pub(super) fn MeField(props: MeFieldProps) -> Element {
+    let MeFieldProps {
+        label,
+        value,
+        on_change,
+        w,
+        big,
+        serif,
+        mono,
+        edited,
+        locked,
+        hint,
+        placeholder,
+    } = props;
     let col_class = match w {
         2 => "me-field me-field-w2",
         _ => "me-field",

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -6,7 +6,7 @@ use dioxus::prelude::*;
 use omnibus_shared::EbookMetadata;
 
 use super::fields::{MeArea, MeField, MeLabel};
-use crate::components::chip_editor::{ChipEditor, SuggestionItem};
+use crate::components::chip_editor::{ChipEditor, ChipEditorOptions, SuggestionItem};
 
 /// Per-field editable signals threaded through the form rows from `MetadataEditForm`.
 #[derive(Clone, Copy, PartialEq)]
@@ -138,12 +138,15 @@ fn FieldGrid(
                 div { class: "me-chip-row",
                     ChipEditor {
                         values: authors,
-                        placeholder: "+ add author\u{2026}".to_string(),
                         on_change: move |_| {},
                         suggestions: author_suggestions,
-                        show_avatar: true,
-                        aria_remove_prefix: "Remove".to_string(),
-                        testid_prefix: "me-authors".to_string(),
+                        options: ChipEditorOptions {
+                            placeholder: "+ add author\u{2026}".to_string(),
+                            show_avatar: true,
+                            aria_remove_prefix: "Remove".to_string(),
+                            testid_prefix: "me-authors".to_string(),
+                            ..ChipEditorOptions::default()
+                        },
                     }
                 }
             }
@@ -172,13 +175,16 @@ fn TagsSection(tags: Signal<Vec<String>>, tag_suggestions: Signal<Vec<Suggestion
         div { class: "me-tag-chips",
             ChipEditor {
                 values: tags,
-                placeholder: "+ add tag\u{2026}".to_string(),
                 on_change: move |_| {},
                 suggestions: tag_suggestions,
-                show_avatar: false,
-                input_class: "me-tag-input".to_string(),
-                aria_remove_prefix: "Remove tag".to_string(),
-                testid_prefix: "me-tags".to_string(),
+                options: ChipEditorOptions {
+                    placeholder: "+ add tag\u{2026}".to_string(),
+                    show_avatar: false,
+                    input_class: "me-tag-input".to_string(),
+                    aria_remove_prefix: "Remove tag".to_string(),
+                    testid_prefix: "me-tags".to_string(),
+                    ..ChipEditorOptions::default()
+                },
             }
         }
     }

--- a/frontend/src/pages/reader/chrome.rs
+++ b/frontend/src/pages/reader/chrome.rs
@@ -7,6 +7,31 @@ use dioxus::prelude::*;
 use super::signals::ReaderStatus;
 use super::ReaderPanelSignals;
 
+/// Display state for [`ReaderTopChrome`]: the titles plus which tools read as
+/// active and the highlight badge count. Grouped to keep the row under the cap.
+#[derive(Clone, PartialEq)]
+struct ReaderChromeState {
+    book_title: String,
+    chapter_title: String,
+    show_aa: bool,
+    toc_active: bool,
+    search_active: bool,
+    highlights_active: bool,
+    bookmarks_active: bool,
+    highlight_count: usize,
+}
+
+/// Click handlers for [`ReaderTopChrome`]: back plus one toggle per tool.
+#[derive(Clone, PartialEq)]
+struct ReaderChromeHandlers {
+    on_back: EventHandler<MouseEvent>,
+    on_toggle_aa: EventHandler<MouseEvent>,
+    on_toggle_toc: EventHandler<MouseEvent>,
+    on_toggle_search: EventHandler<MouseEvent>,
+    on_toggle_highlights: EventHandler<MouseEvent>,
+    on_toggle_bookmarks: EventHandler<MouseEvent>,
+}
+
 /// Owns the mutually-exclusive overlay toggles and renders [`ReaderTopChrome`].
 /// Each tool closes every other surface before opening its own.
 #[component]
@@ -47,44 +72,48 @@ pub(super) fn ReaderTopBar(
 
     rsx! {
         ReaderTopChrome {
-            book_title,
-            chapter_title,
-            show_aa: show_aa(),
-            toc_active: show_toc(),
-            search_active: show_search(),
-            highlights_active: show_highlights(),
-            bookmarks_active: show_bookmarks(),
-            highlight_count,
-            on_back,
-            on_toggle_aa: move |_| {
-                let cur = show_aa();
-                close_overlays();
-                let mut s = show_aa;
-                s.set(!cur);
+            state: ReaderChromeState {
+                book_title,
+                chapter_title,
+                show_aa: show_aa(),
+                toc_active: show_toc(),
+                search_active: show_search(),
+                highlights_active: show_highlights(),
+                bookmarks_active: show_bookmarks(),
+                highlight_count,
             },
-            on_toggle_toc: move |_| {
-                let cur = show_toc();
-                close_overlays();
-                let mut s = show_toc;
-                s.set(!cur);
-            },
-            on_toggle_search: move |_| {
-                let cur = show_search();
-                close_overlays();
-                let mut s = show_search;
-                s.set(!cur);
-            },
-            on_toggle_highlights: move |_| {
-                let cur = show_highlights();
-                close_overlays();
-                let mut s = show_highlights;
-                s.set(!cur);
-            },
-            on_toggle_bookmarks: move |_| {
-                let cur = show_bookmarks();
-                close_overlays();
-                let mut s = show_bookmarks;
-                s.set(!cur);
+            handlers: ReaderChromeHandlers {
+                on_back,
+                on_toggle_aa: EventHandler::new(move |_| {
+                    let cur = show_aa();
+                    close_overlays();
+                    let mut s = show_aa;
+                    s.set(!cur);
+                }),
+                on_toggle_toc: EventHandler::new(move |_| {
+                    let cur = show_toc();
+                    close_overlays();
+                    let mut s = show_toc;
+                    s.set(!cur);
+                }),
+                on_toggle_search: EventHandler::new(move |_| {
+                    let cur = show_search();
+                    close_overlays();
+                    let mut s = show_search;
+                    s.set(!cur);
+                }),
+                on_toggle_highlights: EventHandler::new(move |_| {
+                    let cur = show_highlights();
+                    close_overlays();
+                    let mut s = show_highlights;
+                    s.set(!cur);
+                }),
+                on_toggle_bookmarks: EventHandler::new(move |_| {
+                    let cur = show_bookmarks();
+                    close_overlays();
+                    let mut s = show_bookmarks;
+                    s.set(!cur);
+                }),
             },
         }
     }
@@ -92,22 +121,25 @@ pub(super) fn ReaderTopBar(
 
 /// Top navigation bar: back button, title + chapter display, Aa + bookmark tools.
 #[component]
-fn ReaderTopChrome(
-    book_title: String,
-    chapter_title: String,
-    show_aa: bool,
-    toc_active: bool,
-    search_active: bool,
-    highlights_active: bool,
-    bookmarks_active: bool,
-    highlight_count: usize,
-    on_back: EventHandler<MouseEvent>,
-    on_toggle_aa: EventHandler<MouseEvent>,
-    on_toggle_toc: EventHandler<MouseEvent>,
-    on_toggle_search: EventHandler<MouseEvent>,
-    on_toggle_highlights: EventHandler<MouseEvent>,
-    on_toggle_bookmarks: EventHandler<MouseEvent>,
-) -> Element {
+fn ReaderTopChrome(state: ReaderChromeState, handlers: ReaderChromeHandlers) -> Element {
+    let ReaderChromeState {
+        book_title,
+        chapter_title,
+        show_aa,
+        toc_active,
+        search_active,
+        highlights_active,
+        bookmarks_active,
+        highlight_count,
+    } = state;
+    let ReaderChromeHandlers {
+        on_back,
+        on_toggle_aa,
+        on_toggle_toc,
+        on_toggle_search,
+        on_toggle_highlights,
+        on_toggle_bookmarks,
+    } = handlers;
     rsx! {
         div {
             class: "rd-top",

--- a/frontend/src/pages/reader/overlays.rs
+++ b/frontend/src/pages/reader/overlays.rs
@@ -13,7 +13,7 @@ use super::note_composer::NoteComposer;
 use super::quote_panel::QuotePanel;
 use super::reader_bookmarks::ReaderBookmarksDrawer;
 use super::search_panel::SearchPanel;
-use super::selection::{SelectionData, SelectionPopover};
+use super::selection::{SelectionActions, SelectionAnchor, SelectionData, SelectionPopover};
 use super::toc_drawer::TocDrawer;
 use super::ReaderPanelSignals;
 
@@ -32,61 +32,65 @@ pub(super) fn ReaderSelectionPopover(
     };
     rsx! {
         SelectionPopover {
-            sel_rect_x: sel.rect.x,
-            sel_rect_y: sel.rect.y,
-            sel_rect_width: sel.rect.width,
-            sel_cfi: sel.cfi_range.clone(),
-            sel_text: sel.text.clone(),
-            on_dismiss: move |_| {
-                let mut selection = selection;
-                selection.set(None);
+            anchor: SelectionAnchor {
+                sel_rect_x: sel.rect.x,
+                sel_rect_y: sel.rect.y,
+                sel_rect_width: sel.rect.width,
+                sel_cfi: sel.cfi_range.clone(),
+                sel_text: sel.text.clone(),
             },
-            on_highlight: {
-                let uuid = uuid.clone();
-                move |(cfi, color, text): (String, HighlightColor, String)| {
+            actions: SelectionActions {
+                on_dismiss: EventHandler::new(move |_| {
                     let mut selection = selection;
                     selection.set(None);
-                    spawn_create_highlight(
-                        uuid.clone(), cfi, color, text,
-                        highlights, note_target, quote_target, PostCreate::None,
-                    );
-                }
-            },
-            on_note: {
-                let uuid = uuid.clone();
-                move |(cfi, text): (String, String)| {
+                }),
+                on_highlight: EventHandler::new({
+                    let uuid = uuid.clone();
+                    move |(cfi, color, text): (String, HighlightColor, String)| {
+                        let mut selection = selection;
+                        selection.set(None);
+                        spawn_create_highlight(
+                            uuid.clone(), cfi, color, text,
+                            highlights, note_target, quote_target, PostCreate::None,
+                        );
+                    }
+                }),
+                on_note: EventHandler::new({
+                    let uuid = uuid.clone();
+                    move |(cfi, text): (String, String)| {
+                        let mut selection = selection;
+                        selection.set(None);
+                        spawn_create_highlight(
+                            uuid.clone(), cfi, HighlightColor::Amber, text,
+                            highlights, note_target, quote_target, PostCreate::Note,
+                        );
+                    }
+                }),
+                on_quote: EventHandler::new({
+                    let uuid = uuid.clone();
+                    move |(cfi, text): (String, String)| {
+                        let mut selection = selection;
+                        selection.set(None);
+                        spawn_create_highlight(
+                            uuid.clone(), cfi, HighlightColor::Amber, text,
+                            highlights, note_target, quote_target, PostCreate::Quote,
+                        );
+                    }
+                }),
+                on_copy: EventHandler::new(move |text: String| {
+                    #[cfg(feature = "web")]
+                    super::reader_call_json("copyText", &text);
+                    let _ = &text;
                     let mut selection = selection;
                     selection.set(None);
-                    spawn_create_highlight(
-                        uuid.clone(), cfi, HighlightColor::Amber, text,
-                        highlights, note_target, quote_target, PostCreate::Note,
-                    );
-                }
-            },
-            on_quote: {
-                let uuid = uuid.clone();
-                move |(cfi, text): (String, String)| {
+                }),
+                on_share: EventHandler::new(move |text: String| {
+                    #[cfg(feature = "web")]
+                    super::reader_call_json("shareText", &text);
+                    let _ = &text;
                     let mut selection = selection;
                     selection.set(None);
-                    spawn_create_highlight(
-                        uuid.clone(), cfi, HighlightColor::Amber, text,
-                        highlights, note_target, quote_target, PostCreate::Quote,
-                    );
-                }
-            },
-            on_copy: move |text: String| {
-                #[cfg(feature = "web")]
-                super::reader_call_json("copyText", &text);
-                let _ = &text;
-                let mut selection = selection;
-                selection.set(None);
-            },
-            on_share: move |text: String| {
-                #[cfg(feature = "web")]
-                super::reader_call_json("shareText", &text);
-                let _ = &text;
-                let mut selection = selection;
-                selection.set(None);
+                }),
             },
         }
     }

--- a/frontend/src/pages/reader/selection.rs
+++ b/frontend/src/pages/reader/selection.rs
@@ -23,22 +23,47 @@ pub(crate) struct SelectionRect {
     pub(crate) width: f64,
 }
 
+/// Placement + payload for the selection popover: the live selection's screen
+/// rect plus the CFI/text the action handlers fire with.
+#[derive(Clone, PartialEq)]
+pub(crate) struct SelectionAnchor {
+    pub(crate) sel_rect_x: f64,
+    pub(crate) sel_rect_y: f64,
+    pub(crate) sel_rect_width: f64,
+    pub(crate) sel_cfi: String,
+    pub(crate) sel_text: String,
+}
+
+/// Action handlers for the selection popover — one per swatch/button.
+#[derive(Clone, PartialEq)]
+pub(crate) struct SelectionActions {
+    pub(crate) on_dismiss: EventHandler<MouseEvent>,
+    pub(crate) on_highlight: EventHandler<(String, HighlightColor, String)>,
+    pub(crate) on_note: EventHandler<(String, String)>,
+    pub(crate) on_copy: EventHandler<String>,
+    pub(crate) on_quote: EventHandler<(String, String)>,
+    pub(crate) on_share: EventHandler<String>,
+}
+
 /// Floating popover shown over a text selection: highlight color swatches
 /// plus Note / Copy / Share actions.
 #[component]
-pub(crate) fn SelectionPopover(
-    sel_rect_x: f64,
-    sel_rect_y: f64,
-    sel_rect_width: f64,
-    sel_cfi: String,
-    sel_text: String,
-    on_dismiss: EventHandler<MouseEvent>,
-    on_highlight: EventHandler<(String, HighlightColor, String)>,
-    on_note: EventHandler<(String, String)>,
-    on_copy: EventHandler<String>,
-    on_quote: EventHandler<(String, String)>,
-    on_share: EventHandler<String>,
-) -> Element {
+pub(crate) fn SelectionPopover(anchor: SelectionAnchor, actions: SelectionActions) -> Element {
+    let SelectionAnchor {
+        sel_rect_x,
+        sel_rect_y,
+        sel_rect_width,
+        sel_cfi,
+        sel_text,
+    } = anchor;
+    let SelectionActions {
+        on_dismiss,
+        on_highlight,
+        on_note,
+        on_copy,
+        on_quote,
+        on_share,
+    } = actions;
     let top = (sel_rect_y - 52.0).max(8.0);
     let left = (sel_rect_x + sel_rect_width / 2.0 - 150.0).clamp(8.0, 560.0);
     let style = format!("top:{top}px; left:{left}px;");

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -46,10 +46,12 @@ pub fn SeriesIndexPage() -> Element {
     rsx! {
         div { class: "idx-page",
             SeriesIndexHeader {
-                total_series,
-                total_books,
-                filter: filter_text,
-                sort: current_sort,
+                view: SeriesHeaderView {
+                    total_series,
+                    total_books,
+                    filter: filter_text,
+                    sort: current_sort,
+                },
                 on_filter: move |v| filter.set(v),
                 on_sort: move |s| sort.set(s),
             }
@@ -143,16 +145,29 @@ fn render_series_body(filtered: &[&SeriesSummary], library_empty: bool) -> Eleme
     }
 }
 
-/// Header: breadcrumb, hero heading + subtitle, filter input, sort toggles.
-#[component]
-fn SeriesIndexHeader(
+/// Display state for [`SeriesIndexHeader`]: the two counts plus the current
+/// filter text and sort mode. Grouped to keep the header under the prop cap.
+#[derive(Clone, PartialEq)]
+struct SeriesHeaderView {
     total_series: usize,
     total_books: usize,
     filter: String,
     sort: Sort,
+}
+
+/// Header: breadcrumb, hero heading + subtitle, filter input, sort toggles.
+#[component]
+fn SeriesIndexHeader(
+    view: SeriesHeaderView,
     on_filter: EventHandler<String>,
     on_sort: EventHandler<Sort>,
 ) -> Element {
+    let SeriesHeaderView {
+        total_series,
+        total_books,
+        filter,
+        sort,
+    } = view;
     rsx! {
         div { class: "idx-header",
             nav {


### PR DESCRIPTION
## Summary
- Closes #728. Groups the props of 15 Dioxus components that exceeded the ~5-prop threshold into one or more grouping structs (`#[derive(Props)]` where the struct *is* the component's props, or plain grouping structs / shared contexts threaded through), so no component signature trips clippy's `too_many_arguments`. No `#[allow(clippy::too_many_arguments)]` was added.
- Pure prop-grouping refactor: rendered rsx output is byte-for-byte unchanged (no `data-testid`/`role`/`aria-*`/class changes), so hydration parity (rule 07) and Playwright markup contracts (rule 04) are untouched.
- Stacked on #833 (`refactor/553-remove-section-dividers`) — this PR targets that branch, not `main`.

Groupings introduced, by theme:
- **Journal** (`book_detail/journal.rs`): `JournalComposerState` (composer draft signals), `JournalEntryEditState` (shared inline-edit signals used by the card, its header, and the edit form), `JournalEntryHeaderView` (header display data) — `BdJournalEntryHeader` 12→2 args, `BdJournalComposerFoot` 10→4, `BdJournalEntryEditForm` 8→4.
- **Reader**: `ReaderChromeState` + `ReaderChromeHandlers` (`reader/chrome.rs`, `ReaderTopChrome` 14→2); `SelectionAnchor` + `SelectionActions` (`reader/selection.rs`, `SelectionPopover` 11→2).
- **Landing table** (`landing/table/`): `RowContext` threaded `EbookRow`→`EbookRowMarkup`→`EbookRowCells`, and `CellEditCtx` fanned out to the scalar/title/series cell wrappers; `EditableCell` collapsed to a single `EditableCellProps` (10→1). `EbookRowMarkup` 8→3, `EbookRowCells` 7→2, `RowScalarCell` 8→6.
- **chip_editor.rs**: split `ChipEditorProps` into the data/behavior props + a `ChipEditorOptions` struct for the presentational knobs (call sites pass `options: ChipEditorOptions { .. }`); `ChipInput` 9→1 via `ChipInputProps`.
- **One-offs**: `MeField` 11→1 (`MeFieldProps`, mirrors the existing `MeAreaProps`); `BdStarHalf` 8→5 (`RatingState`); `RegisterForm` 6→2 (`RegisterFormState`); `SeriesIndexHeader` 6→3 (`SeriesHeaderView`).

## Test plan
Run from the workspace inside `nix develop`:

- `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean (this is what enforces the no-`too_many_arguments` AC). **PASS**
- `cargo test -p omnibus-frontend --features server` — 223 passed, 0 failed. **PASS**
- `cargo fmt --check` — clean. **PASS**
- `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` (frontend change → mobile host-target lint) — clean. **PASS**

## Notes
- Grouping structs that carry `Signal`/`EventHandler` fields derive `Clone, PartialEq` (and `Copy` where all fields are `Copy`), as Dioxus requires for prop types.