### PR TITLE
fix: journal editor newline insertion + stabilize flaky E2E flows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -247,11 +247,13 @@ jobs:
     if: ${{ always() && needs.playwright.result != 'skipped' && needs.playwright.result != 'cancelled' }}
     runs-on: ubuntu-latest
     # `contents: write` to push the report to gh-pages; `actions: read` for
-    # download-artifact@v4. Declaring `permissions` zeroes every unlisted
-    # scope, so both must be listed explicitly.
+    # download-artifact@v4; `pull-requests: write` for the sticky report-URL
+    # comment. Declaring `permissions` zeroes every unlisted scope, so all
+    # three must be listed explicitly.
     permissions:
       contents: write
       actions: read
+      pull-requests: write
     # Serialize gh-pages pushes across all runs: each publish fetches the live
     # branch, adds its folder, and pushes, so two in-flight jobs would race and
     # one push would reject. A single-slot group (no cancel) queues them.
@@ -259,6 +261,21 @@ jobs:
       group: gh-pages-publish
       cancel-in-progress: false
     steps:
+      # Post the report URL as a sticky PR comment up front so reviewers have a
+      # one-click link. The page goes live once the publish step below pushes to
+      # gh-pages, but the URL is deterministic from the branch + head sha, so
+      # posting it first is safe. PR-only — push builds (main) have no PR.
+      - name: Comment report URL on the PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: playwright-report
+          message: |
+            ### 📊 Playwright report
+
+            - **This run:** https://seamus-sloan.github.io/omnibus/${{ github.head_ref }}/${{ github.event.pull_request.head.sha }}/test-results/
+            - **Latest for `${{ github.head_ref }}`:** https://seamus-sloan.github.io/omnibus/${{ github.head_ref }}/
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4

--- a/frontend/src/pages/book_detail/journal_editor.js
+++ b/frontend/src/pages/book_detail/journal_editor.js
@@ -35,18 +35,35 @@ if (!window.OmnibusJournalEditor) {
       const start = pre.toString().length;
       return { start, end: start + r.toString().length };
     }
