### PR TITLE
refactor: journal image orphan cleanup (#1083)

### DIFF
--- a/db/src/journal_images.rs
+++ b/db/src/journal_images.rs
@@ -11,7 +11,7 @@
 //! (which deletes the draft row) and an abandoned-then-edited draft. An
 //! upload whose draft is *never* saved or explicitly cancelled (e.g. the tab
 //! is closed mid-compose) is not swept; that residual case was judged not
-//! worth a periodic boot sweep for the added complexity (issue #1083).
+//! worth a periodic boot sweep for the added complexity.
 
 use std::collections::HashSet;
 use std::path::PathBuf;

--- a/db/src/journal_images.rs
+++ b/db/src/journal_images.rs
@@ -1,8 +1,19 @@
 //! Filesystem storage for images embedded in journal entries (F3.2b).
 //! Files live under `<journal_images_dir()>/<uuidv4>.<ext>` and are served by
-//! `GET /api/journals/images/{name}`. Durable user data — not a regenerable
-//! cache like thumbs/kepub — so nothing here evicts.
+//! `GET /api/journals/images/{name}`. Unlike thumbs/kepub this is durable user
+//! data, not a regenerable cache — so there is no capacity-based eviction.
+//! Orphans (an upload whose draft/entry is discarded or edited to remove it)
+//! are cleaned up best-effort by `journals::{update_journal_entry,
+//! delete_journal_entry}`, which diff before/after `body_md` image references
+//! and delete any file no longer referenced by any entry. There is no
+//! separate drafts table — a draft is a `journal_entries` row with
+//! `status = 'draft'` — so this also covers the composer's Cancel button
+//! (which deletes the draft row) and an abandoned-then-edited draft. An
+//! upload whose draft is *never* saved or explicitly cancelled (e.g. the tab
+//! is closed mid-compose) is not swept; that residual case was judged not
+//! worth a periodic boot sweep for the added complexity (issue #1083).
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// Root directory for journal images.
@@ -62,6 +73,43 @@ fn is_valid_image_name(name: &str) -> bool {
         return false;
     };
     matches!(ext, "jpg" | "png" | "gif" | "webp") && uuid::Uuid::parse_str(stem).is_ok()
+}
+
+/// Every journal-image serving name referenced in `body_md` via the
+/// `IMAGE_URL_PREFIX` embed URL (`journals::markdown::IMAGE_URL_PREFIX`), for
+/// orphan-cleanup diffing. Malformed matches (a prefix not followed by a
+/// well-formed `<uuidv4>.<ext>` name) are ignored rather than collected.
+pub fn referenced_image_names(body_md: &str) -> HashSet<String> {
+    let prefix = crate::journals::markdown::IMAGE_URL_PREFIX;
+    let mut names = HashSet::new();
+    let mut rest = body_md;
+    while let Some(pos) = rest.find(prefix) {
+        let after = &rest[pos + prefix.len()..];
+        let end = after
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '.'))
+            .unwrap_or(after.len());
+        let name = &after[..end];
+        if is_valid_image_name(name) {
+            names.insert(name.to_string());
+        }
+        rest = &after[end..];
+    }
+    names
+}
+
+/// Best-effort delete of a stored journal image by its serving name. A
+/// missing file and a malformed name are both no-ops; a real I/O error is
+/// logged, not propagated — this is opportunistic orphan GC, not a
+/// correctness-critical path. Sync `std::fs` — call from `spawn_blocking`.
+pub fn delete_journal_image(name: &str) {
+    if !is_valid_image_name(name) {
+        return;
+    }
+    if let Err(e) = std::fs::remove_file(journal_images_dir().join(name)) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(name, error = %e, "failed to delete orphaned journal image");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/db/src/journal_images/tests.rs
+++ b/db/src/journal_images/tests.rs
@@ -1,5 +1,6 @@
 //! Unit tests for the `journal_images` module — write/read round-trip,
-//! unsupported-mime rejection, and path-traversal/malformed-name rejection.
+//! unsupported-mime rejection, path-traversal/malformed-name rejection, and
+//! the orphan-cleanup helpers (`referenced_image_names`, `delete_journal_image`).
 
 use super::*;
 use crate::test_support::EnvVarGuard;
@@ -45,5 +46,47 @@ fn read_journal_image_rejects_traversal_and_malformed_names() {
         ] {
             assert!(read_journal_image(name).is_none(), "must reject {name}");
         }
+    });
+}
+
+#[test]
+fn referenced_image_names_extracts_every_embed_url_and_ignores_the_rest() {
+    let a = format!(
+        "{}0b0c8bcc-2f5c-4f8e-9df1-0a2f4e21a111.png",
+        crate::journals::markdown::IMAGE_URL_PREFIX
+    );
+    let b = format!(
+        "{}1c1d9ddd-3f6d-5f9f-0e02-1b3f5f32b222.jpg",
+        crate::journals::markdown::IMAGE_URL_PREFIX
+    );
+    let body =
+        format!("![alt]({a}) some text ![alt2]({b}) and a bogus one https://evil.example/x.png");
+    let names = referenced_image_names(&body);
+    assert_eq!(names.len(), 2, "got: {names:?}");
+    assert!(names.contains("0b0c8bcc-2f5c-4f8e-9df1-0a2f4e21a111.png"));
+    assert!(names.contains("1c1d9ddd-3f6d-5f9f-0e02-1b3f5f32b222.jpg"));
+}
+
+#[test]
+fn referenced_image_names_ignores_malformed_names_and_empty_body() {
+    let body = format!(
+        "{}not-a-uuid.png",
+        crate::journals::markdown::IMAGE_URL_PREFIX
+    );
+    assert!(referenced_image_names(&body).is_empty());
+    assert!(referenced_image_names("").is_empty());
+}
+
+#[test]
+fn delete_journal_image_removes_an_existing_file_and_is_a_noop_for_a_missing_one() {
+    with_temp_dir(|| {
+        let name = write_journal_image("image/png", b"bytes").unwrap();
+        assert!(read_journal_image(&name).is_some());
+
+        delete_journal_image(&name);
+        assert!(read_journal_image(&name).is_none());
+
+        // Deleting again (already gone) must not panic.
+        delete_journal_image(&name);
     });
 }

