### PR TITLE
fix: align book-detail journal UI with updated design

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -905,6 +905,7 @@ html, body { overscroll-behavior: none; }
   width: 100%;
   display: flex; align-items: center; gap: 12px;
   padding: 13px 16px;
+  margin-top: 12px;
   text-align: left;
   cursor: text;
   color: var(--ink-3);
@@ -916,7 +917,10 @@ html, body { overscroll-behavior: none; }
 .bd-journal-prompt-plus { color: var(--ink-3); font-size: 18px; }
 
 /* Expanded composer */
-.bd-journal-composer { padding: 14px 16px; }
+.bd-journal-composer {
+ padding: 14px 16px;
+ margin-top: 12px;
+}
 .bd-journal-composer-tabs {
   display: flex; align-items: center; gap: 6px;
   margin-bottom: 12px;

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -897,7 +897,7 @@ html, body { overscroll-behavior: none; }
 .bd-journal-blurb {
   font-size: 11px;
   color: var(--ink-3);
-  margin: -8px 0 18px;
+  margin: -8px 0 26px;
 }
 
 /* Collapsed composer prompt (click to expand) */

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -919,7 +919,7 @@ html, body { overscroll-behavior: none; }
 .bd-journal-composer { padding: 14px 16px; }
 .bd-journal-composer-tabs {
   display: flex; align-items: center; gap: 6px;
-  margin-bottom: 10px;
+  margin-bottom: 12px;
 }
 .bd-tab-active { color: var(--ink-0); border-color: var(--accent); }
 .bd-journal-spoiler-help {
@@ -927,13 +927,18 @@ html, body { overscroll-behavior: none; }
   color: var(--ink-3);
   cursor: help;
 }
-.bd-journal-textarea { font-family: var(--sans); }
+.bd-journal-textarea {
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--ink-1);
+}
 
 /* Formatting toolbar */
 .bd-journal-toolbar-row {
   display: flex; align-items: center; gap: 8px;
   flex-wrap: wrap;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 .bd-journal-toolbar {
   display: flex; align-items: center; gap: 4px;
@@ -990,8 +995,9 @@ html, body { overscroll-behavior: none; }
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--sans);
-  font-size: 15px;
-  line-height: 1.62;
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--ink-1);
   overflow-wrap: anywhere;
 }
 .bd-journal-editor:empty::before {
@@ -1039,13 +1045,13 @@ html, body { overscroll-behavior: none; }
   border-radius: 10px;
   font-family: var(--sans);
   font-size: 14px;
-  line-height: 1.6;
-  color: var(--ink-0);
+  line-height: 1.7;
+  color: var(--ink-1);
 }
 .bd-journal-composer-foot,
 .bd-journal-entry-foot {
   display: flex; align-items: center; gap: 10px;
-  margin-top: 12px;
+  margin-top: 14px;
 }
 .bd-journal-foot-spacer { flex: 1; }
 .bd-journal-progress {
@@ -1104,13 +1110,13 @@ html, body { overscroll-behavior: none; }
 
 /* Entry feed */
 .bd-journal-list {
-  display: flex; flex-direction: column; gap: 14px;
+  display: flex; flex-direction: column; gap: 18px;
   margin-top: 16px;
 }
-.bd-journal-entry { padding: 20px 24px; }
+.bd-journal-entry { padding: 22px 24px; }
 .bd-journal-entry-head {
   display: flex; align-items: flex-start; gap: 12px;
-  margin-bottom: 14px;
+  margin-bottom: 16px;
 }
 .bd-journal-avatar {
   width: 34px; height: 34px; flex-shrink: 0;
@@ -1121,7 +1127,13 @@ html, body { overscroll-behavior: none; }
   font-family: var(--sans);
   font-size: 16px;
 }
-.bd-journal-entry-meta { flex: 1; min-width: 0; }
+.bd-journal-entry-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
 .bd-journal-entry-byline { display: flex; align-items: center; gap: 6px; }
 .bd-journal-author { font-family: var(--sans); font-size: 14px; color: var(--ink-0); }
 .bd-journal-you {
@@ -1133,8 +1145,8 @@ html, body { overscroll-behavior: none; }
   border-color: var(--ink-3); color: var(--ink-2);
   text-transform: uppercase; letter-spacing: 0.06em;
 }
-.bd-journal-entry-date { font-size: 11px; color: var(--ink-3); margin-top: 4px; }
-.bd-journal-entry-actions { display: flex; gap: 8px; }
+.bd-journal-entry-date { font-size: 11px; color: var(--ink-3); }
+.bd-journal-entry-actions { display: flex; gap: 8px; margin-top: 2px; }
 .bd-journal-delete:hover { color: var(--bad); }
 .bd-journal-entry-body {
   position: relative;

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -897,18 +897,20 @@ html, body { overscroll-behavior: none; }
 .bd-journal-blurb {
   font-size: 11px;
   color: var(--ink-3);
-  margin: -10px 0 16px;
+  margin: -8px 0 18px;
 }
 
 /* Collapsed composer prompt (click to expand) */
 .bd-journal-prompt {
   width: 100%;
   display: flex; align-items: center; gap: 12px;
-  padding: 14px 16px;
+  padding: 13px 16px;
   text-align: left;
   cursor: text;
   color: var(--ink-3);
-  font-size: 15px;
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.45;
 }
 .bd-journal-prompt-text { flex: 1; }
 .bd-journal-prompt-plus { color: var(--ink-3); font-size: 18px; }
@@ -925,7 +927,7 @@ html, body { overscroll-behavior: none; }
   color: var(--ink-3);
   cursor: help;
 }
-.bd-journal-textarea { font-family: var(--serif); }
+.bd-journal-textarea { font-family: var(--sans); }
 
 /* Formatting toolbar */
 .bd-journal-toolbar-row {
@@ -987,9 +989,9 @@ html, body { overscroll-behavior: none; }
   min-height: 132px;
   white-space: pre-wrap;
   word-break: break-word;
-  font-family: var(--serif);
-  font-size: 16px;
-  line-height: 1.6;
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.62;
   overflow-wrap: anywhere;
 }
 .bd-journal-editor:empty::before {
@@ -1035,9 +1037,9 @@ html, body { overscroll-behavior: none; }
   background: var(--bg-1);
   border: 1px solid var(--line-2);
   border-radius: 10px;
-  font-family: var(--serif);
-  font-size: 15px;
-  line-height: 1.55;
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.6;
   color: var(--ink-0);
 }
 .bd-journal-composer-foot,
@@ -1103,12 +1105,12 @@ html, body { overscroll-behavior: none; }
 /* Entry feed */
 .bd-journal-list {
   display: flex; flex-direction: column; gap: 14px;
-  margin-top: 14px;
+  margin-top: 16px;
 }
-.bd-journal-entry { padding: 18px 22px; }
+.bd-journal-entry { padding: 20px 24px; }
 .bd-journal-entry-head {
-  display: flex; align-items: center; gap: 12px;
-  margin-bottom: 12px;
+  display: flex; align-items: flex-start; gap: 12px;
+  margin-bottom: 14px;
 }
 .bd-journal-avatar {
   width: 34px; height: 34px; flex-shrink: 0;
@@ -1116,12 +1118,12 @@ html, body { overscroll-behavior: none; }
   border-radius: 50%;
   background: var(--accent-soft, var(--bg-2));
   color: var(--accent-ink, var(--ink-0));
-  font-family: var(--serif);
+  font-family: var(--sans);
   font-size: 16px;
 }
 .bd-journal-entry-meta { flex: 1; min-width: 0; }
-.bd-journal-entry-byline { display: flex; align-items: center; gap: 8px; }
-.bd-journal-author { font-size: 15px; color: var(--ink-0); }
+.bd-journal-entry-byline { display: flex; align-items: center; gap: 6px; }
+.bd-journal-author { font-family: var(--sans); font-size: 14px; color: var(--ink-0); }
 .bd-journal-you {
   padding: 1px 8px; font-size: 10px;
   border-color: var(--accent); color: var(--accent);
@@ -1131,17 +1133,42 @@ html, body { overscroll-behavior: none; }
   border-color: var(--ink-3); color: var(--ink-2);
   text-transform: uppercase; letter-spacing: 0.06em;
 }
-.bd-journal-entry-date { font-size: 11px; color: var(--ink-3); margin-top: 2px; }
-.bd-journal-entry-actions { display: flex; gap: 6px; }
+.bd-journal-entry-date { font-size: 11px; color: var(--ink-3); margin-top: 4px; }
+.bd-journal-entry-actions { display: flex; gap: 8px; }
 .bd-journal-delete:hover { color: var(--bad); }
 .bd-journal-entry-body {
-  font-family: var(--serif);
-  font-size: 15.5px;
-  line-height: 1.6;
-  color: var(--ink-0);
+  position: relative;
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--ink-1);
 }
 .bd-journal-entry-body :first-child { margin-top: 0; }
 .bd-journal-entry-body :last-child { margin-bottom: 0; }
