### PR TITLE
feat: token-auth + CORS the EPUB file stream for the mobile reader

### DIFF
--- a/server/src/auth/gate.rs
+++ b/server/src/auth/gate.rs
@@ -34,6 +34,10 @@ fn is_media_read_path(path: &str) -> bool {
         // `<audio src>`, which can only carry the session as `?token=`. HLS
         // segments are web-only (cookie-authed) so they stay off this list.
         || (path.starts_with("/api/audiobooks/") && path.contains("/parts/"))
+        // The EPUB file stream is fetched by epub.js from the mobile WebView,
+        // a cross-origin XHR that carries neither cookie nor bearer header.
+        // Only `/file` opts in; `/download` and `/kepub` stay header/cookie-only.
+        || (path.starts_with("/api/ebooks/") && path.ends_with("/file"))
 }
 
 /// Reject `/api/*` requests without a live session with `401 Unauthorized`, after exempting `/api/auth/*` and `/api/_health`.

--- a/server/src/auth/gate/tests.rs
+++ b/server/src/auth/gate/tests.rs
@@ -15,6 +15,7 @@ async fn app() -> (Router, sqlx::SqlitePool) {
             "/api/audiobooks/{uuid}/parts/{ordinal}",
             get(|| async { "part ok" }),
         )
+        .route("/api/ebooks/{uuid}/file", get(|| async { "file ok" }))
         .route("/api/auth/login", get(|| async { "login ok" }))
         .route("/api/_health", get(|| async { "health ok" }))
         .route("/", get(|| async { "home" }))
