### PR TITLE
feat: gate oversized EPUBs from Send-to-Kindle email, link to web uploader

### DIFF
--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -53,6 +53,14 @@ pub async fn get_book(
     backfill_creator_ids(pool, std::slice::from_mut(&mut book)).await?;
 
     let files = get_book_files(pool, id).await?;
+    // Size of the EPUB the hero send would deliver (file_id None resolves the
+    // lowest-ordinal EPUB, same as `book_file_path`), so the export menu can
+    // gate the email button on Kindle's size cap.
+    book.epub_size_bytes = files
+        .iter()
+        .filter(|f| f.format.eq_ignore_ascii_case("EPUB"))
+        .min_by_key(|f| f.ordinal)
+        .map(|f| f.size_bytes);
     let has_multipart = files.iter().any(|f| {
         files
             .iter()
@@ -386,8 +394,8 @@ pub async fn get_book_files(
     pool: &SqlitePool,
     book_id: i64,
 ) -> Result<Vec<omnibus_shared::BookFileInfo>, super::BooksError> {
-    let rows = sqlx::query_as::<_, (i64, String, String, i64, Option<String>)>(
-        "SELECT id, format, filename, ordinal, label FROM book_files \
+    let rows = sqlx::query_as::<_, (i64, String, String, i64, Option<String>, i64)>(
+        "SELECT id, format, filename, ordinal, label, size_bytes FROM book_files \
          WHERE book_id = ? ORDER BY format, ordinal",
     )
     .bind(book_id)
@@ -396,12 +404,13 @@ pub async fn get_book_files(
     Ok(rows
         .into_iter()
         .map(
-            |(id, format, filename, ordinal, label)| omnibus_shared::BookFileInfo {
+            |(id, format, filename, ordinal, label, size_bytes)| omnibus_shared::BookFileInfo {
                 id,
                 format,
                 filename,
                 ordinal,
                 label,
+                size_bytes,
             },
         )
         .collect())

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -231,6 +231,9 @@ pub(crate) fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata,
         error: None,
         has_override: false,
         book_files: Vec::new(),
+        // Populated by `get_book` from the resolved EPUB; list/projection rows
+        // don't carry it (no per-book export menu in list contexts).
+        epub_size_bytes: None,
     })
 }
 

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -55,6 +55,64 @@ async fn get_book_formats_machine_timestamps_as_fixed_width_iso() {
 }
 
 #[tokio::test]
+async fn get_book_reports_epub_size_from_lowest_ordinal_epub() {
+    // `epub_size_bytes` drives the export menu's Kindle size gate. It must
+    // mirror what the hero send delivers — the lowest-ordinal EPUB — and ignore
+    // non-EPUB files entirely.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title) \
+         VALUES ('bk', 'b', 1, '/lib/bk', 'Book') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    // Two EPUB editions (ordinal 0 wins) plus an audiobook that must be ignored.
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, ordinal) VALUES \
+         (?1, 'EPUB', 'a', 111, 0), (?1, 'EPUB', 'b', 222, 1), (?1, 'M4B', 'c', 999, 0)",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(book.epub_size_bytes, Some(111));
+}
+
+#[tokio::test]
+async fn get_book_reports_no_epub_size_for_audio_only_book() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title) \
+         VALUES ('bk', 'b', 1, '/lib/bk', 'Book') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, ordinal) \
+         VALUES (?, 'M4B', 'c', 999, 0)",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(book.epub_size_bytes, None);
+}
+
+#[tokio::test]
 async fn library_from_db_returns_empty_for_none_path() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let lib = library_from_db(&pool, None).await.unwrap();

--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -104,6 +104,7 @@ fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> Indexe
             error: None,
             has_override: false,
             book_files: Vec::new(),
+            epub_size_bytes: None,
         },
         cover,
         // Stat values get overwritten by `parse_ebook_targets` before the

--- a/db/src/kindle.rs
+++ b/db/src/kindle.rs
@@ -77,14 +77,15 @@ pub async fn send(
     }
     .ok_or(KindleError::NoEpub)?;
 
