### PR TITLE
feat: Apple Books-style reader chrome for the mobile ereader

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5273,8 +5273,13 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   padding: env(safe-area-inset-top) 32px 0; align-items: center;
   justify-content: center; pointer-events: none; overflow: hidden;
   white-space: nowrap; font-size: 13px; color: var(--ink-3);
-  opacity: 0; transition: opacity .22s ease; }
-.rd-chrome-hidden .rd-ambient-title { opacity: 1; }
+  /* `visibility` rides the fade so the inactive label leaves the
+     accessibility tree (opacity alone keeps it exposed and screen readers
+     would announce the title twice); the markup is `aria-hidden` too since
+     the label only mirrors the toolbar title visually. */
+  opacity: 0; visibility: hidden;
+  transition: opacity .22s ease, visibility .22s; }
+.rd-chrome-hidden .rd-ambient-title { opacity: 1; visibility: visible; }
 /* Phone minimal-chrome footer counterpart to `.rd-ambient-title`: the bare
    centred page number, displayed only by the phone breakpoint while the
    chrome is hidden. */

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -43,6 +43,12 @@
   --warn: oklch(0.78 0.13 75);
   --bad:  oklch(0.72 0.16 25);
 
+  /* Reader page ground — must match the epub.js body background the glue
+     registers per theme (`rendition.themes.register` in
+     `vendor/epub-reader-glue.js`), so the reader surface around the prose
+     is seamless with the page itself. */
+  --rd-page: #201e1b;
+
   --serif: 'Instrument Serif', 'EB Garamond', Georgia, serif;
   --sans:  'Geist', ui-sans-serif, -apple-system, system-ui, sans-serif;
   --mono:  'Geist Mono', ui-monospace, 'SF Mono', monospace;
@@ -77,6 +83,7 @@
   --accent-ink: oklch(0.99 0 0);
   --cover-fallback-bg:  oklch(0.86 0.004 70);
   --cover-fallback-ink: oklch(0.28 0.006 70);
+  --rd-page: #fcfbfa;
   color-scheme: light;
 }
 
@@ -100,6 +107,7 @@
   --accent-ink:  oklch(0.98 0.012 80);
   --cover-fallback-bg:  oklch(0.80 0.030 72);
   --cover-fallback-ink: oklch(0.30 0.036 55);
+  --rd-page: #ede4d0;
   color-scheme: light;
 }
 
