### PR TITLE
refactor: add test coverage for ScanError Lookup/Physical/Sqlx variants (#1263)

### DIFF
--- a/db/src/scan/tests.rs
+++ b/db/src/scan/tests.rs
@@ -9,9 +9,9 @@ use omnibus_shared::physical::WishlistSource;
 use omnibus_shared::scan::ScanOutcome;
 
 use super::*;
-use crate::metadata_lookup::MetadataLookupConfig;
+use crate::metadata_lookup::{MetadataLookupConfig, MetadataLookupError};
 use crate::normalize::{normalize_author, normalize_title};
-use crate::physical::{add_physical_copy, list_physical_copies, list_wishlist};
+use crate::physical::{add_physical_copy, list_physical_copies, list_wishlist, PhysicalError};
 use serde_json::json;
 use std::time::Duration;
 use wiremock::matchers::{method, path};
@@ -113,6 +113,16 @@ async fn mount_ol_hit(server: &MockServer, title: &str, author: &str) {
                 "authors": [{ "name": author }],
             }
         })))
+        .mount(server)
+        .await;
+}
+
+/// Mount Open Library to cleanly miss, leaving Google Books unmounted so the
+/// caller can wire its own (error) response.
+async fn mount_ol_miss(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/api/books"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .mount(server)
         .await;
 }
@@ -408,4 +418,56 @@ async fn wishlist_add_errors_without_target() {
         .await
         .unwrap_err();
     assert!(matches!(err, ScanError::MissingWishlistTarget));
+}
+
+// ── remaining ScanError variants (#1263) ───────────────────────────
+
+#[tokio::test]
+async fn resolve_scan_surfaces_lookup_error_when_both_providers_fail() {
+    let pool = pool().await;
+    let server = MockServer::start().await;
+    mount_ol_miss(&server).await;
+    // A non-retryable Google Books status fails the fallback immediately,
+    // rather than a clean miss — the real code path behind ScanError::Lookup.
+    Mock::given(method("GET"))
+        .and(path("/books/v1/volumes"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let err = resolve_scan(&pool, ISBN, &config_for(&server))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, ScanError::Lookup(MetadataLookupError::Provider(_))),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn wishlist_add_surfaces_physical_error_when_book_uuid_is_unresolvable() {
+    let pool = pool().await;
+    let user = seed_user(&pool, "reader").await;
+
+    // No book carries this uuid, so add_wishlist_entry's canonical-uuid
+    // resolution fails — the real code path behind ScanError::Physical.
+    let err = wishlist_add(&pool, user, Some("nope"), None, WishlistSource::Manual)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, ScanError::Physical(PhysicalError::BookNotFound)),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_scan_surfaces_sqlx_error_when_pool_is_closed() {
+    let pool = pool().await;
+    pool.close().await;
+    let server = MockServer::start().await; // must not be hit — the exact rung fails first
+
+    let err = resolve_scan(&pool, ISBN, &config_for(&server))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, ScanError::Sqlx(_)), "got {err:?}");
 }


### PR DESCRIPTION
## Summary
- Closes #1263
- `db::scan::resolve::ScanError` has 5 variants; only `Isbn` and `MissingWishlistTarget` had dedicated tests. Added one test per remaining variant (`Lookup`, `Physical`, `Sqlx`), each exercising the real failure path rather than constructing the enum value directly:
  - `resolve_scan_surfaces_lookup_error_when_both_providers_fail` — Open Library cleanly misses, Google Books answers with a non-retryable 404, surfacing `MetadataLookupError::Provider` through `ScanError::Lookup`.
  - `wishlist_add_surfaces_physical_error_when_book_uuid_is_unresolvable` — `wishlist_add` called with a `book_uuid` that resolves to no book, surfacing `PhysicalError::BookNotFound` through `ScanError::Physical`.
  - `resolve_scan_surfaces_sqlx_error_when_pool_is_closed` — `resolve_scan` against a closed pool, surfacing a raw `sqlx::Error` through `ScanError::Sqlx` (mirrors the closed-pool pattern used throughout `db/src/**/tests.rs`, e.g. `book_file_paths_propagates_db_error_when_pool_is_closed`).

## Test plan
- [x] `cargo fmt -p omnibus-db --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db scan::` — PASS (23/23, including the 3 new tests)
- [x] `cargo test -p omnibus-db` (full crate) — 1172 passed, 1 failed. The one failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing, unrelated failure: it needs the `test_data/` audiobook fixtures via `just fixtures`, which requires `nix` — unavailable in this environment. Not touched by this change.

## Notes
- New tests are fully synthetic (in-memory pool + `wiremock`), matching the existing style in `db/src/scan/tests.rs` — no dependency on `test_data/` fixtures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaE5NJTCCBMVqXmi4SkLAd)_