### PR TITLE
fix(reader): apply publisher CSS, hyphenation, and reader fonts in the web reader

### DIFF
--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -68,6 +68,7 @@
   var relocateTimer = null;
   var locationsReady = false;
   var tocFlat = [];
+  var currentTheme = "dark";
 
   function emitStatus(state) {
     if (typeof window.__omnibusOnStatus === "function") {
@@ -184,6 +185,7 @@
         body: { background: "#ede4d0", color: "#3b3029" },
       });
       rendition.themes.select(opts.theme || "dark");
+      currentTheme = opts.theme || "dark";
 
       if (opts.fontSize) {
         rendition.themes.fontSize(opts.fontSize + "px");
@@ -370,6 +372,31 @@
     }
   }
 
+  // Reader-owned hyperlink colour. Apple/Kindle paint links with their own
+  // accent and ignore the publisher's — so links stay a consistent, legible
+  // colour instead of whatever hue (or `:hover` red) a given book's CSS ships.
+  // Theme-aware: a dark-ground blue would wash out on the light/sepia grounds.
+  function linkColorForTheme(name) {
+    switch (name) {
+      case "light":
+      case "sepia":
+        return "#2f6fd0";
+      default:
+        return "#6fa8e6";
+    }
+  }
+
+  // Push the current theme's link colour into a section as a CSS var the
+  // baseline stylesheet reads. Runs per section and again on every theme swap.
+  function applyLinkColor(doc) {
+    if (doc && doc.documentElement) {
+      doc.documentElement.style.setProperty(
+        "--omn-link",
+        linkColorForTheme(currentTheme)
+      );
+    }
+  }
+
   // Per-section content enhancement, registered on epub.js's content hook so it
   // runs for every rendered spine item. Three Apple/Kindle-parity fixes the
   // sandboxed iframe would otherwise drop: the book's own stylesheet, then
@@ -399,21 +426,25 @@
         doc.head.appendChild(link);
       }
 
+      applyLinkColor(doc);
+
       // Reader baseline / override layer. The split mirrors Apple Books and
       // Kindle: the reading system owns colour (and font, size, spacing,
       // margins, justification — set elsewhere), while the publisher keeps
       // structure — weight, style, headings, alignment, indents, small-caps.
       // Appended last so it wins, and `!important` on colour so a publisher
-      // hue can't override the theme: this both kills clashes (e.g. Project
-      // Gutenberg's `a:hover{color:red}`) and keeps dark/sepia legible when a
-      // book hard-codes its own text colour.
+      // hue can't override the theme: body text inherits the theme foreground
+      // (killing clashes like Project Gutenberg's `a:hover{color:red}` and
+      // keeping dark/sepia legible), while links get the reader's own accent
+      // in every state — the `a` rule outranks `body *` on specificity.
       if (!doc.getElementById("__omnibus_baseline")) {
         var style = doc.createElement("style");
         style.id = "__omnibus_baseline";
         style.textContent =
           "html,body{-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto;}" +
           "body *{color:inherit!important;}" +
-          "a:link,a:visited,a:hover,a:active{text-decoration:none;}";
+          "a:link,a:visited,a:hover,a:active{" +
+          "color:var(--omn-link,#4a86d8)!important;text-decoration:none;}";
         doc.head.appendChild(style);
       }
     });
