### PR TITLE
feat: link Admin health to /logs and show log details in a Grafana-style stream

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4488,24 +4488,32 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   margin: 1.25rem 0;
 }
 .logs-filters .settings-actions.logs-apply { margin: 0; }
-.logs-table-wrap { overflow-x: auto; }
-.logs-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.85rem;
+/* Grafana-style log stream: one big box that scrolls both axes, one
+   non-wrapping line per record with the details shown inline. */
+.logs-stream {
+  max-height: 70vh;
+  overflow: auto;
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  line-height: 1.6;
 }
-.logs-table th, .logs-table td {
-  text-align: left;
-  padding: 0.4rem 0.6rem;
-  border-bottom: 1px solid var(--line-2);
-  vertical-align: top;
+.logs-line {
+  /* max-content + min-width:100% makes each line grow to its own width so the
+     container's scrollWidth tracks the widest line — that's what enables the
+     horizontal scroll instead of wrapping. */
+  white-space: pre;
+  width: max-content;
+  min-width: 100%;
+  padding: 0.05rem 0;
 }
-.logs-table th { color: var(--ink-2); font-weight: 600; white-space: nowrap; }
-.logs-time, .logs-module-cell { white-space: nowrap; color: var(--ink-1); }
-.logs-message { word-break: break-word; }
-.logs-fields { margin-top: 0.35rem; }
-.logs-fields summary { cursor: pointer; color: var(--ink-2); }
-.logs-fields pre { margin: 0.35rem 0 0; white-space: pre-wrap; word-break: break-word; }
+.logs-line:hover { background: var(--bg-2); }
+.logs-time { color: var(--ink-2); }
+.logs-module-cell { color: var(--ink-2); }
+.logs-message { color: var(--ink-1); }
+.logs-fields { color: var(--ink-2); }
 .logs-level {
   display: inline-block;
   padding: 0.05rem 0.4rem;

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -120,6 +120,11 @@ fn UserMenuPanel(user: UserSummary, open: Signal<bool>) -> Element {
     let nav = use_navigator();
     let theme = use_context::<Signal<Theme>>();
     let on_signout = build_on_signout(open, nav);
+    // `/logs` is admin-gated (both the `LogsPage` chrome and the `rpc_get_logs`
+    // extractor), so only surface the admin row to admins — matching how the
+    // Settings page hides its log-viewer card. Non-admins would otherwise hit a
+    // dead-end "administrator access required" screen.
+    let is_admin = user.is_admin;
 
     let on_keydown = move |evt: Event<KeyboardData>| {
         if evt.key() == Key::Escape {
@@ -160,7 +165,7 @@ fn UserMenuPanel(user: UserSummary, open: Signal<bool>) -> Element {
                 UmStat { label: "Goals", detail: "12 / 24 books" }
             }
 
-            UmAccountRows { open }
+            UmAccountRows { open, is_admin }
             UmSessionRows { on_signout }
 
             UmThemeSeg { theme }
@@ -304,11 +309,12 @@ fn UmNowReading() -> Element {
     }
 }
 
-/// Account-scoped linear rows: Account, Settings, and the Admin log-viewer
-/// link (all real, each closes the menu), plus the stubbed Notifications row.
+/// Account-scoped linear rows: Account and Settings (real, each closes the
+/// menu), the admin-only Admin log-viewer link, plus the stubbed Notifications
+/// row. The admin row only renders for admins, since `/logs` is admin-gated.
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
-fn UmAccountRows(open: Signal<bool>) -> Element {
+fn UmAccountRows(open: Signal<bool>, is_admin: bool) -> Element {
     let mut open = open;
     rsx! {
         div { class: "um-rows",
@@ -326,13 +332,15 @@ fn UmAccountRows(open: Signal<bool>) -> Element {
                 span { class: "um-row-icon", "⚙" }
                 span { class: "um-row-label", "Settings" }
             }
-            Link {
-                to: Route::Logs {},
-                class: "um-row",
-                onclick: move |_| open.set(false),
-                span { class: "um-row-icon", "▣" }
-                span { class: "um-row-label", "Admin · server health" }
-                span { class: "um-row-aside", "logs" }
+            if is_admin {
+                Link {
+                    to: Route::Logs {},
+                    class: "um-row",
+                    onclick: move |_| open.set(false),
+                    span { class: "um-row-icon", "▣" }
+                    span { class: "um-row-label", "Admin · server health" }
+                    span { class: "um-row-aside", "logs" }
+                }
             }
             a {
                 class: "um-row",

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -304,8 +304,8 @@ fn UmNowReading() -> Element {
     }
 }
 
-/// Account-scoped linear rows: Settings (real link, closes the menu),
-/// plus the stubbed Admin/Notifications rows.
+/// Account-scoped linear rows: Account, Settings, and the Admin log-viewer
+/// link (all real, each closes the menu), plus the stubbed Notifications row.
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
 fn UmAccountRows(open: Signal<bool>) -> Element {
@@ -326,15 +326,13 @@ fn UmAccountRows(open: Signal<bool>) -> Element {
                 span { class: "um-row-icon", "⚙" }
                 span { class: "um-row-label", "Settings" }
             }
-            a {
+            Link {
+                to: Route::Logs {},
                 class: "um-row",
-                href: "#",
-                "aria-disabled": "true",
-                tabindex: "-1",
-                onclick: move |evt| evt.prevent_default(),
+                onclick: move |_| open.set(false),
                 span { class: "um-row-icon", "▣" }
                 span { class: "um-row-label", "Admin · server health" }
-                span { class: "um-row-aside", "all ok" }
+                span { class: "um-row-aside", "logs" }
             }
             a {
                 class: "um-row",

--- a/frontend/src/pages/logs.rs
+++ b/frontend/src/pages/logs.rs
@@ -273,54 +273,43 @@ fn LogResults(
         };
     }
     rsx! {
-        LogTable { records: page.records.clone() }
+        LogStream { records: page.records.clone() }
         LogPagination { applied, has_more: page.has_more, loading: loading() }
     }
 }
 
-/// Newest-first table of one page of records.
+/// Newest-first Grafana-style log stream: one page of records rendered as
+/// non-wrapping monospace lines inside a single box that scrolls both axes.
 #[component]
-fn LogTable(records: Vec<LogRecord>) -> Element {
+fn LogStream(records: Vec<LogRecord>) -> Element {
     rsx! {
-        div { class: "logs-table-wrap",
-            table { class: "logs-table", "data-testid": "logs-table",
-                thead {
-                    tr {
-                        th { "Time" }
-                        th { "Level" }
-                        th { "Module" }
-                        th { "Message" }
-                    }
-                }
-                tbody {
-                    for record in records {
-                        LogRow { record }
-                    }
-                }
+        div { class: "logs-stream mono", "data-testid": "logs-table", role: "log",
+            for record in records {
+                LogLine { record }
             }
         }
     }
 }
 
-/// One log record row; folds the extra fields into an expandable detail.
+/// One log record as a single preformatted line: timestamp, colored level,
+/// module, message, and the extra fields ("details") shown inline by default
+/// rather than folded behind a collapse. `white-space: pre` keeps the line
+/// intact so the stream scrolls horizontally instead of wrapping.
 #[component]
-fn LogRow(record: LogRecord) -> Element {
+fn LogLine(record: LogRecord) -> Element {
     let level_class = format!("logs-level logs-level-{}", record.level.to_lowercase());
     rsx! {
-        tr { class: "logs-row", "data-testid": "logs-row",
-            td { class: "logs-time mono", "{record.timestamp}" }
-            td {
-                span { class: "{level_class}", "{record.level}" }
-            }
-            td { class: "logs-module-cell mono", "{record.target}" }
-            td { class: "logs-message",
-                "{record.message}"
-                if let Some(fields) = record.fields {
-                    details { class: "logs-fields",
-                        summary { "details" }
-                        pre { class: "mono", "{fields}" }
-                    }
-                }
+        div { class: "logs-line", "data-testid": "logs-row",
+            span { class: "logs-time", "{record.timestamp}" }
+            " "
+            span { class: "{level_class}", "{record.level}" }
+            " "
+            span { class: "logs-module-cell", "{record.target}" }
+            " "
+            span { class: "logs-message", "{record.message}" }
+            if let Some(fields) = record.fields {
+                " "
+                span { class: "logs-fields", "{fields}" }
             }
         }
     }

--- a/frontend/src/pages/logs.rs
+++ b/frontend/src/pages/logs.rs
@@ -283,7 +283,7 @@ fn LogResults(
 #[component]
 fn LogStream(records: Vec<LogRecord>) -> Element {
     rsx! {
-        div { class: "logs-stream mono", "data-testid": "logs-table", role: "log",
+        div { class: "logs-stream mono", "data-testid": "logs-table", role: "region", "aria-label": "Server log stream",
             for record in records {
                 LogLine { record }
             }

--- a/ui_tests/playwright/tests/flows/user_menu.spec.ts
+++ b/ui_tests/playwright/tests/flows/user_menu.spec.ts
@@ -8,7 +8,8 @@ import { fixturesDir, seedLibrary } from "../utils/seed";
 // The user menu replaces the old top-bar cluster (ThemeToggle, Settings
 // link, Log out button) with a single avatar trigger that opens a dropdown.
 // Most rows in the dropdown are forward-looking stubs (disabled <a>); real
-// wiring covers recent progress, Settings, Sign out, and theme selection.
+// wiring covers recent progress, Account, Settings, the Admin log-viewer
+// link, Sign out, and theme selection.
 
 test.beforeAll(async ({ request }) => {
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
@@ -97,6 +98,14 @@ test("Settings link routes to the settings page", async ({ page }) => {
   await page.getByTestId("user-menu-trigger").click();
   await page.getByRole("link", { name: "Settings" }).click();
   await expect(page).toHaveURL(/\/settings$/);
+});
+
+test("Admin · server health link routes to the log viewer", async ({ page }) => {
+  await gotoReady(page, "/");
+  await page.getByTestId("user-menu-trigger").click();
+  await page.getByRole("link", { name: "Admin · server health" }).click();
+  await expect(page).toHaveURL(/\/logs$/);
+  await expect(page.getByRole("heading", { level: 1, name: "Server logs" })).toBeVisible();
 });
 
 for (const sample of [


### PR DESCRIPTION
## Summary
- The user-menu "Admin · server health" row is now a real link to `/logs` (was a disabled stub); it closes the menu on click like the Account/Settings rows.
- Redesigned the `/logs` viewer as a Grafana-style log stream: one non-wrapping monospace line per record with the extra `fields` ("details") shown inline by default, replacing the structured table + collapsible `<details>`.
- The stream is a single box that scrolls both vertically (`max-height: 70vh`) and horizontally (`white-space: pre`); level color chips and the `logs-table`/`logs-row` testids are preserved.

## Test plan
- [x] `cargo fmt --check` + `cargo clippy -p omnibus-frontend` clean; `just lint-css` clean.
- [x] Playwright `logs.spec.ts` (7) and `user_menu.spec.ts` (9, incl. new Admin→/logs test) pass.
- [x] Verified in-browser: menu link navigates to `/logs`; stream renders details inline and scrolls both axes (scrollWidth 2069 > clientWidth 1134; max-height 504px with vertical overflow).

## Version
- [x] **Patch** — the default; log-viewer presentation tweak, no wire/schema change.

## Notes
- Branched off `main` (the log viewer landed in #1157); no ticket, so `u/sloan/…`.