### PR TITLE
fix: build on macos-26 SDK and stamp CFBundlePackageType for App Store

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -35,7 +35,10 @@ permissions:
 jobs:
   upload:
     name: build + upload to TestFlight
-    runs-on: macos-14
+    # macos-26 ships Xcode 26 / the iOS 26 SDK. App Store Connect rejects any
+    # upload built with an older SDK ("must be built with the iOS 26 SDK or
+    # later"), so the older macos-14/15 images (Xcode 15/16) can't be used.
+    runs-on: macos-26
     permissions:
       contents: read
       # nix-installer-action needs the OIDC token endpoints to auth to FlakeHub

--- a/scripts/ios-package-ipa.sh
+++ b/scripts/ios-package-ipa.sh
@@ -62,6 +62,9 @@ plist_set() {
     || "$plistbuddy" -c "Set :$key \"$value\"" "$info_plist"
 }
 plist_set DTPlatformName string iphoneos
+# App Store validation rejects the bundle without CFBundlePackageType=APPL
+# ("Invalid Bundle OS Type code"); dx omits it like DTPlatformName.
+plist_set CFBundlePackageType string APPL
 plist_set CFBundleVersion string "$BUILD_NUMBER"
 # Only add a floor if the build didn't already declare one.
 "$plistbuddy" -c "Print :MinimumOSVersion" "$info_plist" >/dev/null 2>&1 \


### PR DESCRIPTION
## Summary
- The signed `.ipa` now uploads and reaches Apple's validation (auth + app record are correct), which rejected it with two errors:
  - **Invalid Bundle OS Type code** — dx's Info.plist omits `CFBundlePackageType`. Stamp `APPL` in the packaging script alongside the `DTPlatformName` patch.
  - **SDK version issue** — built with the iOS 17.5 SDK; App Store Connect now requires the **iOS 26 SDK (Xcode 26)**. Move the job from `macos-14` to `macos-26`.

## Test plan
- [x] Local (macOS 26 / Xcode 26.4.1, iOS SDK 26.4) confirms dx omits `CFBundlePackageType`; the new `plist_set CFBundlePackageType APPL` patches it and `plutil -lint` passes.
- [x] `shellcheck` + `actionlint` clean.
- [ ] Re-run the **TestFlight** workflow after merge → altool validation passes → build lands in App Store Connect.

## Version
- [x] **No release** — CI/tooling fix only.

## Notes
> [!NOTE]
> If altool later prompts about export compliance, that's the separate `ITSAppUsesNonExemptEncryption` key — a declaration best made deliberately, so it's left out here; it doesn't block the upload, only the first external-testing release.