### PR TITLE
test: cover multi-chunk batching paths for author photos and suggestions

### DIFF
--- a/db/src/author_photos/tests.rs
+++ b/db/src/author_photos/tests.rs
@@ -668,3 +668,53 @@ async fn refetch_all_skips_manual_and_reports_progress() {
         other => panic!("unexpected status for empty author: {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn refetch_all_processes_every_author_across_multiple_concurrency_chunks() {
+    // REFETCH_CONCURRENCY == 6; seed 8 authors so `to_refetch` spans two
+    // `chunks()` rounds (6 + 2) and the second round is actually exercised.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let mut author_ids = Vec::with_capacity(8);
+    for i in 0..8 {
+        let id: i64 =
+            sqlx::query_scalar("INSERT INTO authors (name, sort) VALUES (?, ?) RETURNING id")
+                .bind(format!("Chunk Test Author {i}"))
+                .bind(format!("Chunk Test Author {i}"))
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        author_ids.push(id);
+    }
+
+    let progress = std::sync::Mutex::new(Vec::new());
+    refetch_all(&pool, |processed, total| {
+        progress.lock().unwrap().push((processed, total));
+    })
+    .await
+    .unwrap();
+
+    let mut calls = progress.into_inner().unwrap();
+    assert_eq!(
+        calls.len(),
+        8,
+        "one progress call per author, spanning both concurrency chunks"
+    );
+    calls.sort_unstable();
+    let expected: Vec<(u32, Option<u32>)> = (1..=8).map(|n| (n, Some(8))).collect();
+    assert_eq!(
+        calls, expected,
+        "the completion counter must reach every value 1..=8 exactly once, \
+         regardless of which chunk (or which author within a chunk) finishes first"
+    );
+
+    // Every author must have run the cascade to completion: either a sticky
+    // `letter` marker (clean Open Library miss) or an absent row (transient
+    // network error, e.g. no network access in this environment). Either
+    // outcome proves the second chunk actually ran, not just the first 6.
+    for id in author_ids {
+        match author_photo_status(&pool, id).await.unwrap() {
+            Some((AuthorPhotoSource::Letter, _)) | None => {}
+            other => panic!("unexpected status for author {id}: {other:?}"),
+        }
+    }
+}

--- a/db/src/suggestions/tests.rs
+++ b/db/src/suggestions/tests.rs
@@ -566,6 +566,129 @@ async fn resolve_with_caches_filtered_survivors_end_to_end() {
 }
 
 #[tokio::test]
+async fn resolve_with_hydrates_covers_across_multiple_concurrency_chunks_with_partial_failure() {
+    // COVER_FETCH_CONCURRENCY == 6; 8 survivors span two `chunks()` rounds
+    // (6 + 2). One cover in the FIRST chunk (book 204) deliberately 404s to
+    // prove a single failure doesn't drop, misorder, or poison its
+    // chunk-mates — the other 5 covers in that same chunk (plus both in the
+    // second chunk) must still hydrate correctly.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_synced_ebook(&pool, "src.epub", "Test Source", "Source Author").await;
+
+    let server = MockServer::start().await;
+
+    // 1. Title fallback resolves the source book.
+    Mock::given(method("POST"))
+        .and(body_string_contains("title: {_eq:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [{
+                "id": 100, "slug": "src", "title": "Test Source",
+                "contributions": [{ "author": { "name": "Source Author" } }],
+                "book_series": [], "image": null
+            }] }
+        })))
+        .mount(&server)
+        .await;
+    // 2. Curated lists.
+    Mock::given(method("POST"))
+        .and(body_string_contains("list_books(where: {book_id:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "list_books": [{ "list_id": 1 }] }
+        })))
+        .mount(&server)
+        .await;
+    // 3. Co-listing members: 8 distinct candidates (201..=208) with strictly
+    //    descending counts (9..=2) so the rank order is deterministic.
+    let mut member_rows = vec![json!({ "book_id": 100 })]; // source book — excluded
+    for (id, count) in (201..=208).zip((2..=9).rev()) {
+        for _ in 0..count {
+            member_rows.push(json!({ "book_id": id }));
+        }
+    }
+    Mock::given(method("POST"))
+        .and(body_string_contains("list_books(where: {list_id:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "list_books": member_rows }
+        })))
+        .mount(&server)
+        .await;
+    // 4. Candidate details: 8 different authors, no series (all survive the
+    //    filter), each with its own cover URL.
+    let books: Vec<serde_json::Value> = (201..=208)
+        .map(|id: i64| {
+            let cover_url = format!("{}/cover{id}.jpg", server.uri());
+            json!({
+                "id": id, "slug": format!("b{id}"), "title": format!("Title {id}"),
+                "contributions": [{ "author": { "name": format!("Author {id}") } }],
+                "book_series": [], "image": { "url": cover_url }
+            })
+        })
+        .collect();
+    Mock::given(method("POST"))
+        .and(body_string_contains("books(where: {id: {_in:"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "data": { "books": books } })),
+        )
+        .mount(&server)
+        .await;
+    // 5. Cover fetches — 7 succeed; book 204 (list_count 6, in the first
+    //    chunk of 201..=206) 404s.
+    for id in 201..=208 {
+        let route = format!("/cover{id}.jpg");
+        if id == 204 {
+            Mock::given(method("GET"))
+                .and(wiremock::matchers::path(route))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+        } else {
+            Mock::given(method("GET"))
+                .and(wiremock::matchers::path(route))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header("content-type", "image/jpeg")
+                        .set_body_bytes(vec![0xFFu8, 0xD8, 0xFF, id as u8]),
+                )
+                .mount(&server)
+                .await;
+        }
+    }
+
+    let cfg = config_for(&server);
+    let image_cfg = RemoteImageConfig {
+        allow_private_addresses: true,
+    };
+    resolve_with(&pool, &uuid, &cfg, &image_cfg).await.unwrap();
+
+    let got = get_suggestions(&pool, &uuid).await.unwrap();
+    assert_eq!(
+        got.len(),
+        8,
+        "all 8 survivors must be persisted, across both concurrency chunks"
+    );
+    let ids: Vec<i64> = got.iter().map(|s| s.hardcover_id).collect();
+    assert_eq!(
+        ids,
+        vec![201, 202, 203, 204, 205, 206, 207, 208],
+        "rank order (by co-listing count desc) must survive the chunked cover fetch"
+    );
+    for s in &got {
+        if s.hardcover_id == 204 {
+            assert!(
+                !s.has_cover,
+                "the 404'd cover must not be recorded as present"
+            );
+        } else {
+            assert!(
+                s.has_cover,
+                "book {}'s cover must survive despite a sibling's cover failing",
+                s.hardcover_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
 async fn mark_pending_propagates_db_error_when_pool_is_closed() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     pool.close().await;
@@ -591,4 +714,69 @@ async fn resolve_book_propagates_http_error_when_server_returns_500() {
         .await
         .unwrap_err();
     assert!(matches!(err, HardcoverError::Http(_)));
+}
+
+#[tokio::test]
+async fn resolve_book_propagates_an_earlier_isbn_error_even_when_a_later_isbn_in_the_same_chunk_would_have_resolved(
+) {
+    // ISBN_RESOLVE_CONCURRENCY == 4; 6 ISBNs span two `chunks()` rounds (4 +
+    // 2). The concurrent per-chunk fetch must still preserve the old
+    // sequential loop's priority-order semantics: walk results in ISBN
+    // order and stop at the first one that either resolves OR errors.
+    // isbn[1] (2nd priority, same chunk as isbn[2]'s would-be winner) errors
+    // — the walk must surface that error rather than skipping past it to
+    // isbn[2]'s eventual match, proving concurrency didn't quietly change
+    // "first-in-priority-order wins" into "first-successful-response wins".
+    let server = MockServer::start().await;
+    let isbns = [
+        "9780000000000", // miss
+        "9780000000001", // errors (500) — must win priority over isbn[2]
+        "9780000000002", // would resolve to book_id 777, but unreached
+        "9780000000003", // miss, same chunk
+        "9780000000004", // miss, 2nd chunk
+        "9780000000005", // miss, 2nd chunk
+    ];
+    for isbn in isbns {
+        let response = if isbn == "9780000000001" {
+            ResponseTemplate::new(500)
+        } else if isbn == "9780000000002" {
+            ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "editions": [{ "book_id": 777 }] }
+            }))
+        } else {
+            ResponseTemplate::new(200).set_body_json(json!({ "data": { "editions": [] } }))
+        };
+        Mock::given(method("POST"))
+            .and(body_string_contains(isbn))
+            .respond_with(response)
+            .mount(&server)
+            .await;
+    }
+
+    let cfg = config_for(&server);
+    let err = resolve_book(
+        &cfg,
+        &isbns.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        "Irrelevant Title",
+        None,
+    )
+    .await
+    .expect_err("an earlier-priority ISBN's error must propagate");
+    assert!(
+        matches!(err, HardcoverError::Http(_)),
+        "expected the 500 from isbn[1] to surface as Http, got {err:?}"
+    );
+
+    // Every ISBN's edition lookup must have fired — the eager per-chunk
+    // `join_all` fetches the whole list before the priority walk runs, so
+    // both chunks (4 + 2) complete even though the walk aborts at isbn[1].
+    let requests = server.received_requests().await.unwrap();
+    let edition_lookups = requests
+        .iter()
+        .filter(|r| String::from_utf8_lossy(&r.body).contains("editions(where:"))
+        .count();
+    assert_eq!(
+        edition_lookups, 6,
+        "all 6 ISBNs across both concurrency chunks must have been queried"
+    );
 }

