### PR TITLE
fix: add spacing above journal empty-state card (#1238)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -972,6 +972,7 @@ html, body { overscroll-behavior: none; }
 .bd-journal-empty {
   padding: 22px 24px;
   display: flex; flex-direction: column; gap: 6px;
+  margin-top: 16px;
 }
 .bd-stub-hint { font-size: 12px; color: var(--ink-3); }
 .bd-stub-strip {


### PR DESCRIPTION
## Summary
- Closes #1238
- The reading-journal empty-state card (`.bd-journal-empty` in `frontend/assets/atrium.css`) had no `margin-top`, so it sat flush against the collapsed composer prompt (`.bd-journal-prompt`) above it. Added `margin-top: 16px` to match the sibling `.bd-journal-list` feed's spacing, keeping the empty and populated states visually consistent.

## Test plan
- [x] Confirmed the bug on `main`: `.bd-journal-empty` had no `margin-top` while `.bd-journal-prompt`/`.bd-journal-composer` set 12px and `.bd-journal-list` set 16px — PASS (bug reproduced before fix)
- [x] Applied minimal one-line CSS fix (`margin-top: 16px` on `.bd-journal-empty`) — PASS
- [x] Manually reviewed the CSS for syntax correctness (balanced braces, matches surrounding nesting/style) — PASS
- [ ] `just lint-css` — not run (requires `nix`, unavailable in this environment)
- [x] Searched `ui_tests/playwright/tests/flows/journal.spec.ts` for existing coverage of the empty-state markup/spacing — none found, so no spec changes needed for this CSS-only visual fix

## Notes
- CSS-only change; no Rust or markup changes required. `BdJournalSection`'s empty-state markup in `frontend/src/pages/book_detail/journal.rs` already renders `class: "bd-journal-empty card"` — only the stylesheet needed the fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_0115EfVqA5BDgSaEGuRwEaEt)_