### PR TITLE
feat: add a pure-black theme matched to Apple Books' macOS dark reader

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -2,17 +2,16 @@
  * ──────────────────────────────────────────────────────────
  * F1.7 foundation. Loaded via Dioxus `asset!` from frontend/src/lib.rs.
  *
- * Tokens are oklch-based warm neutrals. Two themes today (dark default,
- * light via `data-theme="light"` on the `.atrium` wrapper div emitted by
- * the `AtriumRoot` Dioxus component — not on `<html>`). Per-book accent
- * comes from `books.accent_color`, set inline as `--accent` on the cover
- * element.
+ * Tokens are oklch-based. Four themes today, selected via `data-theme`
+ * on the `.atrium` wrapper div emitted by the `AtriumRoot` Dioxus
+ * component (not on `<html>`): `dark` (default, warm neutrals), `black`
+ * (pure #000 grayscale, matched to Apple Books' macOS dark reader),
+ * `light`, and `sepia`. Per-book accent comes from `books.accent_color`,
+ * set inline as `--accent` on the cover element.
  *
  * Fonts: pulled from Google Fonts for the foundation PR. Self-hosting
  * (`@font-face` under `frontend/assets/fonts/`) is tracked as a follow-up
  * inside F1.7 for offline / airgapped installs.
- *
- * Sepia, density, type pairing toggles deferred to F1.9.
  */
 
 @import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap');
@@ -55,6 +54,38 @@
 
   --r-sm: 6px;  --r-md: 10px;  --r-lg: 14px;  --r-xl: 22px;
   --pad: 28px;  --gap: 18px;
+
+  color-scheme: dark;
+}
+
+/* ── Tokens · black (pure black, Apple Books macOS dark) ─────────── */
+/* A pure-black grayscale theme matched to Apple Books' dark reading
+   theme on macOS: a true #000000 base ground so the reader page
+   (registered as `black` in epub-reader-glue.js) and the surrounding
+   chrome/library share one pure-black ground, with bright white text.
+   Achromatic throughout (chroma 0) with a light-neutral accent, so no
+   color reads in the UI. `--bg-1..3` lift slightly off black to raise
+   cards, nav, and inputs. Status colors, fonts, radii, and spacing
+   fall through to `:root`. */
+[data-theme="black"] {
+  --bg-0:    oklch(0 0 0);
+  --bg-1:    oklch(0.150 0 0);
+  --bg-2:    oklch(0.190 0 0);
+  --bg-3:    oklch(0.240 0 0);
+  --line:    oklch(0.34 0 0 / 0.60);
+  --line-2:  oklch(0.34 0 0 / 0.26);
+
+  --ink-0:   oklch(0.99 0 0);
+  --ink-1:   oklch(0.82 0 0);
+  --ink-2:   oklch(0.63 0 0);
+  --ink-3:   oklch(0.48 0 0);
+
+  --accent:      oklch(0.94 0 0);
+  --accent-soft: oklch(0.30 0 0);
+  --accent-ink:  oklch(0.14 0 0);
+
+  --cover-fallback-bg:  oklch(0.26 0 0);
+  --cover-fallback-ink: oklch(0.94 0 0);
 
   color-scheme: dark;
 }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -87,6 +87,11 @@
   --cover-fallback-bg:  oklch(0.26 0 0);
   --cover-fallback-ink: oklch(0.94 0 0);
 
+  /* Matches the `black` reading theme the glue registers, so the strips
+     freed when the reader chrome slides away stay seamless with the page
+     instead of falling back to the default dark ground. */
+  --rd-page: #000000;
+
   color-scheme: dark;
 }
 

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -237,6 +237,11 @@
       rendition.themes.register("dark", {
         body: { background: "#201e1b", color: "#f5f3f0" },
       });
