### PR TITLE
fix: show the latest book in the profile menu

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -2591,32 +2591,43 @@ a.idx-letter-on:focus-visible {
   color: var(--ink-3); text-transform: uppercase;
 }
 
-/* Now reading card (stub) */
+/* Now reading card */
 .um-now-reading {
   display: flex; gap: 12px; padding: 12px;
   background: color-mix(in oklch, var(--accent) 14%, var(--bg-2));
   border: 1px solid color-mix(in oklch, var(--accent) 30%, var(--line-2));
   border-radius: 10px; text-decoration: none; color: inherit;
 }
-.um-now-reading[aria-disabled="true"] { cursor: not-allowed; }
+.um-now-reading[href]:hover {
+  border-color: color-mix(in oklch, var(--accent) 55%, var(--line-2));
+}
+.um-now-reading-state {
+  align-items: center;
+  min-height: 40px;
+  color: var(--ink-2);
+  font-size: 12px;
+}
+.um-now-reading-state.error { color: var(--bad); }
 .um-nr-cover {
   width: 44px; height: 64px; flex: 0 0 44px;
   background: color-mix(in oklch, var(--accent) 35%, var(--bg-3));
   border-radius: 3px;
+  overflow: hidden;
   box-shadow: inset 0 0 0 1px color-mix(in oklch, black 15%, transparent);
+}
+.um-nr-cover .cover-wrap,
+.um-nr-cover .cover {
+  width: 100%;
+  height: 100%;
 }
 .um-nr-meta { display: flex; flex-direction: column; gap: 4px; flex: 1 1 auto; min-width: 0; }
 .um-nr-title { font-family: var(--serif); font-style: italic; color: var(--ink-0); font-size: 14px; }
 .um-nr-author { color: var(--ink-2); font-size: 12px; }
-.um-nr-progress { display: flex; flex-direction: column; gap: 4px; margin-top: auto; }
-.um-nr-pbar {
-  height: 2px; background: color-mix(in oklch, var(--accent) 25%, var(--bg-3));
-  border-radius: 999px; overflow: hidden;
-}
-.um-nr-pbar-fill { display: block; height: 100%; width: 68%; background: var(--accent); }
-.um-nr-stats {
-  display: flex; justify-content: space-between; gap: 8px;
-  font-family: var(--mono); font-size: 10px; color: var(--ink-2);
+.um-nr-action {
+  margin-top: auto;
+  color: var(--ink-2);
+  font-family: var(--mono);
+  font-size: 10px;
 }
 
 /* Stat grid (stubs) */

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -1,13 +1,13 @@
-//! User-menu dropdown mounted in the top nav. Real wiring: Settings,
-//! Sign out, Dark/Light theme. Everything else is a stubbed `<a>`. See
-//! [`UserMenu`] for the SSR/hydration handling of the pre-auth trigger
-//! state.
+//! User-menu dropdown mounted in the top nav. Real wiring: recent progress,
+//! Settings, Sign out, and Dark/Light theme. Other account surfaces remain
+//! stubbed. See [`UserMenu`] for the SSR/hydration handling of the pre-auth
+//! trigger state.
 
 use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};
-use omnibus_shared::UserSummary;
+use omnibus_shared::{ProgressFormat, ResumePoint, UserSummary};
 
-use crate::components::atrium::{persist_theme, Theme};
+use crate::components::atrium::{persist_theme, Cover, Theme};
 use crate::{use_current_user, Route};
 
 /// Derive 1–2 character avatar initials from a username. Empty input falls
@@ -218,30 +218,83 @@ fn UmHeader(user: UserSummary) -> Element {
     }
 }
 
