### PR TITLE
refactor: convert AudiobookError/KepubError to anyhow (#1167)

### DIFF
--- a/db/src/audiobook.rs
+++ b/db/src/audiobook.rs
@@ -24,8 +24,7 @@ pub use chapters::{extract_chapters, RawChapter};
 pub use codec::{classify_filenames, is_direct_playable, mime_for_filename, PlaybackMode};
 pub use group::{group_into_books, AudiobookGroup};
 pub use parse::{
-    parse_audiobook_targets, parse_groups, AudiobookError, AudiobookParseTarget, AudiobookPart,
-    IndexedAudiobook,
+    parse_audiobook_targets, parse_groups, AudiobookParseTarget, AudiobookPart, IndexedAudiobook,
 };
 pub use stat::{stat_audiobook_library, AudiobookStatEntry, AudiobookStatScanResult};
 
@@ -52,7 +51,7 @@ pub type IndexedBook = crate::ebook::IndexedBook;
 /// Build the [`IndexedBook`] for a single audiobook file. Extracted as a
 /// pub helper so the tests can exercise the parse path directly without
 /// the full stat-and-diff machinery.
-pub fn build_indexed_book(path: &Path, filename: String) -> Result<IndexedBook, AudiobookError> {
+pub fn build_indexed_book(path: &Path, filename: String) -> anyhow::Result<IndexedBook> {
     let meta = parse::extract_metadata(path)?;
     let cover = cover::extract_cover(path)?;
     let creators = match meta.artist {
@@ -113,9 +112,9 @@ pub struct InspectedAudiobook {
 /// for `.m4b`/`.m4a` or the ordered `.mp3` parts of a multi-file audiobook.
 ///
 /// Per-part tag failures are tolerated (logged, skipped) so one corrupt file
-/// doesn't sink the inspect; [`AudiobookError::Unsupported`] is returned only
-/// when *no* part yields readable tags.
-pub fn inspect_audiobook_files(paths: &[PathBuf]) -> Result<InspectedAudiobook, AudiobookError> {
+/// doesn't sink the inspect; an error is returned only when *no* part yields
+/// readable tags.
+pub fn inspect_audiobook_files(paths: &[PathBuf]) -> anyhow::Result<InspectedAudiobook> {
     let multi = paths.len() > 1;
     let mut album_title: Option<String> = None;
     let mut first_title: Option<String> = None;
@@ -155,9 +154,7 @@ pub fn inspect_audiobook_files(paths: &[PathBuf]) -> Result<InspectedAudiobook, 
     }
 
     if !any_readable {
-        return Err(AudiobookError::Unsupported(
-            "no readable audio tags in upload".to_string(),
-        ));
+        anyhow::bail!("no readable audio tags in upload");
     }
 
     // Multi-file: the book title lives in the album tag; single-file: the

--- a/db/src/audiobook/cover.rs
+++ b/db/src/audiobook/cover.rs
@@ -4,16 +4,16 @@
 
 use std::path::Path;
 
+use anyhow::Context;
 use lofty::file::TaggedFileExt;
 use lofty::picture::MimeType;
-
-use super::parse::AudiobookError;
 
 /// Best-effort embedded-cover read. `None` when the file has no embedded
 /// artwork; the indexer treats that as "no cover, render the typographic
 /// plate" — same fallback ebooks without embedded covers take.
-pub(super) fn extract_cover(path: &Path) -> Result<Option<(String, Vec<u8>)>, AudiobookError> {
-    let tagged = lofty::read_from_path(path)?;
+pub(super) fn extract_cover(path: &Path) -> anyhow::Result<Option<(String, Vec<u8>)>> {
+    let tagged = lofty::read_from_path(path)
+        .with_context(|| format!("could not read audio tags from {}", path.display()))?;
     Ok(cover_from_tagged(&tagged))
 }
 
@@ -98,15 +98,15 @@ mod tests {
     fn extract_cover_errors_when_path_does_not_exist() {
         // A missing file can't be probed by lofty, so the read surfaces as
         // an `Err` (not `Ok(None)`); the caller in `parse.rs` logs a WARN
-        // and proceeds with no cover. lofty maps the missing file to either
-        // a bare `Io` or a `LoftyError`-wrapped `Tag` depending on platform,
-        // so accept either error variant rather than pinning one.
+        // and proceeds with no cover. The `with_context` wrapper names the
+        // path regardless of whether lofty's underlying failure was a bare
+        // `io::Error` or a `LoftyError` (platform-dependent).
         let dir = tempfile::tempdir().expect("should create tempdir");
         let missing = dir.path().join("omnibus_cover_test_missing.mp3");
         let err = extract_cover(&missing).expect_err("missing path should error");
         assert!(
-            matches!(err, AudiobookError::Io(_) | AudiobookError::Tag(_)),
-            "got {err:?}"
+            err.to_string().contains("omnibus_cover_test_missing.mp3"),
+            "got {err}"
         );
     }
 }

--- a/db/src/audiobook/parse.rs
+++ b/db/src/audiobook/parse.rs
@@ -3,9 +3,10 @@
 //! Opens each file's primary tag and lifts the small set of fields the
 //! basic player cares about: title, primary artist (one author — the
 //! basic player has no UI for narrator vs. author roles), album, and
-//! duration in seconds. Failures roll up as [`AudiobookError`] so the
+//! duration in seconds. Failures roll up as `anyhow::Error` so the
 //! indexer surfaces the per-file error in the same shape the EPUB path
-//! uses.
+//! uses — a foreign-system (codec/I/O) failure space with no caller
+//! branching on the specific cause (rule 02).
 //!
 //! Phase B for multi-file audiobooks is handled by [`parse_groups`], which
 //! reads ID3 tags for every part, sorts by (track, filename), and assembles
@@ -13,24 +14,11 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
 use lofty::file::{AudioFile, TaggedFileExt};
 use lofty::tag::Accessor;
 
 use crate::ebook::extract_accent;
-
-/// Predictable failure space for the audiobook parse + indexer dispatch.
-/// `Io` covers "could not open file"; `Tag` covers any lofty decode /
-/// container error; `Unsupported` is reserved for files whose extension
-/// we accepted but lofty can't probe.
-#[derive(Debug, thiserror::Error)]
-pub enum AudiobookError {
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("tag decode failed: {0}")]
-    Tag(#[from] lofty::error::LoftyError),
-    #[error("unsupported audiobook format: {0}")]
-    Unsupported(String),
-}
 
 /// Tag-only metadata view used by [`super::build_indexed_book`]. Empty
 /// strings collapse to `None` so downstream defaults (filename-stem fall-
@@ -47,8 +35,9 @@ pub struct AudiobookMetadata {
 /// supplies the extension check upstream (via [`super::AUDIOBOOK_EXTENSIONS`]
 /// in the scanner), so this never sees a non-audio file under normal
 /// operation.
-pub(super) fn extract_metadata(path: &Path) -> Result<AudiobookMetadata, AudiobookError> {
-    let tagged = lofty::read_from_path(path)?;
+pub(super) fn extract_metadata(path: &Path) -> anyhow::Result<AudiobookMetadata> {
+    let tagged = lofty::read_from_path(path)
+        .with_context(|| format!("could not read audio tags from {}", path.display()))?;
     Ok(metadata_from_tagged(&tagged))
 }
 

--- a/db/src/audiobook/tests.rs
+++ b/db/src/audiobook/tests.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use super::parse::AudiobookError;
 use super::*;
 
 fn make_test_dir(suffix: &str) -> std::path::PathBuf {
@@ -113,38 +112,21 @@ fn parse_groups_emits_one_book_per_m4b_even_when_stems_share_a_base() {
 }
 
 #[test]
-fn audiobook_error_io_variant_renders_useful_message() {
-    let io = std::io::Error::new(std::io::ErrorKind::NotFound, "missing.m4b");
-    let err: AudiobookError = io.into();
-    let s = err.to_string();
-    assert!(s.starts_with("io error"), "got {s:?}");
-}
-
-#[test]
-fn audiobook_error_unsupported_variant_renders_format_token() {
-    let err = AudiobookError::Unsupported("xyz".into());
-    let s = err.to_string();
-    assert!(s.contains("xyz"), "got {s:?}");
-}
-
-#[test]
-fn build_indexed_book_surfaces_tag_error_for_undecodable_audio() {
-    // `build_indexed_book` propagates the lofty decode/container failure via
-    // `?` as `AudiobookError::Tag` — the direct-propagation counterpart to
+fn build_indexed_book_surfaces_error_for_undecodable_audio() {
+    // `build_indexed_book` propagates the lofty decode/container failure as
+    // an `anyhow::Error` — the direct-propagation counterpart to
     // `parse_audiobook_targets`, which instead folds the same failure into an
     // `error` metadata row. Feeding a file with an audio extension but junk
-    // bytes drives `lofty::read_from_path` to error, which `#[from]` maps to
-    // `Tag`.
+    // bytes drives `lofty::read_from_path` to error.
     let dir = make_test_dir("tag_err");
     let f = dir.join("garbage.m4b");
     fs::write(&f, b"this is not a valid m4b container").unwrap();
     let err =
         build_indexed_book(&f, "garbage.m4b".into()).expect_err("undecodable audio must not parse");
     fs::remove_dir_all(&dir).unwrap();
-    assert!(matches!(err, AudiobookError::Tag(_)), "got {err:?}");
     assert!(
-        err.to_string().starts_with("tag decode failed"),
-        "got {err}"
+        err.to_string().contains("garbage.m4b"),
+        "expected path context in error, got {err}"
     );
 }
 
@@ -196,7 +178,10 @@ fn inspect_audiobook_files_errors_when_no_readable_tags() {
     fs::write(&f, b"not an mp3 at all").unwrap();
     let err = inspect_audiobook_files(&[f]).expect_err("junk must not parse");
     fs::remove_dir_all(&dir).unwrap();
-    assert!(matches!(err, AudiobookError::Unsupported(_)), "got {err:?}");
+    assert!(
+        err.to_string().contains("no readable audio tags"),
+        "got {err}"
+    );
 }
 
 #[test]

--- a/db/src/kepub/convert.rs
+++ b/db/src/kepub/convert.rs
@@ -4,6 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
 use sqlx::SqlitePool;
 
 use super::detect::kepubify_bin;
@@ -19,7 +20,8 @@ use super::KepubError;
 /// the caller then falls back to serving the plain EPUB.
 pub async fn convert_book(pool: &SqlitePool, book_id: i64) -> Result<PathBuf, KepubError> {
     let last_modified = crate::get_last_modified_epoch(pool, book_id)
-        .await?
+        .await
+        .context("look up book last_modified")?
         .ok_or(KepubError::BookNotFound(book_id))?;
 
     let out_path = kepub_path(book_id);
@@ -29,11 +31,14 @@ pub async fn convert_book(pool: &SqlitePool, book_id: i64) -> Result<PathBuf, Ke
     }
 
     let src = crate::book_file_path(pool, book_id, "EPUB")
-        .await?
+        .await
+        .context("look up book's EPUB source path")?
         .ok_or(KepubError::SourceMissing(book_id))?;
 
     let dir = kepub_dir();
-    tokio::fs::create_dir_all(&dir).await?;
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .with_context(|| format!("create kepub cache dir {}", dir.display()))?;
     // Hidden, per-book temp so a crashed run leaves no half-written cache and
     // different books never collide. `.kepub.epub` suffix keeps kepubify happy.
     let tmp = dir.join(format!(".{book_id}.tmp.kepub.epub"));
@@ -41,16 +46,18 @@ pub async fn convert_book(pool: &SqlitePool, book_id: i64) -> Result<PathBuf, Ke
 
     tracing::info!(target: "omnibus::kepub", book_id, ?src, "converting epub to kepub");
     run_kepubify(&src, &tmp).await?;
-    tokio::fs::rename(&tmp, &out_path).await?;
+    tokio::fs::rename(&tmp, &out_path)
+        .await
+        .context("move converted kepub into cache")?;
     tracing::info!(target: "omnibus::kepub", book_id, "kepub conversion complete");
 
     Ok(out_path)
 }
 
-/// Run `kepubify -o <out> -- <src>` and map a non-zero exit to `NonZero`. The
-/// `--` terminates flag parsing so a source path beginning with `-` is always
-/// treated as the positional input, never a flag.
-async fn run_kepubify(src: &Path, out: &Path) -> Result<(), KepubError> {
+/// Run `kepubify -o <out> -- <src>` and bail on a non-zero exit, carrying the
+/// captured stderr. The `--` terminates flag parsing so a source path
+/// beginning with `-` is always treated as the positional input, never a flag.
+async fn run_kepubify(src: &Path, out: &Path) -> anyhow::Result<()> {
     let bin = kepubify_bin();
     tracing::debug!(target: "omnibus::kepub", %bin, ?src, ?out, "spawning kepubify");
     let output = tokio::process::Command::new(&bin)
@@ -59,12 +66,11 @@ async fn run_kepubify(src: &Path, out: &Path) -> Result<(), KepubError> {
         .arg("--")
         .arg(src)
         .output()
-        .await?;
+        .await
+        .with_context(|| format!("spawn kepubify ({bin})"))?;
     if !output.status.success() {
-        return Err(KepubError::NonZero {
-            status: output.status.to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        });
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!("kepubify exited with {}: {stderr}", output.status);
     }
     Ok(())
 }

--- a/db/src/kepub/mod.rs
+++ b/db/src/kepub/mod.rs
@@ -15,24 +15,20 @@ pub use fs::{is_stale, kepub_dir, kepub_path};
 
 /// Errors from the EPUB→KEPUB conversion path.
 ///
-/// The DB lookups (`get_last_modified_epoch`, `book_file_path`) surface as
-/// their owning module's typed error; process spawn / filesystem failures
-/// surface as `Io`; a kepubify run that exits non-zero surfaces as `NonZero`
-/// so the caller can log stderr and fall back to plain EPUB.
+/// `BookNotFound`/`SourceMissing` stay distinct variants because
+/// `worker::handlers::kepub_outcome` branches on them to decide whether the
+/// message is safe to hand back verbatim. Everything else — DB lookup
+/// failures, process spawn / filesystem errors, and a non-zero kepubify exit
+/// — is foreign-system failure with no caller branching on the specific
+/// cause, so it collapses into `Failed` (rule 02: anyhow-territory).
 #[derive(Debug, thiserror::Error)]
 pub enum KepubError {
     #[error("book {0} not found")]
     BookNotFound(i64),
     #[error("book {0} has no EPUB file to convert")]
     SourceMissing(i64),
-    #[error("kepubify exited with {status}: {stderr}")]
-    NonZero { status: String, stderr: String },
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-    #[error(transparent)]
-    Books(#[from] crate::books::BooksError),
-    #[error(transparent)]
-    Covers(#[from] crate::CoversError),
+    #[error("kepub conversion failed: {0}")]
+    Failed(#[from] anyhow::Error),
 }
 
 #[cfg(test)]

--- a/db/src/kepub/tests.rs
+++ b/db/src/kepub/tests.rs
@@ -240,10 +240,11 @@ async fn convert_book_errors_when_kepubify_binary_absent() {
 #[tokio::test]
 async fn convert_book_returns_non_zero_when_kepubify_exits_non_zero() {
     // A kepubify run that exits non-zero (unsupported EPUB, internal error)
-    // must surface as `KepubError::NonZero` carrying the exit status and the
-    // captured stderr, so the caller can log it and fall back to plain EPUB —
-    // never a torn cache file. A fake binary that prints to stderr and exits 3
-    // drives the exit-code branch in `run_kepubify`.
+    // must surface as the collapsed `KepubError::Failed`, with the exit status
+    // and captured stderr folded into the anyhow message so the caller can log
+    // it and fall back to plain EPUB — never a torn cache file. A fake binary
+    // that prints to stderr and exits 3 drives the exit-code branch in
+    // `run_kepubify`.
     let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
     let lib = tempfile::tempdir().unwrap();
     let book_id = seed_epub_book(&pool, lib.path()).await;
@@ -276,7 +277,7 @@ async fn convert_book_propagates_db_error_when_pool_is_closed() {
 
 /// Write a fake `kepubify` at `path` that answers `--version` (so detection
 /// passes) but for any real invocation writes to stderr and exits non-zero,
-/// driving the `NonZero` branch in `run_kepubify`.
+/// driving the non-zero-exit `anyhow::bail!` in `run_kepubify`.
 fn write_failing_kepubify(path: &Path) {
     let script = "#!/bin/sh\n\
          if [ \"$1\" = \"--version\" ]; then echo 'kepubify 0-fake'; exit 0; fi\n\

--- a/db/src/kepub/tests.rs
+++ b/db/src/kepub/tests.rs
@@ -234,7 +234,7 @@ async fn convert_book_errors_when_kepubify_binary_absent() {
     let _env = EnvVarGuard::set_os("OMNIBUS_DATA_DIR", Some(cache.path().as_os_str()))
         .also_set("OMNIBUS_KEPUBIFY_PATH", Some("/no/such/kepubify"));
     let err = convert_book(&pool, book_id).await.unwrap_err();
-    assert!(matches!(err, KepubError::Io(_)), "got {err:?}");
+    assert!(matches!(err, KepubError::Failed(_)), "got {err:?}");
 }
 
 #[tokio::test]
@@ -257,7 +257,7 @@ async fn convert_book_returns_non_zero_when_kepubify_exits_non_zero() {
 
     let err = convert_book(&pool, book_id).await.unwrap_err();
     assert!(
-        matches!(&err, KepubError::NonZero { stderr, .. } if stderr.contains("boom")),
+        matches!(&err, KepubError::Failed(e) if e.to_string().contains("boom")),
         "got {err:?}"
     );
     // No cache file left behind on failure.
@@ -269,9 +269,9 @@ async fn convert_book_propagates_db_error_when_pool_is_closed() {
     let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
     pool.close().await;
     // `convert_book` reads `last_modified` via `crate::covers::CoversError`
-    // first, so a closed pool surfaces as the wrapped `Covers` variant.
+    // first, so a closed pool surfaces as the collapsed `Failed` variant.
     let err = convert_book(&pool, 1).await.unwrap_err();
-    assert!(matches!(err, KepubError::Covers(_)));
+    assert!(matches!(err, KepubError::Failed(_)));
 }
 
 /// Write a fake `kepubify` at `path` that answers `--version` (so detection

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -51,10 +51,10 @@ fn kindle_outcome(result: Result<(), crate::kindle::KindleError>) -> TaskOutcome
 }
 
 /// Variant-aware mapping for [`crate::kepub::KepubError`]: a bad book id or
-/// a missing source EPUB are safe, specific messages; a non-zero
-/// `kepubify` exit carries subprocess stderr, and the remaining variants
-/// wrap I/O or a lower module's internals, so all of those go through
-/// [`sanitized_err`].
+/// a missing source EPUB are safe, specific messages; the collapsed
+/// `Failed` variant (DB lookups, I/O, a non-zero kepubify exit — all
+/// foreign-system failures) carries subprocess stderr / lower-level
+/// internals, so it goes through [`sanitized_err`].
 fn kepub_outcome(result: Result<std::path::PathBuf, crate::kepub::KepubError>) -> TaskOutcome {
     use crate::kepub::KepubError;
     match result {

--- a/db/src/worker/handlers/tests.rs
+++ b/db/src/worker/handlers/tests.rs
@@ -94,10 +94,9 @@ fn kepub_outcome_passes_through_the_safe_book_id_variants() {
 
 #[test]
 fn kepub_outcome_sanitizes_subprocess_stderr() {
-    let msg = err_text(kepub_outcome(Err(KepubError::NonZero {
-        status: "1".to_string(),
-        stderr: "panic: invalid EPUB structure at offset 0xdeadbeef".to_string(),
-    })));
+    let msg = err_text(kepub_outcome(Err(KepubError::Failed(anyhow::anyhow!(
+        "kepubify exited with exit status: 1: panic: invalid EPUB structure at offset 0xdeadbeef"
+    )))));
     assert!(!msg.contains("0xdeadbeef"));
     assert!(msg.contains("kepub conversion"));
 }


### PR DESCRIPTION
## Summary
- Closes #1167. `AudiobookError` (`Io`/`Tag(LoftyError)`/`Unsupported(String)`) and `KepubError` (`BookNotFound`/`SourceMissing`/`NonZero`/`Io`/`Books`/`Covers`) were bespoke `thiserror` enums over foreign-system failure spaces (codec decode, I/O, subprocess exit) that no production caller branched on beyond formatting to a string — matching the `#739` precedent (`ThumbError`/`FetchRemoteImageError`).
- **`AudiobookError` is fully removed** and replaced with `anyhow::Result` throughout `db/src/audiobook.rs`, `db/src/audiobook/parse.rs`, and `db/src/audiobook/cover.rs` (`extract_metadata`, `extract_cover`, `build_indexed_book`, `inspect_audiobook_files`), using `.with_context(...)`/`anyhow::bail!` to name the file path or failure reason. I traced every call site (`server/src/backend/uploads/audiobooks.rs`, `frontend/src/pages/add_books.rs`) — none pattern-match a variant; the sole in-crate consumer (`parse_audiobook_targets`) always did `format!("could not read audiobook: {e}")` regardless of variant.
- **`KepubError` is a partial conversion, kept explicit in the PR per the task's guidance**: `BookNotFound(i64)`/`SourceMissing(i64)` stay as typed variants because `db/src/worker/handlers.rs`'s `kepub_outcome` *does* branch on them — a behavior added by PR #1198 (landed the day after this issue was filed) to decide whether the error text is safe to return verbatim to the client vs. routed through `sanitized_err`. Collapsing those two would have silently changed that safe/sanitize branching. The remaining variants (`Io`, `NonZero{status,stderr}`, `Books`, `Covers`) collapse into a single `Failed(#[from] anyhow::Error)` variant — mirroring the `ThumbError::Failed(String)` + branched-on `NoCover(i64)` shape already in this codebase.
- Updated tests in `db/src/audiobook/tests.rs`, `db/src/audiobook/cover.rs`, `db/src/kepub/tests.rs`, and `db/src/worker/handlers/tests.rs` to match the new error shapes (message/context assertions instead of variant matching, per rule 03's anyhow-fn coverage guidance).

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1179 passed, 1 pre-existing failure: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` needs a downloaded `test_data/audiobooks/public_domain` fixture — `just fixtures` isn't runnable in this environment; unrelated to this change)
- [x] `cargo test -p omnibus` — PASS (387 passed, 2 pre-existing environment-only failures: `backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` simulate a read-only library via `chmod 0o555`, which this sandbox's root user bypasses — unrelated to this change and not in the modified files)

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- `AudiobookError` collapses to nothing (full `anyhow` conversion) since it had zero branched variants anywhere in the workspace.
- `KepubError` keeps `BookNotFound`/`SourceMissing` typed — see Summary above for why; this is the one place this change stops short of a full collapse, and it's intentional.
- No SQL migration, no UI markup/selector changes — Playwright coverage unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn1xVgx2J7pBHCdgJ2Axen)_