### PR TITLE
refactor: add rsx key and address sheet-shell duplication in add_books_sheet (#1226)

### DIFF
--- a/frontend/src/components/add_books_sheet.rs
+++ b/frontend/src/components/add_books_sheet.rs
@@ -68,6 +68,7 @@ pub(super) fn AddBooksSheet(open: Signal<bool>, on_close: EventHandler<()>) -> E
                             let AddRow { route, primary, title, subtitle, icon } = row;
                             rsx! {
                                 button {
+                                    key: "{title}",
                                     r#type: "button",
                                     class: if primary { "m-add-row m-add-row--primary" } else { "m-add-row" },
                                     "data-testid": "add-books-row",


### PR DESCRIPTION
## Summary
- Closes #1226
- Adds the missing `key:` to the "Add to your library" chooser-row loop in `frontend/src/components/add_books_sheet.rs` (keyed on `title`, which is static and unique across the 3 rows).
- Deferred the sheet-shell (scrim + `.m-sheet` + grabber) extraction — see Notes.

## Test plan
- [x] `cargo fmt` — no changes beyond the key edit
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 370 passed; 0 failed
- [x] `cargo clippy -p omnibus-frontend --features web --target wasm32-unknown-unknown -- -D warnings` — SKIPPED, `wasm32-unknown-unknown` target not installed in this environment (no `rustup`)

## Notes
- Deferred the shared `Sheet`/`SheetShell` extraction across the 4 sites (`add_books_sheet.rs`, `listen/mobile/sheets.rs`'s existing `MSheet`, `stats/mod.rs`'s `RangeSheet`, `landing/mobile_filter_sheet.rs`'s `MobileSortFilterSheet`): their close handlers have three different shapes (`EventHandler<()>`, `EventHandler<MouseEvent>`, and a direct `Signal<bool>` write), only one site puts a `data-testid` on the inner `.m-sheet` div itself, and the head row varies per-caller (title only / title + meta element / title + reset button) — not mechanical to unify correctly without live UI verification, which isn't available in this headless environment, so left as a follow-up per the issue's explicit judgment call.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115EfVqA5BDgSaEGuRwEaEt)_