### PR TITLE
docs: add missing rustdoc to frontend/src/data/*.rs CRUD wrappers (#861)

### DIFF
--- a/frontend/src/data/bookmarks.rs
+++ b/frontend/src/data/bookmarks.rs
@@ -12,6 +12,7 @@ use super::DataError;
 #[cfg(feature = "mobile")]
 use super::{drain_error, http_client, note_status, with_bearer};
 
+/// Create a bookmark for the book with the given uuid.
 #[cfg(feature = "mobile")]
 pub async fn create_bookmark(
     server_url: &str,
@@ -28,6 +29,7 @@ pub async fn create_bookmark(
     Ok(response.json::<Bookmark>().await?)
 }
 
+/// List bookmarks for the book with the given uuid.
 #[cfg(feature = "mobile")]
 pub async fn list_bookmarks(server_url: &str, book_uuid: &str) -> Result<Vec<Bookmark>, DataError> {
     let url = format!("{server_url}/api/bookmarks/book/{book_uuid}");
@@ -39,6 +41,7 @@ pub async fn list_bookmarks(server_url: &str, book_uuid: &str) -> Result<Vec<Boo
     Ok(response.json::<Vec<Bookmark>>().await?)
 }
 
+/// Update a bookmark's title.
 #[cfg(feature = "mobile")]
 pub async fn update_bookmark(
     server_url: &str,
@@ -57,6 +60,7 @@ pub async fn update_bookmark(
     Ok(())
 }
 
+/// Delete a bookmark.
 #[cfg(feature = "mobile")]
 pub async fn delete_bookmark(server_url: &str, id: i64) -> Result<(), DataError> {
     let url = format!("{server_url}/api/bookmarks/{id}");
@@ -68,6 +72,7 @@ pub async fn delete_bookmark(server_url: &str, id: i64) -> Result<(), DataError>
     Ok(())
 }
 
+/// Create a bookmark for the book with the given uuid.
 #[cfg(not(feature = "mobile"))]
 pub async fn create_bookmark(
     _server_url: &str,
@@ -78,6 +83,7 @@ pub async fn create_bookmark(
         .map_err(note_server_fn_err)
 }
 
+/// List bookmarks for the book with the given uuid.
 #[cfg(not(feature = "mobile"))]
 pub async fn list_bookmarks(
     _server_url: &str,
@@ -88,6 +94,7 @@ pub async fn list_bookmarks(
         .map_err(note_server_fn_err)
 }
 
+/// Update a bookmark's title.
 #[cfg(not(feature = "mobile"))]
 pub async fn update_bookmark(
     _server_url: &str,
@@ -99,6 +106,7 @@ pub async fn update_bookmark(
         .map_err(note_server_fn_err)
 }
 
+/// Delete a bookmark.
 #[cfg(not(feature = "mobile"))]
 pub async fn delete_bookmark(_server_url: &str, id: i64) -> Result<(), DataError> {
     crate::rpc::rpc_delete_bookmark(id)

--- a/frontend/src/data/highlights.rs
+++ b/frontend/src/data/highlights.rs
@@ -12,6 +12,7 @@ use super::DataError;
 #[cfg(feature = "mobile")]
 use super::{drain_error, http_client, note_status, with_bearer};
 
+/// Create a highlight for the book with the given uuid.
 #[cfg(feature = "mobile")]
 pub async fn create_highlight(
     server_url: &str,
@@ -28,6 +29,7 @@ pub async fn create_highlight(
     Ok(response.json::<Highlight>().await?)
 }
 
+/// List highlights for the book with the given uuid.
 #[cfg(feature = "mobile")]
 pub async fn list_highlights(
     server_url: &str,
@@ -42,6 +44,7 @@ pub async fn list_highlights(
     Ok(response.json::<Vec<Highlight>>().await?)
 }
 
+/// Update a highlight's color.
 #[cfg(feature = "mobile")]
 pub async fn update_highlight_color(
     server_url: &str,
@@ -60,6 +63,7 @@ pub async fn update_highlight_color(
     Ok(())
 }
 
+/// Update a highlight's note text.
 #[cfg(feature = "mobile")]
 pub async fn update_highlight_note(
     server_url: &str,
@@ -78,6 +82,7 @@ pub async fn update_highlight_note(
     Ok(())
 }
 
+/// Delete a highlight.
 #[cfg(feature = "mobile")]
 pub async fn delete_highlight(server_url: &str, id: i64) -> Result<(), DataError> {
     let url = format!("{server_url}/api/highlights/{id}");
@@ -89,6 +94,7 @@ pub async fn delete_highlight(server_url: &str, id: i64) -> Result<(), DataError
     Ok(())
 }
 
+/// Create a highlight for the book with the given uuid.
 #[cfg(not(feature = "mobile"))]
 pub async fn create_highlight(
     _server_url: &str,
@@ -99,6 +105,7 @@ pub async fn create_highlight(
         .map_err(note_server_fn_err)
 }
 
+/// List highlights for the book with the given uuid.
 #[cfg(not(feature = "mobile"))]
 pub async fn list_highlights(
     _server_url: &str,
@@ -109,6 +116,7 @@ pub async fn list_highlights(
         .map_err(note_server_fn_err)
 }
 
+/// Update a highlight's color.
 #[cfg(not(feature = "mobile"))]
 pub async fn update_highlight_color(
     _server_url: &str,
@@ -120,6 +128,7 @@ pub async fn update_highlight_color(
         .map_err(note_server_fn_err)
 }
 
+/// Update a highlight's note text.
 #[cfg(not(feature = "mobile"))]
 pub async fn update_highlight_note(
     _server_url: &str,
@@ -131,6 +140,7 @@ pub async fn update_highlight_note(
         .map_err(note_server_fn_err)
 }
 
+/// Delete a highlight.
 #[cfg(not(feature = "mobile"))]
 pub async fn delete_highlight(_server_url: &str, id: i64) -> Result<(), DataError> {
     crate::rpc::rpc_delete_highlight(id)

--- a/frontend/src/data/shelves.rs
+++ b/frontend/src/data/shelves.rs
@@ -176,6 +176,7 @@ pub async fn preview_shelf_rule(
 
 // Web / SSR (RPC server functions).
 
+/// The caller's visible shelves.
 #[cfg(not(feature = "mobile"))]
 pub async fn list_shelves(_server_url: &str) -> Result<Vec<ShelfSummary>, DataError> {
     crate::rpc::rpc_list_shelves()
@@ -183,6 +184,7 @@ pub async fn list_shelves(_server_url: &str) -> Result<Vec<ShelfSummary>, DataEr
         .map_err(note_server_fn_err)
 }
 
+/// One shelf's detail.
 #[cfg(not(feature = "mobile"))]
 pub async fn get_shelf(_server_url: &str, id: i64) -> Result<Shelf, DataError> {
     crate::rpc::rpc_get_shelf(id)
@@ -190,6 +192,7 @@ pub async fn get_shelf(_server_url: &str, id: i64) -> Result<Shelf, DataError> {
         .map_err(note_server_fn_err)
 }
 
+/// Create a shelf.
 #[cfg(not(feature = "mobile"))]
 pub async fn create_shelf(_server_url: &str, req: CreateShelfRequest) -> Result<Shelf, DataError> {
     crate::rpc::rpc_create_shelf(req)
@@ -197,6 +200,7 @@ pub async fn create_shelf(_server_url: &str, req: CreateShelfRequest) -> Result<
         .map_err(note_server_fn_err)
 }
 
+/// Partially update a shelf.
 #[cfg(not(feature = "mobile"))]
 pub async fn update_shelf(
     _server_url: &str,
@@ -208,6 +212,7 @@ pub async fn update_shelf(
         .map_err(note_server_fn_err)
 }
 
+/// Delete a shelf.
 #[cfg(not(feature = "mobile"))]
 pub async fn delete_shelf(_server_url: &str, id: i64) -> Result<(), DataError> {
     crate::rpc::rpc_delete_shelf(id)
@@ -215,6 +220,7 @@ pub async fn delete_shelf(_server_url: &str, id: i64) -> Result<(), DataError> {
         .map_err(note_server_fn_err)
 }
 
+/// The shelf's member books, sorted per `sort_key`/`sort_dir`.
 #[cfg(not(feature = "mobile"))]
 pub async fn shelf_page(
     _server_url: &str,
@@ -227,6 +233,7 @@ pub async fn shelf_page(
         .map_err(note_server_fn_err)
 }
 
+/// Append books to a hand-picked shelf.
 #[cfg(not(feature = "mobile"))]
 pub async fn add_shelf_books(
     _server_url: &str,
@@ -238,6 +245,7 @@ pub async fn add_shelf_books(
         .map_err(note_server_fn_err)
 }
 
+/// Remove a book from a shelf.
 #[cfg(not(feature = "mobile"))]
 pub async fn remove_shelf_book(
     _server_url: &str,
@@ -249,6 +257,7 @@ pub async fn remove_shelf_book(
         .map_err(note_server_fn_err)
 }
 
+/// Evaluate an unsaved smart-shelf rule.
 #[cfg(not(feature = "mobile"))]
 pub async fn preview_shelf_rule(
     _server_url: &str,

--- a/frontend/src/data/uploads.rs
+++ b/frontend/src/data/uploads.rs
@@ -49,8 +49,7 @@ async fn web_error(res: gloo_net::http::Response) -> DataError {
     DataError::Http { status, body }
 }
 
-/// Upload the file for server-side inspection, returning parsed metadata for
-/// the confirm step without committing anything to the library.
+/// Upload the file for server-side inspection ahead of the confirm step.
 #[cfg(feature = "web")]
 pub async fn inspect_ebook(
     _server_url: &str,
@@ -125,8 +124,7 @@ pub async fn upload_ebook(
 
 // Mobile (reqwest multipart).
 
-/// Upload the file for server-side inspection, returning parsed metadata for
-/// the confirm step without committing anything to the library.
+/// Upload the file for server-side inspection ahead of the confirm step.
 #[cfg(feature = "mobile")]
 pub async fn inspect_ebook(
     server_url: &str,

--- a/frontend/src/data/uploads.rs
+++ b/frontend/src/data/uploads.rs
@@ -49,6 +49,8 @@ async fn web_error(res: gloo_net::http::Response) -> DataError {
     DataError::Http { status, body }
 }
 
+/// Upload the file for server-side inspection, returning parsed metadata for
+/// the confirm step without committing anything to the library.
 #[cfg(feature = "web")]
 pub async fn inspect_ebook(
     _server_url: &str,
@@ -78,6 +80,7 @@ pub async fn inspect_ebook(
         .map_err(|e| DataError::Other(e.to_string()))
 }
 
+/// Commit a previously-inspected ebook to the library with the confirmed metadata.
 #[cfg(feature = "web")]
 pub async fn upload_ebook(
     _server_url: &str,
@@ -122,6 +125,8 @@ pub async fn upload_ebook(
 
 // Mobile (reqwest multipart).
 
+/// Upload the file for server-side inspection, returning parsed metadata for
+/// the confirm step without committing anything to the library.
 #[cfg(feature = "mobile")]
 pub async fn inspect_ebook(
     server_url: &str,
@@ -144,6 +149,7 @@ pub async fn inspect_ebook(
     Ok(response.json::<UploadInspection>().await?)
 }
 
+/// Commit a previously-inspected ebook to the library with the confirmed metadata.
 #[cfg(feature = "mobile")]
 pub async fn upload_ebook(
     server_url: &str,
@@ -178,6 +184,7 @@ pub async fn upload_ebook(
 
 // Fallback stub (SSR / no platform feature).
 
+/// Unavailable in this build — neither `web` nor `mobile` is enabled.
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 pub async fn inspect_ebook(
     _server_url: &str,
@@ -189,6 +196,7 @@ pub async fn inspect_ebook(
     ))
 }
 
+/// Unavailable in this build — neither `web` nor `mobile` is enabled.
 #[cfg(not(any(feature = "web", feature = "mobile")))]
 pub async fn upload_ebook(
     _server_url: &str,


### PR DESCRIPTION
## Summary
- Adds a one-line `///` rustdoc summary to every `pub` CRUD wrapper function in `frontend/src/data/{bookmarks,highlights,shelves,uploads}.rs` (both the mobile-reqwest and web/SSR-RPC `#[cfg]` variants of each), per `.claude/rules/05-rust-style.md` § Function `///`.
- Pure doc-comment addition — no behavior, signature, or test changes.
- Closes #861

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features server -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features web -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (226 passed)

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- `shelves.rs`'s mobile-REST variants already had per-function docs from a prior pass; only the web/SSR-RPC variants needed them here.
- No migration, schema, or RPC-surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jvp9Rz68onJUYTd5YzMcsX)_