### PR TITLE
fix: surface journal entry delete errors to the owner (#901)

### DIFF
--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -173,10 +173,8 @@ pub(super) fn BdJournalEntryCard(
                     class: "bd-journal-entry-body",
                     dangerous_inner_html: "{entry.body_html}",
                 }
-                if !is_owner {
-                    if let Some(msg) = error() {
-                        span { class: "mono bd-journal-error", role: "alert", "{msg}" }
-                    }
+                if let Some(msg) = error() {
+                    span { class: "mono bd-journal-error", role: "alert", "{msg}" }
                 }
             }
         }

--- a/ui_tests/playwright/tests/flows/journal.spec.ts
+++ b/ui_tests/playwright/tests/flows/journal.spec.ts
@@ -281,3 +281,37 @@ test("surfaces an error and keeps the draft when publishing fails", async ({ pag
   await expect(editorMarkdown(page)).toHaveValue("this will fail");
   await expect(page.getByTestId("journal-composer").getByRole("alert")).toBeVisible();
 });
+
+// ---------------------------------------------------------------------------
+// Error path — failed delete surfaces an error for the owner (#901: the error
+// span was gated on `!is_owner`, so an owner never saw a failed Delete)
+// ---------------------------------------------------------------------------
+
+test("surfaces an error on the entry card when the owner's delete fails", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await gotoReady(page, `/books/${uuid}`);
+
+  const marker = `e2e-journal-delete-fail-${Date.now()}`;
+  await publish(page, `Doomed thoughts ${marker}`);
+  const card = page.getByTestId("journal-entry").filter({ hasText: marker });
+  await expect(card).toBeVisible();
+
+  await page.route("**/api/rpc/journals/delete", (route) =>
+    route.fulfill({ status: 500, contentType: "text/plain", body: "delete exploded" }),
+  );
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/rpc/journals/delete", expectedStatus: 500 },
+    async () => card.getByTestId("journal-delete").click(),
+  );
+
+  // The card stays put and the owner sees the inline error (previously hidden).
+  await expect(card).toBeVisible();
+  await expect(card.getByRole("alert")).toBeVisible();
+
+  await page.unroute("**/api/rpc/journals/delete");
+  await deleteEntry(page, marker);
+});


### PR DESCRIPTION
## Summary
- `BdJournalEntryCard` gated the delete-failure error span on `!is_owner`, but Delete is an owner-only action — so the one user who can ever trigger it never saw the failure (unless already mid-edit, which has its own error UI). Render the error unconditionally in the non-editing branch, matching how the edit form and composer already surface errors regardless of ownership.

## Test plan
- [x] `cargo fmt --check -p omnibus-frontend`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (229 passed)
- [x] Added a Playwright regression test (`ui_tests/playwright/tests/flows/journal.spec.ts`) that forces a 500 on `/api/rpc/journals/delete` and asserts the owner's entry card shows the inline alert — this is not runnable in this sandbox (no Nix/Chromium), but type-checks cleanly with `tsc --noEmit` and follows the existing error-path pattern in the same file (see the "failed publish" test directly above it).

## Version
- [x] **Patch** — the default; left unlabeled per the template (bug fix, no behavior addition).

## Notes
- Bug and fix are exactly as scoped in #901 — no scope creep beyond the one conditional and its regression test.

Closes #901


---
_Generated by [Claude Code](https://claude.ai/code/session_015buRcf18BYcVBLpv21c8vP)_