### PR TITLE
feat(dev-env): cache nix print-dev-env for hot just recipes

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -29,6 +29,10 @@ nix develop .#mobile                  # interactive shell with Android NDK + iOS
 
 `.envrc` resolves `use flake` to `default`, so the editor stays on the slim shell at all times. `just serve` works from default because zellij + process-compose live there; each multiplexer pane internally wraps its command in the right `.#shell` (server → `.#web`, mobile → `.#mobile`, playwright → `.#e2e`), so only the panes you actually start realize their extras. `just dev-up` and `just dev-bounce` self-wrap in `.#web`, so they work straight from default too.
 
+## Cached dev-env for hot recipes
+
+Each `nix develop` invocation re-copies the flake source into `/nix/store` and re-evaluates the flake. To avoid paying that on every `just` run, the hot recipes (`dev-up`, `dev-bounce`, `lint`, `lint-css`, `test`) go through [`scripts/with-dev-env.sh`](../../scripts/with-dev-env.sh) `<shell> <cmd…>` instead: it captures `nix print-dev-env .#<shell>` once, cached under `.claude/runtime/nix-env-cache/` keyed on `sha256(flake.nix + flake.lock + shell)`, then sources it (re-running the shellHook, so per-workspace `PORT`/`.env`/sccache stay live) and execs the command. On a cache hit this skips Nix entirely; only a flake edit — or a `nix store gc` collecting a referenced path (the wrapper spot-checks and self-heals) — forces a rebuild. Interactive shells and the cold `.#mobile`/multiplexer paths stay on plain `nix develop`. Escape hatches: `OMNIBUS_NO_ENV_CACHE=1` bypasses the cache; `just env-clear` deletes it.
+
 ## Test fixtures
 
 The public-domain test fixtures (`test_data/{epubs,audiobooks}/public_domain/`, ~156 MB of binaries) are **not in git** — they live as a GitHub release asset (`fixtures-vN`) so `nix develop`'s tree-copy into /nix/store stays small. Fresh checkout bootstrap:

--- a/Justfile
+++ b/Justfile
@@ -17,7 +17,7 @@ serve-pc:
 # Use `source .claude/runtime/env.sh` afterwards to pick up OMNIBUS_PORT
 # and PLAYWRIGHT_BASE_URL for follow-on commands (Playwright, preview).
 dev-up:
-    nix develop .#web --command scripts/dev-server-up.sh
+    scripts/with-dev-env.sh web scripts/dev-server-up.sh
 
 # Peek at THIS workspace's dev server without mutating anything.
 # Exit 0 + emit OMNIBUS_DEV_READY when healthy; exit 1 if no server is
@@ -32,11 +32,17 @@ dev-status:
 dev-down:
     scripts/dev-server-down.sh
 
+# Drop the cached Nix dev-env captured by scripts/with-dev-env.sh. Use if a
+# `nix store gc` or a weird env issue makes `just dev-up`/`lint`/`test`
+# misbehave; the next run repopulates from a fresh `nix print-dev-env`.
+env-clear:
+    rm -rf .claude/runtime/nix-env-cache
+
 # Restart THIS workspace's dev server cleanly. Use after adding a sqlx
 # migration (the running server boots its migrations at startup) or when
 # `dx serve` has wedged on a compile error and `dev-up` exits 2.
 dev-bounce:
-    nix develop .#web --command scripts/dev-server-bounce.sh
+    scripts/with-dev-env.sh web scripts/dev-server-bounce.sh
 
 # Ensure the public-domain test fixtures are present (one-time ~156 MB
 # download from the fixtures-vN release asset, then an instant no-op).
@@ -55,7 +61,7 @@ fixtures:
 # `just lint`).
 # Self-wraps in the slim nix shell so it works from a bare checkout too.
 test: fixtures
-    nix develop --command bash -ec '\
+    scripts/with-dev-env.sh default bash -ec '\
         cargo test -p omnibus-db && \
         cargo test -p omnibus && \
         cargo test -p omnibus-frontend --features server && \
