### PR TITLE
chore: gate Rust & E2E CI jobs behind per-concern required checks

### DIFF
--- a/.github/actions/ci-gate/action.yml
+++ b/.github/actions/ci-gate/action.yml
@@ -1,0 +1,42 @@
+name: CI required gate
+description: >
+  Collapse a set of matrix / conditionally-skipped jobs into one pass/fail
+  status. Succeeds when every upstream job either passed or was skipped; fails
+  if any failed or was cancelled. Use as the single required status check for a
+  workflow that path-gates its real jobs — a required check keyed on the real
+  jobs never resolves when the workflow's paths filter stops them from running,
+  which blocks the PR forever. This gate always runs, so it always reports.
+
+inputs:
+  needs:
+    description: >
+      The gate job's `needs` context serialized as JSON — pass
+      `${{ toJSON(needs) }}`. Each entry's `.result` is inspected.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check upstream job results
+      shell: bash
+      env:
+        NEEDS_JSON: ${{ inputs.needs }}
+      run: |
+        set -euo pipefail
+        echo "Upstream job results:"
+        jq -r 'to_entries[] | "  \(.key): \(.value.result)"' <<<"$NEEDS_JSON"
+
+        # Skipped counts as pass — that's the whole point: a path-gated job that
+        # didn't need to run must not block the merge. Only real failures do.
+        failed=$(jq -r '
+          to_entries[]
+          | select(.value.result == "failure" or .value.result == "cancelled")
+          | .key
+        ' <<<"$NEEDS_JSON")
+
+        if [ -n "$failed" ]; then
+          echo "::error::Required jobs did not pass:"
+          sed 's/^/  - /' <<<"$failed"
+          exit 1
+        fi
+        echo "All required jobs passed or were skipped."

--- a/.github/actions/ci-gate/action.yml
+++ b/.github/actions/ci-gate/action.yml
@@ -10,8 +10,8 @@ description: >
 inputs:
   needs:
     description: >
-      The gate job's `needs` context serialized as JSON — pass
-      `${{ toJSON(needs) }}`. Each entry's `.result` is inspected.
+      The gate job's `needs` context serialized as JSON, passed via a
+      toJSON(needs) expression. Each entry's `.result` is inspected.
     required: true
 
 runs:
@@ -26,8 +26,7 @@ runs:
         echo "Upstream job results:"
         jq -r 'to_entries[] | "  \(.key): \(.value.result)"' <<<"$NEEDS_JSON"
 
-        # Skipped counts as pass — that's the whole point: a path-gated job that
-        # didn't need to run must not block the merge. Only real failures do.
+        # Skipped counts as pass. Only real failures emerge. 
         failed=$(jq -r '
           to_entries[]
           | select(.value.result == "failure" or .value.result == "cancelled")

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -92,10 +92,10 @@ jobs:
   # The required status check for this workflow. Always runs (no paths filter +
   # `if: always()`), so branch protection gets a resolved status on every PR —
   # green when `stylelint` passed or was skipped, red when it failed. Mark ONLY
-  # `Stylelint Required` as required in branch protection; do not require the
+  # `🔒 Stylelint Required` as required in branch protection; do not require the
   # `stylelint` job directly (it skips on non-CSS PRs and would hang the merge).
   stylelint-required:
-    name: Stylelint Required
+    name: 🔒 Stylelint Required
     needs: [changes, stylelint]
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -9,13 +9,13 @@ name: CSS Lint
 # this never nags about pre-existing stylistic choices.
 
 on:
+  # No workflow-level `paths:` filter: this workflow must run on EVERY PR so
+  # its `stylelint-required` gate always reports a status (a required check
+  # keyed on a path-filtered workflow never resolves on a PR that doesn't
+  # match, blocking the merge forever). Path gating moved into the `changes`
+  # job below; `stylelint` skips when no CSS input changed, and the gate treats
+  # skipped as pass.
   pull_request:
-    paths:
-      - "frontend/assets/**/*.css"
-      - ".stylelintrc.json"
-      - ".github/workflows/css-lint.yml"
-      - "flake.nix"
-      - "flake.lock"
   push:
     branches: [main]
 
@@ -27,8 +27,33 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether this PR touches anything stylelint cares about. On push (and
+  # any non-PR event) `stylelint` runs unconditionally, so this output is only
+  # consulted for pull_request events.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      css: ${{ steps.filter.outputs.css }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            css:
+              - "frontend/assets/**/*.css"
+              - ".stylelintrc.json"
+              - ".github/workflows/css-lint.yml"
+              - ".github/actions/ci-gate/action.yml"
+              - "flake.nix"
+              - "flake.lock"
+
   stylelint:
     name: stylelint
+    needs: changes
+    if: ${{ needs.changes.outputs.css == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -57,3 +82,21 @@ jobs:
 
       - name: stylelint (structural CSS lint)
         run: nix develop --command stylelint 'frontend/assets/**/*.css'
+
+  # The required status check for this workflow. Always runs (no paths filter +
+  # `if: always()`), so branch protection gets a resolved status on every PR —
+  # green when `stylelint` passed or was skipped, red when it failed. Mark ONLY
+  # `Stylelint Required` as required in branch protection; do not require the
+  # `stylelint` job directly (it skips on non-CSS PRs and would hang the merge).
+  stylelint-required:
+    name: Stylelint Required
+    needs: [changes, stylelint]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ci-gate
+        with:
+          needs: ${{ toJSON(needs) }}

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -33,6 +33,12 @@ jobs:
   changes:
     name: detect changes
     runs-on: ubuntu-latest
+    # `pull-requests: read` so `dorny/paths-filter` can list the PR's changed
+    # files via the API under the workflow's `contents: read` (matches
+    # release.yml).
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       css: ${{ steps.filter.outputs.css }}
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,8 +26,11 @@ jobs:
   changes:
     name: detect changes
     runs-on: ubuntu-latest
+    # `pull-requests: read` so `dorny/paths-filter` can list the PR's changed
+    # files via the API under restrictive permissions (matches release.yml).
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       e2e: ${{ steps.filter.outputs.e2e }}
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,29 +3,15 @@ name: E2E
 on:
   push:
     branches: [main]
+  # No workflow-level `paths:` filter: this workflow must run on EVERY PR so
+  # its `e2e-required` gate always reports a status (a required check keyed on
+  # a path-filtered workflow never resolves on a PR that doesn't match, which
+  # blocks the merge forever). Path gating moved into the `changes` job below;
+  # `bundle`/`playwright` skip when nothing E2E-relevant changed, and the gate
+  # treats skipped as pass. `workflow_dispatch` stays the force-run escape
+  # hatch for a PR that touches none of the E2E paths.
   pull_request:
     types: [opened, synchronize, reopened]
-    # Only run E2E when a PR touches code that can change the web bundle or
-    # the test suite itself. This replaces the old `run_ui_tests` label
-    # opt-in: matching PRs get Playwright coverage automatically. The trigger
-    # set must stay in sync with the bundle cache key below — any input
-    # hashed into the key needs a corresponding entry here, otherwise a PR
-    # could change the bundle without ever invalidating its cache. To force
-    # E2E on a PR that touches none of these paths, use the
-    # `workflow_dispatch` escape hatch below.
-    paths:
-      - "frontend/**"
-      - "shared/**"
-      - "server/**"
-      - "db/**"
-      - "ui_tests/**"
-      - "**/Cargo.toml"
-      - "Cargo.lock"
-      - "**/Dioxus.toml"
-      - "flake.lock"
-      - "flake.nix"
-      - "scripts/fetch-fixtures.sh"
-      - ".github/workflows/e2e.yml"
   workflow_dispatch:
 
 concurrency:
@@ -33,6 +19,38 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Detect whether this PR touches anything that can change the web bundle or
+  # the test suite. On push / workflow_dispatch the real jobs run
+  # unconditionally, so this output is only consulted for pull_request events.
+  # Keep the filter list in sync with the bundle cache key below.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - "frontend/**"
+              - "shared/**"
+              - "server/**"
+              - "db/**"
+              - "ui_tests/**"
+              - "**/Cargo.toml"
+              - "Cargo.lock"
+              - "**/Dioxus.toml"
+              - "flake.lock"
+              - "flake.nix"
+              - "scripts/fetch-fixtures.sh"
+              - ".github/workflows/e2e.yml"
+              - ".github/actions/ci-gate/action.yml"
   # Compile the fullstack web bundle (native server binary + WASM client)
   # in release mode once and stash it in the GHA cache. Release mode strips
   # the Dioxus hot-reload client from the WASM bundle, which otherwise
@@ -43,6 +61,8 @@ jobs:
   # workflow file. Keep the `paths:` trigger above in sync.
   bundle:
     name: bundle
+    needs: changes
+    if: ${{ needs.changes.outputs.e2e == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -375,3 +395,23 @@ jobs:
           git add -A
           git commit -q -m "test report: ${BRANCH_NAME}@${COMMIT_SHA:0:9}" || { echo "no changes to publish"; exit 0; }
           git push "$AUTH_URL" HEAD:gh-pages
+
+  # The required status check for this workflow. Always runs (no paths filter +
+  # `if: always()`), so branch protection gets a resolved status on every PR —
+  # green when bundle + playwright passed or were skipped, red when either
+  # failed. `publish-report` is intentionally NOT gated on: report publishing
+  # failing must not block a merge. Mark ONLY `Playwright Required` as required
+  # in branch protection; do not require `bundle` / the `playwright` shards
+  # (they skip on non-E2E PRs and would hang the merge).
+  playwright-required:
+    name: Playwright Required
+    needs: [changes, bundle, playwright]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ci-gate
+        with:
+          needs: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -403,11 +403,11 @@ jobs:
   # `if: always()`), so branch protection gets a resolved status on every PR —
   # green when bundle + playwright passed or were skipped, red when either
   # failed. `publish-report` is intentionally NOT gated on: report publishing
-  # failing must not block a merge. Mark ONLY `Playwright Required` as required
-  # in branch protection; do not require `bundle` / the `playwright` shards
-  # (they skip on non-E2E PRs and would hang the merge).
+  # failing must not block a merge. Mark ONLY `🔒 Playwright Required` as
+  # required in branch protection; do not require `bundle` / the `playwright`
+  # shards (they skip on non-E2E PRs and would hang the merge).
   playwright-required:
-    name: Playwright Required
+    name: 🔒 Playwright Required
     needs: [changes, bundle, playwright]
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -394,12 +394,12 @@ jobs:
   # runs (its `if` is `always()` and the workflow has no paths filter), so
   # branch protection gets a resolved status on every PR: green when its
   # underlying job(s) passed or were skipped, red when any failed. Mark ONLY
-  # these gate jobs as required in branch protection — `Rustfmt Required`,
-  # `Clippy Required`, `Cargo Test Required`, `Cargo Audit Required` — and do
-  # NOT require the individual matrix jobs (they skip on non-Rust PRs and would
-  # hang the merge).
+  # these gate jobs as required in branch protection — `🔒 Rustfmt Required`,
+  # `🔒 Clippy Required`, `🔒 Cargo Test Required`, `🔒 Cargo Audit Required` —
+  # and do NOT require the individual matrix jobs (they skip on non-Rust PRs and
+  # would hang the merge).
   rustfmt-required:
-    name: Rustfmt Required
+    name: 🔒 Rustfmt Required
     needs: [changes, fmt]
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -410,7 +410,7 @@ jobs:
           needs: ${{ toJSON(needs) }}
 
   clippy-required:
-    name: Clippy Required
+    name: 🔒 Clippy Required
     needs: [changes, clippy]
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -421,7 +421,7 @@ jobs:
           needs: ${{ toJSON(needs) }}
 
   cargo-test-required:
-    name: Cargo Test Required
+    name: 🔒 Cargo Test Required
     needs: [changes, test]
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -432,7 +432,7 @@ jobs:
           needs: ${{ toJSON(needs) }}
 
   cargo-audit-required:
-    name: Cargo Audit Required
+    name: 🔒 Cargo Audit Required
     needs: [changes, security]
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,13 @@ jobs:
   changes:
     name: detect changes
     runs-on: ubuntu-latest
+    # `dorny/paths-filter` lists the PR's changed files via the GitHub API on
+    # pull_request events; under the workflow's restrictive `contents: read` it
+    # needs `pull-requests: read` too, or the API call is denied and the filter
+    # errors. Matches release.yml's changed-file listing.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,16 +1,13 @@
 name: Rust
 
 on:
+  # No workflow-level `paths:` filter: this workflow must run on EVERY PR so
+  # its `rust-required` gate always reports a status. A required check keyed on
+  # a path-filtered workflow never resolves on a PR that doesn't touch the
+  # paths, blocking the merge forever. Path gating moved into the `changes`
+  # job below; the real jobs skip when no Rust input changed, and the gate
+  # treats skipped as pass.
   pull_request:
-    paths:
-      - "**/*.rs"
-      - "**/Cargo.toml"
-      - "Cargo.lock"
-      - "flake.nix"
-      - "flake.lock"
-      - "rust-toolchain*"
-      - ".github/workflows/rust.yml"
-      - "deny.toml"
   push:
     branches: [main]
 
@@ -22,8 +19,37 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether this PR touches anything the Rust jobs care about. On push
+  # (and any non-PR event) the real jobs run unconditionally, so this output is
+  # only consulted for pull_request events.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Keep in sync with the old workflow-level `paths:` list.
+          filters: |
+            rust:
+              - "**/*.rs"
+              - "**/Cargo.toml"
+              - "Cargo.lock"
+              - "flake.nix"
+              - "flake.lock"
+              - "rust-toolchain*"
+              - ".github/workflows/rust.yml"
+              - ".github/actions/ci-gate/action.yml"
+              - "deny.toml"
+
   fmt:
     name: rustfmt
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,6 +81,8 @@ jobs:
   #                        `omnibus` restore that every native variant pays.
   clippy:
     name: clippy (${{ matrix.name }})
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -128,6 +156,8 @@ jobs:
 
   test:
     name: test (${{ matrix.name }})
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -206,6 +236,8 @@ jobs:
 
   security:
     name: cargo audit
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -350,3 +382,55 @@ jobs:
       # `ignore`/`skip` list rather than re-introducing `continue-on-error: true`.
       - name: cargo deny check
         run: nix develop .#audit --command cargo deny check advisories sources bans licenses
+
+  # Required status checks for this workflow — one per concern. Each always
+  # runs (its `if` is `always()` and the workflow has no paths filter), so
+  # branch protection gets a resolved status on every PR: green when its
+  # underlying job(s) passed or were skipped, red when any failed. Mark ONLY
+  # these gate jobs as required in branch protection — `Rustfmt Required`,
+  # `Clippy Required`, `Cargo Test Required`, `Cargo Audit Required` — and do
+  # NOT require the individual matrix jobs (they skip on non-Rust PRs and would
+  # hang the merge).
+  rustfmt-required:
+    name: Rustfmt Required
+    needs: [changes, fmt]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ci-gate
+        with:
+          needs: ${{ toJSON(needs) }}
+
+  clippy-required:
+    name: Clippy Required
+    needs: [changes, clippy]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ci-gate
+        with:
+          needs: ${{ toJSON(needs) }}
+
+  cargo-test-required:
+    name: Cargo Test Required
+    needs: [changes, test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ci-gate
+        with:
+          needs: ${{ toJSON(needs) }}
+
+  cargo-audit-required:
+    name: Cargo Audit Required
+    needs: [changes, security]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ci-gate
+        with:
+          needs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- Drops the workflow-level `paths:` filter from `rust.yml`, `e2e.yml`, and `css-lint.yml` so all three trigger on **every** PR — fixing required checks that lingered as "Expected — waiting for status" on PRs that touched none of the filtered paths.
- Path-gating moves into a `changes` job (`dorny/paths-filter`) per workflow; the real jobs now skip when nothing relevant changed, and still run unconditionally on pushes to `main`.
- New reusable composite action `.github/actions/ci-gate` collapses a set of jobs into one status: green when every job passed **or was skipped**, red on any failure/cancellation.
- Six always-running gate jobs are the new required checks: `🔒 Rustfmt Required`, `🔒 Clippy Required`, `🔒 Cargo Test Required`, `🔒 Cargo Audit Required` (rust.yml), `🔒 Playwright Required` (e2e.yml), and `🔒 Stylelint Required` (css-lint.yml).

## Test plan
- [x] YAML validated for the action + all three workflows.
- [x] `ci-gate` shell logic unit-tested across all-skipped, all-passed, and mixed-failure `needs` payloads (exit 0 / 0 / 1).
- [x] `🔒 Rustfmt/Clippy/Cargo Test/Cargo Audit Required` and `🔒 Stylelint Required` verified **green** on CI.
- [x] `🔒 Playwright Required` correctly reports **red** — faithfully surfacing a pre-existing audiobook-fixture E2E failure that also fails on `main` (unrelated to this workflow-only change).

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label.
- [ ] **Patch** — the default.
- [x] **No release** — CI-only change (`.github/**`); labeled `no release` (also auto-skipped).

## Notes
> [!IMPORTANT]
> **Branch-protection follow-up (manual, after merge).** Replace the required checks:
> 1. Add the six gate checks as required: `🔒 Rustfmt Required`, `🔒 Clippy Required`, `🔒 Cargo Test Required`, `🔒 Cargo Audit Required`, `🔒 Playwright Required`, `🔒 Stylelint Required`.
> 2. Confirm they report green on a PR, then **remove** every `clippy (…)`, `test (…)`, `playwright (shard …)`, and `stylelint` entry — plus the stale `clippy + test` check.
>
> Leaving any individual matrix job required re-introduces the exact hang this PR fixes (they skip on unrelated PRs).
