### PR TITLE
fix: keep mobile file-picker dropdown inside the viewport

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -815,6 +815,17 @@ html, body { overscroll-behavior: none; }
   font-size: 10px;
   line-height: 1.45;
 }
+/* Long titles/labels wrap instead of forcing the panel wider than its box. */
+.bd-file-picker-item-title, .bd-file-picker-item-meta { overflow-wrap: anywhere; }
+/* Mobile CTA row: the trigger sits at the screen's right edge, so a left-
+   anchored panel opened off-screen and let the whole page scroll sideways.
+   Anchor it to the right and bound its width to the viewport — the 300px min
+   is kept where it fits and only shrinks on a phone too narrow for it. */
+.m-bd-cta .bd-file-picker-panel {
+  right: 0; left: auto;
+  min-width: min(300px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
+}
 
 .bd-progress-meta { margin-top: 22px; max-width: 460px; }
 .bd-progress-line {


### PR DESCRIPTION
## Summary
- The Read/Listen file picker panel inherited `.bd-export-panel`'s absolute `left: 0`. On the mobile CTA row a single-file "Read" button (`flex: 1`) pushes the multi-file "Listen" picker to the screen's right edge, so a `min-width: 300px` panel opened rightward off the viewport — growing page scroll width and letting the whole screen scroll sideways (titles slid off-screen).
- Anchor the panel to the right (`right: 0; left: auto`) and bound its width to the viewport (`min(300px, 100vw-24px)` / `max-width: 100vw-24px`), scoped to `.m-bd-cta` so the desktop hero row is untouched. Long titles/meta wrap instead of forcing the panel wider.
- Follow-up to #1005 (multi-file picker), reported via TestFlight on the audiobook dropdown.

## Test plan
- [x] `just lint-css` — passes (stylelint structural).
- [x] Browser-verified against the live stylesheet at iPhone widths, real mobile DOM (single-file Read + multi-file Listen picker open): 375px → page `scrollWidth` 375 = viewport (was 564, horizontally scrollable pre-fix), panel right edge 359 < 375; 320px → panel clamps to 296px, still on-screen. Panel stays a comfortable 300px where it fits.
- [ ] Native iOS confirmation on an iPhone sim (the only booted sim was an iPad; installed app is a pre-fix build — needs a `dx serve --platform ios` rebuild).

## Version
- [x] **Patch** — CSS-only bug fix.

## Notes
- CSS-only; scoped to the mobile CTA context to avoid desktop regression.