### PR TITLE
feat: mobile reader chrome + bottom sheets per design

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4714,7 +4714,8 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 
   /* Search is the one full-screen surface (keyboard + result list want the
      height); it drops the sheet radius and grabber. */
-  .rd-search-drawer { top: 0; max-height: none; border-radius: 0; border-top: 0; }
+  .rd-search-drawer { top: 0; max-height: none; border-radius: 0; border-top: 0;
+    padding-top: env(safe-area-inset-top); }
   .rd-search-drawer .rd-grabber { display: none; }
   .rd-search-box { padding: 10px 14px; }
   .rd-search-input { height: 38px; border-radius: 10px; font-family: var(--sans); }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4433,6 +4433,15 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .rd-title-sep { font-family: var(--mono); font-size: 11px; color: var(--ink-3);
   margin: 0 10px; }
 .rd-title-ch { font-size: 13px; color: var(--ink-2); }
+/* Phone-only chrome pieces — rendered on every target for hydration parity
+   (rule 07), displayed only by the phone breakpoint at the end of this
+   section. */
+.rd-title-sub { display: none; font-family: var(--mono); font-size: 9.5px;
+  color: var(--ink-3); }
+.rd-bottom-ch { display: none; }
+.rd-grabber { display: none; }
+.rd-drawer-sub { display: none; font-family: var(--mono); font-size: 10px;
+  color: var(--ink-3); }
 
 /* Aa typography panel */
 .rd-aa-panel { position: absolute; top: 66px; right: 26px; width: 320px; z-index: 16;
@@ -4596,6 +4605,8 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 
 /* Search panel (F2.4b). */
 .rd-search-box { padding: 12px 20px; border-bottom: 1px solid var(--line-2); }
+.rd-search-count { padding: 10px 20px 2px; font-family: var(--mono);
+  font-size: 10px; color: var(--ink-3); }
 .rd-search-input { width: 100%; background: var(--bg-2); color: var(--ink-0);
   border: 1px solid var(--line-2); border-radius: 9px; padding: 9px 12px;
   font-size: 14px; }
@@ -4665,47 +4676,93 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   /* Only tighten the horizontal padding here — the vertical padding is the
      safe-area inset set on the base rules, and a `padding: 0 14px` shorthand
      would zero it back out and re-hide the bars under the notch. */
-  .rd-top { padding-left: 14px; padding-right: 14px; gap: 8px; }
-  .rd-bottom { padding-left: 14px; padding-right: 14px; gap: 8px; }
-  .rd-title-book { font-size: 15px; }
-  .rd-title-sep { margin: 0 6px; }
-  .rd-tool { min-width: 32px; padding: 0 6px; }
-  /* Page + progress on the left already carry the position; the centred
-     "Ch. N of M" only crowds a narrow bar (the handoff bottom row is just
-     position on the left, time-left on the right). */
+  .rd-top { padding-left: 6px; padding-right: 8px; gap: 2px; }
+  .rd-bottom { padding-left: 22px; padding-right: 22px; gap: 8px;
+    font-size: 10px; }
+  /* Designed phone toolbar: sans title stacked over a "Ch. N · P%" line,
+     replacing the desktop's inline serif `title · chapter` pair. */
+  .rd-title-center { display: flex; flex-direction: column; align-items: center;
+    justify-content: center; line-height: 1.25; }
+  .rd-title-book { font-family: var(--sans); font-style: normal;
+    font-weight: 600; font-size: 13px; max-width: 100%; overflow: hidden;
+    white-space: nowrap; text-overflow: ellipsis; }
+  .rd-title-sep, .rd-title-ch { display: none; }
+  .rd-title-sub { display: block; }
+  .rd-tool { min-width: 34px; padding: 0 6px; }
+  .rd-aa { font-size: 17px; }
+  /* Phone footer: position on the left, chapter on the right (the centred
+     div is the desktop layout). */
   .rd-bottom > div { display: none; }
-  /* Mobile turns pages by swipe/tap; the circular gutter buttons would sit
-     over the prose on a phone-width column. */
+  .rd-bottom-ch { display: inline; }
+  /* Mobile turns pages by swipe/tap (the glue's `installGestureNav`); the
+     circular gutter buttons would sit over the prose on a phone column. */
   .rd-turn { display: none; }
 
-  /* Drawers (contents / search / highlights / bookmarks / quote card) span
-     the full width instead of a 380–432px side panel. */
-  .rd-drawer, .rd-quote-drawer { width: auto; left: 0; right: 0; }
+  /* Drawers (contents / highlights / bookmarks / quote card) become bottom
+     sheets: grabber, top-rounded, content-capped. Search opts out below. */
+  .rd-drawer, .rd-quote-drawer { top: auto; left: 0; right: 0; bottom: 0;
+    width: auto; max-height: 78vh;
+    border-left: 0; border-top: 1px solid var(--line-2);
+    border-radius: 20px 20px 0 0;
+    box-shadow: 0 -20px 50px -20px rgba(0,0,0,.5);
+    padding-bottom: env(safe-area-inset-bottom); }
+  .rd-grabber { display: block; flex: 0 0 auto; width: 40px; height: 4px;
+    border-radius: 999px; background: var(--bg-3); margin: 12px auto 2px; }
+  .rd-drawer-head { padding: 4px 20px 10px; border-bottom: 0; }
+  .rd-drawer-title { font-size: 20px; }
+  .rd-drawer-sub { display: inline; }
 
-  /* The Aa display panel drops the tool-anchored caret and becomes a sheet
-     pinned below the top bar. */
-  .rd-aa-panel { left: 12px; right: 12px; width: auto;
-    top: calc(64px + env(safe-area-inset-top)); }
+  /* Search is the one full-screen surface (keyboard + result list want the
+     height); it drops the sheet radius and grabber. */
+  .rd-search-drawer { top: 0; max-height: none; border-radius: 0; border-top: 0; }
+  .rd-search-drawer .rd-grabber { display: none; }
+  .rd-search-box { padding: 10px 14px; }
+  .rd-search-input { height: 38px; border-radius: 10px; font-family: var(--sans); }
+  .rd-search-row { border-radius: 10px; padding: 11px 12px;
+    border-bottom: 1px solid var(--line-2); }
+  .rd-search-chapter { font-size: 9.5px; }
+  .rd-search-excerpt { font-family: var(--serif); font-size: 14.5px;
+    line-height: 1.5; }
+
+  /* The Aa display panel becomes a bottom sheet too (no caret). The spread
+     row is desktop-only — a phone column never renders a two-page spread. */
+  .rd-aa-panel { top: auto; bottom: 0; left: 0; right: 0; width: auto;
+    border-left: 0; border-right: 0; border-bottom: 0;
+    border-radius: 20px 20px 0 0;
+    padding: 4px 20px calc(20px + env(safe-area-inset-bottom)); }
   .rd-aa-panel::before { display: none; }
+  .rd-aa-row-spread { display: none; }
+  .rd-seg > button { height: 34px; }
 
   /* Note composer keeps a margin off the viewport edges. */
   .rd-note-composer { width: min(360px, calc(100vw - 32px)); }
 
-  /* Selection popover → bottom sheet ("highlight a passage" handoff). The
-     caret rect drives inline top/left, so the sheet position needs
-     !important to win over them. */
+  /* Selection popover → bottom action sheet ("highlight a passage"), on a
+     fixed dark palette regardless of reader theme per the design. The caret
+     rect drives inline top/left, so the sheet position needs !important. */
   .rd-selection-popover {
     top: auto !important; bottom: calc(66px + env(safe-area-inset-bottom)) !important;
     left: 16px !important; right: 16px !important;
     padding: 14px 12px; border-radius: 16px;
-    background: color-mix(in oklch, var(--bg-1) 96%, transparent);
-    box-shadow: 0 24px 48px -16px rgba(0,0,0,.5); }
+    background: oklch(0.18 0.006 70);
+    border-color: oklch(0.30 0.01 70 / .5);
+    backdrop-filter: none; -webkit-backdrop-filter: none;
+    box-shadow: 0 24px 48px -16px rgba(0,0,0,.6); }
   /* Swatches on one centred row, then a full-width rule, then the actions —
      the divider's 100% width forces the wrap between the two groups. */
