### PR TITLE
feat: show server and app version in profile UI (#1055)

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -102,6 +102,8 @@ Kobo KEPUB conversion (read by `db::kepub`, for the "Send to Kobo" download):
 - `OMNIBUS_KEPUBIFY_PATH` — explicit kepubify path; otherwise kepubify must be on `$PATH`. Absent → download falls back to plain EPUB with a one-time startup warning. Bundled in the `.#web` shell and the release image.
 - `OMNIBUS_KEPUB_DIR` — directory for the KEPUB cache, used verbatim when set; otherwise defaults to `$OMNIBUS_DATA_DIR/kepub/`. Purely a regenerable cache (safe to delete, rebuilt on next download).
 
+- `OMNIBUS_VERSION` — the running release tag (e.g. `v0.8.9`), read once at boot and returned as the `version` field on `GET /api/_health`; the mobile "You" screen fetches it there to show the server's release alongside the app's own compile-time build version (F-1055, `server::backend::app_version`). Also read at **compile time** via `option_env!` by `omnibus_frontend::version::app_version` so the web user-menu version line and a mobile build's own "App version" line report the real tag instead of the crate's pinned `0.1.0`. Baked into the Docker image build-arg (`Dockerfile`, `.github/workflows/docker.yml`) and into the TestFlight build env (`.github/workflows/testflight.yml`, mirroring its already-resolved `MARKETING_VERSION`). Leave unset for local dev — the server reports `"dev"` and the frontend falls back to `CARGO_PKG_VERSION`.
+
 If `ANDROID_HOME` / `ANDROID_NDK_HOME` come back empty inside `nix develop .#mobile`, set them manually:
 
 ```bash

--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,17 @@ OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
 # deployments (same guidance as OMNIBUS_COVERS_DIR / OMNIBUS_THUMBS_DIR).
 #OMNIBUS_KEPUB_DIR=/var/lib/omnibus/kepub
 
+# ── Release version reporting ───────────────────────────────────────────────
+# The running release tag (e.g. v0.8.9), read once at server boot and
+# returned as the `version` field on GET /api/_health — the mobile "You"
+# screen fetches it there to show alongside the app's own build version
+# (#1055). Baked into the Docker image at build time (see Dockerfile,
+# .github/workflows/docker.yml); on mobile, testflight.yml stamps the
+# equivalent compile-time OMNIBUS_VERSION from the resolved marketing
+# version. Leave unset for local dev — the server reports "dev" and the web
+# UI falls back to CARGO_PKG_VERSION (0.1.0).
+#OMNIBUS_VERSION=v0.8.9
+
 # ── Dev build tooling (sccache) ────────────────────────────────────────────
 # In LOCAL dev shells — i.e. when you haven't pinned CARGO_TARGET_DIR or
 # RUSTC_WRAPPER yourself — the Nix shell routes rustc through sccache and

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,6 +98,11 @@ jobs:
           platforms: ${{ matrix.platform }}
           pull: true
           labels: ${{ steps.meta.outputs.labels }}
+          # Threads the release tag into the image as OMNIBUS_VERSION (see
+          # Dockerfile) so the server and web app report the real release
+          # instead of the crate's pinned 0.1.0 (#1055).
+          build-args: |
+            OMNIBUS_VERSION=${{ inputs.tag || github.ref_name }}
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
           # Scope the layer cache per arch so the two legs don't clobber each
           # other's cache entries.

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -176,6 +176,13 @@ jobs:
       # a pre-zipped .ipa, but it neither embeds the provisioning profile nor
       # patches DTPlatformName — scripts/ios-package-ipa.sh does both).
       - name: dx bundle (iOS release)
+        # OMNIBUS_VERSION mirrors the already-resolved MARKETING_VERSION so
+        # `frontend::version::app_version` reports the real release instead
+        # of the crate's pinned 0.1.0 fallback (#1055). Bare (no `v` prefix,
+        # e.g. "0.8.9") — CFBundleShortVersionString can't carry one; the
+        # frontend helper normalizes it to `v0.8.9` for display.
+        env:
+          OMNIBUS_VERSION: ${{ env.MARKETING_VERSION }}
         run: nix develop .#mobile --command dx bundle --platform ios --release --package omnibus-mobile --package-types ios
 
       - name: Sign and package .ipa

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,14 @@ RUN curl -L --proto '=https' --tlsv1.2 -sSf \
 WORKDIR /src
 COPY . .
 
+# Release tag (e.g. "v0.8.9") the crate's own `version` never carries — every
+# merge to main cuts a release (.github/workflows/release.yml) but Cargo.toml
+# stays pinned at 0.1.0. `frontend::version::app_version` reads this via
+# `option_env!` at compile time, so it must be set before `dx bundle`
+# compiles both the server binary and the WASM client (#1055).
+ARG OMNIBUS_VERSION
+ENV OMNIBUS_VERSION=${OMNIBUS_VERSION}
+
 # Produces /src/target/dx/omnibus/release/web/{server, public/, ...}.
 RUN dx bundle --platform web --package omnibus --fullstack --release
 
@@ -78,6 +86,13 @@ COPY --from=builder /src/target/dx/omnibus/release/web/ /app/
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Re-declared in this stage (ARG/ENV don't cross the builder's `FROM`
+# boundary) so the *running* server also reads its own release tag at boot
+# — `server::backend::app_version` calls `std::env::var("OMNIBUS_VERSION")`
+# at runtime, not compile time, unlike the frontend's `option_env!` constant
+# baked in above (#1055).
+ARG OMNIBUS_VERSION
+
 # Bind on all interfaces (Dioxus defaults to 127.0.0.1, unreachable from
 # outside the container) and default the persistent paths into the /config
 # and /cache volumes. Everything here is overridable in docker-compose.yml.
@@ -86,7 +101,8 @@ ENV IP=0.0.0.0 \
     DATABASE_URL="sqlite:///config/omnibus.db?mode=rwc" \
     OMNIBUS_COVERS_DIR=/config/covers \
     OMNIBUS_THUMBS_DIR=/cache/thumbs \
-    OMNIBUS_DATA_DIR=/cache/data
+    OMNIBUS_DATA_DIR=/cache/data \
+    OMNIBUS_VERSION=${OMNIBUS_VERSION}
 
 EXPOSE 3000
 VOLUME ["/config", "/cache"]

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -2710,6 +2710,12 @@ a.idx-letter-on:focus-visible {
 .um-theme-btn.on { background: var(--bg-0); color: var(--ink-0); }
 .um-theme-btn[disabled] { opacity: .45; cursor: not-allowed; }
 
+/* Version line — web app == server, so a single build version (#1055) */
+.um-version {
+  padding-top: 4px; text-align: center;
+  color: var(--ink-3); font-family: var(--mono); font-size: 11px;
+}
+
 /* ── Listen player (F2.3 redesign) ──────────────────────────────────
  *
  * Full-screen audiobook player: two-column cover + controls layout
@@ -5970,6 +5976,18 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   background: var(--bg-0);
   color: var(--ink-0);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+/* Server + app version lines — two builds can differ on mobile (#1055) */
+.m-account-version {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding-top: 4px;
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 11px;
 }
 /* ── Mobile audiobook player ───────────────────────────────────────── */
 /* Full-screen player: pinned to the viewport with `position: fixed` so it can

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -1,7 +1,7 @@
 //! User-menu dropdown mounted in the top nav. Real wiring: recent progress,
-//! Settings, Sign out, and Dark/Light theme. Other account surfaces remain
-//! stubbed. See [`UserMenu`] for the SSR/hydration handling of the pre-auth
-//! trigger state.
+//! Settings, Sign out, Dark/Light theme, and app version. Other account
+//! surfaces remain stubbed. See [`UserMenu`] for the SSR/hydration handling
+//! of the pre-auth trigger state.
 
 use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};
@@ -164,6 +164,7 @@ fn UserMenuPanel(user: UserSummary, open: Signal<bool>) -> Element {
             UmSessionRows { on_signout }
 
             UmThemeSeg { theme }
+            UmVersion {}
         }
     }
 }
@@ -436,6 +437,21 @@ fn UmThemeSeg(theme: Signal<Theme>) -> Element {
                     "Sepia"
                 }
             }
+        }
+    }
+}
+
+/// Single version line at the bottom of the panel. The web app is served by
+/// the server, so the two are always the same build — render the
+/// compile-time constant directly rather than fetching `/api/_health` (AC1).
+/// A compile-time constant renders identically on SSR and first WASM paint,
+/// so there's no hydration-parity concern here (rule 07).
+#[cfg(any(feature = "web", feature = "server"))]
+#[component]
+fn UmVersion() -> Element {
+    rsx! {
+        div { class: "um-version", "data-testid": "user-menu-version",
+            "{crate::version::app_version()}"
         }
     }
 }

--- a/frontend/src/data/auth.rs
+++ b/frontend/src/data/auth.rs
@@ -129,6 +129,25 @@ pub async fn check_server(server_url: &str) -> Result<(), DataError> {
     Ok(())
 }
 
+/// GET `{server_url}/api/_health` (mobile) — resolve the running server's
+/// release version so the account "You" screen can show it alongside the
+/// app's own compile-time version (#1055). Distinct from [`check_server`],
+/// which only probes reachability and discards the body.
+#[cfg(feature = "mobile")]
+pub async fn get_server_version(server_url: &str) -> Result<String, DataError> {
+    #[derive(serde::Deserialize)]
+    struct HealthPayload {
+        version: String,
+    }
+    let url = format!("{server_url}/api/_health");
+    let response = http_client().get(&url).send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<HealthPayload>().await?.version)
+}
+
 #[cfg(feature = "mobile")]
 async fn post_mobile_auth<T: serde::Serialize>(
     server_url: &str,

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -21,6 +21,7 @@ pub mod routes;
 pub mod rpc;
 pub mod scroll_restore;
 pub mod session_tracker;
+pub mod version;
 pub mod view_prefs;
 
 pub use components::Nav;

--- a/frontend/src/pages/account.rs
+++ b/frontend/src/pages/account.rs
@@ -2,8 +2,9 @@
 //!
 //! Web/SSR renders the Send-to-Kindle destination form; the native
 //! shell renders the mobile "You" tab (identity, now-reading, quick links,
-//! account rows, theme). Signals start empty so SSR and the first WASM paint
-//! agree (rule 07); the load effects fill them after mount.
+//! account rows, theme, server/app version). Signals start empty so SSR and
+//! the first WASM paint agree (rule 07); the load effects fill them after
+//! mount.
 
 use dioxus::prelude::*;
 
@@ -276,6 +277,9 @@ fn account_body() -> Element {
     let server_url = use_server_url();
     let mut user = use_signal(|| None::<UserSummary>);
     let mut now_reading = use_signal(|| None::<EbookMetadata>);
+    // Seeded `None` so SSR and the first WASM paint agree (rule 07); the
+    // effect below fills it in after mount.
+    let mut server_version = use_signal(|| None::<String>);
 
     // Resolve the current user from the bearer token. A failure leaves the
     // signal `None` so the identity block keeps its placeholder rather than
@@ -303,6 +307,21 @@ fn account_body() -> Element {
         });
     });
 
+    // Server release version, for comparison against the app's own build
+    // (#1055). No mismatch/update prompt is shown — not every server
+    // release has a matching mobile release, so a version gap doesn't
+    // reliably mean an update exists. Users read and compare the two
+    // numbers themselves.
+    let version_url = server_url.clone();
+    use_effect(move || {
+        let url = version_url.clone();
+        spawn(async move {
+            if let Ok(v) = data::get_server_version(&url).await {
+                server_version.set(Some(v));
+            }
+        });
+    });
+
     rsx! {
         div { class: "m-account", "data-testid": "account-screen",
             AccountIdentity { user: user() }
@@ -310,6 +329,7 @@ fn account_body() -> Element {
             QuickGrid {}
             AccountRows {}
             ThemeControl {}
+            VersionBlock { server_version: server_version() }
         }
     }
 }
@@ -483,6 +503,24 @@ fn ThemeControl() -> Element {
                     }
                 }
             }
+        }
+    }
+}
+
+/// Server + app version lines at the bottom of the "You" tab (AC2): the
+/// server's release (fetched from `/api/_health`, showing a placeholder
+/// until the post-mount fetch in `account_body` resolves) above the app's
+/// own compile-time build version. Deliberately no "update available"
+/// prompt — see the effect comment in `account_body` for why a version gap
+/// doesn't reliably indicate a pending update.
+#[cfg(feature = "mobile")]
+#[component]
+fn VersionBlock(server_version: Option<String>) -> Element {
+    let server = server_version.as_deref().unwrap_or("\u{2026}");
+    rsx! {
+        div { class: "m-account-version", "data-testid": "account-version",
+            div { "Server version: {server}" }
+            div { "App version: {crate::version::app_version()}" }
         }
     }
 }

--- a/frontend/src/version.rs
+++ b/frontend/src/version.rs
@@ -11,16 +11,23 @@
 /// `MARKETING_VERSION` Apple requires (no `v`) — [`normalize`] tolerates
 /// either so callers get one consistent format regardless of source.
 pub fn app_version() -> String {
-    normalize(option_env!("OMNIBUS_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))
+    // A build-arg supplied without a value (e.g. `docker build` with no
+    // `--build-arg OMNIBUS_VERSION=...`) sets the env var to an empty
+    // string rather than leaving it unset, so `option_env!` alone would
+    // treat that as "set" and render the bare "v". Filter it out here so
+    // an empty/whitespace value falls back to CARGO_PKG_VERSION too.
+    let raw = option_env!("OMNIBUS_VERSION")
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .unwrap_or(env!("CARGO_PKG_VERSION"));
+    normalize(raw)
 }
 
-/// Ensure `raw` has exactly one leading `v`.
+/// Ensure `raw` has exactly one leading `v`, trimming whitespace and
+/// collapsing any number of existing leading `v` characters (e.g. a doubled
+/// `"vv0.8.9"`) down to one.
 fn normalize(raw: &str) -> String {
-    if let Some(stripped) = raw.strip_prefix('v') {
-        format!("v{stripped}")
-    } else {
-        format!("v{raw}")
-    }
+    format!("v{}", raw.trim().trim_start_matches('v'))
 }
 
 #[cfg(test)]
@@ -42,5 +49,10 @@ mod tests {
     #[test]
     fn normalize_does_not_double_an_existing_leading_v() {
         assert_eq!(normalize("v0.8.9"), "v0.8.9");
+    }
+
+    #[test]
+    fn normalize_collapses_multiple_leading_v_and_trims_whitespace() {
+        assert_eq!(normalize("  vv0.8.9\n"), "v0.8.9");
     }
 }

--- a/frontend/src/version.rs
+++ b/frontend/src/version.rs
@@ -1,0 +1,46 @@
+//! Compile-time app version. Release CI stamps `OMNIBUS_VERSION` into the
+//! build environment (see `.github/workflows/docker.yml` and
+//! `testflight.yml`); local dev builds fall back to `CARGO_PKG_VERSION` (the
+//! crate version, pinned at `0.1.0`) so `dx serve` / `cargo build` keep
+//! compiling and rendering a version string without the env var set.
+
+/// This build's own version string, always with a single leading `v` (e.g.
+/// `v0.8.9`; `v0.1.0` for a local dev build with no `OMNIBUS_VERSION` set —
+/// AC6). Docker's build-arg carries the full release tag (already
+/// `v`-prefixed, see `Dockerfile`), while TestFlight's carries the bare
+/// `MARKETING_VERSION` Apple requires (no `v`) — [`normalize`] tolerates
+/// either so callers get one consistent format regardless of source.
+pub fn app_version() -> String {
+    normalize(option_env!("OMNIBUS_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))
+}
+
+/// Ensure `raw` has exactly one leading `v`.
+fn normalize(raw: &str) -> String {
+    if let Some(stripped) = raw.strip_prefix('v') {
+        format!("v{stripped}")
+    } else {
+        format!("v{raw}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_version_falls_back_to_v_prefixed_cargo_pkg_version_locally() {
+        // OMNIBUS_VERSION isn't set for `cargo test`, so this pins the local
+        // dev fallback (AC6): "v" + CARGO_PKG_VERSION, currently "v0.1.0".
+        assert_eq!(app_version(), format!("v{}", env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn normalize_adds_a_leading_v_when_absent() {
+        assert_eq!(normalize("0.8.9"), "v0.8.9");
+    }
+
+    #[test]
+    fn normalize_does_not_double_an_existing_leading_v() {
+        assert_eq!(normalize("v0.8.9"), "v0.8.9");
+    }
+}

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -616,12 +616,7 @@ fn current_dir_string() -> String {
         .unwrap_or_default()
 }
 
-/// Running server's release version, sourced from the `OMNIBUS_VERSION` env
-/// var (baked into the Docker image at build time by `docker.yml`) and
-/// captured once at boot. Falls back to the literal `"dev"` when unset —
-/// local `cargo run`/`dx serve` builds have no release tag to report.
-/// Surfaced via `/api/_health` so mobile clients can compare their installed
-/// app version against the running server (#1055).
+/// Running server's release version, captured once at boot.
 ///
 /// `main.rs` calls [`init_app_version`] eagerly during boot, mirroring
 /// [`init_build_id`]/[`init_repo_root`]. `OnceLock::get_or_init` is
@@ -637,45 +632,32 @@ pub fn init_app_version() {
 
 static APP_VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
-/// Reads `OMNIBUS_VERSION` and normalizes it to a single leading `v` (the
-/// Docker build-arg carries the full, already-`v`-prefixed release tag; a
-/// hand-set deployment env might not), or the literal `"dev"` when unset —
-/// distinct from a `v`-prefixed value so a bare "dev" reads unambiguously as
-/// "no release tag", never as a real version.
+/// Reads `OMNIBUS_VERSION` (baked into the Docker image at build time by
+/// `docker.yml`) and normalizes it to a single leading `v` — the Docker
+/// build-arg carries the full, already-`v`-prefixed release tag, but a
+/// hand-set deployment env might not, and a doubled `vv1.2.3` shouldn't
+/// happen either.
+///
+/// Falls back to the literal `"dev"` when the var is unset, empty/whitespace
+/// (a build-arg supplied without a value sets the env to `""` rather than
+/// leaving it unset), or literally just `"v"` after trimming — local `cargo
+/// run`/`dx serve` builds have no release tag to report, and `"dev"` reads
+/// unambiguously as "no release tag", never as a real version.
 fn read_app_version() -> String {
-    match std::env::var("OMNIBUS_VERSION") {
-        Ok(v) if v.starts_with('v') => v,
-        Ok(v) => format!("v{v}"),
-        Err(_) => "dev".to_string(),
-    }
-}
-
-#[cfg(test)]
-mod version_tests {
-    use super::read_app_version;
-
-    #[test]
-    fn read_app_version_normalizes_env_var_and_falls_back_to_dev_when_unset() {
-        // Single test (not several) so the env-var mutations can't race
-        // another test's parallel read/write of the same process-global var
-        // — no other test in this crate touches `OMNIBUS_VERSION`.
-        let prev = std::env::var("OMNIBUS_VERSION").ok();
-
-        std::env::set_var("OMNIBUS_VERSION", "v1.2.3");
-        assert_eq!(read_app_version(), "v1.2.3");
-
-        // A bare version (e.g. TestFlight's MARKETING_VERSION convention)
-        // gets a leading `v` added, so both sources render consistently.
-        std::env::set_var("OMNIBUS_VERSION", "1.2.3");
-        assert_eq!(read_app_version(), "v1.2.3");
-
-        std::env::remove_var("OMNIBUS_VERSION");
-        assert_eq!(read_app_version(), "dev");
-
-        match prev {
-            Some(v) => std::env::set_var("OMNIBUS_VERSION", v),
-            None => std::env::remove_var("OMNIBUS_VERSION"),
+    let trimmed = std::env::var("OMNIBUS_VERSION")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    match trimmed {
+        Some(v) => {
+            let bare = v.trim_start_matches('v');
+            if bare.is_empty() {
+                "dev".to_string()
+            } else {
+                format!("v{bare}")
+            }
         }
+        None => "dev".to_string(),
     }
 }
 

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -616,6 +616,69 @@ fn current_dir_string() -> String {
         .unwrap_or_default()
 }
 
+/// Running server's release version, sourced from the `OMNIBUS_VERSION` env
+/// var (baked into the Docker image at build time by `docker.yml`) and
+/// captured once at boot. Falls back to the literal `"dev"` when unset —
+/// local `cargo run`/`dx serve` builds have no release tag to report.
+/// Surfaced via `/api/_health` so mobile clients can compare their installed
+/// app version against the running server (#1055).
+///
+/// `main.rs` calls [`init_app_version`] eagerly during boot, mirroring
+/// [`init_build_id`]/[`init_repo_root`]. `OnceLock::get_or_init` is
+/// idempotent, so calling [`app_version`] later returns the same value.
+pub fn app_version() -> &'static str {
+    APP_VERSION.get_or_init(read_app_version)
+}
+
+/// Eagerly initialize [`app_version`]. Idempotent.
+pub fn init_app_version() {
+    let _ = APP_VERSION.get_or_init(read_app_version);
+}
+
+static APP_VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Reads `OMNIBUS_VERSION` and normalizes it to a single leading `v` (the
+/// Docker build-arg carries the full, already-`v`-prefixed release tag; a
+/// hand-set deployment env might not), or the literal `"dev"` when unset —
+/// distinct from a `v`-prefixed value so a bare "dev" reads unambiguously as
+/// "no release tag", never as a real version.
+fn read_app_version() -> String {
+    match std::env::var("OMNIBUS_VERSION") {
+        Ok(v) if v.starts_with('v') => v,
+        Ok(v) => format!("v{v}"),
+        Err(_) => "dev".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod version_tests {
+    use super::read_app_version;
+
+    #[test]
+    fn read_app_version_normalizes_env_var_and_falls_back_to_dev_when_unset() {
+        // Single test (not several) so the env-var mutations can't race
+        // another test's parallel read/write of the same process-global var
+        // — no other test in this crate touches `OMNIBUS_VERSION`.
+        let prev = std::env::var("OMNIBUS_VERSION").ok();
+
+        std::env::set_var("OMNIBUS_VERSION", "v1.2.3");
+        assert_eq!(read_app_version(), "v1.2.3");
+
+        // A bare version (e.g. TestFlight's MARKETING_VERSION convention)
+        // gets a leading `v` added, so both sources render consistently.
+        std::env::set_var("OMNIBUS_VERSION", "1.2.3");
+        assert_eq!(read_app_version(), "v1.2.3");
+
+        std::env::remove_var("OMNIBUS_VERSION");
+        assert_eq!(read_app_version(), "dev");
+
+        match prev {
+            Some(v) => std::env::set_var("OMNIBUS_VERSION", v),
+            None => std::env::remove_var("OMNIBUS_VERSION"),
+        }
+    }
+}
+
 /// Attach the pagination hint headers to a list/search response.
 ///
 /// * `X-Total-Count` — the true row count of the underlying query, before

--- a/server/src/backend/health.rs
+++ b/server/src/backend/health.rs
@@ -9,20 +9,24 @@ use axum::{
     Json,
 };
 
-use super::{build_id, repo_root};
+use super::{app_version, build_id, repo_root};
 
 /// Unauthenticated liveness + fingerprint endpoint. The `app` field lets
 /// `scripts/dev-server-up.sh` distinguish an omnibus instance from some
 /// other process that happens to bind the same port. The `repo_root`
 /// field lets it distinguish *this* workspace's server from a sibling
-/// `jj` workspace's server bound to the same port. Whitelisted in
-/// `auth::gate::require_auth` so it remains reachable without a session.
+/// `jj` workspace's server bound to the same port. The `version` field
+/// (from `OMNIBUS_VERSION`, `"dev"` when unset) lets the mobile "You"
+/// screen show the running server's release alongside its own app version
+/// (#1055). Whitelisted in `auth::gate::require_auth` so it remains
+/// reachable without a session.
 pub(super) async fn get_health() -> Response {
     Json(serde_json::json!({
         "app": "omnibus",
         "status": "ok",
         "build_id": build_id().to_string(),
         "repo_root": repo_root(),
+        "version": app_version(),
     }))
     .into_response()
 }
@@ -66,5 +70,12 @@ mod tests {
             repo_root.is_empty() || repo_root.starts_with('/'),
             "repo_root should be absolute or empty, got {repo_root:?}",
         );
+
+        // The test binary doesn't set OMNIBUS_VERSION, so this is "dev" in
+        // practice — but the contract this endpoint guarantees is just
+        // "a non-empty string field", which is what `read_app_version`'s
+        // dedicated fallback test in `backend.rs` covers precisely.
+        let version = json["version"].as_str().expect("version is a string");
+        assert!(!version.is_empty(), "version should not be empty");
     }
 }

--- a/server/src/backend/health.rs
+++ b/server/src/backend/health.rs
@@ -17,9 +17,9 @@ use super::{app_version, build_id, repo_root};
 /// field lets it distinguish *this* workspace's server from a sibling
 /// `jj` workspace's server bound to the same port. The `version` field
 /// (from `OMNIBUS_VERSION`, `"dev"` when unset) lets the mobile "You"
-/// screen show the running server's release alongside its own app version
-/// (#1055). Whitelisted in `auth::gate::require_auth` so it remains
-/// reachable without a session.
+/// screen show the running server's release alongside its own app version.
+/// Whitelisted in `auth::gate::require_auth` so it remains reachable
+/// without a session.
 pub(super) async fn get_health() -> Response {
     Json(serde_json::json!({
         "app": "omnibus",
@@ -74,7 +74,7 @@ mod tests {
         // The test binary doesn't set OMNIBUS_VERSION, so this is "dev" in
         // practice — but the contract this endpoint guarantees is just
         // "a non-empty string field", which is what `read_app_version`'s
-        // dedicated fallback test in `backend.rs` covers precisely.
+        // dedicated fallback test in `backend/tests.rs` covers precisely.
         let version = json["version"].as_str().expect("version is a string");
         assert!(!version.is_empty(), "version should not be empty");
     }

--- a/server/src/backend/tests.rs
+++ b/server/src/backend/tests.rs
@@ -41,6 +41,13 @@ async fn api_health_returns_200_unauth_with_app_and_build_id() {
         "repo_root must be a string, got {:?}",
         body["repo_root"]
     );
+    // `version` is what the mobile "You" screen fetches to show the running
+    // server's release alongside its own compile-time app version (#1055).
+    assert!(
+        body["version"].is_string(),
+        "version must be a string, got {:?}",
+        body["version"]
+    );
 }
 
 // -------------------------------------------------------------------

--- a/server/src/backend/tests.rs
+++ b/server/src/backend/tests.rs
@@ -42,12 +42,59 @@ async fn api_health_returns_200_unauth_with_app_and_build_id() {
         body["repo_root"]
     );
     // `version` is what the mobile "You" screen fetches to show the running
-    // server's release alongside its own compile-time app version (#1055).
+    // server's release alongside its own compile-time app version.
     assert!(
         body["version"].is_string(),
         "version must be a string, got {:?}",
         body["version"]
     );
+}
+
+// -------------------------------------------------------------------
+// read_app_version — OMNIBUS_VERSION normalization for `app_version`.
+// -------------------------------------------------------------------
+
+#[test]
+fn read_app_version_normalizes_env_var_and_falls_back_to_dev_when_unset_or_blank() {
+    // One test (not several) so the env-var mutations can't race another
+    // test's parallel read/write of the same process-global var — no other
+    // test in this crate touches `OMNIBUS_VERSION`.
+    let prev = std::env::var("OMNIBUS_VERSION").ok();
+
+    std::env::set_var("OMNIBUS_VERSION", "v1.2.3");
+    assert_eq!(read_app_version(), "v1.2.3");
+
+    // A bare version (e.g. TestFlight's MARKETING_VERSION convention) gets a
+    // leading `v` added, so both sources render consistently.
+    std::env::set_var("OMNIBUS_VERSION", "1.2.3");
+    assert_eq!(read_app_version(), "v1.2.3");
+
+    // A doubled leading `v` collapses to one.
+    std::env::set_var("OMNIBUS_VERSION", "vv1.2.3");
+    assert_eq!(read_app_version(), "v1.2.3");
+
+    // A Docker build-arg supplied without a value (`--build-arg
+    // OMNIBUS_VERSION=` or omitted entirely with no Dockerfile default) sets
+    // the env var to an empty string rather than leaving it unset — that
+    // must not render the bare "v".
+    std::env::set_var("OMNIBUS_VERSION", "");
+    assert_eq!(read_app_version(), "dev");
+
+    std::env::set_var("OMNIBUS_VERSION", "   \n\t");
+    assert_eq!(read_app_version(), "dev");
+
+    // Literally just "v" (or "v" surrounded by whitespace) has nothing left
+    // after stripping the leading `v`s, so it's treated the same as unset.
+    std::env::set_var("OMNIBUS_VERSION", "v");
+    assert_eq!(read_app_version(), "dev");
+
+    std::env::remove_var("OMNIBUS_VERSION");
+    assert_eq!(read_app_version(), "dev");
+
+    match prev {
+        Some(v) => std::env::set_var("OMNIBUS_VERSION", v),
+        None => std::env::remove_var("OMNIBUS_VERSION"),
+    }
 }
 
 // -------------------------------------------------------------------

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -89,6 +89,10 @@ mod server {
         // workspace's server" from a sibling workspace's server bound to the
         // port I want.
         backend::init_repo_root();
+        // Read OMNIBUS_VERSION once at boot so /api/_health's `version`
+        // field reflects the process's own launch env, not a value that
+        // could drift if something mutated the env var mid-run (#1055).
+        backend::init_app_version();
     }
 
     /// Log a WARN if `OMNIBUS_TRUST_FORWARDED_FOR` is enabled — required only

--- a/ui_tests/playwright/tests/flows/user_menu.spec.ts
+++ b/ui_tests/playwright/tests/flows/user_menu.spec.ts
@@ -74,6 +74,11 @@ test("opens and closes the user menu", async ({ page }) => {
   await expect(page.getByTestId("theme-dark")).toBeVisible();
   await expect(page.getByTestId("theme-light")).toBeVisible();
 
+  // Version line at the bottom of the panel (#1055) — a compile-time
+  // constant, so it's always present regardless of OMNIBUS_VERSION.
+  await expect(page.getByTestId("user-menu-version")).toBeVisible();
+  await expect(page.getByTestId("user-menu-version")).toHaveText(/^v\d+\.\d+\.\d+$/);
+
   // Close via the transparent scrim (click outside the panel).
   await page.getByTestId("user-menu-scrim").click();
   await expect(page.getByTestId("logout-button")).toHaveCount(0);


### PR DESCRIPTION
## Summary
- Closes #1055. Adds a `version` field to `GET /api/_health`, sourced once at boot from `OMNIBUS_VERSION` (falls back to `"dev"`) via `server::backend::app_version` / `init_app_version` (mirrors the existing `build_id`/`repo_root` pattern), called from `init_boot_metadata` in `server/src/main.rs`.
- New `omnibus_frontend::version::app_version()` compile-time helper: `option_env!("OMNIBUS_VERSION")` falling back to `CARGO_PKG_VERSION`. Both the server and frontend getters normalize to a single leading `v` regardless of whether the source string already has one (Docker's build-arg carries the full `v0.8.9` tag; TestFlight's `MARKETING_VERSION` is bare `0.8.9` — Apple's CFBundleShortVersionString can't carry a `v`).
- Web: single version line at the bottom of the user-menu panel (`UmVersion` in `frontend/src/components/user_menu.rs`), after the theme control — a compile-time constant, so SSR and first WASM paint match trivially (rule 07).
- Mobile: two lines at the bottom of the "You" tab (`VersionBlock` in `frontend/src/pages/account.rs`) — "Server version" (fetched via a new `data::get_server_version` hitting `/api/_health`) above "App version" (compile-time). The server-version signal is seeded `None` and filled in a post-mount `use_effect`, so SSR/first-paint markup is deterministic (rule 07). No mismatch/update prompt, per the issue — not every server release has a matching mobile release.
- Docker/CI plumbing (best-effort, see Notes): `Dockerfile` gets `ARG`/`ENV OMNIBUS_VERSION` in both the builder stage (before `dx bundle`, so it's baked into the compiled server binary + WASM bundle) and the runtime stage (so the *running* container also has it as a real env var for the server's runtime `std::env::var` read); `docker.yml` passes `--build-arg OMNIBUS_VERSION=${{ inputs.tag || github.ref_name }}`; `testflight.yml` exports `OMNIBUS_VERSION: ${{ env.MARKETING_VERSION }}` into the `dx bundle` step's env.
- New env var documented in `.env.example` and `.claude/rules/01-dev-environment.md` per the end-of-session checklist.
- Playwright: extended `user_menu.spec.ts`'s existing "opens and closes the user menu" test to assert the version testid is visible and matches `vX.Y.Z`.

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1055 cargo fmt` — PASS (no changes)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1055 cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1055 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1055 cargo test -p omnibus` — 335 passed, 1 failed (`backend::uploads::tests::commit_rejects_read_only_library_with_400`). Confirmed pre-existing and unrelated: it fails identically on unmodified `main` in this sandbox because tests run as root, which bypasses the filesystem read-only permission check the test depends on. Not in the touched-file set.
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1055 cargo test -p omnibus-frontend --features server` — 291 passed, 0 failed (includes new `version::tests::*`, `pages::account::tests::*`, `components::user_menu::tests::*`)
- [x] (extra sanity, not in the mandated list) `cargo check -p omnibus-frontend --features mobile` — PASS, confirms the mobile-only `get_server_version`/`VersionBlock` code compiles, since the mandated commands don't cover the `mobile` feature.

## Notes
- **Best-effort / not runnable in this sandbox:** the Docker build-arg plumbing (`Dockerfile`, `.github/workflows/docker.yml`) and the TestFlight env export (`.github/workflows/testflight.yml`) are textually correct to the best of my review but I could not actually run a Docker build or a TestFlight/Xcode build here to confirm end-to-end (AC4, AC5). Everything else (AC1, AC2, AC3, AC6, AC7) is implemented and covered by the unit tests above. AC8 (Playwright) is written but not executed — no live server/browser in this environment.
- Local dev fallback verified via the new `version_tests`/`version::tests` unit tests: server → `"dev"`, frontend → `"v0.1.0"` (v-prefixed `CARGO_PKG_VERSION`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013aUaEEYJtfSYdmd6jKFedz

---
_Generated by [Claude Code](https://claude.ai/code/session_013aUaEEYJtfSYdmd6jKFedz)_