### PR TITLE
fix: stop cross-format attach clobbering a held slot (#1063)

### DIFF
--- a/db/src/sync/attach/mod.rs
+++ b/db/src/sync/attach/mod.rs
@@ -60,6 +60,50 @@ pub(super) async fn find_attach_target(
     })
 }
 
+/// Is the `(book_id, format)` attachment slot already held by a **different**
+/// file? A book can hold at most one attached file per format; the attach
+/// writers `DELETE FROM book_files WHERE book_id = ? AND format = ?` before
+/// inserting, so attaching a second, distinct file would silently clobber the
+/// incumbent's row while still leaving its own `merged_uuids` breadcrumb
+/// (issue #1063). The writers call this first and refuse when it returns
+/// `true`, so the loser is inserted as its own book instead of destroying the
+/// winner. `scan_key` is the incoming file's own key, excluded so an
+/// idempotent re-attach of the same file still proceeds.
+pub(super) async fn slot_held_by_other(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    format: &str,
+    scan_key: &str,
+) -> Result<bool, sqlx::Error> {
+    let held: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM merged_uuids
+          WHERE book_id = ? AND format = ? AND scan_key <> ? LIMIT 1",
+    )
+    .bind(book_id)
+    .bind(format)
+    .bind(scan_key)
+    .fetch_optional(&mut **tx)
+    .await?;
+    Ok(held.is_some())
+}
+
+/// Drop the `merged_uuids` row for `(library_path, scan_key)`. Called when a
+/// file that previously recorded an attachment is being demoted to its own
+/// book (its slot got taken by another file), so its stale ledger entry
+/// doesn't keep replaying the attach on every future scan (issue #1063).
+pub(super) async fn forget_attachment(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    library_path: &str,
+    scan_key: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM merged_uuids WHERE library_path = ? AND scan_key = ?")
+        .bind(library_path)
+        .bind(scan_key)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
 /// Record (or refresh) the `merged_uuids` row for an attached file.
 /// `library_path` is the scanned root of the *file*, not the target
 /// book's library — the reindex diff filters on it. `scan_key` is the

--- a/db/src/sync/attach/mod.rs
+++ b/db/src/sync/attach/mod.rs
@@ -60,15 +60,8 @@ pub(super) async fn find_attach_target(
     })
 }
 
