### PR TITLE
fix: contain the reading-days heatmap horizontal scroll on mobile

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -6844,9 +6844,16 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   .st-donut-body { flex-direction: column; gap: 16px; }
   .st-donut-legend { width: 100%; }
 
-  /* 52 heatmap columns don't fit a phone — scroll the card's grid. */
-  .st-heatmap { overflow-x: auto; padding-bottom: 4px; }
-  .st-heatmap .st-hm-cell { min-width: 8px; }
+  /* 52 heatmap columns don't fit a phone. Scroll the grid inside a
+     block-level wrapper (iOS WebKit clips a block scroll container far more
+     reliably than a grid-as-scroller, which bled off-screen — #1076), and
+     contain the overscroll so the horizontal swipe can't chain to the page. */
+  .st-heatmap-scroll {
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    padding-bottom: 4px;
+  }
+  .st-heatmap { grid-auto-columns: 8px; }
   .st-hm-months { display: none; }
   .st-streak-value { font-size: 28px; }
   .st-streak-unit { font-size: 13px; }

--- a/frontend/src/pages/stats/heatmap.rs
+++ b/frontend/src/pages/stats/heatmap.rs
@@ -175,11 +175,17 @@ pub(super) fn HeatmapCard(summary: StatsSummary) -> Element {
                     div { class: "label", "Longest streak" }
                 }
             }
-            div { class: "st-heatmap", role: "img", aria_label: "Daily reading activity, trailing year",
-                for cell in cells {
-                    div {
-                        class: if cell.future { "st-hm-cell st-hm-future" } else { "st-hm-cell st-hm-{cell.level}" },
-                        title: if !cell.future && cell.secs > 0 { "{format_active_time(cell.secs)} on {cell.day}" } else { "{cell.day}" },
+            // The grid lives inside a plain block-level scroll container: on a
+            // phone the 52 columns overflow the card, and a block wrapper clips
+            // that overflow far more reliably than a grid-as-scroller does on
+            // iOS WebKit (#1076).
+            div { class: "st-heatmap-scroll",
+                div { class: "st-heatmap", role: "img", aria_label: "Daily reading activity, trailing year",
+                    for cell in cells {
+                        div {
+                            class: if cell.future { "st-hm-cell st-hm-future" } else { "st-hm-cell st-hm-{cell.level}" },
+                            title: if !cell.future && cell.secs > 0 { "{format_active_time(cell.secs)} on {cell.day}" } else { "{cell.day}" },
+                        }
                     }
                 }
             }

--- a/frontend/src/pages/stats/heatmap.rs
+++ b/frontend/src/pages/stats/heatmap.rs
@@ -175,10 +175,7 @@ pub(super) fn HeatmapCard(summary: StatsSummary) -> Element {
                     div { class: "label", "Longest streak" }
                 }
             }
-            // The grid lives inside a plain block-level scroll container: on a
-            // phone the 52 columns overflow the card, and a block wrapper clips
-            // that overflow far more reliably than a grid-as-scroller does on
-            // iOS WebKit (#1076).
+            // Block-level scroll wrapper: iOS WebKit clips this far more reliably than a grid-as-scroller (#1076).
             div { class: "st-heatmap-scroll",
                 div { class: "st-heatmap", role: "img", aria_label: "Daily reading activity, trailing year",
                     for cell in cells {


### PR DESCRIPTION
## Summary
- The `/stats` reading-days heatmap set `overflow-x: auto` directly on the CSS grid. Desktop engines clip a grid-as-scroll-container, but iOS WKWebView doesn't reliably — so the 52-column grid (~569px) pushed the whole document ~235px wide on a phone, stretching the page off-screen.
- Move the scroll onto a block-level `.st-heatmap-scroll` wrapper (reliably clipped on every engine) and add `overscroll-behavior-x: contain` so the horizontal swipe can't chain to the page. Desktop keeps the full-width `1fr` grid unchanged.

Closes #1076.

## Test plan
- [x] Real app @ 375px: `documentElement.scrollWidth - clientWidth` is **0** (was **235**); heatmap scrolls inside its card, nothing bleeds off.
- [x] Real app @ 1280px: heatmap fills full width, `grid-auto-columns: 1fr`, no scroll — no regression.
- [x] Standalone WebKit (Playwright) repro: block wrapper clips to `right < viewport`; the grid-as-scroller was the divergent pattern.
- [x] `just lint-css` + `cargo fmt --check` pass; `stats.spec.ts` selectors still match through the new wrapper.

## Version
- [x] **Patch** — default.

## Notes
- Same grid-as-scroller pattern exists on the drill-in trend chart (`.st-drill-trend`), but it has few columns and isn't on the initial page; left as-is to keep this fix scoped.