### PR TITLE
fix: batch rebuild_all_fts into O(1) statements instead of 2N (#1166)

### DIFF
--- a/db/src/sync/fts.rs
+++ b/db/src/sync/fts.rs
@@ -9,48 +9,59 @@
 //! job [`rebuild_all_fts`] is built on the same door.
 
 use anyhow::Context;
-use sqlx::{Row, SqliteConnection, SqlitePool};
+use sqlx::{SqliteConnection, SqlitePool};
+
+/// The `SELECT` projection shared by the per-book upsert and the
+/// whole-table rebuild: same columns, same correlated subqueries for the
+/// taxonomy joins and the ISBN lookup. Kept as one constant so the two
+/// call sites can't drift apart — append `WHERE b.id = ?` for the
+/// single-book form, or leave it off to project every row.
+///
+/// `authors` / `series` / `tags` mirror the rename-trigger projections in
+/// 0005_fts5.sql so the inline upsert and the triggers agree on the same
+/// text. `isbn` takes the first ISBN-scheme identifier (case-insensitive)
+/// straight from `book_identifiers` — the canonical source now that the
+/// denormalized `books.isbn` column is gone (F8).
+const FTS_SELECT_FROM_BOOKS: &str = "
+    SELECT
+        b.id,
+        COALESCE(b.title, ''),
+        COALESCE((SELECT group_concat(a.name, ' ')
+                  FROM books_authors_link l JOIN authors a ON a.id = l.author
+                  WHERE l.book = b.id), ''),
+        COALESCE((SELECT group_concat(s.name, ' ')
+                  FROM books_series_link l JOIN series s ON s.id = l.series
+                  WHERE l.book = b.id), ''),
+        COALESCE((SELECT group_concat(t.name, ' ')
+                  FROM books_tags_link l JOIN tags t ON t.id = l.tag
+                  WHERE l.book = b.id), ''),
+        COALESCE(b.description, ''),
+        COALESCE((SELECT bi.value FROM book_identifiers bi
+                  WHERE bi.book_id = b.id AND bi.scheme = 'ISBN' COLLATE NOCASE
+                  LIMIT 1), '')
+     FROM books b";
 
 /// Delete-then-insert the `books_fts` row for `book_id`, sourcing the
 /// indexed text from the canonical `books` row plus its taxonomy links.
 ///
-/// This is the only place that inserts a `books_fts` row. The column set
-/// (`title, authors, series, tags, description, isbn`) is identical for
-/// ebooks and audiobooks — both live in the same `books` table and the
-/// joins below read whatever link rows exist — so one door serves both.
-/// A no-op INSERT when `book_id` has no `books` row, but callers only
-/// pass live ids.
+/// This is the only place that inserts a single `books_fts` row (the
+/// whole-table rebuild in [`rebuild_all_fts`] uses the same projection but
+/// batches it into one statement). The column set (`title, authors,
+/// series, tags, description, isbn`) is identical for ebooks and
+/// audiobooks — both live in the same `books` table and the joins below
+/// read whatever link rows exist — so one door serves both. A no-op
+/// INSERT when `book_id` has no `books` row, but callers only pass live
+/// ids.
 pub(crate) async fn upsert_fts(
     conn: &mut SqliteConnection,
     book_id: i64,
 ) -> Result<(), sqlx::Error> {
     delete_fts(&mut *conn, book_id).await?;
-    // `authors` / `series` / `tags` mirror the rename-trigger projections
-    // in 0005_fts5.sql so the inline upsert and the triggers agree on the
-    // same text. `isbn` takes the first ISBN-scheme identifier
-    // (case-insensitive) straight from `book_identifiers` — the canonical
-    // source now that the denormalized `books.isbn` column is gone (F8).
-    sqlx::query(
+    sqlx::query(&format!(
         "INSERT INTO books_fts(rowid, title, authors, series, tags, description, isbn)
-         SELECT
-            b.id,
-            COALESCE(b.title, ''),
-            COALESCE((SELECT group_concat(a.name, ' ')
-                      FROM books_authors_link l JOIN authors a ON a.id = l.author
-                      WHERE l.book = b.id), ''),
-            COALESCE((SELECT group_concat(s.name, ' ')
-                      FROM books_series_link l JOIN series s ON s.id = l.series
-                      WHERE l.book = b.id), ''),
-            COALESCE((SELECT group_concat(t.name, ' ')
-                      FROM books_tags_link l JOIN tags t ON t.id = l.tag
-                      WHERE l.book = b.id), ''),
-            COALESCE(b.description, ''),
-            COALESCE((SELECT bi.value FROM book_identifiers bi
-                      WHERE bi.book_id = b.id AND bi.scheme = 'ISBN' COLLATE NOCASE
-                      LIMIT 1), '')
-         FROM books b
-         WHERE b.id = ?",
-    )
+         {FTS_SELECT_FROM_BOOKS}
+         WHERE b.id = ?"
+    ))
     .bind(book_id)
     .execute(&mut *conn)
     .await?;
@@ -70,14 +81,16 @@ pub(crate) async fn delete_fts(
     Ok(())
 }
 
-/// Rebuild the entire `books_fts` index from `books`: drop every row,
-/// then upsert one row per book through [`upsert_fts`]. Used by the admin
-/// "rebuild search index" job to repair any drift left by a failed
+/// Rebuild the entire `books_fts` index from `books`: drop every row, then
+/// re-insert every row in one batched `INSERT ... SELECT`. Used by the
+/// admin "rebuild search index" job to repair any drift left by a failed
 /// post-commit refresh. Idempotent — safe to re-run.
 ///
-/// Runs in a single transaction so the index is never observed empty
-/// mid-rebuild. Orphan `books_fts` rows (rowid with no `books` row) are
-/// swept by the leading `DELETE`.
+/// Two DML statements total regardless of library size — previously this
+/// looped `upsert_fts` per book (2N statements for N books, one DELETE +
+/// one INSERT each). Runs in a single transaction so the index is never
+/// observed empty mid-rebuild. Orphan `books_fts` rows (rowid with no
+/// `books` row) are swept by the leading `DELETE`.
 pub async fn rebuild_all_fts(pool: &SqlitePool) -> anyhow::Result<()> {
     let mut tx = pool
         .begin()
@@ -87,20 +100,13 @@ pub async fn rebuild_all_fts(pool: &SqlitePool) -> anyhow::Result<()> {
         .execute(&mut *tx)
         .await
         .context("rebuild_all_fts: clear books_fts")?;
-    let ids: Vec<i64> = sqlx::query("SELECT id FROM books ORDER BY id")
-        .fetch_all(&mut *tx)
-        .await
-        .context("rebuild_all_fts: list book ids")?
-        .into_iter()
-        .map(|r| r.get::<i64, _>("id"))
-        .collect();
-    for id in ids {
-        // The DELETE above already cleared every row, but `upsert_fts`
-        // re-runs a per-id delete first; harmless on an empty table.
-        upsert_fts(&mut tx, id)
-            .await
-            .with_context(|| format!("rebuild_all_fts: upsert book {id}"))?;
-    }
+    sqlx::query(&format!(
+        "INSERT INTO books_fts(rowid, title, authors, series, tags, description, isbn)
+         {FTS_SELECT_FROM_BOOKS}"
+    ))
+    .execute(&mut *tx)
+    .await
+    .context("rebuild_all_fts: repopulate books_fts")?;
     tx.commit()
         .await
         .context("rebuild_all_fts: commit transaction")?;

--- a/db/src/sync/fts.rs
+++ b/db/src/sync/fts.rs
@@ -8,6 +8,8 @@
 //! (`&mut **tx`) and on a pooled connection alike. The full-index repair
 //! job [`rebuild_all_fts`] is built on the same door.
 
+use std::sync::OnceLock;
+
 use anyhow::Context;
 use sqlx::{SqliteConnection, SqlitePool};
 
@@ -57,14 +59,15 @@ pub(crate) async fn upsert_fts(
     book_id: i64,
 ) -> Result<(), sqlx::Error> {
     delete_fts(&mut *conn, book_id).await?;
-    sqlx::query(&format!(
-        "INSERT INTO books_fts(rowid, title, authors, series, tags, description, isbn)
-         {FTS_SELECT_FROM_BOOKS}
-         WHERE b.id = ?"
-    ))
-    .bind(book_id)
-    .execute(&mut *conn)
-    .await?;
+    static UPSERT_SQL: OnceLock<String> = OnceLock::new();
+    let sql = UPSERT_SQL.get_or_init(|| {
+        format!(
+            "INSERT INTO books_fts(rowid, title, authors, series, tags, description, isbn)
+             {FTS_SELECT_FROM_BOOKS}
+             WHERE b.id = ?"
+        )
+    });
+    sqlx::query(sql).bind(book_id).execute(&mut *conn).await?;
     Ok(())
 }
 

--- a/db/src/sync/fts/tests.rs
+++ b/db/src/sync/fts/tests.rs
@@ -1,9 +1,12 @@
 //! Acceptance tests for the `books_fts` choke-point: the no-orphan
 //! invariant after every public write path, the cross-format attach gap
 //! regression (a newly-attached format's ISBN must become searchable),
-//! and `rebuild_all_fts` reconstructing a corrupted index.
+//! `rebuild_all_fts` reconstructing a corrupted or fully-emptied index,
+//! and its batched `INSERT ... SELECT` matching the per-book `upsert_fts`
+//! path row-for-row.
 
 use omnibus_shared::{Contributor, EbookMetadata, Identifier};
+use sqlx::Row;
 
 use super::*;
 use crate::ebook::IndexedBook;
@@ -69,6 +72,72 @@ async fn fts_isbn_hits(pool: &sqlx::SqlitePool, isbn: &str) -> i64 {
         .fetch_one(pool)
         .await
         .unwrap()
+}
+
+/// One `books_fts` row's plain-text columns, ordered by `rowid`. Used to
+/// diff the batched rebuild's output against the per-book upsert path.
+type FtsRowSnapshot = (i64, String, String, String, String, String, String);
+
+/// Snapshot every `books_fts` row (all seven columns) ordered by `rowid`,
+/// so two populations of the same `books` table can be compared for exact
+/// content equality regardless of which code path produced them.
+async fn snapshot_fts_rows(pool: &sqlx::SqlitePool) -> Vec<FtsRowSnapshot> {
+    sqlx::query(
+        "SELECT rowid, title, authors, series, tags, description, isbn
+         FROM books_fts ORDER BY rowid",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| {
+        (
+            r.get::<i64, _>("rowid"),
+            r.get::<String, _>("title"),
+            r.get::<String, _>("authors"),
+            r.get::<String, _>("series"),
+            r.get::<String, _>("tags"),
+            r.get::<String, _>("description"),
+            r.get::<String, _>("isbn"),
+        )
+    })
+    .collect()
+}
+
+/// Seed a varied fixture exercising every branch of the FTS projection:
+/// multiple authors, a series, multiple tags, an ISBN, and a book with
+/// none of the optional taxonomy links — so a diff between the per-book
+/// and batched projections would catch a mismatch in any one column.
+async fn seed_varied_fts_fixture(pool: &sqlx::SqlitePool) {
+    sync_books(
+        pool,
+        "/lib",
+        SyncPlan {
+            new_books: vec![
+                indexed(
+                    "multi.epub",
+                    Some("Multi Author Saga"),
+                    &["Ada Lovelace", "Grace Hopper"],
+                    &["fiction", "classic"],
+                    Some(("Saga", "1")),
+                    None,
+                ),
+                indexed_with_isbn("solo.epub", "Solo Work", "Bram Stoker", "9781111111111"),
+                indexed("bare.epub", Some("Bare Book"), &[], &[], None, None),
+                indexed(
+                    "tags.epub",
+                    Some("Tagged Only"),
+                    &["Cy"],
+                    &["nonfiction", "essay", "history"],
+                    None,
+                    None,
+                ),
+            ],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -465,4 +534,80 @@ async fn upsert_and_delete_fts_round_trip_a_single_row() {
         .await
         .unwrap();
     assert_eq!(after_second, 1);
+}
+
+#[tokio::test]
+async fn rebuild_all_fts_batched_insert_matches_per_book_upsert_fts_row_for_row() {
+    // Regression for the batching change (issue #1166): `rebuild_all_fts`
+    // used to loop `upsert_fts` once per book (one DELETE + one INSERT
+    // each); it now does a single whole-table `DELETE` + `INSERT ...
+    // SELECT`. The two share the `FTS_SELECT_FROM_BOOKS` projection, but
+    // this test diffs their actual output row-for-row so a future edit to
+    // either query can't silently drift the two apart.
+    let _covers = CoversTempDir::new("fts_diff_batched_vs_per_book");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_varied_fts_fixture(&pool).await;
+
+    // `sync_books`'s New path already populated `books_fts` by calling
+    // `upsert_fts` once per inserted book — capture that as the per-book
+    // reference before touching the table.
+    let ids: Vec<i64> = sqlx::query_scalar("SELECT id FROM books ORDER BY id")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(ids.len(), 4, "fixture should seed four distinct books");
+    let via_per_book_upsert = snapshot_fts_rows(&pool).await;
+    assert_eq!(via_per_book_upsert.len(), 4);
+
+    // Wipe the index and repopulate it through the new batched rebuild.
+    sqlx::query("DELETE FROM books_fts")
+        .execute(&pool)
+        .await
+        .unwrap();
+    rebuild_all_fts(&pool).await.unwrap();
+    let via_batched_rebuild = snapshot_fts_rows(&pool).await;
+
+    assert_eq!(
+        via_per_book_upsert, via_batched_rebuild,
+        "the batched whole-table INSERT must produce byte-identical rows \
+         to the per-book upsert_fts path for every book"
+    );
+}
+
+#[tokio::test]
+async fn rebuild_all_fts_fully_repopulates_multi_book_library_after_total_index_loss() {
+    // Acceptance criterion: a multi-book fixture's FTS table is fully
+    // repopulated after the batched rebuild, even from a completely empty
+    // index (not just a partially-drifted one, covered separately by
+    // `rebuild_all_fts_reconstructs_index_after_corruption`).
+    let _covers = CoversTempDir::new("fts_rebuild_full_repopulation");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_varied_fts_fixture(&pool).await;
+
+    sqlx::query("DELETE FROM books_fts")
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count_rows(&pool, "SELECT COUNT(*) FROM books_fts").await, 0);
+
+    rebuild_all_fts(&pool).await.unwrap();
+
+    assert_fts_invariant(&pool).await;
+    assert_eq!(count_rows(&pool, "SELECT COUNT(*) FROM books").await, 4);
+    assert_eq!(count_rows(&pool, "SELECT COUNT(*) FROM books_fts").await, 4);
+    // Spot-check every branch of the projection actually landed in the
+    // rebuilt index: multi-author group_concat, ISBN, and multi-tag.
+    let multi_author_hits: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM books_fts WHERE authors MATCH 'Lovelace'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(multi_author_hits, 1);
+    assert_eq!(fts_isbn_hits(&pool, "9781111111111").await, 1);
+    let tag_hits: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM books_fts WHERE tags MATCH 'history'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(tag_hits, 1);
 }


### PR DESCRIPTION
## Summary
- Closes #1166
- `rebuild_all_fts` fetched every book id, then looped `upsert_fts` (one `DELETE` + one `INSERT` per book) inside a single held transaction — 2N sequential DML statements for an N-book library. It now runs one whole-table `DELETE FROM books_fts` followed by one whole-table `INSERT ... SELECT` — two statements regardless of library size.
- Extracted the shared `SELECT` projection (title/authors/series/tags/description/isbn, with the correlated taxonomy + ISBN subqueries) into a `FTS_SELECT_FROM_BOOKS` constant so the per-book `upsert_fts` and the batched rebuild can't drift apart — `upsert_fts` appends `WHERE b.id = ?`, the rebuild omits it to project every row.

## Test plan
- [x] `cargo fmt -p omnibus-db` (clean, no diff)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus-db` — PASS, 1107 passed, 0 failed (after `scripts/fetch-fixtures.sh` for an unrelated missing-audiobook-fixture failure; one unrelated timing-sensitive flake in `periodic_scan_tick_posts_only_the_configured_library_path` reran clean in isolation)
- [x] New test `rebuild_all_fts_batched_insert_matches_per_book_upsert_fts_row_for_row` — diffs the batched rebuild's output against the pre-existing per-book `upsert_fts` path (invoked implicitly by `sync_books`'s New path) row-for-row across a fixture with multiple authors, a series, multiple tags, and an ISBN, confirming the whole-table `INSERT ... SELECT` produces byte-identical rows to the correlated per-book form
- [x] New test `rebuild_all_fts_fully_repopulates_multi_book_library_after_total_index_loss` — confirms a 4-book fixture's `books_fts` table is fully repopulated (count, invariant, and spot-checked multi-author/tag/ISBN content) after the batched rebuild from a completely emptied index

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Scoped strictly to `db/src/sync/fts.rs` and its sibling test file `db/src/sync/fts/tests.rs` — no migration needed, this is app-level query logic only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm1Psjcy7WPBTAysHdMdNK)_