### PR TITLE
fix: include audiobooks in search results

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -29,7 +29,10 @@ pub use list::{
 };
 pub use page::{count_books_page, list_books_page, BookPage, CursorError, PageCursor};
 pub use projection::MAX_BOOKS_RETURNED;
-pub use search::{count_search_books, search_books, search_books_with_total};
+pub use search::{
+    count_search_books, count_search_books_for_paths, search_books, search_books_for_paths,
+    search_books_for_paths_with_total, search_books_with_total,
+};
 
 /// Errors returned by the books read path.
 #[derive(Debug, thiserror::Error)]

--- a/db/src/books/search.rs
+++ b/db/src/books/search.rs
@@ -6,7 +6,7 @@
 use omnibus_shared::EbookMetadata;
 use sqlx::{Row, SqlitePool};
 
-use crate::helpers::{build_fts_match, cap_query_len};
+use crate::helpers::{build_fts_match, cap_query_len, library_paths_json};
 
 use super::projection::{
     backfill_creator_ids, merge_overrides_into_books, row_to_ebook, BOOK_COLUMNS,
@@ -30,7 +30,16 @@ pub async fn search_books(
     library_path: &str,
     q: &str,
 ) -> Result<Vec<EbookMetadata>, super::BooksError> {
-    let (books, _total) = search_books_with_total(pool, library_path, q).await?;
+    search_books_for_paths(pool, &[library_path], q).await
+}
+
+/// Full-text search across every configured library path.
+pub async fn search_books_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    q: &str,
+) -> Result<Vec<EbookMetadata>, super::BooksError> {
+    let (books, _total) = search_books_for_paths_with_total(pool, library_paths, q).await?;
     Ok(books)
 }
 