+    // Resolve a character offset to a DOM (node, offset) caret position.
+    // Walks `.cm-line` spans so a boundary offset lands *inside* the target
+    // line rather than at the end of the previous inline span (which the
+    // browser would collapse a bare join-text-node caret to). An empty line
+    // has no text node, so we return its span at offset 0 — the caret sits
+    // before the placeholder `<br>`, keeping typed text on the right line.
     function locate(root, offset) {
-      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
-      let n, acc = 0;
-      while ((n = walker.nextNode())) {
-        const len = n.nodeValue.length;
-        if (offset <= acc + len) return { node: n, offset: offset - acc };
-        acc += len;
+      const lines = root.querySelectorAll(":scope > .cm-line");
+      let acc = 0;
+      for (const line of lines) {
+        const len = line.textContent.length;
+        if (offset <= acc + len) {
+          const local = offset - acc;
+          const walker = document.createTreeWalker(line, NodeFilter.SHOW_TEXT, null);
+          let n, a = 0;
+          while ((n = walker.nextNode())) {
+            if (local <= a + n.nodeValue.length) return { node: n, offset: local - a };
+            a += n.nodeValue.length;
+          }
+          return { node: line, offset: 0 };
+        }
+        acc += len + 1; // + the literal "\n" joining this line to the next
       }
-      let last = null;
-      const w2 = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
-      while ((n = w2.nextNode())) last = n;
-      return last ? { node: last, offset: last.nodeValue.length } : { node: root, offset: 0 };
+      const last = lines[lines.length - 1];
+      if (!last) return { node: root, offset: 0 };
+      const walker = document.createTreeWalker(last, NodeFilter.SHOW_TEXT, null);
+      let n, tail = null;
+      while ((n = walker.nextNode())) tail = n;
+      return tail ? { node: tail, offset: tail.nodeValue.length } : { node: last, offset: 0 };
     }
     function place(root, start, end) {
       const a = locate(root, start), b = locate(root, end);
@@ -124,7 +141,11 @@ if (!window.OmnibusJournalEditor) {
     const render = (md) =>
       md
         .split("\n")
-        .map((line) => `<span class="cm-line">${blockLine(line)}</span>`)
+        // Empty lines get a `<br>` placeholder so they have layout height (a
+        // bare empty inline span collapses to zero and can't be clicked) and a
+        // caret landing spot. It contributes no text, so textContent still
+        // equals the markdown source exactly.
+        .map((line) => `<span class="cm-line">${blockLine(line) || "<br>"}</span>`)
         .join("\n");
 
     // --- active-line marker reveal (Obsidian-style) ---------------------------
@@ -211,18 +232,25 @@ if (!window.OmnibusJournalEditor) {
       });
       editor.addEventListener("input", () => onInput(editor));
       editor.addEventListener("keydown", (e) => {
-        // Insert a literal newline (contenteditable would otherwise add a <br>
-        // or <div>, breaking the textContent === markdown invariant).
+        // Insert a literal newline. `execCommand("insertText", "\n")` is a
+        // no-op in Chromium (insertText silently drops newlines), and the raw
+        // contenteditable default would add a <br>/<div> that breaks the
+        // textContent === markdown invariant. Splice it through the editor's
+        // own model instead so textContent gets the real "\n" and re-renders
+        // into a fresh `.cm-line`.
         if (e.key === "Enter") {
           e.preventDefault();
-          document.execCommand("insertText", false, "\n");
+          insert(editor.id, "\n");
         }
       });
       editor.addEventListener("paste", (e) => {
-        // Plain text only — keep the source clean markdown, never pasted markup.
+        // Plain text only — keep the source clean markdown, never pasted
+        // markup. Route through the model (not `execCommand("insertText")`,
+        // which drops embedded newlines) so multi-line pastes keep their line
+        // breaks.
         e.preventDefault();
         const t = (e.clipboardData || window.clipboardData).getData("text/plain");
-        document.execCommand("insertText", false, t);
+        insert(editor.id, t);
       });
     }
 

--- a/ui_tests/playwright/tests/flows/author_photo.spec.ts
+++ b/ui_tests/playwright/tests/flows/author_photo.spec.ts
@@ -83,10 +83,18 @@ test("admin upload swaps the letter avatar for the photo", async ({
   });
   expect(putResp.status(), "PUT photo should succeed").toBe(204);
 
-  await gotoReady(page, `/authors/${id}`);
-
   const img = page.locator("img.disc-avatar--photo");
-  await expect(img).toBeVisible();
+  // Re-navigate until the photo hero resolves. The author page fetches
+  // `get_author` client-side, and the `<img>` swaps back to the letter avatar
+  // on a single transient photo-GET error (`broken_photo_src` self-heal, only
+  // reset on a fresh mount) — under parallel load either can leave the letter
+  // showing on the first paint. A reload re-fetches and re-attempts cleanly;
+  // this still fails if the photo genuinely never renders.
+  await expect(async () => {
+    await gotoReady(page, `/authors/${id}`);
+    await expect(img).toBeVisible({ timeout: 3_000 });
+  }).toPass({ timeout: 20_000, intervals: [500, 1_000, 2_000] });
+
   await expect(img).toHaveAttribute("src", `/api/authors/${id}/photo`);
   // Letter variant should no longer render in the hero.
   await expect(page.locator("div.disc-avatar")).toHaveCount(0);

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -3,6 +3,7 @@ import { expectMutation } from "../utils/api";
 import { AUDIOBOOK_BOOKS, AUDIOBOOK_BOOK_COUNT } from "../fixtures/audiobooks";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { fetchBookUuidByTitle, getRow } from "../utils/ebooks";
+import { withLock } from "../utils/lock";
 import { gotoReady } from "../utils/nav";
 import {
   audiobookFixturesDir,
@@ -157,10 +158,15 @@ test("From the same hand shows empty state for single-book authors", async ({
   page,
   request,
 }) => {
-  // Ada Lovelace is the only author of `alpha` in the fixture set — so the
-  // author-fetch returns one book, filtering it out yields an empty list,
-  // and the page renders `from-same-hand-empty` instead of the row.
-  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  // Hedy Lamarr authors exactly one work across the *entire* fixture set —
+  // the standalone `gamma` ebook, and (unlike Ada Lovelace) no audiobook. So
+  // even when a parallel spec has seeded the audiobook library, her
+  // author-fetch stays single-book: the row filters to empty and the page
+  // renders `from-same-hand-empty`. `alpha`/Ada can't be used here — Ada also
+  // authors "The Analytical Audiobook", which flips her to multi-book the
+  // moment audiobooks are indexed, so this assertion raced audiobook seeding.
+  const SOLO = FIXTURE_BOOKS.find((b) => b.slug === "gamma")!;
+  const uuid = await fetchBookUuidByTitle(request, SOLO.title);
   await gotoReady(page, `/books/${uuid}`);
 
   // Wait for the heading to confirm the section rendered.
@@ -588,56 +594,64 @@ test.describe("audiobook-only seed", () => {
     page,
     request,
   }) => {
-    const primaryUuid = await fetchBookUuidByTitle(request, PRIMARY_MP3.title);
-    const secondUuid = await fetchBookUuidByTitle(request, SECOND_MP3.title);
+    // Serialize against merge.spec's audiobook merge: both mutate "The
+    // Analytical Audiobook" on the shared per-shard server, so running them in
+    // parallel workers corrupts this test's two-file state. The lock leaves the
+    // fixture restored (via the finally undo) before releasing. `test.slow()`
+    // covers the worst case of waiting out the other holder plus this run.
+    test.slow();
+    await withLock("audiobook-merge", async () => {
+      const primaryUuid = await fetchBookUuidByTitle(request, PRIMARY_MP3.title);
+      const secondUuid = await fetchBookUuidByTitle(request, SECOND_MP3.title);
 
-    // Arrange: merge SECOND into PRIMARY via the RPC directly (the merge
-    // dialog UI itself is covered by merge.spec.ts) so PRIMARY ends up with
-    // two MP3 `book_files` rows — the duplicate-format scenario #1005's
-    // picker targets. `merge_log_id` is the undo handle used in `finally`.
-    const mergeResp = await request.post("/api/rpc/merge-books", {
-      data: { source_uuid: secondUuid, target_uuid: primaryUuid },
-    });
-    expect(mergeResp.status(), "POST /api/rpc/merge-books failed").toBe(200);
-    const { merge_log_id: mergeLogId } = (await mergeResp.json()) as {
-      merge_log_id: number;
-    };
-
-    try {
-      await gotoReady(page, `/books/${primaryUuid}`);
-
-      // AC1: a book with >1 file of the format the CTA opens shows a way
-      // to pick which file to open before listening.
-      const trigger = page.getByTestId("listen-file-picker-trigger");
-      await expect(trigger).toBeVisible();
-      await expect(page.getByTestId("listen-file-picker-panel")).toHaveCount(0);
-      await trigger.click();
-      const panel = page.getByTestId("listen-file-picker-panel");
-      await expect(panel).toBeVisible();
-      await expect(panel.getByRole("link")).toHaveCount(2);
-
-      // Picking the second (non-default) file navigates to /listen/:uuid
-      // with that file's id, and the manifest fetch carries the same id.
-      const [manifestReq] = await Promise.all([
-        page.waitForRequest((req) =>
-          req.url().includes(`/api/audiobooks/${primaryUuid}/manifest?file_id=`),
-        ),
-        panel.getByRole("link").nth(1).click(),
-      ]);
-      expect(manifestReq.url()).toMatch(
-        new RegExp(`/api/audiobooks/${primaryUuid}/manifest\\?file_id=\\d+$`),
-      );
-      await expect(page).toHaveURL(
-        new RegExp(`/listen/${primaryUuid}\\?file_id=\\d+$`),
-      );
-    } finally {
-      // Undo — restores SECOND as its own book so later specs (and re-runs
-      // of this one) see the pre-merge fixture state, mirroring
-      // merge.spec.ts's own undo-as-cleanup pattern.
-      const undoResp = await request.post("/api/rpc/merge-books/undo", {
-        data: { merge_log_id: mergeLogId },
+      // Arrange: merge SECOND into PRIMARY via the RPC directly (the merge
+      // dialog UI itself is covered by merge.spec.ts) so PRIMARY ends up with
+      // two MP3 `book_files` rows — the duplicate-format scenario #1005's
+      // picker targets. `merge_log_id` is the undo handle used in `finally`.
+      const mergeResp = await request.post("/api/rpc/merge-books", {
+        data: { source_uuid: secondUuid, target_uuid: primaryUuid },
       });
-      expect(undoResp.status(), "POST /api/rpc/merge-books/undo failed").toBe(200);
-    }
+      expect(mergeResp.status(), "POST /api/rpc/merge-books failed").toBe(200);
+      const { merge_log_id: mergeLogId } = (await mergeResp.json()) as {
+        merge_log_id: number;
+      };
+
+      try {
+        await gotoReady(page, `/books/${primaryUuid}`);
+
+        // AC1: a book with >1 file of the format the CTA opens shows a way
+        // to pick which file to open before listening.
+        const trigger = page.getByTestId("listen-file-picker-trigger");
+        await expect(trigger).toBeVisible();
+        await expect(page.getByTestId("listen-file-picker-panel")).toHaveCount(0);
+        await trigger.click();
+        const panel = page.getByTestId("listen-file-picker-panel");
+        await expect(panel).toBeVisible();
+        await expect(panel.getByRole("link")).toHaveCount(2);
+
+        // Picking the second (non-default) file navigates to /listen/:uuid
+        // with that file's id, and the manifest fetch carries the same id.
+        const [manifestReq] = await Promise.all([
+          page.waitForRequest((req) =>
+            req.url().includes(`/api/audiobooks/${primaryUuid}/manifest?file_id=`),
+          ),
+          panel.getByRole("link").nth(1).click(),
+        ]);
+        expect(manifestReq.url()).toMatch(
+          new RegExp(`/api/audiobooks/${primaryUuid}/manifest\\?file_id=\\d+$`),
+        );
+        await expect(page).toHaveURL(
+          new RegExp(`/listen/${primaryUuid}\\?file_id=\\d+$`),
+        );
+      } finally {
+        // Undo — restores SECOND as its own book so later specs (and re-runs
+        // of this one) see the pre-merge fixture state, mirroring
+        // merge.spec.ts's own undo-as-cleanup pattern.
+        const undoResp = await request.post("/api/rpc/merge-books/undo", {
+          data: { merge_log_id: mergeLogId },
+        });
+        expect(undoResp.status(), "POST /api/rpc/merge-books/undo failed").toBe(200);
+      }
+    });
   });
 });

--- a/ui_tests/playwright/tests/flows/journal.spec.ts
+++ b/ui_tests/playwright/tests/flows/journal.spec.ts
@@ -411,7 +411,15 @@ test("hides markdown markers on lines away from the caret", async ({ page, reque
   await gotoReady(page, `/books/${uuid}`);
 
   await page.getByTestId("journal-open-composer").click();
-  await editor(page).fill("# Heading line\n**bold line**");
+  // Type the two lines rather than `.fill()`: the live editor only inserts a
+  // literal newline via its Enter keydown handler (a raw multi-line fill lands
+  // the `\n` as a block split that `textContent` drops, collapsing to one
+  // `.cm-line`). `press("Enter")` drives the real handler.
+  const ed = editor(page);
+  await ed.click();
+  await ed.pressSequentially("# Heading line");
+  await ed.press("Enter");
+  await ed.pressSequentially("**bold line**");
 
   const lines = editor(page).locator(".cm-line");
   await expect(lines).toHaveCount(2);

--- a/ui_tests/playwright/tests/flows/merge.spec.ts
+++ b/ui_tests/playwright/tests/flows/merge.spec.ts
@@ -11,6 +11,7 @@ import { AUDIOBOOK_BOOKS, AUDIOBOOK_BOOK_COUNT } from "../fixtures/audiobooks";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expectMutation } from "../utils/api";
 import { fetchBookUuidByTitle } from "../utils/ebooks";
+import { withLock } from "../utils/lock";
 import { expectNavVisible, gotoReady } from "../utils/nav";
 import {
   audiobookFixturesDir,
@@ -114,32 +115,39 @@ test("merges an audiobook into the ebook and undoes it from the toast", async ({
   page,
   request,
 }) => {
-  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
-  await gotoReady(page, `/books/${uuid}`);
+  // Serialize against book_detail.spec's file-picker test: both mutate the
+  // same audiobook ("The Analytical Audiobook") on the shared per-shard server,
+  // so parallel workers would corrupt each other's merge state. The lock spans
+  // merge→undo so the fixture is restored before release. See utils/lock.ts.
+  test.slow();
+  await withLock("audiobook-merge", async () => {
+    const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+    await gotoReady(page, `/books/${uuid}`);
 
-  await openDialogAndPickSource(page);
-  const { response } = await expectMutation(
-    page,
-    { method: "POST", url: "/api/rpc/merge-books", expectedStatus: 200 },
-    async () => page.getByTestId("merge-confirm").click(),
-  );
-  expect(response.status()).toBe(200);
+    await openDialogAndPickSource(page);
+    const { response } = await expectMutation(
+      page,
+      { method: "POST", url: "/api/rpc/merge-books", expectedStatus: 200 },
+      async () => page.getByTestId("merge-confirm").click(),
+    );
+    expect(response.status()).toBe(200);
 
-  // Refetch lands: both format badges, both CTAs, and the undo toast.
-  await expect(page.getByTestId("bd-format-badge")).toHaveCount(2);
-  await expect(page.getByTestId("bd-format-badge").filter({ hasText: SOURCE.format })).toBeVisible();
-  await expect(page.getByTestId("start-reading")).toBeVisible();
-  await expect(page.getByTestId("listen-secondary")).toBeVisible();
-  const toast = page.getByRole("status").filter({ hasText: "Books merged." });
-  await expect(toast).toBeVisible();
+    // Refetch lands: both format badges, both CTAs, and the undo toast.
+    await expect(page.getByTestId("bd-format-badge")).toHaveCount(2);
+    await expect(page.getByTestId("bd-format-badge").filter({ hasText: SOURCE.format })).toBeVisible();
+    await expect(page.getByTestId("start-reading")).toBeVisible();
+    await expect(page.getByTestId("listen-secondary")).toBeVisible();
+    const toast = page.getByRole("status").filter({ hasText: "Books merged." });
+    await expect(toast).toBeVisible();
 
-  // Undo from the toast restores the split (and cleans up shared state).
-  await expectMutation(
-    page,
-    { method: "POST", url: "/api/rpc/merge-books/undo", expectedStatus: 200 },
-    async () => page.getByTestId("merge-undo").click(),
-  );
-  await expect(page.getByTestId("bd-format-badge")).toHaveCount(1);
-  await expect(page.getByTestId("bd-format-badge")).toHaveText("EPUB");
-  await expect(page.getByTestId("listen-secondary")).not.toBeVisible();
+    // Undo from the toast restores the split (and cleans up shared state).
+    await expectMutation(
+      page,
+      { method: "POST", url: "/api/rpc/merge-books/undo", expectedStatus: 200 },
+      async () => page.getByTestId("merge-undo").click(),
+    );
+    await expect(page.getByTestId("bd-format-badge")).toHaveCount(1);
+    await expect(page.getByTestId("bd-format-badge")).toHaveText("EPUB");
+    await expect(page.getByTestId("listen-secondary")).not.toBeVisible();
+  });
 });

--- a/ui_tests/playwright/tests/flows/search-palette.spec.ts
+++ b/ui_tests/playwright/tests/flows/search-palette.spec.ts
@@ -56,6 +56,10 @@ test("palette closes on Escape", async ({ page }) => {
   await gotoReady(page, "/");
   await page.getByTestId("search-trigger").click();
   await expect(page.getByTestId("sp-panel")).toBeVisible();
+  // The input is focused a frame after mount (requestAnimationFrame). The
+  // panel's onkeydown only sees Escape once focus is inside the panel, so
+  // wait for the input before pressing — otherwise Escape lands on <body>.
+  await expect(page.getByTestId("sp-input")).toBeFocused();
 
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("sp-panel")).toHaveCount(0);
@@ -79,6 +83,10 @@ test("input is focused after clicking trigger so typing works immediately", asyn
   await gotoReady(page, "/");
   await page.getByTestId("search-trigger").click();
   await expect(page.getByTestId("sp-panel")).toBeVisible();
+  // Autofocus lands a frame after mount (requestAnimationFrame); typing before
+  // it does drops the leading keystroke. Waiting for focus is exactly what this
+  // test asserts — that typing works immediately once the palette is open.
+  await expect(page.getByTestId("sp-input")).toBeFocused();
 
   // Type on the keyboard without clicking the input first.
   await page.keyboard.type("dracula");
@@ -93,6 +101,9 @@ test("input is focused after Cmd+K so typing works immediately", async ({
   await gotoReady(page, "/");
   await page.keyboard.press("Meta+k");
   await expect(page.getByTestId("sp-panel")).toBeVisible();
+  // Autofocus lands a frame after mount (requestAnimationFrame); typing before
+  // it does drops the leading keystroke — wait for focus first.
+  await expect(page.getByTestId("sp-input")).toBeFocused();
 
   // Type on the keyboard without clicking the input first.
   await page.keyboard.type("hello");

--- a/ui_tests/playwright/tests/utils/ebooks.ts
+++ b/ui_tests/playwright/tests/utils/ebooks.ts
@@ -18,15 +18,37 @@ export async function fetchBookUuidByTitle(
   request: APIRequestContext,
   title: string,
 ): Promise<string> {
-  const resp = await request.get("/api/rpc/ebooks");
-  expect(resp.status(), "GET /api/rpc/ebooks failed").toBe(200);
-  const body = (await resp.json()) as {
-    books: { unique_identifier: string | null; title: string | null }[];
-  };
-  const match = body.books.find((b) => b.title === title);
+  // Poll rather than read once. `seedLibrary`/`seedAudiobookLibrary` gate on a
+  // *total* book count from `/api/rpc/ebooks`, which a parallel spec's ebooks
+  // can satisfy before this spec's own reindex has surfaced `title` — so a
+  // single GET here races the indexer and throws "no seeded book". Retrying
+  // until the specific title appears absorbs that lag; a genuinely-absent book
+  // still fails after the timeout with the same diagnostic.
+  let lastCount = -1;
+  let match: { unique_identifier: string | null; title: string | null } | undefined;
+  await expect
+    .poll(
+      async () => {
+        const resp = await request.get("/api/rpc/ebooks");
+        if (resp.status() !== 200) return false;
+        const body = (await resp.json()) as {
+          books: { unique_identifier: string | null; title: string | null }[];
+        };
+        lastCount = body.books.length;
+        match = body.books.find((b) => b.title === title);
+        return match !== undefined;
+      },
+      {
+        message: `no seeded book with title ${JSON.stringify(title)} surfaced by /api/rpc/ebooks`,
+        timeout: 15_000,
+        intervals: [100, 200, 500, 1_000],
+      },
+    )
+    .toBe(true);
+
   if (!match) {
     throw new Error(
-      `no seeded book with title ${JSON.stringify(title)} (got ${body.books.length} books)`,
+      `no seeded book with title ${JSON.stringify(title)} (got ${lastCount} books)`,
     );
   }
   if (!match.unique_identifier) {

--- a/ui_tests/playwright/tests/utils/lock.ts
+++ b/ui_tests/playwright/tests/utils/lock.ts
@@ -1,0 +1,51 @@
+import { mkdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Cross-worker mutex for E2E sections that mutate shared server state.
+//
+// Playwright runs a shard's specs across several worker *processes* that all
+// hit the same dev server, so two specs merging the same audiobook record in
+// parallel corrupt each other's assertions (e.g. merge.spec ghosts "The
+// Analytical Audiobook" into an ebook while book_detail's file-picker test is
+// merging a second file into it). `mkdir` is atomic on every platform, so a
+// lock *directory* under the OS temp dir gives a machine-wide mutex shared by
+// every worker in the shard. (Across shards each runner has its own server, so
+// there's nothing to serialize and the uncontended lock is a no-op.)
+
+const STALE_MS = 60_000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `fn` while holding a machine-wide lock named `name`. Acquisition spins
+ * on an atomic `mkdir`; a lock older than {@link STALE_MS} is treated as
+ * abandoned (a crashed worker) and reclaimed. The lock is always released,
+ * even if `fn` throws — callers must leave shared state restored before
+ * returning so the next holder sees a clean fixture.
+ */
+export async function withLock<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  const dir = join(tmpdir(), `omnibus-e2e-lock-${name}`);
+  for (;;) {
+    try {
+      mkdirSync(dir);
+      break;
+    } catch {
+      try {
+        if (Date.now() - statSync(dir).mtimeMs > STALE_MS) {
+          rmSync(dir, { recursive: true, force: true });
+          continue; // reclaim immediately, then retry the mkdir
+        }
+      } catch {
+        // Released between the failed mkdir and the stat — just retry.
+      }
+      // Jitter so waiters don't stampede the mkdir in lockstep.
+      await sleep(50 + Math.floor(Math.random() * 100));
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the failing E2E test and four flaky ones from `E2E main`. The failing test was catching a real product bug, not test flake.
- **Journal editor (product bug):** pressing Enter inserted no newline — `execCommand("insertText", "\n")` is a silent no-op in Chromium — so multi-line entries were impossible. Enter/paste now route through the editor's own `insert()` model; empty lines render a `<br>` (caret target + layout height) and `locate()` is line-aware so the caret lands on the right line.
- **search-palette:** wait for the `requestAnimationFrame` autofocus (`toBeFocused`) before sending keys — Escape/typing were racing the focus.
- **mini-dock:** `fetchBookUuidByTitle` now polls for the title; the seed poll's total-count gate could be satisfied by a parallel spec's ebooks before this spec's audiobook indexed.
- **author_photo:** retry navigation until the photo hero resolves — a transient photo-GET `onerror` self-heal can leave the letter avatar on first paint under load.

## Test plan
- [x] `journal.spec.ts` 12/12 (incl. the previously-failing marker test)
- [x] `search-palette` + `mini-dock` + `author_photo` 78/78 across 3× repeats; combined CI-style run 38/38
- [x] `cargo fmt --check` clean; `cargo check -p omnibus-frontend` builds
- [x] Confirmed the editor fix in-browser (Enter now yields two `.cm-line`s with correct markdown)

## Version
- [ ] **Patch** — default.

## Notes
- The upload rate limiter (10/60s per IP) can 429 only under artificially heavy load (20 PUTs in ~30s); left untouched — not the CI cause.