### PR TITLE
refactor: fix import-ordering drift + expect() in kindle.rs (#859)

### DIFF
--- a/db/src/auth/device/tests.rs
+++ b/db/src/auth/device/tests.rs
@@ -4,12 +4,13 @@
 //! rejection). Validation tests are pure unit; register/list and pre-insert
 //! rejection tests share an in-memory pool via `auth::test_support::pool`.
 
+use sqlx::Row;
+
 use super::*;
 use crate::auth::session::create_session;
 use crate::auth::test_support::pool;
 use crate::auth::users::create_user;
 use crate::auth::SessionKind;
-use sqlx::Row;
 
 #[tokio::test]
 async fn device_register_and_list() {

--- a/db/src/bookmarks/tests.rs
+++ b/db/src/bookmarks/tests.rs
@@ -2,9 +2,10 @@
 //! BookNotFound / NotFound variants, list isolation, title updates, and
 //! delete behaviour.
 
+use omnibus_shared::EbookMetadata;
+
 use super::*;
 use crate::{init_db, replace_books};
-use omnibus_shared::EbookMetadata;
 
 async fn seed(pool: &SqlitePool, library: &str, title: &str) -> (i64, String) {
     replace_books(

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -2,6 +2,8 @@
 //! many cross-cutting helpers (`seed_minimal_books`, etc.) and the tests that
 //! drive `list_books` + `search_books` + `get_book` together stay co-located.
 
+use omnibus_shared::{Contributor, EbookMetadata, Identifier, MetadataOverrides};
+
 use super::*;
 use crate::ebook::IndexedBook;
 use crate::helpers::MAX_QUERY_LEN;
@@ -12,7 +14,6 @@ use crate::test_support::{
     author_id_by_name, indexed, seed_discovery_fixture, seed_minimal_books, series_id_by_name,
     CoversTempDir,
 };
-use omnibus_shared::{Contributor, EbookMetadata, Identifier, MetadataOverrides};
 
 // ---------- Server-side cap (issue #81) ----------
 //

--- a/db/src/browse/tests.rs
+++ b/db/src/browse/tests.rs
@@ -2,13 +2,14 @@
 //! pages: alpha-ordering, override-aware counts, audiobook-library scope,
 //! and `has_photo` propagation.
 
+use omnibus_shared::{Contributor, MetadataOverrides};
+
 use super::*;
 use crate::author_photos_data::{upsert_author_photo, AuthorPhotoSource};
 use crate::books::list_books;
 use crate::metadata_overrides::upsert_metadata_overrides;
 use crate::pool::init_db;
 use crate::test_support::*;
-use omnibus_shared::{Contributor, MetadataOverrides};
 
 // -----------------------------------------------------------------
 // F1.12 index pages — list_authors / list_series

--- a/db/src/covers/tests.rs
+++ b/db/src/covers/tests.rs
@@ -1,3 +1,6 @@
+//! Unit tests for cover resolution: last-modified fallback, missing-file
+//! handling, and override-vs-original cover selection.
+
 use omnibus_shared::MetadataOverrides;
 
 use super::*;

--- a/db/src/covers/tests.rs
+++ b/db/src/covers/tests.rs
@@ -1,10 +1,11 @@
+use omnibus_shared::MetadataOverrides;
+
 use super::*;
 use crate::books::list_books;
 use crate::metadata_overrides::{upsert_metadata_overrides, write_override_cover};
 use crate::pool::init_db;
 use crate::sync::replace_books;
 use crate::test_support::{indexed, CoversTempDir};
-use omnibus_shared::MetadataOverrides;
 
 #[tokio::test]
 async fn get_last_modified_epoch_falls_back_to_now_when_column_null() {

--- a/db/src/discovery/tests.rs
+++ b/db/src/discovery/tests.rs
@@ -1,3 +1,6 @@
+//! Unit tests for the author/series discovery-page queries: book
+//! ordering, series-id population, and missing-id handling.
+
 use omnibus_shared::{Contributor, MetadataOverrides};
 
 use super::*;

--- a/db/src/discovery/tests.rs
+++ b/db/src/discovery/tests.rs
@@ -1,3 +1,5 @@
+use omnibus_shared::{Contributor, MetadataOverrides};
+
 use super::*;
 use crate::author_photos_data::{upsert_author_photo, AuthorPhotoSource};
 use crate::books::list_books;
@@ -8,7 +10,6 @@ use crate::test_support::{
     author_id_by_name, indexed, seed_books_for_one_author_and_series, seed_discovery_fixture,
     series_id_by_name, CoversTempDir,
 };
-use omnibus_shared::{Contributor, MetadataOverrides};
 
 #[tokio::test]
 async fn get_author_returns_author_with_all_books_ordered_by_series_index() {

--- a/db/src/highlights/tests.rs
+++ b/db/src/highlights/tests.rs
@@ -2,9 +2,10 @@
 //! BookNotFound / NotFound variants, list isolation, color + note
 //! updates, and delete behaviour.
 
+use omnibus_shared::EbookMetadata;
+
 use super::*;
 use crate::{init_db, replace_books};
-use omnibus_shared::EbookMetadata;
 
 async fn seed(pool: &SqlitePool, library: &str, title: &str) -> (i64, String) {
     replace_books(

--- a/db/src/journals/tests.rs
+++ b/db/src/journals/tests.rs
@@ -3,9 +3,10 @@
 //! update/delete (with non-owner `NotFound`), and merged-uuid canonical
 //! resolution.
 
+use omnibus_shared::{CreateJournalEntry, EbookMetadata, JournalStatus, UpdateJournalEntry};
+
 use super::*;
 use crate::{init_db, replace_books};
-use omnibus_shared::{CreateJournalEntry, EbookMetadata, JournalStatus, UpdateJournalEntry};
 
 async fn seed(pool: &SqlitePool, library: &str, title: &str) -> String {
     replace_books(

--- a/db/src/kindle.rs
+++ b/db/src/kindle.rs
@@ -49,6 +49,8 @@ pub enum KindleError {
     Build(#[from] lettre::error::Error),
     #[error("SMTP delivery failed: {0}")]
     Smtp(#[from] lettre::transport::smtp::Error),
+    #[error("invalid content type: {0}")]
+    ContentType(#[from] lettre::message::header::ContentTypeErr),
     #[error("SMTP delivery timed out after {}s", SEND_TIMEOUT.as_secs())]
     Timeout,
     #[error(transparent)]
@@ -132,10 +134,8 @@ fn build_epub_email(
     filename: &str,
     bytes: Vec<u8>,
 ) -> Result<Message, KindleError> {
-    let attachment = Attachment::new(filename.to_string()).body(
-        bytes,
-        ContentType::parse("application/epub+zip").expect("static content type parses"),
-    );
+    let attachment = Attachment::new(filename.to_string())
+        .body(bytes, ContentType::parse("application/epub+zip")?);
     let message = Message::builder()
         .from(from.parse()?)
         .to(to.parse()?)

--- a/db/src/kindle/tests.rs
+++ b/db/src/kindle/tests.rs
@@ -155,6 +155,21 @@ fn kindle_error_build_wraps_lettre_message_error() {
     );
 }
 
+#[test]
+fn kindle_error_content_type_wraps_lettre_header_error() {
+    // `build_epub_email` parses the attachment's MIME type via
+    // `ContentType::parse`, surfaced through `#[from] ContentTypeErr` as
+    // `KindleError::ContentType`. Feeding a malformed MIME string through the
+    // `From` bridge asserts that mapping without needing a live SMTP relay.
+    let src = ContentType::parse("not a mime type").unwrap_err();
+    let err: KindleError = src.into();
+    assert!(matches!(err, KindleError::ContentType(_)), "got {err:?}");
+    assert!(
+        err.to_string().starts_with("invalid content type"),
+        "got {err}"
+    );
+}
+
 #[tokio::test]
 async fn send_propagates_db_error_when_pool_is_closed() {
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/library_layout/tests.rs
+++ b/db/src/library_layout/tests.rs
@@ -1,7 +1,8 @@
 //! Unit tests for the `library_layout` module.
 
-use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::*;
 
 fn temp_dir(suffix: &str) -> PathBuf {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -1,3 +1,5 @@
+use omnibus_shared::MetadataOverrides;
+
 use super::*;
 use crate::books::list_merged_rows_for_formats;
 use crate::indexer::diff_library;
@@ -7,7 +9,6 @@ use crate::test_support::{
     count_rows as count, indexed_audiobook, seed_synced_audiobook as seed_audiobook,
     seed_synced_ebook as seed_ebook,
 };
-use omnibus_shared::MetadataOverrides;
 
 async fn seed_user(pool: &sqlx::SqlitePool) -> i64 {
     sqlx::query_scalar(

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -1,3 +1,6 @@
+//! Unit tests for `merge_books`: file/link/log relocation to the target
+//! book, taxonomy and user-data transfer, and the same-book rejection.
+
 use omnibus_shared::MetadataOverrides;
 
 use super::*;

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -2,13 +2,14 @@
 //! its FTS rebuild, and the series-link materialization. Mirrors the
 //! pre-split inline `#[cfg(test)] mod tests` block.
 
+use omnibus_shared::MetadataOverrides;
+
 use super::*;
 use crate::books::{get_book, list_books, search_books};
 use crate::palette::search_palette;
 use crate::pool::init_db;
 use crate::sync::replace_books;
 use crate::test_support::{indexed, CoversTempDir};
-use omnibus_shared::MetadataOverrides;
 
 // -----------------------------------------------------------------
 // F5.1 Metadata overrides

--- a/db/src/missing_files/tests.rs
+++ b/db/src/missing_files/tests.rs
@@ -3,11 +3,10 @@
 //! backfill, and the sync-wired lifecycle (a removed file flags the row, a
 //! returning file clears it, identity + overrides survive a repoint).
 
-use super::*;
-
 use omnibus_shared::{MetadataOverrides, Settings};
 use sqlx::SqlitePool;
 
+use super::*;
 use crate::auth::create_user;
 use crate::covers::find_override_cover_file;
 use crate::list_books;

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -2,14 +2,15 @@
 //! library scoping, override-aware counts, and `EXPLAIN QUERY PLAN`
 //! guards against full-scan regressions on the link tables.
 
+use omnibus_shared::{Contributor, MetadataOverrides};
+use sqlx::{Row, SqlitePool};
+
 use super::*;
 use crate::books::list_books;
 use crate::metadata_overrides::upsert_metadata_overrides;
 use crate::pool::init_db;
 use crate::sync::replace_books;
 use crate::test_support::{indexed, CoversTempDir};
-use omnibus_shared::{Contributor, MetadataOverrides};
-use sqlx::{Row, SqlitePool};
 
 // ── search_palette ───────────────────────────────────────────────
 #[tokio::test]

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -4,9 +4,10 @@
 //! unknown-uuid skip, merged-uuid resolution, and `record_session_tx`
 //! rollback.
 
+use omnibus_shared::EbookMetadata;
+
 use super::*;
 use crate::{init_db, replace_books};
-use omnibus_shared::EbookMetadata;
 
 /// Map a merged/auto-attached `uuid` onto an existing `book_id` the way the
 /// merge transaction does (`db/src/merge/transaction.rs`), so the session path

--- a/db/src/ratings/tests.rs
+++ b/db/src/ratings/tests.rs
@@ -3,9 +3,10 @@
 //! `get_rating` empty-state, `delete_rating` clear + absent no-op, and
 //! merged-uuid canonical resolution.
 
+use omnibus_shared::EbookMetadata;
+
 use super::*;
 use crate::{init_db, replace_books};
-use omnibus_shared::EbookMetadata;
 
 async fn seed(pool: &SqlitePool, library: &str, title: &str) -> (i64, String) {
     replace_books(

--- a/db/src/scanner/tests.rs
+++ b/db/src/scanner/tests.rs
@@ -1,6 +1,7 @@
+use std::fs;
+
 use super::*;
 use crate::test_support::make_test_dir;
-use std::fs;
 
 #[test]
 fn list_files_with_no_path_returns_empty() {

--- a/db/src/scanner/tests.rs
+++ b/db/src/scanner/tests.rs
@@ -1,3 +1,6 @@
+//! Unit tests for the filesystem scanner: empty/missing-path handling,
+//! extension counting, and recursive directory walks.
+
 use std::fs;
 
 use super::*;

--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -1,3 +1,6 @@
+//! Unit tests for shelves: smart-shelf rule matching, manual membership,
+//! and create/update/delete behavior.
+
 use omnibus_shared::{
     CreateShelfRequest, MatchMode, RuleField, RuleOp, ShelfKind, ShelfRule, SortDir, SortKey,
     UpdateShelfRequest, Visibility,

--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -1,11 +1,11 @@
-use super::*;
-use crate::pool::init_db;
-use crate::test_support::{seed_discovery_fixture, seed_minimal_books};
-
 use omnibus_shared::{
     CreateShelfRequest, MatchMode, RuleField, RuleOp, ShelfKind, ShelfRule, SortDir, SortKey,
     UpdateShelfRequest, Visibility,
 };
+
+use super::*;
+use crate::pool::init_db;
+use crate::test_support::{seed_discovery_fixture, seed_minimal_books};
 
 async fn make_user(pool: &sqlx::SqlitePool, username: &str, is_admin: bool) -> i64 {
     sqlx::query_scalar::<_, i64>(

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -4,6 +4,7 @@
 //! the happy path end-to-end, not the per-helper contracts asserted here
 //! (fileless ghosting, per-book link wipe, in-place update, insert).
 
+use omnibus_shared::{Contributor, EbookMetadata, Identifier};
 use sqlx::SqlitePool;
 
 use super::shared::{insert_book_row, insert_metadata_links};
@@ -11,7 +12,6 @@ use super::{sync_changed, sync_new, sync_removed, wipe_per_book_link_rows};
 use crate::ebook::IndexedBook;
 use crate::pool::init_db;
 use crate::test_support::{count_rows, indexed, CoversTempDir};
-use omnibus_shared::{Contributor, EbookMetadata, Identifier};
 
 /// Insert a `scan_roots` row for `/lib` and return its id — the
 /// `library_id` every bucket helper needs.

--- a/db/src/sync/fts/tests.rs
+++ b/db/src/sync/fts/tests.rs
@@ -3,12 +3,13 @@
 //! regression (a newly-attached format's ISBN must become searchable),
 //! and `rebuild_all_fts` reconstructing a corrupted index.
 
+use omnibus_shared::{Contributor, EbookMetadata, Identifier};
+
 use super::*;
 use crate::ebook::IndexedBook;
 use crate::pool::init_db;
 use crate::sync::{sync_audiobooks, sync_books, AudiobookSyncPlan, SyncPlan};
 use crate::test_support::{count_rows, indexed, indexed_audiobook, CoversTempDir};
-use omnibus_shared::{Contributor, EbookMetadata, Identifier};
 
 /// Build an `IndexedBook` with a single ISBN identifier so attach/union
 /// paths have an ISBN to carry into the target's FTS row.

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -1,3 +1,5 @@
+use omnibus_shared::{Contributor, EbookMetadata, Identifier, MetadataOverrides};
+
 use super::*;
 use crate::books::{get_book, list_books, list_indexed_rows, search_books};
 use crate::covers::get_cover;
@@ -6,7 +8,6 @@ use crate::metadata_overrides::upsert_metadata_overrides;
 use crate::pool::init_db;
 use crate::settings::last_indexed_at;
 use crate::test_support::{indexed, indexed_audiobook, indexed_with_stat, CoversTempDir};
-use omnibus_shared::{Contributor, EbookMetadata, Identifier, MetadataOverrides};
 
 #[tokio::test]
 async fn replace_books_inserts_metadata_and_covers() {

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -1,3 +1,7 @@
+//! Unit tests for `replace_books` and the full-library sync entry point:
+//! metadata + cover insertion, accent-color validation, and book-id
+//! preservation across an unchanged re-sync.
+
 use omnibus_shared::{Contributor, EbookMetadata, Identifier, MetadataOverrides};
 
 use super::*;

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -12,10 +12,10 @@ use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use omnibus_shared::{Contributor, EbookMetadata};
 use sqlx::SqlitePool;
 
 use crate::ebook::IndexedBook;
-use omnibus_shared::{Contributor, EbookMetadata};
 
 // ---------------------------------------------------------------------------
 // Filesystem helpers

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -12,13 +12,13 @@
 #![cfg(feature = "mobile")]
 
 use dioxus::prelude::*;
+use dioxus_router::{use_navigator, Link};
 use omnibus_shared::{EbookMetadata, ProgressFormat, ProgressUpdate};
 
 use crate::components::atrium::Cover;
 use crate::contexts::use_server_url;
 use crate::data;
 use crate::Route;
-use dioxus_router::{use_navigator, Link};
 
 mod bookmarks_sheet;
 mod host;

--- a/frontend/src/pages/reader/chrome_handlers.rs
+++ b/frontend/src/pages/reader/chrome_handlers.rs
@@ -5,7 +5,6 @@
 
 use dioxus::prelude::*;
 use dioxus_router::use_navigator;
-
 use omnibus_shared::Highlight;
 
 use super::selection::SelectionData;

--- a/frontend/src/pages/reader/highlights.rs
+++ b/frontend/src/pages/reader/highlights.rs
@@ -4,10 +4,9 @@
 //! panel on the created row. Extracted from `BookReadPage`.
 
 use dioxus::prelude::*;
+use omnibus_shared::{Highlight, HighlightColor};
 
 use crate::data;
-
-use omnibus_shared::{Highlight, HighlightColor};
 
 /// What to open on the created highlight after the swatch/Note/Quote actions.
 #[derive(Clone, Copy)]

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -29,10 +29,9 @@ mod toc_drawer;
 mod typography;
 
 use dioxus::prelude::*;
+use omnibus_shared::Highlight;
 
 use crate::components::atrium::Theme;
-
-use omnibus_shared::Highlight;
 
 use aa_panel::ReaderAaPanel;
 use chrome::{ReaderPageTurnButtons, ReaderTopBar, ReaderViewerStage};

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -4,11 +4,10 @@
 //! reads as plain component wiring.
 
 use dioxus::prelude::*;
+use omnibus_shared::EbookMetadata;
 
 use crate::contexts::use_server_url;
 use crate::data;
-
-use omnibus_shared::EbookMetadata;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]

--- a/server/src/auth/boot/tests.rs
+++ b/server/src/auth/boot/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the OMNIBUS_INITIAL_ADMIN recovery hook.
-use super::*;
 use omnibus_db as db;
+
+use super::*;
 
 // std::env is global so these tests can't be parallelised safely; we
 // serialize on a static mutex. `EnvGuard` acquires this lock itself in

--- a/server/src/auth/csrf/tests.rs
+++ b/server/src/auth/csrf/tests.rs
@@ -1,7 +1,8 @@
 //! Tests for CSRF origin-check middleware.
-use super::*;
 use axum::{body::Body, http::Request, middleware, routing::post, Router};
 use tower::ServiceExt;
+
+use super::*;
 
 fn guarded_router() -> Router {
     Router::new()

--- a/server/src/auth/extractor/tests.rs
+++ b/server/src/auth/extractor/tests.rs
@@ -1,10 +1,11 @@
 //! Tests for AuthUser, AdminUser, and MediaAuthUser extractors.
-use super::*;
-use crate::auth::handlers::auth_router;
-use crate::backend::AppState;
 use axum::{body::Body, http::Request, routing::get, Extension, Router};
 use omnibus_db as db;
 use tower::ServiceExt;
+
+use super::*;
+use crate::auth::handlers::auth_router;
+use crate::backend::AppState;
 
 async fn app() -> (axum::Router, sqlx::SqlitePool) {
     let pool = db::init_db("sqlite::memory:").await.unwrap();

--- a/server/src/auth/gate/tests.rs
+++ b/server/src/auth/gate/tests.rs
@@ -1,9 +1,10 @@
 //! Tests for the auth gate middleware.
-use super::*;
 use axum::{body::Body, http::Request, middleware::from_fn_with_state, routing::get, Router};
 use omnibus_db as db;
 use omnibus_db::auth::SessionKind;
 use tower::ServiceExt;
+
+use super::*;
 
 async fn app() -> (Router, sqlx::SqlitePool) {
     let pool = db::init_db("sqlite::memory:").await.unwrap();

--- a/server/src/auth/handlers/tests.rs
+++ b/server/src/auth/handlers/tests.rs
@@ -1,5 +1,4 @@
 //! Tests for auth register/login/logout/me handlers.
-use super::*;
 use axum::{
     body::Body,
     http::{header, Request},
@@ -7,6 +6,8 @@ use axum::{
 use omnibus_db as db;
 use serde_json::json;
 use tower::ServiceExt;
+
+use super::*;
 
 async fn app() -> (Router, sqlx::SqlitePool) {
     let pool = db::init_db("sqlite::memory:").await.unwrap();


### PR DESCRIPTION
## Summary
- Reordered imports to the `std` → external crates → `crate::`/`super::` convention (`.claude/rules/05-rust-style.md` § Mechanics) in the 4-file `frontend/src/pages/reader/` cluster and 25 `tests.rs` files that opened with `use super::*;`/`use crate::...;` before a later external-crate `use`. `super::`/`self::` stays first within the crate block, matching the established repo convention (verified against untouched files like `db/src/settings/tests.rs`, `server/src/backend/tests.rs`).
- Replaced the banned `.expect()` on `ContentType::parse("application/epub+zip")` at `db/src/kindle.rs:124` with a new `KindleError::ContentType(#[from] lettre::message::header::ContentTypeErr)` variant, propagated via `?` — matching the module's existing `#[from]`-wrapping pattern for the other `lettre` error types in the same enum, per `.claude/rules/02-error-handling.md`. Added `kindle_error_content_type_wraps_lettre_header_error` covering the new variant.
- An independent adversarial review pass (before marking this ready) found 2 more files with the identical ordering violation that the issue's own file search missed — `frontend/src/pages/listen/mobile.rs` and `db/src/test_support.rs` (notably the crate's shared test-support module, which fell outside the "25 `tests.rs` files" search pattern since it isn't itself named `tests.rs`). Same mechanical fix applied to both.
- No logic changes anywhere — pure import reordering plus the one error-propagation site.

## Test plan
- [x] `cargo fmt` — no diffs beyond the intended reordering (import-order isn't rustfmt-enforced in this repo, verified stable under fmt)
- [x] `cargo clippy --all-targets -- -D warnings` (default-members: server, shared, frontend)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-db -p omnibus-frontend --features omnibus-frontend/mobile --all-targets -- -D warnings` (covers the mobile-gated `listen/mobile.rs` change)
- [x] `cargo test -p omnibus-db` — 896 passed, 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` needs `just fixtures`, not available in this sandbox; reproduces identically on unmodified `main`)
- [x] `cargo test -p omnibus-frontend --features server` — 229 passed
- [x] `cargo test -p omnibus` — 313 passed, 1 pre-existing failure unrelated to this change (`backend::uploads::tests::commit_rejects_read_only_library_with_400` — sandbox runs as root, bypassing the `chmod 0o555` the test relies on; reproduces identically on unmodified `main`)
- [x] `cargo test -p omnibus-shared` — 102 passed

## Version
- [x] **Patch** — default, unlabeled.

## Notes
- No migrations touched.
- The issue's own file count ("28 files") is off by one against its cited breakdown (4 `reader/` + 25 `tests.rs` = 29) — pre-existing inconsistency in the issue text, not introduced here.

Closes #859