### PR TITLE
feat: add recent-progress (continue reading/listening) endpoint

### DIFF
--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -224,7 +224,8 @@ async fn audio_totals(
     };
     let parts = hls::get_parts(pool, resolved.book_file_id).await?;
     let total: f64 = parts.iter().map(|p| p.duration_seconds).sum();
-    let chapters = hls::get_chapters(pool, resolved.book_file_id).await?;
+    let mut chapters = hls::get_chapters(pool, resolved.book_file_id).await?;
+    chapters.sort_by(|a, b| a.start_seconds.total_cmp(&b.start_seconds));
     let position = record.audio_position_seconds.unwrap_or(0.0);
     let number = chapter_number_at(&chapters, position);
     let count = (!chapters.is_empty()).then_some(chapters.len() as i64);

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -6,10 +6,12 @@
 //! same merged-uuid-aware canonical resolver so a format-merged uuid stores
 //! the surviving book's identity.
 
-use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, SessionReport};
+use omnibus_shared::{
+    ChapterInfo, ProgressFormat, ProgressRecord, ProgressUpdate, ResumePoint, SessionReport,
+};
 use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
-use crate::{resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec};
+use crate::{hls, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProgressError {
@@ -17,6 +19,14 @@ pub enum ProgressError {
     BookNotFound,
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
+}
+
+impl From<hls::HlsError> for ProgressError {
+    fn from(e: hls::HlsError) -> Self {
+        match e {
+            hls::HlsError::Db(inner) => ProgressError::Sqlx(inner),
+        }
+    }
 }
 
 impl From<crate::books::BooksError> for ProgressError {
@@ -134,6 +144,104 @@ pub async fn get_progress(
         audio_position_seconds: row.try_get::<Option<f64>, _>("audio_position_seconds")?,
         updated_at: row.try_get::<i64, _>("updated_at")?,
     }))
+}
+
+/// The user's most recent progress rows across both formats, newest first.
+/// Feeds the "pick up where you left off" surfaces via [`resume_points`].
+pub async fn recent_progress(
+    pool: &SqlitePool,
+    user_id: i64,
+    limit: i64,
+) -> Result<Vec<ProgressRecord>, ProgressError> {
+    let rows = sqlx::query(
+        "SELECT book_uuid, format, epub_cfi, audio_position_seconds, updated_at
+         FROM reading_progress
+         WHERE user_id = ?
+         ORDER BY updated_at DESC, book_uuid
+         LIMIT ?",
+    )
+    .bind(user_id)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(ProgressRecord {
+                book_uuid: row.try_get::<String, _>("book_uuid")?,
+                format: parse_format(row.try_get::<String, _>("format")?.as_str()),
+                epub_cfi: row.try_get::<Option<String>, _>("epub_cfi")?,
+                audio_position_seconds: row.try_get::<Option<f64>, _>("audio_position_seconds")?,
+                updated_at: row.try_get::<i64, _>("updated_at")?,
+            })
+        })
+        .collect()
+}
+
+/// [`recent_progress`] joined with book metadata and, for audio rows, the
+/// whole-book duration + chapter position. Rows whose book has since been
+/// deleted (progress soft-references `books.uuid` — no cascade) are skipped
+/// rather than erroring, so one ghosted book can't blank the landing card.
+pub async fn resume_points(
+    pool: &SqlitePool,
+    user_id: i64,
+    limit: i64,
+) -> Result<Vec<ResumePoint>, ProgressError> {
+    let records = recent_progress(pool, user_id, limit).await?;
+    let mut points = Vec::with_capacity(records.len());
+    for record in records {
+        let Some(book) = crate::get_book_by_uuid(pool, &record.book_uuid).await? else {
+            continue;
+        };
+        let audio = match record.format {
+            ProgressFormat::Audio => audio_totals(pool, &record.book_uuid, &record).await?,
+            ProgressFormat::Epub => None,
+        };
+        let (total_duration_seconds, chapter_number, chapter_count) = match audio {
+            Some((dur, ch_no, ch_count)) => (Some(dur), ch_no, ch_count),
+            None => (None, None, None),
+        };
+        points.push(ResumePoint {
+            record,
+            book,
+            total_duration_seconds,
+            chapter_number,
+            chapter_count,
+        });
+    }
+    Ok(points)
+}
+
+/// Whole-book duration and chapter position for an audio progress row.
+/// `None` when the book has no resolvable audio file (e.g. the file was
+/// removed after the position was saved).
+async fn audio_totals(
+    pool: &SqlitePool,
+    uuid: &str,
+    record: &ProgressRecord,
+) -> Result<Option<(f64, Option<i64>, Option<i64>)>, ProgressError> {
+    let Some(resolved) = hls::resolve_audiobook(pool, uuid).await? else {
+        return Ok(None);
+    };
+    let parts = hls::get_parts(pool, resolved.book_file_id).await?;
+    let total: f64 = parts.iter().map(|p| p.duration_seconds).sum();
+    let chapters = hls::get_chapters(pool, resolved.book_file_id).await?;
+    let position = record.audio_position_seconds.unwrap_or(0.0);
+    let number = chapter_number_at(&chapters, position);
+    let count = (!chapters.is_empty()).then_some(chapters.len() as i64);
+    Ok(Some((total, number, count)))
+}
+
+/// 1-based chapter number at `elapsed` seconds, mirroring the player's
+/// index-plus-one display (not the stored `file_chapters.ordinal`, which is
+/// container-supplied and not guaranteed dense).
+fn chapter_number_at(chapters: &[ChapterInfo], elapsed: f64) -> Option<i64> {
+    if chapters.is_empty() {
+        return None;
+    }
+    let idx = chapters
+        .partition_point(|c| c.start_seconds <= elapsed)
+        .saturating_sub(1);
+    Some(idx as i64 + 1)
 }
 
 /// Append one session row inside an existing transaction. Returns `Ok(true)`

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -546,3 +546,184 @@ async fn progress_survives_hard_delete_of_book() {
         "reading_progress must survive a hard delete of its book (no cascade)"
     );
 }
