### PR TITLE
fix: allow Open Library + Google Books cover hosts in CSP img-src

### DIFF
--- a/db/src/metadata_lookup/providers.rs
+++ b/db/src/metadata_lookup/providers.rs
@@ -215,9 +215,13 @@ pub async fn googlebooks_lookup(
     let Some(title) = info.title.filter(|t| !t.trim().is_empty()) else {
         return Ok(None);
     };
+    // Google Books serves image links over `http://`; upgrade to `https://`
+    // so the cover isn't blocked as mixed content (or by the https-only CSP
+    // img-src host allowlist) when previewed on the scan result page.
     let cover_url = info
         .image_links
-        .and_then(|l| l.thumbnail.or(l.small_thumbnail));
+        .and_then(|l| l.thumbnail.or(l.small_thumbnail))
+        .map(|u| upgrade_to_https(&u));
 
     Ok(Some(ExternalBookMeta {
         isbn13: isbn13.to_string(),
@@ -230,4 +234,36 @@ pub async fn googlebooks_lookup(
         cover_url,
         source: MetadataProvider::GoogleBooks,
     }))
+}
+
+/// Upgrade an `http://` URL to `https://`; other schemes pass through
+/// unchanged. Google Books returns cover links over plain HTTP, which a
+/// browser blocks as mixed content on an HTTPS page.
+fn upgrade_to_https(url: &str) -> String {
+    match url.strip_prefix("http://") {
+        Some(rest) => format!("https://{rest}"),
+        None => url.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::upgrade_to_https;
+
+    #[test]
+    fn upgrade_to_https_rewrites_http_and_leaves_others() {
+        assert_eq!(
+            upgrade_to_https("http://books.google.com/x.jpg"),
+            "https://books.google.com/x.jpg"
+        );
+        // Already-secure and non-http schemes pass through untouched.
+        assert_eq!(
+            upgrade_to_https("https://covers.openlibrary.org/b/id/1-L.jpg"),
+            "https://covers.openlibrary.org/b/id/1-L.jpg"
+        );
+        assert_eq!(
+            upgrade_to_https("data:image/png;base64,AAAA"),
+            "data:image/png;base64,AAAA"
+        );
+    }
 }

--- a/db/src/metadata_lookup/tests.rs
+++ b/db/src/metadata_lookup/tests.rs
@@ -101,6 +101,12 @@ async fn lookup_falls_through_to_google_books_on_open_library_miss() {
     assert_eq!(meta.source, MetadataProvider::GoogleBooks);
     assert_eq!(meta.title, "Effective Java");
     assert_eq!(meta.description.as_deref(), Some("The definitive guide."));
+    // Google Books' `http://` cover link is upgraded to https so it isn't
+    // blocked as mixed content on the scan result page.
+    assert_eq!(
+        meta.cover_url.as_deref(),
+        Some("https://books.google.com/x.jpg")
+    );
 }
 
 #[tokio::test]

--- a/server/src/security_headers.rs
+++ b/server/src/security_headers.rs
@@ -46,14 +46,18 @@ use tower_http::set_header::SetResponseHeaderLayer;
 /// - `font-src 'self' data: https://fonts.gstatic.com` — Google serves the
 ///   actual WOFF2 files from `fonts.gstatic.com`; without it the `@import`ed
 ///   stylesheet resolves but the glyphs fall back to system fonts.
-/// - `img-src 'self' data: blob:` — `data:` / `blob:` cover thumbnails and
-///   base64-embedded images.
+/// - `img-src 'self' data: blob: https://covers.openlibrary.org
+///   https://books.google.com` — `data:` / `blob:` cover thumbnails and
+///   base64-embedded images, plus the two metadata providers' cover CDNs so
+///   the scan/check-in result page can preview a provider cover before the
+///   book is created (once created, the cover is fetched server-side and
+///   served same-origin from `/api/covers/:uuid`).
 ///
 /// Tighten incrementally as the asset surface stabilizes.
 const DEFAULT_CSP: &str = "default-src 'self'; \
 script-src 'self' 'unsafe-inline' 'unsafe-eval'; \
 style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
-img-src 'self' data: blob:; \
+img-src 'self' data: blob: https://covers.openlibrary.org https://books.google.com; \
 font-src 'self' data: https://fonts.gstatic.com; \
 connect-src 'self'; \
 object-src 'none'; \

--- a/server/src/security_headers/tests.rs
+++ b/server/src/security_headers/tests.rs
@@ -90,8 +90,10 @@ async fn csp_permits_dioxus_hydration_and_fonts() {
         "csp must allow the Google Fonts WOFF2 host: {csp}"
     );
     assert!(
-        csp.contains("img-src 'self' data: blob:"),
-        "csp must allow data: + blob: images: {csp}"
+        csp.contains(
+            "img-src 'self' data: blob: https://covers.openlibrary.org https://books.google.com"
+        ),
+        "csp must allow data:/blob: images + the Open Library / Google Books cover CDNs so the scan result page can preview provider covers: {csp}"
     );
     assert!(
         csp.contains("frame-ancestors 'none'"),


### PR DESCRIPTION
## Summary
The scan / check-in result page (the "Not in your library" chooser and the close-match confirm) previews a cover straight from a provider CDN, but the CSP `img-src` only allowed `'self' data: blob:` — so the browser blocked it and the empty-plate fallback showed instead.
- Allowlist the two providers' cover hosts in `DEFAULT_CSP`: `https://covers.openlibrary.org` and `https://books.google.com`.
- Upgrade Google Books cover links from `http://` → `https://` at the provider layer — Google serves them over plain HTTP, which a browser blocks as mixed content on an HTTPS page (and which wouldn't match the https-only CSP host anyway).
- Once a book is actually added, its cover is still fetched server-side and served same-origin from `/api/covers/:uuid`; this only affects the pre-add preview.

## Test plan
- [x] `just check` green (fmt + clippy + full matrix)
- [x] CSP guard-rail test updated to assert the two provider hosts
- [x] New tests: Google Books cover upgraded to https end-to-end; `upgrade_to_https` unit test (http rewritten, https/data untouched)
- [x] Live dev-server header confirmed: `img-src 'self' data: blob: https://covers.openlibrary.org https://books.google.com`

## Version
- [x] **Patch**

## Notes
No ticket — follow-up from the #1177 check-in work (provider cover previews were CSP-blocked). Considered a same-origin cover proxy instead; went with the host allowlist per request since it's a one-directive change and the providers are fixed/trusted.