### PR TITLE
fix: authors/series mobile chrome — padding + back buttons

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3559,6 +3559,23 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   font-size: 16px;
 }
 .m-icon-btn:hover { border-color: var(--accent); color: var(--ink-0); }
+
+/* Discovery pages (/authors, /series + details) inside the native shell.
+   `.screen` (mobile-only wrapper) already carries the safe-area top padding,
+   so the web-sized hero/header paddings stack into a large blank band —
+   collapse them to the library screen's rhythm. The `.disc-back` button is
+   rendered on every target (rule 07) but only shown here, where the web
+   breadcrumb is hidden in its favor. Declared after `.m-icon-btn` so the
+   hidden-by-default rule wins their specificity tie. */
+.disc-back { display: none; }
+.screen .disc-back { display: grid; margin-bottom: 12px; }
+.screen .disc-hero .breadcrumb,
+.screen .disc-series-header .breadcrumb { display: none; }
+.screen .idx-header { padding: 4px 0 16px; }
+.screen .disc-hero { padding: 4px 0 20px; }
+.screen .disc-hero-grid { margin-top: 12px; }
+.screen .disc-series-header { padding: 4px 0 20px; }
+
 .m-head { padding: 4px 2px 8px; }
 .m-head-top { display: flex; align-items: center; justify-content: space-between; min-height: 32px; }
 .m-head-title {

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -189,6 +189,16 @@ fn author_hero(
     } = text;
     rsx! {
         div { class: "disc-hero", style: "background: {bg_style}",
+            // Mobile-only (CSS-gated via `.screen`) back affordance to the
+            // authors index; web keeps the breadcrumb. Same markup on every
+            // target so the web SSR/WASM trees stay identical (rule 07).
+            Link {
+                to: Route::AuthorsIndex {},
+                class: "m-icon-btn disc-back",
+                "aria-label": "Back to authors",
+                "data-testid": "author-back",
+                "\u{2190}"
+            }
             nav { class: "breadcrumb",
                 Link { to: Route::Landing {}, "Library" }
                 span { class: "breadcrumb-sep", " › " }

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -96,6 +96,16 @@ fn series_header(
     };
     rsx! {
         div { class: "disc-series-header",
+            // Mobile-only (CSS-gated via `.screen`) back affordance to the
+            // series index; web keeps the breadcrumb. Same markup on every
+            // target so the web SSR/WASM trees stay identical (rule 07).
+            Link {
+                to: Route::SeriesIndex {},
+                class: "m-icon-btn disc-back",
+                "aria-label": "Back to series",
+                "data-testid": "series-back",
+                "\u{2190}"
+            }
             nav { class: "breadcrumb", aria_label: "breadcrumb",
                 Link { to: Route::Landing {}, "Library" }
                 span { class: "breadcrumb-sep", " › " }


### PR DESCRIPTION
## Summary
- Inside the native shell, `.screen` already carries the safe-area top padding, so the web-sized `idx-header` / `disc-hero` / `disc-series-header` paddings stacked into a large blank band on the Authors/Series pages — collapsed to the library screen's rhythm via `.screen`-scoped overrides.
- Author/series detail pages gain a round back button to the respective index; the web breadcrumb is hidden on mobile in its favor (web keeps breadcrumbs, markup identical across targets per rule 07 — the gate is pure CSS).

## Test plan
- [x] `stylelint` + `cargo clippy`/`cargo test -p omnibus-frontend --features server` pass (396 tests).
- [x] iOS simulator: Authors + Series indexes and both detail pages start compactly under the status bar; back button on a series detail returns to the series index.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).