### PR TITLE
fix: let native selection handles adjust highlights in the mobile reader

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4743,6 +4743,13 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   /* Note composer keeps a margin off the viewport edges. */
   .rd-note-composer { width: min(360px, calc(100vw - 32px)); }
 
+  /* While a selection is live, the transparent click-scrim must NOT overlay
+     the prose: it would swallow the touches that drag the native selection
+     handles (WebKit then resolves the drag against the host document and
+     snaps the range to the top/bottom of the page). Dismissal on phones is
+     driven by the glue's selection-cleared event instead. */
+  .rd-scrim-clear { display: none; }
+
   /* Selection popover → bottom action sheet ("highlight a passage"), on a
      fixed dark palette regardless of reader theme per the design. The caret
      rect drives inline top/left, so the sheet position needs !important. */

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -41,10 +41,16 @@
  *   copyQuoteCardImage(json)        canvas PNG → clipboard, download fallback
  *   destroy()
  *
- * Selection callback:
+ * Selection callbacks:
  *   - `__omnibusOnSelection(json)` — invoked when the user selects text,
  *     with { cfiRange, text, rect: { x, y, width } } where rect is in
- *     viewport coordinates.
+ *     viewport coordinates. epub.js re-fires this as the selection is
+ *     adjusted (e.g. native handle drags), so the payload tracks the
+ *     live range.
+ *   - `__omnibusOnSelectionCleared(_)` — invoked (debounced) when the
+ *     selection collapses to nothing, so the host can dismiss its
+ *     selection UI without needing a scrim that would swallow the
+ *     native handle drags.
  * Table-of-contents callback:
  *   - `__omnibusOnToc(json)` — invoked once the book is ready (and on
  *     requestToc()), with a flat [{ label, href, level }] array.
@@ -160,6 +166,7 @@
       });
 
       installGestureNav();
