### PR TITLE
feat: stamp TestFlight marketing version from the release tag

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -170,8 +170,11 @@ universal iPhone/iPad app and ships it to TestFlight. `dx` has no signing
 and emits a bare `.app`, so `scripts/ios-package-ipa.sh` does everything
 Xcode normally would: patches Info.plist (the keys dx omits —
 `DTPlatformName`, `CFBundlePackageType`, the `DT*` toolchain-provenance
-keys, `CFBundleSupportedPlatforms`, `UILaunchScreen`, build number),
-compiles the app-icon asset catalog (`mobile/assets/Assets.xcassets`) with
+keys, `CFBundleSupportedPlatforms`, `UILaunchScreen`, build number, and the
+marketing version — `CFBundleShortVersionString`, resolved from the latest
+`v*` release tag so the TestFlight version tracks the server release rather
+than the stale `Cargo.toml` `0.1.0`), compiles the app-icon asset catalog
+(`mobile/assets/Assets.xcassets`) with
 `actool`, embeds the provisioning profile, `codesign`s with the identity
 derived from the imported cert, and zips a `Payload/` `.ipa` that
 `xcrun altool` uploads. Bundle ID `com.omnibus.mobile` lives in

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -87,8 +87,14 @@ jobs:
             [ -n "$tag" ] || { echo "::error::No v* git tag found and no marketing_version input given."; exit 1; }
             version="${tag#v}"
           fi
+          # Reject anything but digits and dots before writing to $GITHUB_ENV: a
+          # dispatch input containing a newline would otherwise inject extra env
+          # assignments into every later step. Same guard the packaging script uses.
+          case "$version" in
+            '' | *[!0-9.]*) echo "::error::marketing version must be numeric/dot-separated, got: '$version'"; exit 1 ;;
+          esac
           echo "Marketing version: $version"
-          echo "MARKETING_VERSION=$version" >> "$GITHUB_ENV"
+          printf 'MARKETING_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -24,6 +24,10 @@ on:
         description: "CFBundleVersion to stamp (must be higher than the last uploaded build). Defaults to the workflow run number."
         required: false
         type: string
+      marketing_version:
+        description: "CFBundleShortVersionString (user-visible version). Defaults to the latest v* release tag, so it tracks the server release."
+        required: false
+        type: string
 
 concurrency:
   group: testflight-${{ github.ref }}
@@ -62,7 +66,29 @@ jobs:
       # crate and rustc read this env var.
       IPHONEOS_DEPLOYMENT_TARGET: "14.0"
     steps:
+      # fetch-depth: 0 pulls full history + tags so `git describe` below can
+      # find the latest release tag (checkout fetches neither by default).
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Resolve the user-visible marketing version so the TestFlight build's
+      # version matches the server's release tag. Prefer the dispatch input;
+      # otherwise use the latest v* git tag (the same tags release.yml mints).
+      - name: Resolve marketing version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.marketing_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
+          else
+            tag="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
+            [ -n "$tag" ] || { echo "::error::No v* git tag found and no marketing_version input given."; exit 1; }
+            version="${tag#v}"
+          fi
+          echo "Marketing version: $version"
+          echo "MARKETING_VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
@@ -150,6 +176,8 @@ jobs:
         env:
           # SHA-1 derived from the imported cert above (not the secret name).
           SIGNING_IDENTITY: ${{ env.SIGNING_IDENTITY_HASH }}
+          # Resolved from the release tag (or dispatch input) above.
+          MARKETING_VERSION: ${{ env.MARKETING_VERSION }}
           IPA_OUT: ${{ github.workspace }}/omnibus-mobile.ipa
         run: |
           set -euo pipefail

--- a/scripts/ios-package-ipa.sh
+++ b/scripts/ios-package-ipa.sh
@@ -10,6 +10,9 @@
 #   SIGNING_IDENTITY   codesign identity, e.g. "Apple Distribution: Name (TEAMID)"
 #   PROVISIONING_PROFILE  path to the decoded .mobileprovision
 #   BUILD_NUMBER       CFBundleVersion to stamp (monotonic; CI run number)
+#   MARKETING_VERSION  optional CFBundleShortVersionString (user-visible version,
+#                      e.g. 1.4.2). Left as dx bundled it (from Cargo.toml) when
+#                      unset; the workflow resolves it from the latest release tag.
 #   APP_DIR            optional; the .app to sign. Defaults to the sole
 #                      target/dx/omnibus-mobile/release/ios/*.app
 #   IPA_OUT            optional output path (default ./omnibus-mobile.ipa)
@@ -66,6 +69,16 @@ plist_set DTPlatformName string iphoneos
 # ("Invalid Bundle OS Type code"); dx omits it like DTPlatformName.
 plist_set CFBundlePackageType string APPL
 plist_set CFBundleVersion string "$BUILD_NUMBER"
+# CFBundleShortVersionString is the user-visible "marketing" version. dx stamps
+# it from mobile/Cargo.toml (0.1.0); override it here so the TestFlight build's
+# version tracks the server's release tag. Same numeric/dot-separated guard as
+# BUILD_NUMBER since it's interpolated into a PlistBuddy command.
+if [ -n "${MARKETING_VERSION:-}" ]; then
+  case "$MARKETING_VERSION" in
+    *[!0-9.]*) die "MARKETING_VERSION must be numeric/dot-separated, got: '$MARKETING_VERSION'" ;;
+  esac
+  plist_set CFBundleShortVersionString string "$MARKETING_VERSION"
+fi
 # Floor at iOS 14 — the minimum for the storyboard-free UILaunchScreen the
 # iPad build needs below. Set unconditionally so it matches the compile-time
 # deployment target the workflow pins.


### PR DESCRIPTION
## Summary
- The iOS TestFlight build's `CFBundleShortVersionString` (the user-visible "marketing" version) came from `mobile/Cargo.toml`, frozen at `0.1.0`, while the web/server release version is the `v*` tag `release.yml` mints — so the two drifted.
- `testflight.yml` now resolves the marketing version from the latest `v*` release tag (overridable via a new `marketing_version` dispatch input) and `scripts/ios-package-ipa.sh` stamps it into `Info.plist`, so the mobile version tracks the server release.
- Build number (`CFBundleVersion`) is unchanged — it stays the monotonic CI run number.

## Test plan
- [ ] `bash -n scripts/ios-package-ipa.sh` (syntax) and yamllint on the workflow — both clean.
- [ ] Dispatch the TestFlight workflow; confirm the uploaded build's version reads `X.Y.Z` (latest tag) instead of `0.1.0`, and that passing `marketing_version` overrides it.

## Version
By default a merge to \`main\` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [x] **Minor** — add the \`minor version\` label (\`vX.Y.Z\` → \`vX.(Y+1).0\`).
- [ ] **Patch** — the default; add the \`patch version\` label or leave unlabeled
  (\`vX.Y.Z\` → \`vX.Y.(Z+1)\`).
- [ ] **No release** — add the \`no release\` label to skip cutting a release.

## Notes
- Requires the checkout to fetch tags (`fetch-depth: 0`); the script keeps the same numeric/dot-separated guard on the version as it does on the build number.