### PR TITLE
fix: denser library grid on tablets (4-up mini, 5-up 12.9" iPad)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4161,6 +4161,11 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px 12px; align-content: start;
 }
+/* A phone's 3-up leaves absurdly large covers on an iPad, so step the count up
+   with width — 4-up on the smaller iPads (mini is 744px wide), 5-up from the
+   12.9" portrait width (1024px) on. */
+@media (min-width: 700px) { .m-cover-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); } }
+@media (min-width: 1000px) { .m-cover-grid { grid-template-columns: repeat(5, minmax(0, 1fr)); } }
 .m-cover-cell { display: block; min-width: 0; text-decoration: none; color: inherit; }
 .m-cover-cell-title {
   margin-top: 6px; font-size: 11.5px; font-weight: 500; color: var(--ink-0);

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4162,8 +4162,8 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   gap: 18px 12px; align-content: start;
 }
 /* A phone's 3-up leaves absurdly large covers on an iPad, so step the count up
-   with width — 4-up on the smaller iPads (mini is 744px wide), 5-up from the
-   12.9" portrait width (1024px) on. */
+   with width. Each threshold sits just under the device it targets: 700px
+   catches the mini (744px wide), 1000px the 12.9" in portrait (1024px). */
 @media (min-width: 700px) { .m-cover-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); } }
 @media (min-width: 1000px) { .m-cover-grid { grid-template-columns: repeat(5, minmax(0, 1fr)); } }
 .m-cover-cell { display: block; min-width: 0; text-decoration: none; color: inherit; }


### PR DESCRIPTION
## Summary
- The mobile Library grid (`.m-cover-grid`) was hard-coded to a fixed 3-up, so covers rendered oversized on iPad regardless of width.
- Step the column count up with viewport width: 4-up from 700px (iPad mini is 744pt), 5-up from 1000px (12.9" portrait is 1024pt).
- Shelf detail shares `.m-cover-grid` and picks up the same density.

## Test plan
- [x] Booted iPad mini (A17 Pro) simulator against a seeded library: Library grid renders 4 columns at 744pt (was 3).
- [x] `just lint-css` passes.
- [ ] 5-up (>=1000px) is present in the bundled CSS but not visually confirmed — no 12.9" sim was booted and the app is portrait-locked.

## Version
- [x] **Patch** — default.

## Notes
- The web grid (`.lib-grid`) is a different class and is untouched; the mobile screens never use it.