### PR TITLE
fix: extend Maestro connect-flow URL assertion past the 7s default (#902)

### DIFF
--- a/ui_tests/maestro/flows/connect.yaml
+++ b/ui_tests/maestro/flows/connect.yaml
@@ -10,8 +10,11 @@
 # (mobile-dev-inc/Maestro#395) — a mangled URL fails the health probe and
 # strands us on the Connect screen. Each attempt re-launches with clearState so
 # it starts from a fresh, empty field (placeholder visible, nothing to erase),
-# then asserts the field actually holds the URL before tapping Connect — a
-# fast fail that triggers another attempt instead of waiting out the nav.
+# then asserts the field actually holds the URL before tapping Connect. That
+# assertion uses extendedWaitUntil (not the 7s assertVisible default) because
+# on a loaded CI simulator the WebView can take longer than 7s to repaint the
+# typed text even when nothing was dropped — a bare assertVisible was timing
+# out and burning a retry on runs that were merely slow, not mangled (#902).
 appId: com.omnibus.mobile
 env:
   SERVER_URL: http://127.0.0.1:3000
@@ -19,8 +22,8 @@ tags:
   - smoke
 ---
 - retry:
-    # Generous count: the assertVisible below fast-fails a dropped-char attempt
-    # (no 15s nav wait), so extra retries are cheap insurance on a janky sim.
+    # Generous count: cheap insurance on a janky sim for the rare attempt that
+    # still mangles the input despite the extendedWaitUntil below.
     maxRetries: 6
     commands:
       - launchApp:
@@ -30,7 +33,9 @@ tags:
       # accessibility identifiers through the WebView) and type the URL.
       - tapOn: "https://omnibus.local:3000"
       - inputText: ${SERVER_URL}
-      - assertVisible: ${SERVER_URL}
+      - extendedWaitUntil:
+          visible: ${SERVER_URL}
+          timeout: 15000
       - tapOn: "Connect"
       # Login screen: connected-to bar + credentials form prove the health
       # probe passed, the URL was persisted, and the router advanced to /login.

--- a/ui_tests/maestro/flows/connect_error.yaml
+++ b/ui_tests/maestro/flows/connect_error.yaml
@@ -10,7 +10,9 @@
 # a janky/CI simulator (mobile-dev-inc/Maestro#395). A mangled URL can land on
 # a *different* state (empty field → "Enter a server URL", or a stray reachable
 # host), so we assert the field holds the exact unreachable URL before tapping
-# Connect, and re-launch clean on any miss.
+# Connect, and re-launch clean on any miss. Same extendedWaitUntil rationale as
+# connect.yaml: a bare assertVisible's 7s default was timing out on a merely
+# slow-to-repaint CI WebView, not just a genuinely dropped-character one (#902).
 appId: com.omnibus.mobile
 tags:
   - smoke
@@ -23,7 +25,9 @@ tags:
       - assertVisible: "Connect to your server to get started."
       - tapOn: "https://omnibus.local:3000"
       - inputText: http://127.0.0.1:1
-      - assertVisible: "http://127.0.0.1:1"
+      - extendedWaitUntil:
+          visible: "http://127.0.0.1:1"
+          timeout: 15000
       - tapOn: "Connect"
       - extendedWaitUntil:
           visible: "Can't reach that server. Check the address and that it's running."


### PR DESCRIPTION
## Summary
- The iOS Maestro `connect`/`connect_error` flows (`ui_tests/maestro/flows/`) have been flaking on `main` (#902): `[Failed] connect (4m 38s) (Assertion is false: "http://127.0.0.1:3000" is visible)`.
- Workflow-run history shows this job passes most runs but fails intermittently (roughly 1 in 4 recent runs on `main`), always exhausting all 6 configured retries in ~46s/attempt each — that's consistent with the WebView needing longer than `assertVisible`'s 7s default to repaint the just-typed URL under CI load, distinct from Maestro's known `inputText` char-drop bug ([mobile-dev-inc/Maestro#395](https://github.com/mobile-dev-inc/maestro/issues/395)) the existing `retry` wrapper already guards against.
- Fix: swap the bare `assertVisible` on the typed URL for `extendedWaitUntil` with a 15s timeout — the same pattern the flow already uses for the following login-screen assertion. Updated the stale comments explaining the retry/assertion rationale in both files accordingly.

## Test plan
- [x] YAML validated (`python3 -c "yaml.safe_load_all(...)"` on both files — parses as the expected 2-document Maestro flow shape)
- [ ] **Needs a manual CI run to confirm** — `mobile-e2e.yml`'s `push`/`pull_request` triggers are currently commented out (tracked separately in #1036), so this PR gets no automatic signal on the very job it fixes, and the bot integration doesn't have permission to dispatch it (`403 Resource not accessible by integration` when I tried). **@seamus-sloan** — please trigger `mobile-e2e.yml` by hand from the Actions tab on this branch (`workflow_dispatch`) to confirm the iOS Maestro job goes green; given the ~1-in-4 flake rate, ideally run it 2-3 times.
- N/A `cargo fmt` / `clippy` / `cargo test` — no Rust files touched (YAML-only change)

## Version
- [x] **No release** — CI-only fix, no user-facing behavior change.

## Notes
- Closes #902
- Diagnosis is based on: the issue's cited CI run logs (job `86345803250`), `ui_tests/maestro/flows/connect*.yaml`, and `mobile-e2e.yml` run history over the last two days (mixed pass/fail, ruling out a hard regression in favor of a timing-sensitive flake) — independently re-verified in review.
- If this doesn't fully resolve the flake rate, the next things to try (not done here, to keep this PR bounded): bump `maxRetries` further, or split `inputText` into per-character commands per the upstream issue's workaround (harder here since `connect.yaml`'s URL is a templated `${SERVER_URL}` env var, not a static literal).
