### PR TITLE
feat: add public book ratings

### DIFF
--- a/db/src/ratings/mod.rs
+++ b/db/src/ratings/mod.rs
@@ -4,7 +4,7 @@
 //! rather than deleting it; the missing-files GC keeps any book a rating
 //! references.
 
-use omnibus_shared::{stars_from_half_stars, RatingRecord, RatingUpdate};
+use omnibus_shared::{stars_from_half_stars, AttributedRating, RatingRecord, RatingUpdate};
 use sqlx::{Row, SqlitePool};
 
 use crate::resolve_canonical_book_uuid;
@@ -98,6 +98,40 @@ pub async fn get_rating(
         stars: stars_from_half_stars(row.try_get::<i64, _>("half_stars")?),
         updated_at: row.try_get::<i64, _>("updated_at")?,
     }))
+}
+
+/// List every other user's rating for a book, newest first. The viewer's own
+/// rating stays in the separate interactive widget.
+pub async fn list_other_ratings(
+    pool: &SqlitePool,
+    viewer_id: i64,
+    book_uuid: &str,
+) -> Result<Vec<AttributedRating>, RatingError> {
+    let Some(canonical) = resolve_canonical_book_uuid(pool, book_uuid).await? else {
+        return Ok(vec![]);
+    };
+    let rows = sqlx::query(
+        "SELECT ur.user_id, u.username, ur.half_stars, ur.updated_at
+           FROM user_ratings ur
+           JOIN users u ON u.id = ur.user_id
+          WHERE ur.book_uuid = ? AND ur.user_id != ?
+          ORDER BY ur.updated_at DESC, ur.user_id DESC",
+    )
+    .bind(canonical)
+    .bind(viewer_id)
+    .fetch_all(pool)
+    .await?;
+
+    rows.iter()
+        .map(|row| {
+            Ok(AttributedRating {
+                user_id: row.try_get("user_id")?,
+                username: row.try_get("username")?,
+                stars: stars_from_half_stars(row.try_get("half_stars")?),
+                updated_at: row.try_get("updated_at")?,
+            })
+        })
+        .collect()
 }
 
 /// Remove the current user's rating for a book (un-rate). A no-op when no row

--- a/db/src/ratings/tests.rs
+++ b/db/src/ratings/tests.rs
@@ -232,3 +232,84 @@ async fn set_rating_propagates_db_error_when_pool_is_closed() {
         .unwrap_err();
     assert!(matches!(err, RatingError::Sqlx(_)));
 }
