### PR TITLE
fix: persist theme selection on mobile (#1125)

### DIFF
--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -11,7 +11,8 @@ use crate::{media_url, use_server_url};
 
 // ── Theme state ────────────────────────────────────────────────────
 
-/// Atrium theme. Persisted under `omn.theme` in localStorage on web.
+/// Atrium theme. Persisted under `omn.theme` via [`crate::client_store`]
+/// (`localStorage` on web, a JSON file on mobile).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Theme {
     Dark,
@@ -46,27 +47,21 @@ impl Theme {
 /// component.
 ///
 /// SSR-safe by construction: the signal always starts as `Theme::Dark` so
-/// server-rendered markup is deterministic and matches the WASM client's
-/// first paint (no hydration mismatch on the `data-theme` attribute). A
-/// web-only `use_effect` then reads `localStorage["omn.theme"]` after the
-/// component mounts and updates the signal if the user has a stored
-/// preference, triggering a single re-render to apply it.
+/// server-rendered markup is deterministic and matches the first paint on
+/// every client target (no hydration mismatch on the `data-theme`
+/// attribute). A target-agnostic `use_effect` then reads the persisted value
+/// back via [`crate::client_store`] (`localStorage` on web, a JSON file on
+/// mobile, always `None` on SSR) after the component mounts and updates the
+/// signal if the user has a stored preference, triggering a single
+/// re-render to apply it. Mirrors the `view_prefs` hydration pattern in
+/// `frontend/src/pages/landing.rs`.
 pub fn init_theme() {
-    // Server / mobile builds only need the signal context — `theme` is
-    // unused in those targets, hence the `_` prefix to keep clippy quiet
-    // under `-D warnings`. The web build shadows it with a mutable binding
-    // inside the `#[cfg(feature = "web")]` block below so the
-    // post-hydration `use_effect` can write to it.
-    let _theme = use_context_provider(|| Signal::new(Theme::Dark));
-    #[cfg(feature = "web")]
-    {
-        let mut theme = _theme;
-        use_effect(move || {
-            if let Some(persisted) = read_persisted_theme() {
-                theme.set(persisted);
-            }
-        });
-    }
+    let mut theme = use_context_provider(|| Signal::new(Theme::Dark));
+    use_effect(move || {
+        if let Some(persisted) = read_persisted_theme() {
+            theme.set(persisted);
+        }
+    });
 }
 
 /// Wrap the app body in the Atrium themed container. The `data-theme`
@@ -200,28 +195,21 @@ pub(crate) fn fallback_title(title: Option<&str>, filename: &str) -> String {
 
 // ── Persistence ───────────────────────────────────────────────────
 
-#[cfg(feature = "web")]
+const THEME_STORAGE_KEY: &str = "omn.theme";
+
+/// Persist the chosen theme via [`crate::client_store`]: `localStorage` on
+/// web, a JSON file under the app data dir on mobile (survives cold
+/// launch — this is what fixes theme reset on app close/reopen, issue
+/// #1125), a no-op on SSR.
 pub(crate) fn persist_theme(t: Theme) {
-    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
-        let _ = storage.set_item("omn.theme", t.as_attr());
-    }
+    crate::client_store::set(THEME_STORAGE_KEY, t.as_attr());
 }
 
-#[cfg(not(feature = "web"))]
-pub(crate) fn persist_theme(_t: Theme) {
-    // TODO(F1.7-mobile): persist to $HOME/.omnibus-theme in debug builds,
-    // analogous to data::token_store.
-}
-
-/// Web-only: read the persisted theme value from `localStorage`. The
-/// `init_theme` `use_effect` call site is itself `#[cfg(feature = "web")]`,
-/// so this function only exists when the WASM client is being built. No
-/// non-web stub — the call is gated, so the symbol is never referenced
-/// on server / mobile builds.
-#[cfg(feature = "web")]
+/// Read the persisted theme value back via [`crate::client_store`]. Returns
+/// `None` when nothing is stored, storage is unavailable, or the stored
+/// value doesn't parse as a known [`Theme`].
 fn read_persisted_theme() -> Option<Theme> {
-    let storage = web_sys::window().and_then(|w| w.local_storage().ok().flatten())?;
-    let value = storage.get_item("omn.theme").ok().flatten()?;
+    let value = crate::client_store::get(THEME_STORAGE_KEY)?;
     Theme::from_attr(&value)
 }
 
@@ -259,5 +247,27 @@ mod tests {
     #[test]
     fn fallback_title_uses_filename_for_whitespace_only_title() {
         assert_eq!(fallback_title(Some("   "), "dune.epub"), "dune.epub");
+    }
+}
+
+// SSR / server-only tests — exercise the no-persistence path that compiles
+// under the default `cargo test -p omnibus-frontend --features server`. The
+// `web`/`mobile` persistence lives in `client_store` behind its own cfgs
+// (already covered there) and is unreachable here; this module pins the
+// documented SSR contract instead: `persist_theme` is inert and
+// `read_persisted_theme` always sees nothing, so `init_theme` keeps its
+// deterministic `Theme::Dark` default for SSR markup (issue #1125 fix:
+// before this change, `persist_theme` had a separate `#[cfg(not(feature =
+// "web"))]` no-op branch that also silently swallowed mobile writes — now
+// mobile routes through `client_store` instead of that branch).
+#[cfg(all(test, not(any(feature = "web", feature = "mobile"))))]
+mod ssr_tests {
+    use super::*;
+
+    #[test]
+    fn persist_theme_is_a_noop_and_read_persisted_theme_stays_none() {
+        assert_eq!(read_persisted_theme(), None);
+        persist_theme(Theme::Sepia);
+        assert_eq!(read_persisted_theme(), None);
     }
 }

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -199,8 +199,7 @@ const THEME_STORAGE_KEY: &str = "omn.theme";
 
 /// Persist the chosen theme via [`crate::client_store`]: `localStorage` on
 /// web, a JSON file under the app data dir on mobile (survives cold
-/// launch — this is what fixes theme reset on app close/reopen, issue
-/// #1125), a no-op on SSR.
+/// launch), a no-op on SSR.
 pub(crate) fn persist_theme(t: Theme) {
     crate::client_store::set(THEME_STORAGE_KEY, t.as_attr());
 }
@@ -250,16 +249,9 @@ mod tests {
     }
 }
 
-// SSR / server-only tests — exercise the no-persistence path that compiles
-// under the default `cargo test -p omnibus-frontend --features server`. The
-// `web`/`mobile` persistence lives in `client_store` behind its own cfgs
-// (already covered there) and is unreachable here; this module pins the
-// documented SSR contract instead: `persist_theme` is inert and
-// `read_persisted_theme` always sees nothing, so `init_theme` keeps its
-// deterministic `Theme::Dark` default for SSR markup (issue #1125 fix:
-// before this change, `persist_theme` had a separate `#[cfg(not(feature =
-// "web"))]` no-op branch that also silently swallowed mobile writes — now
-// mobile routes through `client_store` instead of that branch).
+// SSR has no persistence: `persist_theme` is inert and `read_persisted_theme`
+// always sees nothing, so `init_theme` keeps its deterministic `Theme::Dark`
+// default for SSR markup.
 #[cfg(all(test, not(any(feature = "web", feature = "mobile"))))]
 mod ssr_tests {
     use super::*;


### PR DESCRIPTION
## Summary
- Closes #1125 — on mobile (TestFlight iPhone17_3, build 25), choosing a dark/light/sepia theme didn't survive an app close/reopen; it always reset.
- Root cause: `frontend/src/components/atrium.rs`'s `persist_theme`/`read_persisted_theme` were `localStorage`-backed behind `#[cfg(feature = "web")]`, with a separate `#[cfg(not(feature = "web"))]` branch for `persist_theme` that was a bare no-op — so mobile writes silently went nowhere, and `init_theme`'s load-back `use_effect` never even ran on mobile.
- Fix: route both through `frontend/src/client_store.rs`, the durable key→value store already used by `view_prefs.rs`/`index_prefs.rs` (`localStorage` on web, a JSON file under the app data dir on mobile — survives cold launch, inert on SSR). `init_theme`'s `use_effect` is no longer `#[cfg(feature = "web")]`-gated; it now runs (harmlessly) on every target, mirroring the `view_prefs` hydration pattern in `frontend/src/pages/landing.rs`. No rsx body divergence introduced — same component markup on every target per the hydration-parity rule.

## Test plan
- [x] `cargo fmt` (CARGO_TARGET_DIR=/tmp/omnibus-target-1125) — clean, no reformatting beyond the intended diff
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, 0 warnings
- [x] `cargo clippy -p omnibus-frontend --all-targets --features mobile -- -D warnings` — PASS, 0 warnings (mobile toolchain available in this environment)
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 343 passed; 0 failed
- [x] Added `atrium.rs::ssr_tests::persist_theme_is_a_noop_and_read_persisted_theme_stays_none`, pinning the documented SSR no-persistence contract (mirrors `view_prefs.rs::ssr_tests`)

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- **AC3 tradeoff**: the load-back is a post-mount `use_effect` (unchanged shape from the prior web-only version), so mobile's first paint still renders `Theme::Dark` before the effect corrects it — a brief flash-of-default is possible on cold launch, same as web's existing behavior. `client_store`'s mobile reads are synchronous (an in-memory map seeded once from disk via `OnceLock`, not an async `dioxus::document::eval` round-trip into the WebView), so this is about as tight as it gets without moving the read earlier than component mount.
- Shares the same architectural gap (`web`-only persistence, no mobile equivalent) as issue #1120, which a concurrent PR is fixing for `ReaderPrefs`'s typography prefs. This PR is file-disjoint from that one — it only touches `frontend/src/components/atrium.rs` (app-wide theme), not anything under `frontend/src/pages/reader/`.
- Scope note: this PR does *not* touch `frontend/src/pages/reader/prefs.rs`, which also calls the shared `persist_theme` — that call site is unaffected by this change (same function signature, just a fixed implementation underneath), so #1120's owner doesn't need to coordinate on this file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcLhyy9GtFitcjYNF9qARV)_