### PR TITLE
feat: add Immersive Read CTA and open reader with docked player (#1130)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -744,6 +744,21 @@ html, body { overscroll-behavior: none; }
 }
 .bd-cta-row .btn[disabled] { opacity: 0.65; cursor: not-allowed; }
 
+/* Immersive Read CTA — read + listen at once. Accent-tinted so it reads as a
+   distinct third option beside the primary "Start reading" and the secondary
+   "Listen", with the book+soundwave mark drawn in the accent colour. */
+.bd-immersive-cta {
+  gap: 9px;
+  background: color-mix(in oklch, var(--accent) 16%, var(--bg-1));
+  border-color: color-mix(in oklch, var(--accent) 55%, transparent);
+  color: var(--ink-0);
+}
+.bd-immersive-cta:hover {
+  background: color-mix(in oklch, var(--accent) 24%, var(--bg-1));
+  border-color: color-mix(in oklch, var(--accent) 70%, transparent);
+}
+.bd-immersive-mark { display: inline-flex; color: var(--accent); }
+
 /* Hero "Export" dropdown — trigger + anchored menu. Mirrors the user-menu
    scrim/panel/row pattern (`.um-*`) so the two dropdowns read the same. */
 .bd-export { position: relative; display: inline-flex; }

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -240,6 +240,12 @@ fn BdCtaRow(
                     listen_btn
                 }
             }
+            // Immersive Read — opens the ereader and the audiobook player
+            // (docked, minimized) together for the same book. Only when the
+            // book has both an ebook and an audiobook.
+            if has_audio && has_ebook {
+                BdImmersiveButton { uuid: uuid.clone() }
+            }
             // Download + Send-to-Kindle/Kobo live behind one "Export" menu so
             // the CTA row stays a single primary action plus this dropdown.
             // Author + title feed the Send-to-Kobo `<Author>/<Title>/` layout.
@@ -252,5 +258,120 @@ fn BdCtaRow(
                 epub_size_bytes,
             }
         }
+    }
+}
+
+/// The book+soundwave glyph on the Immersive Read CTA. Factored out so the
+/// active (web) and disabled (mobile) buttons share identical markup.
+fn bd_immersive_mark() -> Element {
+    rsx! {
+        span { class: "bd-immersive-mark", aria_hidden: "true",
+            svg {
+                width: "17",
+                height: "17",
+                view_box: "0 0 24 24",
+                fill: "none",
+                stroke: "currentColor",
+                "stroke-width": "1.7",
+                "stroke-linecap": "round",
+                "stroke-linejoin": "round",
+                path { d: "M4 5.2A2 2 0 0 1 6 4h4.2a1.8 1.8 0 0 1 1.8 1.8V18a1.6 1.6 0 0 0-1.6-1.6H6A2 2 0 0 1 4 14.4V5.2z" }
+                path { d: "M15.5 8v8M18.5 6v12M21 9.5v5" }
+            }
+        }
+    }
+}
+
+/// Immersive Read CTA (web): opens the reader and docks the audiobook player
+/// together. Clicking retargets the app-wide [`crate::PlaybackState`] at this
+/// book — the App-level audio bootstrap then loads + plays it, and the `/read`
+/// route's [`crate::pages::MiniDock`] surfaces once book + uuid resolve — then
+/// navigates to the reader. The playback context and navigator are read inside
+/// the handler (not as render-time hooks) so the button renders under SSR and
+/// in unit tests without a provider, keeping hydration parity (rule 07).
+#[cfg(not(feature = "mobile"))]
+#[component]
+fn BdImmersiveButton(uuid: String) -> Element {
+    let on_click = move |_: MouseEvent| {
+        let playback = consume_context::<crate::PlaybackState>();
+        // Retarget only when the book differs, mirroring the listen page: clear
+        // the previous book's metadata/error and flag loading first so the dock
+        // can't flash the old book under the new reader before the driver reloads.
+        let mut uuid_sig = playback.uuid;
+        if uuid_sig.peek().as_deref() != Some(uuid.as_str()) {
+            let mut book_sig = playback.book;
+            let mut error_sig = playback.error;
+            let mut loading_sig = playback.loading;
+            book_sig.set(None);
+            error_sig.set(None);
+            loading_sig.set(true);
+            uuid_sig.set(Some(uuid.clone()));
+        }
+        dioxus_router::navigator().push(Route::BookRead { uuid: uuid.clone() });
+    };
+    rsx! {
+        button {
+            class: "btn lg bd-immersive-cta",
+            r#type: "button",
+            "data-testid": "immersive-read",
+            title: "Open the ereader and audiobook together, kept in sync",
+            onclick: on_click,
+            {bd_immersive_mark()}
+            "Immersive Read"
+        }
+    }
+}
+
+/// Immersive Read CTA (mobile): disabled stub. Mobile has no web
+/// [`crate::PlaybackState`] to dock a player into; the mobile immersive
+/// experience is tracked separately (#1133).
+#[cfg(feature = "mobile")]
+#[component]
+fn BdImmersiveButton(uuid: String) -> Element {
+    let _ = uuid;
+    rsx! {
+        button {
+            class: "btn lg bd-immersive-cta",
+            disabled: true,
+            "data-testid": "immersive-read",
+            title: "Immersive reading on mobile coming soon",
+            {bd_immersive_mark()}
+            "Immersive Read"
+        }
+    }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+
+    /// SSR-render the CTA row for a book with the given format availability.
+    fn render_cta_row(has_ebook: bool, has_audio: bool) -> String {
+        dioxus::ssr::render_element(rsx! {
+            BdCtaRow {
+                uuid: "book-uuid".to_string(),
+                has_ebook,
+                has_audio,
+            }
+        })
+    }
+
+    #[test]
+    fn immersive_cta_renders_when_book_has_both_ebook_and_audio() {
+        let html = render_cta_row(true, true);
+        assert!(html.contains("data-testid=\"immersive-read\""));
+        assert!(html.contains("Immersive Read"));
+    }
+
+    #[test]
+    fn immersive_cta_absent_when_book_has_ebook_only() {
+        let html = render_cta_row(true, false);
+        assert!(!html.contains("data-testid=\"immersive-read\""));
+    }
+
+    #[test]
+    fn immersive_cta_absent_when_book_has_audio_only() {
+        let html = render_cta_row(false, true);
+        assert!(!html.contains("data-testid=\"immersive-read\""));
     }
 }

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -240,9 +240,7 @@ fn BdCtaRow(
                     listen_btn
                 }
             }
