### PR TITLE
feat: show and edit book ISBN-13 in metadata editor (#1088)

### DIFF
--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -151,6 +151,25 @@ pub(crate) fn parse_json_array<T: serde::de::DeserializeOwned>(
     }
 }
 
+/// Derive the book's primary ISBN-13 from its scanned `book_identifiers`
+/// rows: the first identifier whose scheme mentions "isbn" (case-
+/// insensitive — OPF scheme text is free-form) and whose value strips down
+/// to exactly 13 ASCII digits. `None` when no identifier matches; the
+/// metadata-edit override (`apply_overrides`) is then the only source.
+pub(crate) fn derive_isbn13(identifiers: &[Identifier]) -> Option<String> {
+    identifiers.iter().find_map(|ident| {
+        let is_isbn_scheme = ident
+            .scheme
+            .as_deref()
+            .is_some_and(|s| s.to_ascii_lowercase().contains("isbn"));
+        if !is_isbn_scheme {
+            return None;
+        }
+        let digits: String = ident.value.chars().filter(char::is_ascii_digit).collect();
+        (digits.chars().count() == 13).then_some(digits)
+    })
+}
+
 /// Sanitize an EPUB `<dc:description>` payload for safe rendering via
 /// `dangerous_inner_html`. OPF descriptions are commonly HTML fragments
 /// (`<p>`, `<b>`, `<em>`, lists, links). We rely on ammonia's default
@@ -207,6 +226,7 @@ pub(crate) fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata,
                 scheme: Some(i.scheme),
             })
             .collect();
+    let isbn13 = derive_isbn13(&identifiers);
 
     Ok(EbookMetadata {
         id,
@@ -220,6 +240,7 @@ pub(crate) fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata,
         creators,
         subjects,
         identifiers,
+        isbn13,
         series: series_name,
         series_index: series_index.map(format_series_index),
         series_id: series_link_id,

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -2134,6 +2134,157 @@ async fn get_book_uuid_by_scan_key_returns_none_for_unknown_key() {
         .is_none());
 }
 
+// ---------- ISBN-13 (issue #1088) ----------
+
+/// Seed one book with a single scanned identifier and return the row's
+/// `books.id` alongside its stable uuid.
+async fn seed_book_with_identifier(
+    pool: &sqlx::SqlitePool,
+    scheme: &str,
+    value: &str,
+) -> (i64, String) {
+    replace_books(
+        pool,
+        "/lib",
+        vec![IndexedBook {
+            metadata: EbookMetadata {
+                filename: "isbn.epub".into(),
+                title: Some("Book With Identifier".into()),
+                identifiers: vec![Identifier {
+                    value: value.into(),
+                    scheme: Some(scheme.into()),
+                }],
+                ..Default::default()
+            },
+            cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
+        }],
+    )
+    .await
+    .unwrap();
+    let books = list_books(pool, "/lib").await.unwrap();
+    let book = &books[0];
+    (book.id, book.unique_identifier.clone().unwrap())
+}
+
+#[tokio::test]
+async fn get_book_derives_isbn13_from_scanned_isbn_scheme_identifier() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let (id, _) = seed_book_with_identifier(&pool, "ISBN", "9780134685991").await;
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(book.isbn13.as_deref(), Some("9780134685991"));
+}
+
+#[tokio::test]
+async fn get_book_strips_hyphens_when_deriving_isbn13() {
+    // OPF ISBN values are commonly hyphenated; the derivation strips
+    // non-digit characters before checking the 13-digit length.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let (id, _) = seed_book_with_identifier(&pool, "ISBN", "978-0-13-468599-1").await;
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(book.isbn13.as_deref(), Some("9780134685991"));
+}
+
+#[tokio::test]
+async fn get_book_ignores_ten_digit_isbn_when_deriving_isbn13() {
+    // An ISBN-10 (10 digits) is a distinct identifier value; it must not be
+    // mistaken for an ISBN-13.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let (id, _) = seed_book_with_identifier(&pool, "ISBN", "0134685997").await;
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert!(book.isbn13.is_none());
+}
+
+#[tokio::test]
+async fn get_book_isbn13_is_none_when_no_isbn_scheme_identifier_present() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let (id, _) = seed_book_with_identifier(&pool, "calibre", "some-opaque-id").await;
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert!(book.isbn13.is_none());
+}
+
+#[tokio::test]
+async fn get_book_isbn13_override_wins_over_scanned_value() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let (id, uuid) = seed_book_with_identifier(&pool, "ISBN", "9780134685991").await;
+
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            isbn13: Some("9780316769488".into()),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(book.isbn13.as_deref(), Some("9780316769488"));
+}
+
+#[tokio::test]
+async fn get_book_isbn13_override_clears_scanned_value_with_empty_string() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let (id, uuid) = seed_book_with_identifier(&pool, "ISBN", "9780134685991").await;
+
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            isbn13: Some(String::new()),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert!(
+        book.isbn13.is_none(),
+        "an empty-string override must clear the scanned ISBN-13, not persist as an empty string"
+    );
+}
+
+#[tokio::test]
+async fn get_book_isbn13_override_applies_when_no_scanned_value_present() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let (id, uuid) = seed_book_with_identifier(&pool, "calibre", "opaque-id").await;
+
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            isbn13: Some("9780134685991".into()),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let book = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(book.isbn13.as_deref(), Some("9780134685991"));
+}
+
 // ---------- BooksError variants ----------
 
 #[test]

