### PR TITLE
fix: declare encryption exemption so ASC skips the compliance gate

### DIFF
--- a/scripts/ios-package-ipa.sh
+++ b/scripts/ios-package-ipa.sh
@@ -68,13 +68,12 @@ plist_set DTPlatformName string iphoneos
 # App Store validation rejects the bundle without CFBundlePackageType=APPL
 # ("Invalid Bundle OS Type code"); dx omits it like DTPlatformName.
 plist_set CFBundlePackageType string APPL
-# Declare export-compliance exemption up front. The app's only cryptography is
-# the HTTPS/TLS it uses to talk to its own server — Apple-exempt "standard"
-# encryption. Without this key App Store Connect blocks every build on a manual
-# "Missing Compliance" gate (the US export-compliance question, plus a second
-# France-specific encryption declaration), which stops TestFlight auto-
-# distribution. Declaring false answers both and lets builds flow to testers.
-plist_set ITSAppUsesNonExemptEncryption bool false
+# Pre-declare export-compliance exemption (HTTPS/TLS to our own server is
+# Apple-exempt) so ASC skips the "Missing Compliance" gate that blocks
+# TestFlight auto-distribution. Set via PlistBuddy directly, unquoted, so the
+# value is a real boolean (plist_set is for string keys).
+"$plistbuddy" -c "Add :ITSAppUsesNonExemptEncryption bool false" "$info_plist" 2>/dev/null \
+  || "$plistbuddy" -c "Set :ITSAppUsesNonExemptEncryption false" "$info_plist"
 plist_set CFBundleVersion string "$BUILD_NUMBER"
 # CFBundleShortVersionString is the user-visible "marketing" version. dx stamps
 # it from mobile/Cargo.toml (0.1.0); override it here so the TestFlight build's

--- a/scripts/ios-package-ipa.sh
+++ b/scripts/ios-package-ipa.sh
@@ -68,6 +68,13 @@ plist_set DTPlatformName string iphoneos
 # App Store validation rejects the bundle without CFBundlePackageType=APPL
 # ("Invalid Bundle OS Type code"); dx omits it like DTPlatformName.
 plist_set CFBundlePackageType string APPL
+# Declare export-compliance exemption up front. The app's only cryptography is
+# the HTTPS/TLS it uses to talk to its own server — Apple-exempt "standard"
+# encryption. Without this key App Store Connect blocks every build on a manual
+# "Missing Compliance" gate (the US export-compliance question, plus a second
+# France-specific encryption declaration), which stops TestFlight auto-
+# distribution. Declaring false answers both and lets builds flow to testers.
+plist_set ITSAppUsesNonExemptEncryption bool false
 plist_set CFBundleVersion string "$BUILD_NUMBER"
 # CFBundleShortVersionString is the user-visible "marketing" version. dx stamps
 # it from mobile/Cargo.toml (0.1.0); override it here so the TestFlight build's


### PR DESCRIPTION
## Summary
- Stamp `ITSAppUsesNonExemptEncryption = false` into the iOS Info.plist in `scripts/ios-package-ipa.sh`.
- The app's only cryptography is HTTPS/TLS to its own server — Apple-exempt — so declaring the exemption in the binary is correct.
- Without it, every TestFlight upload stalled on App Store Connect's manual "Missing Compliance" gate (US export-compliance prompt + a second France-specific encryption declaration), blocking auto-distribution to testers.

## Test plan
- [ ] Run the `TestFlight` workflow and confirm the uploaded build lands in App Store Connect with no encryption/France compliance prompt and is eligible for automatic TestFlight distribution.

## Version
- [x] **No release** — iOS packaging tooling only; no server-facing change.

## Notes
> [!NOTE]
> This clears the *compliance* gate. Hands-free delivery to testers still needs the one-time ASC toggle: TestFlight → Internal Testing group → "Automatically distribute builds".