### PR TITLE
fix: keep the mobile play/pause icon in sync with actual playback

### DIFF
--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -334,10 +334,7 @@ fn render_player(p: PlayerProps) -> Element {
             persist_position(&uuid_seek, &su_seek, secs);
         }
     };
-    // No optimistic flip: the JS surface toggles off the element's real
-    // `paused` state and the resulting `play`/`pause` events (plus the
-    // per-tick `Time` reconciliation) drive `ctx.playing`. Guessing here can
-    // desync the icon from actual playback (issue #1250).
+    // Let audio events drive `ctx.playing`; an optimistic flip can desync the icon.
     let on_toggle = move |_| interop::toggle();
     let on_back = move |_| interop::skip(-30.0);
     let on_fwd = move |_| interop::skip(30.0);

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -334,12 +334,11 @@ fn render_player(p: PlayerProps) -> Element {
             persist_position(&uuid_seek, &su_seek, secs);
         }
     };
-    let mut playing_sig = ctx.playing;
-    let on_toggle = move |_| {
-        interop::toggle();
-        let now = *playing_sig.peek();
-        playing_sig.set(!now);
-    };
+    // No optimistic flip: the JS surface toggles off the element's real
+    // `paused` state and the resulting `play`/`pause` events (plus the
+    // per-tick `Time` reconciliation) drive `ctx.playing`. Guessing here can
+    // desync the icon from actual playback (issue #1250).
+    let on_toggle = move |_| interop::toggle();
     let on_back = move |_| interop::skip(-30.0);
     let on_fwd = move |_| interop::skip(30.0);
 

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -238,6 +238,13 @@ async fn load_and_drain(
     }
 }
 
