### PR TITLE
feat: add a Scan Library button to settings and pad section spacing

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3707,6 +3707,12 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 }
 
 /* ── Settings page ─────────────────────────────────────────────────── */
+/* Stack the settings cards with breathing room between each section. */
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
 .settings-form {
   display: flex;
   flex-direction: column;

--- a/frontend/src/data/books.rs
+++ b/frontend/src/data/books.rs
@@ -287,6 +287,26 @@ pub async fn worker_status(_server_url: &str) -> Result<WorkerStatus, DataError>
     Ok(WorkerStatus::default())
 }
 
+/// Admin: manually trigger a rescan of the configured library paths.
+#[cfg(not(feature = "mobile"))]
+pub async fn scan_library(_server_url: &str) -> Result<(), DataError> {
+    crate::rpc::rpc_scan_library()
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Mobile stub for `scan_library` — posts the ebook reindex REST route.
+#[cfg(feature = "mobile")]
+pub async fn scan_library(server_url: &str) -> Result<(), DataError> {
+    let url = format!("{server_url}/api/reindex");
+    let response = with_bearer(http_client().post(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(())
+}
+
 /// Admin: manually trigger chapter extraction for audiobooks missing chapters.
 #[cfg(not(feature = "mobile"))]
 pub async fn backfill_chapters(_server_url: &str) -> Result<(), DataError> {

--- a/frontend/src/data/books.rs
+++ b/frontend/src/data/books.rs
@@ -295,10 +295,10 @@ pub async fn scan_library(_server_url: &str) -> Result<(), DataError> {
         .map_err(note_server_fn_err)
 }
 
-/// Mobile stub for `scan_library` — posts the ebook reindex REST route.
+/// Mobile stub for `scan_library` — queues both library scans via REST.
 #[cfg(feature = "mobile")]
 pub async fn scan_library(server_url: &str) -> Result<(), DataError> {
-    let url = format!("{server_url}/api/reindex");
+    let url = format!("{server_url}/api/scan-library");
     let response = with_bearer(http_client().post(&url)).send().await?;
     let status = note_status(response.status());
     if !status.is_success() {

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -27,6 +27,7 @@ pub fn SettingsPage() -> Element {
     let library = use_signal(LibraryContents::default);
     let refetch_in_flight = use_signal(|| false);
     let backfill_in_flight = use_signal(|| false);
+    let scan_in_flight = use_signal(|| false);
     // Bumped after a successful save to re-trigger the library-refresh effect.
     let library_refresh = use_signal(|| 0u32);
 
@@ -56,6 +57,7 @@ pub fn SettingsPage() -> Element {
     );
 
     rsx! {
+        div { class: "settings-page",
         section { class: "card",
             h1 { "Settings" }
             p { class: "subtitle", "Configure your library paths." }
@@ -78,6 +80,8 @@ pub fn SettingsPage() -> Element {
                         status_is_error,
                         refetch_in_flight,
                         backfill_in_flight,
+                        scan_in_flight,
+                        library_refresh,
                     }
                 }
             }
@@ -93,6 +97,7 @@ pub fn SettingsPage() -> Element {
         if is_admin() {
             HardcoverKeyField {}
             SmtpConfigField {}
+        }
         }
     }
 }
@@ -226,19 +231,48 @@ fn LibraryPathFields(
     }
 }
 
-/// Ghost buttons for one-off maintenance jobs (author photo refetch, chapter backfill).
+/// Ghost buttons for one-off maintenance jobs (library rescan, author photo
+/// refetch, chapter backfill).
 #[component]
 fn MaintenanceActions(
     mut status: Signal<Option<String>>,
     mut status_is_error: Signal<bool>,
     mut refetch_in_flight: Signal<bool>,
     mut backfill_in_flight: Signal<bool>,
+    mut scan_in_flight: Signal<bool>,
+    mut library_refresh: Signal<u32>,
 ) -> Element {
     let server_url = use_server_url();
+    let url_for_scan = server_url.clone();
     let url_for_refetch = server_url.clone();
     let url_for_backfill = server_url;
 
     rsx! {
+        button {
+            r#type: "button",
+            class: "btn ghost",
+            disabled: scan_in_flight(),
+            "data-testid": "scan-library",
+            onclick: move |_| {
+                let url = url_for_scan.clone();
+                scan_in_flight.set(true);
+                spawn(async move {
+                    match data::scan_library(&url).await {
+                        Ok(()) => {
+                            status.set(Some("Library scan queued.".into()));
+                            status_is_error.set(false);
+                            library_refresh.set(library_refresh() + 1);
+                        }
+                        Err(e) => {
+                            status.set(Some(format!("Failed to start library scan: {e}")));
+                            status_is_error.set(true);
+                        }
+                    }
+                    scan_in_flight.set(false);
+                });
+            },
+            "Scan Library"
+        }
         button {
             r#type: "button",
             class: "btn ghost",

--- a/frontend/src/rpc/settings.rs
+++ b/frontend/src/rpc/settings.rs
@@ -152,6 +152,30 @@ pub async fn rpc_send_smtp_test() -> Result<()> {
     Ok(())
 }
 
+/// Admin: manually trigger a rescan of the configured ebook and audiobook
+/// library paths. Posts `Task::Scan` / `Task::ScanAudiobooks` to the shared
+/// worker (same tasks a settings save would) and returns immediately;
+/// progress surfaces via the `WorkerStatusIndicator`. Errors when neither
+/// library path is configured.
+#[post("/api/rpc/scan-library", pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
+pub async fn rpc_scan_library() -> Result<()> {
+    let settings = db::get_settings(&pool.0).await?;
+    if settings.ebook_library_path.is_none() && settings.audiobook_library_path.is_none() {
+        return Err(ServerFnError::new("no library path configured").into());
+    }
+    if let Some(library_path) = settings.ebook_library_path {
+        worker
+            .0
+            .post(omnibus_db::worker::Task::Scan { library_path });
+    }
+    if let Some(library_path) = settings.audiobook_library_path {
+        worker
+            .0
+            .post(omnibus_db::worker::Task::ScanAudiobooks { library_path });
+    }
+    Ok(())
+}
+
 /// Admin: manually trigger chapter extraction for audiobooks missing
 /// chapters. Posts `Task::BackfillChapters` to the background worker and
 /// returns immediately.

--- a/frontend/src/rpc/settings.rs
+++ b/frontend/src/rpc/settings.rs
@@ -159,16 +159,19 @@ pub async fn rpc_send_smtp_test() -> Result<()> {
 /// library path is configured.
 #[post("/api/rpc/scan-library", pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
 pub async fn rpc_scan_library() -> Result<()> {
-    let settings = db::get_settings(&pool.0).await?;
-    if settings.ebook_library_path.is_none() && settings.audiobook_library_path.is_none() {
+    let Settings {
+        ebook_library_path,
+        audiobook_library_path,
+    } = db::get_settings(&pool.0).await?;
+    if ebook_library_path.is_none() && audiobook_library_path.is_none() {
         return Err(ServerFnError::new("no library path configured").into());
     }
-    if let Some(library_path) = settings.ebook_library_path {
+    if let Some(library_path) = ebook_library_path {
         worker
             .0
             .post(omnibus_db::worker::Task::Scan { library_path });
     }
-    if let Some(library_path) = settings.audiobook_library_path {
+    if let Some(library_path) = audiobook_library_path {
         worker
             .0
             .post(omnibus_db::worker::Task::ScanAudiobooks { library_path });

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -253,6 +253,7 @@ fn content_routes() -> Router<AppState> {
         .route("/api/settings", get(settings::get_settings))
         .route("/api/settings", post(settings::post_settings))
         .route("/api/reindex", post(settings::post_reindex))
+        .route("/api/scan-library", post(settings::post_scan_library))
         .route("/api/fts/rebuild", post(settings::post_rebuild_fts))
         .route("/api/library", get(ebooks::get_library))
         .route("/api/ebooks", get(ebooks::get_ebooks))

--- a/server/src/backend/settings.rs
+++ b/server/src/backend/settings.rs
@@ -86,6 +86,35 @@ pub(super) async fn post_reindex(_admin: AdminUser, State(state): State<AppState
     }
 }
 
+/// Admin-only: queue a rescan of both configured library paths on the shared
+/// worker (fire-and-forget), mirroring the web `rpc_scan_library`. Unlike
+/// `post_reindex` (ebook-only, synchronous), this covers audiobooks too and
+/// returns as soon as the tasks are queued. 200 once queued, 409 when neither
+/// path is configured.
+pub(super) async fn post_scan_library(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+) -> Response {
+    let settings = match db::get_settings(&state.pool).await {
+        Ok(s) => s,
+        Err(error) => return internal("read settings", error),
+    };
+    if settings.ebook_library_path.is_none() && settings.audiobook_library_path.is_none() {
+        return (
+            axum::http::StatusCode::CONFLICT,
+            "no library path configured",
+        )
+            .into_response();
+    }
+    if let Some(library_path) = settings.ebook_library_path {
+        state.worker.post(Task::Scan { library_path });
+    }
+    if let Some(library_path) = settings.audiobook_library_path {
+        state.worker.post(Task::ScanAudiobooks { library_path });
+    }
+    axum::http::StatusCode::OK.into_response()
+}
+
 /// Admin-only synchronous rebuild of the `books_fts` search index: clears
 /// and re-derives every row from `books`. 200 on success, 500 on worker
 /// failure. Repairs any drift left by a failed post-commit FTS refresh.

--- a/server/src/backend/settings/tests.rs
+++ b/server/src/backend/settings/tests.rs
@@ -327,6 +327,92 @@ async fn reindex_returns_200_when_scan_succeeds() {
 }
 
 #[tokio::test]
+async fn scan_library_returns_200_when_a_path_is_configured() {
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    // Fire-and-forget: the handler returns 200 as soon as the tasks are
+    // queued, so a not-yet-existent path still yields 200 (unlike the
+    // synchronous `/api/reindex`, which awaits the scan and would 500).
+    let settings = omnibus_shared::Settings {
+        ebook_library_path: Some("/some/library".to_string()),
+        audiobook_library_path: None,
+    };
+    db::set_settings(&pool, &settings)
+        .await
+        .expect("set_settings should persist the path");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/scan-library")
+                .method("POST")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn scan_library_returns_409_when_no_library_path_configured() {
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/scan-library")
+                .method("POST")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn scan_library_returns_401_when_anonymous() {
+    let (app, _, _) = fixture().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/scan-library")
+                .method("POST")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn scan_library_returns_403_when_not_admin() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/scan-library")
+                .method("POST")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn post_fts_rebuild_returns_200_for_admin() {
     let (app, _state, pool) = fixture().await;
     let admin = auth_test_support::create_admin(&pool, "admin").await;

--- a/ui_tests/playwright/tests/flows/settings.spec.ts
+++ b/ui_tests/playwright/tests/flows/settings.spec.ts
@@ -31,6 +31,7 @@ test("renders the settings page layout", async ({ page }) => {
   await expect(ebookInput(page)).toBeVisible();
   await expect(audiobookInput(page)).toBeVisible();
   await expect(saveButton(page)).toBeVisible();
+  await expect(page.getByTestId("scan-library")).toBeVisible();
   await expect(settingsStatus(page)).toBeAttached();
   await expect(page.getByTestId("ebook-library-summary")).toBeAttached();
   await expect(page.getByTestId("audiobook-library-summary")).toBeAttached();
@@ -140,6 +141,26 @@ test("shows an error status when saving settings fails", async ({ page }) => {
   );
 
   await expect(settingsStatus(page)).toHaveText("Failed to save settings.");
+  await expect(settingsStatus(page)).toHaveClass(/error/);
+});
+
+test("shows an error status when a manual library scan fails", async ({ page }) => {
+  await gotoReady(page, "/settings");
+
+  await page.route("**/api/rpc/scan-library", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ status: 500, contentType: "text/plain", body: "forced failure" });
+    }
+    return route.continue();
+  });
+
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/rpc/scan-library", expectedStatus: 500 },
+    async () => page.getByTestId("scan-library").click(),
+  );
+
+  await expect(settingsStatus(page)).toContainText("Failed to start library scan");
   await expect(settingsStatus(page)).toHaveClass(/error/);
 });
 


### PR DESCRIPTION
## Summary
- Add an admin **Scan Library** maintenance action on `/settings` that posts `Task::Scan` / `Task::ScanAudiobooks` to the shared worker for the configured library paths — triggering a rescan without re-saving settings. Modeled on the existing `Extract Audiobook Chapters` action; progress surfaces via the `WorkerStatusIndicator` and the on-disk counts refresh on success.
- Wrap the settings cards in a `.settings-page` flex column with a `1.5rem` gap so the Settings / Suggestions / SMTP sections are visually separated.
- Errors when neither library path is configured.

## Test plan
- [x] `cargo check` (frontend `--features server` and `--features mobile`), `cargo clippy`, `cargo fmt --check`, `just lint-css` — all clean.
- [x] Manual: clicking the button fires `POST /api/rpc/scan-library → 200`, shows "Library scan queued.", and re-fetches the library counts.
- [x] Added an error-path E2E + layout assertion in `settings.spec.ts` (run in CI — local Nix Chromium bundle mismatches the pinned `@playwright/test`).

## Notes
- Manual trigger only; filesystem auto-detection of new files is a possible follow-up.