### PR TITLE
refactor: fix dependency-audit.md drift for rustc-hash and lettre (#1268)

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -120,10 +120,12 @@ urlencoding = "2"
 # never pull in OpenSSL; `builder` provides the multipart `Message` API.
 # Default features are off to drop the sync `native-tls` transport and
 # file/sendmail transports we don't use.
-# PRE-1.0 PIN: builds/sends the outbound Send-to-Kindle email from
-#   server-controlled data only — the user's own EPUB file and their
-#   configured `kindle_email` setting — so no attacker-controlled network
-#   input reaches lettre's message-building/parsing paths.
+# PRE-1.0 PIN: the MIME message body/attachment lettre builds comes only from
+#   server-controlled data — the user's own EPUB file and their configured
+#   `kindle_email` setting — so no attacker-controlled input reaches the
+#   message-building path. `smtp-transport` does still parse SMTP responses
+#   from the configured relay, which is real (if narrow) untrusted-network
+#   surface this pin does not eliminate.
 lettre = { version = "0.11", default-features = false, features = [
     "builder",
     "hostname",

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -120,6 +120,10 @@ urlencoding = "2"
 # never pull in OpenSSL; `builder` provides the multipart `Message` API.
 # Default features are off to drop the sync `native-tls` transport and
 # file/sendmail transports we don't use.
+# PRE-1.0 PIN: builds/sends the outbound Send-to-Kindle email from
+#   server-controlled data only — the user's own EPUB file and their
+#   configured `kindle_email` setting — so no attacker-controlled network
+#   input reaches lettre's message-building/parsing paths.
 lettre = { version = "0.11", default-features = false, features = [
     "builder",
     "hostname",

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -1,6 +1,6 @@
 # Dependency Audit — Cargo.lock Duplicate Families
 
-Last updated: 2026-07-18 (issues #1147, #643).
+Last updated: 2026-07-23 (issue #1268; previously issues #1147, #643).
 
 Run `cargo tree -d` and inspect the output any time Dioxus or Axum are bumped.
 The `deny.toml` `[bans]` section has matching `skip` entries for all accepted
@@ -25,6 +25,7 @@ this list.
 | `tower-http` | 0.6.11, 0.7.0 | 0.6.11 via `dioxus-fullstack`/`dioxus-server` 0.7.9 and transitively via **both** `reqwest` 0.12.28 and 0.13.4 (each vendors its own `tower-http` dependency); 0.7.0 via our own `omnibus` server crate directly | **blocked by upstream** | Not purely a Dioxus-version-lag issue like `axum-extra` above — `reqwest` 0.13.4 (our own workspace-pinned version, not just the older `dioxus-fullstack` copy) also depends directly on `tower-http 0.6.11` (see `Cargo.lock`'s `reqwest 0.13.4` dependency block). So a Dioxus bump alone won't collapse this: it persists until `reqwest` itself upgrades to `tower-http 0.7`, or our own server crate's direct `tower-http` dep is downgraded to 0.6.11 to match. |
 | `reqwest` | 0.12.28, 0.13.4 | 0.12.28 via `dioxus-fullstack` 0.7.9 (the git-pinned Dioxus tag); 0.13.4 via `omnibus-db`, `omnibus-frontend`, `omnibus-mobile` — the workspace-pinned version per `Cargo.toml`'s `[workspace.dependencies] reqwest = { version = "0.13", ... }` | **blocked by upstream** | Two-*major*-version split, the largest gap in this table (the rest is minor-version churn). Exists because `dioxus-fullstack`'s git-pinned tag hasn't caught up to the `reqwest 0.13` the workspace standardized on. Should collapse on the next Dioxus bump, same caveat as the `tungstenite`/`const-serialize` rows. |
 | `digest` | 0.10.7 (×2) | Both consumers are `sha1` (axum/tungstenite) + `blake2`/`sha2` (argon2/sqlx) | N/A — same version | `cargo tree -d` shows two entry paths to the same version (different consumers). No actual duplicate in the lockfile. |
+| `rustc-hash` | 1.1.0, 2.1.2 | 1.1.0 via `sledgehammer_utils` (pulled in by `dioxus-interpreter-js`, which both `dioxus-web` and `dioxus-server` depend on); 2.1.2 as a direct dependency of `dioxus-core` | **blocked by upstream** | Verified with `cargo tree -i rustc-hash@1.1.0` / `@2.1.2` (not assumed): both versions are reachable from the default, non-mobile build via `dioxus-core`/`dioxus-server`/`dioxus-web`, which `omnibus` and `omnibus-frontend` depend on directly — i.e. **inside** the shipped web/WASM bundle, not confined to the `wry`/`tao` mobile native-shell subtree (despite that subtree's skip-tree comment in `deny.toml` also naming `rustc-hash` among its duplicates — the mobile subtree apparently resolves to one of these same two versions rather than introducing a third). Collapses when Dioxus unifies its internal `rustc-hash` pin. |
 | `bytes`, `futures-*`, `num-traits`, `tokio`, `manganis-core` | (shown ×2 each) | Multiple downstream consumers | N/A — same version | Same pattern as `digest`: one version, multiple reverse-dependency entry points in the `cargo tree -d` output. Not true duplicates. |
 
 ## First-party skew resolved in this PR


### PR DESCRIPTION
## Summary
- `docs/dependency-audit.md` gains an inventory row for the untriaged `rustc-hash` duplicate (1.1.0 / 2.1.2), and `db/Cargo.toml`'s `lettre` entry gains a `# PRE-1.0 PIN` rationale comment matching the existing `pulldown-cmark`/`lofty` style.
- The `rustc-hash` row is backed by real `cargo tree -i rustc-hash@1.1.0` / `@2.1.2` output rather than the issue's assumption — see Notes below, this corrects the record rather than confirming it.

Closes #1268

## Test plan
- `cargo check -p omnibus-db` → `Finished` cleanly, no new errors/warnings — PASS

## Notes
- **Correction to the issue's assumption:** the issue speculated `rustc-hash` might be confined to the `wry`/`tao` mobile native-shell subtree (per an existing `deny.toml` skip-tree comment). Actual `cargo tree -i` output shows the opposite: both `rustc-hash` versions are reachable via `dioxus-core`/`dioxus-server`/`dioxus-web`, which `omnibus` and `omnibus-frontend` depend on directly — i.e. inside the shipped web/WASM bundle, not mobile-only. No `omnibus-mobile`/`wry`/`tao` nodes appear in either tree. Classified as **blocked by upstream** (same bucket as the table's other Dioxus-internal-version-skew rows); `deny.toml` itself is untouched since this issue's scope was limited to the audit doc and `Cargo.toml`, but the maintainer may want a follow-up to correct that skip-tree comment's implication.

---
_Generated by [Claude Code](https://claude.ai/code/session_018dp84TTsr7ckeNd5AsqnxG)_