--- a/db/src/suggestions/tests.rs
+++ b/db/src/suggestions/tests.rs
@@ -752,6 +752,21 @@ async fn resolve_book_propagates_an_earlier_isbn_error_even_when_a_later_isbn_in
             .mount(&server)
             .await;
     }
+    // isbn[2]'s edition lookup resolves to book_id 777, so `resolve_by_isbn`
+    // follows up with this detail fetch as part of the SAME concurrent
+    // `join_all` chunk that also runs isbn[1]'s failing request — stubbed so
+    // isbn[2] genuinely completes as a would-be winner, not an unmatched
+    // (and therefore also-erroring) request that would prove nothing.
+    Mock::given(method("POST"))
+        .and(body_string_contains("books(where: {id: {_eq: 777}}"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [{
+                "id": 777, "slug": "would-be-winner", "title": "Would Be Winner",
+                "contributions": [], "book_series": [], "image": null
+            }] }
+        })))
+        .mount(&server)
+        .await;
 
     let cfg = config_for(&server);
     let err = resolve_book(
@@ -778,5 +793,18 @@ async fn resolve_book_propagates_an_earlier_isbn_error_even_when_a_later_isbn_in
     assert_eq!(
         edition_lookups, 6,
         "all 6 ISBNs across both concurrency chunks must have been queried"
+    );
+    // isbn[2]'s book-777 detail fetch must have actually fired — proving it
+    // was a genuine, fully-resolved would-be winner that the earlier error
+    // beat, not a mock gap that made the "earlier error wins" assertion
+    // vacuously true.
+    let book_777_fetches = requests
+        .iter()
+        .filter(|r| String::from_utf8_lossy(&r.body).contains("books(where: {id: {_eq: 777}}"))
+        .count();
+    assert_eq!(
+        book_777_fetches, 1,
+        "isbn[2] must have fully resolved to book 777 in the background, even though \
+         the earlier isbn[1] error is what the walk actually surfaces"
     );
 }


