### PR TITLE
fix: clear error when the ebook library mount is read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Built with Rust ([Axum](https://github.com/tokio-rs/axum) + [Dioxus](https://dio
 The fastest way to run Omnibus. The image is published to
 [Docker Hub as `sesloan/omnibus`](https://hub.docker.com/r/sesloan/omnibus/tags),
 and the repo ships a Jellyfin-style [`docker-compose.yml`](docker-compose.yml):
-bind-mount your library read-only, durable state in `/config`, regenerable cache
-in `/cache`.
+bind-mount your ebook library read-write (in-UI uploads file into it; use `:ro`
+if you never upload), durable state in `/config`, regenerable cache in `/cache`.
 
 ```bash
 # 1. Point the library mounts at your books and set your access URL.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Omnibus — self-hosted ebook/audiobook library.
 #
 # Quick start:
-#   1. Edit the two `:ro` library bind mounts below to point at your books.
+#   1. Edit the two library bind mounts below to point at your books.
 #   2. Set OMNIBUS_PUBLIC_ORIGIN to the URL you'll actually open in a browser.
 #   3. `docker compose up -d --build`
 #   4. Open the app and register — the FIRST account created becomes admin.
@@ -9,7 +9,7 @@
 # Volume model (Jellyfin-style):
 #   /config      durable state — SQLite DB + cover images (back this up)
 #   /cache       regenerable — WebP thumbnails + HLS transcode segments
-#   /books       your ebook library      (read-only)
+#   /books       your ebook library      (read-write for uploads)
 #   /audiobooks  your audiobook library  (read-only)
 
 services:
@@ -29,8 +29,8 @@ services:
       # Persistent app state and regenerable cache. Created on first run.
       - ./config:/config
       - ./cache:/cache
-      # Your media. Edit the left side; keep `:ro` so Omnibus never writes here.
-      - /path/to/your/ebooks:/books:ro
+      # Your media. Edit the left side.
+      - /path/to/your/ebooks:/books
       - /path/to/your/audiobooks:/audiobooks:ro
 
     environment:

--- a/server/src/backend/uploads.rs
+++ b/server/src/backend/uploads.rs
@@ -50,6 +50,9 @@ pub(super) enum UploadError {
     Forbidden,
     /// No ebook library path configured → 400.
     NotConfigured,
+    /// Library root exists but rejects writes (read-only mount / bad
+    /// permissions) → 400 with a remediation hint instead of an opaque 500.
+    LibraryNotWritable,
     /// File field absent from the multipart body → 400.
     MissingFile,
     /// Title/author missing, so the file can't be placed → 400.
@@ -87,6 +90,12 @@ impl IntoResponse for UploadError {
             UploadError::NotConfigured => (
                 StatusCode::BAD_REQUEST,
                 "Configure an ebook library path in Settings first",
+            )
+                .into_response(),
+            UploadError::LibraryNotWritable => (
+                StatusCode::BAD_REQUEST,
+                "The ebook library is not writable — uploads need a read-write \
+                 library mount (remove `:ro` from the books volume)",
             )
                 .into_response(),
             UploadError::MissingFile => {
@@ -310,7 +319,13 @@ pub(super) async fn post_upload_ebook(
     })
     .await
     .map_err(|e| UploadError::internal("spawn_blocking(file ebook)", e))?
-    .map_err(|e| UploadError::internal("file uploaded ebook", e))?;
+    .map_err(|e| match e.kind() {
+        std::io::ErrorKind::ReadOnlyFilesystem | std::io::ErrorKind::PermissionDenied => {
+            tracing::warn!(error = %e, dest = %dest.display(), "ebook library is not writable");
+            UploadError::LibraryNotWritable
+        }
+        _ => UploadError::internal("file uploaded ebook", e),
+    })?;
 
     // Reindex so the indexer mints the uuid, extracts the cover, and updates
     // FTS — the single source of truth for inserting books.

--- a/server/src/backend/uploads/tests.rs
+++ b/server/src/backend/uploads/tests.rs
@@ -270,6 +270,54 @@ async fn commit_requires_configured_library_path() {
 }
 
 #[tokio::test]
+async fn commit_rejects_read_only_library_with_400() {
+    let (app, _state, pool) = fixture().await;
+    let library = tempfile::tempdir().expect("temp library dir");
+    let library_path = library.path().to_string_lossy().to_string();
+    db::set_settings(
+        &pool,
+        &Settings {
+            ebook_library_path: Some(library_path),
+            audiobook_library_path: None,
+        },
+    )
+    .await
+    .expect("set library path");
+
+    // Strip the write bit so filing the book hits PermissionDenied — the same
+    // failure class as a `:ro` bind mount in the deployed container.
+    let mut perms = std::fs::metadata(library.path()).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o555);
+    std::fs::set_permissions(library.path(), perms).expect("chmod library read-only");
+
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let (ct, body) = multipart_body(&[
+        ("title", None, b"Some Title"),
+        ("author", None, b"Some Author"),
+        ("file", Some("book.epub"), &fixture_epub()),
+    ]);
+    let res = app
+        .oneshot(post_multipart("/api/uploads/ebooks", &token, &ct, body))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let msg = String::from_utf8_lossy(&bytes);
+    assert!(
+        msg.contains("not writable"),
+        "error should name the read-only library, got: {msg}"
+    );
+
+    // Restore the write bit so the tempdir can be cleaned up.
+    let mut perms = std::fs::metadata(library.path()).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(library.path(), perms).expect("chmod library back");
+}
+
+#[tokio::test]
 async fn commit_rejects_non_epub_with_415() {
     let (app, _state, pool) = fixture().await;
     let admin = auth_test_support::create_admin(&pool, "admin").await;


### PR DESCRIPTION
## Summary
- Uploading an epub into a library mounted `:ro` failed with an opaque 500; the commit handler now maps `ReadOnlyFilesystem`/`PermissionDenied` to a 400 that names the fix (make the books mount writable).
- Compose template + README no longer prescribe `:ro` for the ebook mount — in-UI uploads and cover sidecars file into the library by design (F5.3), so `:ro` is now the documented opt-out.
- Existing deployments that want uploads must drop `:ro` from their books volume; the app change only improves the error, it can't write through a read-only mount.

## Test plan
- [x] New integration test: commit into a chmod-555 library → 400 with "not writable" message.
- [x] `cargo test -p omnibus uploads` — 15 passed.
- [x] `cargo fmt` + `cargo clippy -p omnibus --tests` clean.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.