### PR TITLE
fix(mobile): allow HTTP origins in iOS WKWebView for self-hosted servers

### DIFF
--- a/mobile/Dioxus.toml
+++ b/mobile/Dioxus.toml
@@ -15,3 +15,15 @@ identifier = "com.omnibus.mobile"
 
 [android]
 uses_cleartext_traffic = true
+
+[ios.raw]
+# Omnibus is a self-hosted app; users connect over HTTP on their LAN or via
+# Tailscale. WKWebView enforces ATS and would otherwise block <img> loads from
+# http:// origins even though reqwest (which uses its own TCP stack) is exempt.
+info_plist = """
+<key>NSAppTransportSecurity</key>
+<dict>
+	<key>NSAllowsArbitraryLoads</key>
+	<true/>
+</dict>
+"""

--- a/mobile/Dioxus.toml
+++ b/mobile/Dioxus.toml
@@ -20,10 +20,11 @@ uses_cleartext_traffic = true
 # Omnibus is a self-hosted app; users connect over HTTP on their LAN or via
 # Tailscale. WKWebView enforces ATS and would otherwise block <img> loads from
 # http:// origins even though reqwest (which uses its own TCP stack) is exempt.
+# InWebContent scopes the exception to WKWebView loads only (iOS 10+).
 info_plist = """
 <key>NSAppTransportSecurity</key>
 <dict>
-	<key>NSAllowsArbitraryLoads</key>
+	<key>NSAllowsArbitraryLoadsInWebContent</key>
 	<true/>
 </dict>
 """


### PR DESCRIPTION
## Summary
- Add `[ios.raw] info_plist` to `mobile/Dioxus.toml` with `NSAllowsArbitraryLoads = true`, bringing iOS to parity with the existing `uses_cleartext_traffic = true` Android setting

## Test plan
- [ ] Build and run on an iOS device connected to a self-hosted Omnibus server over HTTP (LAN or Tailscale) — cover thumbnails should load in the library grid

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes

Cover thumbnails were silently failing on iOS when the server was reached over HTTP. The root cause is a split between two code paths:

- `reqwest` API calls (`/api/ebooks`, etc.) use their own TCP/TLS stack (hyper, not `NSURLSession`) and are **never subject to ATS** — so the library list loaded fine.
- ``'&lt;img src="http://..."&gt;'`` tags in WKWebView go through Apple's URL loading system, which **enforces ATS** — blocking thumbnail requests before they reached the network, producing no server-side log entries.

`NSAllowsArbitraryLoads` is the correct policy here: Omnibus is explicitly designed to connect to operator-controlled servers at user-supplied URLs. Android already opts in via `uses_cleartext_traffic = true`; this brings iOS to parity.

The `[ios.raw] info_plist` hook injects the ATS dict as raw XML into `dx`'s generated `Info.plist` at build time, covering both `dx serve` (development) and `dx bundle` (TestFlight/release) builds.

## 

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xwd5SdUWyrVYeJn5xirTNx)_