### PR TITLE
fix: make entire series book card clickable (#1004)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1398,11 +1398,6 @@ button.spoiler {
   color: var(--ink-0);
   line-height: 1.2;
 }
-.series-card-title a {
-  color: inherit;
-  text-decoration: none;
-}
-.series-card-title a:hover { text-decoration: underline; }
 .series-card-desc {
   margin-top: 12px;
   font-size: 13.5px;

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -139,18 +139,17 @@ fn series_header(
     }
 }
 
-/// One book card in the series grid: cover, index/year label, title link, and
-/// an optional description.
+/// One book card in the series grid: cover, index/year label, title, and an
+/// optional description, all wrapped in a single card-spanning link so the
+/// whole card — not just the cover and title text — navigates to the book.
 fn series_book_row(book: &EbookMetadata) -> Element {
     rsx! {
-        article {
+        Link {
             key: "{book.id}",
+            to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
             class: "card series-card",
             div { class: "series-card-cover",
-                Link {
-                    to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
-                    Cover { book: book.clone() }
-                }
+                Cover { book: book.clone() }
             }
             div { class: "series-card-info",
                 span { class: "label",
@@ -162,10 +161,7 @@ fn series_book_row(book: &EbookMetadata) -> Element {
                     }
                 }
                 h3 { class: "series-card-title",
-                    Link {
-                        to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
-                        "{book.title.as_deref().unwrap_or(&book.filename)}"
-                    }
+                    "{book.title.as_deref().unwrap_or(&book.filename)}"
                 }
                 if let Some(ref desc) = book.description {
                     div { class: "series-card-desc",

--- a/ui_tests/playwright/tests/flows/discovery.spec.ts
+++ b/ui_tests/playwright/tests/flows/discovery.spec.ts
@@ -158,11 +158,28 @@ test("series page shows books in order", async ({ page, request }) => {
   await gotoReady(page, `/series/${seriesId}`);
 
   // Should have multiple book cards — "Pioneers" has 5 books in fixtures
-  const cards = page.locator("article.series-card");
+  const cards = page.locator(".series-card");
   await expect(cards).toHaveCount(5);
 
   // First book should show "Book #1"
   await expect(cards.first().getByText("Book #1")).toBeVisible();
+});
+
+test("clicking a non-text area of a series book card navigates to the book", async ({
+  page,
+  request,
+}) => {
+  // The whole card — cover, title, index/year label, and surrounding
+  // whitespace — is one link (issue #1004). Click near the card's edge,
+  // away from the cover image and title text, to prove the click target
+  // isn't limited to those two elements.
+  const seriesId = await fetchSeriesIdByName(request, "Pioneers");
+  await gotoReady(page, `/series/${seriesId}`);
+
+  const firstCard = page.locator(".series-card").first();
+  await firstCard.click({ position: { x: 5, y: 5 } });
+
+  await expect(page).toHaveURL(/\/books\/[\w-]+$/);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- On the series detail page, `series_book_row` (`frontend/src/pages/series.rs`) wrapped only the cover image and the title text in two separate `Link`s, so clicking the description, the index/year label, or any of the card's whitespace/padding did nothing.
- Collapsed both inner `Link`s into a single card-spanning `Link` that carries the `card series-card` class — the same "whole tile is one `Link`" pattern already used for book tiles on the author page (`frontend/src/pages/author.rs`) and `CoverTileKind::MemberLink` (`frontend/src/components/cover_tile.rs`). `series.rs` has no `#[cfg(feature = "mobile")]` split, so this is one shared implementation and the fix covers both web and the mobile WebView.
- Removed the now-dead `.series-card-title a` / `.series-card-title a:hover` CSS rules that only existed to style the removed nested anchor (the existing `.atrium a { color: inherit; text-decoration: none; }` global reset and `.card:hover { border-color: var(--line); }` already cover the new full-card link's appearance).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default members)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (229 passed)
- [x] `npx stylelint --config .stylelintrc.json 'frontend/assets/**/*.css'` (structural CSS lint; this sandbox has no Nix, so I ran stylelint directly via npx instead of `just lint-css`)
- [x] Added a Playwright test to `ui_tests/playwright/tests/flows/discovery.spec.ts` — clicks the series card near its edge (away from the cover and title) and asserts navigation to `/books/:uuid`; updated the existing card-count locator from `article.series-card` to `.series-card` since the root element is now an `<a>` instead of an `<article>`.
- [ ] Not run in this sandbox (no Nix/`dx`/Playwright browser toolchain available here): `npx playwright test discovery` and a live-browser check via `ui-validate`. The change is a markup restructure with no new logic — `.card { padding: 22px }` + `display: grid` on an `<a>` is standard, well-supported CSS, and the new structure mirrors the shipped `author.rs` pattern exactly, but this should get a real Playwright/browser run before merge.

## Version
- [x] **Patch** — leaving unlabeled (bug fix).

## Notes
- No `db`/`server`/`shared` changes; no migrations touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XTQeeDXDLAYAuRDMrNDeeg)_