### PR TITLE
fix: persist playback rate across resource loads in WKWebView

### DIFF
--- a/frontend/src/pages/listen/mobile/interop.rs
+++ b/frontend/src/pages/listen/mobile/interop.rs
@@ -195,6 +195,16 @@ fn surface_js(parts_json: &str, resume_lit: &str, rate_lit: &str, meta_lit: &str
   document.body.appendChild(el);
   try {{ el.playbackRate = rate; }} catch(_e) {{}}
 
+  // WKWebView resets `playbackRate` to 1.0 every time a new resource
+  // loads, so the rate set above (and every `setRate`) is wiped by the
+  // seed / cross-part / auto-advance `el.load()` calls below — the book
+  // plays at 1.0 while the UI shows the saved speed. Re-apply the tracked
+  // rate on every `loadedmetadata` to keep the element in sync.
+  el.addEventListener('loadedmetadata', function(){{
+    var oa = window.OmnibusMobileAudio;
+    if (oa) {{ try {{ el.playbackRate = oa._rate; }} catch(_e) {{}} }}
+  }});
+
   function absTime() {{
     var oa = window.OmnibusMobileAudio;
     if (!oa) return el.currentTime || 0;
@@ -205,10 +215,13 @@ fn surface_js(parts_json: &str, resume_lit: &str, rate_lit: &str, meta_lit: &str
     _parts: parts,
     _offsets: offsets,
     _index: 0,
+    // Tracked separately because WKWebView drops `el.playbackRate` to 1.0
+    // on every resource load; the `loadedmetadata` listener re-applies it.
+    _rate: rate,
     play: function(){{ var p = el.play(); if (p && p.catch) p.catch(function(){{}}); }},
     pause: function(){{ el.pause(); }},
     toggle: function(){{ if (el.paused) {{ this.play(); }} else {{ this.pause(); }} }},
-    setRate: function(r){{ try {{ el.playbackRate = r; }} catch(_e) {{}} }},
+    setRate: function(r){{ this._rate = r; try {{ el.playbackRate = r; }} catch(_e) {{}} }},
     seek: function(absSeconds){{
       var s = Math.max(0, absSeconds || 0);
       var i = 0;
@@ -317,6 +330,17 @@ mod tests {
         let js = surface_js("[{\"url\":\"u\",\"duration\":1}]", "12.5", "1.2", &meta);
         assert!(js.contains("var resume = 12.5;"));
         assert!(js.contains("el.playbackRate = rate;"));
+        // WKWebView wipes playbackRate on every load, so the tracked rate is
+        // re-applied on loadedmetadata and setRate persists it.
+        assert!(js.contains("_rate: rate,"), "tracked rate field missing");
+        assert!(
+            js.contains("el.playbackRate = oa._rate;"),
+            "loadedmetadata rate re-apply missing"
+        );
+        assert!(
+            js.contains("setRate: function(r){ this._rate = r;"),
+            "setRate should persist the tracked rate"
+        );
         assert!(js.contains("window.OmnibusMobileAudio"));
         assert!(js.contains("dioxus.send"));
         // Media Session wiring landed.


### PR DESCRIPTION
## Summary

WKWebView resets the `playbackRate` property to 1.0 whenever a new audio resource loads, which occurs during seed/cross-part/auto-advance operations. This caused the UI to show the saved playback speed while the audio actually played at 1.0x.

The fix tracks the desired playback rate separately in `window.OmnibusMobileAudio._rate` and re-applies it on every `loadedmetadata` event, keeping the audio element in sync with the UI.

**Changes:**
- Added `_rate` field to track the desired playback rate independently
- Added `loadedmetadata` event listener to re-apply the tracked rate after resource loads
- Updated `setRate()` to persist the rate in `_rate` before setting `el.playbackRate`
- Added test assertions to verify the tracking and re-application logic

## Test plan

- [x] Existing unit tests pass (new assertions verify `_rate` field, `loadedmetadata` listener, and `setRate` persistence are present in generated JS)

## Version

- [ ] **Minor** — add the `minor version` label
- [x] **Patch** — the default
- [ ] **No release** — add the `no release` label

## Notes

This is a targeted fix for WKWebView's resource-load behavior. The `loadedmetadata` listener approach is safe across all platforms (it's a standard HTML5 event) and has no performance impact.

https://claude.ai/code/session_01DnfZESGvxfJjxJYy4FiTSm