@@ -3329,7 +3337,7 @@ a.idx-letter-on:focus-visible {
    the full-width bar at the very bottom edge (no collision offset needed —
    the reader's bottom bar becomes a slim footer pinned above the dock),
    while mobile keeps the base 68px floating-bar values. */
-.rd-host { --rd-dock-h: 68px; --rd-dock-gap: 8px; }
+.rd-host { --rd-dock-h: 68px; --rd-dock-gap: 8px; --rd-bottom-h: 54px; }
 .rd-dock-full { --rd-dock-h: 78px; --rd-foot-h: 40px; }
 
 /* LEFT cluster — cover + title/meta. Capped so it can't run under the
@@ -5134,8 +5142,12 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .ratings-slot, .suggestions-slot { min-height: 1px; }
 
 /* ── Reader chrome (F2.4) ─────────────────────────────────────── */
+/* The surface shares the page ground `--rd-page`, not the app `--bg-0` —
+   Apple-Books-style: when the chrome slides away the freed strips are
+   indistinguishable from the page. The bars keep their own `--bg-0` tint so
+   visible chrome still reads as chrome, slightly distinct from the page. */
 .rd-surface { position: relative; height: 100vh; width: 100%; overflow: hidden;
-  background: var(--bg-0); color: var(--ink-0); font-family: var(--sans); }
+  background: var(--rd-page); color: var(--ink-0); font-family: var(--sans); }
 .rd-top, .rd-bottom { position: absolute; left: 0; right: 0; z-index: 6;
   display: flex; align-items: center; gap: 16px; padding: 0 26px;
   background: color-mix(in oklch, var(--bg-0) 80%, transparent);
@@ -5148,7 +5160,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
    insets non-zero. */
 .rd-top { top: 0; height: calc(60px + env(safe-area-inset-top));
   padding-top: env(safe-area-inset-top); border-bottom: 1px solid var(--line-2); }
-.rd-bottom { bottom: 0; height: calc(54px + env(safe-area-inset-bottom));
+.rd-bottom { bottom: 0; height: calc(var(--rd-bottom-h, 54px) + env(safe-area-inset-bottom));
   padding-bottom: env(safe-area-inset-bottom); border-top: 1px solid var(--line-2);
   font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
 .rd-tool { display: inline-flex; align-items: center; justify-content: center; gap: 7px;
@@ -5164,7 +5176,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
    indicator). Matches the bar heights above; env insets are 0 on desktop. */
 .rd-stage { position: absolute; left: 0; right: 0;
   top: calc(60px + env(safe-area-inset-top));
-  bottom: calc(54px + env(safe-area-inset-bottom));
+  bottom: calc(var(--rd-bottom-h, 54px) + env(safe-area-inset-bottom));
   overflow: hidden; }
 /* Immersive reflow: while the audiobook bar is docked (`rd-immersive` set by
    the /read route), the stage's bottom inset grows by the bar's height plus
@@ -5173,7 +5185,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
    clickable beneath it. Shares --rd-dock-h/--rd-dock-gap with the dock rules
    in the mini-dock section — one source of truth for the reserved band. */
 .rd-immersive .rd-stage {
-  bottom: calc(54px + env(safe-area-inset-bottom) + var(--rd-dock-h) + 2 * var(--rd-dock-gap));
+  bottom: calc(var(--rd-bottom-h, 54px) + env(safe-area-inset-bottom) + var(--rd-dock-h) + 2 * var(--rd-dock-gap));
 }
 /* Web immersive (`rd-dock-full`, set by the web /read route): the full-width
    AudioDockBar sits at the bottom edge, the reader's own bottom bar becomes
@@ -5212,20 +5224,31 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 @media (max-width: 480px), (hover: none) and (pointer: coarse) { .rd-turn { display: none; } }
 /* Tap-center hides the chrome for a distraction-free page view — a centre tap
    flips the host's `chrome_hidden` signal, which adds `rd-chrome-hidden` to the
-   surface; the bars slide out and the progress ribbon fades. */
+   surface; the bars slide out and the progress ribbon fades.
+   The hidden-state rules only apply where a tap can bring the chrome back —
+   phones and coarse-pointer (touch) screens, the same gate as the page-turn
+   gutters above. On a mouse-only viewport the bars stay pinned regardless of
+   the signal, so resizing a phone-width window (chrome hidden) up to desktop
+   can never strand the reader with no way to summon the menus. */
 .rd-top, .rd-bottom { transition: transform .22s ease; }
-.rd-chrome-hidden .rd-top { transform: translateY(-100%); }
-.rd-chrome-hidden .rd-bottom { transform: translateY(100%); }
-.rd-chrome-hidden .rd-ribbon { opacity: 0; transition: opacity .22s ease; }
+@media (max-width: 480px), (hover: none) and (pointer: coarse) {
+  .rd-chrome-hidden .rd-top { transform: translateY(-100%); }
+  .rd-chrome-hidden .rd-bottom { transform: translateY(100%); }
+  .rd-chrome-hidden .rd-ribbon { opacity: 0; transition: opacity .22s ease; }
+  .rd-chrome-hidden .rd-wash { opacity: 0; }
+}
 .rd-ribbon { position: absolute; left: 0; right: 0; bottom: 0; height: 2px;
   background: var(--bg-2); z-index: 7; }
 .rd-ribbon > i { display: block; height: 100%; background: var(--accent); transition: width .3s; }
 .rd-overlay { position: absolute; inset: 0; z-index: 8; display: flex;
-  align-items: center; justify-content: center; color: var(--ink-2); background: var(--bg-0); }
+  align-items: center; justify-content: center; color: var(--ink-2); background: var(--rd-page); }
+/* The accent wash rides with the chrome: hidden-chrome mode is pure page
+   color edge to edge, so the tint fades out alongside the bars (the fade
+   rule lives in the tap-to-hide media block above). */
 .rd-wash { position: absolute; top: 0; left: 0; right: 0; height: 200px; z-index: 0;
   background: radial-gradient(70% 120% at 50% -20%,
     color-mix(in oklch, var(--accent) 16%, transparent), transparent 70%);
-  pointer-events: none; }
+  pointer-events: none; transition: opacity .22s ease; }
 .rd-title-center { flex: 1; text-align: center; min-width: 0; overflow: hidden;
   white-space: nowrap; text-overflow: ellipsis; }
 .rd-title-book { font-family: var(--serif); font-style: italic; font-size: 16px;
@@ -5240,6 +5263,22 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
    buttons) across the same breakpoint. */
 .rd-title-sub { display: none; font-family: var(--mono); font-size: 9.5px;
   color: var(--ink-3); }
+/* Ambient book-title label for the phone minimal-chrome state: occupies the
+   same band as the toolbar and fades in as it slides away (Books-style —
+   hidden chrome still names the book up top and the page down below).
+   Rendered on every target for hydration parity; only the phone breakpoint
+   displays it. */
+.rd-ambient-title { display: none; position: absolute; top: 0; left: 0; right: 0;
+  z-index: 5; height: calc(60px + env(safe-area-inset-top));
+  padding: env(safe-area-inset-top) 32px 0; align-items: center;
+  justify-content: center; pointer-events: none; overflow: hidden;
+  white-space: nowrap; font-size: 13px; color: var(--ink-3);
+  opacity: 0; transition: opacity .22s ease; }
+.rd-chrome-hidden .rd-ambient-title { opacity: 1; }
+/* Phone minimal-chrome footer counterpart to `.rd-ambient-title`: the bare
+   centred page number, displayed only by the phone breakpoint while the
+   chrome is hidden. */
+.rd-ambient-page { display: none; }
 .rd-bottom-ch { display: none; }
 .rd-grabber { display: none; }
 .rd-drawer-sub { display: none; font-family: var(--mono); font-size: 10px;
@@ -5478,6 +5517,20 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
  * second `@media` later in the file, whose equal specificity would win the
  * cascade and silently override these. */
 @media (max-width: 480px) {
+  /* Apple-Books-style minimal chrome: the bands stay reserved (prose never
+     slides under the chrome), but the bottom band slims to fit its tiny
+     mono label, and hiding the chrome swaps content instead of leaving
+     empty strips — the footer stays put as the ambient page indicator
+     (its rule and blur tint dropped so it reads as part of the page) and
+     the small `rd-ambient-title` fades in up top where the toolbar was. */
+  .rd-host { --rd-bottom-h: 30px; }
+  .rd-chrome-hidden .rd-bottom { transform: none; border-top-color: transparent;
+    background: transparent; backdrop-filter: none; -webkit-backdrop-filter: none; }
+  .rd-ambient-title { display: flex; }
+  /* Footer content swap: hidden chrome shows only the bare page number,
+     centred; the richer position/chapter readout rides with the chrome. */
+  .rd-chrome-hidden .rd-bottom-page, .rd-chrome-hidden .rd-bottom-ch { display: none; }
+  .rd-chrome-hidden .rd-ambient-page { display: block; flex: 1; text-align: center; }
   /* Only tighten the horizontal padding here — the vertical padding is the
      safe-area inset set on the base rules, and a `padding: 0 14px` shorthand
      would zero it back out and re-hide the bars under the notch. */
@@ -6802,7 +6855,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
    layout lets the transport row fill the pinned height with no dead space. */
 .rd-host .m-mini {
   left: 8px; right: 8px;
-  bottom: calc(54px + env(safe-area-inset-bottom) + var(--rd-dock-gap));
+  bottom: calc(var(--rd-bottom-h, 54px) + env(safe-area-inset-bottom) + var(--rd-dock-gap));
   height: var(--rd-dock-h);
   display: flex; flex-direction: column;
 }

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -19,7 +19,8 @@
  *   init(elementId, fileUrl, opts)  opts = { cfi?, fontSize?, theme?,
  *                                           fontFamily?, lineHeight?,
  *                                           maxWidth?, justify?,
- *                                           allowScriptedContent? }
+ *                                           allowScriptedContent?,
+ *                                           locationsKey? }
  *   next()
  *   prev()
  *   setFontSize(px)
@@ -227,6 +228,9 @@
       installContentLinkNav();
       installStageResizeWatch(elementId);
 
+      // These body backgrounds are mirrored by the per-theme `--rd-page`
+      // token in atrium.css (the reader-surface ground) — change both
+      // together or the chrome strips stop matching the page.
       rendition.themes.register("light", {
         body: { background: "#fcfbfa", color: "#2a2725" },
       });
@@ -252,6 +256,14 @@
       return;
     }
 
+    // Page numbers come from epub.js "locations" — a whole-book pagination
+    // pass that takes seconds on desktop and much longer in the mobile
+    // WebView. Cache the result per book (keyed by the host-supplied
+    // `locationsKey`, the book uuid) so only the very first open pays it.
+    // Storage failures (quota, private mode) and corrupt entries just fall
+    // back to regeneration. Caveat: replacing a book's file under the same
+    // uuid can leave slightly stale page numbers until the entry is cleared.
+    var locationsCacheKey = opts.locationsKey ? "omn.locs::" + opts.locationsKey : null;
     book.ready
       .then(function () {
         tocFlat = [];
@@ -259,7 +271,25 @@
           flattenToc(book.navigation.toc, tocFlat);
         }
         emitToc();
-        return book.locations.generate(1024);
+        var cached = null;
+        if (locationsCacheKey) {
+          try {
+            cached = window.localStorage.getItem(locationsCacheKey);
+          } catch (e) { /* storage unavailable */ }
+        }
+        if (cached) {
+          try {
+            book.locations.load(cached);
+            return null;
+          } catch (e) { /* corrupt cache — regenerate below */ }
+        }
+        return book.locations.generate(1024).then(function () {
+          if (locationsCacheKey) {
+            try {
+              window.localStorage.setItem(locationsCacheKey, book.locations.save());
+            } catch (e) { /* quota/unavailable — regenerate next open */ }
+          }
+        });
       })
       .then(function () {
         locationsReady = true;

--- a/frontend/src/pages/reader/bootstrap.rs
+++ b/frontend/src/pages/reader/bootstrap.rs
@@ -17,6 +17,8 @@ pub(crate) struct BootstrapArgs<'a> {
     pub max_width_lit: &'a str,
     pub justify_val: bool,
     pub spread_lit: &'a str,
+    /// Book uuid, the glue's per-book locations-cache key.
+    pub locations_key_lit: &'a str,
 }
 
 /// Build the JS IIFE that mounts the reader once the vendored scripts are
@@ -34,9 +36,10 @@ pub(crate) fn reader_bootstrap_js(args: &BootstrapArgs<'_>) -> String {
         max_width_lit,
         justify_val,
         spread_lit,
+        locations_key_lit,
     } = *args;
     format!(
-        r#"(function(){{ var n=0; (function go(){{ if (window.OmnibusReader && window.ePub) {{ window.OmnibusReader.init("omnibus-viewer", {url_lit}, {{ cfi: {cfi_arg}, fontSize: {font_size}, theme: {theme_lit}, fontFamily: {font_family_lit}, lineHeight: {line_height_lit}, maxWidth: {max_width_lit}, justify: {justify_val}, spread: {spread_lit} }}); }} else if (n++ < 200) {{ setTimeout(go, 50); }} else if (typeof window.__omnibusOnStatus === "function") {{ window.__omnibusOnStatus("error"); }} }})(); }})();"#
+        r#"(function(){{ var n=0; (function go(){{ if (window.OmnibusReader && window.ePub) {{ window.OmnibusReader.init("omnibus-viewer", {url_lit}, {{ cfi: {cfi_arg}, fontSize: {font_size}, theme: {theme_lit}, fontFamily: {font_family_lit}, lineHeight: {line_height_lit}, maxWidth: {max_width_lit}, justify: {justify_val}, spread: {spread_lit}, locationsKey: {locations_key_lit} }}); }} else if (n++ < 200) {{ setTimeout(go, 50); }} else if (typeof window.__omnibusOnStatus === "function") {{ window.__omnibusOnStatus("error"); }} }})(); }})();"#
     )
 }
 
@@ -56,6 +59,7 @@ mod tests {
             max_width_lit: "null",
             justify_val: false,
             spread_lit: "\"auto\"",
+            locations_key_lit: "\"x\"",
         });
         assert!(js.contains("window.OmnibusReader.init"));
         assert!(js.contains("window.ePub"));
