### PR TITLE
feat: surface physical-only books in browse and the cover grid (#1181)

### DIFF
--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -29,9 +29,30 @@ fn placeholders(n: usize) -> String {
     std::iter::repeat_n("(?)", n).collect::<Vec<_>>().join(", ")
 }
 
+/// "In the library" for the browse indexes: under a configured scan root, or
+/// holding at least one physical copy (#1181).
+///
+/// Deliberately *not* the landing read path's rule, which also demands a
+/// `book_files` row. Browse counts a ghosted (fileless) book so its author
+/// doesn't vanish while the file is merely missing, and that stays true here.
+/// The physical arm is what surfaces a physical-only book: those live under the
+/// synthetic `physical://local` root, which is never in `lib_paths`. A pure
+/// wishlist entry sits under that same root with no copy, so it matches
+/// neither arm and stays hidden.
+///
+/// `book` / `root` name the `books` / `scan_roots` aliases in the enclosing
+/// query, which differ per subquery here.
+fn visible(book: &str, root: &str) -> String {
+    format!(
+        "({root}.path IN (SELECT p FROM lib_paths) \
+          OR EXISTS (SELECT 1 FROM physical_copies pc WHERE pc.book_uuid = {book}.uuid))"
+    )
+}
+
 /// Return every author with their book count and an optional cover-derived
-/// accent, scoped to `library_paths`, ordered by name ascending and capped
-/// at [`INDEX_LIMIT`]. Empty list when no paths match or the slice is empty.
+/// accent, scoped to books `visible` under `library_paths`, ordered by name
+/// ascending and capped at [`INDEX_LIMIT`]. Empty list when no paths match or
+/// the slice is empty.
 ///
 /// Currently returns results across all users (single-tenant). When F4.x
 /// per-user ACL lands, add a `user_id: i64` parameter and scope the query
@@ -44,6 +65,8 @@ pub async fn list_authors(
         return Ok(Vec::new());
     }
     let ph = placeholders(library_paths.len());
+    let vis = visible("b", "l");
+    let vis2 = visible("b2", "l2");
     // `effective(author_id, book_id)` is the override-aware membership set,
     // built once: arm (1) canonical link rows whose book has no creators
     // override, arm (2) override-derived `(authors.id, book_id)` pairs.
@@ -61,7 +84,7 @@ pub async fn list_authors(
               JOIN books b ON b.id = bal.book
               JOIN scan_roots l ON l.id = b.library_id
               LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-             WHERE l.path IN (SELECT p FROM lib_paths)
+             WHERE {vis}
                AND (mo.book_uuid IS NULL
                     OR json_type(mo.overrides, '$.creators') IS NULL)
             UNION
@@ -73,7 +96,7 @@ pub async fn list_authors(
               JOIN json_each(mo.overrides, '$.creators') je
               JOIN authors a2
                 ON a2.name = json_extract(je.value, '$.name') COLLATE NOCASE
-             WHERE l.path IN (SELECT p FROM lib_paths)
+             WHERE {vis}
                AND json_type(mo.overrides, '$.creators') IS NOT NULL
         ),
         counts AS (
@@ -88,7 +111,7 @@ pub async fn list_authors(
                   JOIN books b2 ON b2.id = bal2.book
                   JOIN scan_roots l2 ON l2.id = b2.library_id
                  WHERE bal2.author = a.id
-                   AND l2.path IN (SELECT p FROM lib_paths)
+                   AND {vis2}
                    AND b2.accent_color IS NOT NULL
                  ORDER BY b2.sort, b2.id
                  LIMIT 1) AS accent,
@@ -105,7 +128,7 @@ pub async fn list_authors(
               JOIN books b ON b.id = bal.book
               JOIN scan_roots l ON l.id = b.library_id
              WHERE bal.author = a.id
-               AND l.path IN (SELECT p FROM lib_paths)
+               AND {vis}
           )
         ORDER BY COALESCE(a.sort, a.name) COLLATE NOCASE ASC
         LIMIT ?
@@ -163,6 +186,9 @@ pub async fn list_series(
 /// so the books table is scanned once instead of once per series.
 fn series_index_sql(n: usize) -> String {
     let ph = placeholders(n);
+    let vis = visible("b", "l");
+    let vis2 = visible("b2", "l2");
+    let vis3 = visible("b3", "l3");
     format!(
         r"
         WITH lib_paths(p) AS (VALUES {ph}),
@@ -173,7 +199,7 @@ fn series_index_sql(n: usize) -> String {
               JOIN books b ON b.id = bsl.book
               JOIN scan_roots l ON l.id = b.library_id
               LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-             WHERE l.path IN (SELECT p FROM lib_paths)
+             WHERE {vis}
                AND (mo.book_uuid IS NULL
                     OR json_type(mo.overrides, '$.series') IS NULL)
             UNION
@@ -184,7 +210,7 @@ fn series_index_sql(n: usize) -> String {
               JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
               JOIN series s2
                 ON s2.name = json_extract(mo.overrides, '$.series') COLLATE NOCASE
-             WHERE l.path IN (SELECT p FROM lib_paths)
+             WHERE {vis}
                AND json_type(mo.overrides, '$.series') IS NOT NULL
         ),
         counts AS (
@@ -209,7 +235,7 @@ fn series_index_sql(n: usize) -> String {
                   JOIN scan_roots l2 ON l2.id = b2.library_id
                   LEFT JOIN metadata_overrides mo2 ON mo2.book_uuid = b2.uuid
                  WHERE bsl2.series = s.id
-                   AND l2.path IN (SELECT p FROM lib_paths)
+                   AND {vis2}
                  ORDER BY b2.series_index NULLS LAST, b2.sort, b2.id
                  LIMIT 1) AS primary_author,
                (SELECT b3.accent_color
@@ -217,7 +243,7 @@ fn series_index_sql(n: usize) -> String {
                   JOIN books b3 ON b3.id = bsl3.book
                   JOIN scan_roots l3 ON l3.id = b3.library_id
                  WHERE bsl3.series = s.id
-                   AND l3.path IN (SELECT p FROM lib_paths)
+                   AND {vis3}
                    AND b3.accent_color IS NOT NULL
                  ORDER BY b3.series_index NULLS LAST, b3.sort, b3.id
                  LIMIT 1) AS accent
@@ -228,7 +254,7 @@ fn series_index_sql(n: usize) -> String {
               JOIN books b ON b.id = bsl.book
               JOIN scan_roots l ON l.id = b.library_id
              WHERE bsl.series = s.id
-               AND l.path IN (SELECT p FROM lib_paths)
+               AND {vis}
           )
         ORDER BY COALESCE(s.sort, s.name) COLLATE NOCASE ASC
         LIMIT ?

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -25,7 +25,15 @@ const INDEX_LIMIT: i64 = 10_000;
 /// Build a `VALUES (?)` list for a CTE that materializes the library-path
 /// set once. At most two entries (ebook + audiobook), so the bind count
 /// stays trivial.
+///
+/// With no configured scan roots the CTE still needs a row to be valid SQL, so
+/// `n == 0` yields `(NULL)` — a path no book matches, leaving the physical arm
+/// of [`visible`] as the only way in. That's the physical-only library: books
+/// checked in before any ebook/audiobook path was set must still browse.
 fn placeholders(n: usize) -> String {
+    if n == 0 {
+        return "(NULL)".to_string();
+    }
     std::iter::repeat_n("(?)", n).collect::<Vec<_>>().join(", ")
 }
 
@@ -51,8 +59,8 @@ fn visible(book: &str, root: &str) -> String {
 
 /// Return every author with their book count and an optional cover-derived
 /// accent, scoped to books `visible` under `library_paths`, ordered by name
-/// ascending and capped at [`INDEX_LIMIT`]. Empty list when no paths match or
-/// the slice is empty.
+/// ascending and capped at [`INDEX_LIMIT`]. An empty `library_paths` is not an
+/// empty result: physical-only books still browse (see [`placeholders`]).
 ///
 /// Currently returns results across all users (single-tenant). When F4.x
 /// per-user ACL lands, add a `user_id: i64` parameter and scope the query
@@ -61,9 +69,6 @@ pub async fn list_authors(
     pool: &SqlitePool,
     library_paths: &[&str],
 ) -> Result<Vec<AuthorSummary>, BrowseError> {
-    if library_paths.is_empty() {
-        return Ok(Vec::new());
-    }
     let ph = placeholders(library_paths.len());
     let vis = visible("b", "l");
     let vis2 = visible("b2", "l2");
@@ -155,8 +160,9 @@ pub async fn list_authors(
 }
 
 /// Return every series with book count, primary author, and an optional
-/// accent, scoped to `library_paths`, ordered by name ascending and capped
-/// at [`INDEX_LIMIT`]. Empty list when no paths match or the slice is empty.
+/// accent, scoped to books `visible` under `library_paths`, ordered by name
+/// ascending and capped at [`INDEX_LIMIT`]. An empty `library_paths` is not an
+/// empty result: physical-only books still browse (see [`placeholders`]).
 ///
 /// Currently returns results across all users (single-tenant). When F4.x
 /// per-user ACL lands, add a `user_id: i64` parameter and scope the query
@@ -165,9 +171,6 @@ pub async fn list_series(
     pool: &SqlitePool,
     library_paths: &[&str],
 ) -> Result<Vec<SeriesSummary>, BrowseError> {
-    if library_paths.is_empty() {
-        return Ok(Vec::new());
-    }
     let sql = series_index_sql(library_paths.len());
     let mut q = sqlx::query(&sql);
     for path in library_paths {

--- a/db/src/browse/tests.rs
+++ b/db/src/browse/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the `browse` module — `/authors` and `/series` index
 //! pages: alpha-ordering, override-aware counts, audiobook-library scope,
-//! and `has_photo` propagation.
+//! `has_photo` propagation, and physical-only vs wishlist-only visibility.
 
 use omnibus_shared::{Contributor, MetadataOverrides};
 
@@ -8,6 +8,7 @@ use super::*;
 use crate::author_photos_data::{upsert_author_photo, AuthorPhotoSource};
 use crate::books::list_books;
 use crate::metadata_overrides::upsert_metadata_overrides;
+use crate::physical::{add_physical_copy, create_fileless_book, FilelessBook};
 use crate::pool::init_db;
 use crate::test_support::*;
 
@@ -503,4 +504,118 @@ async fn list_authors_propagates_db_error_when_pool_is_closed() {
     pool.close().await;
     let err = list_authors(&pool, &["/lib"]).await.unwrap_err();
     assert!(matches!(err, BrowseError::Db(_)));
+}
+
+// -----------------------------------------------------------------
+// Physical-only visibility — #1181
+// -----------------------------------------------------------------
+
+/// Mint a fileless book (synthetic `physical://local` root) with one author.
+async fn seed_fileless(pool: &SqlitePool, title: &str, author: &str) -> String {
+    create_fileless_book(
+        pool,
+        FilelessBook {
+            title: title.to_string(),
+            authors: vec![author.to_string()],
+            isbn: None,
+            pubdate: None,
+            description: None,
+            cover: None,
+        },
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn list_authors_includes_an_author_whose_only_book_is_a_physical_copy() {
+    let _guard = CoversTempDir::new("browse_physical_author");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_fileless(&pool, "Paper Only", "Ada Lovelace").await;
+    add_physical_copy(&pool, &uuid, Some("9780000000001"), None, None)
+        .await
+        .unwrap();
+
+    // "/lib" is the configured scan root; the book lives under the synthetic
+    // physical root, so only the physical arm can surface it.
+    let authors = list_authors(&pool, &["/lib"]).await.unwrap();
+    assert_eq!(
+        authors.len(),
+        1,
+        "physical-only book must surface its author"
+    );
+    assert_eq!(authors[0].name, "Ada Lovelace");
+    assert_eq!(authors[0].book_count, 1);
+}
+
+#[tokio::test]
+async fn list_authors_hides_an_author_whose_only_book_is_wishlist_only() {
+    let _guard = CoversTempDir::new("browse_wishlist_author");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_fileless(&pool, "Someday", "Grace Hopper").await;
+
+    let authors = list_authors(&pool, &["/lib"]).await.unwrap();
+    assert!(
+        authors.is_empty(),
+        "a wishlist-only book has no copy and no files — it belongs to no author index"
+    );
+}
+
+#[tokio::test]
+async fn list_series_includes_a_series_whose_only_book_is_a_physical_copy() {
+    let _guard = CoversTempDir::new("browse_physical_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_fileless(&pool, "Paper Saga #1", "Ada Lovelace").await;
+    link_series(&pool, &uuid, "Paper Saga").await;
+    add_physical_copy(&pool, &uuid, None, None, None)
+        .await
+        .unwrap();
+
+    let series = list_series(&pool, &["/lib"]).await.unwrap();
+    assert_eq!(
+        series.len(),
+        1,
+        "physical-only book must surface its series"
+    );
+    assert_eq!(series[0].name, "Paper Saga");
+    assert_eq!(series[0].book_count, 1);
+}
+
+#[tokio::test]
+async fn list_series_hides_a_series_whose_only_book_is_wishlist_only() {
+    let _guard = CoversTempDir::new("browse_wishlist_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_fileless(&pool, "Someday Saga #1", "Grace Hopper").await;
+    link_series(&pool, &uuid, "Someday Saga").await;
+
+    let series = list_series(&pool, &["/lib"]).await.unwrap();
+    assert!(
+        series.is_empty(),
+        "wishlist-only book must not surface a series"
+    );
+}
+
+/// Attach `uuid`'s book to a (created-on-demand) series.
+async fn link_series(pool: &SqlitePool, uuid: &str, name: &str) {
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?1")
+        .bind(uuid)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT OR IGNORE INTO series (name) VALUES (?1)")
+        .bind(name)
+        .execute(pool)
+        .await
+        .unwrap();
+    let series_id: i64 = sqlx::query_scalar("SELECT id FROM series WHERE name = ?1")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO books_series_link (book, series) VALUES (?1, ?2)")
+        .bind(book_id)
+        .bind(series_id)
+        .execute(pool)
+        .await
+        .unwrap();
 }

--- a/db/src/browse/tests.rs
+++ b/db/src/browse/tests.rs
@@ -619,3 +619,47 @@ async fn link_series(pool: &SqlitePool, uuid: &str, name: &str) {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn list_authors_surfaces_physical_only_books_with_no_scan_roots_configured() {
+    let _guard = CoversTempDir::new("browse_no_roots_author");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_fileless(&pool, "Paper Only", "Ada Lovelace").await;
+    add_physical_copy(&pool, &uuid, None, None, None)
+        .await
+        .unwrap();
+
+    // A library that has only ever checked in print copies has no ebook or
+    // audiobook path set — the physical arm must still carry the index.
+    let authors = list_authors(&pool, &[]).await.unwrap();
+
+    assert_eq!(authors.len(), 1);
+    assert_eq!(authors[0].name, "Ada Lovelace");
+    assert_eq!(authors[0].book_count, 1);
+}
+
+#[tokio::test]
+async fn list_series_surfaces_physical_only_books_with_no_scan_roots_configured() {
+    let _guard = CoversTempDir::new("browse_no_roots_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_fileless(&pool, "Paper Saga #1", "Ada Lovelace").await;
+    link_series(&pool, &uuid, "Paper Saga").await;
+    add_physical_copy(&pool, &uuid, None, None, None)
+        .await
+        .unwrap();
+
+    let series = list_series(&pool, &[]).await.unwrap();
+
+    assert_eq!(series.len(), 1);
+    assert_eq!(series[0].name, "Paper Saga");
+}
+
+#[tokio::test]
+async fn list_authors_returns_empty_with_no_scan_roots_and_no_physical_books() {
+    let _guard = CoversTempDir::new("browse_no_roots_empty");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_fileless(&pool, "Someday", "Grace Hopper").await;
+
+    // `(NULL)` matches no path, so a wishlist-only book stays hidden.
+    assert!(list_authors(&pool, &[]).await.unwrap().is_empty());
+}

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5171,6 +5171,16 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   display: block;
   text-decoration: none;
   cursor: pointer;
+  position: relative;
+}
+/* Pins to the cover's top-right — the Cover is the tile's first child, so the
+   tile box starts at the artwork. Opaque ground because `.format-badge` is
+   transparent by default and would be unreadable over cover art. */
+.lib-tile-phys {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: var(--bg-0);
 }
 .lib-tile:focus-visible {
   outline: 2px solid var(--accent);

--- a/frontend/src/pages/landing/grid.rs
+++ b/frontend/src/pages/landing/grid.rs
@@ -8,7 +8,7 @@ use dioxus::prelude::*;
 use dioxus_router::use_navigator;
 use omnibus_shared::EbookMetadata;
 
-use super::sorting::{contributor_names, row_slug};
+use super::sorting::{contributor_names, row_ident};
 use crate::Route;
 
 #[component]
@@ -17,7 +17,7 @@ pub(super) fn BookGrid(books: Vec<EbookMetadata>, server_url: String) -> Element
         div { class: "lib-grid", "data-testid": "lib-grid", role: "list",
             for book in books.into_iter() {
                 GridTile {
-                    key: "{book.filename}",
+                    key: "{row_ident(&book)}",
                     book: book,
                     server_url: server_url.clone(),
                 }
@@ -32,7 +32,7 @@ fn GridTile(book: EbookMetadata, server_url: String) -> Element {
     // (see `Route::BookDetail`).
     let uuid = book.unique_identifier.clone().unwrap_or_default();
     let display_title = book.title.as_deref().unwrap_or(&book.filename).to_string();
-    let tile_testid = format!("ebook-tile-{}", row_slug(&book.filename));
+    let tile_testid = format!("ebook-tile-{}", row_ident(&book));
     let authors = contributor_names(&book.creators);
     // Read before `book` moves into `Cover`. Mirrors the table's formats cell,
     // which carries the same badge (#1181).

--- a/frontend/src/pages/landing/grid.rs
+++ b/frontend/src/pages/landing/grid.rs
@@ -34,6 +34,9 @@ fn GridTile(book: EbookMetadata, server_url: String) -> Element {
     let display_title = book.title.as_deref().unwrap_or(&book.filename).to_string();
     let tile_testid = format!("ebook-tile-{}", row_slug(&book.filename));
     let authors = contributor_names(&book.creators);
+    // Read before `book` moves into `Cover`. Mirrors the table's formats cell,
+    // which carries the same badge (#1181).
+    let has_physical = book.has_physical;
     let nav = use_navigator();
 
     // Prefer the responsive `/api/thumbs/:uuid/{sm,md,lg}` endpoint over the
@@ -72,6 +75,14 @@ fn GridTile(book: EbookMetadata, server_url: String) -> Element {
                     "(max-width: 640px) 160px, (max-width: 1280px) 200px, 240px"
                         .to_string(),
                 ),
+            }
+            if has_physical {
+                span {
+                    class: "lib-tile-phys format-badge format-badge--physical",
+                    "data-testid": "format-badge-physical",
+                    title: "In your physical collection",
+                    "PHYS"
+                }
             }
             div { class: "lib-tile-title", "{display_title}" }
             if !authors.is_empty() {

--- a/frontend/src/pages/landing/sorting.rs
+++ b/frontend/src/pages/landing/sorting.rs
@@ -211,6 +211,20 @@ pub(crate) fn row_slug(filename: &str) -> String {
     out
 }
 
+/// Stable per-book identity for a row/tile `key` and testid slug.
+///
+/// A fileless book (physical-only, or a ghost) has no `book_files` row, and
+/// `row_to_ebook` leaves its `filename` empty — slugging that alone would
+/// collapse every such book onto the same key and testid, breaking Dioxus
+/// diffing and making Playwright selectors ambiguous. Fall back to the uuid,
+/// which is always present and unique.
+pub(crate) fn row_ident(book: &EbookMetadata) -> String {
+    if book.filename.is_empty() {
+        return row_slug(book.unique_identifier.as_deref().unwrap_or_default());
+    }
+    row_slug(&book.filename)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -336,6 +350,32 @@ mod tests {
     #[test]
     fn sort_key_from_value_returns_none_for_unrecognized_token() {
         assert_eq!(sort_key_from_value("not-a-real-key"), None);
+    }
+
+    /// A book carrying just the two fields `row_ident` reads.
+    fn ident_book(filename: &str, uuid: &str) -> EbookMetadata {
+        EbookMetadata {
+            filename: filename.into(),
+            unique_identifier: Some(uuid.into()),
+            ..EbookMetadata::default()
+        }
+    }
+
+    #[test]
+    fn row_ident_uses_the_filename_slug_for_a_file_backed_book() {
+        let b = ident_book("Alpha.epub", "11111111-2222-3333-4444-555555555555");
+        assert_eq!(row_ident(&b), "alpha");
+    }
+
+    #[test]
+    fn row_ident_falls_back_to_the_uuid_for_a_fileless_book() {
+        // Two physical-only books both have an empty `filename`; keying on it
+        // would collide, so each must fall back to its own uuid.
+        let a = ident_book("", "aaaaaaaa-0000-0000-0000-000000000000");
+        let b = ident_book("", "bbbbbbbb-0000-0000-0000-000000000000");
+
+        assert_eq!(row_ident(&a), "aaaaaaaa-0000-0000-0000-000000000000");
+        assert_ne!(row_ident(&a), row_ident(&b));
     }
 
     // sort_books cases.

--- a/frontend/src/pages/landing/table/mod.rs
+++ b/frontend/src/pages/landing/table/mod.rs
@@ -104,7 +104,7 @@ pub(super) fn BookTable(
                 tbody {
                     for book in books.into_iter() {
                         EbookRow {
-                            key: "{book.filename}",
+                            key: "{super::sorting::row_ident(&book)}",
                             book: book,
                             ctx: ctx.clone(),
                         }

--- a/frontend/src/pages/landing/table/row.rs
+++ b/frontend/src/pages/landing/table/row.rs
@@ -8,7 +8,7 @@ use dioxus::prelude::*;
 use dioxus_router::use_navigator;
 use omnibus_shared::EbookMetadata;
 
-use super::super::sorting::{contributor_names, row_slug};
+use super::super::sorting::{contributor_names, row_ident};
 use super::cells::{
     build_save_authors, build_save_field, AuthorsCell, CellEditCtx, EbookRowCoverCell,
     EbookRowFormatsCell, RowContext, RowScalarCell, RowScalarCellDisplay, RowSeriesCell,
@@ -131,7 +131,7 @@ fn derive_row_display(
     uuid: &str,
     cover_bust: u32,
 ) -> RowDisplay {
-    let row_testid = format!("ebook-row-{}", row_slug(&book.filename));
+    let row_testid = format!("ebook-row-{}", row_ident(book));
     // Per-variant URLs (not a shared base) so mobile's `?token=` attaches to
     // each `srcset` candidate; see `crate::thumb_url`.
     let bust = |url: String| crate::contexts::append_cache_bust(url, cover_bust);


### PR DESCRIPTION
## Summary
- Browse (`/authors`, `/series`) scoped membership purely on `scan_roots.path`, so a physical-only book — which lives under the synthetic `physical://local` root — never appeared. Adds a physical-copy OR-arm to every membership, count, primary-author, and accent subquery in both indexes.
- Adds the `PHYS` badge to the cover-grid tile, matching the one the table's formats cell already renders.
- The browse predicate is deliberately *not* the landing read path's rule: landing also demands a `book_files` row, browse does not, so a ghosted book still counts toward its author. A pure wishlist entry matches neither arm and stays hidden.

Closes #1181. Discovery *detail* (`get_author` / `get_series`) applies no visibility filter at all today and can still surface a wishlist-only book — left alone here as its own concern.

## Test plan
- [x] 4 new `db::browse` tests: physical-only surfaces its author/series, wishlist-only surfaces neither.
- [x] Existing `fileless_book_still_appears_in_author_browse` still passes — ghost behavior unchanged (AC4).
- [x] `just test` green (1174 db + 384 server + frontend + shared); `cargo fmt --check`, clippy across db / frontend-server / frontend-wasm32, `just lint-css` all clean.
- [x] Verified against a live dev server: checked in a copy, confirmed `PHYS` renders top-right of the grid tile with no console errors; created a physical-only and a wishlist-only book and confirmed `/authors` lists the former and not the latter.

## Version
- [ ] **Minor**
- [x] **Patch** — the default.
- [ ] **No release**

## Notes
- E2E coverage for the badge and the visibility rule belongs to #1189, which covers the whole check-in feature; no Playwright spec added here (the table's badge shipped without one too).