### PR TITLE
feat: warn when a large number of books lose their files during a scan (#1057)

### DIFF
--- a/.claude/rules/02-error-handling.md
+++ b/.claude/rules/02-error-handling.md
@@ -45,7 +45,8 @@ pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<Re
     if let Some(msg) = stat.error {
         anyhow::bail!("scan of {library_path} failed: {msg}");
     }
-    Ok(stats)
+    // ... diff, sync, etc.
+    Ok(ReindexStats::default())
 }
 ```
 

--- a/.claude/rules/02-error-handling.md
+++ b/.claude/rules/02-error-handling.md
@@ -40,12 +40,12 @@ just propagates. `anyhow::bail!` with a context-rich format string is
 honest about the open-ended failure space:
 
 ```rust
-pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
+pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<ReindexStats> {
     let stat = scan(library_path).await?;
     if let Some(msg) = stat.error {
         anyhow::bail!("scan of {library_path} failed: {msg}");
     }
-    Ok(())
+    Ok(stats)
 }
 ```
 

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -60,7 +60,7 @@ pub const MASS_MISSING_MIN_ABSOLUTE: usize = 10;
 /// but still large enough that a dropped mount or partial sync shouldn't
 /// ghost books silently. Half the abort fraction — a scan in this band
 /// still proceeds (unlike the abort guard) but its `Done` state carries a
-/// dismissable warning (issue #1057).
+/// dismissible warning (issue #1057).
 pub const MASS_MISSING_WARN_FRACTION: f64 = 0.10;
 
 /// Error raised when the removal pass would flag an implausible share of the

--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -56,6 +56,13 @@ pub const MASS_MISSING_FRACTION: f64 = 0.20;
 /// percentage guard.
 pub const MASS_MISSING_MIN_ABSOLUTE: usize = 10;
 
+/// Warn threshold: below [`MASS_MISSING_FRACTION`] (the #819 abort guard)
+/// but still large enough that a dropped mount or partial sync shouldn't
+/// ghost books silently. Half the abort fraction — a scan in this band
+/// still proceeds (unlike the abort guard) but its `Done` state carries a
+/// dismissable warning (issue #1057).
+pub const MASS_MISSING_WARN_FRACTION: f64 = 0.10;
+
 /// Error raised when the removal pass would flag an implausible share of the
 /// library missing. Surfaced (not swallowed) so the worker logs it and the
 /// existing index is left intact — the underlying files are almost certainly
@@ -112,6 +119,44 @@ fn check_mass_missing(removed: usize, db_file_backed: usize) -> Result<(), MassM
         });
     }
     Ok(())
+}
+
+/// `true` when a scan's ghost count clears [`MASS_MISSING_WARN_FRACTION`]:
+/// more than [`MASS_MISSING_MIN_ABSOLUTE`] books *and* more than the warn
+/// fraction of the file-backed library. Reuses the abort guard's absolute
+/// floor so an ordinary small-library edit never warns either. Callers only
+/// reach this after [`check_mass_missing`] has already passed, so the warn
+/// band is implicitly capped above by [`MASS_MISSING_FRACTION`].
+fn ghost_warning_threshold_exceeded(removed: usize, db_file_backed: usize) -> bool {
+    if removed <= MASS_MISSING_MIN_ABSOLUTE || db_file_backed == 0 {
+        return false;
+    }
+    removed as f64 / db_file_backed as f64 > MASS_MISSING_WARN_FRACTION
+}
+
+/// Per-scan tallies handed back to the worker so it can decide whether to
+/// attach a [`omnibus_shared::GhostFilesWarning`] to the task's `Done`
+/// state. `removed` is this scan's ghost count; `file_backed_total` is the
+/// file-backed library size [`check_mass_missing`] measured it against.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReindexStats {
+    pub removed: usize,
+    pub file_backed_total: usize,
+}
+
+impl ReindexStats {
+    /// Project this scan's tallies into a wire-facing warning when the
+    /// ghost count clears [`MASS_MISSING_WARN_FRACTION`]; `None` below the
+    /// threshold, which is the ordinary silent-ghosting path (AC2).
+    pub fn ghost_warning(&self) -> Option<omnibus_shared::GhostFilesWarning> {
+        if !ghost_warning_threshold_exceeded(self.removed, self.file_backed_total) {
+            return None;
+        }
+        Some(omnibus_shared::GhostFilesWarning {
+            removed: u32::try_from(self.removed).unwrap_or(u32::MAX),
+            total: u32::try_from(self.file_backed_total).unwrap_or(u32::MAX),
+        })
+    }
 }
 
 /// True when a refresh should be kicked off: no state at all, or state
@@ -308,19 +353,20 @@ pub fn diff_library(
 /// (which would also suppress retries until [`REFRESH_AFTER_SECS`]
 /// elapses). Per-book parse failures are *not* fatal; they land in the
 /// DB as rows with `error = Some(_)`, same as before.
-pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
+pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<ReindexStats> {
     reindex_with_progress(pool, library_path, |_, _| {}).await
 }
 
 /// [`reindex`] variant that calls `on_progress(processed, total)` after
 /// each per-book write inside `sync_books`. Used by
 /// [`crate::worker::Worker`] to report determinate `processed / total`
-/// counts to the UI indicator.
+/// counts to the UI indicator. Returns the scan's ghost-count tallies
+/// (issue #1057) so the caller can decide whether to attach a warning.
 pub async fn reindex_with_progress(
     pool: &SqlitePool,
     library_path: &str,
     on_progress: impl FnMut(u32, u32),
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ReindexStats> {
     let path_for_scan = library_path.to_owned();
     let library_key_for_scan = library_path.to_owned();
     let stat = tokio::task::spawn_blocking(move || {
@@ -356,7 +402,8 @@ pub async fn reindex_with_progress(
         );
     }
     let mut diff = diff_library(&stat.entries, &db_rows, &library_root, trustworthy);
-    check_mass_missing(diff.removed.len(), db_file_backed)?;
+    let removed_count = diff.removed.len();
+    check_mass_missing(removed_count, db_file_backed)?;
 
     // Parse Phase B only for the buckets that need it. `diff.removed`/
     // `.backfill` are read again below, but `.new`/`.changed` are not, so
@@ -384,7 +431,10 @@ pub async fn reindex_with_progress(
     };
     sync::sync_books_with_progress(pool, library_path, plan, on_progress).await?;
     gc_missing_files_best_effort(pool).await;
-    Ok(())
+    Ok(ReindexStats {
+        removed: removed_count,
+        file_backed_total: db_file_backed,
+    })
 }
 
 /// Best-effort GC of books whose files have been missing past the retention
@@ -408,7 +458,10 @@ async fn gc_missing_files_best_effort(pool: &SqlitePool) {
 /// Audiobook-library sibling of [`reindex`]. Groups audio files by folder,
 /// reads multi-part tags, then calls [`sync::sync_audiobooks`] to write
 /// `book_file_parts` rows.
-pub async fn reindex_audiobooks(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
+pub async fn reindex_audiobooks(
+    pool: &SqlitePool,
+    library_path: &str,
+) -> anyhow::Result<ReindexStats> {
     reindex_audiobooks_with_progress(pool, library_path, |_, _| {}).await
 }
 
@@ -471,12 +524,13 @@ fn project_groups_to_stat(groups: &[audiobook::AudiobookGroup]) -> Vec<ebook::St
 /// [`reindex_audiobooks`] variant that calls `on_progress(processed,
 /// total)` after each per-book write inside `sync_audiobooks`. Used by
 /// [`crate::worker::Worker`] to report determinate `processed / total`
-/// counts to the UI indicator.
+/// counts to the UI indicator. Returns the scan's ghost-count tallies
+/// (issue #1057) so the caller can decide whether to attach a warning.
 pub async fn reindex_audiobooks_with_progress(
     pool: &SqlitePool,
     library_path: &str,
     on_progress: impl FnMut(u32, u32),
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ReindexStats> {
     let (groups, signals) = stat_and_group_audiobooks(library_path).await?;
 
     // Diff groups against DB rows (project groups to the ebook StatEntry shape
@@ -508,7 +562,8 @@ pub async fn reindex_audiobooks_with_progress(
         );
     }
     let diff = diff_library(&groups_as_stat, &db_rows, &library_root, trustworthy);
-    check_mass_missing(diff.removed.len(), db_file_backed)?;
+    let removed_count = diff.removed.len();
+    check_mass_missing(removed_count, db_file_backed)?;
 
     // Phase B: parse only the New and Changed groups.
     let groups_by_group_path: std::collections::HashMap<String, audiobook::AudiobookGroup> = groups
@@ -544,7 +599,10 @@ pub async fn reindex_audiobooks_with_progress(
     };
     sync::sync_audiobooks_with_progress(pool, library_path, plan, on_progress).await?;
     gc_missing_files_best_effort(pool).await;
-    Ok(())
+    Ok(ReindexStats {
+        removed: removed_count,
+        file_backed_total: db_file_backed,
+    })
 }
 
 /// Fill `file_chapters` for audiobook `book_files` rows that have none.

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -333,6 +333,77 @@ fn check_mass_missing_reports_counts_and_percent_in_the_error() {
     assert!((err.percent - 50.0).abs() < f64::EPSILON);
 }
 
+// ---------- #1057: warn threshold (the sub-abort middle ground) ----------
+
+#[test]
+fn ghost_warning_threshold_exceeded_is_false_below_the_warn_fraction() {
+    // 10 of 100 (10%) sits at the warn boundary, not over it — silent.
+    assert!(!ghost_warning_threshold_exceeded(10, 100));
+    // 9 of 100 (9%) is comfortably under the warn fraction.
+    assert!(!ghost_warning_threshold_exceeded(9, 100));
+}
+
+#[test]
+fn ghost_warning_threshold_exceeded_is_false_under_the_absolute_floor_regardless_of_percent() {
+    // Deleting the only book in a 1-book library is 100% but under the
+    // absolute floor shared with the abort guard — never warns.
+    assert!(!ghost_warning_threshold_exceeded(1, 1));
+    assert!(!ghost_warning_threshold_exceeded(
+        MASS_MISSING_MIN_ABSOLUTE,
+        MASS_MISSING_MIN_ABSOLUTE
+    ));
+}
+
+#[test]
+fn ghost_warning_threshold_exceeded_is_false_when_the_library_has_no_file_backed_books() {
+    assert!(!ghost_warning_threshold_exceeded(50, 0));
+}
+
+#[test]
+fn ghost_warning_threshold_exceeded_is_true_in_the_warn_band_below_the_abort_guard() {
+    // 15 of 100 (15%) clears the 10% warn fraction but stays under the 20%
+    // abort fraction — the sub-abort middle ground this issue adds.
+    assert!(ghost_warning_threshold_exceeded(15, 100));
+    assert!(
+        check_mass_missing(15, 100).is_ok(),
+        "the warn band must not trip the #819 abort guard"
+    );
+}
+
+#[test]
+fn ghost_warning_threshold_exceeded_is_true_up_to_the_abort_boundary() {
+    // 20 of 100 (20%) is the abort guard's own boundary (still allowed
+    // through by check_mass_missing) and clears the warn fraction too.
+    assert!(ghost_warning_threshold_exceeded(20, 100));
+    assert!(check_mass_missing(20, 100).is_ok());
+    // 21 of 100 (21%) crosses into the abort guard.
+    assert!(check_mass_missing(21, 100).is_err());
+}
+
+#[test]
+fn reindex_stats_ghost_warning_is_none_below_the_warn_threshold() {
+    let stats = ReindexStats {
+        removed: 5,
+        file_backed_total: 100,
+    };
+    assert_eq!(stats.ghost_warning(), None);
+}
+
+#[test]
+fn reindex_stats_ghost_warning_carries_the_removed_and_total_counts_in_the_warn_band() {
+    let stats = ReindexStats {
+        removed: 15,
+        file_backed_total: 100,
+    };
+    assert_eq!(
+        stats.ghost_warning(),
+        Some(omnibus_shared::GhostFilesWarning {
+            removed: 15,
+            total: 100,
+        })
+    );
+}
+
 #[test]
 fn is_stale_decision_respects_window_boundaries() {
     // Pure window logic: not stale strictly inside the window, stale at
@@ -720,6 +791,34 @@ async fn backfill_chapters_is_idempotent_after_all_books_have_chapters() {
         progress_calls, 0,
         "on_progress must not be called when all books already have chapters"
     );
+}
+
+// ---------- #1057: ReindexStats plumbed off a real scan ----------
+
+/// `reindex` returns the ghost count and pre-scan file-backed total it
+/// measured, not just `()` — the tally the worker projects into a
+/// [`omnibus_shared::GhostFilesWarning`] on the wire.
+#[tokio::test]
+async fn reindex_returns_stats_with_the_removed_count_and_file_backed_total() {
+    let _covers = CoversTempDir::new("reindex-stats");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = make_test_dir("reindex-stats-lib");
+    let lib_path = lib.to_string_lossy().into_owned();
+
+    seed_ebook_at(&pool, &lib_path, "a.epub", "Dracula").await;
+    seed_ebook_at(&pool, &lib_path, "b.epub", "Frankenstein").await;
+    seed_ebook_at(&pool, &lib_path, "c.epub", "Carmilla").await;
+    std::fs::remove_file(lib.join("b.epub")).unwrap();
+
+    let stats = reindex(&pool, &lib_path).await.unwrap();
+
+    assert_eq!(stats.removed, 1, "exactly one book's file went missing");
+    assert_eq!(
+        stats.file_backed_total, 3,
+        "the pre-scan file-backed total is measured before this scan's removal"
+    );
+
+    let _ = std::fs::remove_dir_all(&lib);
 }
 
 // ---------- #819: incomplete-enumeration data-loss guard ----------

--- a/db/src/worker/exec.rs
+++ b/db/src/worker/exec.rs
@@ -98,9 +98,11 @@ impl Worker {
     /// success, the last reported `processed` count is pulled out of the
     /// progress map so a Phase-2 in-flight report stays reflected in the final
     /// `Done` (today there is no in-flight reporter, so this is always 0).
+    /// `ghost_warning` (issue #1057) rides straight through from the
+    /// `TaskOutcome` onto the `Done` state.
     fn project_terminal(&self, id: TaskId, outcome: &TaskOutcome) -> ProgressState {
         match outcome {
-            TaskOutcome::Ok => {
+            TaskOutcome::Ok(ghost_warning) => {
                 let processed = lock_unpoison(&self.progress)
                     .get(&id)
                     .and_then(|e| match e.progress.state {
@@ -108,7 +110,10 @@ impl Worker {
                         _ => None,
                     })
                     .unwrap_or(0);
-                ProgressState::Done { processed }
+                ProgressState::Done {
+                    processed,
+                    ghost_warning: ghost_warning.clone(),
+                }
             }
             TaskOutcome::Err(msg) => ProgressState::Failed {
                 message: msg.clone(),

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -9,10 +9,12 @@ use super::types::{Task, TaskId, TaskOutcome, Worker};
 
 /// Map a handler's `Result` into a [`TaskOutcome`], stringifying the error.
 /// The `Ok` payload is discarded (some handlers return a path/id), so `Ok(())`
-/// and `Ok(value)` collapse to [`TaskOutcome::Ok`] identically.
+/// and `Ok(value)` collapse to [`TaskOutcome::Ok(None)`] identically. Scan
+/// tasks that need to surface a ghost-count warning (issue #1057) build
+/// their `TaskOutcome` directly instead of going through this helper.
 fn outcome_of<T, E: std::fmt::Display>(result: Result<T, E>) -> TaskOutcome {
     match result {
-        Ok(_) => TaskOutcome::Ok,
+        Ok(_) => TaskOutcome::Ok(None),
         Err(e) => TaskOutcome::Err(e.to_string()),
     }
 }
@@ -20,16 +22,20 @@ fn outcome_of<T, E: std::fmt::Display>(result: Result<T, E>) -> TaskOutcome {
 impl Worker {
     pub(super) async fn execute(self: &Arc<Self>, task: Task, id: TaskId) -> TaskOutcome {
         match task {
-            Task::Scan { library_path } => outcome_of(
-                crate::indexer::reindex_with_progress(
+            Task::Scan { library_path } => {
+                match crate::indexer::reindex_with_progress(
                     &self.pool,
                     &library_path,
                     |processed, total| {
                         self.report_progress(id, processed, Some(total));
                     },
                 )
-                .await,
-            ),
+                .await
+                {
+                    Ok(stats) => TaskOutcome::Ok(stats.ghost_warning()),
+                    Err(e) => TaskOutcome::Err(e.to_string()),
+                }
+            }
             Task::ScanAudiobooks { library_path } => {
                 self.handle_scan_audiobooks(library_path, id).await
             }
@@ -113,9 +119,10 @@ impl Worker {
         )
         .await
         {
-            Ok(()) => {
+            Ok(stats) => {
+                let warning = stats.ghost_warning();
                 self.post(Task::BackfillChapters { library_path });
-                TaskOutcome::Ok
+                TaskOutcome::Ok(warning)
             }
             Err(e) => TaskOutcome::Err(e.to_string()),
         }
@@ -146,7 +153,7 @@ impl Worker {
         })
         .await
         {
-            Ok(Ok(())) => TaskOutcome::Ok,
+            Ok(Ok(())) => TaskOutcome::Ok(None),
             Ok(Err(e)) => TaskOutcome::Err(e.to_string()),
             Err(join_err) => {
                 let kind = if join_err.is_panic() {
@@ -175,5 +182,5 @@ async fn handle_test_task(
     if let Some(f) = on_done.as_ref() {
         f();
     }
-    TaskOutcome::Ok
+    TaskOutcome::Ok(None)
 }

--- a/db/src/worker/tests.rs
+++ b/db/src/worker/tests.rs
@@ -8,8 +8,11 @@ use std::sync::Arc;
 use std::sync::Mutex as TestMutex;
 use std::time::{Duration, Instant};
 
-use omnibus_shared::{ProgressState, TaskKind};
+use omnibus_shared::{GhostFilesWarning, ProgressState, TaskKind};
 use sqlx::SqlitePool;
+
+use crate::sync::{sync_books, SyncPlan};
+use crate::test_support::{indexed_with_stat, make_test_dir};
 
 use super::types::{Task, TaskOutcome, Worker, WorkerConfig};
 
@@ -33,7 +36,7 @@ async fn post_runs_a_task() {
         on_done: None,
     });
     match w.await_completion(id).await {
-        TaskOutcome::Ok => {}
+        TaskOutcome::Ok(_) => {}
         other => panic!("expected Ok, got {other:?}"),
     }
 }
@@ -319,8 +322,8 @@ async fn same_resource_serialized_tasks_leave_no_lock_behind() {
     let id1 = mk(&w, "s1");
     let id2 = mk(&w, "s2");
     let (o1, o2) = tokio::join!(w.await_completion(id1), w.await_completion(id2));
-    assert!(matches!(o1, TaskOutcome::Ok));
-    assert!(matches!(o2, TaskOutcome::Ok));
+    assert!(matches!(o1, TaskOutcome::Ok(_)));
+    assert!(matches!(o2, TaskOutcome::Ok(_)));
     // The run loop prunes after dropping its guard; allow the second
     // task's cleanup to land after its outcome was observed.
     let drained = poll_resource_locks_empty(&w).await;
@@ -544,7 +547,7 @@ async fn poisoned_progress_lock_recovers_instead_of_panicking() {
         on_done: None,
     });
     match w.await_completion(id).await {
-        TaskOutcome::Ok => {}
+        TaskOutcome::Ok(_) => {}
         other => panic!("expected Ok after poison recovery, got {other:?}"),
     }
 
@@ -673,7 +676,7 @@ async fn poisoned_completions_lock_recovers_instead_of_panicking() {
         .unwrap();
     });
     match outcome {
-        TaskOutcome::Ok => {}
+        TaskOutcome::Ok(_) => {}
         other => panic!("expected Ok after poison recovery, got {other:?}"),
     }
 }
@@ -716,7 +719,7 @@ async fn task_state_reports_running_then_terminal() {
     );
 
     match w.await_completion(id).await {
-        TaskOutcome::Ok => {}
+        TaskOutcome::Ok(_) => {}
         other => panic!("expected Ok, got {other:?}"),
     }
     assert!(
@@ -758,3 +761,94 @@ async fn owned_task_state_scopes_reads_to_the_owner() {
 
 // `periodic_scan_tick` tests moved to `worker::periodic_scan::tests`, a
 // sibling of `periodic_scan.rs`.
+
+// ---------- #1057: mass-missing warning plumbed onto Task::Scan's Done ----------
+
+/// Seed `count` on-disk stub ebooks under `library_path` through the real
+/// `sync_books` write path, each with its actual on-disk `(mtime, size)`
+/// stat so a later `Task::Scan` classifies an untouched file as Unchanged.
+async fn seed_stub_ebooks(pool: &SqlitePool, library_path: &str, count: usize) {
+    for i in 0..count {
+        let filename = format!("book-{i}.epub");
+        let abs = std::path::Path::new(library_path).join(&filename);
+        std::fs::write(&abs, b"not a zip").unwrap();
+        let meta = std::fs::metadata(&abs).unwrap();
+        let mtime = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let book = indexed_with_stat(&filename, Some(&filename), mtime, meta.len() as i64);
+        sync_books(
+            pool,
+            library_path,
+            SyncPlan {
+                new_books: vec![book],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    }
+}
+
+/// AC2: a scan that ghosts only a few books (below the warn threshold)
+/// completes with the ordinary `Done { ghost_warning: None }` — the
+/// existing `DoneRow` behavior is unchanged.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn task_scan_reports_no_ghost_warning_below_the_warn_threshold() {
+    let pool = pool().await;
+    let lib = make_test_dir("worker-scan-no-warning");
+    let library_path = lib.to_string_lossy().into_owned();
+    seed_stub_ebooks(&pool, &library_path, 20).await;
+    // 3 of 20 ghosted books is under MASS_MISSING_MIN_ABSOLUTE (10) — always
+    // silent, regardless of the 15% fraction.
+    for i in 0..3 {
+        std::fs::remove_file(lib.join(format!("book-{i}.epub"))).unwrap();
+    }
+
+    let w = make_worker_default(pool);
+    let id = w.post(Task::Scan { library_path });
+    match w.await_completion(id).await {
+        TaskOutcome::Ok(warning) => assert_eq!(warning, None),
+        other => panic!("expected Ok, got {other:?}"),
+    }
+
+    let _ = std::fs::remove_dir_all(&lib);
+}
+
+/// AC1/AC5: a scan that ghosts a large-but-sub-abort-threshold number of
+/// books completes successfully (the #819 abort guard does not trip) but
+/// its `Done` state carries a [`GhostFilesWarning`] naming the ghost count
+/// and the pre-scan file-backed total — the wire type the settings page
+/// renders a distinct warning row from.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn task_scan_reports_ghost_warning_in_the_warn_band_below_abort() {
+    let pool = pool().await;
+    let lib = make_test_dir("worker-scan-warning-band");
+    let library_path = lib.to_string_lossy().into_owned();
+    seed_stub_ebooks(&pool, &library_path, 100).await;
+    // 15 of 100 (15%) clears the 10% warn fraction but stays under the 20%
+    // abort fraction — the sub-abort middle ground this issue adds.
+    for i in 0..15 {
+        std::fs::remove_file(lib.join(format!("book-{i}.epub"))).unwrap();
+    }
+
+    let w = make_worker_default(pool);
+    let id = w.post(Task::Scan { library_path });
+    match w.await_completion(id).await {
+        TaskOutcome::Ok(warning) => {
+            assert_eq!(
+                warning,
+                Some(GhostFilesWarning {
+                    removed: 15,
+                    total: 100,
+                })
+            );
+        }
+        other => panic!("expected Ok with a ghost warning, got {other:?}"),
+    }
+
+    let _ = std::fs::remove_dir_all(&lib);
+}

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -207,8 +207,11 @@ pub type TaskId = u64;
 /// Terminal result of a task, delivered to awaiters of its [`TaskId`].
 #[derive(Clone, Debug)]
 pub enum TaskOutcome {
-    /// The handler ran to completion successfully.
-    Ok,
+    /// The handler ran to completion successfully. `Some(_)` only for a
+    /// scan whose ghost count cleared the warn threshold (issue #1057);
+    /// every other task kind (and a scan under the threshold) reports
+    /// `None`.
+    Ok(Option<omnibus_shared::GhostFilesWarning>),
     /// The handler failed; the string is the stringified underlying error.
     /// Also produced when the spawned task is dropped or panics before
     /// reporting (see [`Worker::await_completion`]).

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -186,7 +186,7 @@ coarsened to the shape below — see "Coarse variants".
 [db/src/indexer.rs](../db/src/indexer.rs):
 
 ```rust
-pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<()> {
+pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<ReindexStats> {
     // ...
     if let Some(msg) = stat.error {
         anyhow::bail!("scan of {library_path} failed: {msg}");

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -2508,6 +2508,12 @@ a.idx-letter-on:focus-visible {
   color: var(--ink-0);
   align-items: flex-start;
 }
+.worker-status-warn {
+  border-left: 3px solid var(--warn);
+  background: color-mix(in oklch, var(--warn) 8%, var(--bg-1));
+  color: var(--ink-0);
+  align-items: flex-start;
+}
 .worker-status-label {
   flex: 1;
   font-variant-numeric: tabular-nums;

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -100,7 +100,7 @@ fn terminal_row(
 ) -> Element {
     let id = task.task_id;
     match &task.state {
-        // A ghost-count warning (issue #1057) renders a distinct dismissable
+        // A ghost-count warning (issue #1057) renders a distinct dismissible
         // WarnRow instead of the ordinary green DoneRow — AC1/AC3. Below the
         // warn threshold `ghost_warning` is `None` and behavior is unchanged
         // (AC2).

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -7,7 +7,7 @@
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
-use omnibus_shared::{ProgressState, TaskKind, TaskProgress, WorkerStatus};
+use omnibus_shared::{GhostFilesWarning, ProgressState, TaskKind, TaskProgress, WorkerStatus};
 
 use crate::{data, use_server_url};
 
@@ -100,7 +100,29 @@ fn terminal_row(
 ) -> Element {
     let id = task.task_id;
     match &task.state {
-        ProgressState::Done { .. } => rsx! {
+        // A ghost-count warning (issue #1057) renders a distinct dismissable
+        // WarnRow instead of the ordinary green DoneRow — AC1/AC3. Below the
+        // warn threshold `ghost_warning` is `None` and behavior is unchanged
+        // (AC2).
+        ProgressState::Done {
+            ghost_warning: Some(warning),
+            ..
+        } => rsx! {
+            WarnRow {
+                key: "{id}",
+                kind: task.kind,
+                warning: warning.clone(),
+                on_dismiss: move |_| {
+                    let mut set = dismissed();
+                    set.insert(id);
+                    dismissed.set(set);
+                },
+            }
+        },
+        ProgressState::Done {
+            ghost_warning: None,
+            ..
+        } => rsx! {
             DoneRow {
                 key: "{id}",
                 kind: task.kind,
@@ -175,6 +197,39 @@ fn DoneRow(kind: TaskKind, on_dismiss: EventHandler<MouseEvent>) -> Element {
     }
 }
 
+/// A scan that ghosted a large-but-sub-abort-threshold number of books
+/// (issue #1057) — distinct from both the green [`DoneRow`] and the red
+/// [`FailedRow`]: the scan still succeeded (files really are gone from the
+/// index), but the count is large enough that a dropped mount or partial
+/// sync is the more likely explanation.
+#[component]
+fn WarnRow(
+    kind: TaskKind,
+    warning: GhostFilesWarning,
+    on_dismiss: EventHandler<MouseEvent>,
+) -> Element {
+    let label = kind_label(kind, /* running */ false);
+    let message = ghost_warning_message(&warning);
+    rsx! {
+        div {
+            class: "worker-status-row worker-status-warn",
+            "data-testid": "worker-status-warn-row",
+            span { class: "worker-status-icon", aria_hidden: "true", "!" }
+            div { class: "worker-status-body",
+                div { class: "worker-status-label", "{label} finished with a warning" }
+                div { class: "worker-status-message", "{message}" }
+            }
+            button {
+                class: "worker-status-dismiss",
+                r#type: "button",
+                aria_label: "Dismiss",
+                onclick: move |evt| on_dismiss.call(evt),
+                "✕"
+            }
+        }
+    }
+}
+
 #[component]
 fn FailedRow(kind: TaskKind, message: String, on_dismiss: EventHandler<MouseEvent>) -> Element {
     let label = kind_label(kind, /* running */ false);
@@ -225,6 +280,17 @@ fn kind_label(kind: TaskKind, running: bool) -> &'static str {
     }
 }
 
+/// Render a [`GhostFilesWarning`] into the [`WarnRow`] message text —
+/// factored out of the component body so the exact wording is unit
+/// testable per AC1 ("names the count and total").
+fn ghost_warning_message(warning: &GhostFilesWarning) -> String {
+    let GhostFilesWarning { removed, total } = warning;
+    format!(
+        "{removed} of {total} books lost their files in this scan — \
+         check that your library path is mounted."
+    )
+}
+
 // ── Platform-gated 1 Hz poll sleeper ─────────────────────────────
 //
 // Web compiles with `gloo_timers` (already a dep under the `web` feature).
@@ -260,5 +326,22 @@ mod tests {
             assert!(!kind_label(kind, true).is_empty());
             assert!(!kind_label(kind, false).is_empty());
         }
+    }
+
+    #[test]
+    fn ghost_warning_message_names_the_removed_count_and_total() {
+        let warning = GhostFilesWarning {
+            removed: 15,
+            total: 100,
+        };
+        let message = ghost_warning_message(&warning);
+        assert!(
+            message.contains("15"),
+            "message must name the count: {message}"
+        );
+        assert!(
+            message.contains("100"),
+            "message must name the total: {message}"
+        );
     }
 }

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -337,7 +337,7 @@ pub(super) async fn get_ebook_kepub(
 async fn kepub_conversion_succeeded(state: &AppState, book_id: i64) -> bool {
     let task_id = state.worker.post(Task::KepubConvert { book_id });
     match tokio::time::timeout(KEPUB_CONVERT_BUDGET, state.worker.await_completion(task_id)).await {
-        Ok(TaskOutcome::Ok) => true,
+        Ok(TaskOutcome::Ok(_)) => true,
         Ok(TaskOutcome::Err(msg)) => {
             tracing::warn!(book_id, error = %msg, "kepub conversion failed; serving plain epub");
             false

--- a/server/src/backend/settings.rs
+++ b/server/src/backend/settings.rs
@@ -81,7 +81,7 @@ pub(super) async fn post_reindex(_admin: AdminUser, State(state): State<AppState
     };
     let task_id = state.worker.post(Task::Scan { library_path });
     match state.worker.await_completion(task_id).await {
-        TaskOutcome::Ok => axum::http::StatusCode::OK.into_response(),
+        TaskOutcome::Ok(_) => axum::http::StatusCode::OK.into_response(),
         TaskOutcome::Err(e) => internal("reindex", e),
     }
 }
@@ -121,7 +121,7 @@ pub(super) async fn post_scan_library(
 pub(super) async fn post_rebuild_fts(_admin: AdminUser, State(state): State<AppState>) -> Response {
     let task_id = state.worker.post(Task::RebuildFtsIndex);
     match state.worker.await_completion(task_id).await {
-        TaskOutcome::Ok => axum::http::StatusCode::OK.into_response(),
+        TaskOutcome::Ok(_) => axum::http::StatusCode::OK.into_response(),
         TaskOutcome::Err(e) => internal("rebuild fts", e),
     }
 }

--- a/server/src/backend/settings/tests.rs
+++ b/server/src/backend/settings/tests.rs
@@ -162,7 +162,7 @@ async fn post_settings_triggers_scan_via_worker() {
 
     let outcome = state.worker().await_completion(task_id).await;
     assert!(
-        matches!(outcome, TaskOutcome::Ok),
+        matches!(outcome, TaskOutcome::Ok(_)),
         "worker scan should succeed on a valid fixture dir, got {outcome:?}"
     );
 

--- a/shared/src/worker.rs
+++ b/shared/src/worker.rs
@@ -42,10 +42,25 @@ pub enum ProgressState {
     },
     Done {
         processed: u32,
+        /// Set when a scan ghosted a large-but-sub-abort-threshold number of
+        /// books (issue #1057) — the UI renders a dismissable warning row
+        /// instead of the ordinary success row.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ghost_warning: Option<GhostFilesWarning>,
     },
     Failed {
         message: String,
     },
+}
+
+/// Ghost-count tally attached to a scan's `Done` state (issue #1057): `removed`
+/// books lost their backing file this scan out of `total` file-backed books in
+/// the library, clearing the warn threshold but staying under the #819 abort
+/// guard.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GhostFilesWarning {
+    pub removed: u32,
+    pub total: u32,
 }
 
 impl ProgressState {
@@ -93,5 +108,39 @@ impl WorkerStatus {
     /// `true` when no tasks are active or recently completed.
     pub fn is_empty(&self) -> bool {
         self.active.is_empty() && self.recent_complete.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn done_without_a_ghost_warning_omits_the_field_from_the_wire() {
+        // AC5: the wire type must stay compact for the ordinary (no
+        // warning) case — no `ghost_warning` key at all, not even `null`.
+        let state = ProgressState::Done {
+            processed: 3,
+            ghost_warning: None,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(
+            !json.contains("ghost_warning"),
+            "expected no ghost_warning key, got {json}"
+        );
+    }
+
+    #[test]
+    fn done_with_a_ghost_warning_round_trips_the_removed_and_total_counts() {
+        let state = ProgressState::Done {
+            processed: 100,
+            ghost_warning: Some(GhostFilesWarning {
+                removed: 15,
+                total: 100,
+            }),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let round_tripped: ProgressState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state, round_tripped);
     }
 }

--- a/shared/src/worker.rs
+++ b/shared/src/worker.rs
@@ -43,7 +43,7 @@ pub enum ProgressState {
     Done {
         processed: u32,
         /// Set when a scan ghosted a large-but-sub-abort-threshold number of
-        /// books (issue #1057) — the UI renders a dismissable warning row
+        /// books (issue #1057) — the UI renders a dismissible warning row
         /// instead of the ordinary success row.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         ghost_warning: Option<GhostFilesWarning>,


### PR DESCRIPTION
## Summary
- Plumb the reindex diff's ghost count (books whose file vanished this scan) onto the wire instead of discarding it, so a large-but-sub-abort-threshold ghosting surfaces a dismissable warning instead of ghosting silently.
- `db/src/indexer.rs`: `reindex`/`reindex_with_progress` and the audiobook siblings now return `ReindexStats { removed, file_backed_total }`. Added `MASS_MISSING_WARN_FRACTION` (10%, half the #819 abort guard's 20%) and `ghost_warning_threshold_exceeded`, reusing the abort guard's absolute floor (`MASS_MISSING_MIN_ABSOLUTE`) so ordinary small-library edits never warn.
- `shared/src/worker.rs`: `ProgressState::Done` gains an optional `ghost_warning: Option<GhostFilesWarning>` field (`skip_serializing_if`, so existing payloads with no warning are unaffected on the wire).
- `db/src/worker/{types,handlers,exec}.rs`: `TaskOutcome::Ok` now carries the optional warning, threaded from `Task::Scan` / `Task::ScanAudiobooks` through to `ProgressState::Done`.
- `frontend/src/components/worker_status.rs`: a new dismissable `WarnRow` renders when `ghost_warning` is `Some`, styled distinctly (amber `--warn`, not red `--bad`) from the existing `DoneRow`/`FailedRow`, naming the ghost count and file-backed total.
- `server/src/backend/{ebooks,settings}.rs` + their tests: updated for the `TaskOutcome::Ok(_)` signature change.
- `docs/style-guide.md` + `.claude/rules/02-error-handling.md`: refreshed the `reindex` code example to match its new return type.
- Closes #1057

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1057 cargo fmt` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1057 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1057 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1057 cargo clippy -p omnibus-shared --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1057 cargo test -p omnibus-db` — PASS (972 passed; 1 pre-existing unrelated failure: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` — missing audio fixture in this sandbox, needs `just fixtures`, not touched by this change)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1057 cargo test -p omnibus-frontend --features server` — PASS (289 passed)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1057 cargo test -p omnibus-shared` — PASS (122 passed)

New tests added: boundary tests for `ghost_warning_threshold_exceeded`/`ReindexStats::ghost_warning` (below-warn / warn-band / abort boundary) and an end-to-end `reindex` stats test in `db/src/indexer/tests.rs`; two `Task::Scan` worker-integration tests (no warning below threshold, warning in the warn band) in `db/src/worker/tests.rs`; a wire serde round-trip test in `shared/src/worker.rs`; a message-formatting test in `frontend/src/components/worker_status.rs`.

## Notes
- The one failing db test (`extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is pre-existing and unrelated — it needs `just fixtures` (network/Nix), which isn't available in this sandbox.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_013aUaEEYJtfSYdmd6jKFedz)_