### PR TITLE
refactor: derive contexts.rs admin/user-summary signals with use_memo (#855)

### DIFF
--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -132,57 +132,72 @@ pub fn use_current_user() -> CurrentUser {
     use_context::<CurrentUser>()
 }
 
-/// Derive `is_admin` from the app-wide [`CurrentUser`] context instead of an
-/// independent per-mount `/api/auth/me` fetch. Starts `false` so SSR and the
-/// first WASM paint agree (rule 07); only the web build wires the effect
-/// that flips it once the context resolves an admin user. Mobile stays at
-/// the default since `CurrentUser` isn't provided there; SSR has the context
-/// but it stays unresolved until the web client's boot effect runs post-mount.
-#[cfg_attr(not(feature = "web"), allow(unused_mut))]
-pub fn use_is_admin() -> Signal<bool> {
-    let mut is_admin = use_signal(|| false);
-    #[cfg(feature = "web")]
-    {
-        let user_ctx = use_current_user().0;
-        use_effect(move || {
-            is_admin.set(matches!(user_ctx(), Some(Some(ref u)) if u.is_admin));
-        });
-    }
-    is_admin
+/// Derive `is_admin` from the app-wide [`CurrentUser`] context — a pure
+/// function of its value, so `use_memo` recomputes it inline with no extra
+/// render pass. Web-only: mobile has no `CurrentUser` context to read, and
+/// SSR renders this crate without the `web` feature at all, so both instead
+/// return a `false`-valued signal — the same default the web memo evaluates
+/// to on first paint (before the client's boot effect resolves `CurrentUser`),
+/// keeping SSR/first-WASM-paint parity (rule 07). Returns a boxed
+/// [`ReadSignal`] (rather than `Memo`/`Signal` directly) so call sites that
+/// store the handle in a struct field see one type regardless of which of
+/// the three arms below compiled.
+#[cfg(feature = "web")]
+pub fn use_is_admin() -> ReadSignal<bool> {
+    let user_ctx = use_current_user().0;
+    ReadSignal::new(use_memo(
+        move || matches!(user_ctx(), Some(Some(ref u)) if u.is_admin),
+    ))
+}
+
+/// Non-web fallback for [`use_is_admin`] — mobile has no `CurrentUser`
+/// context and SSR never resolves one, so both stay at the `false` default.
+#[cfg(not(feature = "web"))]
+pub fn use_is_admin() -> ReadSignal<bool> {
+    ReadSignal::new(use_signal(|| false))
 }
 
 /// Derive the resolved current user from the app-wide [`CurrentUser`]
-/// context instead of an independent per-mount `/api/auth/me` fetch,
-/// flattening "not yet resolved" and "unauthenticated" alike to `None`.
-/// Starts `None` so SSR and the first WASM paint agree (rule 07); an effect
-/// then fills it in post-mount. The web build reads it from the resolved
-/// [`CurrentUser`] context; mobile has no such context (bearer auth, not
-/// cookies), so it resolves the user directly via `/api/auth/me` — this is
-/// what lets owner-only affordances (e.g. journal edit/delete) light up on
-/// mobile. SSR (neither feature) stays at the `None` default.
-#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(unused_mut))]
-pub fn use_current_user_summary() -> Signal<Option<omnibus_shared::UserSummary>> {
+/// context — a pure function of its value, so `use_memo` recomputes it
+/// inline with no extra render pass, flattening "not yet resolved" and
+/// "unauthenticated" alike to `None`. The memo evaluates to `None` on first
+/// paint (before the client's boot effect resolves `CurrentUser`), matching
+/// the SSR default and keeping hydration parity (rule 07). Returns a boxed
+/// [`ReadSignal`], same reasoning as [`use_is_admin`].
+#[cfg(feature = "web")]
+pub fn use_current_user_summary() -> ReadSignal<Option<omnibus_shared::UserSummary>> {
+    let user_ctx = use_current_user().0;
+    ReadSignal::new(use_memo(move || user_ctx().flatten()))
+}
+
+/// Mobile fallback for [`use_current_user_summary`]. Mobile has no
+/// `CurrentUser` context (bearer auth, not cookies), so — unlike the web
+/// memo — this resolves the user via an async `/api/auth/me` fetch, which
+/// isn't a pure derivation and so can't be a `use_memo`; it stays a
+/// `use_signal` written from a post-mount `use_effect`, starting at `None`
+/// to match the web/SSR default until the fetch lands. This is what lets
+/// owner-only affordances (e.g. journal edit/delete) light up on mobile.
+#[cfg(feature = "mobile")]
+pub fn use_current_user_summary() -> ReadSignal<Option<omnibus_shared::UserSummary>> {
     let mut current = use_signal(|| None);
-    #[cfg(feature = "web")]
-    {
-        let user_ctx = use_current_user().0;
-        use_effect(move || {
-            current.set(user_ctx().flatten());
+    let server_url = use_server_url();
+    use_effect(move || {
+        let server_url = server_url.clone();
+        spawn(async move {
+            if let Ok(user) = data::get_me(&server_url).await {
+                current.set(Some(user));
+            }
         });
-    }
-    #[cfg(feature = "mobile")]
-    {
-        let server_url = use_server_url();
-        use_effect(move || {
-            let server_url = server_url.clone();
-            spawn(async move {
-                if let Ok(user) = data::get_me(&server_url).await {
-                    current.set(Some(user));
-                }
-            });
-        });
-    }
-    current
+    });
+    ReadSignal::new(current)
+}
+
+/// SSR fallback for [`use_current_user_summary`] — neither `web` nor
+/// `mobile`, so there's no context and no fetch; stays at the `None`
+/// default that the web memo and mobile signal both start from.
+#[cfg(not(any(feature = "web", feature = "mobile")))]
+pub fn use_current_user_summary() -> ReadSignal<Option<omnibus_shared::UserSummary>> {
+    ReadSignal::new(use_signal(|| None))
 }
 
 /// App-wide audiobook playback state. Owned by [`crate::App`] via

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -177,7 +177,7 @@ fn render_book_shell(
     merge: MergeSignals,
     author_books: Vec<EbookMetadata>,
     suggestions: Option<SuggestionsResponse>,
-    is_admin: Signal<bool>,
+    is_admin: ReadSignal<bool>,
     server_url: String,
 ) -> Element {
     // `is_admin` starts at `false` and only flips to `true` on the web

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -76,7 +76,7 @@ struct LandingSignals {
     error: Signal<Option<String>>,
     prefs: Signal<ViewPrefs>,
     want_more: Signal<u32>,
-    is_admin: Signal<bool>,
+    is_admin: ReadSignal<bool>,
     pools: SuggestionPools,
 }
 
@@ -149,7 +149,7 @@ fn wire_landing_effects(
     query: Signal<String>,
     mut prefs: Signal<ViewPrefs>,
     want_more: Signal<u32>,
-    is_admin: Signal<bool>,
+    is_admin: ReadSignal<bool>,
     pools: SuggestionPools,
     fetch_sigs: FetchSignals,
 ) {

--- a/frontend/src/pages/landing/effects.rs
+++ b/frontend/src/pages/landing/effects.rs
@@ -34,7 +34,7 @@ pub(super) struct FetchSignals {
 /// Refetch the admin-only author/tag suggestion pools whenever `is_admin` changes.
 pub(super) fn spawn_suggestion_pools_effect(
     server_url: String,
-    is_admin: Signal<bool>,
+    is_admin: ReadSignal<bool>,
     pools: SuggestionPools,
 ) {
     let SuggestionPools {


### PR DESCRIPTION
## Summary
- Closes #855 — rewrites `use_is_admin` and `use_current_user_summary` in `frontend/src/contexts.rs` so the web build derives each value with `use_memo` directly over the `CurrentUser` context signal, instead of a `use_signal` written from inside a `use_effect` (which cost an extra render pass on every `CurrentUser` change).
- Mobile (no `CurrentUser` context; `use_current_user_summary` needs an async `/api/auth/me` fetch, which isn't a pure derivation) and SSR (no `web` feature at all) keep an equivalent `use_signal`-based default, unchanged in behavior from before.
- Both functions now return a boxed `ReadSignal<T>` (rather than `Memo<T>`/`Signal<T>` directly) so the small number of call sites that store the handle in a typed struct field (`LandingSignals::is_admin`, `wire_landing_effects`, `spawn_suggestion_pools_effect`, `render_book_shell`) compile to one consistent type regardless of which of the three platform arms built them — preserving SSR/first-WASM-paint hydration parity per rule 07 (both the memo's first-paint value and the signal's default evaluate to the same `false`/`None`).

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (270 passed; 0 failed)

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- No downstream behavior change intended: derived values still start at the same SSR/pre-hydration defaults (`false` / `None`) and update reactively once `CurrentUser` resolves — just via memo recomputation instead of an effect writing a separate signal.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VN3icm6R2wzWBUkqA2a9WW)_