### PR TITLE
refactor: fix mechanical pedantic clippy clusters (#480)

### DIFF
--- a/db/src/bookmarks/tests.rs
+++ b/db/src/bookmarks/tests.rs
@@ -183,13 +183,13 @@ async fn delete_bookmark_returns_not_found_for_other_user() {
 /// 1500-row response-cap fixture.
 async fn seed_bookmarks_raw(pool: &SqlitePool, user_id: i64, book_uuid: &str, count: i64) {
     sqlx::query(
-        r#"
+        r"
         WITH RECURSIVE n(i) AS (
             SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
         )
         INSERT INTO bookmarks (user_id, book_uuid, position, created_at)
         SELECT ?, ?, 'p' || i, i FROM n
-        "#,
+        ",
     )
     .bind(count)
     .bind(user_id)

--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -318,20 +318,20 @@ mod tests {
     // `epub` crate's tolerance for a missing mimetype.
     const MIMETYPE: &[u8] = b"application/epub+zip";
 
-    const CONTAINER_XML: &[u8] = br##"<?xml version="1.0"?>
+    const CONTAINER_XML: &[u8] = br#"<?xml version="1.0"?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
   <rootfiles><rootfile full-path="content.opf" media-type="application/oebps-package+xml"/></rootfiles>
-</container>"##;
+</container>"#;
 
     // Minimal EPUB3 navigation document the OPF manifest references. Included
     // so the manifest points at a real resource instead of a dangling href.
-    const NAV_XHTML: &[u8] = br##"<?xml version="1.0" encoding="utf-8"?>
+    const NAV_XHTML: &[u8] = br#"<?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
   <head><title>Contents</title></head>
   <body>
     <nav epub:type="toc"><ol><li><a href="content.opf">Start</a></li></ol></nav>
   </body>
-</html>"##;
+</html>"#;
 
     /// Parse an in-memory EPUB whose sole OPF is `opf`. The manifest/spine are
     /// required by the parser, so every fixture below wraps its `<metadata>`
@@ -351,14 +351,14 @@ mod tests {
     /// where `opf:*` attributes on `<dc:*>` become refinements).
     fn opf_package(version: &str, metadata_body: &str) -> String {
         format!(
-            r##"<?xml version="1.0"?>
+            r#"<?xml version="1.0"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="{version}" unique-identifier="pub-id">
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
 {metadata_body}
   </metadata>
   <manifest><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml"/></manifest>
   <spine><itemref idref="nav"/></spine>
-</package>"##
+</package>"#
         )
     }
 
@@ -437,7 +437,7 @@ mod tests {
         // `<dc:creator>` element rather than separate `<meta refines>` nodes.
         let doc = doc_from_opf(&opf_package(
             "2.0",
-            r##"    <dc:creator opf:role="aut" opf:file-as="Le Guin, Ursula K.">Ursula K. Le Guin</dc:creator>"##,
+            r#"    <dc:creator opf:role="aut" opf:file-as="Le Guin, Ursula K.">Ursula K. Le Guin</dc:creator>"#,
         ));
         let creators = collect_contributors(&doc, "creator");
         assert_eq!(creators.len(), 1);
@@ -453,9 +453,9 @@ mod tests {
         // for the second role the pipeline merges in.
         let doc = doc_from_opf(&opf_package(
             "3.0",
-            r##"    <dc:creator>Primary Author</dc:creator>
+            r"    <dc:creator>Primary Author</dc:creator>
     <dc:contributor>   </dc:contributor>
-    <dc:contributor>Jane Editor</dc:contributor>"##,
+    <dc:contributor>Jane Editor</dc:contributor>",
         ));
         let contributors = collect_contributors(&doc, "contributor");
         assert_eq!(contributors.len(), 1);
@@ -484,8 +484,8 @@ mod tests {
         // supply both the name and the index.
         let doc = doc_from_opf(&opf_package(
             "2.0",
-            r##"    <meta name="calibre:series" content="Earthsea"/>
-    <meta name="calibre:series_index" content="2.0"/>"##,
+            r#"    <meta name="calibre:series" content="Earthsea"/>
+    <meta name="calibre:series_index" content="2.0"/>"#,
         ));
         let (series, index) = collect_series(&doc);
         assert_eq!(series.as_deref(), Some("Earthsea"));
@@ -494,10 +494,7 @@ mod tests {
 
     #[test]
     fn collect_series_returns_none_when_no_series_metadata_present() {
-        let doc = doc_from_opf(&opf_package(
-            "3.0",
-            r##"    <dc:title>Standalone</dc:title>"##,
-        ));
+        let doc = doc_from_opf(&opf_package("3.0", r"    <dc:title>Standalone</dc:title>"));
         let (series, index) = collect_series(&doc);
         assert_eq!(series, None);
         assert_eq!(index, None);
@@ -524,7 +521,7 @@ mod tests {
         // the parser surfaces as a `scheme` refinement.
         let doc = doc_from_opf(&opf_package(
             "2.0",
-            r##"    <dc:identifier id="pub-id" opf:scheme="ISBN">9780000000000</dc:identifier>"##,
+            r#"    <dc:identifier id="pub-id" opf:scheme="ISBN">9780000000000</dc:identifier>"#,
         ));
         let ids = collect_identifiers(&doc);
         assert_eq!(ids.len(), 1);
@@ -536,8 +533,8 @@ mod tests {
     fn collect_identifiers_leaves_scheme_none_when_unspecified_and_skips_blanks() {
         let doc = doc_from_opf(&opf_package(
             "3.0",
-            r##"    <dc:identifier>plain-id</dc:identifier>
-    <dc:identifier>   </dc:identifier>"##,
+            r"    <dc:identifier>plain-id</dc:identifier>
+    <dc:identifier>   </dc:identifier>",
         ));
         let ids = collect_identifiers(&doc);
         assert_eq!(ids.len(), 1);
@@ -551,7 +548,7 @@ mod tests {
     fn first_returns_trimmed_value_for_present_key_and_none_otherwise() {
         let doc = doc_from_opf(&opf_package(
             "3.0",
-            r##"    <dc:title>  Earthsea  </dc:title>"##,
+            r"    <dc:title>  Earthsea  </dc:title>",
         ));
         assert_eq!(first(&doc, "title").as_deref(), Some("Earthsea"));
         assert_eq!(first(&doc, "publisher"), None);

--- a/db/src/highlights/tests.rs
+++ b/db/src/highlights/tests.rs
@@ -253,13 +253,13 @@ async fn delete_highlight_returns_not_found_for_other_user() {
 /// 1500-row response-cap fixture.
 async fn seed_highlights_raw(pool: &SqlitePool, user_id: i64, book_uuid: &str, count: i64) {
     sqlx::query(
-        r#"
+        r"
         WITH RECURSIVE n(i) AS (
             SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
         )
         INSERT INTO highlights (user_id, book_uuid, epub_cfi_range, color, created_at)
         SELECT ?, ?, 'epubcfi(/' || i || ')', 'amber', i FROM n
-        "#,
+        ",
     )
     .bind(count)
     .bind(user_id)

--- a/db/src/journals/tests.rs
+++ b/db/src/journals/tests.rs
@@ -239,13 +239,13 @@ async fn create_resolves_merged_uuid_to_surviving_book() {
 /// `create_journal_entry` — too slow at over-cap row counts.
 async fn seed_entries_raw(pool: &SqlitePool, user_id: i64, book_uuid: &str, count: i64) {
     sqlx::query(
-        r#"
+        r"
         WITH RECURSIVE n(i) AS (
             SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
         )
         INSERT INTO journal_entries (user_id, book_uuid, body_md, created_at)
         SELECT ?, ?, 'entry ' || i, i FROM n
-        "#,
+        ",
     )
     .bind(count)
     .bind(user_id)

--- a/db/src/merge/snapshot.rs
+++ b/db/src/merge/snapshot.rs
@@ -284,6 +284,6 @@ mod tests {
         assert_eq!(ts(r#"{"timestamp":"2024-01-02 03:04:05"}"#), None);
         // Null / missing -> None.
         assert_eq!(ts(r#"{"timestamp":null}"#), None);
-        assert_eq!(ts(r#"{}"#), None);
+        assert_eq!(ts(r"{}"), None);
     }
 }

--- a/db/src/normalize/tests.rs
+++ b/db/src/normalize/tests.rs
@@ -82,7 +82,7 @@ fn tricky_inputs() -> Vec<String> {
         "trailing comma,",
     ]
     .iter()
-    .map(|s| s.to_string())
+    .map(ToString::to_string)
     .collect();
     // A very long input to exercise the capacity/allocation path.
     v.push("Tomás Ërník ".repeat(5_000));

--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -426,13 +426,13 @@ async fn list_visible_scopes_by_owner_public_and_admin() {
 /// through `create_shelf` — too slow at over-cap row counts.
 async fn seed_shelves_raw(pool: &sqlx::SqlitePool, owner_id: i64, count: i64) {
     sqlx::query(
-        r#"
+        r"
         WITH RECURSIVE n(i) AS (
             SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
         )
         INSERT INTO shelves (owner_user_id, kind, name, position)
         SELECT ?, 'manual', 'Shelf ' || i, i FROM n
-        "#,
+        ",
     )
     .bind(count)
     .bind(owner_id)

--- a/db/src/shelves/write.rs
+++ b/db/src/shelves/write.rs
@@ -5,7 +5,9 @@
 //! still points at the surviving book. Name collisions per owner surface as
 //! [`ShelfError::NameTaken`].
 
-use omnibus_shared::{CreateShelfRequest, Shelf, ShelfKind, ShelfRule, UpdateShelfRequest};
+use omnibus_shared::{
+    CreateShelfRequest, MatchMode, Shelf, ShelfKind, ShelfRule, UpdateShelfRequest, Visibility,
+};
 use sqlx::{Sqlite, SqlitePool, Transaction};
 
 use super::read::get_shelf;
@@ -43,7 +45,7 @@ pub async fn create_shelf(
     .bind(req.name.trim())
     .bind(req.description.as_deref())
     .bind(req.visibility.as_str())
-    .bind(req.match_mode.map(|m| m.as_str()))
+    .bind(req.match_mode.map(MatchMode::as_str))
     .bind(&accent)
     .bind(position)
     .fetch_one(&mut *tx)
@@ -113,8 +115,8 @@ pub async fn update_shelf(
     )
     .bind(req.name.as_deref().map(str::trim))
     .bind(req.description.as_deref())
-    .bind(req.visibility.map(|v| v.as_str()))
-    .bind(req.match_mode.map(|m| m.as_str()))
+    .bind(req.visibility.map(Visibility::as_str))
+    .bind(req.match_mode.map(MatchMode::as_str))
     .bind(id)
     .execute(&mut *tx)
     .await

--- a/db/src/suggestions/hardcover.rs
+++ b/db/src/suggestions/hardcover.rs
@@ -328,7 +328,7 @@ pub async fn co_listed_counts(
     }
     let ids_csv = list_ids
         .iter()
-        .map(|id| id.to_string())
+        .map(i64::to_string)
         .collect::<Vec<_>>()
         .join(", ");
     let mut counts: HashMap<i64, i64> = HashMap::new();

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -76,7 +76,7 @@ impl EnvVarGuard {
     pub fn set_os(var: &'static str, value: Option<&OsStr>) -> Self {
         let lock = ENV_LOCK
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var_os(var);
         // SAFETY: ENV_LOCK is held; no other thread in this process
         // mutates the environment concurrently.
@@ -152,7 +152,7 @@ impl CoversTempDir {
     pub fn new(tag: &str) -> Self {
         let guard = COVERS_ENV_LOCK
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let pid = std::process::id();
         let seq = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -204,7 +204,7 @@ pub async fn seed_minimal_books(pool: &SqlitePool, count: i64) {
         .await
         .unwrap();
     sqlx::query(
-        r#"
+        r"
         WITH RECURSIVE n(i) AS (
             SELECT 1
             UNION ALL
@@ -214,7 +214,7 @@ pub async fn seed_minimal_books(pool: &SqlitePool, count: i64) {
         SELECT 'uuid-' || i, 'b' || i || '.epub', ?, '/lib/b' || i, 'Title ' || i,
                'Title ' || printf('%010d', i)
           FROM n
-        "#,
+        ",
     )
     .bind(count)
     .bind(lib_id)
@@ -423,7 +423,7 @@ pub async fn seed_books_for_one_author_and_series(pool: &SqlitePool, count: i64)
             .await
             .unwrap();
     sqlx::query(
-        r#"
+        r"
         WITH RECURSIVE n(i) AS (
             SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
         )
@@ -431,7 +431,7 @@ pub async fn seed_books_for_one_author_and_series(pool: &SqlitePool, count: i64)
         SELECT 'uuid-' || i, ?, '/lib/b' || i, 'Title ' || i,
                'Title ' || printf('%010d', i), i
           FROM n
-        "#,
+        ",
     )
     .bind(count)
     .bind(lib_id)

--- a/frontend/src/components/create_shelf_modal.rs
+++ b/frontend/src/components/create_shelf_modal.rs
@@ -123,7 +123,7 @@ pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<She
         let req = match kind() {
             ShelfKind::Smart => {
                 let wire: Vec<ShelfRule> =
-                    rules.read().iter().filter_map(|r| r.to_rule()).collect();
+                    rules.read().iter().filter_map(RuleDraft::to_rule).collect();
                 CreateShelfRequest {
                     kind: ShelfKind::Smart,
                     name: name(),
@@ -287,7 +287,7 @@ fn SmartBody(
     // Recompute the preview whenever the rule set or match mode changes. Keyed
     // on a memo of the encoded rules so unrelated re-renders don't refetch.
     let preview_key = use_memo(move || {
-        let complete: Vec<ShelfRule> = rules.read().iter().filter_map(|r| r.to_rule()).collect();
+        let complete: Vec<ShelfRule> = rules.read().iter().filter_map(RuleDraft::to_rule).collect();
         (match_mode, complete)
     });
     let preview_url = server_url.clone();

--- a/server/src/backend/uploads.rs
+++ b/server/src/backend/uploads.rs
@@ -147,7 +147,7 @@ fn norm(value: &Option<String>) -> Option<String> {
         .as_ref()
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
+        .map(str::to_string)
 }
 
 // --- Streaming helper -------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes the two verified mechanical, no-behavior-change pedantic clippy clusters cited in #480: `clippy::redundant_closure_for_method_calls` (10 sites — closures that just call a method, e.g. `.map(|m| m.as_str())` → `.map(MatchMode::as_str)`) and `clippy::needless_raw_string_hashes` (17 sites — raw string/byte-string literals using more `#` delimiters than their content requires, e.g. `r##"..."##` → `r"..."` where the content has no embedded `"`/`"#`).
- **The issue's third cited cluster does not hold up under a fresh clippy run.** #480 labels its `String`-by-value findings (`db/src/audiobook.rs:63`, `db/src/ebook/parse.rs:33`, `frontend/src/pages/author.rs:84`, `frontend/src/pages/series.rs:60`) as `clippy::ptr_arg`, but that lint only fires on *reference* parameters (`&String`, `&Vec`, `&PathBuf`) — never on owned arguments. Running `-W clippy::ptr_arg` across the workspace today produces **zero** warnings. The closest real lint for "owned value where a borrow would do," `clippy::needless_pass_by_value`, currently flags 35+ sites, many of them Dioxus component props where taking ownership is intentional (component reactivity, closures) — reclassifying those is a judgment call per-site, not a mechanical fix, so it's out of scope here.
- Also out of scope (same rationale as #832/#848's item-4 deferral): the CI-gating workflow change and the `missing_errors_doc`/`must_use_candidate` doc-comment additions across ~140 functions — both are larger, separately-reviewable changes.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings`
- [x] `cargo test -p omnibus` — 307 passed
- [x] `cargo test -p omnibus-db` — 869 + 2 integration passed
- [x] `cargo test -p omnibus-frontend --features server` — 223 passed
- [x] `cargo test -p omnibus-shared` — 99 passed
- [x] Verified `-W clippy::redundant_closure_for_method_calls -W clippy::needless_raw_string_hashes` produces zero warnings workspace-wide after the fix

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
Closes #480 for the two verified mechanical clusters. The `ptr_arg` citation is a mislabeling in the original issue (see Summary); the CI-gating step and the doc-comment work are flagged as follow-up and not covered by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014qzHH38eeRJdgZoD9iFVqf)_