@@ -491,6 +522,15 @@
   function setTheme(name) {
     if (!rendition) return;
     rendition.themes.select(name);
+    currentTheme = name;
+    // Re-tint links in every already-rendered section for the new ground.
+    try {
+      rendition.getContents().forEach(function (c) {
+        applyLinkColor(c.document);
+      });
+    } catch (e) {
+      /* no rendered sections yet */
+    }
   }
 
   function setFont(family) {

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -432,19 +432,25 @@
       // Kindle: the reading system owns colour (and font, size, spacing,
       // margins, justification — set elsewhere), while the publisher keeps
       // structure — weight, style, headings, alignment, indents, small-caps.
-      // Appended last so it wins, and `!important` on colour so a publisher
-      // hue can't override the theme: body text inherits the theme foreground
-      // (killing clashes like Project Gutenberg's `a:hover{color:red}` and
-      // keeping dark/sepia legible), while links get the reader's own accent
-      // in every state — the `a` rule outranks `body *` on specificity.
+      //
+      // Appended last, and `!important` on colour so a publisher hue can't
+      // override the theme: `body *` forces every element to the theme
+      // foreground (killing clashes like Project Gutenberg's `a:hover{color:
+      // red}` and keeping dark/sepia legible), and only *real* links — `a`
+      // with an `href` — get the reader's accent. Confirmed against Apple
+      // Books: it styles/hovers only real links, ignoring publisher `:hover`
+      // on ordinary elements. Scoping to `[href]` also spares body text that
+      // Gutenberg wraps in a self-closing *named* anchor (`<a id="chapN"/>`,
+      // no href) which the HTML parser leaves open across the chapter — that
+      // text stays inert, theme-coloured prose (cursor included).
       if (!doc.getElementById("__omnibus_baseline")) {
         var style = doc.createElement("style");
         style.id = "__omnibus_baseline";
         style.textContent =
           "html,body{-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto;}" +
           "body *{color:inherit!important;}" +
-          "a:link,a:visited,a:hover,a:active{" +
-          "color:var(--omn-link,#4a86d8)!important;text-decoration:none;}";
+          "a:not([href]){cursor:auto;}" +
+          "a[href]{color:var(--omn-link,#4a86d8)!important;text-decoration:none;}";
         doc.head.appendChild(style);
       }
     });

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -172,6 +172,7 @@
 
       installGestureNav();
       installSelectionClearWatch();
+      installContentEnhancements();
 
       rendition.themes.register("light", {
         body: { background: "#fcfbfa", color: "#2a2725" },
@@ -312,6 +313,104 @@
           }
         }, 300);
       });
+    });
+  }
+
+  // Google Fonts stylesheet for the app's reading typefaces. The parent
+  // document loads these via atrium.css, but webfonts don't cascade into the
+  // section iframe — so `themes.font("'Instrument Serif'…")` renders as the
+  // Times fallback unless the face is also declared inside the iframe.
+  var READER_FONTS_HREF =
+    "https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&" +
+    "family=EB+Garamond:ital,wght@0,400;0,500;1,400;1,500&display=swap";
+
+  // Inject the book's own stylesheets as inline <style>. epub.js rewrites each
+  // section `<link>` to a `blob:` URL, but the sandboxed iframe's opaque origin
+  // can't load a parent-minted blob (and the app CSP blocks fetching it too),
+  // so the publisher CSS silently drops and prose renders as UA defaults. We
+  // instead read the CSS straight out of epub.js's in-memory archive (JSZip)
+  // and inline it — an inline <style> the iframe honours. Fire-and-forget and
+  // fully guarded so a parsing hiccup can never stall or break the render.
+  function inlineBookStylesheets(doc) {
+    try {
+      if (!book || !book.archive || !book.packaging || doc.__omnibusBookCss) {
+        return;
+      }
+      doc.__omnibusBookCss = true;
+      var manifest = book.packaging.manifest || {};
+      var paths = [];
+      Object.keys(manifest).forEach(function (id) {
+        var item = manifest[id];
+        if (item && item.type === "text/css" && item.href) {
+          try {
+            paths.push(book.resolve(item.href));
+          } catch (e) {
+            /* unresolvable href — skip */
+          }
+        }
+      });
+      paths.forEach(function (path) {
+        book.archive
+          .getText(path)
+          .then(function (css) {
+            if (!css || !doc.head) return;
+            var style = doc.createElement("style");
+            style.setAttribute("data-omnibus-book-css", "");
+            style.textContent = css;
+            // Prepend so book CSS sits ahead of the reader baseline, which
+            // only touches html/body and should win any tie (e.g. hyphens).
+            doc.head.insertBefore(style, doc.head.firstChild);
+          })
+          .catch(function () {
+            /* unreadable asset — leave prose on UA defaults */
+          });
+      });
+    } catch (e) {
+      /* never let styling break rendering */
+    }
+  }
+
+  // Per-section content enhancement, registered on epub.js's content hook so it
+  // runs for every rendered spine item. Three Apple/Kindle-parity fixes the
+  // sandboxed iframe would otherwise drop: the book's own stylesheet, then
+  // hyphenation for justified prose (off by CSS default), and the app typeface
+  // loaded *inside* the iframe.
+  function installContentEnhancements() {
+    if (!rendition || !rendition.hooks || !rendition.hooks.content) return;
+    rendition.hooks.content.register(function (contents) {
+      var doc = contents.document;
+      if (!doc || !doc.head) return;
+
+      inlineBookStylesheets(doc);
+
+      // Hyphenation needs a language for its dictionary; inherit the book's,
+      // defaulting to English, without clobbering a per-document `lang`.
+      var meta = book && book.packaging && book.packaging.metadata;
+      var lang = (meta && meta.language) || "en";
+      if (doc.documentElement && !doc.documentElement.getAttribute("lang")) {
+        doc.documentElement.setAttribute("lang", lang);
+      }
+
+      if (!doc.getElementById("__omnibus_fonts")) {
+        var link = doc.createElement("link");
+        link.id = "__omnibus_fonts";
+        link.rel = "stylesheet";
+        link.href = READER_FONTS_HREF;
+        doc.head.appendChild(link);
+      }
+
+      // Reader baseline. Kept intentionally thin (html/body selectors the book
+      // rarely targets) so the publisher's own CSS still drives layout: just
+      // hyphenate justified text and drop the UA underline on structural
+      // anchors (chapter-heading links), matching Apple/Kindle.
+      if (!doc.getElementById("__omnibus_baseline")) {
+        var style = doc.createElement("style");
+        style.id = "__omnibus_baseline";
+        style.textContent =
+          "html,body{-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto;}" +
+          "a:link,a:visited{text-decoration:none;}";
+        doc.head.appendChild(style);
+      }
     });
   }
 

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -399,16 +399,21 @@
         doc.head.appendChild(link);
       }
 