@@ -67,13 +73,13 @@ test: fixtures
 # An unclosed `}` silently reparents later rules under CSS nesting, so a
 # missing brace must fail the build. stylelint is Nix-pinned in slimPackages.
 lint-css:
-    nix develop --command stylelint 'frontend/assets/**/*.css'
+    scripts/with-dev-env.sh default stylelint 'frontend/assets/**/*.css'
 
 # Format check + clippy, including the crate/feature combos a bare
 # `cargo clippy` (default-members, default features) misses. Depends on
 # `lint-css` so the CSS structural guard rides the same gate as fmt/clippy.
 lint: lint-css
-    nix develop --command bash -ec '\
+    scripts/with-dev-env.sh default bash -ec '\
         cargo fmt --check && \
         cargo clippy --all-targets && \
         cargo clippy -p omnibus-frontend --features server --all-targets && \

--- a/scripts/with-dev-env.sh
+++ b/scripts/with-dev-env.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Run a command inside a Nix dev shell WITHOUT paying the per-invocation
+# `nix develop` cost (which re-copies the flake source into /nix/store and
+# re-evaluates the flake every time).
+#
+# Usage: scripts/with-dev-env.sh <shell> <command> [args...]
+#          e.g. scripts/with-dev-env.sh web scripts/dev-server-up.sh
+#
+# How: `nix print-dev-env .#<shell>` is captured once and cached, keyed on
+# sha256(flake.nix + flake.lock + shell). The cache is sourced (which re-runs
+# the shellHook, so per-workspace PORT / .env / sccache guards stay live) and
+# the command exec'd. On a cache hit this skips Nix entirely — only a flake
+# edit (or `nix store gc` collecting a referenced path) forces a rebuild.
+#
+# Escape hatches:
+#   OMNIBUS_NO_ENV_CACHE=1   bypass the cache, run plain `nix develop`
+#   just env-clear           delete the cache dir
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <shell> <command> [args...]" >&2
+  exit 1
+fi
+shell="$1"
+shift
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Bypass: straight to nix develop.
+if [ -n "${OMNIBUS_NO_ENV_CACHE:-}" ]; then
+  exec nix develop "$repo_root#$shell" --command "$@"
+fi
+
+sha256_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum | cut -d' ' -f1
+  else shasum -a 256 | cut -d' ' -f1; fi
+}
+
+cache_dir="$repo_root/.claude/runtime/nix-env-cache"
+key="$( (cat "$repo_root/flake.nix" "$repo_root/flake.lock"; echo "$shell") | sha256_hex | cut -c1-16 )"
+cache_file="$cache_dir/$shell-$key.env.bash"
+
+# Self-heal: a `nix store gc` can collect a store path the cached env
+# references, leaving a poisoned cache. Spot-check the first /nix/store path.
+cache_is_stale() {
+  [ ! -f "$cache_file" ] && return 0
+  local p
+  p="$(grep -o '/nix/store/[^\"'\'' :]*' "$cache_file" | head -1 || true)"
+  [ -n "$p" ] && [ ! -e "$p" ]
+}
+
+if cache_is_stale; then
+  mkdir -p "$cache_dir"
+  rm -f "$cache_dir/$shell-"*.env.bash   # drop superseded keys for this shell
+  if ! nix print-dev-env "$repo_root#$shell" > "$cache_file.tmp" 2>/dev/null; then
+    # Flake eval failed (dirty tree, network, etc.) — fall back to nix develop.
+    rm -f "$cache_file.tmp"
+    exec nix develop "$repo_root#$shell" --command "$@"
+  fi
+  mv "$cache_file.tmp" "$cache_file"
+fi
+
+# Source the env (shellHook stdout → stderr so it can't corrupt a command's
+# stdout contract, e.g. dev-server-up.sh's single OMNIBUS_DEV_READY line),
+# then exec the command.
+exec bash -c 'source "$1" >&2; shift; exec "$@"' _ "$cache_file" "$@"

