### PR TITLE
feat: stats headline tiles (#919, #1027)

### DIFF
--- a/db/src/stats/mod.rs
+++ b/db/src/stats/mod.rs
@@ -129,6 +129,7 @@ async fn compute(
     )
     .await?;
     let sessions = session_count(pool, user_id, start).await?;
+    let avg_stars = avg_stars(pool, user_id, start).await?;
     let heatmap = heatmap(pool, user_id, start).await?;
     let (active_days, longest_streak_days) = streak(pool, user_id, start).await?;
     let (busiest_week_start, busiest_week_seconds) = busiest_week(pool, user_id, start).await?;
@@ -140,6 +141,7 @@ async fn compute(
         range,
         reading_seconds,
         listening_seconds,
+        avg_stars,
         sessions,
         active_days,
         longest_streak_days,
@@ -188,6 +190,20 @@ async fn sum_seconds(
         .bind(start)
         .fetch_one(pool)
         .await?)
+}
+
+/// Mean star rating over books the user rated within the window (keyed on
+/// `user_ratings.updated_at`), in stars — `half_stars` is 1..=10, so the
+/// SQL mean halves it. `None` when nothing was rated in the window.
+async fn avg_stars(pool: &SqlitePool, user_id: i64, start: i64) -> Result<Option<f64>, StatsError> {
+    Ok(sqlx::query_scalar(
+        "SELECT AVG(half_stars) / 2.0 FROM user_ratings
+         WHERE user_id = ? AND updated_at >= ?",
+    )
+    .bind(user_id)
+    .bind(start)
+    .fetch_one(pool)
+    .await?)
 }
 
 async fn session_count(pool: &SqlitePool, user_id: i64, start: i64) -> Result<i64, StatsError> {

--- a/db/src/stats/tests.rs
+++ b/db/src/stats/tests.rs
@@ -98,6 +98,20 @@ async fn link_tag(pool: &SqlitePool, book: i64, name: &str) {
         .unwrap();
 }
 
+async fn rate_book(pool: &SqlitePool, user: i64, uuid: &str, half_stars: i64, updated_at: i64) {
+    sqlx::query(
+        "INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+         VALUES (?, ?, ?, ?)",
+    )
+    .bind(user)
+    .bind(uuid)
+    .bind(half_stars)
+    .bind(updated_at)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
 async fn finish_journal(pool: &SqlitePool, user: i64, uuid: &str, created_at: i64) {
     sqlx::query(
         "INSERT INTO journal_entries (user_id, book_uuid, body_md, progress, created_at)
@@ -283,6 +297,36 @@ async fn cache_serves_within_ttl_and_refreshes_after_expiry() {
         .await
         .unwrap();
     assert_eq!(refreshed.reading_seconds, 1500);
+}
+
+#[tokio::test]
+async fn avg_stars_means_ratings_updated_in_the_window() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 3).await;
+    let user = seed_user(&pool, "alice").await;
+
+    // 8 half-stars (4.0★) and 9 half-stars (4.5★) → mean 4.25★; a rating
+    // updated before the window start must not drag the mean down.
+    rate_book(&pool, user, "uuid-1", 8, T0).await;
+    rate_book(&pool, user, "uuid-2", 9, T0).await;
+    rate_book(&pool, user, "uuid-3", 1, T0 - DAY).await;
+
+    let in_window = avg_stars(&pool, user, T0).await.unwrap();
+    assert_eq!(in_window, Some(4.25));
+
+    let all = avg_stars(&pool, user, 0).await.unwrap();
+    assert_eq!(all, Some(3.0));
+}
+
+#[tokio::test]
+async fn avg_stars_is_none_when_nothing_was_rated() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "loner").await;
+
+    assert_eq!(avg_stars(&pool, user, 0).await.unwrap(), None);
+
+    let s = compute(&pool, user, StatsRange::AllTime).await.unwrap();
+    assert_eq!(s.avg_stars, None);
 }
 
 #[tokio::test]

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -6215,6 +6215,24 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .st-divider-em { font-style: italic; }
 .st-divider-sub { margin: 0; font-size: 12.5px; color: var(--ink-3); }
 
+/* ── Headline metric tiles ────────────────────────────────────────── */
+.st-tiles {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+}
+.st-tile { padding: 16px 16px 14px; }
+.st-tile-value {
+  font-family: var(--serif);
+  font-size: 46px;
+  line-height: 1;
+  color: var(--ink-0);
+}
+.st-tile-accent .st-tile-value { color: var(--accent); }
+.st-tile-unit { font-size: 0.45em; color: var(--ink-3); }
+.st-tile-accent .st-tile-unit { color: var(--accent); }
+.st-tile-label { margin-top: 6px; }
+
 /* ── Scaffold cards (replaced by tiles / heatmap as modules land) ─── */
 .st-summary-card { display: flex; flex-direction: column; gap: 8px; }
 .st-summary-line { font-size: 14px; color: var(--ink-1); }
@@ -6229,4 +6247,10 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   .st-page { padding-top: 8px; }
   .st-seg { display: none; }
   .st-range-trigger { display: inline-flex; }
+
+  /* Tiles collapse to a 2×2 grid; the hero pair (Finished, Avg rating)
+     stays larger, per the converged design. */
+  .st-tiles { grid-template-columns: repeat(2, 1fr); gap: 12px; }
+  .st-tile-value { font-size: 28px; }
+  .st-tile-hero .st-tile-value { font-size: 40px; }
 }