-  .rd-swatch-row { flex-wrap: wrap; justify-content: center; row-gap: 12px; }
+  .rd-swatch-row { flex-wrap: wrap; justify-content: center; gap: 12px;
+    row-gap: 12px; }
   .rd-swatch { width: 30px; height: 30px; }
-  .rd-pop-div { width: 100%; height: 1px; align-self: auto; margin: 2px 4px; }
-  .rd-act { height: 36px; }
+  .rd-pop-div { width: 100%; height: 1px; align-self: auto; margin: 2px 4px;
+    background: oklch(0.30 0.01 70 / .4); }
+  /* Icon-over-label actions, Quote tinted as the primary. Scoped to the
+     popover so drawer-row `.rd-act` buttons keep their inline shape. */
+  .rd-selection-popover .rd-act { flex-direction: column; height: auto;
+    padding: 4px 12px; gap: 5px; font-size: 11px;
+    color: oklch(0.82 0.01 75); }
+  .rd-selection-popover .rd-act:hover { background: transparent;
+    color: oklch(0.97 0.006 80); }
+  .rd-selection-popover .rd-act-accent { color: var(--accent); }
 }
 
 /* ── F5.10 merge dialog (book detail) — "Merge duplicates" redesign ──

--- a/frontend/src/pages/reader/aa_panel.rs
+++ b/frontend/src/pages/reader/aa_panel.rs
@@ -20,6 +20,7 @@ pub(crate) fn ReaderAaPanel(on_close: EventHandler<MouseEvent>) -> Element {
             class: "rd-aa-panel",
             onclick: move |evt: MouseEvent| evt.stop_propagation(),
 
+            div { class: "rd-grabber" }
             ThemeRow {}
             TypefaceRow {}
             TextSizeRow {}
@@ -210,7 +211,9 @@ fn PageViewRow() -> Element {
     let prefs = use_context::<ReaderPrefs>();
     let spread = *prefs.spread.read();
     rsx! {
-        div { class: "rd-aa-row",
+        // `rd-aa-row-spread` lets the phone breakpoint hide this row — a
+        // phone column never renders a two-page spread.
+        div { class: "rd-aa-row rd-aa-row-spread",
             div { class: "rd-aa-label", "Page view" }
             div {
                 class: "rd-seg",

--- a/frontend/src/pages/reader/chrome.rs
+++ b/frontend/src/pages/reader/chrome.rs
@@ -13,6 +13,7 @@ use super::ReaderPanelSignals;
 struct ReaderChromeState {
     book_title: String,
     chapter_title: String,
+    title_sub: String,
     show_aa: bool,
     toc_active: bool,
     search_active: bool,
@@ -38,6 +39,7 @@ struct ReaderChromeHandlers {
 pub(super) fn ReaderTopBar(
     book_title: String,
     chapter_title: String,
+    title_sub: String,
     panels: ReaderPanelSignals,
     on_back: EventHandler<MouseEvent>,
 ) -> Element {
@@ -75,6 +77,7 @@ pub(super) fn ReaderTopBar(
             state: ReaderChromeState {
                 book_title,
                 chapter_title,
+                title_sub,
                 show_aa: show_aa(),
                 toc_active: show_toc(),
                 search_active: show_search(),
@@ -125,6 +128,7 @@ fn ReaderTopChrome(state: ReaderChromeState, handlers: ReaderChromeHandlers) -> 
     let ReaderChromeState {
         book_title,
         chapter_title,
+        title_sub,
         show_aa,
         toc_active,
         search_active,
@@ -162,6 +166,11 @@ fn ReaderTopChrome(state: ReaderChromeState, handlers: ReaderChromeHandlers) -> 
                 if !chapter_title.is_empty() {
                     span { class: "rd-title-sep", "\u{b7}" }
                     span { class: "rd-title-ch", "{chapter_title}" }
+                }
+                // Phone sub-line ("Ch. 14 · 68%") — the breakpoint stacks the
+                // title block and swaps the inline chapter for this.
+                if !title_sub.is_empty() {
+                    span { class: "rd-title-sub", "{title_sub}" }
                 }
             }
             div {

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -108,6 +108,7 @@ pub(super) fn HighlightsDrawer(
     rsx! {
         div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
         div { class: "rd-drawer", "data-testid": "reader-highlights-drawer",
+            div { class: "rd-grabber" }
             div { class: "rd-drawer-head",
                 h4 { class: "rd-drawer-title",
                     "Highlights & notes "

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -41,7 +41,10 @@ use overlays::{OverlayMeta, ReaderOverlays, ReaderSelectionPopover};
 use prefs::init_reader_prefs;
 use search_panel::SearchResult;
 use selection::SelectionData;
-use signals::{format_progress_labels, use_book_metadata, ReaderStatus, RelocateData};
+use signals::{
+    format_contents_progress, format_progress_labels, format_title_sub, use_book_metadata,
+    ReaderStatus, RelocateData,
+};
 use toc_drawer::TocEntry;
 
 const JSZIP_JS: Asset = asset!("/assets/vendor/jszip.min.js");
@@ -117,6 +120,8 @@ pub fn BookReadPage(uuid: String) -> Element {
     let ReaderDisplay {
         page_str,
         chapter_str,
+        title_sub,
+        contents_progress,
         pct,
         chapter_title,
         current_cfi,
@@ -134,10 +139,12 @@ pub fn BookReadPage(uuid: String) -> Element {
                 book_accent,
                 chapter_title,
                 current_cfi,
+                contents_progress,
             },
             progress: ReaderProgress {
                 page_str,
                 chapter_str,
+                title_sub,
                 pct,
                 status: status(),
             },
@@ -274,6 +281,8 @@ fn use_reader_signals(uuid: &str, theme: Signal<Theme>) -> ReaderSignals {
 struct ReaderDisplay {
     page_str: String,
     chapter_str: String,
+    title_sub: String,
+    contents_progress: String,
     pct: u32,
     chapter_title: String,
     current_cfi: String,
@@ -288,6 +297,8 @@ fn derive_reader_display(
     book_meta: Signal<Option<omnibus_shared::EbookMetadata>>,
 ) -> ReaderDisplay {
     let (page_str, chapter_str) = format_progress_labels(&loc.read());
+    let title_sub = format_title_sub(&loc.read());
+    let contents_progress = format_contents_progress(&loc.read());
     let pct = loc.read().pct;
     let chapter_title = loc.read().chapter_title.clone();
     let current_cfi = loc.read().cfi.clone().unwrap_or_default();
@@ -309,6 +320,8 @@ fn derive_reader_display(
     ReaderDisplay {
         page_str,
         chapter_str,
+        title_sub,
+        contents_progress,
         pct,
         chapter_title,
         current_cfi,
@@ -327,6 +340,8 @@ pub(super) struct ReaderMeta {
     pub book_accent: String,
     pub chapter_title: String,
     pub current_cfi: String,
+    /// Contents-drawer progress line ("184 / 272 · 68%").
+    pub contents_progress: String,
 }
 
 /// Bottom-bar progress labels and the load-status overlay state.
@@ -334,6 +349,9 @@ pub(super) struct ReaderMeta {
 pub(super) struct ReaderProgress {
     pub page_str: String,
     pub chapter_str: String,
+    /// Phone top-bar sub-line ("Ch. 14 · 68%") — rendered on every target,
+    /// shown only by the phone breakpoint.
+    pub title_sub: String,
     pub pct: u32,
     pub status: ReaderStatus,
 }
@@ -378,10 +396,12 @@ fn ReaderLayout(
         book_accent,
         chapter_title,
         current_cfi,
+        contents_progress,
     } = meta;
     let ReaderProgress {
         page_str,
         chapter_str,
+        title_sub,
         pct,
         status,
     } = progress;
@@ -424,6 +444,7 @@ fn ReaderLayout(
             ReaderTopBar {
                 book_title: book_title.clone(),
                 chapter_title: chapter_title.clone(),
+                title_sub: title_sub.clone(),
                 panels,
                 on_back,
             }
@@ -436,7 +457,10 @@ fn ReaderLayout(
                 class: "rd-bottom",
                 span { style: "color:var(--ink-2);", "{page_str}" }
                 div { style: "flex:1; text-align:center; letter-spacing:.08em;", "{chapter_str}" }
-                span {}
+                // The phone footer moves the chapter position to the right
+                // edge (the centred div above is hidden there) — rendered on
+                // every target, shown only by the phone breakpoint (rule 07).
+                span { class: "rd-bottom-ch", "{chapter_str}" }
             }
             div { class: "rd-ribbon", i { style: "width:{pct}%;" } }
 
@@ -465,6 +489,7 @@ fn ReaderLayout(
                     book_accent: book_accent.clone(),
                     chapter_title: chapter_title.clone(),
                     current_cfi: current_cfi.clone(),
+                    contents_progress: contents_progress.clone(),
                 },
                 panels,
             }

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -296,12 +296,14 @@ fn derive_reader_display(
     loc: Signal<RelocateData>,
     book_meta: Signal<Option<omnibus_shared::EbookMetadata>>,
 ) -> ReaderDisplay {
-    let (page_str, chapter_str) = format_progress_labels(&loc.read());
-    let title_sub = format_title_sub(&loc.read());
-    let contents_progress = format_contents_progress(&loc.read());
-    let pct = loc.read().pct;
-    let chapter_title = loc.read().chapter_title.clone();
-    let current_cfi = loc.read().cfi.clone().unwrap_or_default();
+    // One read: every derived label comes from the same relocate snapshot.
+    let loc_now = loc.read();
+    let (page_str, chapter_str) = format_progress_labels(&loc_now);
+    let title_sub = format_title_sub(&loc_now);
+    let contents_progress = format_contents_progress(&loc_now);
+    let pct = loc_now.pct;
+    let chapter_title = loc_now.chapter_title.clone();
+    let current_cfi = loc_now.cfi.clone().unwrap_or_default();
     let book_title = book_meta
         .read()
         .as_ref()

--- a/frontend/src/pages/reader/overlays.rs
+++ b/frontend/src/pages/reader/overlays.rs
@@ -110,6 +110,8 @@ pub(super) struct OverlayMeta {
     pub book_accent: String,
     pub chapter_title: String,
     pub current_cfi: String,
+    /// Contents-drawer progress line ("184 / 272 · 68%").
+    pub contents_progress: String,
 }
 
 /// The toggleable reader overlays: contents, highlights, search, bookmarks
@@ -124,6 +126,7 @@ pub(super) fn ReaderOverlays(meta: OverlayMeta, panels: ReaderPanelSignals) -> E
         book_accent,
         chapter_title,
         current_cfi,
+        contents_progress,
     } = meta;
     let ReaderPanelSignals {
         highlights,
@@ -143,6 +146,7 @@ pub(super) fn ReaderOverlays(meta: OverlayMeta, panels: ReaderPanelSignals) -> E
             TocDrawer {
                 entries: toc.read().clone(),
                 current_title: chapter_title.clone(),
+                progress_label: contents_progress.clone(),
                 on_navigate: move |href: String| {
                     #[cfg(any(feature = "web", feature = "mobile"))]
                     super::reader_call_json("display", &href);

--- a/frontend/src/pages/reader/quote_panel.rs
+++ b/frontend/src/pages/reader/quote_panel.rs
@@ -105,6 +105,7 @@ pub(super) fn QuotePanel(
     rsx! {
         div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
         div { class: "rd-drawer rd-quote-drawer", "data-testid": "reader-quote-drawer",
+            div { class: "rd-grabber" }
             div { class: "rd-drawer-head",
                 div {
                     div { class: "rd-quote-kicker", "From your highlight" }

--- a/frontend/src/pages/reader/reader_bookmarks.rs
+++ b/frontend/src/pages/reader/reader_bookmarks.rs
@@ -65,6 +65,7 @@ pub(super) fn ReaderBookmarksDrawer(
     rsx! {
         div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
         div { class: "rd-drawer", "data-testid": "reader-bookmarks-drawer",
+            div { class: "rd-grabber" }
             div { class: "rd-drawer-head",
                 h4 { class: "rd-drawer-title",
                     "Bookmarks "

--- a/frontend/src/pages/reader/search_panel.rs
+++ b/frontend/src/pages/reader/search_panel.rs
@@ -57,7 +57,9 @@ pub(super) fn SearchPanel(
                     },
                 }
             }
-            if !hits.is_empty() {
+            if hits.len() == 1 {
+                div { class: "rd-search-count", "1 match \u{b7} in this book" }
+            } else if !hits.is_empty() {
                 div { class: "rd-search-count", "{hits.len()} matches \u{b7} in this book" }
             }
             div { class: "rd-drawer-body",

--- a/frontend/src/pages/reader/search_panel.rs
+++ b/frontend/src/pages/reader/search_panel.rs
@@ -27,7 +27,10 @@ pub(super) fn SearchPanel(
 
     rsx! {
         div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
-        div { class: "rd-drawer", "data-testid": "reader-search-drawer",
+        // `rd-search-drawer` lets the phone breakpoint take this one drawer
+        // full-screen while the rest stay bottom sheets.
+        div { class: "rd-drawer rd-search-drawer", "data-testid": "reader-search-drawer",
+            div { class: "rd-grabber" }
             div { class: "rd-drawer-head",
                 h4 { class: "rd-drawer-title", "Search" }
                 button {
@@ -53,6 +56,9 @@ pub(super) fn SearchPanel(
                         }
                     },
                 }
+            }
+            if !hits.is_empty() {
+                div { class: "rd-search-count", "{hits.len()} matches \u{b7} in this book" }
             }
             div { class: "rd-drawer-body",
                 if hits.is_empty() {

--- a/frontend/src/pages/reader/selection.rs
+++ b/frontend/src/pages/reader/selection.rs
@@ -110,7 +110,13 @@ pub(crate) fn SelectionPopover(anchor: SelectionAnchor, actions: SelectionAction
                         let text = sel_text.clone();
                         move |_| on_note.call((cfi.clone(), text.clone()))
                     },
-                    "Note"
+                    svg {
+                        width: "15", height: "15", view_box: "0 0 24 24",
+                        fill: "none", stroke: "currentColor",
+                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                        path { d: "M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" }
+                    }
+                    span { "Note" }
                 }
                 button {
                     class: "rd-act",
@@ -120,10 +126,19 @@ pub(crate) fn SelectionPopover(anchor: SelectionAnchor, actions: SelectionAction
                         let text = sel_text.clone();
                         move |_| on_copy.call(text.clone())
                     },
-                    "Copy"
+                    svg {
+                        width: "15", height: "15", view_box: "0 0 24 24",
+                        fill: "none", stroke: "currentColor",
+                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                        rect { x: "9", y: "9", width: "12", height: "12", rx: "2" }
+                        path { d: "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" }
+                    }
+                    span { "Copy" }
                 }
                 button {
-                    class: "rd-act",
+                    // `rd-act-accent`: the phone popover tints Quote as the
+                    // primary action, per the mobile design.
+                    class: "rd-act rd-act-accent",
                     r#type: "button",
                     "data-testid": "selection-quote",
                     onclick: {
@@ -131,7 +146,12 @@ pub(crate) fn SelectionPopover(anchor: SelectionAnchor, actions: SelectionAction
                         let text = sel_text.clone();
                         move |_| on_quote.call((cfi.clone(), text.clone()))
                     },
-                    "Quote"
+                    svg {
+                        width: "15", height: "15", view_box: "0 0 24 24",
+                        fill: "currentColor", stroke: "none",
+                        path { d: "M10 8c0 3.5-2 6-5 7l-.8-1.6c1.7-.8 2.7-2 3-3.4H4V4h6v4zm10 0c0 3.5-2 6-5 7l-.8-1.6c1.7-.8 2.7-2 3-3.4H14V4h6v4z" }
+                    }
+                    span { "Quote" }
                 }
                 button {
                     class: "rd-act",
@@ -141,7 +161,13 @@ pub(crate) fn SelectionPopover(anchor: SelectionAnchor, actions: SelectionAction
                         let text = sel_text.clone();
                         move |_| on_share.call(text.clone())
                     },
-                    "Share"
+                    svg {
+                        width: "15", height: "15", view_box: "0 0 24 24",
+                        fill: "none", stroke: "currentColor",
+                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                        path { d: "M12 3v13M7 8l5-5 5 5M5 14v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5" }
+                    }
+                    span { "Share" }
                 }
             }
         }

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -58,6 +58,30 @@ pub(crate) fn format_progress_labels(loc: &RelocateData) -> (String, String) {
     (page, chapter)
 }
 
+/// Format the phone top-bar sub-line under the book title: "Ch. 3 · 14%".
+/// Falls back to the percent alone before the TOC resolves; empty until
+/// epub.js has produced a relocation. Rendered on every target (rule 07);
+/// only the phone breakpoint displays it.
+pub(crate) fn format_title_sub(loc: &RelocateData) -> String {
+    if loc.chapter > 0 {
+        format!("Ch.\u{a0}{} \u{b7} {}%", loc.chapter, loc.pct)
+    } else if loc.pct > 0 {
+        format!("{}%", loc.pct)
+    } else {
+        String::new()
+    }
+}
+
+/// Format the contents-drawer progress line: "184 / 272 · 68%". Empty until
+/// epub.js has paginated the book.
+pub(crate) fn format_contents_progress(loc: &RelocateData) -> String {
+    if loc.total_pages > 0 {
+        format!("{} / {} \u{b7} {}%", loc.page, loc.total_pages, loc.pct)
+    } else {
+        String::new()
+    }
+}
+
 /// Drop the previous book's title and kick off a fresh `get_ebook` fetch
 /// whenever `uuid` changes. SPA navigations between books would otherwise
 /// flash the previous title while the request is in flight, and an epoch
@@ -128,6 +152,31 @@ mod tests {
         assert!(chapter.contains("Ch"));
         assert!(chapter.contains("3"));
         assert!(chapter.contains("24"));
+    }
+
+    #[test]
+    fn format_title_sub_formats_chapter_and_pct_and_falls_back() {
+        let mut data = RelocateData {
+            chapter: 14,
+            pct: 68,
+            ..Default::default()
+        };
+        assert_eq!(format_title_sub(&data), "Ch.\u{a0}14 \u{b7} 68%");
+        data.chapter = 0;
+        assert_eq!(format_title_sub(&data), "68%");
+        assert_eq!(format_title_sub(&RelocateData::default()), "");
+    }
+
+    #[test]
+    fn format_contents_progress_formats_pages_and_is_empty_before_pagination() {
+        let data = RelocateData {
+            page: 184,
+            total_pages: 272,
+            pct: 68,
+            ..Default::default()
+        };
+        assert_eq!(format_contents_progress(&data), "184 / 272 \u{b7} 68%");
+        assert_eq!(format_contents_progress(&RelocateData::default()), "");
     }
 
     #[test]

--- a/frontend/src/pages/reader/toc_drawer.rs
+++ b/frontend/src/pages/reader/toc_drawer.rs
@@ -14,20 +14,26 @@ pub(crate) struct TocEntry {
     pub level: u32,
 }
 
-/// Right-side contents drawer. `current_title` highlights the entry matching
-/// the reader's current chapter.
+/// Right-side contents drawer (bottom sheet on phones). `current_title`
+/// highlights the entry matching the reader's current chapter;
+/// `progress_label` is the phone sheet's "184 / 272 · 68%" line.
 #[component]
 pub(super) fn TocDrawer(
     entries: Vec<TocEntry>,
     current_title: String,
+    progress_label: String,
     on_navigate: EventHandler<String>,
     on_close: EventHandler<()>,
 ) -> Element {
     rsx! {
         div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
         div { class: "rd-drawer", "data-testid": "reader-toc-drawer",
+            div { class: "rd-grabber" }
             div { class: "rd-drawer-head",
                 h4 { class: "rd-drawer-title", "Contents" }
+                if !progress_label.is_empty() {
+                    span { class: "rd-drawer-sub", "{progress_label}" }
+                }
                 button {
                     class: "rd-x",
                     r#type: "button",


### PR DESCRIPTION
## Summary
- Implements the mobile reader chrome from the design canvas (Omnibus · Mobile): stacked sans title + "Ch. N · P%" sub-line in the top bar, chapter position on the footer's right edge, and the contents/highlights/bookmarks/quote drawers restyled as grabber-handled bottom sheets on phone widths.
- In-book search goes full-screen on phones with the designed input pill and serif result excerpts + match count; the Aa panel becomes a bottom sheet and drops its page-view row (no two-page spread on a phone column).
- Selection popover becomes the designed bottom action sheet on a fixed dark palette, with icon-over-label actions and Quote tinted as the primary; the actions gain icons on desktop too, matching the desktop design.
- All markup additions render on every target and are toggled purely by the existing 480px breakpoint (rule 07 hydration parity); every existing data-testid is preserved.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 225 passed (includes new `format_title_sub` / `format_contents_progress` unit tests).
- [x] `cargo check` server + mobile + wasm targets; clippy server + mobile clean; `cargo fmt --check`; `just lint-css` green.
- [ ] Visual pass on the iOS simulator + 380px web against the seven design artboards (in progress; fixes land as stacked commits).

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
>[!NOTE]
> Stacked on #874 (merged). `u/sloan/mobile-reader-ui-2` (combined annotations sheet + quote share) follows on top of this.