-            // Immersive Read — opens the ereader and the audiobook player
-            // (docked, minimized) together for the same book. Only when the
-            // book has both an ebook and an audiobook.
+            // Immersive Read is a dual-format-only action, so gate it on both.
             if has_audio && has_ebook {
                 BdImmersiveButton { uuid: uuid.clone() }
             }
@@ -284,11 +282,13 @@ fn bd_immersive_mark() -> Element {
 
 /// Immersive Read CTA (web): opens the reader and docks the audiobook player
 /// together. Clicking retargets the app-wide [`crate::PlaybackState`] at this
-/// book — the App-level audio bootstrap then loads + plays it, and the `/read`
-/// route's [`crate::pages::MiniDock`] surfaces once book + uuid resolve — then
-/// navigates to the reader. The playback context and navigator are read inside
-/// the handler (not as render-time hooks) so the button renders under SSR and
-/// in unit tests without a provider, keeping hydration parity (rule 07).
+/// book — the App-level audio bootstrap then loads its manifest and the `/read`
+/// route's [`crate::pages::MiniDock`] surfaces (paused, at the resume position)
+/// once book + uuid resolve — then navigates to the reader. Playback itself
+/// starts on the first transport action, not on load. The playback context and
+/// navigator are read inside the handler (not as render-time hooks) so the
+/// button renders under SSR and in unit tests without a provider, keeping
+/// hydration parity (rule 07).
 #[cfg(not(feature = "mobile"))]
 #[component]
 fn BdImmersiveButton(uuid: String) -> Element {


### PR DESCRIPTION
## Summary
- Adds an **Immersive Read** CTA to book detail, shown only when a book has both an ebook and an audiobook. It opens the EPUB reader and docks the minimized audiobook player together. Part of the Immersive Reading epic (#1129), sub-issue #1130.
- Web: the button retargets the app-wide `PlaybackState` at the book, so the App-level audio bootstrap loads its manifest and the `/read` route's `MiniDock` surfaces (paused, at the resume position); then navigates to `/read/:uuid`. Playback starts on the first transport action, not on load. Mobile: a disabled stub — mobile immersive is tracked in #1133.
- Playback context + navigator are read inside the click handler (not render-time hooks), so the button renders under SSR and in unit tests without a provider, keeping hydration parity.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 3 new SSR tests (present with both formats; absent for ebook-only and audio-only)
- [x] `cargo clippy` clean on web/server + mobile; `cargo fmt`; `just lint-css`
- [x] Browser: immersive button correctly **absent** on an ebook-only book (no CTA-row regression); `.bd-immersive-cta` accent-tinted styling verified
- [ ] E2E open-both flow not included — see Notes

## Version
- [x] **Patch** — one sub-issue of the epic, no mobile-breaking or architectural change.

## Notes
>[!NOTE]
> The Playwright "open-both" flow (part of #1130 AC4) is **not** included: it needs a dual-format (EPUB + M4B) fixture, which doesn't exist yet — the dev/fixture library is EPUB-only, so no book satisfies the both-formats condition today. Presence/absence is covered by the new unit tests; the fixture + E2E flow are best landed with the epic's test infra.