### PR TITLE
refactor: eliminate avoidable EbookMetadata clone in GridTile (#1170)

### DIFF
--- a/frontend/src/pages/landing/grid.rs
+++ b/frontend/src/pages/landing/grid.rs
@@ -34,7 +34,6 @@ fn GridTile(book: EbookMetadata, server_url: String) -> Element {
     let display_title = book.title.as_deref().unwrap_or(&book.filename).to_string();
     let tile_testid = format!("ebook-tile-{}", row_slug(&book.filename));
     let authors = contributor_names(&book.creators);
-    let book_for_cover = book.clone();
     let nav = use_navigator();
 
     // Prefer the responsive `/api/thumbs/:uuid/{sm,md,lg}` endpoint over the
@@ -66,7 +65,7 @@ fn GridTile(book: EbookMetadata, server_url: String) -> Element {
                 }
             },
             crate::components::atrium::Cover {
-                book: book_for_cover,
+                book,
                 src_override: thumb_src,
                 srcset: thumb_srcset,
                 sizes: Some(


### PR DESCRIPTION
## Summary
- Closes #1170
- `GridTile` (landing page cover-grid view) cloned the entire `EbookMetadata` struct into `book_for_cover` even though the original `book` is never used again after its last real borrow (`thumb_srcs(&book, &uuid, &server_url, cover_bust)`, a few lines earlier). Removed the clone and let `book` move directly into `crate::components::atrium::Cover { book, ... }` — the rsx output passed to `Cover` is unchanged (same fields, same values), so there's no rendering/hydration risk (pure Rust-side data-flow change, no markup contract touched).
- Left the `server_url` clones in `BookGrid` (`frontend/src/pages/landing/grid.rs`) and `build_save_field`/`build_save_authors` (`frontend/src/pages/landing/table/row.rs`) untouched, per the issue's own guidance: they're cheap short-string clones, and de-duplicating them (e.g. via `Rc<str>`) would ripple into the prop types of `BookGrid`, `BookTableContext`, and their several callers (`sections.rs`, `effects.rs`, `mobile.rs`) — out of scope for this low-severity tech-debt fix.

## Test plan
- [x] `cargo fmt` — no diff
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 348 passed; 0 failed

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Purely a clone-elimination perf refactor; no behavior or rendered-output change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm1Psjcy7WPBTAysHdMdNK)_