-/// Is the `(book_id, format)` attachment slot already held by a **different**
-/// file? A book can hold at most one attached file per format; the attach
-/// writers `DELETE FROM book_files WHERE book_id = ? AND format = ?` before
-/// inserting, so attaching a second, distinct file would silently clobber the
-/// incumbent's row while still leaving its own `merged_uuids` breadcrumb
-/// (issue #1063). The writers call this first and refuse when it returns
-/// `true`, so the loser is inserted as its own book instead of destroying the
-/// winner. `scan_key` is the incoming file's own key, excluded so an
-/// idempotent re-attach of the same file still proceeds.
+/// Return whether another file holds the `(book_id, format)` attachment slot.
+/// The incoming `scan_key` is excluded so re-attaching the same file proceeds.
 pub(super) async fn slot_held_by_other(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -131,6 +131,234 @@ async fn attach_skipped_when_titles_differ() {
 }
 
 #[tokio::test]
+async fn two_audiobooks_matching_one_ebook_in_one_plan_do_not_clobber() {
+    // Two distinct M4B files for the same work land in a single New plan. The
+    // first attaches as the ebook's M4B edition; the second must become its
+    // own book, not overwrite the first's file row (#1063).
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_ebook(
+        &pool,
+        "Sanderson/Wind and Truth.epub",
+        "Wind and Truth",
+        "Brandon Sanderson",
+    )
+    .await;
+    sync_audiobooks(
+        &pool,
+        "/audio",
+        AudiobookSyncPlan {
+            new_books: vec![
+                indexed_audiobook(
+                    "Sanderson/wt-a.m4b",
+                    "Wind and Truth",
+                    Some("Brandon Sanderson"),
+                ),
+                indexed_audiobook(
+                    "Sanderson/wt-b.m4b",
+                    "Wind and Truth",
+                    Some("Brandon Sanderson"),
+                ),
+            ],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // One attaches to the ebook, the other stands alone → 2 books, and both
+    // M4B files survive (no delete-then-replace).
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM books").await, 2);
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'M4B'"
+        )
+        .await,
+        2
+    );
+    // Only the attached file records a ledger row; the standalone book is
+    // native, so exactly one merged_uuids row exists.
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM merged_uuids").await, 1);
+}
+
+#[tokio::test]
+async fn replayed_ledger_collision_does_not_clobber_the_incumbent_file() {
+    // Regression for #1063: two merged_uuids rows pointing at the same
+    // (book, M4B) slot — the frozen state a pre-fix clobber leaves behind. A
+    // rescan that replays the second file must refuse rather than delete the
+    // incumbent's file row and replace it. Pre-fix this collapsed to one file
+    // row (data loss); post-fix the incumbent survives and the loser becomes
+    // its own book.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_ebook(
+        &pool,
+        "Sanderson/Wind and Truth.epub",
+        "Wind and Truth",
+        "Brandon Sanderson",
+    )
+    .await;
+
+    // File A attaches to the ebook the normal way.
+    sync_audiobooks(
+        &pool,
+        "/audio",
+        AudiobookSyncPlan {
+            new_books: vec![indexed_audiobook(
+                "Sanderson/wt-a.m4b",
+                "Wind and Truth",
+                Some("Brandon Sanderson"),
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let ebook_id: i64 = sqlx::query_scalar(
+        "SELECT book_id FROM merged_uuids WHERE scan_key = 'Sanderson/wt-a.m4b'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    // Forge the legacy bad state: a second ledger row for file B on A's slot.
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('forged-b', ?, 'M4B', '/audio', 'Sanderson/wt-b.m4b')",
+    )
+    .bind(ebook_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Replay file B through the Changed bucket.
+    sync_audiobooks(
+        &pool,
+        "/audio",
+        AudiobookSyncPlan {
+            changed_books: vec![indexed_audiobook(
+                "Sanderson/wt-b.m4b",
+                "Wind and Truth",
+                Some("Brandon Sanderson"),
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // The incumbent A's file row on the ebook is untouched (its filename is
+    // A's stem, not B's) — the DELETE-then-replace never fired.
+    let incumbent: String =
+        sqlx::query_scalar("SELECT filename FROM book_files WHERE book_id = ? AND format = 'M4B'")
+            .bind(ebook_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(incumbent, "wt-a");
+    // B survives too — as its own book, not a lost row.
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'M4B'"
+        )
+        .await,
+        2
+    );
+    // B's stale ledger row was forgotten, so the slot no longer has two rows
+    // fighting over it.
+    assert_eq!(
+        count(
+            &pool,
+            &format!(
+                "SELECT COUNT(*) FROM merged_uuids WHERE book_id = {ebook_id} AND format = 'M4B'"
+            )
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn replayed_ebook_ledger_collision_does_not_clobber_the_incumbent_file() {
+    // The ebook attach writer shares the same guard (#1063). Same shape as the
+    // audiobook case, roles swapped: a native audiobook holds an attached EPUB,
+    // and a forged second-EPUB ledger row must not clobber the incumbent.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_audiobook(&pool, "Herbert/Dune.m4b", "Dune", "Frank Herbert").await;
+
+    // EPUB A attaches to the audiobook.
+    sync_books(
+        &pool,
+        "/books",
+        SyncPlan {
+            new_books: vec![indexed(
+                "Herbert/dune-a.epub",
+                Some("Dune"),
+                &["Frank Herbert"],
+                &[],
+                None,
+                None,
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let book_id: i64 = sqlx::query_scalar("SELECT book_id FROM merged_uuids WHERE format = 'EPUB'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // Forge a second EPUB ledger row for file B on A's slot.
+    let scan_key_b = crate::helpers::scan_key_for("Herbert/dune-b.epub");
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('forged-eb', ?, 'EPUB', '/books', ?)",
+    )
+    .bind(book_id)
+    .bind(&scan_key_b)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Replay EPUB B through the Changed bucket.
+    sync_books(
+        &pool,
+        "/books",
+        SyncPlan {
+            changed_books: vec![indexed(
+                "Herbert/dune-b.epub",
+                Some("Dune"),
+                &["Frank Herbert"],
+                &[],
+                None,
+                None,
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // Incumbent A's EPUB row is intact; B became its own book.
+    let incumbent: String =
+        sqlx::query_scalar("SELECT filename FROM book_files WHERE book_id = ? AND format = 'EPUB'")
+            .bind(book_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(incumbent, "dune-a");
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'EPUB'"
+        )
+        .await,
+        2
+    );
+}
+
+#[tokio::test]
 async fn reindex_diff_classifies_attached_file_as_unchanged() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -245,10 +245,22 @@ async fn sync_audiobooks_changed(
             if let Some((_uuid, target_id, format)) =
                 attach::find_attachment_by_scan_key(tx, library_path, &b.scan_key).await?
             {
-                attach_audiobook_file(tx, target_id, &format, library_path, b, &mut changed_covers)
-                    .await?;
-                on_book_written();
-                continue;
+                if attach_audiobook_file(
+                    tx,
+                    target_id,
+                    &format,
+                    library_path,
+                    b,
+                    &mut changed_covers,
+                )
+                .await?
+                {
+                    on_book_written();
+                    continue;
+                }
+                // Slot taken by a different file: forget the stale ledger row
+                // and fall through to insert this file as its own book.
+                attach::forget_attachment(tx, library_path, &b.scan_key).await?;
             }
             insert_new_audiobook(tx, library_id, b, &mut changed_covers).await?;
             on_book_written();
@@ -431,8 +443,13 @@ async fn try_attach_new_audiobook(
     if let Some((_uuid, target_id, format)) =
         attach::find_attachment_by_scan_key(tx, library_path, &b.scan_key).await?
     {
-        attach_audiobook_file(tx, target_id, &format, library_path, b, covers).await?;
-        return Ok(true);
+        if attach_audiobook_file(tx, target_id, &format, library_path, b, covers).await? {
+            return Ok(true);
+        }
+        // Slot taken by a different file: drop this file's stale ledger row so
+        // it stops replaying, and fall through to insert it as its own book.
+        attach::forget_attachment(tx, library_path, &b.scan_key).await?;
+        return Ok(false);
     }
     let (Some(title_norm), Some(author_norm)) = (
         normalize_title(&b.title),
@@ -446,8 +463,10 @@ async fn try_attach_new_audiobook(
     else {
         return Ok(false);
     };
-    attach_audiobook_file(tx, target_id, &b.format, library_path, b, covers).await?;
-    Ok(true)
+    // find_attach_target excludes a book that already has this format's file
+    // row, but the writer re-checks the ledger and may still refuse a slot a
+    // different file holds — return whatever it decides.
+    attach_audiobook_file(tx, target_id, &b.format, library_path, b, covers).await
 }
 
 /// Write (or rewrite) an attached audiobook's `book_files` row (plus
@@ -458,6 +477,10 @@ async fn try_attach_new_audiobook(
 /// row carries its own `(library_path, path)` location override — the
 /// target book may live in a different library, and the HLS read path
 /// resolves part filenames against the *audio* root.
+///
+/// Returns `Ok(false)` without writing anything when the `(book_id, format)`
+/// slot is already held by a **different** file — the caller then inserts
+/// this file as its own book rather than clobbering the incumbent (#1063).
 async fn attach_audiobook_file(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
@@ -465,7 +488,12 @@ async fn attach_audiobook_file(
     library_path: &str,
     b: &crate::audiobook::IndexedAudiobook,
     covers: &mut Vec<(String, String, Vec<u8>)>,
-) -> Result<(), SyncError> {
+) -> Result<bool, SyncError> {
+    // One attached file per (book, format) slot: refuse rather than delete a
+    // different file's row (the DELETE below is scoped only to the format).
+    if attach::slot_held_by_other(tx, book_id, format, &b.scan_key).await? {
+        return Ok(false);
+    }
     // Idempotent re-attach: the refresh path lands here too.
     sqlx::query("DELETE FROM book_files WHERE book_id = ? AND format = ?")
         .bind(book_id)
@@ -496,7 +524,7 @@ async fn attach_audiobook_file(
     if let Some(cover) = attach::maybe_adopt_cover(tx, book_id, b.cover.as_ref()).await? {
         covers.push(cover);
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Return type from a fresh audiobook insert — the ids needed by the

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -478,9 +478,7 @@ async fn try_attach_new_audiobook(
 /// target book may live in a different library, and the HLS read path
 /// resolves part filenames against the *audio* root.
 ///
-/// Returns `Ok(false)` without writing anything when the `(book_id, format)`
-/// slot is already held by a **different** file — the caller then inserts
-/// this file as its own book rather than clobbering the incumbent (#1063).
+/// Returns `Ok(false)` without writing when another file holds the slot.
 async fn attach_audiobook_file(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,

--- a/db/src/sync/books/changed.rs
+++ b/db/src/sync/books/changed.rs
@@ -103,7 +103,7 @@ async fn sync_changed_one(
         if let Some((merged_uuid, target_id, format)) =
             attach::find_attachment_by_scan_key(tx, library_path, scan_key).await?
         {
-            attach_ebook_file(
+            if attach_ebook_file(
                 tx,
                 target_id,
                 &format,
@@ -112,8 +112,13 @@ async fn sync_changed_one(
                 b,
                 changed_covers,
             )
-            .await?;
-            return Ok(());
+            .await?
+            {
+                return Ok(());
+            }
+            // Slot taken by a different file: forget the stale ledger row and
+            // fall through to promote this file to its own New insert.
+            attach::forget_attachment(tx, library_path, scan_key).await?;
         }
         // … or a TOCTOU: the diff said this scan_key existed in the DB,
         // but a concurrent process removed it between Phase A and

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -70,7 +70,7 @@ pub(super) async fn try_attach_new_ebook(
     if let Some((merged_uuid, target_id, format)) =
         attach::find_attachment_by_scan_key(tx, library_path, &scan_key).await?
     {
-        attach_ebook_file(
+        if attach_ebook_file(
             tx,
             target_id,
             &format,
@@ -79,8 +79,14 @@ pub(super) async fn try_attach_new_ebook(
             b,
             covers,
         )
-        .await?;
-        return Ok(true);
+        .await?
+        {
+            return Ok(true);
+        }
+        // Slot taken by a different file: drop this file's stale ledger row so
+        // it stops replaying, and fall through to insert it as its own book.
+        attach::forget_attachment(tx, library_path, &scan_key).await?;
+        return Ok(false);
     }
 
     let title = m.title.clone().unwrap_or_else(|| m.filename.clone());
@@ -99,8 +105,10 @@ pub(super) async fn try_attach_new_ebook(
     // A brand-new attachment: mint a stable handle for the ledger row (the
     // lookup above is by scan_key, so this uuid is only an identifier).
     let uuid = stable_uuid(library_path, &m.filename);
-    attach_ebook_file(tx, target_id, &file_ext, library_path, &uuid, b, covers).await?;
-    Ok(true)
+    // find_attach_target excludes a book that already has this format's file
+    // row, but the writer re-checks the ledger and may still refuse a slot a
+    // different file holds — return whatever it decides.
+    attach_ebook_file(tx, target_id, &file_ext, library_path, &uuid, b, covers).await
 }
 
 /// Write (or rewrite) an attached ebook's `book_files` row under
@@ -110,6 +118,10 @@ pub(super) async fn try_attach_new_ebook(
 /// target metadata wins — but the FTS row is refreshed via the door so
 /// the newly-unioned identifiers (incl. an attached-only ISBN) become
 /// searchable immediately.
+///
+/// Returns `Ok(false)` without writing anything when the `(book_id, format)`
+/// slot is already held by a **different** file — the caller then inserts
+/// this file as its own book rather than clobbering the incumbent (#1063).
 pub(super) async fn attach_ebook_file(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
@@ -118,7 +130,16 @@ pub(super) async fn attach_ebook_file(
     uuid: &str,
     b: &crate::ebook::IndexedBook,
     covers: &mut Vec<(String, String, Vec<u8>)>,
-) -> Result<(), sqlx::Error> {
+) -> Result<bool, sqlx::Error> {
+    // The attached file's own relative path is its diff key (F2), so a repoint
+    // of the file's scan root re-matches it instead of resurfacing it as a
+    // duplicate; it's also the ledger key written below.
+    let scan_key = scan_key_for(&b.metadata.filename);
+    // One attached file per (book, format) slot: refuse rather than delete a
+    // different file's row (the DELETE below is scoped only to the format).
+    if attach::slot_held_by_other(tx, book_id, format, &scan_key).await? {
+        return Ok(false);
+    }
     // Idempotent re-attach: the refresh path (and the self-healing "uuid
     // known but attachment row missing" path) both land here.
     sqlx::query("DELETE FROM book_files WHERE book_id = ? AND format = ?")
@@ -140,10 +161,6 @@ pub(super) async fn attach_ebook_file(
     .execute(&mut **tx)
     .await?;
     insert_identifier_links(tx, book_id, &b.metadata).await?;
-    // The attached file's own relative path is its diff key (F2), so a
-    // repoint of the file's scan root re-matches it instead of resurfacing
-    // it as a duplicate.
-    let scan_key = scan_key_for(&b.metadata.filename);
     attach::record_attachment(tx, uuid, book_id, format, library_path, &scan_key).await?;
     // The unioned identifiers (incl. a new ISBN from this format) just
     // changed the target's searchable text — refresh its FTS row.
@@ -151,7 +168,7 @@ pub(super) async fn attach_ebook_file(
     if let Some(cover) = attach::maybe_adopt_cover(tx, book_id, b.cover.as_ref()).await? {
         covers.push(cover);
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Insert the `book_files` row for an existing `books.id`. Shared by the

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -119,9 +119,7 @@ pub(super) async fn try_attach_new_ebook(
 /// the newly-unioned identifiers (incl. an attached-only ISBN) become
 /// searchable immediately.
 ///
-/// Returns `Ok(false)` without writing anything when the `(book_id, format)`
-/// slot is already held by a **different** file — the caller then inserts
-/// this file as its own book rather than clobbering the incumbent (#1063).
+/// Returns `Ok(false)` without writing when another file holds the slot.
 pub(super) async fn attach_ebook_file(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,


### PR DESCRIPTION
## Summary
- The cross-format attach writers (`attach_audiobook_file`, `attach_ebook_file`) ran `DELETE FROM book_files WHERE book_id = ? AND format = ?` unconditionally before inserting, so when multiple distinct files claimed the same `(book, format)` slot each destroyed the previous file's row while still leaving a `merged_uuids` breadcrumb — the "N ledger rows, 1 file row" data loss (#1063).
- New shared invariant, one file per `(book, format)` attachment slot: `attach::slot_held_by_other` makes both writers refuse (no writes) when the slot is held by a *different* file; the caller then inserts it as its own book instead of clobbering the incumbent.
- On the `merged_uuids` replay path a refused file drops its stale ledger row (`attach::forget_attachment`) so it stops re-triggering the attach every scan. Applied to both audiobook and ebook paths across the New and Changed branches.
- Prevents new occurrences only — repairing books already frozen in the bad state is #1064.

Closes #1063.

## Test plan
- [x] 3 new regression tests in `db/src/sync/attach/tests.rs` (incumbent file survives a replay collision; two files matching one book → two books, no clobber; ebook-path parity). The collision test fails pre-fix.
- [x] `cargo test -p omnibus-db` (full suite) + `-p omnibus -p omnibus-shared` green.
- [x] `cargo clippy` + `cargo fmt --check` clean.

## Version
- [x] **Patch** — bug fix, no schema or wire change.

## Notes
- Idempotent same-file re-attach (the refresh path) is unaffected — the guard excludes the incoming file's own `scan_key`, and the existing `changed_attached_file_refreshes_file_row_without_touching_target` test still passes.