+      // Matches Apple Books' dark reading theme on macOS: a pure-black
+      // #000000 page with bright #ffffff text.
+      rendition.themes.register("black", {
+        body: { background: "#000000", color: "#ffffff" },
+      });
       rendition.themes.register("sepia", {
         body: { background: "#ede4d0", color: "#3b3029" },
       });

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -17,16 +17,18 @@ use crate::{media_url, use_server_url};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Theme {
     Dark,
+    Black,
     Light,
     Sepia,
 }
 
 impl Theme {
     /// Map this theme variant to its `data-theme` HTML attribute string
-    /// (e.g. `"dark"`, `"light"`, `"sepia"`).
+    /// (e.g. `"dark"`, `"black"`, `"light"`, `"sepia"`).
     pub fn as_attr(self) -> &'static str {
         match self {
             Theme::Dark => "dark",
+            Theme::Black => "black",
             Theme::Light => "light",
             Theme::Sepia => "sepia",
         }
@@ -37,6 +39,7 @@ impl Theme {
     pub fn from_attr(s: &str) -> Option<Self> {
         match s {
             "dark" => Some(Theme::Dark),
+            "black" => Some(Theme::Black),
             "light" => Some(Theme::Light),
             "sepia" => Some(Theme::Sepia),
             _ => None,
@@ -233,9 +236,11 @@ mod tests {
     #[test]
     fn theme_attr_round_trips() {
         assert_eq!(Theme::Dark.as_attr(), "dark");
+        assert_eq!(Theme::Black.as_attr(), "black");
         assert_eq!(Theme::Light.as_attr(), "light");
         assert_eq!(Theme::Sepia.as_attr(), "sepia");
         assert_eq!(Theme::from_attr("dark"), Some(Theme::Dark));
+        assert_eq!(Theme::from_attr("black"), Some(Theme::Black));
         assert_eq!(Theme::from_attr("light"), Some(Theme::Light));
         assert_eq!(Theme::from_attr("sepia"), Some(Theme::Sepia));
         assert_eq!(Theme::from_attr("nope"), None);

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -414,6 +414,7 @@ fn UmThemeSeg(theme: Signal<Theme>) -> Element {
     let mut theme = theme;
     let current = *theme.read();
     let dark_on = matches!(current, Theme::Dark);
+    let black_on = matches!(current, Theme::Black);
     let light_on = matches!(current, Theme::Light);
     let sepia_on = matches!(current, Theme::Sepia);
     rsx! {
@@ -429,6 +430,16 @@ fn UmThemeSeg(theme: Signal<Theme>) -> Element {
                         persist_theme(Theme::Dark);
                     },
                     "Dark"
+                }
+                button {
+                    class: if black_on { "um-theme-btn on" } else { "um-theme-btn" },
+                    r#type: "button",
+                    "data-testid": "theme-black",
+                    onclick: move |_| {
+                        theme.set(Theme::Black);
+                        persist_theme(Theme::Black);
+                    },
+                    "Black"
                 }
                 button {
                     class: if light_on { "um-theme-btn on" } else { "um-theme-btn" },

--- a/frontend/src/pages/account.rs
+++ b/frontend/src/pages/account.rs
@@ -66,8 +66,9 @@ pub fn identity_subline(username: &str, is_admin: bool) -> String {
 
 /// Cycle order for the theme segmented control.
 #[cfg(any(feature = "mobile", test))]
-pub const THEME_ORDER: [(&str, ThemeKind); 3] = [
+pub const THEME_ORDER: [(&str, ThemeKind); 4] = [
     ("Dark", ThemeKind::Dark),
+    ("Black", ThemeKind::Black),
     ("Light", ThemeKind::Light),
     ("Sepia", ThemeKind::Sepia),
 ];
@@ -79,6 +80,7 @@ pub const THEME_ORDER: [(&str, ThemeKind); 3] = [
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ThemeKind {
     Dark,
+    Black,
     Light,
     Sepia,
 }
@@ -90,6 +92,7 @@ impl ThemeKind {
     fn to_theme(self) -> Theme {
         match self {
             ThemeKind::Dark => Theme::Dark,
+            ThemeKind::Black => Theme::Black,
             ThemeKind::Light => Theme::Light,
             ThemeKind::Sepia => Theme::Sepia,
         }
@@ -101,6 +104,7 @@ impl ThemeKind {
     pub fn as_attr(self) -> &'static str {
         match self {
             ThemeKind::Dark => "dark",
+            ThemeKind::Black => "black",
             ThemeKind::Light => "light",
             ThemeKind::Sepia => "sepia",
         }
@@ -485,7 +489,7 @@ fn AccountLinkRow(to: Route, label: String) -> Element {
     }
 }
 
-/// Dark / Light / Sepia segmented control wired to the app-wide theme signal.
+/// Dark / Black / Light / Sepia segmented control wired to the app-wide theme signal.
 #[cfg(feature = "mobile")]
 #[component]
 fn ThemeControl() -> Element {
@@ -570,6 +574,6 @@ mod tests {
     #[test]
     fn theme_order_matches_css_attrs() {
         let attrs: Vec<&str> = THEME_ORDER.iter().map(|(_, k)| k.as_attr()).collect();
-        assert_eq!(attrs, ["dark", "light", "sepia"]);
+        assert_eq!(attrs, ["dark", "black", "light", "sepia"]);
     }
 }

--- a/frontend/src/pages/reader/aa_panel.rs
+++ b/frontend/src/pages/reader/aa_panel.rs
@@ -32,7 +32,7 @@ pub(crate) fn ReaderAaPanel(on_close: EventHandler<MouseEvent>) -> Element {
     }
 }
 
-/// Theme segmented control (Dark / Light / Sepia).
+/// Theme segmented control (Dark / Black / Light / Sepia).
 #[component]
 fn ThemeRow() -> Element {
     let prefs = use_context::<ReaderPrefs>();
@@ -47,6 +47,12 @@ fn ThemeRow() -> Element {
                     r#type: "button",
                     onclick: move |_| prefs.set_theme(Theme::Dark),
                     "Dark"
+                }
+                button {
+                    class: if theme == Theme::Black { "on" } else { "" },
+                    r#type: "button",
+                    onclick: move |_| prefs.set_theme(Theme::Black),
+                    "Black"
                 }
                 button {
                     class: if theme == Theme::Light { "on" } else { "" },

--- a/ui_tests/playwright/tests/flows/theme_toggle.spec.ts
+++ b/ui_tests/playwright/tests/flows/theme_toggle.spec.ts
@@ -2,9 +2,8 @@ import { expect, test } from "../fixtures/test";
 import { gotoReady } from "../utils/nav";
 
 // F1.6 Atrium theme toggle. The theme controls now live inside the user-menu
-// dropdown (Dark / Light / Sepia segmented control). Sepia is stubbed —
-// disabled until a Sepia theme variant lands. The web build persists the
-// choice under `omn.theme` in localStorage and applies it in a
+// dropdown (Dark / Black / Light / Sepia segmented control). The web build
+// persists the choice under `omn.theme` in localStorage and applies it in a
 // post-hydration `use_effect` so SSR markup stays deterministic.
 //
 // Notes for future test authors:
@@ -51,6 +50,25 @@ test("toggles dark to light, persists across reload", async ({ page }) => {
   // pre-effect frame.
   await page.reload();
   await expect.poll(async () => root.getAttribute("data-theme")).toBe("light");
+});
+
+test("toggles dark to black, persists across reload", async ({ page }) => {
+  await gotoReady(page, "/");
+
+  const root = page.locator("div.atrium").first();
+  await expect(root).toHaveAttribute("data-theme", "dark");
+
+  await openUserMenu(page);
+  await page.getByTestId("theme-black").click();
+  await expect(root).toHaveAttribute("data-theme", "black");
+
+  const stored = await page.evaluate(() => window.localStorage.getItem("omn.theme"));
+  expect(stored).toBe("black");
+
+  // Reload: SSR renders `dark`, then the post-hydration effect reads
+  // localStorage and flips to `black`. Poll for the follow-up render.
+  await page.reload();
+  await expect.poll(async () => root.getAttribute("data-theme")).toBe("black");
 });
 
 test("clicking light then dark flips back and clears divergence from default", async ({ page }) => {


### PR DESCRIPTION
## Description

Adds a fourth Atrium theme — **Black** — a fully achromatic (chroma 0) dark theme on a true `#000000` ground, alongside the existing warm **Dark**, **Light**, and **Sepia**.

It's **opt-in and additive**: the warm Dark theme is still the default, and nothing changes for anyone who doesn't pick Black.

The reading surface is matched to **Apple Books' dark reader on macOS** — a pure-black `#000000` page with bright `#ffffff` text. The app chrome uses that same pure-black ground, so the reader page and its surrounding margins are seamless rather than a black page inside a dark-gray frame.

### Note for @seamus-sloan 👋

If you don't like how **four** themes look in the picker, I don't have to ship it as another UI option — I can put it behind an environment variable (or similar) instead, so it's available without adding a fourth button to the theme selector. Happy to switch it over; just say the word.

## Implementation

- **`frontend/assets/atrium.css`** — new `[data-theme="black"]` token block. Fully achromatic: `--bg-0` is a true `oklch(0 0 0)`, with `--bg-1..3` lifting slightly off black to raise cards, nav, and inputs. Neutral light accent so no color reads anywhere in the UI. Status colors, fonts, radii, and spacing fall through to `:root`.
- **`frontend/assets/vendor/epub-reader-glue.js`** — registers the `black` reading theme (`#000000` / `#ffffff`) with epub.js.
- **`frontend/src/components/atrium.rs`** — `Theme::Black` variant plus `as_attr` / `from_attr` round-tripping.
- **`frontend/src/components/user_menu.rs`** — Black button in the web theme selector (`data-testid="theme-black"`).
- **`frontend/src/pages/account.rs`** — `ThemeKind::Black` + `THEME_ORDER` entry for the mobile "You" tab selector.
- **`frontend/src/pages/reader/aa_panel.rs`** — Black option in the reader's own Aa panel theme row.

### Drive-by fix

The reader had a latent gap worth calling out: `epub-reader-glue.js` only registered `light` / `dark` / `sepia` with epub.js. Any theme outside that set called `rendition.themes.select()` on a name that was never registered, so the book content silently kept its previous colors while the surrounding chrome changed. This is why the new theme initially applied to the app but not to the actual pages. `black` is now registered, and the reader's Aa panel gained the matching option — so the theme applies to the prose, not just the chrome.

## Affected Crates

- `frontend` (CSS tokens, vendored reader glue, theme enum, web + mobile selectors, reader Aa panel)

## Acceptance Criteria

- [x] Black is selectable from the web user menu and the mobile "You" tab
- [x] Selecting Black sets `data-theme="black"` and persists to `omn.theme`
- [x] The choice survives a reload (post-hydration effect; SSR markup stays deterministic)
- [x] The reader **page content** renders on `#000000` with `#ffffff` text, verified as `rgb(0,0,0)` / `rgb(255,255,255)`
- [x] Reader page and chrome share one ground (no seam)
- [x] Default theme is unchanged for existing users
- [x] `cargo fmt` / `clippy` / `stylelint` clean; frontend tests pass under both `server` and `mobile` features
- [x] Playwright `theme_toggle.spec.ts` extended and passing (4/4)

## Testing

- `cargo test -p omnibus-frontend --features server` — theme attr round-trip + `THEME_ORDER` ↔ CSS attr alignment
- `cargo check -p omnibus-frontend --features mobile` — mobile selector paths compile
- `npx playwright test theme_toggle` — 4/4 passing, including a new `toggles dark to black, persists across reload`
- Verified live in the browser: app chrome, the reader page colors, and the Aa panel; no console errors and no hydration mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)