### PR TITLE
refactor: cap device list query and registrations per user (#865)

### DIFF
--- a/db/migrations/0041_devices_per_user_cap.sql
+++ b/db/migrations/0041_devices_per_user_cap.sql
@@ -1,0 +1,20 @@
+-- #865: cap how many devices a single user can accumulate. Devices grow
+-- only through the user's own repeated logins (not attacker-controlled bulk
+-- insertion the way a comment/tag field would be), so a trigger-based,
+-- evict-oldest-on-overflow cap is a low-risk fit — it runs atomically with
+-- every INSERT regardless of call site (pool or transaction executor), so
+-- it needs no change to `register_device`'s generic `Executor` signature.
+--
+-- The cap (50) must stay in sync with `MAX_DEVICES_PER_USER` in
+-- `db/src/auth/device.rs` — a test asserts the two agree.
+CREATE TRIGGER trg_devices_cap_per_user AFTER INSERT ON devices
+BEGIN
+    DELETE FROM devices
+     WHERE user_id = NEW.user_id
+       AND id NOT IN (
+           SELECT id FROM devices
+            WHERE user_id = NEW.user_id
+            ORDER BY last_seen_at DESC, id DESC
+            LIMIT 50
+       );
+END;

--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -14,7 +14,7 @@ mod users;
 
 pub use device::{
     list_devices_for_user, register_device, validate_client_version, validate_device_name,
-    MAX_CLIENT_VERSION_CHARS, MAX_DEVICE_NAME_CHARS,
+    LIST_DEVICES_LIMIT, MAX_CLIENT_VERSION_CHARS, MAX_DEVICES_PER_USER, MAX_DEVICE_NAME_CHARS,
 };
 pub use login::verify_login;
 pub use password::{hash_password, validate_password, validate_username, verify_password};

--- a/db/src/auth/device.rs
+++ b/db/src/auth/device.rs
@@ -19,6 +19,22 @@ pub const MAX_DEVICE_NAME_CHARS: usize = 255;
 /// chars covers `1.2.3-rc.10+build.20251205abcdef` with headroom.
 pub const MAX_CLIENT_VERSION_CHARS: usize = 64;
 
+/// Hard cap on how many devices `list_devices_for_user` returns for a
+/// single user. Matches `LIST_SHELVES_LIMIT`/`LIST_BOOKMARKS_LIMIT` — a
+/// defensive ceiling so a pathological device count can't produce an
+/// unbounded REST response. In practice `MAX_DEVICES_PER_USER` (enforced
+/// by the `trg_devices_cap_per_user` DB trigger, migration `0041`) keeps
+/// the real row count far below this.
+pub const LIST_DEVICES_LIMIT: i64 = 500;
+
+/// Per-user device cap enforced by the `trg_devices_cap_per_user` trigger
+/// (migration `0041`): on every INSERT it evicts the least-recently-seen
+/// device(s) for that `user_id` beyond this count. Kept as a Rust constant
+/// purely for documentation and test cross-checking — the trigger's SQL
+/// hardcodes the same number, since a trigger body can't reference a Rust
+/// const; a test asserts the two stay in sync.
+pub const MAX_DEVICES_PER_USER: i64 = 50;
+
 /// Reject ASCII control characters (incl. CR/LF) and oversize strings
 /// before INSERT. We *reject* rather than truncate so a buggy or
 /// malicious client gets a deterministic error instead of silently
@@ -64,6 +80,9 @@ pub fn validate_client_version(version: Option<&str>) -> AuthResult<()> {
 /// path in `server::auth::handlers::issue_session` uses the latter to keep the
 /// device + session inserts atomic (see #627: an orphan device row leaks if
 /// `create_session` fails after `register_device` has already committed).
+/// The `trg_devices_cap_per_user` trigger (migration `0041`) evicts the
+/// user's least-recently-seen device(s) beyond `MAX_DEVICES_PER_USER` as
+/// part of this same INSERT, so callers don't need a separate step.
 pub async fn register_device<'e, E>(
     executor: E,
     user_id: i64,
@@ -100,13 +119,14 @@ where
     })
 }
 
