### PR TITLE
fix: marquee long audiobook titles on the mobile player (#1001)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5803,7 +5803,13 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   50%, 62% { transform: translateX(var(--marquee-shift, 0)); }
   100% { transform: translateX(0); }
 }
+/* Reduced motion drops the animation but must not trade it for permanently
+   clipped text — let an overflowing title wrap onto multiple lines instead
+   so it's still fully readable without scrolling. */
 @media (prefers-reduced-motion: reduce) {
+  .atrium .m-player-title[data-marquee="true"] {
+    overflow: visible; white-space: normal;
+  }
   .atrium .m-player-title[data-marquee="true"] .m-em { animation: none; }
 }
 .m-player-by { margin-top: 8px; color: var(--ink-1); font-size: 14px; }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5788,6 +5788,23 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .atrium .m-player-title {
   font-family: var(--serif); font-weight: 400; font-size: 26px;
   line-height: 1.05; margin-top: 10px;
+  overflow: hidden; white-space: nowrap;
+}
+.atrium .m-player-title .m-em { display: inline-block; }
+/* Marquee only kicks in once JS (`interop::measure_title_marquee`) confirms
+   the title overflows its header width and sets `--marquee-shift`; a title
+   that fits keeps the default centered, static layout. */
+.atrium .m-player-title[data-marquee="true"] { text-align: left; }
+.atrium .m-player-title[data-marquee="true"] .m-em {
+  animation: m-marquee 9s ease-in-out infinite;
+}
+@keyframes m-marquee {
+  0%, 12% { transform: translateX(0); }
+  50%, 62% { transform: translateX(var(--marquee-shift, 0)); }
+  100% { transform: translateX(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .atrium .m-player-title[data-marquee="true"] .m-em { animation: none; }
 }
 .m-player-by { margin-top: 8px; color: var(--ink-1); font-size: 14px; }
 .m-player-chline {

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -86,6 +86,15 @@ pub fn MobilePlayer(uuid: String) -> Element {
         }
     }));
 
+    // Re-measure the marquee whenever the displayed title changes (including
+    // the initial load) — after `ctx.view` updates the DOM already carries
+    // the new title, so the JS-side overflow check reads the right width.
+    use_effect(move || {
+        if (ctx.view)().is_some() {
+            interop::measure_title_marquee();
+        }
+    });
+
     if let Some(msg) = (ctx.error)() {
         return render_error(&msg);
     }

--- a/frontend/src/pages/listen/mobile/interop.rs
+++ b/frontend/src/pages/listen/mobile/interop.rs
@@ -144,16 +144,16 @@ pub fn set_rate(rate: f64) {
 pub fn measure_title_marquee() {
     fire(
         "var wrap = document.querySelector('.m-player-title'); \
-         if (!wrap) return; \
-         var em = wrap.querySelector('.m-em'); \
-         if (!em) return; \
-         var over = Math.ceil(em.scrollWidth - wrap.clientWidth); \
-         if (over > 4) { \
-           wrap.setAttribute('data-marquee', 'true'); \
-           wrap.style.setProperty('--marquee-shift', (-(over + 12)) + 'px'); \
-         } else { \
-           wrap.removeAttribute('data-marquee'); \
-           wrap.style.removeProperty('--marquee-shift'); \
+         var em = wrap ? wrap.querySelector('.m-em') : null; \
+         if (wrap && em) { \
+           var over = Math.ceil(em.scrollWidth - wrap.clientWidth); \
+           if (over > 4) { \
+             wrap.setAttribute('data-marquee', 'true'); \
+             wrap.style.setProperty('--marquee-shift', (-(over + 12)) + 'px'); \
+           } else { \
+             wrap.removeAttribute('data-marquee'); \
+             wrap.style.removeProperty('--marquee-shift'); \
+           } \
          }",
     );
 }

--- a/frontend/src/pages/listen/mobile/interop.rs
+++ b/frontend/src/pages/listen/mobile/interop.rs
@@ -137,6 +137,27 @@ pub fn set_rate(rate: f64) {
     ));
 }
 
+/// Re-measure the now-playing title against its header width and toggle the
+/// marquee animation: `data-marquee` (plus a `--marquee-shift` distance) is
+/// set only when the title actually overflows, so a short title never
+/// animates.
+pub fn measure_title_marquee() {
+    fire(
+        "var wrap = document.querySelector('.m-player-title'); \
+         if (!wrap) return; \
+         var em = wrap.querySelector('.m-em'); \
+         if (!em) return; \
+         var over = Math.ceil(em.scrollWidth - wrap.clientWidth); \
+         if (over > 4) { \
+           wrap.setAttribute('data-marquee', 'true'); \
+           wrap.style.setProperty('--marquee-shift', (-(over + 12)) + 'px'); \
+         } else { \
+           wrap.removeAttribute('data-marquee'); \
+           wrap.style.removeProperty('--marquee-shift'); \
+         }",
+    );
+}
+
 /// Fire-and-forget control eval (no event stream).
 fn fire(js: &str) {
     let _ = dioxus::document::eval(js);


### PR DESCRIPTION
## Summary
- On the mobile "now playing" screen, a long audiobook title just truncated/wrapped statically instead of scrolling into view.
- `interop::measure_title_marquee` (`frontend/src/pages/listen/mobile/interop.rs`) re-measures the title's `scrollWidth` against its header (`.m-player-title`) width after each load and toggles a `data-marquee` attribute plus a `--marquee-shift` custom property — only when the title actually overflows.
- CSS (`frontend/assets/atrium.css`) adds the `@keyframes m-marquee` animation gated on `[data-marquee="true"]`, and a `prefers-reduced-motion` override that disables it.
- Wired via a `use_effect` in `MobilePlayer` (`frontend/src/pages/listen/mobile.rs`) keyed on `ctx.view`, so it re-measures on the initial load and whenever the book/title changes.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — clean
- [x] `cargo clippy` (default members) — clean
- [x] `cargo test -p omnibus-frontend --features mobile` — 230 passed
- [x] `cargo test -p omnibus-frontend --features server` — 259 passed
- [x] `npx stylelint frontend/assets/atrium.css` — clean
- [ ] No Playwright/Maestro coverage added: this surface is mobile-only (`#[cfg(feature = "mobile")]`, no web Playwright coverage per rule 04), and the Mobile E2E (Maestro) workflow is currently disabled repo-wide (#1036) pending cleanup — visual/animation-state assertions aren't practical there either. Verified the overflow math (fires only when `scrollWidth > clientWidth`) via code review of the existing `interop.rs` eval patterns; on-device confirmation would need a TestFlight pass, same caveat as PR #1031.

## Version
- [x] **Patch** — the default; bug fix only.

## Notes
- No migrations, no schema changes, no new dependencies.
- Followed the fire-and-forget eval convention already used by `interop::toggle`/`seek`/`pause` etc. — no dedicated unit test for `measure_title_marquee` itself since it has no return value to assert (matches its untested siblings in the same module).

Closes #1001


---
_Generated by [Claude Code](https://claude.ai/code/session_01YGDtDa2TsA7yhoowrrWZZw)_