### PR TITLE
feat: converge audio mini-dock onto compact r-dock design (#1132)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3263,14 +3263,20 @@ a.idx-letter-on:focus-visible {
 
 .mini-dock {
   position: fixed; left: 24px; right: 24px; bottom: 18px; z-index: 40;
-  display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(0, 1.6fr) auto auto;
-  gap: 18px; align-items: center;
-  padding: 12px 18px; border-radius: 16px;
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 16px; border-radius: 16px;
   background: color-mix(in oklch, var(--bg-1) 95%, transparent);
   backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
   border: 1px solid var(--line);
   box-shadow: 0 24px 50px -10px rgba(0, 0, 0, .6);
+  /* Clip the full-width top progress line to the rounded corners. */
+  overflow: hidden;
 }
+
+/* Thin progress line pinned to the top edge — replaces the old inline
+   elapsed/total track; the clock now rides in the subtitle. */
+.mini-dock-prog { position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--bg-2); }
+.mini-dock-prog > i { display: block; height: 100%; background: var(--accent); }
 
 /* On `/read` the dock renders as a sibling of `.rd-surface` (#988), so raise
    it above the reader's own bottom bar (`.rd-bottom`, 54px + safe-area) —
@@ -3282,6 +3288,7 @@ a.idx-letter-on:focus-visible {
 }
 
 .mini-dock-now {
+  flex: 1 1 auto;
   display: flex; align-items: center; gap: 12px;
   min-width: 0; text-decoration: none; color: inherit;
 }
@@ -3297,13 +3304,7 @@ a.idx-letter-on:focus-visible {
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 
-.mini-dock-track { min-width: 0; }
-.mini-dock-times {
-  display: flex; justify-content: space-between;
-  font-family: var(--mono); font-size: 10px; color: var(--ink-3); margin-bottom: 6px;
-}
-
-.mini-dock-controls { display: flex; align-items: center; gap: 12px; color: var(--ink-1); }
+.mini-dock-controls { display: flex; align-items: center; gap: 10px; flex: none; color: var(--ink-1); }
 .mini-dock-btn {
   background: transparent; border: 1px solid var(--line);
   color: var(--ink-1); cursor: pointer; transition: color .15s, background .15s;
@@ -3328,23 +3329,28 @@ a.idx-letter-on:focus-visible {
 }
 .mini-dock-ico-pause { display: flex; gap: 4px; }
 .mini-dock-ico-pause-bar { width: 4px; height: 14px; background: currentColor; border-radius: 1px; }
-.mini-dock-rate {
-  font-family: var(--mono); font-size: 11px; color: var(--ink-2);
+/* Speed / Sleep chips — pill buttons that shed on narrow viewports. */
+.mini-dock-chip {
+  flex: none; display: inline-flex; align-items: center; gap: 6px;
+  height: 32px; padding: 0 12px; border-radius: 999px;
+  border: 1px solid var(--line-2); background: transparent; color: var(--ink-1);
+  font-family: var(--sans); font-size: 12.5px; white-space: nowrap;
+  text-decoration: none; cursor: pointer; transition: color .14s, background .14s;
 }
+.mini-dock-chip:hover { background: var(--bg-2); color: var(--ink-0); }
+.mini-dock-chip.mono { font-family: var(--mono); }
 
-.lp-volume.compact {
-  margin-left: 0; gap: 6px;
-}
-.lp-volume.compact .lp-volume-input { width: 64px; }
+/* Thin divider before the inline icon actions. */
+.mini-dock-div { flex: none; width: 1px; height: 34px; background: var(--line-2); }
 
