### PR TITLE
fix: resolve E2E failures — merge-undo scan_key duplicate and audiobook player boot race

### DIFF
--- a/db/src/merge/snapshot.rs
+++ b/db/src/merge/snapshot.rs
@@ -36,6 +36,14 @@ pub(super) struct SourceSnapshot {
     /// The source book's `scan_roots.path` (re-resolved or recreated on
     /// undo) — also the `merged_uuids.library_path` for the guard row.
     pub library_path: String,
+    /// `books.scan_key` — the library-relative path the reindex diff (F2)
+    /// matches disk against. Undo must restore it, or the next reindex
+    /// can't match the on-disk file/folder to the recreated row and
+    /// inserts a duplicate. `#[serde(default)]` keeps pre-fix `merge_log`
+    /// JSON (no `scan_key` key) replaying — those degrade to `None`, the
+    /// prior behaviour.
+    #[serde(default)]
+    pub scan_key: Option<String>,
     pub path: String,
     pub title: String,
     pub sort: Option<String>,
@@ -87,6 +95,7 @@ pub(super) struct SourceSnapshot {
 struct BookSnapshot {
     uuid: String,
     library_path: String,
+    scan_key: Option<String>,
     path: String,
     title: String,
     sort: Option<String>,
@@ -126,7 +135,7 @@ pub(super) async fn build_snapshot(
     book_id: i64,
 ) -> Result<SourceSnapshot, sqlx::Error> {
     let row: BookSnapshot = sqlx::query_as(
-        "SELECT b.uuid, l.path AS library_path, b.path, b.title, b.sort, b.author_sort,
+        "SELECT b.uuid, l.path AS library_path, b.scan_key, b.path, b.title, b.sort, b.author_sort,
                 b.series_sort, b.series_index, b.pubdate, b.timestamp, b.has_cover,
                 b.description, b.accent_color, b.title_norm, b.author_norm
            FROM books b JOIN scan_roots l ON l.id = b.library_id
@@ -142,6 +151,7 @@ pub(super) async fn build_snapshot(
     Ok(SourceSnapshot {
         uuid: row.uuid,
         library_path: row.library_path,
+        scan_key: row.scan_key,
         path: row.path,
         title: row.title,
         sort: row.sort,

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -4,7 +4,7 @@
 use omnibus_shared::MetadataOverrides;
 
 use super::*;
-use crate::books::list_merged_rows_for_formats;
+use crate::books::{list_indexed_rows_for_formats, list_merged_rows_for_formats};
 use crate::indexer::diff_library;
 use crate::pool::init_db;
 use crate::sync::{sync_audiobooks, AudiobookSyncPlan};
@@ -598,6 +598,51 @@ async fn undo_merge_restores_source_book_and_moves_file_back() {
         .unwrap();
     assert!(undone.is_some());
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM books_fts").await, 2);
+}
+
+#[tokio::test]
+async fn undo_merge_restores_scan_key_so_reindex_finds_no_duplicate() {
+    // Regression: undo used to omit `books.scan_key` from the recreated row,
+    // leaving it NULL. The next reindex then couldn't match the on-disk file
+    // to the restored (scan_key-less) row and inserted a second copy — the
+    // duplicate that destabilized the audiobook E2E suite.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let target = seed_ebook(&pool, "A/Dracula.epub", "Dracula", "Bram Stoker").await;
+    let source = seed_audiobook(&pool, "B/Drakula.m4b", "Drakula", "Bram Stoker").await;
+    let source_scan_key = crate::helpers::scan_key_for("B/Drakula.m4b");
+
+    let out = merge_books(&pool, &source, &target, None).await.unwrap();
+    undo_merge(&pool, out.merge_log_id).await.unwrap();
+
+    // The recreated row carries the source's original scan_key back.
+    let restored_scan_key: Option<String> =
+        sqlx::query_scalar("SELECT scan_key FROM books WHERE uuid = ?")
+            .bind(&source)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(restored_scan_key.as_deref(), Some(source_scan_key.as_str()));
+
+    // A reindex now matches the on-disk file to the restored native row and
+    // classifies it Unchanged — no `new` entry, so no duplicate insert.
+    let ab = indexed_audiobook("B/Drakula.m4b", "Drakula", Some("Bram Stoker"));
+    let db_rows = list_indexed_rows_for_formats(&pool, "/audio", &["M4B", "M4A", "MP3"])
+        .await
+        .unwrap();
+    let disk = vec![crate::ebook::StatEntry {
+        filename: ab.group_path.clone(),
+        scan_key: ab.scan_key.clone(),
+        mtime_epoch: ab.max_mtime_epoch,
+        size_bytes: ab.total_size_bytes,
+        error: None,
+    }];
+    let diff = diff_library(&disk, &db_rows, std::path::Path::new("/audio"), true);
+    assert!(
+        diff.new.is_empty(),
+        "restored book must not reindex as New (would duplicate): {:?}",
+        diff.new
+    );
+    assert_eq!(diff.unchanged, vec![source]);
 }
 
 #[tokio::test]

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -125,7 +125,8 @@ async fn rebuild_target_fts_best_effort(
 
 /// Recreate the source `books` row from the snapshot. The original uuid
 /// is free to reuse — the `merged_uuids` guard kept reindexes from
-/// resurrecting it.
+/// resurrecting it. `scan_key` is restored too so the next reindex matches
+/// the on-disk file/folder to this row instead of inserting a duplicate.
 async fn recreate_source_row(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     snap: &SourceSnapshot,
@@ -153,14 +154,16 @@ async fn recreate_source_row(
     // now for the same reason. The `pubdate` COALESCE is pre-existing.
     let id: i64 = sqlx::query_scalar(
         "INSERT INTO books
-            (uuid, library_id, path, title, sort, author_sort, series_sort, series_index, pubdate,
-             timestamp, last_modified, has_cover, description, accent_color, title_norm, author_norm)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')),
+            (uuid, library_id, scan_key, path, title, sort, author_sort, series_sort, series_index,
+             pubdate, timestamp, last_modified, has_cover, description, accent_color, title_norm,
+             author_norm)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')),
                  COALESCE(?, strftime('%s','now')), strftime('%s','now'), ?, ?, ?, ?, ?)
          RETURNING id",
     )
     .bind(&snap.uuid)
     .bind(library_id)
+    .bind(&snap.scan_key)
     .bind(&snap.path)
     .bind(&snap.title)
     .bind(&snap.sort)

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -83,6 +83,16 @@ pub(crate) fn install_audio_bootstrap(playback: crate::PlaybackState) {
 
     use_effect(move || {
         let resolved_user = current_user();
+        // Auth may still be resolving on a fresh page load (`None` = unknown).
+        // Booting now would capture `user_id = None`; the manifest task's
+        // `is_current` guard then bails once `current_user` resolves to a real
+        // id, leaving the player stuck "preparing". Wait for resolution —
+        // this effect re-runs when `current_user` flips — instead of booting
+        // early, because the `needs_reload` gate would otherwise suppress the
+        // corrected re-boot.
+        if resolved_user.is_none() {
+            return;
+        }
         if matches!(resolved_user, Some(None)) {
             let mut uuid = playback.uuid;
             uuid.set(None);

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -742,48 +742,65 @@ test.describe("audiobook-only seed", () => {
           .filter((f) => /^(mp3|m4b|m4a)$/i.test(f.format))
           .map((f) => f.id);
         expect(audioIds.length, "expected two audio files after merge").toBe(2);
-        const [firstId, secondId] = audioIds;
 
-        // Load the FIRST part directly — this makes the book the active
-        // playback book (uuid now set on the app-root PlaybackState).
-        const [firstManifest] = await Promise.all([
-          page.waitForRequest((req) =>
-            req.url().includes(`/api/audiobooks/${primaryUuid}/manifest?file_id=${firstId}`),
-          ),
-          gotoReady(page, `/listen/${primaryUuid}?file_id=${firstId}`),
-        ]);
-        expect(firstManifest.url()).toContain(`file_id=${firstId}`);
+        // The whole flow below is one single-page-app session: a single full
+        // load of the book-detail page, then every navigation is a real Dioxus
+        // `<Link>` (the file picker) or an in-app history transition
+        // (`goBack`). The `__repickSentinel` on `window` is set once after that
+        // initial load and must survive to the end — a full page load anywhere
+        // clears it, and a full reload refetches the manifest regardless of the
+        // app-root driver fix, so the sentinel is what proves the *driver* (not
+        // a reload) rebooted onto the newly-picked part.
+        //
+        // (A raw injected `<a>` is NOT usable here: dioxus-web routes clicks
+        // through its `Link` components, not a document-level delegated
+        // listener, so an injected anchor full-page-loads and defeats the
+        // sentinel. The real picker links are the only faithful in-app nav.)
+        const manifestFor = (fid: string) =>
+          new RegExp(`/api/audiobooks/${primaryUuid}/manifest\\?file_id=${fid}$`);
+        const pickerLinks = async () => {
+          await page.getByTestId("listen-file-picker-trigger").click();
+          await expect(page.getByTestId("listen-file-picker-panel")).toBeVisible();
+          return page.getByTestId("listen-file-picker-panel").getByRole("link");
+        };
+        const fileIdOf = (manifestUrl: string) =>
+          new URL(manifestUrl).searchParams.get("file_id");
 
-        // SPA-navigate to the SECOND part of the *same* book (uuid unchanged,
-        // only file_id differs). A true anchor click keeps it client-side, so
-        // the app-root driver must notice the file_id change and reboot.
-        // Sentinel on `window` proves the nav stayed in-app: a full page load
-        // would clear it, and a full load refetches the manifest regardless of
-        // the fix — so without this guard the test could false-positive.
-        await page.evaluate((url) => {
+        await gotoReady(page, `/books/${primaryUuid}`);
+        await page.evaluate(() => {
           (window as unknown as { __repickSentinel?: boolean }).__repickSentinel = true;
-          const a = document.createElement("a");
-          a.href = url;
-          a.id = "__test-repick-nav";
-          a.textContent = "repick-nav";
-          a.style.cssText =
-            "position:fixed;top:0;left:0;padding:8px;background:#000;color:#fff;z-index:99999;";
-          document.body.appendChild(a);
-        }, `/listen/${primaryUuid}?file_id=${secondId}`);
+        });
 
-        // Before the fix this request never fired (uuid unchanged → no reboot).
-        const [secondManifest] = await Promise.all([
-          page.waitForRequest(
-            (req) =>
-              req.url().includes(`/api/audiobooks/${primaryUuid}/manifest?file_id=${secondId}`),
-            { timeout: 10_000 },
-          ),
-          page.locator("#__test-repick-nav").click(),
+        // Pick the FIRST part via the picker → SPA-navigate to /listen and make
+        // the book the active playback book (uuid now set on the app-root
+        // PlaybackState).
+        const [firstManifest] = await Promise.all([
+          page.waitForRequest((req) => manifestFor("\\d+").test(req.url())),
+          (await pickerLinks()).nth(0).click(),
         ]);
-        expect(secondManifest.url()).toContain(`file_id=${secondId}`);
+        const firstFileId = fileIdOf(firstManifest.url());
+        await expect(page).toHaveURL(new RegExp(`/listen/${primaryUuid}\\?file_id=\\d+$`));
 
-        // The nav must have been a client-side SPA transition — if the page
-        // fully reloaded, the manifest fetch above proves nothing.
+        // Back to the detail page in-app (history popstate — no full load).
+        await page.goBack();
+        await expect(page).toHaveURL(new RegExp(`/books/${primaryUuid}$`));
+
+        // Re-pick the SECOND part of the *already-active* book. Before the fix
+        // the driver keyed only on the (unchanged) uuid, so this fired no fresh
+        // manifest and stayed on part 1.
+        const [secondManifest] = await Promise.all([
+          page.waitForRequest((req) => manifestFor("\\d+").test(req.url()), {
+            timeout: 10_000,
+          }),
+          (await pickerLinks()).nth(1).click(),
+        ]);
+        const secondFileId = fileIdOf(secondManifest.url());
+        expect(secondFileId, "re-pick must reboot onto a different part").not.toBe(
+          firstFileId,
+        );
+
+        // The whole session stayed client-side — if any hop fully reloaded, the
+        // manifest fetch above would prove nothing.
         const stayedInApp = await page.evaluate(
           () => (window as unknown as { __repickSentinel?: boolean }).__repickSentinel === true,
         );


### PR DESCRIPTION
Fixes **all** E2E failures that had `main` red on both Playwright shards. Two independent regressions, both traceable to the window after the last green run (`100851d0c`) — i.e. **PR #1156** ("fix: reload web audiobook player when re-picking a part").

## Fix 1 — merge-undo dropped `books.scan_key` → duplicate audiobook (shard 1)
- **Symptoms:** `toHaveCount` mismatches, a `getByTestId('action-listen')` "strict mode violation: resolved to 2 elements", "no seeded book titled *The Compiled Tales* surfaced", "expected at least 54 books" — across `listen`/`merge`/`book_detail`.
- **Root cause:** `undo_merge`'s `recreate_source_row` recreated the source `books` row **without `scan_key`** (left `NULL`). The reindex diff matches on-disk files against `books.scan_key`, so the next audiobook reindex couldn't match the restored row to its folder and inserted a **duplicate** book. #1156's new merge/undo test exposed this latent bug on the shared per-shard server.
- **Fix:** capture `books.scan_key` in the merge `SourceSnapshot` (`#[serde(default)]` so old `merge_log` JSON still replays) and restore it in `recreate_source_row`.

## Fix 2 — audiobook player booted before auth resolved → stuck "preparing" (shard 2)
- **Symptoms:** 11 `mini-dock.spec.ts` failures at `waitForPlayerReady` — `getByTestId('listen-preparing')` never clears; `OmnibusAudio` installs but `_mode` stays `null` and no manifest request fires.
- **Root cause:** on a fresh listen-page load, the App-level playback driver effect runs while `current_user()` is still `None` (unresolved), capturing `user_id = None`. The manifest-init task then bails at its `is_current` guard once `current_user` resolves to a real id (`Some(id) != None`), so it never fetches the manifest. Pre-#1156 the effect re-ran on user resolution and re-booted with the right id; #1156's `needs_reload` gate suppresses that re-boot.
- **Fix:** return early from the driver effect while the user is unresolved, so it re-runs and boots once with the real `user_id`.

## Fix 3 — re-pick E2E test drove SPA nav via an injected anchor (shard 1)
- **Symptom:** `book_detail.spec.ts` "re-picking a different part…" failed at the `__repickSentinel` check ("re-pick nav must stay in-app"). This assertion had been failing since #1156 added it, but was **masked** — the test died earlier at setup because Fix 1's duplicate broke the seed. With Fixes 1 & 2 in place the test runs to completion and exposes the flaw.
- **Cause:** the test injected a raw `<a>` into the DOM and expected dioxus-web to intercept the click as client-side routing. dioxus-web routes clicks through its `Link` components (not a document-level delegated listener), so the injected anchor triggers a full page load and clears the sentinel.
- **Fix:** drive both hops through genuine in-app navigation — pick the first part via the real file-picker `Link`, `goBack()` (history popstate) to the detail page, then re-pick the second part. Verified locally: `book_detail.spec.ts` 18/18 pass.

## CI evidence

## Test plan
- [x] `db`: new regression test `undo_merge_restores_scan_key_so_reindex_finds_no_duplicate`; full `cargo test -p omnibus-db` green; end-to-end against real fixtures — merge→undo→reindex yields exactly one *The Compiled Tales* (was two).
- [x] `frontend`: `cargo clippy --features web` clean, `cargo fmt --check` clean, listen-bootstrap unit tests pass.
- [x] **Playwright, run locally against a real dev server: `mini-dock.spec.ts` 11/11 pass** (was 0/11); confirmed the manifest now fetches and `_mode='direct'`. `listen.spec.ts` player-readiness paths pass. (Remaining local-only noise was dev-DB pollution from repeated runs + the known `fetchBookUuidByTitle` seed race that CI's `retries: 2` absorbs.)

## Version
- [x] **Patch** — two targeted bug fixes; no schema, API, or UX change.

## Notes
- No migration needed — `books.scan_key` already exists (migration `0026`).
- No new unit test for Fix 2: the boot-effect wiring isn't unit-testable without component-render infra (per `overlays.rs`, that path is covered by Playwright) — `mini-dock.spec.ts` is the regression guard.