@@ -63,6 +67,7 @@ mod tests {
         assert!(js.contains("theme: \"dark\""));
         assert!(js.contains("justify: false"));
         assert!(js.contains("spread: \"auto\""));
+        assert!(js.contains("locationsKey: \"x\""));
         assert!(js.contains("__omnibusOnStatus"));
     }
 
@@ -78,6 +83,7 @@ mod tests {
             max_width_lit: "\"42rem\"",
             justify_val: true,
             spread_lit: "\"none\"",
+            locations_key_lit: "\"book-uuid\"",
         });
         assert!(js.contains("spread: \"none\""));
         assert!(js.contains("cfi: \"epubcfi(/6/2)\""));

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -241,6 +241,7 @@ async fn spawn_bootstrap_and_highlights(
         .and_then(|r| r.epub_cfi);
     let chosen = server_cfi.or(local_saved);
     let cfi_arg = json_literal(&chosen);
+    let locations_key_lit = json_literal(&uuid);
     let js = reader_bootstrap_js(&BootstrapArgs {
         url_lit: &lits.url_lit,
         cfi_arg: &cfi_arg,
@@ -251,6 +252,7 @@ async fn spawn_bootstrap_and_highlights(
         max_width_lit: &lits.max_width_lit,
         justify_val: lits.justify_val,
         spread_lit: &lits.spread_lit,
+        locations_key_lit: &locations_key_lit,
     });
     let _ = dioxus::document::eval(&js);
 

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -133,7 +133,7 @@ async fn mount_and_drain(
     };
     let eval = interop::install_reader_surface(
         &file_url,
-        &init_opts(prefs, cfi),
+        &init_opts(&uuid, prefs, cfi),
         &scripts,
         crate::native_share::supported(),
     );
@@ -149,7 +149,7 @@ async fn mount_and_drain(
 
 /// Build the glue `init` options bag from the current reader prefs and the
 /// resume CFI. Field names match the vendored glue's `opts` keys.
-fn init_opts(prefs: ReaderPrefs, cfi: Option<String>) -> serde_json::Value {
+fn init_opts(uuid: &str, prefs: ReaderPrefs, cfi: Option<String>) -> serde_json::Value {
     serde_json::json!({
         "cfi": cfi,
         "fontSize": *prefs.font_size.peek(),
@@ -159,6 +159,10 @@ fn init_opts(prefs: ReaderPrefs, cfi: Option<String>) -> serde_json::Value {
         "maxWidth": prefs.margins.peek().to_css(),
         "justify": *prefs.justify.peek(),
         "spread": prefs.spread.peek().to_css(),
+        // Per-book locations-cache key: page numbers appear instantly on
+        // re-opens instead of waiting out the WebView's slow whole-book
+        // pagination pass (see the glue's locations cache).
+        "locationsKey": uuid,
         // WKWebView dispatches no events to listeners inside a sandboxed
         // iframe without `allow-scripts` — swipe/tap page turns and the
         // `selected` relay never fire without this. Mobile-only; the web

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -42,8 +42,8 @@ use prefs::init_reader_prefs;
 use search_panel::SearchResult;
 use selection::SelectionData;
 use signals::{
-    format_contents_progress, format_progress_labels, format_title_sub, use_book_metadata,
-    ReaderStatus, RelocateData,
+    format_ambient_page, format_contents_progress, format_progress_labels, format_title_sub,
+    use_book_metadata, ReaderStatus, RelocateData,
 };
 use toc_drawer::TocEntry;
 
@@ -124,6 +124,7 @@ pub fn BookReadPage(uuid: String) -> Element {
     let ReaderDisplay {
         page_str,
         chapter_str,
+        ambient_page,
         title_sub,
         contents_progress,
         pct,
@@ -148,6 +149,7 @@ pub fn BookReadPage(uuid: String) -> Element {
             progress: ReaderProgress {
                 page_str,
                 chapter_str,
+                ambient_page,
                 title_sub,
                 pct,
                 status: status(),
@@ -229,10 +231,12 @@ fn use_reader_signals(uuid: &str, theme: Signal<Theme>) -> ReaderSignals {
     let show_annotations = use_signal(|| false);
     let loc = use_signal(RelocateData::default);
     let book_meta = use_book_metadata(uuid.to_string());
-    // Chrome starts visible; a centre tap (glue → `__omnibusOnToggleChrome`)
-    // flips this. Seeded identically so SSR and the first WASM paint match,
-    // keeping hydration stable — the class only appears after a post-mount tap.
-    let chrome_hidden = use_signal(|| false);
+    // Chrome starts hidden on the native app (Books-style: opening a book
+    // lands on the clean page; a centre tap summons the menus) and visible
+    // everywhere else. `cfg!` is a compile-time constant, so SSR and the web
+    // client both seed `false` — first-paint markup still matches and
+    // hydration stays stable (rule 07); mobile has no SSR to mismatch.
+    let chrome_hidden = use_signal(|| cfg!(feature = "mobile"));
 
     // Record reading time against this book while the reader is open (and,
     // on web, the tab visible) — the rows behind the `/stats` aggregates.
@@ -306,6 +310,7 @@ fn use_reader_signals(uuid: &str, theme: Signal<Theme>) -> ReaderSignals {
 struct ReaderDisplay {
     page_str: String,
     chapter_str: String,
+    ambient_page: String,
     title_sub: String,
     contents_progress: String,
     pct: u32,
@@ -324,6 +329,7 @@ fn derive_reader_display(
     // One read: every derived label comes from the same relocate snapshot.
     let loc_now = loc.read();
     let (page_str, chapter_str) = format_progress_labels(&loc_now);
+    let ambient_page = format_ambient_page(&loc_now);
     let title_sub = format_title_sub(&loc_now);
     let contents_progress = format_contents_progress(&loc_now);
     let pct = loc_now.pct;
@@ -347,6 +353,7 @@ fn derive_reader_display(
     ReaderDisplay {
         page_str,
         chapter_str,
+        ambient_page,
         title_sub,
         contents_progress,
         pct,
@@ -376,6 +383,10 @@ pub(super) struct ReaderMeta {
 pub(super) struct ReaderProgress {
     pub page_str: String,
     pub chapter_str: String,
+    /// Phone minimal-chrome footer: the bare page number ("142"). Rendered
+    /// on every target, shown only by the phone breakpoint while the
+    /// chrome is hidden (the richer labels swap in with the chrome).
+    pub ambient_page: String,
     /// Phone top-bar sub-line ("Ch. 14 · 68%") — rendered on every target,
     /// shown only by the phone breakpoint.
     pub title_sub: String,
@@ -430,6 +441,7 @@ fn ReaderLayout(
     let ReaderProgress {
         page_str,
         chapter_str,
+        ambient_page,
         title_sub,
         pct,
         status,
@@ -470,6 +482,11 @@ fn ReaderLayout(
 
             div { class: "rd-wash" }
 
+            // Ambient minimal-chrome label: the book title that fades in where
+            // the toolbar was while the chrome is hidden (phone breakpoint
+            // only; displayed purely by CSS so every target renders it — rule 07).
+            div { class: "rd-ambient-title", "{book_title}" }
+
             ReaderTopBar {
                 book_title: book_title.clone(),
                 chapter_title: chapter_title.clone(),
@@ -485,12 +502,16 @@ fn ReaderLayout(
             div {
                 class: "rd-bottom",
                 "data-testid": "reader-footer",
-                span { style: "color:var(--ink-2);", "{page_str}" }
+                span { class: "rd-bottom-page", style: "color:var(--ink-2);", "{page_str}" }
                 div { style: "flex:1; text-align:center; letter-spacing:.08em;", "{chapter_str}" }
                 // The phone footer moves the chapter position to the right
                 // edge (the centred div above is hidden there) — rendered on
                 // every target, shown only by the phone breakpoint (rule 07).
                 span { class: "rd-bottom-ch", "{chapter_str}" }
+                // Phone minimal-chrome swap: the bare centred page number the
+                // footer shows while the chrome is hidden (CSS-only display,
+                // rendered on every target — rule 07).
+                span { class: "rd-ambient-page", "{ambient_page}" }
             }
             div { class: "rd-ribbon", i { style: "width:{pct}%;" } }
 

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -485,7 +485,9 @@ fn ReaderLayout(
             // Ambient minimal-chrome label: the book title that fades in where
             // the toolbar was while the chrome is hidden (phone breakpoint
             // only; displayed purely by CSS so every target renders it — rule 07).
-            div { class: "rd-ambient-title", "{book_title}" }
+            // aria-hidden: it only mirrors the toolbar title visually, so it
+            // must never be announced alongside it.
+            div { class: "rd-ambient-title", "aria-hidden": "true", "{book_title}" }
 
             ReaderTopBar {
                 book_title: book_title.clone(),

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -57,6 +57,20 @@ pub(crate) fn format_progress_labels(loc: &RelocateData) -> (String, String) {
     (page, chapter)
 }
 
+/// Format the phone minimal-chrome footer: just the page number (or the
+/// percent, before pagination resolves) — no "of total", no chapter. The
+/// richer [`format_progress_labels`] readout is what the visible footer
+/// shows; this is deliberately the bare number for the hidden-chrome state.
+pub(crate) fn format_ambient_page(loc: &RelocateData) -> String {
+    if loc.total_pages > 0 {
+        loc.page.to_string()
+    } else if loc.pct > 0 {
+        format!("{}%", loc.pct)
+    } else {
+        String::new()
+    }
+}
+
 /// Format the phone top-bar sub-line under the book title: "Ch. 3 · 14%".
 /// Falls back to the percent alone before the TOC resolves; empty until
 /// epub.js has produced a relocation. Rendered on every target (rule 07);
@@ -151,6 +165,28 @@ mod tests {
         assert!(chapter.contains("Ch"));
         assert!(chapter.contains("3"));
         assert!(chapter.contains("24"));
+    }
+
+    #[test]
+    fn format_ambient_page_returns_bare_page_number_when_paginated() {
+        let data = RelocateData {
+            page: 142,
+            total_pages: 300,
+            pct: 47,
+            ..Default::default()
+        };
+        assert_eq!(format_ambient_page(&data), "142");
+    }
+
+    #[test]
+    fn format_ambient_page_falls_back_to_pct_then_empty() {
+        let mut data = RelocateData {
+            pct: 47,
+            ..Default::default()
+        };
+        assert_eq!(format_ambient_page(&data), "47%");
+        data.pct = 0;
+        assert_eq!(format_ambient_page(&data), "");
     }
 
     #[test]


### PR DESCRIPTION
## What

Reworks the ereader chrome — primarily for the mobile app, with the web reader kept consistent — to match the Apple Books reading experience.

### Seamless page ground (no more black bezels)
The reader surface is now painted with the per-theme epub page color (a new `--rd-page` token mirroring the glue's registered body backgrounds: `#201e1b` dark / `#fcfbfa` light / `#ede4d0` sepia), so the strips where the bars live are indistinguishable from the page once the chrome hides. The bars themselves keep their `--bg-0` tint, so summoned menus still read as chrome. The loading/error overlay follows the page color too.

### Slim ambient footer + minimal-chrome labels (phone breakpoint)
- The bottom band slims from 54px to 30px via a shared `--rd-bottom-h` variable — the footer, the stage inset, the immersive (docked audiobook) inset, and the mini-player's pinned position all follow it, so the bottom stack stays aligned.
- Hiding the chrome swaps content instead of leaving empty strips: a small centred book-title label fades in where the toolbar was, and the footer shows only the bare centred page number (new `format_ambient_page`). The richer readout (`p. 4 of 845 · 0%` / `Ch 4 of 32`) rides with the summoned menus.
- The native app now opens books with the chrome hidden (`cfg!(feature = "mobile")` seed — SSR/web still seed visible, keeping hydration parity per rule 07).

### No stranded readers on web
The hide-transforms are now gated to `@media (max-width: 480px), (hover: none) and (pointer: coarse)` (the same gate as the page-turn gutters). A mouse-only viewport always shows the bars — hiding the chrome at phone width and resizing up can no longer leave the reader with no way to summon the menus. Touch tablets (iPad) keep tap-to-hide since a tap there can always bring the chrome back.

### Instant page numbers on re-open
epub.js recomputed its whole-book "locations" pagination on every open — seconds on desktop, much slower in the mobile WebView, during which no page number exists. The glue now caches the generated locations per book in localStorage (keyed by the new `locationsKey` init opt, the book uuid), threaded through both the web bootstrap and the mobile init opts. First open still generates once; every open after shows the page number as soon as the book renders (~0.8s measured, full page load included).

## Testing

- `just lint` (fmt + clippy matrix incl. mobile + stylelint) clean
- `cargo test -p omnibus-frontend --features server`: 370 passed (adds `format_ambient_page` + bootstrap `locationsKey` coverage)
- Playwright `reader.spec.ts`: 10/10, incl. the phone-viewport tests
- Browser-verified across dark/sepia/light at desktop + phone widths: measured the ambient title/page centring (dead-centre), the 30px footer geometry (no prose overlap), the desktop gate (`rd-chrome-hidden` inert on a mouse viewport), and the locations-cache reload timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)