### PR TITLE
refactor: split shelf-detail owner-actions and group RowScalarCell props

### DIFF
--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -259,51 +259,59 @@ fn UmNowReading() -> Element {
                         "Unable to load reading progress."
                     }
                 },
-                Some(Ok(Some(point))) => {
-                    let is_audio = point.record.format == ProgressFormat::Audio;
-                    let title = point
-                        .book
-                        .title
-                        .as_deref()
-                        .filter(|title| !title.trim().is_empty())
-                        .unwrap_or(&point.book.filename)
-                        .to_string();
-                    let author = point
-                        .book
-                        .creators
-                        .first()
-                        .map(|creator| creator.name.clone())
-                        .filter(|author| !author.trim().is_empty());
-                    let action = if is_audio {
-                        "Continue listening"
-                    } else {
-                        "Continue reading"
-                    };
-                    let uuid = point.record.book_uuid.clone();
-                    let to = if is_audio {
-                        Route::BookListen { uuid, file_id: None }
-                    } else {
-                        Route::BookRead { uuid }
-                    };
-                    let aria_label = format!("{action} {title}");
+                Some(Ok(Some(point))) => um_now_reading_row(point),
+            }
+        }
+    }
+}
 
-                    rsx! {
-                        Link {
-                            to,
-                            class: "um-now-reading",
-                            "data-testid": "user-menu-now-reading",
-                            "aria-label": "{aria_label}",
-                            div { class: "um-nr-cover", Cover { book: point.book } }
-                            div { class: "um-nr-meta",
-                                div { class: "um-nr-title", "{title}" }
-                                if let Some(author) = author {
-                                    div { class: "um-nr-author", "{author}" }
-                                }
-                                div { class: "um-nr-action", "{action}" }
-                            }
-                        }
-                    }
+/// The "in progress" row for [`UmNowReading`]: cover, title, author, and a
+/// resume link that routes to the reader or the player depending on format.
+#[cfg(any(feature = "web", feature = "server"))]
+fn um_now_reading_row(point: ResumePoint) -> Element {
+    let is_audio = point.record.format == ProgressFormat::Audio;
+    let title = point
+        .book
+        .title
+        .as_deref()
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or(&point.book.filename)
+        .to_string();
+    let author = point
+        .book
+        .creators
+        .first()
+        .map(|creator| creator.name.clone())
+        .filter(|author| !author.trim().is_empty());
+    let action = if is_audio {
+        "Continue listening"
+    } else {
+        "Continue reading"
+    };
+    let uuid = point.record.book_uuid.clone();
+    let to = if is_audio {
+        Route::BookListen {
+            uuid,
+            file_id: None,
+        }
+    } else {
+        Route::BookRead { uuid }
+    };
+    let aria_label = format!("{action} {title}");
+
+    rsx! {
+        Link {
+            to,
+            class: "um-now-reading",
+            "data-testid": "user-menu-now-reading",
+            "aria-label": "{aria_label}",
+            div { class: "um-nr-cover", Cover { book: point.book } }
+            div { class: "um-nr-meta",
+                div { class: "um-nr-title", "{title}" }
+                if let Some(author) = author {
+                    div { class: "um-nr-author", "{author}" }
                 }
+                div { class: "um-nr-action", "{action}" }
             }
         }
     }

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -162,18 +162,33 @@ pub(super) fn RowSeriesCell(series_line: String, series_text: String, ctx: CellE
     }
 }
 
