### PR TITLE
refactor: cover scan physical-only/wishlist REST endpoints with tests

### DIFF
--- a/server/src/backend/scan/tests.rs
+++ b/server/src/backend/scan/tests.rs
@@ -7,6 +7,7 @@ use axum::{
     body::{to_bytes, Body},
     http::{header::AUTHORIZATION, Request, StatusCode},
 };
+use omnibus_shared::physical::WishlistSource;
 use omnibus_shared::{BookRef, ScanOutcome};
 use tower::ServiceExt;
 
@@ -14,6 +15,22 @@ use crate::auth::test_support as auth_test_support;
 use crate::backend::test_support::*;
 
 const ISBN: &str = "9780134685991";
+
+/// A well-formed `ExternalBookMeta` JSON body, as `AddPhysicalOnlyRequest` and
+/// `WishlistAddRequest` embed it.
+fn external_meta_json(title: &str, isbn13: &str) -> serde_json::Value {
+    serde_json::json!({
+        "isbn13": isbn13,
+        "title": title,
+        "authors": ["Jane Doe"],
+        "year": null,
+        "pages": null,
+        "publisher": null,
+        "description": null,
+        "cover_url": null,
+        "source": "open_library",
+    })
+}
 
 fn post(uri: &str, token: &str, body: serde_json::Value) -> Request<Body> {
     Request::builder()
@@ -156,4 +173,175 @@ async fn api_scan_check_in_records_a_copy() {
             .len(),
         1
     );
+}
+
+#[tokio::test]
+async fn api_scan_add_physical_only_requires_auth() {
+    let (app, _state, _pool) = fixture().await;
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/scan/physical-only")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "meta": external_meta_json("Some Book", ISBN) })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_scan_wishlist_add_requires_auth() {
+    let (app, _state, _pool) = fixture().await;
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/scan/wishlist")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "book_uuid": "x", "source": "scan" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_scan_add_physical_only_creates_a_book() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let res = app
+        .oneshot(post(
+            "/api/scan/physical-only",
+            &token,
+            serde_json::json!({ "meta": external_meta_json("The Pragmatic Programmer", ISBN) }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: BookRef = json_body(res).await;
+
+    let (title, path): (String, String) =
+        sqlx::query_as("SELECT title, path FROM books WHERE uuid = ?1")
+            .bind(&body.book_uuid)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(title, "The Pragmatic Programmer");
+    assert_eq!(path, "", "a physical-only book is fileless");
+    assert_eq!(
+        omnibus_db::list_physical_copies(&pool, &body.book_uuid)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn api_scan_add_physical_only_returns_500_on_db_failure() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    sqlx::query("DROP TABLE physical_copies")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(post(
+            "/api/scan/physical-only",
+            &token,
+            serde_json::json!({ "meta": external_meta_json("Some Book", ISBN) }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn api_scan_wishlist_add_records_entry_by_uuid() {
+    let (app, _state, pool) = fixture().await;
+    let uuid = seed_book_with_isbn(&pool, "Effective Java", ISBN).await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let res = app
+        .oneshot(post(
+            "/api/scan/wishlist",
+            &token,
+            serde_json::json!({ "book_uuid": uuid, "source": "scan" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: BookRef = json_body(res).await;
+    assert_eq!(body.book_uuid, uuid);
+
+    let entries = omnibus_db::list_wishlist(&pool, user.id).await.unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].book_uuid, uuid);
+    assert_eq!(entries[0].source, WishlistSource::Scan);
+}
+
+#[tokio::test]
+async fn api_scan_wishlist_add_records_entry_by_meta() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let res = app
+        .oneshot(post(
+            "/api/scan/wishlist",
+            &token,
+            serde_json::json!({
+                "meta": external_meta_json("Wishlisted Book", ISBN),
+                "source": "detail",
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: BookRef = json_body(res).await;
+
+    let (title, path): (String, String) =
+        sqlx::query_as("SELECT title, path FROM books WHERE uuid = ?1")
+            .bind(&body.book_uuid)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(title, "Wishlisted Book");
+    assert_eq!(path, "", "a wishlisted-by-meta book is fileless");
+
+    let entries = omnibus_db::list_wishlist(&pool, user.id).await.unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].book_uuid, body.book_uuid);
+    assert_eq!(entries[0].source, WishlistSource::Detail);
+}
+
+#[tokio::test]
+async fn api_scan_wishlist_add_returns_400_when_neither_uuid_nor_meta_given() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let res = app
+        .oneshot(post(
+            "/api/scan/wishlist",
+            &token,
+            serde_json::json!({ "source": "manual" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }

--- a/server/src/backend/scan/tests.rs
+++ b/server/src/backend/scan/tests.rs
@@ -330,6 +330,48 @@ async fn api_scan_wishlist_add_records_entry_by_meta() {
 }
 
 #[tokio::test]
+async fn api_scan_wishlist_add_prefers_book_uuid_over_meta_when_both_given() {
+    let (app, _state, pool) = fixture().await;
+    let uuid = seed_book_with_isbn(&pool, "Effective Java", ISBN).await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let books_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(post(
+            "/api/scan/wishlist",
+            &token,
+            serde_json::json!({
+                "book_uuid": uuid,
+                "meta": external_meta_json("Should Be Ignored", ISBN),
+                "source": "scan",
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: BookRef = json_body(res).await;
+    assert_eq!(body.book_uuid, uuid, "book_uuid should win over meta");
+
+    let books_after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        books_after, books_before,
+        "meta must not create a new book when book_uuid is present"
+    );
+
+    let entries = omnibus_db::list_wishlist(&pool, user.id).await.unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].book_uuid, uuid);
+}
+
+#[tokio::test]
 async fn api_scan_wishlist_add_returns_400_when_neither_uuid_nor_meta_given() {
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;


### PR DESCRIPTION
## Summary
- `post_add_physical_only` and `post_wishlist_add` in `server/src/backend/scan.rs` (added in #1182) had zero test coverage — `server/src/backend/scan/tests.rs` only covered `post_resolve`/`post_check_in`.
- Adds 8 new integration tests to `server/src/backend/scan/tests.rs`, mirroring the existing suite's shape (drive `rest_router(AppState::new(pool))` via `tower::ServiceExt::oneshot` against an in-memory DB): auth-required for both handlers, a happy-path fileless-book + physical-copy creation for `add_physical_only`, all three branches (`book_uuid`-only, `meta`-only, and both-present precedence) of the wishlist precedence documented in `shared/src/scan.rs`, a 400 for the `MissingWishlistTarget` case, and a 500-on-DB-failure case (`DROP TABLE physical_copies`) mirroring the pattern used elsewhere in the suite.
- Test-only change — no production code was touched.

Closes #1207

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1207 cargo clippy -p omnibus --all-targets --features server -- -D warnings` — clean
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1207 cargo test -p omnibus --features server` — `backend::scan::tests` 14 passed; 0 failed (full crate run also green)

## Notes
- Test-only PR — no production code changes.
