### PR TITLE
fix: reserve gutter so page-turn arrows never overlap reader prose (#1236)

### DIFF
--- a/frontend/src/pages/reader/typography.rs
+++ b/frontend/src/pages/reader/typography.rs
@@ -86,13 +86,7 @@ pub(crate) enum Margins {
 
 #[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
 impl Margins {
-    /// A plain percentage lets `Narrow` reach edge-to-edge on a mid-width
-    /// desktop viewport, sliding the prose column under the `.rd-turn`
-    /// page-turn buttons (`left`/`right: 22px`, 48px wide, in
-    /// `atrium.css`). `min(pct, calc(100% - 172px))` caps the column so it
-    /// can never leave less than 86px clear on either side — comfortably
-    /// past the button's 70px reach — regardless of viewport width or which
-    /// margin preset is active (#1236).
+    /// The column's max-width, clamped to keep it clear of the `.rd-turn` buttons.
     pub(crate) fn to_css(self) -> &'static str {
         match self {
             Self::Narrow => "min(95%, calc(100% - 172px))",
@@ -207,13 +201,12 @@ mod tests {
 
     #[test]
     fn margins_to_css_reserves_a_fixed_gutter_for_every_variant() {
-        // Regression guard for #1236: every preset must keep the `calc(100%
-        // - 172px)` clamp so the reading column can never slide under the
-        // `.rd-turn` page-turn buttons, no matter how wide its own percentage
-        // allowance is.
-        for variant in [Margins::Narrow, Margins::Normal, Margins::Wide] {
-            assert!(variant.to_css().contains("calc(100% - 172px)"));
-        }
+        // Regression guard for #1236: pins the exact clamped value per
+        // variant so a regressed percentage (not just a dropped clamp)
+        // fails here too.
+        assert_eq!(Margins::Narrow.to_css(), "min(95%, calc(100% - 172px))");
+        assert_eq!(Margins::Normal.to_css(), "min(80%, calc(100% - 172px))");
+        assert_eq!(Margins::Wide.to_css(), "min(65%, calc(100% - 172px))");
     }
 
     #[test]

--- a/frontend/src/pages/reader/typography.rs
+++ b/frontend/src/pages/reader/typography.rs
@@ -86,11 +86,18 @@ pub(crate) enum Margins {
 
 #[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
 impl Margins {
+    /// A plain percentage lets `Narrow` reach edge-to-edge on a mid-width
+    /// desktop viewport, sliding the prose column under the `.rd-turn`
+    /// page-turn buttons (`left`/`right: 22px`, 48px wide, in
+    /// `atrium.css`). `min(pct, calc(100% - 172px))` caps the column so it
+    /// can never leave less than 86px clear on either side — comfortably
+    /// past the button's 70px reach — regardless of viewport width or which
+    /// margin preset is active (#1236).
     pub(crate) fn to_css(self) -> &'static str {
         match self {
-            Self::Narrow => "95%",
-            Self::Normal => "80%",
-            Self::Wide => "65%",
+            Self::Narrow => "min(95%, calc(100% - 172px))",
+            Self::Normal => "min(80%, calc(100% - 172px))",
+            Self::Wide => "min(65%, calc(100% - 172px))",
         }
     }
 
@@ -195,6 +202,17 @@ mod tests {
     fn margins_round_trips_through_storage_for_every_variant() {
         for variant in [Margins::Narrow, Margins::Normal, Margins::Wide] {
             assert_eq!(Margins::from_storage(variant.to_storage()), Some(variant));
+        }
+    }
+
+    #[test]
+    fn margins_to_css_reserves_a_fixed_gutter_for_every_variant() {
+        // Regression guard for #1236: every preset must keep the `calc(100%
+        // - 172px)` clamp so the reading column can never slide under the
+        // `.rd-turn` page-turn buttons, no matter how wide its own percentage
+        // allowance is.
+        for variant in [Margins::Narrow, Margins::Normal, Margins::Wide] {
+            assert!(variant.to_css().contains("calc(100% - 172px)"));
         }
     }
 


### PR DESCRIPTION
## Summary
- Closes #1236
- The web EPUB reader's `.rd-turn` page-turn buttons (`atrium.css`: `left`/`right: 22px`, 48px wide) are positioned in the same coordinate space as the reading column (`.rd-viewer`/`.rd-stage` are edge-to-edge, and `.rd-turn` is a sibling of the stage inside the same `position: relative` `.rd-surface`). The reading column's width, however, was a plain percentage (`Margins::to_css()` in `frontend/src/pages/reader/typography.rs`: Narrow 95% / Normal 80% / Wide 65%) applied by `setMargins` in `epub-reader-glue.js` as an inline `max-width` on the epub.js section body — so at mid-width desktop viewports (particularly with the Narrow preset) the column could reach right up to the viewport edge and slide under the 48px circular buttons.
- Fix: wrap each preset in `min(pct, calc(100% - 172px))`. Since `calc()`/`min()` resolve against the section body's own rendered width (the same box `.rd-turn` is positioned against), this caps the column so it can never leave less than 86px clear on either side — well past the button's 70px (22px offset + 48px width) reach — at any viewport width, for any margin preset, in single- or two-page spread. This is fix-direction #2 from the issue ("cap the reading column's max-width so it can never reach under the arrows").
- Deliberately did not touch `atrium.css` or `chrome.rs`: the `.rd-turn` positioning, the 480px/coarse-pointer hide breakpoint (AC3), and the button markup are all unchanged and untouched by this diff.
- Note: this same `Margins::to_css()` also feeds the mobile WebView reader (`mobile.rs`). Mobile never shows `.rd-turn` (hidden by the existing `(hover: none) and (pointer: coarse)` rule on every touch device), so the cap has no arrow-overlap effect there — it only marginally narrows the column on a rare fine-pointer/wide-tablet mobile session, which is an acceptable, harmless trade-off for keeping one shared source of truth instead of forking the value per platform.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (390 passed, 0 failed), including a new regression test (`margins_to_css_reserves_a_fixed_gutter_for_every_variant`) pinning the `calc(100% - 172px)` clamp for every `Margins` preset
- [x] `python3 -c "print(open('frontend/assets/atrium.css').read().count('{'), open('frontend/assets/atrium.css').read().count('}'))"` — 2240 / 2240 (balanced; file untouched by this change)
- [ ] Visual/Playwright verification — **not run**. This sandbox has no `nix`, no `dx serve`, and no browser, so the actual rendered geometry at intermediate viewport widths (the core of AC1/AC2) could not be visually confirmed. The fix was reasoned through the CSS/JS mechanics (epub.js's `Themes.override("max-width", …)` sets an inline style directly on the section body via `Contents.css()`, so the `calc(100%…)` resolves against that body's own on-screen width, the same coordinate space the `.rd-turn` buttons are positioned in) rather than observed. A human or CI (Playwright) should eyeball the reader at widths between 480px and desktop, across all three margin presets and both single/double spread, before merging.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- Scope: only `frontend/src/pages/reader/typography.rs` changed. No CSS or markup edits were needed because the actual reading-column width is computed here and pushed into the iframe as an inline style by the existing JS glue — capping it at the source is sufficient and lower-risk than trying to reason about epub.js's own container-sizing internals (`clientWidth` vs `getBoundingClientRect`, etc.) without a browser to confirm.
- Flagging for `run_ui_tests` label since this touches reader geometry that the Playwright reader specs exercise, even though this PR itself couldn't run them locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn1xVgx2J7pBHCdgJ2Axen)_