-.mini-dock-actions { display: flex; gap: 6px; }
-.mini-dock-btn.mini-dock-expand-btn,
-.mini-dock-btn.mini-dock-dismiss {
-  height: 30px; padding: 0 12px; border-radius: 999px;
-  display: inline-flex; align-items: center;
-  font-family: var(--mono); font-size: 11px; text-decoration: none;
+.mini-dock-actions { display: flex; align-items: center; gap: 4px; flex: none; }
+.mini-dock-ico {
+  display: grid; place-items: center; width: 34px; height: 34px;
+  border-radius: 9px; border: 1px solid transparent; background: transparent;
+  color: var(--ink-2); cursor: pointer; text-decoration: none;
+  transition: color .14s, background .14s, border-color .14s;
 }
-.mini-dock-btn.mini-dock-dismiss { width: 30px; padding: 0; justify-content: center; font-size: 16px; }
+.mini-dock-ico:hover { background: var(--bg-2); color: var(--ink-0); border-color: var(--line-2); }
 
 /* ── Responsive ─────────────────────────────────────────────── */
 @media (max-width: 900px) {
@@ -3358,13 +3364,12 @@ a.idx-letter-on:focus-visible {
   .lp-sleep-panel { width: calc(100vw - 48px); right: 24px; bottom: 80px; }
   .lp-drawer { width: 100%; }
 
-  /* Stack the dock into two rows when the four-column grid won't fit. */
+  /* Narrow the dock and shed the secondary controls (±30 seeks, speed and
+     sleep chips) so cover, title, play, and expand/close stay on one row. */
   .mini-dock {
-    left: 12px; right: 12px; bottom: 12px;
-    grid-template-columns: auto 1fr auto; gap: 12px;
+    left: 12px; right: 12px; bottom: 12px; gap: 10px; padding: 10px 12px;
   }
-  .mini-dock-track { grid-column: 1 / -1; order: 3; }
-  .mini-dock-actions .mini-dock-expand-btn { display: none; }
+  .mini-dock .mini-dock-hide { display: none; }
 }
 
 /* ── Legacy globals (layout primitives, sr-only) ───────────────────── */
@@ -6275,7 +6280,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 }
 .m-mini-progress { height: 2px; background: var(--bg-3); }
 .m-mini-progress div { height: 100%; background: var(--accent); }
-.m-mini-row { display: flex; align-items: center; gap: 11px; padding: 9px 11px; }
+.m-mini-row { display: flex; align-items: center; gap: 7px; padding: 9px 10px; }
 .m-mini-main {
   flex: 1; min-width: 0; display: flex; align-items: center; gap: 11px;
   text-decoration: none; color: inherit;
@@ -6308,6 +6313,11 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 }
 .m-mini-pause { display: flex; gap: 3.5px; }
 .m-mini-pause span { width: 3.5px; height: 13px; border-radius: 1px; background: var(--accent-ink); }
+.m-mini-expand {
+  width: 32px; height: 32px; flex: 0 0 32px; border-radius: 999px;
+  border: none; background: transparent; color: var(--ink-1);
+  display: grid; place-items: center; cursor: pointer; text-decoration: none;
+}
 
 /* Player status / error messages. */
 .m-player-msg, .m-player-loading {

--- a/frontend/src/pages/listen/controls.rs
+++ b/frontend/src/pages/listen/controls.rs
@@ -143,32 +143,19 @@ pub(super) fn TransportButtons(state: TransportState, callbacks: TransportCallba
                 "{rate_label}"
             }
 
-            VolumeControl { volume, on_volume, compact: false }
+            VolumeControl { volume, on_volume }
         }
     }
 }
 
 /// Volume slider — updates the shared `<audio>` element's volume in real
-/// time. `compact` selects the mini-dock's narrower sizing and drops the
-/// percentage readout; both variants read/write the same
-/// [`crate::PlaybackState::volume`] signal via `helpers::apply_volume`, so
-/// the full player and the mini-dock always agree.
+/// time via `helpers::apply_volume`, writing the same
+/// [`crate::PlaybackState::volume`] signal the rest of the player reads.
 #[component]
