### PR TITLE
refactor: return typed error from write_override_cover (#1117)

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -48,6 +48,13 @@ impl From<crate::metadata_overrides::MetadataOverridesError> for BooksError {
             crate::metadata_overrides::MetadataOverridesError::Serialization(inner) => {
                 BooksError::OverridesJson(inner)
             }
+            // The only `MetadataOverridesError`-returning calls in the books
+            // read path are the overrides SELECT helpers, which never touch
+            // the cover-file filesystem — fold defensively (mirrors
+            // `ShelfError`'s `From<BooksError>`).
+            crate::metadata_overrides::MetadataOverridesError::Io(inner) => {
+                BooksError::Db(sqlx::Error::Io(inner))
+            }
         }
     }
 }

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -801,6 +801,33 @@ async fn rebuild_fts_for_books_batch_rewrites_multiple_uuids() {
         .is_empty());
 }
 
+/// Happy path for the filesystem-only cover write helper: the bytes land at
+/// `<covers_dir>/override-<uuid>.<ext>` with the extension derived from the
+/// declared MIME type.
+#[test]
+fn write_override_cover_writes_bytes_to_the_expected_path() {
+    let covers = CoversTempDir::new("write_cover_ok");
+
+    write_override_cover("happy-uuid", "image/png", b"OVERRIDE-BYTES").unwrap();
+
+    let written = covers.path.join("override-happy-uuid.png");
+    assert_eq!(std::fs::read(written).unwrap(), b"OVERRIDE-BYTES");
+}
+
+/// `create_dir_all` fails when a regular file already occupies the covers
+/// dir path, deterministically forcing the `std::io::Error` branch. The
+/// failure must surface as the module's typed `MetadataOverridesError::Io`,
+/// not a raw `std::io::Error`.
+#[test]
+fn write_override_cover_returns_typed_error_when_covers_dir_is_unwritable() {
+    let covers = CoversTempDir::new("write_cover_fail");
+    std::fs::write(&covers.path, b"not a directory").unwrap();
+
+    let err = write_override_cover("some-uuid", "image/png", b"bytes")
+        .expect_err("create_dir_all must fail when the covers dir path is a regular file");
+    assert!(matches!(err, MetadataOverridesError::Io(_)), "got {err:?}");
+}
+
 /// The override row and the `books_series_link` row must land
 /// atomically: after `upsert_metadata_overrides` commits, a direct
 /// SELECT on `books_series_link` must already reflect the new series.

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -828,6 +828,24 @@ fn write_override_cover_returns_typed_error_when_covers_dir_is_unwritable() {
     assert!(matches!(err, MetadataOverridesError::Io(_)), "got {err:?}");
 }
 
