### PR TITLE
fix: repair ghosted audiobook attachments

### DIFF
--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -1,6 +1,6 @@
 //! SQLite pool initialization for the omnibus data layer. Owns
 //! `init_db` (which runs the embedded migrations, applies per-connection
-//! PRAGMAs, and performs the one-time legacy cover-cache cleanup).
+//! PRAGMAs, runs boot backfills, and performs legacy cache cleanup).
 
 use std::path::Path;
 
@@ -82,6 +82,8 @@ async fn connect_pool(database_url: &str, is_memory: bool) -> Result<SqlitePool,
 /// migrations couldn't compute. Each is a no-op once caught up and is safe
 /// against in-memory test DBs (all pure DB work, no filesystem reads).
 async fn run_boot_backfills(pool: &SqlitePool) -> Result<(), InitDbError> {
+    // Clear clobbered slots before synthetic ledger rows hide them from reindex.
+    repair_ghosted_audiobook_attachments(pool).await?;
     // Auto-attach match key for rows indexed before migration 0016.
     crate::normalize::backfill_norm_columns(pool).await?;
     // F2 `scan_key` diff key for rows indexed before migration 0026,
@@ -95,6 +97,59 @@ async fn run_boot_backfills(pool: &SqlitePool) -> Result<(), InitDbError> {
     crate::missing_files::backfill_missing_files_flags(pool).await?;
     Ok(())
 }
+
+/// Clear audiobook attachment slots bearing the legacy multi-attach clobber
+/// signature: multiple ledger rows for one `(book, format)`, backed by exactly
+/// one file row. The surviving `books` row and all uuid-keyed user data remain.
+async fn repair_ghosted_audiobook_attachments(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let damaged_slots: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT mu.book_id, UPPER(mu.format)
+           FROM merged_uuids mu
+           JOIN book_files bf
+             ON bf.book_id = mu.book_id AND bf.format = mu.format
+          WHERE UPPER(mu.format) IN ('M4B', 'M4A', 'MP3')
+          GROUP BY mu.book_id, UPPER(mu.format)
+         HAVING COUNT(*) > 1 AND COUNT(DISTINCT bf.id) = 1",
+    )
+    .fetch_all(&mut *tx)
+    .await?;
+    if damaged_slots.is_empty() {
+        tx.commit().await?;
+        return Ok(());
+    }
+
+    for chunk in damaged_slots.chunks(GHOSTED_SLOT_REPAIR_CHUNK) {
+        let predicate =
+            std::iter::repeat_n("(book_id = ? AND format = ? COLLATE NOCASE)", chunk.len())
+                .collect::<Vec<_>>()
+                .join(" OR ");
+
+        let delete_files_sql = format!("DELETE FROM book_files WHERE {predicate}");
+        let mut delete_files = sqlx::query(&delete_files_sql);
+        for (book_id, format) in chunk {
+            delete_files = delete_files.bind(book_id).bind(format);
+        }
+        delete_files.execute(&mut *tx).await?;
+
+        let delete_ledger_sql = format!("DELETE FROM merged_uuids WHERE {predicate}");
+        let mut delete_ledger = sqlx::query(&delete_ledger_sql);
+        for (book_id, format) in chunk {
+            delete_ledger = delete_ledger.bind(book_id).bind(format);
+        }
+        delete_ledger.execute(&mut *tx).await?;
+    }
+
+    tx.commit().await?;
+    tracing::info!(
+        repaired_slots = damaged_slots.len(),
+        "boot backfill: cleared ghosted audiobook attachment slots"
+    );
+    Ok(())
+}
+
+/// Two binds per slot keeps each repair statement under SQLite's 999-bind cap.
+const GHOSTED_SLOT_REPAIR_CHUNK: usize = 400;
 
 /// Run the one-time legacy cover-cache purge on the blocking pool.
 ///

--- a/db/src/pool/tests.rs
+++ b/db/src/pool/tests.rs
@@ -468,6 +468,230 @@ async fn migrator_is_idempotent_on_rerun() {
     let _ = std::fs::remove_file(&tmp);
 }
 