+.bd-journal-entry-body p,
+.bd-journal-entry-body ul,
+.bd-journal-entry-body ol,
+.bd-journal-entry-body blockquote { margin: 0 0 10px; }
+.bd-journal-entry-body-collapsed {
+  max-height: 230px;
+  overflow: hidden;
+}
+.bd-journal-entry-body-collapsed::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 64px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, transparent, var(--bg-1) 92%);
+}
+.bd-journal-show-more {
+  margin-top: 4px;
+  font-family: var(--sans);
+  font-size: 12px;
+  padding-right: 10px;
+}
 
 /* Embedded journal images — the toolbar's file-picker control and the
    captioned figures `wrap_figures` emits (alt text doubles as the caption). */

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1877,6 +1877,17 @@ a.idx-letter-on:focus-visible {
   border-color: color-mix(in oklch, var(--accent) 60%, transparent);
 }
 
+/* Journal write surface overrides the metadata editor textarea defaults.
+   Keep this block after `.me-textarea` so the live journal editor and its
+   textarea mirror render with the same typography as published journal text. */
+.me-textarea.bd-journal-textarea,
+.me-textarea.bd-journal-editor {
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--ink-1);
+}
+
 /* Chip rows (authors, tags) */
 .me-chip-row {
   display: flex;

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1020,8 +1020,20 @@ html, body { overscroll-behavior: none; }
   border-radius: 4px;
   padding: 0 2px;
 }