+/// Whether the transport icon (`playing`) disagrees with the element's real
+/// `paused` state and must be flipped. `playing` should always be the negation
+/// of `paused`; equality means they've drifted (a missed `play`/`pause` event).
+fn playing_out_of_sync(playing: bool, paused: bool) -> bool {
+    playing == paused
+}
+
 /// `true` when direct playback of `uuid` is doomed: the app is known-offline
 /// and no completed audio download exists to serve the parts locally.
 fn audio_blocked_offline(uuid: &str) -> bool {
@@ -344,8 +351,15 @@ async fn drain_audio_events(
     let mut last_saved = 0.0_f64;
     loop {
         match eval.recv::<interop::AudioEvent>().await {
-            Ok(interop::AudioEvent::Time { seconds }) => {
+            Ok(interop::AudioEvent::Time { seconds, paused }) => {
                 elapsed.set(seconds);
+                // Reconcile the transport icon against the element's real
+                // paused state: WKWebView can resume after an audio
+                // interruption without re-firing `play`, which would otherwise
+                // leave the button stuck on "play" while playback advances.
+                if playing_out_of_sync(*playing.peek(), paused) {
+                    playing.set(!paused);
+                }
                 let armed = *sleep.peek();
                 if let SleepState::EndOfChapter { at_seconds } = armed {
                     if seconds >= at_seconds {
@@ -372,8 +386,19 @@ async fn drain_audio_events(
 
 #[cfg(test)]
 mod tests {
-    use super::{audio_blocked_offline, first_audio_file_id};
+    use super::{audio_blocked_offline, first_audio_file_id, playing_out_of_sync};
     use omnibus_shared::BookFileInfo;
+
+    #[test]
+    fn playing_out_of_sync_flags_only_drifted_state() {
+        // Agreement: playing == !paused — nothing to reconcile.
+        assert!(!playing_out_of_sync(true, false));
+        assert!(!playing_out_of_sync(false, true));
+        // Drift: the icon and the element disagree (the issue #1250 case where
+        // audio resumed but the button stayed on "play").
+        assert!(playing_out_of_sync(false, false));
+        assert!(playing_out_of_sync(true, true));
+    }
 
     #[test]
     fn audio_blocked_offline_only_while_offline_without_a_download() {

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -353,10 +353,7 @@ async fn drain_audio_events(
         match eval.recv::<interop::AudioEvent>().await {
             Ok(interop::AudioEvent::Time { seconds, paused }) => {
                 elapsed.set(seconds);
-                // Reconcile the transport icon against the element's real
-                // paused state: WKWebView can resume after an audio
-                // interruption without re-firing `play`, which would otherwise
-                // leave the button stuck on "play" while playback advances.
+                // WKWebView can resume after an interruption without re-firing `play`; reconcile the icon.
                 if playing_out_of_sync(*playing.peek(), paused) {
                     playing.set(!paused);
                 }
@@ -394,8 +391,7 @@ mod tests {
         // Agreement: playing == !paused — nothing to reconcile.
         assert!(!playing_out_of_sync(true, false));
         assert!(!playing_out_of_sync(false, true));
-        // Drift: the icon and the element disagree (the issue #1250 case where
-        // audio resumed but the button stayed on "play").
+        // Drift: the icon and the element disagree and must be flipped.
         assert!(playing_out_of_sync(false, false));
         assert!(playing_out_of_sync(true, true));
     }

--- a/frontend/src/pages/listen/mobile/interop.rs
+++ b/frontend/src/pages/listen/mobile/interop.rs
@@ -20,8 +20,12 @@ use super::view::part_token_url;
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(tag = "kind")]
 pub enum AudioEvent {
-    /// Current absolute (cross-part) position, in seconds.
-    Time { seconds: f64 },
+    /// Current absolute (cross-part) position, in seconds, plus the element's
+    /// authoritative `paused` state. The `paused` flag lets the drain
+    /// reconcile the transport icon on every tick — WKWebView can resume after
+    /// an audio interruption without re-dispatching a `play` event, so the
+    /// discrete `Play`/`Pause` events alone can leave the button stuck.
+    Time { seconds: f64, paused: bool },
     /// Playback started.
     Play,
     /// Playback paused (carries the position at pause).
@@ -286,7 +290,7 @@ fn surface_js(parts_json: &str, resume_lit: &str, rate_lit: &str, meta_lit: &str
     setH('seekto', function(d){{ if (d && d.seekTime != null) oa.seek(d.seekTime); }});
   }}
 
-  el.addEventListener('timeupdate', function(){{ dioxus.send({{ kind: 'Time', seconds: absTime() }}); updatePositionState(); }});
+  el.addEventListener('timeupdate', function(){{ dioxus.send({{ kind: 'Time', seconds: absTime(), paused: el.paused }}); updatePositionState(); }});
   el.addEventListener('play',  function(){{ dioxus.send({{ kind: 'Play' }}); if (hasMediaSession) navigator.mediaSession.playbackState = 'playing'; updatePositionState(); }});
   el.addEventListener('pause', function(){{ dioxus.send({{ kind: 'Pause', seconds: absTime() }}); if (hasMediaSession) navigator.mediaSession.playbackState = 'paused'; }});
   // Cross-part auto-advance: chain to the next part on natural end.
@@ -347,6 +351,12 @@ mod tests {
         );
         assert!(js.contains("window.OmnibusMobileAudio"));
         assert!(js.contains("dioxus.send"));
+        // The timeupdate tick carries the element's paused state so the drain
+        // can reconcile the transport icon (issue #1250).
+        assert!(
+            js.contains("kind: 'Time', seconds: absTime(), paused: el.paused"),
+            "timeupdate must report the element's paused state"
+        );
         // Media Session wiring landed.
         assert!(js.contains("new MediaMetadata"), "media session missing");
         assert!(js.contains("setActionHandler"), "action handlers missing");
@@ -393,6 +403,19 @@ mod tests {
         assert_eq!(v["artist"], "A");
         assert_eq!(v["album"], "Omnibus");
         assert_eq!(v["artwork"], "http://h/c?token=t");
+    }
+
+    #[test]
+    fn audio_event_time_deserializes_with_paused_flag() {
+        let ev: AudioEvent =
+            serde_json::from_str(r#"{"kind":"Time","seconds":42.5,"paused":false}"#).unwrap();
+        match ev {
+            AudioEvent::Time { seconds, paused } => {
+                assert_eq!(seconds, 42.5);
+                assert!(!paused);
+            }
+            other => panic!("expected Time, got {other:?}"),
+        }
     }
 
     #[test]

--- a/frontend/src/pages/listen/mobile/interop.rs
+++ b/frontend/src/pages/listen/mobile/interop.rs
@@ -351,8 +351,7 @@ mod tests {
         );
         assert!(js.contains("window.OmnibusMobileAudio"));
         assert!(js.contains("dioxus.send"));
-        // The timeupdate tick carries the element's paused state so the drain
-        // can reconcile the transport icon (issue #1250).
+        // The timeupdate tick must carry the element's paused state for the drain to reconcile.
         assert!(
             js.contains("kind: 'Time', seconds: absTime(), paused: el.paused"),
             "timeupdate must report the element's paused state"

--- a/frontend/src/pages/listen/mobile/mini.rs
+++ b/frontend/src/pages/listen/mobile/mini.rs
@@ -68,8 +68,7 @@ pub fn MobileMiniPlayer() -> Element {
         .map(|a| format!("--accent: {a};"))
         .unwrap_or_default();
 
-    // No optimistic flip — the JS surface + `play`/`pause`/`Time` events are
-    // the source of truth for `ctx.playing` (issue #1250).
+    // Let audio events drive `ctx.playing`; an optimistic flip can desync the icon.
     let on_toggle = move |_| interop::toggle();
 
     rsx! {

--- a/frontend/src/pages/listen/mobile/mini.rs
+++ b/frontend/src/pages/listen/mobile/mini.rs
@@ -68,12 +68,9 @@ pub fn MobileMiniPlayer() -> Element {
         .map(|a| format!("--accent: {a};"))
         .unwrap_or_default();
 
-    let mut playing_sig = ctx.playing;
-    let on_toggle = move |_| {
-        interop::toggle();
-        let now = *playing_sig.peek();
-        playing_sig.set(!now);
-    };
+    // No optimistic flip — the JS surface + `play`/`pause`/`Time` events are
+    // the source of truth for `ctx.playing` (issue #1250).
+    let on_toggle = move |_| interop::toggle();
 
     rsx! {
         div { class: "m-mini", style: "{accent_style}", "data-testid": "mobile-miniplayer",


### PR DESCRIPTION
## Summary
- Fixes #1250 — on iOS (WKWebView) the mobile audiobook play/pause button worked but stayed stuck on the "play" triangle while audio kept advancing.
- Root cause: the transport icon reflected `ctx.playing`, which was only written by the discrete `play`/`pause` audio events plus an optimistic flip in the tap handler. WKWebView can resume after an audio interruption (or a background/lock-screen transition) **without re-dispatching a `play` event**, and the optimistic flip is an unsound guess that never self-corrects during steady playback (only `timeupdate` fires then). Either path leaves the icon desynced from actual playback.
- Fix: the `timeupdate` tick now carries the `<audio>` element's authoritative `paused` state, and the drain loop reconciles `ctx.playing` against it on every tick — so the icon self-heals within a tick regardless of a missed `play`/`pause` event.
- Dropped the optimistic flip in both the full player (`mobile.rs`) and the mini-player (`mini.rs`); the JS surface + events are now the single source of truth.

## Test plan
- [x] `cargo test -p omnibus-frontend --features mobile listen::mobile` — 46 passed, including new coverage:
  - `playing_out_of_sync_flags_only_drifted_state` (reconciliation predicate)
  - `audio_event_time_deserializes_with_paused_flag` (wire shape)
  - `surface_js` now asserts the `timeupdate` payload includes `paused: el.paused`
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets` — clean
- [x] `cargo fmt -p omnibus-frontend --check` — clean

## Version
- [x] **Patch** — behavioral fix, no schema/markup/mobile-compat changes.

## Notes
- No markup / `data-testid` / role changes, so no Playwright or Maestro spec updates are needed.
- All changes are inside the `#[cfg(feature = "mobile")]`-gated module, so non-mobile builds are unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XvaqJBXKFT3BvUqZYBfene)_