### PR TITLE
chore: publish Playwright report to GitHub Pages

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -203,17 +203,19 @@ jobs:
           nix develop .#e2e --command bash -c '
             set -euo pipefail
             cd ui_tests/playwright
-            npx playwright test --shard=${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}
+            npx playwright test --shard=${{ matrix.shard }}/${{ env.TOTAL_SHARDS }} --reporter=list,blob
           '
 
-      - name: Upload Playwright report
-        if: failure()
+      # Blob reports (one per shard, attachments embedded) are the input the
+      # `publish-report` job stitches into a single hosted HTML report.
+      # Uploaded on every run — pass and fail — so the Pages report always
+      # reflects the latest run, not just failures.
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-shard-${{ matrix.shard }}
-          path: |
-            ui_tests/playwright/playwright-report
-            ui_tests/playwright/test-results
+          name: blob-report-${{ matrix.shard }}
+          path: ui_tests/playwright/blob-report
           retention-days: 7
 
       - name: Upload server log
@@ -223,3 +225,56 @@ jobs:
           name: server-log-shard-${{ matrix.shard }}
           path: server.log
           retention-days: 7
+
+  # Stitch the per-shard blob reports into one browsable HTML report and
+  # deploy it to GitHub Pages, so failures (and passes) are inspectable at a
+  # stable URL without downloading an artifact and running
+  # `npx playwright show-report` locally. Runs whether or not the shards
+  # passed (but skips if a shard was cancelled or never ran), so the hosted
+  # report tracks the latest run. `merge-reports` needs @playwright/test but
+  # no browser, so this job stays on plain setup-node — no Nix.
+  publish-report:
+    name: publish report
+    needs: playwright
+    if: ${{ always() && needs.playwright.result != 'skipped' && needs.playwright.result != 'cancelled' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    # GitHub Pages allows one in-flight deployment at a time; a dedicated
+    # group (distinct from the workflow's ref-keyed cancel group above) keeps
+    # concurrent main/PR runs from cancelling each other mid-deploy.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Download all blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge blob reports into one HTML report
+        working-directory: ui_tests/playwright
+        run: |
+          npm ci
+          npx playwright merge-reports --reporter html ../../all-blob-reports
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ui_tests/playwright/playwright-report
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -316,14 +316,35 @@ jobs:
           mkdir -p "$DEST"
           cp -R "${GITHUB_WORKSPACE}/ui_tests/playwright/playwright-report/." "$DEST/"
 
-          # Point the root redirect at this report only on `main`, so `/` keeps
-          # tracking the latest main report and PR runs don't move it. Relative
-          # URL so it works under the /omnibus/ project-pages base path.
+          # Write a meta-refresh redirect page. $1 = relative target URL,
+          # $2 = output file. Relative URLs so they work under the /omnibus/
+          # project-pages base path.
+          write_redirect() {
+            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=%s">\n<title>Omnibus — Playwright report</title>\n<a href="%s">Latest Playwright report →</a>\n' "$1" "$1" > "$2"
+          }
+
+          # Per-branch pointer: /omnibus/<branch>/ → this branch's newest report.
+          # Updated every run, so a branch's latest report is reachable without
+          # knowing the sha.
+          write_redirect "./${COMMIT_SHA}/test-results/" "${BRANCH_NAME}/index.html"
+
+          # Root pointer, main only: /omnibus/ → latest main report. PR runs
+          # never touch it, so the README badge stays pinned to main.
           if [ "$BRANCH_NAME" = "main" ]; then
-            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=./%s/">\n<title>Omnibus — Playwright report</title>\n<a href="./%s/">Latest Playwright report →</a>\n' "$DEST" "$DEST" > index.html
+            write_redirect "./${DEST}/" "index.html"
           fi
+
           # Serve the report assets verbatim (no Jekyll processing of _ paths).
           touch .nojekyll
+
+          # Link both URLs from the run's summary so the report is one click from
+          # the Actions page — no sha-hunting.
+          {
+            echo "### 📊 Playwright report"
+            echo ""
+            echo "- **This run:** https://seamus-sloan.github.io/omnibus/${DEST}/"
+            echo "- **Latest for \`${BRANCH_NAME}\`:** https://seamus-sloan.github.io/omnibus/${BRANCH_NAME}/"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           git add -A
           git commit -q -m "test report: ${BRANCH_NAME}@${COMMIT_SHA:0:9}" || { echo "no changes to publish"; exit 0; }

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -328,10 +328,19 @@ jobs:
           # knowing the sha.
           write_redirect "./${COMMIT_SHA}/test-results/" "${BRANCH_NAME}/index.html"
 
-          # Root pointer, main only: /omnibus/ → latest main report. PR runs
-          # never touch it, so the README badge stays pinned to main.
+          # Track the latest main report in a sentinel file so the root can
+          # always point at it — even on a PR run, which must not move the root
+          # off main. Only main runs advance the sentinel.
           if [ "$BRANCH_NAME" = "main" ]; then
-            write_redirect "./${DEST}/" "index.html"
+            printf '%s\n' "$DEST" > .main-latest
+          fi
+          # Keep a root index every run so `/omnibus/` never 404s: redirect to
+          # the latest main report if one exists, else a small landing page
+          # until the first main run publishes.
+          if [ -f .main-latest ]; then
+            write_redirect "./$(cat .main-latest)/" "index.html"
+          else
+            printf '<!doctype html>\n<meta charset="utf-8">\n<title>Omnibus — Playwright reports</title>\n<h1>Omnibus — Playwright reports</h1>\n<p>No <code>main</code> report has been published yet. Reports are published per branch at <code>/omnibus/&lt;branch&gt;/</code>; this page will redirect to the latest <code>main</code> report once one exists.</p>\n' > "index.html"
           fi
 
           # Serve the report assets verbatim (no Jekyll processing of _ paths).

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -279,10 +279,19 @@ jobs:
           npm ci
           npx playwright merge-reports --reporter html ../../all-blob-reports
 
+      # GitHub Pages serves a single site per repo and each deploy replaces it
+      # wholesale, so we can't publish to an independent URL — instead we nest
+      # the report under a `test-results/` folder in the Pages artifact so it
+      # lands at <pages-url>/test-results/ rather than the site root.
+      - name: Stage report under /test-results
+        run: |
+          mkdir -p site/test-results
+          mv ui_tests/playwright/playwright-report/* site/test-results/
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ui_tests/playwright/playwright-report
+          path: site
 
       - name: Deploy to GitHub Pages
         id: deploy

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -227,34 +227,37 @@ jobs:
           retention-days: 7
 
   # Stitch the per-shard blob reports into one browsable HTML report and
-  # deploy it to GitHub Pages, so failures (and passes) are inspectable at a
-  # stable URL without downloading an artifact and running
-  # `npx playwright show-report` locally. Runs whether or not the shards
-  # passed (but skips if a shard was cancelled or never ran), so the hosted
-  # report tracks the latest run. `merge-reports` needs @playwright/test but
-  # no browser, so this job stays on plain setup-node — no Nix.
+  # publish it to the `gh-pages` branch (which GitHub Pages serves), so
+  # failures and passes are inspectable at a URL without downloading an
+  # artifact and running `npx playwright show-report` locally. Runs whether or
+  # not the shards passed (but skips if a shard was cancelled or never ran).
+  # `merge-reports` needs @playwright/test but no browser, so this job stays on
+  # plain setup-node — no Nix.
+  #
+  # Each run adds a NEW `<branch>/<sha>/test-results/` directory and preserves
+  # every prior one (we fetch the live gh-pages tree and only replace this
+  # run's own folder), so historical reports stay addressable. The root
+  # `index.html` redirect is rewritten only on `main` deploys, so `/` always
+  # points at the latest `main` report (the stable target the README badge
+  # links to); feature-branch reports are reachable at their own URL but never
+  # hijack the root.
   publish-report:
     name: publish report
     needs: playwright
     if: ${{ always() && needs.playwright.result != 'skipped' && needs.playwright.result != 'cancelled' }}
     runs-on: ubuntu-latest
-    # Declaring `permissions` zeroes every unlisted scope, so the reads that
-    # `actions/checkout` (contents) and `download-artifact@v4` (actions) rely
-    # on must be listed explicitly alongside the Pages write scopes.
+    # `contents: write` to push the report to gh-pages; `actions: read` for
+    # download-artifact@v4. Declaring `permissions` zeroes every unlisted
+    # scope, so both must be listed explicitly.
     permissions:
-      contents: read
+      contents: write
       actions: read
-      pages: write
-      id-token: write
-    # GitHub Pages allows one in-flight deployment at a time; a dedicated
-    # group (distinct from the workflow's ref-keyed cancel group above) keeps
-    # concurrent main/PR runs from cancelling each other mid-deploy.
+    # Serialize gh-pages pushes across all runs: each publish fetches the live
+    # branch, adds its folder, and pushes, so two in-flight jobs would race and
+    # one push would reject. A single-slot group (no cancel) queues them.
     concurrency:
-      group: pages
+      group: gh-pages-publish
       cancel-in-progress: false
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -270,29 +273,58 @@ jobs:
           merge-multiple: true
 
       - name: Merge blob reports into one HTML report
-        working-directory: ui_tests/playwright
         env:
           # merge-reports needs @playwright/test but no browser binaries;
           # skip the ~150 MB Chromium download the postinstall would run.
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: |
+          cd ui_tests/playwright
           npm ci
           npx playwright merge-reports --reporter html ../../all-blob-reports
 
-      # GitHub Pages serves a single site per repo and each deploy replaces it
-      # wholesale, so we can't publish to an independent URL — instead we nest
-      # the report under a `test-results/` folder in the Pages artifact so it
-      # lands at <pages-url>/test-results/ rather than the site root.
-      - name: Stage report under /test-results
+      # Publish into gh-pages at <branch>/<sha>/test-results/, preserving every
+      # other report already there, and point the root redirect at this one.
+      - name: Publish report to gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # head_ref is set on pull_request events (the PR branch); ref_name is
+          # the branch on push events. head.sha is the PR's real head; on push,
+          # github.sha is the pushed commit (not a synthetic merge commit).
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          mkdir -p site/test-results
-          mv ui_tests/playwright/playwright-report/* site/test-results/
+          set -euo pipefail
+          DEST="${BRANCH_NAME}/${COMMIT_SHA}/test-results"
+          AUTH_URL="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
+          # Clone the existing gh-pages tree; create an orphan branch if it's
+          # the first run and the branch doesn't exist yet.
+          if git clone --depth 1 --branch gh-pages "$AUTH_URL" gh-pages 2>/dev/null; then
+            cd gh-pages
+          else
+            git clone --depth 1 "$AUTH_URL" gh-pages
+            cd gh-pages
+            git checkout --orphan gh-pages
+            git rm -rfq . || true
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@v4
+          # Replace only this run's folder; leave all other reports intact.
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+          cp -R "${GITHUB_WORKSPACE}/ui_tests/playwright/playwright-report/." "$DEST/"
+
+          # Point the root redirect at this report only on `main`, so `/` keeps
+          # tracking the latest main report and PR runs don't move it. Relative
+          # URL so it works under the /omnibus/ project-pages base path.
+          if [ "$BRANCH_NAME" = "main" ]; then
+            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=./%s/">\n<title>Omnibus — Playwright report</title>\n<a href="./%s/">Latest Playwright report →</a>\n' "$DEST" "$DEST" > index.html
+          fi
+          # Serve the report assets verbatim (no Jekyll processing of _ paths).
+          touch .nojekyll
+
+          git add -A
+          git commit -q -m "test report: ${BRANCH_NAME}@${COMMIT_SHA:0:9}" || { echo "no changes to publish"; exit 0; }
+          git push "$AUTH_URL" HEAD:gh-pages

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -238,7 +238,12 @@ jobs:
     needs: playwright
     if: ${{ always() && needs.playwright.result != 'skipped' && needs.playwright.result != 'cancelled' }}
     runs-on: ubuntu-latest
+    # Declaring `permissions` zeroes every unlisted scope, so the reads that
+    # `actions/checkout` (contents) and `download-artifact@v4` (actions) rely
+    # on must be listed explicitly alongside the Pages write scopes.
     permissions:
+      contents: read
+      actions: read
       pages: write
       id-token: write
     # GitHub Pages allows one in-flight deployment at a time; a dedicated
@@ -266,6 +271,10 @@ jobs:
 
       - name: Merge blob reports into one HTML report
         working-directory: ui_tests/playwright
+        env:
+          # merge-reports needs @playwright/test but no browser binaries;
+          # skip the ~150 MB Chromium download the postinstall would run.
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: |
           npm ci
           npx playwright merge-reports --reporter html ../../all-blob-reports

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A self-hosted ebook & audiobook library — read in the browser, listen anywhere
 Built with Rust ([Axum](https://github.com/tokio-rs/axum) + [Dioxus](https://dioxuslabs.com/)), SQLite, and a native iOS / Android shell.
 
 [![Clippy & Tests](https://img.shields.io/github/actions/workflow/status/seamus-sloan/omnibus/rust.yml?branch=main&label=Clippy%20%26%20Tests&logo=rust&logoColor=white)](https://github.com/seamus-sloan/omnibus/actions/workflows/rust.yml)
-[![Playwright](https://img.shields.io/github/actions/workflow/status/seamus-sloan/omnibus/e2e.yml?branch=main&label=Playwright&logo=playwright&logoColor=white)](https://github.com/seamus-sloan/omnibus/actions/workflows/e2e.yml)
+[![Playwright](https://img.shields.io/github/actions/workflow/status/seamus-sloan/omnibus/e2e.yml?branch=main&label=Playwright&logo=playwright&logoColor=white)](https://seamus-sloan.github.io/omnibus/)
 [![CSS Lint](https://img.shields.io/github/actions/workflow/status/seamus-sloan/omnibus/css-lint.yml?branch=main&label=CSS%20Lint)](https://github.com/seamus-sloan/omnibus/actions/workflows/css-lint.yml)
 [![Docker Hub](https://img.shields.io/docker/v/sesloan/omnibus?sort=semver&logo=docker&logoColor=white&label=docker%20hub&color=2496ED)](https://hub.docker.com/r/sesloan/omnibus/tags)
 [![Image size](https://img.shields.io/docker/image-size/sesloan/omnibus?sort=semver&logo=docker&logoColor=white&label=image&color=2496ED)](https://hub.docker.com/r/sesloan/omnibus/tags)


### PR DESCRIPTION
## Summary

Publishes the Playwright E2E HTML report to **GitHub Pages** on every run, so you never have to download an artifact and run `npx playwright show-report` locally. Each run's report is preserved at its own URL, and the site root always points at the latest `main` report.

## How it works

1. **Shards emit `blob` reports.** Each `playwright` shard runs with `--reporter=list,blob` (`list` keeps CI logs readable; `blob` is a merge-able report with traces/screenshots embedded) and uploads its blob as an artifact on every run — pass or fail.
2. **A `publish-report` job merges + publishes.** It downloads both shards' blobs, runs `playwright merge-reports --reporter html` into one report (on plain `setup-node` — no Nix, no browser; `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` skips the ~150 MB Chromium install), then pushes it into the **`gh-pages`** branch.
3. **Reports accumulate; they don't overwrite each other.** The job fetches the live `gh-pages` tree and replaces **only** its own `<branch>/<sha>/test-results/` folder, leaving every other report intact. The only files rewritten are small redirect pages (below).
4. **Pages serves the `gh-pages` branch.** Runs on `always()`, so failing runs publish a report too.

## Viewing reports

| I want to see… | Go to |
|---|---|
| **Latest `main` report** | **https://seamus-sloan.github.io/omnibus/** (root) — also where the README Playwright badge links |
| **The latest report for a branch** | `https://seamus-sloan.github.io/omnibus/<branch>/` (e.g. `…/omnibus/u/sloan/publish-playwright-report-to-pages/`) |
| **A specific run's report** | `https://seamus-sloan.github.io/omnibus/<branch>/<sha>/test-results/` (permanent — never overwritten) |
| **This run's report from the Actions page** | The **Summary** of each `publish report` job links both its exact-run URL and its branch-latest URL — no sha-hunting |

There's intentionally **no single "latest across all branches" URL** — the root is pinned to `main` so the README badge is stable. Use the per-branch URL (or the run summary link) for feature-branch runs.

## What redirects to what

- `…/omnibus/` **(root)** → meta-refresh → latest **`main`** report. Rewritten **only on `main` runs**, so PR runs never move it.
- `…/omnibus/<branch>/` → meta-refresh → that branch's **newest** report. Rewritten every run for that branch.
- `…/omnibus/<branch>/<sha>/test-results/` → the actual report. **No redirect**, permanent content.

## Repo settings changed

- **Pages source:** `main` branch → GitHub Actions → **`gh-pages` branch** (final state). Serving from the branch is what lets reports accumulate.
- **`github-pages` environment** deployment-branch policy loosened to all branches (so non-`main` runs can publish).

## README

The existing Playwright badge (already using the `logo=playwright` masks logo) now links to the report root instead of the Actions page.

## Test plan

- [x] `publish report` job succeeds; a PR-branch report is live and returns HTTP 200 with `<title>Playwright Test Report</title>` at `…/omnibus/u/sloan/publish-playwright-report-to-pages/<sha>/test-results/`.
- [x] `gh-pages` accumulates per-`<branch>/<sha>` folders; only the run's own folder + redirect pages change.
- [ ] Root `…/omnibus/` and the README badge go live after the first **post-merge `main`** run (root tracks latest `main` by design).
- [ ] Pre-existing `journal.spec.ts:409` failure on `main` must be fixed before the E2E check is fully green — **not introduced by this PR** (tracked separately).

## Notes

>[!WARNING]
> The report site is **public** (repo is already public), and **every branch/PR run publishes** its report there. Failure traces/screenshots — including seeded test data — are world-readable.

>[!NOTE]
> `gh-pages` grows ~1–3 MB per run and is never pruned yet. A retention job (drop PR-branch reports on close, keep last N on `main`) is a sensible follow-up.

## Version

- [ ] **No release** — CI-only change; the template's `.github/`-only rule auto-skips the release.