### PR TITLE
refactor: rename 10 test names to include function-under-test (#863)

### DIFF
--- a/frontend/src/pages/landing/sorting.rs
+++ b/frontend/src/pages/landing/sorting.rs
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn sorts_by_title_asc_and_desc() {
+    fn sort_books_by_title_asc_and_desc() {
         let s = sample();
         let asc = sort_books(s.clone(), SortKey::Title, SortDir::Asc);
         assert_eq!(ids(&asc), vec![1, 2, 3]);
@@ -323,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn sorts_by_author_asc() {
+    fn sort_books_by_author_asc() {
         let s = sample();
         let asc = sort_books(s, SortKey::Author, SortDir::Asc);
         // Asimov < Le Guin < Tolkien
@@ -331,7 +331,7 @@ mod tests {
     }
 
     #[test]
-    fn sorts_by_series_grouping_with_index_then_pushes_seriesless_last() {
+    fn sort_books_by_series_grouping_with_index_then_pushes_seriesless_last() {
         let s = sample();
         let asc = sort_books(s, SortKey::Series, SortDir::Asc);
         // Foundation #1 (id 1), Foundation #2 (id 2), then no-series (id 3).
@@ -339,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn sorts_by_last_updated_desc_picks_most_recent_first() {
+    fn sort_books_by_last_updated_desc_picks_most_recent_first() {
         let s = sample();
         let desc = sort_books(s, SortKey::LastUpdated, SortDir::Desc);
         // beta 2024-06 > alpha 2024-01 > gamma 2023
@@ -347,7 +347,7 @@ mod tests {
     }
 
     #[test]
-    fn sorts_by_newest_added_desc() {
+    fn sort_books_by_newest_added_desc() {
         let s = sample();
         let desc = sort_books(s, SortKey::NewestAdded, SortDir::Desc);
         // alpha 2025-03 > gamma 2025-02 > beta 2025-01
@@ -355,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_timestamps_always_sort_last_even_on_desc() {
+    fn sort_books_missing_timestamps_always_sort_last_even_on_desc() {
         // Two timestamped books + one with no `modified` value. In descending
         // order the most-recent timestamp comes first, but the missing-value
         // book stays at the end (it doesn't get flipped to the top by the

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -189,7 +189,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn allows_up_to_max_then_blocks() {
+    async fn rate_limiter_allow_up_to_max_then_blocks() {
         let rl = RateLimiter::with_policy(Duration::from_secs(60), 3);
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
         assert!(rl.allow(ip).await);
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn separate_ips_have_separate_buckets() {
+    async fn rate_limiter_allow_separate_ips_have_separate_buckets() {
         let rl = RateLimiter::with_policy(Duration::from_secs(60), 1);
         let a: IpAddr = "127.0.0.1".parse().unwrap();
         let b: IpAddr = "127.0.0.2".parse().unwrap();
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn window_resets_after_elapsed() {
+    async fn rate_limiter_allow_window_resets_after_elapsed() {
         let rl = RateLimiter::with_policy(Duration::from_millis(10), 1);
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
         assert!(rl.allow(ip).await);
@@ -418,7 +418,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prunes_stale_entries_at_cap() {
+    async fn rate_limiter_allow_prunes_stale_entries_at_cap() {
         let rl = RateLimiter::with_policy(Duration::from_millis(1), MAX_REQUESTS);
         // Fill to just under the cap using distinct IPs.
         for i in 0..MAX_BUCKETS {


### PR DESCRIPTION
## Summary
- Closes #863. Renames 10 test names in `server/src/rate_limit.rs` and `frontend/src/pages/landing/sorting.rs` to include the function/type under test, following the `fn_under_test_does_X_when_Y` naming convention (`.claude/rules/05-rust-style.md` § Tests → Naming). Continues the family closed in #738.

## Test plan
- [x] `cd /home/user/omnibus-wt-863 && CARGO_TARGET_DIR=/tmp/omnibus-target-863 cargo fmt` — PASS (no diff)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-863 cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-863 cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-863 cargo test -p omnibus` — 325 passed, 1 failed. The failure (`backend::uploads::tests::commit_rejects_read_only_library_with_400`) is a pre-existing, environment-only failure unrelated to this change: the sandbox runs as root, which bypasses the `chmod 0o555` permission check the test relies on. Confirmed by stashing this PR's diff and re-running the same test against unmodified `main` code — it fails identically. All 4 renamed `rate_limit` tests pass.
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-863 cargo test -p omnibus-frontend --features server` — 270 passed, 0 failed. All 6 renamed `sort_books` tests pass.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Pure rename, no test bodies or production logic changed.
- `server/src/rate_limit.rs`: all four tests (`allows_up_to_max_then_blocks`, `separate_ips_have_separate_buckets`, `window_resets_after_elapsed`, `prunes_stale_entries_at_cap`) directly instantiate `RateLimiter::with_policy(...)` and call `.allow()` — none actually invoke the `rate_limit_by_ip` middleware fn — so they're prefixed `rate_limiter_allow_` (merging the redundant `allow`/`allows` verb, mirroring how the issue's own `sort_books_by_title_asc_and_desc` example drops the redundant `sorts`).
- `frontend/src/pages/landing/sorting.rs`: prefixed with `sort_books_`, the confirmed function under test at line 123.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VN3icm6R2wzWBUkqA2a9WW)_