### PR TITLE
feat: journal drafts and autosave

### DIFF
--- a/.claude/rules/06-migrations.md
+++ b/.claude/rules/06-migrations.md
@@ -13,7 +13,7 @@ works in production.
 
 1. **Name it `NNNN_short_description.sql`.** Take the next zero-padded
    number after the highest existing file (latest is
-   `0038_unify_timestamps_to_unix_seconds.sql`). The number is the version
+   `0040_journal_entries_status.sql`). The number is the version
    `_sqlx_migrations` records; renumbering or renaming an applied file
    breaks the applied-version bookkeeping.
 2. **Never edit an applied migration.** Once a file has run anywhere

--- a/db/migrations/0040_journal_entries_status.sql
+++ b/db/migrations/0040_journal_entries_status.sql
@@ -1,0 +1,6 @@
+-- Draft support for journal entries (F3.2b). `status` distinguishes a
+-- per-user-private draft from a published entry; existing rows default to
+-- 'published' so nothing disappears from the shared feed on upgrade. The
+-- feed query filters to published rows plus the viewer's own drafts.
+ALTER TABLE journal_entries ADD COLUMN status TEXT NOT NULL DEFAULT 'published'
+    CHECK (status IN ('draft', 'published'));

--- a/db/src/journals/mod.rs
+++ b/db/src/journals/mod.rs
@@ -1,7 +1,8 @@
 //! Public per-book journal CRUD.
 //!
-//! Entries are public: [`list_journal_entries`] returns every user's entries for
-//! a book (a shared reading log), attributed by author. Create/update/delete are
+//! Published entries are public: [`list_journal_entries`] returns every user's
+//! published entries for a book (a shared reading log), attributed by author,
+//! plus the viewer's own drafts. Create/update/delete are
 //! owner-scoped — a non-owner edit/delete is indistinguishable from a missing
 //! row (`NotFound`). Bodies soft-reference the durable `books.uuid` (no
 //! FK/cascade) through the merged-uuid-aware canonical resolver. Markdown is
@@ -20,7 +21,8 @@ mod tests;
 /// Columns + author join shared by every entry read. `user_id` surfaces as
 /// `author_id`; `users.username` as `author_name`.
 const SELECT_ENTRY: &str = "SELECT je.id, je.book_uuid, je.user_id AS author_id,
-        u.username AS author_name, je.body_md, je.progress, je.created_at, je.updated_at
+        u.username AS author_name, je.body_md, je.progress, je.status,
+        je.created_at, je.updated_at
    FROM journal_entries je
    JOIN users u ON u.id = je.user_id";
 
@@ -67,32 +69,39 @@ pub async fn create_journal_entry(
         .await?
         .ok_or(JournalError::BookNotFound)?;
     let id = sqlx::query_scalar::<_, i64>(
-        "INSERT INTO journal_entries (user_id, book_uuid, body_md, progress)
-         VALUES (?, ?, ?, ?) RETURNING id",
+        "INSERT INTO journal_entries (user_id, book_uuid, body_md, progress, status)
+         VALUES (?, ?, ?, ?, ?) RETURNING id",
     )
     .bind(user_id)
     .bind(&book_uuid)
     .bind(&input.body_md)
     .bind(input.progress.map(|p| p as i64))
+    .bind(input.status.as_str())
     .fetch_one(pool)
     .await?;
 
     get_entry_by_id(pool, id).await
 }
 
