### PR TITLE
fix: batch stats pages-tile book lookup and cover untested StatsError paths

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -16,9 +16,9 @@ mod tests;
 
 pub use facets::library_facets;
 pub use get::{
-    book_file_path, book_file_path_by_id, get_book, get_book_by_uuid, get_book_files,
-    get_book_uuid_by_scan_key, resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec,
-    resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
+    book_file_path, book_file_path_by_id, book_file_paths, get_book, get_book_by_uuid,
+    get_book_files, get_book_uuid_by_scan_key, resolve_book_id_by_uuid,
+    resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
     resolve_canonical_book_uuids_bulk_exec,
 };
 pub use list::{

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -322,6 +322,50 @@ pub async fn resolve_canonical_book_uuids_bulk_exec(
     Ok(out)
 }
 
+/// Bulk counterpart to [`book_file_path`]: resolve every id in `ids` to its
+/// on-disk path for `format` in one round trip instead of a per-id loop —
+/// `db/src/stats/pages.rs`'s `pages_read` is the motivating caller, which
+/// previously issued one query per finished book. Chunked at 499 ids (the
+/// `get_books_by_ids`/`resolve_book_ids_bulk` convention in this file) to
+/// stay under SQLite's 999 bind-parameter cap; each chunk also binds the
+/// shared `format`, so a chunk never exceeds 500 params. Ids with no
+/// matching file are absent from the map. When multiple files share a
+/// format, the lowest `ordinal` wins per id — the query orders by
+/// `(id, ordinal)` and `entry().or_insert()` below keeps only the first
+/// (lowest-ordinal) row per id, mirroring `book_file_path`'s `LIMIT 1`.
+pub async fn book_file_paths(
+    pool: &SqlitePool,
+    ids: &[i64],
+    format: &str,
+) -> Result<HashMap<i64, std::path::PathBuf>, super::BooksError> {
+    let mut map = HashMap::with_capacity(ids.len());
+    for chunk in ids.chunks(499) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT b.id, COALESCE(bf.library_path, l.path), COALESCE(bf.path, b.path), \
+                    bf.filename, bf.format \
+             FROM books b \
+             JOIN scan_roots l ON l.id = b.library_id \
+             JOIN book_files bf ON bf.book_id = b.id \
+             WHERE b.id IN ({placeholders}) AND bf.format = ? COLLATE NOCASE \
+             ORDER BY b.id, bf.ordinal"
+        );
+        let mut q = sqlx::query_as::<_, (i64, String, String, String, String)>(&sql);
+        for id in chunk {
+            q = q.bind(id);
+        }
+        q = q.bind(format);
+        for (id, lib, dir, stem, fmt) in q.fetch_all(pool).await? {
+            map.entry(id).or_insert_with(|| {
+                std::path::Path::new(&lib)
+                    .join(&dir)
+                    .join(format!("{stem}.{}", fmt.to_lowercase()))
+            });
+        }
+    }
+    Ok(map)
+}
+
 /// Resolve the on-disk path of a book's file for the given format
 /// (e.g. "EPUB"). When multiple files of the same format exist, returns
 /// the one with the lowest ordinal. Ok(None) when absent.

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -323,16 +323,10 @@ pub async fn resolve_canonical_book_uuids_bulk_exec(
 }
 
 /// Bulk counterpart to [`book_file_path`]: resolve every id in `ids` to its