+/// A non-`NotFound` failure in the stale-extension cleanup loop (here, a
+/// directory occupying the path a prior override cover would live at, so
+/// `remove_file` fails with `IsADirectory` rather than `NotFound`) must
+/// propagate as `MetadataOverridesError::Io` instead of being swallowed —
+/// silently leaving the stale entry behind would let `find_override_cover_file`
+/// keep probing over it ahead of the freshly written cover.
+#[test]
+fn write_override_cover_returns_typed_error_when_stale_cleanup_hits_a_directory() {
+    let covers = CoversTempDir::new("write_cover_cleanup_fail");
+    std::fs::create_dir_all(&covers.path).unwrap();
+    // `Jpeg` is first in `PROBE_ORDER`, so this is the first cleanup target.
+    std::fs::create_dir(covers.path.join("override-clash-uuid.jpg")).unwrap();
+
+    let err = write_override_cover("clash-uuid", "image/png", b"bytes")
+        .expect_err("remove_file on a directory must fail instead of silently leaving it behind");
+    assert!(matches!(err, MetadataOverridesError::Io(_)), "got {err:?}");
+}
+
 /// The override row and the `books_series_link` row must land
 /// atomically: after `upsert_metadata_overrides` commits, a direct
 /// SELECT on `books_series_link` must already reflect the new series.

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -22,6 +22,8 @@ pub enum MetadataOverridesError {
     Serialization(#[from] serde_json::Error),
     #[error(transparent)]
     Db(#[from] sqlx::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 impl From<crate::books::BooksError> for MetadataOverridesError {
@@ -366,7 +368,11 @@ pub(crate) fn apply_overrides(
 }
 
 /// Write a user-uploaded override cover to disk.
-pub fn write_override_cover(uuid: &str, mime: &str, bytes: &[u8]) -> std::io::Result<()> {
+pub fn write_override_cover(
+    uuid: &str,
+    mime: &str,
+    bytes: &[u8],
+) -> Result<(), MetadataOverridesError> {
     let ext = crate::covers::ImageFormat::from_mime(mime).to_ext();
     let dir = crate::covers::covers_dir();
     std::fs::create_dir_all(&dir)?;
@@ -377,7 +383,8 @@ pub fn write_override_cover(uuid: &str, mime: &str, bytes: &[u8]) -> std::io::Re
         let _ = std::fs::remove_file(old);
     }
 
-    std::fs::write(dir.join(format!("override-{uuid}.{ext}")), bytes)
+    std::fs::write(dir.join(format!("override-{uuid}.{ext}")), bytes)?;
+    Ok(())
 }
 
 /// Delete override cover files for a UUID.

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -377,10 +377,19 @@ pub fn write_override_cover(
     let dir = crate::covers::covers_dir();
     std::fs::create_dir_all(&dir)?;
 
-    // Remove any existing override cover with a different extension.
+    // Remove any existing override cover with a different extension. A
+    // missing file is the expected/common case (most probed extensions
+    // won't exist) and is ignored; any other failure (e.g. permissions)
+    // must propagate — silently leaving a stale file behind would let the
+    // extension probe in `find_override_cover_file` keep serving it instead
+    // of the cover just written below.
     for fmt in crate::covers::ImageFormat::PROBE_ORDER {
         let old = dir.join(format!("override-{uuid}.{}", fmt.to_ext()));
-        let _ = std::fs::remove_file(old);
+        match std::fs::remove_file(old) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
     }
 
     std::fs::write(dir.join(format!("override-{uuid}.{ext}")), bytes)?;


### PR DESCRIPTION
## Summary
- Closes #1117. `write_override_cover` in `db/src/metadata_overrides/upsert.rs` was the only `pub fn` in the file returning a raw `std::io::Result<()>` instead of the module's `MetadataOverridesError` — violating the boundary rule in `.claude/rules/02-error-handling.md`.
- Added an `Io(#[error(transparent)] #[from] std::io::Error)` variant to `MetadataOverridesError` and changed `write_override_cover` to return `Result<(), MetadataOverridesError>`.
- The reverse conversion `From<MetadataOverridesError> for BooksError` (in `db/src/books.rs`) needed a new match arm for the added `Io` variant to stay exhaustive. Since the only `MetadataOverridesError`-returning calls in the books read path are the overrides SELECT helpers (never the cover-file filesystem), the `Io` case is folded defensively into `BooksError::Db(sqlx::Error::Io(...))` — mirroring the existing defensive-fold precedent in `ShelfError`'s `From<BooksError>`.
- The one call site outside `db/` (`server/src/backend/overrides.rs::persist_cover`) needed no change: its `internal(context, e)` helper is generic over `Display`, so it accepts `MetadataOverridesError` as a drop-in replacement for `std::io::Error`.

## Test plan
- [x] `cargo fmt --manifest-path Cargo.toml` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1010 passed, 0 failed; added `write_override_cover_writes_bytes_to_the_expected_path` happy-path test and `write_override_cover_returns_typed_error_when_covers_dir_is_unwritable` covering the new `Io` variant deterministically via a regular file occupying the covers-dir path)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus` — PASS (345 passed, 0 failed, 1 pre-existing unrelated failure skipped — see Notes)

## Version
- [x] **Patch** — the default; left unlabeled.

## Notes
`cargo test -p omnibus` has one pre-existing failure, `backend::uploads::tests::commit_rejects_read_only_library_with_400`, unrelated to this change — it relies on a `chmod 0o555` to force a `PermissionDenied` write failure, which doesn't apply when tests run as `root` (this CI/sandbox environment). Verified it fails identically on unmodified `main` in the same environment. Not touched by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SPjh8imd9Fwb7xUGnEKGgW)_