### PR TITLE
fix: route mobile EPUB link clicks through settle-corrected display (#1121)

### DIFF
--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -32,7 +32,9 @@
  *   removeAnnotation(cfiRange)
  *   clearAnnotations()
  *   requestToc()                    re-emits __omnibusOnToc
- *   display(target)                 navigate to a TOC href or CFI
+ *   display(target)                 navigate to a TOC href or CFI (also the
+ *                                   target of in-book content-link taps —
+ *                                   see installContentLinkNav())
  *   copyText(text)                  clipboard write
  *   shareText(text)                 navigator.share, clipboard fallback
  *   exportQuoteCard(json)           canvas PNG → <a download>
@@ -174,6 +176,7 @@
       installGestureNav();
       installSelectionClearWatch();
       installContentEnhancements();
+      installContentLinkNav();
 
       rendition.themes.register("light", {
         body: { background: "#fcfbfa", color: "#2a2725" },
@@ -645,6 +648,33 @@
 
   function requestToc() {
     emitToc();
+  }
+
+  // epub.js's own content-link handling (wired in its Rendition constructor,
+  // ahead of any hook this file registers) calls the *plain* `rendition
+  // .display(href)` on every `<a href>` tap inside the book — bypassing both
+  // corrections `display()` below applies (zero-size anchor resolution and
+  // the fonts/theme settle-then-redisplay), which is why in-book links land
+  // a page or two off while TOC/CFI navigation (which already goes through
+  // `display()`) is accurate. epub.js emits a "linkClicked" event with the
+  // fully-resolved in-book path *before* issuing that plain display, so we
+  // piggyback on its own resolution (no need to reimplement href/base-tag
+  // parsing) and re-run the same href through our corrected `display()`.
+  // epub.js's own plain display() still fires first, but `rendition.display`
+  // serializes calls through an internal queue and short-circuits a
+  // still-in-flight one when a newer call arrives — the same "call display,
+  // then call it again" pattern `displaySettled()` already relies on to
+  // correct TOC navigation — so our corrected redisplay simply supersedes
+  // the stale uncorrected one before the user sees it settle.
+  function installContentLinkNav() {
+    if (!rendition || !rendition.hooks || !rendition.hooks.content) return;
+    rendition.hooks.content.register(function (contents) {
+      if (!contents || typeof contents.on !== "function") return;
+      contents.on("linkClicked", function (href) {
+        if (!book || !book.path) return;
+        display(book.path.relative(href));
+      });
+    });
   }
 
   // Navigate to a TOC href or a CFI (highlight / bookmark target).


### PR DESCRIPTION
## Summary
- In-book EPUB link taps (footnote refs, cross-references, in-text anchors) were navigating a few pages past their target because epub.js's built-in link handling intercepts `<a href>` clicks and calls the plain `rendition.display(href)` directly, bypassing the two corrections the glue's own `display()` already applies for TOC/CFI navigation: zero-size `<a id>` anchor resolution and the fonts/theme settle-then-redisplay pass. Drift was most visible on mobile, where webfont swap + theme CSS injection cause the largest reflow.
- Fixed by registering a `rendition.hooks.content` hook (`installContentLinkNav` in `frontend/assets/vendor/epub-reader-glue.js`) that listens for epub.js's own `"linkClicked"` event — reusing its href resolution rather than reimplementing base-tag/relative-URL parsing — and re-runs the resolved href through the glue's corrected `display()`. epub.js's own uncorrected `display()` still fires first, but `rendition.display()` serializes calls through an internal queue and short-circuits an in-flight call when a newer one arrives (the same "display, then redisplay" pattern `displaySettled()` already relies on for TOC navigation), so the corrected redisplay supersedes the stale one before the user sees it settle.
- Closes #1121

## Test plan
- [x] `cargo fmt --manifest-path /home/user/omnibus-wt-1121/Cargo.toml` (workspace is virtual; ran `cargo fmt --all` — no Rust files changed, this is a JS-only fix) — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1121 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1121 cargo test -p omnibus-frontend --features server` — PASS (308 passed, 0 failed)
- [x] `node --check frontend/assets/vendor/epub-reader-glue.js` — PASS (no JS lint/prettier config exists for `frontend/assets/vendor/`, so this substituted for one)

## Notes
- AC3 (web behavior unchanged/improved): the fix only reroutes internal in-book links through the already-battle-tested `display()`/`displaySettled()` path used by TOC/CFI navigation on both web and mobile; external (`://`) and `mailto:` links never emit epub.js's `"linkClicked"` event (epub.js's own `Contents.linksHandler()` skips assigning an intercepting `onclick` for those), so they're untouched and keep native browser behavior on both platforms. No web-specific behavior was changed — this is the shared vendored glue asset used by both targets.
- No Rust files changed — the fix lives entirely in the vendored JS glue asset shared by web and mobile; `frontend/src/pages/reader/mobile/interop.rs` (mentioned in the issue as relevant context) only mounts the glue and needed no changes since it doesn't touch link navigation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SPjh8imd9Fwb7xUGnEKGgW)_