### PR DESCRIPTION
## Summary
- Closes #1082
- `refetch_all` (`db/src/author_photos/cascade.rs`, `REFETCH_CONCURRENCY = 6`): new test seeds 8 authors so `to_refetch` spans two `chunks()` rounds (6 + 2), asserting the completion counter reaches every value 1..=8 exactly once and every author's cascade actually ran.
- `resolve_with` (`db/src/suggestions/cascade.rs`, `COVER_FETCH_CONCURRENCY = 6`): new test hydrates 8 survivors (two chunks: 6 + 2) via wiremock, with one cover in the first chunk deliberately 404ing — asserts the other 7 covers (and rank order) survive that sibling failure.
- `resolve_book` (`db/src/suggestions/hardcover.rs`, `ISBN_RESOLVE_CONCURRENCY = 4`): new test queries 6 ISBNs (two chunks: 4 + 2), with the 2nd-priority ISBN erroring (500) ahead of a 3rd-priority ISBN that would have resolved — asserts the earlier-priority error still propagates (preserving the old sequential loop's stop-at-first-match-or-error semantics) and that all 6 ISBNs across both chunks were actually queried.

Test-only change — no production batching logic touched.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 988 passed, 1 failed; the failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing environment gap (missing binary audiobook fixtures normally fetched via `just fixtures`, unavailable in this sandbox — unrelated to this change). All 3 new tests individually verified passing.

## Notes
- No new environment variables, migrations, or production code paths were introduced.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WQejhkuAgqjyQ6jyGEW2Hr)_