+      installSelectionClearWatch();
 
       rendition.themes.register("light", {
         body: { background: "#fcfbfa", color: "#2a2725" },
@@ -270,6 +277,39 @@
     rendition.prev();
   }
 
+  // Emit `__omnibusOnSelectionCleared` (debounced) when the iframe selection
+  // collapses. epub.js only reports selections that exist ("selected"); the
+  // host needs the opposite edge — tap-away, iOS "done", a completed Copy —
+  // to dismiss its popover, now that no scrim overlays the prose (a scrim
+  // would swallow the native selection-handle drags, turning a range adjust
+  // into a page-spanning selection).
+  function installSelectionClearWatch() {
+    if (!rendition || !rendition.hooks || !rendition.hooks.content) return;
+    rendition.hooks.content.register(function (contents) {
+      var doc = contents.document;
+      var win = contents.window || window;
+      var clearTimer = null;
+      doc.addEventListener("selectionchange", function () {
+        if (clearTimer) clearTimeout(clearTimer);
+        // Debounce past the transient collapse WebKit emits mid-drag when a
+        // handle crosses a line boundary — only a settled empty selection
+        // should dismiss.
+        clearTimer = setTimeout(function () {
+          clearTimer = null;
+          var s = win.getSelection && win.getSelection();
+          if (s && !s.isCollapsed && String(s).trim()) return;
+          if (typeof window.__omnibusOnSelectionCleared === "function") {
+            try {
+              window.__omnibusOnSelectionCleared("");
+            } catch (e) {
+              /* ignore handler errors */
+            }
+          }
+        }, 300);
+      });
+    });
+  }
+
   // Touch page-turn for mobile: a horizontal swipe turns the page, and a tap in
   // the outer 20% gutters pages forward (right) / back (left). Registered on
   // every rendered section's iframe document via epub.js's content hook, so it
@@ -280,16 +320,20 @@
     rendition.hooks.content.register(function (contents) {
       var doc = contents.document;
       var win = contents.window || window;
-      var sx = 0, sy = 0, st = 0;
+      var sx = 0, sy = 0, st = 0, hadSel = false;
       doc.addEventListener("touchstart", function (e) {
         var t = e.changedTouches[0];
         sx = t.clientX; sy = t.clientY; st = Date.now();
+        // Snapshot whether a selection was live when the touch began: the
+        // tap that *dismisses* a selection clears it before touchend fires,
+        // and must not double as a page turn.
+        hadSel = !!(win.getSelection && String(win.getSelection()).length > 0);
       }, { passive: true });
       doc.addEventListener("touchend", function (e) {
-        // Never hijack the gesture that just made a text selection — that's the
-        // highlight/note flow, not a page turn.
+        // Never hijack a gesture that made — or just dismissed — a text
+        // selection; that's the highlight/note flow, not a page turn.
         var sel = win.getSelection && win.getSelection();
-        if (sel && String(sel).length > 0) return;
+        if (hadSel || (sel && String(sel).length > 0)) return;
         var t = e.changedTouches[0];
         var dx = t.clientX - sx, dy = t.clientY - sy, dt = Date.now() - st;
         // A dominant horizontal swipe turns a page (swipe left = forward).

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -156,6 +156,13 @@ fn register_window_callbacks(
             selection.set(Some(data));
         }
     });
+    // Glue reports the selection collapsed (tap-away / handle drag ended
+    // empty): dismiss the popover. On phone widths this is the only dismiss
+    // path — the click-scrim is hidden there so native selection-handle
+    // drags reach the prose.
+    let on_selection_cleared = Closure::<dyn FnMut(String)>::new(move |_: String| {
+        selection.set(None);
+    });
     let on_toc = Closure::<dyn FnMut(String)>::new(move |json: String| {
         if let Ok(entries) = serde_json::from_str::<Vec<TocEntry>>(&json) {
             toc.set(entries);
@@ -170,6 +177,7 @@ fn register_window_callbacks(
         ("__omnibusOnRelocate", &relocate),
         ("__omnibusOnStatus", &on_status),
         ("__omnibusOnSelection", &on_selection),
+        ("__omnibusOnSelectionCleared", &on_selection_cleared),
         ("__omnibusOnToc", &on_toc),
         ("__omnibusOnSearchResults", &on_search),
     ] {
@@ -179,7 +187,14 @@ fn register_window_callbacks(
             cb.as_ref().unchecked_ref(),
         );
     }
-    vec![relocate, on_status, on_selection, on_toc, on_search]
+    vec![
+        relocate,
+        on_status,
+        on_selection,
+        on_selection_cleared,
+        on_toc,
+        on_search,
+    ]
 }
 
 /// The pre-serialized JS literals + scalars the bootstrap IIFE needs, bundled

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -42,6 +42,7 @@ enum ReaderEvent {
     Relocate { json: String },
     Status { state: String },
     Selection { json: String },
+    SelectionCleared,
     Toc { json: String },
     Search { json: String },
 }
@@ -195,6 +196,10 @@ async fn drain_reader_events(
                     selection.set(Some(data));
                 }
             }
+            // The selection collapsed (tap-away / adjusted to nothing):
+            // dismiss the popover. This is the only dismiss path on mobile —
+            // no scrim overlays the prose, so native handle drags get through.
+            Ok(ReaderEvent::SelectionCleared) => selection.set(None),
             Ok(ReaderEvent::Toc { json }) => {
                 if let Ok(entries) = serde_json::from_str::<Vec<TocEntry>>(&json) {
                     toc.set(entries);

--- a/frontend/src/pages/reader/mobile/interop.rs
+++ b/frontend/src/pages/reader/mobile/interop.rs
@@ -51,6 +51,7 @@ pub(super) fn install_surface_js(
   window.__omnibusOnRelocate=function(j){{dioxus.send({{kind:"Relocate",json:j}});}};
   window.__omnibusOnStatus=function(s){{dioxus.send({{kind:"Status",state:s}});}};
   window.__omnibusOnSelection=function(j){{dioxus.send({{kind:"Selection",json:j}});}};
+  window.__omnibusOnSelectionCleared=function(){{dioxus.send({{kind:"SelectionCleared"}});}};
   window.__omnibusOnToc=function(j){{dioxus.send({{kind:"Toc",json:j}});}};
   window.__omnibusOnSearchResults=function(j){{dioxus.send({{kind:"Search",json:j}});}};
   function load(src){{return new Promise(function(res,rej){{
@@ -114,6 +115,7 @@ mod tests {
             "__omnibusOnRelocate",
             "__omnibusOnStatus",
             "__omnibusOnSelection",
+            "__omnibusOnSelectionCleared",
             "__omnibusOnToc",
             "__omnibusOnSearchResults",
         ] {


### PR DESCRIPTION
## Summary
- While the selection popover was up, the transparent full-screen click-scrim (`rd-scrim-clear`) overlaid the epub iframe, swallowing the touches that drag WebKit's native selection handles — adjusting a bound snapped the selection to the whole top/bottom of the page.
- On phone widths the scrim is hidden; dismissal is driven by a new glue-side `selectionchange` watcher that emits `__omnibusOnSelectionCleared` (debounced) when the selection collapses, wired through both the web (wasm closure) and mobile (`dioxus.send`) interops.
- The touch page-turn gesture now snapshots selection state at `touchstart` so the tap that dismisses a selection can't double as a page turn; epub.js re-fires `selected` during handle drags, so the popover tracks the adjusted range.

## Test plan
- [x] `stylelint` + clippy/tests for `--features server` (226) and `--features mobile` (170) pass, including the updated `install_surface_js` shim-list unit test.
- [x] iOS simulator: reader loads and paginates with the modified glue (All Systems Red, p.1/176).
- [ ] On-device: select text → drag the upper/lower handles → range adjusts instead of flooding the page; tap away dismisses the sheet without turning the page.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
>[!NOTE]
> The handle-drag itself can't be automated in the simulator (native WebKit selection UI); the unchecked test-plan item is the on-device pass.