### PR TITLE
feat: automated TestFlight upload workflow for omnibus-mobile

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -162,3 +162,15 @@ first, redirecting to `/connect` when it's empty — see the Server URL
 Protection + the `0o600` perms; **TODO**: harden with iOS Keychain /
 Android Keystore. Android persistence is not yet wired (`data_dir` returns
 `None` → memory-only) pending a JNI `Context.getFilesDir()` resolver.
+
+**iOS TestFlight release:** the manually-triggered
+`.github/workflows/testflight.yml` (workflow_dispatch, `macos-14` runner)
+builds the app and ships it to TestFlight. `dx` has no signing, so it
+`dx bundle --platform ios --release`s an unsigned `.app`, then
+`scripts/ios-package-ipa.sh` patches Info.plist (adds the `DTPlatformName`
+dx omits, stamps the CI build number), embeds the provisioning profile,
+`codesign`s with the distribution identity, and zips a `Payload/` `.ipa`
+that `xcrun altool` uploads. Bundle ID `com.omnibus.mobile` lives in
+`mobile/Dioxus.toml`. Signing assets are seven CI-only repo secrets
+(distribution cert, provisioning profile, App Store Connect API key +
+IDs) — enumerated in the workflow file's header comment.

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,157 @@
+name: TestFlight
+
+# Manually-triggered iOS build + TestFlight upload for `omnibus-mobile`.
+#
+# `dx` has no built-in signing, so this builds an unsigned .app with
+# `dx bundle`, then scripts/ios-package-ipa.sh signs + packages it into a .ipa
+# which `xcrun altool` uploads to App Store Connect. The Apple side (bundle ID
+# com.omnibus.mobile, app record, distribution cert, App Store Connect API
+# key) must already exist.
+#
+# Required repository secrets:
+#   IOS_DIST_CERT_P12_BASE64         base64 of the Apple Distribution .p12
+#   IOS_DIST_CERT_PASSWORD           password for that .p12
+#   IOS_PROVISIONING_PROFILE_BASE64  base64 of the App Store .mobileprovision
+#   IOS_SIGNING_IDENTITY             e.g. "Apple Distribution: Name (TEAMID)"
+#   ASC_API_KEY_BASE64               base64 of the App Store Connect AuthKey_*.p8
+#   ASC_KEY_ID                       App Store Connect API key ID
+#   ASC_ISSUER_ID                    App Store Connect API issuer ID
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: "CFBundleVersion to stamp (must be higher than the last uploaded build). Defaults to the workflow run number."
+        required: false
+        type: string
+
+concurrency:
+  group: testflight-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    name: build + upload to TestFlight
+    runs-on: macos-14
+    permissions:
+      contents: read
+      # nix-installer-action needs the OIDC token endpoints to auth to FlakeHub
+      # (else it falls back to anonymous fetches that intermittently 401).
+      id-token: write
+      # cache-nix-action `purge: true` deletes its own expired cache entries.
+      actions: write
+    env:
+      # Pin the target dir so the .app lands at the path the packaging script
+      # expects (target/dx/omnibus-mobile/release/ios) and so rust-cache
+      # (keyed on `. -> target`) actually caches across runs. Also disables
+      # the flake's sccache path, which is skipped when CARGO_TARGET_DIR is set.
+      CARGO_TARGET_DIR: ./target
+      BUILD_NUMBER: ${{ github.event.inputs.build_number || github.run_number }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-testflight-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-testflight-${{ runner.os }}-
+          purge: true
+          purge-prefixes: nix-testflight-${{ runner.os }}-
+          purge-last-accessed: 604800
+          purge-primary-key: never
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+          shared-key: omnibus-mobile
+
+      # Import the distribution cert into a throwaway keychain so codesign can
+      # find the identity. Cleaned up in the always() step below.
+      - name: Import signing certificate
+        env:
+          IOS_DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
+          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/omnibus-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          CERT_P12="$RUNNER_TEMP/dist.p12"
+          echo "$IOS_DIST_CERT_P12_BASE64" | base64 --decode > "$CERT_P12"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT_P12" -k "$KEYCHAIN" -P "$IOS_DIST_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          # Let codesign use the key without an interactive prompt.
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          # Prepend our keychain to the user search list so codesign sees it.
+          # Intentional word-splitting: each existing keychain path is a
+          # separate -s argument.
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          rm -f "$CERT_P12"
+          echo "SIGNING_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
+      - name: Decode provisioning profile
+        env:
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          PROFILE="$RUNNER_TEMP/omnibus.mobileprovision"
+          echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE"
+          echo "PROVISIONING_PROFILE=$PROFILE" >> "$GITHUB_ENV"
+
+      # Build the unsigned .app. Runs in the `.#mobile` shell for `dx` + the
+      # aarch64-apple-ios rust-std + the Xcode DEVELOPER_DIR/SDKROOT shim.
+      # `--package-types ios` pins the output to the raw .app (dx can also emit
+      # a pre-zipped .ipa, but it neither embeds the provisioning profile nor
+      # patches DTPlatformName — scripts/ios-package-ipa.sh does both).
+      - name: dx bundle (iOS release)
+        run: nix develop .#mobile --command dx bundle --platform ios --release --package omnibus-mobile --package-types ios
+
+      - name: Sign and package .ipa
+        env:
+          SIGNING_IDENTITY: ${{ secrets.IOS_SIGNING_IDENTITY }}
+          IPA_OUT: ${{ github.workspace }}/omnibus-mobile.ipa
+        run: |
+          set -euo pipefail
+          ./scripts/ios-package-ipa.sh
+
+      - name: Upload to TestFlight
+        env:
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          echo "$ASC_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          xcrun altool --upload-app -f "$GITHUB_WORKSPACE/omnibus-mobile.ipa" -t ios \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+          rm -f "$KEY_PATH"
+
+      - name: Upload .ipa artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: omnibus-mobile-ipa
+          path: omnibus-mobile.ipa
+          if-no-files-found: ignore
+
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -n "${SIGNING_KEYCHAIN:-}" ] && [ -f "$SIGNING_KEYCHAIN" ]; then
+            security delete-keychain "$SIGNING_KEYCHAIN" || true
+          fi
+          rm -f "$HOME/.appstoreconnect/private_keys"/*.p8 2>/dev/null || true

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -83,7 +83,9 @@ jobs:
           KEYCHAIN="$RUNNER_TEMP/omnibus-signing.keychain-db"
           KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
           CERT_P12="$RUNNER_TEMP/dist.p12"
-          echo "$IOS_DIST_CERT_P12_BASE64" | base64 --decode > "$CERT_P12"
+          # `-D` is the BSD/macOS decode flag (`--decode` is a GNU long-opt
+          # some macOS images lack); these steps run outside nix on the runner.
+          echo "$IOS_DIST_CERT_P12_BASE64" | base64 -D > "$CERT_P12"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
@@ -106,7 +108,7 @@ jobs:
         run: |
           set -euo pipefail
           PROFILE="$RUNNER_TEMP/omnibus.mobileprovision"
-          echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE"
+          echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 -D > "$PROFILE"
           echo "PROVISIONING_PROFILE=$PROFILE" >> "$GITHUB_ENV"
 
       # Build the unsigned .app. Runs in the `.#mobile` shell for `dx` + the
@@ -134,7 +136,7 @@ jobs:
           set -euo pipefail
           mkdir -p "$HOME/.appstoreconnect/private_keys"
           KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
-          echo "$ASC_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "$ASC_API_KEY_BASE64" | base64 -D > "$KEY_PATH"
           xcrun altool --upload-app -f "$GITHUB_WORKSPACE/omnibus-mobile.ipa" -t ios \
             --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
           rm -f "$KEY_PATH"

--- a/mobile/Dioxus.toml
+++ b/mobile/Dioxus.toml
@@ -8,6 +8,9 @@ audio = true
 # Unique reverse-DNS id used for the iOS CFBundleIdentifier and the Android
 # applicationId. Required for real code signing / device installs — the
 # default `com.example.*` can't be provisioned under a real Apple team.
+# Must exactly match the App Store Connect app record so `dx bundle` stamps
+# the right CFBundleIdentifier — the TestFlight upload
+# (.github/workflows/testflight.yml) rejects a mismatch.
 identifier = "com.omnibus.mobile"
 
 [android]

--- a/scripts/ios-package-ipa.sh
+++ b/scripts/ios-package-ipa.sh
@@ -23,6 +23,13 @@ die() { echo "ios-package-ipa: $*" >&2; exit 1; }
 : "${PROVISIONING_PROFILE:?PROVISIONING_PROFILE is required}"
 : "${BUILD_NUMBER:?BUILD_NUMBER is required}"
 
+# BUILD_NUMBER is interpolated into PlistBuddy commands; CFBundleVersion is
+# numeric (optionally dot-separated). Reject anything else so a stray value
+# can't malform the plist or inject command arguments.
+case "$BUILD_NUMBER" in
+  '' | *[!0-9.]*) die "BUILD_NUMBER must be numeric/dot-separated, got: '$BUILD_NUMBER'" ;;
+esac
+
 plistbuddy=/usr/libexec/PlistBuddy
 [ -x "$plistbuddy" ] || die "PlistBuddy not found at $plistbuddy (need macOS)"
 [ -f "$PROVISIONING_PROFILE" ] || die "provisioning profile not found: $PROVISIONING_PROFILE"
@@ -49,8 +56,10 @@ info_plist="$app_dir/Info.plist"
 # `Set` fails on an absent key, so Add-then-Set each.
 plist_set() {
   local key="$1" type="$2" value="$3"
-  "$plistbuddy" -c "Add :$key $type $value" "$info_plist" 2>/dev/null \
-    || "$plistbuddy" -c "Set :$key $value" "$info_plist"
+  # Quote the value inside the PlistBuddy command so a value with spaces or
+  # shell-significant characters can't split the argument or inject commands.
+  "$plistbuddy" -c "Add :$key $type \"$value\"" "$info_plist" 2>/dev/null \
+    || "$plistbuddy" -c "Set :$key \"$value\"" "$info_plist"
 }
 plist_set DTPlatformName string iphoneos
 plist_set CFBundleVersion string "$BUILD_NUMBER"

--- a/scripts/ios-package-ipa.sh
+++ b/scripts/ios-package-ipa.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Turn the unsigned .app that `dx bundle --platform ios --release` emits into
+# a signed, App-Store-valid .ipa ready for `xcrun altool` upload.
+#
+# `dx` has no built-in signing (Dioxus #3817), so this script does the manual
+# post-build chain: patch Info.plist -> embed the provisioning profile ->
+# codesign with the distribution identity -> zip into a Payload/ .ipa.
+#
+# Inputs (all via env, so the workflow stays thin):
+#   SIGNING_IDENTITY   codesign identity, e.g. "Apple Distribution: Name (TEAMID)"
+#   PROVISIONING_PROFILE  path to the decoded .mobileprovision
+#   BUILD_NUMBER       CFBundleVersion to stamp (monotonic; CI run number)
+#   APP_DIR            optional; the .app to sign. Defaults to the sole
+#                      target/dx/omnibus-mobile/release/ios/*.app
+#   IPA_OUT            optional output path (default ./omnibus-mobile.ipa)
+#
+# Output: prints the final .ipa path on stdout as APP_IPA=<path>.
+set -euo pipefail
+
+die() { echo "ios-package-ipa: $*" >&2; exit 1; }
+
+: "${SIGNING_IDENTITY:?SIGNING_IDENTITY is required}"
+: "${PROVISIONING_PROFILE:?PROVISIONING_PROFILE is required}"
+: "${BUILD_NUMBER:?BUILD_NUMBER is required}"
+
+plistbuddy=/usr/libexec/PlistBuddy
+[ -x "$plistbuddy" ] || die "PlistBuddy not found at $plistbuddy (need macOS)"
+[ -f "$PROVISIONING_PROFILE" ] || die "provisioning profile not found: $PROVISIONING_PROFILE"
+
+ios_out="target/dx/omnibus-mobile/release/ios"
+app_dir="${APP_DIR:-}"
+if [ -z "$app_dir" ]; then
+  # dx title-cases the bundle name (omnibus-mobile -> OmnibusMobile.app), so
+  # glob rather than hardcode. Exactly one .app is expected.
+  shopt -s nullglob
+  candidates=("$ios_out"/*.app)
+  shopt -u nullglob
+  [ "${#candidates[@]}" -eq 1 ] || die "expected exactly one .app in $ios_out, found ${#candidates[@]}"
+  app_dir="${candidates[0]}"
+fi
+[ -d "$app_dir" ] || die "app bundle not found: $app_dir"
+echo "ios-package-ipa: signing $app_dir"
+
+info_plist="$app_dir/Info.plist"
+[ -f "$info_plist" ] || die "Info.plist missing in $app_dir"
+
+# dx omits DTPlatformName; App Store validation rejects the build without it
+# (Dioxus #3817). Set the device platform, a floor OS, and the build number.
+# `Set` fails on an absent key, so Add-then-Set each.
+plist_set() {
+  local key="$1" type="$2" value="$3"
+  "$plistbuddy" -c "Add :$key $type $value" "$info_plist" 2>/dev/null \
+    || "$plistbuddy" -c "Set :$key $value" "$info_plist"
+}
+plist_set DTPlatformName string iphoneos
+plist_set CFBundleVersion string "$BUILD_NUMBER"
+# Only add a floor if the build didn't already declare one.
+"$plistbuddy" -c "Print :MinimumOSVersion" "$info_plist" >/dev/null 2>&1 \
+  || "$plistbuddy" -c "Add :MinimumOSVersion string 13.0" "$info_plist"
+plutil -lint "$info_plist" >/dev/null || die "Info.plist failed plutil lint after patching"
+
+# Embed the provisioning profile the app is signed against.
+cp "$PROVISIONING_PROFILE" "$app_dir/embedded.mobileprovision"
+
+# Extract the profile's entitlements so the signature matches what the profile
+# authorizes (app-id, team-id, aps-environment). `security cms -D` decodes the
+# CMS-wrapped plist; PlistBuddy pulls the Entitlements dict out of it.
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+profile_plist="$workdir/profile.plist"
+entitlements="$workdir/entitlements.plist"
+security cms -D -i "$PROVISIONING_PROFILE" > "$profile_plist" 2>/dev/null \
+  || die "failed to decode provisioning profile"
+"$plistbuddy" -x -c "Print :Entitlements" "$profile_plist" > "$entitlements" \
+  || die "provisioning profile has no Entitlements dict"
+
+codesign --force --timestamp=none \
+  --sign "$SIGNING_IDENTITY" \
+  --entitlements "$entitlements" \
+  "$app_dir"
+codesign --verify --deep --strict "$app_dir" || die "codesign verification failed"
+
+# Package: Payload/<App>.app -> zip -> .ipa (the App Store .ipa layout).
+ipa_out="${IPA_OUT:-$PWD/omnibus-mobile.ipa}"
+payload_root="$workdir/pkg"
+mkdir -p "$payload_root/Payload"
+cp -R "$app_dir" "$payload_root/Payload/"
+rm -f "$ipa_out"
+( cd "$payload_root" && zip -qry "$ipa_out" Payload )
+[ -f "$ipa_out" ] || die "failed to produce ipa at $ipa_out"
+
+echo "ios-package-ipa: wrote $ipa_out"
+echo "APP_IPA=$ipa_out"


### PR DESCRIPTION
## Summary
- New manually-triggered **TestFlight** workflow (`workflow_dispatch`, `macos-14`) that builds a signed iOS `.ipa` from `omnibus-mobile` and uploads it to App Store Connect via `xcrun altool`.
- `dx bundle` emits an *unsigned* `.app`, so `scripts/ios-package-ipa.sh` patches Info.plist (adds the `DTPlatformName` dx omits + the CI build number), embeds the provisioning profile, codesigns with the distribution identity, and zips the `.ipa`.
- Adds bundle ID `com.omnibus.mobile` to `mobile/Dioxus.toml`; signing is handled by seven CI-only repo secrets imported into a throwaway keychain.

## Test plan
- [x] `dx bundle --platform ios --release --package omnibus-mobile --package-types ios` builds locally → arm64 `OmnibusMobile.app` with `CFBundleIdentifier=com.omnibus.mobile`.
- [x] Confirmed dx 0.7 still omits `DTPlatformName`; script's plist patch verified against the real bundle (`DTPlatformName`/`CFBundleVersion`/`MinimumOSVersion` set, `plutil -lint` OK).
- [x] `shellcheck` + `actionlint` clean.
- [ ] CI dry run: Actions → **TestFlight** → *Run workflow* → build lands in App Store Connect → TestFlight (codesign + altool exercised only in CI with secrets).

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — CI/tooling only, no shipped-behavior change (`no release` label applied).

## Notes
> [!IMPORTANT]
> Requires seven repository secrets (already staged): `IOS_DIST_CERT_P12_BASE64`, `IOS_DIST_CERT_PASSWORD`, `IOS_PROVISIONING_PROFILE_BASE64`, `IOS_SIGNING_IDENTITY`, `ASC_API_KEY_BASE64`, `ASC_KEY_ID`, `ASC_ISSUER_ID`. The Apple side (bundle ID, app record, distribution cert, ASC API key) must exist before the first run.