@@ -46,6 +55,18 @@ pub async fn search_books_with_total(
     library_path: &str,
     q: &str,
 ) -> Result<(Vec<EbookMetadata>, i64), super::BooksError> {
+    search_books_for_paths_with_total(pool, &[library_path], q).await
+}
+
+/// Search across `library_paths` and return capped rows plus the true hit count.
+pub async fn search_books_for_paths_with_total(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    q: &str,
+) -> Result<(Vec<EbookMetadata>, i64), super::BooksError> {
+    if library_paths.is_empty() {
+        return Ok((Vec::new(), 0));
+    }
     // Cap query length before parsing to bound the FTS5 MATCH expression size,
     // matching `search_palette` (issue #189). Normal/short queries are
     // unaffected; see `cap_query_len`.
@@ -54,7 +75,7 @@ pub async fn search_books_with_total(
         return Ok((Vec::new(), 0));
     };
 
-    let rows = fetch_search_rows(pool, library_path, &match_expr).await?;
+    let rows = fetch_search_rows(pool, library_paths, &match_expr).await?;
 
     // `total_count` is the scalar `COUNT(*)` over the materialized matches, so
     // it's identical on every row; read it off the first. An empty result set
@@ -79,7 +100,7 @@ pub async fn search_books_with_total(
 /// references books_fts, so it must live inside the CTE.
 async fn fetch_search_rows(
     pool: &SqlitePool,
-    library_path: &str,
+    library_paths: &[&str],
     match_expr: &str,
 ) -> Result<Vec<sqlx::sqlite::SqliteRow>, sqlx::Error> {
     let sql = format!(
@@ -90,7 +111,8 @@ async fn fetch_search_rows(
             FROM books_fts
             JOIN books b ON b.id = books_fts.rowid
             JOIN scan_roots l ON l.id = b.library_id
-            WHERE books_fts MATCH ? AND l.path = ?
+            WHERE books_fts MATCH ?
+              AND l.path IN (SELECT value FROM json_each(?))
         )
         SELECT {BOOK_COLUMNS},
                (SELECT COUNT(*) FROM matches)               AS total_count
@@ -102,7 +124,7 @@ async fn fetch_search_rows(
     );
     sqlx::query(&sql)
         .bind(match_expr)
-        .bind(library_path)
+        .bind(library_paths_json(library_paths))
         .bind(MAX_BOOKS_RETURNED)
         .fetch_all(pool)
         .await
@@ -116,6 +138,18 @@ pub async fn count_search_books(
     library_path: &str,
     q: &str,
 ) -> Result<i64, super::BooksError> {
+    count_search_books_for_paths(pool, &[library_path], q).await
+}
+
+/// Count FTS5 hits across every configured library path.
+pub async fn count_search_books_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    q: &str,
+) -> Result<i64, super::BooksError> {
+    if library_paths.is_empty() {
+        return Ok(0);
+    }
     // Cap query length before parsing to mirror `search_books` /
     // `search_palette` (issue #189). Normal/short queries are unaffected;
     // see `cap_query_len`.
@@ -129,11 +163,12 @@ pub async fn count_search_books(
           FROM books_fts
           JOIN books b ON b.id = books_fts.rowid
           JOIN scan_roots l ON l.id = b.library_id
-         WHERE books_fts MATCH ? AND l.path = ?
+         WHERE books_fts MATCH ?
+           AND l.path IN (SELECT value FROM json_each(?))
         ",
     )
     .bind(&match_expr)
-    .bind(library_path)
+    .bind(library_paths_json(library_paths))
     .fetch_one(pool)
     .await?)
 }

--- a/db/src/helpers.rs
+++ b/db/src/helpers.rs
@@ -1,4 +1,4 @@
-//! Pure, dependency-free helpers shared across the db query layer:
+//! Pure helpers shared across the db query layer:
 //! deterministic UUID derivation, filename / accent-color sanitisation,
 //! and the FTS5 query / match builders.
 
@@ -18,6 +18,17 @@ pub(crate) const MAX_QUERY_LEN: usize = 256;
 /// by every search entrypoint so the cap is applied identically everywhere.
 pub(crate) fn cap_query_len(q: &str) -> String {
     q.trim().chars().take(MAX_QUERY_LEN).collect()
+}
+
+/// Encode library paths for binding through SQLite's `json_each`.
+pub(crate) fn library_paths_json(library_paths: &[&str]) -> String {
+    serde_json::Value::Array(
+        library_paths
+            .iter()
+            .map(|path| serde_json::Value::String((*path).to_string()))
+            .collect(),
+    )
+    .to_string()
 }
 
 /// Deterministic UUIDv5 derived from `(library_path, filename)` so reindexing

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -51,13 +51,14 @@ pub mod worker;
 pub use author_photos_data::*;
 pub use books::{
     book_file_path, book_file_path_by_id, book_file_paths, collect_paths, count_books,
-    count_books_for_paths, count_books_page, count_search_books, get_book, get_book_by_uuid,
-    get_book_files, get_book_uuid_by_scan_key, library_facets, library_from_db,
-    library_from_db_combined, library_from_db_with_total, library_from_db_with_total_combined,
-    list_books, list_books_for_paths, list_books_page, list_indexed_rows,
-    list_indexed_rows_for_formats, list_merged_rows_for_formats, resolve_book_id_by_uuid,
-    resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
-    resolve_canonical_book_uuids_bulk_exec, search_books, search_books_with_total, BookPage,
+    count_books_for_paths, count_books_page, count_search_books, count_search_books_for_paths,
+    get_book, get_book_by_uuid, get_book_files, get_book_uuid_by_scan_key, library_facets,
+    library_from_db, library_from_db_combined, library_from_db_with_total,
+    library_from_db_with_total_combined, list_books, list_books_for_paths, list_books_page,
+    list_indexed_rows, list_indexed_rows_for_formats, list_merged_rows_for_formats,
+    resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid,
+    resolve_canonical_book_uuid_exec, resolve_canonical_book_uuids_bulk_exec, search_books,
+    search_books_for_paths, search_books_for_paths_with_total, search_books_with_total, BookPage,
     BooksError, CursorError, IndexedRow, PageCursor, MAX_BOOKS_RETURNED,
 };
 pub use browse::*;

--- a/db/src/palette/authors.rs
+++ b/db/src/palette/authors.rs
@@ -6,6 +6,8 @@
 use omnibus_shared::PaletteAuthorHit;
 use sqlx::{Row, SqlitePool};
 
+use crate::helpers::library_paths_json;
+
 use super::PaletteError;
 
 /// Authors-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
@@ -42,7 +44,7 @@ const SEARCH_AUTHORS_SQL: &str = r"
             JOIN books b ON b.id = bal.book
             JOIN scan_roots l2 ON l2.id = b.library_id
             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE l2.path = ?1
+           WHERE l2.path IN (SELECT value FROM json_each(?1))
              AND (mo.book_uuid IS NULL
                   OR json_type(mo.overrides, '$.creators') IS NULL)
           UNION
@@ -53,7 +55,7 @@ const SEARCH_AUTHORS_SQL: &str = r"
             JOIN scan_roots l2 ON l2.id = b.library_id
             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
             JOIN json_each(mo.overrides, '$.creators') je
-           WHERE l2.path = ?1
+           WHERE l2.path IN (SELECT value FROM json_each(?1))
              AND json_type(mo.overrides, '$.creators') IS NOT NULL
         )
         SELECT a.id, a.name,
@@ -64,7 +66,8 @@ const SEARCH_AUTHORS_SQL: &str = r"
              JOIN books b3 ON b3.id = bal3.book
              JOIN scan_roots l3 ON l3.id = b3.library_id
              LEFT JOIN metadata_overrides mo3 ON mo3.book_uuid = b3.uuid
-            WHERE bal3.author = a.id AND l3.path = ?1
+            WHERE bal3.author = a.id
+              AND l3.path IN (SELECT value FROM json_each(?1))
             ORDER BY b3.sort, b3.id LIMIT 1) AS lead_book_title
         FROM authors a
         WHERE a.name LIKE ?2 ESCAPE '\'