+/// Display fields for a [`RowScalarCell`]: column class, testid, current
+/// value, and placeholder. Grouped so the cell wrapper stays under the
+/// component prop cap. Named `*Display` (not `*Props`) since `#[component]`
+/// already generates a `RowScalarCellProps` for the function itself.
+#[derive(Clone, PartialEq)]
+pub(super) struct RowScalarCellDisplay {
+    pub col_class: String,
+    pub cell_testid: String,
+    pub value: String,
+    pub placeholder: String,
+}
+
 /// Plain scalar-text cell wrapper for publisher / published / language —
 /// collapses the boilerplate of wiring `EditableCell` to the shared
 /// `save_field` callback.
 #[component]
 pub(super) fn RowScalarCell(
-    col_class: String,
-    cell_testid: String,
+    display: RowScalarCellDisplay,
     field: EditField,
-    value: String,
-    placeholder: String,
     ctx: CellEditCtx,
 ) -> Element {
+    let RowScalarCellDisplay {
+        col_class,
+        cell_testid,
+        value,
+        placeholder,
+    } = display;
     let CellEditCtx {
         is_admin,
         editing,

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -162,10 +162,7 @@ pub(super) fn RowSeriesCell(series_line: String, series_text: String, ctx: CellE
     }
 }
 
-/// Display fields for a [`RowScalarCell`]: column class, testid, current
-/// value, and placeholder. Grouped so the cell wrapper stays under the
-/// component prop cap. Named `*Display` (not `*Props`) since `#[component]`
-/// already generates a `RowScalarCellProps` for the function itself.
+/// Grouped display fields (column class, testid, value, placeholder) for a [`RowScalarCell`].
 #[derive(Clone, PartialEq)]
 pub(super) struct RowScalarCellDisplay {
     pub col_class: String,

--- a/frontend/src/pages/landing/table/row.rs
+++ b/frontend/src/pages/landing/table/row.rs
@@ -11,7 +11,8 @@ use omnibus_shared::EbookMetadata;
 use super::super::sorting::{contributor_names, row_slug};
 use super::cells::{
     build_save_authors, build_save_field, AuthorsCell, CellEditCtx, EbookRowCoverCell,
-    EbookRowFormatsCell, RowContext, RowScalarCell, RowSeriesCell, RowTitleCell,
+    EbookRowFormatsCell, RowContext, RowScalarCell, RowScalarCellDisplay, RowSeriesCell,
+    RowTitleCell,
 };
 use super::{BookTableContext, EditField};
 use crate::Route;
@@ -272,30 +273,36 @@ fn EbookRowCells(display: RowDisplay, ctx: RowContext) -> Element {
         }
         RowSeriesCell { series_line, series_text, ctx: cell_ctx.clone() }
         RowScalarCell {
-            col_class: "ebook-col-publisher".to_string(),
-            cell_testid: "ebook-cell-publisher".to_string(),
+            display: RowScalarCellDisplay {
+                col_class: "ebook-col-publisher".to_string(),
+                cell_testid: "ebook-cell-publisher".to_string(),
+                value: publisher,
+                placeholder: "Publisher".to_string(),
+            },
             field: EditField::Publisher,
-            value: publisher,
-            placeholder: "Publisher".to_string(),
             ctx: cell_ctx.clone(),
         }
         RowScalarCell {
-            col_class: "ebook-col-published".to_string(),
-            cell_testid: "ebook-cell-published".to_string(),
+            display: RowScalarCellDisplay {
+                col_class: "ebook-col-published".to_string(),
+                cell_testid: "ebook-cell-published".to_string(),
+                value: published,
+                placeholder: "YYYY-MM-DD".to_string(),
+            },
             field: EditField::Published,
-            value: published,
-            placeholder: "YYYY-MM-DD".to_string(),
             ctx: cell_ctx.clone(),
         }
         EbookRowFormatsCell { formats: book.formats, has_physical: book.has_physical }
         td { class: "ebook-col-updated", "data-testid": "ebook-cell-updated", "{updated}" }
         td { class: "ebook-col-added", "data-testid": "ebook-cell-added", "{added}" }
         RowScalarCell {
-            col_class: "ebook-col-language".to_string(),
-            cell_testid: "ebook-cell-language".to_string(),
+            display: RowScalarCellDisplay {
+                col_class: "ebook-col-language".to_string(),
+                cell_testid: "ebook-cell-language".to_string(),
+                value: language,
+                placeholder: "en".to_string(),
+            },
             field: EditField::Language,
-            value: language,
-            placeholder: "en".to_string(),
             ctx: cell_ctx,
         }
     }

--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -31,71 +31,46 @@ mod mobile;
 #[component]
 pub fn ShelfDetailPage(id: i64) -> Element {
     let server_url = use_server_url();
-    let mut shelf = use_signal(|| None::<Shelf>);
-    let mut books = use_signal(Vec::<EbookMetadata>::new);
-    let mut loading = use_signal(|| true);
-    let mut error = use_signal(|| None::<String>);
+    let shelf = use_signal(|| None::<Shelf>);
+    let books = use_signal(Vec::<EbookMetadata>::new);
+    let loading = use_signal(|| true);
+    let error = use_signal(|| None::<String>);
     crate::use_page_title(move || shelf.read().as_ref().map(|s| s.name.clone()));
     let sort_key = use_signal(|| SortKey::Title);
+    // Mobile mutates these directly (see the mobile `body` branch below);
+    // web only threads them by value into `web_shelf_body`/`shelf_detail_modals`,
+    // so only the mobile build needs the bindings themselves to be `mut`.
+    #[cfg(feature = "mobile")]
     let mut show_add = use_signal(|| false);
+    #[cfg(not(feature = "mobile"))]
+    let show_add = use_signal(|| false);
+    #[cfg(feature = "mobile")]
     let mut edit_rules = use_signal(|| false);
+    #[cfg(not(feature = "mobile"))]
+    let edit_rules = use_signal(|| false);
     // Bumped to force a refetch after a membership edit.
+    #[cfg(feature = "mobile")]
     let mut reload = use_signal(|| 0u32);
+    #[cfg(not(feature = "mobile"))]
+    let reload = use_signal(|| 0u32);
     // Set when the member-books refetch fails, so a transient network error
     // renders distinctly from a shelf that is genuinely empty (mirrors
     // `search_mobile.rs`'s `errored` signal for the same failure class).
-    let mut errored = use_signal(|| false);
+    let errored = use_signal(|| false);
 
-    // Fetch the shelf detail whenever the id changes. `id` is a plain prop
-    // (not a signal), so it must be wrapped in `use_reactive!` to re-arm this
-    // effect on navigation between shelves — see `BookDetailPage` for why.
-    let shelf_url = server_url.clone();
-    use_effect(use_reactive!(|id| {
-        let url = shelf_url.clone();
-        let _ = reload();
-        spawn(async move {
-            loading.set(true);
-            match data::get_shelf(&url, id).await {
-                Ok(s) => {
-                    shelf.set(Some(s));
-                    error.set(None);
-                }
-                Err(e) => {
-                    shelf.set(None);
-                    error.set(Some(e.to_string()));
-                }
-            }
-            loading.set(false);
-        });
-    }));
-
-    // Fetch the member books, re-running on id/sort change or a membership
-    // edit. `sort_key()` is a signal read, already tracked; `id` needs the
-    // same `use_reactive!` wrapping as above.
-    let page_url = server_url.clone();
-    use_effect(use_reactive!(|id| {
-        let url = page_url.clone();
-        let key = sort_key();
-        let _ = reload();
-        spawn(async move {
-            let dir = default_dir_for(key);
-            match data::shelf_page(&url, id, key, dir).await {
-                Ok(page) => {
-                    books.set(page.books);
-                    errored.set(false);
-                }
-                Err(_) => {
-                    // `tracing` isn't linked under the `web` (WASM) feature,
-                    // so the signal alone carries the failure to the UI.
-                    // Clear the stale list too — otherwise a refetch failure
-                    // after navigating shelves leaves the prior shelf's
-                    // books on screen under the error banner.
-                    books.set(Vec::new());
-                    errored.set(true);
-                }
-            }
-        });
-    }));
+    use_shelf_effects(
+        id,
+        server_url.clone(),
+        sort_key,
+        reload,
+        ShelfFetchSignals {
+            shelf,
+            loading,
+            error,
+            books,
+            errored,
+        },
+    );
 
     if loading() && shelf.read().is_none() {
         return render_page_state(id, rsx! { p { class: "subtitle", "Loading\u{2026}" } });
@@ -145,10 +120,23 @@ pub fn ShelfDetailPage(id: i64) -> Element {
 
     rsx! {
         {body}
+        {shelf_detail_modals(id, current, show_add, edit_rules, reload)}
+    }
+}
 
+/// The "Add books" and "Edit rules" modals, shown when their respective
+/// signals flip true; both bump `reload` on success so the parent refetches.
+fn shelf_detail_modals(
+    shelf_id: i64,
+    current: Shelf,
+    mut show_add: Signal<bool>,
+    mut edit_rules: Signal<bool>,
+    mut reload: Signal<u32>,
+) -> Element {
+    rsx! {
         if show_add() {
             AddBooksModal {
-                shelf_id: id,
+                shelf_id,
                 on_close: move |_| show_add.set(false),
                 on_added: move |_| {
                     show_add.set(false);
@@ -168,6 +156,89 @@ pub fn ShelfDetailPage(id: i64) -> Element {
             }
         }
     }
+}
+
+/// Data signals populated by the shelf detail fetch effects. `Copy` (Dioxus
+/// signals), so grouping them keeps [`use_shelf_effects`] under the
+/// too-many-arguments cap without changing call-site ergonomics.
+#[derive(Clone, Copy)]
+struct ShelfFetchSignals {
+    shelf: Signal<Option<Shelf>>,
+    loading: Signal<bool>,
+    error: Signal<Option<String>>,
+    books: Signal<Vec<EbookMetadata>>,
+    errored: Signal<bool>,
+}
+
+/// Wires the two data-fetch effects backing [`ShelfDetailPage`]: the shelf
+/// detail itself (id-driven) and its member books (id/sort/reload-driven).
+/// Extracted to keep the page component under the line cap; mirrors
+/// `book_detail::use_book_data_effects`.
+fn use_shelf_effects(
+    id: i64,
+    server_url: String,
+    sort_key: Signal<SortKey>,
+    reload: Signal<u32>,
+    sig: ShelfFetchSignals,
+) {
+    let ShelfFetchSignals {
+        mut shelf,
+        mut loading,
+        mut error,
+        mut books,
+        mut errored,
+    } = sig;
+
+    // Fetch the shelf detail whenever the id changes. `id` is a plain prop
+    // (not a signal), so it must be wrapped in `use_reactive!` to re-arm this
+    // effect on navigation between shelves — see `BookDetailPage` for why.
+    let shelf_url = server_url.clone();
+    use_effect(use_reactive!(|id| {
+        let url = shelf_url.clone();
+        let _ = reload();
+        spawn(async move {
+            loading.set(true);
+            match data::get_shelf(&url, id).await {
+                Ok(s) => {
+                    shelf.set(Some(s));
+                    error.set(None);
+                }
+                Err(e) => {
+                    shelf.set(None);
+                    error.set(Some(e.to_string()));
+                }
+            }
+            loading.set(false);
+        });
+    }));
+
+    // Fetch the member books, re-running on id/sort change or a membership
+    // edit. `sort_key()` is a signal read, already tracked; `id` needs the
+    // same `use_reactive!` wrapping as above.
+    let page_url = server_url;
+    use_effect(use_reactive!(|id| {
+        let url = page_url.clone();
+        let key = sort_key();
+        let _ = reload();
+        spawn(async move {
+            let dir = default_dir_for(key);
+            match data::shelf_page(&url, id, key, dir).await {
+                Ok(page) => {
+                    books.set(page.books);
+                    errored.set(false);
+                }
+                Err(_) => {
+                    // `tracing` isn't linked under the `web` (WASM) feature,
+                    // so the signal alone carries the failure to the UI.
+                    // Clear the stale list too — otherwise a refetch failure
+                    // after navigating shelves leaves the prior shelf's
+                    // books on screen under the error banner.
+                    books.set(Vec::new());
+                    errored.set(true);
+                }
+            }
+        });
+    }));
 }
 
 /// Loading / not-found chrome. Web wraps in the rail layout; mobile renders
@@ -335,9 +406,9 @@ fn ShelfHeader(
 ) -> Element {
     let nav = use_navigator();
     let server_url = use_server_url();
-    let mut renaming = use_signal(|| false);
+    let renaming = use_signal(|| false);
     let mut draft_name = use_signal(|| shelf.name.clone());
-    let mut menu_open = use_signal(|| false);
+    let menu_open = use_signal(|| false);
 
     // Owner/admin gating; `None` until the boot effect resolves the viewer, so
     // controls stay hidden on SSR + first paint (hydration parity, rule 07). The
@@ -364,46 +435,11 @@ fn ShelfHeader(
         Visibility::Public => Visibility::Private,
     };
 
-    let del_url = server_url.clone();
-    let on_delete = move |_| {
-        let url = del_url.clone();
-        spawn(async move {
-            if data::delete_shelf(&url, id).await.is_ok() {
-                nav.push(Route::Landing {});
-            }
-        });
-    };
-
-    let vis_url = server_url.clone();
-    let on_toggle_vis = move |_| {
-        let url = vis_url.clone();
-        menu_open.set(false);
-        spawn(async move {
-            let req = UpdateShelfRequest {
-                visibility: Some(next_vis),
-                ..Default::default()
-            };
-            if data::update_shelf(&url, id, req).await.is_ok() {
-                on_changed.call(());
-            }
-        });
-    };
-
-    let rename_url = server_url.clone();
-    let on_rename_save = move |_| {
-        let url = rename_url.clone();
-        let name = draft_name();
-        renaming.set(false);
-        spawn(async move {
-            let req = UpdateShelfRequest {
-                name: Some(name),
-                ..Default::default()
-            };
-            if data::update_shelf(&url, id, req).await.is_ok() {
-                on_changed.call(());
-            }
-        });
-    };
+    let on_delete = build_on_delete(server_url.clone(), id, nav);
+    let on_toggle_vis =
+        build_on_toggle_vis(server_url.clone(), id, next_vis, menu_open, on_changed);
+    let on_rename_save =
+        build_on_rename_save(server_url.clone(), id, renaming, draft_name, on_changed);
 
     rsx! {
         header { class: "shelf-detail-header", "data-testid": "shelf-detail-header",
@@ -431,52 +467,141 @@ fn ShelfHeader(
                     button {
                         r#type: "button", class: "btn shelf-btn-primary",
                         "data-testid": "shelf-rename-save",
-                        onclick: on_rename_save,
+                        onclick: move |_| on_rename_save.call(()),
                         "Save"
                     }
                 } else {
                     h1 { class: "shelf-title", "{shelf.name}" }
                     if can_manage {
-                    div { class: "shelf-actions",
+                        {shelf_actions_menu(
+                            is_smart,
+                            menu_open,
+                            renaming,
+                            on_edit_rules,
+                            on_toggle_vis,
+                            on_delete,
+                        )}
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Builds the delete-shelf handler: deletes then navigates back to the
+/// library on success.
+#[cfg(not(feature = "mobile"))]
+fn build_on_delete(server_url: String, id: i64, nav: dioxus_router::Navigator) -> EventHandler<()> {
+    EventHandler::new(move |()| {
+        let url = server_url.clone();
+        spawn(async move {
+            if data::delete_shelf(&url, id).await.is_ok() {
+                nav.push(Route::Landing {});
+            }
+        });
+    })
+}
+
+/// Builds the visibility-toggle handler: closes the actions menu, flips
+/// visibility, and refetches on success.
+#[cfg(not(feature = "mobile"))]
+fn build_on_toggle_vis(
+    server_url: String,
+    id: i64,
+    next_vis: Visibility,
+    mut menu_open: Signal<bool>,
+    on_changed: EventHandler<()>,
+) -> EventHandler<()> {
+    EventHandler::new(move |()| {
+        let url = server_url.clone();
+        menu_open.set(false);
+        spawn(async move {
+            let req = UpdateShelfRequest {
+                visibility: Some(next_vis),
+                ..Default::default()
+            };
+            if data::update_shelf(&url, id, req).await.is_ok() {
+                on_changed.call(());
+            }
+        });
+    })
+}
+
+/// Builds the rename-save handler: saves the draft name and refetches on
+/// success.
+#[cfg(not(feature = "mobile"))]
+fn build_on_rename_save(
+    server_url: String,
+    id: i64,
+    mut renaming: Signal<bool>,
+    draft_name: Signal<String>,
+    on_changed: EventHandler<()>,
+) -> EventHandler<()> {
+    EventHandler::new(move |()| {
+        let url = server_url.clone();
+        let name = draft_name();
+        renaming.set(false);
+        spawn(async move {
+            let req = UpdateShelfRequest {
+                name: Some(name),
+                ..Default::default()
+            };
+            if data::update_shelf(&url, id, req).await.is_ok() {
+                on_changed.call(());
+            }
+        });
+    })
+}
+
+/// Owner-only actions trigger + dropdown: edit rules (smart shelves only),
+/// rename, toggle visibility, delete. Split out of [`ShelfHeader`] to keep
+/// it under the line cap, mirroring `member_grid`'s plain-fn split.
+#[cfg(not(feature = "mobile"))]
+fn shelf_actions_menu(
+    is_smart: bool,
+    mut menu_open: Signal<bool>,
+    mut renaming: Signal<bool>,
+    on_edit_rules: EventHandler<()>,
+    on_toggle_vis: EventHandler<()>,
+    on_delete: EventHandler<()>,
+) -> Element {
+    rsx! {
+        div { class: "shelf-actions",
+            button {
+                r#type: "button",
+                class: "shelf-actions-btn",
+                "data-testid": "shelf-actions",
+                "aria-label": "Shelf actions",
+                onclick: move |_| menu_open.toggle(),
+                "\u{22EF}"
+            }
+            if menu_open() {
+                div { class: "shelf-actions-menu",
+                    if is_smart {
                         button {
-                            r#type: "button",
-                            class: "shelf-actions-btn",
-                            "data-testid": "shelf-actions",
-                            "aria-label": "Shelf actions",
-                            onclick: move |_| menu_open.toggle(),
-                            "\u{22EF}"
-                        }
-                        if menu_open() {
-                            div { class: "shelf-actions-menu",
-                                if is_smart {
-                                    button {
-                                        r#type: "button", class: "shelf-menu-item",
-                                        "data-testid": "shelf-edit-rules",
-                                        onclick: move |_| { menu_open.set(false); on_edit_rules.call(()); },
-                                        "Edit rules"
-                                    }
-                                }
-                                button {
-                                    r#type: "button", class: "shelf-menu-item",
-                                    "data-testid": "shelf-rename",
-                                    onclick: move |_| { menu_open.set(false); renaming.set(true); },
-                                    "Rename"
-                                }
-                                button {
-                                    r#type: "button", class: "shelf-menu-item",
-                                    "data-testid": "shelf-toggle-visibility",
-                                    onclick: on_toggle_vis,
-                                    "Change visibility"
-                                }
-                                button {
-                                    r#type: "button", class: "shelf-menu-item shelf-menu-item--danger",
-                                    "data-testid": "shelf-delete",
-                                    onclick: on_delete,
-                                    "Delete"
-                                }
-                            }
+                            r#type: "button", class: "shelf-menu-item",
+                            "data-testid": "shelf-edit-rules",
+                            onclick: move |_| { menu_open.set(false); on_edit_rules.call(()); },
+                            "Edit rules"
                         }
                     }
+                    button {
+                        r#type: "button", class: "shelf-menu-item",
+                        "data-testid": "shelf-rename",
+                        onclick: move |_| { menu_open.set(false); renaming.set(true); },
+                        "Rename"
+                    }
+                    button {
+                        r#type: "button", class: "shelf-menu-item",
+                        "data-testid": "shelf-toggle-visibility",
+                        onclick: move |_| on_toggle_vis.call(()),
+                        "Change visibility"
+                    }
+                    button {
+                        r#type: "button", class: "shelf-menu-item shelf-menu-item--danger",
+                        "data-testid": "shelf-delete",
+                        onclick: move |_| on_delete.call(()),
+                        "Delete"
                     }
                 }
             }
@@ -488,20 +613,12 @@ fn ShelfHeader(
 #[component]
 fn AddBooksModal(shelf_id: i64, on_close: EventHandler<()>, on_added: EventHandler<()>) -> Element {
     let server_url = use_server_url();
-    let mut library = use_signal(Vec::<EbookMetadata>::new);
+    let library = use_signal(Vec::<EbookMetadata>::new);
     let mut query = use_signal(String::new);
     let picked = use_signal(Vec::<String>::new);
     let mut saving = use_signal(|| false);
 
-    let effect_url = server_url.clone();
-    use_effect(move || {
-        let url = effect_url.clone();
-        spawn(async move {
-            if let Ok(lib) = data::get_ebooks(&url).await {
-                library.set(lib.books);
-            }
-        });
-    });
+    use_library_fetch(server_url.clone(), library);
 
     let add_url = server_url.clone();
     let on_add = move |_| {
@@ -520,19 +637,8 @@ fn AddBooksModal(shelf_id: i64, on_close: EventHandler<()>, on_added: EventHandl
         });
     };
 
-    let q = query.read().to_lowercase();
-    let books = library.read();
-    let filtered: Vec<&EbookMetadata> = books
-        .iter()
-        .filter(|b| {
-            q.is_empty()
-                || b.title
-                    .as_deref()
-                    .unwrap_or(&b.filename)
-                    .to_lowercase()
-                    .contains(&q)
-        })
-        .collect();
+    let library_books = library.read();
+    let filtered = filter_library(&library_books, &query.read());
     let picked_count = picked.read().len();
 
     rsx! {
@@ -555,29 +661,7 @@ fn AddBooksModal(shelf_id: i64, on_close: EventHandler<()>, on_added: EventHandl
                         }
                         span { class: "mono shelf-picker-count", "Selected \u{b7} {picked_count}" }
                     }
-                    div { class: "shelf-picker-grid",
-                        for book in filtered.iter().map(|b| (*b).clone()) {
-                            {
-                                let uuid = book.unique_identifier.clone().unwrap_or_default();
-                                let selected = picked.read().contains(&uuid);
-                                let mut picked = picked;
-                                rsx! {
-                                    div {
-                                        key: "{book.id}",
-                                        CoverTile {
-                                            book,
-                                            server_url: server_url.to_string(),
-                                            sizes: "120px".to_string(),
-                                            kind: CoverTileKind::Selectable {
-                                                selected,
-                                                on_toggle: EventHandler::new(move |_| toggle_picked(&mut picked, &uuid)),
-                                            },
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    {add_books_picker_grid(&filtered, &server_url, picked)}
                 }
                 div { class: "shelf-modal-foot",
                     button {
@@ -591,6 +675,69 @@ fn AddBooksModal(shelf_id: i64, on_close: EventHandler<()>, on_added: EventHandl
                         disabled: saving(),
                         onclick: on_add,
                         if saving() { "Adding\u{2026}" } else { "Add \u{b7} {picked_count}" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Fetches the full library once on mount, for the "Add books" search/pick UI.
+fn use_library_fetch(server_url: String, mut library: Signal<Vec<EbookMetadata>>) {
+    use_effect(move || {
+        let url = server_url.clone();
+        spawn(async move {
+            if let Ok(lib) = data::get_ebooks(&url).await {
+                library.set(lib.books);
+            }
+        });
+    });
+}
+
+/// Library books whose title (or filename fallback) contains `query`,
+/// case-insensitively; an empty query matches everything.
+fn filter_library<'a>(books: &'a [EbookMetadata], query: &str) -> Vec<&'a EbookMetadata> {
+    let q = query.to_lowercase();
+    books
+        .iter()
+        .filter(|b| {
+            q.is_empty()
+                || b.title
+                    .as_deref()
+                    .unwrap_or(&b.filename)
+                    .to_lowercase()
+                    .contains(&q)
+        })
+        .collect()
+}
+
+/// Selectable cover grid for the "Add books" modal; toggles membership in
+/// `picked` via `CoverTile`'s `Selectable` kind.
+fn add_books_picker_grid(
+    filtered: &[&EbookMetadata],
+    server_url: &str,
+    picked: Signal<Vec<String>>,
+) -> Element {
+    rsx! {
+        div { class: "shelf-picker-grid",
+            for book in filtered.iter().map(|b| (*b).clone()) {
+                {
+                    let uuid = book.unique_identifier.clone().unwrap_or_default();
+                    let selected = picked.read().contains(&uuid);
+                    let mut picked = picked;
+                    rsx! {
+                        div {
+                            key: "{book.id}",
+                            CoverTile {
+                                book,
+                                server_url: server_url.to_string(),
+                                sizes: "120px".to_string(),
+                                kind: CoverTileKind::Selectable {
+                                    selected,
+                                    on_toggle: EventHandler::new(move |_| toggle_picked(&mut picked, &uuid)),
+                                },
+                            }
+                        }
                     }
                 }
             }

--- a/frontend/src/pages/shelf_detail.rs
+++ b/frontend/src/pages/shelf_detail.rs
@@ -37,9 +37,7 @@ pub fn ShelfDetailPage(id: i64) -> Element {
     let error = use_signal(|| None::<String>);
     crate::use_page_title(move || shelf.read().as_ref().map(|s| s.name.clone()));
     let sort_key = use_signal(|| SortKey::Title);
-    // Mobile mutates these directly (see the mobile `body` branch below);
-    // web only threads them by value into `web_shelf_body`/`shelf_detail_modals`,
-    // so only the mobile build needs the bindings themselves to be `mut`.
+    // Only mobile mutates these directly, so only it needs `mut` bindings.
     #[cfg(feature = "mobile")]
     let mut show_add = use_signal(|| false);
     #[cfg(not(feature = "mobile"))]


### PR DESCRIPTION
## Summary
- Closes #1205
- Splits `ShelfDetailPage`, `ShelfHeader`, and `AddBooksModal` in `frontend/src/pages/shelf_detail.rs` (each was over the ~80-line function cap) into named helpers, mirroring the file's existing `member_grid`/`web_shelf_body` split-fn pattern: `use_shelf_effects`/`ShelfFetchSignals` (data fetch effects), `shelf_detail_modals` (Add-books/Edit-rules modal wrappers), `shelf_actions_menu` + `build_on_delete`/`build_on_toggle_vis`/`build_on_rename_save` (owner-only actions menu + its handlers), and `use_library_fetch`/`filter_library`/`add_books_picker_grid` (Add-books modal).
- Extracts `UmNowReading`'s `Some(Ok(Some(point)))` render arm in `frontend/src/components/user_menu.rs` into `um_now_reading_row`.
- Groups `RowScalarCell`'s four scalar display props (`col_class`, `cell_testid`, `value`, `placeholder`) into a `RowScalarCellDisplay` struct in `frontend/src/pages/landing/table/cells.rs`, bringing the component to 3 top-level params; updates the three call sites in `frontend/src/pages/landing/table/row.rs`.
- Pure structural extraction — no rendered markup, `data-testid`, role, or behavior changed.

## Test plan
- [x] `cargo fmt -p omnibus-frontend --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1205 cargo clippy -p omnibus-frontend --features web -- -D warnings` — PASS, no warnings
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1205 cargo check -p omnibus-frontend --features mobile` — PASS (sanity check that the mobile-only branch of `ShelfDetailPage` still compiles after the signal-mutability cfg-split)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1205 cargo test -p omnibus-frontend --features server` — PASS, 367 passed; 0 failed

## Notes
- Confirmed the four target functions/component were still over their respective caps before making changes (not already fixed).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LswnHm3J2hADgkPpSH7mEP)_