### PR TITLE
ci: run omnibus-frontend --features mobile tests (#867)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,6 +115,12 @@ jobs:
       - name: Clippy frontend (web)
         run: nix develop --command cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings
 
+      # Lints the same cfg-split mobile code path the test step below covers.
+      # Only needs reqwest/tokio (no GTK/wry — that's `omnibus-mobile` below),
+      # so this runs in the default shell like the other frontend variants.
+      - name: Clippy frontend (mobile)
+        run: nix develop --command cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings
+
       - name: Clippy shared
         run: nix develop --command cargo clippy -p omnibus-shared --all-targets -- -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,6 +142,16 @@ jobs:
       - name: cargo test (frontend)
         run: nix develop --command cargo test -p omnibus-frontend --features server
 
+      # `--features mobile` exercises a distinct cfg-split code path from
+      # `server` above (`data::token_store` / `app_dirs` native token
+      # persistence) that was previously untested in CI, even though
+      # `just test` has run it locally all along. Only needs reqwest/tokio
+      # (no GTK/wry), so it runs in the default shell like the other test
+      # steps rather than `.#mobile` (that shell is for `omnibus-mobile`'s
+      # desktop GTK backend, a different crate).
+      - name: cargo test (frontend mobile)
+        run: nix develop --command cargo test -p omnibus-frontend --features mobile
+
       - name: cargo test (shared)
         run: nix develop --command cargo test -p omnibus-shared
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ dx serve --platform web -p omnibus
 cargo run -p omnibus                                        # start at http://0.0.0.0:3000
 
 # Tests & lint — aggregate targets cover the full crate matrix in one go
-just test                                                   # db + server + frontend(--features server) + shared
+just test                                                   # db + server + frontend(server + mobile features) + shared
 just lint                                                   # cargo fmt --check + clippy (incl. mobile + frontend-server) + stylelint
 just lint-css                                               # structural CSS lint only (stylelint; catches unclosed rules in frontend/assets)
 just check                                                  # lint then test


### PR DESCRIPTION
## Summary
- Adds a `cargo test -p omnibus-frontend --features mobile` step to the `check` job in `.github/workflows/rust.yml`, alongside the existing `server`/`shared`/`db` test steps.
- The `mobile` feature exercises a distinct cfg-split code path from `server` (`frontend/src/data.rs`'s `token_store`/`app_dirs` native token-persistence, plus the `mobile`-gated `DataError` variants) that had zero CI signal — even though `Justfile`'s `test` recipe has run it locally all along (`just test` → `cargo test -p omnibus-frontend --features mobile`).
- The `mobile` feature only pulls in `reqwest`/`tokio`/`jni`/`ndk-context` (checked `frontend/Cargo.toml`), not the GTK/wry desktop backend that `omnibus-mobile` needs — so the new step runs in the plain `nix develop` shell like the other test steps, not `.#mobile`. Confirmed locally (189 tests pass under this feature set).
- One-line doc fix in `CLAUDE.md`'s quick-commands section: `just test`'s comment said `frontend(--features server)` but the recipe has run both `server` and `mobile` feature sets for a while — updated to match reality.
- Closes #867

## Test plan
- [x] `cargo test -p omnibus-frontend --features mobile` — 189 passed, 0 failed (ran directly; this sandbox has no Nix, so `nix develop --command cargo test ...` itself wasn't invoked, but the underlying command is identical).
- [x] `cargo fmt --check` — no changes needed (no `.rs` files touched).
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] CI: this PR's own `check` job run is the first real exercise of the new step end-to-end (Nix shell, cache, etc.) — watching for green.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — CI-only + docs change; per the template, unlabeled PRs touching only `.github/` and `*.md` skip the release automatically, so left unlabeled.

## Notes
- No Rust code changed — CI workflow + one doc line only.
- Verified the gap was still current before implementing: `origin/main`'s `check` job already had `cargo clippy (mobile)` (targeting the `omnibus-mobile` crate) but no `--features mobile` test step for `omnibus-frontend`, matching the issue's evidence.


---
_Generated by [Claude Code](https://claude.ai/code/session_0177tto1482EzTkQuz2jn5Sh)_