### PR TITLE
fix: add regression coverage for second-admin library scan (#1056)

### DIFF
--- a/server/src/backend/settings/tests.rs
+++ b/server/src/backend/settings/tests.rs
@@ -328,6 +328,51 @@ async fn reindex_returns_200_when_scan_succeeds() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
+// Regression test for #1056: same as `scan_library_returns_200_when_
+// triggered_by_a_second_promoted_admin` below, but for the synchronous
+// `/api/reindex` handler the issue also named.
+#[tokio::test]
+async fn reindex_returns_200_when_triggered_by_a_second_promoted_admin() {
+    let (app, _state, pool) = fixture().await;
+    auth_test_support::create_admin(&pool, "owner").await;
+    let second_admin = auth_test_support::create_admin(&pool, "second-admin").await;
+    let token = auth_test_support::bearer_token(&pool, second_admin.id).await;
+
+    let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../test_data/epubs/generated")
+        .canonicalize()
+        .expect("fixtures dir should resolve");
+    let scratch = tempfile::tempdir().expect("create scratch dir");
+    for entry in std::fs::read_dir(&source).expect("read fixtures dir") {
+        let entry = entry.expect("fixture entry");
+        if entry.file_type().expect("file type").is_file() {
+            let dest = scratch.path().join(entry.file_name());
+            std::fs::copy(entry.path(), dest).expect("copy fixture");
+        }
+    }
+    let settings = omnibus_shared::Settings {
+        ebook_library_path: Some(scratch.path().to_string_lossy().to_string()),
+        audiobook_library_path: None,
+        scan_interval_hours: None,
+    };
+    db::set_settings(&pool, &settings)
+        .await
+        .expect("set_settings should persist the fixture path");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/reindex")
+                .method("POST")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
 #[tokio::test]
 async fn scan_library_returns_200_when_a_path_is_configured() {
     let (app, _state, pool) = fixture().await;
@@ -413,6 +458,42 @@ async fn scan_library_returns_403_when_not_admin() {
         .await
         .expect("request should succeed");
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+// Regression test for #1056: `AdminUser` gates purely on the live
+// `users.is_admin` column, with no first-user/owner/`id == 1`
+// special-casing anywhere on the scan path — a second, later-promoted
+// admin must pass identically to the very first admin account.
+#[tokio::test]
+async fn scan_library_returns_200_when_triggered_by_a_second_promoted_admin() {
+    let (app, _state, pool) = fixture().await;
+    // Seed a first admin (mirrors the account created at registration)
+    // before creating the second one the issue is about.
+    auth_test_support::create_admin(&pool, "owner").await;
+    let second_admin = auth_test_support::create_admin(&pool, "second-admin").await;
+    let token = auth_test_support::bearer_token(&pool, second_admin.id).await;
+
+    let settings = omnibus_shared::Settings {
+        ebook_library_path: Some("/some/library".to_string()),
+        audiobook_library_path: None,
+        scan_interval_hours: None,
+    };
+    db::set_settings(&pool, &settings)
+        .await
+        .expect("set_settings should persist the path");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/scan-library")
+                .method("POST")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test]

--- a/server/src/backend/settings/tests.rs
+++ b/server/src/backend/settings/tests.rs
@@ -9,6 +9,25 @@ use super::*;
 use crate::auth::test_support as auth_test_support;
 use crate::backend::test_support::*;
 
+/// Copies the generated EPUB fixtures into a fresh temp dir so scan/reindex
+/// tests don't materialize cover sidecars back into the shared fixtures dir.
+fn copy_epub_fixtures_to_tempdir() -> tempfile::TempDir {
+    let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../test_data/epubs/generated")
+        .canonicalize()
+        .expect("fixtures dir should resolve");
+    assert!(source.is_dir(), "fixtures dir missing: {source:?}");
+    let scratch = tempfile::tempdir().expect("create scratch dir");
+    for entry in std::fs::read_dir(&source).expect("read fixtures dir") {
+        let entry = entry.expect("fixture entry");
+        if entry.file_type().expect("file type").is_file() {
+            let dest = scratch.path().join(entry.file_name());
+            std::fs::copy(entry.path(), dest).expect("copy fixture");
+        }
+    }
+    scratch
+}
+
 #[tokio::test]
 async fn api_get_settings_returns_null_defaults() {
     let (app, _state, pool) = fixture().await;
@@ -110,19 +129,7 @@ async fn post_settings_triggers_scan_via_worker() {
     // into the shared fixtures dir on every CI run. `tempfile::TempDir`
     // cleans itself up on Drop, so a panic before the assert below doesn't
     // leak under /tmp.
-    let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../test_data/epubs/generated")
-        .canonicalize()
-        .expect("fixtures dir should resolve");
-    assert!(source.is_dir(), "fixtures dir missing: {source:?}");
-    let scratch = tempfile::tempdir().expect("create scratch dir");
-    for entry in std::fs::read_dir(&source).expect("read fixtures dir") {
-        let entry = entry.expect("fixture entry");
-        if entry.file_type().expect("file type").is_file() {
-            let dest = scratch.path().join(entry.file_name());
-            std::fs::copy(entry.path(), dest).expect("copy fixture");
-        }
-    }
+    let scratch = copy_epub_fixtures_to_tempdir();
     let path_str = scratch.path().to_string_lossy().to_string();
 
     let body = serde_json::json!({
@@ -293,18 +300,7 @@ async fn reindex_returns_200_when_scan_succeeds() {
     // so the scan finds a real EPUB and `Task::Scan` returns `Ok`. We use
     // a tempdir to keep the reindex from materializing cover sidecars
     // back into the shared fixtures directory.
-    let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../test_data/epubs/generated")
-        .canonicalize()
-        .expect("fixtures dir should resolve");
-    let scratch = tempfile::tempdir().expect("create scratch dir");
-    for entry in std::fs::read_dir(&source).expect("read fixtures dir") {
-        let entry = entry.expect("fixture entry");
-        if entry.file_type().expect("file type").is_file() {
-            let dest = scratch.path().join(entry.file_name());
-            std::fs::copy(entry.path(), dest).expect("copy fixture");
-        }
-    }
+    let scratch = copy_epub_fixtures_to_tempdir();
     let settings = omnibus_shared::Settings {
         ebook_library_path: Some(scratch.path().to_string_lossy().to_string()),
         audiobook_library_path: None,
@@ -328,9 +324,10 @@ async fn reindex_returns_200_when_scan_succeeds() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-// Regression test for #1056: same as `scan_library_returns_200_when_
-// triggered_by_a_second_promoted_admin` below, but for the synchronous
-// `/api/reindex` handler the issue also named.
+// Regression test for #1056: same as
+// `scan_library_returns_200_when_triggered_by_a_second_promoted_admin`
+// below, but for the synchronous `/api/reindex` handler the issue also
+// named.
 #[tokio::test]
 async fn reindex_returns_200_when_triggered_by_a_second_promoted_admin() {
     let (app, _state, pool) = fixture().await;
@@ -338,18 +335,7 @@ async fn reindex_returns_200_when_triggered_by_a_second_promoted_admin() {
     let second_admin = auth_test_support::create_admin(&pool, "second-admin").await;
     let token = auth_test_support::bearer_token(&pool, second_admin.id).await;
 
-    let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../test_data/epubs/generated")
-        .canonicalize()
-        .expect("fixtures dir should resolve");
-    let scratch = tempfile::tempdir().expect("create scratch dir");
-    for entry in std::fs::read_dir(&source).expect("read fixtures dir") {
-        let entry = entry.expect("fixture entry");
-        if entry.file_type().expect("file type").is_file() {
-            let dest = scratch.path().join(entry.file_name());
-            std::fs::copy(entry.path(), dest).expect("copy fixture");
-        }
-    }
+    let scratch = copy_epub_fixtures_to_tempdir();
     let settings = omnibus_shared::Settings {
         ebook_library_path: Some(scratch.path().to_string_lossy().to_string()),
         audiobook_library_path: None,


### PR DESCRIPTION
## Summary
- Closes #1056
- Investigated the reported "second admin gets 403 on scan" bug. `AdminUser` (`server/src/auth/extractor.rs`, mirrored in `frontend/src/rpc/mod.rs`) gates purely on the live `users.is_admin` column resolved fresh on every request — there is no first-user/owner/`id == 1` special-casing anywhere on the scan path (`post_reindex`, `post_scan_library`, `rpc_scan_library`). A genuinely promoted second admin already passes the gate identically to the first admin on `main`.
- The issue's two fallback acceptance criteria are also already satisfied on `main`: `OMNIBUS_INITIAL_ADMIN` is a documented (recovery-only) promotion path for a second admin (`.env.example`, `.claude/rules/01-dev-environment.md`), and the `origin_check` CSRF middleware's `OMNIBUS_PUBLIC_ORIGIN` multi-origin/proxy behavior is documented in `.env.example` with a clear `"origin mismatch"` 403 body (not a silent failure).
- The one concrete gap left by the issue's acceptance criteria (AC4) was regression coverage pinning "a second `is_admin=1` user passes the `AdminUser` gate on the scan endpoint" — this PR adds that for both scan endpoints the issue named: `POST /api/scan-library` and `POST /api/reindex`.

## Test plan
- [x] `cargo fmt --check -p omnibus` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus backend::settings::tests` — PASS, 26/26 (includes the two new regression tests plus the existing `reindex_returns_403_when_not_admin` / `scan_library_returns_403_when_not_admin` cases)
- [x] `cargo test -p omnibus` (full crate) — 327/328 passed. The one failure, `backend::uploads::tests::commit_rejects_read_only_library_with_400`, is pre-existing and unrelated to this change (it asserts a `chmod 0o555` directory rejects a write, which fails only because this sandbox runs tests as `root`, which ignores Unix permission bits — reproduces in isolation on an unmodified checkout, outside anything touched here).

## Version
- [x] **Patch** — the default; unlabeled.

## Notes
- No production code changed — the investigation found the auth gate already correct; this PR adds the missing regression tests (AC4) that the issue called for.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar2Z7PPFwrNkEYGcC8DRLz)_