### PR TITLE
refactor: bundle AnnotationsSheet and SleepPanelBody props (#1252)

### DIFF
--- a/frontend/src/pages/listen/mini_dock/popovers.rs
+++ b/frontend/src/pages/listen/mini_dock/popovers.rs
@@ -7,7 +7,7 @@ use dioxus::prelude::*;
 
 use super::super::chapter_nav::chapter_index_for_elapsed;
 use super::super::sleep::{end_of_chapter_seconds, sleep_chip_label};
-use super::super::sleep_panel::SleepPanelBody;
+use super::super::sleep_panel::{SleepPanelBody, SleepPanelState};
 use super::super::speed_panel::SpeedPanelBody;
 use crate::use_playback;
 
@@ -148,13 +148,15 @@ pub(super) fn DockSleep(open_panel: Signal<Option<DockPanel>>) -> Element {
             }
             DockPopover { open, testid: "mini-dock-pop-sleep", class: "mini-dock-pop-sleep",
                 SleepPanelBody {
-                    remaining,
-                    choice,
-                    fade,
-                    has_chapters,
-                    on_select,
-                    on_end_of_chapter,
-                    on_toggle_fade,
+                    state: SleepPanelState {
+                        remaining,
+                        choice,
+                        fade,
+                        has_chapters,
+                        on_select: EventHandler::new(on_select),
+                        on_end_of_chapter: EventHandler::new(on_end_of_chapter),
+                        on_toggle_fade: EventHandler::new(on_toggle_fade),
+                    },
                 }
             }
         }

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -15,7 +15,7 @@ use super::chapter_nav::{chapter_index_for_elapsed, chapter_next_target, chapter
 use super::chapters_drawer::ChaptersDrawer;
 use super::overlays::{FailedOverlay, PreparingOverlay};
 use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep, SleepChoice};
-use super::sleep_panel::SleepPanel;
+use super::sleep_panel::{SleepPanel, SleepPanelState};
 use super::speed_panel::SpeedPanel;
 use super::stage::{
     PlaybackPosition, PlayerCallbacks, PlayerContent, PlayerStage, ToolbarState, TransportState,
@@ -386,13 +386,15 @@ pub(super) fn PlayerOverlays(
         }
         if sleep_panel_open() {
             SleepPanel {
-                remaining: sleep_display.remaining,
-                choice: sleep_display.choice,
-                fade: sleep_display.fade,
-                has_chapters: sleep_display.has_chapters,
-                on_select: move |secs: i32| on_sleep_select.call(secs),
-                on_end_of_chapter: move |_| on_sleep_end_of_chapter.call(()),
-                on_toggle_fade: move |_| on_sleep_toggle_fade.call(()),
+                state: SleepPanelState {
+                    remaining: sleep_display.remaining,
+                    choice: sleep_display.choice,
+                    fade: sleep_display.fade,
+                    has_chapters: sleep_display.has_chapters,
+                    on_select: EventHandler::new(move |secs: i32| on_sleep_select.call(secs)),
+                    on_end_of_chapter: EventHandler::new(move |_| on_sleep_end_of_chapter.call(())),
+                    on_toggle_fade: EventHandler::new(move |_| on_sleep_toggle_fade.call(())),
+                },
                 on_close: move |_| sleep_panel_open.set(false),
             }
         }

--- a/frontend/src/pages/listen/sleep_panel.rs
+++ b/frontend/src/pages/listen/sleep_panel.rs
@@ -12,18 +12,23 @@ use dioxus::prelude::*;
 
 use super::sleep::{format_countdown, SleepChoice, PRESETS};
 
+/// Reactive sleep-timer values + mutators shared by [`SleepPanel`] and
+/// [`SleepPanelBody`], so the full-player wrapper can forward them 1:1
+/// without duplicating the field list across both signatures.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct SleepPanelState {
+    pub remaining: Option<i32>,
+    pub choice: SleepChoice,
+    pub fade: bool,
+    pub has_chapters: bool,
+    pub on_select: EventHandler<i32>,
+    pub on_end_of_chapter: EventHandler<()>,
+    pub on_toggle_fade: EventHandler<()>,
+}
+
 /// Full-player sleep overlay: scrim + panel chrome around [`SleepPanelBody`].
 #[component]