-/// List all registered devices for a user, ordered by most-recently-seen first.
+/// List all registered devices for a user, ordered by most-recently-seen first, up to `LIST_DEVICES_LIMIT`.
 pub async fn list_devices_for_user(pool: &SqlitePool, user_id: i64) -> AuthResult<Vec<Device>> {
     let rows = sqlx::query(
         "SELECT id, user_id, name, client_kind, client_version, created_at, last_seen_at
-         FROM devices WHERE user_id = ? ORDER BY last_seen_at DESC",
+         FROM devices WHERE user_id = ? ORDER BY last_seen_at DESC LIMIT ?",
     )
     .bind(user_id)
+    .bind(LIST_DEVICES_LIMIT)
     .fetch_all(pool)
     .await?;
     Ok(rows

--- a/db/src/auth/device/tests.rs
+++ b/db/src/auth/device/tests.rs
@@ -1,16 +1,41 @@
 //! Unit tests for `auth::device` — covers the SQL roundtrip
 //! (`register_device` / `list_devices_for_user`) plus the input-validation
 //! guards on `device_name` / `client_version` (length cap, control-char
-//! rejection). Validation tests are pure unit; register/list and pre-insert
-//! rejection tests share an in-memory pool via `auth::test_support::pool`.
+//! rejection), the `LIST_DEVICES_LIMIT` response ceiling, and the
+//! `trg_devices_cap_per_user` eviction trigger. Validation tests are pure
+//! unit; register/list and pre-insert rejection tests share an in-memory
+//! pool via `auth::test_support::pool`.
 
-use sqlx::Row;
+use std::collections::HashSet;
+
+use sqlx::{Row, SqlitePool};
 
 use super::*;
 use crate::auth::session::create_session;
 use crate::auth::test_support::pool;
 use crate::auth::users::create_user;
 use crate::auth::SessionKind;
+
+/// Bulk-insert `count` device rows for `user_id` without going through
+/// `register_device` — used only to exercise `list_devices_for_user`'s
+/// `LIST_DEVICES_LIMIT` in isolation, above what the per-user registration
+/// cap would ever let `register_device` accumulate.
+async fn seed_devices_raw(pool: &SqlitePool, user_id: i64, count: i64) {
+    sqlx::query(
+        r"
+        WITH RECURSIVE n(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
+        )
+        INSERT INTO devices (user_id, name, client_kind, created_at, last_seen_at)
+        SELECT ?, 'd' || i, 'ios', i, i FROM n
+        ",
+    )
+    .bind(count)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
 
 #[tokio::test]
 async fn device_register_and_list() {
@@ -23,6 +48,68 @@ async fn device_register_and_list() {
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].id, d.id);
     assert_eq!(list[0].client_kind, "ios");
+}
+
+/// Regression for #865: `list_devices_for_user` must not return more than
+/// `LIST_DEVICES_LIMIT` rows even when the underlying table holds more.
+/// `trg_devices_cap_per_user` would otherwise mask this by keeping the
+/// table itself under the limit, so the trigger is dropped here to
+/// exercise the SELECT-side ceiling in isolation.
+#[tokio::test]
+async fn list_devices_for_user_caps_response_at_list_devices_limit() {
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    sqlx::query("DROP TRIGGER trg_devices_cap_per_user")
+        .execute(&p)
+        .await
+        .unwrap();
+    let over_cap = LIST_DEVICES_LIMIT + 50;
+    seed_devices_raw(&p, u.id, over_cap).await;
+
+    let list = list_devices_for_user(&p, u.id).await.unwrap();
+    assert_eq!(
+        list.len() as i64,
+        LIST_DEVICES_LIMIT,
+        "list_devices_for_user must not return more than LIST_DEVICES_LIMIT rows",
+    );
+}
+
+/// Regression for #865: `register_device` must not let a single user
+/// accumulate unbounded devices — `trg_devices_cap_per_user` evicts the
+/// least-recently-seen device(s) beyond `MAX_DEVICES_PER_USER` on every
+/// INSERT, keeping the most-recently-registered devices.
+#[tokio::test]
+async fn register_device_evicts_oldest_when_over_max_devices_per_user() {
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    let total = MAX_DEVICES_PER_USER + 5;
+    for i in 0..total {
+        register_device(&p, u.id, &format!("d{i}"), "ios", None)
+            .await
+            .unwrap();
+    }
+
+    let list = list_devices_for_user(&p, u.id).await.unwrap();
+    assert_eq!(
+        list.len() as i64,
+        MAX_DEVICES_PER_USER,
+        "register_device must evict down to MAX_DEVICES_PER_USER devices",
+    );
+    let names: HashSet<&str> = list.iter().map(|d| d.name.as_str()).collect();
+    for i in 0..5 {
+        let evicted = format!("d{i}");
+        assert!(
+            !names.contains(evicted.as_str()),
+            "earliest-registered device {evicted} should have been evicted, got {names:?}",
+        );
+    }
+    for i in 5..total {
+        let kept = format!("d{i}");
+        assert!(
+            names.contains(kept.as_str()),
+            "most-recently-registered device {kept} should be retained, got {names:?}",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Closes #865. `list_devices_for_user` gets a `LIST_DEVICES_LIMIT` (500) constant + `LIMIT ?` clause, matching the `LIST_SHELVES_LIMIT`/`LIST_BOOKMARKS_LIMIT`/`LIST_HIGHLIGHTS_LIMIT` convention (`db/src/auth/device.rs`).
- `register_device` gains a `MAX_DEVICES_PER_USER` cap (50), enforced by a new `trg_devices_cap_per_user` `AFTER INSERT` trigger (`db/migrations/0041_devices_per_user_cap.sql`) that evicts the least-recently-seen device(s) for that user on overflow.
- **Design note on the eviction mechanism:** `register_device` accepts a generic `sqlx::Executor` (either `&SqlitePool` or `&mut *tx`, consumed once per call) so it can insert atomically alongside `create_session` inside a transaction (#627). That rules out a second Rust-level query reusing the same executor value without a broader generic-executor refactor. A DB trigger sidesteps this entirely — it runs atomically with the same `INSERT` regardless of call site, mirrors the existing `books_fts` trigger precedent (`db/migrations/0005_fts5.sql`), and needed no changes to `register_device`'s signature or any call site. The cap (50) is duplicated as a Rust `MAX_DEVICES_PER_USER` constant for documentation/test cross-checking (a test would fail if the two drift out of sync).

## Test plan
- [x] `cd /home/user/omnibus-wt-865 && CARGO_TARGET_DIR=/tmp/omnibus-target-865 cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-865 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-865 cargo test -p omnibus-db` — PASS (940/941; the one failure, `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, is a pre-existing missing-fixture skip unrelated to this change — `just fixtures` wasn't run in this sandbox). All `auth::device` tests pass (12/12), including two new tests: `list_devices_for_user_caps_response_at_list_devices_limit` and `register_device_evicts_oldest_when_over_max_devices_per_user`.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Devices are registered ereaders/sync destinations (Kobo, Kindle, OPDS clients), not browser sessions (see `docs/roadmap/0-3-auth.md`), so 50 is generous headroom that should never bother a real user while still bounding the row count.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VN3icm6R2wzWBUkqA2a9WW)_