### PR TITLE
fix: cover physical-only visibility in list_books_page/count_books_page

### DIFF
--- a/db/src/books/page/tests.rs
+++ b/db/src/books/page/tests.rs
@@ -558,6 +558,88 @@ fn page_cursor_decode_rejects_malformed() {
     ));
 }
 
+// ---------------------------------------------------------------------------
+// F Physical Check-In: physical-only visibility (#1181) on the landing/browse
+// path — mirrors `physical_only_book_is_visible_but_wishlist_only_is_hidden`
+// in `crate::books::tests`, which covers the equivalent `list.rs` path.
+// ---------------------------------------------------------------------------
+
+async fn seed_fileless(pool: &SqlitePool, title: &str, authors: Vec<&str>) -> String {
+    crate::physical::create_fileless_book(
+        pool,
+        crate::physical::FilelessBook {
+            title: title.into(),
+            authors: authors.into_iter().map(str::to_string).collect(),
+            isbn: None,
+            pubdate: None,
+            description: None,
+            cover: None,
+        },
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn list_books_page_shows_physical_only_book_but_hides_wishlist_only() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await; // one normal /lib book
+
+    // Physical-only: fileless book with a checked-in copy.
+    let phys = seed_fileless(&pool, "Physical Only Title", vec!["Print Author"]).await;
+    crate::physical::add_physical_copy(&pool, &phys, None, None, None)
+        .await
+        .unwrap();
+    // Wishlist-only: fileless book, no physical copy.
+    let wish = seed_fileless(&pool, "Wishlist Only Title", vec![]).await;
+
+    let f = ViewFilters::default();
+    let page = list_books_page(&pool, &["/lib"], SortKey::Title, SortDir::Asc, &f, None, 50)
+        .await
+        .unwrap();
+    let uuids: Vec<&str> = page
+        .books
+        .iter()
+        .filter_map(|b| b.unique_identifier.as_deref())
+        .collect();
+    assert!(
+        uuids.contains(&phys.as_str()),
+        "physical-only book must appear in the browse page"
+    );
+    assert!(
+        !uuids.contains(&wish.as_str()),
+        "wishlist-only book must be hidden from the browse page"
+    );
+
+    let phys_row = page
+        .books
+        .iter()
+        .find(|b| b.unique_identifier.as_deref() == Some(&phys))
+        .unwrap();
+    assert!(phys_row.has_physical, "physical flag drives the badge");
+}
+
+#[tokio::test]
+async fn count_books_page_counts_physical_only_book_but_not_wishlist_only() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await; // one normal /lib book
+
+    let phys = seed_fileless(&pool, "Physical Only Title", vec!["Print Author"]).await;
+    crate::physical::add_physical_copy(&pool, &phys, None, None, None)
+        .await
+        .unwrap();
+    seed_fileless(&pool, "Wishlist Only Title", vec![]).await;
+
+    // 1 normal book + 1 physical-only book; the wishlist-only book is excluded.
+    let count = count_books_page(&pool, &["/lib"], &ViewFilters::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        count, 2,
+        "count includes physical-only but not wishlist-only"
+    );
+}
+
 #[tokio::test]
 async fn count_books_page_matches_unfiltered_count_and_applies_format_filter() {
     let (pool, _guard) = seed_discovery_fixture().await; // all EPUB


### PR DESCRIPTION
## Summary
- Closes #1204
- The physical-only-books-visible feature (#1181) added an `OR EXISTS (SELECT 1 FROM physical_copies pc WHERE pc.book_uuid = b.uuid)` visibility clause to four query-building files. Three of them (`list.rs`, `facets.rs`, `search.rs`) got a dedicated regression test; `db/src/books/page.rs` — which backs the default landing-page/browse view (`list_books_page` / `count_books_page`) — did not.
- Adds `list_books_page_shows_physical_only_book_but_hides_wishlist_only` and `count_books_page_counts_physical_only_book_but_not_wishlist_only` to `db/src/books/page/tests.rs`, mirroring the seed shape of the existing `physical_only_book_is_visible_but_wishlist_only_is_hidden` test in `db/src/books/tests.rs`. Pure test-coverage change — no production logic touched.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1204 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS, no warnings
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1204 cargo test -p omnibus-db` — 1140 passed, 3 failed; all 3 failures confirmed unrelated to this change and pass individually in isolation: `ebook::accent::tests::extract_accent_completes_within_budget` (timing budget flake under parallel load), `worker::tests::send_to_kindle_task_fails_when_smtp_unconfigured` (task-registry race under parallel load), `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` (missing `test_data/audiobooks/public_domain/` fixture — not present in this plain checkout, no `just fixtures` available). The two new tests (`list_books_page_shows_physical_only_book_but_hides_wishlist_only`, `count_books_page_counts_physical_only_book_but_not_wishlist_only`) pass, along with the full `physical_only` test group.

## Notes
-


---
_Generated by [Claude Code](https://claude.ai/code/session_01LswnHm3J2hADgkPpSH7mEP)_