### PR TITLE
fix: pin IPHONEOS_DEPLOYMENT_TARGET so aws-lc-sys links on CI

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -50,6 +50,13 @@ jobs:
       # the flake's sccache path, which is skipped when CARGO_TARGET_DIR is set.
       CARGO_TARGET_DIR: ./target
       BUILD_NUMBER: ${{ github.event.inputs.build_number || github.run_number }}
+      # Pin the iOS deployment target so the C crypto deps (aws-lc-sys, ring)
+      # and the final Rust link agree on the min-iOS version. Without it dx
+      # links at iOS 10.0 while the runner's SDK compiles the C objects for
+      # 17.5, leaving `___chkstk_darwin` unresolved at link time. Matches the
+      # MinimumOSVersion the packaging script stamps into Info.plist. Both the
+      # `cc` crate and rustc read this env var.
+      IPHONEOS_DEPLOYMENT_TARGET: "13.0"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- The first TestFlight run (#839) failed at link with `___chkstk_darwin` undefined for arm64, preceded by hundreds of `object file ... built for newer 'iOS' version (17.5) than being linked (10.0)` warnings.
- Root cause: `dx` links the iOS binary at min-iOS **10.0** while the runner's SDK compiles the C crypto deps (`aws-lc-sys`, `ring`) for **17.5**; at that low floor the linker can't resolve `___chkstk_darwin`.
- Fix: pin `IPHONEOS_DEPLOYMENT_TARGET=13.0` in the workflow job env (read by both the `cc` crate and rustc), matching the `MinimumOSVersion` the packaging script stamps.

## Test plan
- [x] Local `dx bundle --platform ios --release ... --package-types ios` with the pin set → builds clean, and the binary now reports `LC_BUILD_VERSION minos 13.0` (was the mismatched default).
- [x] `actionlint` clean.
- [ ] Re-run the **TestFlight** workflow after merge → `dx bundle` links successfully → build reaches App Store Connect.

## Version
- [x] **No release** — CI/tooling fix only.

## Notes
> [!NOTE]
> Scoped to the CI job env rather than the flake's `.#mobile` shell, since local `dx bundle` already links fine here — the mismatch only surfaced with the runner's SDK. If a local `dx serve --platform ios` ever hits the same `___chkstk_darwin` error, promote this to `flake.nix`'s `mobileHook` so local and CI share one floor.