### PR TITLE
docs: strip issue-number references from doc comments

### DIFF
--- a/db/src/auth/device/tests.rs
+++ b/db/src/auth/device/tests.rs
@@ -50,7 +50,7 @@ async fn device_register_and_list() {
     assert_eq!(list[0].client_kind, "ios");
 }
 
-/// Regression for #865: `list_devices_for_user` must not return more than
+/// `list_devices_for_user` must not return more than
 /// `LIST_DEVICES_LIMIT` rows even when the underlying table holds more.
 /// `trg_devices_cap_per_user` would otherwise mask this by keeping the
 /// table itself under the limit, so the trigger is dropped here to
@@ -74,7 +74,7 @@ async fn list_devices_for_user_caps_response_at_list_devices_limit() {
     );
 }
 
-/// Regression for #865: `register_device` must not let a single user
+/// `register_device` must not let a single user
 /// accumulate unbounded devices — `trg_devices_cap_per_user` evicts the
 /// least-recently-seen device(s) beyond `MAX_DEVICES_PER_USER` on every
 /// INSERT, keeping the most-recently-registered devices.
@@ -248,7 +248,7 @@ async fn list_devices_for_user_query_plan_uses_covering_index() {
 
 #[tokio::test]
 async fn failed_session_insert_after_register_device_rolls_back_device_row() {
-    // Regression for #627: `issue_session` wraps `register_device` +
+    // `issue_session` wraps `register_device` +
     // `create_session` in a single transaction so a failed session insert
     // can't leave an orphan device row. Force `create_session` to fail
     // inside the shared transaction by pointing it at a non-existent

--- a/db/src/covers/tests.rs
+++ b/db/src/covers/tests.rs
@@ -187,7 +187,7 @@ async fn cover_returns_none_for_missing_book_id() {
 
 /// A minimal but valid 1x1 GIF87a: header + logical-screen descriptor + a
 /// 2-colour global table + one image descriptor and a single-pixel LZW frame.
-/// Enough for `image` to sniff the format and decode a first frame (#828).
+/// Enough for `image` to sniff the format and decode a first frame.
 const GIF_1X1: &[u8] = &[
     0x47, 0x49, 0x46, 0x38, 0x37, 0x61, // "GIF87a"
     0x01, 0x00, 0x01, 0x00, // 1x1 logical screen
@@ -200,7 +200,7 @@ const GIF_1X1: &[u8] = &[
 
 /// A cover whose bytes are really a GIF must be written as `<uuid>.gif` even
 /// when the caller hands us `image/jpeg` — the extension is sniffed from the
-/// bytes, not trusted from the mime (#828). This is the root cause of covers
+/// bytes, not trusted from the mime. This is the root cause of covers
 /// landing as `<uuid>.jpg` and later failing to decode.
 #[tokio::test]
 async fn write_cover_file_stores_gif_when_bytes_are_gif_despite_jpeg_mime() {

--- a/db/src/sync/attach/mod.rs
+++ b/db/src/sync/attach/mod.rs
@@ -83,7 +83,7 @@ pub(super) async fn slot_held_by_other(
 /// Drop the `merged_uuids` row for `(library_path, scan_key)`. Called when a
 /// file that previously recorded an attachment is being demoted to its own
 /// book (its slot got taken by another file), so its stale ledger entry
-/// doesn't keep replaying the attach on every future scan (issue #1063).
+/// doesn't keep replaying the attach on every future scan.
 pub(super) async fn forget_attachment(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_path: &str,

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -134,7 +134,7 @@ async fn attach_skipped_when_titles_differ() {
 async fn two_audiobooks_matching_one_ebook_in_one_plan_do_not_clobber() {
     // Two distinct M4B files for the same work land in a single New plan. The
     // first attaches as the ebook's M4B edition; the second must become its
-    // own book, not overwrite the first's file row (#1063).
+    // own book, not overwrite the first's file row.
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_ebook(
         &pool,
@@ -183,12 +183,12 @@ async fn two_audiobooks_matching_one_ebook_in_one_plan_do_not_clobber() {
 
 #[tokio::test]
 async fn replayed_ledger_collision_does_not_clobber_the_incumbent_file() {
-    // Regression for #1063: two merged_uuids rows pointing at the same
-    // (book, M4B) slot — the frozen state a pre-fix clobber leaves behind. A
-    // rescan that replays the second file must refuse rather than delete the
-    // incumbent's file row and replace it. Pre-fix this collapsed to one file
-    // row (data loss); post-fix the incumbent survives and the loser becomes
-    // its own book.
+    // Two merged_uuids rows pointing at the same (book, M4B) slot — the
+    // frozen state a pre-fix clobber leaves behind. A rescan that replays
+    // the second file must refuse rather than delete the incumbent's file
+    // row and replace it. Pre-fix this collapsed to one file row (data
+    // loss); post-fix the incumbent survives and the loser becomes its own
+    // book.
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_ebook(
         &pool,
@@ -280,7 +280,7 @@ async fn replayed_ledger_collision_does_not_clobber_the_incumbent_file() {
 
 #[tokio::test]
 async fn replayed_ebook_ledger_collision_does_not_clobber_the_incumbent_file() {
-    // The ebook attach writer shares the same guard (#1063). Same shape as the
+    // The ebook attach writer shares the same guard. Same shape as the
     // audiobook case, roles swapped: a native audiobook holds an attached EPUB,
     // and a forged second-EPUB ledger row must not clobber the incumbent.
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/frontend/src/pages/stats/drill_in.rs
+++ b/frontend/src/pages/stats/drill_in.rs
@@ -301,7 +301,7 @@ fn render_delta(delta: Option<Delta>, vs: &str) -> Element {
 }
 
 /// The metric's trend chart — pure-CSS bar columns — or a placeholder note
-/// for the Pages tile. The headline tile carries a real estimate (#1029),
+/// for the Pages tile. The headline tile carries a real estimate,
 /// but a day/month-bucketed trend series over it isn't computed yet.
 fn render_trend(metric: Metric, bars: &[TrendBar]) -> Element {
     if metric == Metric::Pages {

--- a/frontend/src/pages/stats/tiles.rs
+++ b/frontend/src/pages/stats/tiles.rs
@@ -61,7 +61,7 @@ fn group_thousands(n: i64) -> String {
 }
 
 /// The four-tile headline row. Finished carries the accent tint; Pages is a
-/// spine-word-count estimate (#1029) rather than a real page position, so
+/// spine-word-count estimate rather than a real page position, so
 /// its label is explicit about that. Takes only the scalar fields it
 /// renders — never the whole `StatsSummary` — so a re-render doesn't clone
 /// the DTO's heatmap / finished-books vectors. `expanded` is set by a

--- a/frontend/src/routes.rs
+++ b/frontend/src/routes.rs
@@ -122,7 +122,7 @@ pub fn MetadataEdit(uuid: String) -> Element {
 /// full-screen surface with its own slim control bar, so the app's top/bottom
 /// nav is suppressed. Same uuid-keyed stability rationale as [`BookDetail`].
 /// Non-mobile also layers the persistent audiobook [`crate::pages::MiniDock`]
-/// alongside the reader (#988) — unlike `/listen`, the reader has no
+/// alongside the reader — unlike `/listen`, the reader has no
 /// transport of its own, so a book playing in the background would
 /// otherwise be invisible and uncontrollable while reading.
 #[cfg(not(feature = "mobile"))]
@@ -137,8 +137,8 @@ pub fn BookRead(uuid: String) -> Element {
 
 /// Mobile variant of [`BookRead`]: the reader only. Mobile's persistent
 /// playback surface is [`crate::pages::MobileMiniPlayer`], scoped to
-/// [`ScreenLayout`]; extending it into the immersive reader is out of
-/// scope for #988.
+/// [`ScreenLayout`]; extending it into the immersive reader is
+/// deliberately not implemented here.
 #[cfg(feature = "mobile")]
 #[component]
 pub fn BookRead(uuid: String) -> Element {

--- a/server/src/backend/journals.rs
+++ b/server/src/backend/journals.rs
@@ -102,7 +102,7 @@ pub(super) async fn post_journal_image(
         Ok(pair) => pair,
         Err(response) => return response,
     };
-    // Sync `std::fs` write — run on the blocking pool (#106).
+    // Sync `std::fs` write — run on the blocking pool.
     match tokio::task::spawn_blocking(move || {
         db::journal_images::write_journal_image(&mime, &bytes)
     })
@@ -120,7 +120,7 @@ pub(super) async fn post_journal_image(
 /// Serve a stored journal image by its minted name. 404 for a malformed name
 /// (the traversal guard) or a missing file. Media-gated like covers/thumbs.
 pub(super) async fn get_journal_image(_user: MediaAuthUser, Path(name): Path<String>) -> Response {
-    // Sync `std::fs` read — run on the blocking pool (#106).
+    // Sync `std::fs` read — run on the blocking pool.
     match tokio::task::spawn_blocking(move || db::journal_images::read_journal_image(&name)).await {
         Ok(Some((mime, bytes))) => (
             [

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -128,8 +128,8 @@ pub struct PeriodComparison {
 ///
 /// Book completion is sourced from `journal_entries.progress = 100` (the only
 /// progress fraction persisted today) rather than the session tables, which
-/// carry duration but no progress; a first-class read/unread state (#980)
-/// feeds the same field once it lands.
+/// carry duration but no progress; a future first-class read/unread state
+/// would feed the same field instead.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct StatsSummary {
     pub range: StatsRange,
@@ -181,7 +181,7 @@ pub struct StatsSummary {
     /// same trailing-window convention as `books_per_month`.
     #[serde(default)]
     pub rating_monthly: Vec<TrendPoint>,
-    /// Estimated pages read in the window — the Pages tile (#1029). Summed
+    /// Estimated pages read in the window — the Pages tile. Summed
     /// from a word-count estimate over books finished in the window (see
     /// `db::stats` for the sourcing model); `None` when no finished book in
     /// the window has an estimate available, driving the tile's em-dash

--- a/shared/src/stats/tests.rs
+++ b/shared/src/stats/tests.rs
@@ -96,7 +96,7 @@ fn previous_and_trend_fields_default_when_absent_from_the_wire() {
 #[test]
 fn pages_read_defaults_to_none_when_absent_from_the_wire() {
     // Same older-payload contract as avg_stars/books_per_month — the Pages
-    // tile field (#1029) is newer, so a pre-existing payload without it must
+    // tile field is newer, so a pre-existing payload without it must
     // still parse.
     let s: StatsSummary = serde_json::from_str(
         r#"{"range":"month","reading_seconds":0,"listening_seconds":0,"sessions":0,


### PR DESCRIPTION
## Summary
- Closes #1077
- Rephrases `///`/`//` doc comments that had reintroduced issue/roadmap-number references (a regression of #860's cleanup), so each comment describes the invariant/behavior itself instead of pointing at a ticket number that will eventually rot.
- Touched files: `db/src/sync/attach/mod.rs`, `db/src/sync/attach/tests.rs`, `db/src/auth/device/tests.rs`, `frontend/src/routes.rs`, `shared/src/stats.rs`, `server/src/backend/journals.rs`. (`frontend/src/pages/book_detail/file_picker.rs` and `frontend/src/pages/book_detail/mobile.rs`, also cited in the issue, were already clean — fixed by concurrent work.) Also swept two additional issue-number references in the already-touched `shared/src/stats.rs` and `db/src/auth/device/tests.rs` files that weren't explicitly listed but match the same anti-pattern, per the issue's acceptance criteria that a repo-wide grep come back empty.
- Comment-only change; no behavior change.

## Test plan
- [x] `cargo fmt` — no diff
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 986 passed
- [x] `cargo test -p omnibus-frontend --features server` — 299 passed
- [x] `cargo test -p omnibus` — 337 passed, 1 pre-existing environment failure (`backend::uploads::tests::commit_rejects_read_only_library_with_400` relies on `chmod` to induce a permission error; this container runs as root, which bypasses Unix permission bits — unrelated to this change and in a file this PR doesn't touch)
- [x] `cargo test -p omnibus-shared` — 130 passed

## Notes
- Only the cited over-referencing comments were rewritten; no unrelated code in these files was touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WQejhkuAgqjyQ6jyGEW2Hr)_