### PR TITLE
feat: show loading indicator while hardcover suggestions fetch (#1090)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4208,6 +4208,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
 }
 .m-strip-note { font-size: 13px; color: var(--ink-2); line-height: 1.5; }
+.m-suggest-loading { display: flex; align-items: center; gap: 8px; }
 
 /* Shelf detail: at phone widths the shared markup (rail hidden) reads as a
    mobile screen — tighten the grid to three columns to match the design. */
@@ -5323,6 +5324,23 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .bd-suggest-pending,
 .bd-suggest-connect { margin-top: 4px; }
 .bd-suggest-pending { padding: 16px 18px; }
+.bd-suggest-loading { display: flex; align-items: center; gap: 10px; }
+
+/* Inline loading spinner (F3.3 suggestions fetch) — a rotating ring, shared
+   by the web `.bd-suggest-loading` and mobile `.m-suggest-loading` blocks. */
+.suggest-spinner {
+  width: 13px; height: 13px; flex-shrink: 0;
+  border-radius: 50%;
+  border: 2px solid color-mix(in oklch, var(--accent) 40%, transparent);
+  border-top-color: var(--accent);
+  animation: suggest-spin 0.9s linear infinite;
+}
+@keyframes suggest-spin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .suggest-spinner { animation: none; }
+}
 
 .bd-suggest-connect { display: flex; align-items: center; justify-content: space-between;
   gap: 22px; padding: 22px 24px; border: 1px dashed var(--line-2); }

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -10,7 +10,7 @@ use crate::Route;
 
 use super::discovery::{
     cover_src, list_count_label, same_hand_author_label, same_hand_title, same_hand_year,
-    suggestion_cover_book,
+    suggestion_cover_book, SuggestionsSpinner,
 };
 use super::journal::BdJournalSection;
 use super::{BdInsightCell, BdMetaRow, BdSectionHead};
@@ -219,9 +219,10 @@ pub(super) fn BdSuggestionsStrip(
                 Some(SuggestionsResponse::NotConfigured) => rsx! {
                     SuggestionsConnectCard { is_admin }
                 },
-                // None (first paint, pre-fetch) or Pending → quiet placeholder.
+                // None (first paint, pre-fetch) or Pending → loading placeholder.
                 _ => rsx! {
-                    div { class: "bd-suggest-pending card", "data-testid": "suggestions-pending",
+                    div { class: "bd-suggest-pending bd-suggest-loading card", "data-testid": "suggestions-pending",
+                        SuggestionsSpinner {}
                         p { class: "mono bd-stub-hint", "Looking for read-alikes via Hardcover\u{2026}" }
                     }
                 },

--- a/frontend/src/pages/book_detail/discovery.rs
+++ b/frontend/src/pages/book_detail/discovery.rs
@@ -2,6 +2,7 @@
 //! author cluster + Hardcover suggestions), shared by the web [`super::body`] and
 //! [`super::mobile`] layouts so both render identical titles/years/labels.
 
+use dioxus::prelude::*;
 use omnibus_shared::{BookSuggestion, Contributor, EbookMetadata};
 
 /// Display title for a same-hand tile — the book title, falling back to the
@@ -58,6 +59,17 @@ pub(super) fn list_count_label(n: i64) -> String {
         "on 1 list".to_string()
     } else {
         format!("on {n} lists")
+    }
+}
+
+/// Inline loading spinner for the Hardcover suggestions pending state.
+/// Rendered identically by [`super::body`] and [`super::mobile`] while a
+/// lookup is in flight; the adjacent copy already carries the accessible
+/// label, so the icon itself is `aria-hidden`.
+#[component]
+pub(super) fn SuggestionsSpinner() -> Element {
+    rsx! {
+        span { class: "suggest-spinner", "data-testid": "suggestions-spinner", aria_hidden: "true" }
     }
 }
 

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -12,7 +12,7 @@ use crate::Route;
 
 use super::discovery::{
     cover_src, list_count_label, same_hand_author_label, same_hand_title, same_hand_year,
-    suggestion_cover_book,
+    suggestion_cover_book, SuggestionsSpinner,
 };
 use super::file_picker::{is_audio_book_file, BdFilePickerMenu, FilePickerKind};
 use super::journal::BdJournalSection;
@@ -316,9 +316,10 @@ fn suggestions_section(
                         }
                     }
                 },
-                // None (pre-fetch) or Pending → quiet placeholder.
+                // None (pre-fetch) or Pending → loading placeholder.
                 _ => rsx! {
-                    p { class: "m-strip-note", "data-testid": "mobile-suggestions-pending",
+                    p { class: "m-strip-note m-suggest-loading", "data-testid": "mobile-suggestions-pending",
+                        SuggestionsSpinner {}
                         "Looking for read-alikes via Hardcover\u{2026}"
                     }
                 },

--- a/ui_tests/playwright/tests/flows/suggestions.spec.ts
+++ b/ui_tests/playwright/tests/flows/suggestions.spec.ts
@@ -108,6 +108,7 @@ test("shows a pending placeholder while a resolution is enqueued", async ({ page
 
   await expect(page.getByTestId("suggestions-pending")).toBeVisible();
   await expect(page.getByText("Looking for read-alikes via Hardcover…")).toBeVisible();
+  await expect(page.getByTestId("suggestions-spinner")).toBeVisible();
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Added a shared `SuggestionsSpinner` component (`frontend/src/pages/book_detail/discovery.rs`) rendering a rotating-ring icon, used by both the web (`body.rs`) and mobile (`mobile.rs`) book-detail layouts.
- The spinner now renders inside the existing "pending" placeholder for the Hardcover suggestions strip — shown the instant a lookup starts (`suggestions` signal reset to `None` in `mod.rs`'s fetch effect) and removed as soon as the response resolves to `Ready`/`NotConfigured`, or on fetch failure (which already degrades to an empty `Ready` result).
- Added `.suggest-spinner` / `.bd-suggest-loading` / `.m-suggest-loading` CSS in `frontend/assets/atrium.css` (rotating-ring animation mirroring the existing `.worker-status-spinner` pattern), with a `prefers-reduced-motion` override.
- No cfg-gating of rsx bodies — the spinner markup is identical on SSR and first WASM paint (rule 07); only the existing epoch-guarded fetch effect controls when it shows.
- Closes #1090

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1090 cargo fmt` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1090 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1090 cargo test -p omnibus-frontend --features server` — PASS (288 passed; 0 failed)

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The "pending" placeholder already existed (copy: "Looking for read-alikes via Hardcover…") for both the pre-fetch `None` state and the worker's `Pending` state; this change only adds the visible spinner icon to that existing state, it does not introduce a new state machine branch.
- The "no results" (`Ready` with empty items) and "not configured" states intentionally do not show the spinner — only the actual in-flight lookup does.
- Release-label checkboxes above are left unchecked per maintainer convention; no release label was applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_013aUaEEYJtfSYdmd6jKFedz)_