-      // Reader baseline. Kept intentionally thin (html/body selectors the book
-      // rarely targets) so the publisher's own CSS still drives layout: just
-      // hyphenate justified text and drop the UA underline on structural
-      // anchors (chapter-heading links), matching Apple/Kindle.
+      // Reader baseline / override layer. The split mirrors Apple Books and
+      // Kindle: the reading system owns colour (and font, size, spacing,
+      // margins, justification — set elsewhere), while the publisher keeps
+      // structure — weight, style, headings, alignment, indents, small-caps.
+      // Appended last so it wins, and `!important` on colour so a publisher
+      // hue can't override the theme: this both kills clashes (e.g. Project
+      // Gutenberg's `a:hover{color:red}`) and keeps dark/sepia legible when a
+      // book hard-codes its own text colour.
       if (!doc.getElementById("__omnibus_baseline")) {
         var style = doc.createElement("style");
         style.id = "__omnibus_baseline";
         style.textContent =
           "html,body{-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto;}" +
-          "a:link,a:visited{text-decoration:none;}";
+          "body *{color:inherit!important;}" +
+          "a:link,a:visited,a:hover,a:active{text-decoration:none;}";
         doc.head.appendChild(style);
       }
     });

--- a/frontend/src/pages/reader/typography.rs
+++ b/frontend/src/pages/reader/typography.rs
@@ -15,9 +15,11 @@ pub(crate) enum Typeface {
 #[cfg_attr(not(feature = "web"), allow(dead_code))]
 impl Typeface {
     pub(crate) fn to_css(self) -> &'static str {
+        // Georgia sits ahead of the generic `serif` so a webfont that fails to
+        // load in the section iframe degrades to a real book serif, not Times.
         match self {
-            Self::Editorial => "'Instrument Serif',serif",
-            Self::Classic => "'EB Garamond',serif",
+            Self::Editorial => "'Instrument Serif',Georgia,serif",
+            Self::Classic => "'EB Garamond',Georgia,serif",
             Self::Modern => "Georgia,serif",
         }
     }


### PR DESCRIPTION
## Summary

Fixes the web EPUB reader rendering prose as unstyled browser defaults — the core defect behind Empire of the Vampire (and most trade EPUBs) looking far worse than Apple Books / Kindle.

Closes #1010.

The root cause: epub.js rewrites each section's `<link>` stylesheet to a `blob:` URL minted in the parent context, but the reader renders content in a `sandbox="allow-same-origin"` iframe with an opaque origin that **can't load a parent-minted blob** — and the app CSP blocks fetching it too. So the publisher's stylesheet silently dropped and the book fell back to UA defaults: ragged-left text, no first-line indents, blank-line paragraph spacing, and UA-blue underlined heading links.

## What changed (`frontend/assets/vendor/epub-reader-glue.js`)

All applied per-section via epub.js's `content` hook:

1. **Publisher CSS** — read each stylesheet straight from epub.js's in-memory JSZip archive (`book.archive.getText`, resolved via the manifest) and inline it as a `<style>` the sandboxed iframe honours. Fire-and-forget and fully guarded so a parsing hiccup can never stall or break the render. (I first tried `replacements: "base64"` + decode, but base64-embedding the whole archive was ~10× slower to open; the archive read is instant.)
2. **Hyphenation** — inject `hyphens: auto` and set the document `lang` from EPUB metadata, so justified text isn't loose/rivery.
3. **Reader typeface in the iframe** — load the app's Google-Fonts faces *inside* the section iframe (webfonts don't cascade in, so the selected "Editorial"/"Classic" face silently rendered as Times).
4. **Heading links** — drop the UA underline on structural `<a>` links (chapter headings), matching Apple/Kindle.

