### PR TITLE
fix: resolve current user on mobile so journal edit/delete buttons render (#893)

### DIFF
--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -151,12 +151,13 @@ pub fn use_is_admin() -> Signal<bool> {
     is_admin
 }
 
-/// Derive the resolved current user from the app-wide [`CurrentUser`]
-/// context instead of an independent per-mount `/api/auth/me` fetch,
-/// flattening "not yet resolved" and "unauthenticated" alike to `None`.
-/// Starts `None` so SSR and the first WASM paint agree (rule 07); only the
-/// web build wires the effect that fills it in once the context resolves.
-#[cfg_attr(not(feature = "web"), allow(unused_mut))]
+/// Derive the resolved current user: on web, from the app-wide
+/// [`CurrentUser`] context instead of an independent per-mount
+/// `/api/auth/me` fetch; on mobile (which has no `CurrentUser` context,
+/// only a bearer token), via a direct `data::get_me` call mirroring the
+/// Account screen's mobile identity fetch. Starts `None` so SSR and the
+/// first WASM paint agree (rule 07); the post-mount effect fills it in.
+#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(unused_mut))]
 pub fn use_current_user_summary() -> Signal<Option<omnibus_shared::UserSummary>> {
     let mut current = use_signal(|| None);
     #[cfg(feature = "web")]
@@ -164,6 +165,18 @@ pub fn use_current_user_summary() -> Signal<Option<omnibus_shared::UserSummary>>
         let user_ctx = use_current_user().0;
         use_effect(move || {
             current.set(user_ctx().flatten());
+        });
+    }
+    #[cfg(feature = "mobile")]
+    {
+        let server_url = use_server_url();
+        use_effect(move || {
+            let server_url = server_url.clone();
+            spawn(async move {
+                if let Ok(user) = data::get_me(&server_url).await {
+                    current.set(Some(user));
+                }
+            });
         });
     }
     current

--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -24,9 +24,10 @@ use entry_card::BdJournalEntryCard;
 pub(super) fn BdJournalSection(uuid: String) -> Element {
     let server_url = use_server_url();
     let mut entries = use_signal(Vec::<JournalEntry>::new);
-    // Derived from the app-wide `CurrentUser` context (`crate::use_current_user_summary`)
-    // instead of an independent per-mount `/api/auth/me` fetch. Mobile/SSR
-    // stay at the `None` default since the context is web-only.
+    // Web: derived from the app-wide `CurrentUser` context. Mobile: resolved
+    // via its own bearer-authenticated `/api/auth/me` fetch, since mobile has
+    // no `CurrentUser` context. Both funnel through `use_current_user_summary`
+    // (`crate::contexts`); SSR stays at the `None` default until hydration.
     let current_user = crate::use_current_user_summary();
     // Bumped after any mutation to refetch the server-authoritative feed.
     let reload = use_signal(|| 0u32);


### PR DESCRIPTION
## Summary
- `use_current_user_summary` (`frontend/src/contexts.rs`) only populated its signal via the web-only `CurrentUser` context. On mobile builds that context doesn't exist, so the signal stayed `None` forever, `is_owner` in `BdJournalEntryCard` was permanently `false`, and the owner-only Edit/Delete action row never rendered — for anyone, on any journal entry, on mobile.
- Added a mobile branch to `use_current_user_summary` that resolves the current user via a direct bearer-authenticated `data::get_me` fetch, mirroring the identical pattern already used by the Account screen's mobile identity fetch (`frontend/src/pages/account.rs`). The rest of the edit/delete flow (`BdJournalEntryEditForm`, the mobile `PATCH /api/journals/{id}` transport, the server handler, the db update) was already correct and platform-agnostic — only the ownership signal was broken.
- Updated a stale comment in `frontend/src/pages/book_detail/journal.rs` that documented the old (buggy) "mobile stays `None`" behavior as intentional.

## Investigation notes
- Issue #893 was initially investigated as a web-only ticket and found to be already fully implemented there (see the first comment on the issue) — the reporter then clarified the gap is mobile-specific, which is what this PR addresses.
- Root cause confirmed by reading `use_current_user_summary`'s web-only `#[cfg(feature = "web")]` effect gate alongside `entry_card.rs`'s `is_owner` derivation; not a markup/hydration cfg-gate issue (rule 07 was already honored — the Edit form's rsx is identical across targets), purely a data-population gap.

## Test plan
- [x] `cargo fmt -p omnibus-frontend --check`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (229 passed)
- [ ] No direct unit test added: `use_current_user_summary` is a Dioxus hook (`use_signal`/`use_effect`/`spawn`) with no existing test harness in this codebase for that class of code — every other hook in `contexts.rs` (`use_is_admin`, etc.) and the analogous mobile `get_me` fetch in `account.rs` are untested the same way; issue #888 ("Add VirtualDom Tests to Augment Maestro Tests") tracks building that harness. Also confirmed there is **no existing Maestro coverage of journals at all** (only `connect`/`connect_error` flows exist under `ui_tests/maestro/flows/`) — adding first-time journal Maestro coverage is a larger, separate effort than this focused fix and is left out of scope here.

## Version
- [x] **Patch** — the default; left unlabeled per the template (bug fix, no behavior addition).

## Notes
- Scope stayed to the exact ownership-signal bug described in #893; no unrelated cleanup.

Closes #893

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG8aGToZGCcNwoyvuuMqTP)_