### PR TITLE
fix: apply playback rate to mobile audiobook time-left labels (#1000)

### DIFF
--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -31,7 +31,7 @@ mod view;
 use bookmarks_sheet::{use_mobile_bookmarks, BookmarksSheet, MobileBookmarks};
 use sheets::{snap_rate, ChaptersSheet, SleepSheet, SpeedSheet};
 use state::{sleep_pill_label, use_mobile_playback, SleepState};
-use view::{chapter_index_for_elapsed, format_hms, format_ms, PlayerView};
+use view::{chapter_index_for_elapsed, format_hms, format_ms, time_left_at_rate, PlayerView};
 
 pub use host::MobileAudioHost;
 pub use mini::MobileMiniPlayer;
@@ -364,10 +364,10 @@ fn render_player(p: PlayerProps) -> Element {
                     span { "{format_hms(elapsed)}" }
                     if has_chapters {
                         span { class: "m-player-chtime",
-                            "{format_ms(within)} / {format_ms(chapter_dur)} \u{00b7} {format_ms(chapter_left)} left"
+                            "{format_ms(within)} / {format_ms(chapter_dur)} \u{00b7} {format_ms(time_left_at_rate(chapter_left, rate))} left"
                         }
                     }
-                    span { "-{format_hms(remaining_book)}" }
+                    span { "-{format_hms(time_left_at_rate(remaining_book, rate))}" }
                 }
             }
 

--- a/frontend/src/pages/listen/mobile/mini.rs
+++ b/frontend/src/pages/listen/mobile/mini.rs
@@ -11,7 +11,7 @@ use crate::contexts::use_server_url;
 use crate::Route;
 
 use super::state::use_mobile_playback;
-use super::view::{chapter_index_for_elapsed, format_hms};
+use super::view::{chapter_index_for_elapsed, format_hms, time_left_at_rate};
 use super::{cover_src, interop};
 
 /// Renders the docked mini-player, or nothing when no audiobook is loaded.
@@ -42,11 +42,13 @@ pub fn MobileMiniPlayer() -> Element {
         0.0
     };
     let remaining = (duration - elapsed).max(0.0);
+    let rate = (ctx.rate)();
+    let remaining_label = format_hms(time_left_at_rate(remaining, rate));
     let subtitle = if view.chapters.is_empty() {
-        format!("{} left", format_hms(remaining))
+        format!("{remaining_label} left")
     } else {
         let ch_no = chapter_index_for_elapsed(&view.chapters, elapsed) + 1;
-        format!("Ch. {ch_no} \u{00b7} {} left", format_hms(remaining))
+        format!("Ch. {ch_no} \u{00b7} {remaining_label} left")
     };
     let accent_style = view
         .accent

--- a/frontend/src/pages/listen/mobile/view.rs
+++ b/frontend/src/pages/listen/mobile/view.rs
@@ -142,9 +142,10 @@ pub fn remaining_in_chapter(chapters: &[ChapterInfo], idx: usize, elapsed: f64) 
     }
 }
 
-/// Wall-clock time left to reach `remaining_seconds` of audio content at the
-/// given playback `rate` — e.g. half the content-time remains at 2x speed.
-/// Falls back to the raw remaining time for a non-positive rate.
+/// Wall-clock time left to play `remaining_seconds` of audio content at the
+/// given playback `rate` — e.g. it takes half as long to play at 2x speed,
+/// even though the content-time remaining is unchanged. Falls back to the
+/// raw remaining time for a non-positive rate.
 pub fn time_left_at_rate(remaining_seconds: f64, rate: f64) -> f64 {
     if rate > 0.0 {
         remaining_seconds / rate

--- a/frontend/src/pages/listen/mobile/view.rs
+++ b/frontend/src/pages/listen/mobile/view.rs
@@ -142,6 +142,17 @@ pub fn remaining_in_chapter(chapters: &[ChapterInfo], idx: usize, elapsed: f64) 
     }
 }
 
