### PR TITLE
fix: rate-adjust remaining-time labels on mobile audiobook player (#1000)

### DIFF
--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -31,7 +31,7 @@ mod view;
 use bookmarks_sheet::{use_mobile_bookmarks, BookmarksSheet, MobileBookmarks};
 use sheets::{snap_rate, ChaptersSheet, SleepSheet, SpeedSheet};
 use state::{sleep_pill_label, use_mobile_playback, SleepState};
-use view::{chapter_index_for_elapsed, format_hms, format_ms, PlayerView};
+use view::{chapter_index_for_elapsed, format_hms, format_ms, remaining_at_rate, PlayerView};
 
 pub use host::MobileAudioHost;
 pub use mini::MobileMiniPlayer;
@@ -245,8 +245,11 @@ fn render_player(p: PlayerProps) -> Element {
     let chapter_start = current.map(|c| c.start_seconds).unwrap_or(0.0);
     let chapter_dur = current.map(|c| c.duration_seconds).unwrap_or(0.0);
     let within = (elapsed - chapter_start).max(0.0);
-    let chapter_left = view::remaining_in_chapter(&view.chapters, chapter_index, elapsed);
-    let remaining_book = (duration - elapsed).max(0.0);
+    let chapter_left = remaining_at_rate(
+        view::remaining_in_chapter(&view.chapters, chapter_index, elapsed),
+        rate,
+    );
+    let remaining_book = remaining_at_rate((duration - elapsed).max(0.0), rate);
     let scrub_max = if duration > 0.0 { duration } else { 1.0 };
 
     let accent_style = view

--- a/frontend/src/pages/listen/mobile/mini.rs
+++ b/frontend/src/pages/listen/mobile/mini.rs
@@ -11,7 +11,7 @@ use crate::contexts::use_server_url;
 use crate::Route;
 
 use super::state::use_mobile_playback;
-use super::view::{chapter_index_for_elapsed, format_hms};
+use super::view::{chapter_index_for_elapsed, format_hms, remaining_at_rate};
 use super::{cover_src, interop};
 
 /// Renders the docked mini-player, or nothing when no audiobook is loaded.
@@ -41,7 +41,7 @@ pub fn MobileMiniPlayer() -> Element {
     } else {
         0.0
     };
-    let remaining = (duration - elapsed).max(0.0);
+    let remaining = remaining_at_rate((duration - elapsed).max(0.0), (ctx.rate)());
     let subtitle = if view.chapters.is_empty() {
         format!("{} left", format_hms(remaining))
     } else {

--- a/frontend/src/pages/listen/mobile/view.rs
+++ b/frontend/src/pages/listen/mobile/view.rs
@@ -142,10 +142,8 @@ pub fn remaining_in_chapter(chapters: &[ChapterInfo], idx: usize, elapsed: f64) 
     }
 }
 
-/// Convert a real (1x) remaining-seconds duration into "time left at the
-/// current playback rate" — e.g. 10 real minutes left plays out in 5 minutes
-/// of listening at 2x. Falls back to `remaining` unscaled when `rate` is
-/// non-finite or non-positive (guards a not-yet-loaded rate signal).
+/// Rate-adjusted "time left" for a real (1x) `remaining` duration; falls back
+/// to `remaining` unscaled when `rate` is non-finite or non-positive.
 pub fn remaining_at_rate(remaining: f64, rate: f64) -> f64 {
     if !rate.is_finite() || rate <= 0.0 {
         return remaining;

--- a/frontend/src/pages/listen/mobile/view.rs
+++ b/frontend/src/pages/listen/mobile/view.rs
@@ -142,6 +142,17 @@ pub fn remaining_in_chapter(chapters: &[ChapterInfo], idx: usize, elapsed: f64) 
     }
 }
 
+/// Convert a real (1x) remaining-seconds duration into "time left at the
+/// current playback rate" — e.g. 10 real minutes left plays out in 5 minutes
+/// of listening at 2x. Falls back to `remaining` unscaled when `rate` is
+/// non-finite or non-positive (guards a not-yet-loaded rate signal).
+pub fn remaining_at_rate(remaining: f64, rate: f64) -> f64 {
+    if !rate.is_finite() || rate <= 0.0 {
+        return remaining;
+    }
+    remaining / rate
+}
+
 /// Resolve the "previous chapter" seek target:
 /// - >3s into the current chapter → its start;
 /// - within 3s of the start and not the first → the previous chapter's start;
@@ -256,6 +267,21 @@ mod tests {
         // Past the end clamps to zero, and OOB is zero.
         assert_eq!(remaining_in_chapter(&chs, 0, 400.0), 0.0);
         assert_eq!(remaining_in_chapter(&chs, 9, 0.0), 0.0);
+    }
+
+    #[test]
+    fn remaining_at_rate_divides_by_the_playback_rate() {
+        assert!((remaining_at_rate(600.0, 2.0) - 300.0).abs() < f64::EPSILON);
+        assert!((remaining_at_rate(600.0, 0.5) - 1200.0).abs() < f64::EPSILON);
+        assert!((remaining_at_rate(600.0, 1.0) - 600.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn remaining_at_rate_falls_back_to_unscaled_for_invalid_rate() {
+        assert_eq!(remaining_at_rate(600.0, 0.0), 600.0);
+        assert_eq!(remaining_at_rate(600.0, -1.0), 600.0);
+        assert_eq!(remaining_at_rate(600.0, f64::NAN), 600.0);
+        assert_eq!(remaining_at_rate(600.0, f64::INFINITY), 600.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Closes #1000.
- The full player's scrubber block (`frontend/src/pages/listen/mobile.rs`, `m-player-times`) and the mini-player's "X left" subtitle (`frontend/src/pages/listen/mobile/mini.rs`) both computed remaining time as raw `duration - elapsed`, ignoring the current playback rate — so a listener at 2x saw a "time left" countdown that didn't match how quickly they were actually finishing the book.
- Added `view::remaining_at_rate(remaining, rate)`, which divides real remaining seconds by the playback rate (falling back to unscaled when `rate` is non-finite/non-positive, e.g. before the rate signal loads). Applied it everywhere a remaining-time label renders: the full player's chapter-remaining and book-remaining labels, and the mini-player's subtitle.

>[!NOTE]
> `elapsed` is deliberately left unscaled — it's the raw scrubber position and reflects where you are in the book's content, matching the `<input type=range>` `value`. `remaining`/`left` labels are wall-clock-scaled (how much real listening time is left at the current speed) — same convention as Overcast/Apple Podcasts. As a result `elapsed + remaining_book` no longer sums to `duration` once `rate != 1`; that's intentional (position vs. wall-clock are different units), not a residual bug — no on-screen label pairs the two in a way that would expose the mismatch.

>[!WARNING]
> CI's `playwright (shard 1/2)` check is red on this PR, but it's a pre-existing, unrelated failure — `journal.spec.ts:409` ("hides markdown markers on lines away from the caret") fails deterministically (3/3 attempts) on `main` at the exact commit this branch forked from (`b0e7e82`), most likely a regression from #1008. Tracked separately as #1020; not fixed here since it's out of scope for the mobile audiobook player and touches unrelated journal-editor code.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server,mobile` — 197 passed, including 2 new `remaining_at_rate` unit tests (normal rates + NaN/zero/negative fallback) alongside the existing `format_hms`/chapter-time tests in `frontend/src/pages/listen/mobile/view.rs`.
- [x] `cargo clippy -p omnibus-frontend --features server,mobile --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check -p omnibus-frontend` — clean.
- [x] Grepped `format_hms(`/`format_ms(` across `frontend/src/pages/listen/` to confirm no other remaining-time label was missed — the desktop listen surface (`chapter_map.rs`, `chapters_drawer.rs`, `mini_dock.rs`, `bookmarks_drawer.rs`) is separate from `mobile/` and out of scope per the issue's mobile-only framing; `sheets.rs`/`bookmarks_sheet.rs` render chapter-total-duration and bookmark position, not remaining-time, so correctly untouched.
- [x] CI: rustfmt, cargo audit, bundle, clippy+test, playwright (shard 2/2) green. `playwright (shard 1/2)` red — pre-existing, unrelated (see warning above, #1020).

## Version
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- First commit on this branch (`chore: open draft PR for #1000`) is an empty placeholder pushed to open this PR as a draft before implementation started, per the automated fixer workflow's "signal work in progress" step. A later empty commit (`chore: retrigger CI after unrelated Playwright flake`) retriggered CI after the first `playwright (shard 1/2)` failure, since the GitHub App token here lacks `actions:rerun` permission — it failed identically, confirming the pre-existing/unrelated diagnosis in #1020.
- Scope stayed to the two render sites the issue cited — no changes to `PlayerContext`/`PlayerView` plumbing were needed since `rate` was already threaded through both.
- Adversarial review pass confirmed AC1/AC2 satisfied, no missed call sites, no migrations touched, tight scope. Two Copilot nitpicks addressed: rustdoc trimmed to one line; pre-existing test-placement debt in `mobile/view.rs` (15 tests already inline before this change) explained as out of scope rather than folded into this PR.
