### PR TITLE
fix: touch-friendly journal progress slider on mobile (#979)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1043,6 +1043,10 @@ html, body { overscroll-behavior: none; }
   box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent) 22%, transparent);
   cursor: pointer;
 }
+.bd-journal-progress-range::-webkit-slider-runnable-track {
+  height: 6px; border-radius: 999px;
+  background: transparent; /* let the inline fill gradient on the input show through */
+}
 .bd-journal-progress-range::-moz-range-track {
   height: 6px; border-radius: 999px; background: var(--bg-3);
 }
@@ -1065,6 +1069,7 @@ html, body { overscroll-behavior: none; }
     width: 30px; height: 30px;
     box-shadow: 0 0 0 6px color-mix(in oklch, var(--accent) 22%, transparent);
   }
+  .bd-journal-progress-range::-webkit-slider-runnable-track { height: 8px; }
   .bd-journal-progress-range::-moz-range-thumb { width: 30px; height: 30px; }
 }
 .bd-journal-error { color: var(--bad); font-size: 12px; }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1024,8 +1024,49 @@ html, body { overscroll-behavior: none; }
 .bd-journal-progress {
   display: flex; align-items: center; gap: 8px;
 }
-.bd-journal-progress input[type="range"] { accent-color: var(--accent); cursor: pointer; }
-.bd-journal-progress-val { font-size: 12px; color: var(--ink-1); width: 36px; text-align: right; }
+.bd-journal-progress-slider {
+  display: flex; align-items: center; gap: 8px;
+  flex: 1; min-width: 0;
+}
+/* Custom track/thumb (appearance: none) so the fill gradient set inline from
+   Rust is visible on touch — the unstyled native control is what issue #979
+   reported as glitchy inside the iOS WebView. */
+.bd-journal-progress-range {
+  -webkit-appearance: none; -moz-appearance: none; appearance: none;
+  flex: 1; min-width: 60px; height: 6px;
+  border-radius: 999px; cursor: pointer; outline: none;
+}
+.bd-journal-progress-range::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 20px; height: 20px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent) 22%, transparent);
+  cursor: pointer;
+}
+.bd-journal-progress-range::-moz-range-track {
+  height: 6px; border-radius: 999px; background: var(--bg-3);
+}
+.bd-journal-progress-range::-moz-range-progress {
+  background: var(--accent); height: 6px; border-radius: 999px;
+}
+.bd-journal-progress-range::-moz-range-thumb {
+  width: 20px; height: 20px; border: none; border-radius: 50%;
+  background: var(--accent); cursor: pointer;
+}
+.bd-journal-progress-val {
+  font-size: 12px; color: var(--ink-1); width: 36px; text-align: right;
+  flex-shrink: 0; font-variant-numeric: tabular-nums;
+}
+/* Coarse pointers (touch) get a bigger thumb + taller track so dragging the
+   reading-progress slider on iOS WebView doesn't need pixel-precise contact. */
+@media (pointer: coarse) {
+  .bd-journal-progress-range { height: 8px; }
+  .bd-journal-progress-range::-webkit-slider-thumb {
+    width: 30px; height: 30px;
+    box-shadow: 0 0 0 6px color-mix(in oklch, var(--accent) 22%, transparent);
+  }
+  .bd-journal-progress-range::-moz-range-thumb { width: 30px; height: 30px; }
+}
 .bd-journal-error { color: var(--bad); font-size: 12px; }
 
 /* Entry feed */

--- a/frontend/src/pages/book_detail/journal/composer.rs
+++ b/frontend/src/pages/book_detail/journal/composer.rs
@@ -298,19 +298,31 @@ fn BdJournalProgressToggle(track_progress: Signal<bool>, progress: Signal<i64>) 
             }
             span { class: "label", "Progress" }
             if track_progress() {
-                input {
-                    r#type: "range",
-                    min: "0",
-                    max: "100",
-                    value: "{progress}",
-                    "data-testid": "journal-progress",
-                    oninput: move |e| {
-                        if let Ok(v) = e.value().parse::<i64>() {
-                            progress.set(v);
+                {
+                    let pct = progress();
+                    rsx! {
+                        div { class: "bd-journal-progress-slider",
+                            input {
+                                r#type: "range",
+                                class: "bd-journal-progress-range",
+                                min: "0",
+                                max: "100",
+                                value: "{progress}",
+                                // Paints the played portion directly (Chrome/Safari drop
+                                // native fill once `appearance: none` is set), so drag
+                                // affordance stays visible on touch, not just the thumb.
+                                style: "background: linear-gradient(to right, var(--accent) 0%, var(--accent) {pct}%, var(--bg-3) {pct}%, var(--bg-3) 100%);",
+                                "data-testid": "journal-progress",
+                                oninput: move |e| {
+                                    if let Ok(v) = e.value().parse::<i64>() {
+                                        progress.set(v);
+                                    }
+                                },
+                            }
+                            span { class: "mono bd-journal-progress-val", "{progress}%" }
                         }
-                    },
+                    }
                 }
-                span { class: "mono bd-journal-progress-val", "{progress}%" }
             }
         }
     }


