### PR TITLE
fix: make entire series book card clickable (#1004)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1385,6 +1385,7 @@ button.spoiler {
   gap: 20px;
   align-items: flex-start;
   padding: 22px;
+  position: relative;
 }
 @media (max-width: 480px) {
   .series-card { grid-template-columns: 80px 1fr; gap: 12px; padding: 14px; }
@@ -1403,6 +1404,11 @@ button.spoiler {
   text-decoration: none;
 }
 .series-card-title a:hover { text-decoration: underline; }
+.series-card-hit::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
 .series-card-desc {
   margin-top: 12px;
   font-size: 13.5px;

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -164,6 +164,7 @@ fn series_book_row(book: &EbookMetadata) -> Element {
                 h3 { class: "series-card-title",
                     Link {
                         to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
+                        class: "series-card-hit",
                         "{book.title.as_deref().unwrap_or(&book.filename)}"
                     }
                 }

--- a/ui_tests/playwright/tests/flows/discovery.spec.ts
+++ b/ui_tests/playwright/tests/flows/discovery.spec.ts
@@ -174,10 +174,28 @@ test("clicking a non-linked area of a series book card navigates to the book", a
 
   await gotoReady(page, `/series/${seriesId}`);
 
-  // "Book #1" is plain label text, not the cover or title link — clicking it
-  // exercises the full-card stretched-link hit area, not the anchors.
+  // "Book #1" is plain label text, not the cover or title link, and it's a
+  // sibling (not an ancestor/descendant) of the stretched-link overlay — so
+  // Playwright's actionability check correctly refuses a direct `.click()`
+  // on the label itself (a different element receives the pointer event).
+  // Click through the card, an ancestor of the overlay, at the label's
+  // position instead, so the browser's real hit-testing routes the click to
+  // the full-card overlay.
   const firstCard = page.locator("article.series-card").first();
-  await firstCard.getByText("Book #1").click();
+  const label = firstCard.getByText("Book #1");
+  await expect(label).toBeVisible();
+
+  const cardBox = await firstCard.boundingBox();
+  const labelBox = await label.boundingBox();
+  if (!cardBox || !labelBox) {
+    throw new Error("expected the card and label to have a bounding box");
+  }
+  await firstCard.click({
+    position: {
+      x: labelBox.x + labelBox.width / 2 - cardBox.x,
+      y: labelBox.y + labelBox.height / 2 - cardBox.y,
+    },
+  });
 
   await expect(page).toHaveURL(/\/books\/[^/]+$/);
 });

--- a/ui_tests/playwright/tests/flows/discovery.spec.ts
+++ b/ui_tests/playwright/tests/flows/discovery.spec.ts
@@ -165,6 +165,23 @@ test("series page shows books in order", async ({ page, request }) => {
   await expect(cards.first().getByText("Book #1")).toBeVisible();
 });
 
+test("clicking a non-linked area of a series book card navigates to the book", async ({
+  page,
+  request,
+}) => {
+  const seriesName = "Pioneers";
+  const seriesId = await fetchSeriesIdByName(request, seriesName);
+
+  await gotoReady(page, `/series/${seriesId}`);
+
+  // "Book #1" is plain label text, not the cover or title link — clicking it
+  // exercises the full-card stretched-link hit area, not the anchors.
+  const firstCard = page.locator("article.series-card").first();
+  await firstCard.getByText("Book #1").click();
+
+  await expect(page).toHaveURL(/\/books\/[^/]+$/);
+});
+
 // ---------------------------------------------------------------------------
 // Tag cloud page
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The series-card cover and title `Link`s were the only click targets on a series book card; the description text, the index/year label, and surrounding whitespace weren't clickable at all.
- Added a `series-card-hit` class to the title `Link` and a `::after` stretched-link overlay (`position: relative` on `.series-card`, `position: absolute; inset: 0` on `.series-card-hit::after`) so the entire card is clickable, without wrapping the card's `dangerous_inner_html` description in an anchor (which would risk invalid nested `<a>` markup if a book's description ever contains a link).
- `series.rs` has no web/mobile split, so this fixes the card on both targets.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-frontend --features server` — 229 passed
- [x] `stylelint` (`.stylelintrc.json`) against `frontend/assets/atrium.css` — clean
- [x] Added a Playwright test (`ui_tests/playwright/tests/flows/discovery.spec.ts`) clicking through the card at the "Book #1" label's position — a non-linked area — and asserting navigation to `/books/:uuid`, covering AC2. The first version directly `.click()`ed the label locator, which Playwright correctly refused (the overlay, a sibling, intercepts the pointer event there); fixed by clicking the card — an ancestor of the overlay — at the label's coordinates instead, verified against CI's actual failure output plus a standalone headless-Chromium repro of the exact markup/CSS.
- [ ] Playwright wasn't run against the full app in this sandbox (no `nix`/`dx` here to bring up `dx serve`), so this went through two rounds against real CI (`run_ui_tests` label applied) instead — see review comments below.

## Known pre-existing failure (unrelated to this PR)
- `journal.spec.ts:409:5 › hides markdown markers on lines away from the caret` fails in this PR's CI run, but it already fails identically (`.cm-line` count 1 vs expected 2) on `main` at this PR's base commit (b0e7e826, [run 29176003689](https://github.com/seamus-sloan/omnibus/actions/runs/29176003689)) — pre-existing and unrelated to the series-card change, not fixed here.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- No migrations, no schema changes, no new dependencies.
- Copilot's automated review flagged the overlay as needing an explicit `z-index`; pushed back on that thread with CSS-stacking-order reasoning plus a headless-Chromium hit-test confirming the overlay already captures clicks everywhere on the card without one — see the resolved thread for details.