### PR TITLE
fix: cap unbounded array/string inputs before validation (#1164)

### DIFF
--- a/frontend/src/rpc/books.rs
+++ b/frontend/src/rpc/books.rs
@@ -215,6 +215,9 @@ async fn merge_candidates(
     pool: &sqlx::SqlitePool,
     q: &str,
 ) -> Result<Vec<EbookMetadata>, ServerFnError> {
+    if omnibus_shared::search_query_too_long(q) {
+        return Err(ServerFnError::new("query too long"));
+    }
     let settings = db::get_settings(pool)
         .await
         .map_err(|e| internal_rpc_error("get settings", e))?;
@@ -249,7 +252,17 @@ async fn merge_candidates(
 /// when the vec is truncated.
 #[post("/api/rpc/search", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
-    let settings = db::get_settings(&pool.0)
+    Ok(search_ebooks(&pool.0, &q).await?)
+}
+
+/// Server-side body of [`rpc_search`], extracted so the length-cap guard and
+/// the FTS5 call can be unit-tested without the server-fn transport.
+#[cfg(feature = "server")]
+async fn search_ebooks(pool: &sqlx::SqlitePool, q: &str) -> Result<EbookLibrary, ServerFnError> {
+    if omnibus_shared::search_query_too_long(q) {
+        return Err(ServerFnError::new("query too long"));
+    }
+    let settings = db::get_settings(pool)
         .await
         .map_err(|e| internal_rpc_error("get settings", e))?;
     let ebook = settings.ebook_library_path;
@@ -260,7 +273,7 @@ pub async fn rpc_search(q: String) -> Result<EbookLibrary> {
     }
     let path = paths[0].to_string();
     // Issue #241: single FTS5 pass returns the capped vec and the full count.
-    let (books, total) = db::search_books_for_paths_with_total(&pool.0, &paths, &q)
+    let (books, total) = db::search_books_for_paths_with_total(pool, &paths, q)
         .await
         .map_err(|e| internal_rpc_error("search books", e))?;
     Ok(EbookLibrary {
@@ -332,9 +345,9 @@ pub async fn rpc_get_suggestions(uuid: String) -> Result<SuggestionsResponse> {
 // server`.
 #[cfg(all(test, feature = "server"))]
 mod tests {
-    use super::{ebooks_page, merge_candidates};
+    use super::{ebooks_page, merge_candidates, search_ebooks};
     use omnibus_db::test_support::seed_synced_ebook;
-    use omnibus_shared::{Settings, SortDir, SortKey, ViewFilters};
+    use omnibus_shared::{Settings, SortDir, SortKey, ViewFilters, SEARCH_QUERY_MAX_LEN};
 
     async fn configured_pool(audiobook_path: Option<&str>) -> sqlx::SqlitePool {
         let pool = omnibus_db::init_db("sqlite::memory:").await.unwrap();
@@ -451,5 +464,25 @@ mod tests {
             out.iter().all(|b| seen.insert(b.unique_identifier.clone())),
             "no duplicate unique_identifier may survive the dedup"
         );
+    }
+
+    #[tokio::test]
+    async fn search_ebooks_rejects_query_over_the_length_cap() {
+        let pool = configured_pool(None).await;
+        let oversized = "a".repeat(SEARCH_QUERY_MAX_LEN + 1);
+
+        let result = search_ebooks(&pool, &oversized).await;
+
+        assert!(result.is_err(), "oversized query must be rejected");
+    }
+
+    #[tokio::test]
+    async fn merge_candidates_rejects_query_over_the_length_cap() {
+        let pool = configured_pool(None).await;
+        let oversized = "a".repeat(SEARCH_QUERY_MAX_LEN + 1);
+
+        let result = merge_candidates(&pool, &oversized).await;
+
+        assert!(result.is_err(), "oversized query must be rejected");
     }
 }

--- a/frontend/src/rpc/kindle.rs
+++ b/frontend/src/rpc/kindle.rs
@@ -27,9 +27,9 @@ use super::{internal_rpc_error, AuthUser, PoolExt, WorkerExt};
 /// delivery runs on the worker; poll [`rpc_kindle_send_status`] for its result.
 #[post("/api/rpc/kindle/send", pool: PoolExt, worker: WorkerExt, user: AuthUser)]
 pub async fn rpc_send_to_kindle(book_uuid: String, file_id: Option<i64>) -> Result<u64> {
-    if book_uuid.chars().count() > omnibus_shared::BOOK_UUID_MAX_LEN {
+    if book_uuid.len() > omnibus_shared::BOOK_UUID_MAX_LEN {
         return Err(ServerFnError::new(format!(
-            "book_uuid must be ≤ {} characters",
+            "book_uuid must be ≤ {} bytes",
             omnibus_shared::BOOK_UUID_MAX_LEN
         ))
         .into());

--- a/frontend/src/rpc/kindle.rs
+++ b/frontend/src/rpc/kindle.rs
@@ -27,6 +27,13 @@ use super::{internal_rpc_error, AuthUser, PoolExt, WorkerExt};
 /// delivery runs on the worker; poll [`rpc_kindle_send_status`] for its result.
 #[post("/api/rpc/kindle/send", pool: PoolExt, worker: WorkerExt, user: AuthUser)]
 pub async fn rpc_send_to_kindle(book_uuid: String, file_id: Option<i64>) -> Result<u64> {
+    if book_uuid.chars().count() > omnibus_shared::BOOK_UUID_MAX_LEN {
+        return Err(ServerFnError::new(format!(
+            "book_uuid must be ≤ {} characters",
+            omnibus_shared::BOOK_UUID_MAX_LEN
+        ))
+        .into());
+    }
     let recipient = db::auth::get_kindle_email(&pool.0, user.id)
         .await
         .map_err(|e| internal_rpc_error("get kindle email", e))?;

--- a/frontend/src/rpc/palette.rs
+++ b/frontend/src/rpc/palette.rs
@@ -30,6 +30,9 @@ pub async fn rpc_search_palette(q: String) -> Result<PaletteResults> {
 /// search can be unit-tested without the server-fn transport.
 #[cfg(feature = "server")]
 async fn search_palette(pool: &sqlx::SqlitePool, q: &str) -> Result<PaletteResults, ServerFnError> {
+    if omnibus_shared::search_query_too_long(q) {
+        return Err(ServerFnError::new("query too long"));
+    }
     let settings = db::get_settings(pool)
         .await
         .map_err(|e| internal_rpc_error("get settings", e))?;
@@ -52,6 +55,7 @@ async fn search_palette(pool: &sqlx::SqlitePool, q: &str) -> Result<PaletteResul
 mod tests {
     use super::search_palette;
     use omnibus_db::test_support::seed_synced_ebook;
+    use omnibus_shared::SEARCH_QUERY_MAX_LEN;
 
     #[tokio::test]
     async fn search_palette_groups_book_hits_for_a_configured_library() {
@@ -77,5 +81,15 @@ mod tests {
         let pool = omnibus_db::init_db("sqlite::memory:").await.unwrap();
         let results = search_palette(&pool, "anything").await.unwrap();
         assert_eq!(results, omnibus_shared::PaletteResults::default());
+    }
+
+    #[tokio::test]
+    async fn search_palette_rejects_query_over_the_length_cap() {
+        let pool = omnibus_db::init_db("sqlite::memory:").await.unwrap();
+        let oversized = "a".repeat(SEARCH_QUERY_MAX_LEN + 1);
+
+        let result = search_palette(&pool, &oversized).await;
+
+        assert!(result.is_err(), "oversized query must be rejected");
     }
 }

--- a/frontend/src/rpc/shelves.rs
+++ b/frontend/src/rpc/shelves.rs
@@ -4,9 +4,12 @@
 use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
 use omnibus_shared::{
-    validate_book_uuids, validate_rule_count, CreateShelfRequest, MatchMode, RulePreview, Shelf,
-    ShelfPage, ShelfRule, ShelfSummary, SortDir, SortKey, UpdateShelfRequest,
+    CreateShelfRequest, MatchMode, RulePreview, Shelf, ShelfPage, ShelfRule, ShelfSummary, SortDir,
+    SortKey, UpdateShelfRequest,
 };
+
+#[cfg(feature = "server")]
+use omnibus_shared::{validate_book_uuids, validate_rule_count};
 
 #[cfg(feature = "server")]
 use omnibus_db as db;

--- a/frontend/src/rpc/shelves.rs
+++ b/frontend/src/rpc/shelves.rs
@@ -4,8 +4,8 @@
 use dioxus::fullstack::{get, post};
 use dioxus::prelude::*;
 use omnibus_shared::{
-    CreateShelfRequest, MatchMode, RulePreview, Shelf, ShelfPage, ShelfRule, ShelfSummary, SortDir,
-    SortKey, UpdateShelfRequest,
+    validate_book_uuids, validate_rule_count, CreateShelfRequest, MatchMode, RulePreview, Shelf,
+    ShelfPage, ShelfRule, ShelfSummary, SortDir, SortKey, UpdateShelfRequest,
 };
 
 #[cfg(feature = "server")]
@@ -116,6 +116,9 @@ pub async fn rpc_get_shelf_page(
 /// Append books to a hand-picked shelf (owner or admin).
 #[post("/api/rpc/shelves/add-books", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_add_shelf_books(id: i64, book_uuids: Vec<String>) -> Result<()> {
+    if let Err(e) = validate_book_uuids(&book_uuids) {
+        return Err(ServerFnError::new(e).into());
+    }
     shelf_for_edit(&pool.0, id, &user).await?;
     Ok(db::add_books(&pool.0, id, &book_uuids, user.id)
         .await
@@ -137,6 +140,9 @@ pub async fn rpc_preview_shelf_rule(
     match_mode: MatchMode,
     rules: Vec<ShelfRule>,
 ) -> Result<RulePreview> {
+    if let Err(e) = validate_rule_count(&rules) {
+        return Err(ServerFnError::new(e).into());
+    }
     for rule in &rules {
         if let Err(e) = rule.validate() {
             return Err(ServerFnError::new(e).into());

--- a/server/src/backend/kindle.rs
+++ b/server/src/backend/kindle.rs
@@ -28,9 +28,9 @@ impl SendBody {
     /// Reject a `book_uuid` over [`omnibus_shared::BOOK_UUID_MAX_LEN`] before
     /// any DB round trip.
     fn validate(&self) -> Result<(), String> {
-        if self.book_uuid.chars().count() > omnibus_shared::BOOK_UUID_MAX_LEN {
+        if self.book_uuid.len() > omnibus_shared::BOOK_UUID_MAX_LEN {
             return Err(format!(
-                "book_uuid must be ≤ {} characters",
+                "book_uuid must be ≤ {} bytes",
                 omnibus_shared::BOOK_UUID_MAX_LEN
             ));
         }

--- a/server/src/backend/kindle.rs
+++ b/server/src/backend/kindle.rs
@@ -24,6 +24,20 @@ pub(super) struct SendBody {
     file_id: Option<i64>,
 }
 
+impl SendBody {
+    /// Reject a `book_uuid` over [`omnibus_shared::BOOK_UUID_MAX_LEN`] before
+    /// any DB round trip.
+    fn validate(&self) -> Result<(), String> {
+        if self.book_uuid.chars().count() > omnibus_shared::BOOK_UUID_MAX_LEN {
+            return Err(format!(
+                "book_uuid must be ≤ {} characters",
+                omnibus_shared::BOOK_UUID_MAX_LEN
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Enqueue a send of the EPUB to the authenticated user's Kindle address and
 /// return the worker `task_id` to poll (`{"task_id": N}`). Fast pre-checks (no
 /// Kindle email, SMTP unconfigured, unknown book) still fail synchronously; the
@@ -33,6 +47,9 @@ pub(super) async fn post_send(
     State(state): State<AppState>,
     Json(body): Json<SendBody>,
 ) -> Response {
+    if let Err(msg) = body.validate() {
+        return (StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
+    }
     let recipient = match db::auth::get_kindle_email(&state.pool, user.id).await {
         Ok(Some(email)) => email,
         Ok(None) => {

--- a/server/src/backend/kindle/tests.rs
+++ b/server/src/backend/kindle/tests.rs
@@ -200,6 +200,24 @@ async fn send_returns_422_when_user_has_no_kindle_email() {
 }
 
 #[tokio::test]
+async fn send_returns_422_when_book_uuid_exceeds_the_length_cap() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let oversized = "a".repeat(omnibus_shared::BOOK_UUID_MAX_LEN + 1);
+    let response = app
+        .oneshot(post_json(
+            "/api/kindle/send",
+            &token,
+            serde_json::json!({ "book_uuid": oversized }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
 async fn send_returns_404_when_gates_pass_but_book_missing() {
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "reader").await;

--- a/server/src/backend/search.rs
+++ b/server/src/backend/search.rs
@@ -11,15 +11,13 @@ use axum::{
     Json,
 };
 use omnibus_db::{self as db};
+use omnibus_shared::search_query_too_long;
+#[cfg(test)]
+use omnibus_shared::SEARCH_QUERY_MAX_LEN as MAX_SEARCH_QUERY_LEN;
 use serde::Deserialize;
 
 use super::{internal, with_pagination_headers, AppState};
 use crate::auth::AuthUser;
-
-/// Handler-level cap on the decoded `q` parameter length, in bytes. Rejects
-/// abusive input before the search db calls; the db layer still applies its
-/// own finer char-count trim (`cap_query_len`) as a fallback.
-const MAX_SEARCH_QUERY_LEN: usize = 1024;
 
 #[derive(Deserialize)]
 pub(super) struct SearchQuery {
@@ -28,10 +26,10 @@ pub(super) struct SearchQuery {
 
 /// Reject an over-length query with 400 so oversized input is never forwarded
 /// into the search db calls. Returns `Some(response)` when `q` exceeds
-/// [`MAX_SEARCH_QUERY_LEN`].
+/// `omnibus_shared::SEARCH_QUERY_MAX_LEN` — the same cap the RPC search
+/// entrypoints enforce via [`search_query_too_long`].
 fn reject_if_over_length(q: &str) -> Option<Response> {
-    (q.len() > MAX_SEARCH_QUERY_LEN)
-        .then(|| (StatusCode::BAD_REQUEST, "query too long").into_response())
+    search_query_too_long(q).then(|| (StatusCode::BAD_REQUEST, "query too long").into_response())
 }
 
 pub(super) async fn get_search(

--- a/server/src/backend/shelves.rs
+++ b/server/src/backend/shelves.rs
@@ -14,7 +14,8 @@ use axum::{
 };
 use omnibus_db::{self as db, shelves::ShelfError};
 use omnibus_shared::{
-    CreateShelfRequest, RulePreviewRequest, Shelf, SortDir, SortKey, UpdateShelfRequest,
+    validate_book_uuids, CreateShelfRequest, RulePreviewRequest, Shelf, SortDir, SortKey,
+    UpdateShelfRequest,
 };
 
 use super::{internal, AppState};
@@ -113,6 +114,9 @@ pub(super) async fn add_shelf_books(
     Path(id): Path<i64>,
     Json(req): Json<AddBooksRequest>,
 ) -> Response {
+    if let Err(msg) = req.validate() {
+        return (StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
+    }
     if let Err(resp) = load_for_edit(&state, id, &user).await {
         return resp;
     }
@@ -143,10 +147,8 @@ pub(super) async fn preview_rule(
     State(state): State<AppState>,
     Json(req): Json<RulePreviewRequest>,
 ) -> Response {
-    for rule in &req.rules {
-        if let Err(msg) = rule.validate() {
-            return (StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
-        }
+    if let Err(msg) = req.validate() {
+        return (StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
     }
     match db::preview_rule(&state.pool, user.id, req.match_mode, &req.rules).await {
         Ok(preview) => Json(preview).into_response(),
@@ -208,6 +210,13 @@ fn map_err(e: ShelfError) -> Response {
 #[derive(serde::Deserialize)]
 pub(super) struct AddBooksRequest {
     pub book_uuids: Vec<String>,
+}
+
+impl AddBooksRequest {
+    /// Reject an over-long or malformed book uuid list before any DB round trip.
+    fn validate(&self) -> Result<(), String> {
+        validate_book_uuids(&self.book_uuids)
+    }
 }
 
 /// Query string for the shelf page (`?sort=&dir=`).

--- a/server/src/backend/shelves/tests.rs
+++ b/server/src/backend/shelves/tests.rs
@@ -281,6 +281,64 @@ async fn api_list_returns_only_visible_shelves() {
 }
 
 #[tokio::test]
+async fn api_add_book_rejects_oversized_book_uuids_array_with_422() {
+    let (app, _s, pool) = fixture().await;
+    seed_book(&pool, "bk1").await;
+    let alice = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, alice.id).await;
+
+    let created = app
+        .clone()
+        .oneshot(req(
+            "POST",
+            "/api/shelves",
+            Some(&token),
+            Some(serde_json::json!({ "kind": "manual", "name": "Picks", "visibility": "private" })),
+        ))
+        .await
+        .unwrap();
+    let id = shelf_from(created).await.id;
+
+    let too_many: Vec<String> = (0..omnibus_shared::MAX_SHELF_BOOK_UUIDS + 1)
+        .map(|i| i.to_string())
+        .collect();
+    let res = app
+        .oneshot(req(
+            "POST",
+            &format!("/api/shelves/{id}/books"),
+            Some(&token),
+            Some(serde_json::json!({ "book_uuids": too_many })),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn api_preview_rule_rejects_too_many_rules_with_422() {
+    let (app, _s, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let rules: Vec<_> = std::iter::repeat_n(
+        serde_json::json!({ "field": "tag", "op": "is", "value": "Fantasy" }),
+        omnibus_shared::MAX_PREVIEW_RULES + 1,
+    )
+    .collect();
+    let body = serde_json::json!({ "match_mode": "any", "rules": rules });
+    let res = app
+        .oneshot(req(
+            "POST",
+            "/api/shelves/preview",
+            Some(&token),
+            Some(body),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
 async fn api_add_book_to_manual_shelf_returns_204() {
     let (app, _s, pool) = fixture().await;
     seed_book(&pool, "bk1").await;

--- a/server/src/backend/uploads.rs
+++ b/server/src/backend/uploads.rs
@@ -253,13 +253,13 @@ async fn read_text_field_capped(
             .await
             .map_err(|e| UploadError::internal("read multipart text chunk", e))?;
         let Some(chunk) = chunk else { break };
-        buf.extend_from_slice(&chunk);
-        if buf.len() > cap {
+        if buf.len() + chunk.len() > cap {
             return Err(UploadError::FieldTooLarge {
                 field: field_name,
                 cap,
             });
         }
+        buf.extend_from_slice(&chunk);
     }
     Ok(String::from_utf8(buf).ok())
 }

--- a/server/src/backend/uploads.rs
+++ b/server/src/backend/uploads.rs
@@ -30,6 +30,13 @@ use crate::auth::AuthUser;
 /// unparseable. Generous so it survives the future large-audiobook case.
 pub const DEFAULT_MAX_UPLOAD_BYTES: usize = 1024 * 1024 * 1024;
 
+/// Per-field byte cap for the commit multipart's text fields
+/// (title/author/series/series_index), enforced incrementally while
+/// streaming so an oversized field is rejected before it's fully buffered.
+/// Generous headroom over `MetadataOverrides`' char caps (500 for title, 250
+/// for the rest) while still bounding memory ahead of that later validation.
+const MAX_TEXT_FIELD_BYTES: usize = 8 * 1024;
+
 /// Resolve the configured upload size cap from `OMNIBUS_MAX_UPLOAD_BYTES`,
 /// falling back to [`DEFAULT_MAX_UPLOAD_BYTES`]. Read at router-build time for
 /// the body limit and again per-request as a defense-in-depth backstop.
@@ -63,6 +70,9 @@ pub(super) enum UploadError {
     BadEpub(String),
     /// File exceeds the configured byte cap → 413.
     TooLarge(usize),
+    /// A multipart text field (title/author/series/series_index) exceeds its
+    /// per-field byte cap, rejected before it's fully buffered → 413.
+    FieldTooLarge { field: &'static str, cap: usize },
     /// Override validation failed (a field too long) → 400.
     Validation(String),
     /// Unexpected internal failure → 500 (logged; detail not leaked to the wire).
@@ -115,6 +125,11 @@ impl IntoResponse for UploadError {
             UploadError::TooLarge(cap) => (
                 StatusCode::PAYLOAD_TOO_LARGE,
                 format!("file exceeds the {cap}-byte upload limit"),
+            )
+                .into_response(),
+            UploadError::FieldTooLarge { field, cap } => (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!("{field} exceeds the {cap}-byte limit"),
             )
                 .into_response(),
             UploadError::Validation(msg) => (StatusCode::BAD_REQUEST, msg).into_response(),
@@ -220,6 +235,33 @@ async fn stream_upload_to_tempfile(
         return Err(UploadError::UnsupportedFormat);
     }
     Ok(tmp)
+}
+
+/// Read a multipart text field incrementally, capping the bytes buffered
+/// before it is fully read (mirrors `stream_upload_to_tempfile`'s incremental
+/// cap on the `file` field). Returns `Ok(None)` for non-UTF-8 bytes, matching
+/// `field.text().await.ok()`'s prior silent-drop behavior.
+async fn read_text_field_capped(
+    mut field: Field<'_>,
+    field_name: &'static str,
+    cap: usize,
+) -> Result<Option<String>, UploadError> {
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        let chunk = field
+            .chunk()
+            .await
+            .map_err(|e| UploadError::internal("read multipart text chunk", e))?;
+        let Some(chunk) = chunk else { break };
+        buf.extend_from_slice(&chunk);
+        if buf.len() > cap {
+            return Err(UploadError::FieldTooLarge {
+                field: field_name,
+                cap,
+            });
+        }
+    }
+    Ok(String::from_utf8(buf).ok())
 }
 
 // --- Inspect ---------------------------------------------------------------
@@ -396,10 +438,23 @@ async fn parse_commit_multipart(
                     "file" => {
                         form.tmp_file = Some(stream_upload_to_tempfile(field, cap).await?);
                     }
-                    "title" => form.title = field.text().await.ok(),
-                    "author" => form.author = field.text().await.ok(),
-                    "series" => form.series = field.text().await.ok(),
-                    "series_index" => form.series_index = field.text().await.ok(),
+                    "title" => {
+                        form.title =
+                            read_text_field_capped(field, "title", MAX_TEXT_FIELD_BYTES).await?
+                    }
+                    "author" => {
+                        form.author =
+                            read_text_field_capped(field, "author", MAX_TEXT_FIELD_BYTES).await?
+                    }
+                    "series" => {
+                        form.series =
+                            read_text_field_capped(field, "series", MAX_TEXT_FIELD_BYTES).await?
+                    }
+                    "series_index" => {
+                        form.series_index =
+                            read_text_field_capped(field, "series_index", MAX_TEXT_FIELD_BYTES)
+                                .await?
+                    }
                     _ => continue,
                 }
             }

--- a/server/src/backend/uploads/tests.rs
+++ b/server/src/backend/uploads/tests.rs
@@ -292,6 +292,23 @@ async fn commit_requires_configured_library_path() {
 }
 
 #[tokio::test]
+async fn commit_rejects_oversized_title_field_with_413_before_full_buffering() {
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    // The oversized text field is rejected while streaming, before the parser
+    // even reaches the (absent here) `file` field.
+    let oversized_title = "a".repeat(MAX_TEXT_FIELD_BYTES + 1);
+    let (ct, body) = multipart_body(&[("title", None, oversized_title.as_bytes())]);
+    let res = app
+        .oneshot(post_multipart("/api/uploads/ebooks", &token, &ct, body))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
 async fn commit_rejects_read_only_library_with_400() {
     let (app, _state, pool) = fixture().await;
     let library = tempfile::tempdir().expect("temp library dir");

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -44,6 +44,24 @@ pub const SMTP_PASSWORD_MAX_LEN: usize = 1024;
 /// commonly-cited practical upper bound for `local@domain`.
 pub const EMAIL_MAX_LEN: usize = 320;
 
+/// Maximum byte length of a `book_uuid` used purely as a lookup key (Kindle
+/// send, shelf membership). A minted book uuid is a 36-byte hyphenated
+/// UUIDv4; this leaves headroom for other id formats while still rejecting
+/// abusive input before it reaches a DB lookup.
+pub const BOOK_UUID_MAX_LEN: usize = 64;
+
+/// Handler-level cap on a decoded search query's length, in bytes. Shared by
+/// the REST search/palette handlers and their RPC counterparts so both
+/// boundaries reject oversized input before any FTS5 call; the db layer still
+/// applies its own char-count trim (`cap_query_len`) as a fallback.
+pub const SEARCH_QUERY_MAX_LEN: usize = 1024;
+
+/// `true` once `q` exceeds [`SEARCH_QUERY_MAX_LEN`] and should be rejected
+/// before it reaches a search db call.
+pub fn search_query_too_long(q: &str) -> bool {
+    q.len() > SEARCH_QUERY_MAX_LEN
+}
+
 pub use audiobook::*;
 pub use auth::*;
 pub use bookmark::*;
@@ -66,3 +84,14 @@ pub use suggestion::*;
 pub use upload::*;
 pub use view_prefs::*;
 pub use worker::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_query_too_long_rejects_over_cap_and_accepts_at_cap() {
+        assert!(!search_query_too_long(&"a".repeat(SEARCH_QUERY_MAX_LEN)));
+        assert!(search_query_too_long(&"a".repeat(SEARCH_QUERY_MAX_LEN + 1)));
+    }
+}

--- a/shared/src/shelves.rs
+++ b/shared/src/shelves.rs
@@ -362,9 +362,9 @@ pub fn validate_book_uuids(uuids: &[String]) -> Result<(), String> {
         ));
     }
     for uuid in uuids {
-        if uuid.chars().count() > crate::BOOK_UUID_MAX_LEN {
+        if uuid.len() > crate::BOOK_UUID_MAX_LEN {
             return Err(format!(
-                "book uuid must be ≤ {} characters",
+                "book uuid must be ≤ {} bytes",
                 crate::BOOK_UUID_MAX_LEN
             ));
         }

--- a/shared/src/shelves.rs
+++ b/shared/src/shelves.rs
@@ -19,6 +19,16 @@ pub const SHELF_DESCRIPTION_MAX_LEN: usize = 2048;
 /// (a tag/author/series name, a rating, a date window), never free text.
 pub const SHELF_RULE_VALUE_MAX_LEN: usize = 512;
 
+/// Max number of book uuids accepted in one create/add-books request. Bulk
+/// membership writes chunk the DB insert, but the request itself still needs
+/// a cap so an unbounded array can't force a large batch before rejection.
+pub const MAX_SHELF_BOOK_UUIDS: usize = 2000;
+
+/// Max number of smart-rule conditions accepted in one create/preview
+/// request. Each rule's `value` is capped individually; this bounds the
+/// count so a request can't force an unbounded per-rule validation pass.
+pub const MAX_PREVIEW_RULES: usize = 50;
+
 /// Kind of shelf, fixed at creation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -249,6 +259,7 @@ impl CreateShelfRequest {
     pub fn validate(&self) -> Result<(), String> {
         validate_name(&self.name)?;
         validate_description(&self.description)?;
+        validate_book_uuids(&self.book_uuids)?;
         match self.kind {
             ShelfKind::Smart => {
                 if self.match_mode.is_none() {
@@ -260,6 +271,7 @@ impl CreateShelfRequest {
                 if !self.book_uuids.is_empty() {
                     return Err("smart shelves cannot have hand-picked books".into());
                 }
+                validate_rule_count(&self.rules)?;
                 for r in &self.rules {
                     r.validate()?;
                 }
@@ -321,10 +333,55 @@ pub struct RulePreviewRequest {
     pub rules: Vec<ShelfRule>,
 }
 
+impl RulePreviewRequest {
+    /// Reject more than [`MAX_PREVIEW_RULES`] conditions, then each rule
+    /// itself. Handlers translate `Err(_)` into a 400/422.
+    pub fn validate(&self) -> Result<(), String> {
+        validate_rule_count(&self.rules)?;
+        for r in &self.rules {
+            r.validate()?;
+        }
+        Ok(())
+    }
+}
+
 /// One page of a shelf's books (v1: capped, no cursor).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ShelfPage {
     pub books: Vec<EbookMetadata>,
+}
+
+/// Reject an over-long list of book uuids, or any uuid string itself over
+/// [`crate::BOOK_UUID_MAX_LEN`], before a DB round trip. Shared by
+/// `CreateShelfRequest::validate`, the REST `AddBooksRequest`, and
+/// `rpc_add_shelf_books`.
+pub fn validate_book_uuids(uuids: &[String]) -> Result<(), String> {
+    if uuids.len() > MAX_SHELF_BOOK_UUIDS {
+        return Err(format!(
+            "cannot submit more than {MAX_SHELF_BOOK_UUIDS} book uuids at once"
+        ));
+    }
+    for uuid in uuids {
+        if uuid.chars().count() > crate::BOOK_UUID_MAX_LEN {
+            return Err(format!(
+                "book uuid must be ≤ {} characters",
+                crate::BOOK_UUID_MAX_LEN
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Reject more than [`MAX_PREVIEW_RULES`] conditions before validating each
+/// one. Shared by `RulePreviewRequest::validate`, `CreateShelfRequest::validate`,
+/// and `rpc_preview_shelf_rule`.
+pub fn validate_rule_count(rules: &[ShelfRule]) -> Result<(), String> {
+    if rules.len() > MAX_PREVIEW_RULES {
+        return Err(format!(
+            "cannot submit more than {MAX_PREVIEW_RULES} conditions at once"
+        ));
+    }
+    Ok(())
 }
 
 /// Reject an empty or over-long shelf name.

--- a/shared/src/shelves/tests.rs
+++ b/shared/src/shelves/tests.rs
@@ -188,6 +188,73 @@ fn create_validate_enforces_manual_invariants() {
 }
 
 #[test]
+fn create_validate_rejects_too_many_book_uuids_and_overlong_uuid() {
+    let base = CreateShelfRequest {
+        kind: ShelfKind::Manual,
+        name: "Best of 2026".into(),
+        description: None,
+        visibility: Visibility::Private,
+        match_mode: None,
+        rules: vec![],
+        book_uuids: vec!["u1".into(), "u2".into()],
+    };
+    assert!(base.validate().is_ok());
+
+    let too_many = CreateShelfRequest {
+        book_uuids: (0..MAX_SHELF_BOOK_UUIDS + 1)
+            .map(|i| i.to_string())
+            .collect(),
+        ..base.clone()
+    };
+    assert!(too_many.validate().is_err());
+
+    let overlong_uuid = CreateShelfRequest {
+        book_uuids: vec!["u".repeat(crate::BOOK_UUID_MAX_LEN + 1)],
+        ..base.clone()
+    };
+    assert!(overlong_uuid.validate().is_err());
+}
+
+#[test]
+fn create_validate_rejects_too_many_smart_rules() {
+    let rule = ShelfRule {
+        field: RuleField::Tag,
+        op: RuleOp::Is,
+        value: "Fantasy".into(),
+    };
+    let too_many = CreateShelfRequest {
+        kind: ShelfKind::Smart,
+        name: "Fantasy".into(),
+        description: None,
+        visibility: Visibility::Private,
+        match_mode: Some(MatchMode::Any),
+        rules: std::iter::repeat_n(rule, MAX_PREVIEW_RULES + 1).collect(),
+        book_uuids: vec![],
+    };
+    assert!(too_many.validate().is_err());
+}
+
+#[test]
+fn rule_preview_validate_rejects_too_many_rules_and_accepts_at_cap() {
+    let rule = ShelfRule {
+        field: RuleField::Tag,
+        op: RuleOp::Is,
+        value: "Fantasy".into(),
+    };
+    let at_cap = RulePreviewRequest {
+        match_mode: MatchMode::Any,
+        rules: std::iter::repeat_n(rule.clone(), MAX_PREVIEW_RULES).collect(),
+    };
+    assert!(at_cap.validate().is_ok());
+
+    let too_many = RulePreviewRequest {
+        match_mode: MatchMode::Any,
+        rules: std::iter::repeat_n(rule, MAX_PREVIEW_RULES + 1).collect(),
+    };
+    assert!(too_many.validate().is_err());
+}
+
+#[test]
 fn create_validate_rejects_blank_and_overlong_names() {
     let base = CreateShelfRequest {
         kind: ShelfKind::Manual,


### PR DESCRIPTION
## Summary
- Closes #1164
- `CreateShelfRequest.book_uuids` and the REST `AddBooksRequest`/`rpc_add_shelf_books` now reject an over-long array or an over-long individual uuid via a new shared `validate_book_uuids` helper (`MAX_SHELF_BOOK_UUIDS = 2000`, `BOOK_UUID_MAX_LEN = 64`) before any DB round trip.
- `RulePreviewRequest` (and `CreateShelfRequest`'s smart-shelf rules) now reject more than `MAX_PREVIEW_RULES` (50) conditions via a new `RulePreviewRequest::validate()` / `validate_rule_count` helper, shared by the REST handler and `rpc_preview_shelf_rule`.
- `SendBody.book_uuid` (REST) and `rpc_send_to_kindle`'s `book_uuid` now share the same `BOOK_UUID_MAX_LEN` cap.
- `rpc_search`, `rpc_search_palette`, and `rpc_merge_candidates` now reject an oversized `q` at the RPC boundary via a new shared `search_query_too_long`/`SEARCH_QUERY_MAX_LEN`, mirroring the REST `/api/search` handler's existing cap (which was refactored to reuse the same shared constant/helper instead of a locally-duplicated one).
- `parse_commit_multipart`'s `title`/`author`/`series`/`series_index` text fields are now read via a new `read_text_field_capped` helper that enforces a per-field byte cap (`MAX_TEXT_FIELD_BYTES = 8 KiB`) incrementally while streaming, instead of `field.text().await.ok()` fully buffering an unbounded field before any validation runs.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1105 + 2 passed)
- [x] `cargo test -p omnibus --features server` — PASS (360 passed; 1 pre-existing failure, `commit_rejects_read_only_library_with_400`, confirmed present on unmodified `main` too — the dev sandbox runs as root, which bypasses the test's `chmod 0o555` read-only check; unrelated to this change)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (351 passed)
- [x] `cargo test -p omnibus-shared` — PASS (150 passed)

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The pre-existing `commit_rejects_read_only_library_with_400` failure is a sandbox artifact (tests running as root), not a regression from this change — verified by reproducing it against unmodified `main` in the same environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm1Psjcy7WPBTAysHdMdNK)_