### PR TITLE
fix: persist mobile server URL + auth token across app close

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -19,7 +19,7 @@ Default `cargo build` / `clippy` covers `server`, `shared`, `frontend` only. Mob
 
 **Database:** schema ships as numbered SQL migrations under [db/migrations/](../db/migrations/), embedded via `sqlx::migrate!` and run on pool init in `omnibus_db::init_db`. Applied versions are recorded in the `_sqlx_migrations` table. Add new migrations as `NNNN_description.sql` — never edit an applied file. All tests use `sqlite::memory:` for isolation; the migrator runs against them the same as production.
 
-**Server URL (mobile):** the backend base URL is a reactive `ServerUrl(Signal<String>)` context, seeded at launch from `data::server_url_store` (persisted at `$HOME/.omnibus-server`, plaintext, all builds — the URL isn't secret). Empty on first run → the mobile `ScreenLayout` gate routes to the unguarded `/connect` route (`pages/server_connect.rs`), which validates reachability via `data::check_server` (`GET /api/_health`) before persisting and advancing to `/login`. The login screen shows a connected-to bar with a Back button to change it. `use_server_url()` still returns a `String` snapshot, so all readers are unchanged; `use_server_url_signal()` is the writer accessor.
+**Server URL (mobile):** the backend base URL is a reactive `ServerUrl(Signal<String>)` context, seeded at launch from `data::server_url_store` (persisted at `<data_dir>/server` — `Library/Application Support/omnibus/server` on iOS, `$HOME/.omnibus/server` on desktop/dev — plaintext, all builds; the URL isn't secret). Empty on first run → the mobile `ScreenLayout` gate routes to the unguarded `/connect` route (`pages/server_connect.rs`), which validates reachability via `data::check_server` (`GET /api/_health`) before persisting and advancing to `/login`. The login screen shows a connected-to bar with a Back button to change it. `use_server_url()` still returns a `String` snapshot, so all readers are unchanged; `use_server_url_signal()` is the writer accessor.
 
 ## shared/src/
 
@@ -149,11 +149,16 @@ Mobile auth: bearer-token login flow lives in `frontend/src/data.rs` under
 `feature = "mobile"`. `data::mobile_login` / `mobile_register` POST to
 `/api/auth/{login,register}` with `client_kind: ios|android|bearer` so the
 server returns a bearer token in the JSON body. `data::token_store` keeps
-the token in a process-local `OnceLock<RwLock<...>>` and — **only in
-debug builds** (`cfg!(debug_assertions)`) — persists it to
-`$HOME/.omnibus-token`. Release builds keep the token in memory only and
-require re-login on every cold start. UI components subscribe to
-`data::token_store::subscribe()` (a `tokio::sync::watch` receiver) so a
-401-driven `token_store::clear()` reactively redirects to `/login` (the gate checks the `ServerUrl` context first, redirecting to `/connect` when it's empty — see the Server URL (mobile) note above).
-**TODO**: replace the disk-persistence stub with iOS Keychain / Android
-Keystore and flip persistence on unconditionally — see the module docs.
+the token in a process-local `OnceLock<RwLock<...>>` and persists it (in
+every build) to `<data_dir>/token` with `0o600` perms, where `data_dir`
+(`data::app_dirs`) resolves to `Library/Application Support/omnibus` on iOS
+and `$HOME/.omnibus` on desktop/dev. So the user stays signed in across a
+cold start and is only logged out when the server rejects the bearer. UI
+components subscribe to `data::token_store::subscribe()` (a
+`tokio::sync::watch` receiver) so a 401-driven `token_store::clear()`
+reactively redirects to `/login` (the gate checks the `ServerUrl` context
+first, redirecting to `/connect` when it's empty — see the Server URL
+(mobile) note above). At-rest protection is the iOS sandbox + Data
+Protection + the `0o600` perms; **TODO**: harden with iOS Keychain /
+Android Keystore. Android persistence is not yet wired (`data_dir` returns
+`None` → memory-only) pending a JNI `Context.getFilesDir()` resolver.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4357,6 +4357,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Justfile
+++ b/Justfile
@@ -40,14 +40,17 @@ dev-bounce:
 
 # Run the full unit/integration test matrix. `cargo test --workspace` is a
 # trap here — it silently skips the frontend rpc/page tests (they need
-# --features server) — so run each crate explicitly. Mobile is not listed
-# because it has no tests of its own (lint covers it via `just lint`).
+# --features server) — so run each crate explicitly. The frontend runs twice
+# under mutually-exclusive features: `server` (rpc/page tests) and `mobile`
+# (the `data::token_store` / `app_dirs` persistence tests). The `omnibus-mobile`
+# shell crate itself has no tests (lint covers it via `just lint`).
 # Self-wraps in the slim nix shell so it works from a bare checkout too.
 test:
     nix develop --command bash -ec '\
         cargo test -p omnibus-db && \
         cargo test -p omnibus && \
         cargo test -p omnibus-frontend --features server && \
+        cargo test -p omnibus-frontend --features mobile && \
         cargo test -p omnibus-shared'
 
 # Structural CSS lint — stylelint over frontend/assets, scoped to parse /

--- a/Justfile
+++ b/Justfile
@@ -41,9 +41,11 @@ dev-bounce:
 # Run the full unit/integration test matrix. `cargo test --workspace` is a
 # trap here — it silently skips the frontend rpc/page tests (they need
 # --features server) — so run each crate explicitly. The frontend runs twice
-# under mutually-exclusive features: `server` (rpc/page tests) and `mobile`
-# (the `data::token_store` / `app_dirs` persistence tests). The `omnibus-mobile`
-# shell crate itself has no tests (lint covers it via `just lint`).
+# with different feature sets: `server` (rpc/page tests) and `mobile` (the
+# `data::token_store` / `app_dirs` persistence tests) — the `web`/`mobile`/
+# `server` impls are cfg-split, so each set exercises a different code path.
+# The `omnibus-mobile` shell crate itself has no tests (lint covers it via
+# `just lint`).
 # Self-wraps in the slim nix shell so it works from a bare checkout too.
 test:
     nix develop --command bash -ec '\

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -43,6 +43,10 @@ tokio = { workspace = true, optional = true }
 # pull tracing into the bundle.
 tracing = { workspace = true, optional = true }
 
+[dev-dependencies]
+# Sandboxed temp dirs for the mobile `token_store` / `app_dirs` file tests.
+tempfile.workspace = true
+
 [features]
 default = []
 # Web client (WASM): uses dioxus-fullstack server-function client stubs.

--- a/frontend/src/audiobook_progress.rs
+++ b/frontend/src/audiobook_progress.rs
@@ -187,15 +187,22 @@ fn save_rate_impl(_uuid: &str, _rate: f64) {}
 #[cfg(all(test, feature = "mobile"))]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // These tests share one process-global map and each `clear()`s it, so
+    // running them in parallel wipes each other. Serialize them.
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
 
     #[test]
     fn returns_none_when_unset() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         mobile_store::clear();
         assert_eq!(load("book-a"), None);
     }
 
     #[test]
     fn round_trips_per_uuid() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         mobile_store::clear();
         save("book-a", 12.5);
         save("book-b", 600.0);
@@ -205,6 +212,7 @@ mod tests {
 
     #[test]
     fn rate_defaults_and_persists_per_book() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         mobile_store::clear();
         assert!((load_rate("book-a") - 1.0).abs() < f64::EPSILON);
         save_rate("book-a", 1.5);

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -102,6 +102,71 @@ impl DataError {
 pub struct ServerUrl(pub dioxus::prelude::Signal<String>);
 
 #[cfg(feature = "mobile")]
+pub mod app_dirs {
+    //! Resolves the writable, per-app directory that [`super::token_store`]
+    //! and [`super::server_url_store`] persist into. Historically both wrote
+    //! to `$HOME/.omnibus-*`, but on iOS `$HOME` is the app-container *root*,
+    //! which is read-only — only its `Library`/`Documents`/`tmp` subdirs are
+    //! writable — so every write silently failed and nothing survived a cold
+    //! start. We now target `Library/Application Support/omnibus` on iOS (the
+    //! Apple-sanctioned, backed-up location for app-managed data) and
+    //! `$HOME/.omnibus` on desktop/dev.
+    use std::path::{Path, PathBuf};
+
+    /// Pure per-platform base-dir resolution from a home dir. No I/O, so it's
+    /// unit-testable without touching the process environment.
+    pub(crate) fn data_dir_from_home(home: &Path) -> PathBuf {
+        #[cfg(target_os = "ios")]
+        {
+            home.join("Library/Application Support/omnibus")
+        }
+        #[cfg(not(target_os = "ios"))]
+        {
+            home.join(".omnibus")
+        }
+    }
+
+    /// Resolve and create the writable data dir. `None` → the caller keeps
+    /// its in-memory-only behavior (unchanged from before): no home dir, an
+    /// unwritable location, or Android (persistence not yet wired — see the
+    /// GH issue tracking the JNI `Context.getFilesDir()` resolver).
+    pub fn data_dir() -> Option<PathBuf> {
+        // Android's `$HOME` under tao/wry isn't the app files dir; resolving
+        // it needs JNI. Until that lands, stay memory-only (no regression).
+        #[cfg(target_os = "android")]
+        {
+            // TODO(#837): resolve Context.getFilesDir() via JNI, then persist.
+            return None;
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let home = std::env::var_os("HOME")?;
+            let dir = data_dir_from_home(Path::new(&home));
+            std::fs::create_dir_all(&dir).ok()?;
+            Some(dir)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn data_dir_from_home_targets_platform_subdir() {
+            let dir = data_dir_from_home(Path::new("/home/reader"));
+            if cfg!(target_os = "ios") {
+                assert_eq!(
+                    dir,
+                    Path::new("/home/reader/Library/Application Support/omnibus")
+                );
+            } else {
+                assert_eq!(dir, Path::new("/home/reader/.omnibus"));
+            }
+        }
+    }
+}
+
+#[cfg(feature = "mobile")]
 pub mod server_url_store {
     //! On-disk persistence for the user-entered backend base URL. Far
     //! simpler than [`super::token_store`]: the URL is not a secret, so it
@@ -112,11 +177,10 @@ pub mod server_url_store {
     //! it back when the user connects.
     use std::path::PathBuf;
 
-    /// On-disk path for the persisted server URL, or `None` when no home
-    /// directory is available (same `HOME`-based resolution as the token
-    /// store; iOS sandboxes set `HOME` to the app container).
+    /// On-disk path for the persisted server URL, or `None` when no writable
+    /// app data dir is available (see [`super::app_dirs::data_dir`]).
     pub fn server_path() -> Option<PathBuf> {
-        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".omnibus-server"))
+        super::app_dirs::data_dir().map(|d| d.join("server"))
     }
 
     /// Trim persisted file contents into a usable URL, rejecting an
@@ -219,14 +283,12 @@ pub mod token_store {
 
     /// On-disk path for the persisted bearer token.
     ///
-    /// Returns `None` when no platform-appropriate home directory is
-    /// available (`HOME` unset on a non-Unix-y target, etc.). In that case
-    /// the token stays in memory only and the user re-logs in on next
-    /// launch — strictly safer than dropping a token file in an arbitrary
-    /// working directory. iOS app sandboxes set `HOME` to the app's
-    /// container, so the common path is covered.
+    /// Returns `None` when no writable app data dir is available (see
+    /// [`super::app_dirs::data_dir`]); the token then stays in memory only and
+    /// the user re-logs in on next launch — strictly safer than dropping a
+    /// token file in an arbitrary or unwritable location.
     pub fn token_path() -> Option<PathBuf> {
-        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".omnibus-token"))
+        super::app_dirs::data_dir().map(|d| d.join("token"))
     }
 
     /// Read the on-disk token (if any) into the in-memory store. Call once
@@ -261,16 +323,15 @@ pub mod token_store {
         unpoison(cell().read()).clone()
     }
 
-    /// `true` when this build is allowed to persist the bearer token to
-    /// disk. Gated behind `cfg(debug_assertions)` so a release build can
-    /// never accidentally write a long-lived credential to the
-    /// filesystem in plaintext — release users re-login on every cold
-    /// start until iOS Keychain / Android Keystore support lands and
-    /// flips this to unconditionally `true` (against secure storage).
-    /// Dev builds (`dx serve --platform ios|android`) keep the
-    /// persistence path so the dev-loop UX isn't crippled.
+    /// `true` when this build persists the bearer token to disk. Now
+    /// unconditional: the token lands in the sandboxed app data dir (see
+    /// [`super::app_dirs`]) with `0o600` perms, protected at rest by the iOS
+    /// sandbox + Data Protection. Release builds persist too, so users stay
+    /// signed in across a cold start and are only logged out when the server
+    /// rejects the bearer (expiry/revoke). iOS Keychain / Android Keystore
+    /// remains a future hardening step, not a prerequisite for persistence.
     fn persistence_enabled() -> bool {
-        cfg!(debug_assertions)
+        true
     }
 
     /// Set the token in memory immediately, notify UI subscribers, and
@@ -412,6 +473,41 @@ pub mod token_store {
     fn write_token_file(path: &Path, token: &[u8]) -> std::io::Result<()> {
         std::fs::write(path, token)
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn persistence_enabled_is_true_in_every_build() {
+            // Release builds must persist too — a false here would resurrect
+            // the "logged out on app close" bug.
+            assert!(persistence_enabled());
+        }
+
+        #[test]
+        fn write_token_file_round_trips_the_token() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("token");
+            write_token_file(&path, b"secret-bearer").expect("write");
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), "secret-bearer");
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn write_token_file_is_owner_only_on_unix() {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("token");
+            // Pre-create with loose perms to prove the mode is re-applied even
+            // when the file already exists (the buggy-older-build case).
+            std::fs::write(&path, b"old").unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+            write_token_file(&path, b"secret-bearer").expect("write");
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
 }
 
 /// Best-effort `client_kind` for the bearer-login request body, used
@@ -452,6 +548,10 @@ pub(crate) fn with_bearer(rb: reqwest::RequestBuilder) -> reqwest::RequestBuilde
 /// Inspect a response: if it's a 401, clear the stored bearer token so the
 /// next render of the auth-aware UI can route to `/login`. Returns the same
 /// status the caller was about to inspect.
+///
+/// The server is the sole authority on session expiry (bearer TTL is 90 days);
+/// this 401 path is the *only* logout trigger. Do not add a client-side clock
+/// — the persisted token intentionally survives cold starts.
 #[cfg(feature = "mobile")]
 pub(crate) fn note_status(status: reqwest::StatusCode) -> reqwest::StatusCode {
     if status == reqwest::StatusCode::UNAUTHORIZED {

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -142,7 +142,12 @@ pub mod app_dirs {
         {
             let home = std::env::var_os("HOME")?;
             let dir = data_dir_from_home(Path::new(&home));
-            std::fs::create_dir_all(&dir).ok()?;
+            // Log before falling back to memory-only: a silent create failure
+            // is exactly the class of bug this module exists to fix.
+            if let Err(e) = std::fs::create_dir_all(&dir) {
+                tracing::warn!(error = %e, path = %dir.display(), "could not create app data dir; persistence disabled this launch");
+                return None;
+            }
             Some(dir)
         }
     }
@@ -170,11 +175,13 @@ pub mod app_dirs {
 pub mod server_url_store {
     //! On-disk persistence for the user-entered backend base URL. Far
     //! simpler than [`super::token_store`]: the URL is not a secret, so it
-    //! persists in every build (no `debug_assertions` gate) with default
-    //! permissions, and there is no in-memory cache or change channel — the
-    //! reactive [`super::ServerUrl`] context signal is the in-memory source
-    //! of truth, while this module only reads it once at launch and writes
-    //! it back when the user connects.
+    //! persists with default permissions and no in-memory cache or change
+    //! channel — the reactive [`super::ServerUrl`] context signal is the
+    //! in-memory source of truth, while this module only reads it once at
+    //! launch and writes it back when the user connects. Persistence is
+    //! conditional on a writable dir (see [`super::app_dirs::data_dir`]):
+    //! available on iOS/desktop, but currently `None` on Android, which stays
+    //! memory-only.
     use std::path::PathBuf;
 
     /// On-disk path for the persisted server URL, or `None` when no writable
@@ -323,20 +330,22 @@ pub mod token_store {
         unpoison(cell().read()).clone()
     }
 
-    /// `true` when this build persists the bearer token to disk. Now
-    /// unconditional: the token lands in the sandboxed app data dir (see
-    /// [`super::app_dirs`]) with `0o600` perms, protected at rest by the iOS
-    /// sandbox + Data Protection. Release builds persist too, so users stay
+    /// `true` when this build persists the bearer token to disk. No longer
+    /// gated on `debug_assertions` — release builds persist too, so users stay
     /// signed in across a cold start and are only logged out when the server
-    /// rejects the bearer (expiry/revoke). iOS Keychain / Android Keystore
-    /// remains a future hardening step, not a prerequisite for persistence.
+    /// rejects the bearer (expiry/revoke). The actual write still depends on a
+    /// writable dir: on iOS/desktop the token lands in the sandboxed app data
+    /// dir (see [`super::app_dirs`]) with `0o600` perms (protected at rest by
+    /// the iOS sandbox + Data Protection); on Android [`token_path`] is `None`,
+    /// so persistence is a no-op there until the JNI resolver lands. iOS
+    /// Keychain / Android Keystore remains a future hardening step.
     fn persistence_enabled() -> bool {
         true
     }
 
-    /// Set the token in memory immediately, notify UI subscribers, and
-    /// (in dev builds only) enqueue a disk write on the persistence
-    /// worker.
+    /// Set the token in memory immediately, notify UI subscribers, and (when
+    /// a writable [`token_path`] exists) enqueue a disk write on the
+    /// persistence worker.
     pub fn set(token: String) {
         *unpoison(cell().write()) = Some(token.clone());
         notify(true);
@@ -348,10 +357,10 @@ pub mod token_store {
         }
     }
 
-    /// Clear the token from memory immediately, notify UI subscribers,
-    /// and (in dev builds only) enqueue a disk delete on the persistence
-    /// worker. Channel ordering guarantees a clear always supersedes any
-    /// earlier set.
+    /// Clear the token from memory immediately, notify UI subscribers, and
+    /// (when a writable [`token_path`] exists) enqueue a disk delete on the
+    /// persistence worker. Channel ordering guarantees a clear always
+    /// supersedes any earlier set.
     pub fn clear() {
         *unpoison(cell().write()) = None;
         notify(false);

--- a/frontend/src/reader_progress.rs
+++ b/frontend/src/reader_progress.rs
@@ -112,15 +112,22 @@ fn save_impl(_uuid: &str, _cfi: &str) {}
 #[cfg(all(test, feature = "mobile"))]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // These tests share one process-global map and each `clear()`s it, so
+    // running them in parallel wipes each other. Serialize them.
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
 
     #[test]
     fn returns_none_when_unset() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         mobile_store::clear();
         assert_eq!(load("book-a"), None);
     }
 
     #[test]
     fn round_trips_and_isolates_per_uuid() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         mobile_store::clear();
         save("book-a", "epubcfi(/6/4[chap01]!/4/2/1:0)");
         save("book-b", "epubcfi(/6/8[chap04]!/4/10/2:42)");
@@ -138,6 +145,7 @@ mod tests {
 
     #[test]
     fn save_overwrites_prior_position() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         mobile_store::clear();
         save("book-a", "epubcfi(/6/4!/4/2/1:0)");
         save("book-a", "epubcfi(/6/12!/4/8/3:7)");

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -130,9 +130,15 @@ fn save_impl(_library_path: &str, _prefs: &ViewPrefs) {}
 mod tests {
     use super::*;
     use omnibus_shared::{SortDir, SortKey, ViewMode};
+    use std::sync::Mutex;
+
+    // These tests share one process-global map and each `clear()`s it, so
+    // running them in parallel wipes each other. Serialize them.
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
 
     #[test]
     fn returns_default_when_unset() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         mobile_store::clear();
         let prefs = load("/library/a");
         assert_eq!(prefs, ViewPrefs::default());
@@ -140,6 +146,7 @@ mod tests {
 
     #[test]
     fn round_trips_and_isolates_per_library() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         mobile_store::clear();
         let a = ViewPrefs {
             view_mode: ViewMode::Grid,

--- a/mobile/src/main.rs
+++ b/mobile/src/main.rs
@@ -14,9 +14,11 @@ use omnibus_frontend::{
 
 fn main() {
     // Pull any persisted bearer token into the in-memory store before the
-    // first render so the initial API calls go out authenticated. Persists in
-    // every build now (0o600 file under the sandboxed app data dir), so users
-    // stay signed in across a cold start.
+    // first render so the initial API calls go out authenticated. On
+    // iOS/desktop this persists in every build (0o600 file under the sandboxed
+    // app data dir), so users stay signed in across a cold start. On Android
+    // it's a no-op until the JNI data-dir resolver lands (#837) — the user
+    // re-logs in on each launch there.
     //
     // TODO: harden at-rest storage with iOS Keychain / Android Keystore.
     // Current protection is the iOS sandbox + Data Protection + 0o600 — see the

--- a/mobile/src/main.rs
+++ b/mobile/src/main.rs
@@ -14,11 +14,13 @@ use omnibus_frontend::{
 
 fn main() {
     // Pull any persisted bearer token into the in-memory store before the
-    // first render so the initial API calls go out authenticated.
+    // first render so the initial API calls go out authenticated. Persists in
+    // every build now (0o600 file under the sandboxed app data dir), so users
+    // stay signed in across a cold start.
     //
-    // TODO(F0.3 follow-up): the token is currently plaintext on disk.
-    // Replace with iOS Keychain / Android Keystore before shipping to end
-    // users — see the module docs on `omnibus_frontend::data::token_store`.
+    // TODO: harden at-rest storage with iOS Keychain / Android Keystore.
+    // Current protection is the iOS sandbox + Data Protection + 0o600 — see the
+    // module docs on `omnibus_frontend::data::token_store` / `app_dirs`.
     token_store::load_from_disk();
 
     dioxus::launch(Root);


### PR DESCRIPTION
## Summary
- On iOS `$HOME` is the app-container root (read-only), so `token_store` and `server_url_store` writing to `$HOME/.omnibus-*` silently failed — the app lost the server URL and bearer token on every cold start. Token persistence was also gated behind `cfg!(debug_assertions)`, so release builds never persisted it at all.
- New `data::app_dirs::data_dir()` resolves a writable per-app dir (`Library/Application Support/omnibus` on iOS, `$HOME/.omnibus` on desktop/dev); both stores persist there, and token persistence is now unconditional (`0o600`, protected at rest by the iOS sandbox + Data Protection).
- Android stays memory-only (no regression) pending a JNI `getFilesDir()` resolver — tracked in #837.
- The user is now only logged out when the server rejects the bearer (401); no client-side expiry was added — the server's 90-day TTL is authoritative.

## Test plan
- [x] `just check` — fmt + clippy (all combos incl. mobile) + full test matrix; added `cargo test -p omnibus-frontend --features mobile` to the matrix.
- [x] New unit tests: platform dir resolver, token-file round-trip + `0o600` perms, persistence-enabled. Fixed pre-existing parallel-flakiness in the mobile `audiobook_progress`/`reader_progress`/`view_prefs` tests (shared global map).
- [x] iOS simulator, end-to-end: fresh install → connect (`http://127.0.0.1:3000`) → login → library; container held `Library/Application Support/omnibus/{server,token}` (token `-rw-------`), nothing at legacy paths; **force-quit + cold relaunch landed straight on the authenticated library** — no server-URL or login screen.

## Version
- [x] **Patch** — the default.

## Notes
- The original bug reproduces mainly on-device / in release builds (the simulator's container root happens to be writable); the sim run proves the new path works and unit tests + the release-gate removal cover the on-device delta.