### PR TITLE
fix: book-detail back button returns to the originating page

### DIFF
--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -48,9 +48,7 @@ pub(super) fn render_loaded_mobile(b: EbookMetadata, server_url: String) -> Elem
             // Hero — accent glow, top actions, centered cover.
             div { class: "m-bd-hero",
                 div { class: "m-bd-hero-bar",
-                    // History-aware back: a book opened from Authors/Series/etc.
-                    // returns there, not to the library. Landing is only the
-                    // deep-link fallback (fresh stack, nothing to pop).
+                    // History-aware back; Landing is only the deep-link fallback.
                     button {
                         r#type: "button",
                         class: "m-icon-btn",
@@ -61,7 +59,7 @@ pub(super) fn render_loaded_mobile(b: EbookMetadata, server_url: String) -> Elem
                             if nav.can_go_back() {
                                 nav.go_back();
                             } else {
-                                nav.push(Route::Landing {});
+                                nav.replace(Route::Landing {});
                             }
                         },
                         "\u{2190}"

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -48,7 +48,24 @@ pub(super) fn render_loaded_mobile(b: EbookMetadata, server_url: String) -> Elem
             // Hero — accent glow, top actions, centered cover.
             div { class: "m-bd-hero",
                 div { class: "m-bd-hero-bar",
-                    Link { to: Route::Landing {}, class: "m-icon-btn", "aria-label": "Back", "\u{2190}" }
+                    // History-aware back: a book opened from Authors/Series/etc.
+                    // returns there, not to the library. Landing is only the
+                    // deep-link fallback (fresh stack, nothing to pop).
+                    button {
+                        r#type: "button",
+                        class: "m-icon-btn",
+                        "aria-label": "Back",
+                        "data-testid": "mobile-bd-back",
+                        onclick: move |_| {
+                            let nav = dioxus_router::navigator();
+                            if nav.can_go_back() {
+                                nav.go_back();
+                            } else {
+                                nav.push(Route::Landing {});
+                            }
+                        },
+                        "\u{2190}"
+                    }
                     Link {
                         to: Route::MetadataEdit { uuid: uuid.clone() },
                         class: "m-icon-btn",


### PR DESCRIPTION
## Summary
- The mobile book-detail back button was a hardcoded `Link` to the library, so a book opened from an author, series, or search screen always dumped back to the library.
- Replaces it with a history-aware `navigator().go_back()`, keeping the library as the deep-link fallback when there's no history to pop.

## Test plan
- [x] `cargo clippy -p omnibus-frontend --features mobile` + `cargo test -p omnibus-frontend --features mobile` pass.
- [x] iOS simulator: opened a book from a series detail page; the back button returned to that series page, not the library.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).