+
+#[tokio::test]
+async fn list_other_ratings_excludes_viewer_and_orders_newest_first() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let alice = seed_user(&pool, "alice").await;
+    let bob = seed_user(&pool, "bob").await;
+    let carol = seed_user(&pool, "carol").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+
+    set_rating(&pool, alice, &update(&uuid, 1.0)).await.unwrap();
+    set_rating(&pool, bob, &update(&uuid, 4.5)).await.unwrap();
+    set_rating(&pool, carol, &update(&uuid, 3.0)).await.unwrap();
+    sqlx::query(
+        "UPDATE user_ratings SET updated_at = CASE user_id
+             WHEN ? THEN 100
+             WHEN ? THEN 300
+             WHEN ? THEN 200
+         END WHERE book_uuid = ?",
+    )
+    .bind(alice)
+    .bind(bob)
+    .bind(carol)
+    .bind(&uuid)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let ratings = list_other_ratings(&pool, alice, &uuid).await.unwrap();
+
+    assert_eq!(ratings.len(), 2);
+    assert_eq!(ratings[0].user_id, bob);
+    assert_eq!(ratings[0].username, "bob");
+    assert_eq!(ratings[0].stars, 4.5);
+    assert_eq!(ratings[0].updated_at, 300);
+    assert_eq!(ratings[1].user_id, carol);
+}
+
+#[tokio::test]
+async fn list_other_ratings_returns_empty_for_unknown_or_unrated_book() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let alice = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+
+    assert!(list_other_ratings(&pool, alice, "no-such-book")
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(list_other_ratings(&pool, alice, &uuid)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn list_other_ratings_resolves_merged_uuid() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let alice = seed_user(&pool, "alice").await;
+    let bob = seed_user(&pool, "bob").await;
+    let (book_id, canonical) = seed(&pool, "/lib", "Book A").await;
+    seed_merged_uuid(&pool, "attached-uuid", book_id, "EPUB").await;
+    set_rating(&pool, bob, &update(&canonical, 4.0))
+        .await
+        .unwrap();
+
+    let ratings = list_other_ratings(&pool, alice, "attached-uuid")
+        .await
+        .unwrap();
+
+    assert_eq!(ratings.len(), 1);
+    assert_eq!(ratings[0].username, "bob");
+}
+
+#[tokio::test]
+async fn list_other_ratings_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+
+    let err = list_other_ratings(&pool, 1, "book").await.unwrap_err();
+
+    assert!(matches!(err, RatingError::Sqlx(_)));
+}

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -831,6 +831,34 @@ html, body { overscroll-behavior: none; }
 .bd-star-half-left { left: 0; }
 .bd-star-half-right { right: 0; }
 .bd-star-half:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.bd-other-ratings {
+  display: flex; flex-direction: column; gap: 8px;
+  margin-top: 14px; padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+.bd-other-rating-row {
+  display: flex; align-items: center; gap: 6px;
+  min-width: 0; font-size: 13px; color: var(--ink-2);
+}
+.bd-other-rating-avatar {
+  width: 24px; height: 24px; flex: 0 0 24px;
+  display: grid; place-items: center;
+  border-radius: 50%;
+  background: var(--accent-soft, var(--bg-2));
+  color: var(--accent); font-size: 11px; font-weight: 700;
+}
+.bd-other-rating-name {
+  overflow: hidden; color: var(--ink); font-weight: 600;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+.bd-other-rating-stars {
+  display: inline-flex; gap: 1px; flex: 0 0 auto;
+  color: var(--accent); font-size: 13px; line-height: 1;
+}
+.bd-other-rating-star-slot {
+  position: relative; display: inline-block; width: 1em; height: 1em;
+}
+.bd-other-rating-age { flex: 0 0 auto; color: var(--ink-3); font-size: 10px; }
 .bd-action-head, .bd-shelves-head { margin-bottom: 8px; }
 .bd-actions {
   display: flex; flex-direction: column; gap: 4px;

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -847,9 +847,13 @@ html, body { overscroll-behavior: none; }
   background: var(--accent-soft, var(--bg-2));
   color: var(--accent); font-size: 11px; font-weight: 700;
 }
+.bd-other-rating-content {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 4px;
+  min-width: 0;
+}
+.bd-other-rating-byline { color: var(--ink-2); font-size: 13px; }
 .bd-other-rating-name {
-  overflow: hidden; color: var(--ink); font-weight: 600;
-  text-overflow: ellipsis; white-space: nowrap;
+  color: var(--ink); font-weight: 600;
 }
 .bd-other-rating-stars {
   display: inline-flex; gap: 1px; flex: 0 0 auto;
@@ -858,7 +862,6 @@ html, body { overscroll-behavior: none; }
 .bd-other-rating-star-slot {
   position: relative; display: inline-block; width: 1em; height: 1em;
 }
-.bd-other-rating-age { flex: 0 0 auto; color: var(--ink-3); font-size: 10px; }
 .bd-action-head, .bd-shelves-head { margin-bottom: 8px; }
 .bd-actions {
   display: flex; flex-direction: column; gap: 4px;

--- a/frontend/src/data/ratings.rs
+++ b/frontend/src/data/ratings.rs
@@ -3,7 +3,7 @@
 //! web/SSR variants share each function's public signature so callers stay
 //! platform-agnostic; the `#[cfg]` gates carry the split.
 
-use omnibus_shared::{RatingRecord, RatingUpdate};
+use omnibus_shared::{AttributedRating, RatingRecord, RatingUpdate};
 
 #[cfg(not(feature = "mobile"))]
 use super::note_server_fn_err;
@@ -37,6 +37,21 @@ pub async fn get_rating(server_url: &str, uuid: &str) -> Result<Option<RatingRec
     Ok(response.json::<Option<RatingRecord>>().await?)
 }
 
+/// GET `/api/ratings/others/{uuid}` — list every other user's rating.
+#[cfg(feature = "mobile")]
+pub async fn list_other_ratings(
+    server_url: &str,
+    uuid: &str,
+) -> Result<Vec<AttributedRating>, DataError> {
+    let url = format!("{server_url}/api/ratings/others/{uuid}");
+    let response = with_bearer(http_client().get(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<Vec<AttributedRating>>().await?)
+}
+
 /// DELETE `/api/ratings/{uuid}` — clear (un-rate) the current rating.
 #[cfg(feature = "mobile")]
 pub async fn clear_rating(server_url: &str, uuid: &str) -> Result<(), DataError> {
@@ -64,6 +79,17 @@ pub async fn set_rating(
 #[cfg(not(feature = "mobile"))]
 pub async fn get_rating(_server_url: &str, uuid: &str) -> Result<Option<RatingRecord>, DataError> {
     crate::rpc::rpc_get_rating(uuid.to_string())
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Web/SSR attributed-rating list — server-function wrapper.
+#[cfg(not(feature = "mobile"))]
+pub async fn list_other_ratings(
+    _server_url: &str,
+    uuid: &str,
+) -> Result<Vec<AttributedRating>, DataError> {
+    crate::rpc::rpc_list_other_ratings(uuid.to_string())
         .await
         .map_err(note_server_fn_err)
 }

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -172,7 +172,7 @@ pub(super) fn render_loaded_mobile(view: MobileBookView) -> Element {
             }
 
             // Rating
-            section { class: "m-section m-section-row",
+            section { class: "m-section",
                 div { class: "label", "Your rating" }
                 BdRatingWidget { uuid: uuid.clone() }
             }

--- a/frontend/src/pages/book_detail/rating.rs
+++ b/frontend/src/pages/book_detail/rating.rs
@@ -6,7 +6,7 @@
 //! value clears it (un-rate).
 
 use dioxus::prelude::*;
-use omnibus_shared::{RatingRecord, RatingUpdate};
+use omnibus_shared::{AttributedRating, RatingRecord, RatingUpdate};
 
 use crate::{data, use_server_url};
 
@@ -19,6 +19,7 @@ struct RatingState {
     hover: Signal<Option<f32>>,
     failed: Signal<bool>,
     op_seq: Signal<u64>,
+    other_ratings: Signal<Vec<AttributedRating>>,
 }
 
 /// Clickable 0.5–5.0 star rating bound to the current user and `uuid`.
@@ -30,15 +31,18 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
     // the effect below reconciles on the client only.
     let mut current = use_signal(|| None::<RatingRecord>);
     let mut hover = use_signal(|| None::<f32>);
-    let failed = use_signal(|| false);
+    let mut failed = use_signal(|| false);
     // Monotonic write counter: a save only applies its result if it's still the
     // latest, so an out-of-order (slow) response can't clobber a newer click.
-    let op_seq = use_signal(|| 0u64);
+    let mut op_seq = use_signal(|| 0u64);
+    let mut load_seq = use_signal(|| 0u64);
+    let mut other_ratings = use_signal(Vec::<AttributedRating>::new);
     let state = RatingState {
         current,
         hover,
         failed,
         op_seq,
+        other_ratings,
     };
 
     let load_url = server_url.clone();
@@ -46,11 +50,25 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
         if uuid.is_empty() {
             return;
         }
+        let my_load = *load_seq.peek() + 1;
+        let next_op = *op_seq.peek() + 1;
+        load_seq.set(my_load);
+        op_seq.set(next_op);
+        current.set(None);
+        other_ratings.set(Vec::new());
+        failed.set(false);
         let load_url = load_url.clone();
         let uuid = uuid.clone();
         spawn(async move {
             if let Ok(rec) = data::get_rating(&load_url, &uuid).await {
-                current.set(rec);
+                if *load_seq.peek() == my_load {
+                    current.set(rec);
+                }
+            }
+            if let Ok(ratings) = data::list_other_ratings(&load_url, &uuid).await {
+                if *load_seq.peek() == my_load {
+                    other_ratings.set(ratings);
+                }
             }
         });
     }));
@@ -118,6 +136,19 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
             "data-testid": "rating-meta",
             "{meta_text}"
         }
+        if !other_ratings().is_empty() {
+            div {
+                class: "bd-other-ratings",
+                "data-testid": "other-ratings",
+                aria_label: "Other ratings",
+                for rating in other_ratings() {
+                    BdOtherRatingRow {
+                        key: "{rating.user_id}",
+                        rating,
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -136,6 +167,7 @@ fn BdStarHalf(
         mut hover,
         failed,
         op_seq,
+        other_ratings,
     } = state;
     rsx! {
         button {
@@ -153,7 +185,15 @@ fn BdStarHalf(
                 } else {
                     Some(value)
                 };
-                apply_rating(current, failed, op_seq, uuid.clone(), server_url.clone(), target);
+                apply_rating(
+                    current,
+                    failed,
+                    op_seq,
+                    other_ratings,
+                    uuid.clone(),
+                    server_url.clone(),
+                    target,
+                );
             },
         }
     }
@@ -168,6 +208,7 @@ fn apply_rating(
     mut current: Signal<Option<RatingRecord>>,
     mut failed: Signal<bool>,
     mut op_seq: Signal<u64>,
+    mut other_ratings: Signal<Vec<AttributedRating>>,
     uuid: String,
     server_url: String,
     target: Option<f32>,
@@ -199,13 +240,79 @@ fn apply_rating(
             return;
         }
         match result {
-            Ok(rec) => current.set(rec),
+            Ok(rec) => {
+                current.set(rec);
+                if let Ok(ratings) = data::list_other_ratings(&server_url, &uuid).await {
+                    other_ratings.set(ratings);
+                }
+            }
             Err(_) => {
                 current.set(prev);
                 failed.set(true);
             }
         }
     });
+}
+
+#[component]
+fn BdOtherRatingRow(rating: AttributedRating) -> Element {
+    let initial = rating
+        .username
+        .chars()
+        .next()
+        .map(|c| c.to_uppercase().to_string())
+        .unwrap_or_else(|| "?".to_string());
+    let age = rating_age_days(now_unix(), rating.updated_at);
+    rsx! {
+        div {
+            class: "bd-other-rating-row",
+            "data-testid": "other-rating-row",
+            span {
+                class: "bd-other-rating-avatar",
+                aria_hidden: "true",
+                "{initial}"
+            }
+            span { class: "bd-other-rating-name", "{rating.username}" }
+            span { "rated" }
+            BdOtherRatingStars { stars: rating.stars }
+            span { class: "mono bd-other-rating-age", "{age}" }
+        }
+    }
+}
+
+#[component]
+fn BdOtherRatingStars(stars: f32) -> Element {
+    rsx! {
+        span {
+            class: "bd-other-rating-stars",
+            aria_label: "{fmt_stars(stars)} out of 5 stars",
+            for i in 1..=5u8 {
+                {
+                    let slot = i as f32;
+                    let fill = if stars >= slot {
+                        100
+                    } else if stars >= slot - 0.5 {
+                        50
+                    } else {
+                        0
+                    };
+                    rsx! {
+                        span {
+                            key: "{i}",
+                            class: "bd-other-rating-star-slot",
+                            aria_hidden: "true",
+                            span { class: "bd-star-bg", "\u{2605}" }
+                            span {
+                                class: "bd-star-fg",
+                                style: "width: {fill}%",
+                                "\u{2605}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Render a star value without a trailing `.0` (`4.5` stays, `4.0` → `4`).
@@ -244,6 +351,12 @@ fn rated_ago(updated_at: i64) -> String {
     }
 }
 
+fn rating_age_days(now: i64, updated_at: i64) -> String {
+    let days = (now - updated_at).max(0) / 86_400;
+    let suffix = if days == 1 { "day" } else { "days" };
+    format!("{days} {suffix} ago")
+}
+
 /// Current unix time in seconds. Only ever called client-side (the relative
 /// timestamp renders after the post-mount load, and the optimistic write runs
 /// on click), so SSR never invokes the JS clock.
@@ -258,5 +371,25 @@ fn now_unix() -> i64 {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rating_age_days;
+
+    #[test]
+    fn rating_age_uses_zero_days_for_recent_rating() {
+        assert_eq!(rating_age_days(1_000, 999), "0 days ago");
+    }
+
+    #[test]
+    fn rating_age_singularizes_one_day() {
+        assert_eq!(rating_age_days(172_800, 86_400), "1 day ago");
+    }
+
+    #[test]
+    fn rating_age_pluralizes_multiple_days() {
+        assert_eq!(rating_age_days(432_000, 172_800), "3 days ago");
     }
 }

--- a/frontend/src/pages/book_detail/rating.rs
+++ b/frontend/src/pages/book_detail/rating.rs
@@ -272,10 +272,17 @@ fn BdOtherRatingRow(rating: AttributedRating) -> Element {
                 aria_hidden: "true",
                 "{initial}"
             }
-            span { class: "bd-other-rating-name", "{rating.username}" }
-            span { "rated" }
-            BdOtherRatingStars { stars: rating.stars }
-            span { class: "mono bd-other-rating-age", "{age}" }
+            div {
+                class: "bd-other-rating-content",
+                "data-testid": "other-rating-content",
+                div {
+                    class: "bd-other-rating-byline",
+                    "data-testid": "other-rating-byline",
+                    span { class: "bd-other-rating-name", "{rating.username}" }
+                    " rated {age}"
+                }
+                BdOtherRatingStars { stars: rating.stars }
+            }
         }
     }
 }

--- a/frontend/src/pages/book_detail/rating.rs
+++ b/frontend/src/pages/book_detail/rating.rs
@@ -353,8 +353,11 @@ fn rated_ago(updated_at: i64) -> String {
 
 fn rating_age_days(now: i64, updated_at: i64) -> String {
     let days = (now - updated_at).max(0) / 86_400;
-    let suffix = if days == 1 { "day" } else { "days" };
-    format!("{days} {suffix} ago")
+    match days {
+        0 => "today".to_string(),
+        1 => "1 day ago".to_string(),
+        _ => format!("{days} days ago"),
+    }
 }
 
 /// Current unix time in seconds. Only ever called client-side (the relative
@@ -379,8 +382,8 @@ mod tests {
     use super::rating_age_days;
 
     #[test]
-    fn rating_age_uses_zero_days_for_recent_rating() {
-        assert_eq!(rating_age_days(1_000, 999), "0 days ago");
+    fn rating_age_uses_today_for_recent_rating() {
+        assert_eq!(rating_age_days(1_000, 999), "today");
     }
 
     #[test]

--- a/frontend/src/pages/book_detail/rating.rs
+++ b/frontend/src/pages/book_detail/rating.rs
@@ -243,7 +243,9 @@ fn apply_rating(
             Ok(rec) => {
                 current.set(rec);
                 if let Ok(ratings) = data::list_other_ratings(&server_url, &uuid).await {
-                    other_ratings.set(ratings);
+                    if op_seq() == my_op {
+                        other_ratings.set(ratings);
+                    }
                 }
             }
             Err(_) => {

--- a/frontend/src/rpc/ratings.rs
+++ b/frontend/src/rpc/ratings.rs
@@ -2,7 +2,7 @@
 
 use dioxus::fullstack::post;
 use dioxus::prelude::*;
-use omnibus_shared::{RatingRecord, RatingUpdate};
+use omnibus_shared::{AttributedRating, RatingRecord, RatingUpdate};
 
 #[cfg(feature = "server")]
 use omnibus_db as db;
@@ -34,6 +34,14 @@ pub async fn rpc_get_rating(uuid: String) -> Result<Option<RatingRecord>> {
     Ok(db::ratings::get_rating(&pool.0, user.id, &uuid)
         .await
         .map_err(|e| internal_rpc_error("get rating", e))?)
+}
+
+/// Fetch every other user's attributed rating for a book, newest first.
+#[post("/api/rpc/ratings/others", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_list_other_ratings(uuid: String) -> Result<Vec<AttributedRating>> {
+    Ok(db::ratings::list_other_ratings(&pool.0, user.id, &uuid)
+        .await
+        .map_err(|e| internal_rpc_error("list other ratings", e))?)
 }
 
 /// Clear (un-rate) the current user's rating for a book. A no-op when no

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -347,6 +347,10 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
         // `/api/rpc/ratings/*` server functions.
         .route("/api/ratings", post(ratings::post_rating))
         .route(
+            "/api/ratings/others/{uuid}",
+            get(ratings::get_other_ratings),
+        )
+        .route(
             "/api/ratings/{uuid}",
             get(ratings::get_rating).delete(ratings::delete_rating),
         )

--- a/server/src/backend/ratings.rs
+++ b/server/src/backend/ratings.rs
@@ -49,6 +49,18 @@ pub(super) async fn get_rating(
     }
 }
 
+/// Fetch every other user's attributed rating for a book, newest first.
+pub(super) async fn get_other_ratings(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(uuid): Path<String>,
+) -> Response {
+    match db::ratings::list_other_ratings(&state.pool, user.id, &uuid).await {
+        Ok(ratings) => Json(ratings).into_response(),
+        Err(e) => internal("get_other_ratings", e),
+    }
+}
+
 /// Clear (un-rate) the current user's rating for a book. Idempotent — clearing
 /// an absent rating still returns 204.
 pub(super) async fn delete_rating(

--- a/server/src/backend/ratings/tests.rs
+++ b/server/src/backend/ratings/tests.rs
@@ -220,7 +220,7 @@ async fn api_other_ratings_requires_auth() {
 }
 
 #[tokio::test]
-async fn api_other_ratings_returns_other_users_newest_first() {
+async fn api_other_ratings_returns_other_users_and_excludes_viewer() {
     let (app, _state, pool) = fixture().await;
     let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
     let alice = auth_test_support::create_user(&pool, "alice").await;

--- a/server/src/backend/ratings/tests.rs
+++ b/server/src/backend/ratings/tests.rs
@@ -3,7 +3,7 @@ use axum::{
     body::{to_bytes, Body},
     http::{header::AUTHORIZATION, Request, StatusCode},
 };
-use omnibus_shared::RatingRecord;
+use omnibus_shared::{AttributedRating, RatingRecord};
 use tower::ServiceExt;
 
 use crate::auth::test_support as auth_test_support;
@@ -200,4 +200,84 @@ async fn api_rating_is_isolated_per_user() {
     let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
     let rec: Option<RatingRecord> = serde_json::from_slice(&bytes).unwrap();
     assert!(rec.is_none(), "bob sees no rating from alice");
+}
+
+#[tokio::test]
+async fn api_other_ratings_requires_auth() {
+    let (app, _state, _pool) = fixture().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/ratings/others/book")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_other_ratings_returns_other_users_newest_first() {
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let alice = auth_test_support::create_user(&pool, "alice").await;
+    let alice_token = auth_test_support::bearer_token(&pool, alice.id).await;
+    let bob = auth_test_support::create_user(&pool, "bob").await;
+    let bob_token = auth_test_support::bearer_token(&pool, bob.id).await;
+
+    app.clone()
+        .oneshot(post_rating_req(
+            &alice_token,
+            serde_json::json!({ "book_uuid": uuid, "stars": 2 }),
+        ))
+        .await
+        .unwrap();
+    app.clone()
+        .oneshot(post_rating_req(
+            &bob_token,
+            serde_json::json!({ "book_uuid": uuid, "stars": 4.5 }),
+        ))
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/ratings/others/{uuid}"),
+            &alice_token,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let ratings: Vec<AttributedRating> = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(ratings.len(), 1);
+    assert_eq!(ratings[0].user_id, bob.id);
+    assert_eq!(ratings[0].username, "bob");
+    assert_eq!(ratings[0].stars, 4.5);
+}
+
+#[tokio::test]
+async fn api_other_ratings_returns_500_on_db_failure() {
+    let (app, _state, pool) = fixture().await;
+    let (_, uuid) = seed_book_with_uuid(&pool, "/lib", "Book A").await;
+    let alice = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, alice.id).await;
+    sqlx::query("DROP TABLE user_ratings")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/ratings/others/{uuid}"),
+            &token,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/shared/src/ratings.rs
+++ b/shared/src/ratings.rs
@@ -55,5 +55,15 @@ pub struct RatingRecord {
     pub updated_at: i64,
 }
 
+/// A rating with the user identity needed for an attributed book-detail row.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AttributedRating {
+    pub user_id: i64,
+    pub username: String,
+    /// Star rating in `0.5..=5.0`, in half-star steps.
+    pub stars: f32,
+    pub updated_at: i64,
+}
+
 #[cfg(test)]
 mod tests;

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -443,6 +443,46 @@ test("shows an error when the Kindle send fails", async ({ page, request }) => {
 // Action — star rating (F3.2)
 // ---------------------------------------------------------------------------
 
+test("hides other ratings when no one else has rated the book", async ({ page, request }) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await page.route("**/api/rpc/ratings/others", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+
+  await gotoReady(page, `/books/${uuid}`);
+
+  await expect(page.getByTestId("other-ratings")).toHaveCount(0);
+});
+
+test("shows attributed ratings from other users", async ({ page, request }) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  const twoDaysAgo = Math.floor(Date.now() / 1000) - 2 * 86_400;
+  await page.route("**/api/rpc/ratings/others", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          user_id: 42,
+          username: "reader",
+          stars: 4.5,
+          updated_at: twoDaysAgo,
+        },
+      ]),
+    }),
+  );
+
+  await gotoReady(page, `/books/${uuid}`);
+
+  const row = page.getByTestId("other-rating-row");
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("R");
+  await expect(row.getByText("reader", { exact: true })).toBeVisible();
+  await expect(row.getByText("rated", { exact: true })).toBeVisible();
+  await expect(row.getByLabel("4.5 out of 5 stars")).toBeVisible();
+  await expect(row).toContainText("2 days ago");
+});
+
 test("rates a book a half-star, persists across reload, then un-rates", async ({ page, request }) => {
   // Use a Wirth book so the rating never collides with the alpha-focused
   // assertions elsewhere in this serial file.

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -477,10 +477,9 @@ test("shows attributed ratings from other users", async ({ page, request }) => {
   const row = page.getByTestId("other-rating-row");
   await expect(row).toBeVisible();
   await expect(row).toContainText("R");
-  await expect(row.getByText("reader", { exact: true })).toBeVisible();
-  await expect(row.getByText("rated", { exact: true })).toBeVisible();
+  await expect(row.getByTestId("other-rating-byline")).toHaveText("reader rated 2 days ago");
+  await expect(row.getByTestId("other-rating-content")).toHaveCSS("flex-direction", "column");
   await expect(row.getByLabel("4.5 out of 5 stars")).toBeVisible();
-  await expect(row).toContainText("2 days ago");
 });
 
 test("rates a book a half-star, persists across reload, then un-rates", async ({ page, request }) => {


### PR DESCRIPTION
## Summary
- Show attributed ratings from other users beneath the viewer's interactive rating.
- Add authenticated, merged-UUID-aware reads across DB, web RPC, and mobile REST transports.
- Keep the list hydration-safe, newest-first, viewer-excluding, and hidden when empty.

## Test plan
- [x] `just check`
- [x] Targeted DB, REST, frontend-server, and mobile checks
- [x] Focused Playwright book-detail rating tests

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Closes #1092.