-    let bytes = tokio::fs::read(&path).await?;
     // Defense in depth: the UI disables the button for oversized EPUBs, but the
-    // REST/RPC endpoints (and mobile) can still enqueue a send. Reject here so a
-    // doomed 150 MB delivery never reaches the relay — surfaced to the poller as
-    // a clear Failed message via `TooLarge`'s display text.
-    if omnibus_shared::kindle_email_oversize(bytes.len() as u64) {
+    // REST/RPC endpoints (and mobile) can still enqueue a send. Check the size
+    // from the file's metadata *before* reading it, so a doomed 150 MB delivery
+    // is rejected without first allocating the whole file in memory — surfaced
+    // to the poller as a clear Failed message via `TooLarge`'s display text.
+    if omnibus_shared::kindle_email_oversize(tokio::fs::metadata(&path).await?.len()) {
         return Err(KindleError::TooLarge);
     }
+    let bytes = tokio::fs::read(&path).await?;
     let filename = path
         .file_name()
         .and_then(|s| s.to_str())

--- a/db/src/kindle.rs
+++ b/db/src/kindle.rs
@@ -36,6 +36,11 @@ pub enum KindleError {
     NotConfigured,
     #[error("this book has no EPUB file to send")]
     NoEpub,
+    #[error(
+        "this EPUB is larger than the 50 MB limit for emailing files to a Kindle; upload it on \
+         Amazon's Send to Kindle page (amazon.com/sendtokindle), which accepts files up to 200 MB"
+    )]
+    TooLarge,
     #[error("failed to read the EPUB file: {0}")]
     Io(#[from] std::io::Error),
     #[error("invalid email address: {0}")]
@@ -73,6 +78,13 @@ pub async fn send(
     .ok_or(KindleError::NoEpub)?;
 
     let bytes = tokio::fs::read(&path).await?;
+    // Defense in depth: the UI disables the button for oversized EPUBs, but the
+    // REST/RPC endpoints (and mobile) can still enqueue a send. Reject here so a
+    // doomed 150 MB delivery never reaches the relay — surfaced to the poller as
+    // a clear Failed message via `TooLarge`'s display text.
+    if omnibus_shared::kindle_email_oversize(bytes.len() as u64) {
+        return Err(KindleError::TooLarge);
+    }
     let filename = path
         .file_name()
         .and_then(|s| s.to_str())

--- a/db/src/kindle/tests.rs
+++ b/db/src/kindle/tests.rs
@@ -48,6 +48,51 @@ async fn send_returns_no_epub_when_config_present_but_book_missing() {
 }
 
 #[tokio::test]
+async fn send_returns_too_large_when_epub_exceeds_email_cap() {
+    let _env = EnvVarGuard::set("SMTP_HOST", None).also_set("SMTP_FROM_EMAIL", None);
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_smtp(&pool).await;
+
+    // Point a scan root at a temp dir holding a sparse EPUB one byte over the
+    // email cap, so `send` reaches the size guard after resolving the path.
+    let dir = tempfile::TempDir::new().unwrap();
+    let lib = dir.path().to_str().unwrap();
+    let epub = dir.path().join("big.epub");
+    std::fs::File::create(&epub)
+        .unwrap()
+        .set_len(omnibus_shared::KINDLE_EMAIL_MAX_BYTES + 1)
+        .unwrap();
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(lib)
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let book_id = sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title) VALUES ('uuid-big', ?, '', 'Big')",
+    )
+    .bind(lib_id)
+    .execute(&pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'big', 0)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let err = send(&pool, book_id, None, "reader@kindle.com")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, KindleError::TooLarge), "got {err:?}");
+}
+
+#[tokio::test]
 async fn send_test_returns_not_configured_when_unset() {
     let _env = EnvVarGuard::set("SMTP_HOST", None).also_set("SMTP_FROM_EMAIL", None);
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/docs/roadmap/4-3-kindle.md
+++ b/docs/roadmap/4-3-kindle.md
@@ -15,6 +15,7 @@ Kindle is the dominant e-reader; the send-to-email flow is how most users load b
 ## Technical considerations
 
 - **EPUB direct — no conversion.** Amazon has accepted `.epub` via send-to-Kindle email since 2024 ([assumption A4](0-0-summary.md#assumptions)). The v1 implication that we'd need MOBI/AZW3 conversion is outdated.
+- **Kindle size cap.** Amazon rejects send-to-Kindle *email* over 50 MB (`KINDLE_EMAIL_MAX_BYTES` in `shared`); its web/app uploader takes up to 200 MB. We gate only Kindle's own limits, not per-SMTP-provider caps. Over-cap EPUBs disable the email button (export dropdown shows a greyed row + a link to the web uploader) and the worker guards with `KindleError::TooLarge`.
 - SMTP config lives in admin settings ([F5.4](5-4-admin-panel.md)). Single SMTP config shared with registration/password-reset email once those ship.
 - Send job runs on the [F0.5 worker](0-5-background-worker.md); failures log to [F5.2 observability](5-2-observability.md).
 

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -774,6 +774,17 @@ html, body { overscroll-behavior: none; }
 .bd-export-item:hover:not([disabled]) { background: var(--bg-2); color: var(--ink-0); }
 .bd-export-item[disabled] { opacity: .5; cursor: not-allowed; pointer-events: none; }
 .bd-export-item-label { flex: 1 1 auto; }
+/* Oversized Send-to-Kindle: greyed but still hoverable (keep the title tip),
+   so no `pointer-events: none` here — it's inert markup, not a real button. */
+.bd-export-item-muted { color: var(--ink-2); cursor: not-allowed; }
+.bd-export-item-muted:hover { background: transparent; color: var(--ink-2); }
+/* Scope to the panel so the accent color beats the app's base anchor color
+   (equal single-class specificity would otherwise lose to it). */
+.bd-export-panel .bd-export-subnote {
+  display: block; padding: 0 10px 8px;
+  font-size: 11px; line-height: 1.35; color: var(--accent); text-decoration: none;
+}
+.bd-export-panel .bd-export-subnote:hover { text-decoration: underline; }
 
 .bd-progress-meta { margin-top: 22px; max-width: 460px; }
 .bd-progress-line {

--- a/frontend/src/components/format_switcher/kindle.rs
+++ b/frontend/src/components/format_switcher/kindle.rs
@@ -21,7 +21,10 @@ use super::async_sleep_ms;
 /// (rule 07: keep cfg out of rsx bodies).
 #[cfg(not(feature = "mobile"))]
 pub(super) fn send_to_kindle_action(uuid: &str, file_id: Option<i64>, size_bytes: i64) -> Element {
-    if omnibus_shared::kindle_email_oversize(size_bytes as u64) {
+    // `u64::try_from` over an `as` cast so a negative size can't wrap into a
+    // huge value; a bad size just falls through to the normal email button (the
+    // backend still enforces the real cap).
+    if u64::try_from(size_bytes).is_ok_and(omnibus_shared::kindle_email_oversize) {
         return rsx! {
             a {
                 class: "btn",

--- a/frontend/src/components/format_switcher/kindle.rs
+++ b/frontend/src/components/format_switcher/kindle.rs
@@ -13,18 +13,38 @@ use omnibus_shared::KindleSendStatus;
 use super::async_sleep_ms;
 
 /// "Send to Kindle" CTA (F4.3). Web/SSR renders the interactive
-/// [`SendToKindleButton`]; mobile renders a disabled placeholder. The cfg gate
-/// lives at the helper definition (rule 07: keep cfg out of rsx bodies), and
-/// SSR + first WASM paint emit the same enabled button so hydration holds.
+/// [`SendToKindleButton`]; when the EPUB is over Kindle's email cap
+/// (`size_bytes` provided by the server, so SSR + first WASM paint agree) the
+/// email path can't work, so it becomes a link to Amazon's Send to Kindle page
+/// (up to 200 MB) instead — a real action, not a dead disabled button. Mobile
+/// renders a disabled placeholder. The cfg gate lives at the helper definition
+/// (rule 07: keep cfg out of rsx bodies).
 #[cfg(not(feature = "mobile"))]
-pub(super) fn send_to_kindle_action(uuid: &str, file_id: Option<i64>) -> Element {
+pub(super) fn send_to_kindle_action(uuid: &str, file_id: Option<i64>, size_bytes: i64) -> Element {
+    if omnibus_shared::kindle_email_oversize(size_bytes as u64) {
+        return rsx! {
+            a {
+                class: "btn",
+                href: omnibus_shared::KINDLE_WEB_UPLOAD_URL,
+                target: "_blank",
+                rel: "noopener noreferrer",
+                title: "This EPUB is larger than the 50 MB limit for emailing files to a Kindle. Amazon's Send to Kindle page (opens in a new tab) accepts files up to 200 MB.",
+                "data-testid": "action-kindle-oversize",
+                "Send to Kindle\u{2026}"
+            }
+        };
+    }
     rsx! {
         SendToKindleButton { uuid: uuid.to_string(), file_id }
     }
 }
 
 #[cfg(feature = "mobile")]
-pub(super) fn send_to_kindle_action(_uuid: &str, _file_id: Option<i64>) -> Element {
+pub(super) fn send_to_kindle_action(
+    _uuid: &str,
+    _file_id: Option<i64>,
+    _size_bytes: i64,
+) -> Element {
     rsx! {
         button {
             class: "btn",

--- a/frontend/src/components/format_switcher/mod.rs
+++ b/frontend/src/components/format_switcher/mod.rs
@@ -38,6 +38,9 @@ pub fn FormatSwitcher(
     // (see [`SendToKoboButton`]). Default empty → write at the drive root.
     #[props(default)] book_author: String,
     #[props(default)] book_title: String,
+    // Size of the single-file EPUB, so the Send-to-Kindle action can gate on
+    // Kindle's email cap. Multi-EPUB books carry per-file sizes on `book_files`.
+    #[props(default)] epub_size_bytes: Option<i64>,
 ) -> Element {
     let rows = prepare_rows(&formats);
     if rows.is_empty() {
@@ -74,6 +77,7 @@ pub fn FormatSwitcher(
                                 uuid: uuid.clone(),
                                 book_author: book_author.clone(),
                                 book_title: book_title.clone(),
+                                epub_size_bytes,
                             }
                         }
                     }
@@ -89,6 +93,7 @@ fn FormatRow(
     uuid: String,
     #[props(default)] book_author: String,
     #[props(default)] book_title: String,
+    #[props(default)] epub_size_bytes: Option<i64>,
 ) -> Element {
     let label = kind.label();
     let testid = format!("format-row-{}", label.to_ascii_lowercase());
@@ -106,7 +111,7 @@ fn FormatRow(
                         // The cfg lives at the helper definition (rule 07:
                         // hydration parity — keep cfg gates out of rsx).
                         {read_book_action(&uuid)}
-                        {send_to_kindle_action(&uuid, None)}
+                        {send_to_kindle_action(&uuid, None, epub_size_bytes.unwrap_or_default())}
                         {send_to_kobo_action(&uuid, &book_author, &book_title)}
                     },
                     FormatKind::M4b | FormatKind::Mp3 => rsx! {
@@ -160,6 +165,7 @@ fn MultiFileRow(
                     .unwrap_or_else(|| format!("Part {}", file.ordinal + 1));
                 let file_testid = format!("format-file-{}", file.id);
                 let file_id = file.id;
+                let file_size = file.size_bytes;
                 rsx! {
                     div {
                         key: "{file_id}",
@@ -173,7 +179,7 @@ fn MultiFileRow(
                                 // cfg gates out of rsx bodies).
                                 FormatKind::Epub => rsx! {
                                     {read_file_action(&uuid, file_id)}
-                                    {send_to_kindle_action(&uuid, Some(file_id))}
+                                    {send_to_kindle_action(&uuid, Some(file_id), file_size)}
                                 },
                                 FormatKind::M4b | FormatKind::Mp3 => rsx! {
                                     {listen_file_action(&uuid, file_id)}

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -391,6 +391,7 @@ pub(super) fn BdRailSection(
                     // folder layout on the device.
                     book_author: b.creators.first().map(|c| c.name.clone()).unwrap_or_default(),
                     book_title: title.clone(),
+                    epub_size_bytes: b.epub_size_bytes,
                 }
                 Link {
                     to: Route::MetadataEdit { uuid: uuid.clone() },

--- a/frontend/src/pages/book_detail/export_menu.rs
+++ b/frontend/src/pages/book_detail/export_menu.rs
@@ -111,7 +111,13 @@ fn BdExportPanel(
             // Kindle's email cap, the button can't work — swap in a disabled
             // row that explains why and links to the web uploader instead.
             if has_ebook {
-                if epub_size_bytes.is_some_and(|n| kindle_email_oversize(n as u64)) {
+                // `u64::try_from` over an `as` cast so a negative size (corrupt
+                // DB row / sentinel) can't wrap into a huge value and wrongly
+                // hide the email button.
+                if epub_size_bytes
+                    .and_then(|n| u64::try_from(n).ok())
+                    .is_some_and(kindle_email_oversize)
+                {
                     KindleOversizeItem { open }
                 } else {
                     SendToKindleButton {

--- a/frontend/src/pages/book_detail/export_menu.rs
+++ b/frontend/src/pages/book_detail/export_menu.rs
@@ -4,6 +4,7 @@
 //! menu. Web/server only; the book-detail hero isn't compiled on mobile.
 
 use dioxus::prelude::*;
+use omnibus_shared::{kindle_email_oversize, KINDLE_WEB_UPLOAD_URL};
 
 use crate::components::{SendToKindleButton, SendToKoboButton};
 
@@ -17,6 +18,7 @@ pub(super) fn BdExportMenu(
     has_audio: bool,
     #[props(default)] book_author: String,
     #[props(default)] book_title: String,
+    #[props(default)] epub_size_bytes: Option<i64>,
 ) -> Element {
     let mut open = use_signal(|| false);
     rsx! {
@@ -40,7 +42,7 @@ pub(super) fn BdExportMenu(
                     "data-testid": "hero-export-scrim",
                     onclick: move |_| open.set(false),
                 }
-                BdExportPanel { uuid, has_ebook, has_audio, book_author, book_title, open }
+                BdExportPanel { uuid, has_ebook, has_audio, book_author, book_title, epub_size_bytes, open }
             }
         }
     }
@@ -59,6 +61,7 @@ fn BdExportPanel(
     has_audio: bool,
     book_author: String,
     book_title: String,
+    epub_size_bytes: Option<i64>,
     open: Signal<bool>,
 ) -> Element {
     let mut open = open;
@@ -104,13 +107,19 @@ fn BdExportPanel(
             // Send-to-Kindle only applies to books with an EPUB (the backend
             // errors with `NoEpub` otherwise). Reuses the interactive button,
             // styled as a menu row; the menu stays open while it reports
-            // "Sending…" and raises its own toast.
+            // "Sending…" and raises its own toast. When the EPUB exceeds
+            // Kindle's email cap, the button can't work — swap in a disabled
+            // row that explains why and links to the web uploader instead.
             if has_ebook {
-                SendToKindleButton {
-                    uuid: uuid.clone(),
-                    file_id: None,
-                    class: "bd-export-item".to_string(),
-                    testid: "hero-send-kindle".to_string(),
+                if epub_size_bytes.is_some_and(|n| kindle_email_oversize(n as u64)) {
+                    KindleOversizeItem { open }
+                } else {
+                    SendToKindleButton {
+                        uuid: uuid.clone(),
+                        file_id: None,
+                        class: "bd-export-item".to_string(),
+                        testid: "hero-send-kindle".to_string(),
+                    }
                 }
             }
             // Send-to-Kobo writes the KEPUB straight onto a plugged-in Kobo
@@ -127,6 +136,33 @@ fn BdExportPanel(
                     testid: "hero-send-kobo".to_string(),
                 }
             }
+        }
+    }
+}
+
+/// Disabled Send-to-Kindle row for an EPUB over Kindle's 50 MB email cap. The
+/// greyed row reads as unavailable; the visible sub-note below it links to
+/// Amazon's Send to Kindle page (up to 200 MB), which the email path can't
+/// match. Rendered as inert markup (no button/handler) since there is nothing
+/// to send — the sub-note carries the reason and the way forward.
+#[component]
+fn KindleOversizeItem(open: Signal<bool>) -> Element {
+    let mut open = open;
+    rsx! {
+        div {
+            class: "bd-export-item bd-export-item-muted",
+            "data-testid": "hero-send-kindle-oversize",
+            aria_disabled: "true",
+            span { class: "bd-export-item-label", "Send to Kindle" }
+        }
+        a {
+            class: "bd-export-subnote",
+            "data-testid": "hero-send-kindle-web-link",
+            href: KINDLE_WEB_UPLOAD_URL,
+            target: "_blank",
+            rel: "noopener noreferrer",
+            onclick: move |_| open.set(false),
+            "Too large to email. Upload it on Amazon's Send to Kindle page (up to 200 MB) \u{2192}"
         }
     }
 }

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -143,6 +143,7 @@ fn BdTitleCol(
                 has_audio,
                 book_author: b.creators.first().map(|c| c.name.clone()).unwrap_or_default(),
                 book_title: title.clone(),
+                epub_size_bytes: b.epub_size_bytes,
             }
             div { class: "bd-progress-meta", aria_hidden: "true",
                 div { class: "bd-progress-line",
@@ -171,6 +172,7 @@ fn BdCtaRow(
     has_audio: bool,
     #[props(default)] book_author: String,
     #[props(default)] book_title: String,
+    #[props(default)] epub_size_bytes: Option<i64>,
 ) -> Element {
     rsx! {
         div { class: "bd-cta-row",
@@ -211,6 +213,7 @@ fn BdCtaRow(
                 has_audio,
                 book_author: book_author.clone(),
                 book_title: book_title.clone(),
+                epub_size_bytes,
             }
         }
     }

--- a/shared/src/ebook/metadata.rs
+++ b/shared/src/ebook/metadata.rs
@@ -100,6 +100,12 @@ pub struct EbookMetadata {
     /// single-file-per-format books — the `formats` vec is sufficient.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub book_files: Vec<BookFileInfo>,
+
+    /// On-disk size of the EPUB the hero "Send to Kindle" would deliver (the
+    /// lowest-ordinal EPUB). `None` when the book has no EPUB. Drives the
+    /// oversized-file gate on the email button — see `kindle_email_oversize`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epub_size_bytes: Option<i64>,
 }
 
 /// One `book_files` row — a single physical file on disk. Exposed to the
@@ -112,4 +118,8 @@ pub struct BookFileInfo {
     pub ordinal: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    /// On-disk size of this file. Lets the per-file Send-to-Kindle rows gate
+    /// oversized EPUBs the same way the hero export menu does.
+    #[serde(default)]
+    pub size_bytes: i64,
 }

--- a/shared/src/settings.rs
+++ b/shared/src/settings.rs
@@ -137,11 +137,16 @@ pub struct SmtpConfigStatus {
 /// over 50 MB, while the web / app uploader at [`KINDLE_WEB_UPLOAD_URL`] accepts
 /// up to 200 MB. An EPUB over the email cap disables the email button and points
 /// the user at the uploader instead.
-pub const KINDLE_EMAIL_MAX_BYTES: u64 = 50 * 1024 * 1024;
+///
+/// Expressed as **decimal** megabytes (50 * 10^6) to match Amazon's documented
+/// "50 MB" / "200 MB" figures and the UI copy — not binary MiB. The decimal
+/// value is also the slightly stricter cap, so we never pass a file the email
+/// path would then reject.
+pub const KINDLE_EMAIL_MAX_BYTES: u64 = 50_000_000;
 
 /// Upper bound of the Send-to-Kindle web / app uploader, surfaced in the UI hint
-/// so the user knows the larger path exists.
-pub const KINDLE_WEB_MAX_BYTES: u64 = 200 * 1024 * 1024;
+/// so the user knows the larger path exists. Decimal MB, as with the email cap.
+pub const KINDLE_WEB_MAX_BYTES: u64 = 200_000_000;
 
 /// Amazon's Send-to-Kindle web uploader. Linked from the disabled email button
 /// as the fallback for oversized files.

--- a/shared/src/settings.rs
+++ b/shared/src/settings.rs
@@ -131,6 +131,33 @@ pub struct SmtpConfigStatus {
     pub source: String,
 }
 
+/// Amazon Send-to-Kindle size limits — Kindle-imposed and provider-independent.
+/// We deliberately don't model per-SMTP-provider caps (e.g. Gmail's 25 MB),
+/// only Amazon's own: email delivery of a personal document rejects messages
+/// over 50 MB, while the web / app uploader at [`KINDLE_WEB_UPLOAD_URL`] accepts
+/// up to 200 MB. An EPUB over the email cap disables the email button and points
+/// the user at the uploader instead.
+pub const KINDLE_EMAIL_MAX_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Upper bound of the Send-to-Kindle web / app uploader, surfaced in the UI hint
+/// so the user knows the larger path exists.
+pub const KINDLE_WEB_MAX_BYTES: u64 = 200 * 1024 * 1024;
+
+/// Amazon's Send-to-Kindle web uploader. Linked from the disabled email button
+/// as the fallback for oversized files.
+pub const KINDLE_WEB_UPLOAD_URL: &str = "https://www.amazon.com/sendtokindle";
+
+/// Whether an EPUB of `size_bytes` is too large to email to Kindle (strictly
+/// over [`KINDLE_EMAIL_MAX_BYTES`]). Shared so the disabled-button gate in the
+/// UI and the worker-side send guard agree on one threshold. Compares the raw
+/// file size against Amazon's documented 50 MB figure — base64 transfer
+/// encoding inflates the on-wire message further, so a file just under the cap
+/// can still bounce; those rare boundary failures fall through to the normal
+/// send-error toast.
+pub fn kindle_email_oversize(size_bytes: u64) -> bool {
+    size_bytes > KINDLE_EMAIL_MAX_BYTES
+}
+
 /// Terminal-or-pending status of a Send-to-Kindle job, returned by the
 /// `kindle/send/status` poll endpoint keyed on the `task_id` that the enqueue
 /// call handed back. The send runs on the background worker; the client posts

--- a/shared/src/settings/tests.rs
+++ b/shared/src/settings/tests.rs
@@ -82,6 +82,27 @@ fn settings_validate_rejects_audiobook_path_over_max_len() {
 }
 
 #[test]
+fn kindle_email_oversize_is_false_at_and_below_the_cap() {
+    // The cap itself fits (strictly-greater comparison), as does a small file.
+    assert!(!kindle_email_oversize(0));
+    assert!(!kindle_email_oversize(KINDLE_EMAIL_MAX_BYTES));
+}
+
+#[test]
+fn kindle_email_oversize_is_true_one_byte_over_the_cap() {
+    assert!(kindle_email_oversize(KINDLE_EMAIL_MAX_BYTES + 1));
+}
+
+#[test]
+fn kindle_size_limits_match_amazons_documented_figures() {
+    // Email = 50 MB, web uploader = 200 MB. Guards against an accidental
+    // unit slip (MB vs MiB or a wrong multiplier) since both feed user-facing
+    // copy and the send guard.
+    assert_eq!(KINDLE_EMAIL_MAX_BYTES, 50 * 1024 * 1024);
+    assert_eq!(KINDLE_WEB_MAX_BYTES, 200 * 1024 * 1024);
+}
+
+#[test]
 fn settings_validate_reports_ebook_field_when_both_are_over_max_len() {
     // Ebook is checked first; the error must name it rather than the
     // audiobook field so the caller surfaces the right form field.

--- a/shared/src/settings/tests.rs
+++ b/shared/src/settings/tests.rs
@@ -95,11 +95,12 @@ fn kindle_email_oversize_is_true_one_byte_over_the_cap() {
 
 #[test]
 fn kindle_size_limits_match_amazons_documented_figures() {
-    // Email = 50 MB, web uploader = 200 MB. Guards against an accidental
-    // unit slip (MB vs MiB or a wrong multiplier) since both feed user-facing
-    // copy and the send guard.
-    assert_eq!(KINDLE_EMAIL_MAX_BYTES, 50 * 1024 * 1024);
-    assert_eq!(KINDLE_WEB_MAX_BYTES, 200 * 1024 * 1024);
+    // Email = 50 MB, web uploader = 200 MB, expressed as decimal megabytes to
+    // match Amazon's user-facing figures and the UI copy. Guards against an
+    // accidental unit slip (decimal MB vs binary MiB, or a wrong multiplier)
+    // since both feed user-facing copy and the send guard.
+    assert_eq!(KINDLE_EMAIL_MAX_BYTES, 50_000_000);
+    assert_eq!(KINDLE_WEB_MAX_BYTES, 200_000_000);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Amazon's **Send-to-Kindle email** rejects files over **50 MB**; its **web/app uploader** accepts up to **200 MB**. This gates the email path on Kindle's own limit — when a book's EPUB exceeds 50 MB, the Send-to-Kindle email action is disabled and the UI points the user at Amazon's Send to Kindle page instead. Per-SMTP-provider caps (e.g. Gmail's 25 MB) are deliberately **not** modeled — only Kindle-imposed limits.

## Changes

**`shared/`**
- `KINDLE_EMAIL_MAX_BYTES` (50 MB), `KINDLE_WEB_MAX_BYTES` (200 MB), `KINDLE_WEB_UPLOAD_URL`, and `kindle_email_oversize()` — one threshold shared by the UI gate and the send guard.
- New `EbookMetadata.epub_size_bytes` and `BookFileInfo.size_bytes`.

**`db/`**
- `get_book` populates `epub_size_bytes` from the lowest-ordinal EPUB (what the hero send delivers); `get_book_files` returns `size_bytes`.
- `send()` guards over-cap files with a new `KindleError::TooLarge` — defense in depth so REST/mobile callers get a clear failure instead of a doomed relay attempt.

**`frontend/`**
- Export dropdown: a disabled "Send to Kindle" row plus a link — *"Too large to email. Upload it on Amazon's Send to Kindle page (up to 200 MB) →"*.
- Format-switcher rail: the Send-to-Kindle action becomes that same link (opens Amazon's Send to Kindle page in a new tab) when the EPUB is oversized, rather than a dead disabled button.

**Docs/tests**
- Note in `docs/roadmap/4-3-kindle.md`.
- Unit tests: shared oversize helper + constants, `get_book` size population (incl. audio-only), and the `send` `TooLarge` guard.

## Testing

- `just test` + `just lint` matrix green.
- Verified live in the dev browser: export dropdown and format rail on an oversized book; enabled path unchanged for normal-sized books.

## Notes

- Gate compares **raw file size vs 50 MB** to match Amazon's user-facing number. Base64 transfer encoding inflates the wire message, so a file within a few MB of the cap can still bounce — those rare boundary cases fall through to the normal send-error toast.
- Existing Playwright specs are unaffected (small fixtures stay under the cap → enabled path). An oversize E2E would need an impractical >50 MB fixture, so that logic is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