--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -90,6 +90,11 @@ fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> Indexe
             creators,
             subjects: all(&doc, "subject"),
             identifiers,
+            // Derived at read time from `book_identifiers` (`row_to_ebook`
+            // -> `derive_isbn13`), not at parse time — this struct is
+            // written into the normalized tables before that derivation
+            // ever runs.
+            isbn13: None,
 
             series,
             series_index,

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -343,6 +343,12 @@ pub(crate) fn apply_overrides(
     if let Some(ref si) = ov.series_index {
         book.series_index = Some(si.clone());
     }
+    if let Some(ref i) = ov.isbn13 {
+        // Empty string is the clear sentinel (mirrors `build_overrides` on
+        // the frontend) — an override that clears the field must read back
+        // as "no ISBN", not as a literal empty string.
+        book.isbn13 = if i.is_empty() { None } else { Some(i.clone()) };
+    }
     if let Some(ref c) = ov.creators {
         book.creators = c.clone();
     }

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -130,6 +130,7 @@ struct EditedFields<'a> {
     language: &'a str,
     series: &'a str,
     series_index: &'a str,
+    isbn13: &'a str,
     authors: &'a [String],
     tags: &'a [String],
 }
@@ -177,6 +178,7 @@ fn build_overrides(orig: &EbookMetadata, edited: EditedFields<'_>) -> MetadataOv
         language: opt(edited.language, orig.language.as_deref()),
         series: opt(edited.series, orig.series.as_deref()),
         series_index: opt(edited.series_index, orig.series_index.as_deref()),
+        isbn13: opt(edited.isbn13, orig.isbn13.as_deref()),
         creators,
         subjects,
     }

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -18,6 +18,7 @@ pub(super) struct FormFields {
     pub language: Signal<String>,
     pub series: Signal<String>,
     pub series_index: Signal<String>,
+    pub isbn13: Signal<String>,
     pub authors: Signal<Vec<String>>,
     pub tags: Signal<Vec<String>>,
     pub sort_by: Signal<String>,
@@ -68,6 +69,7 @@ fn FieldGrid(
     let mut publisher = fields.publisher;
     let mut published = fields.published;
     let mut language = fields.language;
+    let mut isbn13 = fields.isbn13;
     let authors = fields.authors;
     let sort_by = fields.sort_by;
     let filename = fields.filename;
@@ -130,6 +132,18 @@ fn FieldGrid(
                 value: language,
                 on_change: move |v: String| language.set(v),
                 edited: language() != orig().language.clone().unwrap_or_default(),
+            }
+
+            // ISBN-13 — exactly 13 digits, enforced server-side on save
+            // (`MetadataOverrides::validate`); an empty value clears it.
+            MeField {
+                label: "ISBN-13",
+                value: isbn13,
+                on_change: move |v: String| isbn13.set(v),
+                mono: true,
+                edited: isbn13() != orig().isbn13.clone().unwrap_or_default(),
+                hint: "13 digits",
+                placeholder: "e.g. 9780134685991",
             }
 
             // Authors — chip row spanning 4 cols

--- a/frontend/src/pages/metadata_edit/state.rs
+++ b/frontend/src/pages/metadata_edit/state.rs
@@ -85,6 +85,7 @@ fn use_field_signals(book: &EbookMetadata) -> FormFields {
     let language = use_signal(|| book.language.clone().unwrap_or_default());
     let series = use_signal(|| book.series.clone().unwrap_or_default());
     let series_index = use_signal(|| book.series_index.clone().unwrap_or_default());
+    let isbn13 = use_signal(|| book.isbn13.clone().unwrap_or_default());
 
     // Authors as a signal of Vec<String> (names only for v1).
     let authors = use_signal(|| {
@@ -115,6 +116,7 @@ fn use_field_signals(book: &EbookMetadata) -> FormFields {
         language,
         series,
         series_index,
+        isbn13,
         authors,
         tags,
         sort_by,
@@ -199,6 +201,7 @@ fn use_dirty_fields(orig: Signal<EbookMetadata>, fields: FormFields) -> Memo<Vec
         language,
         series,
         series_index,
+        isbn13,
         authors,
         tags,
         sort_by: _,
@@ -227,6 +230,9 @@ fn use_dirty_fields(orig: Signal<EbookMetadata>, fields: FormFields) -> Memo<Vec
         }
         if series_index() != o.series_index.clone().unwrap_or_default() {
             dirty.push("Book #");
+        }
+        if isbn13() != o.isbn13.clone().unwrap_or_default() {
+            dirty.push("ISBN-13");
         }
         let orig_authors: Vec<String> = o.creators.iter().map(|c| c.name.clone()).collect();
         if authors() != orig_authors {
@@ -287,6 +293,7 @@ fn build_on_save(
         language,
         series,
         series_index,
+        isbn13,
         authors,
         tags,
         sort_by: _,
@@ -310,6 +317,7 @@ fn build_on_save(
                     language: &language(),
                     series: &series(),
                     series_index: &series_index(),
+                    isbn13: &isbn13(),
                     authors: &authors(),
                     tags: &tags(),
                 },

--- a/frontend/src/pages/metadata_edit/tests.rs
+++ b/frontend/src/pages/metadata_edit/tests.rs
@@ -32,6 +32,7 @@ fn edited<'a>(
         language: "",
         series: "",
         series_index: "",
+        isbn13: "",
         authors,
         tags,
     }
@@ -90,6 +91,47 @@ fn build_overrides_replaces_full_creator_and_subject_lists() {
         ov.subjects,
         Some(vec!["scifi".to_string(), "classic".to_string()])
     );
+}
+
+#[test]
+fn build_overrides_sets_isbn13_when_changed() {
+    let orig = book_with(Some("Dune"), &[], &[]);
+    let ov = build_overrides(
+        &orig,
+        EditedFields {
+            isbn13: "9780134685991",
+            ..edited("Dune", "", &[], &[])
+        },
+    );
+    assert_eq!(ov.isbn13.as_deref(), Some("9780134685991"));
+}
+
+#[test]
+fn build_overrides_clearing_a_populated_isbn13_emits_empty_string() {
+    // AC4: orig.isbn13 = Some(..), edited to "" -> the override must carry
+    // the empty string so the merge/apply path clears it.
+    let orig = EbookMetadata {
+        isbn13: Some("9780134685991".into()),
+        ..book_with(Some("Dune"), &[], &[])
+    };
+    let ov = build_overrides(&orig, edited("Dune", "", &[], &[]));
+    assert_eq!(ov.isbn13.as_deref(), Some(""));
+}
+
+#[test]
+fn build_overrides_leaves_isbn13_none_when_unchanged() {
+    let orig = EbookMetadata {
+        isbn13: Some("9780134685991".into()),
+        ..book_with(Some("Dune"), &[], &[])
+    };
+    let ov = build_overrides(
+        &orig,
+        EditedFields {
+            isbn13: "9780134685991",
+            ..edited("Dune", "", &[], &[])
+        },
+    );
+    assert!(ov.isbn13.is_none());
 }
 
 #[test]

--- a/shared/src/ebook/metadata.rs
+++ b/shared/src/ebook/metadata.rs
@@ -57,10 +57,11 @@ pub struct EbookMetadata {
     pub subjects: Vec<String>,
     pub identifiers: Vec<Identifier>,
 
-    /// Primary ISBN-13: derived from the first scanned `identifiers` entry
-    /// whose scheme mentions "isbn" and whose value normalizes to 13 ASCII
-    /// digits, or a user override from `metadata_overrides` layered on top
-    /// at read time. `None` when neither source has one.
+    /// Primary ISBN-13: derived from whichever `identifiers` entry (in
+    /// DB-projection order, not original OPF scan order) has a scheme
+    /// mentioning "isbn" and a value that normalizes to 13 ASCII digits, or
+    /// a user override from `metadata_overrides` layered on top at read
+    /// time. `None` when neither source has one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub isbn13: Option<String>,
 

--- a/shared/src/ebook/metadata.rs
+++ b/shared/src/ebook/metadata.rs
@@ -57,6 +57,13 @@ pub struct EbookMetadata {
     pub subjects: Vec<String>,
     pub identifiers: Vec<Identifier>,
 
+    /// Primary ISBN-13: derived from the first scanned `identifiers` entry
+    /// whose scheme mentions "isbn" and whose value normalizes to 13 ASCII
+    /// digits, or a user override from `metadata_overrides` layered on top
+    /// at read time. `None` when neither source has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isbn13: Option<String>,
+
     // Series / collection (Calibre + EPUB3 belongs-to-collection).
     pub series: Option<String>,
     pub series_index: Option<String>,

--- a/shared/src/ebook/overrides.rs
+++ b/shared/src/ebook/overrides.rs
@@ -31,6 +31,12 @@ pub struct MetadataOverrides {
     pub series: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub series_index: Option<String>,
+    /// ISBN-13 override. `Some("")` clears any scanned/prior-override value
+    /// (mirrors the empty-string-clears convention used by the other scalar
+    /// fields); a non-empty value must be exactly 13 ASCII digits, enforced
+    /// by `validate`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isbn13: Option<String>,
     /// Replaces the entire creators list when present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub creators: Option<Vec<Contributor>>,
@@ -79,8 +85,25 @@ impl MetadataOverrides {
         check("series", &self.series, Self::NAME_MAX_LEN)?;
         check("series_index", &self.series_index, Self::NAME_MAX_LEN)?;
         check("description", &self.description, Self::DESCRIPTION_MAX_LEN)?;
+        self.validate_isbn13()?;
         self.validate_creators()?;
         self.validate_subjects()?;
+        Ok(())
+    }
+
+    /// ISBN-13 input rule: empty (clears the override) or exactly 13 ASCII
+    /// digits. Hyphens/spaces are rejected rather than stripped — the
+    /// client submits a normalized digit string.
+    fn validate_isbn13(&self) -> Result<(), String> {
+        let Some(ref v) = self.isbn13 else {
+            return Ok(());
+        };
+        if v.is_empty() {
+            return Ok(());
+        }
+        if v.chars().count() != 13 || !v.chars().all(|c| c.is_ascii_digit()) {
+            return Err("ISBN-13 must be exactly 13 digits".to_string());
+        }
         Ok(())
     }
 
@@ -149,6 +172,7 @@ impl MetadataOverrides {
             language: incoming.language.clone().or(self.language.clone()),
             series: incoming.series.clone().or(self.series.clone()),
             series_index: incoming.series_index.clone().or(self.series_index.clone()),
+            isbn13: incoming.isbn13.clone().or(self.isbn13.clone()),
             creators: incoming.creators.clone().or(self.creators.clone()),
             subjects: incoming.subjects.clone().or(self.subjects.clone()),
         }

--- a/shared/src/ebook/tests.rs
+++ b/shared/src/ebook/tests.rs
@@ -19,6 +19,7 @@ fn validate_accepts_well_formed_override() {
         language: Some("en".into()),
         series: Some("Some Series".into()),
         series_index: Some("1".into()),
+        isbn13: Some("9780134685991".into()),
         creators: Some(vec![contributor("Ada Lovelace")]),
         subjects: Some(vec!["fiction".into(), "history".into()]),
     };
@@ -232,6 +233,76 @@ fn validate_accepts_tag_at_length_cap() {
     assert_eq!(ov.validate(), Ok(()));
 }
 
+#[test]
+fn validate_accepts_a_well_formed_13_digit_isbn() {
+    let ov = MetadataOverrides {
+        isbn13: Some("9780134685991".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(ov.validate(), Ok(()));
+}
+
+#[test]
+fn validate_accepts_empty_isbn13_as_a_clear() {
+    // AC4: an empty string is the "clear the override" sentinel, not an
+    // invalid value.
+    let ov = MetadataOverrides {
+        isbn13: Some(String::new()),
+        ..Default::default()
+    };
+    assert_eq!(ov.validate(), Ok(()));
+}
+
+#[test]
+fn validate_accepts_missing_isbn13_field() {
+    // `None` means "don't touch the ISBN override" — trivially valid.
+    assert_eq!(MetadataOverrides::default().validate(), Ok(()));
+}
+
+#[test]
+fn validate_rejects_isbn13_with_twelve_digits() {
+    let ov = MetadataOverrides {
+        isbn13: Some("978013468599".to_string()),
+        ..Default::default()
+    };
+    let err = ov.validate().expect_err("12-digit ISBN should be rejected");
+    assert!(err.contains("13 digits"), "unexpected message: {err}");
+}
+
+#[test]
+fn validate_rejects_isbn13_with_fourteen_digits() {
+    let ov = MetadataOverrides {
+        isbn13: Some("97801346859912".to_string()),
+        ..Default::default()
+    };
+    let err = ov.validate().expect_err("14-digit ISBN should be rejected");
+    assert!(err.contains("13 digits"), "unexpected message: {err}");
+}
+
+#[test]
+fn validate_rejects_isbn13_containing_non_digit_characters() {
+    let ov = MetadataOverrides {
+        isbn13: Some("978-0134685991".to_string()),
+        ..Default::default()
+    };
+    let err = ov
+        .validate()
+        .expect_err("hyphenated ISBN should be rejected");
+    assert!(err.contains("13 digits"), "unexpected message: {err}");
+}
+
+#[test]
+fn validate_rejects_isbn13_with_whitespace() {
+    let ov = MetadataOverrides {
+        isbn13: Some(" 9780134685991".to_string()),
+        ..Default::default()
+    };
+    assert!(
+        ov.validate().is_err(),
+        "leading whitespace should push the char count/content out of range"
+    );
+}
+
 // --- merge() -----------------------------------------------------------
 //
 // NOTE on contract: the issue describes `merge` as "applies an override
@@ -324,4 +395,29 @@ fn merge_preserves_untouched_scalar_fields_from_base() {
     assert_eq!(merged.title, Some("New Title".into()));
     assert_eq!(merged.publisher, Some("Kept Publisher".into()));
     assert_eq!(merged.series, Some("Kept Series".into()));
+}
+
+#[test]
+fn merge_incoming_isbn13_wins_over_base_isbn13() {
+    let base = MetadataOverrides {
+        isbn13: Some("9780134685991".into()),
+        ..Default::default()
+    };
+    let incoming = MetadataOverrides {
+        isbn13: Some("9780316769488".into()),
+        ..Default::default()
+    };
+    let merged = base.merge(&incoming);
+    assert_eq!(merged.isbn13, Some("9780316769488".into()));
+}
+
+#[test]
+fn merge_none_isbn13_preserves_base_isbn13() {
+    let base = MetadataOverrides {
+        isbn13: Some("9780134685991".into()),
+        ..Default::default()
+    };
+    let incoming = MetadataOverrides::default();
+    let merged = base.merge(&incoming);
+    assert_eq!(merged.isbn13, Some("9780134685991".into()));
 }


### PR DESCRIPTION
## Summary
- Adds a derived + user-overridable `isbn13` field to `EbookMetadata`, so books display and can edit their ISBN-13. Closes #1088.
- **Identifier-model decision**: migration `0023_drop_books_isbn.sql` deliberately dropped the denormalized `books.isbn` column in favor of the multi-value `book_identifiers` table (migration `0022`). Rather than reintroducing a column, `isbn13` is computed at read time in `db::books::projection::derive_isbn13` from `book_identifiers` (first identifier whose scheme mentions "isbn" and whose value normalizes to 13 digits), and is layered with a user override via the existing `metadata_overrides` mechanism (same pattern as `title`/`publisher`/`series`, etc.) — not written back into `book_identifiers`, which stays scanner-owned and gets rebuilt on every reindex. This keeps the ISBN edit consistent with how every other metadata field is edited in this codebase and survives reindex the same way overrides already do.
- `MetadataOverrides::validate` enforces "exactly 13 ASCII digits, or empty to clear" and surfaces as a save error via the existing save-bar error display.
- Added an "ISBN-13" field to the metadata edit form grid (`frontend/src/pages/metadata_edit/`), wired through the existing per-field signal / dirty-tracking / save-overrides plumbing — no new frontend machinery needed.
- **No migration added** — this reuses the existing `book_identifiers` table (scanned values) and the existing `metadata_overrides` JSON blob (user edits).

## Test plan
- [x] PASS `CARGO_TARGET_DIR=/tmp/omnibus-target-1088 cargo fmt` (no diff)
- [x] PASS `CARGO_TARGET_DIR=/tmp/omnibus-target-1088 cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] PASS `CARGO_TARGET_DIR=/tmp/omnibus-target-1088 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings`
- [x] PASS `CARGO_TARGET_DIR=/tmp/omnibus-target-1088 cargo clippy -p omnibus-shared --all-targets -- -D warnings`
- [x] PASS `CARGO_TARGET_DIR=/tmp/omnibus-target-1088 cargo test -p omnibus-db` (969 passed; 1 failed — `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails only because the public-domain audio fixture isn't downloaded in this sandbox (`just fixtures` prerequisite, no `just`/network access here); unrelated to this change — `db/src/audiobook/cover.rs` was not touched)
- [x] PASS `CARGO_TARGET_DIR=/tmp/omnibus-target-1088 cargo test -p omnibus-frontend --features server` (291 passed)
- [x] PASS `CARGO_TARGET_DIR=/tmp/omnibus-target-1088 cargo test -p omnibus-shared` (129 passed)

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- No new SQL migration — ISBN-13 reuses the existing `book_identifiers` table (scanned) and `metadata_overrides` table (edited), both already present.
- New/changed public surface: `EbookMetadata.isbn13: Option<String>`, `MetadataOverrides.isbn13: Option<String>` (both in `shared/src/ebook/`), `db::books::projection::derive_isbn13` (crate-private).
- Unit test coverage: `shared/src/ebook/tests.rs` (validate boundary cases: 12/13/14 digits, non-digit chars, whitespace, empty-clears; merge semantics), `db/src/books/tests.rs` (derive-from-scan, hyphen stripping, ISBN-10 rejection, override wins/clears/applies-when-absent), `frontend/src/pages/metadata_edit/tests.rs` (`build_overrides` set/clear/unchanged for isbn13).


---
_Generated by [Claude Code](https://claude.ai/code/session_013aUaEEYJtfSYdmd6jKFedz)_