### PR TITLE
refactor: batch orphaned-image existence check across purge and journals (#1258)

### DIFF
--- a/db/src/deletion/purge.rs
+++ b/db/src/deletion/purge.rs
@@ -149,25 +149,13 @@ pub(super) async fn journal_image_names(
 }
 
 /// Narrow `candidates` to the names no surviving `journal_entries.body_md`
-/// still embeds. Matched on the full embed path rather than the bare name for
-/// the same reason as `journals::cleanup_orphaned_images`: a bare-name
-/// substring can false-positive on unrelated body text.
+/// still embeds, via the shared batched check in
+/// [`crate::journals::unreferenced_image_names`] — unlike its
+/// swallow-and-log sibling `journals::cleanup_orphaned_images`, this caller
+/// propagates a DB error to the deletion transaction it guards.
 pub(super) async fn orphaned_images(
     pool: &SqlitePool,
     candidates: Vec<String>,
 ) -> Result<Vec<String>, DeleteError> {
-    let mut orphaned = Vec::new();
-    for name in candidates {
-        let embed = format!("{}{name}", crate::journals::markdown::IMAGE_URL_PREFIX);
-        let still_referenced: bool = sqlx::query_scalar(
-            "SELECT EXISTS(SELECT 1 FROM journal_entries WHERE instr(body_md, ?) > 0)",
-        )
-        .bind(&embed)
-        .fetch_one(pool)
-        .await?;
-        if !still_referenced {
-            orphaned.push(name);
-        }
-    }
-    Ok(orphaned)
+    Ok(crate::journals::unreferenced_image_names(pool, candidates).await?)
 }

--- a/db/src/journals/mod.rs
+++ b/db/src/journals/mod.rs
@@ -233,6 +233,10 @@ pub(crate) async fn unreferenced_image_names(
     pool: &SqlitePool,
     candidates: impl IntoIterator<Item = String>,
 ) -> Result<Vec<String>, sqlx::Error> {
+    let candidates: Vec<String> = candidates.into_iter().collect();
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
     let bodies: Vec<String> = sqlx::query_scalar("SELECT body_md FROM journal_entries")
         .fetch_all(pool)
         .await?;

--- a/db/src/journals/mod.rs
+++ b/db/src/journals/mod.rs
@@ -184,37 +184,25 @@ pub async fn delete_journal_entry(
 }
 
 /// Best-effort delete of any `candidates` no longer referenced by any
-/// `journal_entries.body_md` (matched by the full embed path, not the bare
-/// name — see the substring-collision note below). Called only after the
-/// caller's own mutation has already committed, so no self-exclusion is
-/// needed: the caller's row either no longer contains the name (edit) or no
-/// longer exists (delete). Failures — a DB error on the reference check, or
-/// a panic in the filesystem unlink — are logged and swallowed: this is
-/// opportunistic GC of an orphanable-but-durable file store, not a
-/// correctness-critical path, and must never fail the journal mutation that
-/// triggered it (mirrors `set_settings`'s cover cleanup).
+/// `journal_entries.body_md`. Called only after the caller's own mutation has
+/// already committed, so no self-exclusion is needed: the caller's row either
+/// no longer contains the name (edit) or no longer exists (delete). Failures —
+/// a DB error on the reference check, or a panic in the filesystem unlink —
+/// are logged and swallowed: this is opportunistic GC of an
+/// orphanable-but-durable file store, not a correctness-critical path, and
+/// must never fail the journal mutation that triggered it (mirrors
+/// `set_settings`'s cover cleanup). [`purge::orphaned_images`] is the sibling
+/// caller that instead propagates the DB error — see [`unreferenced_image_names`].
+///
+/// [`purge::orphaned_images`]: crate::deletion::purge::orphaned_images
 async fn cleanup_orphaned_images(pool: &SqlitePool, candidates: HashSet<String>) {
-    let mut orphaned = Vec::new();
-    for name in &candidates {
-        // Match the full embed path, not the bare name — a bare-name substring
-        // match could false-positive on an unrelated file whose uuid happens to
-        // contain this one as a substring, or on stray body text, and wrongly
-        // treat a true orphan as still-referenced.
-        let full_path = format!("{}{name}", markdown::IMAGE_URL_PREFIX);
-        let still_referenced: Result<bool, sqlx::Error> = sqlx::query_scalar(
-            "SELECT EXISTS(SELECT 1 FROM journal_entries WHERE instr(body_md, ?) > 0)",
-        )
-        .bind(&full_path)
-        .fetch_one(pool)
-        .await;
-        match still_referenced {
-            Ok(false) => orphaned.push(name.clone()),
-            Ok(true) => {}
-            Err(e) => {
-                tracing::warn!(name, error = %e, "cleanup_orphaned_images: reference check failed")
-            }
+    let orphaned = match unreferenced_image_names(pool, candidates).await {
+        Ok(names) => names,
+        Err(e) => {
+            tracing::warn!(error = %e, "cleanup_orphaned_images: reference check failed");
+            return;
         }
-    }
+    };
     if orphaned.is_empty() {
         return;
     }
@@ -227,6 +215,34 @@ async fn cleanup_orphaned_images(pool: &SqlitePool, candidates: HashSet<String>)
     {
         tracing::error!("cleanup_orphaned_images: spawn_blocking failed: {join_err}");
     }
+}
+
+/// Narrow `candidates` to the names no `journal_entries.body_md` still embeds
+/// — matched on the full embed path rather than the bare name, since a
+/// bare-name substring match could false-positive on an unrelated file whose
+/// uuid happens to contain this one as a substring, or on stray body text.
+///
+/// Fetches every `body_md` once and matches all candidates in memory, rather
+/// than one `instr()` scan per candidate — `journal_entries` is expected to
+/// stay small enough that a single fetch always wins over N per-candidate
+/// scans. Shared by [`cleanup_orphaned_images`] (swallow-and-log) and
+/// `deletion::purge::orphaned_images` (propagate), which differ only in how
+/// they handle the `Err` case — this helper stays agnostic and returns the
+/// raw `sqlx::Error` for each caller to decide.
+pub(crate) async fn unreferenced_image_names(
+    pool: &SqlitePool,
+    candidates: impl IntoIterator<Item = String>,
+) -> Result<Vec<String>, sqlx::Error> {
+    let bodies: Vec<String> = sqlx::query_scalar("SELECT body_md FROM journal_entries")
+        .fetch_all(pool)
+        .await?;
+    Ok(candidates
+        .into_iter()
+        .filter(|name| {
+            let embed = format!("{}{name}", markdown::IMAGE_URL_PREFIX);
+            !bodies.iter().any(|body| body.contains(&embed))
+        })
+        .collect())
 }
 
 /// Re-read one entry by id (no user scope — callers have already authorized).

--- a/db/src/journals/tests.rs
+++ b/db/src/journals/tests.rs
@@ -1,7 +1,8 @@
 //! Unit tests for the `journals` module: create round-trip + markdown render,
 //! `BookNotFound`, the public all-users list ordering, owner-scoped
 //! update/delete (with non-owner `NotFound`), merged-uuid canonical
-//! resolution, and the update/delete orphan-image-cleanup diffing.
+//! resolution, the update/delete orphan-image-cleanup diffing, and the
+//! shared `unreferenced_image_names` batched check.
 
 use omnibus_shared::{CreateJournalEntry, EbookMetadata, JournalStatus, UpdateJournalEntry};
 
@@ -547,4 +548,26 @@ async fn cleanup_ignores_a_bare_name_substring_that_is_not_a_real_embed_referenc
         !journal_images_dir().join(&name).exists(),
         "a bare-name substring elsewhere must not block the sweep of a true orphan"
     );
+}
+
+#[tokio::test]
+async fn unreferenced_image_names_returns_only_the_candidates_no_body_still_embeds() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = seed(&pool, "/lib", "Book A").await;
+    let referenced_name = "11111111-1111-4111-8111-111111111111.png";
+    let orphaned_name = "22222222-2222-4222-8222-222222222222.png";
+    let body = format!("![img]({}{referenced_name})", markdown::IMAGE_URL_PREFIX);
+    create_journal_entry(&pool, user, &create(&uuid, &body, None))
+        .await
+        .unwrap();
+
+    let unreferenced = unreferenced_image_names(
+        &pool,
+        vec![referenced_name.to_string(), orphaned_name.to_string()],
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(unreferenced, vec![orphaned_name.to_string()]);
 }

--- a/db/src/journals/tests.rs
+++ b/db/src/journals/tests.rs
@@ -571,3 +571,14 @@ async fn unreferenced_image_names_returns_only_the_candidates_no_body_still_embe
 
     assert_eq!(unreferenced, vec![orphaned_name.to_string()]);
 }