--- a/frontend/src/pages/stats/mod.rs
+++ b/frontend/src/pages/stats/mod.rs
@@ -9,6 +9,10 @@ use omnibus_shared::{StatsRange, StatsSummary};
 use crate::components::{PageError, PageLoading};
 use crate::{data, use_server_url, Route};
 
+mod tiles;
+
+use tiles::HeadlineTiles;
+
 /// The italicized period word in the page title.
 fn period_word(range: StatsRange) -> &'static str {
     match range {
@@ -16,17 +20,6 @@ fn period_word(range: StatsRange) -> &'static str {
         StatsRange::Month => "month",
         StatsRange::Year => "year",
         StatsRange::AllTime => "lifetime",
-    }
-}
-
-/// Compact duration for summary strips: "42 m", "3 h", "3 h 20 m".
-fn format_active_time(secs: i64) -> String {
-    let hours = secs / 3600;
-    let minutes = (secs % 3600) / 60;
-    match (hours, minutes) {
-        (0, m) => format!("{m} m"),
-        (h, 0) => format!("{h} h"),
-        (h, m) => format!("{h} h {m} m"),
     }
 }
 
@@ -82,20 +75,37 @@ pub fn StatsPage() -> Element {
 
 /// Refetch the period-scoped summary whenever the switcher changes. The
 /// signal read inside the effect subscribes it to `range`.
+///
+/// A monotonic `epoch` ticket guards against out-of-order completion: rapid
+/// switcher changes fan out concurrent fetches, and a slower earlier request
+/// must not overwrite a newer range's data. Only the fetch holding the current
+/// ticket applies its result, and a success clears any prior error so a
+/// transient failure can't stick the page in the error state.
 fn use_period_fetch_effect(
     server_url: String,
     range: Signal<StatsRange>,
     period: Signal<Option<StatsSummary>>,
     error: Signal<Option<String>>,
 ) {
+    let mut epoch = use_signal(|| 0u64);
     use_effect(move || {
         let r = range();
+        let ticket = *epoch.peek() + 1;
+        epoch.set(ticket);
         let url = server_url.clone();
         let mut period = period;
         let mut error = error;
         spawn(async move {
-            match data::fetch_stats(&url, r).await {
-                Ok(summary) => period.set(Some(summary)),
+            let result = data::fetch_stats(&url, r).await;
+            // A newer switcher change superseded this fetch — drop the stale result.
+            if *epoch.peek() != ticket {
+                return;
+            }
+            match result {
+                Ok(summary) => {
+                    period.set(Some(summary));
+                    error.set(None);
+                }
                 Err(e) => error.set(Some(e.to_string())),
             }
         });
@@ -195,19 +205,19 @@ fn RangeSheet(range: Signal<StatsRange>, sheet_open: Signal<bool>) -> Element {
     }
 }
 
-/// Period-scoped summary strip — scaffold the metric tiles replace next.
+/// The period-scoped module stack: the headline tile row (a placeholder card
+/// until the first fetch lands).
 #[component]
 fn PeriodSummary(period: Signal<Option<StatsSummary>>) -> Element {
     let guard = period.read();
     let Some(summary) = guard.as_ref() else {
         return rsx! { div { class: "card st-card-placeholder", aria_hidden: "true" } };
     };
-    let sessions = summary.sessions;
-    let time = format_active_time(summary.total_seconds());
     rsx! {
-        div { class: "card st-summary-card", "data-testid": "stats-period-summary",
-            div { class: "label", "This period" }
-            div { class: "st-summary-line mono", "{sessions} sessions \u{00B7} {time}" }
+        HeadlineTiles {
+            books_finished: summary.books_finished,
+            avg_stars: summary.avg_stars,
+            listening_seconds: summary.listening_seconds,
         }
     }
 }
@@ -254,14 +264,5 @@ mod tests {
         assert_eq!(period_word(StatsRange::Month), "month");
         assert_eq!(period_word(StatsRange::Year), "year");
         assert_eq!(period_word(StatsRange::AllTime), "lifetime");
-    }
-
-    #[test]
-    fn format_active_time_covers_minute_hour_and_mixed_spans() {
-        assert_eq!(format_active_time(0), "0 m");
-        assert_eq!(format_active_time(59), "0 m");
-        assert_eq!(format_active_time(42 * 60), "42 m");
-        assert_eq!(format_active_time(3 * 3600), "3 h");
-        assert_eq!(format_active_time(3 * 3600 + 20 * 60), "3 h 20 m");
     }
 }

--- a/frontend/src/pages/stats/tiles.rs
+++ b/frontend/src/pages/stats/tiles.rs
@@ -1,0 +1,134 @@
+//! Headline metric tiles for the stats page: Finished (accent), Avg rating,
+//! Pages (placeholder — no page data exists yet), and Listening. All four are
+//! period-scoped and re-render when the switcher changes.
+
+use dioxus::prelude::*;
+
+/// Value + unit for a duration tile: minutes under an hour, one-decimal
+/// hours under ten, whole hours beyond ("42" m · "3.5" h · "142" h).
+fn duration_value(secs: i64) -> (String, &'static str) {
+    if secs < 3600 {
+        return ((secs / 60).to_string(), "m");
+    }
+    let hours = secs as f64 / 3600.0;
+    if hours < 10.0 {
+        (format!("{hours:.1}"), "h")
+    } else {
+        (format!("{:.0}", hours.floor()), "h")
+    }
+}
+
+/// One-decimal star mean, or the em-dash empty state — never NaN or 0.0.
+/// Rounds half away from zero (explicit `round`) so a quarter-step mean like
+/// 4.25 shows as 4.3, not the 4.2 that `{:.1}`'s round-half-to-even yields.
+fn avg_stars_value(avg: Option<f64>) -> String {
+    match avg {
+        Some(stars) => format!("{:.1}", (stars * 10.0).round() / 10.0),
+        None => "\u{2014}".to_string(),
+    }
+}
+
+/// The four-tile headline row. Finished carries the accent tint; Pages ships
+/// as an em-dash placeholder until a page-count source exists. Takes only the
+/// scalar fields it renders — never the whole `StatsSummary` — so a re-render
+/// doesn't clone the DTO's heatmap / finished-books vectors.
+#[component]
+pub(super) fn HeadlineTiles(
+    books_finished: i64,
+    avg_stars: Option<f64>,
+    listening_seconds: i64,
+) -> Element {
+    let finished = books_finished.to_string();
+    let avg = avg_stars_value(avg_stars);
+    let has_avg = avg_stars.is_some();
+    let (listen_value, listen_unit) = duration_value(listening_seconds);
+    rsx! {
+        div { class: "st-tiles",
+            StatTile {
+                value: finished,
+                unit: None,
+                label: "Finished",
+                accent: true,
+                hero: true,
+                testid: "stats-tile-finished",
+            }
+            StatTile {
+                value: avg,
+                unit: if has_avg { Some(" \u{2605}".to_string()) } else { None },
+                label: "Avg rating",
+                accent: false,
+                hero: true,
+                testid: "stats-tile-avg-rating",
+            }
+            StatTile {
+                value: "\u{2014}",
+                unit: None,
+                label: "Pages",
+                accent: false,
+                hero: false,
+                testid: "stats-tile-pages",
+            }
+            StatTile {
+                value: listen_value,
+                unit: Some(listen_unit.to_string()),
+                label: "Listening",
+                accent: false,
+                hero: false,
+                testid: "stats-tile-listening",
+            }
+        }
+    }
+}
+
+/// One metric tile: a big serif number (with an optional smaller unit) over
+/// a micro-label. `hero` sizes the phone layout's top pair larger.
+#[component]
+fn StatTile(
+    value: String,
+    unit: Option<String>,
+    label: &'static str,
+    accent: bool,
+    hero: bool,
+    testid: &'static str,
+) -> Element {
+    let mut class = String::from("card st-tile");
+    if accent {
+        class.push_str(" st-tile-accent");
+    }
+    if hero {
+        class.push_str(" st-tile-hero");
+    }
+    rsx! {
+        div { class: "{class}", "data-testid": testid,
+            div { class: "st-tile-value",
+                {value}
+                if let Some(u) = unit {
+                    span { class: "st-tile-unit", {u} }
+                }
+            }
+            div { class: "label st-tile-label", {label} }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_value_scales_minutes_decimal_hours_and_whole_hours() {
+        assert_eq!(duration_value(0), ("0".into(), "m"));
+        assert_eq!(duration_value(42 * 60), ("42".into(), "m"));
+        assert_eq!(duration_value(3 * 3600 + 1800), ("3.5".into(), "h"));
+        assert_eq!(duration_value(142 * 3600 + 120), ("142".into(), "h"));
+    }
+
+    #[test]
+    fn avg_stars_value_rounds_half_up_to_one_decimal_or_em_dash() {
+        // 4.25 rounds half away from zero → 4.3 (not {:.1}'s half-to-even 4.2).
+        assert_eq!(avg_stars_value(Some(4.25)), "4.3");
+        assert_eq!(avg_stars_value(Some(4.24)), "4.2");
+        assert_eq!(avg_stars_value(Some(5.0)), "5.0");
+        assert_eq!(avg_stars_value(None), "\u{2014}");
+    }
+}

--- a/server/src/backend/stats/tests.rs
+++ b/server/src/backend/stats/tests.rs
@@ -1,9 +1,7 @@
-//! Tests for the reading-stats REST handler.
-//!
-//! The `db::stats` cache is process-wide and keyed on `(user_id, range)`,
-//! and every fixture pool restarts user ids at 1 — so each content-asserting
-//! test here must use a distinct range to keep its cache key unique across
-//! the test binary.
+//! Tests for the reading-stats REST handler. The `db::stats` cache is
+//! process-wide and keyed on `(user_id, range)`, and every fixture pool
+//! restarts user ids at 1 — so each content-asserting test uses a distinct
+//! range to keep its cache key unique across the test binary.
 
 use axum::{
     body::{to_bytes, Body},

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -86,11 +86,16 @@ pub struct FinishedBook {
 /// progress fraction persisted today) rather than the session tables, which
 /// carry duration but no progress; a first-class read/unread state (#980)
 /// feeds the same field once it lands.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct StatsSummary {
     pub range: StatsRange,
     pub reading_seconds: i64,
     pub listening_seconds: i64,
+    /// Mean of the user's star ratings (0.5..=5.0) over books rated within
+    /// the window; `None` when nothing was rated. `f64` keeps the struct
+    /// `PartialEq`-only.
+    #[serde(default)]
+    pub avg_stars: Option<f64>,
     pub sessions: i64,
     pub active_days: i64,
     pub longest_streak_days: i64,

--- a/shared/src/stats/tests.rs
+++ b/shared/src/stats/tests.rs
@@ -41,6 +41,19 @@ fn range_defaults_to_month_and_serializes_snake_case() {
 }
 
 #[test]
+fn avg_stars_defaults_to_none_when_absent_from_the_wire() {
+    // Older payloads predate the field; serde(default) keeps them parseable.
+    let s: StatsSummary = serde_json::from_str(
+        r#"{"range":"month","reading_seconds":0,"listening_seconds":0,"sessions":0,
+            "active_days":0,"longest_streak_days":0,"busiest_week_start":null,
+            "busiest_week_seconds":0,"books_finished":0,"heatmap":[],
+            "top_authors":[],"top_tags":[],"finished_books":[]}"#,
+    )
+    .unwrap();
+    assert_eq!(s.avg_stars, None);
+}
+
+#[test]
 fn as_query_matches_the_serde_wire_name() {
     for range in StatsRange::ALL {
         let wire = serde_json::to_string(&range).unwrap();

--- a/ui_tests/playwright/tests/flows/stats.spec.ts
+++ b/ui_tests/playwright/tests/flows/stats.spec.ts
@@ -27,19 +27,33 @@ test.beforeAll(async ({ request }) => {
   const uuid = await fetchBookUuidByTitle(request, FIXTURE_BOOKS[0].title);
 
   const now = Math.floor(Date.now() / 1000);
-  const session = (startedAt: number, secs: number) => ({
+  const session = (startedAt: number, secs: number, format: "epub" | "audio") => ({
     book_uuid: uuid,
-    format: "epub",
+    format,
     started_at: startedAt,
     ended_at: startedAt + secs,
     progress_units: secs,
   });
   const resp = await request.post("/api/progress/sessions", {
-    data: [session(now - 60, 600), session(OLD_SESSION_AT, 900)],
+    data: [
+      session(now - 60, 600, "epub"),
+      session(OLD_SESSION_AT, 900, "epub"),
+      session(now - 120, 900, "audio"),
+    ],
   });
   expect(resp.status(), "seeding stats sessions failed").toBe(200);
   const body = (await resp.json()) as { recorded: number };
-  expect(body.recorded, "session seeds were skipped").toBe(2);
+  expect(body.recorded, "session seeds were skipped").toBe(3);
+
+  // Feed the headline tiles: a star rating and a finished (100%) journal.
+  const rating = await request.post("/api/ratings", {
+    data: { book_uuid: uuid, stars: 4.5 },
+  });
+  expect(rating.status(), "seeding a rating failed").toBe(200);
+  const journal = await request.post("/api/journals", {
+    data: { book_uuid: uuid, body_md: "Finished it — stats spec seed.", progress: 100 },
+  });
+  expect(journal.status(), "seeding a finished journal failed").toBe(200);
 });
 
 test("renders the stats page layout", async ({ page }) => {
@@ -63,6 +77,19 @@ test("renders the stats page layout", async ({ page }) => {
   await expect(page.getByTestId("stats-period-section")).toBeVisible();
   await expect(page.getByText("Not tied to the period above.")).toBeVisible();
   await expect(page.getByTestId("stats-alltime-section")).toBeVisible();
+});
+
+test("headline tiles render finished, avg rating, pages, and listening", async ({ page }) => {
+  await gotoReady(page, "/stats");
+
+  // Values are asserted by shape, not exact numbers — other specs sharing the
+  // test user can add sessions/ratings/journals; the arithmetic is covered by
+  // the db::stats unit tests.
+  await expect(page.getByTestId("stats-tile-finished")).toContainText(/\d/);
+  await expect(page.getByTestId("stats-tile-finished")).toContainText("Finished");
+  await expect(page.getByTestId("stats-tile-avg-rating")).toContainText(/\d\.\d\s*★/);
+  await expect(page.getByTestId("stats-tile-pages")).toContainText("—");
+  await expect(page.getByTestId("stats-tile-listening")).toContainText(/\d+\s*(m|h)/);
 });
 
 test("switching the period re-queries and updates the period section", async ({ page }) => {


### PR DESCRIPTION
## Summary
Closes #919, closes #1027. Second PR of the Reading Stats train (#916), stacked on #1028 — the period-scoped summary strip becomes the converged design's headline tile row: **Finished (accent) · Avg rating · Pages · Listening**.

- `db::stats` gains an `avg_stars` aggregation (mean of `user_ratings.half_stars` updated in the window, halved to stars); `StatsSummary` carries it as `Option<f64>` and drops `Eq` per the shared-types rule.
- New `frontend/src/pages/stats/tiles.rs`: 4-tile grid (2×2 with a larger hero pair on phone widths), em-dash degradation for no-rating and the Pages placeholder.
- Pages has no data source (sessions carry seconds only) — the tile ships as a placeholder; sourcing is #1029.

>[!NOTE]
> Per the converged design there is no finished-books rail on the page — the finished list arrives with the #1025 drill-in. Divergence noted on #919.

## Test plan
- [x] `just lint` + `just test` — full matrix green.
- [x] `db::stats` tests: windowed mean, pre-window ratings excluded, none-rated → `None`; shared wire-compat test for the defaulted field.
- [x] `stats.spec.ts` 5/5 — new tiles test rides seeded rating + finished journal + audio session.
- [x] Verified in-browser: tile row renders 1 / 4.5★ / — / 15m, no hydration console errors.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)