-/// List every user's entries for a book, newest first. Returns an empty list —
-/// not an error — for an unknown uuid or a book with no entries yet.
+/// List a book's entries for `viewer_id`, newest first: every user's published
+/// entries plus the viewer's own drafts (drafts stay per-user-private until
+/// published). Returns an empty list — not an error — for an unknown uuid or a
+/// book with no entries yet.
 pub async fn list_journal_entries(
     pool: &SqlitePool,
+    viewer_id: i64,
     book_uuid: &str,
 ) -> Result<Vec<JournalEntry>, JournalError> {
     let Some(canonical) = resolve_canonical_book_uuid(pool, book_uuid).await? else {
         return Ok(vec![]);
     };
     let rows = sqlx::query(&format!(
-        "{SELECT_ENTRY} WHERE je.book_uuid = ? ORDER BY je.created_at DESC, je.id DESC LIMIT ?"
+        "{SELECT_ENTRY} WHERE je.book_uuid = ?
+            AND (je.status = 'published' OR je.user_id = ?)
+          ORDER BY je.created_at DESC, je.id DESC LIMIT ?"
     ))
     .bind(&canonical)
+    .bind(viewer_id)
     .bind(LIST_JOURNAL_ENTRIES_LIMIT)
     .fetch_all(pool)
     .await?;
@@ -110,11 +119,13 @@ pub async fn update_journal_entry(
 ) -> Result<JournalEntry, JournalError> {
     let result = sqlx::query(
         "UPDATE journal_entries
-            SET body_md = ?, progress = ?, updated_at = strftime('%s','now')
+            SET body_md = ?, progress = ?, status = COALESCE(?, status),
+                updated_at = strftime('%s','now')
           WHERE id = ? AND user_id = ?",
     )
     .bind(&input.body_md)
     .bind(input.progress.map(|p| p as i64))
+    .bind(input.status.map(|s| s.as_str()))
     .bind(entry_id)
     .bind(user_id)
     .execute(pool)
@@ -158,6 +169,7 @@ fn row_to_entry(row: &sqlx::sqlite::SqliteRow) -> Result<JournalEntry, JournalEr
     let body_md: String = row.try_get("body_md")?;
     let body_html = markdown::render(&body_md);
     let progress: Option<i64> = row.try_get("progress")?;
+    let status: String = row.try_get("status")?;
     Ok(JournalEntry {
         id: row.try_get("id")?,
         book_uuid: row.try_get("book_uuid")?,
@@ -166,6 +178,7 @@ fn row_to_entry(row: &sqlx::sqlite::SqliteRow) -> Result<JournalEntry, JournalEr
         body_md,
         body_html,
         progress: progress.map(|p| p as u8),
+        status: omnibus_shared::JournalStatus::from_db(&status),
         created_at: row.try_get("created_at")?,
         updated_at: row.try_get("updated_at")?,
     })

--- a/db/src/journals/tests.rs
+++ b/db/src/journals/tests.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 use crate::{init_db, replace_books};
-use omnibus_shared::{CreateJournalEntry, EbookMetadata, UpdateJournalEntry};
+use omnibus_shared::{CreateJournalEntry, EbookMetadata, JournalStatus, UpdateJournalEntry};
 
 async fn seed(pool: &SqlitePool, library: &str, title: &str) -> String {
     replace_books(
@@ -67,6 +67,14 @@ fn create(uuid: &str, body: &str, progress: Option<u8>) -> CreateJournalEntry {
         book_uuid: uuid.to_string(),
         body_md: body.to_string(),
         progress,
+        status: JournalStatus::default(),
+    }
+}
+
+fn create_draft(uuid: &str, body: &str) -> CreateJournalEntry {
+    CreateJournalEntry {
+        status: JournalStatus::Draft,
+        ..create(uuid, body, None)
     }
 }
 
@@ -111,8 +119,12 @@ async fn list_returns_all_users_entries_newest_first() {
         .await
         .unwrap();
 
-    let entries = list_journal_entries(&pool, &uuid).await.unwrap();
-    assert_eq!(entries.len(), 2, "every user's entries are public");
+    let entries = list_journal_entries(&pool, alice, &uuid).await.unwrap();
+    assert_eq!(
+        entries.len(),
+        2,
+        "every user's published entries are public"
+    );
     // Newest first (created_at DESC, id DESC) — bob inserted last.
     assert_eq!(entries[0].author_name, "bob");
     assert_eq!(entries[0].body_md, "bob second");
@@ -122,7 +134,7 @@ async fn list_returns_all_users_entries_newest_first() {
 #[tokio::test]
 async fn list_returns_empty_for_unknown_uuid() {
     let pool = init_db("sqlite::memory:").await.unwrap();
-    assert!(list_journal_entries(&pool, "no-such-book")
+    assert!(list_journal_entries(&pool, 1, "no-such-book")
         .await
         .unwrap()
         .is_empty());
@@ -144,6 +156,7 @@ async fn update_by_owner_changes_body() {
         &UpdateJournalEntry {
             body_md: "*revised*".into(),
             progress: Some(90),
+            status: None,
         },
     )
     .await
@@ -170,13 +183,14 @@ async fn update_by_non_owner_returns_not_found() {
         &UpdateJournalEntry {
             body_md: "hijack".into(),
             progress: None,
+            status: None,
         },
     )
     .await
     .unwrap_err();
     assert!(matches!(err, JournalError::NotFound));
     // Untouched.
-    let entries = list_journal_entries(&pool, &uuid).await.unwrap();
+    let entries = list_journal_entries(&pool, alice, &uuid).await.unwrap();
     assert_eq!(entries[0].body_md, "mine");
 }
 
@@ -190,7 +204,10 @@ async fn delete_by_owner_removes_row() {
         .unwrap();
 
     delete_journal_entry(&pool, user, entry.id).await.unwrap();
-    assert!(list_journal_entries(&pool, &uuid).await.unwrap().is_empty());
+    assert!(list_journal_entries(&pool, user, &uuid)
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]
@@ -207,7 +224,13 @@ async fn delete_by_non_owner_returns_not_found() {
         .await
         .unwrap_err();
     assert!(matches!(err, JournalError::NotFound));
-    assert_eq!(list_journal_entries(&pool, &uuid).await.unwrap().len(), 1);
+    assert_eq!(
+        list_journal_entries(&pool, alice, &uuid)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 #[tokio::test]
@@ -223,14 +246,17 @@ async fn create_resolves_merged_uuid_to_surviving_book() {
     assert_eq!(saved.book_uuid, canonical);
     // Readable via both the merged and the canonical uuid.
     assert_eq!(
-        list_journal_entries(&pool, "attached-uuid")
+        list_journal_entries(&pool, user, "attached-uuid")
             .await
             .unwrap()
             .len(),
         1
     );
     assert_eq!(
-        list_journal_entries(&pool, &canonical).await.unwrap().len(),
+        list_journal_entries(&pool, user, &canonical)
+            .await
+            .unwrap()
+            .len(),
         1
     );
 }
@@ -263,12 +289,86 @@ async fn list_journal_entries_caps_response_at_hard_limit() {
     let over_cap = LIST_JOURNAL_ENTRIES_LIMIT + 500;
     seed_entries_raw(&pool, user, &uuid, over_cap).await;
 
-    let list = list_journal_entries(&pool, &uuid).await.unwrap();
+    let list = list_journal_entries(&pool, user, &uuid).await.unwrap();
     assert_eq!(
         list.len() as i64,
         LIST_JOURNAL_ENTRIES_LIMIT,
         "list_journal_entries must not return more than LIST_JOURNAL_ENTRIES_LIMIT rows",
     );
+}
+
+#[tokio::test]
+async fn list_hides_drafts_from_other_viewers_but_shows_them_to_the_owner() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let alice = seed_user(&pool, "alice").await;
+    let bob = seed_user(&pool, "bob").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+
+    create_journal_entry(&pool, alice, &create(&uuid, "published note", None))
+        .await
+        .unwrap();
+    let draft = create_journal_entry(&pool, alice, &create_draft(&uuid, "secret draft"))
+        .await
+        .unwrap();
+    assert_eq!(draft.status, JournalStatus::Draft);
+
+    let for_bob = list_journal_entries(&pool, bob, &uuid).await.unwrap();
+    assert_eq!(for_bob.len(), 1, "bob must not see alice's draft");
+    assert_eq!(for_bob[0].body_md, "published note");
+
+    let for_alice = list_journal_entries(&pool, alice, &uuid).await.unwrap();
+    assert_eq!(for_alice.len(), 2, "alice sees her own draft");
+    assert!(for_alice
+        .iter()
+        .any(|e| e.status == JournalStatus::Draft && e.body_md == "secret draft"));
+}
+
+#[tokio::test]
+async fn update_publishes_a_draft_and_none_keeps_the_stored_status() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let alice = seed_user(&pool, "alice").await;
+    let bob = seed_user(&pool, "bob").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+    let draft = create_journal_entry(&pool, alice, &create_draft(&uuid, "wip"))
+        .await
+        .unwrap();
+
+    // `status: None` keeps the entry a draft.
+    let still_draft = update_journal_entry(
+        &pool,
+        alice,
+        draft.id,
+        &UpdateJournalEntry {
+            body_md: "wip more".into(),
+            progress: None,
+            status: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(still_draft.status, JournalStatus::Draft);
+    assert!(list_journal_entries(&pool, bob, &uuid)
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Publishing flips the status and surfaces the entry to everyone.
+    let published = update_journal_entry(
+        &pool,
+        alice,
+        draft.id,
+        &UpdateJournalEntry {
+            body_md: "done".into(),
+            progress: None,
+            status: Some(JournalStatus::Published),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(published.status, JournalStatus::Published);
+    let for_bob = list_journal_entries(&pool, bob, &uuid).await.unwrap();
+    assert_eq!(for_bob.len(), 1);
+    assert_eq!(for_bob[0].body_md, "done");
 }
 
 #[tokio::test]

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1027,6 +1027,7 @@ html, body { overscroll-behavior: none; }
 .bd-journal-progress input[type="range"] { accent-color: var(--accent); cursor: pointer; }
 .bd-journal-progress-val { font-size: 12px; color: var(--ink-1); width: 36px; text-align: right; }
 .bd-journal-error { color: var(--bad); font-size: 12px; }
+.bd-journal-autosaved { color: var(--ink-3); font-size: 11px; }
 
 /* Entry feed */
 .bd-journal-list {
@@ -1053,6 +1054,11 @@ html, body { overscroll-behavior: none; }
 .bd-journal-you {
   padding: 1px 8px; font-size: 10px;
   border-color: var(--accent); color: var(--accent);
+}
+.bd-journal-draft {
+  padding: 1px 8px; font-size: 10px;
+  border-color: var(--ink-3); color: var(--ink-2);
+  text-transform: uppercase; letter-spacing: 0.06em;
 }
 .bd-journal-entry-date { font-size: 11px; color: var(--ink-3); margin-top: 2px; }
 .bd-journal-entry-actions { display: flex; gap: 6px; }

--- a/frontend/src/pages/book_detail/journal/composer.rs
+++ b/frontend/src/pages/book_detail/journal/composer.rs
@@ -538,17 +538,23 @@ fn BdJournalComposerFoot(
             button {
                 r#type: "button",
                 class: "btn ghost sm",
+                disabled: saving(),
                 onclick: move |_| {
-                    // Discard: an autosaved draft row is deleted (best-effort)
-                    // so cancelling leaves nothing behind in the owner's feed.
-                    let discarded = draft_id();
                     let url = server_url.clone();
-                    state.reset_and_close();
-                    if let Some(id) = discarded {
-                        spawn(async move {
-                            let _ = data::delete_journal_entry(&url, id).await;
-                        });
+                    if let Some(t) = state.autosave_task.write().take() {
+                        t.cancel();
                     }
+                    saving.set(true);
+                    spawn(async move {
+                        // Discard any autosaved draft row (best-effort) BEFORE
+                        // closing — reset_and_close() unmounts this scope, and
+                        // a task spawned after unmount is dropped unpolled.
+                        if let Some(id) = draft_id() {
+                            let _ = data::delete_journal_entry(&url, id).await;
+                        }
+                        saving.set(false);
+                        state.reset_and_close();
+                    });
                 },
                 "Cancel"
             }

--- a/frontend/src/pages/book_detail/journal/composer.rs
+++ b/frontend/src/pages/book_detail/journal/composer.rs
@@ -2,8 +2,9 @@
 //! editor with a Write/Preview toggle, a "from highlights" insert popover, an
 //! optional reading-progress slider, and the Publish/Cancel footer.
 
+use dioxus::core::Task;
 use dioxus::prelude::*;
-use omnibus_shared::{CreateJournalEntry, Highlight};
+use omnibus_shared::{CreateJournalEntry, Highlight, JournalStatus, UpdateJournalEntry};
 
 use crate::data;
 use crate::pages::book_detail::journal_editor::*;
@@ -19,6 +20,47 @@ struct JournalComposerState {
     saving: Signal<bool>,
     error: Signal<Option<String>>,
     show_preview: Signal<bool>,
+    /// Id of the server-side draft row the composer is riding (created by the
+    /// first autosave or Save-draft click); publish/cancel resolve it.
+    draft_id: Signal<Option<i64>>,
+    /// In-flight debounced autosave, cancelled per keystroke (search-palette
+    /// pattern) and before any explicit save/publish/cancel.
+    autosave_task: Signal<Option<Task>>,
+    /// Seconds since the last successful autosave — `Some(0)` right after a
+    /// save, bumped by [`JournalComposerState::autosaved_ticker`]; `None`
+    /// until the first autosave lands.
+    autosaved_secs: Signal<Option<u64>>,
+    /// The ticking task behind the "Auto-saved Ns ago" indicator.
+    autosaved_ticker: Signal<Option<Task>>,
+}
+
+impl JournalComposerState {
+    /// Cancel pending autosave work and reset every composer signal back to
+    /// the collapsed-prompt state.
+    fn reset_and_close(mut self) {
+        if let Some(t) = self.autosave_task.write().take() {
+            t.cancel();
+        }
+        if let Some(t) = self.autosaved_ticker.write().take() {
+            t.cancel();
+        }
+        self.draft_id.set(None);
+        self.autosaved_secs.set(None);
+        self.body.set(String::new());
+        self.show_preview.set(false);
+        self.track_progress.set(false);
+        self.error.set(None);
+        self.open.set(false);
+    }
+
+    /// The optional progress payload derived from the footer toggle/slider.
+    fn progress_payload(&self) -> Option<u8> {
+        if (self.track_progress)() {
+            Some((self.progress)() as u8)
+        } else {
+            None
+        }
+    }
 }
 
 /// Collapsed prompt → expanded markdown composer with a Write/Preview toggle, an
@@ -44,6 +86,46 @@ pub(super) fn BdJournalComposer(uuid: String, server_url: String, reload: Signal
     let highlights = use_signal(Vec::<Highlight>::new);
     let highlights_open = use_signal(|| false);
     let highlights_loaded = use_signal(|| false);
+    let draft_id = use_signal(|| None::<i64>);
+    let mut autosave_task = use_signal(|| None::<Task>);
+    let autosaved_secs = use_signal(|| None::<u64>);
+    let autosaved_ticker = use_signal(|| None::<Task>);
+
+    let state = JournalComposerState {
+        open,
+        body,
+        track_progress,
+        progress,
+        saving,
+        error,
+        show_preview,
+        draft_id,
+        autosave_task,
+        autosaved_secs,
+        autosaved_ticker,
+    };
+
+    // Debounced autosave: each body change cancels the pending task and arms a
+    // fresh one (search-palette pattern), so at most one save is queued and a
+    // typing burst produces a single write once the user pauses.
+    let autosave_url = server_url.clone();
+    let autosave_uuid = uuid.clone();
+    use_effect(move || {
+        let text = body();
+        if !open() || saving() || text.trim().is_empty() {
+            return;
+        }
+        if let Some(prev) = autosave_task.write().take() {
+            prev.cancel();
+        }
+        let url = autosave_url.clone();
+        let uuid = autosave_uuid.clone();
+        let task = spawn(async move {
+            async_sleep_ms(AUTOSAVE_DEBOUNCE_MS).await;
+            autosave_draft(&url, &uuid, text, state).await;
+        });
+        autosave_task.set(Some(task));
+    });
 
     if !open() {
         return rsx! {
@@ -84,15 +166,7 @@ pub(super) fn BdJournalComposer(uuid: String, server_url: String, reload: Signal
                 uuid,
                 server_url,
                 reload,
-                state: JournalComposerState {
-                    open,
-                    body,
-                    track_progress,
-                    progress,
-                    saving,
-                    error,
-                    show_preview,
-                },
+                state,
             }
         }
     }
@@ -316,8 +390,65 @@ fn BdJournalProgressToggle(track_progress: Signal<bool>, progress: Signal<i64>) 
     }
 }
 
-/// Composer footer: reading-progress toggle/slider, inline error, cancel, and
-/// publish. Publishing posts the entry, then resets and closes the composer.
+/// Debounce window between the last keystroke and the autosave write.
+const AUTOSAVE_DEBOUNCE_MS: u32 = 2_000;
+
+/// How often the "Auto-saved Ns ago" indicator ticks forward.
+const AUTOSAVE_TICK_MS: u32 = 5_000;
+
+/// Persist the composer body as a per-user draft: the first save creates the
+/// draft row (and starts the indicator ticker), later saves update it in
+/// place. Failures are silent — the explicit Save-draft/Publish paths surface
+/// errors, and the next keystroke re-arms the autosave anyway.
+async fn autosave_draft(url: &str, uuid: &str, body_md: String, state: JournalComposerState) {
+    let mut state = state;
+    let saved_id = match (state.draft_id)() {
+        Some(id) => data::update_journal_entry(
+            url,
+            id,
+            UpdateJournalEntry {
+                body_md,
+                progress: state.progress_payload(),
+                status: None,
+            },
+        )
+        .await
+        .map(|e| e.id),
+        None => data::create_journal_entry(
+            url,
+            CreateJournalEntry {
+                book_uuid: uuid.to_string(),
+                body_md,
+                progress: state.progress_payload(),
+                status: JournalStatus::Draft,
+            },
+        )
+        .await
+        .map(|e| e.id),
+    };
+    let Ok(id) = saved_id else { return };
+    state.draft_id.set(Some(id));
+    state.autosaved_secs.set(Some(0));
+    if state.autosaved_ticker.peek().is_none() {
+        let mut secs = state.autosaved_secs;
+        let ticker = spawn(async move {
+            loop {
+                async_sleep_ms(AUTOSAVE_TICK_MS).await;
+                let current = *secs.peek();
+                if let Some(s) = current {
+                    secs.set(Some(s + u64::from(AUTOSAVE_TICK_MS / 1_000)));
+                }
+            }
+        });
+        state.autosaved_ticker.set(Some(ticker));
+    }
+}
+
+/// Composer footer: reading-progress toggle/slider, the "Auto-saved Ns ago"
+/// indicator, inline error, cancel, save-draft, and publish. Save draft keeps
+/// the entry owner-private; publish surfaces it in the shared feed. Both
+/// reset and close the composer; cancel additionally discards any autosaved
+/// draft.
 #[component]
 fn BdJournalComposerFoot(
     uuid: String,
@@ -326,25 +457,81 @@ fn BdJournalComposerFoot(
     state: JournalComposerState,
 ) -> Element {
     let JournalComposerState {
-        open,
         body,
-        mut track_progress,
-        progress,
         saving,
         error,
-        show_preview,
+        autosaved_secs,
+        draft_id,
+        ..
     } = state;
     let mut reload = reload;
-    let mut open = open;
-    let mut body = body;
     let mut saving = saving;
     let mut error = error;
-    let mut show_preview = show_preview;
+
+    // Save the current body as `status`, then reset/close/reload. Shared by
+    // the Save-draft and Publish buttons — the only difference is the status
+    // the entry ends up in (an existing autosaved draft row is reused).
+    let save_url = server_url.clone();
+    let save_uuid = uuid.clone();
+    let mut save_as = move |status: JournalStatus| {
+        let url = save_url.clone();
+        let uuid = save_uuid.clone();
+        let mut state = state;
+        if let Some(t) = state.autosave_task.write().take() {
+            t.cancel();
+        }
+        saving.set(true);
+        error.set(None);
+        spawn(async move {
+            let result = match draft_id() {
+                Some(id) => data::update_journal_entry(
+                    &url,
+                    id,
+                    UpdateJournalEntry {
+                        body_md: body(),
+                        progress: state.progress_payload(),
+                        status: Some(status),
+                    },
+                )
+                .await
+                .map(|_| ()),
+                None => data::create_journal_entry(
+                    &url,
+                    CreateJournalEntry {
+                        book_uuid: uuid,
+                        body_md: body(),
+                        progress: state.progress_payload(),
+                        status,
+                    },
+                )
+                .await
+                .map(|_| ()),
+            };
+            match result {
+                Ok(()) => {
+                    state.reset_and_close();
+                    reload.set(reload() + 1);
+                }
+                Err(e) => error.set(Some(e.to_string())),
+            }
+            saving.set(false);
+        });
+    };
 
     rsx! {
         div { class: "bd-journal-composer-foot",
-            BdJournalProgressToggle { track_progress, progress }
+            BdJournalProgressToggle {
+                track_progress: state.track_progress,
+                progress: state.progress,
+            }
             span { class: "bd-journal-foot-spacer" }
+            if let Some(secs) = autosaved_secs() {
+                span {
+                    class: "mono bd-journal-autosaved",
+                    "data-testid": "journal-autosaved",
+                    if secs == 0 { "Auto-saved just now" } else { "Auto-saved {secs}s ago" }
+                }
+            }
             if let Some(msg) = error() {
                 span { class: "mono bd-journal-error", role: "alert", "{msg}" }
             }
@@ -352,43 +539,51 @@ fn BdJournalComposerFoot(
                 r#type: "button",
                 class: "btn ghost sm",
                 onclick: move |_| {
-                    open.set(false);
-                    body.set(String::new());
-                    show_preview.set(false);
-                    error.set(None);
+                    // Discard: an autosaved draft row is deleted (best-effort)
+                    // so cancelling leaves nothing behind in the owner's feed.
+                    let discarded = draft_id();
+                    let url = server_url.clone();
+                    state.reset_and_close();
+                    if let Some(id) = discarded {
+                        spawn(async move {
+                            let _ = data::delete_journal_entry(&url, id).await;
+                        });
+                    }
                 },
                 "Cancel"
+            }
+            button {
+                r#type: "button",
+                class: "btn ghost sm",
+                "data-testid": "journal-save-draft",
+                disabled: saving() || body().trim().is_empty(),
+                onclick: {
+                    let mut save_as = save_as.clone();
+                    move |_| save_as(JournalStatus::Draft)
+                },
+                if saving() { "Saving\u{2026}" } else { "Save draft" }
             }
             button {
                 r#type: "button",
                 class: "btn primary sm",
                 "data-testid": "journal-publish",
                 disabled: saving() || body().trim().is_empty(),
-                onclick: move |_| {
-                    let url = server_url.clone();
-                    let input = CreateJournalEntry {
-                        book_uuid: uuid.clone(),
-                        body_md: body(),
-                        progress: if track_progress() { Some(progress() as u8) } else { None },
-                    };
-                    saving.set(true);
-                    error.set(None);
-                    spawn(async move {
-                        match data::create_journal_entry(&url, input).await {
-                            Ok(_) => {
-                                body.set(String::new());
-                                show_preview.set(false);
-                                track_progress.set(false);
-                                open.set(false);
-                                reload.set(reload() + 1);
-                            }
-                            Err(e) => error.set(Some(e.to_string())),
-                        }
-                        saving.set(false);
-                    });
-                },
+                onclick: move |_| save_as(JournalStatus::Published),
                 if saving() { "Publishing\u{2026}" } else { "Publish entry" }
             }
         }
     }
+}
+
+// Platform-gated async sleep for the autosave debounce + indicator ticker:
+// web uses `gloo_timers`; mobile and the SSR/server build use `tokio::time`
+// (mirrors `search_palette::overlay`).
+#[cfg(feature = "web")]
+async fn async_sleep_ms(ms: u32) {
+    gloo_timers::future::TimeoutFuture::new(ms).await;
+}
+
+#[cfg(not(feature = "web"))]
+async fn async_sleep_ms(ms: u32) {
+    tokio::time::sleep(std::time::Duration::from_millis(u64::from(ms))).await;
 }

--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -3,7 +3,7 @@
 //! same progressive-enhancement editor as the composer.
 
 use dioxus::prelude::*;
-use omnibus_shared::{JournalEntry, UpdateJournalEntry, UserSummary};
+use omnibus_shared::{JournalEntry, JournalStatus, UpdateJournalEntry, UserSummary};
 
 use crate::data;
 use crate::pages::book_detail::journal_editor::*;
@@ -26,9 +26,11 @@ struct JournalEntryHeaderView {
     author_name: String,
     initial: String,
     is_owner: bool,
+    is_draft: bool,
     meta_line: String,
     entry_id: i64,
     body_for_edit: String,
+    entry_progress: Option<u8>,
     server_url: String,
 }
 
@@ -42,9 +44,11 @@ fn BdJournalEntryHeader(view: JournalEntryHeaderView, edit: JournalEntryEditStat
         author_name,
         initial,
         is_owner,
+        is_draft,
         meta_line,
         entry_id,
         body_for_edit,
+        entry_progress,
         server_url,
     } = view;
     let JournalEntryEditState {
@@ -69,11 +73,50 @@ fn BdJournalEntryHeader(view: JournalEntryHeaderView, edit: JournalEntryEditStat
                     if is_owner {
                         span { class: "chip bd-journal-you", "you" }
                     }
+                    if is_draft {
+                        span {
+                            class: "chip bd-journal-draft",
+                            "data-testid": "journal-draft-chip",
+                            "Draft"
+                        }
+                    }
                 }
                 div { class: "mono bd-journal-entry-date", "{meta_line}" }
             }
             if is_owner && !editing() {
                 div { class: "bd-journal-entry-actions",
+                    if is_draft {
+                        button {
+                            r#type: "button",
+                            class: "btn primary sm",
+                            "data-testid": "journal-publish-draft",
+                            disabled: saving(),
+                            onclick: {
+                                let url = server_url.clone();
+                                let body_md = body_for_edit.clone();
+                                move |_| {
+                                    let url = url.clone();
+                                    let input = UpdateJournalEntry {
+                                        body_md: body_md.clone(),
+                                        progress: entry_progress,
+                                        status: Some(JournalStatus::Published),
+                                    };
+                                    saving.set(true);
+                                    error.set(None);
+                                    spawn(async move {
+                                        match data::update_journal_entry(&url, entry_id, input)
+                                            .await
+                                        {
+                                            Ok(_) => reload.set(reload() + 1),
+                                            Err(e) => error.set(Some(e.to_string())),
+                                        }
+                                        saving.set(false);
+                                    });
+                                }
+                            },
+                            "Publish"
+                        }
+                    }
                     button {
                         r#type: "button",
                         class: "btn ghost sm",
@@ -154,9 +197,11 @@ pub(super) fn BdJournalEntryCard(
                     author_name: entry.author_name.clone(),
                     initial,
                     is_owner,
+                    is_draft: entry.status == JournalStatus::Draft,
                     meta_line,
                     entry_id,
                     body_for_edit: entry.body_md.clone(),
+                    entry_progress,
                     server_url: server_url.clone(),
                 },
                 edit,
@@ -264,6 +309,9 @@ fn BdJournalEntryEditForm(
                     let input = UpdateJournalEntry {
                         body_md: edit_body(),
                         progress: entry_progress,
+                        // Editing never flips draft/published — the card's
+                        // Publish action owns that transition.
+                        status: None,
                     };
                     saving.set(true);
                     error.set(None);

--- a/frontend/src/rpc/journals.rs
+++ b/frontend/src/rpc/journals.rs
@@ -32,12 +32,12 @@ pub async fn rpc_create_journal_entry(input: CreateJournalEntry) -> Result<Journ
     }
 }
 
-/// List all journal entries for a book (every user's — journals are public),
-/// newest first. Returns an empty list when the uuid is unknown or has no
-/// entries yet.
-#[post("/api/rpc/journals/list", pool: PoolExt, _user: AuthUser)]
+/// List a book's journal entries, newest first: every user's published entries
+/// (journals are public) plus the caller's own drafts. Returns an empty list
+/// when the uuid is unknown or has no entries yet.
+#[post("/api/rpc/journals/list", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_list_journal_entries(book_uuid: String) -> Result<Vec<JournalEntry>> {
-    match db::journals::list_journal_entries(&pool.0, &book_uuid).await {
+    match db::journals::list_journal_entries(&pool.0, user.id, &book_uuid).await {
         Ok(list) => Ok(list),
         Err(e) => Err(internal_rpc_error("list journal entries", e).into()),
     }

--- a/server/src/backend/journals.rs
+++ b/server/src/backend/journals.rs
@@ -40,13 +40,14 @@ pub(super) async fn post_journal(
     }
 }
 
-/// List every user's journal entries for a book, newest first.
+/// List every user's published journal entries for a book — plus the caller's
+/// own drafts — newest first.
 pub(super) async fn get_journal_entries(
-    _user: AuthUser,
+    user: AuthUser,
     State(state): State<AppState>,
     Path(book_uuid): Path<String>,
 ) -> Response {
-    match db::journals::list_journal_entries(&state.pool, &book_uuid).await {
+    match db::journals::list_journal_entries(&state.pool, user.id, &book_uuid).await {
         Ok(list) => Json(list).into_response(),
         Err(e) => internal("list_journal_entries", e),
     }

--- a/server/src/backend/journals/tests.rs
+++ b/server/src/backend/journals/tests.rs
@@ -245,6 +245,86 @@ async fn api_journal_preview_rejects_body_over_max_len() {
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
 
+#[tokio::test]
+async fn api_journal_draft_is_owner_private_until_published() {
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let alice = auth_test_support::create_user(&pool, "alice").await;
+    let alice_token = auth_test_support::bearer_token(&pool, alice.id).await;
+    let bob = auth_test_support::create_user(&pool, "bob").await;
+    let bob_token = auth_test_support::bearer_token(&pool, bob.id).await;
+
+    let res = app
+        .clone()
+        .oneshot(post_journal_req(
+            &alice_token,
+            serde_json::json!({
+                "book_uuid": uuid, "body_md": "wip", "progress": null, "status": "draft"
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let draft = entries_one(res).await;
+    assert_eq!(draft.status, omnibus_shared::JournalStatus::Draft);
+
+    // Bob's feed excludes the draft; Alice's includes it.
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/api/journals/book/{uuid}"),
+            &bob_token,
+        ))
+        .await
+        .unwrap();
+    assert!(entries(res).await.is_empty(), "draft hidden from bob");
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/api/journals/book/{uuid}"),
+            &alice_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(entries(res).await.len(), 1, "owner sees own draft");
+
+    // Publishing via PATCH surfaces it to everyone.
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/journals/{}", draft.id))
+                .method("PATCH")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {alice_token}"))
+                .body(Body::from(
+                    serde_json::json!({
+                        "body_md": "wip", "progress": null, "status": "published"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let published = entries_one(res).await;
+    assert_eq!(published.status, omnibus_shared::JournalStatus::Published);
+
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/journals/book/{uuid}"),
+            &bob_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        entries(res).await.len(),
+        1,
+        "published entry visible to bob"
+    );
+}
+
 /// Decode a single created/updated entry from a handler response.
 async fn entries_one(res: axum::response::Response) -> JournalEntry {
     let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();

--- a/shared/src/journal.rs
+++ b/shared/src/journal.rs
@@ -33,9 +33,8 @@ fn validate_body(body_md: &str, progress: Option<u8>) -> Result<(), String> {
     Ok(())
 }
 
-/// Publication state of a journal entry. Drafts are visible only to their
-/// owner and excluded from the shared feed until published. Defaults to
-/// `Published` so pre-drafts clients and rows keep their old behaviour.
+/// Publication state of a journal entry: owner-private `Draft` vs shared-feed
+/// `Published` (the default, so pre-drafts clients/rows keep their behaviour).
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum JournalStatus {

--- a/shared/src/journal.rs
+++ b/shared/src/journal.rs
@@ -33,6 +33,36 @@ fn validate_body(body_md: &str, progress: Option<u8>) -> Result<(), String> {
     Ok(())
 }
 
+/// Publication state of a journal entry. Drafts are visible only to their
+/// owner and excluded from the shared feed until published. Defaults to
+/// `Published` so pre-drafts clients and rows keep their old behaviour.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum JournalStatus {
+    Draft,
+    #[default]
+    Published,
+}
+
+impl JournalStatus {
+    /// The lowercase form persisted in the `journal_entries.status` column.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Draft => "draft",
+            Self::Published => "published",
+        }
+    }
+
+    /// Parse the persisted column value; anything unrecognised reads as
+    /// `Published` (fail-open matches the column's CHECK + default).
+    pub fn from_db(s: &str) -> Self {
+        match s {
+            "draft" => Self::Draft,
+            _ => Self::Published,
+        }
+    }
+}
+
 /// A persisted journal entry as rendered for display. `body_html` is the
 /// server-rendered, sanitized markdown; `body_md` is the raw source (the owner
 /// edits it). `created_at` / `updated_at` are unix seconds.
@@ -45,16 +75,21 @@ pub struct JournalEntry {
     pub body_md: String,
     pub body_html: String,
     pub progress: Option<u8>,
+    #[serde(default)]
+    pub status: JournalStatus,
     pub created_at: i64,
     pub updated_at: i64,
 }
 
-/// Write payload: create a new journal entry on a book.
+/// Write payload: create a new journal entry on a book. `status` defaults to
+/// `published` so pre-drafts mobile clients keep their old behaviour.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateJournalEntry {
     pub book_uuid: String,
     pub body_md: String,
     pub progress: Option<u8>,
+    #[serde(default)]
+    pub status: JournalStatus,
 }
 
 impl CreateJournalEntry {
@@ -68,10 +103,14 @@ impl CreateJournalEntry {
 }
 
 /// Write payload: edit an existing journal entry's body and/or progress.
+/// `status: Some(_)` transitions the entry (publish a draft); `None` — the
+/// default, so pre-drafts clients are unaffected — keeps the stored status.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UpdateJournalEntry {
     pub body_md: String,
     pub progress: Option<u8>,
+    #[serde(default)]
+    pub status: Option<JournalStatus>,
 }
 
 impl UpdateJournalEntry {

--- a/shared/src/journal/tests.rs
+++ b/shared/src/journal/tests.rs
@@ -7,6 +7,7 @@ fn create(body: &str) -> CreateJournalEntry {
         book_uuid: "book-1".into(),
         body_md: body.into(),
         progress: None,
+        status: JournalStatus::default(),
     }
 }
 
@@ -67,14 +68,43 @@ fn create_accepts_progress_at_bounds() {
 fn update_validates_body_and_progress() {
     assert!(UpdateJournalEntry {
         body_md: "ok".into(),
-        progress: Some(100)
+        progress: Some(100),
+        status: None,
     }
     .validate()
     .is_ok());
     assert!(UpdateJournalEntry {
         body_md: " ".into(),
-        progress: None
+        progress: None,
+        status: None,
     }
     .validate()
     .is_err());
+}
+
+#[test]
+fn status_defaults_keep_pre_drafts_payloads_compatible() {
+    // A pre-drafts client omits `status` entirely: creates default to
+    // `published`, updates default to `None` (keep the stored status).
+    let c: CreateJournalEntry =
+        serde_json::from_str(r#"{"book_uuid":"b","body_md":"x","progress":null}"#)
+            .expect("create without status deserializes");
+    assert_eq!(c.status, JournalStatus::Published);
+    let u: UpdateJournalEntry = serde_json::from_str(r#"{"body_md":"x","progress":null}"#)
+        .expect("update without status deserializes");
+    assert_eq!(u.status, None);
+}
+
+#[test]
+fn status_serializes_lowercase() {
+    assert_eq!(
+        serde_json::to_string(&JournalStatus::Draft).expect("serializes"),
+        r#""draft""#
+    );
+    assert_eq!(JournalStatus::from_db("draft"), JournalStatus::Draft);
+    assert_eq!(
+        JournalStatus::from_db("published"),
+        JournalStatus::Published
+    );
+    assert_eq!(JournalStatus::from_db("bogus"), JournalStatus::Published);
 }

--- a/ui_tests/playwright/tests/flows/journal.spec.ts
+++ b/ui_tests/playwright/tests/flows/journal.spec.ts
@@ -27,13 +27,18 @@ type Page = import("@playwright/test").Page;
 const editor = (page: Page) => page.getByTestId("journal-editor");
 const editorMarkdown = (page: Page) => page.getByTestId("journal-body");
 
-/** Open the inline composer and publish `body`, asserting the create POST. */
+// Publishing rides `create` normally, but if the debounced autosave already
+// created the draft row the publish click lands as an `update` instead —
+// match either so the assertion is deterministic.
+const SAVE_URL = /\/api\/rpc\/journals\/(create|update)/;
+
+/** Open the inline composer and publish `body`, asserting the save POST. */
 async function publish(page: Page, body: string) {
   await page.getByTestId("journal-open-composer").click();
   await editor(page).fill(body);
   await expectMutation(
     page,
-    { method: "POST", url: "/api/rpc/journals/create", expectedStatus: 200 },
+    { method: "POST", url: SAVE_URL, expectedStatus: 200 },
     async () => page.getByTestId("journal-publish").click(),
   );
 }
@@ -102,6 +107,11 @@ test("wraps the selected text in markdown when a toolbar button is clicked", asy
   await editor(page).selectText();
   await page.getByTestId("journal-toolbar").getByRole("button", { name: "Quote" }).click();
   await expect(editorMarkdown(page)).toHaveValue("> a thought");
+
+  // Cancel so an autosaved draft (the debounce may have fired mid-test) is
+  // discarded rather than leaking into later tests' feeds.
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByTestId("journal-composer")).toHaveCount(0);
 });
 
 // ---------------------------------------------------------------------------
@@ -137,6 +147,11 @@ test("inserts a saved highlight into the draft as a blockquote", async ({ page, 
     new RegExp(`> ${quote}[\\s\\S]*saved from highlights`),
   );
   await expect(page.getByTestId("journal-highlights-pop")).toHaveCount(0);
+
+  // Cancel so an autosaved draft (the debounce may have fired mid-test) is
+  // discarded rather than leaking into later tests' feeds.
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByTestId("journal-composer")).toHaveCount(0);
 });
 
 // ---------------------------------------------------------------------------
@@ -201,7 +216,7 @@ test("renders a markdown preview and blurs spoilers until clicked", async ({ pag
   await editor(page).fill(`reveal ${marker}: ||the secret||`);
   await expectMutation(
     page,
-    { method: "POST", url: "/api/rpc/journals/create", expectedStatus: 200 },
+    { method: "POST", url: SAVE_URL, expectedStatus: 200 },
     async () => page.getByTestId("journal-publish").click(),
   );
 
@@ -256,6 +271,74 @@ test("reveals a spoiler with Enter and toggles it back with Space", async ({ pag
 });
 
 // ---------------------------------------------------------------------------
+// Action — save a draft, publish it from its card
+// ---------------------------------------------------------------------------
+
+test("saves a draft that stays marked Draft until published from its card", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await gotoReady(page, `/books/${uuid}`);
+
+  const marker = `e2e-draft-${Date.now()}`;
+  await page.getByTestId("journal-open-composer").click();
+  await editor(page).fill(`Draft thoughts ${marker}`);
+  await expectMutation(
+    page,
+    { method: "POST", url: SAVE_URL, expectedStatus: 200 },
+    async () => page.getByTestId("journal-save-draft").click(),
+  );
+
+  // The composer closes and the entry renders with a Draft chip + a Publish
+  // action (drafts are owner-private, so only this user sees it).
+  const card = page.getByTestId("journal-entry").filter({ hasText: marker });
+  await expect(card).toBeVisible();
+  await expect(card.getByTestId("journal-draft-chip")).toBeVisible();
+
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/rpc/journals/update", expectedStatus: 200 },
+    async () => card.getByTestId("journal-publish-draft").click(),
+  );
+  await expect(card.getByTestId("journal-draft-chip")).toHaveCount(0);
+  await expect(card.getByTestId("journal-publish-draft")).toHaveCount(0);
+
+  await deleteEntry(page, marker);
+});
+
+// ---------------------------------------------------------------------------
+// Action — debounced autosave while typing, discarded on cancel
+// ---------------------------------------------------------------------------
+
+test("autosaves the draft while typing and discards it on cancel", async ({ page, request }) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await gotoReady(page, `/books/${uuid}`);
+
+  const marker = `e2e-autosave-${Date.now()}`;
+  await page.getByTestId("journal-open-composer").click();
+
+  // Typing arms the 2s debounce; the autosave create fires without any click
+  // and the footer surfaces the "Auto-saved" indicator.
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/rpc/journals/create", expectedStatus: 200 },
+    async () => editor(page).fill(`Autosaved thoughts ${marker}`),
+  );
+  await expect(page.getByTestId("journal-autosaved")).toContainText("Auto-saved");
+
+  // Cancel discards the autosaved draft row and closes the composer; nothing
+  // is left behind in the feed.
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/rpc/journals/delete", expectedStatus: 200 },
+    async () => page.getByRole("button", { name: "Cancel" }).click(),
+  );
+  await expect(page.getByTestId("journal-composer")).toHaveCount(0);
+  await expect(page.getByTestId("journal-entry").filter({ hasText: marker })).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
 // Error path — failed publish surfaces an error, composer stays open
 // ---------------------------------------------------------------------------
 
@@ -263,7 +346,12 @@ test("surfaces an error and keeps the draft when publishing fails", async ({ pag
   const uuid = await fetchBookUuidByTitle(request, TARGET.title);
   await gotoReady(page, `/books/${uuid}`);
 
+  // Fail both save routes — the debounced autosave may have already created
+  // the draft row, turning the publish click into an update.
   await page.route("**/api/rpc/journals/create", (route) =>
+    route.fulfill({ status: 500, contentType: "text/plain", body: "journal exploded" }),
+  );
+  await page.route("**/api/rpc/journals/update", (route) =>
     route.fulfill({ status: 500, contentType: "text/plain", body: "journal exploded" }),
   );
 
@@ -271,7 +359,7 @@ test("surfaces an error and keeps the draft when publishing fails", async ({ pag
   await editor(page).fill("this will fail");
   await expectMutation(
     page,
-    { method: "POST", url: "/api/rpc/journals/create", expectedStatus: 500 },
+    { method: "POST", url: SAVE_URL, expectedStatus: 500 },
     async () => page.getByTestId("journal-publish").click(),
   );
 

--- a/ui_tests/playwright/tests/flows/journal.spec.ts
+++ b/ui_tests/playwright/tests/flows/journal.spec.ts
@@ -43,6 +43,24 @@ async function publish(page: Page, body: string) {
   );
 }
 
+/**
+ * Discard the open composer deterministically: wait for the debounced
+ * autosave to land (so the draft row definitely exists), then Cancel and
+ * assert the discard DELETE — every mutation stays `expectMutation`-asserted
+ * and no draft leaks into later tests' feeds.
+ */
+async function cancelComposerDiscardingDraft(page: Page) {
+  await expect(page.getByTestId("journal-autosaved")).toContainText("Auto-saved", {
+    timeout: 10_000,
+  });
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/rpc/journals/delete", expectedStatus: 200 },
+    async () => page.getByRole("button", { name: "Cancel" }).click(),
+  );
+  await expect(page.getByTestId("journal-composer")).toHaveCount(0);
+}
+
 /** Delete the entry whose rendered body contains `marker`. */
 async function deleteEntry(page: import("@playwright/test").Page, marker: string) {
   const card = page.getByTestId("journal-entry").filter({ hasText: marker });
@@ -108,10 +126,7 @@ test("wraps the selected text in markdown when a toolbar button is clicked", asy
   await page.getByTestId("journal-toolbar").getByRole("button", { name: "Quote" }).click();
   await expect(editorMarkdown(page)).toHaveValue("> a thought");
 
-  // Cancel so an autosaved draft (the debounce may have fired mid-test) is
-  // discarded rather than leaking into later tests' feeds.
-  await page.getByRole("button", { name: "Cancel" }).click();
-  await expect(page.getByTestId("journal-composer")).toHaveCount(0);
+  await cancelComposerDiscardingDraft(page);
 });
 
 // ---------------------------------------------------------------------------
@@ -148,10 +163,7 @@ test("inserts a saved highlight into the draft as a blockquote", async ({ page, 
   );
   await expect(page.getByTestId("journal-highlights-pop")).toHaveCount(0);
 
-  // Cancel so an autosaved draft (the debounce may have fired mid-test) is
-  // discarded rather than leaking into later tests' feeds.
-  await page.getByRole("button", { name: "Cancel" }).click();
-  await expect(page.getByTestId("journal-composer")).toHaveCount(0);
+  await cancelComposerDiscardingDraft(page);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds draft support + debounced autosave to the reading-journal composer (closes #912, part of #911).
- Migration `0040` adds a `status` column (`draft|published`, default `published`) to `journal_entries`; existing rows stay published and the feed query now returns published entries plus the viewer's own drafts.
- `CreateJournalEntry`/`UpdateJournalEntry` carry the status with backwards-compatible serde defaults (`published` on create, "keep stored status" on update), so pre-drafts mobile clients are unaffected.
- Composer footer gains **Save draft** vs **Publish entry**, an "Auto-saved Ns ago" indicator, and a 2s-debounced autosave that creates the draft row once and updates it thereafter; Cancel discards the autosaved draft.
- Owner-only Draft chip + Publish action on draft entry cards.

## Test plan
- [x] `just lint` (fmt + clippy matrix + stylelint) green
- [x] `just test` full matrix green — new db tests (draft visibility, publish transition), REST test (draft lifecycle over `/api/journals*`), shared serde-default tests
- [x] Playwright `journal.spec.ts` updated: save-draft/publish-from-card and autosave/cancel-discard action tests; existing publish assertions widened to `create|update` (autosave may own the create)
- [x] Verified live against a dev server: autosave POST + ticking indicator, Save draft → Draft chip + Publish on card, publish from card, cancel-discard; no console/hydration errors

## Version
- [x] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).

## Notes
- Drafts are owner-private: the list query filters `status = 'published' OR user_id = viewer`, and both the RPC and REST list handlers now pass the authenticated viewer.
- Editing an entry never flips its status (`status: None` keeps the stored value); the card's Publish action owns the draft→published transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
