### PR TITLE
fix: isolate HARDCOVER_API_KEY in summary REST tests

### DIFF
--- a/.claude/rules/03-unit-testing.md
+++ b/.claude/rules/03-unit-testing.md
@@ -27,13 +27,20 @@ All tests use `sqlite::memory:` for isolation — never the on-disk DB.
 
 ## Shared helpers
 
-Every crate has a `test_support` module
-(`<crate>/src/test_support.rs`, gated
-`#[cfg(any(test, feature = "test-support"))]`) for cross-cutting
-helpers: in-memory pool init, seed factories, fixture builders. No
-duplicated `make_test_dir()` / `seed_minimal_books()` across files.
+Cross-cutting helpers — in-memory pool init, seed factories, fixture
+builders — live in a `test_support` module, never duplicated across
+files (no per-file `make_test_dir()` / `seed_minimal_books()`). Put it
+at the scope its helpers serve:
 
-Another crate reuses these by depending on it with the feature on —
+- **Crate-wide** → `<crate>/src/test_support.rs`, gated
+  `#[cfg(any(test, feature = "test-support"))]`, as in
+  [db/src/test_support.rs](../../db/src/test_support.rs). Only this
+  shape is reusable from another crate.
+- **One module tree** → a sibling `test_support.rs` next to the code
+  it serves, e.g. `server/src/backend/test_support.rs` (REST fixtures)
+  and `server/src/auth/test_support.rs` (user + token factories).
+
+To reuse a crate-wide one elsewhere, depend on it with the feature on —
 `omnibus-db = { path = "../db", features = ["test-support"] }` under
 `[dev-dependencies]`, which cargo unifies into test builds only.
 

--- a/.claude/rules/03-unit-testing.md
+++ b/.claude/rules/03-unit-testing.md
@@ -33,6 +33,21 @@ Every crate has a `test_support` module
 helpers: in-memory pool init, seed factories, fixture builders. No
 duplicated `make_test_dir()` / `seed_minimal_books()` across files.
 
+Another crate reuses these by depending on it with the feature on —
+`omnibus-db = { path = "../db", features = ["test-support"] }` under
+`[dev-dependencies]`, which cargo unifies into test builds only.
+
+## No ambient environment
+
+A test must never depend on an env var it didn't set. Every var with an
+`effective_*` / seeds-if-unset fallback (`HARDCOVER_API_KEY`, `SMTP_*`,
+`EBOOK_LIBRARY_PATH`, …) is set in a developer's gitignored `.env` and
+absent in CI, so a test that assumes "unset" passes in CI and fails
+locally. Pin it with `EnvVarGuard` from `omnibus_db::test_support` —
+`EnvVarGuard::set("HARDCOVER_API_KEY", None)` removes the var for the
+test and restores it on drop, under a process-wide lock. Never
+hand-roll a set/restore guard.
+
 ## Coverage expectations
 
 - **Every `pub` fn:** one happy-path test, plus one test per

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -57,6 +57,10 @@ omnibus-db = { path = "../db", optional = true }
 
 [dev-dependencies]
 tower = "0.5"
+# Test-only view of the same db crate, with `test-support` on so integration
+# tests can reuse `EnvVarGuard` instead of hand-rolling env isolation. Cargo
+# unifies this with the optional `omnibus-db` above for test builds only.
+omnibus-db = { path = "../db", features = ["test-support"] }
 # RAII temp directories so panicking integration tests don't leak fixture
 # copies under /tmp. Already a transitive dep elsewhere — explicit here only
 # for the backend integration tests.

--- a/server/src/backend/summary/tests.rs
+++ b/server/src/backend/summary/tests.rs
@@ -4,6 +4,7 @@ use axum::{
     body::{to_bytes, Body},
     http::{header::AUTHORIZATION, Request, StatusCode},
 };
+use omnibus_db::test_support::EnvVarGuard;
 use tower::ServiceExt;
 
 use crate::auth::test_support as auth_test_support;
@@ -66,7 +67,10 @@ async fn api_post_summary_fetch_requires_edit_permission() {
 async fn api_post_summary_fetch_returns_null_when_hardcover_key_is_unset() {
     // With no Hardcover key configured, `db::fetch_summary` short-circuits to
     // `Ok(None)` before making any network call — safe to exercise here
-    // without a wiremock server (that path is covered at the db layer).
+    // without a wiremock server (that path is covered at the db layer). The
+    // guard removes an ambient `HARDCOVER_API_KEY` (a developer's `.env`)
+    // that would otherwise send this test out to the real Hardcover API.
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
     let (app, _state, pool) = fixture().await;
     let (_id, uuid) = seed_book_with_uuid(&pool, "/lib", "Original").await;
     let admin = auth_test_support::create_admin(&pool, "admin").await;
@@ -86,6 +90,9 @@ async fn api_post_summary_fetch_returns_null_when_hardcover_key_is_unset() {
 
 #[tokio::test]
 async fn api_hardcover_configured_reflects_saved_key_for_any_authenticated_user() {
+    // `hardcover_key_status` falls back to `HARDCOVER_API_KEY`, so the
+    // pre-save "false" assertion below only holds with the var removed.
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None);
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "reader").await;
     let token = auth_test_support::bearer_token(&pool, user.id).await;


### PR DESCRIPTION
## Summary
- Two tests in `server/src/backend/summary/tests.rs` assumed `HARDCOVER_API_KEY` was unset. Since `effective_hardcover_api_key` / `hardcover_key_status` fall back to that env var, both failed for any developer whose gitignored `.env` sets it — and passed in CI only because CI has no `.env`.
- Both now pin the var with `EnvVarGuard` from `omnibus_db::test_support`, which required adding a `test-support`-enabled dev-dependency on `omnibus-db` to the server crate (cargo unifies it into test builds only, so `cargo build` is unaffected).
- `api_post_summary_fetch_returns_null_when_hardcover_key_is_unset` was the more dangerous of the two: with an ambient key, `db::fetch_summary` stops short-circuiting and the test makes a real network call to the Hardcover API.
- Audited the neighbours — the suggestions tests already defend by writing a settings key (settings wins over env), and no server test asserts an unconfigured SMTP default, since the Kindle-email gate in `post_send` fires before the SMTP check. The db-layer Hardcover/SMTP tests already use `EnvVarGuard`.

## Test plan
- [x] `HARDCOVER_API_KEY=hc_dummy cargo test -p omnibus --lib summary` — 5 passed (the reported failure)
- [x] Same, with the var unset — 5 passed
- [x] `cargo test -p omnibus` with `HARDCOVER_API_KEY` + `SMTP_HOST` + `SMTP_FROM_EMAIL` all set — 374 passed, confirming no remaining latent env dependency
- [x] `cargo test -p omnibus-db` with the same vars set — 1143 passed
- [x] `cargo fmt --check` + `cargo clippy -p omnibus --all-targets -D warnings` — clean

## Version
- [x] **No release** — test code, a dev-dependency, and a rules doc; no production behavior changes.

## Notes
- Added a "No ambient environment" section to `.claude/rules/03-unit-testing.md`. This failure mode (green in CI, red locally) will recur for every `effective_*` / seeds-if-unset variable, so the rule names `EnvVarGuard` as the one sanctioned tool and bans hand-rolled set/restore guards.