### PR TITLE
fix: marquee long audiobook titles in player header (#1001)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5788,12 +5788,16 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .atrium .m-player-title {
   font-family: var(--serif); font-weight: 400; font-size: 26px;
   line-height: 1.05; margin-top: 10px;
-  overflow: hidden; white-space: nowrap;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
 }
 /* `.m-marquee-track` is always the same size as its text; `--m-marquee-distance`
    (set in JS from the measured overflow) is only consumed once `.m-marquee-active`
-   is toggled on, so a title that fits never animates. */
+   is toggled on, so a title that fits never animates and stays centered like the
+   rest of `.m-player-now`. Active titles switch to left-aligned so the resting
+   (`translateX(0)`) frame actually shows the start of the title instead of the
+   browser's default centering clipping an equal slice off each edge. */
 .m-player-title .m-marquee-track { display: inline-block; }
+.m-player-title.m-marquee-active { text-align: left; }
 .m-player-title.m-marquee-active .m-marquee-track {
   animation: m-marquee-scroll 7s ease-in-out infinite alternate;
 }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5788,6 +5788,21 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .atrium .m-player-title {
   font-family: var(--serif); font-weight: 400; font-size: 26px;
   line-height: 1.05; margin-top: 10px;
+  overflow: hidden; white-space: nowrap;
+}
+/* `.m-marquee-track` is always the same size as its text; `--m-marquee-distance`
+   (set in JS from the measured overflow) is only consumed once `.m-marquee-active`
+   is toggled on, so a title that fits never animates. */
+.m-player-title .m-marquee-track { display: inline-block; }
+.m-player-title.m-marquee-active .m-marquee-track {
+  animation: m-marquee-scroll 7s ease-in-out infinite alternate;
+}
+@keyframes m-marquee-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(var(--m-marquee-distance, 0px)); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .m-player-title.m-marquee-active .m-marquee-track { animation: none; }
 }
 .m-player-by { margin-top: 8px; color: var(--ink-1); font-size: 14px; }
 .m-player-chline {

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5788,17 +5788,25 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .atrium .m-player-title {
   font-family: var(--serif); font-weight: 400; font-size: 26px;
   line-height: 1.05; margin-top: 10px;
-  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+  overflow: hidden; white-space: nowrap;
 }
-/* `.m-marquee-track` is always the same size as its text; `--m-marquee-distance`
-   (set in JS from the measured overflow) is only consumed once `.m-marquee-active`
-   is toggled on, so a title that fits never animates and stays centered like the
-   rest of `.m-player-now`. Active titles switch to left-aligned so the resting
-   (`translateX(0)`) frame actually shows the start of the title instead of the
-   browser's default centering clipping an equal slice off each edge. */
-.m-player-title .m-marquee-track { display: inline-block; }
+/* `text-overflow: ellipsis` on the parent doesn't ellipsize an atomic
+   inline-block child, so the track ellipsizes itself, bounded to the
+   parent's width; the active (marquee) state lifts that bound so the track
+   can render its full natural (overflowing) width for the animation.
+   `--m-marquee-distance` (set in JS from the measured overflow) is only
+   consumed once `.m-marquee-active` is toggled on, so a title that fits
+   never animates and stays centered like the rest of `.m-player-now`.
+   Active titles switch to left-aligned so the resting (`translateX(0)`)
+   frame actually shows the start of the title instead of the browser's
+   default centering clipping an equal slice off each edge. */
+.m-player-title .m-marquee-track {
+  display: inline-block; max-width: 100%; overflow: hidden;
+  text-overflow: ellipsis; vertical-align: top;
+}
 .m-player-title.m-marquee-active { text-align: left; }
 .m-player-title.m-marquee-active .m-marquee-track {
+  max-width: none; overflow: visible;
   animation: m-marquee-scroll 7s ease-in-out infinite alternate;
 }
 @keyframes m-marquee-scroll {

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -173,10 +173,12 @@ fn persist_position(uuid: &str, server_url: &str, seconds: f64) {
 /// fits the header width, a slow back-and-forth scroll when it doesn't
 /// (issue #1001 AC1/AC2). The actual overflow check runs in JS on mount
 /// since it needs a real layout measurement (`scrollWidth` vs `clientWidth`)
-/// that isn't available at render time.
+/// that isn't available at render time. `id` gives the eval a stable,
+/// single-element lookup instead of a page-wide class scan.
 fn player_title(title: &str) -> Element {
     rsx! {
         h1 {
+            id: "m-player-title",
             class: "m-player-title",
             onmounted: move |_| check_title_marquee(),
             span { class: "m-marquee-track", span { class: "m-em", "{title}" } }
@@ -184,24 +186,36 @@ fn player_title(title: &str) -> Element {
     }
 }
 
-/// Toggle `.m-marquee-active` (and the scroll distance custom property) on
-/// every `.m-player-title` whose track overflows its header width; a title
-/// that already fits is left untouched. Fire-and-forget, mirroring the
-/// `fire()` evals in `mobile::interop`.
+/// Arm the marquee on `#m-player-title` if its track overflows the header
+/// width, else leave it static. Installs `window.OmnibusMarqueeCheck` once
+/// (idempotent — `eval` reruns on every mount) so a `resize`/rotation event
+/// re-evaluates the same element instead of going stale, and re-checks after
+/// `document.fonts.ready` since the serif webfont can still be swapping in
+/// when the first (mount-time) measurement runs. The 12px pad keeps the
+/// last character from sitting exactly flush against the clipped edge.
 fn check_title_marquee() {
-    let _ = dioxus::document::eval(
-        "document.querySelectorAll('.m-player-title').forEach(function (el) { \
-           var track = el.querySelector('.m-marquee-track'); \
-           if (!track) return; \
-           var overflow = track.scrollWidth - el.clientWidth; \
-           if (overflow > 1) { \
-             el.style.setProperty('--m-marquee-distance', (-overflow - 12) + 'px'); \
-             el.classList.add('m-marquee-active'); \
-           } else { \
-             el.classList.remove('m-marquee-active'); \
-             el.style.removeProperty('--m-marquee-distance'); \
-           } \
-         });",
+    interop::fire(
+        "if (!window.OmnibusMarqueeCheck) { \
+           window.OmnibusMarqueeCheck = function () { \
+             var el = document.getElementById('m-player-title'); \
+             if (!el) return; \
+             var track = el.querySelector('.m-marquee-track'); \
+             if (!track) return; \
+             var overflow = track.scrollWidth - el.clientWidth; \
+             if (overflow > 1) { \
+               el.style.setProperty('--m-marquee-distance', (-overflow - 12) + 'px'); \
+               el.classList.add('m-marquee-active'); \
+             } else { \
+               el.classList.remove('m-marquee-active'); \
+               el.style.removeProperty('--m-marquee-distance'); \
+             } \
+           }; \
+           window.addEventListener('resize', window.OmnibusMarqueeCheck); \
+         } \
+         window.OmnibusMarqueeCheck(); \
+         if (document.fonts && document.fonts.ready) { \
+           document.fonts.ready.then(window.OmnibusMarqueeCheck); \
+         }",
     );
 }
 

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -169,6 +169,42 @@ fn persist_position(uuid: &str, server_url: &str, seconds: f64) {
     });
 }
 
+/// Player title with an overflow-triggered marquee: static when the title
+/// fits the header width, a slow back-and-forth scroll when it doesn't
+/// (issue #1001 AC1/AC2). The actual overflow check runs in JS on mount
+/// since it needs a real layout measurement (`scrollWidth` vs `clientWidth`)
+/// that isn't available at render time.
+fn player_title(title: &str) -> Element {
+    rsx! {
+        h1 {
+            class: "m-player-title",
+            onmounted: move |_| check_title_marquee(),
+            span { class: "m-marquee-track", span { class: "m-em", "{title}" } }
+        }
+    }
+}
+
+/// Toggle `.m-marquee-active` (and the scroll distance custom property) on
+/// every `.m-player-title` whose track overflows its header width; a title
+/// that already fits is left untouched. Fire-and-forget, mirroring the
+/// `fire()` evals in `mobile::interop`.
+fn check_title_marquee() {
+    let _ = dioxus::document::eval(
+        "document.querySelectorAll('.m-player-title').forEach(function (el) { \
+           var track = el.querySelector('.m-marquee-track'); \
+           if (!track) return; \
+           var overflow = track.scrollWidth - el.clientWidth; \
+           if (overflow > 1) { \
+             el.style.setProperty('--m-marquee-distance', (-overflow - 12) + 'px'); \
+             el.classList.add('m-marquee-active'); \
+           } else { \
+             el.classList.remove('m-marquee-active'); \
+             el.style.removeProperty('--m-marquee-distance'); \
+           } \
+         });",
+    );
+}
+
 fn render_error(msg: &str) -> Element {
     rsx! {
         div { class: "m-player-msg",
@@ -206,7 +242,7 @@ fn render_unsupported(
                 }
             }
             div { class: "m-player-now",
-                h1 { class: "m-player-title", span { class: "m-em", "{view.title}" } }
+                {player_title(&view.title)}
                 div { class: "m-player-by", "by {view.author}" }
             }
             div { class: "m-player-msg",
@@ -342,7 +378,7 @@ fn render_player(p: PlayerProps) -> Element {
                 div { class: "label m-player-eyebrow",
                     "Now playing \u{00b7} Chapter {chapter_no} of {chapter_count}"
                 }
-                h1 { class: "m-player-title", span { class: "m-em", "{view.title}" } }
+                {player_title(&view.title)}
                 div { class: "m-player-by", "by {view.author}" }
                 if has_chapters {
                     div { class: "m-player-chline", "Ch. {chapter_no} \u{00b7} {chapter_title}" }

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -169,12 +169,8 @@ fn persist_position(uuid: &str, server_url: &str, seconds: f64) {
     });
 }
 
-/// Player title with an overflow-triggered marquee: static when the title
-/// fits the header width, a slow back-and-forth scroll when it doesn't
-/// (issue #1001 AC1/AC2). The actual overflow check runs in JS on mount
-/// since it needs a real layout measurement (`scrollWidth` vs `clientWidth`)
-/// that isn't available at render time. `id` gives the eval a stable,
-/// single-element lookup instead of a page-wide class scan.
+/// Player title with an overflow-triggered marquee (static unless the title
+/// overflows its header width). `id` scopes the mount-time JS check.
 fn player_title(title: &str) -> Element {
     rsx! {
         h1 {
@@ -186,13 +182,10 @@ fn player_title(title: &str) -> Element {
     }
 }
 
-/// Arm the marquee on `#m-player-title` if its track overflows the header
-/// width, else leave it static. Installs `window.OmnibusMarqueeCheck` once
-/// (idempotent — `eval` reruns on every mount) so a `resize`/rotation event
-/// re-evaluates the same element instead of going stale, and re-checks after
-/// `document.fonts.ready` since the serif webfont can still be swapping in
-/// when the first (mount-time) measurement runs. The 12px pad keeps the
-/// last character from sitting exactly flush against the clipped edge.
+/// Toggle the marquee on `#m-player-title` by measured overflow. Installs a
+/// guarded `window.OmnibusMarqueeCheck` so `resize` and `document.fonts.ready`
+/// (the serif webfont can still be swapping in at mount) both re-measure
+/// instead of only the initial, possibly-stale layout.
 fn check_title_marquee() {
     interop::fire(
         "if (!window.OmnibusMarqueeCheck) { \

--- a/frontend/src/pages/listen/mobile/interop.rs
+++ b/frontend/src/pages/listen/mobile/interop.rs
@@ -138,7 +138,7 @@ pub fn set_rate(rate: f64) {
 }
 
 /// Fire-and-forget control eval (no event stream).
-fn fire(js: &str) {
+pub(crate) fn fire(js: &str) {
     let _ = dioxus::document::eval(js);
 }
 


### PR DESCRIPTION
## Summary
- On the full mobile player screen, a long audiobook title just wrapped/clipped statically in `h1.m-player-title` — there was no way to read the full title.
- Adds an overflow-triggered marquee: `player_title()` (`frontend/src/pages/listen/mobile.rs`) wraps the title in a `span.m-marquee-track`, and a JS check (`check_title_marquee`, reusing `mobile::interop::fire`) measures `scrollWidth` vs `clientWidth` on mount, arming a CSS `translateX` back-and-forth scroll (`m-marquee-active` + `--m-marquee-distance`) only when the title actually overflows — a title that fits stays exactly as it rendered before (AC1/AC2).
- Both call sites (`render_unsupported`'s hero state and `render_player`'s loaded state) go through the same `player_title()` helper.

### Fixed during self-review
An adversarial review pass (3 independent finder agents) against the initial implementation caught real bugs, folded into a second commit:
- `.m-player-now`'s inherited `text-align: center` meant the marquee's resting `translateX(0)` frame was already centered — it clipped an equal slice off *both* edges of the title instead of showing the true start. Now left-aligns only while `.m-marquee-active` is set, so a fitting (non-animating) title's layout is unchanged.
- `.m-player-title` had no `text-overflow: ellipsis` fallback, so if the JS check hasn't run yet (or fails) a long title hard-clips mid-character instead of degrading gracefully like every other truncated-title rule in `atrium.css`.
- The overflow measurement ran once on mount with no re-check — it could race the async serif webfont swap and never updated on rotation/resize. Now installs a guarded `window.OmnibusMarqueeCheck`, re-run after `document.fonts.ready` and on `resize`.
- Reused the existing `mobile::interop::fire()` eval helper (promoted `fire` to `pub(crate)`) instead of a duplicate raw `dioxus::document::eval` call, and scoped the JS lookup to `#m-player-title` instead of a page-wide `.m-player-title` class scan.

### Known gaps (flagging, not fixing — out of scope for this issue)
- The docked **mini-player** title (`m-mini-title` in `frontend/src/pages/listen/mobile/mini.rs`) has the same long-title problem but still just ellipsis-truncates with no marquee — issue #1001 scopes this to "the full player screen" only. Worth a follow-up issue if desired.
- No RTL/`dir` handling — the scroll direction is hardcoded to reveal a left-to-right title's tail. No other component in this codebase handles RTL today, so this isn't a regression, just an unaddressed gap.
- **No E2E coverage.** `frontend/src/pages/listen/mobile.rs` is `#[cfg(feature = "mobile")]` — a native WKWebView page, not reachable by Playwright (rule 04: Playwright reaches Android WebView but not iOS WKWebView). The repo's Mobile E2E (Maestro) workflow's `pull_request`/`push` triggers are currently commented out in `.github/workflows/mobile-e2e.yml` (manual `workflow_dispatch` only), and this sandbox has no booted iOS/Android simulator to run Maestro locally. Verification here is: `cargo test -p omnibus-frontend --features mobile` (230 passing, none targeting this new markup — no existing precedent in this crate for rendering a plain `fn(...) -> Element` to a string and asserting on markup, so adding that harness felt like its own architectural decision rather than part of this bug fix), plus careful code-level reasoning about the CSS/JS behavior (see review section above) and manual reasoning through both animation frames. A real device/simulator check before merge would be worthwhile.

## Test plan
- [x] `cargo fmt --check` (`-p omnibus-frontend`) — clean
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — clean
- [x] `cargo clippy --all-targets -- -D warnings` (default members) — clean
- [x] `cargo test -p omnibus-frontend --features mobile` — 230 passed
- [x] `cargo test -p omnibus-frontend --features server` — 259 passed
- [x] `npx stylelint --config .stylelintrc.json frontend/assets/atrium.css` — clean
- [ ] Not run in this sandbox (no Nix/`dx`/simulator toolchain available): a live Maestro run against a booted iOS simulator. Mobile E2E CI is currently `workflow_dispatch`-only (see gaps above), so this didn't get an automated real-device check either.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- No migrations, no schema changes, no new dependencies.
- No Dioxus prop signature changes; both existing call sites were updated to the new `player_title()` helper with no other behavior change.