+
+/// Seed an audiobook (books + book_files + parts + chapters) with two 600 s
+/// parts and three chapters, returning its uuid.
+async fn seed_audiobook(pool: &SqlitePool, uuid: &str) -> i64 {
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/ab', 'ab')")
+        .execute(pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let book_id =
+        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, '/ab', 'A')")
+            .bind(uuid)
+            .bind(lib_id)
+            .execute(pool)
+            .await
+            .unwrap()
+            .last_insert_rowid();
+    let file_id = sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'M4B', 'a', 1)",
+    )
+    .bind(book_id)
+    .execute(pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    for (ordinal, dur) in [(0i64, 600.0f64), (1, 600.0)] {
+        sqlx::query(
+            "INSERT INTO book_file_parts \
+                (book_file_id, ordinal, filename, size_bytes, mtime_epoch, duration_seconds) \
+             VALUES (?, ?, 'p', 1, 0, ?)",
+        )
+        .bind(file_id)
+        .bind(ordinal)
+        .bind(dur)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+    for (ordinal, start, dur) in [
+        (1i64, 0.0f64, 400.0f64),
+        (2, 400.0, 400.0),
+        (3, 800.0, 400.0),
+    ] {
+        sqlx::query(
+            "INSERT INTO file_chapters \
+                (book_file_id, ordinal, title, start_seconds, duration_seconds) \
+             VALUES (?, ?, 'ch', ?, ?)",
+        )
+        .bind(file_id)
+        .bind(ordinal)
+        .bind(start)
+        .bind(dur)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+    book_id
+}
+
+#[tokio::test]
+async fn recent_progress_returns_rows_newest_first_within_limit() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid_a) = seed(&pool, "/lib", "Book A").await;
+    let (_, uuid_b) = seed(&pool, "/lib", "Book B").await;
+    for uuid in [&uuid_a, &uuid_b] {
+        upsert_progress(
+            &pool,
+            user,
+            &ProgressUpdate {
+                book_uuid: uuid.clone(),
+                format: ProgressFormat::Epub,
+                epub_cfi: Some("epubcfi(/6/4!/4/2/1:0)".into()),
+                audio_position_seconds: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+    // upserts land in the same wall-clock second; force a strict order.
+    sqlx::query("UPDATE reading_progress SET updated_at = 100 WHERE book_uuid = ?")
+        .bind(&uuid_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE reading_progress SET updated_at = 200 WHERE book_uuid = ?")
+        .bind(&uuid_b)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let rows = recent_progress(&pool, user, 10).await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].book_uuid, uuid_b, "newest row first");
+    assert_eq!(rows[1].book_uuid, uuid_a);
+
+    let capped = recent_progress(&pool, user, 1).await.unwrap();
+    assert_eq!(capped.len(), 1);
+    assert_eq!(capped[0].book_uuid, uuid_b);
+}
+
+#[tokio::test]
+async fn resume_points_enrich_audio_rows_with_duration_and_chapter() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    seed_audiobook(&pool, uuid).await;
+    upsert_progress(
+        &pool,
+        user,
+        &ProgressUpdate {
+            book_uuid: uuid.into(),
+            format: ProgressFormat::Audio,
+            epub_cfi: None,
+            // 450 s → inside chapter 2 (starts at 400 s).
+            audio_position_seconds: Some(450.0),
+        },
+    )
+    .await
+    .unwrap();
+
+    let points = resume_points(&pool, user, 5).await.unwrap();
+    assert_eq!(points.len(), 1);
+    let p = &points[0];
+    assert_eq!(p.book.title.as_deref(), Some("A"));
+    assert_eq!(p.total_duration_seconds, Some(1200.0));
+    assert_eq!(p.chapter_number, Some(2));
+    assert_eq!(p.chapter_count, Some(3));
+}
+
+#[tokio::test]
+async fn resume_points_skip_rows_whose_book_is_gone_and_leave_epub_totals_empty() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (ghost_id, ghost_uuid) = seed(&pool, "/lib", "Ghost").await;
+    let (_, kept_uuid) = seed(&pool, "/lib", "Kept").await;
+    for uuid in [&ghost_uuid, &kept_uuid] {
+        upsert_progress(
+            &pool,
+            user,
+            &ProgressUpdate {
+                book_uuid: uuid.clone(),
+                format: ProgressFormat::Epub,
+                epub_cfi: Some("epubcfi(/6/4!/4/2/1:0)".into()),
+                audio_position_seconds: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+    sqlx::query("DELETE FROM books WHERE id = ?")
+        .bind(ghost_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let points = resume_points(&pool, user, 5).await.unwrap();
+    assert_eq!(points.len(), 1, "ghosted book's row is skipped");
+    let p = &points[0];
+    assert_eq!(p.record.book_uuid, kept_uuid);
+    assert_eq!(p.total_duration_seconds, None);
+    assert_eq!(p.chapter_number, None);
+    assert_eq!(p.chapter_count, None);
+}
+
+#[test]
+fn chapter_number_at_tracks_boundaries_and_empty_list() {
+    let ch = |start: f64, dur: f64| ChapterInfo {
+        ordinal: 1,
+        title: "x".into(),
+        start_seconds: start,
+        duration_seconds: dur,
+    };
+    assert_eq!(chapter_number_at(&[], 10.0), None);
+    let chs = vec![ch(0.0, 400.0), ch(400.0, 400.0)];
+    assert_eq!(chapter_number_at(&chs, 0.0), Some(1));
+    assert_eq!(chapter_number_at(&chs, 399.9), Some(1));
+    assert_eq!(chapter_number_at(&chs, 400.0), Some(2));
+    assert_eq!(chapter_number_at(&chs, 9000.0), Some(2));
+}

--- a/frontend/src/data/progress.rs
+++ b/frontend/src/data/progress.rs
@@ -3,7 +3,7 @@
 //! functions on web/SSR. Public signatures are identical across the
 //! `#[cfg]` split so callers stay platform-agnostic.
 
-use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, SessionReport};
+use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, ResumePoint, SessionReport};
 
 #[cfg(not(feature = "mobile"))]
 use super::note_server_fn_err;
@@ -66,6 +66,18 @@ pub async fn record_sessions(
     Ok(body.get("recorded").and_then(|v| v.as_u64()).unwrap_or(0))
 }
 
+/// GET `/api/progress/recent?limit=…` — the "pick up where you left off" feed.
+#[cfg(feature = "mobile")]
+pub async fn recent_progress(server_url: &str, limit: i64) -> Result<Vec<ResumePoint>, DataError> {
+    let url = format!("{server_url}/api/progress/recent?limit={limit}");
+    let response = with_bearer(http_client().get(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<Vec<ResumePoint>>().await?)
+}
+
 /// Web/SSR `save_progress` — server-function wrapper that proxies to `rpc_save_progress`.
 #[cfg(not(feature = "mobile"))]
 pub async fn save_progress(
@@ -85,6 +97,14 @@ pub async fn get_progress(
     format: ProgressFormat,
 ) -> Result<Option<ProgressRecord>, DataError> {
     crate::rpc::rpc_get_progress(uuid.to_string(), format)
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Web/SSR `recent_progress` — server-function wrapper that proxies to `rpc_recent_progress`.
+#[cfg(not(feature = "mobile"))]
+pub async fn recent_progress(_server_url: &str, limit: i64) -> Result<Vec<ResumePoint>, DataError> {
+    crate::rpc::rpc_recent_progress(limit)
         .await
         .map_err(note_server_fn_err)
 }

--- a/frontend/src/rpc/progress.rs
+++ b/frontend/src/rpc/progress.rs
@@ -53,11 +53,11 @@ pub async fn rpc_get_progress(
 /// `GET /api/progress/recent`; `limit` is clamped to the same 1..=20 range.
 #[post("/api/rpc/progress/recent", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_recent_progress(limit: i64) -> Result<Vec<ResumePoint>> {
-    let limit = limit.clamp(1, 20);
+    const LIMIT_CAP: i64 = 20;
+    let limit = limit.clamp(1, LIMIT_CAP);
     Ok(db::progress::resume_points(&pool.0, user.id, limit)
         .await
         .map_err(|e| internal_rpc_error("recent progress", e))?)
-}
 
 /// Reject over-cap session batches at the RPC boundary, mirroring the mobile
 /// REST route's 422 rejection in `server::backend::progress::post_sessions`.

--- a/frontend/src/rpc/progress.rs
+++ b/frontend/src/rpc/progress.rs
@@ -2,7 +2,7 @@
 
 use dioxus::fullstack::post;
 use dioxus::prelude::*;
-use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, SessionReport};
+use omnibus_shared::{ProgressFormat, ProgressRecord, ProgressUpdate, ResumePoint, SessionReport};
 
 #[cfg(feature = "server")]
 use omnibus_db as db;
@@ -46,6 +46,17 @@ pub async fn rpc_get_progress(
     Ok(db::progress::get_progress(&pool.0, user.id, &uuid, format)
         .await
         .map_err(|e| internal_rpc_error("get progress", e))?)
+}
+
+/// The user's most recent progress rows joined with their books — the
+/// "pick up where you left off" feed. Mirrors the mobile REST route
+/// `GET /api/progress/recent`; `limit` is clamped to the same 1..=20 range.
+#[post("/api/rpc/progress/recent", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_recent_progress(limit: i64) -> Result<Vec<ResumePoint>> {
+    let limit = limit.clamp(1, 20);
+    Ok(db::progress::resume_points(&pool.0, user.id, limit)
+        .await
+        .map_err(|e| internal_rpc_error("recent progress", e))?)
 }
 
 /// Reject over-cap session batches at the RPC boundary, mirroring the mobile

--- a/frontend/src/rpc/progress.rs
+++ b/frontend/src/rpc/progress.rs
@@ -58,6 +58,7 @@ pub async fn rpc_recent_progress(limit: i64) -> Result<Vec<ResumePoint>> {
     Ok(db::progress::resume_points(&pool.0, user.id, limit)
         .await
         .map_err(|e| internal_rpc_error("recent progress", e))?)
+}
 
 /// Reject over-cap session batches at the RPC boundary, mirroring the mobile
 /// REST route's 422 rejection in `server::backend::progress::post_sessions`.

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -302,6 +302,7 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
         // `/api/rpc/progress*` server functions defined in `omnibus_frontend::rpc`.
         .route("/api/progress", post(progress::post_progress))
         .route("/api/progress/sessions", post(progress::post_sessions))
+        .route("/api/progress/recent", get(progress::get_recent_progress))
         .route("/api/progress/{uuid}", get(progress::get_progress))
         // F2.4b highlight annotations — mobile-facing REST. Web hits the
         // analogous `/api/rpc/highlights/*` server functions.

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -26,6 +26,20 @@ fn default_format() -> ProgressFormat {
     ProgressFormat::Epub
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct RecentQuery {
+    #[serde(default = "default_recent_limit")]
+    limit: i64,
+}
+
+fn default_recent_limit() -> i64 {
+    1
+}
+
+/// Ceiling on `?limit=` for `GET /api/progress/recent` — the surface is a
+/// small "pick up where you left off" strip, not a history browser.
+const RECENT_LIMIT_CAP: i64 = 20;
+
 /// Persist a new reading/listening position. Last-write-wins on
 /// `(user, book, format)`; returns the server-authoritative record so the
 /// caller can sync forward.
@@ -58,6 +72,22 @@ pub(super) async fn get_progress(
     match db::progress::get_progress(&state.pool, user.id, &uuid, q.format).await {
         Ok(rec) => Json(rec).into_response(),
         Err(e) => internal("get_progress", e),
+    }
+}
+
+/// The user's most recent progress rows joined with their books — the
+/// mobile "pick up where you left off" feed. `limit` defaults to 1 and is
+/// capped at [`RECENT_LIMIT_CAP`]. Rows whose book has vanished are skipped
+/// in the db layer.
+pub(super) async fn get_recent_progress(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Query(q): Query<RecentQuery>,
+) -> Response {
+    let limit = q.limit.clamp(1, RECENT_LIMIT_CAP);
+    match db::progress::resume_points(&state.pool, user.id, limit).await {
+        Ok(points) => Json(points).into_response(),
+        Err(e) => internal("resume_points", e),
     }
 }
 

--- a/server/src/backend/progress/tests.rs
+++ b/server/src/backend/progress/tests.rs
@@ -461,3 +461,69 @@ async fn api_post_sessions_rollback_on_second_insert_error() {
         "rolled-back transaction must leave no reading_sessions rows"
     );
 }
+
+#[tokio::test]
+async fn api_get_recent_progress_requires_auth() {
+    let (app, _state, _pool) = fixture().await;
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/progress/recent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_get_recent_progress_returns_resume_points_newest_first() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let (_, uuid_a) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let (_, uuid_b) = seed_book_with_uuid(&pool, "/lib", "Book B").await;
+    for uuid in [&uuid_a, &uuid_b] {
+        omnibus_db::progress::upsert_progress(
+            &pool,
+            user.id,
+            &omnibus_shared::ProgressUpdate {
+                book_uuid: uuid.clone(),
+                format: omnibus_shared::ProgressFormat::Epub,
+                epub_cfi: Some("epubcfi(/6/4!/4/2/1:0)".into()),
+                audio_position_seconds: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+    // Same-second upserts tie on updated_at; force Book B newest.
+    sqlx::query("UPDATE reading_progress SET updated_at = 200 WHERE book_uuid = ?")
+        .bind(&uuid_b)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE reading_progress SET updated_at = 100 WHERE book_uuid = ?")
+        .bind(&uuid_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/progress/recent?limit=1")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let points: Vec<omnibus_shared::ResumePoint> = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(points.len(), 1);
+    assert_eq!(points[0].record.book_uuid, uuid_b);
+    assert_eq!(points[0].book.title.as_deref(), Some("Book B"));
+}

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -8,6 +8,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::highlight::CreateHighlight;
+use crate::EbookMetadata;
 
 #[cfg(test)]
 mod tests;
@@ -108,6 +109,25 @@ pub struct ProgressRecord {
     pub epub_cfi: Option<String>,
     pub audio_position_seconds: Option<f64>,
     pub updated_at: i64,
+}
+
+/// One "pick up where you left off" entry: a recent progress row joined
+/// with its book and, for audio rows, whole-book playback totals. Returned
+/// by `GET /api/progress/recent` (mobile) and `rpc_recent_progress` (web),
+/// newest first.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResumePoint {
+    pub record: ProgressRecord,
+    pub book: EbookMetadata,
+    /// Whole-book audio duration (sum of parts). `None` for epub rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_duration_seconds: Option<f64>,
+    /// 1-based chapter number at the saved position. `None` for epub rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chapter_number: Option<i64>,
+    /// Total chapter count, for a "Ch. 3 of 12" readout. `None` for epub rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chapter_count: Option<i64>,
 }
 
 /// Batched session row (reader / audio open-to-close span). Mobile

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -111,10 +111,7 @@ pub struct ProgressRecord {
     pub updated_at: i64,
 }
 
-/// One "pick up where you left off" entry: a recent progress row joined
-/// with its book and, for audio rows, whole-book playback totals. Returned
-/// by `GET /api/progress/recent` (mobile) and `rpc_recent_progress` (web),
-/// newest first.
+/// "Pick up where you left off" entry returned by `GET /api/progress/recent` and `rpc_recent_progress`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ResumePoint {
     pub record: ProgressRecord,


### PR DESCRIPTION
## Summary
- 

## Test plan
- [ ] 

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- 

<!--
Use the following for callouts:

>[!NOTE]
> Blue message!

>[!WARNING]
> Yello message!

>[!IMPORTANT]
> Purple message!

>[!CAUTION]
> Red message!

>[!TIP]
> Green message!
-->