--- a/scripts/with-dev-env.sh
+++ b/scripts/with-dev-env.sh
@@ -24,6 +24,17 @@ fi
 shell="$1"
 shift
 
+# Validate against the flake's devShells. `shell` is interpolated into the
+# cache path and a `rm -f "$cache_dir/$shell-"*` glob, so an unconstrained
+# value (`/`, `..`) could read/delete outside the cache dir.
+case "$shell" in
+  default | web | e2e | mobile | audit) ;;
+  *)
+    echo "with-dev-env: unknown shell '$shell' (expected: default|web|e2e|mobile|audit)" >&2
+    exit 2
+    ;;
+esac
+
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Bypass: straight to nix develop.
@@ -52,11 +63,14 @@ cache_is_stale() {
 if cache_is_stale; then
   mkdir -p "$cache_dir"
   rm -f "$cache_dir/$shell-"*.env.bash   # drop superseded keys for this shell
-  if ! nix print-dev-env "$repo_root#$shell" > "$cache_file.tmp" 2>/dev/null; then
-    # Flake eval failed (dirty tree, network, etc.) — fall back to nix develop.
-    rm -f "$cache_file.tmp"
+  if ! nix print-dev-env "$repo_root#$shell" > "$cache_file.tmp" 2>"$cache_file.err"; then
+    # Flake eval failed (dirty tree, network, etc.) — surface why, then fall
+    # back to nix develop (which re-runs the same eval and would re-emit it).
+    cat "$cache_file.err" >&2
+    rm -f "$cache_file.tmp" "$cache_file.err"
     exec nix develop "$repo_root#$shell" --command "$@"
   fi
+  rm -f "$cache_file.err"
   mv "$cache_file.tmp" "$cache_file"
 fi
 


### PR DESCRIPTION
> [!NOTE]
> #885 (the fixtures release-asset change this was stacked on) is now **merged**; this branch has been rebased onto `main` and its diff is only the dev-env wrapper.

## Summary
- Hot-path `just` recipes (`dev-up`, `dev-bounce`, `lint`, `lint-css`, `test`) went through `nix develop` on every run — each re-copies the flake source into `/nix/store` and re-evaluates the flake (~5s even when the source is already staged; ~30s+ when it isn't).
- New `scripts/with-dev-env.sh <shell> <cmd…>` captures `nix print-dev-env .#<shell>` once, cached under `.claude/runtime/nix-env-cache/` keyed on `sha256(flake.nix + flake.lock + shell)`, then sources it and execs the command. On a cache hit it skips Nix entirely.
- The sourced env re-runs the shellHook, so per-workspace `PORT`, `.env`, and the sccache guards stay live. ShellHook stdout is redirected to stderr so it can't corrupt a command's stdout contract (e.g. `dev-server-up.sh`'s single `OMNIBUS_DEV_READY` line).
- Self-heals when a `nix store gc` collects a referenced store path. Escape hatches: `OMNIBUS_NO_ENV_CACHE=1` bypasses; `just env-clear` drops the cache. Cold `.#mobile`/interactive/multiplexer paths stay on plain `nix develop`.

## Test plan
- [x] Warm hit **0.21s** vs **4.9s** for plain `nix develop --command` (~23×).
- [x] Stdout contract: `bash -c 'echo SENTINEL'` yields exactly `SENTINEL`; `dev-up | head -1` is a clean `OMNIBUS_DEV_READY …`.
- [x] Live env: `PORT` + `OMNIBUS_PUBLIC_ORIGIN` correct; `.env` sourced — proves the shellHook re-ran.
- [x] Invalidation: editing `flake.nix` mints a new key and prunes the old; `OMNIBUS_NO_ENV_CACHE=1` falls through; `just lint-css` runs green through the wrapper.

## Version
- [x] **No release** — dev tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)