-/// on-disk path for `format` in one round trip instead of a per-id loop —
-/// `db/src/stats/pages.rs`'s `pages_read` is the motivating caller, which
-/// previously issued one query per finished book. Chunked at 499 ids (the
-/// `get_books_by_ids`/`resolve_book_ids_bulk` convention in this file) to
-/// stay under SQLite's 999 bind-parameter cap; each chunk also binds the
-/// shared `format`, so a chunk never exceeds 500 params. Ids with no
-/// matching file are absent from the map. When multiple files share a
-/// format, the lowest `ordinal` wins per id — the query orders by
-/// `(id, ordinal)` and `entry().or_insert()` below keeps only the first
-/// (lowest-ordinal) row per id, mirroring `book_file_path`'s `LIMIT 1`.
+/// on-disk path for `format` in one round trip. Chunked at 499 ids to stay
+/// under SQLite's bind-parameter cap; when multiple files share a format,
+/// the lowest `ordinal` wins per id, same as `book_file_path`. Ids with no
+/// matching file are absent from the map.
 pub async fn book_file_paths(
     pool: &SqlitePool,
     ids: &[i64],
@@ -340,7 +334,9 @@ pub async fn book_file_paths(
 ) -> Result<HashMap<i64, std::path::PathBuf>, super::BooksError> {
     let mut map = HashMap::with_capacity(ids.len());
     for chunk in ids.chunks(499) {
-        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
         let sql = format!(
             "SELECT b.id, COALESCE(bf.library_path, l.path), COALESCE(bf.path, b.path), \
                     bf.filename, bf.format \

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -1804,6 +1804,90 @@ async fn book_file_path_returns_none_when_no_file_row_for_format() {
     assert!(path.is_none());
 }
 
+#[tokio::test]
+async fn book_file_paths_resolves_every_id_in_one_batch() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let book_a = sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title) \
+         VALUES ('uuid-a', ?, 'sub/dir', 'Book A')",
+    )
+    .bind(lib_id)
+    .execute(&pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    let book_b = sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title) \
+         VALUES ('uuid-b', ?, 'other', 'Book B')",
+    )
+    .bind(lib_id)
+    .execute(&pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'book-a', 0)",
+    )
+    .bind(book_a)
+    .execute(&pool)
+    .await
+    .unwrap();
+    // book_b has two EPUB files; the lower ordinal must win, same tie-break
+    // as `book_file_path`.
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, ordinal, size_bytes) \
+         VALUES (?, 'EPUB', 'book-b-second', 1, 0)",
+    )
+    .bind(book_b)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, ordinal, size_bytes) \
+         VALUES (?, 'EPUB', 'book-b-first', 0, 0)",
+    )
+    .bind(book_b)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let map = book_file_paths(&pool, &[book_a, book_b, 9999], "EPUB")
+        .await
+        .unwrap();
+
+    assert_eq!(map.len(), 2, "the unknown id must be absent, got {map:?}");
+    assert_eq!(
+        map.get(&book_a),
+        Some(&std::path::PathBuf::from("/lib/sub/dir/book-a.epub"))
+    );
+    assert_eq!(
+        map.get(&book_b),
+        Some(&std::path::PathBuf::from("/lib/other/book-b-first.epub")),
+        "the lower-ordinal file must win"
+    );
+}
+
+#[tokio::test]
+async fn book_file_paths_returns_empty_map_for_empty_ids() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let map = book_file_paths(&pool, &[], "EPUB").await.unwrap();
+    assert!(map.is_empty());
+}
+
+#[tokio::test]
+async fn book_file_paths_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = book_file_paths(&pool, &[1], "EPUB").await.unwrap_err();
+    assert!(matches!(err, BooksError::Db(_)), "got {err:?}");
+}
+
 // ---------- list_indexed_rows_for_formats (#328) ----------
 
 #[tokio::test]

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -50,13 +50,13 @@ pub mod worker;
 // and mirrors how `db.rs` looked before the extraction.
 pub use author_photos_data::*;
 pub use books::{
-    book_file_path, book_file_path_by_id, collect_paths, count_books, count_books_for_paths,
-    count_books_page, count_search_books, get_book, get_book_by_uuid, get_book_files,
-    get_book_uuid_by_scan_key, library_facets, library_from_db, library_from_db_combined,
-    library_from_db_with_total, library_from_db_with_total_combined, list_books,
-    list_books_for_paths, list_books_page, list_indexed_rows, list_indexed_rows_for_formats,
-    list_merged_rows_for_formats, resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec,
-    resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
+    book_file_path, book_file_path_by_id, book_file_paths, collect_paths, count_books,
+    count_books_for_paths, count_books_page, count_search_books, get_book, get_book_by_uuid,
+    get_book_files, get_book_uuid_by_scan_key, library_facets, library_from_db,
+    library_from_db_combined, library_from_db_with_total, library_from_db_with_total_combined,
+    list_books, list_books_for_paths, list_books_page, list_indexed_rows,
+    list_indexed_rows_for_formats, list_merged_rows_for_formats, resolve_book_id_by_uuid,
+    resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
     resolve_canonical_book_uuids_bulk_exec, search_books, search_books_with_total, BookPage,
     BooksError, CursorError, IndexedRow, PageCursor, MAX_BOOKS_RETURNED,
 };

