### PR TITLE
feat: remove breadcrumbs from author & series pages (#994)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3713,13 +3713,11 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
    `.screen` (mobile-only wrapper) already carries the safe-area top padding,
    so the web-sized hero/header paddings stack into a large blank band —
    collapse them to the library screen's rhythm. The `.disc-back` button is
-   rendered on every target (rule 07) but only shown here, where the web
-   breadcrumb is hidden in its favor. Declared after `.m-icon-btn` so the
+   rendered on every target (rule 07) but only shown here; web has no
+   breadcrumb affordance on these pages. Declared after `.m-icon-btn` so the
    hidden-by-default rule wins their specificity tie. */
 .disc-back { display: none; }
 .screen .disc-back { display: grid; margin-bottom: 12px; }
-.screen .disc-hero .breadcrumb,
-.screen .disc-series-header .breadcrumb { display: none; }
 .screen .idx-header { padding: 4px 0 16px; }
 .screen .disc-hero { padding: 4px 0 20px; }
 .screen .disc-hero-grid { margin-top: 12px; }

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -179,8 +179,8 @@ struct AuthorHeroText<'a> {
     bg_style: &'a str,
 }
 
-/// Hero header: breadcrumb, avatar (with the hover-revealed photo-edit
-/// overlay), name + admin delete affordance, and the book-count stat.
+/// Hero header: avatar (with the hover-revealed photo-edit overlay), name +
+/// admin delete affordance, and the book-count stat.
 fn author_hero(
     a: &AuthorDetail,
     server_url: &str,
@@ -197,19 +197,14 @@ fn author_hero(
     rsx! {
         div { class: "disc-hero", style: "background: {bg_style}",
             // Mobile-only (CSS-gated via `.screen`) back affordance to the
-            // authors index; web keeps the breadcrumb. Same markup on every
-            // target so the web SSR/WASM trees stay identical (rule 07).
+            // authors index. Same markup on every target so the web
+            // SSR/WASM trees stay identical (rule 07).
             Link {
                 to: Route::AuthorsIndex {},
                 class: "m-icon-btn disc-back",
                 "aria-label": "Back to authors",
                 "data-testid": "author-back",
                 "\u{2190}"
-            }
-            nav { class: "breadcrumb",
-                Link { to: Route::Landing {}, "Library" }
-                span { class: "breadcrumb-sep", " › " }
-                span { "{a.name}" }
             }
             div { class: "disc-hero-grid",
                 {author_avatar(a, server_url, author, initial)}

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -56,19 +56,9 @@ fn render_series(s: SeriesDetail) -> Element {
         .find_map(|b| b.accent.as_deref())
         .unwrap_or("var(--accent)");
 
-    // Primary author from the first book's first creator. Capture the
-    // author id alongside the name so the breadcrumb can render a Link
-    // when the row is resolvable; books whose first creator is an
-    // override-only string (no `authors` row) fall back to a plain span.
-    let (primary_author, primary_author_id) = s
-        .books
-        .iter()
-        .find_map(|b| b.creators.first().map(|c| (c.name.clone(), c.id)))
-        .unwrap_or_default();
-
     rsx! {
         div { class: "disc-page", style: "--accent: {accent}",
-            {series_header(&s, &primary_author, primary_author_id)}
+            {series_header(&s)}
             div { class: "disc-body",
                 div { class: "series-cards",
                     for book in s.books.iter() {
@@ -80,13 +70,9 @@ fn render_series(s: SeriesDetail) -> Element {
     }
 }
 
-/// Series page header: breadcrumb (with an optional linked author crumb) and
-/// the italic-first-word hero title.
-fn series_header(
-    s: &SeriesDetail,
-    primary_author: &str,
-    primary_author_id: Option<i64>,
-) -> Element {
+/// Series page header: mobile back affordance and the italic-first-word
+/// hero title.
+fn series_header(s: &SeriesDetail) -> Element {
     // Split series name for italic styling on key word.
     let title_parts: Vec<&str> = s.name.splitn(2, ' ').collect();
     let title_first = title_parts.first().copied().unwrap_or("");
@@ -98,31 +84,14 @@ fn series_header(
     rsx! {
         div { class: "disc-series-header",
             // Mobile-only (CSS-gated via `.screen`) back affordance to the
-            // series index; web keeps the breadcrumb. Same markup on every
-            // target so the web SSR/WASM trees stay identical (rule 07).
+            // series index. Same markup on every target so the web
+            // SSR/WASM trees stay identical (rule 07).
             Link {
                 to: Route::SeriesIndex {},
                 class: "m-icon-btn disc-back",
                 "aria-label": "Back to series",
                 "data-testid": "series-back",
                 "\u{2190}"
-            }
-            nav { class: "breadcrumb", aria_label: "breadcrumb",
-                Link { to: Route::Landing {}, "Library" }
-                span { class: "breadcrumb-sep", " › " }
-                if !primary_author.is_empty() {
-                    if let Some(author_id) = primary_author_id {
-                        Link {
-                            to: Route::AuthorDetail { id: author_id },
-                            "data-testid": "series-crumb-author",
-                            "{primary_author}"
-                        }
-                    } else {
-                        span { "data-testid": "series-crumb-author", "{primary_author}" }
-                    }
-                    span { class: "breadcrumb-sep", " › " }
-                }
-                span { "{s.name}" }
             }
             div { class: "disc-series-head-row",
                 div {

--- a/ui_tests/playwright/tests/flows/discovery.spec.ts
+++ b/ui_tests/playwright/tests/flows/discovery.spec.ts
@@ -67,10 +67,6 @@ test("renders the author page layout", async ({ page, request }) => {
 
   // Book count stat is visible
   await expect(page.getByText("In your library")).toBeVisible();
-
-  // Breadcrumb has "Library" link
-  const breadcrumb = page.locator("nav.breadcrumb");
-  await expect(breadcrumb.getByRole("link", { name: "Library" })).toBeVisible();
 });
 
 test("author page shows books by the author", async ({ page, request }) => {
@@ -92,8 +88,7 @@ test("author page shows books by the author", async ({ page, request }) => {
 test("author series section heading links to the series page", async ({ page, request }) => {
   // Niklaus Wirth's four books all belong to "Code Quartet", so the author
   // page renders a single series section whose heading is a router Link to
-  // /series/:id. The author-page breadcrumb only carries a "Library" link, so
-  // the "Code Quartet" link role is unambiguous on this page.
+  // /series/:id, and it's the only "Code Quartet" link role on the page.
   const authorId = await fetchAuthorIdByName(request, "Niklaus Wirth");
   await gotoReady(page, `/authors/${authorId}`);
 
@@ -145,10 +140,6 @@ test("renders the series page layout", async ({ page, request }) => {
 
   // Book count label is visible
   await expect(page.getByText(/in library/)).toBeVisible();
-
-  // Breadcrumb has "Library" link
-  const breadcrumb = page.locator("nav.breadcrumb");
-  await expect(breadcrumb.getByRole("link", { name: "Library" })).toBeVisible();
 });
 
 test("series page shows books in order", async ({ page, request }) => {


### PR DESCRIPTION
## Summary
- Removes the web-only `nav.breadcrumb` from the author detail hero (`frontend/src/pages/author.rs::author_hero`) and the series detail header (`frontend/src/pages/series.rs::series_header`). Mobile's `disc-back` button already covers the same "go back" affordance on both pages, so it's redundant.
- Removes the now-dead `primary_author`/`primary_author_id` breadcrumb-crumb derivation in `series.rs` (it existed only to feed the removed breadcrumb link) and simplifies `series_header`'s signature accordingly.
- Removes the now-dead `.screen .disc-hero .breadcrumb, .screen .disc-series-header .breadcrumb { display: none; }` CSS override in `frontend/assets/atrium.css` (nothing matches those selectors anymore). The general `.breadcrumb` / `.breadcrumb-sep` rules are left in place — `authors_index.rs`, `series_index.rs`, and `search.rs` still render breadcrumbs and depend on them.
- Updates `ui_tests/playwright/tests/flows/discovery.spec.ts` to drop the two `nav.breadcrumb` assertions on the author/series detail-page layout tests (no `series-crumb-author` selector existed elsewhere in the suite to update).

Closes #994

## Test plan
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, clean
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 270 passed / 0 failed
- [ ] Playwright / browser verification — **not possible in this environment** (no Node/nix toolchain available); the `discovery.spec.ts` edits were verified by inspection only. Please run `npx playwright test discovery.spec.ts` (and ideally the full suite) before merging.

## Version
- [ ] **Minor**
- [x] **Patch** — default, unlabeled
- [ ] **No release**

## Notes
- Confirmed via grep that `.breadcrumb` markup is still used by `authors_index.rs`, `series_index.rs`, and `search.rs`, and that `.bd-crumb` (book detail / metadata edit) is a distinct class — so this change is scoped to the author/series *detail* pages only, per the issue's acceptance criteria.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar2Z7PPFwrNkEYGcC8DRLz)_