+
+#[tokio::test]
+async fn unreferenced_image_names_skips_the_query_when_candidates_is_empty() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let unreferenced = unreferenced_image_names(&pool, Vec::<String>::new())
+        .await
+        .unwrap();
+
+    assert!(unreferenced.is_empty());
+}


### PR DESCRIPTION
## Summary
- `db/src/deletion/purge.rs`'s `orphaned_images` and `db/src/journals/mod.rs`'s `cleanup_orphaned_images` each duplicated an identical per-candidate `instr()` existence-check loop against `journal_entries` (one full-table scan per candidate image).
- Added a shared `pub(crate) async fn unreferenced_image_names` in `db/src/journals/mod.rs` (the module that owns the `journal_entries` table) doing one batched fetch of all `body_md` plus an in-memory substring check, instead of N per-candidate scans.
- Both `purge::orphaned_images` and `journals::cleanup_orphaned_images` now call the shared helper. It returns `Result<Vec<String>, sqlx::Error>`; each caller keeps its own existing error-handling convention — `purge::orphaned_images` still propagates via `DeleteError`'s `#[from] sqlx::Error`, while `cleanup_orphaned_images` still logs-and-swallows (its documented "must never fail the journal mutation that triggered it" contract).

Closes #1258

## Test plan
- `cargo fmt --check` — PASS
- `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- `cargo test -p omnibus-db` — 1167 passed, 1 failed (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`), which fails only because this environment doesn't have the binary test fixtures downloaded (`just fixtures` requires the Nix dev shell, unavailable in this cloud container) — unrelated to this change. Targeted reruns of the touched modules pass 100%: `journals::` (36/36, including the new `unreferenced_image_names_returns_only_the_candidates_no_body_still_embeds`) and `deletion::` (17/17).

## Notes
- The shared helper lives in `journals/mod.rs` rather than a new module, since it queries the `journal_entries` table that module already owns; `deletion` already depends on `journals` (for `markdown::IMAGE_URL_PREFIX`), so this adds no new circularity.


---
_Generated by [Claude Code](https://claude.ai/code/session_018dp84TTsr7ckeNd5AsqnxG)_