--- a/db/src/stats/pages.rs
+++ b/db/src/stats/pages.rs
@@ -28,12 +28,10 @@ pub(super) async fn pages_read(
     start: i64,
 ) -> Result<Option<i64>, StatsError> {
     let book_ids = finished_book_ids(pool, user_id, start).await?;
-    let mut paths = Vec::with_capacity(book_ids.len());
-    for id in book_ids {
-        if let Some(path) = crate::book_file_path(pool, id, "EPUB").await? {
-            paths.push(path);
-        }
-    }
+    let paths: Vec<PathBuf> = crate::book_file_paths(pool, &book_ids, "EPUB")
+        .await?
+        .into_values()
+        .collect();
     if paths.is_empty() {
         return Ok(None);
     }
@@ -55,7 +53,7 @@ fn words_to_pages(words: i64) -> i64 {
 
 /// Distinct `books.id` for the user's hundred-percent journal entries in the
 /// window — the same finished-book set [`super::finished_books`] surfaces,
-/// but ids (for [`crate::book_file_path`]) rather than display rows.
+/// but ids (for [`crate::book_file_paths`]) rather than display rows.
 async fn finished_book_ids(
     pool: &SqlitePool,
     user_id: i64,

--- a/db/src/stats/pages/tests.rs
+++ b/db/src/stats/pages/tests.rs
@@ -189,17 +189,10 @@ async fn pages_read_propagates_books_error_when_the_batched_lookup_fails() {
     seed_book_with_fixture(&pool, &dir, "alpha.epub", "uuid-alpha").await;
     finish_journal(&pool, user, "uuid-alpha", T0).await;
 
-    // `finished_book_ids` only touches `journal_entries`/`books`, so it still
-    // succeeds once `book_files` is gone — the failure surfaces from the
-    // batched `book_file_paths` lookup itself (it joins `book_files`),
-    // forcing the previously-untested `StatsError::Books` variant. Dropping
-    // `scan_roots` instead would *also* work for the join, but SQLite runs
-    // an implicit cascading `DELETE FROM` on `DROP TABLE` when FK
-    // constraints are enabled — since `books.library_id` cascades from
-    // `scan_roots`, that silently deletes the seeded book too, leaving
-    // `finished_book_ids` empty and masking the very failure this test
-    // wants to force. `book_files` is a *child* of `books` (nothing
-    // references it), so dropping it can't cascade back up.
+    // Drop `book_files` (not `scan_roots`): `finished_book_ids` doesn't
+    // touch it, so it still succeeds, isolating the failure to the batched
+    // `book_file_paths` join. Dropping `scan_roots` cascades via
+    // `books.library_id ON DELETE CASCADE` and deletes the seeded book too.
     sqlx::query("DROP TABLE book_files")
         .execute(&pool)
         .await

--- a/db/src/stats/pages/tests.rs
+++ b/db/src/stats/pages/tests.rs
@@ -177,3 +177,53 @@ async fn pages_read_skips_a_finished_book_with_no_epub_file() {
 
     assert_eq!(pages_read(&pool, user, 0).await.unwrap(), None);
 }
+
+// ---------- StatsError variants (#1099) ----------
+
+#[tokio::test]
+async fn pages_read_propagates_books_error_when_the_batched_lookup_fails() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let dir = make_test_dir("stats-pages-books-error");
+
+    seed_book_with_fixture(&pool, &dir, "alpha.epub", "uuid-alpha").await;
+    finish_journal(&pool, user, "uuid-alpha", T0).await;
+
+    // `finished_book_ids` only touches `journal_entries`/`books`, so it still
+    // succeeds once `book_files` is gone — the failure surfaces from the
+    // batched `book_file_paths` lookup itself (it joins `book_files`),
+    // forcing the previously-untested `StatsError::Books` variant. Dropping
+    // `scan_roots` instead would *also* work for the join, but SQLite runs
+    // an implicit cascading `DELETE FROM` on `DROP TABLE` when FK
+    // constraints are enabled — since `books.library_id` cascades from
+    // `scan_roots`, that silently deletes the seeded book too, leaving
+    // `finished_book_ids` empty and masking the very failure this test
+    // wants to force. `book_files` is a *child* of `books` (nothing
+    // references it), so dropping it can't cascade back up.
+    sqlx::query("DROP TABLE book_files")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let err = pages_read(&pool, user, 0).await.unwrap_err();
+    assert!(matches!(err, StatsError::Books(_)), "got {err:?}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn spawn_blocking_panic_surfaces_as_pages_task_variant() {
+    // The `spawn_blocking` call in `pages_read` runs `sum_word_counts` off
+    // the async runtime; a panic there (corrupt zip state, an allocation
+    // failure) must propagate as `StatsError::PagesTask` via `?` rather than
+    // being swallowed. Forcing an actual EPUB-parse panic isn't practical
+    // deterministically, so this exercises the identical `spawn_blocking` +
+    // `?` shape `pages_read` uses, with a closure that panics on purpose.
+    async fn forced() -> Result<(), StatsError> {
+        tokio::task::spawn_blocking(|| panic!("intentional test panic")).await?;
+        Ok(())
+    }
+
+    let err = forced().await.unwrap_err();
+    assert!(matches!(err, StatsError::PagesTask(_)), "got {err:?}");
+}


### PR DESCRIPTION
## Summary
- Closes #1099
- Add a batched `book_file_paths(pool, ids, format) -> HashMap<i64, PathBuf>` helper in `db/src/books/get.rs`, chunked at 499 ids to stay under SQLite's bind-parameter cap.
- `pages_read` in `db/src/stats/pages.rs` now calls the batched helper once instead of looping `book_file_path` per finished book (previously one query per book on every stats-page load).
- Add tests forcing the two previously-untested `StatsError` variants: `Books` (via `pages_read` after dropping the `book_files` table so the batched lookup itself fails, while `finished_book_ids` still succeeds) and `PagesTask` (via a `spawn_blocking` closure that panics, joined through the same `?` shape `pages_read` uses).
- Add direct coverage for the new `book_file_paths` helper: batches multiple ids in one round trip, lowest-ordinal tie-break, unknown ids absent from the map, empty-input no-op, and the `BooksError::Db` variant via a closed pool.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 990 passed, 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails only because the audiobook test fixture isn't downloaded in this sandbox — `test_data/audiobooks/` doesn't exist here; unaffected by this diff)

## Notes
- None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WQejhkuAgqjyQ6jyGEW2Hr)_