### PR TITLE
fix: pad mobile screens clear of the fixed tab bar

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3083,7 +3083,11 @@ body {
      inherited var so full-bleed children (e.g. the book-detail hero glow) can
      cancel it and reach the screen edge. */
   --screen-pad-top: calc(1.5rem + max(20px, env(safe-area-inset-top)));
-  padding: var(--screen-pad-top) 1rem 5rem;
+  /* Bottom padding must clear the fixed .m-tabbar (~60px of bar chrome plus
+     the OS home-indicator inset, which the bar adds to its own padding) or
+     the tail of every scrolling page — e.g. the library's "Load more"
+     button — sits unreachable behind it. */
+  padding: var(--screen-pad-top) 1rem calc(5rem + env(safe-area-inset-bottom));
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- `.screen`'s fixed 5rem bottom padding didn't account for the OS home-indicator inset, so the fixed `.m-tabbar` (~60px + `env(safe-area-inset-bottom)`) covered the tail of every scrolling page — most visibly the library's "Load more" button, which couldn't be pressed.
- Adds `env(safe-area-inset-bottom)` to the shell's bottom padding so page tails clear the bar on inset devices and keep the same 20px margin on devices without one.

## Test plan
- [x] `stylelint` structural lint passes.
- [x] iOS simulator (iPhone 17): scrolled the 234-book library to the bottom — "Load more" renders fully above the tab bar and is tappable.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).