@@ -72,7 +75,8 @@ const SEARCH_AUTHORS_SQL: &str = r"
             SELECT 1 FROM books_authors_link bal
               JOIN books b ON b.id = bal.book
               JOIN scan_roots l ON l.id = b.library_id
-             WHERE bal.author = a.id AND l.path = ?1
+             WHERE bal.author = a.id
+               AND l.path IN (SELECT value FROM json_each(?1))
           )
         ORDER BY book_count DESC, a.name
         LIMIT ?3
@@ -86,8 +90,21 @@ pub async fn search_authors(
     like_pattern: &str,
     limit: i32,
 ) -> Result<Vec<PaletteAuthorHit>, PaletteError> {
+    search_authors_for_paths(pool, &[library_path], like_pattern, limit).await
+}
+
+/// Run the authors arm across every configured library path.
+pub async fn search_authors_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    like_pattern: &str,
+    limit: i32,
+) -> Result<Vec<PaletteAuthorHit>, PaletteError> {
+    if library_paths.is_empty() {
+        return Ok(Vec::new());
+    }
     let rows = sqlx::query(SEARCH_AUTHORS_SQL)
-        .bind(library_path)
+        .bind(library_paths_json(library_paths))
         .bind(like_pattern)
         .bind(limit)
         .fetch_all(pool)
@@ -113,6 +130,18 @@ pub async fn count_authors(
     library_path: &str,
     like_pattern: &str,
 ) -> Result<i64, PaletteError> {
+    count_authors_for_paths(pool, &[library_path], like_pattern).await
+}
+
+/// Count visible matching authors across every configured library path.
+pub async fn count_authors_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    like_pattern: &str,
+) -> Result<i64, PaletteError> {
+    if library_paths.is_empty() {
+        return Ok(0);
+    }
     Ok(sqlx::query_scalar::<_, i64>(
         r"
         SELECT COUNT(*) FROM authors a
@@ -121,11 +150,12 @@ pub async fn count_authors(
             SELECT 1 FROM books_authors_link bal
               JOIN books b ON b.id = bal.book
               JOIN scan_roots l ON l.id = b.library_id
-             WHERE bal.author = a.id AND l.path = ?1
+             WHERE bal.author = a.id
+               AND l.path IN (SELECT value FROM json_each(?1))
           )
         ",
     )
-    .bind(library_path)
+    .bind(library_paths_json(library_paths))
     .bind(like_pattern)
     .fetch_one(pool)
     .await?)

--- a/db/src/palette/books.rs
+++ b/db/src/palette/books.rs
@@ -6,7 +6,7 @@ use omnibus_shared::PaletteBookHit;
 use sqlx::{Row, SqlitePool};
 
 use crate::books::parse_json_array;
-use crate::helpers::build_fts_match;
+use crate::helpers::{build_fts_match, library_paths_json};
 use crate::metadata_overrides::load_overrides_bulk;
 
 use super::PaletteError;
@@ -22,7 +22,8 @@ const SEARCH_BOOKS_SQL: &str = r"
             FROM books_fts
             JOIN books b ON b.id = books_fts.rowid
             JOIN scan_roots l ON l.id = b.library_id
-            WHERE books_fts MATCH ?1 AND l.path = ?2
+            WHERE books_fts MATCH ?1
+              AND l.path IN (SELECT value FROM json_each(?2))
         )
         SELECT b.id, b.uuid, b.title, b.has_cover, b.accent_color,
                SUBSTR(b.pubdate, 1, 4) AS year,
