### PR TITLE
feat: hide journal editor markdown markers off the active line

### DIFF
--- a/docs/roadmap/3-2b-journal-rich-editor.md
+++ b/docs/roadmap/3-2b-journal-rich-editor.md
@@ -6,11 +6,13 @@ A WYSIWYG editing experience layered on top of F3.2's plain-markdown journals.
 
 ## Status
 
-**Partially shipped.** The composer's Write surface is now a **live editor** —
+**Shipped.** The composer's Write surface is a **live editor** —
 a `contenteditable` whose `textContent` stays exactly equal to the markdown
 source: formatting is applied in place as you type (bold/italic/strikethrough,
 H1/H2, quote, bullet/numbered/checklist, inline code, link, spoiler), with the
-markdown markers kept but dimmed (Obsidian source-mode style). It is hand-rolled
+markdown markers hidden except on the caret's line (Obsidian/Slack
+live-preview style — each rendered line is wrapped in a `.cm-line` span and a
+`selectionchange` listener toggles `.cm-active`). It is hand-rolled
 (no editor framework) in [`journal_editor.js`](../../frontend/src/pages/book_detail/journal_editor.js):
 on each input it re-renders decoration spans and restores the caret by character
 offset, mirrors the markdown into a hidden `<textarea>` (which keeps the `body`
@@ -22,16 +24,24 @@ highlights API. Checklist rendering required enabling `pulldown-cmark` task
 lists in `db::journals::markdown::render` (sanitizer pinned to a read-only
 `<input type="checkbox">`).
 
+**Drafts + autosave** landed with a `status` column (`draft`|`published`,
+default `published`) on `journal_entries` — the feed returns published entries
+plus the viewer's own drafts, the composer footer offers Save draft vs Publish
+with a debounced autosave and an "Auto-saved Ns ago" indicator, and draft
+cards carry a Draft chip + Publish action. **Embedded images** landed once
+F5.3 shipped: the toolbar's insert-image control uploads to
+`POST /api/journals/images` (shared image-validation pipeline, stored under
+`db::journal_images`), and a lone-image paragraph renders as a captioned
+`<figure>`; the sanitizer only admits `img src` under the journal-images
+serving prefix.
+
 The editor is web-only (it rides the `dioxus::document::eval` channel); SSR and
 native mobile fall back to the plain markdown textarea. The composer is only
 mounted after a click, so it never participates in first-paint hydration
 (rule 07).
 
-Still deferred: **drafts + autosave** (the `status` column), **embedded images**
-(blocked on [F5.3 Uploads](5-3-uploads.md)), and the standalone **full-page
-editor** screen. A future polish pass could hide markers entirely when the caret
-leaves a span (full Obsidian/Slack live-preview), which a hand-rolled editor
-can't do without atomic ranges.
+The standalone **full-page editor** screen was closed out separately without a
+dedicated screen (#914) — the inline composer covers the authoring flows.
 
 ## Objective
 

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -988,8 +988,11 @@ html, body { overscroll-behavior: none; }
   color: var(--ink-3);
   pointer-events: none;
 }
-/* Markdown markers stay in the text but recede. */
-.cm-mark { opacity: 0.38; }
+/* Markdown markers stay in the text (the caret math depends on every source
+   character keeping its geometry) but are fully faded except on the line the
+   caret is on — `journal_editor.js` toggles `.cm-active` per line. */
+.cm-mark { opacity: 0; transition: opacity 120ms ease; }
+.cm-line.cm-active .cm-mark { opacity: 0.38; }
 .cm-strong { font-weight: 700; color: var(--ink-0); }
 .cm-em { font-style: italic; }
 .cm-strike { text-decoration: line-through; }
@@ -1008,8 +1011,10 @@ html, body { overscroll-behavior: none; }
   border-left: 3px solid var(--accent);
   padding-left: 8px;
 }
