### PR TITLE
fix: iOS app installs as "Omnibus", not "OmnibusMobile"

### DIFF
--- a/scripts/apply-ios-icon.sh
+++ b/scripts/apply-ios-icon.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Inject the Omnibus app icon into a dx-built iOS `.app` bundle.
+# Brand a dx-built iOS `.app` bundle: inject the Omnibus launcher icon and set
+# the home-screen display name to "Omnibus".
 #
 # dx 0.7.x installs no iOS launcher icon, and `Dioxus.toml`'s `[bundle] icon`
 # only feeds the desktop bundlers (upstream bug DioxusLabs/dioxus#3685). So we
@@ -17,7 +18,7 @@ APP="${1:?usage: apply-ios-icon.sh <path/to/App.app> [iphonesimulator|iphoneos]}
 SDK="${2:-iphonesimulator}"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ICON="$REPO_ROOT/mobile/assets/app-icon.png"
+ICON="$REPO_ROOT/mobile/assets/Assets.xcassets/AppIcon.appiconset/app-icon.png"
 PLIST="$APP/Info.plist"
 
 [ -d "$APP" ] || { echo "error: no .app at $APP" >&2; exit 1; }
@@ -55,4 +56,12 @@ xcrun actool "$work/AppIcon.xcassets" \
 /usr/libexec/PlistBuddy -c "Delete :CFBundleIcons~ipad" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Merge $work/partial.plist" "$PLIST"
 
-echo "injected app icon into $APP (sdk=$SDK)"
+# dx names the bundle after the Cargo package (omnibus-mobile), title-cased to
+# "OmnibusMobile" — the home-screen label. dx ignores Dioxus.toml's
+# `[application] name`, so override both bundle-name keys here to read "Omnibus".
+for key in CFBundleDisplayName CFBundleName; do
+  /usr/libexec/PlistBuddy -c "Set :$key Omnibus" "$PLIST" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :$key string Omnibus" "$PLIST"
+done
+
+echo "injected app icon and name into $APP (sdk=$SDK)"

--- a/scripts/ios-package-ipa.sh
+++ b/scripts/ios-package-ipa.sh
@@ -68,6 +68,12 @@ plist_set DTPlatformName string iphoneos
 # App Store validation rejects the bundle without CFBundlePackageType=APPL
 # ("Invalid Bundle OS Type code"); dx omits it like DTPlatformName.
 plist_set CFBundlePackageType string APPL
+# dx names the bundle after the Cargo package (omnibus-mobile), title-cased to
+# "OmnibusMobile" — the home-screen label — and ignores Dioxus.toml's
+# `[application] name`. Override both name keys so the installed app reads
+# "Omnibus". (The local install paths do the same in scripts/apply-ios-icon.sh.)
+plist_set CFBundleDisplayName string Omnibus
+plist_set CFBundleName string Omnibus
 # Pre-declare export-compliance exemption (HTTPS/TLS to our own server is
 # Apple-exempt) so ASC skips the "Missing Compliance" gate that blocks
 # TestFlight auto-distribution. Set via PlistBuddy directly, unquoted, so the


### PR DESCRIPTION
## Summary
- The installed iOS app showed up as **`OmnibusMobile`** on the home screen instead of **`Omnibus`**.
- Root cause: `dx` title-cases the Cargo package name `omnibus-mobile` into the bundle's `CFBundleName`/`CFBundleDisplayName` and **ignores** `Dioxus.toml`'s `[application] name = "Omnibus"` (the same quirk that produces `OmnibusMobile.app`).
- Fix: override both name keys to `Omnibus` in the post-build `Info.plist` patch on every install path — `scripts/apply-ios-icon.sh` (local simulator + on-device) and `scripts/ios-package-ipa.sh` (CI TestFlight).
- Drive-by: repointed `apply-ios-icon.sh`'s icon master from the stale `mobile/assets/app-icon.png` to `mobile/assets/Assets.xcassets/AppIcon.appiconset/app-icon.png` (the file had moved into the asset catalog, silently breaking the script's early `missing master icon` check).

## Test plan
- [x] Ran `scripts/apply-ios-icon.sh <App.app> iphonesimulator` against a freshly-built sim `.app`; `PlistBuddy -c "Print :CFBundleDisplayName"` and `:CFBundleName` both now read **`Omnibus`**, and the AppIcon catalog compiles (`Assets.car` + loose PNGs emitted).
- [x] `bash -n` syntax-checks both scripts.
- [ ] Reviewer: confirm the TestFlight/altool upload still validates (name keys are set before `codesign`).

## Notes
- Purely a bundle-metadata change; no Rust code touched. `Dioxus.toml`'s `[application] name` is left in place as intent even though dx ignores it.