-.cm-h1 { font-size: 1.5em; font-weight: 700; line-height: 1.3; }
-.cm-h2 { font-size: 1.25em; font-weight: 700; line-height: 1.35; }
+.cm-h1 {
+  font-family: inherit;
+  font-size: 1.5em;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+.cm-h2 {
+  font-family: inherit;
+  font-size: 1.25em;
+  font-weight: 700;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+}
 .cm-quote {
   color: var(--ink-1);
   font-style: italic;
@@ -1157,6 +1169,27 @@ html, body { overscroll-behavior: none; }
 }
 .bd-journal-entry-body :first-child { margin-top: 0; }
 .bd-journal-entry-body :last-child { margin-bottom: 0; }
+.bd-journal-preview h1,
+.bd-journal-entry-body h1,
+.bd-journal-preview h2,
+.bd-journal-entry-body h2 {
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ink-0);
+}
+.bd-journal-preview h1,
+.bd-journal-entry-body h1 {
+  font-size: 1.5em;
+  line-height: 1.3;
+  margin: 0 0 10px;
+}
+.bd-journal-preview h2,
+.bd-journal-entry-body h2 {
+  font-size: 1.25em;
+  line-height: 1.35;
+  margin: 0 0 10px;
+}
 .bd-journal-entry-body p,
 .bd-journal-entry-body ul,
 .bd-journal-entry-body ol,