@@ -61,13 +62,26 @@ pub async fn search_books(
     trimmed: &str,
     limit: i32,
 ) -> Result<(Vec<PaletteBookHit>, i64), PaletteError> {
+    search_books_for_paths(pool, &[library_path], trimmed, limit).await
+}
+
+/// Run the books arm across every configured library path.
+pub async fn search_books_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    trimmed: &str,
+    limit: i32,
+) -> Result<(Vec<PaletteBookHit>, i64), PaletteError> {
+    if library_paths.is_empty() {
+        return Ok((Vec::new(), 0));
+    }
     let Some(match_expr) = build_fts_match(trimmed) else {
         return Ok((Vec::new(), 0));
     };
 
     let rows = sqlx::query(SEARCH_BOOKS_SQL)
         .bind(&match_expr)
-        .bind(library_path)
+        .bind(library_paths_json(library_paths))
         .bind(limit)
         .fetch_all(pool)
         .await?;

--- a/db/src/palette/mod.rs
+++ b/db/src/palette/mod.rs
@@ -2,7 +2,7 @@
 //! series, and tags. Books go through the FTS5 MATCH path (with
 //! override-aware overlays applied after hydration); taxonomy categories
 //! use scoped `LIKE` substring matches against the name columns. Bounded
-//! per category and scoped to `library_path`.
+//! per category and scoped to one or more configured library paths.
 
 use omnibus_shared::PaletteResults;
 use sqlx::SqlitePool;
@@ -23,9 +23,16 @@ mod tests;
 // publicly exposed pre-split; the arm helpers stay reachable internally
 // for `search_palette` and externally only via the fully-qualified
 // `palette::authors::search_authors` path.
+use authors::{count_authors_for_paths, search_authors_for_paths};
+use books::search_books_for_paths;
+use series::{count_series_for_paths, search_series_for_paths};
+use tags::{count_tags_for_paths, search_tags_for_paths};
+
+#[cfg(test)]
 use authors::{count_authors, search_authors};
-use books::search_books;
+#[cfg(test)]
 use series::{count_series, search_series};
+#[cfg(test)]
 use tags::{count_tags, search_tags};
 
 /// Errors returned by the search palette.
@@ -39,8 +46,10 @@ pub enum PaletteError {
 /// uncapped per-category totals (`book_total` etc.) are computed separately.
 const LIMIT: i32 = 5;
 
-/// Grouped command-palette results: up to 5 books, authors, series, and
-/// tags scoped to `library_path`, plus server-side timing in `duration_ms`.
+/// Grouped command-palette results for one library path.
+///
+/// Returns up to 5 books, authors, series, and tags plus server-side timing in
+/// `duration_ms`.
 /// Books are matched via FTS5 (`build_fts_match`); taxonomy categories use
 /// `LIKE '%q%'`. Empty/whitespace queries return `PaletteResults::default()`.
 pub async fn search_palette(
@@ -48,6 +57,18 @@ pub async fn search_palette(
     library_path: &str,
     q: &str,
 ) -> Result<PaletteResults, PaletteError> {
+    search_palette_for_paths(pool, &[library_path], q).await
+}
+
+/// Search every configured library path as one ranked palette result set.
+pub async fn search_palette_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    q: &str,
+) -> Result<PaletteResults, PaletteError> {
+    if library_paths.is_empty() {
+        return Ok(PaletteResults::default());
+    }
     let trimmed = q.trim();
     if trimmed.is_empty() {
         return Ok(PaletteResults::default());
@@ -64,7 +85,7 @@ pub async fn search_palette(
     // displays (FTS already matches on the merged text — see
     // `rebuild_fts_for_book` in the override write path). The books arm also
     // returns its uncapped total in the same FTS5 pass.
-    let (books, book_total) = search_books(pool, library_path, trimmed, LIMIT).await?;
+    let (books, book_total) = search_books_for_paths(pool, library_paths, trimmed, LIMIT).await?;
 
     // Escape the query for LIKE pattern: backslash first (it's the ESCAPE char),
     // then the LIKE wildcards percent and underscore.
@@ -75,27 +96,30 @@ pub async fn search_palette(
     let like_pattern = format!("%{like_q}%");
 
     // B. Authors — substring match, scoped to library, ordered by book count.
-    let authors = search_authors(pool, library_path, &like_pattern, LIMIT).await?;
+    let authors = search_authors_for_paths(pool, library_paths, &like_pattern, LIMIT).await?;
 
     // C. Series — substring match with primary author from first book.
-    let series = search_series(pool, library_path, &like_pattern, LIMIT).await?;
+    let series = search_series_for_paths(pool, library_paths, &like_pattern, LIMIT).await?;
 
     // D. Tags — substring match, scoped to library.
-    let tags = search_tags(pool, library_path, &like_pattern, LIMIT).await?;
+    let tags = search_tags_for_paths(pool, library_paths, &like_pattern, LIMIT).await?;
 
     // Uncapped per-category totals for the full-page results header. Each is a
     // cheap COUNT over the same visibility predicate the arm uses; books got
     // theirs in-pass above. Skipped when the capped vec already holds the whole
     // match set (len < LIMIT ⇒ no more rows to count).
     let author_total = total_for(authors.len(), || {
-        count_authors(pool, library_path, &like_pattern)
+        count_authors_for_paths(pool, library_paths, &like_pattern)
     })
     .await?;
     let series_total = total_for(series.len(), || {
-        count_series(pool, library_path, &like_pattern)
+        count_series_for_paths(pool, library_paths, &like_pattern)
     })
     .await?;
-    let tag_total = total_for(tags.len(), || count_tags(pool, library_path, &like_pattern)).await?;
+    let tag_total = total_for(tags.len(), || {
+        count_tags_for_paths(pool, library_paths, &like_pattern)
+    })
+    .await?;
 
     let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 

--- a/db/src/palette/series.rs
+++ b/db/src/palette/series.rs
@@ -6,6 +6,8 @@
 use omnibus_shared::PaletteSeriesHit;
 use sqlx::{Row, SqlitePool};
 
+use crate::helpers::library_paths_json;
+
 use super::PaletteError;
 
 /// Series-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
@@ -37,7 +39,7 @@ const SEARCH_SERIES_SQL: &str = r"
             JOIN books b ON b.id = bsl.book
             JOIN scan_roots l2 ON l2.id = b.library_id
             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE l2.path = ?1
+           WHERE l2.path IN (SELECT value FROM json_each(?1))
              AND (mo.book_uuid IS NULL
                   OR json_type(mo.overrides, '$.series') IS NULL)
           UNION
@@ -47,7 +49,7 @@ const SEARCH_SERIES_SQL: &str = r"
             FROM books b
             JOIN scan_roots l2 ON l2.id = b.library_id
             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE l2.path = ?1
+           WHERE l2.path IN (SELECT value FROM json_each(?1))
              AND json_type(mo.overrides, '$.series') IS NOT NULL
         )
         SELECT s.id, s.name,
@@ -67,14 +69,16 @@ const SEARCH_SERIES_SQL: &str = r"
              JOIN books b2 ON b2.id = bsl2.book
              JOIN scan_roots l2 ON l2.id = b2.library_id
              LEFT JOIN metadata_overrides mo2 ON mo2.book_uuid = b2.uuid
-            WHERE bsl2.series = s.id AND l2.path = ?1
+            WHERE bsl2.series = s.id
+              AND l2.path IN (SELECT value FROM json_each(?1))
             ORDER BY b2.sort, b2.id LIMIT 1) AS author_display,
           (SELECT COALESCE(json_extract(mo3.overrides, '$.title'), b3.title)
              FROM books_series_link bsl3
              JOIN books b3 ON b3.id = bsl3.book
              JOIN scan_roots l3 ON l3.id = b3.library_id
              LEFT JOIN metadata_overrides mo3 ON mo3.book_uuid = b3.uuid
-            WHERE bsl3.series = s.id AND l3.path = ?1
+            WHERE bsl3.series = s.id
+              AND l3.path IN (SELECT value FROM json_each(?1))
             ORDER BY b3.sort, b3.id LIMIT 1) AS lead_book_title
         FROM series s
         WHERE s.name LIKE ?2 ESCAPE '\'
@@ -82,7 +86,8 @@ const SEARCH_SERIES_SQL: &str = r"
             SELECT 1 FROM books_series_link bsl
               JOIN books b ON b.id = bsl.book
               JOIN scan_roots l ON l.id = b.library_id
-             WHERE bsl.series = s.id AND l.path = ?1
+             WHERE bsl.series = s.id
+               AND l.path IN (SELECT value FROM json_each(?1))
           )
         ORDER BY book_count DESC, s.name
         LIMIT ?3
@@ -96,8 +101,21 @@ pub async fn search_series(
     like_pattern: &str,
     limit: i32,
 ) -> Result<Vec<PaletteSeriesHit>, PaletteError> {
+    search_series_for_paths(pool, &[library_path], like_pattern, limit).await
+}
+
+/// Run the series arm across every configured library path.
+pub async fn search_series_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    like_pattern: &str,
+    limit: i32,
+) -> Result<Vec<PaletteSeriesHit>, PaletteError> {
+    if library_paths.is_empty() {
+        return Ok(Vec::new());
+    }
     let rows = sqlx::query(SEARCH_SERIES_SQL)
-        .bind(library_path)
+        .bind(library_paths_json(library_paths))
         .bind(like_pattern)
         .bind(limit)
         .fetch_all(pool)
@@ -123,6 +141,18 @@ pub async fn count_series(
     library_path: &str,
     like_pattern: &str,
 ) -> Result<i64, PaletteError> {
+    count_series_for_paths(pool, &[library_path], like_pattern).await
+}
+
+/// Count visible matching series across every configured library path.
+pub async fn count_series_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    like_pattern: &str,
+) -> Result<i64, PaletteError> {
+    if library_paths.is_empty() {
+        return Ok(0);
+    }
     Ok(sqlx::query_scalar::<_, i64>(
         r"
         SELECT COUNT(*) FROM series s
@@ -131,11 +161,12 @@ pub async fn count_series(
             SELECT 1 FROM books_series_link bsl
               JOIN books b ON b.id = bsl.book
               JOIN scan_roots l ON l.id = b.library_id
-             WHERE bsl.series = s.id AND l.path = ?1
+             WHERE bsl.series = s.id
+               AND l.path IN (SELECT value FROM json_each(?1))
           )
         ",
     )
-    .bind(library_path)
+    .bind(library_paths_json(library_paths))
     .bind(like_pattern)
     .fetch_one(pool)
     .await?)

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -6,6 +6,8 @@
 use omnibus_shared::PaletteTagHit;
 use sqlx::{Row, SqlitePool};
 
+use crate::helpers::library_paths_json;
+
 use super::PaletteError;
 
 /// Run the tags arm of the palette for `like_pattern` (already escaped)
@@ -16,6 +18,19 @@ pub async fn search_tags(
     like_pattern: &str,
     limit: i32,
 ) -> Result<Vec<PaletteTagHit>, PaletteError> {
+    search_tags_for_paths(pool, &[library_path], like_pattern, limit).await
+}
+
+/// Run the tags arm across every configured library path.
+pub async fn search_tags_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    like_pattern: &str,
+    limit: i32,
+) -> Result<Vec<PaletteTagHit>, PaletteError> {
+    if library_paths.is_empty() {
+        return Ok(Vec::new());
+    }
     // F5.1: the count uses the effective (override-aware) subject set,
     // not the raw `books_tags_link` rows. `MetadataOverrides.subjects`
     // (Option<Vec<String>>) replaces the canonical tag list wholesale
@@ -42,7 +57,7 @@ pub async fn search_tags(
             JOIN books b ON b.id = btl.book
             JOIN scan_roots l2 ON l2.id = b.library_id
             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE l2.path = ?1
+           WHERE l2.path IN (SELECT value FROM json_each(?1))
              AND (mo.book_uuid IS NULL
                   OR json_type(mo.overrides, '$.subjects') IS NULL)
           UNION
@@ -51,7 +66,7 @@ pub async fn search_tags(
             JOIN scan_roots l2 ON l2.id = b.library_id
             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
             JOIN json_each(mo.overrides, '$.subjects') je
-           WHERE l2.path = ?1
+           WHERE l2.path IN (SELECT value FROM json_each(?1))
              AND json_type(mo.overrides, '$.subjects') IS NOT NULL
         )
         SELECT t.id, t.name,
@@ -63,13 +78,14 @@ pub async fn search_tags(
             SELECT 1 FROM books_tags_link btl
               JOIN books b ON b.id = btl.book
               JOIN scan_roots l ON l.id = b.library_id
-             WHERE btl.tag = t.id AND l.path = ?1
+             WHERE btl.tag = t.id
+               AND l.path IN (SELECT value FROM json_each(?1))
           )
         ORDER BY book_count DESC, t.name
         LIMIT ?3
         ",
     )
-    .bind(library_path)
+    .bind(library_paths_json(library_paths))
     .bind(like_pattern)
     .bind(limit)
     .fetch_all(pool)
@@ -93,6 +109,18 @@ pub async fn count_tags(
     library_path: &str,
     like_pattern: &str,
 ) -> Result<i64, PaletteError> {
+    count_tags_for_paths(pool, &[library_path], like_pattern).await
+}
+
+/// Count visible matching tags across every configured library path.
+pub async fn count_tags_for_paths(
+    pool: &SqlitePool,
+    library_paths: &[&str],
+    like_pattern: &str,
+) -> Result<i64, PaletteError> {
+    if library_paths.is_empty() {
+        return Ok(0);
+    }
     Ok(sqlx::query_scalar::<_, i64>(
         r"
         SELECT COUNT(*) FROM tags t
@@ -101,11 +129,12 @@ pub async fn count_tags(
             SELECT 1 FROM books_tags_link btl
               JOIN books b ON b.id = btl.book
               JOIN scan_roots l ON l.id = b.library_id
-             WHERE btl.tag = t.id AND l.path = ?1
+             WHERE btl.tag = t.id
+               AND l.path IN (SELECT value FROM json_each(?1))
           )
         ",
     )
-    .bind(library_path)
+    .bind(library_paths_json(library_paths))
     .bind(like_pattern)
     .fetch_one(pool)
     .await?)

--- a/frontend/src/rpc/books.rs
+++ b/frontend/src/rpc/books.rs
@@ -177,10 +177,8 @@ pub async fn rpc_undo_merge(merge_log_id: i64) -> Result<String> {
 }
 
 /// Admin: candidate search for the merge dialog. Same FTS5 query as
-/// `rpc_search`, but across **both** configured libraries — the typical
-/// merge pairs an ebook with an audiobook, and `rpc_search` is scoped
-/// to the ebook root only. Deduped by uuid for the shared-directory
-/// case; capped small (the dialog shows a handful of rows).
+/// `rpc_search`, explicitly deduped by uuid for the shared-directory case and
+/// capped small because the dialog shows only a handful of rows.
 #[post("/api/rpc/merge-books/candidates", pool: PoolExt, _admin: AdminUser)]
 pub async fn rpc_merge_candidates(q: String) -> Result<Vec<EbookMetadata>> {
     let settings = db::get_settings(&pool.0)
@@ -203,8 +201,8 @@ pub async fn rpc_merge_candidates(q: String) -> Result<Vec<EbookMetadata>> {
     Ok(out)
 }
 
-/// FTS5-backed search across the configured ebook library. Empty or
-/// whitespace-only `q` returns an empty library.
+/// FTS5-backed search across the configured ebook and audiobook libraries.
+/// Empty or whitespace-only `q` returns an empty library.
 ///
 /// POST (not GET) so the query string can ride in the JSON body — Dioxus
 /// `#[get]` server functions reject arg bodies because HTTP spec forbids
@@ -220,11 +218,19 @@ pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
     let settings = db::get_settings(&pool.0)
         .await
         .map_err(|e| internal_rpc_error("get settings", e))?;
-    let Some(path) = settings.ebook_library_path else {
+    let ebook = settings.ebook_library_path;
+    let audiobook = settings.audiobook_library_path;
+    let path = ebook
+        .as_deref()
+        .or(audiobook.as_deref())
+        .unwrap_or_default()
+        .to_string();
+    let paths = db::collect_paths(ebook.as_deref(), audiobook.as_deref());
+    if paths.is_empty() {
         return Ok(EbookLibrary::default());
-    };
+    }
     // Issue #241: single FTS5 pass returns the capped vec and the full count.
-    let (books, total) = db::search_books_with_total(&pool.0, &path, &q)
+    let (books, total) = db::search_books_for_paths_with_total(&pool.0, &paths, &q)
         .await
         .map_err(|e| internal_rpc_error("search books", e))?;
     Ok(EbookLibrary {

--- a/frontend/src/rpc/books.rs
+++ b/frontend/src/rpc/books.rs
@@ -220,15 +220,11 @@ pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
         .map_err(|e| internal_rpc_error("get settings", e))?;
     let ebook = settings.ebook_library_path;
     let audiobook = settings.audiobook_library_path;
-    let path = ebook
-        .as_deref()
-        .or(audiobook.as_deref())
-        .unwrap_or_default()
-        .to_string();
     let paths = db::collect_paths(ebook.as_deref(), audiobook.as_deref());
     if paths.is_empty() {
         return Ok(EbookLibrary::default());
     }
+    let path = paths[0].to_string();
     // Issue #241: single FTS5 pass returns the capped vec and the full count.
     let (books, total) = db::search_books_for_paths_with_total(&pool.0, &paths, &q)
         .await

--- a/frontend/src/rpc/palette.rs
+++ b/frontend/src/rpc/palette.rs
@@ -26,10 +26,14 @@ pub async fn rpc_search_palette(q: String) -> Result<PaletteResults> {
     let settings = db::get_settings(&pool.0)
         .await
         .map_err(|e| internal_rpc_error("get settings", e))?;
-    let Some(path) = settings.ebook_library_path else {
+    let paths = db::collect_paths(
+        settings.ebook_library_path.as_deref(),
+        settings.audiobook_library_path.as_deref(),
+    );
+    if paths.is_empty() {
         return Ok(PaletteResults::default());
-    };
-    Ok(db::search_palette(&pool.0, &path, &q)
+    }
+    Ok(db::search_palette_for_paths(&pool.0, &paths, &q)
         .await
         .map_err(|e| internal_rpc_error("search palette", e))?)
 }

--- a/server/src/backend/search.rs
+++ b/server/src/backend/search.rs
@@ -49,11 +49,6 @@ pub(super) async fn get_search(
     };
     let ebook = settings.ebook_library_path;
     let audiobook = settings.audiobook_library_path;
-    let path = ebook
-        .as_deref()
-        .or(audiobook.as_deref())
-        .unwrap_or_default()
-        .to_string();
     let paths = db::collect_paths(ebook.as_deref(), audiobook.as_deref());
     if paths.is_empty() {
         // Match the `/api/ebooks` contract: even an empty result attaches
@@ -64,6 +59,7 @@ pub(super) async fn get_search(
             0,
         );
     }
+    let path = paths[0].to_string();
     // Issue #241: one FTS5 pass yields both the (capped) vec and the *full*
     // hit count via a scalar COUNT over the materialized matches CTE, replacing
     // the prior search_books + count_search_books double pass.

--- a/server/src/backend/search.rs
+++ b/server/src/backend/search.rs
@@ -1,6 +1,6 @@
 //! `GET /api/search` handler.
 //!
-//! Cookie-gated FTS5 search across the configured library. Returns a
+//! Cookie-gated FTS5 search across the configured libraries. Returns a
 //! capped result vec plus the full hit count via `X-Total-Count` /
 //! `X-Total-Cap` headers so clients can detect truncation without parsing
 //! the body. Mounted on a sub-router that carries its own rate limit.
@@ -47,7 +47,15 @@ pub(super) async fn get_search(
         Ok(s) => s,
         Err(error) => return internal("read settings", error),
     };
-    let Some(path) = settings.ebook_library_path else {
+    let ebook = settings.ebook_library_path;
+    let audiobook = settings.audiobook_library_path;
+    let path = ebook
+        .as_deref()
+        .or(audiobook.as_deref())
+        .unwrap_or_default()
+        .to_string();
+    let paths = db::collect_paths(ebook.as_deref(), audiobook.as_deref());
+    if paths.is_empty() {
         // Match the `/api/ebooks` contract: even an empty result attaches
         // `X-Total-Count: 0` so clients can rely on the header always
         // being present.
@@ -55,14 +63,15 @@ pub(super) async fn get_search(
             Json(omnibus_shared::EbookLibrary::default()).into_response(),
             0,
         );
-    };
+    }
     // Issue #241: one FTS5 pass yields both the (capped) vec and the *full*
     // hit count via a scalar COUNT over the materialized matches CTE, replacing
     // the prior search_books + count_search_books double pass.
-    let (books, total) = match db::search_books_with_total(&state.pool, &path, &params.q).await {
-        Ok(pair) => pair,
-        Err(error) => return internal("search books", error),
-    };
+    let (books, total) =
+        match db::search_books_for_paths_with_total(&state.pool, &paths, &params.q).await {
+            Ok(pair) => pair,
+            Err(error) => return internal("search books", error),
+        };
     // The full hit count rides the `X-Total-Count` / `X-Total-Cap` headers so
     // clients can detect truncation without changing the JSON body shape.
     let body = Json(omnibus_shared::EbookLibrary {
@@ -87,10 +96,14 @@ pub(super) async fn get_search_palette(
         Ok(s) => s,
         Err(error) => return internal("read settings", error),
     };
-    let Some(path) = settings.ebook_library_path else {
+    let paths = db::collect_paths(
+        settings.ebook_library_path.as_deref(),
+        settings.audiobook_library_path.as_deref(),
+    );
+    if paths.is_empty() {
         return Json(omnibus_shared::PaletteResults::default()).into_response();
-    };
-    match db::search_palette(&state.pool, &path, &params.q).await {
+    }
+    match db::search_palette_for_paths(&state.pool, &paths, &params.q).await {
         Ok(results) => Json(results).into_response(),
         Err(error) => internal("search palette", error),
     }

--- a/server/src/backend/search/tests.rs
+++ b/server/src/backend/search/tests.rs
@@ -8,6 +8,49 @@ use crate::auth::test_support as auth_test_support;
 use crate::backend::test_support::*;
 use crate::backend::SEARCH_RATE_LIMIT_MAX;
 
+async fn configure_and_seed_audiobook(pool: &sqlx::SqlitePool) {
+    db::set_settings(
+        pool,
+        &Settings {
+            ebook_library_path: Some("/ebooks".into()),
+            audiobook_library_path: Some("/audiobooks".into()),
+            scan_interval_hours: None,
+        },
+    )
+    .await
+    .unwrap();
+    db::sync_audiobooks(
+        pool,
+        "/audiobooks",
+        db::sync::AudiobookSyncPlan {
+            new_books: vec![db::audiobook::IndexedAudiobook {
+                scan_key: "Le Guin/Earthsea.m4b".into(),
+                group_path: "Le Guin/Earthsea.m4b".into(),
+                format: "M4B".into(),
+                title: "A Wizard of Earthsea".into(),
+                creator_name: Some("Ursula K. Le Guin".into()),
+                cover: None,
+                accent: None,
+                parts: vec![db::audiobook::AudiobookPart {
+                    ordinal: 0,
+                    filename: "Le Guin/Earthsea.m4b".into(),
+                    size_bytes: 1,
+                    mtime_epoch: 1,
+                    duration_seconds: 1.0,
+                }],
+                chapters: vec![],
+                total_size_bytes: 1,
+                max_mtime_epoch: 1,
+                description: None,
+                error: None,
+            }],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+}
+
 #[tokio::test]
 async fn api_get_search_sets_total_count_header_with_indexed_library() {
     // Issue #81: /api/search must attach X-Total-Count on every response,
@@ -71,6 +114,27 @@ async fn api_get_search_sets_total_count_header_with_indexed_library() {
     assert!(
         response.headers().get("X-Total-Cap").is_none(),
         "X-Total-Cap must not be set when search results fit under the cap"
+    );
+}
+
+#[tokio::test]
+async fn api_get_search_returns_matching_audiobook_from_configured_audiobook_library() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    configure_and_seed_audiobook(&pool).await;
+
+    let response = app
+        .oneshot(get_with_bearer("/api/search?q=Earthsea", &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let library: omnibus_shared::EbookLibrary = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(library.books.len(), 1);
+    assert_eq!(
+        library.books[0].title.as_deref(),
+        Some("A Wizard of Earthsea")
     );
 }
 
@@ -161,6 +225,25 @@ async fn api_search_returns_401_when_anonymous() {
 // -------------------------------------------------------------------
 // /api/search/palette — search palette (F1.5)
 // -------------------------------------------------------------------
+
+#[tokio::test]
+async fn api_search_palette_returns_matching_audiobook_from_configured_audiobook_library() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    configure_and_seed_audiobook(&pool).await;
+
+    let response = app
+        .oneshot(get_with_bearer("/api/search/palette?q=Earthsea", &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let results: omnibus_shared::PaletteResults = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(results.books.len(), 1);
+    assert_eq!(results.books[0].title, "A Wizard of Earthsea");
+    assert_eq!(results.books[0].formats, ["M4B"]);
+}
 
 #[tokio::test]
 async fn api_search_palette_returns_empty_when_path_not_configured() {


### PR DESCRIPTION
## Summary
- Search books and grouped palette results across both configured library roots.
- Keep relevance ranking, totals, and taxonomy counts unified across REST and Dioxus RPC search.

## Test plan
- [x] `just check`
- [x] Regression coverage for audiobook matches in `/api/search` and `/api/search/palette`

## Version
- [ ] **Minor**
- [x] **Patch**
- [ ] **No release**