### PR DESCRIPTION
## Summary
- `BdJournalProgressToggle`'s reading-progress slider (`frontend/src/pages/book_detail/journal/composer.rs`) was a bare unstyled `input[type=range]`, which behaved awkwardly on iOS WebView touch (small hit target, no fill affordance).
- Added custom track/thumb styling in `frontend/assets/atrium.css` (`-webkit-appearance`/`-moz-appearance: none` with dedicated `::-webkit-slider-thumb`, `::-webkit-slider-runnable-track`, `::-moz-range-track`, `::-moz-range-progress`, `::-moz-range-thumb` rules), following the existing `.m-player-range` precedent in `frontend/src/pages/listen/mobile.rs`: 20px thumb / 6px track by default, bumped to 30px thumb / 8px track under `@media (pointer: coarse)` for touch devices.
- Wrapped the input in a `bd-journal-progress-slider` container and added a live linear-gradient fill bound to the `progress` signal so the played portion is visible. The `::-webkit-slider-runnable-track` is explicitly styled with a transparent background so that inline gradient shows through on Safari/iOS WebView instead of the browser's default track look. The `journal-progress` testid and the `progress`/publish-payload wiring are unchanged.
- Design-only — no changes to the `progress` data model or the publish payload.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (229 passed)
- [x] `npx stylelint frontend/assets/atrium.css --config .stylelintrc.json` (no Nix in this sandbox; ran via plain `npx`) — clean
- [ ] Live iOS WebView / `dx serve` / Playwright verification — not possible in this sandbox (no Nix, no `dx` CLI, no Chromium/simulator). The existing `ui_tests/playwright/tests/flows/journal.spec.ts` doesn't exercise the `journal-progress` control; since this change adds no new testid/role/label, no new spec was added per the judgment call in `.claude/rules/04-playwright.md`.

## Version
- [x] **Patch** — default, unlabeled.

## Notes
- Independently re-verified via an adversarial review pass: CSS vendor pseudo-elements are each their own rule (not invalidly comma-combined), brace balance is correct, gradient percent math matches the `0-100` range of the `progress: Signal<i64>` (no 0.0–1.0 mismatch), `journal-progress` testid preserved, no `db/migrations/` touched, no scope creep beyond the slider's CSS/markup.
- Addressed Copilot's automated review (2 findings, both legitimate given #979 is specifically about iOS WebView rendering): added an explicit `::-webkit-slider-runnable-track` rule (transparent background so the inline gradient shows through, since WebKit paints the track via that pseudo-element and can otherwise fall back to the default look) and bumped its height alongside the thumb under `@media (pointer: coarse)`. See resolved review threads for details.
- CI's `clippy + test` job failed once on `worker::tests::poisoned_progress_lock_recovers_instead_of_panicking` in `db/src/worker/tests.rs` — this PR touches only `frontend/assets/atrium.css` and one `frontend` component, no `db` crate files, so this is unrelated pre-existing flakiness (an intentional-panic-then-recover mutex test, inherently sensitive to CI scheduling), not something introduced by this change. Re-triggered by the follow-up push.
- CI's `maestro (iOS simulator)` job failed on the `connect` flow (`Assertion is false: "http://127.0.0.1:3000" is visible`) — this exactly matches the pre-existing, `main`-wide failure tracked separately in #902 ("ci: maestro iOS mobile-e2e connect/connect_error flows failing on main"), unrelated to this PR's journal-composer CSS change. Not attempted here; #902 already flags it needs dedicated simulator-level investigation.

Closes #979
