### PR TITLE
fix: disable maestro for now

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -9,23 +9,23 @@ name: Mobile E2E
 # `GET /api/_health` — a server or boot regression can fail these runs even when
 # nothing mobile changed.
 on:
-  push:
-    branches: [main]
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - "mobile/**"
-      - "frontend/**"
-      - "shared/**"
-      - "server/**"
-      - "db/**"
-      - "ui_tests/maestro/**"
-      - "**/Cargo.toml"
-      - "Cargo.lock"
-      - "**/Dioxus.toml"
-      - "flake.lock"
-      - "flake.nix"
-      - ".github/workflows/mobile-e2e.yml"
+#  push:
+#    branches: [main]
+#  pull_request:
+#    types: [opened, synchronize, reopened]
+#    paths:
+#      - "mobile/**"
+#      - "frontend/**"
+#      - "shared/**"
+#      - "server/**"
+#      - "db/**"
+#      - "ui_tests/maestro/**"
+#      - "**/Cargo.toml"
+#      - "Cargo.lock"
+#      - "**/Dioxus.toml"
+#      - "flake.lock"
+#      - "flake.nix"
+#      - ".github/workflows/mobile-e2e.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Maestro is a 20+ minute workflow that leaves a red CI mark on PRs.
- Needs to be cleaned up before we can use it accurately. 
- Look at #1034 and #1035

## Test plan
- N/A

<!--
Generally, patch versions are sufficient. Minor versions should only be used in
one of the following different cases:
1. There was a change that will not allow older versions of the mobile app to 
work with the new server version.
2. There was a fairly large UX change (i.e. a roadmap feature was complete).
3. There was a large architectural shift introduced in the PR.
-->

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- 

<!--
Use the following for callouts:

>[!NOTE]
> Blue message!

>[!WARNING]
> Yello message!

>[!IMPORTANT]
> Purple message!

>[!CAUTION]
> Red message!

>[!TIP]
> Green message!
-->
