### PR TITLE
feat: browser-tab favicon + per-route document title

### DIFF
--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -105,17 +105,6 @@ fn format_page_title(subtitle: Option<&str>) -> String {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::format_page_title;
-
-    #[test]
-    fn format_page_title_prefixes_subtitle_and_bares_none() {
-        assert_eq!(format_page_title(Some("Settings")), "Omnibus | Settings");
-        assert_eq!(format_page_title(None), "Omnibus");
-    }
-}
-
 /// App-wide cached `/api/auth/me` result. Owned by [`App`] via
 /// `use_context_provider` so every component that needs to gate on
 /// `is_admin` (top nav avatar, landing inline edits, author Delete) reads
@@ -238,4 +227,15 @@ impl Default for PlaybackState {
 #[cfg(not(feature = "mobile"))]
 pub fn use_playback() -> PlaybackState {
     use_context::<PlaybackState>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_page_title;
+
+    #[test]
+    fn format_page_title_prefixes_subtitle_and_omits_when_none() {
+        assert_eq!(format_page_title(Some("Settings")), "Omnibus | Settings");
+        assert_eq!(format_page_title(None), "Omnibus");
+    }
 }

--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -79,6 +79,43 @@ pub fn use_search_query() -> SearchQuery {
     use_context::<SearchQuery>()
 }
 
+/// Browser-tab title. Owned by [`crate::App`] via `use_context_provider` and
+/// rendered once as the App-level `document::Title`; each route sets its own
+/// subtitle through [`use_page_title`]. Kept target-agnostic (mobile's WebView
+/// has no visible tab, but the write is harmless and avoids a `cfg` gate).
+#[derive(Copy, Clone)]
+pub struct PageTitle(pub Signal<String>);
+
+/// Set the browser-tab title to `Omnibus | {subtitle}` — or the bare app name
+/// when `subtitle()` returns `None` (the landing page). `subtitle` is read
+/// inside the effect, so a page whose name arrives asynchronously (book /
+/// author / series detail) can pass a signal-backed closure and the title
+/// re-renders once its data lands. Post-mount only, so SSR and the first WASM
+/// paint keep the default title and hydration parity holds (rule 07).
+pub fn use_page_title(subtitle: impl Fn() -> Option<String> + 'static) {
+    let PageTitle(mut title) = use_context::<PageTitle>();
+    use_effect(move || title.set(format_page_title(subtitle().as_deref())));
+}
+
+/// Compose the browser-tab title from an optional page subtitle.
+fn format_page_title(subtitle: Option<&str>) -> String {
+    match subtitle {
+        Some(sub) => format!("Omnibus | {sub}"),
+        None => "Omnibus".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_page_title;
+
+    #[test]
+    fn format_page_title_prefixes_subtitle_and_bares_none() {
+        assert_eq!(format_page_title(Some("Settings")), "Omnibus | Settings");
+        assert_eq!(format_page_title(None), "Omnibus");
+    }
+}
+
 /// App-wide cached `/api/auth/me` result. Owned by [`App`] via
 /// `use_context_provider` so every component that needs to gate on
 /// `is_admin` (top nav avatar, landing inline edits, author Delete) reads

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -169,6 +169,10 @@ fn ScreenLayout(children: Element) -> Element {
 /// the WASM bundle.
 const ATRIUM_CSS: Asset = asset!("/assets/atrium.css");
 
+/// Browser-tab favicon — the Omnibus brand mark, served as a hashed static
+/// asset via Manganis. 128² PNG; browsers downscale it to the tab size.
+const FAVICON: Asset = asset!("/assets/omnibus-stoat.png");
+
 /// Install the search-palette context and the global `⌘K` shortcut.
 ///
 /// Called unconditionally from [`App`] so the call site has no
@@ -304,6 +308,10 @@ fn use_mobile_viewport_fix() {}
 #[component]
 pub fn App() -> Element {
     use_context_provider(|| SearchQuery(Signal::new(String::new())));
+    // Browser-tab title, defaulting to the bare app name. Each route refines it
+    // via `use_page_title`; rendered once as `document::Title` below.
+    let page_title = use_signal(|| "Omnibus".to_string());
+    use_context_provider(|| PageTitle(page_title));
     // Hook calls in App() are unconditional — the feature gates live inside
     // the helper bodies (mobile compiles them to no-op stubs). This keeps
     // rule 07's SSR-vs-WASM hydration parity within the not(mobile) build,
@@ -328,7 +336,8 @@ pub fn App() -> Element {
     let audio_host = rsx! { pages::MobileAudioHost {} };
 
     rsx! {
-        document::Title { "Omnibus" }
+        document::Title { "{page_title}" }
+        document::Link { rel: "icon", href: FAVICON }
         document::Stylesheet { href: ATRIUM_CSS }
         components::atrium::AtriumRoot {
             {audio_host}

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -20,6 +20,7 @@ pub fn AuthorPage(id: i64) -> Element {
     let mut author: Signal<Option<AuthorDetail>> = use_signal(|| None);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
+    crate::use_page_title(move || author.read().as_ref().map(|a| a.name.clone()));
 
     // F5.9-lite admin gating for the Delete button — derived from the
     // app-wide `CurrentUser` context (`crate::use_is_admin`) instead of an

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -37,6 +37,8 @@ use hero::BdHeroSection;
 pub fn BookDetailPage(uuid: String) -> Element {
     let server_url = use_server_url();
     let book: Signal<Option<EbookMetadata>> = use_signal(|| None);
+    // Reflect the loaded book title in the browser tab (e.g. "Omnibus | Dracula").
+    crate::use_page_title(move || book.read().as_ref().and_then(|b| b.title.clone()));
     let author_books: Signal<Vec<EbookMetadata>> = use_signal(Vec::new);
     // F3.3 suggestions. Starts `None` on both SSR and the first WASM paint so
     // hydration markup matches (rule 07); the client effect below populates it.

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -16,6 +16,7 @@ pub fn SeriesPage(id: i64) -> Element {
     let mut series: Signal<Option<SeriesDetail>> = use_signal(|| None);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
+    crate::use_page_title(move || series.read().as_ref().map(|s| s.name.clone()));
 
     // See `BookDetailPage` for why `id` needs `use_reactive!`.
     let url = server_url.clone();

--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -34,6 +34,7 @@ pub fn ShelfDetailPage(id: i64) -> Element {
     let mut books = use_signal(Vec::<EbookMetadata>::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
+    crate::use_page_title(move || shelf.read().as_ref().map(|s| s.name.clone()));
     let sort_key = use_signal(|| SortKey::Title);
     let mut show_add = use_signal(|| false);
     // Bumped to force a refetch after a membership edit.

--- a/frontend/src/routes.rs
+++ b/frontend/src/routes.rs
@@ -8,7 +8,7 @@ use dioxus::prelude::*;
 use dioxus_router::Routable;
 
 use crate::pages::*;
-use crate::ScreenLayout;
+use crate::{use_page_title, ScreenLayout};
 
 /// Top-level router for every omnibus frontend target.
 #[derive(Clone, Debug, PartialEq, Eq, Routable)]
@@ -58,6 +58,7 @@ pub enum Route {
 /// Route target for `/` — wraps [`LandingPage`] in the platform screen layout.
 #[component]
 pub fn Landing() -> Element {
+    use_page_title(|| None);
     rsx! {
         ScreenLayout { LandingPage {} }
     }
@@ -66,6 +67,7 @@ pub fn Landing() -> Element {
 /// Route target for `/settings` — wraps [`SettingsPage`] in the platform screen layout.
 #[component]
 pub fn Settings() -> Element {
+    use_page_title(|| Some("Settings".into()));
     rsx! {
         ScreenLayout { SettingsPage {} }
     }
@@ -76,6 +78,7 @@ pub fn Settings() -> Element {
 /// renders the mobile "You" tab.
 #[component]
 pub fn Account() -> Element {
+    use_page_title(|| Some("Account".into()));
     rsx! {
         ScreenLayout { AccountPage {} }
     }
@@ -84,6 +87,7 @@ pub fn Account() -> Element {
 /// Route target for `/add-books` — wraps [`AddBooksPage`] in the platform screen layout.
 #[component]
 pub fn AddBooks() -> Element {
+    use_page_title(|| Some("Add Books".into()));
     rsx! {
         ScreenLayout { AddBooksPage {} }
     }
@@ -105,6 +109,7 @@ pub fn BookDetail(uuid: String) -> Element {
 /// stability rationale as [`BookDetail`].
 #[component]
 pub fn MetadataEdit(uuid: String) -> Element {
+    use_page_title(|| Some("Edit Metadata".into()));
     rsx! {
         ScreenLayout { MetadataEditPage { uuid } }
     }
@@ -116,6 +121,7 @@ pub fn MetadataEdit(uuid: String) -> Element {
 /// nav is suppressed. Same uuid-keyed stability rationale as [`BookDetail`].
 #[component]
 pub fn BookRead(uuid: String) -> Element {
+    use_page_title(|| Some("Reader".into()));
     rsx! {
         BookReadPage { uuid }
     }
@@ -126,6 +132,7 @@ pub fn BookRead(uuid: String) -> Element {
 /// player owns its own slim top bar.
 #[component]
 pub fn BookListen(uuid: String) -> Element {
+    use_page_title(|| Some("Player".into()));
     rsx! {
         BookListenPage { uuid }
     }
@@ -136,6 +143,7 @@ pub fn BookListen(uuid: String) -> Element {
 /// reachable before authentication; on web it redirects to `/`.
 #[component]
 pub fn ServerConnect() -> Element {
+    use_page_title(|| Some("Connect".into()));
     rsx! { ServerConnectPage {} }
 }
 
@@ -144,6 +152,7 @@ pub fn ServerConnect() -> Element {
 /// own full-page chrome via [`crate::components::auth::AuthShell`].
 #[component]
 pub fn Login() -> Element {
+    use_page_title(|| Some("Log in".into()));
     rsx! { LoginPage {} }
 }
 
@@ -158,6 +167,7 @@ pub fn AuthorDetail(id: i64) -> Element {
 /// Route target for `/authors` — browse-all authors index.
 #[component]
 pub fn AuthorsIndex() -> Element {
+    use_page_title(|| Some("Authors".into()));
     rsx! {
         ScreenLayout { AuthorsIndexPage {} }
     }
@@ -174,6 +184,7 @@ pub fn SeriesDetail(id: i64) -> Element {
 /// Route target for `/series` — browse-all series index.
 #[component]
 pub fn SeriesIndex() -> Element {
+    use_page_title(|| Some("Series".into()));
     rsx! {
         ScreenLayout { SeriesIndexPage {} }
     }
@@ -182,6 +193,7 @@ pub fn SeriesIndex() -> Element {
 /// Route target for `/tags` — tag cloud discovery page.
 #[component]
 pub fn TagCloud() -> Element {
+    use_page_title(|| Some("Tags".into()));
     rsx! {
         ScreenLayout { TagCloudPage {} }
     }
@@ -190,6 +202,7 @@ pub fn TagCloud() -> Element {
 /// Route target for `/shelves` — the shelves index (mobile-first; web renders a plain list).
 #[component]
 pub fn Shelves() -> Element {
+    use_page_title(|| Some("Shelves".into()));
     rsx! {
         ScreenLayout { ShelvesIndexPage {} }
     }
@@ -211,6 +224,7 @@ pub fn ShelfDetail(id: i64) -> Element {
 #[cfg(feature = "mobile")]
 #[component]
 pub fn MobileSearch() -> Element {
+    use_page_title(|| Some("Search".into()));
     rsx! {
         ScreenLayout { MobileSearchPage {} }
     }
@@ -231,6 +245,8 @@ pub fn MobileSearch() -> Element {
 /// Route target for `/search/:query` — full-page search results.
 #[component]
 pub fn Search(query: String) -> Element {
+    let heading = query.clone();
+    use_page_title(move || Some(format!("Search: {heading}")));
     rsx! {
         ScreenLayout { SearchPage { query } }
     }
@@ -240,5 +256,6 @@ pub fn Search(query: String) -> Element {
 /// [`Login`] so the two pages feel like one flow.
 #[component]
 pub fn Register() -> Element {
+    use_page_title(|| Some("Register".into()));
     rsx! { RegisterPage {} }
 }


### PR DESCRIPTION
## Summary
- The web app shipped **no favicon** and a static `Omnibus` browser-tab title on every route.
- Added a favicon using the Omnibus brand mark (`omnibus-stoat.png`), emitted once from `App` as `document::Link { rel: "icon" }`.
- Made the tab title per-route: **`Omnibus`** on `/`, **`Omnibus | <page>`** elsewhere (`Omnibus | Settings`, `Omnibus | All Systems Red` on a book detail, etc.).

## How it works
- `App` owns a `PageTitle` context signal, rendered once as `document::Title`. Each route sets its subtitle via a new `use_page_title` hook (`frontend/src/contexts.rs`).
- Static routes set a constant label in their `routes.rs` wrapper. The book / author / series / shelf detail pages pass a **signal-backed closure**, so the title updates once the loaded record name lands.
- The write happens in a **post-mount effect only**, so SSR and the first WASM paint keep the default `Omnibus` title — hydration parity holds (rule 07).

## Test plan
- [x] `cargo check` + `cargo clippy` pass for `omnibus-frontend` on both `--features web` and `--features mobile`.
- [x] New unit test `format_page_title_prefixes_subtitle_and_bares_none` passes (`cargo test -p omnibus-frontend --features server`).
- [x] Verified live against `just dev-up`:
  - SSR `<head>` contains `<title>Omnibus</title>` + `<link rel="icon" …>`; favicon serves `200 image/png`.
  - In-browser tab titles: `Omnibus` (landing), `Omnibus | Settings`, `Omnibus | Log in`, `Omnibus | All Systems Red` (dynamic book detail). No console/hydration errors.

## Notes
- `run_ui_tests` label applied since this touches SSR `<head>` markup.
