### PR TITLE
refactor: add missing row LIMIT to list_wishlist (#1259)

### DIFF
--- a/db/src/physical/mod.rs
+++ b/db/src/physical/mod.rs
@@ -16,7 +16,7 @@ mod tests;
 
 pub use copies::{add_physical_copy, delete_physical_copy, list_physical_copies};
 pub use fileless::{create_fileless_book, FilelessBook, FilelessCover};
-pub use wishlist::{add_wishlist_entry, list_wishlist, remove_wishlist_entry};
+pub use wishlist::{add_wishlist_entry, list_wishlist, remove_wishlist_entry, LIST_WISHLIST_LIMIT};
 
 /// Errors from the physical ownership data layer.
 #[derive(Debug, thiserror::Error)]

--- a/db/src/physical/tests.rs
+++ b/db/src/physical/tests.rs
@@ -200,6 +200,43 @@ async fn remove_wishlist_entry_deletes_and_is_a_noop_when_absent() {
     remove_wishlist_entry(&pool, user, "uuid-1").await.unwrap();
 }
 
+/// Raw bulk insert bypassing `add_wishlist_entry` — the CRUD helper resolves
+/// the book uuid on every call, too slow for a 1500-row response-cap
+/// fixture. `wishlist_entries` uniques on `(user_id, book_uuid)`, so each
+/// row needs a distinct synthetic uuid; the soft-reference (no FK) means
+/// these need not resolve to real `books` rows for this query-shape test.
+async fn seed_wishlist_raw(pool: &SqlitePool, user_id: i64, count: i64) {
+    sqlx::query(
+        r"
+        WITH RECURSIVE n(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
+        )
+        INSERT INTO wishlist_entries (user_id, book_uuid, added_at, source)
+        SELECT ?, 'seed-uuid-' || i, i, 'manual' FROM n
+        ",
+    )
+    .bind(count)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn list_wishlist_caps_response_at_hard_limit() {
+    let pool = pool().await;
+    let user = seed_user(&pool, "alice").await;
+    let over_cap = LIST_WISHLIST_LIMIT + 500;
+    seed_wishlist_raw(&pool, user, over_cap).await;
+
+    let list = list_wishlist(&pool, user).await.unwrap();
+    assert_eq!(
+        list.len() as i64,
+        LIST_WISHLIST_LIMIT,
+        "list_wishlist must not return more than LIST_WISHLIST_LIMIT rows",
+    );
+}
+
 #[tokio::test]
 async fn list_wishlist_is_scoped_per_user() {
     let pool = pool().await;

--- a/db/src/physical/wishlist.rs
+++ b/db/src/physical/wishlist.rs
@@ -9,6 +9,12 @@ use omnibus_shared::physical::{WishlistEntry, WishlistSource};
 use super::PhysicalError;
 use crate::books::resolve_canonical_book_uuid;
 
+/// Hard cap on how many entries `list_wishlist` returns for a single user.
+/// Practical usage stays well under this; the cap exists so a pathological
+/// or automated wishlist pipeline can't produce an unbounded REST response,
+/// mirroring `bookmarks::LIST_BOOKMARKS_LIMIT`.
+pub const LIST_WISHLIST_LIMIT: i64 = 1_000;
+
 /// A `wishlist_entries` row as read back from the DB, in column order.
 type WishlistRow = (i64, i64, String, i64, String);
 
@@ -81,7 +87,7 @@ pub async fn remove_wishlist_entry(
     Ok(())
 }
 
-/// List a user's wishlist, newest first.
+/// List a user's wishlist, newest first, capped at [`LIST_WISHLIST_LIMIT`].
 pub async fn list_wishlist(
     pool: &SqlitePool,
     user_id: i64,
@@ -90,9 +96,11 @@ pub async fn list_wishlist(
         "SELECT id, user_id, book_uuid, added_at, source
            FROM wishlist_entries
           WHERE user_id = ?1
-          ORDER BY added_at DESC, id DESC",
+          ORDER BY added_at DESC, id DESC
+          LIMIT ?2",
     )
     .bind(user_id)
+    .bind(LIST_WISHLIST_LIMIT)
     .fetch_all(pool)
     .await?;
     Ok(rows.into_iter().map(map_entry).collect())


### PR DESCRIPTION
## Summary
- Closes #1259
- `list_wishlist` had no `LIMIT` clause, unlike every sibling per-user list function (`list_bookmarks`, `list_highlights`, `list_journal_entries`, `list_other_ratings`), which all cap at 1,000 rows.
- Added `LIST_WISHLIST_LIMIT: i64 = 1_000` in `db/src/physical/wishlist.rs`, mirroring the exact convention (doc comment, `LIMIT ?N` bound as the final parameter, `ORDER BY ... LIMIT` clause ordering) used by `LIST_BOOKMARKS_LIMIT` / `LIST_HIGHLIGHTS_LIMIT` / `LIST_JOURNAL_ENTRIES_LIMIT` / `LIST_OTHER_RATINGS_LIMIT`.
- Re-exported the constant from `db/src/physical/mod.rs` alongside the existing `wishlist::*` re-exports so it's reachable from the sibling test module.

## Test plan
- [x] `cargo fmt -p omnibus-db --check` — PASS (no diff)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test -p omnibus-db wishlist` — PASS (13/13, including new `list_wishlist_caps_response_at_hard_limit`, which raw-seeds 1,500 wishlist rows for one user via a recursive CTE — mirroring `seed_bookmarks_raw` — and asserts `list_wishlist` returns exactly `LIST_WISHLIST_LIMIT` rows)
- [x] `cargo test -p omnibus-db` — 1170/1171 passed; the one failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing, unrelated missing-fixture panic (`run \`just fixtures\``) in this sandboxed environment where `just`/`nix` aren't available — not caused by this change.

## Notes
- No schema change: `wishlist_entries` already has `UNIQUE(user_id, book_uuid)`, so the test's raw seed helper uses distinct synthetic `book_uuid` values per row (soft-referenced, no FK, so they need not resolve to real `books` rows for this query-shape test).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaE5NJTCCBMVqXmi4SkLAd)_