@@ -264,6 +265,40 @@ async fn audiobook_part_get_without_auth_is_401() {
         .oneshot(
             Request::builder()
                 .uri("/api/audiobooks/some-uuid/parts/0")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn ebook_file_get_with_query_token_passes() {
+    // epub.js fetches the EPUB from the mobile WebView with the session as
+    // `?token=`; the `/file` stream must accept it like the audiobook parts do.
+    let (app, pool) = app().await;
+    let token = seed_bearer_token(&pool).await;
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/ebooks/some-uuid/file?token={token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ebook_file_get_without_auth_is_401() {
+    let (app, pool) = app().await;
+    seed_bearer_token(&pool).await;
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/ebooks/some-uuid/file")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -1,6 +1,6 @@
 //! `/api/ebooks/*` handlers.
 //!
-//! Cookie-gated reads that list the configured library, look up a single
+//! Session-gated reads that list the configured library, look up a single
 //! book by uuid, and stream the raw EPUB bytes for the in-app reader.
 //! Mounted on the mobile REST router in [`super::rest_router`]. The
 //! `/file` stream additionally accepts a `?token=` query param
@@ -214,7 +214,24 @@ pub(super) async fn get_ebook_file(
     Path(uuid): Path<String>,
     Query(query): Query<EbookFileQuery>,
 ) -> Response {
-    let path = match resolve_epub_path(&state, &uuid, query.file_id).await {
+    let mut resp = read_ebook_file(&state, &uuid, query.file_id).await;
+    // epub.js reads this stream over a cross-origin XHR from inside the mobile
+    // WebView (unlike the CORS-exempt `<img>`/`<audio>` media the app uses
+    // elsewhere), so the ACAO must ride *every* response — including the 404 /
+    // 500 error paths — or the WebView can't read the outcome. The URL query
+    // token is the only credential, so a wildcard never widens real access.
+    resp.headers_mut().insert(
+        header::ACCESS_CONTROL_ALLOW_ORIGIN,
+        HeaderValue::from_static("*"),
+    );
+    resp
+}
+
+/// Resolve the on-disk EPUB and stream its bytes (200), or the resolution /
+/// read failure as a 404 / 500. CORS is layered on by the caller so it covers
+/// every arm uniformly.
+async fn read_ebook_file(state: &AppState, uuid: &str, file_id: Option<i64>) -> Response {
+    let path = match resolve_epub_path(state, uuid, file_id).await {
         Ok(p) => p,
         Err(resp) => return resp,
     };
@@ -225,12 +242,6 @@ pub(super) async fn get_ebook_file(
                 (header::CACHE_CONTROL, "private, max-age=86400"),
                 (header::VARY, "Cookie"),
                 (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
-                // epub.js reads this stream over XHR from inside the mobile
-                // WebView — a cross-origin, readable fetch (unlike the
-                // CORS-exempt `<img>`/`<audio>` media the app uses elsewhere).
-                // The URL query token is the only credential, so a wildcard
-                // ACAO is safe: it never widens access beyond holding the token.
-                (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
             ],
             bytes,
         )

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -2,7 +2,10 @@
 //!
 //! Cookie-gated reads that list the configured library, look up a single
 //! book by uuid, and stream the raw EPUB bytes for the in-app reader.
-//! Mounted on the mobile REST router in [`super::rest_router`].
+//! Mounted on the mobile REST router in [`super::rest_router`]. The
+//! `/file` stream additionally accepts a `?token=` query param
+//! ([`MediaAuthUser`]) so epub.js can fetch the book from the mobile WebView,
+//! which carries neither a cookie nor an `Authorization` header.
 
 use axum::{
     extract::{Path, Query, Request, State},
@@ -18,7 +21,7 @@ use omnibus_shared::{EbookLibrary, SortDir, SortKey, ViewFilters};
 use serde::Deserialize;
 
 use super::{internal, with_pagination_headers, AppState};
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, MediaAuthUser};
 
 /// Default keyset page size for the paginated `GET /api/ebooks` form (F5b
 /// open question #1). A grid renders ~30–60 cards above the fold and the table
@@ -200,8 +203,13 @@ async fn resolve_epub_path(
 
 /// Streams the raw EPUB bytes. Accepts optional `?file_id=N` to target
 /// a specific `book_files` row for multi-EPUB books.
+///
+/// Gated by [`MediaAuthUser`] rather than [`AuthUser`]: epub.js fetches this
+/// URL from inside the mobile WebView, which can carry neither a session
+/// cookie nor a bearer header, so the session token rides a `?token=` query
+/// param. The web reader's same-origin cookie fetch keeps working unchanged.
 pub(super) async fn get_ebook_file(
-    _user: AuthUser,
+    _user: MediaAuthUser,
     State(state): State<AppState>,
     Path(uuid): Path<String>,
     Query(query): Query<EbookFileQuery>,
@@ -217,6 +225,12 @@ pub(super) async fn get_ebook_file(
                 (header::CACHE_CONTROL, "private, max-age=86400"),
                 (header::VARY, "Cookie"),
                 (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+                // epub.js reads this stream over XHR from inside the mobile
+                // WebView — a cross-origin, readable fetch (unlike the
+                // CORS-exempt `<img>`/`<audio>` media the app uses elsewhere).
+                // The URL query token is the only credential, so a wildcard
+                // ACAO is safe: it never widens access beyond holding the token.
+                (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
             ],
             bytes,
         )

--- a/server/src/backend/ebooks/tests.rs
+++ b/server/src/backend/ebooks/tests.rs
@@ -483,6 +483,13 @@ async fn api_get_ebook_file_returns_200_with_query_token() {
         .await
         .expect("request should succeed");
     assert_eq!(res.status(), StatusCode::OK);
+    // The cross-origin XHR path must carry the CORS opt-in.
+    assert_eq!(
+        res.headers()
+            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|v| v.to_str().ok()),
+        Some("*"),
+    );
     let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
     assert_eq!(&bytes[..], b"PK\x03\x04 fake-epub");
 

--- a/server/src/backend/ebooks/tests.rs
+++ b/server/src/backend/ebooks/tests.rs
@@ -429,6 +429,66 @@ async fn api_get_ebook_file_returns_200_with_epub_bytes() {
     std::fs::remove_dir_all(&tmp).ok();
 }
 
+/// The `/file` stream is gated by `MediaAuthUser`, so a `?token=` query param
+/// authenticates it with neither a cookie nor a bearer header — the path
+/// epub.js takes from inside the mobile WebView. Mirrors the bearer 200 test
+/// but authenticates purely via the query token on an otherwise-anonymous GET.
+#[tokio::test]
+async fn api_get_ebook_file_returns_200_with_query_token() {
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp = std::env::temp_dir().join(format!("omnibus_ebook_file_token_test_{pid}_{nanos}"));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let stem = "alpha";
+    std::fs::write(tmp.join(format!("{stem}.epub")), b"PK\x03\x04 fake-epub").unwrap();
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(tmp.to_str().unwrap())
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let uuid = "44444444-4444-4444-4444-444444444444";
+    let book_id =
+        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, 'Alpha')")
+            .bind(uuid)
+            .bind(lib_id)
+            .bind(tmp.to_str().unwrap())
+            .execute(&pool)
+            .await
+            .unwrap()
+            .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', ?, 0)",
+    )
+    .bind(book_id)
+    .bind(stem)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    // Anonymous request (no Authorization header) — the query token is the
+    // only credential, exactly as an `<... src>` fetch from the WebView.
+    let res = app
+        .oneshot(get_anon(&format!("/api/ebooks/{uuid}/file?token={token}")))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&bytes[..], b"PK\x03\x04 fake-epub");
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
 /// Drives the first `internal(...)` arm of `get_ebook_file`: when
 /// `db::resolve_book_id_by_uuid` returns `Err`, the handler must
 /// surface 500 (not 404). The induce-sqlx-error idiom is to drop


### PR DESCRIPTION
## Summary
- Switch `GET /api/ebooks/:uuid/file` from `AuthUser` to `MediaAuthUser` (and add it to the auth gate's `is_media_read_path`) so epub.js can fetch the EPUB from inside the mobile WebView via a `?token=` query — a cross-origin request that carries neither a session cookie nor an `Authorization` header.
- Emit a wildcard `Access-Control-Allow-Origin` on the `/file` response: epub.js reads the stream over a cross-origin XHR (unlike the CORS-exempt `<img>`/`<audio>` media used elsewhere). The URL token is the only credential, so the wildcard never widens real access.
- Web reader's same-origin cookie fetch is unaffected; `/download` and `/kepub` stay header/cookie-only.

## Test plan
- [x] `cargo test -p omnibus` — new `api_get_ebook_file_returns_200_with_query_token`, plus gate tests `ebook_file_get_with_query_token_passes` / `_without_auth_is_401`.
- [x] `just check` (fmt + clippy matrix + full test suite) green.

## Version
- [x] **No release** — base PR of a 3-PR stack; the head PR (`-3`) cuts the single release.

## Notes
- Base of the mobile EPUB reader stack (`-1` → `-2` → `-3`). Prerequisite only; no user-visible change on its own.