-pub(super) fn SleepPanel(
-    remaining: Option<i32>,
-    choice: SleepChoice,
-    fade: bool,
-    has_chapters: bool,
-    on_select: EventHandler<i32>,
-    on_end_of_chapter: EventHandler<()>,
-    on_toggle_fade: EventHandler<()>,
-    on_close: EventHandler<()>,
-) -> Element {
+pub(super) fn SleepPanel(state: SleepPanelState, on_close: EventHandler<()>) -> Element {
     rsx! {
         div {
             class: "lp-scrim",
@@ -31,15 +36,7 @@ pub(super) fn SleepPanel(
         }
 
         div { class: "lp-panel lp-sleep-panel", "data-testid": "sleep-panel",
-            SleepPanelBody {
-                remaining,
-                choice,
-                fade,
-                has_chapters,
-                on_select,
-                on_end_of_chapter,
-                on_toggle_fade,
-            }
+            SleepPanelBody { state }
         }
     }
 }
@@ -48,15 +45,16 @@ pub(super) fn SleepPanel(
 /// of positioning chrome so the full player and the mini-dock popover can
 /// both host it.
 #[component]
-pub(super) fn SleepPanelBody(
-    remaining: Option<i32>,
-    choice: SleepChoice,
-    fade: bool,
-    has_chapters: bool,
-    on_select: EventHandler<i32>,
-    on_end_of_chapter: EventHandler<()>,
-    on_toggle_fade: EventHandler<()>,
-) -> Element {
+pub(super) fn SleepPanelBody(state: SleepPanelState) -> Element {
+    let SleepPanelState {
+        remaining,
+        choice,
+        fade,
+        has_chapters,
+        on_select,
+        on_end_of_chapter,
+        on_toggle_fade,
+    } = state;
     let status = match remaining {
         Some(s) if s > 0 => format_countdown(s),
         _ => "\u{2014}".to_string(),

--- a/frontend/src/pages/listen/sleep_panel.rs
+++ b/frontend/src/pages/listen/sleep_panel.rs
@@ -15,7 +15,7 @@ use super::sleep::{format_countdown, SleepChoice, PRESETS};
 /// Reactive sleep-timer values + mutators shared by [`SleepPanel`] and
 /// [`SleepPanelBody`], so the full-player wrapper can forward them 1:1
 /// without duplicating the field list across both signatures.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub(super) struct SleepPanelState {
     pub remaining: Option<i32>,
     pub choice: SleepChoice,

--- a/frontend/src/pages/reader/annotations_sheet.rs
+++ b/frontend/src/pages/reader/annotations_sheet.rs
@@ -35,18 +35,41 @@ fn format_annotation_counts(highlights: usize, bookmarks: usize) -> String {
     format!("{highlights} {h} \u{b7} {bookmarks} {b}")
 }
 
+/// Props for [`AnnotationsSheet`]: the open book's identity/position plus the
+/// highlight list and the callbacks it forwards to its rows.
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct AnnotationsSheetProps {
+    /// UUID of the open book, used to load/create bookmarks.
+    pub uuid: String,
+    /// Current reader CFI, used as the position for a new bookmark.
+    pub current_cfi: String,
+    /// Current chapter label, used as the default title for a new bookmark.
+    pub current_label: String,
+    /// The open book's highlights, filterable by kind/color.
+    pub highlights: Signal<Vec<Highlight>>,
+    /// Fired with a highlight when its "Quote" action is tapped.
+    pub on_quote: EventHandler<Highlight>,
+    /// Fired with a highlight when its "Add/Edit note" action is tapped.
+    pub on_edit_note: EventHandler<Highlight>,
+    /// Fired with a CFI when a bookmark row is tapped.
+    pub on_navigate: EventHandler<String>,
+    /// Fired when the scrim or close button dismisses the sheet.
+    pub on_close: EventHandler<()>,
+}
+
 /// The combined annotations bottom sheet.
 #[component]
-pub(super) fn AnnotationsSheet(
-    uuid: String,
-    current_cfi: String,
-    current_label: String,
-    highlights: Signal<Vec<Highlight>>,
-    on_quote: EventHandler<Highlight>,
-    on_edit_note: EventHandler<Highlight>,
-    on_navigate: EventHandler<String>,
-    on_close: EventHandler<()>,
-) -> Element {
+pub(super) fn AnnotationsSheet(props: AnnotationsSheetProps) -> Element {
+    let AnnotationsSheetProps {
+        uuid,
+        current_cfi,
+        current_label,
+        highlights,
+        on_quote,
+        on_edit_note,
+        on_navigate,
+        on_close,
+    } = props;
     let mut filter = use_signal(|| AnnFilter::All);
     let bookmarks = use_signal(Vec::<Bookmark>::new);
     let server_url = crate::contexts::use_server_url();


### PR DESCRIPTION
## Summary
- `AnnotationsSheet` (`frontend/src/pages/reader/annotations_sheet.rs`) had 8 individual props. It now takes a single `AnnotationsSheetProps` struct (`#[derive(Props, Clone, PartialEq)]`), mirroring the established pattern for this family (`MobileShelfDetailProps`, `ChaptersSheetProps`, `MeFieldProps`, etc.) — the call site in `pages/reader/overlays.rs` is unchanged since the flattened-field invocation syntax still works.
- `SleepPanelBody` (`frontend/src/pages/listen/sleep_panel.rs`) had 7 props and its wrapper `SleepPanel` forwarded the same 7 fields 1:1 plus its own `on_close`. Both now share one `SleepPanelState` struct (the fields `SleepPanel` forwards), so the field list isn't duplicated across the two signatures. Updated the two call sites (`ready_player.rs`, `mini_dock/popovers.rs`) to build `SleepPanelState` instead of passing the fields individually.
- Closes #1252

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features web --all-targets --target wasm32-unknown-unknown -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (389 passed; 0 failed)

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- Surgical refactor only — no behavior change, no markup/selector changes, so no Playwright updates needed.
- `SleepPanel` itself drops from 8 props to 2 (`state`, `on_close`) as a side effect of sharing `SleepPanelState` with `SleepPanelBody`; it remains tracked separately by #853 for its own accounting, this PR doesn't attempt to close that issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn1xVgx2J7pBHCdgJ2Axen)_