### PR TITLE
fix: close Authors cell editor on blur (#992)

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -27,7 +27,11 @@ gloo-timers = { version = "0.4", features = ["futures"], optional = true }
 # F1.11: FormData/Blob/BlobPropertyBag are used by `data::upload_author_photo`
 # to build a multipart body for the author profile photo upload — the only
 # path that needs to ship raw bytes from the web client.
-web-sys = { version = "0.3", features = ["Window", "Storage", "KeyboardEvent", "FormData", "Blob", "BlobPropertyBag"], optional = true }
+# Element/HtmlElement/FocusEvent/EventTarget/Node (#992): ChipEditor's blur
+# handler downcasts to the raw `web_sys::FocusEvent` to read `related_target`
+# and check DOM containment against the editor's own root, so Tab moving
+# focus to a chip's Remove button doesn't close the editor.
+web-sys = { version = "0.3", features = ["Window", "Storage", "KeyboardEvent", "FormData", "Blob", "BlobPropertyBag", "Element", "HtmlElement", "FocusEvent", "EventTarget", "Node"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 js-sys = { version = "0.3", optional = true }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1816,9 +1816,17 @@ a.idx-letter-on:focus-visible {
 }
 .me-tag-input:focus { border-color: var(--accent); }
 
-/* ChipEditor (F5.9-lite) — input + suggestion dropdown. The wrap is
+/* ChipEditor (F5.9-lite) — input + suggestion dropdown. The root wraps the
+   whole component (chips + input + dropdown) purely so blur handling can
+   check DOM containment (#992); `display: contents` keeps it invisible to
+   the host's flex layout so chips/input stay direct flex items of whatever
+   container the consumer wraps ChipEditor in (`.ebook-cell-chip-host`,
+   `.me-chip-row`, `.me-tag-chips`). The input-wrap below is
    position:relative so the absolute dropdown anchors to it; flex 1 lets
    the input grow inside the parent's chip row. */
+.chip-editor-root {
+  display: contents;
+}
 .chip-editor-input-wrap {
   position: relative;
   flex: 1;

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -11,6 +11,16 @@ use dioxus::prelude::*;
 /// user requirement.
 const MAX_SUGGESTIONS: usize = 5;
 
+/// Per-instance handle to the editor's own root DOM node, captured on mount
+/// so a later blur can check whether focus is still somewhere inside this
+/// subtree (see [`close_unless_focus_stayed_inside`]). `()` off the web
+/// target: SSR never fires real DOM events, and mobile's WebView renderer
+/// doesn't route through `dioxus::web`'s `WebEventExt`.
+#[cfg(feature = "web")]
+type ChipEditorRoot = web_sys::Element;
+#[cfg(not(feature = "web"))]
+type ChipEditorRoot = ();
+
 /// One entry in the autocomplete pool. Carries the canonical name plus
 /// the number of books currently linked to it, both of which the
 /// dropdown row renders. Counts are display-only — the component never
@@ -103,9 +113,12 @@ pub struct ChipEditorProps {
     /// the wrapping `ReadSignal`; an empty signal suppresses the
     /// dropdown entirely.
     pub suggestions: ReadSignal<Vec<SuggestionItem>>,
-    /// Fired when the user presses Escape inside the input. Useful for
-    /// host components that want to exit a wrapping edit mode in
-    /// addition to clearing the dropdown highlight. Default no-op.
+    /// Fired when the user presses Escape inside the input, or blurs away
+    /// from the editor entirely (a genuine click-away, or Tab past the
+    /// whole subtree — but not Tab onto a chip's own Remove button, nor a
+    /// suggestion-row pick; see [`ChipEditor`]'s blur handling). Useful for
+    /// host components that want to exit a wrapping edit mode in addition
+    /// to clearing the dropdown highlight. Default no-op.
     #[props(default)]
     pub on_close: EventHandler<()>,
     /// Presentational knobs (placeholder, avatar, testids, …).
@@ -126,6 +139,9 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
     let mut highlight = use_signal::<Option<usize>>(|| None);
     let mut focused = use_signal(|| props.options.autofocus);
     let mut suppress_open = use_signal(|| false);
+    // Captured by the wrapper's `onmounted` below; read by
+    // `close_unless_focus_stayed_inside` on blur.
+    let mut root_el = use_signal(|| None::<ChipEditorRoot>);
 
     let selection = compute_selection(&props, input(), focused(), suppress_open());
     let selection_kd = selection.clone();
@@ -156,7 +172,14 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
     };
 
     rsx! {
-        Fragment {
+        // `display: contents` (atrium.css) keeps this wrapper invisible to
+        // the host's flex layout — it exists only so blur handling can tell
+        // "focus left the whole editor" (chips + input + dropdown) apart
+        // from "focus moved to another focusable element inside it" (e.g. a
+        // chip's Remove button reached via Tab).
+        div {
+            class: "chip-editor-root",
+            onmounted: move |evt: Event<MountedData>| capture_chip_editor_root(evt, &mut root_el),
             ChipList {
                 values: values_sig,
                 show_avatar: props.options.show_avatar,
@@ -179,9 +202,21 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
                     focused.set(true);
                     suppress_open.set(false);
                 },
-                on_blur: move |_| {
+                on_blur: move |evt: Event<FocusData>| {
                     focused.set(false);
                     highlight.set(None);
+                    // Mirrors `EditableCell`'s onblur: a genuine click-away
+                    // (or Tab past the whole editor) exits the host's
+                    // wrapping edit mode the same way Escape does — but Tab
+                    // *within* the editor (e.g. onto a chip's Remove
+                    // button) must not, so this only closes when the
+                    // element gaining focus falls outside `root_el`.
+                    // Suggestion-row picks never reach here at all:
+                    // `SuggestionDropdown`'s `onmousedown` calls
+                    // `prevent_default()`, suppressing the browser's
+                    // default focus-shift so the input never blurs during
+                    // a pick.
+                    close_unless_focus_stayed_inside(evt, root_el, on_close);
                 },
                 on_input: move |value: String| {
                     input.set(value);
@@ -193,6 +228,65 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
             }
         }
     }
+}
+
+/// Store a handle to the editor's own root DOM node the first time it
+/// mounts. No-op off the web target — see [`ChipEditorRoot`].
+#[cfg(feature = "web")]
+fn capture_chip_editor_root(evt: Event<MountedData>, root_el: &mut Signal<Option<ChipEditorRoot>>) {
+    use dioxus::web::WebEventExt;
+    if let Some(el) = evt.try_as_web_event() {
+        root_el.set(Some(el));
+    }
+}
+
+#[cfg(not(feature = "web"))]
+fn capture_chip_editor_root(
+    _evt: Event<MountedData>,
+    _root_el: &mut Signal<Option<ChipEditorRoot>>,
+) {
+}
+
+/// Close the host's wrapping edit mode unless the element gaining focus (the
+/// blur event's `relatedTarget`) is still inside the editor's own root — see
+/// the call site in [`ChipEditor`] for why that distinction matters. A
+/// `relatedTarget` of `None` (focus landed on nothing focusable — the usual
+/// case for clicking a plain heading or block of text) counts as "left the
+/// editor" and closes it, matching real click-away behavior.
+///
+/// Off the web target, there is no `relatedTarget` to inspect, so this
+/// always closes — reproducing the simple pre-fix behavior for mobile's
+/// touch-first interaction model, where a physical Tab key isn't in play.
+#[cfg(feature = "web")]
+fn close_unless_focus_stayed_inside(
+    evt: Event<FocusData>,
+    root_el: Signal<Option<ChipEditorRoot>>,
+    on_close: EventHandler<()>,
+) {
+    use dioxus::web::WebEventExt;
+    use wasm_bindgen::JsCast;
+
+    let stayed_inside = root_el
+        .read()
+        .as_ref()
+        .zip(evt.try_as_web_event().and_then(|e| e.related_target()))
+        .is_some_and(|(root, related)| {
+            related
+                .dyn_ref::<web_sys::Node>()
+                .is_some_and(|node| root.contains(Some(node)))
+        });
+    if !stayed_inside {
+        on_close.call(());
+    }
+}
+
+#[cfg(not(feature = "web"))]
+fn close_unless_focus_stayed_inside(
+    _evt: Event<FocusData>,
+    _root_el: Signal<Option<ChipEditorRoot>>,
+    on_close: EventHandler<()>,
+) {
+    on_close.call(());
 }
 
 /// Props for the [`ChipInputArea`] sub-component.
@@ -207,7 +301,7 @@ struct ChipInputAreaProps {
     selection: SelectionView,
     highlight: Option<usize>,
     on_focus: EventHandler<()>,
-    on_blur: EventHandler<()>,
+    on_blur: EventHandler<Event<FocusData>>,
     on_input: EventHandler<String>,
     on_keydown: EventHandler<Event<KeyboardData>>,
     on_pick: EventHandler<String>,
@@ -431,7 +525,7 @@ struct ChipInputProps {
     testid: String,
     autofocus: bool,
     on_focus: EventHandler<()>,
-    on_blur: EventHandler<()>,
+    on_blur: EventHandler<Event<FocusData>>,
     on_input: EventHandler<String>,
     on_keydown: EventHandler<Event<KeyboardData>>,
 }
@@ -457,13 +551,53 @@ fn ChipInput(props: ChipInputProps) -> Element {
             placeholder: "{placeholder}",
             value: "{input}",
             autofocus,
+            // The `autofocus` attribute alone does not reliably move real
+            // DOM focus onto a node mounted post-hydration by a click
+            // handler (as opposed to one present at initial page load) —
+            // without this, blur-based close-on-click-away silently never
+            // fires because the input was never actually focused to begin
+            // with. Deferred to the next frame: calling `.focus()`
+            // synchronously inside `onmounted` lands before layout
+            // finishes and no-ops (same pattern as
+            // `search_palette::focus_palette_input`).
+            onmounted: move |evt: Event<MountedData>| {
+                if autofocus {
+                    focus_chip_input(evt);
+                }
+            },
             onfocus: move |_| on_focus.call(()),
-            onblur: move |_| on_blur.call(()),
+            onblur: move |evt: Event<FocusData>| on_blur.call(evt),
             oninput: move |e| on_input.call(e.value()),
             onkeydown: move |e| on_keydown.call(e),
         }
     }
 }
+
+#[cfg(feature = "web")]
+fn focus_chip_input(evt: Event<MountedData>) {
+    use dioxus::web::WebEventExt;
+    use wasm_bindgen::prelude::*;
+
+    let Some(element) = evt.try_as_web_event() else {
+        return;
+    };
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let cb = Closure::once_into_js(move || {
+        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
+            let _ = html_el.focus();
+        }
+    });
+    let _ = window.request_animation_frame(cb.unchecked_ref());
+}
+
+/// Non-web stub: SSR never paints an interactive input and mobile's touch
+/// keyboard doesn't need the same rAF-deferred focus nudge. Defined so the
+/// `onmounted` handler can call `focus_chip_input` unconditionally (rule
+/// 07: hydration parity — keep cfg gates out of rsx bodies).
+#[cfg(not(feature = "web"))]
+fn focus_chip_input(_evt: Event<MountedData>) {}
 
 /// Rendered chip row — one chip per value with an avatar (optional) and
 /// remove button. Fires `on_remove` with the new full list after each removal.
@@ -496,6 +630,12 @@ fn ChipList(
                 button {
                     class: "me-chip-remove",
                     "aria-label": "{aria_remove_prefix} {value}",
+                    // Same reasoning as the suggestion rows' onmousedown:
+                    // without prevent_default, clicking Remove blurs the
+                    // input first, and (now that blur closes the editor)
+                    // that unmounts this very button before its click event
+                    // fires, so the chip never actually gets removed.
+                    onmousedown: move |e: Event<MouseData>| e.prevent_default(),
                     onclick: move |_| {
                         let mut new_values = values.read().clone();
                         if i < new_values.len() {

--- a/frontend/src/pages/landing/table/row.rs
+++ b/frontend/src/pages/landing/table/row.rs
@@ -152,7 +152,7 @@ fn derive_row_display(book: &EbookMetadata, server_url: &str, uuid: &str) -> Row
 /// derived; this component does no signal seeding of its own.
 #[component]
 fn EbookRowMarkup(display: RowDisplay, uuid: String, ctx: RowContext) -> Element {
-    let editing = ctx.editing;
+    let mut editing = ctx.editing;
     let nav = use_navigator();
     let uuid_click = uuid.clone();
     let uuid_key = uuid;
@@ -182,6 +182,16 @@ fn EbookRowMarkup(display: RowDisplay, uuid: String, ctx: RowContext) -> Element
             },
             onkeydown: move |evt: Event<KeyboardData>| {
                 if editing().is_some() {
+                    // Fallback close: the open cell's own input handles
+                    // Escape (and stops propagation) when it holds focus,
+                    // but focus can end up elsewhere in the row — a chip's
+                    // remove button, or a fresh editor whose autofocus
+                    // didn't land — leaving `editing` stuck with no input
+                    // listening for Escape. Catch it here so the amber
+                    // highlight can always be dismissed.
+                    if evt.key() == Key::Escape {
+                        editing.set(None);
+                    }
                     return;
                 }
                 let key = evt.key();

--- a/ui_tests/playwright/tests/flows/landing_inline_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/landing_inline_edit.spec.ts
@@ -145,3 +145,95 @@ test("clicking the Authors cell renders the chip editor inline", async ({ page }
   await chipInput.press("Escape");
   await expect(chipInput).toHaveCount(0);
 });
+
+// #992 — the Authors cell's ChipEditor only closed on Escape; blurring away
+// (clicking elsewhere) left the amber `ebook-cell-editing` highlight stuck.
+
+test("clicking away from an open Authors cell editor closes it", async ({ page }) => {
+  await gotoReady(page, "/");
+
+  const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
+  const authorsCell = row.getByTestId("ebook-cell-author");
+  await authorsCell.click();
+
+  const chipInput = authorsCell.getByTestId("ebook-cell-author-input");
+  await expect(chipInput).toBeVisible();
+  await expect(authorsCell).toHaveClass(/ebook-cell-editing/);
+
+  // Click a neutral, always-present element well outside the row/table —
+  // a genuine click-away, not a suggestion pick.
+  await page.getByRole("heading", { level: 1, name: "Your Library" }).click();
+
+  await expect(chipInput).toHaveCount(0);
+  await expect(authorsCell).not.toHaveClass(/ebook-cell-editing/);
+});
+
+test("Tab from the chip input reaches a chip's Remove button without closing the editor", async ({
+  page,
+}) => {
+  await gotoReady(page, "/");
+
+  const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
+  const authorsCell = row.getByTestId("ebook-cell-author");
+  await authorsCell.click();
+
+  const chipInput = authorsCell.getByTestId("ebook-cell-author-input");
+  await expect(chipInput).toBeVisible();
+
+  // ChipList (chips + Remove buttons) renders before the input in DOM
+  // order, so Shift+Tab moves focus backward onto the preceding chip's
+  // Remove button — the exact keyboard path the #992 follow-up fix
+  // protects (blur must not close the editor when the newly-focused
+  // element is still inside it).
+  await chipInput.press("Shift+Tab");
+
+  const removeButton = authorsCell.getByRole("button", {
+    name: `Remove ${TARGET.authors[0]}`,
+  });
+  await expect(removeButton).toBeFocused();
+  await expect(chipInput).toBeVisible();
+  await expect(authorsCell).toHaveClass(/ebook-cell-editing/);
+});
+
+test("selecting an author suggestion keeps the editor open; a later click away closes it", async ({
+  page,
+  request,
+}) => {
+  await gotoReady(page, "/");
+
+  const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
+  const authorsCell = row.getByTestId("ebook-cell-author");
+  await authorsCell.click();
+
+  const chipInput = authorsCell.getByTestId("ebook-cell-author-input");
+  await chipInput.fill("Grace");
+
+  const dropdown = authorsCell.getByTestId("ebook-cell-author-suggestions");
+  const suggestion = dropdown.getByRole("option", { name: /Grace Hopper/ });
+  await expect(suggestion).toBeVisible();
+
+  // AC1: picking a suggestion commits the chip via `onmousedown` +
+  // `preventDefault` (so the input never blurs) and must NOT close the
+  // editor — the admin can keep adding authors.
+  await expectMutation(
+    page,
+    { method: "POST", url: /\/api\/rpc\/ebook\/overrides$/, expectedStatus: 200 },
+    async () => suggestion.click(),
+  );
+  await expect(authorsCell.getByText("Grace Hopper", { exact: true })).toBeVisible();
+  await expect(chipInput).toBeVisible();
+  await expect(authorsCell).toHaveClass(/ebook-cell-editing/);
+
+  // AC2 (regression, chained): a genuine click-away after the pick still
+  // closes the editor and clears the highlight.
+  await page.getByRole("heading", { level: 1, name: "Your Library" }).click();
+  await expect(chipInput).toHaveCount(0);
+  await expect(authorsCell).not.toHaveClass(/ebook-cell-editing/);
+
+  // Cleanup: revert the accumulated authors override.
+  const uuid = await fetchBookIdByTitle(request, TARGET.title);
+  const revertResp = await request.post(`/api/rpc/ebook/overrides/delete`, {
+    data: { uuid },
+  });
+  expect(revertResp.status(), "cleanup revert must succeed").toBe(200);
+});


### PR DESCRIPTION
## Summary
- `ChipEditor`'s `on_blur` handler only reset local focus/highlight state and never called `on_close`, so the Authors cell's `editing` signal only cleared on Escape — picking a suggestion or clicking away left the chip editor and amber `ebook-cell-editing` highlight stuck open.
- `ChipEditor`'s blur handling now closes based on **DOM containment**, not "any blur": the element gaining focus (the blur event's `relatedTarget`) is checked against the editor's own root DOM subtree (chips + input + dropdown, wrapped in a `display: contents` root captured on mount). `relatedTarget` outside the subtree (or `None` — clicking a plain heading/text) closes the editor; `relatedTarget` still inside it (Tab moving focus onto a chip's Remove button) does not. Containment is checked via `dioxus::web::WebEventExt` downcasting to the raw `web_sys::FocusEvent` (Dioxus 0.7's typed `FocusData` doesn't expose `relatedTarget` itself).
- `ChipInput` now also explicitly focuses itself via a rAF-deferred `.focus()` on mount (mirroring the existing `search_palette::focus_palette_input` pattern), instead of relying solely on the native `autofocus` HTML attribute — real DOM focus does not reliably land via `autofocus` alone on a node mounted post-hydration by a click handler, so without a genuine focus, blur never fires at all and click-away silently never closed the editor.
- Landing table row: Escape only reached the open cell's own `onkeydown` when focus was actually inside that cell's input. Added a fallback in the row's `onkeydown` so Escape also clears `editing` when focus has moved elsewhere within the row (e.g. onto a chip's Remove button).
- `metadata_edit`'s two `ChipEditor` hosts (author/tag chip rows) never set `on_close` (defaults to a no-op), so none of this is a regression there.
- Rebased onto current `main` to pick up #986 (mobile journal edit/delete), which this branch's older base was missing — see Notes for why that mattered.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default-members: server, shared, frontend)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features web --target wasm32-unknown-unknown -- -D warnings` — exercises the actual `web_sys`/`wasm_bindgen` blur/containment code path added in this fix (installed the `wasm32-unknown-unknown` target via rustup since `dx`/nix weren't available in this sandbox).
- [x] `cargo clippy -p omnibus-frontend --features mobile -- -D warnings` — clean, including the restored `use_current_user_summary` mobile branch from #986.
- [ ] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` (the whole mobile crate, not just `omnibus-frontend --features mobile`) — still could not run in this sandbox (no GTK3/WebKitGTK system libs; normally provided by the `nix develop .#mobile` shell).
- [x] `cargo test -p omnibus-frontend --features server` (229 passed)
- [x] `cargo test -p omnibus` (313 passed, 1 pre-existing unrelated failure — `backend::uploads::tests::commit_rejects_read_only_library_with_400` fails because this sandbox runs as root, which bypasses the `chmod 0o555` the test relies on; confirmed the same failure reproduces on `main` unmodified)
- [x] `stylelint` on `frontend/assets/**/*.css` (touched `atrium.css` for the new `.chip-editor-root { display: contents; }` rule) — clean.
- [x] Added Playwright coverage in `ui_tests/playwright/tests/flows/landing_inline_edit.spec.ts` (AC1/AC2/AC4, plus the keyboard-Tab containment path): click-away closes the Authors cell editor and clears the highlight; Shift+Tab from the input reaches a chip's Remove button without closing the editor; picking a suggestion keeps the editor open, and a later click-away still closes it.
- [x] Could not bring up the full `dx serve --fullstack` dev server in this sandbox (no `nix`, no `dx`/dioxus-cli) to run the spec end-to-end against real hydrated WASM. In lieu of that, verified the exact DOM mechanics this fix depends on against a **real headless Chromium** via an ad hoc Playwright script driving a minimal static page reproducing `ChipEditor`'s actual DOM shape: confirmed (a) clicking a non-focusable element blurs a focused input with `relatedTarget: null` — validating click-away-closes; (b) Shift+Tab from the input onto the preceding Remove button reports `relatedTarget: "remove"` with `root.contains(relatedTarget) === true` — validating Tab-does-not-close. CI (all 9 checks, including both Playwright shards) is green on this branch's prior revision with the same fix logic.

## Version
- [x] **Patch** — default, unlabeled.

## Notes
Blur/pick-race handling: `SuggestionDropdown` rows and the chip Remove button both use `onmousedown` + `prevent_default()` so the browser's default focus-shift-on-mousedown never happens — the input never actually blurs for either interaction, so the containment check only has to arbitrate genuine focus moves (keyboard Tab, real click-away).

Keyboard-Tab containment fix: an earlier revision of this PR closed the editor unconditionally on any blur, which regressed keyboard accessibility — Tab from the chip input onto a chip's Remove button would close/unmount the editor mid-Tab. Fixed by checking the blur event's `relatedTarget` for DOM containment within a new `display: contents` root wrapping the whole `ChipEditor`, captured via `onmounted`, using `dioxus::web::WebEventExt` to downcast to the raw `web_sys::FocusEvent`. A prior CI failure on the click-away test was root-caused to `autofocus` not reliably landing real DOM focus on a node mounted post-hydration by a click handler — fixed by explicitly calling `.focus()` via `requestAnimationFrame` on mount.

Stale-base fix: a later review caught that this branch's `frontend/src/contexts.rs` was missing the `#[cfg(feature = "mobile")]` branch of `use_current_user_summary()` that resolves the current user via `data::get_me` on mobile — used by the book-detail journal's owner-only edit/delete affordances. Investigation confirmed this was never an edit *I* made: `git log -- frontend/src/contexts.rs` on this branch shows no commit of mine touching that file, and the branch had simply been forked before #986 ("feat: edit and delete journals on mobile") landed on `main` and added that branch. Rebased onto current `main` (`git rebase origin/main`) rather than hand-restoring the code, so the fix comes from its real source; confirmed `git diff origin/main..HEAD -- frontend/src/contexts.rs` is now empty.

Closes #992