### PR TITLE
fix: list TestFlight feedback via app relationship (403 on top-level collection)

### DIFF
--- a/scripts/testflight_feedback_to_issues.py
+++ b/scripts/testflight_feedback_to_issues.py
@@ -88,10 +88,14 @@ def resolve_app_id(token):
 
 
 def fetch_submissions(token, app_id):
-    """Yield (submission, included-index) across up to MAX_PAGES pages, newest first."""
-    url = "/v1/betaFeedbackScreenshotSubmissions"
-    params = {"filter[app]": app_id, "include": "build,tester",
-              "sort": "-createdDate", "limit": 50}
+    """Yield (submission, included-index) across up to MAX_PAGES pages, newest first.
+
+    Listed via the app relationship — the top-level
+    `/v1/betaFeedbackScreenshotSubmissions` collection does not allow
+    GET_COLLECTION (403), only per-app/per-build listing does.
+    """
+    url = f"/v1/apps/{app_id}/betaFeedbackScreenshotSubmissions"
+    params = {"include": "build,tester", "sort": "-createdDate", "limit": 50}
     for _ in range(MAX_PAGES):
         page = asc_get(url, token, params)
         included = {(i["type"], i["id"]): i.get("attributes", {}) for i in page.get("included", [])}


### PR DESCRIPTION
## Summary
- The daily TestFlight-feedback job 403'd: Apple doesn't allow `GET_COLLECTION` on the top-level `/v1/betaFeedbackScreenshotSubmissions` resource. Switched to listing via the app relationship `GET /v1/apps/{id}/betaFeedbackScreenshotSubmissions`.
- Not an auth/permission problem — the Admin key authenticated fine (app id resolved).

## Test plan
- [x] `workflow_dispatch` (dry run) on this branch succeeded and pulled 3 real feedback submissions with tester comment + device + build, rendering the expected `[TestFlight] …` issue titles.

## Version
- [x] **No release** — CI/tooling only.

## Notes
- 