### PR TITLE
fix: play the audio file on mobile for combined ebook+audiobook books (#1136)

### DIFF
--- a/frontend/src/components/format_switcher/mod.rs
+++ b/frontend/src/components/format_switcher/mod.rs
@@ -254,7 +254,7 @@ pub(super) async fn async_sleep_ms(ms: u32) {
 fn listen_book_action(uuid: &str) -> Element {
     rsx! {
         Link {
-            to: Route::BookListen { uuid: uuid.to_string() },
+            to: Route::BookListen { uuid: uuid.to_string(), file_id: None },
             class: "btn",
             "data-testid": "action-listen",
             "Listen"

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -276,7 +276,7 @@ fn UmNowReading() -> Element {
                     };
                     let uuid = point.record.book_uuid.clone();
                     let to = if is_audio {
-                        Route::BookListen { uuid }
+                        Route::BookListen { uuid, file_id: None }
                     } else {
                         Route::BookRead { uuid }
                     };

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -174,7 +174,10 @@ fn resume_card(point: &ResumePoint, server_url: &str) -> Element {
         .unwrap_or_default();
     let is_audio = point.record.format == ProgressFormat::Audio;
     let to = if is_audio {
-        Route::BookListen { uuid: uuid.clone() }
+        Route::BookListen {
+            uuid: uuid.clone(),
+            file_id: None,
+        }
     } else {
         Route::BookRead { uuid: uuid.clone() }
     };

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -75,16 +75,19 @@ pub(crate) use mobile::{MobileAudioHost, MobileMiniPlayer, MobilePlayback};
 /// forward on the next open. Across direct-mode parts the JS shim reports
 /// absolute (cross-part) seconds so the same shape works for both modes.
 #[component]
-pub fn BookListenPage(uuid: String) -> Element {
+pub fn BookListenPage(uuid: String, file_id: Option<i64>) -> Element {
     #[cfg(feature = "mobile")]
     {
         return rsx! {
-            mobile::MobilePlayer { uuid }
+            mobile::MobilePlayer { uuid, file_id }
         };
     }
 
     #[cfg(not(feature = "mobile"))]
     {
+        // Web resolves the picker's `?file_id=` from `window.location` in the
+        // app-root playback bootstrap, so the routed prop is unused here.
+        let _ = file_id;
         let playback = use_playback();
 
         // Point the app-wide player at this route's book. The App-level

--- a/frontend/src/pages/listen/mini_dock.rs
+++ b/frontend/src/pages/listen/mini_dock.rs
@@ -115,7 +115,7 @@ pub fn MiniDock() -> Element {
                 }
 
                 Link {
-                    to: Route::BookListen { uuid: uuid.clone() },
+                    to: Route::BookListen { uuid: uuid.clone(), file_id: None },
                     class: "mini-dock-now",
                     "data-testid": "mini-dock-expand",
                     "aria-label": "Expand player",
@@ -129,7 +129,7 @@ pub fn MiniDock() -> Element {
                 MiniDockControls { playing: playing }
                 MiniDockSpeed { rate: rate, uuid: uuid.clone(), user_id: user_id }
                 Link {
-                    to: Route::BookListen { uuid: uuid.clone() },
+                    to: Route::BookListen { uuid: uuid.clone(), file_id: None },
                     class: "mini-dock-chip mini-dock-hide",
                     "data-testid": "mini-dock-sleep",
                     "aria-label": "Sleep timer \u{2014} open player",
@@ -246,7 +246,7 @@ fn MiniDockActions(uuid: String) -> Element {
     rsx! {
         div { class: "mini-dock-actions",
             Link {
-                to: Route::BookListen { uuid: uuid.clone() },
+                to: Route::BookListen { uuid: uuid.clone(), file_id: None },
                 class: "mini-dock-ico",
                 "data-testid": "mini-dock-expand-btn",
                 "aria-label": "Expand to full player",

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -52,7 +52,7 @@ enum OpenSheet {
 /// playback context and renders its state; the heavy lifting (fetch, audio
 /// surface, event drain) lives in the app-root [`host::MobileAudioHost`].
 #[component]
-pub fn MobilePlayer(uuid: String) -> Element {
+pub fn MobilePlayer(uuid: String, file_id: Option<i64>) -> Element {
     let server_url = use_server_url();
     let ctx = use_mobile_playback();
     let sheet = use_signal(|| OpenSheet::None);
@@ -79,8 +79,12 @@ pub fn MobilePlayer(uuid: String) -> Element {
     // so re-entering the currently-playing book (e.g. from the mini-player)
     // is seamless instead of restarting the surface.
     let route_uuid = uuid.clone();
-    use_effect(use_reactive!(|route_uuid| {
+    use_effect(use_reactive!(|(route_uuid, file_id)| {
         let mut uuid_sig = ctx.uuid;
+        let mut file_sig = ctx.file_id;
+        // Publish the picker's selection first so the host reads the right file
+        // when the uuid change kicks off the load.
+        file_sig.set(file_id);
         if uuid_sig.peek().as_deref() != Some(route_uuid.as_str()) {
             uuid_sig.set(Some(route_uuid.clone()));
         }

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -13,6 +13,24 @@ use super::view::PlayerView;
 use super::{interop, persist_position, resolve_resume};
 use crate::data;
 
+/// `book_files.id` of the first audio file, lowest ordinal wins, or `None`.
+///
+/// A book with both an ebook and an audiobook lists the ebook format first
+/// (`get_book_files` orders by format), so `book_files.first()` would hand the
+/// audiobook manifest an EPUB id and 404. Filter to the audio formats the HLS
+/// resolver accepts (`db::hls::resolve_audiobook`'s `format IN
+/// ('M4B','M4A','MP3')`) before picking.
+fn first_audio_file_id(files: &[omnibus_shared::BookFileInfo]) -> Option<i64> {
+    files
+        .iter()
+        .filter(|f| {
+            let fmt = f.format.to_ascii_uppercase();
+            fmt == "M4B" || fmt == "M4A" || fmt == "MP3"
+        })
+        .min_by_key(|f| f.ordinal)
+        .map(|f| f.id)
+}
+
 /// Render-less app-root component owning the load → install → drain pipeline.
 #[component]
 pub fn MobileAudioHost() -> Element {
@@ -156,7 +174,7 @@ async fn load_and_drain(ctx: MobilePlayback, uuid: String, server_url: String) {
             return;
         }
     };
-    let file_id = book.book_files.first().map(|f| f.id);
+    let file_id = first_audio_file_id(&book.book_files);
     let manifest = match data::get_manifest(&server_url, &uuid, file_id).await {
         Ok(m) => m,
         Err(e) => {
@@ -273,5 +291,42 @@ async fn drain_audio_events(
             // Channel closed (surface torn down) — stop draining.
             Err(_) => return,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::first_audio_file_id;
+    use omnibus_shared::BookFileInfo;
+
+    fn bf(id: i64, format: &str, ordinal: i64) -> BookFileInfo {
+        BookFileInfo {
+            id,
+            format: format.into(),
+            filename: String::new(),
+            ordinal,
+            label: None,
+            size_bytes: 0,
+        }
+    }
+
+    #[test]
+    fn first_audio_file_id_skips_a_leading_ebook_format() {
+        // A merged ebook+audiobook lists EPUB first (ordered by format); the
+        // audiobook manifest must still receive the M4B id, not the EPUB's.
+        let files = vec![bf(698, "EPUB", 0), bf(917, "M4B", 0), bf(922, "M4B", 1)];
+        assert_eq!(first_audio_file_id(&files), Some(917));
+    }
+
+    #[test]
+    fn first_audio_file_id_picks_lowest_ordinal() {
+        let files = vec![bf(5, "M4B", 2), bf(3, "M4B", 0), bf(4, "M4B", 1)];
+        assert_eq!(first_audio_file_id(&files), Some(3));
+    }
+
+    #[test]
+    fn first_audio_file_id_is_none_without_an_audio_file() {
+        let files = vec![bf(1, "EPUB", 0), bf(2, "PDF", 0)];
+        assert_eq!(first_audio_file_id(&files), None);
     }
 }

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -24,11 +24,27 @@ fn first_audio_file_id(files: &[omnibus_shared::BookFileInfo]) -> Option<i64> {
     files
         .iter()
         .filter(|f| {
-            let fmt = f.format.to_ascii_uppercase();
-            fmt == "M4B" || fmt == "M4A" || fmt == "MP3"
+            f.format.eq_ignore_ascii_case("M4B")
+                || f.format.eq_ignore_ascii_case("M4A")
+                || f.format.eq_ignore_ascii_case("MP3")
         })
         .min_by_key(|f| f.ordinal)
         .map(|f| f.id)
+}
+
+/// Whether the host must (re)load for a newly-requested `(uuid, file_id)`.
+///
+/// A different book always reloads. The *same* book reloads only on an
+/// explicit, different file selection — so tapping another part in the picker
+/// switches files, while the mini-player (which links with no `file_id`)
+/// resumes the current part instead of restarting from the first file.
+fn needs_reload(loaded: &Option<(String, Option<i64>)>, uuid: &str, file_id: Option<i64>) -> bool {
+    match loaded {
+        Some((loaded_uuid, loaded_file)) if loaded_uuid == uuid => {
+            file_id.is_some() && file_id != *loaded_file
+        }
+        _ => true,
+    }
 }
 
 /// Render-less app-root component owning the load → install → drain pipeline.
@@ -39,7 +55,8 @@ pub fn MobileAudioHost() -> Element {
     // The live drain task, cancelled before every reinstall so a superseded
     // loop can't sit on a dead eval channel forever.
     let mut drain_task = use_signal(|| None::<Task>);
-    let mut loaded_uuid = use_signal(|| None::<String>);
+    // What's currently loaded: (book uuid, the file_id it was loaded with).
+    let mut loaded_key = use_signal(|| None::<(String, Option<i64>)>);
 
     use_future(move || async move {
         let mut auth = crate::data::token_store::subscribe();
@@ -55,27 +72,32 @@ pub fn MobileAudioHost() -> Element {
     // the `/stats` aggregates, POSTed to `/api/progress/sessions`.
     crate::session_tracker::use_listening_session(ctx.uuid, ctx.playing, server_url);
 
-    // Loader: reacts to the listen page retargeting `ctx.uuid`.
+    // Loader: reacts to the listen page retargeting `ctx.uuid` / `ctx.file_id`.
     use_effect(move || {
-        let requested = (ctx.uuid)();
-        if requested == *loaded_uuid.peek() {
+        let requested_uuid = (ctx.uuid)();
+        let requested_file = (ctx.file_id)();
+        let Some(uuid) = requested_uuid else {
+            // Nothing requested — tear down if a book was loaded.
+            if loaded_key.peek().is_some() {
+                if let Some(task) = drain_task.write().take() {
+                    task.cancel();
+                }
+                loaded_key.set(None);
+                interop::teardown();
+                reset_playback(ctx);
+            }
+            return;
+        };
+        if !needs_reload(&loaded_key.peek().clone(), &uuid, requested_file) {
             return;
         }
         if let Some(task) = drain_task.write().take() {
             task.cancel();
         }
-        loaded_uuid.set(requested.clone());
-        match requested {
-            Some(uuid) => {
-                let server = server_url.peek().clone();
-                let task = spawn(load_and_drain(ctx, uuid, server));
-                drain_task.set(Some(task));
-            }
-            None => {
-                interop::teardown();
-                reset_playback(ctx);
-            }
-        }
+        loaded_key.set(Some((uuid.clone(), requested_file)));
+        let server = server_url.peek().clone();
+        let task = spawn(load_and_drain(ctx, uuid, requested_file, server));
+        drain_task.set(Some(task));
     });
 
     // Wall-clock sleep countdown: a self-re-arming 1 s tick (the mobile
@@ -137,7 +159,12 @@ fn reset_playback(ctx: MobilePlayback) {
 /// Fetch metadata + manifest for `uuid`, seed the context, install the audio
 /// control surface for direct-play books (or flag HLS as unsupported), then
 /// drain its events until superseded.
-async fn load_and_drain(ctx: MobilePlayback, uuid: String, server_url: String) {
+async fn load_and_drain(
+    ctx: MobilePlayback,
+    uuid: String,
+    selected_file_id: Option<i64>,
+    server_url: String,
+) {
     let MobilePlayback {
         mut view,
         mut loading,
@@ -174,7 +201,9 @@ async fn load_and_drain(ctx: MobilePlayback, uuid: String, server_url: String) {
             return;
         }
     };
-    let file_id = first_audio_file_id(&book.book_files);
+    // Honor the picker's explicit choice; otherwise default to the first audio
+    // file (a bare `/listen/:uuid` with no `?file_id=`).
+    let file_id = selected_file_id.or_else(|| first_audio_file_id(&book.book_files));
     let manifest = match data::get_manifest(&server_url, &uuid, file_id).await {
         Ok(m) => m,
         Err(e) => {
@@ -328,5 +357,29 @@ mod tests {
     fn first_audio_file_id_is_none_without_an_audio_file() {
         let files = vec![bf(1, "EPUB", 0), bf(2, "PDF", 0)];
         assert_eq!(first_audio_file_id(&files), None);
+    }
+
+    use super::needs_reload;
+
+    #[test]
+    fn needs_reload_when_nothing_loaded_or_book_changed() {
+        assert!(needs_reload(&None, "book-a", None));
+        let loaded = Some(("book-a".to_string(), Some(917)));
+        assert!(needs_reload(&loaded, "book-b", Some(940)));
+    }
+
+    #[test]
+    fn needs_reload_on_explicit_different_part_of_same_book() {
+        let loaded = Some(("book-a".to_string(), Some(917)));
+        assert!(needs_reload(&loaded, "book-a", Some(918)));
+    }
+
+    #[test]
+    fn no_reload_for_same_part_or_bare_relink_of_same_book() {
+        let loaded = Some(("book-a".to_string(), Some(917)));
+        // Same part re-selected → no restart.
+        assert!(!needs_reload(&loaded, "book-a", Some(917)));
+        // Mini-player relinks with no file_id → keep the current part.
+        assert!(!needs_reload(&loaded, "book-a", None));
     }
 }

--- a/frontend/src/pages/listen/mobile/mini.rs
+++ b/frontend/src/pages/listen/mobile/mini.rs
@@ -66,7 +66,7 @@ pub fn MobileMiniPlayer() -> Element {
             div { class: "m-mini-progress", div { style: "width:{pct}%" } }
             div { class: "m-mini-row",
                 Link {
-                    to: Route::BookListen { uuid: uuid.clone() },
+                    to: Route::BookListen { uuid: uuid.clone(), file_id: None },
                     class: "m-mini-main",
                     "aria-label": "Open player for {view.title}",
                     span { class: "m-mini-cover",
@@ -105,7 +105,7 @@ pub fn MobileMiniPlayer() -> Element {
                     "+30"
                 }
                 Link {
-                    to: Route::BookListen { uuid: uuid.clone() },
+                    to: Route::BookListen { uuid: uuid.clone(), file_id: None },
                     class: "m-mini-expand",
                     "data-testid": "mini-expand",
                     "aria-label": "Expand to full player",

--- a/frontend/src/pages/listen/mobile/state.rs
+++ b/frontend/src/pages/listen/mobile/state.rs
@@ -34,6 +34,10 @@ pub enum SleepState {
 #[derive(Copy, Clone)]
 pub struct MobilePlayback {
     pub uuid: Signal<Option<String>>,
+    /// The specific `book_files` row to play, from the listen route's
+    /// `?file_id=` (the file picker's selection). `None` lets the host pick the
+    /// first audio file — the default "just play the audiobook" entry.
+    pub file_id: Signal<Option<i64>>,
     pub view: Signal<Option<PlayerView>>,
     pub loading: Signal<bool>,
     pub error: Signal<Option<String>>,
@@ -53,6 +57,7 @@ impl MobilePlayback {
     pub fn new() -> Self {
         Self {
             uuid: Signal::new(None),
+            file_id: Signal::new(None),
             view: Signal::new(None),
             loading: Signal::new(false),
             error: Signal::new(None),

--- a/frontend/src/routes.rs
+++ b/frontend/src/routes.rs
@@ -27,8 +27,8 @@ pub enum Route {
     MetadataEdit { uuid: String },
     #[route("/read/:uuid")]
     BookRead { uuid: String },
-    #[route("/listen/:uuid")]
-    BookListen { uuid: String },
+    #[route("/listen/:uuid?:file_id")]
+    BookListen { uuid: String, file_id: Option<i64> },
     #[route("/authors")]
     AuthorsIndex {},
     #[route("/authors/:id")]
@@ -152,10 +152,10 @@ pub fn BookRead(uuid: String) -> Element {
 /// Same uuid-keyed stability + no-chrome rationale as [`BookRead`]; the
 /// player owns its own slim top bar.
 #[component]
-pub fn BookListen(uuid: String) -> Element {
+pub fn BookListen(uuid: String, file_id: Option<i64>) -> Element {
     use_page_title(|| Some("Player".into()));
     rsx! {
-        BookListenPage { uuid }
+        BookListenPage { uuid, file_id }
     }
 }
 

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -620,9 +620,10 @@ test.describe("audiobook-only seed", () => {
     // format that CTA opens (see the merge-based test below).
     await expect(page.getByTestId("listen-file-picker-trigger")).toHaveCount(0);
 
-    // Clicking the primary CTA must SPA-navigate to the listen page.
+    // Clicking the primary CTA must SPA-navigate to the listen page. Dioxus
+    // serializes the optional `?file_id=` route param as a bare trailing `?`.
     await startListening.click();
-    await expect(page).toHaveURL(new RegExp(`/listen/${uuid}$`));
+    await expect(page).toHaveURL(new RegExp(`/listen/${uuid}\\??$`));
   });
 
   // ---------------------------------------------------------------------------

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -223,7 +223,9 @@ test("opens the listen page from the book detail Listen action", async ({
   await gotoReady(page, `/books/${uuid}`);
 
   await page.getByTestId("action-listen").click();
-  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}$`));
+  // Dioxus serializes the optional `?file_id=` route param as a bare trailing
+  // `?` when unset, so allow it (functionally `/listen/:uuid`).
+  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}\\??$`));
   await expect(page.getByRole("button", { name: "Play", exact: true })).toBeVisible();
 });
 

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -151,7 +151,7 @@ test("dock expand navigates back to the full player", async ({
   await expect(page.getByTestId("mini-dock")).toBeVisible();
   await page.getByTestId("mini-dock-expand-btn").click();
 
-  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}$`));
+  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}\\??$`));
   await expect(
     page.getByRole("button", { name: "Play", exact: true }),
   ).toBeVisible();
@@ -232,7 +232,7 @@ test("dock speed chip cycles playback rate and reaches the shared audio + full p
   // Expanding back to the full player must show the same rate — proof both
   // controls share one signal rather than each tracking its own copy.
   await page.getByTestId("mini-dock-expand-btn").click();
-  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}$`));
+  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}\\??$`));
   await expect(page.getByTestId("listen-rate")).toContainText(next.toFixed(1));
 });
 
@@ -247,7 +247,7 @@ test("dock sleep chip opens the full player", async ({ page, request }) => {
   await spaNavigateToLibrary(page);
 
   await page.getByTestId("mini-dock-sleep").click();
-  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}$`));
+  await expect(page).toHaveURL(new RegExp(`/listen/${uuid}\\??$`));
 });
 
 // ---------------------------------------------------------------------------

--- a/ui_tests/playwright/tests/flows/user_menu.spec.ts
+++ b/ui_tests/playwright/tests/flows/user_menu.spec.ts
@@ -119,7 +119,12 @@ for (const sample of [
       name: `${sample.action} ${latest.title}`,
     });
     await expect(card).toBeVisible();
-    await expect(card).toHaveAttribute("href", `/${sample.path}/${latest.uuid}`);
+    // The `/listen/:uuid?:file_id` route serializes an unset file_id as a bare
+    // trailing `?`, so tolerate it (the `/read` destination stays clean).
+    await expect(card).toHaveAttribute(
+      "href",
+      new RegExp(`^/${sample.path}/${latest.uuid}\\??$`),
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
On mobile, opening a book that has **both** an ebook and an audiobook (a merged EPUB + multi-part `.m4b`) errored, and — more fundamentally — the mobile player ignored **which part you picked** in the Listen dropdown, always loading the first file. Two problems:

1. `host.rs` used `book_files.first()` for the manifest `file_id`; `get_book_files` orders by format, so the EPUB sorts ahead of `M4B` and its id 404s against the audio manifest.
2. Mobile never read the picker's `?file_id=` at all — the route captured only `:uuid`, so tapping part 2/3 was discarded.

**Fix:**
- Select the first **audio** file (lowest ordinal among M4B/M4A/MP3) as the fallback — `first_audio_file_id`.
- Thread the picker's selection end-to-end: `file_id` is now a routed query param on `BookListen` (`Option<i64>`), carried through the `BookListen` wrapper → `BookListenPage` → `MobilePlayer` → `MobilePlayback`, and `host.rs` loads the selected file. `needs_reload` reloads on an explicit part switch but not on a bare mini-player relink (so resume doesn't restart from part 1). Web is unchanged (still reads `?file_id=` from `window.location`).

## Test plan
- [x] `cargo test -p omnibus-frontend --features mobile` (281) — new unit tests: `first_audio_file_id` (EPUB-first skip / lowest-ordinal / no-audio) and `needs_reload` (book change, explicit part switch, same-part/bare-relink no-op).
- [x] `cargo test -p omnibus-frontend --features server` (313) — web/route change no regressions.
- [x] `cargo clippy` + `cargo fmt` clean on both `--features mobile` and `--features server`.
- [x] Reproduced the 404 against the live DB (EPUB file_id resolves to 0 rows; M4B id resolves).

## Version
- [x] **Patch** — mobile playback bug fix.