### PR TITLE
refactor: fix deny.toml skip-tree comment for rustc-hash (#1276)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -245,9 +245,10 @@ skip = [
 # platform crates). These are old pinned versions carried by the native webview
 # stack (e.g. bitflags 1, derive_more 0.99, heck 0.4, html5ever/markup5ever,
 # string_cache, jni, png, raw-window-handle, siphasher, the
-# windows-sys/windows-targets family — spot-checked with `cargo tree -p
-# omnibus` / `-p omnibus-frontend`, #1276). None of these link into the
-# shipped `omnibus` server binary — they exist only under the native shell.
+# windows-sys/windows-targets family). Spot-checked against the default-build
+# packages with `cargo tree -p omnibus` and `cargo tree -p omnibus-frontend`
+# (see #1276). None of these link into the shipped `omnibus` server binary —
+# they exist only under the native shell.
 # Exception: `rustc-hash` also duplicates via `dioxus-core` in the default
 # (non-mobile) build, so it's deliberately left off this list — see
 # docs/dependency-audit.md's rustc-hash row. Collapsing the rest requires

--- a/deny.toml
+++ b/deny.toml
@@ -244,13 +244,17 @@ skip = [
 # on Linux, muda/tray-icon, plus the windows-* and core-foundation/core-graphics
 # platform crates). These are old pinned versions carried by the native webview
 # stack (e.g. bitflags 1, derive_more 0.99, heck 0.4, html5ever/markup5ever,
-# string_cache, jni, png, raw-window-handle, rustc-hash, siphasher, the
-# windows-sys/windows-targets family). None link into the shipped `omnibus`
-# server binary — they exist only under the native shell. Collapsing them
-# requires upstream wry/tao to migrate off gtk-rs 0.18 / bitflags 1 etc., which
-# is gated on the Dioxus pin (see [patch.crates-io] in root Cargo.toml). We
-# skip the whole subtree rather than enumerate ~40 leaf crates that all share
-# this single root cause. Revisit when Dioxus upgrades wry/tao.
+# string_cache, jni, png, raw-window-handle, siphasher, the
+# windows-sys/windows-targets family — spot-checked with `cargo tree -p
+# omnibus` / `-p omnibus-frontend`, #1276). None of these link into the
+# shipped `omnibus` server binary — they exist only under the native shell.
+# Exception: `rustc-hash` also duplicates via `dioxus-core` in the default
+# (non-mobile) build, so it's deliberately left off this list — see
+# docs/dependency-audit.md's rustc-hash row. Collapsing the rest requires
+# upstream wry/tao to migrate off gtk-rs 0.18 / bitflags 1 etc., which is
+# gated on the Dioxus pin (see [patch.crates-io] in root Cargo.toml). We skip
+# the whole subtree rather than enumerate ~40 leaf crates that all share this
+# single root cause. Revisit when Dioxus upgrades wry/tao.
 skip-tree = [
     { name = "wry" },
     { name = "tao" },


### PR DESCRIPTION
## Summary
- Closes #1276
- `deny.toml`'s "Accepted duplicate SUBTREES (skip-tree)" comment claimed every crate in its list (bitflags 1, derive_more 0.99, heck 0.4, html5ever/markup5ever, string_cache, jni, png, raw-window-handle, rustc-hash, siphasher, windows-sys/windows-targets) is confined to the Dioxus desktop/mobile native shell and "None link into the shipped `omnibus` server binary." That's false for `rustc-hash`: its 2.1.2 duplicate reaches the default (non-mobile) build directly via `dioxus-core`, as already documented in `docs/dependency-audit.md`'s `rustc-hash` row.
- Spot-checked every other crate named in the list with `cargo tree -p omnibus` / `-p omnibus-frontend` (the actual default-build packages) — all of them are genuinely absent from those trees, i.e. confined to the native shell as claimed. `rustc-hash` is the sole exception.
- Fix: drop `rustc-hash` from the "confined" bullet list, add an explicit exception sentence cross-referencing `docs/dependency-audit.md`'s existing `rustc-hash` row, and note the crates were spot-checked via `cargo tree -p omnibus`/`-p omnibus-frontend` (referencing #1276) so future readers know the claim is verified, not assumed.
- No `deny.toml` behavior changes — this is comment-only, matching the issue's "Low severity, documentation-accuracy" scope. `docs/dependency-audit.md` itself was not changed (its `rustc-hash` row was already accurate from #1268), so its "Last updated" line was left as-is per the issue's conditional acceptance criterion.

## Test plan
- `cargo fmt --check` (workspace-wide) — PASS, no-op since this is a TOML comment change, not Rust source.
- `cargo deny check` — NOTE: cargo-deny is not available in this environment; changes verified by manual inspection against `cargo tree -p omnibus`, `-p omnibus-frontend`, and `-p omnibus-mobile` (plus `--target aarch64-linux-android` / `--target all` for the Android- and Windows-only crates in the list, e.g. `jni`, `windows-sys`) instead. Confirmed the comment's "confined to native shell" claim holds for every named crate except `rustc-hash`, matching the issue's evidence.

## Notes
- This is a pure comment-accuracy fix (`deny.toml`'s actual `skip-tree` suppression behavior is unaffected either way), continuing the precedent chain #412 → #1100 → #1147 → #1268 → #1276.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaE5NJTCCBMVqXmi4SkLAd)_