### PR TITLE
docs: update PR template and README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 <!--
 Generally, patch versions are sufficient. Minor versions should only be used in
-two different cases:
+one of the following different cases:
 1. There was a change that will not allow older versions of the mobile app to 
 work with the new server version.
 2. There was a fairly large UX change (i.e. a roadmap feature was complete).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,15 @@
 ## Test plan
 - [ ] 
 
+<!--
+Generally, patch versions are sufficient. Minor versions should only be used in
+two different cases:
+1. There was a change that will not allow older versions of the mobile app to 
+work with the new server version.
+2. There was a fairly large UX change (i.e. a roadmap feature was complete).
+3. There was a large architectural shift introduced in the PR.
+-->
+
 ## Version
 By default a merge to `main` cuts a patch release. Pick the version update this
 PR should trigger; labels override the default:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Built with Rust ([Axum](https://github.com/tokio-rs/axum) + [Dioxus](https://dio
 </div>
 
 > [!NOTE]
-> **Status: early development.** Foundations and browse/discovery have shipped;
+> **This is in active development.** Foundations and browse/discovery have shipped;
 > reading/listening is in progress. The landing grid/table, EPUB reader,
 > audiobook player, command-palette search, auth, and author/series/tag
-> discovery are live. See the [roadmap](docs/roadmap/0-0-summary.md) for what's
+> discovery are live. See the [roadmap](https://github.com/users/seamus-sloan/projects/2) for what's
 > next.
 
 ## Features
@@ -184,7 +184,8 @@ npm install                 # first time only; do NOT run `npx playwright instal
 npx playwright test
 ```
 
-*Mobile UI tests will land later using [MobileWright](https://mobilewright.dev/).*
+Mobile tests are using [Maestro](https://maestro.dev/) to allow for writing a test once
+and being able to validate on both operating systems.
 
 ## Project layout
 
@@ -203,8 +204,3 @@ Deeper architecture — module maps, request-flow diagrams, mobile-auth — is i
 under [.claude/](.claude/) (dev environment, error handling, testing, migrations,
 style).
 
-## Roadmap
-
-See [docs/roadmap/0-0-summary.md](docs/roadmap/0-0-summary.md) for the phased plan
-— foundations, browse/discovery, reading/listening, personalization, device sync,
-admin, and mobile.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Built with Rust ([Axum](https://github.com/tokio-rs/axum) + [Dioxus](https://dio
 > **This is in active development.** Foundations and browse/discovery have shipped;
 > reading/listening is in progress. The landing grid/table, EPUB reader,
 > audiobook player, command-palette search, auth, and author/series/tag
-> discovery are live. See the [roadmap](https://github.com/users/seamus-sloan/projects/2) for what's
-> next.
+> discovery are live. See the [roadmap](https://github.com/users/seamus-sloan/projects/2/views/9) for what's next.
 
 ## Features
 
@@ -185,7 +184,7 @@ npx playwright test
 ```
 
 Mobile tests are using [Maestro](https://maestro.dev/) to allow for writing a test once
-and being able to validate on both operating systems.
+validating on both operating systems.
 
 ## Project layout
 


### PR DESCRIPTION
## Summary
- Updates the PR description to add a comment for Claude to read when opening PRs
- Updated the repo README with a link to the roadmap in the [Omnibus project](https://github.com/users/seamus-sloan/projects/2/views/9)

## Test plan
- [N/A 

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- 

<!--
Use the following for callouts:

>[!NOTE]
> Blue message!

>[!WARNING]
> Yello message!

>[!IMPORTANT]
> Purple message!

>[!CAUTION]
> Red message!

>[!TIP]
> Green message!
-->
