### PR TITLE
fix: mobile mini-player hides book-detail "Back to library" button (#894)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3086,16 +3086,23 @@ body {
   /* Bottom padding must clear the fixed .m-tabbar (~60px of bar chrome plus
      the OS home-indicator inset, which the bar adds to its own padding) or
      the tail of every scrolling page — e.g. the library's "Load more"
-     button — sits unreachable behind it. */
-  padding: var(--screen-pad-top) 1rem calc(5rem + env(safe-area-inset-bottom));
+     button — sits unreachable behind it. Defaults to the larger reserve
+     below (enough to also clear `.m-mini`, docked above the tab bar) since
+     the project's iOS 14 floor predates `:has()` support (Safari 15.4+) —
+     browsers that support it shrink back down when no mini-player is
+     mounted, via the `@supports` rule below. */
+  padding: var(--screen-pad-top) 1rem calc(9rem + env(safe-area-inset-bottom));
 }
 
 /* `.m-mini` docks at `bottom: calc(64px + safe-area)` with ~60px of its own
-   chrome, stacking well past the tabbar-only reserve above (its top edge
-   lands around 124px up) — without extra room, scrolled-to-bottom content
-   (e.g. the book-detail footer button) sits behind it while a book plays. */
-.screen:has(.m-mini) {
-  padding-bottom: calc(9rem + env(safe-area-inset-bottom));
+   chrome, stacking well past the tabbar-only reserve (its top edge lands
+   around 124px up) — the default padding above already covers that. Shrink
+   back to the tabbar-only reserve when no mini-player is mounted, on
+   browsers new enough to detect it. */
+@supports selector(:has(a)) {
+  .screen:not(:has(.m-mini)) {
+    padding-bottom: calc(5rem + env(safe-area-inset-bottom));
+  }
 }
 
 .sr-only {

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3090,6 +3090,14 @@ body {
   padding: var(--screen-pad-top) 1rem calc(5rem + env(safe-area-inset-bottom));
 }
 
+/* `.m-mini` docks at `bottom: calc(64px + safe-area)` with ~60px of its own
+   chrome, stacking well past the tabbar-only reserve above (its top edge
+   lands around 124px up) — without extra room, scrolled-to-bottom content
+   (e.g. the book-detail footer button) sits behind it while a book plays. */
+.screen:has(.m-mini) {
+  padding-bottom: calc(9rem + env(safe-area-inset-bottom));
+}
+
 .sr-only {
   position: absolute;
   width: 1px; height: 1px;


### PR DESCRIPTION
## Summary
- Fixes #894: on the mobile book-detail page, scrolling to the bottom while an audiobook is playing hides the "Back to library" button behind the docked mini-player.
- Root cause: `.screen`'s bottom padding only reserved room for the fixed `.m-tabbar` (~60px, covered by the existing `5rem`/80px reserve). `.m-mini` docks *above* the tab bar (`bottom: calc(64px + safe-area)`) with ~60px of its own chrome, so its top edge lands ~124px above the viewport bottom — well past the 80px reserve — whenever a book is loaded (`MobileMiniPlayer` is mounted on every `ScreenLayout` page, not just book-detail).
- Fix: added `.screen:has(.m-mini)` in `frontend/assets/atrium.css` to bump the bottom reserve to `9rem` only while the mini-player is actually mounted, so pages without an active book keep the original spacing.

## Test plan
- [x] `stylelint` (CSS structural lint) passes on the changed file.
- [ ] CI: `cargo fmt` / `cargo clippy` / `cargo test` (no Rust changed) / Playwright.
- [ ] Manual verification via `ui-validate` on `/book/:uuid` (mobile) with an audiobook actively playing, scrolled to the bottom — button clears the mini-player.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- CSS-only change; no Rust code touched. This session's sandbox doesn't have the Nix dev shell available, so local verification was `stylelint` only — flagging so CI's full matrix and a follow-up in-browser check are the real gate before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01STeFQPgN4vP5m4pRuQavKU)_