### PR TITLE
feat: show the audio mini-dock on the immersive reader (#988)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3209,6 +3209,14 @@ body {
 .app-shell > main {
   padding: 0 clamp(1.25rem, 4vw, 3.5rem);
 }
+/* Reserve room for the persistent mini-dock so its fixed bar doesn't sit
+   over — and intercept clicks on — the last row of page content. Mirrors
+   the mobile `.screen` reserve for `.m-mini` above; same `:has()` floor. */
+@supports selector(:has(a)) {
+  .app-shell > main:has(+ .mini-dock-host:not(:empty)) {
+    padding-bottom: 7rem;
+  }
+}
 
 .screen {
   display: flex;

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3095,6 +3095,15 @@ a.idx-letter-on:focus-visible {
   box-shadow: 0 24px 50px -10px rgba(0, 0, 0, .6);
 }
 
+/* On `/read` the dock renders as a sibling of `.rd-surface` (#988), so raise
+   it above the reader's own bottom bar (`.rd-bottom`, 54px + safe-area) —
+   otherwise the two fixed-position bars visually collide at the bottom
+   edge. Higher specificity than the plain `.mini-dock` rule (incl. the
+   phone breakpoint below), so it wins at every viewport width. */
+.rd-surface + .mini-dock-host .mini-dock {
+  bottom: calc(54px + env(safe-area-inset-bottom) + 8px);
+}
+
 .mini-dock-now {
   display: flex; align-items: center; gap: 12px;
   min-width: 0; text-decoration: none; color: inherit;

--- a/frontend/src/pages/listen/mini_dock.rs
+++ b/frontend/src/pages/listen/mini_dock.rs
@@ -1,10 +1,9 @@
 //! Persistent mini-dock audiobook bar, rendered by the web
-//! [`crate::ScreenLayout`] so it shows on every main page. Also rendered
-//! directly by the immersive `/read` route (#988) — the reader has no
-//! transport of its own — but stays absent from `/listen`, whose full
-//! player already owns one. Reads the app-wide [`crate::PlaybackState`]
-//! (the `<audio>` element + signals live at the App root) and drives
-//! transport through the shared `helpers::audio_call` seam.
+//! [`crate::ScreenLayout`] on every main page and by the immersive
+//! `/read` route (which has no transport of its own); stays absent
+//! from `/listen`, whose full player already owns one. Reads the
+//! app-wide [`crate::PlaybackState`] and drives transport through the
+//! shared `helpers::audio_call` seam.
 
 #![cfg(not(feature = "mobile"))]
 
@@ -250,10 +249,7 @@ mod tests {
         assert_eq!(progress_pct(f64::INFINITY, 100.0), 0.0);
     }
 
-    /// Mirrors [`MiniDock`]'s "renders empty host vs. active bar" branch —
-    /// the piece of logic that decides whether the dock shows content when
-    /// navigated to alongside another page (#988), without needing a full
-    /// component render.
+    // Mirrors MiniDock's "renders empty host vs. active bar" branch without needing a full component render.
     #[test]
     fn dock_active_state_is_none_when_nothing_is_playing() {
         assert_eq!(dock_active_state(None, None), None);

--- a/frontend/src/pages/listen/mini_dock.rs
+++ b/frontend/src/pages/listen/mini_dock.rs
@@ -1,8 +1,10 @@
 //! Persistent mini-dock audiobook bar, rendered by the web
-//! [`crate::ScreenLayout`] so it shows on every main page and is absent on the
-//! immersive `/listen` + `/read` routes. Reads the app-wide
-//! [`crate::PlaybackState`] (the `<audio>` element + signals live at the App
-//! root) and drives transport through the shared `helpers::audio_call` seam.
+//! [`crate::ScreenLayout`] so it shows on every main page. Also rendered
+//! directly by the immersive `/read` route (#988) — the reader has no
+//! transport of its own — but stays absent from `/listen`, whose full
+//! player already owns one. Reads the app-wide [`crate::PlaybackState`]
+//! (the `<audio>` element + signals live at the App root) and drives
+//! transport through the shared `helpers::audio_call` seam.
 
 #![cfg(not(feature = "mobile"))]
 
@@ -26,24 +28,34 @@ pub(super) fn progress_pct(elapsed: f64, duration: f64) -> f64 {
     ((elapsed / duration) * 100.0).clamp(0.0, 100.0)
 }
 
+/// Whether the mini-dock has both a loaded book and a resolved uuid — the
+/// two pieces of playback state its active transport bar needs. `None`
+/// means it should render the empty host instead: `book` alone isn't
+/// enough because the Expand link would point at an empty `/listen/` route
+/// (e.g. mid-dismiss, when `book` is set but `uuid` has momentarily
+/// cleared).
+pub(super) fn dock_active_state(
+    book: Option<omnibus_shared::EbookMetadata>,
+    uuid: Option<String>,
+) -> Option<(omnibus_shared::EbookMetadata, String)> {
+    match (book, uuid) {
+        (Some(book), Some(uuid)) => Some((book, uuid)),
+        _ => None,
+    }
+}
+
 /// Persistent bottom dock. Renders only its empty host wrapper until an
 /// audiobook is loaded, keeping SSR and first-WASM-paint markup identical
 /// (`book` is `None` on both).
 #[component]
 pub fn MiniDock() -> Element {
     let playback = use_playback();
-    let book = playback.book.read().clone();
 
     // Stable host wrapper so hydration node-counting stays consistent; only
-    // the inner bar is conditional on a loaded book.
-    let Some(book) = book else {
-        return rsx! { div { class: "mini-dock-host" } };
-    };
-
-    // Require a real uuid before rendering the bar so the Expand links never
-    // point at an empty `/listen/` route (e.g. mid-dismiss, when `book` is set
-    // but `uuid` has momentarily cleared).
-    let Some(uuid) = playback.uuid.read().clone() else {
+    // the inner bar is conditional on both a loaded book and a resolved uuid.
+    let Some((book, uuid)) =
+        dock_active_state(playback.book.read().clone(), playback.uuid.read().clone())
+    else {
         return rsx! { div { class: "mini-dock-host" } };
     };
 
@@ -212,7 +224,9 @@ fn MiniDockActions(uuid: String) -> Element {
 
 #[cfg(test)]
 mod tests {
-    use super::progress_pct;
+    use omnibus_shared::EbookMetadata;
+
+    use super::{dock_active_state, progress_pct};
 
     #[test]
     fn progress_pct_is_zero_when_duration_unknown() {
@@ -234,5 +248,40 @@ mod tests {
     fn progress_pct_treats_non_finite_elapsed_as_zero() {
         assert_eq!(progress_pct(f64::NAN, 100.0), 0.0);
         assert_eq!(progress_pct(f64::INFINITY, 100.0), 0.0);
+    }
+
+    /// Mirrors [`MiniDock`]'s "renders empty host vs. active bar" branch —
+    /// the piece of logic that decides whether the dock shows content when
+    /// navigated to alongside another page (#988), without needing a full
+    /// component render.
+    #[test]
+    fn dock_active_state_is_none_when_nothing_is_playing() {
+        assert_eq!(dock_active_state(None, None), None);
+    }
+
+    #[test]
+    fn dock_active_state_is_none_when_uuid_has_not_resolved_yet() {
+        let book = EbookMetadata {
+            title: Some("Test Audiobook".into()),
+            ..Default::default()
+        };
+        assert_eq!(dock_active_state(Some(book), None), None);
+    }
+
+    #[test]
+    fn dock_active_state_is_none_when_book_has_not_loaded_yet() {
+        assert_eq!(dock_active_state(None, Some("uuid-1".to_string())), None);
+    }
+
+    #[test]
+    fn dock_active_state_returns_both_when_book_and_uuid_are_present() {
+        let book = EbookMetadata {
+            title: Some("Test Audiobook".into()),
+            ..Default::default()
+        };
+        let (got_book, got_uuid) =
+            dock_active_state(Some(book.clone()), Some("uuid-1".to_string())).unwrap();
+        assert_eq!(got_book, book);
+        assert_eq!(got_uuid, "uuid-1");
     }
 }

--- a/frontend/src/routes.rs
+++ b/frontend/src/routes.rs
@@ -121,6 +121,25 @@ pub fn MetadataEdit(uuid: String) -> Element {
 /// Deliberately rendered **without** [`ScreenLayout`]: the reader is a
 /// full-screen surface with its own slim control bar, so the app's top/bottom
 /// nav is suppressed. Same uuid-keyed stability rationale as [`BookDetail`].
+/// Non-mobile also layers the persistent audiobook [`crate::pages::MiniDock`]
+/// alongside the reader (#988) — unlike `/listen`, the reader has no
+/// transport of its own, so a book playing in the background would
+/// otherwise be invisible and uncontrollable while reading.
+#[cfg(not(feature = "mobile"))]
+#[component]
+pub fn BookRead(uuid: String) -> Element {
+    use_page_title(|| Some("Reader".into()));
+    rsx! {
+        BookReadPage { uuid }
+        MiniDock {}
+    }
+}
+
+/// Mobile variant of [`BookRead`]: the reader only. Mobile's persistent
+/// playback surface is [`crate::pages::MobileMiniPlayer`], scoped to
+/// [`ScreenLayout`]; extending it into the immersive reader is out of
+/// scope for #988.
+#[cfg(feature = "mobile")]
 #[component]
 pub fn BookRead(uuid: String) -> Element {
     use_page_title(|| Some("Reader".into()));

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -3,20 +3,28 @@ import { AUDIOBOOK_BOOKS, AUDIOBOOK_BOOK_COUNT } from "../fixtures/audiobooks";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { fetchBookUuidByTitle } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
-import { audiobookFixturesDir, fixturesDir, seedLibrary } from "../utils/seed";
+import {
+  audiobookFixturesDir,
+  fixturesDir,
+  seedAudiobookLibrary,
+  seedLibrary,
+} from "../utils/seed";
 import { setRangeValue } from "../utils/sliders";
 
 // Both libraries seeded: the reader-visibility test needs an EPUB to read
 // alongside an audiobook playing in the background. No fixture pair shares
 // a normalized (title, author), so auto-attach leaves them as separate rows
 // and the counts stay additive — same reasoning as `merge.spec.ts`. Seeded
-// in one call so indexing only runs once instead of twice.
+// as two sequential settings writes (not one combined call): a single write
+// that reindexes both libraries at once was observed to leave the ebook
+// fixture the reader test depends on unresolvable by row testid in CI —
+// see the investigation note in the PR. Reverted to the two-step seed.
 test.beforeAll(async ({ request }) => {
-  await seedLibrary(
+  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
+  await seedAudiobookLibrary(
     request,
-    fixturesDir(),
-    FIXTURE_BOOKS.length + AUDIOBOOK_BOOK_COUNT,
     audiobookFixturesDir(),
+    FIXTURE_BOOKS.length + AUDIOBOOK_BOOK_COUNT,
   );
 });
 

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -235,7 +235,15 @@ test("shows the mini-dock on the immersive reader while an audiobook is loaded",
   // way — a native page load at any hop would remount `App` and drop the
   // in-memory playback context the dock reads from.
   await spaNavigateToLibrary(page);
-  await page.getByTestId(`ebook-row-${READER_BOOK.slug}`).click();
+  // Click the cover cell, not the bare row: a plain `.click()` on the `<tr>`
+  // lands at its horizontal center, which is one of the inline-editable
+  // cells (authors/series/etc.) — those stop propagation on click, so the
+  // row's own navigate-on-click handler never fires. The cover cell has no
+  // click handler of its own and safely bubbles to the row.
+  await page
+    .getByTestId(`ebook-row-${READER_BOOK.slug}`)
+    .getByTestId("ebook-cell-cover")
+    .click();
   await expect(page).toHaveURL(new RegExp(`/books/${readerUuid}$`));
   await page.getByTestId("start-reading").click();
   await expect(page).toHaveURL(new RegExp(`/read/${readerUuid}$`));

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -1,21 +1,36 @@
 import { expect, test } from "../fixtures/test";
 import { AUDIOBOOK_BOOKS, AUDIOBOOK_BOOK_COUNT } from "../fixtures/audiobooks";
+import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { fetchBookUuidByTitle } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
-import { audiobookFixturesDir, seedAudiobookLibrary } from "../utils/seed";
+import {
+  audiobookFixturesDir,
+  fixturesDir,
+  seedAudiobookLibrary,
+  seedLibrary,
+} from "../utils/seed";
 import { setRangeValue } from "../utils/sliders";
 
+// Both libraries seeded: the reader-visibility test (#988) needs an EPUB to
+// read alongside an audiobook playing in the background. No fixture pair
+// shares a normalized (title, author), so auto-attach leaves them as
+// separate rows and the counts stay additive — same reasoning as
+// `merge.spec.ts`.
 test.beforeAll(async ({ request }) => {
+  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
   await seedAudiobookLibrary(
     request,
     audiobookFixturesDir(),
-    AUDIOBOOK_BOOK_COUNT,
+    FIXTURE_BOOKS.length + AUDIOBOOK_BOOK_COUNT,
   );
 });
 
 const MP3_BOOK = AUDIOBOOK_BOOKS.find(
   (b) => b.format === "MP3" && b.source === "generated",
 )!;
+// Distinct author from every audiobook fixture so auto-attach never merges
+// this EPUB with the playing audiobook mid-test.
+const READER_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "gamma")!;
 
 /**
  * Wait until the App-level playback driver has run `OmnibusAudio.initDirect`
@@ -196,4 +211,58 @@ test("dock dismiss clears playback and removes the dock", async ({
   await page.getByTestId("mini-dock-dismiss").click();
 
   await expect(page.getByTestId("mini-dock")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// 5. Dock shows on the immersive reader — the reader has no transport of
+//    its own, so a book playing in the background needs the dock (#988)
+// ---------------------------------------------------------------------------
+
+test("shows the mini-dock on the immersive reader while an audiobook is loaded", async ({
+  page,
+  request,
+}) => {
+  const audiobookUuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  const readerUuid = await fetchBookUuidByTitle(request, READER_BOOK.title);
+
+  await gotoReady(page, `/listen/${audiobookUuid}`);
+  await waitForPlayerReady(page);
+
+  // Reach the reader via real Dioxus `Link`/`nav.push` navigation the whole
+  // way — a native page load at any hop would remount `App` and drop the
+  // in-memory playback context the dock reads from.
+  await spaNavigateToLibrary(page);
+  await page.getByTestId(`ebook-row-${READER_BOOK.slug}`).click();
+  await expect(page).toHaveURL(new RegExp(`/books/${readerUuid}$`));
+  await page.getByTestId("start-reading").click();
+  await expect(page).toHaveURL(new RegExp(`/read/${readerUuid}$`));
+
+  await expect(page.getByTestId("reader-viewer")).toBeVisible();
+  await expect(page.getByTestId("mini-dock")).toBeVisible();
+  await expect(page.getByTestId("mini-dock-title")).toHaveText(MP3_BOOK.title);
+
+  // A dock control works identically on the reader as elsewhere (AC3):
+  // drive the shared `playing` signal and confirm the toggle reflects it,
+  // then confirm a real click reaches the same `OmnibusAudio` surface the
+  // other mini-dock tests exercise.
+  const toggle = page.getByTestId("mini-dock-toggle");
+  await expect(toggle).toHaveAttribute("aria-label", "Play");
+  await page.evaluate(() => {
+    (
+      window as unknown as { __omnibusOnAudioPlay?: (s: number) => void }
+    ).__omnibusOnAudioPlay?.(0);
+  });
+  await expect(toggle).toHaveAttribute("aria-label", "Pause");
+  await toggle.click();
+
+  // The reader's own bottom bar and the dock must not visually collide —
+  // assert the dock sits above it rather than overlapping (AC2). `.rd-bottom`
+  // renders unconditionally in `BookReadPage`, so this is a plain assertion.
+  const dockBottom = await page
+    .getByTestId("mini-dock")
+    .evaluate((el) => el.getBoundingClientRect().bottom);
+  const readerBarTop = await page
+    .locator(".rd-bottom")
+    .evaluate((el) => el.getBoundingClientRect().top);
+  expect(dockBottom).toBeLessThanOrEqual(readerBarTop);
 });

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -3,25 +3,20 @@ import { AUDIOBOOK_BOOKS, AUDIOBOOK_BOOK_COUNT } from "../fixtures/audiobooks";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { fetchBookUuidByTitle } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
-import {
-  audiobookFixturesDir,
-  fixturesDir,
-  seedAudiobookLibrary,
-  seedLibrary,
-} from "../utils/seed";
+import { audiobookFixturesDir, fixturesDir, seedLibrary } from "../utils/seed";
 import { setRangeValue } from "../utils/sliders";
 
-// Both libraries seeded: the reader-visibility test (#988) needs an EPUB to
-// read alongside an audiobook playing in the background. No fixture pair
-// shares a normalized (title, author), so auto-attach leaves them as
-// separate rows and the counts stay additive — same reasoning as
-// `merge.spec.ts`.
+// Both libraries seeded: the reader-visibility test needs an EPUB to read
+// alongside an audiobook playing in the background. No fixture pair shares
+// a normalized (title, author), so auto-attach leaves them as separate rows
+// and the counts stay additive — same reasoning as `merge.spec.ts`. Seeded
+// in one call so indexing only runs once instead of twice.
 test.beforeAll(async ({ request }) => {
-  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
-  await seedAudiobookLibrary(
+  await seedLibrary(
     request,
-    audiobookFixturesDir(),
+    fixturesDir(),
     FIXTURE_BOOKS.length + AUDIOBOOK_BOOK_COUNT,
+    audiobookFixturesDir(),
   );
 });
 


### PR DESCRIPTION
## Summary
- `BookRead` (non-mobile) now renders `MiniDock` alongside the reader so a book playing in the background is visible and controllable while reading — previously the reader had no playback indicator at all.
- Added a scoped CSS rule (`.rd-surface + .mini-dock-host .mini-dock`) that raises the dock above the reader's own `.rd-bottom` bar so the two fixed-position bars don't collide at any viewport width.
- Extracted `dock_active_state` from `MiniDock` so the "book loaded + uuid resolved" branch is unit-testable without a full component render.
- Mobile keeps the reader-only variant — its persistent playback surface (`MobileMiniPlayer`) is scoped to `ScreenLayout` and extending it into the immersive reader is out of scope here.

Closes #988.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — clean
- [x] `cargo test -p omnibus-frontend --features server` — 274 passed, incl. new `dock_active_state_*` cases in `pages::listen::mini_dock::tests`
- [x] Added Playwright coverage in `ui_tests/playwright/tests/flows/mini-dock.spec.ts` (AC4): seeds both an ebook and an audiobook, starts audiobook playback, navigates to the reader via real SPA links (Library → book detail → "Start reading"), and asserts the dock is visible with the correct title, a control (play/pause) reflects and drives shared playback state, and the dock's bottom edge sits above the reader's `.rd-bottom` bar (AC2/AC3)
- [x] `npx tsc --noEmit` clean for the new spec (pre-existing unrelated type errors in `book_detail.spec.ts`/`landing.spec.ts`/`metadata_edit.spec.ts`/`stats.spec.ts` are untouched by this change)

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- CI's Playwright job will exercise the new spec end-to-end; I could not run `npx playwright test` locally in this sandbox (no Nix-provided Chromium here), so I verified the flow by tracing the exact route/testid wiring in `frontend/src/pages/landing/table/row.rs`, `frontend/src/pages/book_detail/hero.rs`, and `frontend/src/routes.rs` instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar2Z7PPFwrNkEYGcC8DRLz)_