### PR TITLE
feat: edit and delete journals on mobile

### DIFF
--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -154,11 +154,12 @@ pub fn use_is_admin() -> Signal<bool> {
 /// Derive the resolved current user from the app-wide [`CurrentUser`]
 /// context instead of an independent per-mount `/api/auth/me` fetch,
 /// flattening "not yet resolved" and "unauthenticated" alike to `None`.
-/// Starts `None` so SSR and the first WASM paint agree (rule 07); only the
-/// web build wires the effect that fills it in once the context resolves.
-/// Mobile has no `CurrentUser` context (bearer auth, not cookies), so it
-/// resolves the user directly via `/api/auth/me` — this is what lets
-/// owner-only affordances (e.g. journal edit/delete) light up on mobile.
+/// Starts `None` so SSR and the first WASM paint agree (rule 07); an effect
+/// then fills it in post-mount. The web build reads it from the resolved
+/// [`CurrentUser`] context; mobile has no such context (bearer auth, not
+/// cookies), so it resolves the user directly via `/api/auth/me` — this is
+/// what lets owner-only affordances (e.g. journal edit/delete) light up on
+/// mobile. SSR (neither feature) stays at the `None` default.
 #[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(unused_mut))]
 pub fn use_current_user_summary() -> Signal<Option<omnibus_shared::UserSummary>> {
     let mut current = use_signal(|| None);

--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -156,7 +156,10 @@ pub fn use_is_admin() -> Signal<bool> {
 /// flattening "not yet resolved" and "unauthenticated" alike to `None`.
 /// Starts `None` so SSR and the first WASM paint agree (rule 07); only the
 /// web build wires the effect that fills it in once the context resolves.
-#[cfg_attr(not(feature = "web"), allow(unused_mut))]
+/// Mobile has no `CurrentUser` context (bearer auth, not cookies), so it
+/// resolves the user directly via `/api/auth/me` — this is what lets
+/// owner-only affordances (e.g. journal edit/delete) light up on mobile.
+#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(unused_mut))]
 pub fn use_current_user_summary() -> Signal<Option<omnibus_shared::UserSummary>> {
     let mut current = use_signal(|| None);
     #[cfg(feature = "web")]
@@ -164,6 +167,18 @@ pub fn use_current_user_summary() -> Signal<Option<omnibus_shared::UserSummary>>
         let user_ctx = use_current_user().0;
         use_effect(move || {
             current.set(user_ctx().flatten());
+        });
+    }
+    #[cfg(feature = "mobile")]
+    {
+        let server_url = use_server_url();
+        use_effect(move || {
+            let server_url = server_url.clone();
+            spawn(async move {
+                if let Ok(user) = data::get_me(&server_url).await {
+                    current.set(Some(user));
+                }
+            });
         });
     }
     current


### PR DESCRIPTION
## Summary
- Resolve the current user on mobile via `/api/auth/me` in `use_current_user_summary`, so `is_owner` is true for the signed-in reader's own journal entries.
- This lights up the existing Edit/Delete affordances on the mobile book-detail journal (previously web-only, since mobile had no `CurrentUser` context). The REST transport and UI already existed — only user identity was missing.

## Test plan
- [x] `cargo clippy -p omnibus-frontend` clean for `web`, `mobile`, and `server` features.
- [x] `cargo test -p omnibus-frontend --features server` — 229 passed.
- [x] Manual on iOS simulator: published a journal entry (shows "you" chip + Edit/Delete), edited it (round-tripped), deleted it (removed).

## Version
- [ ] **Patch** — default.

## Notes
- Web/SSR path is untouched; the new resolution is `#[cfg(feature = "mobile")]` only.

Closes #893