### PR TITLE
fix: raise Playwright seed-hook timeout so audiobook E2E stops timing out

### DIFF
--- a/ui_tests/playwright/playwright.config.ts
+++ b/ui_tests/playwright/playwright.config.ts
@@ -19,6 +19,13 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: "list",
+  // Most specs seed in a `beforeAll` that polls the indexer for up to 45s
+  // (see `pollForBookCount` — cold GitHub-runner indexing of the full
+  // public-domain set measured 27–36s). Hooks inherit the test timeout, so
+  // the Playwright 30s default cut the seed off before the poll could finish.
+  // 60s clears a single-library seed with margin; dual-library seeding hooks
+  // (two sequential polls) raise their own timeout via `test.setTimeout`.
+  timeout: 60_000,
   globalSetup: require.resolve("./globalSetup.ts"),
   use: {
     baseURL: BASE_URL,

--- a/ui_tests/playwright/tests/flows/immersive.spec.ts
+++ b/ui_tests/playwright/tests/flows/immersive.spec.ts
@@ -21,6 +21,9 @@ import {
 import type { APIRequestContext } from "@playwright/test";
 
 test.beforeAll(async ({ request }) => {
+  // Two sequential seed polls (ebooks then audiobooks), up to 45s each, so
+  // this hook needs more than the 60s config default.
+  test.setTimeout(120_000);
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
   await seedAudiobookLibrary(
     request,

--- a/ui_tests/playwright/tests/flows/merge.spec.ts
+++ b/ui_tests/playwright/tests/flows/merge.spec.ts
@@ -29,6 +29,9 @@ test.describe.configure({ mode: "serial" });
 // book, so the combined total is the additive sum minus AUTO_ATTACHED_PAIRS.
 // The merge TARGET/SOURCE below are chosen to avoid that pair.
 test.beforeAll(async ({ request }) => {
+  // Two sequential seed polls (ebooks then audiobooks), up to 45s each, so
+  // this hook needs more than the 60s config default.
+  test.setTimeout(120_000);
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
   await seedAudiobookLibrary(
     request,

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -24,6 +24,9 @@ import {
 // fixture the reader test depends on unresolvable by row testid in CI —
 // see the investigation note in the PR. Reverted to the two-step seed.
 test.beforeAll(async ({ request }) => {
+  // Two sequential seed polls (ebooks then audiobooks), up to 45s each, so
+  // this hook needs more than the 60s config default.
+  test.setTimeout(120_000);
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
   await seedAudiobookLibrary(
     request,


### PR DESCRIPTION
## Summary
- The E2E (Playwright) job has been failing on `main` since `e8dcc36` (#1156); the parent commit `100851d0` was green. It is **not** a flake and not caused by any open feature PR — every branch cut from `e8dcc36` inherits the red E2E.
- **Root cause:** seeding `beforeAll` hooks poll the indexer for up to **45s** (`pollForBookCount` — cold GitHub-runner indexing of the full public-domain fixture set measured 27–36s), but Playwright hooks inherit the **test** timeout, which was left at the framework's **30s** default. The hook was killed at 30s before the 45s poll could finish, so the audiobook library seeded short (`expected at least 54 books … Received: 53`, with the two-part MP3 `"The Compiled Tales"` indexing last and never surfacing). Every audiobook-dependent spec then failed downstream: `listen.spec.ts`, `mini-dock.spec.ts`, `book_detail.spec.ts` (audiobook-only), `merge.spec.ts`.
- #1156 tipped a latent, on-the-edge condition over: it added two heavy `test.slow()` audiobook **merge** tests to the same shard, pushing indexing consistently past the 30s hook ceiling.
- **Fix:** set a `timeout: 60_000` in `playwright.config.ts` so any single-library seed hook clears the 45s poll with margin, and raise the three **dual-library** seeding hooks (`merge`, `mini-dock`, `immersive` — two sequential 45s polls) to `120_000` via `test.setTimeout`. No product code changes; test-infra only.

## Test plan
- [x] Diff is self-contained and uses documented Playwright API (`timeout` config field + `test.setTimeout()`); `test` is the fixture re-export of `@playwright/test`.
- [ ] **CI is the verification** for this change by design — running the Playwright suite requires the Nix/Chromium toolchain, which isn't available in the authoring sandbox. The E2E job on this PR should now seed the full library and go green where `main` currently does not.

## Notes
- Test-infra only — touches `ui_tests/playwright/` (no `db`/`server`/`frontend` code). It restores a green E2E baseline that the currently-open feature PRs (#1158, #1159, #1160, #1161, #1162) will inherit once they rebase onto `main`.
- Leaving the version/release decision to the maintainer per convention; since this touches neither `*.md`/`docs/` nor `.github/`, an unlabeled merge would cut a patch release — apply `no release` if that's not wanted.

Co-Authored-By: Claude Opus 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcLhyy9GtFitcjYNF9qARV)_