+/// Wall-clock time left to reach `remaining_seconds` of audio content at the
+/// given playback `rate` — e.g. half the content-time remains at 2x speed.
+/// Falls back to the raw remaining time for a non-positive rate.
+pub fn time_left_at_rate(remaining_seconds: f64, rate: f64) -> f64 {
+    if rate > 0.0 {
+        remaining_seconds / rate
+    } else {
+        remaining_seconds
+    }
+}
+
 /// Resolve the "previous chapter" seek target:
 /// - >3s into the current chapter → its start;
 /// - within 3s of the start and not the first → the previous chapter's start;
@@ -256,6 +267,19 @@ mod tests {
         // Past the end clamps to zero, and OOB is zero.
         assert_eq!(remaining_in_chapter(&chs, 0, 400.0), 0.0);
         assert_eq!(remaining_in_chapter(&chs, 9, 0.0), 0.0);
+    }
+
+    #[test]
+    fn time_left_at_rate_scales_inversely_with_speed() {
+        assert!((time_left_at_rate(600.0, 1.0) - 600.0).abs() < f64::EPSILON);
+        assert!((time_left_at_rate(600.0, 1.5) - 400.0).abs() < f64::EPSILON);
+        assert!((time_left_at_rate(600.0, 0.5) - 1200.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn time_left_at_rate_falls_back_to_raw_for_non_positive_rate() {
+        assert_eq!(time_left_at_rate(600.0, 0.0), 600.0);
+        assert_eq!(time_left_at_rate(600.0, -1.0), 600.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- On the mobile audiobook player, the "time left" labels (full-player scrubber remaining time, the within-chapter "X left" readout, and the mini-player's "X left" subtitle) were computed as raw audio-content time remaining (`duration - elapsed`), with no adjustment for the current playback rate — so at 1.5x speed the app still reported the same "time left" as at 1x, which reads as wrong once you're actually finishing the book faster.
- Position labels (the elapsed time, the within-chapter position) are correctly left alone — they represent where you are in the book's content, which doesn't change with playback speed.
- Added a small pure helper, `time_left_at_rate(remaining_seconds, rate)`, in `frontend/src/pages/listen/mobile/view.rs` and applied it at the three "time left" display sites in `frontend/src/pages/listen/mobile.rs` (scrubber remaining + chapter countdown) and `frontend/src/pages/listen/mobile/mini.rs` (mini-player subtitle). `rate` was already threaded through `MobilePlayback`/`PlayerProps`, so no new plumbing was needed beyond reading `ctx.rate` in the mini-player.

## Root cause detail (for reviewers)
The issue's screenshot shows `elapsed = 12:37` next to a within-chapter readout of `12:13 / 17:34 · 5:21 left` and a whole-book `-11:53:03`, at `1.50×`. The `12:37` vs `12:13` values are *not* a bug — one is whole-book position, the other is within-chapter position, offset by that chapter's ~24s start; they were always different quantities. The actual bug the title points at is that neither `5:21 left` nor `-11:53:03` accounted for the circled `1.50×` rate — both are pure audio-content-time subtractions. This PR leaves position math untouched and only scales the "left"/remaining labels by `1/rate`.

Desktop (`frontend/src/pages/listen/ready_player.rs` / `stage.rs`) has the same unscaled `remaining` computation, but the issue scoped this fix to the two named mobile files, so desktop is left as-is — flagging it here as related follow-up debt if wanted.

## Test plan
- [x] `cargo fmt --check` (repo-wide) — clean
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-frontend --features mobile` — 29 passed, including 2 new `time_left_at_rate` tests (inverse-scaling case + non-positive-rate fallback)
- [x] `cargo clippy -p omnibus-frontend --features server` — clean (unaffected build path, sanity-checked)

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- Scope: only the two files cited in #1000 (`mobile.rs`, `mobile/mini.rs`) plus the new pure helper + tests in `mobile/view.rs`. No behavior change to position (elapsed/within-chapter) labels.

Closes #1000


---
_Generated by [Claude Code](https://claude.ai/code/session_0138RaiyyHmLSNyesjEmWvxk)_