### PR TITLE
fix: surface fetch-error states distinct from empty in 4 spots (#1168)

### DIFF
--- a/db/src/hls/transcode.rs
+++ b/db/src/hls/transcode.rs
@@ -280,7 +280,10 @@ async fn stream_progress(
                 last_write = Some(std::time::Instant::now());
             }
             Ok(None) => break, // EOF: ffmpeg closed stdout, we're done.
-            Err(_) => break,
+            Err(e) => {
+                tracing::warn!(error = %e, "ffmpeg stdout heartbeat read failed");
+                break;
+            }
         }
     }
 }

--- a/frontend/src/components/search_palette/overlay.rs
+++ b/frontend/src/components/search_palette/overlay.rs
@@ -23,6 +23,9 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
     let mut results = use_signal(|| Option::<PaletteResults>::None);
     let mut selected = use_signal(|| 0_usize);
     let mut loading = use_signal(|| false);
+    // Set on a failed search, distinct from "no matches" (mirrors
+    // `search_mobile.rs`'s `errored` signal for the same underlying call).
+    let mut errored = use_signal(|| false);
     // Tracks whether the user has driven selection with arrow keys this
     // session. When false, pressing Enter navigates to the full-page
     // search results instead of drilling into `selected`.
@@ -66,16 +69,21 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
             if trimmed.is_empty() {
                 results.set(None);
                 loading.set(false);
+                errored.set(false);
                 return;
             }
             loading.set(true);
+            errored.set(false);
             match data::search_palette(&url, &trimmed).await {
                 Ok(r) => {
                     selected.set(0);
                     results.set(Some(r));
                 }
                 Err(_) => {
+                    // `tracing` isn't linked under the `web` (WASM) feature,
+                    // so the signal alone carries the failure to the UI.
                     results.set(None);
+                    errored.set(true);
                 }
             }
             loading.set(false);
@@ -90,6 +98,7 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
     // resets to 0 after each search response), and pressing ArrowDown
     // would visually jump to index 1 instead of 0.
     let is_loading = loading();
+    let is_errored = errored();
 
     let total = res
         .as_ref()
@@ -130,6 +139,14 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
                 if res.is_some() {
                     div { class: "sp-meta", "data-testid": "sp-result-count",
                         "{total} result{plural(total)} · {duration}ms"
+                    }
+                }
+
+                // Distinct from "no matches": a fetch failure, not an empty
+                // result set.
+                if is_errored {
+                    p { role: "alert", class: "error", "data-testid": "sp-error",
+                        "Couldn\u{2019}t run that search. Check your connection and try again."
                     }
                 }
 

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -329,7 +329,17 @@ fn poll_suggestions_until_resolved(
                                     break;
                                 }
                             }
-                            Err(_) => break,
+                            Err(_) => {
+                                // Mirror the initial-fetch error path below: fall
+                                // back to the empty-ready state so the UI doesn't
+                                // get stuck on "loading suggestions" forever.
+                                if is_current() {
+                                    suggestions.set(Some(SuggestionsResponse::Ready {
+                                        items: Vec::new(),
+                                    }));
+                                }
+                                break;
+                            }
                         }
                     }
                 }

--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -41,6 +41,10 @@ pub fn ShelfDetailPage(id: i64) -> Element {
     let mut edit_rules = use_signal(|| false);
     // Bumped to force a refetch after a membership edit.
     let mut reload = use_signal(|| 0u32);
+    // Set when the member-books refetch fails, so a transient network error
+    // renders distinctly from a shelf that is genuinely empty (mirrors
+    // `search_mobile.rs`'s `errored` signal for the same failure class).
+    let mut errored = use_signal(|| false);
 
     // Fetch the shelf detail whenever the id changes. `id` is a plain prop
     // (not a signal), so it must be wrapped in `use_reactive!` to re-arm this
@@ -75,11 +79,16 @@ pub fn ShelfDetailPage(id: i64) -> Element {
         let _ = reload();
         spawn(async move {
             let dir = default_dir_for(key);
-            // Clear on error so a failed refetch can't leave a stale list from a
-            // prior sort/id rendered.
             match data::shelf_page(&url, id, key, dir).await {
-                Ok(page) => books.set(page.books),
-                Err(_) => books.set(Vec::new()),
+                Ok(page) => {
+                    books.set(page.books);
+                    errored.set(false);
+                }
+                Err(_) => {
+                    // `tracing` isn't linked under the `web` (WASM) feature,
+                    // so the signal alone carries the failure to the UI.
+                    errored.set(true);
+                }
             }
         });
     }));