-/// "Now reading" stub card — static placeholder content pending the
-/// reading-progress integration.
+/// Most recently progressed book across reading and listening.
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
 fn UmNowReading() -> Element {
+    let mut recent = use_signal(|| None::<Result<Option<ResumePoint>, String>>);
+
+    use_effect(move || {
+        spawn(async move {
+            let result = crate::data::recent_progress("", 1)
+                .await
+                .map(|points| points.into_iter().next())
+                .map_err(|error| error.to_string());
+            recent.set(Some(result));
+        });
+    });
+
     rsx! {
         div { class: "um-section",
             div { class: "um-section-label", "NOW READING" }
-            a {
-                class: "um-now-reading",
-                href: "#",
-                "aria-disabled": "true",
-                tabindex: "-1",
-                onclick: move |evt| evt.prevent_default(),
-                div { class: "um-nr-cover" }
-                div { class: "um-nr-meta",
-                    div { class: "um-nr-title", "Piranesi" }
-                    div { class: "um-nr-author", "Susanna Clarke" }
-                    div { class: "um-nr-progress",
-                        div { class: "um-nr-pbar", div { class: "um-nr-pbar-fill" } }
-                        div { class: "um-nr-stats",
-                            span { "68%" }
-                            span { "ch. 22" }
-                            span { "4h 12m left" }
+            match recent() {
+                None => rsx! {
+                    div { class: "um-now-reading um-now-reading-state", role: "status",
+                        "Loading reading progress..."
+                    }
+                },
+                Some(Ok(None)) => rsx! {
+                    div { class: "um-now-reading um-now-reading-state",
+                        "Nothing in progress"
+                    }
+                },
+                Some(Err(_)) => rsx! {
+                    div { class: "um-now-reading um-now-reading-state error", role: "alert",
+                        "Unable to load reading progress."
+                    }
+                },
+                Some(Ok(Some(point))) => {
+                    let is_audio = point.record.format == ProgressFormat::Audio;
+                    let title = point
+                        .book
+                        .title
+                        .as_deref()
+                        .filter(|title| !title.trim().is_empty())
+                        .unwrap_or(&point.book.filename)
+                        .to_string();
+                    let author = point
+                        .book
+                        .creators
+                        .first()
+                        .map(|creator| creator.name.clone())
+                        .filter(|author| !author.trim().is_empty());
+                    let action = if is_audio {
+                        "Continue listening"
+                    } else {
+                        "Continue reading"
+                    };
+                    let uuid = point.record.book_uuid.clone();
+                    let to = if is_audio {
+                        Route::BookListen { uuid }
+                    } else {
+                        Route::BookRead { uuid }
+                    };
+                    let aria_label = format!("{action} {title}");
+
+                    rsx! {
+                        Link {
+                            to,
+                            class: "um-now-reading",
+                            "data-testid": "user-menu-now-reading",
+                            "aria-label": "{aria_label}",
+                            div { class: "um-nr-cover", Cover { book: point.book } }
+                            div { class: "um-nr-meta",
+                                div { class: "um-nr-title", "{title}" }
+                                if let Some(author) = author {
+                                    div { class: "um-nr-author", "{author}" }
+                                }
+                                div { class: "um-nr-action", "{action}" }
+                            }
                         }
                     }
                 }

--- a/ui_tests/playwright/tests/flows/user_menu.spec.ts
+++ b/ui_tests/playwright/tests/flows/user_menu.spec.ts
@@ -1,11 +1,53 @@
 import { expect, test } from "../fixtures/test";
+import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expectMutation } from "../utils/api";
+import { fetchBookUuidByTitle } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
+import { fixturesDir, seedLibrary } from "../utils/seed";
 
 // The user menu replaces the old top-bar cluster (ThemeToggle, Settings
 // link, Log out button) with a single avatar trigger that opens a dropdown.
 // Most rows in the dropdown are forward-looking stubs (disabled <a>); real
-// wiring covers Settings, Sign out, and the Dark/Light theme buttons.
+// wiring covers recent progress, Settings, Sign out, and theme selection.
+
+test.beforeAll(async ({ request }) => {
+  await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
+});
+
+async function recentPoint(
+  request: import("@playwright/test").APIRequestContext,
+  format: "epub" | "audio",
+) {
+  const target = FIXTURE_BOOKS[1];
+  const uuid = await fetchBookUuidByTitle(request, target.title);
+  const response = await request.get("/api/rpc/ebooks");
+  expect(response.status()).toBe(200);
+  const books = ((await response.json()) as {
+    books: Record<string, unknown>[];
+  }).books;
+  const book = books.find((candidate) => candidate.unique_identifier === uuid);
+  if (!book) {
+    throw new Error(`book ${JSON.stringify(target.title)} disappeared after lookup`);
+  }
+
+  return {
+    uuid,
+    title: target.title,
+    point: {
+      record: {
+        book_uuid: uuid,
+        format,
+        epub_cfi: format === "epub" ? "epubcfi(/6/2)" : null,
+        audio_position_seconds: format === "audio" ? 90 : null,
+        updated_at: 123,
+      },
+      book,
+      total_duration_seconds: null,
+      chapter_number: null,
+      chapter_count: null,
+    },
+  };
+}
 
 test("renders the user menu trigger after login", async ({ page }) => {
   await gotoReady(page, "/");
@@ -50,6 +92,53 @@ test("Settings link routes to the settings page", async ({ page }) => {
   await page.getByTestId("user-menu-trigger").click();
   await page.getByRole("link", { name: "Settings" }).click();
   await expect(page).toHaveURL(/\/settings$/);
+});
+
+for (const sample of [
+  { format: "epub" as const, action: "Continue reading", path: "read" },
+  { format: "audio" as const, action: "Continue listening", path: "listen" },
+]) {
+  test(`shows the latest ${sample.format} and its resume destination`, async ({
+    page,
+    request,
+  }) => {
+    const latest = await recentPoint(request, sample.format);
+    await page.route("**/api/rpc/progress/recent", async (route) => {
+      await route.fulfill({ status: 200, json: [latest.point] });
+    });
+
+    await gotoReady(page, "/");
+    await page.getByTestId("user-menu-trigger").click();
+
+    const card = page.getByRole("link", {
+      name: `${sample.action} ${latest.title}`,
+    });
+    await expect(card).toBeVisible();
+    await expect(card).toHaveAttribute("href", `/${sample.path}/${latest.uuid}`);
+  });
+}
+
+test("shows an empty state when no book has progress", async ({ page }) => {
+  await page.route("**/api/rpc/progress/recent", async (route) => {
+    await route.fulfill({ status: 200, json: [] });
+  });
+
+  await gotoReady(page, "/");
+  await page.getByTestId("user-menu-trigger").click();
+
+  await expect(page.getByText("Nothing in progress")).toBeVisible();
+  await expect(page.getByText("Piranesi")).toHaveCount(0);
+});
+
+test("surfaces a recent-progress fetch failure", async ({ page }) => {
+  await page.route("**/api/rpc/progress/recent", async (route) => {
+    await route.fulfill({ status: 500, body: "forced failure" });
+  });
+
+  await gotoReady(page, "/");
+  await page.getByTestId("user-menu-trigger").click();
+
+  await expect(page.getByRole("alert")).toHaveText("Unable to load reading progress.");
 });
 
 test("Sign out clears the session and routes to /login", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Replace the fabricated Piranesi card with the latest EPUB or audiobook progress for the authenticated user.
- Link directly to the matching reader/player and show explicit empty and error states.

## Test plan
- [x] cargo test -p omnibus-frontend --features server
- [x] cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings
- [x] just lint-css
- [x] Playwright user-menu flow (8 passed)

## Version
By default a merge to main cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** - add the minor version label.
- [x] **Patch** - the default; leave the version label unset.
- [ ] **No release** - add the no release label.