### PR TITLE
feat: mobile EPUB reader — core reading via epub.js in the WebView

### DIFF
--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -175,17 +175,7 @@ fn BdCtaRow(
     rsx! {
         div { class: "bd-cta-row",
             if has_ebook {
-                {
-                    #[cfg(not(feature = "mobile"))]
-                    let start_reading = rsx! {
-                        Link { to: Route::BookRead { uuid: uuid.clone() }, class: "btn primary lg", "data-testid": "start-reading", "Start reading" }
-                    };
-                    #[cfg(feature = "mobile")]
-                    let start_reading = rsx! {
-                        button { class: "btn primary lg", disabled: true, title: "Reading on mobile coming soon", "Start reading" }
-                    };
-                    start_reading
-                }
+                Link { to: Route::BookRead { uuid: uuid.clone() }, class: "btn primary lg", "data-testid": "start-reading", "Start reading" }
             } else if has_audio {
                 {
                     #[cfg(not(feature = "mobile"))]

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -80,10 +80,14 @@ pub(super) fn render_loaded_mobile(b: EbookMetadata, server_url: String) -> Elem
                 }
             }
 
-            // Primary CTAs — reading stays stubbed; listening opens the player.
+            // Primary CTAs — reading opens the in-app reader; listening opens the player.
             div { class: "m-bd-cta",
                 if has_ebook {
-                    button { class: "btn primary lg", disabled: true, title: "Reading on mobile coming soon", "Read" }
+                    Link {
+                        to: Route::BookRead { uuid: uuid.clone() },
+                        class: "btn primary lg",
+                        "Read"
+                    }
                 }
                 if has_audio {
                     Link {

--- a/frontend/src/pages/reader/chrome_handlers.rs
+++ b/frontend/src/pages/reader/chrome_handlers.rs
@@ -1,7 +1,8 @@
 //! Top-bar / page-turn / keydown event handlers for `BookReadPage`.
 //! Extracted so the parent component reads as setup → render rather than
 //! a 60-line block of cfg-gated closures. Each handler bridges signal
-//! state with the (web-only) JS calls and (non-mobile) router navigation.
+//! state with the (web/mobile) JS glue calls and (non-mobile) router
+//! navigation.
 
 use dioxus::prelude::*;
 #[cfg(not(feature = "mobile"))]
@@ -64,7 +65,7 @@ enum Direction {
 }
 
 /// Clear any live selection and ask the epub.js glue to page in `dir`.
-#[cfg(feature = "web")]
+#[cfg(any(feature = "web", feature = "mobile"))]
 fn advance_page(mut selection: Signal<Option<SelectionData>>, dir: Direction) {
     selection.set(None);
     match dir {
@@ -73,8 +74,8 @@ fn advance_page(mut selection: Signal<Option<SelectionData>>, dir: Direction) {
     }
 }
 
-/// Non-web stub: the JS glue only exists in the browser, so paging is a no-op.
-#[cfg(not(feature = "web"))]
+/// SSR stub: the JS glue only exists in the WebView, so paging is a no-op.
+#[cfg(not(any(feature = "web", feature = "mobile")))]
 fn advance_page(_: Signal<Option<SelectionData>>, _: Direction) {}
 
 /// Reader keyboard map: arrows page the book; Escape peels back the topmost
@@ -89,12 +90,12 @@ fn handle_keydown(
     match evt.key() {
         Key::ArrowLeft => {
             evt.prevent_default();
-            #[cfg(feature = "web")]
+            #[cfg(any(feature = "web", feature = "mobile"))]
             super::reader_call("prev", "");
         }
         Key::ArrowRight => {
             evt.prevent_default();
-            #[cfg(feature = "web")]
+            #[cfg(any(feature = "web", feature = "mobile"))]
             super::reader_call("next", "");
         }
         Key::Escape => {

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -1,0 +1,210 @@
+//! Mobile reader interop — mounts the vendored epub.js in the wry WebView and
+//! bridges its events into the shared reader signals.
+//!
+//! Mobile compiles the same reader chrome + overlays as web, but runs natively
+//! (not WASM), so the web `web_sys`/`wasm_bindgen` callback registration can't
+//! be reused. This installer instead evals a script that forwards the glue's
+//! `window.__omnibusOn*` calls into `dioxus.send(...)` and drains them with
+//! `Eval::recv().await`, mirroring `listen/mobile`. Reading position and saved
+//! highlights are synced through the mobile REST [`crate::data`] layer.
+
+#![cfg(feature = "mobile")]
+
+use dioxus::prelude::*;
+
+use omnibus_shared::{Highlight, ProgressFormat, ProgressUpdate};
+
+use crate::data;
+
+use super::prefs::ReaderPrefs;
+use super::search_panel::SearchResult;
+use super::selection::SelectionData;
+use super::toc_drawer::TocEntry;
+use super::{reader_call_json, reader_call_json2, ReaderStatus, RelocateData};
+
+mod interop;
+
+/// The signals the reader drives from the JS event channel — the mobile mirror
+/// of the web `interop::InteropSignals`.
+#[derive(Copy, Clone)]
+pub(super) struct InteropSignals {
+    pub status: Signal<ReaderStatus>,
+    pub loc: Signal<RelocateData>,
+    pub selection: Signal<Option<SelectionData>>,
+    pub highlights: Signal<Vec<Highlight>>,
+    pub toc: Signal<Vec<TocEntry>>,
+    pub search_results: Signal<Vec<SearchResult>>,
+}
+
+/// JS→Rust reader events, forwarded by the shims the install script defines in
+/// the WebView. The `json` payloads are the glue's own `JSON.stringify`ed
+/// structs, parsed into the reader types on receipt (same shapes web parses).
+#[derive(serde::Deserialize)]
+#[serde(tag = "kind")]
+enum ReaderEvent {
+    Relocate { json: String },
+    Status { state: String },
+    Selection { json: String },
+    Toc { json: String },
+    Search { json: String },
+}
+
+/// Install the mobile reader interop: on every `uuid` change, mount epub.js
+/// against the tokened file URL and drain its event channel into the reader
+/// signals; separately, re-apply the theme whenever it changes. Runs as
+/// unconditional hooks (rule 07) from `BookReadPage`'s `use_reader_signals`.
+pub(super) fn install_reader_mobile_interop(
+    uuid: String,
+    prefs: ReaderPrefs,
+    sigs: InteropSignals,
+    server_url: String,
+) {
+    let mut status = sigs.status;
+    use_effect(use_reactive!(|(uuid, server_url)| {
+        status.set(ReaderStatus::Loading);
+        spawn(mount_and_drain(
+            uuid.clone(),
+            prefs,
+            sigs,
+            server_url.clone(),
+        ));
+    }));
+
+    // Theme is app-wide (not pushed by the prefs setter), so mirror it into the
+    // glue whenever it changes — the web interop does the same.
+    let theme = prefs.theme;
+    use_effect(move || {
+        reader_call_json("setTheme", theme.read().as_attr());
+    });
+}
+
+/// Resolve the resume CFI, mount epub.js, then drain its events forever. The
+/// starting position is server-authoritative (falling back to the local
+/// in-memory cache), matching the web bootstrap.
+async fn mount_and_drain(
+    uuid: String,
+    prefs: ReaderPrefs,
+    sigs: InteropSignals,
+    server_url: String,
+) {
+    let local_saved = crate::reader_progress::load(&uuid);
+    let server_cfi = data::get_progress(&server_url, &uuid, ProgressFormat::Epub)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|r| r.epub_cfi);
+    let cfi = server_cfi.or(local_saved);
+
+    let token = data::token_store::get();
+    let file_url = interop::file_token_url(&server_url, &uuid, token.as_deref());
+    let eval = interop::install_reader_surface(&file_url, &init_opts(prefs, cfi));
+
+    // Fetch the saved highlights up front; they're replayed into the viewer
+    // once the glue reports `ready` (annotations need a live rendition).
+    let saved = data::list_highlights(&server_url, &uuid)
+        .await
+        .unwrap_or_default();
+
+    drain_reader_events(eval, uuid, server_url, sigs, saved).await;
+}
+
+/// Build the glue `init` options bag from the current reader prefs and the
+/// resume CFI. Field names match the vendored glue's `opts` keys.
+fn init_opts(prefs: ReaderPrefs, cfi: Option<String>) -> serde_json::Value {
+    serde_json::json!({
+        "cfi": cfi,
+        "fontSize": *prefs.font_size.peek(),
+        "theme": prefs.theme.peek().as_attr(),
+        "fontFamily": prefs.typeface.peek().to_css(),
+        "lineHeight": prefs.line_spacing.peek().to_css(),
+        "maxWidth": prefs.margins.peek().to_css(),
+        "justify": *prefs.justify.peek(),
+        "spread": prefs.spread.peek().to_css(),
+    })
+}
+
+/// Drain the JS→Rust reader event channel forever, updating the reader signals
+/// and persisting position on relocate. Returns when the channel closes
+/// (surface torn down / navigation).
+async fn drain_reader_events(
+    mut eval: dioxus::document::Eval,
+    uuid: String,
+    server_url: String,
+    sigs: InteropSignals,
+    saved_highlights: Vec<Highlight>,
+) {
+    let InteropSignals {
+        mut status,
+        mut loc,
+        mut selection,
+        mut highlights,
+        mut toc,
+        mut search_results,
+    } = sigs;
+    let mut last_cfi: Option<String> = None;
+    loop {
+        match eval.recv::<ReaderEvent>().await {
+            Ok(ReaderEvent::Relocate { json }) => {
+                if let Ok(data) = serde_json::from_str::<RelocateData>(&json) {
+                    if let Some(cfi) = data.cfi.clone() {
+                        crate::reader_progress::save(&uuid, &cfi);
+                        // Only POST on an actual position change (the glue
+                        // debounces, but re-renders can re-emit the same CFI).
+                        if last_cfi.as_deref() != Some(cfi.as_str()) {
+                            last_cfi = Some(cfi.clone());
+                            persist_progress(&uuid, &server_url, cfi);
+                        }
+                    }
+                    loc.set(data);
+                }
+            }
+            Ok(ReaderEvent::Status { state }) => {
+                let st = match state.as_str() {
+                    "ready" => ReaderStatus::Ready,
+                    "error" => ReaderStatus::Failed,
+                    _ => ReaderStatus::Loading,
+                };
+                status.set(st);
+                // Replay saved highlights into the freshly-mounted rendition.
+                if matches!(st, ReaderStatus::Ready) && highlights.peek().is_empty() {
+                    for h in &saved_highlights {
+                        reader_call_json2("addAnnotation", &h.epub_cfi_range, h.color.as_str());
+                    }
+                    highlights.set(saved_highlights.clone());
+                }
+            }
+            Ok(ReaderEvent::Selection { json }) => {
+                if let Ok(data) = serde_json::from_str::<SelectionData>(&json) {
+                    selection.set(Some(data));
+                }
+            }
+            Ok(ReaderEvent::Toc { json }) => {
+                if let Ok(entries) = serde_json::from_str::<Vec<TocEntry>>(&json) {
+                    toc.set(entries);
+                }
+            }
+            Ok(ReaderEvent::Search { json }) => {
+                if let Ok(rs) = serde_json::from_str::<Vec<SearchResult>>(&json) {
+                    search_results.set(rs);
+                }
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+/// Persist the latest CFI to the server (fire-and-forget); the local in-memory
+/// save already happened on the calling side.
+fn persist_progress(uuid: &str, server_url: &str, cfi: String) {
+    let uuid = uuid.to_string();
+    let server_url = server_url.to_string();
+    spawn(async move {
+        let update = ProgressUpdate {
+            book_uuid: uuid,
+            format: ProgressFormat::Epub,
+            epub_cfi: Some(cfi),
+            audio_position_seconds: None,
+        };
+        let _ = data::save_progress(&server_url, update).await;
+    });
+}

--- a/frontend/src/pages/reader/mobile/interop.rs
+++ b/frontend/src/pages/reader/mobile/interop.rs
@@ -1,0 +1,101 @@
+//! Mobile reader interop — the pure JS-string builders plus the
+//! `dioxus::document::eval` seam that mounts the vendored epub.js glue inside
+//! the wry WebView.
+//!
+//! The vendored `window.OmnibusReader` glue (loaded by the `<script>` tags in
+//! the shared reader chrome) reports events by calling a set of
+//! `window.__omnibusOn*` callbacks. On web those are `wasm_bindgen` closures;
+//! mobile runs natively (not WASM), so instead we install JS shims that forward
+//! each call into `dioxus.send(...)` and drain them with `Eval::recv().await`
+//! (see [`super`]) — the same JS↔Rust seam the mobile audio player uses. Only
+//! the two pure builders here are unit-tested; `install_reader_surface` is the
+//! eval seam.
+
+use dioxus::document::Eval;
+
+/// Build the tokened, absolute EPUB-file URL epub.js fetches from the WebView.
+/// That cross-origin XHR can carry neither a cookie nor a bearer header, so the
+/// session token rides the `?token=` query (server side: `MediaAuthUser`).
+pub(super) fn file_token_url(server_url: &str, uuid: &str, token: Option<&str>) -> String {
+    let base = format!("{server_url}/api/ebooks/{uuid}/file");
+    match token {
+        Some(t) => format!("{base}?token={t}"),
+        None => base,
+    }
+}
+
+/// Build the install IIFE: define the `__omnibusOn*` → `dioxus.send` shims,
+/// poll ~10 s (200 × 50 ms) for the vendored globals, then mount the book.
+/// Mirrors the web `reader_bootstrap_js` poll/timeout, but the callback sink is
+/// the Dioxus eval channel rather than `window` closures. `opts` is any
+/// JSON-serializable value shaped like the glue's `init` options bag.
+pub(super) fn install_surface_js(url: &str, opts: &serde_json::Value) -> String {
+    let url_lit = serde_json::to_string(url).unwrap_or_else(|_| "\"\"".into());
+    let opts_lit = serde_json::to_string(opts).unwrap_or_else(|_| "{}".into());
+    format!(
+        r#"(function(){{
+  window.__omnibusOnRelocate=function(j){{dioxus.send({{kind:"Relocate",json:j}});}};
+  window.__omnibusOnStatus=function(s){{dioxus.send({{kind:"Status",state:s}});}};
+  window.__omnibusOnSelection=function(j){{dioxus.send({{kind:"Selection",json:j}});}};
+  window.__omnibusOnToc=function(j){{dioxus.send({{kind:"Toc",json:j}});}};
+  window.__omnibusOnSearchResults=function(j){{dioxus.send({{kind:"Search",json:j}});}};
+  var n=0;(function go(){{
+    if(window.OmnibusReader&&window.ePub){{
+      window.OmnibusReader.init("omnibus-viewer",{url_lit},{opts_lit});
+    }}else if(n++<200){{setTimeout(go,50);}}
+    else{{dioxus.send({{kind:"Status",state:"error"}});}}
+  }})();
+}})();"#
+    )
+}
+
+/// Eval the install script and return the persistent [`Eval`] the caller drains
+/// for reader events.
+pub(super) fn install_reader_surface(url: &str, opts: &serde_json::Value) -> Eval {
+    dioxus::document::eval(&install_surface_js(url, opts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_token_url_appends_token_and_prefixes_origin() {
+        assert_eq!(
+            file_token_url("http://h:3000", "abc", Some("tok")),
+            "http://h:3000/api/ebooks/abc/file?token=tok"
+        );
+        assert_eq!(
+            file_token_url("http://h:3000", "abc", None),
+            "http://h:3000/api/ebooks/abc/file"
+        );
+    }
+
+    #[test]
+    fn install_surface_js_defines_shims_and_calls_init_with_url_and_opts() {
+        let opts = serde_json::json!({ "cfi": "epubcfi(/6/2)", "fontSize": 18, "theme": "sepia" });
+        let js = install_surface_js("http://h/api/ebooks/x/file?token=t", &opts);
+        // Every glue callback is shimmed into the Dioxus eval channel.
+        for cb in [
+            "__omnibusOnRelocate",
+            "__omnibusOnStatus",
+            "__omnibusOnSelection",
+            "__omnibusOnToc",
+            "__omnibusOnSearchResults",
+        ] {
+            assert!(js.contains(cb), "missing shim for {cb}");
+        }
+        assert!(js.contains("dioxus.send"));
+        // Mounts against the shared viewer element with the tokened URL + opts.
+        assert!(js.contains(r#"window.OmnibusReader.init("omnibus-viewer""#));
+        assert!(js.contains(r#""http://h/api/ebooks/x/file?token=t""#));
+        assert!(js.contains(r#""theme":"sepia""#));
+        assert!(js.contains(r#""fontSize":18"#));
+        // Polls for the vendored globals and errors out after the budget.
+        assert!(js.contains("window.OmnibusReader&&window.ePub"));
+        assert!(js.contains(r#"{kind:"Status",state:"error"}"#));
+        // No leaked `format!` escape pairs.
+        assert!(!js.contains("{{"), "literal {{ leaked into JS");
+        assert!(!js.contains("}}"), "literal }} leaked into JS");
+    }
+}

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -1,8 +1,10 @@
 //! Immersive full-screen EPUB reader. Loads the vendored epub.js +
 //! JSZip glue (`window.OmnibusReader`) via `dioxus::document::eval`, streams
-//! bytes from cookie-gated `GET /api/ebooks/:uuid/file`, and persists
-//! position via [`crate::reader_progress`]. Chrome compiles on every
-//! target; the JS interop that mounts a book is web-only.
+//! bytes from `GET /api/ebooks/:uuid/file`, and persists position via
+//! [`crate::reader_progress`]. Chrome compiles on every target; the JS interop
+//! that mounts a book has a per-target seam — `interop` (web, `wasm_bindgen`
+//! callbacks + same-origin cookie fetch) and `mobile` (wry WebView,
+//! `dioxus.send` event channel + tokened cross-origin fetch).
 
 mod aa_panel;
 mod bootstrap;
@@ -12,6 +14,8 @@ mod highlights;
 mod highlights_drawer;
 #[cfg(feature = "web")]
 mod interop;
+#[cfg(feature = "mobile")]
+mod mobile;
 mod note_composer;
 mod overlays;
 mod prefs;
@@ -44,7 +48,10 @@ const JSZIP_JS: Asset = asset!("/assets/vendor/jszip.min.js");
 const EPUBJS_JS: Asset = asset!("/assets/vendor/epub.min.js");
 const READER_GLUE_JS: Asset = asset!("/assets/vendor/epub-reader-glue.js");
 
-#[cfg(feature = "web")]
+// The `reader_call*` helpers drive the same `window.OmnibusReader` glue on both
+// interactive targets: web (WASM) and mobile (wry WebView). Only SSR compiles
+// them out. `dioxus::document::eval` is the shared seam.
+#[cfg(any(feature = "web", feature = "mobile"))]
 fn reader_call(method: &str, arg_js: &str) {
     let js = format!("window.OmnibusReader && window.OmnibusReader.{method}({arg_js});");
     let _ = dioxus::document::eval(&js);
@@ -53,20 +60,20 @@ fn reader_call(method: &str, arg_js: &str) {
 /// Encode `value` as a JS literal, falling back to `null` on the
 /// unreachable-in-practice encode failure (every caller passes a
 /// `str`/enum/bool, none of which can fail to serialize).
-#[cfg(feature = "web")]
+#[cfg(any(feature = "web", feature = "mobile"))]
 fn json_literal<T: serde::Serialize + ?Sized>(value: &T) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "null".into())
 }
 
 /// [`reader_call`] with a single JSON-encoded argument — the common case.
-#[cfg(feature = "web")]
+#[cfg(any(feature = "web", feature = "mobile"))]
 fn reader_call_json<T: serde::Serialize + ?Sized>(method: &str, value: &T) {
     reader_call(method, &json_literal(value));
 }
 
 /// [`reader_call`] with two JSON-encoded arguments, e.g.
 /// `addAnnotation(cfi, color)`.
-#[cfg(feature = "web")]
+#[cfg(any(feature = "web", feature = "mobile"))]
 fn reader_call_json2<A: serde::Serialize + ?Sized, B: serde::Serialize + ?Sized>(
     method: &str,
     a: &A,
@@ -221,10 +228,28 @@ fn use_reader_signals(uuid: &str, theme: Signal<Theme>) -> ReaderSignals {
         },
     );
 
-    // Suppress the `prefs` unused-variable warning on non-web targets:
-    // `install_reader_web_interop` is web-only, so on SSR / mobile the
-    // local binding is published via context but never read.
-    #[cfg(not(feature = "web"))]
+    // Mobile drives the same glue through the wry WebView's `dioxus.send`
+    // event channel rather than `wasm_bindgen` window callbacks. `use_effect`
+    // hooks inside run unconditionally, so hook order stays stable (rule 07).
+    #[cfg(feature = "mobile")]
+    mobile::install_reader_mobile_interop(
+        uuid.to_string(),
+        prefs,
+        mobile::InteropSignals {
+            status,
+            loc,
+            selection,
+            highlights,
+            toc,
+            search_results,
+        },
+        crate::contexts::use_server_url(),
+    );
+
+    // Suppress the `prefs` unused-variable warning on SSR: the interop that
+    // reads it is web/mobile-only, so on SSR the binding is published via
+    // context but never read.
+    #[cfg(not(any(feature = "web", feature = "mobile")))]
     let _ = prefs;
 
     ReaderSignals {

--- a/frontend/src/pages/reader/prefs.rs
+++ b/frontend/src/pages/reader/prefs.rs
@@ -8,9 +8,9 @@ use dioxus::prelude::*;
 
 use crate::components::atrium::{persist_theme, Theme};
 
-#[cfg(feature = "web")]
+#[cfg(any(feature = "web", feature = "mobile"))]
 use super::reader_call;
-#[cfg(feature = "web")]
+#[cfg(any(feature = "web", feature = "mobile"))]
 use super::reader_call_json;
 #[cfg(feature = "web")]
 use super::typography::save_reader_pref;
@@ -49,68 +49,62 @@ impl ReaderPrefs {
         let mut font_size = self.font_size;
         let next = (*font_size.read() - 1).clamp(FONT_SIZE_MIN, FONT_SIZE_MAX);
         font_size.set(next);
+        #[cfg(any(feature = "web", feature = "mobile"))]
+        reader_call("setFontSize", &next.to_string());
         #[cfg(feature = "web")]
-        {
-            reader_call("setFontSize", &next.to_string());
-            save_reader_pref("omn.fontSize", &next.to_string());
-        }
+        save_reader_pref("omn.fontSize", &next.to_string());
     }
 
     /// Step the font size up one px (clamped to `FONT_SIZE_MAX`), push to
-    /// JS, persist to localStorage.
+    /// JS, persist to localStorage (web).
     pub(crate) fn increase_font(self) {
         let mut font_size = self.font_size;
         let next = (*font_size.read() + 1).clamp(FONT_SIZE_MIN, FONT_SIZE_MAX);
         font_size.set(next);
+        #[cfg(any(feature = "web", feature = "mobile"))]
+        reader_call("setFontSize", &next.to_string());
         #[cfg(feature = "web")]
-        {
-            reader_call("setFontSize", &next.to_string());
-            save_reader_pref("omn.fontSize", &next.to_string());
-        }
+        save_reader_pref("omn.fontSize", &next.to_string());
     }
 
     /// Apply a typeface, push to JS, persist to localStorage.
     pub(crate) fn set_typeface(self, t: Typeface) {
         let mut typeface = self.typeface;
         typeface.set(t);
+        #[cfg(any(feature = "web", feature = "mobile"))]
+        reader_call_json("setFont", t.to_css());
         #[cfg(feature = "web")]
-        {
-            reader_call_json("setFont", t.to_css());
-            save_reader_pref("omn.typeface", t.to_storage());
-        }
+        save_reader_pref("omn.typeface", t.to_storage());
     }
 
     /// Apply a line-spacing choice, push to JS, persist to localStorage.
     pub(crate) fn set_line_spacing(self, ls: LineSpacing) {
         let mut line_spacing = self.line_spacing;
         line_spacing.set(ls);
+        #[cfg(any(feature = "web", feature = "mobile"))]
+        reader_call_json("setLineHeight", ls.to_css());
         #[cfg(feature = "web")]
-        {
-            reader_call_json("setLineHeight", ls.to_css());
-            save_reader_pref("omn.lineSpacing", ls.to_storage());
-        }
+        save_reader_pref("omn.lineSpacing", ls.to_storage());
     }
 
     /// Apply a margins choice, push to JS, persist to localStorage.
     pub(crate) fn set_margins(self, m: Margins) {
         let mut margins = self.margins;
         margins.set(m);
+        #[cfg(any(feature = "web", feature = "mobile"))]
+        reader_call_json("setMargins", m.to_css());
         #[cfg(feature = "web")]
-        {
-            reader_call_json("setMargins", m.to_css());
-            save_reader_pref("omn.margins", m.to_storage());
-        }
+        save_reader_pref("omn.margins", m.to_storage());
     }
 
     /// Apply a page-view (spread) choice, push to JS, persist to localStorage.
     pub(crate) fn set_spread(self, s: Spread) {
         let mut spread = self.spread;
         spread.set(s);
+        #[cfg(any(feature = "web", feature = "mobile"))]
+        reader_call_json("setSpread", s.to_css());
         #[cfg(feature = "web")]
-        {
-            reader_call_json("setSpread", s.to_css());
-            save_reader_pref("omn.spread", s.to_storage());
-        }
+        save_reader_pref("omn.spread", s.to_storage());
     }
 
     /// Flip the justify toggle and push the new boolean into the JS glue.
@@ -118,11 +112,10 @@ impl ReaderPrefs {
         let mut justify = self.justify;
         let next = !*justify.read();
         justify.set(next);
+        #[cfg(any(feature = "web", feature = "mobile"))]
+        reader_call("setJustify", if next { "true" } else { "false" });
         #[cfg(feature = "web")]
-        {
-            reader_call("setJustify", if next { "true" } else { "false" });
-            save_reader_pref("omn.justify", if next { "true" } else { "false" });
-        }
+        save_reader_pref("omn.justify", if next { "true" } else { "false" });
     }
 
     /// Slider position for the AA-panel size track, expressed as 0–100%.

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -11,7 +11,7 @@ use crate::data;
 use omnibus_shared::EbookMetadata;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(not(feature = "web"), allow(dead_code))]
+#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
 pub(crate) enum ReaderStatus {
     // INVARIANT: `Loading` is the SSR/WASM-first-paint seed (see
     // `BookReadPage`). Changing the default flips the rendered overlay and
@@ -26,8 +26,8 @@ pub(crate) enum ReaderStatus {
 #[derive(Clone, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RelocateData {
-    // Only the web-feature progress-save path reads `cfi`; the other fields are read unconditionally by the bottom-bar render.
-    #[cfg_attr(not(feature = "web"), allow(dead_code))]
+    // The web + mobile progress-save paths read `cfi`; the other fields are read unconditionally by the bottom-bar render.
+    #[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
     pub(crate) cfi: Option<String>,
     pub(crate) page: u32,
     pub(crate) total_pages: u32,


### PR DESCRIPTION
## Summary
Mobile is a wry WebView (not a JS-less native renderer), so the reader mounts the **same** vendored epub.js glue used on web. Because mobile runs natively (not WASM), the web `wasm_bindgen` callback path can't be reused — a new `reader/mobile` interop forwards the glue's `window.__omnibusOn*` callbacks over the Dioxus `Eval` channel (`dioxus.send` → `Eval::recv`), mirroring the mobile audio player.

- Mount epub.js in the WebView; fetch the EPUB from a tokened absolute URL; sync reading position through the REST data layer as epub.js **CFIs** — the same position space the web reader uses, so progress round-trips across web and mobile.
- Widen the `reader_call*` glue helpers, page-turn handlers, and typography/theme setters from web-only to `any(web, mobile)`; localStorage persistence stays web-only.
- Enable the previously-stubbed **Read** / **Start reading** buttons on the mobile book-detail surfaces.

Core reading only: open, paginate, themes, TOC, Aa typography, progress sync, existing-highlight display. Highlight *creation*/editing, quote cards, and in-book search land in `-3`.

## Test plan
- [x] `cargo test -p omnibus-frontend --features mobile` — new `reader::mobile::interop` unit tests (tokened URL + install-script builder).
- [x] `cargo check -p omnibus-mobile` (host target) + `cargo clippy` mobile & web clean; existing web reader tests unchanged.
- [x] `just check` green.
- [ ] Manual simulator sweep (open book → paginate → theme → TOC → resume) — recommended before wide use.

## Version
- [x] **No release** — stacked on `-1`; release cut by `-3`.

## Notes
>[!NOTE]
> Stacked on #869. No mobile E2E exists (Playwright can't reach the Native WebView); web SSR/WASM output is unchanged by this PR.