--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -8,6 +8,9 @@ use omnibus_shared::{JournalEntry, JournalStatus, UpdateJournalEntry, UserSummar
 use crate::data;
 use crate::pages::book_detail::journal_editor::*;
 
+const JOURNAL_COLLAPSE_CHAR_THRESHOLD: usize = 900;
+const JOURNAL_COLLAPSE_LINE_THRESHOLD: usize = 12;
+
 /// Per-entry inline-edit signals shared by the entry card, its header action
 /// row, and the edit form. Grouped so those components stay under the prop cap.
 #[derive(Clone, Copy, PartialEq)]
@@ -169,6 +172,7 @@ pub(super) fn BdJournalEntryCard(
         error: use_signal(|| None::<String>),
         reload,
     };
+    let mut expanded = use_signal(|| false);
     let editing = edit.editing;
     let error = edit.error;
 
@@ -189,6 +193,12 @@ pub(super) fn BdJournalEntryCard(
     };
     let entry_id = entry.id;
     let entry_progress = entry.progress;
+    let can_expand = should_show_more_button(&entry.body_md);
+    let body_class = if can_expand && !expanded() {
+        "bd-journal-entry-body bd-journal-entry-body-collapsed"
+    } else {
+        "bd-journal-entry-body"
+    };
 
     rsx! {
         article { class: "card bd-journal-entry", "data-testid": "journal-entry",
@@ -215,8 +225,18 @@ pub(super) fn BdJournalEntryCard(
                 }
             } else {
                 div {
-                    class: "bd-journal-entry-body",
+                    class: "{body_class}",
                     dangerous_inner_html: "{entry.body_html}",
+                }
+                if can_expand && !expanded() {
+                    button {
+                        r#type: "button",
+                        class: "btn ghost sm bd-journal-show-more",
+                        "data-testid": "journal-show-more",
+                        "aria-expanded": "{expanded()}",
+                        onclick: move |_| expanded.set(true),
+                        "Show more \u{2193}"
+                    }
                 }
                 if let Some(msg) = error() {
                     span { class: "mono bd-journal-error", role: "alert", "{msg}" }
@@ -387,9 +407,15 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
     (if m <= 2 { y + 1 } else { y }, m, d)
 }
 
+fn should_show_more_button(markdown: &str) -> bool {
+    let line_count = markdown.lines().count();
+    markdown.trim().chars().count() > JOURNAL_COLLAPSE_CHAR_THRESHOLD
+        || line_count > JOURNAL_COLLAPSE_LINE_THRESHOLD
+}
+
 #[cfg(test)]
 mod tests {
-    use super::fmt_long_date;
+    use super::{fmt_long_date, should_show_more_button};
 
     #[test]
     fn formats_known_epoch_dates() {
@@ -397,5 +423,20 @@ mod tests {
         assert_eq!(fmt_long_date(1_779_019_200), "May 17, 2026");
         // The unix epoch itself.
         assert_eq!(fmt_long_date(0), "January 1, 1970");
+    }
+
+    #[test]
+    fn shows_more_for_long_markdown() {
+        let long = "x".repeat(901);
+        assert!(should_show_more_button(&long));
+        let multiline = (0..13).map(|_| "line").collect::<Vec<_>>().join("\n");
+        assert!(should_show_more_button(&multiline));
+    }
+
+    #[test]
+    fn skips_show_more_for_short_markdown() {
+        assert!(!should_show_more_button("Short entry"));
+        let exactly_twelve = (0..12).map(|_| "line").collect::<Vec<_>>().join("\n");
+        assert!(!should_show_more_button(&exactly_twelve));
     }
 }

--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -408,9 +408,21 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
 }
 
 fn should_show_more_button(markdown: &str) -> bool {
-    let line_count = markdown.lines().count();
-    markdown.trim().chars().count() > JOURNAL_COLLAPSE_CHAR_THRESHOLD
-        || line_count > JOURNAL_COLLAPSE_LINE_THRESHOLD
+    if markdown
+        .trim()
+        .chars()
+        .take(JOURNAL_COLLAPSE_CHAR_THRESHOLD + 1)
+        .count()
+        > JOURNAL_COLLAPSE_CHAR_THRESHOLD
+    {
+        return true;
+    }
+
+    markdown
+        .lines()
+        .take(JOURNAL_COLLAPSE_LINE_THRESHOLD + 1)
+        .count()
+        > JOURNAL_COLLAPSE_LINE_THRESHOLD
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Align the book-detail journal UI with the provided design by updating journal typography from serif-heavy styles to the app sans stack across prompt/editor/preview/entry content.
- Tune journal spacing and sizing in the section, entry header, metadata row, and action areas so field rhythm matches the target layout.
- Add long-entry collapsing on journal cards with a fade-out treatment and a `Show more ↓` control, using markdown length/line-count thresholds so only long entries get the affordance.
- Add focused unit coverage for the long-entry `Show more` threshold helper in `entry_card.rs`.

## Test plan
- [x] `nix develop --command cargo test -p omnibus-frontend --features server journal::entry_card::tests`
- [x] `nix develop --command just lint-css`

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- N/A

Closes #1089