-.cm-list .cm-mark { color: var(--accent); opacity: 0.7; }
-.cm-task .cm-mark { color: var(--accent); opacity: 0.7; }
+.cm-list .cm-mark,
+.cm-task .cm-mark { color: var(--accent); }
+.cm-line.cm-active .cm-list .cm-mark,
+.cm-line.cm-active .cm-task .cm-mark { opacity: 0.7; }
 .cm-link { color: var(--accent); }
 .cm-spoiler {
   background: color-mix(in oklch, var(--accent) 14%, transparent);

--- a/frontend/src/pages/book_detail/journal_editor.js
+++ b/frontend/src/pages/book_detail/journal_editor.js
@@ -2,7 +2,8 @@
 //
 // A `contenteditable` surface whose `textContent` always stays exactly equal to
 // the markdown source — we never add or remove characters, we only wrap
-// constructs in decoration spans (markers kept but dimmed via `.cm-mark`). On
+// constructs in decoration spans (`.cm-mark` markers are kept in the text but
+// fully faded except on the caret's `.cm-active` line, Obsidian-style). On
 // every input we re-render those decorations and restore the caret by absolute
 // character offset (offsets are stable because the text length never changes).
 //
@@ -118,7 +119,46 @@ if (!window.OmnibusJournalEditor) {
     }
 
     // Newlines kept as literal text so textContent === the markdown source.
-    const render = (md) => md.split("\n").map(blockLine).join("\n");
+    // Each line is wrapped in a `.cm-line` span (adds no text) so the
+    // active-line pass below can reveal markers per line.
+    const render = (md) =>
+      md
+        .split("\n")
+        .map((line) => `<span class="cm-line">${blockLine(line)}</span>`)
+        .join("\n");
+
+    // --- active-line marker reveal (Obsidian-style) ---------------------------
+    // Markers are fully faded by CSS except on the `.cm-active` line. The
+    // characters stay in the layout either way, so caret-by-offset math and
+    // the mirrored markdown are untouched.
+    function markActive(editor) {
+      const sel = caret(editor);
+      const active =
+        sel === null ? -1 : editor.textContent.slice(0, sel.start).split("\n").length - 1;
+      editor.querySelectorAll(":scope > .cm-line").forEach((line, i) => {
+        line.classList.toggle("cm-active", i === active);
+      });
+    }
+
+    // Caret moves that don't change the text (arrow keys, clicks, blur) never
+    // re-render, so one document-level selectionchange listener drives the
+    // active-line class across every attached editor. Disconnected editors
+    // (unmounted entry edit forms) are dropped as they're encountered.
+    const editors = new Set();
+    function trackActiveLine(editor) {
+      editors.add(editor);
+      if (window.__omnibusJournalSelChange) return;
+      window.__omnibusJournalSelChange = true;
+      document.addEventListener("selectionchange", () => {
+        editors.forEach((ed) => {
+          if (!ed.isConnected) {
+            editors.delete(ed);
+            return;
+          }
+          markActive(ed);
+        });
+      });
+    }
 
     function sync(editor) {
       const mirror = byId(editor.getAttribute("data-mirror"));
@@ -131,6 +171,7 @@ if (!window.OmnibusJournalEditor) {
       const sel = caret(editor);
       editor.innerHTML = render(editor.textContent);
       if (sel) place(editor, sel.start, sel.end);
+      markActive(editor);
     }
     function onInput(editor) {
       highlight(editor);
@@ -161,6 +202,7 @@ if (!window.OmnibusJournalEditor) {
       const mirror = byId(mirrorId);
       if (mirror && mirror.value) editor.textContent = mirror.value;
       highlight(editor);
+      trackActiveLine(editor);
 
       editor.addEventListener("compositionstart", () => { editor.__composing = true; });
       editor.addEventListener("compositionend", () => {

--- a/ui_tests/playwright/tests/flows/journal.spec.ts
+++ b/ui_tests/playwright/tests/flows/journal.spec.ts
@@ -403,6 +403,38 @@ test("uploads an image from the toolbar and renders it as a captioned figure", a
 });
 
 // ---------------------------------------------------------------------------
+// Action — markers are revealed only on the caret's line (editor-only)
+// ---------------------------------------------------------------------------
+
+test("hides markdown markers on lines away from the caret", async ({ page, request }) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await gotoReady(page, `/books/${uuid}`);
+
+  await page.getByTestId("journal-open-composer").click();
+  await editor(page).fill("# Heading line\n**bold line**");
+
+  const lines = editor(page).locator(".cm-line");
+  await expect(lines).toHaveCount(2);
+
+  // Put the caret on line 2 — its markers show at the dimmed opacity while
+  // line 1's are fully faded (the characters stay in the layout either way).
+  await lines.nth(1).click();
+  await expect(lines.nth(1)).toHaveClass(/cm-active/);
+  await expect(lines.nth(0)).not.toHaveClass(/cm-active/);
+  await expect(lines.nth(1).locator(".cm-mark").first()).toHaveCSS("opacity", "0.38");
+  await expect(lines.nth(0).locator(".cm-mark").first()).toHaveCSS("opacity", "0");
+
+  // Moving the caret to line 1 swaps which line's markers are revealed, and
+  // the mirrored markdown is untouched by the class toggling.
+  await lines.nth(0).click();
+  await expect(lines.nth(0)).toHaveClass(/cm-active/);
+  await expect(lines.nth(1)).not.toHaveClass(/cm-active/);
+  await expect(editorMarkdown(page)).toHaveValue("# Heading line\n**bold line**");
+
+  await cancelComposerDiscardingDraft(page);
+});
+
+// ---------------------------------------------------------------------------
 // Error path — failed publish surfaces an error, composer stays open
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Active-line marker hiding for the journal live editor (closes #915, part of #911): markdown markers are now fully faded except on the line the caret is on, Obsidian/Slack live-preview style.
- `journal_editor.js` wraps each rendered line in a `.cm-line` span (adds no text, so the textContent === markdown invariant and caret-by-offset math are untouched) and toggles `.cm-active` on the caret's line — re-computed after every re-render and, via a single document-level `selectionchange` listener shared by all attached editors, on caret-only moves (arrows, clicks, blur).
- CSS: `.cm-mark` goes to `opacity: 0` (with a short transition) and is revealed at the old dimmed opacities only under `.cm-line.cm-active`. Marker characters keep their geometry, so hiding them never corrupts the mirrored markdown or the caret position.

## Test plan
- [x] New Playwright action test: two-line draft → markers on the non-caret line at computed opacity 0, caret line at 0.38; clicking between lines swaps `.cm-active`; mirrored markdown unchanged.
- [x] `just lint-css` green (no Rust changes).
- [x] Verified live against a dev server: line wrapping, class toggling on caret movement, computed opacities, mirror intact; no console errors.

## Version
- [x] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).

## Notes
- Markers are hidden with opacity (characters keep their layout space) rather than removed — removing them would need the atomic-range machinery the roadmap notes this hand-rolled editor deliberately avoids, and would break caret-offset restoration.
- When the editor is unfocused, no line is active and all markers are hidden (rendered-view feel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