@@ -108,6 +117,7 @@ pub fn ShelfDetailPage(id: i64) -> Element {
         mobile::MobileShelfDetail {
             shelf: current.clone(),
             books: books.read().clone(),
+            errored: errored(),
             server_url: server_url.clone(),
             on_add: move |_| show_add.set(true),
             on_edit_rules: move |_| edit_rules.set(true),
@@ -119,11 +129,14 @@ pub fn ShelfDetailPage(id: i64) -> Element {
     let body = web_shelf_body(
         &current,
         &books.read(),
+        errored(),
         &server_url,
-        sort_key,
-        show_add,
-        edit_rules,
-        reload,
+        ShelfBodySignals {
+            sort_key,
+            show_add,
+            edit_rules,
+            reload,
+        },
     );
 
     rsx! {
@@ -174,18 +187,34 @@ fn render_page_state(id: i64, inner: Element) -> Element {
     }
 }
 
+/// UI-state signals threaded into [`web_shelf_body`]. `Copy` (Dioxus
+/// signals), so grouping them keeps the function under clippy's
+/// too-many-arguments cap without changing call-site ergonomics.
+#[cfg(not(feature = "mobile"))]
+#[derive(Clone, Copy)]
+struct ShelfBodySignals {
+    sort_key: Signal<SortKey>,
+    show_add: Signal<bool>,
+    edit_rules: Signal<bool>,
+    reload: Signal<u32>,
+}
+
 /// Web presentation: rail + header (badges/actions), rule chips + sort row
 /// for smart shelves, and the `CoverTile` member grid.
 #[cfg(not(feature = "mobile"))]
 fn web_shelf_body(
     current: &Shelf,
     books: &[EbookMetadata],
+    errored: bool,
     server_url: &str,
-    mut sort_key: Signal<SortKey>,
-    mut show_add: Signal<bool>,
-    mut edit_rules: Signal<bool>,
-    mut reload: Signal<u32>,
+    signals: ShelfBodySignals,
 ) -> Element {
+    let ShelfBodySignals {
+        mut sort_key,
+        mut show_add,
+        mut edit_rules,
+        mut reload,
+    } = signals;
     let id = current.id;
     let is_smart = current.kind == ShelfKind::Smart;
     rsx! {
@@ -224,6 +253,15 @@ fn web_shelf_body(
                     }
                 } else if let Some(desc) = current.description.as_ref() {
                     p { class: "shelf-desc", "{desc}" }
+                }
+
+                if errored {
+                    p {
+                        role: "alert",
+                        class: "error",
+                        "data-testid": "shelf-refetch-error",
+                        "Couldn\u{2019}t refresh this shelf. Check your connection and try again."
+                    }
                 }
 
                 {member_grid(books, server_url, is_smart, move |_| show_add.set(true))}

--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -87,6 +87,10 @@ pub fn ShelfDetailPage(id: i64) -> Element {
                 Err(_) => {
                     // `tracing` isn't linked under the `web` (WASM) feature,
                     // so the signal alone carries the failure to the UI.
+                    // Clear the stale list too — otherwise a refetch failure
+                    // after navigating shelves leaves the prior shelf's
+                    // books on screen under the error banner.
+                    books.set(Vec::new());
                     errored.set(true);
                 }
             }

--- a/frontend/src/pages/shelf_detail/mobile.rs
+++ b/frontend/src/pages/shelf_detail/mobile.rs
@@ -22,6 +22,9 @@ pub(super) struct MobileShelfDetailProps {
     pub shelf: Shelf,
     /// The shelf's member books to render as cover cells.
     pub books: Vec<EbookMetadata>,
+    /// Set when the member-books refetch failed, distinct from a genuinely
+    /// empty shelf.
+    pub errored: bool,
     /// Base server URL used to build thumbnail `src`/`srcset`.
     pub server_url: String,
     /// Opens the shared add-books modal (manual shelves).
@@ -39,6 +42,7 @@ pub(super) fn MobileShelfDetail(props: MobileShelfDetailProps) -> Element {
     let MobileShelfDetailProps {
         shelf,
         books,
+        errored,
         server_url,
         on_add,
         on_edit_rules,
@@ -123,6 +127,15 @@ pub(super) fn MobileShelfDetail(props: MobileShelfDetailProps) -> Element {
                     span { class: "m-shelves-entry-sub", "Smart & hand-picked collections" }
                 }
                 span { class: "m-shelves-entry-chevron", {chevron()} }
+            }
+
+            if errored {
+                p {
+                    role: "alert",
+                    class: "error",
+                    "data-testid": "shelf-refetch-error",
+                    "Couldn\u{2019}t refresh this shelf. Check your connection and try again."
+                }
             }
 
             div { class: "m-cover-grid m-shelf-grid", "data-testid": "shelf-grid", role: "list",

--- a/ui_tests/playwright/tests/flows/shelves.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelves.spec.ts
@@ -95,7 +95,11 @@ test("surfaces a distinct error when the member-books refetch fails", async ({
     route.fulfill({ status: 500, body: "boom" }),
   );
 
-  await gotoReady(page, `/shelves/${shelf.id}`);
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/rpc/shelves/page", expectedStatus: 500 },
+    async () => gotoReady(page, `/shelves/${shelf.id}`),
+  );
 
   await expect(page.getByTestId("shelf-detail-header")).toContainText(name);
   await expect(page.getByTestId("shelf-refetch-error")).toBeVisible();

--- a/ui_tests/playwright/tests/flows/shelves.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelves.spec.ts
@@ -67,6 +67,40 @@ test("surfaces an error when shelf creation fails", async ({ page }) => {
   await expect(page.getByTestId("shelf-create-error")).toBeVisible();
 });
 
+test("surfaces a distinct error when the member-books refetch fails", async ({
+  page,
+  request,
+}) => {
+  // A genuinely empty manual shelf renders the grid with zero tiles and no
+  // error text — force the page-fetch to 500 so this test can tell the two
+  // states apart via the dedicated `shelf-refetch-error` banner.
+  const name = `E2E Refetch Fail ${Date.now()}`;
+  const createResp = await request.post("/api/rpc/shelves/create", {
+    data: {
+      req: {
+        kind: "manual",
+        name,
+        description: null,
+        visibility: "private",
+        match_mode: null,
+        rules: [],
+        book_uuids: [],
+      },
+    },
+  });
+  expect(createResp.status(), "POST /api/rpc/shelves/create failed").toBe(200);
+  const shelf = (await createResp.json()) as { id: number };
+
+  await page.route("**/api/rpc/shelves/page", (route) =>
+    route.fulfill({ status: 500, body: "boom" }),
+  );
+
+  await gotoReady(page, `/shelves/${shelf.id}`);
+
+  await expect(page.getByTestId("shelf-detail-header")).toContainText(name);
+  await expect(page.getByTestId("shelf-refetch-error")).toBeVisible();
+});
+
 test("switches shelves via the rail without a full reload", async ({ page, request }) => {
   // Two hand-picked shelves, each holding one distinct fixture book, so the
   // header and grid content can only match if the rail switch actually


### PR DESCRIPTION
## Summary
- `shelf_detail.rs`'s member-books refetch now sets a dedicated `errored` signal on failure (web + mobile), rendering a `shelf-refetch-error` banner distinct from a genuinely empty shelf — mirrors `search_mobile.rs`'s existing `errored` pattern.
- `book_detail/mod.rs`'s suggestions retry-poll `Err(_)` arm now falls back to `SuggestionsResponse::Ready { items: Vec::new() }` instead of leaving the UI stuck on "loading suggestions" forever.
- `search_palette/overlay.rs` tracks an `errored` signal on a failed search and renders an `sp-error` alert, distinct from "no matches."
- `db/src/hls/transcode.rs`'s heartbeat-read `Err(_)` arm now logs `tracing::warn!` before breaking, instead of being silently indistinguishable from clean EOF.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features server` (348 passed)
- [x] `cargo test -p omnibus-db` (1105 passed, incl. audiobook fixture tests after `scripts/fetch-fixtures.sh`)
- [x] Added a new Playwright assertion (`ui_tests/playwright/tests/flows/shelves.spec.ts`) covering the new `shelf-refetch-error` banner

Closes #1168

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Pre-existing flaky tests (worker poisoned-lock, uploads `inspect_allows_non_admin_with_can_upload`) were not affected by this change and were not encountered in this run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm1Psjcy7WPBTAysHdMdNK)_