### PR TITLE
refactor: enforce -D warnings and wasm32 clippy in just lint (#1270)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ cargo run -p omnibus                                        # start at http://0.
 
 # Tests & lint — aggregate targets cover the full crate matrix in one go
 just test                                                   # db + server + frontend(server + mobile features) + shared
-just lint                                                   # cargo fmt --check + clippy (incl. mobile + frontend-server) + stylelint
+just lint                                                   # cargo fmt --check + clippy -D warnings (incl. mobile + frontend-server + frontend-web wasm32) + stylelint
 just lint-css                                               # structural CSS lint only (stylelint; catches unclosed rules in frontend/assets)
 just check                                                  # lint then test
 # …or per-crate (note: `cargo test --workspace` SKIPS frontend rpc/page tests

--- a/Justfile
+++ b/Justfile
@@ -76,14 +76,18 @@ lint-css:
     scripts/with-dev-env.sh default stylelint 'frontend/assets/**/*.css'
 
 # Format check + clippy, including the crate/feature combos a bare
-# `cargo clippy` (default-members, default features) misses. Depends on
-# `lint-css` so the CSS structural guard rides the same gate as fmt/clippy.
+# `cargo clippy` (default-members, default features) misses. `-D warnings` on
+# every invocation and the wasm32 `frontend-web` variant mirror CI's clippy
+# matrix (.github/workflows/rust.yml) so a clean local run can't go on to fail
+# in CI. Depends on `lint-css` so the CSS structural guard rides the same gate
+# as fmt/clippy.
 lint: lint-css
     scripts/with-dev-env.sh default bash -ec '\
         cargo fmt --check && \
-        cargo clippy --all-targets && \
-        cargo clippy -p omnibus-frontend --features server --all-targets && \
-        cargo clippy -p omnibus-mobile --all-targets'
+        cargo clippy --all-targets -- -D warnings && \
+        cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings && \
+        cargo clippy -p omnibus-mobile --all-targets -- -D warnings'
+    scripts/with-dev-env.sh web cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings
 
 # Lint then test — the pre-push gate referenced by rule 99.
 check: lint test


### PR DESCRIPTION
## Summary
- Closes #1270
- `just lint`'s three `cargo clippy` invocations were missing `-D warnings`, and the recipe had no wasm32 `frontend-web` (`--features web --target wasm32-unknown-unknown`) variant — both enforced by CI's clippy matrix (`.github/workflows/rust.yml`). Added `-- -D warnings` to every existing invocation and a new `scripts/with-dev-env.sh web cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings` step, mirroring CI's `frontend-web` matrix entry exactly.
- Updated `CLAUDE.md`'s Quick commands `just lint` description to mention `-D warnings` and the new wasm32 variant.

## Test plan
Sandbox has no `nix`, so `just lint` itself couldn't be run here. Instead ran the individual `cargo clippy` invocations the updated recipe now contains directly (`CARGO_TARGET_DIR` pointed at a scratch dir, matching the recipe's flags):
- [x] `cargo clippy --all-targets -- -D warnings` — PASS, clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS, clean
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings` — PASS, clean (installed the `wasm32-unknown-unknown` rustup target first)
- [ ] `cargo clippy -p omnibus-mobile --all-targets -- -D warnings` — NOTE: could not run in this sandbox. `omnibus-mobile` needs GTK3/WebKitGTK (`gdk-3.0` via pkg-config), normally supplied by the flake's `.#mobile` Nix shell, which isn't available here (no `nix` binary, no system GTK dev packages). The Justfile edit to this line is additive-only (`-- -D warnings` appended, nothing else changed) so it carries the same low risk as the other three, but it's unverified locally — flagging for CI's `clippy (mobile)` job to confirm.

No new warnings surfaced on the three variants that could be run locally, so no source-code changes were needed beyond the Justfile/CLAUDE.md.

## Version
- [x] **No release** — add the `no release` label to skip cutting a release.

(Justfile/CLAUDE.md-only change, no runtime behavior affected.)

## Notes
- Left the `omnibus-mobile` clippy line running in the `default` shell (unchanged from the existing recipe), matching the issue's own suggested diff — the acceptance criteria only ask for `-D warnings` on existing invocations plus the new wasm32 variant, not a shell change for mobile. CI's `clippy (mobile)` job runs that same command in `.#mobile` (for the GTK/wry libs); the local recipe already ran it in `default` before this PR, so that pre-existing local/CI shell mismatch is unchanged by this PR and out of scope for #1270.
