### PR TITLE
fix: reload web audiobook player when re-picking a part of the active book

### DIFF
--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -215,6 +215,10 @@ pub fn use_current_user_summary() -> ReadSignal<Option<omnibus_shared::UserSumma
 #[derive(Copy, Clone)]
 pub struct PlaybackState {
     pub uuid: Signal<Option<String>>,
+    /// The `book_files` row the picker selected (`?file_id=`). `None` lets the
+    /// backend pick the lowest-ordinal audio file. Tracked as a signal so the
+    /// App-level driver reboots when the *same* book's selected file changes.
+    pub file_id: Signal<Option<i64>>,
     pub book: Signal<Option<omnibus_shared::EbookMetadata>>,
     pub loading: Signal<bool>,
     pub error: Signal<Option<String>>,
@@ -238,6 +242,7 @@ impl PlaybackState {
     pub fn new() -> Self {
         Self {
             uuid: Signal::new(None),
+            file_id: Signal::new(None),
             book: Signal::new(None),
             loading: Signal::new(false),
             error: Signal::new(None),

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -101,6 +101,9 @@ pub fn BookListenPage(uuid: String, file_id: Option<i64>) -> Element {
             let mut loading_sig = playback.loading;
             let mut book_sig = playback.book;
             let mut error_sig = playback.error;
+            // Publish the picker's selection first so the driver reads the right
+            // file when the uuid change kicks off the load (mirrors mobile).
+            file_sig.set(route_file_id);
             if uuid_sig.peek().as_deref() != Some(route_uuid.as_str()) {
                 // Clear the previous book's app-global metadata before
                 // retargeting so a re-render can't show the old book (or its
@@ -111,7 +114,6 @@ pub fn BookListenPage(uuid: String, file_id: Option<i64>) -> Element {
                 loading_sig.set(true);
                 uuid_sig.set(Some(route_uuid.clone()));
             }
-            file_sig.set(route_file_id);
         }));
 
         let active = playback.uuid.read().as_deref() == Some(uuid.as_str());

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -84,18 +84,20 @@ pub fn BookListenPage(uuid: String, file_id: Option<i64>) -> Element {
 
     #[cfg(not(feature = "mobile"))]
     {
-        // Web resolves the picker's `?file_id=` from `window.location` in the
-        // app-root playback bootstrap, so the routed prop is unused here.
-        let _ = file_id;
         let playback = use_playback();
 
-        // Point the app-wide player at this route's book. The App-level
-        // driver (install_audio_bootstrap) reacts to `uuid` and does the
-        // fetch + manifest init; we only retarget it, and only when it
-        // differs so re-entering an already-playing book is seamless.
+        // Point the app-wide player at this route's book + selected file. The
+        // App-level driver (install_audio_bootstrap) reacts to both `uuid` and
+        // `file_id` and does the fetch + manifest init; we only retarget. The
+        // uuid write (which clears the prior book) fires only when the book
+        // differs so re-entering an already-playing book is seamless, but the
+        // file_id signal always tracks the route so the picker's `?file_id=`
+        // reboots the *same* book onto the chosen part.
         let route_uuid = uuid.clone();
-        use_effect(use_reactive!(|route_uuid| {
+        let route_file_id = file_id;
+        use_effect(use_reactive!(|(route_uuid, route_file_id)| {
             let mut uuid_sig = playback.uuid;
+            let mut file_sig = playback.file_id;
             let mut loading_sig = playback.loading;
             let mut book_sig = playback.book;
             let mut error_sig = playback.error;
@@ -109,6 +111,7 @@ pub fn BookListenPage(uuid: String, file_id: Option<i64>) -> Element {
                 loading_sig.set(true);
                 uuid_sig.set(Some(route_uuid.clone()));
             }
+            file_sig.set(route_file_id);
         }));
 
         let active = playback.uuid.read().as_deref() == Some(uuid.as_str());

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -30,12 +30,20 @@ fn resolve_resume_pos(server_pos: Option<f64>, local_pos: f64) -> f64 {
     server_pos.unwrap_or(local_pos)
 }
 
-/// Extract `file_id` from the current URL's query string (`?file_id=N`),
-/// targeting a specific `book_files` row for multi-file audiobooks.
-fn parse_file_id_from_url() -> Option<i64> {
-    let search = web_sys::window()?.location().search().ok()?;
-    let params = web_sys::UrlSearchParams::new_with_str(&search).ok()?;
-    params.get("file_id")?.parse().ok()
+/// Whether the driver must (re)load for a newly-requested `(uuid, file_id)`.
+///
+/// A different book always reloads. The *same* book reloads only on an
+/// explicit, different file selection — so picking another part in the file
+/// picker switches parts, while the mini-dock (which relinks with no
+/// `file_id`) resumes the current part instead of restarting from the first
+/// file. Mirrors `pages::listen::mobile::host::needs_reload`.
+fn needs_reload(loaded: &Option<(String, Option<i64>)>, uuid: &str, file_id: Option<i64>) -> bool {
+    match loaded {
+        Some((loaded_uuid, loaded_file)) if loaded_uuid == uuid => {
+            file_id.is_some() && file_id != *loaded_file
+        }
+        _ => true,
+    }
 }
 
 /// App-root playback driver. Installs the `window.OmnibusAudio` shim and
@@ -43,10 +51,11 @@ fn parse_file_id_from_url() -> Option<i64> {
 ///
 /// Called once from [`crate::App`] (so the audio element and all signals
 /// outlive any single route). The inner `use_effect` reacts to
-/// `playback.uuid`: setting it (the listen page on mount, or a dock dismiss
-/// that clears it) loads, swaps, or tears down playback. Because the signals
-/// now outlive the page, every book swap must reset the prior book's state
-/// before installing fresh callbacks.
+/// `playback.uuid` and `playback.file_id`: retargeting either (the listen
+/// page on mount / a picker selection, or a dock dismiss that clears the
+/// uuid) loads, swaps, or tears down playback, gated by [`needs_reload`].
+/// Because the signals now outlive the page, every book swap must reset the
+/// prior book's state before installing fresh callbacks.
 pub(crate) fn install_audio_bootstrap(playback: crate::PlaybackState) {
     let cb_holder: JsCallbackHolder =
         use_hook(|| std::rc::Rc::new(std::cell::RefCell::new(Vec::new())));
@@ -67,6 +76,11 @@ pub(crate) fn install_audio_bootstrap(playback: crate::PlaybackState) {
     let server_url = use_signal(String::new);
     crate::session_tracker::use_listening_session(playback.uuid, playback.playing, server_url);
 
+    // What's currently booted: (book uuid, the file_id it was booted with).
+    // Gates re-boot so a same-book file-pick reloads but a bare mini-dock
+    // relink resumes the current part. Held across renders via `use_hook`.
+    let mut loaded_key = use_hook(|| Signal::new(None::<(String, Option<i64>)>));
+
     use_effect(move || {
         let resolved_user = current_user();
         if matches!(resolved_user, Some(None)) {
@@ -74,16 +88,32 @@ pub(crate) fn install_audio_bootstrap(playback: crate::PlaybackState) {
             uuid.set(None);
             return;
         }
-        // The only reactive dependency — re-run when the active book changes.
-        let Some(uuid) = playback.uuid.read().clone() else {
+        // Reactive dependencies — re-run when the active book *or* the selected
+        // file changes (the picker retargets `file_id` without changing uuid).
+        let requested_uuid = playback.uuid.read().clone();
+        let requested_file = *playback.file_id.read();
+        let Some(uuid) = requested_uuid else {
             // Dismissed via the dock × button. The handler already stopped
-            // the element; clear the book so the dock hides everywhere.
+            // the element; clear the book so the dock hides everywhere, and
+            // forget the booted key so re-selecting the same book reloads.
             let mut book = playback.book;
             book.set(None);
+            loaded_key.set(None);
             return;
         };
+        if !needs_reload(&loaded_key.peek().clone(), &uuid, requested_file) {
+            return;
+        }
+        loaded_key.set(Some((uuid.clone(), requested_file)));
         let user_id = resolved_user.flatten().map(|user| user.id);
-        boot_new_book(&cb_holder, &uuid, user_id, current_user, playback);
+        boot_new_book(
+            &cb_holder,
+            &uuid,
+            requested_file,
+            user_id,
+            current_user,
+            playback,
+        );
     });
 }
 
@@ -94,6 +124,7 @@ pub(crate) fn install_audio_bootstrap(playback: crate::PlaybackState) {
 fn boot_new_book(
     cb_holder: &JsCallbackHolder,
     uuid: &str,
+    file_id: Option<i64>,
     user_id: Option<i64>,
     current_user: Signal<Option<Option<omnibus_shared::UserSummary>>>,
     playback: crate::PlaybackState,
@@ -134,6 +165,7 @@ fn boot_new_book(
     spawn_book_metadata_fetch(uuid.to_string(), guard, playback);
     spawn_manifest_init(
         uuid.to_string(),
+        file_id,
         user_id,
         initial_position,
         playback,
@@ -199,19 +231,26 @@ fn spawn_book_metadata_fetch(
 }
 
 /// Kick off the manifest fetch + branch on `mode` (direct/HLS/none). The
-/// active book's `file_id` (multi-file books) rides on the listen route's
-/// query string; read it here since the App-level driver no longer
-/// receives it as a param.
+/// active book's `file_id` (multi-file books) is the picker's selection,
+/// threaded down from the driver's `(uuid, file_id)` reload key.
 fn spawn_manifest_init(
     uuid: String,
+    file_id: Option<i64>,
     user_id: Option<i64>,
     initial_position: f64,
     playback: crate::PlaybackState,
     current_user: Signal<Option<Option<omnibus_shared::UserSummary>>>,
 ) {
-    let fid = parse_file_id_from_url();
     spawn(async move {
-        run_manifest_init(uuid, fid, user_id, initial_position, playback, current_user).await;
+        run_manifest_init(
+            uuid,
+            file_id,
+            user_id,
+            initial_position,
+            playback,
+            current_user,
+        )
+        .await;
     });
 }
 
@@ -529,5 +568,27 @@ mod tests {
     #[test]
     fn resolve_resume_pos_returns_zero_local_when_both_absent() {
         assert!((resolve_resume_pos(None, 0.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn needs_reload_when_nothing_booted_or_book_changed() {
+        assert!(needs_reload(&None, "book-a", None));
+        let booted = Some(("book-a".to_string(), Some(917)));
+        assert!(needs_reload(&booted, "book-b", Some(940)));
+    }
+
+    #[test]
+    fn needs_reload_on_explicit_different_part_of_same_book() {
+        let booted = Some(("book-a".to_string(), Some(917)));
+        assert!(needs_reload(&booted, "book-a", Some(918)));
+    }
+
+    #[test]
+    fn no_reload_for_same_part_or_bare_relink_of_same_book() {
+        let booted = Some(("book-a".to_string(), Some(917)));
+        // Same part re-selected → no restart.
+        assert!(!needs_reload(&booted, "book-a", Some(917)));
+        // Mini-dock relinks with no file_id → keep the current part.
+        assert!(!needs_reload(&booted, "book-a", None));
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "omnibus-xray",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -704,4 +704,85 @@ test.describe("audiobook-only seed", () => {
       }
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Regression: picking a different part of the *already-playing* book must
+  // switch parts. The app-root web driver used to react only to the book uuid
+  // (constant across a book's files), so re-picking a file on the active book
+  // silently kept part 1. Assert a fresh manifest fetch fires for the newly
+  // selected file_id even when the uuid is unchanged.
+  // ---------------------------------------------------------------------------
+
+  test("re-picking a different part of the already-active audiobook reloads onto that part", async ({
+    page,
+    request,
+  }) => {
+    test.slow();
+    await withLock("audiobook-merge", async () => {
+      const primaryUuid = await fetchBookUuidByTitle(request, PRIMARY_MP3.title);
+      const secondUuid = await fetchBookUuidByTitle(request, SECOND_MP3.title);
+
+      const mergeResp = await request.post("/api/rpc/merge-books", {
+        data: { source_uuid: secondUuid, target_uuid: primaryUuid },
+      });
+      expect(mergeResp.status(), "POST /api/rpc/merge-books failed").toBe(200);
+      const { merge_log_id: mergeLogId } = (await mergeResp.json()) as {
+        merge_log_id: number;
+      };
+
+      try {
+        // The two audio `book_files` rows the merge produced, in file-picker
+        // order (`GET /api/ebooks/:uuid` returns them by ordinal).
+        const detailResp = await request.get(`/api/ebooks/${primaryUuid}`);
+        expect(detailResp.status(), "GET /api/ebooks/:uuid failed").toBe(200);
+        const detail = (await detailResp.json()) as {
+          book_files: { id: number; format: string }[];
+        };
+        const audioIds = detail.book_files
+          .filter((f) => /^(mp3|m4b|m4a)$/i.test(f.format))
+          .map((f) => f.id);
+        expect(audioIds.length, "expected two audio files after merge").toBe(2);
+        const [firstId, secondId] = audioIds;
+
+        // Load the FIRST part directly — this makes the book the active
+        // playback book (uuid now set on the app-root PlaybackState).
+        const [firstManifest] = await Promise.all([
+          page.waitForRequest((req) =>
+            req.url().includes(`/api/audiobooks/${primaryUuid}/manifest?file_id=${firstId}`),
+          ),
+          gotoReady(page, `/listen/${primaryUuid}?file_id=${firstId}`),
+        ]);
+        expect(firstManifest.url()).toContain(`file_id=${firstId}`);
+
+        // SPA-navigate to the SECOND part of the *same* book (uuid unchanged,
+        // only file_id differs). A true anchor click keeps it client-side, so
+        // the app-root driver must notice the file_id change and reboot.
+        await page.evaluate((url) => {
+          const a = document.createElement("a");
+          a.href = url;
+          a.id = "__test-repick-nav";
+          a.textContent = "repick-nav";
+          a.style.cssText =
+            "position:fixed;top:0;left:0;padding:8px;background:#000;color:#fff;z-index:99999;";
+          document.body.appendChild(a);
+        }, `/listen/${primaryUuid}?file_id=${secondId}`);
+
+        // Before the fix this request never fired (uuid unchanged → no reboot).
+        const [secondManifest] = await Promise.all([
+          page.waitForRequest(
+            (req) =>
+              req.url().includes(`/api/audiobooks/${primaryUuid}/manifest?file_id=${secondId}`),
+            { timeout: 10_000 },
+          ),
+          page.locator("#__test-repick-nav").click(),
+        ]);
+        expect(secondManifest.url()).toContain(`file_id=${secondId}`);
+      } finally {
+        const undoResp = await request.post("/api/rpc/merge-books/undo", {
+          data: { merge_log_id: mergeLogId },
+        });
+        expect(undoResp.status(), "POST /api/rpc/merge-books/undo failed").toBe(200);
+      }
+    });
+  });
 });

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -757,7 +757,11 @@ test.describe("audiobook-only seed", () => {
         // SPA-navigate to the SECOND part of the *same* book (uuid unchanged,
         // only file_id differs). A true anchor click keeps it client-side, so
         // the app-root driver must notice the file_id change and reboot.
+        // Sentinel on `window` proves the nav stayed in-app: a full page load
+        // would clear it, and a full load refetches the manifest regardless of
+        // the fix — so without this guard the test could false-positive.
         await page.evaluate((url) => {
+          (window as unknown as { __repickSentinel?: boolean }).__repickSentinel = true;
           const a = document.createElement("a");
           a.href = url;
           a.id = "__test-repick-nav";
@@ -777,6 +781,13 @@ test.describe("audiobook-only seed", () => {
           page.locator("#__test-repick-nav").click(),
         ]);
         expect(secondManifest.url()).toContain(`file_id=${secondId}`);
+
+        // The nav must have been a client-side SPA transition — if the page
+        // fully reloaded, the manifest fetch above proves nothing.
+        const stayedInApp = await page.evaluate(
+          () => (window as unknown as { __repickSentinel?: boolean }).__repickSentinel === true,
+        );
+        expect(stayedInApp, "re-pick nav must stay in-app (no full page load)").toBe(true);
       } finally {
         const undoResp = await request.post("/api/rpc/merge-books/undo", {
           data: { merge_log_id: mergeLogId },


### PR DESCRIPTION
## Summary
Selecting a different part of an audiobook that was **already playing** silently kept part 1 on web. The app-root playback driver reacted only to `playback.uuid` (constant across a book's files) and read `file_id` once from the URL at boot, so a same-book file pick never rebooted playback.

- Add a `file_id` signal to web `PlaybackState`; `BookListenPage` retargets it from the listen route.
- Gate the driver's re-boot on a `needs_reload((uuid, file_id))` check mirroring the mobile host — a same-book file pick reloads, a bare mini-dock relink (`file_id: None`) resumes the current part.

## Test plan
- [x] `cargo check` + `clippy` clean on `server` and `wasm32` (web) targets; `cargo fmt` clean.
- [x] `cargo test -p omnibus-frontend --features server` — 330 passed; added a `needs_reload` unit test.
- [ ] Playwright regression `re-picking a different part of the already-active audiobook reloads onto that part` (CI — local Chromium unavailable).

## Version
- [ ] **Minor**
- [x] **Patch** — default.
- [ ] **No release**

## Notes
- Web-only fix; the mobile host already had the `needs_reload` gate this mirrors.