### PR TITLE
fix: re-fetch shelf detail when switching shelves via the rail (#993)

### DIFF
--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -40,9 +40,11 @@ pub fn ShelfDetailPage(id: i64) -> Element {
     // Bumped to force a refetch after a membership edit.
     let mut reload = use_signal(|| 0u32);
 
-    // Fetch the shelf detail whenever the id changes.
+    // Fetch the shelf detail whenever the id changes. `id` is a plain prop
+    // (not a signal), so it must be wrapped in `use_reactive!` to re-arm this
+    // effect on navigation between shelves — see `BookDetailPage` for why.
     let shelf_url = server_url.clone();
-    use_effect(move || {
+    use_effect(use_reactive!(|id| {
         let url = shelf_url.clone();
         let _ = reload();
         spawn(async move {
@@ -59,11 +61,13 @@ pub fn ShelfDetailPage(id: i64) -> Element {
             }
             loading.set(false);
         });
-    });
+    }));
 
-    // Fetch the member books, re-running on sort change or a membership edit.
+    // Fetch the member books, re-running on id/sort change or a membership
+    // edit. `sort_key()` is a signal read, already tracked; `id` needs the
+    // same `use_reactive!` wrapping as above.
     let page_url = server_url.clone();
-    use_effect(move || {
+    use_effect(use_reactive!(|id| {
         let url = page_url.clone();
         let key = sort_key();
         let _ = reload();
@@ -76,7 +80,7 @@ pub fn ShelfDetailPage(id: i64) -> Element {
                 Err(_) => books.set(Vec::new()),
             }
         });
-    });
+    }));
 
     if loading() && shelf.read().is_none() {
         return render_page_state(id, rsx! { p { class: "subtitle", "Loading\u{2026}" } });

--- a/ui_tests/playwright/tests/flows/shelves.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelves.spec.ts
@@ -70,7 +70,7 @@ test("surfaces an error when shelf creation fails", async ({ page }) => {
 test("switches shelves via the rail without a full reload", async ({ page, request }) => {
   // Two hand-picked shelves, each holding one distinct fixture book, so the
   // header and grid content can only match if the rail switch actually
-  // re-fetched — see issue #993 (missing `use_reactive!` on the id prop).
+  // re-fetched.
   const alphaUuid = await fetchBookUuidByTitle(request, "Alpha");
   const betaUuid = await fetchBookUuidByTitle(request, "Beta in the Series");
 

--- a/ui_tests/playwright/tests/flows/shelves.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelves.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../fixtures/test";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { fetchBookUuidByTitle } from "../utils/ebooks";
 import { expectNavVisible, gotoReady } from "../utils/nav";
 import { expectMutation } from "../utils/api";
 import { fixturesDir, seedLibrary } from "../utils/seed";
@@ -64,4 +65,54 @@ test("surfaces an error when shelf creation fails", async ({ page }) => {
   );
 
   await expect(page.getByTestId("shelf-create-error")).toBeVisible();
+});
+
+test("switches shelves via the rail without a full reload", async ({ page, request }) => {
+  // Two hand-picked shelves, each holding one distinct fixture book, so the
+  // header and grid content can only match if the rail switch actually
+  // re-fetched — see issue #993 (missing `use_reactive!` on the id prop).
+  const alphaUuid = await fetchBookUuidByTitle(request, "Alpha");
+  const betaUuid = await fetchBookUuidByTitle(request, "Beta in the Series");
+
+  const nameA = `E2E Rail A ${Date.now()}`;
+  const nameB = `E2E Rail B ${Date.now()}`;
+
+  const createManualShelf = async (name: string, bookUuid: string) => {
+    const resp = await request.post("/api/rpc/shelves/create", {
+      data: {
+        req: {
+          kind: "manual",
+          name,
+          description: null,
+          visibility: "private",
+          match_mode: null,
+          rules: [],
+          book_uuids: [bookUuid],
+        },
+      },
+    });
+    expect(resp.status(), `POST /api/rpc/shelves/create failed for ${name}`).toBe(200);
+    const shelf = (await resp.json()) as { id: number };
+    return shelf.id;
+  };
+
+  const shelfAId = await createManualShelf(nameA, alphaUuid);
+  const shelfBId = await createManualShelf(nameB, betaUuid);
+
+  await gotoReady(page, `/shelves/${shelfAId}`);
+  await expect(page.getByTestId("shelf-detail-header")).toContainText(nameA);
+  await expect(page.getByTestId("shelf-grid")).toContainText("Alpha");
+
+  await page.getByTestId(`rail-shelf-${shelfBId}`).click();
+
+  await expect(page.getByTestId("shelf-detail-header")).toContainText(nameB);
+  await expect(page.getByTestId("shelf-grid")).toContainText("Beta in the Series");
+  await expect(page.getByTestId("shelf-grid")).not.toContainText("Alpha");
+
+  // And back the other way, confirming both directions re-fetch.
+  await page.getByTestId(`rail-shelf-${shelfAId}`).click();
+
+  await expect(page.getByTestId("shelf-detail-header")).toContainText(nameA);
+  await expect(page.getByTestId("shelf-grid")).toContainText("Alpha");
+  await expect(page.getByTestId("shelf-grid")).not.toContainText("Beta in the Series");
 });


### PR DESCRIPTION
## Summary
- `ShelfDetailPage`'s two `use_effect` blocks in `frontend/src/pages/shelf_detail.rs` closed over the `id: i64` route prop directly instead of through a tracked reactive dependency, so Dioxus never re-ran them when the rail's `Link` navigated to a new shelf id without remounting the component — the header and grid kept showing the previously-viewed shelf's data.
- Wrapped both effects in `use_reactive!(|id| ...)`, mirroring the existing precedent in `frontend/src/pages/book_detail/mod.rs` and `frontend/src/pages/series.rs`. The member-books effect's existing `sort_key()` signal read continues to provide its own reactivity unchanged.
- Added Playwright coverage in `ui_tests/playwright/tests/flows/shelves.spec.ts`: seeds two hand-picked shelves each holding one distinct fixture book, navigates to shelf A, clicks shelf B in the rail, and asserts the header + grid content switch (both directions).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` — 229 passed
- [ ] Playwright `shelves.spec.ts` — **not run locally**: this sandbox has no Nix/`dx`/wasm32 toolchain available to bundle the WASM client, which is required to exercise the client-side hydration bug this fix addresses. The new spec was validated with `tsc --noEmit` (no type errors) and `playwright test --list` (parses and lists correctly); it should run in CI's `.#e2e` Nix shell.

## Version
- [x] **Patch** — default.

## Notes
- Scope is limited to the two `use_effect` blocks in `ShelfDetailPage`; no other behavior changed.

Closes #993

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnMye6caJvjsAqVHo2V2EX)_