### PR TITLE
refactor: drop unused isbn subquery from find_book_by_isbn (#1227)

### DIFF
--- a/db/src/scan/resolve.rs
+++ b/db/src/scan/resolve.rs
@@ -158,13 +158,7 @@ async fn find_book_by_isbn(
                 (SELECT group_concat(a.name, ', ')
                    FROM books_authors_link bal JOIN authors a ON a.id = bal.author
                   WHERE bal.book = b.id ORDER BY bal.position) AS authors,
-                EXISTS (SELECT 1 FROM physical_copies pc WHERE pc.book_uuid = b.uuid) AS has_physical,
-                (SELECT REPLACE(REPLACE(bi2.value, '-', ''), ' ', '')
-                   FROM book_identifiers bi2
-                  WHERE bi2.book_id = b.id AND bi2.scheme LIKE '%isbn%'
-                    AND REPLACE(REPLACE(bi2.value, '-', ''), ' ', '')
-                        GLOB '[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
-                  ORDER BY bi2.rowid LIMIT 1) AS isbn
+                EXISTS (SELECT 1 FROM physical_copies pc WHERE pc.book_uuid = b.uuid) AS has_physical
            FROM books b
            JOIN book_identifiers bi ON bi.book_id = b.id
           WHERE bi.scheme LIKE '%isbn%'
@@ -174,7 +168,11 @@ async fn find_book_by_isbn(
     .bind(isbn13)
     .fetch_optional(pool)
     .await?;
-    Ok(row.map(row_to_scan_book))
+    // The exact-match confirm screen (ConfirmScreen -> LibraryBookCard) never
+    // reads `isbn` — it shows the scanned ISBN via a separate prop instead —
+    // so skip the correlated subquery `find_book_by_norm` still needs for
+    // CloseMatchScreen's "library edition ISBN" line.
+    Ok(row.map(|r| row_to_scan_book(r, None)))
 }
 
 /// Fuzzy rung: a single library book whose normalized (title, author) matches
@@ -212,20 +210,23 @@ async fn find_book_by_norm(
     .await?;
     // Exactly one candidate is a close match; zero or many is not.
     Ok(if rows.len() == 1 {
-        rows.into_iter().next().map(row_to_scan_book)
+        rows.into_iter().next().map(|r| {
+            let isbn = r.get::<Option<String>, _>("isbn").filter(|s| !s.is_empty());
+            row_to_scan_book(r, isbn)
+        })
     } else {
         None
     })
 }
 
-fn row_to_scan_book(r: sqlx::sqlite::SqliteRow) -> ScanBook {
+fn row_to_scan_book(r: sqlx::sqlite::SqliteRow, isbn: Option<String>) -> ScanBook {
     let uuid: String = r.get("uuid");
     let has_cover: i64 = r.get("has_cover");
     let authors: Option<String> = r.get("authors");
     let has_physical: i64 = r.get("has_physical");
     ScanBook {
         cover_url: (has_cover != 0).then(|| format!("/api/covers/{uuid}")),
-        isbn: r.get::<Option<String>, _>("isbn").filter(|s| !s.is_empty()),
+        isbn,
         authors: authors
             .filter(|s| !s.is_empty())
             .map(|s| s.split(", ").map(str::to_string).collect())

--- a/db/src/scan/resolve.rs
+++ b/db/src/scan/resolve.rs
@@ -168,10 +168,7 @@ async fn find_book_by_isbn(
     .bind(isbn13)
     .fetch_optional(pool)
     .await?;
-    // The exact-match confirm screen (ConfirmScreen -> LibraryBookCard) never
-    // reads `isbn` — it shows the scanned ISBN via a separate prop instead —
-    // so skip the correlated subquery `find_book_by_norm` still needs for
-    // CloseMatchScreen's "library edition ISBN" line.
+    // No caller on this rung reads `isbn`, so skip the correlated subquery.
     Ok(row.map(|r| row_to_scan_book(r, None)))
 }
 

--- a/db/src/scan/tests.rs
+++ b/db/src/scan/tests.rs
@@ -168,6 +168,24 @@ async fn resolve_exact_isbn_returns_already_owned_when_physical_exists() {
 }
 
 #[tokio::test]
+async fn resolve_exact_isbn_leaves_book_isbn_unset() {
+    // The exact-match confirm screen never reads `book.isbn` (it shows the
+    // scanned ISBN via a separate prop instead), so find_book_by_isbn skips
+    // the correlated subquery find_book_by_norm still needs for CloseMatch.
+    let pool = pool().await;
+    seed_book(&pool, "u1", "Effective Java", "Joshua Bloch", Some(ISBN)).await;
+    let server = MockServer::start().await; // must not be hit
+
+    let outcome = resolve_scan(&pool, ISBN, &config_for(&server))
+        .await
+        .unwrap();
+    match outcome {
+        ScanOutcome::InLibraryUnowned { book } => assert!(book.isbn.is_none()),
+        other => panic!("expected InLibraryUnowned, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn resolve_exact_isbn_tolerates_urn_scheme_and_separators() {
     let pool = pool().await;
     seed_book(&pool, "u1", "Effective Java", "Joshua Bloch", None).await;

--- a/db/src/scan/tests.rs
+++ b/db/src/scan/tests.rs
@@ -169,9 +169,7 @@ async fn resolve_exact_isbn_returns_already_owned_when_physical_exists() {
 
 #[tokio::test]
 async fn resolve_exact_isbn_leaves_book_isbn_unset() {
-    // The exact-match confirm screen never reads `book.isbn` (it shows the
-    // scanned ISBN via a separate prop instead), so find_book_by_isbn skips
-    // the correlated subquery find_book_by_norm still needs for CloseMatch.
+    // find_book_by_isbn no longer computes isbn — nothing on this rung reads it.
     let pool = pool().await;
     seed_book(&pool, "u1", "Effective Java", "Joshua Bloch", Some(ISBN)).await;
     let server = MockServer::start().await; // must not be hit


### PR DESCRIPTION
## Summary
- `find_book_by_isbn` (in `db/src/scan/resolve.rs`) ran a correlated subquery to populate `ScanBook.isbn`, but the only caller that reaches the 3a "already in library" confirm screen (`ConfirmScreen` → `LibraryBookCard` in `frontend/src/pages/check_in/screens.rs`) never reads that field — it displays the *scanned* ISBN via a separate prop instead.
- Split the shared `row_to_scan_book` mapper to take `isbn: Option<String>` explicitly instead of always reading an `isbn` column off the row: `find_book_by_isbn`'s SQL no longer runs the isbn subquery and passes `None`; `find_book_by_norm` (which feeds `CloseMatchScreen`, which *does* render `book.isbn` as "Library edition ISBN") is unaffected and still computes it.
- Closes #1227

## Test plan
- [x] `cargo fmt` — no diff
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus-db` — PASS (1144 passed, 1 pre-existing unrelated failure: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails in this sandbox because the audiobook test fixtures aren't downloaded here — `just fixtures` needs nix, unavailable in this environment; unrelated to this change)
- [x] `cargo test -p omnibus-db --lib scan::` — PASS (20/20, including the new `resolve_exact_isbn_leaves_book_isbn_unset`)
- [x] Added `scan::tests::resolve_exact_isbn_leaves_book_isbn_unset`, asserting the exact-match ladder rung now returns `book.isbn == None`

## Notes
- Went with approach (a) from the issue (drop the subquery) rather than (b) (keep it + test it) — splitting the mapper to take an explicit `isbn: Option<String>` parameter was a small, low-risk change and is the real perf/dead-code fix per the issue's stated preference.
- `find_book_by_norm`'s query and its isbn subquery are untouched; only `find_book_by_isbn`'s SQL and the shared mapper signature changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_0115EfVqA5BDgSaEGuRwEaEt)_