-pub(super) fn VolumeControl(volume: f64, on_volume: EventHandler<f64>, compact: bool) -> Element {
+pub(super) fn VolumeControl(volume: f64, on_volume: EventHandler<f64>) -> Element {
     let pct = (volume * 100.0).round();
-    let wrap_class = if compact {
-        "lp-volume compact"
-    } else {
-        "lp-volume"
-    };
-    let testid = if compact {
-        "mini-dock-volume"
-    } else {
-        "listen-volume"
-    };
-
     rsx! {
-        div { class: wrap_class, "data-testid": "{testid}",
+        div { class: "lp-volume", "data-testid": "listen-volume",
             span { class: "lp-volume-icon", aria_hidden: "true", "\u{1F50A}" }
             input {
                 r#type: "range",
@@ -184,9 +171,7 @@ pub(super) fn VolumeControl(volume: f64, on_volume: EventHandler<f64>, compact: 
                     }
                 },
             }
-            if !compact {
-                span { class: "lp-volume-pct", "{pct:.0}%" }
-            }
+            span { class: "lp-volume-pct", "{pct:.0}%" }
         }
     }
 }

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -8,6 +8,10 @@
 // all gated to non-mobile targets, so the import is too (unused on mobile).
 #[cfg(not(feature = "mobile"))]
 use dioxus::prelude::*;
+#[cfg(not(feature = "mobile"))]
+use omnibus_shared::{
+    MAX_AUDIOBOOK_PLAYBACK_RATE as MAX_RATE, MIN_AUDIOBOOK_PLAYBACK_RATE as MIN_RATE,
+};
 
 /// Vendored hls.js for the HLS fallback path.
 #[cfg(feature = "web")]
@@ -111,6 +115,52 @@ pub(super) fn apply_volume(volume: &mut Signal<f64>, v: f64) {
     audio_call("setVolume", &clamped.to_string());
 }
 
+/// Fine-tune granularity for playback rate — the speed panel's stepper and
+/// the mini-dock's "is this preset active" check both snap to this.
+#[cfg(not(feature = "mobile"))]
+pub(super) const RATE_STEP: f64 = 0.05;
+
+/// Clamp `new_rate` to `[MIN_RATE, MAX_RATE]` and snap to the nearest
+/// `RATE_STEP`. Pure logic extracted for unit testing — no signal or JS
+/// side-effects.
+#[cfg(not(feature = "mobile"))]
+fn clamp_and_round_rate(new_rate: f64) -> f64 {
+    let clamped = new_rate.clamp(MIN_RATE, MAX_RATE);
+    (clamped / RATE_STEP).round() * RATE_STEP
+}
+
+/// Snap/clamp `new_rate`, update the shared signal, persist it per-book, and
+/// forward it to the JS audio shim so playback speed changes in real time.
+/// Shared by the full player's speed panel and the mini-dock's speed chip so
+/// the two always agree. `rate_error` surfaces a save failure to the UI.
+#[cfg(not(feature = "mobile"))]
+pub(super) fn apply_rate(
+    rate: &mut Signal<f64>,
+    rate_error: Signal<Option<String>>,
+    user_id: Option<i64>,
+    uuid: &str,
+    new_rate: f64,
+) {
+    let rounded = clamp_and_round_rate(new_rate);
+    rate.set(rounded);
+    if let Some(user_id) = user_id {
+        crate::audiobook_progress::save_rate(user_id, uuid, rounded);
+    }
+    #[cfg(feature = "web")]
+    audio_call("setRate", &rounded.to_string());
+    let uuid = uuid.to_string();
+    spawn(async move {
+        let mut rate_error = rate_error;
+        let update = omnibus_shared::AudiobookPlaybackRateUpdate {
+            playback_rate: rounded,
+        };
+        match crate::data::set_playback_rate("", &uuid, update).await {
+            Ok(_) => rate_error.set(None),
+            Err(error) => rate_error.set(Some(format!("Could not save playback speed: {error}"))),
+        }
+    });
+}
+
 /// Format `seconds` as `H:MM:SS` (or `MM:SS` when under an hour).
 #[cfg_attr(feature = "mobile", allow(dead_code))]
 pub(super) fn format_hms(seconds: f64) -> String {
@@ -177,11 +227,33 @@ mod tests {
     }
 }
 
-// `clamp_volume`/`load_volume` don't exist on mobile (the slider is web-only),
-// so their tests live in a separately-gated module.
+// `clamp_volume`/`load_volume`/`clamp_and_round_rate` don't exist on mobile
+// (the slider and speed panel are web-only), so their tests live in a
+// separately-gated module.
 #[cfg(all(test, not(feature = "mobile")))]
 mod volume_tests {
-    use super::{clamp_volume, load_volume};
+    use super::{clamp_and_round_rate, clamp_volume, load_volume, MAX_RATE, MIN_RATE};
+
+    #[test]
+    fn clamp_and_round_rate_accepts_value_within_range() {
+        assert!((clamp_and_round_rate(1.0) - 1.0).abs() < f64::EPSILON * 10.0);
+    }
+
+    #[test]
+    fn clamp_and_round_rate_clamps_below_minimum() {
+        assert!((clamp_and_round_rate(0.0) - MIN_RATE).abs() < f64::EPSILON * 10.0);
+    }
+
+    #[test]
+    fn clamp_and_round_rate_clamps_above_maximum() {
+        assert!((clamp_and_round_rate(10.0) - MAX_RATE).abs() < f64::EPSILON * 10.0);
+    }
+
+    #[test]
+    fn clamp_and_round_rate_rounds_to_nearest_step() {
+        assert!((clamp_and_round_rate(1.07) - 1.05).abs() < 0.001);
+        assert!((clamp_and_round_rate(1.08) - 1.10).abs() < 0.001);
+    }
 
     #[test]
     fn clamp_volume_within_range_is_unchanged() {

--- a/frontend/src/pages/listen/mini_dock.rs
+++ b/frontend/src/pages/listen/mini_dock.rs
@@ -202,7 +202,10 @@ fn MiniDockSpeed(rate: f64, uuid: String, user_id: Option<i64>) -> Element {
         let rate_error = playback.rate_error;
         let uuid = uuid.clone();
         move |_: MouseEvent| {
-            let next = cycle_rate(rate);
+            // Cycle from the live signal, not the render-time `rate` prop, so
+            // rapid taps before a re-render each advance a full step instead of
+            // recomputing the same `next` from a stale value.
+            let next = cycle_rate(*rate_sig.peek());
             super::helpers::apply_rate(&mut rate_sig, rate_error, user_id, &uuid, next);
         }
     };

--- a/frontend/src/pages/listen/mini_dock.rs
+++ b/frontend/src/pages/listen/mini_dock.rs
@@ -10,11 +10,11 @@
 use dioxus::prelude::*;
 use dioxus_router::Link;
 
-use super::controls::VolumeControl;
 use super::helpers::format_hms;
 use super::ready_player::chapter_index_for_elapsed;
 use super::stage::chapter_sub_text;
 use crate::components::atrium::Cover;
+use crate::contexts::use_current_user_summary;
 use crate::{use_playback, Route};
 
 /// Progress fill percent (0–100) for the dock's mini progress bar. Returns 0
@@ -43,12 +43,43 @@ pub(super) fn dock_active_state(
     }
 }
 
+/// Playback speeds the dock's speed chip steps through on each tap.
+const RATE_CYCLE: &[f64] = &[0.8, 1.0, 1.2, 1.5, 1.8, 2.0];
+
+/// Next speed for the dock's speed chip: the first cycle value above
+/// `current`, wrapping back to the slowest once past the top. A rate set
+/// from the full player's fine-tune (e.g. 1.35×) advances to the next
+/// preset above it.
+fn cycle_rate(current: f64) -> f64 {
+    RATE_CYCLE
+        .iter()
+        .copied()
+        .find(|&r| r > current + 0.001)
+        .unwrap_or(RATE_CYCLE[0])
+}
+
+/// Build the dock subtitle: the chapter label (when present) followed by the
+/// inline `elapsed / total` clock. The single-row bar has no separate time
+/// track, so the clock lives here.
+fn dock_sub_text(chapter_sub: Option<String>, elapsed: f64, duration: f64) -> String {
+    let time = format!("{} / {}", format_hms(elapsed), format_hms(duration));
+    match chapter_sub {
+        Some(sub) => format!("{sub} \u{00b7} {time}"),
+        None => time,
+    }
+}
+
 /// Persistent bottom dock. Renders only its empty host wrapper until an
 /// audiobook is loaded, keeping SSR and first-WASM-paint markup identical
 /// (`book` is `None` on both).
 #[component]
 pub fn MiniDock() -> Element {
     let playback = use_playback();
+    // Declared unconditionally (before the early return) so hook order stays
+    // stable across the empty-host / active-bar branches. Only drives the
+    // speed chip's per-book save; never affects rendered markup, so it can't
+    // cause a hydration mismatch.
+    let current_user = use_current_user_summary();
 
     // Stable host wrapper so hydration node-counting stays consistent; only
     // the inner bar is conditional on both a loaded book and a resolved uuid.
@@ -63,10 +94,13 @@ pub fn MiniDock() -> Element {
     let playing = (playback.playing)();
     let rate = (playback.rate)();
     let chapters = (playback.chapters)();
+    let user_id = current_user().map(|user| user.id);
 
     let idx = chapter_index_for_elapsed(&chapters, elapsed);
     let chapter_sub = chapter_sub_text(&chapters, idx);
+    let sub = dock_sub_text(chapter_sub, elapsed, duration);
     let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    let fill = format!("width: {:.1}%", progress_pct(elapsed, duration));
 
     rsx! {
         div { class: "mini-dock-host",
@@ -76,6 +110,10 @@ pub fn MiniDock() -> Element {
                 role: "region",
                 "aria-label": "Now playing",
 
+                div { class: "mini-dock-prog",
+                    i { style: "{fill}" }
+                }
+
                 Link {
                     to: Route::BookListen { uuid: uuid.clone() },
                     class: "mini-dock-now",
@@ -84,69 +122,41 @@ pub fn MiniDock() -> Element {
                     div { class: "mini-dock-cover", Cover { book: book.clone() } }
                     div { class: "mini-dock-meta",
                         div { class: "mini-dock-title", "data-testid": "mini-dock-title", "{title}" }
-                        if let Some(sub) = chapter_sub {
-                            div { class: "mini-dock-sub", "{sub}" }
-                        }
+                        div { class: "mini-dock-sub", "{sub}" }
                     }
                 }
 
-                MiniDockProgress { elapsed: elapsed, duration: duration }
-                MiniDockControls { playing: playing, rate: rate }
-                MiniDockVolume {}
+                MiniDockControls { playing: playing }
+                MiniDockSpeed { rate: rate, uuid: uuid.clone(), user_id: user_id }
+                Link {
+                    to: Route::BookListen { uuid: uuid.clone() },
+                    class: "mini-dock-chip mini-dock-hide",
+                    "data-testid": "mini-dock-sleep",
+                    "aria-label": "Sleep timer \u{2014} open player",
+                    title: "Sleep timer \u{2014} open player",
+                    "Sleep"
+                }
+
+                span { class: "mini-dock-div" }
                 MiniDockActions { uuid: uuid.clone() }
             }
         }
     }
 }
 
-/// Compact volume slider, rendered as a sibling of the dock's action
-/// buttons so it doesn't crowd the transport cluster in the narrow bar.
-/// Reads/writes the same [`crate::PlaybackState::volume`] signal as the
-/// full player's slider via `helpers::apply_volume`.
+/// Transport cluster: skip-back, play/pause, skip-forward. The ±30 seeks
+/// carry `mini-dock-hide` so the narrow-viewport rule sheds them, leaving the
+/// play button always reachable.
 #[component]
-fn MiniDockVolume() -> Element {
-    let playback = use_playback();
-    let volume = (playback.volume)();
-    let on_volume = move |v: f64| {
-        let mut vol_sig = playback.volume;
-        super::helpers::apply_volume(&mut vol_sig, v);
-    };
-    rsx! {
-        VolumeControl { volume, on_volume, compact: true }
-    }
-}
-
-/// Elapsed/total labels and progress bar for the dock.
-#[component]
-fn MiniDockProgress(elapsed: f64, duration: f64) -> Element {
-    let fill = format!("width: {:.1}%", progress_pct(elapsed, duration));
-    let elapsed_label = format_hms(elapsed);
-    let total_label = format_hms(duration);
-    rsx! {
-        div { class: "mini-dock-track",
-            div { class: "mini-dock-times",
-                span { "{elapsed_label}" }
-                span { "{total_label}" }
-            }
-            div { class: "pbar",
-                i { style: "{fill}" }
-            }
-        }
-    }
-}
-
-/// Transport cluster: skip-back, play/pause, skip-forward, rate badge.
-#[component]
-fn MiniDockControls(playing: bool, rate: f64) -> Element {
+fn MiniDockControls(playing: bool) -> Element {
     let play_label = if playing { "Pause" } else { "Play" }.to_string();
-    let rate_label = format!("{rate:.2}\u{00d7}");
     let on_toggle = super::helpers::on_toggle_playback();
     let on_skip_back = super::helpers::on_skip_back_30();
     let on_skip_forward = super::helpers::on_skip_forward_30();
     rsx! {
         div { class: "mini-dock-controls",
             button {
-                class: "mini-dock-btn mini-dock-skip",
+                class: "mini-dock-btn mini-dock-skip mini-dock-hide",
                 r#type: "button",
                 "data-testid": "mini-dock-skip-back",
                 "aria-label": "Back 30 seconds",
@@ -169,19 +179,48 @@ fn MiniDockControls(playing: bool, rate: f64) -> Element {
                 }
             }
             button {
-                class: "mini-dock-btn mini-dock-skip",
+                class: "mini-dock-btn mini-dock-skip mini-dock-hide",
                 r#type: "button",
                 "data-testid": "mini-dock-skip-forward",
                 "aria-label": "Forward 30 seconds",
                 onclick: on_skip_forward,
                 "+30"
             }
-            span { class: "mini-dock-rate", "data-testid": "mini-dock-rate", "{rate_label}" }
         }
     }
 }
 
-/// Expand link + dismiss button; dismiss clears [`crate::PlaybackState`] via `use_playback`.
+/// Speed chip. Displays the current rate and cycles to the next preset on
+/// click, writing through the shared `helpers::apply_rate` seam so the change
+/// persists per-book and stays in sync with the full player's speed panel.
+#[component]
+fn MiniDockSpeed(rate: f64, uuid: String, user_id: Option<i64>) -> Element {
+    let playback = use_playback();
+    let label = format!("{rate:.1}\u{00d7}");
+    let on_click = {
+        let mut rate_sig = playback.rate;
+        let rate_error = playback.rate_error;
+        let uuid = uuid.clone();
+        move |_: MouseEvent| {
+            let next = cycle_rate(rate);
+            super::helpers::apply_rate(&mut rate_sig, rate_error, user_id, &uuid, next);
+        }
+    };
+    rsx! {
+        button {
+            class: "mini-dock-chip mono mini-dock-hide",
+            r#type: "button",
+            "data-testid": "mini-dock-speed",
+            "aria-label": "Playback speed",
+            title: "Change playback speed",
+            onclick: on_click,
+            "{label}"
+        }
+    }
+}
+
+/// Inline icon actions on the right of the bar: expand to the full player and
+/// dismiss. Dismiss clears [`crate::PlaybackState`] via `use_playback`.
 #[component]
 fn MiniDockActions(uuid: String) -> Element {
     let playback = use_playback();
@@ -205,17 +244,40 @@ fn MiniDockActions(uuid: String) -> Element {
         div { class: "mini-dock-actions",
             Link {
                 to: Route::BookListen { uuid: uuid.clone() },
-                class: "mini-dock-btn mini-dock-expand-btn",
+                class: "mini-dock-ico",
                 "data-testid": "mini-dock-expand-btn",
-                "\u{2191} Expand"
+                "aria-label": "Expand to full player",
+                title: "Expand to full player",
+                svg {
+                    width: "17",
+                    height: "17",
+                    view_box: "0 0 24 24",
+                    fill: "none",
+                    stroke: "currentColor",
+                    stroke_width: "1.8",
+                    stroke_linecap: "round",
+                    stroke_linejoin: "round",
+                    path { d: "M8 14l-4 4M4 14v4h4M16 10l4-4M20 10V6h-4" }
+                }
             }
             button {
-                class: "mini-dock-btn mini-dock-dismiss",
+                class: "mini-dock-ico",
                 r#type: "button",
                 "data-testid": "mini-dock-dismiss",
                 "aria-label": "Stop and close player",
+                title: "Close audio \u{2014} keep reading",
                 onclick: on_dismiss,
-                "\u{00d7}"
+                svg {
+                    width: "17",
+                    height: "17",
+                    view_box: "0 0 24 24",
+                    fill: "none",
+                    stroke: "currentColor",
+                    stroke_width: "1.8",
+                    stroke_linecap: "round",
+                    stroke_linejoin: "round",
+                    path { d: "M6 6l12 12M18 6L6 18" }
+                }
             }
         }
     }
@@ -225,7 +287,7 @@ fn MiniDockActions(uuid: String) -> Element {
 mod tests {
     use omnibus_shared::EbookMetadata;
 
-    use super::{dock_active_state, progress_pct};
+    use super::{cycle_rate, dock_active_state, dock_sub_text, progress_pct};
 
     #[test]
     fn progress_pct_is_zero_when_duration_unknown() {
@@ -247,6 +309,39 @@ mod tests {
     fn progress_pct_treats_non_finite_elapsed_as_zero() {
         assert_eq!(progress_pct(f64::NAN, 100.0), 0.0);
         assert_eq!(progress_pct(f64::INFINITY, 100.0), 0.0);
+    }
+
+    #[test]
+    fn cycle_rate_advances_to_next_preset() {
+        assert!((cycle_rate(1.0) - 1.2).abs() < f64::EPSILON);
+        assert!((cycle_rate(0.8) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cycle_rate_wraps_after_the_fastest() {
+        assert!((cycle_rate(2.0) - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cycle_rate_advances_from_a_fine_tuned_value() {
+        // 1.35× (set from the full player's slider) steps up to the next preset.
+        assert!((cycle_rate(1.35) - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cycle_rate_starts_at_slowest_from_below_the_range() {
+        assert!((cycle_rate(0.5) - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn dock_sub_text_includes_chapter_and_inline_clock() {
+        let sub = dock_sub_text(Some("Ch. 2 \u{00b7} The Journey".into()), 65.0, 3600.0);
+        assert_eq!(sub, "Ch. 2 \u{00b7} The Journey \u{00b7} 1:05 / 1:00:00");
+    }
+
+    #[test]
+    fn dock_sub_text_is_just_the_clock_without_chapters() {
+        assert_eq!(dock_sub_text(None, 65.0, 130.0), "1:05 / 2:10");
     }
 
     // Mirrors MiniDock's "renders empty host vs. active bar" branch without needing a full component render.

--- a/frontend/src/pages/listen/mobile/mini.rs
+++ b/frontend/src/pages/listen/mobile/mini.rs
@@ -98,6 +98,24 @@ pub fn MobileMiniPlayer() -> Element {
                         span { class: "m-mini-tri" }
                     }
                 }
+                button {
+                    r#type: "button", class: "m-mini-skip mono",
+                    "data-testid": "mini-skip-forward", "aria-label": "Forward 30 seconds",
+                    onclick: move |_| interop::skip(30.0),
+                    "+30"
+                }
+                Link {
+                    to: Route::BookListen { uuid: uuid.clone() },
+                    class: "m-mini-expand",
+                    "data-testid": "mini-expand",
+                    "aria-label": "Expand to full player",
+                    svg {
+                        width: "18", height: "18", view_box: "0 0 24 24", fill: "none",
+                        stroke: "currentColor", stroke_width: "1.9",
+                        stroke_linecap: "round", stroke_linejoin: "round",
+                        path { d: "M6 15l6-6 6 6" }
+                    }
+                }
             }
         }
     }

--- a/frontend/src/pages/listen/speed_panel.rs
+++ b/frontend/src/pages/listen/speed_panel.rs
@@ -11,75 +11,9 @@ use omnibus_shared::{
     MAX_AUDIOBOOK_PLAYBACK_RATE as MAX_RATE, MIN_AUDIOBOOK_PLAYBACK_RATE as MIN_RATE,
 };
 
+use super::helpers::{apply_rate, RATE_STEP as STEP};
+
 const PRESETS: &[f64] = &[0.5, 0.8, 1.0, 1.1, 1.2, 1.5, 1.8, 2.0];
-const STEP: f64 = 0.05;
-
-/// Clamp `new_rate` to `[MIN_RATE, MAX_RATE]` and snap to the nearest `STEP`.
-/// Pure logic extracted for unit testing — no signal or JS side-effects.
-fn clamp_and_round_rate(new_rate: f64) -> f64 {
-    let clamped = new_rate.clamp(MIN_RATE, MAX_RATE);
-    (clamped / STEP).round() * STEP
-}
-
-fn apply_rate(
-    rate: &mut Signal<f64>,
-    rate_error: Signal<Option<String>>,
-    user_id: Option<i64>,
-    uuid: &str,
-    new_rate: f64,
-) {
-    let rounded = clamp_and_round_rate(new_rate);
-    rate.set(rounded);
-    if let Some(user_id) = user_id {
-        crate::audiobook_progress::save_rate(user_id, uuid, rounded);
-    }
-    #[cfg(feature = "web")]
-    super::helpers::audio_call("setRate", &rounded.to_string());
-    let uuid = uuid.to_string();
-    spawn(async move {
-        let mut rate_error = rate_error;
-        let update = omnibus_shared::AudiobookPlaybackRateUpdate {
-            playback_rate: rounded,
-        };
-        match crate::data::set_playback_rate("", &uuid, update).await {
-            Ok(_) => rate_error.set(None),
-            Err(error) => rate_error.set(Some(format!("Could not save playback speed: {error}"))),
-        }
-    });
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn clamp_and_round_rate_accepts_value_within_range() {
-        let result = clamp_and_round_rate(1.0);
-        assert!((result - 1.0).abs() < f64::EPSILON * 10.0);
-    }
-
-    #[test]
-    fn clamp_and_round_rate_clamps_below_minimum() {
-        let result = clamp_and_round_rate(0.0);
-        assert!((result - MIN_RATE).abs() < f64::EPSILON * 10.0);
-    }
-
-    #[test]
-    fn clamp_and_round_rate_clamps_above_maximum() {
-        let result = clamp_and_round_rate(10.0);
-        assert!((result - MAX_RATE).abs() < f64::EPSILON * 10.0);
-    }
-
-    #[test]
-    fn clamp_and_round_rate_rounds_to_nearest_step() {
-        // 1.07 rounds to 1.05
-        let result = clamp_and_round_rate(1.07);
-        assert!((result - 1.05).abs() < 0.001);
-        // 1.08 rounds to 1.10
-        let result2 = clamp_and_round_rate(1.08);
-        assert!((result2 - 1.10).abs() < 0.001);
-    }
-}
 
 /// Frosted-glass speed panel with preset grid, fine-tune slider, and stepper.
 #[component]

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../fixtures/test";
 import { AUDIOBOOK_BOOKS, AUDIOBOOK_BOOK_COUNT } from "../fixtures/audiobooks";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
+import { expectMutation } from "../utils/api";
 import { fetchBookUuidByTitle } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
 import {
@@ -33,6 +34,9 @@ const MP3_BOOK = AUDIOBOOK_BOOKS.find(
 // Distinct author from every audiobook fixture so auto-attach never merges
 // this EPUB with the playing audiobook mid-test.
 const READER_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "gamma")!;
+
+// The web speed control posts through the `rpc_set_playback_rate` server fn.
+const PLAYBACK_RATE_SET_URL = /\/api\/rpc\/audiobooks\/playback-rate\/set(?:\?|$)/;
 
 /**
  * Wait until the App-level playback driver has run `OmnibusAudio.initDirect`
@@ -192,11 +196,26 @@ test("dock speed chip cycles playback rate and reaches the shared audio + full p
   await waitForPlayerReady(page);
   await spaNavigateToLibrary(page);
 
+  // Speed persists per-book, so don't assume a fixed starting rate — read the
+  // chip's current value and assert the transition to the next cycle preset.
+  const RATE_CYCLE = [0.8, 1.0, 1.2, 1.5, 1.8, 2.0];
   const speed = page.getByTestId("mini-dock-speed");
-  await expect(speed).toHaveText("1.0×");
+  const start = parseFloat((await speed.textContent()) ?? "");
+  const next = RATE_CYCLE.find((r) => r > start + 0.001) ?? RATE_CYCLE[0];
 
-  await speed.click();
-  await expect(speed).toHaveText("1.2×");
+  // The chip cycles the rate and persists it via `rpc_set_playback_rate`;
+  // assert that POST fired with the next preset before checking UI/audio state.
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: PLAYBACK_RATE_SET_URL,
+      expectedStatus: 200,
+      expectedBody: { uuid, update: { playback_rate: next } },
+    },
+    async () => speed.click(),
+  );
+  await expect(speed).toHaveText(`${next.toFixed(1)}×`);
 
   // The chip writes through the shared apply_rate seam, so the change must
   // reach the shared `<audio>` element's playbackRate in real time.
@@ -208,13 +227,13 @@ test("dock speed chip cycles playback rate and reaches the shared audio + full p
             ?.playbackRate ?? null,
       ),
     )
-    .toBeCloseTo(1.2, 2);
+    .toBeCloseTo(next, 2);
 
   // Expanding back to the full player must show the same rate — proof both
   // controls share one signal rather than each tracking its own copy.
   await page.getByTestId("mini-dock-expand-btn").click();
   await expect(page).toHaveURL(new RegExp(`/listen/${uuid}$`));
-  await expect(page.getByTestId("listen-rate")).toContainText("1.2");
+  await expect(page.getByTestId("listen-rate")).toContainText(next.toFixed(1));
 });
 
 // ---------------------------------------------------------------------------

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -9,7 +9,6 @@ import {
   seedAudiobookLibrary,
   seedLibrary,
 } from "../utils/seed";
-import { setRangeValue } from "../utils/sliders";
 
 // Both libraries seeded: the reader-visibility test needs an EPUB to read
 // alongside an audiobook playing in the background. No fixture pair shares
@@ -156,10 +155,10 @@ test("dock expand navigates back to the full player", async ({
 });
 
 // ---------------------------------------------------------------------------
-// 3b. Volume slider stays in sync with the full player (#989)
+// 3b. Compact bar: single flex row, no volume slider (AC1)
 // ---------------------------------------------------------------------------
 
-test("dock volume slider updates the shared audio element and stays in sync with the full player", async ({
+test("dock is a single-row flex bar with no volume slider", async ({
   page,
   request,
 }) => {
@@ -168,33 +167,68 @@ test("dock volume slider updates the shared audio element and stays in sync with
   await waitForPlayerReady(page);
   await spaNavigateToLibrary(page);
 
-  const dockSlider = page
-    .getByTestId("mini-dock-volume")
-    .getByRole("slider", { name: "Volume" });
-  await expect(dockSlider).toBeVisible();
-  await expect(dockSlider).toHaveValue("1");
+  const dock = page.getByTestId("mini-dock");
+  await expect(dock).toBeVisible();
 
-  await setRangeValue(dockSlider, 0.4);
+  // The bar is one content-sized flex row now, not the old 4-column grid that
+  // wrapped a trailing actions row (the residual bottom whitespace, #1132).
+  await expect(dock).toHaveCSS("display", "flex");
+  await expect(dock).not.toHaveCSS("flex-wrap", "wrap");
 
-  // Both sliders read/write PlaybackState.volume, so the dock's change must
-  // reach the shared `<audio>` element in real time.
+  // The volume slider moved out of the dock in the compact design.
+  await expect(page.getByTestId("mini-dock-volume")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// 3c. Speed chip cycles the rate and stays in sync with the full player
+// ---------------------------------------------------------------------------
+
+test("dock speed chip cycles playback rate and reaches the shared audio + full player", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+  await spaNavigateToLibrary(page);
+
+  const speed = page.getByTestId("mini-dock-speed");
+  await expect(speed).toHaveText("1.0×");
+
+  await speed.click();
+  await expect(speed).toHaveText("1.2×");
+
+  // The chip writes through the shared apply_rate seam, so the change must
+  // reach the shared `<audio>` element's playbackRate in real time.
   await expect
     .poll(() =>
       page.evaluate(
         () =>
           (document.getElementById("omnibus-audio") as HTMLAudioElement | null)
-            ?.volume ?? null,
+            ?.playbackRate ?? null,
       ),
     )
-    .toBeCloseTo(0.4, 2);
+    .toBeCloseTo(1.2, 2);
 
-  // Expanding back to the full player must show the same volume — proof
-  // both controls share one signal rather than each tracking its own copy.
+  // Expanding back to the full player must show the same rate — proof both
+  // controls share one signal rather than each tracking its own copy.
   await page.getByTestId("mini-dock-expand-btn").click();
   await expect(page).toHaveURL(new RegExp(`/listen/${uuid}$`));
+  await expect(page.getByTestId("listen-rate")).toContainText("1.2");
+});
 
-  const fullSlider = page.getByRole("slider", { name: "Volume" });
-  await expect(fullSlider).toHaveValue("0.4");
+// ---------------------------------------------------------------------------
+// 3d. Sleep chip expands to the full player (where the sleep timer lives)
+// ---------------------------------------------------------------------------
+
+test("dock sleep chip opens the full player", async ({ page, request }) => {
+  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+  await spaNavigateToLibrary(page);
+
+  await page.getByTestId("mini-dock-sleep").click();
+  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}$`));
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Rebuild the persistent audio mini-dock as a single-row flex bar (design `.r-dock`): thin top progress line, inline clock in the subtitle, speed + Sleep chips, and inline expand/close icon buttons — replacing the old 4-column grid whose trailing actions wrapped to a second row (the bottom whitespace in #1132).
- Speed chip cycles playback rate inline through a new shared `helpers::apply_rate` seam (the full player's speed panel now writes through the same path); the volume slider is dropped from the dock but stays in the full player.
- Mobile mini-player gains a `+30` seek and an explicit expand chevron to match the mobile design.
- Narrow-viewport rule sheds the ±30 seeks and speed/Sleep chips; `data-testid`s `mini-dock-expand-btn` / `mini-dock-dismiss` preserved.

## Test plan
- [x] `cargo check` + `clippy` clean on `server` and `mobile` features
- [x] `cargo test -p omnibus-frontend --features server` — 314 pass (incl. new `cycle_rate`, `dock_sub_text`, and relocated rate-clamp tests)
- [x] `cargo fmt` + stylelint clean
- [x] All 8 `mini-dock.spec.ts` Playwright tests pass (updated for the icon actions, speed-cycle, sleep-expand, and no-volume design)
- [x] Browser-verified: compact dock on the library page, narrow-viewport collapse at 560px, no console errors

## Version
- [ ] **Minor**
- [x] **Patch** — default
- [ ] **No release**

## Notes
> [!NOTE]
> Two behaviors the design left unspecified: the speed chip **cycles** rate inline (0.8→2.0×, persisted per-book), and the Sleep chip **expands to the full player** — the sleep-timer controller lives in the full player's subtree, not shared \`PlaybackState\`, so an inline sleep panel would be a larger refactor. Closes #1132.