### PR TITLE
feat: own the tracing subscriber + readable request logs (#1039)

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -78,6 +78,8 @@ Key vars (see `.env.example` for the full annotated list):
 - `HARDCOVER_API_KEY` — account-level Hardcover Bearer token for F3.3 "Readers also enjoyed" suggestions. Unlike the library paths, the **Settings page is the source of truth**: the `seed_hardcover_key_from_env` boot hook seeds this value only when none is saved (settings wins thereafter), and `effective_hardcover_api_key` falls back to it when settings is empty. Server-wide, never per-user; leave unset to keep suggestions disabled.
 - `SMTP_HOST` / `SMTP_PORT` / `SMTP_SECURITY` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_FROM_EMAIL` — F4.3 Send-to-Kindle SMTP relay. Same source-of-truth model as the Hardcover key: `seed_smtp_from_env` seeds the config only when no host is saved (Settings page wins thereafter), and `effective_smtp_config` falls back to the env vars when settings is empty. `SMTP_HOST` + `SMTP_FROM_EMAIL` are required; port defaults to 587 and security to `starttls` (`tls` for implicit TLS on 465). Server-wide; leave unset to keep Send-to-Kindle disabled. (A user's own `kindle_email` lives per-account on the `/account` page, not here.)
 
+- `RUST_LOG` — console log filter (tracing `EnvFilter` syntax). The server owns its subscriber (`init_tracing` in `server/src/main.rs`), so this works under both `cargo run -p omnibus` and `dx serve`. Default when unset: `info,omnibus=debug` — one INFO line per HTTP request (method, path, status, latency; query strings never logged).
+
 **Security-sensitive (never set casually in production):**
 
 - `OMNIBUS_INITIAL_ADMIN=username` — promotes the named user to admin on **every** boot while set. One-time account recovery only — UNSET IMMEDIATELY AFTER USE.

--- a/.env.example
+++ b/.env.example
@@ -169,3 +169,10 @@ OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
 #
 # Resize the shared sccache cache (default 20G). Accepts sccache size suffixes.
 #SCCACHE_CACHE_SIZE=20G
+
+# ── Logging ────────────────────────────────────────────────────────────────
+# Console log filter (standard tracing EnvFilter syntax). The server owns its
+# tracing subscriber, so this works with `cargo run -p omnibus` and `dx serve`
+# alike. Default when unset: info,omnibus=debug — one INFO line per HTTP
+# request (method, path, status, latency; query strings never logged).
+#RUST_LOG=debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4102,6 +4102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4362,6 +4371,7 @@ dependencies = [
  "tower",
  "tower-http 0.7.0",
  "tracing",
+ "tracing-subscriber",
  "wiremock",
 ]
 
@@ -6923,6 +6933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -6936,18 +6947,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7149,6 +7174,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,6 +26,9 @@ serde_json = { workspace = true, optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"], optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"], optional = true }
 tracing = { workspace = true, optional = true }
+# Owns the global subscriber (RUST_LOG-driven console logs); installed before
+# `dioxus::serve` so dioxus-logger's default subscriber never takes over.
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 time = { version = "0.3", optional = true }
 # Re-exported by dioxus::serve as the return error type, and used by the
 # native startup helpers in main.rs that previously lived inside an inline
@@ -70,6 +73,7 @@ server = [
     "dep:sqlx",
     "dep:tokio",
     "dep:tracing",
+    "dep:tracing-subscriber",
     "dep:time",
     "dep:anyhow",
     "dep:tempfile",

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -44,8 +44,15 @@ mod server {
     pub(crate) fn init_tracing() {
         use tracing_subscriber::EnvFilter;
 
-        let filter = EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| EnvFilter::new("info,omnibus=debug"));
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|err| {
+            // try_from_default_env also errs when RUST_LOG is simply unset —
+            // only an actually-set-but-unparsable value deserves a warning.
+            // eprintln because no subscriber exists yet to carry the event.
+            if std::env::var_os("RUST_LOG").is_some() {
+                eprintln!("invalid RUST_LOG ({err}); falling back to default log filter");
+            }
+            EnvFilter::new("info,omnibus=debug")
+        });
         // try_init over init: a second subscriber (e.g. in tests) is a no-op,
         // not a panic.
         tracing_subscriber::fmt()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
 
     #[cfg(feature = "server")]
     {
+        server::init_tracing();
         dioxus::serve(server::launch);
     }
 }
@@ -35,6 +36,24 @@ mod server {
     use sqlx::SqlitePool;
 
     use crate::App;
+
+    /// Install the global tracing subscriber. Must run before `dioxus::serve`,
+    /// which otherwise installs dioxus-logger's default subscriber with a
+    /// fixed filter that ignores `RUST_LOG`. `RUST_LOG` wins when set; the
+    /// fallback keeps omnibus events visible without dependency noise.
+    pub(crate) fn init_tracing() {
+        use tracing_subscriber::EnvFilter;
+
+        let filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new("info,omnibus=debug"));
+        // try_init over init: a second subscriber (e.g. in tests) is a no-op,
+        // not a panic.
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .compact()
+            .try_init()
+            .ok();
+    }
 
     /// Entry point handed to `dioxus::serve`: boots the stack and returns the wired Axum `Router`.
     pub(crate) async fn launch() -> anyhow::Result<Router> {
@@ -249,17 +268,21 @@ mod server {
         // body-limit guards above. Span logs only the path, never the query
         // string: media reads carry the session as `?token=`, and the default
         // span records the full URI — which would leak live tokens into logs.
+        // The span and the on-response event sit at INFO so the default
+        // filter yields one line per request (method, path, status, latency).
         router.layer(
-            tower_http::trace::TraceLayer::new_for_http().make_span_with(
-                |req: &axum::http::Request<_>| {
-                    tracing::debug_span!(
+            tower_http::trace::TraceLayer::new_for_http()
+                .make_span_with(|req: &axum::http::Request<_>| {
+                    tracing::info_span!(
                         "request",
                         method = %req.method(),
                         path = %req.uri().path(),
                         version = ?req.version(),
                     )
-                },
-            ),
+                })
+                .on_response(
+                    tower_http::trace::DefaultOnResponse::new().level(tracing::Level::INFO),
+                ),
         )
     }
 }


### PR DESCRIPTION
## Summary
- Install our own `tracing_subscriber` (compact fmt + `EnvFilter`) in `main()` before `dioxus::serve`, so `RUST_LOG` actually controls output instead of dioxus-logger's fixed default.
- Promote the `TraceLayer` request span to INFO and add an INFO `on_response` line — one line per request with method, path, status, latency (path only; query strings still never logged).
- Document `RUST_LOG` in `.env.example` and rule 01.

Closes #1039.

## Test plan
- [x] `cargo run -p omnibus` + curl: one INFO line per request incl. status/latency; `?token=…` absent from logs (AC1).
- [x] `RUST_LOG=debug` rerun: request-start/eos DEBUG lines appear (AC2); default filter hides them.
- [x] `cargo fmt` + `cargo clippy -p omnibus` clean.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.