--- a/db/src/journals/mod.rs
+++ b/db/src/journals/mod.rs
@@ -8,6 +8,8 @@
 //! FK/cascade) through the merged-uuid-aware canonical resolver. Markdown is
 //! rendered to sanitized HTML on read (see [`markdown`]).
 
+use std::collections::HashSet;
+
 use omnibus_shared::{CreateJournalEntry, JournalEntry, UpdateJournalEntry};
 use sqlx::{Row, SqlitePool};
 
@@ -110,13 +112,21 @@ pub async fn list_journal_entries(
 
 /// Edit an entry owned by `user_id`, returning the updated row. Errors with
 /// `NotFound` when the id does not exist or belongs to another user (the two
-/// cases are deliberately indistinguishable).
+/// cases are deliberately indistinguishable). Any journal image referenced in
+/// the old body but not the new one is opportunistically GC'd (issue #1083)
+/// — see [`cleanup_orphaned_images`].
 pub async fn update_journal_entry(
     pool: &SqlitePool,
     user_id: i64,
     entry_id: i64,
     input: &UpdateJournalEntry,
 ) -> Result<JournalEntry, JournalError> {
+    let old_body: Option<String> =
+        sqlx::query_scalar("SELECT body_md FROM journal_entries WHERE id = ? AND user_id = ?")
+            .bind(entry_id)
+            .bind(user_id)
+            .fetch_optional(pool)
+            .await?;
     let result = sqlx::query(
         "UPDATE journal_entries
             SET body_md = ?, progress = ?, status = COALESCE(?, status),
@@ -133,25 +143,83 @@ pub async fn update_journal_entry(
     if result.rows_affected() == 0 {
         return Err(JournalError::NotFound);
     }
+    if let Some(old_body) = old_body {
+        let removed: HashSet<String> = crate::journal_images::referenced_image_names(&old_body)
+            .difference(&crate::journal_images::referenced_image_names(
+                &input.body_md,
+            ))
+            .cloned()
+            .collect();
+        cleanup_orphaned_images(pool, removed).await;
+    }
     get_entry_by_id(pool, entry_id).await
 }
 
 /// Delete an entry owned by `user_id`. Errors with `NotFound` when the id does
-/// not exist or belongs to another user.
+/// not exist or belongs to another user. Any journal image uniquely
+/// referenced by the deleted entry's body is opportunistically GC'd (issue
+/// #1083, e.g. the composer's Cancel button discarding a draft) — see
+/// [`cleanup_orphaned_images`].
 pub async fn delete_journal_entry(
     pool: &SqlitePool,
     user_id: i64,
     entry_id: i64,
 ) -> Result<(), JournalError> {
-    let result = sqlx::query("DELETE FROM journal_entries WHERE id = ? AND user_id = ?")
-        .bind(entry_id)
-        .bind(user_id)
-        .execute(pool)
-        .await?;
-    if result.rows_affected() == 0 {
+    let deleted: Option<String> = sqlx::query_scalar(
+        "DELETE FROM journal_entries WHERE id = ? AND user_id = ? RETURNING body_md",
+    )
+    .bind(entry_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+    let Some(body_md) = deleted else {
         return Err(JournalError::NotFound);
-    }
+    };
+    cleanup_orphaned_images(
+        pool,
+        crate::journal_images::referenced_image_names(&body_md),
+    )
+    .await;
     Ok(())
+}
+
+/// Best-effort delete of any `candidates` no longer referenced by any
+/// `journal_entries.body_md`. Called only after the caller's own mutation
+/// has already committed, so a plain substring scan (no self-exclusion) is
+/// correct: the caller's row either no longer contains the name (edit) or no
+/// longer exists (delete). Failures — a DB error on the reference check, or
+/// a panic in the filesystem unlink — are logged and swallowed: this is
+/// opportunistic GC of an orphanable-but-durable file store, not a
+/// correctness-critical path, and must never fail the journal mutation that
+/// triggered it (mirrors `set_settings`'s cover cleanup).
+async fn cleanup_orphaned_images(pool: &SqlitePool, candidates: HashSet<String>) {
+    let mut orphaned = Vec::new();
+    for name in &candidates {
+        let still_referenced: Result<bool, sqlx::Error> =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM journal_entries WHERE body_md LIKE ?)")
+                .bind(format!("%{name}%"))
+                .fetch_one(pool)
+                .await;
+        match still_referenced {
+            Ok(false) => orphaned.push(name.clone()),
+            Ok(true) => {}
+            Err(e) => {
+                tracing::warn!(name, error = %e, "cleanup_orphaned_images: reference check failed")
+            }
+        }
+    }
+    if orphaned.is_empty() {
+        return;
+    }
+    if let Err(join_err) = tokio::task::spawn_blocking(move || {
+        for name in &orphaned {
+            crate::journal_images::delete_journal_image(name);
+        }
+    })
+    .await
+    {
+        tracing::error!("cleanup_orphaned_images: spawn_blocking failed: {join_err}");
+    }
 }
 
 /// Re-read one entry by id (no user scope — callers have already authorized).

--- a/db/src/journals/mod.rs
+++ b/db/src/journals/mod.rs
@@ -113,8 +113,8 @@ pub async fn list_journal_entries(
 /// Edit an entry owned by `user_id`, returning the updated row. Errors with
 /// `NotFound` when the id does not exist or belongs to another user (the two
 /// cases are deliberately indistinguishable). Any journal image referenced in
-/// the old body but not the new one is opportunistically GC'd (issue #1083)
-/// — see [`cleanup_orphaned_images`].
+/// the old body but not the new one is opportunistically GC'd — see
+/// [`cleanup_orphaned_images`].
 pub async fn update_journal_entry(
     pool: &SqlitePool,
     user_id: i64,
@@ -157,8 +157,8 @@ pub async fn update_journal_entry(
 
 /// Delete an entry owned by `user_id`. Errors with `NotFound` when the id does
 /// not exist or belongs to another user. Any journal image uniquely
-/// referenced by the deleted entry's body is opportunistically GC'd (issue
-/// #1083, e.g. the composer's Cancel button discarding a draft) — see
+/// referenced by the deleted entry's body is opportunistically GC'd (e.g. the
+/// composer's Cancel button discarding a draft) — see
 /// [`cleanup_orphaned_images`].
 pub async fn delete_journal_entry(
     pool: &SqlitePool,
@@ -184,9 +184,10 @@ pub async fn delete_journal_entry(
 }
 
 /// Best-effort delete of any `candidates` no longer referenced by any
-/// `journal_entries.body_md`. Called only after the caller's own mutation
-/// has already committed, so a plain substring scan (no self-exclusion) is
-/// correct: the caller's row either no longer contains the name (edit) or no
+/// `journal_entries.body_md` (matched by the full embed path, not the bare
+/// name — see the substring-collision note below). Called only after the
+/// caller's own mutation has already committed, so no self-exclusion is
+/// needed: the caller's row either no longer contains the name (edit) or no
 /// longer exists (delete). Failures — a DB error on the reference check, or
 /// a panic in the filesystem unlink — are logged and swallowed: this is
 /// opportunistic GC of an orphanable-but-durable file store, not a
@@ -195,11 +196,17 @@ pub async fn delete_journal_entry(
 async fn cleanup_orphaned_images(pool: &SqlitePool, candidates: HashSet<String>) {
     let mut orphaned = Vec::new();
     for name in &candidates {
-        let still_referenced: Result<bool, sqlx::Error> =
-            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM journal_entries WHERE body_md LIKE ?)")
-                .bind(format!("%{name}%"))
-                .fetch_one(pool)
-                .await;
+        // Match the full embed path, not the bare name — a bare-name substring
+        // match could false-positive on an unrelated file whose uuid happens to
+        // contain this one as a substring, or on stray body text, and wrongly
+        // treat a true orphan as still-referenced.
+        let full_path = format!("{}{name}", markdown::IMAGE_URL_PREFIX);
+        let still_referenced: Result<bool, sqlx::Error> = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM journal_entries WHERE instr(body_md, ?) > 0)",
+        )
+        .bind(&full_path)
+        .fetch_one(pool)
+        .await;
         match still_referenced {
             Ok(false) => orphaned.push(name.clone()),
             Ok(true) => {}

--- a/db/src/journals/tests.rs
+++ b/db/src/journals/tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for the `journals` module: create round-trip + markdown render,
 //! `BookNotFound`, the public all-users list ordering, owner-scoped
 //! update/delete (with non-owner `NotFound`), merged-uuid canonical
-//! resolution, and the update/delete orphan-image-cleanup diffing (#1083).
+//! resolution, and the update/delete orphan-image-cleanup diffing.
 
 use omnibus_shared::{CreateJournalEntry, EbookMetadata, JournalStatus, UpdateJournalEntry};
 
@@ -515,5 +515,36 @@ async fn delete_keeps_an_image_still_referenced_by_another_entry() {
     assert!(
         journal_images_dir().join(&shared_name).exists(),
         "image referenced by another surviving entry must not be deleted"
+    );
+}
+
+#[tokio::test]
+async fn cleanup_ignores_a_bare_name_substring_that_is_not_a_real_embed_reference() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _env = EnvVarGuard::set_os("OMNIBUS_JOURNAL_IMAGES_DIR", Some(tmp.path().as_os_str()));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+    let (embed, name) = write_image();
+    let entry = create_journal_entry(&pool, user, &create(&uuid, &embed, None))
+        .await
+        .unwrap();
+    // A second entry's body happens to contain the bare serving name as a
+    // substring (e.g. quoted in prose), without the `IMAGE_URL_PREFIX` that
+    // makes it a real embed. A bare-name `LIKE %name%` match would wrongly
+    // count this as "still referenced" and skip the sweep.
+    create_journal_entry(
+        &pool,
+        user,
+        &create(&uuid, &format!("mentions the file {name} in passing"), None),
+    )
+    .await
+    .unwrap();
+
+    delete_journal_entry(&pool, user, entry.id).await.unwrap();
+
+    assert!(
+        !journal_images_dir().join(&name).exists(),
+        "a bare-name substring elsewhere must not block the sweep of a true orphan"
     );
 }

--- a/db/src/journals/tests.rs
+++ b/db/src/journals/tests.rs
@@ -1,11 +1,13 @@
 //! Unit tests for the `journals` module: create round-trip + markdown render,
 //! `BookNotFound`, the public all-users list ordering, owner-scoped
-//! update/delete (with non-owner `NotFound`), and merged-uuid canonical
-//! resolution.
+//! update/delete (with non-owner `NotFound`), merged-uuid canonical
+//! resolution, and the update/delete orphan-image-cleanup diffing (#1083).
 
 use omnibus_shared::{CreateJournalEntry, EbookMetadata, JournalStatus, UpdateJournalEntry};
 
 use super::*;
+use crate::journal_images::{self, journal_images_dir};
+use crate::test_support::EnvVarGuard;
 use crate::{init_db, replace_books};
 
 async fn seed(pool: &SqlitePool, library: &str, title: &str) -> String {
@@ -383,4 +385,135 @@ async fn create_propagates_db_error_when_pool_is_closed() {
         .await
         .unwrap_err();
     assert!(matches!(err, JournalError::Sqlx(_)));
+}
+
+/// Write a real journal image file and return its `IMAGE_URL_PREFIX`-embedded
+/// markdown reference plus its bare serving name. Caller must hold an
+/// `OMNIBUS_JOURNAL_IMAGES_DIR` `EnvVarGuard` pointed at a temp dir.
+fn write_image() -> (String, String) {
+    let name = journal_images::write_journal_image("image/png", b"bytes").unwrap();
+    let embed = format!("![img]({}{name})", markdown::IMAGE_URL_PREFIX);
+    (embed, name)
+}
+
+#[tokio::test]
+async fn update_deletes_an_image_dropped_from_the_body_but_keeps_one_still_referenced() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _env = EnvVarGuard::set_os("OMNIBUS_JOURNAL_IMAGES_DIR", Some(tmp.path().as_os_str()));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+    let (dropped_embed, dropped_name) = write_image();
+    let (kept_embed, kept_name) = write_image();
+    let entry = create_journal_entry(
+        &pool,
+        user,
+        &create(&uuid, &format!("{dropped_embed} {kept_embed}"), None),
+    )
+    .await
+    .unwrap();
+
+    update_journal_entry(
+        &pool,
+        user,
+        entry.id,
+        &UpdateJournalEntry {
+            body_md: kept_embed,
+            progress: None,
+            status: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        !journal_images_dir().join(&dropped_name).exists(),
+        "image removed from the body must be swept"
+    );
+    assert!(
+        journal_images_dir().join(&kept_name).exists(),
+        "image still referenced by the new body must survive"
+    );
+}
+
+#[tokio::test]
+async fn update_keeps_an_image_still_referenced_by_another_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _env = EnvVarGuard::set_os("OMNIBUS_JOURNAL_IMAGES_DIR", Some(tmp.path().as_os_str()));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+    let (shared_embed, shared_name) = write_image();
+    let other = create_journal_entry(&pool, user, &create(&uuid, &shared_embed, None))
+        .await
+        .unwrap();
+    let entry = create_journal_entry(&pool, user, &create(&uuid, &shared_embed, None))
+        .await
+        .unwrap();
+
+    update_journal_entry(
+        &pool,
+        user,
+        entry.id,
+        &UpdateJournalEntry {
+            body_md: "no images now".into(),
+            progress: None,
+            status: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        journal_images_dir().join(&shared_name).exists(),
+        "image referenced by another surviving entry must not be deleted"
+    );
+    // Sanity: the other entry is untouched.
+    assert_eq!(
+        get_entry_by_id(&pool, other.id).await.unwrap().body_md,
+        shared_embed
+    );
+}
+
+#[tokio::test]
+async fn delete_removes_an_image_uniquely_referenced_by_the_deleted_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _env = EnvVarGuard::set_os("OMNIBUS_JOURNAL_IMAGES_DIR", Some(tmp.path().as_os_str()));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+    let (embed, name) = write_image();
+    let entry = create_journal_entry(&pool, user, &create(&uuid, &embed, None))
+        .await
+        .unwrap();
+
+    delete_journal_entry(&pool, user, entry.id).await.unwrap();
+
+    assert!(
+        !journal_images_dir().join(&name).exists(),
+        "image uniquely referenced by the deleted entry must be swept"
+    );
+}
+
+#[tokio::test]
+async fn delete_keeps_an_image_still_referenced_by_another_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _env = EnvVarGuard::set_os("OMNIBUS_JOURNAL_IMAGES_DIR", Some(tmp.path().as_os_str()));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+    let (shared_embed, shared_name) = write_image();
+    create_journal_entry(&pool, user, &create(&uuid, &shared_embed, None))
+        .await
+        .unwrap();
+    let entry = create_journal_entry(&pool, user, &create(&uuid, &shared_embed, None))
+        .await
+        .unwrap();
+
+    delete_journal_entry(&pool, user, entry.id).await.unwrap();
+
+    assert!(
+        journal_images_dir().join(&shared_name).exists(),
+        "image referenced by another surviving entry must not be deleted"
+    );
 }


### PR DESCRIPTION
## Summary
- Closes #1083. Journal image uploads (`db/src/journal_images.rs`) had no lifecycle — nothing ever removed a file left behind when a composer draft was cancelled or an edit dropped an embedded image.
- Chose option (b) (best-effort cleanup on cancel/edit) over a `pool.rs` boot sweep, per the issue's guidance to minimize merge-conflict risk with the concurrent #1126 work also touching `db/src/pool.rs`. Since journal drafts have no separate drafts table (a draft is just a `journal_entries` row with `status = 'draft'`), wiring the cleanup into `db::journals::{update_journal_entry, delete_journal_entry}` covers both the composer's Cancel button (which already deletes the draft row) *and* the "edit a saved entry to remove an image" scenario the issue also calls out — without touching `pool.rs` at all.
- `update_journal_entry` diffs old vs new `body_md` image references and sweeps any image dropped from the body that's no longer referenced by any other entry. `delete_journal_entry` sweeps any image uniquely referenced by the deleted entry. Both share a `cleanup_orphaned_images` helper (DB reference check, then best-effort `spawn_blocking` unlink — errors logged and swallowed, mirroring `set_settings`'s cover cleanup).
- Updated `journal_images.rs`'s module doc to document the new policy, including the one residual gap it doesn't cover (an upload whose draft is abandoned without ever autosaving or hitting Cancel — judged not worth a periodic boot sweep for the added complexity/merge risk).

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1083 cargo fmt` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1083 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1083 cargo test -p omnibus-db` — PASS (1034 passed; 1 pre-existing failure unrelated to this change — `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails because `test_data/audiobooks/public_domain/` fixtures were never downloaded in this worktree, i.e. `just fixtures` was not run; confirmed via `cargo test -p omnibus-db journal` — all 44 journal-scoped tests, including the 8 new orphan-cleanup ones, pass cleanly)

## Notes
- Only `omnibus-db` was touched (`db/src/journal_images.rs`, `db/src/journal_images/tests.rs`, `db/src/journals/mod.rs`, `db/src/journals/tests.rs`), so `server`/`frontend` clippy/tests were not re-run.
- No frontend changes needed — the cleanup is transparent to `frontend/src/pages/book_detail/journal/composer.rs`, which already calls `delete_journal_entry` on Cancel.

## Version
- [ ] Minor
- [ ] Patch (default)
- [ ] No release

(Leaving version/release labeling to the maintainer per instructions.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AcLhyy9GtFitcjYNF9qARV)_