### PR TITLE
fix: eliminate hydration trap in reader prefs (#1255)

### DIFF
--- a/frontend/src/pages/reader/prefs.rs
+++ b/frontend/src/pages/reader/prefs.rs
@@ -152,20 +152,53 @@ impl ReaderPrefs {
     }
 }
 
-/// Construct the reader-prefs signals, seeding each from localStorage on
-/// web (with a target-agnostic default fallback). Mobile seeds the same
-/// defaults here and overwrites them asynchronously once
-/// `mobile::prefs_storage::load_and_apply_reader_prefs` resolves the
-/// WebView's `localStorage` (see that function's doc for the first-paint
-/// timing tradeoff). `theme` is borrowed from the app-wide atrium signal so
-/// changes here flip both reader and the surrounding chrome.
+/// Construct the reader-prefs signals.
+///
+/// SSR-safe by construction: every signal starts at the same
+/// target-agnostic default on every target (server, web, mobile) so the
+/// first paint matches on every target — no hydration mismatch. A
+/// target-agnostic `use_effect` then reads any persisted `localStorage`
+/// values back in (web only; a no-op everywhere else) after the component
+/// mounts and updates the signals that have a saved preference, triggering
+/// a single re-render to apply it. Mobile overwrites the same defaults
+/// asynchronously once `mobile::prefs_storage::load_and_apply_reader_prefs`
+/// resolves the WebView's `localStorage` (see that function's doc for the
+/// first-paint timing tradeoff). Mirrors the `init_theme` hydration pattern
+/// in `frontend/src/components/atrium.rs`. `theme` is borrowed from the
+/// app-wide atrium signal so changes here flip both reader and the
+/// surrounding chrome.
 pub(crate) fn init_reader_prefs(theme: Signal<Theme>) -> ReaderPrefs {
-    let font_size = use_signal(load_font_size_or_default);
-    let typeface = use_signal(load_typeface_or_default);
-    let line_spacing = use_signal(load_line_spacing_or_default);
-    let margins = use_signal(load_margins_or_default);
-    let justify = use_signal(load_justify_or_default);
-    let spread = use_signal(load_spread_or_default);
+    let font_size = use_signal(default_font_size);
+    let typeface = use_signal(default_typeface);
+    let line_spacing = use_signal(default_line_spacing);
+    let margins = use_signal(default_margins);
+    let justify = use_signal(default_justify);
+    let spread = use_signal(default_spread);
+
+    use_effect(move || {
+        #[cfg(feature = "web")]
+        {
+            if let Some(v) = load_persisted_font_size() {
+                font_size.set(v);
+            }
+            if let Some(v) = load_persisted_typeface() {
+                typeface.set(v);
+            }
+            if let Some(v) = load_persisted_line_spacing() {
+                line_spacing.set(v);
+            }
+            if let Some(v) = load_persisted_margins() {
+                margins.set(v);
+            }
+            if let Some(v) = load_persisted_justify() {
+                justify.set(v);
+            }
+            if let Some(v) = load_persisted_spread() {
+                spread.set(v);
+            }
+        }
+    });
+
     ReaderPrefs {
         theme,
         font_size,
@@ -177,100 +210,62 @@ pub(crate) fn init_reader_prefs(theme: Signal<Theme>) -> ReaderPrefs {
     }
 }
 
-fn load_font_size_or_default() -> i32 {
-    #[cfg(feature = "web")]
-    {
-        super::typography::load_reader_pref("omn.fontSize")
-            .and_then(|s| s.parse::<i32>().ok())
-            .map(|n| n.clamp(FONT_SIZE_MIN, FONT_SIZE_MAX))
-            .unwrap_or(18)
-    }
-    #[cfg(not(feature = "web"))]
+fn default_font_size() -> i32 {
     18
 }
 
-fn load_typeface_or_default() -> Typeface {
-    #[cfg(feature = "web")]
-    {
-        super::typography::load_reader_pref("omn.typeface")
-            .and_then(|s| Typeface::from_storage(&s))
-            .unwrap_or(Typeface::Editorial)
-    }
-    #[cfg(not(feature = "web"))]
+#[cfg(feature = "web")]
+fn load_persisted_font_size() -> Option<i32> {
+    super::typography::load_reader_pref("omn.fontSize")
+        .and_then(|s| s.parse::<i32>().ok())
+        .map(|n| n.clamp(FONT_SIZE_MIN, FONT_SIZE_MAX))
+}
+
+fn default_typeface() -> Typeface {
     Typeface::Editorial
 }
 
-fn load_line_spacing_or_default() -> LineSpacing {
-    #[cfg(feature = "web")]
-    {
-        super::typography::load_reader_pref("omn.lineSpacing")
-            .and_then(|s| LineSpacing::from_storage(&s))
-            .unwrap_or(LineSpacing::Cozy)
-    }
-    #[cfg(not(feature = "web"))]
+#[cfg(feature = "web")]
+fn load_persisted_typeface() -> Option<Typeface> {
+    super::typography::load_reader_pref("omn.typeface").and_then(|s| Typeface::from_storage(&s))
+}
+
+fn default_line_spacing() -> LineSpacing {
     LineSpacing::Cozy
 }
 
-fn load_margins_or_default() -> Margins {
-    #[cfg(feature = "web")]
-    {
-        super::typography::load_reader_pref("omn.margins")
-            .and_then(|s| Margins::from_storage(&s))
-            .unwrap_or(Margins::Normal)
-    }
-    #[cfg(not(feature = "web"))]
+#[cfg(feature = "web")]
+fn load_persisted_line_spacing() -> Option<LineSpacing> {
+    super::typography::load_reader_pref("omn.lineSpacing")
+        .and_then(|s| LineSpacing::from_storage(&s))
+}
+
+fn default_margins() -> Margins {
     Margins::Normal
 }
 
-fn load_justify_or_default() -> bool {
-    #[cfg(feature = "web")]
-    {
-        super::typography::load_reader_pref("omn.justify").as_deref() == Some("true")
-    }
-    #[cfg(not(feature = "web"))]
+#[cfg(feature = "web")]
+fn load_persisted_margins() -> Option<Margins> {
+    super::typography::load_reader_pref("omn.margins").and_then(|s| Margins::from_storage(&s))
+}
+
+fn default_justify() -> bool {
     false
 }
 
-fn load_spread_or_default() -> Spread {
-    #[cfg(feature = "web")]
-    {
-        super::typography::load_reader_pref("omn.spread")
-            .and_then(|s| Spread::from_storage(&s))
-            .unwrap_or(Spread::Double)
-    }
-    #[cfg(not(feature = "web"))]
+#[cfg(feature = "web")]
+fn load_persisted_justify() -> Option<bool> {
+    super::typography::load_reader_pref("omn.justify").map(|s| s == "true")
+}
+
+fn default_spread() -> Spread {
     Spread::Double
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // `Signal::new` needs a Dioxus runtime, so this runs inside a `VirtualDom` (see `contexts::tests`).
-    #[test]
-    fn font_pct_maps_font_size_bounds_and_midpoint_to_expected_percentage() {
-        #[component]
-        fn AssertFontPct() -> Element {
-            let prefs = ReaderPrefs {
-                theme: Signal::new(Theme::Dark),
-                font_size: Signal::new(FONT_SIZE_MIN),
-                typeface: Signal::new(Typeface::Editorial),
-                line_spacing: Signal::new(LineSpacing::Cozy),
-                margins: Signal::new(Margins::Normal),
-                justify: Signal::new(false),
-                spread: Signal::new(Spread::Single),
-            };
-            assert_eq!(prefs.font_pct(), 0.0, "min font size maps to 0%");
-
-            let mut font_size = prefs.font_size;
-            font_size.set(FONT_SIZE_MAX);
-            assert_eq!(prefs.font_pct(), 100.0, "max font size maps to 100%");
-
-            font_size.set((FONT_SIZE_MIN + FONT_SIZE_MAX) / 2);
-            assert_eq!(prefs.font_pct(), 50.0, "midpoint font size maps to 50%");
-
-            rsx! {}
-        }
-        VirtualDom::new(AssertFontPct).rebuild_in_place();
-    }
+#[cfg(feature = "web")]
+fn load_persisted_spread() -> Option<Spread> {
+    super::typography::load_reader_pref("omn.spread").and_then(|s| Spread::from_storage(&s))
 }
+
+#[cfg(test)]
+mod tests;

--- a/frontend/src/pages/reader/prefs.rs
+++ b/frontend/src/pages/reader/prefs.rs
@@ -168,34 +168,36 @@ impl ReaderPrefs {
 /// app-wide atrium signal so changes here flip both reader and the
 /// surrounding chrome.
 pub(crate) fn init_reader_prefs(theme: Signal<Theme>) -> ReaderPrefs {
-    let font_size = use_signal(default_font_size);
-    let typeface = use_signal(default_typeface);
-    let line_spacing = use_signal(default_line_spacing);
-    let margins = use_signal(default_margins);
-    let justify = use_signal(default_justify);
-    let spread = use_signal(default_spread);
+    let mut font_size = use_signal(default_font_size);
+    let mut typeface = use_signal(default_typeface);
+    let mut line_spacing = use_signal(default_line_spacing);
+    let mut margins = use_signal(default_margins);
+    let mut justify = use_signal(default_justify);
+    let mut spread = use_signal(default_spread);
 
+    // Unconditional (not `#[cfg(feature = "web")]`-gated): `load_persisted_*`
+    // itself carries the cfg and returns `None` on every non-web target, so
+    // these `.set()` calls compile — and stay real no-ops — on every target.
+    // Gating the block instead would make each `mut` binding unused (and
+    // clippy `-D warnings` deny it) whenever `web` is off.
     use_effect(move || {
-        #[cfg(feature = "web")]
-        {
-            if let Some(v) = load_persisted_font_size() {
-                font_size.set(v);
-            }
-            if let Some(v) = load_persisted_typeface() {
-                typeface.set(v);
-            }
-            if let Some(v) = load_persisted_line_spacing() {
-                line_spacing.set(v);
-            }
-            if let Some(v) = load_persisted_margins() {
-                margins.set(v);
-            }
-            if let Some(v) = load_persisted_justify() {
-                justify.set(v);
-            }
-            if let Some(v) = load_persisted_spread() {
-                spread.set(v);
-            }
+        if let Some(v) = load_persisted_font_size() {
+            font_size.set(v);
+        }
+        if let Some(v) = load_persisted_typeface() {
+            typeface.set(v);
+        }
+        if let Some(v) = load_persisted_line_spacing() {
+            line_spacing.set(v);
+        }
+        if let Some(v) = load_persisted_margins() {
+            margins.set(v);
+        }
+        if let Some(v) = load_persisted_justify() {
+            justify.set(v);
+        }
+        if let Some(v) = load_persisted_spread() {
+            spread.set(v);
         }
     });
 
@@ -221,6 +223,11 @@ fn load_persisted_font_size() -> Option<i32> {
         .map(|n| n.clamp(FONT_SIZE_MIN, FONT_SIZE_MAX))
 }
 
+#[cfg(not(feature = "web"))]
+fn load_persisted_font_size() -> Option<i32> {
+    None
+}
+
 fn default_typeface() -> Typeface {
     Typeface::Editorial
 }
@@ -228,6 +235,11 @@ fn default_typeface() -> Typeface {
 #[cfg(feature = "web")]
 fn load_persisted_typeface() -> Option<Typeface> {
     super::typography::load_reader_pref("omn.typeface").and_then(|s| Typeface::from_storage(&s))
+}
+
+#[cfg(not(feature = "web"))]
+fn load_persisted_typeface() -> Option<Typeface> {
+    None
 }
 
 fn default_line_spacing() -> LineSpacing {
@@ -240,6 +252,11 @@ fn load_persisted_line_spacing() -> Option<LineSpacing> {
         .and_then(|s| LineSpacing::from_storage(&s))
 }
 
+#[cfg(not(feature = "web"))]
+fn load_persisted_line_spacing() -> Option<LineSpacing> {
+    None
+}
+
 fn default_margins() -> Margins {
     Margins::Normal
 }
@@ -247,6 +264,11 @@ fn default_margins() -> Margins {
 #[cfg(feature = "web")]
 fn load_persisted_margins() -> Option<Margins> {
     super::typography::load_reader_pref("omn.margins").and_then(|s| Margins::from_storage(&s))
+}
+
+#[cfg(not(feature = "web"))]
+fn load_persisted_margins() -> Option<Margins> {
+    None
 }
 
 fn default_justify() -> bool {
@@ -258,6 +280,11 @@ fn load_persisted_justify() -> Option<bool> {
     super::typography::load_reader_pref("omn.justify").map(|s| s == "true")
 }
 
+#[cfg(not(feature = "web"))]
+fn load_persisted_justify() -> Option<bool> {
+    None
+}
+
 fn default_spread() -> Spread {
     Spread::Double
 }
@@ -265,6 +292,11 @@ fn default_spread() -> Spread {
 #[cfg(feature = "web")]
 fn load_persisted_spread() -> Option<Spread> {
     super::typography::load_reader_pref("omn.spread").and_then(|s| Spread::from_storage(&s))
+}
+
+#[cfg(not(feature = "web"))]
+fn load_persisted_spread() -> Option<Spread> {
+    None
 }
 
 #[cfg(test)]

--- a/frontend/src/pages/reader/prefs/tests.rs
+++ b/frontend/src/pages/reader/prefs/tests.rs
@@ -1,0 +1,65 @@
+//! Pins the target-agnostic defaults each `default_*` function feeds into
+//! `init_reader_prefs`'s `use_signal` initializers. These run unconditionally
+//! on every target (server/web/mobile) — the hydration-safety invariant from
+//! `.claude/rules/07-hydration.md` — so a drift here would produce a first-paint
+//! mismatch between SSR and the web client.
+
+use super::*;
+
+#[test]
+fn default_font_size_matches_the_documented_starting_size() {
+    assert_eq!(default_font_size(), 18);
+}
+
+#[test]
+fn default_typeface_matches_the_documented_starting_typeface() {
+    assert_eq!(default_typeface(), Typeface::Editorial);
+}
+
+#[test]
+fn default_line_spacing_matches_the_documented_starting_spacing() {
+    assert_eq!(default_line_spacing(), LineSpacing::Cozy);
+}
+
+#[test]
+fn default_margins_matches_the_documented_starting_margins() {
+    assert_eq!(default_margins(), Margins::Normal);
+}
+
+#[test]
+fn default_justify_is_off_by_default() {
+    assert!(!default_justify());
+}
+
+#[test]
+fn default_spread_matches_the_documented_starting_spread() {
+    assert_eq!(default_spread(), Spread::Double);
+}
+
+// `Signal::new` needs a Dioxus runtime, so this runs inside a `VirtualDom` (see `contexts::tests`).
+#[test]
+fn font_pct_maps_font_size_bounds_and_midpoint_to_expected_percentage() {
+    #[component]
+    fn AssertFontPct() -> Element {
+        let prefs = ReaderPrefs {
+            theme: Signal::new(Theme::Dark),
+            font_size: Signal::new(FONT_SIZE_MIN),
+            typeface: Signal::new(Typeface::Editorial),
+            line_spacing: Signal::new(LineSpacing::Cozy),
+            margins: Signal::new(Margins::Normal),
+            justify: Signal::new(false),
+            spread: Signal::new(Spread::Single),
+        };
+        assert_eq!(prefs.font_pct(), 0.0, "min font size maps to 0%");
+
+        let mut font_size = prefs.font_size;
+        font_size.set(FONT_SIZE_MAX);
+        assert_eq!(prefs.font_pct(), 100.0, "max font size maps to 100%");
+
+        font_size.set((FONT_SIZE_MIN + FONT_SIZE_MAX) / 2);
+        assert_eq!(prefs.font_pct(), 50.0, "midpoint font size maps to 50%");
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertFontPct).rebuild_in_place();
+}


### PR DESCRIPTION
## Summary
- Closes #1255
- `frontend/src/pages/reader/prefs.rs`'s six `load_*_or_default` functions branched `#[cfg(feature = "web")] { load from localStorage } #[cfg(not(feature = "web"))] { default }` as synchronous `use_signal` initializers in `init_reader_prefs` — structurally identical to the hydration-mismatch anti-pattern documented in `.claude/rules/07-hydration.md` ("state that differs SSR vs client at first paint"). Not an active bug today (the only consumer, `ReaderAaPanel`, is gated behind `show_aa()`, which itself seeds identically on every target), but a latent trap for the next caller that isn't gated.
- Each signal now seeds with the same target-agnostic default on every target (`default_font_size`, `default_typeface`, `default_line_spacing`, `default_margins`, `default_justify`, `default_spread`), and a single post-mount `use_effect` reconciles from `localStorage` on web only — mirroring the `init_theme` fix in `frontend/src/components/atrium.rs` (cited by the rule as the worked example alongside `frontend/src/view_prefs.rs`).
- No behavior change for `ReaderAaPanel`, the current only consumer.

## Test plan
- [x] `cargo fmt --check -p omnibus-frontend` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (395 passed, 0 failed), including 6 new tests in `frontend/src/pages/reader/prefs/tests.rs` pinning each `default_*` function's target-agnostic value

## Version
- [ ] Minor
- [x] Patch
- [ ] No release

## Notes
- Low-severity latent-risk fix per the issue; no observable behavior change today since the only consumer is already gated behind `show_aa()`.
- Stayed surgical: only `frontend/src/pages/reader/prefs.rs` changed, plus the new sibling `frontend/src/pages/reader/prefs/tests.rs`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn1xVgx2J7pBHCdgJ2Axen)_