+struct GhostedRepairFixture {
+    audio_path: String,
+    target_id: i64,
+    target_uuid: String,
+    healthy_uuid: String,
+}
+
+async fn seed_ghosted_repair_fixture(pool: &SqlitePool) -> GhostedRepairFixture {
+    let audio_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("test_data")
+        .join("audiobooks")
+        .join("generated")
+        .join("grace_hopper_series");
+    let audio_path = audio_root.to_string_lossy().into_owned();
+    let target_uuid = crate::test_support::seed_synced_ebook(
+        pool,
+        "Hopper/The Compiled Tales.epub",
+        "The Compiled Tales",
+        "Grace Hopper",
+    )
+    .await;
+    let healthy_uuid = crate::test_support::seed_synced_ebook(
+        pool,
+        "Lovelace/Notes.epub",
+        "Notes",
+        "Ada Lovelace",
+    )
+    .await;
+    crate::sync::sync_audiobooks(
+        pool,
+        "/healthy-audio",
+        crate::sync::AudiobookSyncPlan {
+            new_books: vec![crate::test_support::indexed_audiobook(
+                "Lovelace/Notes.m4b",
+                "Notes",
+                Some("Ada Lovelace"),
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    crate::indexer::reindex_audiobooks(pool, &audio_path)
+        .await
+        .unwrap();
+    let target_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?")
+        .bind(&target_uuid)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    let audio_file_id: i64 =
+        sqlx::query_scalar("SELECT id FROM book_files WHERE book_id = ? AND format = 'MP3'")
+            .bind(target_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    let initial_parts: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM book_file_parts WHERE book_file_id = ?")
+            .bind(audio_file_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(initial_parts, 2, "fixture must begin as a two-part book");
+
+    sqlx::query("DELETE FROM book_file_parts WHERE book_file_id = ? AND ordinal = 0")
+        .bind(audio_file_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('ghosted-chapter-1', ?, 'MP3', ?, 'the_compiled_tales/chapter01.mp3')",
+    )
+    .bind(target_id)
+    .bind(&audio_path)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    seed_repair_user_data(pool, &target_uuid).await;
+    assert_eq!(ghosted_slot_counts(pool, target_id).await, (2, 1));
+
+    GhostedRepairFixture {
+        audio_path,
+        target_id,
+        target_uuid,
+        healthy_uuid,
+    }
+}
+
+async fn seed_repair_user_data(pool: &SqlitePool, target_uuid: &str) {
+    sqlx::query(
+        "INSERT INTO users (id, username, password_hash, is_admin)
+         VALUES (1, 'repair-user', 'hash', 1)",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO reading_progress
+            (user_id, book_uuid, format, audio_position_seconds)
+         VALUES (1, ?, 'audio', 321.5)",
+    )
+    .bind(target_uuid)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO user_ratings (user_id, book_uuid, half_stars)
+         VALUES (1, ?, 9)",
+    )
+    .bind(target_uuid)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO journal_entries (user_id, book_uuid, body_md)
+         VALUES (1, ?, 'Preserve this note')",
+    )
+    .bind(target_uuid)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn ghosted_slot_counts(pool: &SqlitePool, target_id: i64) -> (i64, i64) {
+    sqlx::query_as(
+        "SELECT
+             (SELECT COUNT(*) FROM merged_uuids
+               WHERE book_id = ? AND format = 'MP3'),
+             (SELECT COUNT(*) FROM book_files
+               WHERE book_id = ? AND format = 'MP3')",
+    )
+    .bind(target_id)
+    .bind(target_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn repair_user_data_counts(pool: &SqlitePool, target_uuid: &str) -> (i64, i64, i64) {
+    sqlx::query_as(
+        "SELECT
+             (SELECT COUNT(*) FROM reading_progress WHERE book_uuid = ?),
+             (SELECT COUNT(*) FROM user_ratings WHERE book_uuid = ?),
+             (SELECT COUNT(*) FROM journal_entries WHERE book_uuid = ?)",
+    )
+    .bind(target_uuid)
+    .bind(target_uuid)
+    .bind(target_uuid)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn boot_backfill_repairs_ghosted_multi_attach_and_preserves_surviving_book_data() {
+    let _covers = crate::test_support::CoversTempDir::new("ghosted-multi-attach-repair");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let fixture = seed_ghosted_repair_fixture(&pool).await;
+
+    run_boot_backfills(&pool).await.unwrap();
+    let repaired_slot = ghosted_slot_counts(&pool, fixture.target_id).await;
+    assert_eq!(
+        repaired_slot,
+        (0, 0),
+        "repair must clear the corrupt attachment slot so disk files re-flow"
+    );
+    run_boot_backfills(&pool).await.unwrap();
+    assert_eq!(
+        ghosted_slot_counts(&pool, fixture.target_id).await,
+        repaired_slot
+    );
+    let preserved_books: (i64, i64, i64) = sqlx::query_as(
+        "SELECT
+             (SELECT COUNT(*) FROM books WHERE uuid = ?),
+             (SELECT COUNT(*) FROM book_files bf
+               JOIN books b ON b.id = bf.book_id
+              WHERE b.uuid = ?),
+             (SELECT COUNT(*) FROM merged_uuids
+               WHERE book_id = (SELECT id FROM books WHERE uuid = ?))",
+    )
+    .bind(&fixture.target_uuid)
+    .bind(&fixture.healthy_uuid)
+    .bind(&fixture.healthy_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(preserved_books, (1, 2, 1));
+    assert_eq!(
+        repair_user_data_counts(&pool, &fixture.target_uuid).await,
+        (1, 1, 1)
+    );
+
+    crate::indexer::reindex_audiobooks(&pool, &fixture.audio_path)
+        .await
+        .unwrap();
+    let rebuilt: (i64, i64, i64) = sqlx::query_as(
+        "SELECT
+             (SELECT COUNT(*) FROM books WHERE uuid = ?),
+             (SELECT COUNT(*) FROM book_files
+               WHERE book_id = ? AND format = 'MP3'),
+             (SELECT COUNT(*) FROM book_file_parts p
+               JOIN book_files bf ON bf.id = p.book_file_id
+              WHERE bf.book_id = ? AND bf.format = 'MP3')",
+    )
+    .bind(&fixture.target_uuid)
+    .bind(fixture.target_id)
+    .bind(fixture.target_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        rebuilt,
+        (1, 1, 2),
+        "the surviving book identity must regain one two-part audio file"
+    );
+    assert_eq!(
+        repair_user_data_counts(&pool, &fixture.target_uuid).await,
+        (1, 1, 1)
+    );
+}
+
 #[test]
 fn purge_legacy_covers_once_sweeps_then_no_ops() {
     // Standalone temp dir so we don't depend on CoversTempDir's env var

--- a/db/src/sync/attach/mod.rs
+++ b/db/src/sync/attach/mod.rs
@@ -60,6 +60,50 @@ pub(super) async fn find_attach_target(
     })
 }
 
+/// Is the `(book_id, format)` attachment slot already held by a **different**
+/// file? A book can hold at most one attached file per format; the attach
+/// writers `DELETE FROM book_files WHERE book_id = ? AND format = ?` before
+/// inserting, so attaching a second, distinct file would silently clobber the
+/// incumbent's row while still leaving its own `merged_uuids` breadcrumb
+/// (issue #1063). The writers call this first and refuse when it returns
+/// `true`, so the loser is inserted as its own book instead of destroying the
+/// winner. `scan_key` is the incoming file's own key, excluded so an
+/// idempotent re-attach of the same file still proceeds.
+pub(super) async fn slot_held_by_other(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    format: &str,
+    scan_key: &str,
+) -> Result<bool, sqlx::Error> {
+    let held: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM merged_uuids
+          WHERE book_id = ? AND format = ? AND scan_key <> ? LIMIT 1",
+    )
+    .bind(book_id)
+    .bind(format)
+    .bind(scan_key)
+    .fetch_optional(&mut **tx)
+    .await?;
+    Ok(held.is_some())
+}
+
+/// Drop the `merged_uuids` row for `(library_path, scan_key)`. Called when a
+/// file that previously recorded an attachment is being demoted to its own
+/// book (its slot got taken by another file), so its stale ledger entry
+/// doesn't keep replaying the attach on every future scan (issue #1063).
+pub(super) async fn forget_attachment(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    library_path: &str,
+    scan_key: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM merged_uuids WHERE library_path = ? AND scan_key = ?")
+        .bind(library_path)
+        .bind(scan_key)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
 /// Record (or refresh) the `merged_uuids` row for an attached file.
 /// `library_path` is the scanned root of the *file*, not the target
 /// book's library — the reindex diff filters on it. `scan_key` is the

--- a/db/src/sync/attach/mod.rs
+++ b/db/src/sync/attach/mod.rs
@@ -60,15 +60,8 @@ pub(super) async fn find_attach_target(
     })
 }
 
-/// Is the `(book_id, format)` attachment slot already held by a **different**
-/// file? A book can hold at most one attached file per format; the attach
-/// writers `DELETE FROM book_files WHERE book_id = ? AND format = ?` before
-/// inserting, so attaching a second, distinct file would silently clobber the
-/// incumbent's row while still leaving its own `merged_uuids` breadcrumb
-/// (issue #1063). The writers call this first and refuse when it returns
-/// `true`, so the loser is inserted as its own book instead of destroying the
-/// winner. `scan_key` is the incoming file's own key, excluded so an
-/// idempotent re-attach of the same file still proceeds.
+/// Return whether another file holds the `(book_id, format)` attachment slot.
+/// The incoming `scan_key` is excluded so re-attaching the same file proceeds.
 pub(super) async fn slot_held_by_other(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -131,6 +131,234 @@ async fn attach_skipped_when_titles_differ() {
 }
 
 #[tokio::test]
+async fn two_audiobooks_matching_one_ebook_in_one_plan_do_not_clobber() {
+    // Two distinct M4B files for the same work land in a single New plan. The
+    // first attaches as the ebook's M4B edition; the second must become its
+    // own book, not overwrite the first's file row (#1063).
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_ebook(
+        &pool,
+        "Sanderson/Wind and Truth.epub",
+        "Wind and Truth",
+        "Brandon Sanderson",
+    )
+    .await;
+    sync_audiobooks(
+        &pool,
+        "/audio",
+        AudiobookSyncPlan {
+            new_books: vec![
+                indexed_audiobook(
+                    "Sanderson/wt-a.m4b",
+                    "Wind and Truth",
+                    Some("Brandon Sanderson"),
+                ),
+                indexed_audiobook(
+                    "Sanderson/wt-b.m4b",
+                    "Wind and Truth",
+                    Some("Brandon Sanderson"),
+                ),
+            ],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // One attaches to the ebook, the other stands alone → 2 books, and both
+    // M4B files survive (no delete-then-replace).
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM books").await, 2);
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'M4B'"
+        )
+        .await,
+        2
+    );
+    // Only the attached file records a ledger row; the standalone book is
+    // native, so exactly one merged_uuids row exists.
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM merged_uuids").await, 1);
+}
+
+#[tokio::test]
+async fn replayed_ledger_collision_does_not_clobber_the_incumbent_file() {
+    // Regression for #1063: two merged_uuids rows pointing at the same
+    // (book, M4B) slot — the frozen state a pre-fix clobber leaves behind. A
+    // rescan that replays the second file must refuse rather than delete the
+    // incumbent's file row and replace it. Pre-fix this collapsed to one file
+    // row (data loss); post-fix the incumbent survives and the loser becomes
+    // its own book.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_ebook(
+        &pool,
+        "Sanderson/Wind and Truth.epub",
+        "Wind and Truth",
+        "Brandon Sanderson",
+    )
+    .await;
+
+    // File A attaches to the ebook the normal way.
+    sync_audiobooks(
+        &pool,
+        "/audio",
+        AudiobookSyncPlan {
+            new_books: vec![indexed_audiobook(
+                "Sanderson/wt-a.m4b",
+                "Wind and Truth",
+                Some("Brandon Sanderson"),
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let ebook_id: i64 = sqlx::query_scalar(
+        "SELECT book_id FROM merged_uuids WHERE scan_key = 'Sanderson/wt-a.m4b'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    // Forge the legacy bad state: a second ledger row for file B on A's slot.
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('forged-b', ?, 'M4B', '/audio', 'Sanderson/wt-b.m4b')",
+    )
+    .bind(ebook_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Replay file B through the Changed bucket.
+    sync_audiobooks(
+        &pool,
+        "/audio",
+        AudiobookSyncPlan {
+            changed_books: vec![indexed_audiobook(
+                "Sanderson/wt-b.m4b",
+                "Wind and Truth",
+                Some("Brandon Sanderson"),
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // The incumbent A's file row on the ebook is untouched (its filename is
+    // A's stem, not B's) — the DELETE-then-replace never fired.
+    let incumbent: String =
+        sqlx::query_scalar("SELECT filename FROM book_files WHERE book_id = ? AND format = 'M4B'")
+            .bind(ebook_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(incumbent, "wt-a");
+    // B survives too — as its own book, not a lost row.
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'M4B'"
+        )
+        .await,
+        2
+    );
+    // B's stale ledger row was forgotten, so the slot no longer has two rows
+    // fighting over it.
+    assert_eq!(
+        count(
+            &pool,
+            &format!(
+                "SELECT COUNT(*) FROM merged_uuids WHERE book_id = {ebook_id} AND format = 'M4B'"
+            )
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn replayed_ebook_ledger_collision_does_not_clobber_the_incumbent_file() {
+    // The ebook attach writer shares the same guard (#1063). Same shape as the
+    // audiobook case, roles swapped: a native audiobook holds an attached EPUB,
+    // and a forged second-EPUB ledger row must not clobber the incumbent.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_audiobook(&pool, "Herbert/Dune.m4b", "Dune", "Frank Herbert").await;
+
+    // EPUB A attaches to the audiobook.
+    sync_books(
+        &pool,
+        "/books",
+        SyncPlan {
+            new_books: vec![indexed(
+                "Herbert/dune-a.epub",
+                Some("Dune"),
+                &["Frank Herbert"],
+                &[],
+                None,
+                None,
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let book_id: i64 = sqlx::query_scalar("SELECT book_id FROM merged_uuids WHERE format = 'EPUB'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // Forge a second EPUB ledger row for file B on A's slot.
+    let scan_key_b = crate::helpers::scan_key_for("Herbert/dune-b.epub");
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('forged-eb', ?, 'EPUB', '/books', ?)",
+    )
+    .bind(book_id)
+    .bind(&scan_key_b)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Replay EPUB B through the Changed bucket.
+    sync_books(
+        &pool,
+        "/books",
+        SyncPlan {
+            changed_books: vec![indexed(
+                "Herbert/dune-b.epub",
+                Some("Dune"),
+                &["Frank Herbert"],
+                &[],
+                None,
+                None,
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // Incumbent A's EPUB row is intact; B became its own book.
+    let incumbent: String =
+        sqlx::query_scalar("SELECT filename FROM book_files WHERE book_id = ? AND format = 'EPUB'")
+            .bind(book_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(incumbent, "dune-a");
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'EPUB'"
+        )
+        .await,
+        2
+    );
+}
+
+#[tokio::test]
 async fn reindex_diff_classifies_attached_file_as_unchanged() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -245,10 +245,22 @@ async fn sync_audiobooks_changed(
             if let Some((_uuid, target_id, format)) =
                 attach::find_attachment_by_scan_key(tx, library_path, &b.scan_key).await?
             {
-                attach_audiobook_file(tx, target_id, &format, library_path, b, &mut changed_covers)
-                    .await?;
-                on_book_written();
-                continue;
+                if attach_audiobook_file(
+                    tx,
+                    target_id,
+                    &format,
+                    library_path,
+                    b,
+                    &mut changed_covers,
+                )
+                .await?
+                {
+                    on_book_written();
+                    continue;
+                }
+                // Slot taken by a different file: forget the stale ledger row
+                // and fall through to insert this file as its own book.
+                attach::forget_attachment(tx, library_path, &b.scan_key).await?;
             }
             insert_new_audiobook(tx, library_id, b, &mut changed_covers).await?;
             on_book_written();
@@ -431,8 +443,13 @@ async fn try_attach_new_audiobook(
     if let Some((_uuid, target_id, format)) =
         attach::find_attachment_by_scan_key(tx, library_path, &b.scan_key).await?
     {
-        attach_audiobook_file(tx, target_id, &format, library_path, b, covers).await?;
-        return Ok(true);
+        if attach_audiobook_file(tx, target_id, &format, library_path, b, covers).await? {
+            return Ok(true);
+        }
+        // Slot taken by a different file: drop this file's stale ledger row so
+        // it stops replaying, and fall through to insert it as its own book.
+        attach::forget_attachment(tx, library_path, &b.scan_key).await?;
+        return Ok(false);
     }
     let (Some(title_norm), Some(author_norm)) = (
         normalize_title(&b.title),
@@ -446,8 +463,10 @@ async fn try_attach_new_audiobook(
     else {
         return Ok(false);
     };
-    attach_audiobook_file(tx, target_id, &b.format, library_path, b, covers).await?;
-    Ok(true)
+    // find_attach_target excludes a book that already has this format's file
+    // row, but the writer re-checks the ledger and may still refuse a slot a
+    // different file holds — return whatever it decides.
+    attach_audiobook_file(tx, target_id, &b.format, library_path, b, covers).await
 }
 
 /// Write (or rewrite) an attached audiobook's `book_files` row (plus
@@ -458,6 +477,10 @@ async fn try_attach_new_audiobook(
 /// row carries its own `(library_path, path)` location override — the
 /// target book may live in a different library, and the HLS read path
 /// resolves part filenames against the *audio* root.
+///
+/// Returns `Ok(false)` without writing anything when the `(book_id, format)`
+/// slot is already held by a **different** file — the caller then inserts
+/// this file as its own book rather than clobbering the incumbent (#1063).
 async fn attach_audiobook_file(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
@@ -465,7 +488,12 @@ async fn attach_audiobook_file(
     library_path: &str,
     b: &crate::audiobook::IndexedAudiobook,
     covers: &mut Vec<(String, String, Vec<u8>)>,
-) -> Result<(), SyncError> {
+) -> Result<bool, SyncError> {
+    // One attached file per (book, format) slot: refuse rather than delete a
+    // different file's row (the DELETE below is scoped only to the format).
+    if attach::slot_held_by_other(tx, book_id, format, &b.scan_key).await? {
+        return Ok(false);
+    }
     // Idempotent re-attach: the refresh path lands here too.
     sqlx::query("DELETE FROM book_files WHERE book_id = ? AND format = ?")
         .bind(book_id)
@@ -496,7 +524,7 @@ async fn attach_audiobook_file(
     if let Some(cover) = attach::maybe_adopt_cover(tx, book_id, b.cover.as_ref()).await? {
         covers.push(cover);
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Return type from a fresh audiobook insert — the ids needed by the

--- a/db/src/sync/audiobooks.rs
+++ b/db/src/sync/audiobooks.rs
@@ -478,9 +478,7 @@ async fn try_attach_new_audiobook(
 /// target book may live in a different library, and the HLS read path
 /// resolves part filenames against the *audio* root.
 ///
-/// Returns `Ok(false)` without writing anything when the `(book_id, format)`
-/// slot is already held by a **different** file — the caller then inserts
-/// this file as its own book rather than clobbering the incumbent (#1063).
+/// Returns `Ok(false)` without writing when another file holds the slot.
 async fn attach_audiobook_file(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,

--- a/db/src/sync/books/changed.rs
+++ b/db/src/sync/books/changed.rs
@@ -103,7 +103,7 @@ async fn sync_changed_one(
         if let Some((merged_uuid, target_id, format)) =
             attach::find_attachment_by_scan_key(tx, library_path, scan_key).await?
         {
-            attach_ebook_file(
+            if attach_ebook_file(
                 tx,
                 target_id,
                 &format,
@@ -112,8 +112,13 @@ async fn sync_changed_one(
                 b,
                 changed_covers,
             )
-            .await?;
-            return Ok(());
+            .await?
+            {
+                return Ok(());
+            }
+            // Slot taken by a different file: forget the stale ledger row and
+            // fall through to promote this file to its own New insert.
+            attach::forget_attachment(tx, library_path, scan_key).await?;
         }
         // … or a TOCTOU: the diff said this scan_key existed in the DB,
         // but a concurrent process removed it between Phase A and

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -70,7 +70,7 @@ pub(super) async fn try_attach_new_ebook(
     if let Some((merged_uuid, target_id, format)) =
         attach::find_attachment_by_scan_key(tx, library_path, &scan_key).await?
     {
-        attach_ebook_file(
+        if attach_ebook_file(
             tx,
             target_id,
             &format,
@@ -79,8 +79,14 @@ pub(super) async fn try_attach_new_ebook(
             b,
             covers,
         )
-        .await?;
-        return Ok(true);
+        .await?
+        {
+            return Ok(true);
+        }
+        // Slot taken by a different file: drop this file's stale ledger row so
+        // it stops replaying, and fall through to insert it as its own book.
+        attach::forget_attachment(tx, library_path, &scan_key).await?;
+        return Ok(false);
     }
 
     let title = m.title.clone().unwrap_or_else(|| m.filename.clone());
@@ -99,8 +105,10 @@ pub(super) async fn try_attach_new_ebook(
     // A brand-new attachment: mint a stable handle for the ledger row (the
     // lookup above is by scan_key, so this uuid is only an identifier).
     let uuid = stable_uuid(library_path, &m.filename);
-    attach_ebook_file(tx, target_id, &file_ext, library_path, &uuid, b, covers).await?;
-    Ok(true)
+    // find_attach_target excludes a book that already has this format's file
+    // row, but the writer re-checks the ledger and may still refuse a slot a
+    // different file holds — return whatever it decides.
+    attach_ebook_file(tx, target_id, &file_ext, library_path, &uuid, b, covers).await
 }
 
 /// Write (or rewrite) an attached ebook's `book_files` row under
@@ -110,6 +118,10 @@ pub(super) async fn try_attach_new_ebook(
 /// target metadata wins — but the FTS row is refreshed via the door so
 /// the newly-unioned identifiers (incl. an attached-only ISBN) become
 /// searchable immediately.
+///
+/// Returns `Ok(false)` without writing anything when the `(book_id, format)`
+/// slot is already held by a **different** file — the caller then inserts
+/// this file as its own book rather than clobbering the incumbent (#1063).
 pub(super) async fn attach_ebook_file(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
@@ -118,7 +130,16 @@ pub(super) async fn attach_ebook_file(
     uuid: &str,
     b: &crate::ebook::IndexedBook,
     covers: &mut Vec<(String, String, Vec<u8>)>,
-) -> Result<(), sqlx::Error> {
+) -> Result<bool, sqlx::Error> {
+    // The attached file's own relative path is its diff key (F2), so a repoint
+    // of the file's scan root re-matches it instead of resurfacing it as a
+    // duplicate; it's also the ledger key written below.
+    let scan_key = scan_key_for(&b.metadata.filename);
+    // One attached file per (book, format) slot: refuse rather than delete a
+    // different file's row (the DELETE below is scoped only to the format).
+    if attach::slot_held_by_other(tx, book_id, format, &scan_key).await? {
+        return Ok(false);
+    }
     // Idempotent re-attach: the refresh path (and the self-healing "uuid
     // known but attachment row missing" path) both land here.
     sqlx::query("DELETE FROM book_files WHERE book_id = ? AND format = ?")
@@ -140,10 +161,6 @@ pub(super) async fn attach_ebook_file(
     .execute(&mut **tx)
     .await?;
     insert_identifier_links(tx, book_id, &b.metadata).await?;
-    // The attached file's own relative path is its diff key (F2), so a
-    // repoint of the file's scan root re-matches it instead of resurfacing
-    // it as a duplicate.
-    let scan_key = scan_key_for(&b.metadata.filename);
     attach::record_attachment(tx, uuid, book_id, format, library_path, &scan_key).await?;
     // The unioned identifiers (incl. a new ISBN from this format) just
     // changed the target's searchable text — refresh its FTS row.
@@ -151,7 +168,7 @@ pub(super) async fn attach_ebook_file(
     if let Some(cover) = attach::maybe_adopt_cover(tx, book_id, b.cover.as_ref()).await? {
         covers.push(cover);
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Insert the `book_files` row for an existing `books.id`. Shared by the

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -119,9 +119,7 @@ pub(super) async fn try_attach_new_ebook(
 /// the newly-unioned identifiers (incl. an attached-only ISBN) become
 /// searchable immediately.
 ///
-/// Returns `Ok(false)` without writing anything when the `(book_id, format)`
-/// slot is already held by a **different** file — the caller then inserts
-/// this file as its own book rather than clobbering the incumbent (#1063).
+/// Returns `Ok(false)` without writing when another file holds the slot.
 pub(super) async fn attach_ebook_file(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,


### PR DESCRIPTION
## Summary
- Detect legacy audiobook slots with multiple `merged_uuids` rows backed by one `book_files` row and clear only that corrupt slot at boot.
- Preserve the surviving book identity and uuid-keyed user data so the next scan re-attaches and reconstructs every on-disk part.
- The repair is idempotent and leaves healthy native and cross-format attachments untouched.

## Test plan
- [x] Regression-first `sqlite::memory:` test using the committed two-part MP3 fixture.
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-db` (942 unit tests plus fixture integration; two base-branch fixture guards excluded as noted below)

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Stacked on and depends on #1068; base is `u/sloan/fix-attach-slot-clobber`.
- `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` and `public_domain_epubs_parse_with_expected_metadata` require `just fixtures` and fail identically on the base branch.
- Closes #1064.