### PR TITLE
refactor: make test-only await-holding-lock invariant enforceable (#1169)

### DIFF
--- a/server/src/auth/boot/tests.rs
+++ b/server/src/auth/boot/tests.rs
@@ -15,18 +15,14 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 /// prior value on drop.
 ///
 /// `EnvGuard::set` / `EnvGuard::unset` acquire `ENV_LOCK` themselves and
-/// store the `MutexGuard` inside the struct.  The guard is released when
-/// the `EnvGuard` is dropped (after the env var is restored), so it is
-/// structurally impossible to mutate the environment without holding the
-/// lock — no documentation contract for callers to misunderstand.
-///
-/// The `MutexGuard` is held across `.await` points in the tests that use
-/// this helper, which clippy flags.  The `#[allow]` is on the individual
-/// tests that do so (rather than the whole module) so it is scoped as
-/// tightly as possible.  An async mutex is not appropriate here: the lock
-/// guards the process-global environment, not just a single coroutine
-/// turn, so we must use a `std::sync::Mutex` and intentionally hold it
-/// across yield points to prevent other tests from racing on env.
+/// store the `MutexGuard` inside the struct, so it is structurally
+/// impossible to mutate the environment without holding the lock. That
+/// `MutexGuard` is then held across `.await` in every test below — sound
+/// only under tokio's current-thread runtime (see the module doc on
+/// `backend::test_support` for the full rationale, and
+/// `assert_current_thread_test_runtime` there, which `set`/`unset` call
+/// below to make the assumption an enforced `debug_assert` rather than a
+/// comment (#1169).
 struct EnvGuard {
     key: &'static str,
     prev: Option<String>,
@@ -38,6 +34,7 @@ struct EnvGuard {
 
 impl EnvGuard {
     fn set(key: &'static str, value: &str) -> Self {
+        crate::backend::test_support::assert_current_thread_test_runtime();
         // Recover from a poisoned lock (a prior test panicked while
         // holding it) instead of cascading the panic into every
         // subsequent env-var test — matches the repo's other ENV_LOCK
@@ -60,6 +57,7 @@ impl EnvGuard {
     }
 
     fn unset(key: &'static str) -> Self {
+        crate::backend::test_support::assert_current_thread_test_runtime();
         // Recover from a poisoned lock (a prior test panicked while
         // holding it) instead of cascading the panic into every
         // subsequent env-var test — matches the repo's other ENV_LOCK
@@ -97,7 +95,6 @@ impl Drop for EnvGuard {
     }
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn unset_env_is_noop() {
     let _g = EnvGuard::unset("OMNIBUS_INITIAL_ADMIN");
@@ -114,7 +111,6 @@ async fn unset_env_is_noop() {
     assert!(u.is_admin);
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn env_promotes_existing_non_admin() {
     let pool = db::init_db("sqlite::memory:").await.unwrap();
@@ -144,7 +140,6 @@ async fn env_promotes_existing_non_admin() {
     assert!(bob.is_admin);
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn env_for_unknown_user_is_noop_no_error() {
     let pool = db::init_db("sqlite::memory:").await.unwrap();
@@ -154,7 +149,6 @@ async fn env_for_unknown_user_is_noop_no_error() {
 
 // ----- seed_dev_user -----
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn seed_unset_env_is_noop() {
     let _g = EnvGuard::unset("OMNIBUS_DEV_SEED_USER");
@@ -166,7 +160,6 @@ async fn seed_unset_env_is_noop() {
         .is_none());
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn seed_creates_admin_when_user_absent() {
     let _g = EnvGuard::set("OMNIBUS_DEV_SEED_USER", "admin:omnibus-dev");
@@ -179,7 +172,6 @@ async fn seed_creates_admin_when_user_absent() {
     assert!(u.is_admin, "seeded user should be admin");
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn seed_is_idempotent_when_user_exists() {
     let pool = db::init_db("sqlite::memory:").await.unwrap();
@@ -198,7 +190,6 @@ async fn seed_is_idempotent_when_user_exists() {
         .expect("original password should still authenticate");
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn seed_malformed_env_is_noop_no_error() {
     let pool = db::init_db("sqlite::memory:").await.unwrap();
@@ -211,7 +202,6 @@ async fn seed_malformed_env_is_noop_no_error() {
         .is_none());
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn seed_works_when_other_users_already_exist() {
     let pool = db::init_db("sqlite::memory:").await.unwrap();
@@ -230,7 +220,6 @@ async fn seed_works_when_other_users_already_exist() {
     assert!(u.is_admin);
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn seed_restores_prior_registration_enabled_flag() {
     // Reviewer PR #71 / boot.rs:94 — seed_dev_user used to leave

--- a/server/src/auth/boot/tests.rs
+++ b/server/src/auth/boot/tests.rs
@@ -21,8 +21,8 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 /// only under tokio's current-thread runtime (see the module doc on
 /// `backend::test_support` for the full rationale, and
 /// `assert_current_thread_test_runtime` there, which `set`/`unset` call
-/// below to make the assumption an enforced `debug_assert` rather than a
-/// comment (#1169).
+/// below to make the assumption an enforced assertion rather than a
+/// comment.
 struct EnvGuard {
     key: &'static str,
     prev: Option<String>,

--- a/server/src/backend/audiobooks/tests.rs
+++ b/server/src/backend/audiobooks/tests.rs
@@ -3,8 +3,6 @@
 //! the legacy HLS fallback (`playlist.m3u8`, `segments/{seg}`, `status`),
 //! including auth gating, 4xx client errors, and 5xx DB-failure paths.
 
-use std::sync::Mutex;
-
 use axum::{
     body::{to_bytes, Body},
     http::{Request, StatusCode},
@@ -15,13 +13,6 @@ use tower::ServiceExt;
 use super::*;
 use crate::auth::test_support as auth_test_support;
 use crate::backend::test_support::*;
-
-/// Serializes the status-endpoint tests that mutate `OMNIBUS_DATA_DIR`.
-/// `hls::has_failed` reads the env var on every call, so two tests
-/// pointing at different tempdirs will race and one will see the
-/// other's `.failed` marker. Mirrors the `ENV_LOCK` pattern in
-/// `db/src/thumbs.rs`.
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 /// Seed one audiobook book + book_files + book_file_parts row for tests.
 async fn seed_one_audiobook(pool: &sqlx::SqlitePool) -> String {
@@ -313,24 +304,13 @@ async fn api_get_audiobook_status_returns_404_for_unknown_uuid() {
 }
 
 #[tokio::test]
-// Std mutex held across awaits is the intent — env vars are
-// process-global and we serialize sibling tests that mutate
-// `OMNIBUS_DATA_DIR`. Safe under tokio's current-thread test runtime.
-#[allow(clippy::await_holding_lock)]
 async fn api_get_audiobook_status_returns_preparing_when_not_transcoded() {
-    // Hold the env lock for the whole test so the `failed_marker`
-    // sibling test below can't interleave its `.failed` write into
-    // our `OMNIBUS_DATA_DIR`. Tempdir keeps us isolated from any
-    // pre-existing `./data/hls/*/audio64.failed` files on the host.
-    let _env = ENV_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let dir = tempfile::tempdir().unwrap();
-    let prev = std::env::var("OMNIBUS_DATA_DIR").ok();
-    // SAFETY: held under ENV_LOCK; no other thread mutates the env.
-    unsafe {
-        std::env::set_var("OMNIBUS_DATA_DIR", dir.path());
-    }
+    // `hls::has_failed` reads `OMNIBUS_DATA_DIR` on every call, so this
+    // must serialize against the `failed_marker` sibling test below —
+    // `DataDirGuard` holds the shared env lock for its RAII lifetime
+    // (see its doc comment in `backend::test_support` for why that's
+    // safe to hold across `.await` in this test suite).
+    let _data_dir = DataDirGuard::new("audiobook_status_preparing");
 
     let (_, _, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;
@@ -354,32 +334,17 @@ async fn api_get_audiobook_status_returns_preparing_when_not_transcoded() {
     // New `state` field (#339 / Bug 4 of #338) — lets the UI
     // distinguish "preparing" from "failed".
     assert_eq!(json["state"], "preparing");
-
-    unsafe {
-        match prev {
-            Some(v) => std::env::set_var("OMNIBUS_DATA_DIR", v),
-            None => std::env::remove_var("OMNIBUS_DATA_DIR"),
-        }
-    }
 }
 
 #[tokio::test]
-#[allow(clippy::await_holding_lock)] // see sibling test for rationale
 async fn api_get_audiobook_status_returns_failed_when_failed_marker_present() {
     // Direct fs poke: write the `.failed` marker that
     // `cleanup_segment_dir` writes on a terminal ffmpeg failure, then
     // assert the status endpoint surfaces `state: "failed"` instead of
     // the legacy `ready:false, progress:0` shape that the UI couldn't
-    // distinguish from "preparing".
-    let _env = ENV_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let dir = tempfile::tempdir().unwrap();
-    let prev = std::env::var("OMNIBUS_DATA_DIR").ok();
-    // SAFETY: held under ENV_LOCK; no other thread mutates the env.
-    unsafe {
-        std::env::set_var("OMNIBUS_DATA_DIR", dir.path());
-    }
+    // distinguish from "preparing". See sibling test above for why the
+    // `OMNIBUS_DATA_DIR` swap must serialize against it.
+    let data_dir = DataDirGuard::new("audiobook_status_failed");
 
     let (_, _, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;
@@ -390,7 +355,7 @@ async fn api_get_audiobook_status_returns_failed_when_failed_marker_present() {
         .fetch_one(&pool)
         .await
         .unwrap();
-    let book_dir = dir.path().join("hls").join(book_id.to_string());
+    let book_dir = data_dir.path.join("hls").join(book_id.to_string());
     std::fs::create_dir_all(&book_dir).unwrap();
     std::fs::write(book_dir.join("audio64.failed"), "").unwrap();
 
@@ -408,13 +373,6 @@ async fn api_get_audiobook_status_returns_failed_when_failed_marker_present() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["state"], "failed");
-
-    unsafe {
-        match prev {
-            Some(v) => std::env::set_var("OMNIBUS_DATA_DIR", v),
-            None => std::env::remove_var("OMNIBUS_DATA_DIR"),
-        }
-    }
 }
 
 /// Seed an audiobook with N custom parts. Used by the manifest tests

--- a/server/src/backend/test_support.rs
+++ b/server/src/backend/test_support.rs
@@ -1,10 +1,33 @@
 //! Shared test fixtures and helpers for `/api/*` REST integration tests.
+//!
+//! The `*DirGuard` types below hold a `std::sync::MutexGuard` across
+//! `.await` points in their callers (#1169) — sound only because
+//! `#[tokio::test]` defaults to the current-thread runtime, so this OS
+//! thread never contends with another task for the same lock; a
+//! multi-threaded runtime blocking a worker on a std `Mutex` mid-`.await`
+//! could stall or deadlock unrelated tasks. `auth::boot::tests::EnvGuard`
+//! relies on the same invariant.
 use axum::{
     body::Body,
     http::{header::AUTHORIZATION, Request},
 };
 
 use super::*;
+
+/// Asserts the calling test runs on tokio's current-thread flavor — the
+/// invariant every `*DirGuard` in this module (and `EnvGuard` in
+/// `auth::boot::tests`) relies on to hold its lock across `.await` (#1169).
+/// Call this as the first line of a guard's constructor rather than only
+/// documenting the assumption, so a future switch to a multi-threaded test
+/// runtime fails loudly instead of silently reintroducing a deadlock risk.
+pub(crate) fn assert_current_thread_test_runtime() {
+    debug_assert_eq!(
+        tokio::runtime::Handle::current().runtime_flavor(),
+        tokio::runtime::RuntimeFlavor::CurrentThread,
+        "holding a std::sync::MutexGuard across .await is only sound on tokio's \
+         current-thread runtime — see backend::test_support module doc (#1169)"
+    );
+}
 
 /// Build a router + AppState wired against a fresh in-memory DB.
 pub(crate) async fn fixture() -> (Router, AppState, sqlx::SqlitePool) {
@@ -165,6 +188,7 @@ pub(crate) struct CoversDirGuard {
 
 impl CoversDirGuard {
     pub(crate) fn new(tag: &str) -> Self {
+        assert_current_thread_test_runtime();
         let guard = COVER_DIR_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -212,6 +236,7 @@ pub(crate) struct ThumbsDirGuard {
 
 impl ThumbsDirGuard {
     pub(crate) fn new(tag: &str) -> Self {
+        assert_current_thread_test_runtime();
         let guard = THUMBS_DIR_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -251,7 +276,8 @@ pub(crate) static DATA_DIR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::ne
 /// RAII guard that points `OMNIBUS_DATA_DIR` (the KEPUB cache root lives at
 /// `<data_dir>/kepub/`) at a fresh scratch dir for one test and restores the
 /// previous value on drop. `path` is public so a test can pre-populate the
-/// cache. Holds [`DATA_DIR_ENV_LOCK`] so parallel tests serialize their writes.
+/// cache. Holds [`DATA_DIR_ENV_LOCK`] so parallel tests serialize their
+/// writes (module doc explains why holding it across `.await` is safe).
 pub(crate) struct DataDirGuard {
     pub(crate) path: std::path::PathBuf,
     prev: Option<String>,
@@ -260,6 +286,7 @@ pub(crate) struct DataDirGuard {
 
 impl DataDirGuard {
     pub(crate) fn new(tag: &str) -> Self {
+        assert_current_thread_test_runtime();
         let guard = DATA_DIR_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/server/src/backend/test_support.rs
+++ b/server/src/backend/test_support.rs
@@ -1,12 +1,8 @@
 //! Shared test fixtures and helpers for `/api/*` REST integration tests.
 //!
-//! The `*DirGuard` types below hold a `std::sync::MutexGuard` across
-//! `.await` points in their callers (#1169) — sound only because
-//! `#[tokio::test]` defaults to the current-thread runtime, so this OS
-//! thread never contends with another task for the same lock; a
-//! multi-threaded runtime blocking a worker on a std `Mutex` mid-`.await`
-//! could stall or deadlock unrelated tasks. `auth::boot::tests::EnvGuard`
-//! relies on the same invariant.
+//! The `*DirGuard` types hold a `std::sync::MutexGuard` across `.await` in
+//! their callers — sound only on tokio's current-thread runtime, which
+//! `assert_current_thread_test_runtime` below enforces.
 use axum::{
     body::Body,
     http::{header::AUTHORIZATION, Request},
@@ -16,16 +12,19 @@ use super::*;
 
 /// Asserts the calling test runs on tokio's current-thread flavor — the
 /// invariant every `*DirGuard` in this module (and `EnvGuard` in
-/// `auth::boot::tests`) relies on to hold its lock across `.await` (#1169).
-/// Call this as the first line of a guard's constructor rather than only
+/// `auth::boot::tests`) relies on to hold its lock across `.await`. Call
+/// this as the first line of a guard's constructor rather than only
 /// documenting the assumption, so a future switch to a multi-threaded test
 /// runtime fails loudly instead of silently reintroducing a deadlock risk.
+/// Plain `assert_eq!` (not `debug_assert_eq!`): this module is
+/// `#[cfg(test)]`-only, but `debug_assert!` also compiles out under
+/// `cargo test --release`, which would silently defeat the check.
 pub(crate) fn assert_current_thread_test_runtime() {
-    debug_assert_eq!(
+    assert_eq!(
         tokio::runtime::Handle::current().runtime_flavor(),
         tokio::runtime::RuntimeFlavor::CurrentThread,
         "holding a std::sync::MutexGuard across .await is only sound on tokio's \
-         current-thread runtime — see backend::test_support module doc (#1169)"
+         current-thread runtime — see backend::test_support module doc"
     );
 }
 


### PR DESCRIPTION
## Summary
- Closes #1169. Ten test functions (`server/src/backend/audiobooks/tests.rs`, `server/src/auth/boot/tests.rs`) hold a `std::sync::Mutex` guard across `.await`, each suppressed with `#[allow(clippy::await_holding_lock)]` and a comment claiming safety because `#[tokio::test]` defaults to the current-thread runtime — an assumption nothing actually checked.
- Added `assert_current_thread_test_runtime` (a `debug_assert` on `Handle::current().runtime_flavor()`) to `server::backend::test_support`, and call it from every guard constructor that relies on the invariant: `CoversDirGuard`, `ThumbsDirGuard`, `DataDirGuard`, and `auth::boot::tests::EnvGuard`. The assumption now fails loudly instead of silently regressing if the test runtime flavor ever changes.
- Documented the invariant once, in the `backend::test_support` module doc, instead of repeating it in 10 near-identical per-test comments.
- The two `audiobooks/tests.rs` status-endpoint tests had their own local `ENV_LOCK` + manual `OMNIBUS_DATA_DIR` set/restore; switched them to the already-established `DataDirGuard` convention (already used by the journals/ebooks/uploads/covers tests). That also drops the need for `#[allow(clippy::await_holding_lock)]` there entirely, since the lock is now held via an opaque RAII wrapper rather than a bare `MutexGuard` binding (clippy's lint only matches a directly-bound guard type, not one hidden behind a struct field — verified empirically before relying on it).
- `auth::boot::tests::EnvGuard` already used the same opaque-wrapper shape, so its 9 `#[allow(clippy::await_holding_lock)]` attributes were dead weight even before this change; removed them along with the stale comment claiming clippy needed them.

## Test plan
- [x] `cargo fmt` — no diff
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus` — 394 passed, 2 failed. The 2 failures (`backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400`) are the pre-existing, unrelated root-sandbox flake (chmod 0o555 bypassed by root) called out in the issue's own test notes — not caused by this change. All touched tests (`auth::boot::tests::*`, `backend::audiobooks::tests::*`) pass.

## Version
- [x] **No release** — test-only change, no user-facing behavior.

## Notes
- Confirmed via a local experiment that clippy's `await_holding_lock` lint only fires on a directly-bound `MutexGuard` local, not one wrapped inside a struct field — this is why `EnvVarGuard`/`CoversDirGuard`-style RAII wrappers elsewhere in the codebase never needed the suppression in the first place.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZvPoTt3YLcAaBrbR7GJXS)_