### PR TITLE
chore: add SAFETY comment to unsafe block in native_share.rs (#1115)

### DIFF
--- a/frontend/src/native_share.rs
+++ b/frontend/src/native_share.rs
@@ -136,6 +136,9 @@ mod ios {
             return;
         };
 
+        // SAFETY: called on the main thread per `mtm`'s `MainThreadMarker` proof above;
+        // `activity_items` and `alloc(mtm)` are both valid Objective-C objects owned for
+        // the duration of this call.
         let avc = unsafe {
             UIActivityViewController::initWithActivityItems_applicationActivities(
                 UIActivityViewController::alloc(mtm),


### PR DESCRIPTION
## Summary
- Closes #1115
- Adds the `// SAFETY:` comment required by `.claude/rules/05-rust-style.md` § Mechanics to the `unsafe` block in `frontend/src/native_share.rs:139` (iOS `UIActivityViewController` FFI call), matching the convention already followed by the sibling JNI `unsafe` blocks in `frontend/src/data.rs`.

## Test plan
- [x] `cargo fmt -p omnibus-frontend` — no diff beyond the comment addition — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — 322 passed, 0 failed — PASS
- Note: the `#[cfg(target_os = "ios")]` module isn't compiled on this Linux build host, so the edit was verified by direct inspection plus `cargo fmt`'s (cfg-independent) source parsing rather than a mobile clippy run.

## Notes
- Comment-only change; no logic or behavior modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSQuYNkrrDbnJsoPxUMZNr)_