### PR TITLE
refactor: fix misplaced doc comment on backfill_chapters (#1265)

### DIFF
--- a/db/src/indexer.rs
+++ b/db/src/indexer.rs
@@ -609,22 +609,6 @@ pub async fn reindex_audiobooks_with_progress(
     })
 }
 
-/// Fill `file_chapters` for audiobook `book_files` rows that have none.
-///
-/// The chapter extraction pipeline was added after the initial audiobook
-/// indexer, so books indexed before the migration have zero `file_chapters`
-/// rows. The normal diff-based reindex skips unchanged files, so this
-/// backfill runs as a separate worker task and is a no-op once all books
-/// have chapters. `on_progress(processed, total)` is called after each
-/// book so the UI can render a progress bar.
-///
-/// ## Query efficiency
-///
-/// All `book_file_parts` rows for the backfill set are fetched in a single
-/// `WHERE book_file_id IN (…)` bulk query before the loop rather than one
-/// per book, and all chapter inserts are committed in batches of 250 books
-/// to avoid per-book WAL flushes (mirrors the sync/audiobooks.rs backfill
-/// pattern).
 /// Query the first-part filename (ordinal=0) and format for every book
 /// under `library_path` that needs chapter backfill (no `file_chapters`
 /// rows yet).
@@ -693,6 +677,22 @@ async fn bulk_fetch_parts(
     Ok(parts_by_id)
 }
 
+/// Fill `file_chapters` for audiobook `book_files` rows that have none.
+///
+/// The chapter extraction pipeline was added after the initial audiobook
+/// indexer, so books indexed before the migration have zero `file_chapters`
+/// rows. The normal diff-based reindex skips unchanged files, so this
+/// backfill runs as a separate worker task and is a no-op once all books
+/// have chapters. `on_progress(processed, total)` is called after each
+/// book so the UI can render a progress bar.
+///
+/// ## Query efficiency
+///
+/// All `book_file_parts` rows for the backfill set are fetched in a single
+/// `WHERE book_file_id IN (…)` bulk query before the loop rather than one
+/// per book, and all chapter inserts are committed in batches of 250 books
+/// to avoid per-book WAL flushes (mirrors the sync/audiobooks.rs backfill
+/// pattern).
 pub(crate) async fn backfill_chapters(
     pool: &SqlitePool,
     library_path: &str,


### PR DESCRIPTION
## Summary
- `db/src/indexer.rs`'s doc comment (including the `## Query efficiency` batching rationale) was physically stranded above `fetch_backfill_candidates` instead of `backfill_chapters`, the function it actually describes. `backfill_chapters` had no doc at all, and `fetch_backfill_candidates`'s own genuine one-line doc was squeezed in mid-block after the misplaced content.
- Pure comment relocation — `fetch_backfill_candidates` now has a clean standalone one-line doc, and `backfill_chapters` carries the full description + `## Query efficiency` block. No logic changed.

Closes #1265

## Test plan
- `cargo doc --no-deps -p omnibus-db` — PASS (only pre-existing, unrelated warnings elsewhere in the crate)
- `cargo test -p omnibus-db` — 1167 passed, 1 failed (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`), which fails only because this environment doesn't have the binary test fixtures downloaded (`just fixtures` requires the Nix dev shell, unavailable in this cloud container) — unrelated to this doc-only change and expected to pass in CI, which fetches fixtures itself.

## Notes
- 


---
_Generated by [Claude Code](https://claude.ai/code/session_018dp84TTsr7ckeNd5AsqnxG)_