Plus `frontend/src/pages/reader/typography.rs`: font fallbacks now degrade to **Georgia** rather than the generic `serif` (Times) if a webfont fails to load.

## Style precedence (Apple Books / Kindle model)

Inlining the publisher CSS raised the question of *who wins* when the book and the reader disagree. This PR draws the same line Apple and Kindle do:

- **Reader owns:** background + **text colour** (theme), **link colour**, font family, font size, line-height, margins/width, justification, hyphenation. A publisher colour never overrides the theme — enforced with `body *{color:inherit!important}`, so e.g. Project Gutenberg's `a:hover{color:red}` no longer flashes links red, and a book that hard-codes dark body text stays legible on the dark theme (it would otherwise render invisible).
- **Publisher owns:** structure — bold, italic, small-caps, headings, blockquotes, lists, alignment (centered headings), first-line indents, images.

**Real links only** (`a[href]` — chapter-heading nav, footnote refs, TOC entries) get the reading system's own accent: a **theme-aware blue** (bright on the dark ground, darker on light/sepia), re-tinted live on theme switch, instead of whatever colour each book ships. This is confirmed behavior, not a guess — a crafted repro EPUB opened in Apple Books shows it styles/hovers **only** genuine `a[href]` links and ignores publisher `:hover` on ordinary elements.

Scoping to `[href]` also fixes a jarring real-world case: Project Gutenberg wraps each chapter start in a self-closing *named* anchor (`<a id="chapN"/>`, no href), which the HTML parser leaves open so it swallows the whole chapter body. Colouring bare `a` (especially `:hover`) tinted all that prose — blue at rest, red on hover from the book's own `a:hover{color:red}`. Scoped to `[href]`, those wrapper anchors are skipped, so the body stays inert theme-coloured prose with a normal text cursor. (The underlying cause is that epub.js picks its parser by file extension — `.html` → HTML — while the manifest correctly declares `application/xhtml+xml`; a spec-correct XHTML parse, which is what Apple does, would leave the anchor empty. A follow-up could parse by media-type; the CSS scoping matches Apple's observable behavior in the meantime.)

The reader baseline otherwise stays thin (html/body-level rules) so the publisher's own CSS still drives layout.

## Verification

Verified in Chrome against **Empire of the Vampire, ch. XI "How Stories Work"** — the same chapter as the issue's Apple Books screenshot. Computed styles in the reader iframe went from UA defaults to the book's intent:

| property (`p.calibre_13`) | before | after |
|---|---|---|
| `text-align` | `start` | `justify` |
| `text-indent` | `0` | `1em` |
| paragraph `margin` | `18px` (UA `1em`) | `0` |
| `hyphens` | `manual` | `auto` |
| Instrument Serif | falls back to Times | renders |

## Screenshots

_Before (main) → After (this branch), Empire of the Vampire ch. XI:_

<!-- Drag the before/after images here -->
| Before | After |
|---|---|
| _paste before.png_ | _paste after.png_ |

## Notes / follow-ups (not in this PR)

- A glyph-clipping artifact at CSS-column boundaries (first letter of the last line before a break) remains — a separate epub.js multi-column quirk.
- Verify on the mobile shell (WKWebView uses `allowScriptedContent`, a different sandbox); the fix is shared glue so it should apply, but it wasn't exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
