### PR TITLE
refactor: cover scattered pure-logic test gaps in db/frontend (#1264)

### DIFF
--- a/db/src/hls/tests.rs
+++ b/db/src/hls/tests.rs
@@ -440,6 +440,7 @@ fn evict_if_over_cap_removes_oldest_book_directory() {
         let book_dir = base.join(i.to_string()).join(AUDIO64);
         std::fs::create_dir_all(&book_dir).unwrap();
         std::fs::write(book_dir.join("seg0.ts"), vec![0u8; 100]).unwrap();
+        // Small sleep to ensure distinct mtimes on coarse-resolution filesystems.
         std::thread::sleep(Duration::from_millis(50));
     }
 

--- a/db/src/hls/tests.rs
+++ b/db/src/hls/tests.rs
@@ -424,3 +424,33 @@ async fn get_parts_propagates_db_error_when_pool_is_closed() {
     let err = get_parts(&pool, 1).await.unwrap_err();
     assert!(matches!(err, HlsError::Db(_)));
 }
+
+/// Mirrors `thumbs::tests::evict_if_over_cap_removes_oldest_files`'s shape:
+/// FIFO-by-mtime eviction, but scoped to whole `<book_id>/<profile>/` segment
+/// directories rather than individual thumbnail files.
+#[test]
+fn evict_if_over_cap_removes_oldest_book_directory() {
+    let (_guard, _dir) = data_dir_guard();
+    let base = hls_dir();
+
+    // Three book directories with staggered mtimes (we can only guarantee
+    // ordering, not specific times, so create sequentially and trust OS
+    // mtime, as the thumbs test does).
+    for i in 0u8..3 {
+        let book_dir = base.join(i.to_string()).join(AUDIO64);
+        std::fs::create_dir_all(&book_dir).unwrap();
+        std::fs::write(book_dir.join("seg0.ts"), vec![0u8; 100]).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // Cap at 200 bytes → should delete the 1 oldest book dir (100 bytes each,
+    // 3x100 = 300 total).
+    evict_if_over_cap(200).unwrap();
+
+    let remaining: Vec<_> = std::fs::read_dir(&base).unwrap().flatten().collect();
+    assert_eq!(remaining.len(), 2, "should have evicted 1 oldest book dir");
+    assert!(
+        !base.join("0").exists(),
+        "the oldest book dir (0) should be evicted"
+    );
+}

--- a/db/src/kindle/tests.rs
+++ b/db/src/kindle/tests.rs
@@ -181,3 +181,88 @@ async fn send_propagates_db_error_when_pool_is_closed() {
         .unwrap_err();
     assert!(matches!(err, KindleError::Settings(_)));
 }
+
+#[test]
+fn kindle_error_io_wraps_filesystem_error() {
+    // `send` surfaces a failed metadata/read on the resolved EPUB path
+    // through `#[from] std::io::Error` as `KindleError::Io`. Constructing
+    // one directly via the `From` bridge asserts that mapping without
+    // needing a real vanished file mid-send.
+    let src = std::io::Error::new(std::io::ErrorKind::NotFound, "epub vanished");
+    let err: KindleError = src.into();
+    assert!(matches!(err, KindleError::Io(_)), "got {err:?}");
+    assert!(
+        err.to_string().starts_with("failed to read the EPUB file"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn kindle_error_books_wraps_books_error() {
+    // `book_file_path`/`book_file_path_by_id` return `crate::books::BooksError`,
+    // surfaced through `#[from]` as `KindleError::Books`.
+    let src = crate::books::BooksError::Db(sqlx::Error::RowNotFound);
+    let err: KindleError = src.into();
+    assert!(matches!(err, KindleError::Books(_)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn send_returns_smtp_error_when_relay_connection_is_refused() {
+    let _env = EnvVarGuard::set("SMTP_HOST", None).also_set("SMTP_FROM_EMAIL", None);
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    // Bind an ephemeral port and drop the listener immediately so the SMTP
+    // config points at a definitely-closed port: the connection attempt
+    // inside `deliver` fails fast with a transport error (`KindleError::Smtp`)
+    // instead of hanging for the full `SEND_TIMEOUT`.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    set_smtp_config(
+        &pool,
+        &SmtpConfigUpdate {
+            host: "127.0.0.1".into(),
+            port,
+            username: String::new(),
+            from_email: "library@example.com".into(),
+            security: SmtpSecurity::Starttls,
+            password: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let lib = dir.path().to_str().unwrap();
+    let epub = dir.path().join("small.epub");
+    std::fs::write(&epub, b"epub-bytes").unwrap();
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(lib)
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let book_id = sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title) VALUES ('uuid-small', ?, '', 'Small')",
+    )
+    .bind(lib_id)
+    .execute(&pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'small', 0)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let err = send(&pool, book_id, None, "reader@kindle.com")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, KindleError::Smtp(_)), "got {err:?}");
+}

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -1330,3 +1330,455 @@ async fn search_palette_propagates_db_error_when_pool_is_closed() {
     let err = search_palette(&pool, "/lib", "query").await.unwrap_err();
     assert!(matches!(err, PaletteError::Db(_)));
 }
+
+// ── `_for_paths` multi-library scoping (issue #1264) ─────────────
+// Each `*_for_paths` arm accepts a slice of library paths (the single-path
+// helpers above just forward `&[library_path]`); these seed three distinct
+// libraries and scope each call to a two-path subset, asserting the third
+// library's rows are excluded.
+
+#[tokio::test]
+async fn search_palette_for_paths_scopes_to_given_library_paths() {
+    let _covers = CoversTempDir::new("for_paths_palette");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed(
+            "a.epub",
+            Some("Shared Alpha"),
+            &["Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed(
+            "b.epub",
+            Some("Shared Beta"),
+            &["Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-c",
+        vec![indexed(
+            "c.epub",
+            Some("Shared Gamma"),
+            &["Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let results = search_palette_for_paths(&pool, &["/lib-a", "/lib-b"], "Shared")
+        .await
+        .unwrap();
+    let titles: Vec<&str> = results.books.iter().map(|b| b.title.as_str()).collect();
+    assert!(titles.contains(&"Shared Alpha"));
+    assert!(titles.contains(&"Shared Beta"));
+    assert!(
+        !titles.contains(&"Shared Gamma"),
+        "book from the unlisted /lib-c must not appear, got {titles:?}"
+    );
+}
+
+#[tokio::test]
+async fn search_authors_for_paths_scopes_to_given_library_paths() {
+    let _covers = CoversTempDir::new("for_paths_authors");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed(
+            "a.epub",
+            Some("A"),
+            &["Match Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed(
+            "b.epub",
+            Some("B"),
+            &["Match Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-c",
+        vec![indexed(
+            "c.epub",
+            Some("C"),
+            &["Match Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let hits = search_authors_for_paths(&pool, &["/lib-a", "/lib-b"], "%match%", LIMIT)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1, "one author, aggregated across the two paths");
+    assert_eq!(
+        hits[0].book_count, 2,
+        "count should include /lib-a and /lib-b but not /lib-c"
+    );
+}
+
+#[tokio::test]
+async fn count_authors_for_paths_counts_across_given_library_paths() {
+    let _covers = CoversTempDir::new("for_paths_count_authors");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed(
+            "a.epub",
+            Some("A"),
+            &["Match One"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed(
+            "b.epub",
+            Some("B"),
+            &["Match Two"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-c",
+        vec![indexed(
+            "c.epub",
+            Some("C"),
+            &["Match Three"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let total = count_authors_for_paths(&pool, &["/lib-a", "/lib-b"], "%match%")
+        .await
+        .unwrap();
+    assert_eq!(total, 2, "should count /lib-a and /lib-b but not /lib-c");
+}
+
+#[tokio::test]
+async fn search_books_for_paths_scopes_to_given_library_paths() {
+    let _covers = CoversTempDir::new("for_paths_books");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed(
+            "a.epub",
+            Some("Quest Alpha"),
+            &["Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed(
+            "b.epub",
+            Some("Quest Beta"),
+            &["Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-c",
+        vec![indexed(
+            "c.epub",
+            Some("Quest Gamma"),
+            &["Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let (hits, total) = search_books_for_paths(&pool, &["/lib-a", "/lib-b"], "quest", LIMIT)
+        .await
+        .unwrap();
+    assert_eq!(total, 2, "match total scoped to /lib-a and /lib-b");
+    let titles: Vec<&str> = hits.iter().map(|b| b.title.as_str()).collect();
+    assert!(titles.contains(&"Quest Alpha"));
+    assert!(titles.contains(&"Quest Beta"));
+    assert!(!titles.contains(&"Quest Gamma"));
+}
+
+#[tokio::test]
+async fn search_series_for_paths_scopes_to_given_library_paths() {
+    let _covers = CoversTempDir::new("for_paths_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed(
+            "a.epub",
+            Some("A"),
+            &["Author"],
+            &[],
+            Some(("Match Series", "1")),
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed(
+            "b.epub",
+            Some("B"),
+            &["Author"],
+            &[],
+            Some(("Match Series", "2")),
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-c",
+        vec![indexed(
+            "c.epub",
+            Some("C"),
+            &["Author"],
+            &[],
+            Some(("Match Series", "3")),
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let hits = search_series_for_paths(&pool, &["/lib-a", "/lib-b"], "%match%", LIMIT)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].book_count, 2,
+        "count should include /lib-a and /lib-b but not /lib-c"
+    );
+}
+
+#[tokio::test]
+async fn count_series_for_paths_counts_across_given_library_paths() {
+    let _covers = CoversTempDir::new("for_paths_count_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed(
+            "a.epub",
+            Some("A"),
+            &["X"],
+            &[],
+            Some(("Match Alpha", "1")),
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed(
+            "b.epub",
+            Some("B"),
+            &["X"],
+            &[],
+            Some(("Match Beta", "1")),
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-c",
+        vec![indexed(
+            "c.epub",
+            Some("C"),
+            &["X"],
+            &[],
+            Some(("Match Gamma", "1")),
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let total = count_series_for_paths(&pool, &["/lib-a", "/lib-b"], "%match%")
+        .await
+        .unwrap();
+    assert_eq!(total, 2, "should count /lib-a and /lib-b but not /lib-c");
+}
+
+#[tokio::test]
+async fn search_tags_for_paths_scopes_to_given_library_paths() {
+    let _covers = CoversTempDir::new("for_paths_tags");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed(
+            "a.epub",
+            Some("A"),
+            &["Author"],
+            &["Match Tag"],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed(
+            "b.epub",
+            Some("B"),
+            &["Author"],
+            &["Match Tag"],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-c",
+        vec![indexed(
+            "c.epub",
+            Some("C"),
+            &["Author"],
+            &["Match Tag"],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let hits = search_tags_for_paths(&pool, &["/lib-a", "/lib-b"], "%match%", LIMIT)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].book_count, 2,
+        "count should include /lib-a and /lib-b but not /lib-c"
+    );
+}
+
+#[tokio::test]
+async fn count_tags_for_paths_counts_across_given_library_paths() {
+    let _covers = CoversTempDir::new("for_paths_count_tags");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    replace_books(
+        &pool,
+        "/lib-a",
+        vec![indexed(
+            "a.epub",
+            Some("A"),
+            &["X"],
+            &["Match One"],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-b",
+        vec![indexed(
+            "b.epub",
+            Some("B"),
+            &["X"],
+            &["Match Two"],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    replace_books(
+        &pool,
+        "/lib-c",
+        vec![indexed(
+            "c.epub",
+            Some("C"),
+            &["X"],
+            &["Match Three"],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+
+    let total = count_tags_for_paths(&pool, &["/lib-a", "/lib-b"], "%match%")
+        .await
+        .unwrap();
+    assert_eq!(total, 2, "should count /lib-a and /lib-b but not /lib-c");
+}

--- a/db/src/suggestions/tests.rs
+++ b/db/src/suggestions/tests.rs
@@ -8,7 +8,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::author_photos::RemoteImageConfig;
 use crate::pool::init_db;
-use crate::suggestions::cascade::resolve_with;
+use crate::suggestions::cascade::{extract_isbns, resolve_with};
 use crate::suggestions::data::{
     decide, delete_suggestions, get_suggestion_cover, get_suggestions, mark_pending,
     replace_suggestions, suggestion_state, NewSuggestion, SuggestionState, SuggestionsDataError,
@@ -871,5 +871,58 @@ async fn resolve_book_propagates_an_earlier_isbn_error_even_when_a_later_isbn_in
         book_777_fetches, 1,
         "isbn[2] must have fully resolved to book 777 in the background, even though \
          the earlier isbn[1] error is what the walk actually surfaces"
+    );
+}
+
+// ── extract_isbns(): candidate ISBN extraction from identifiers ──
+
+#[test]
+fn extract_isbns_matches_identifiers_whose_scheme_names_isbn() {
+    let book = omnibus_shared::EbookMetadata {
+        identifiers: vec![
+            omnibus_shared::Identifier {
+                value: "978-0-13-468599-1".into(),
+                scheme: Some("ISBN".into()),
+            },
+            // A differently-schemed identifier with no digits at all must
+            // still be excluded (cleaned value is empty).
+            omnibus_shared::Identifier {
+                value: "not-an-isbn".into(),
+                scheme: Some("mobi-asin".into()),
+            },
+        ],
+        ..Default::default()
+    };
+    let isbns = extract_isbns(&book);
+    assert_eq!(
+        isbns,
+        vec!["9780134685991".to_string()],
+        "scheme-named ISBN identifier should survive with hyphens stripped"
+    );
+}
+
+#[test]
+fn extract_isbns_matches_bare_digit_values_via_heuristic_when_scheme_is_unrecognized() {
+    let book = omnibus_shared::EbookMetadata {
+        identifiers: vec![
+            // Common `scheme = "unknown"` case: no "isbn" in the scheme name,
+            // but the value is a bare 10-digit string.
+            omnibus_shared::Identifier {
+                value: "0141439513".into(),
+                scheme: Some("unknown".into()),
+            },
+            // Too short to look like an ISBN and not scheme-named — excluded.
+            omnibus_shared::Identifier {
+                value: "12345".into(),
+                scheme: None,
+            },
+        ],
+        ..Default::default()
+    };
+    let isbns = extract_isbns(&book);
+    assert_eq!(
+        isbns,
+        vec!["0141439513".to_string()],
+        "10-digit bare value should be picked up by the length heuristic alone"
     );
 }

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -807,4 +807,23 @@ mod tests {
         assert!(!err.is_unauthorized());
         assert_eq!(err.to_string(), "missing value field");
     }
+
+    // `Decode` only exists on the web/mobile builds that link `serde_json`
+    // for direct body deserialization (see the variant's doc comment); gated
+    // to match so this test simply doesn't compile into a server-only build.
+    #[cfg(any(feature = "mobile", feature = "web"))]
+    #[test]
+    fn decode_wraps_a_malformed_json_body_parse_failure() {
+        // A truncated/invalid body run through the same `serde_json`
+        // deserializer the web/SSR path uses, surfaced through `#[from]` as
+        // `DataError::Decode`.
+        let src = serde_json::from_str::<serde_json::Value>("{not valid json").unwrap_err();
+        let err: DataError = src.into();
+        assert!(matches!(err, DataError::Decode(_)), "got {err:?}");
+        assert!(
+            err.to_string()
+                .starts_with("response deserialization failed"),
+            "got {err}"
+        );
+    }
 }

--- a/frontend/src/pages/landing/sorting.rs
+++ b/frontend/src/pages/landing/sorting.rs
@@ -277,6 +277,67 @@ mod tests {
         assert_eq!(row_slug("plain"), "plain");
     }
 
+    // contributor_names cases.
+    #[test]
+    fn contributor_names_joins_multiple_creators_with_comma_space() {
+        let creators = vec![
+            Contributor {
+                name: "First Author".into(),
+                role: None,
+                file_as: None,
+                id: None,
+            },
+            Contributor {
+                name: "Second Author".into(),
+                role: None,
+                file_as: None,
+                id: None,
+            },
+        ];
+        assert_eq!(contributor_names(&creators), "First Author, Second Author");
+    }
+
+    #[test]
+    fn contributor_names_returns_empty_string_for_no_creators() {
+        assert_eq!(contributor_names(&[]), "");
+    }
+
+    // toggle_dir cases.
+    #[test]
+    fn toggle_dir_flips_asc_and_desc() {
+        assert_eq!(toggle_dir(SortDir::Asc), SortDir::Desc);
+        assert_eq!(toggle_dir(SortDir::Desc), SortDir::Asc);
+    }
+
+    // sort_key_value / sort_key_label / sort_key_from_value cases.
+    #[test]
+    fn sort_key_value_delegates_to_the_shared_wire_vocabulary() {
+        for key in SORT_KEYS {
+            assert_eq!(sort_key_value(key), key.as_wire());
+        }
+    }
+
+    #[test]
+    fn sort_key_label_names_every_sort_key() {
+        assert_eq!(sort_key_label(SortKey::Title), "Title");
+        assert_eq!(sort_key_label(SortKey::Author), "Author");
+        assert_eq!(sort_key_label(SortKey::Series), "Series");
+        assert_eq!(sort_key_label(SortKey::LastUpdated), "Last Updated");
+        assert_eq!(sort_key_label(SortKey::NewestAdded), "Newest Added");
+    }
+
+    #[test]
+    fn sort_key_from_value_round_trips_every_sort_key_through_its_wire_value() {
+        for key in SORT_KEYS {
+            assert_eq!(sort_key_from_value(sort_key_value(key)), Some(key));
+        }
+    }
+
+    #[test]
+    fn sort_key_from_value_returns_none_for_unrecognized_token() {
+        assert_eq!(sort_key_from_value("not-a-real-key"), None);
+    }
+
     // sort_books cases.
     fn sample() -> Vec<EbookMetadata> {
         vec![

--- a/frontend/src/pages/reader/prefs.rs
+++ b/frontend/src/pages/reader/prefs.rs
@@ -241,3 +241,38 @@ fn load_spread_or_default() -> Spread {
     #[cfg(not(feature = "web"))]
     Spread::Double
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `Signal::new` requires an active Dioxus runtime, so the assertions run
+    // inside a throwaway component driven by a bare `VirtualDom` rebuild —
+    // mirrors `contexts::tests::bump_cover_cache_bust_is_observed_by_other_readers_of_the_same_signal`.
+    #[test]
+    fn font_pct_maps_font_size_bounds_and_midpoint_to_expected_percentage() {
+        #[component]
+        fn AssertFontPct() -> Element {
+            let prefs = ReaderPrefs {
+                theme: Signal::new(Theme::Dark),
+                font_size: Signal::new(FONT_SIZE_MIN),
+                typeface: Signal::new(Typeface::Editorial),
+                line_spacing: Signal::new(LineSpacing::Cozy),
+                margins: Signal::new(Margins::Normal),
+                justify: Signal::new(false),
+                spread: Signal::new(Spread::Single),
+            };
+            assert_eq!(prefs.font_pct(), 0.0, "min font size maps to 0%");
+
+            let mut font_size = prefs.font_size;
+            font_size.set(FONT_SIZE_MAX);
+            assert_eq!(prefs.font_pct(), 100.0, "max font size maps to 100%");
+
+            font_size.set((FONT_SIZE_MIN + FONT_SIZE_MAX) / 2);
+            assert_eq!(prefs.font_pct(), 50.0, "midpoint font size maps to 50%");
+
+            rsx! {}
+        }
+        VirtualDom::new(AssertFontPct).rebuild_in_place();
+    }
+}

--- a/frontend/src/pages/reader/prefs.rs
+++ b/frontend/src/pages/reader/prefs.rs
@@ -246,9 +246,7 @@ fn load_spread_or_default() -> Spread {
 mod tests {
     use super::*;
 
-    // `Signal::new` requires an active Dioxus runtime, so the assertions run
-    // inside a throwaway component driven by a bare `VirtualDom` rebuild —
-    // mirrors `contexts::tests::bump_cover_cache_bust_is_observed_by_other_readers_of_the_same_signal`.
+    // `Signal::new` needs a Dioxus runtime, so this runs inside a `VirtualDom` (see `contexts::tests`).
     #[test]
     fn font_pct_maps_font_size_bounds_and_midpoint_to_expected_percentage() {
         #[component]

--- a/frontend/src/pages/reader/typography.rs
+++ b/frontend/src/pages/reader/typography.rs
@@ -151,6 +151,11 @@ fn local_storage() -> Option<web_sys::Storage> {
     web_sys::window().and_then(|w| w.local_storage().ok().flatten())
 }
 
+// `save_reader_pref`/`load_reader_pref` are thin `web_sys::Storage` wrappers
+// with no branching logic of their own — and `web_sys::window()` only
+// resolves inside a real browser, so there's no host to unit-test against.
+// No test needed per the coverage rule's thin-wrapper carve-out.
+
 /// Persist a single reader preference under its `omn.*` key.
 #[cfg(feature = "web")]
 pub(crate) fn save_reader_pref(key: &str, value: &str) {

--- a/frontend/src/pages/reader/typography.rs
+++ b/frontend/src/pages/reader/typography.rs
@@ -151,10 +151,7 @@ fn local_storage() -> Option<web_sys::Storage> {
     web_sys::window().and_then(|w| w.local_storage().ok().flatten())
 }
 
-// `save_reader_pref`/`load_reader_pref` are thin `web_sys::Storage` wrappers
-// with no branching logic of their own — and `web_sys::window()` only
-// resolves inside a real browser, so there's no host to unit-test against.
-// No test needed per the coverage rule's thin-wrapper carve-out.
+// Thin `web_sys::Storage` wrappers, no browser to test against — no test per the thin-wrapper carve-out.
 
 /// Persist a single reader preference under its `omn.*` key.
 #[cfg(feature = "web")]

--- a/shared/src/physical.rs
+++ b/shared/src/physical.rs
@@ -61,3 +61,28 @@ pub struct WishlistEntry {
     pub added_at: i64,
     pub source: WishlistSource,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wishlist_source_round_trips_through_the_db_string_for_every_variant() {
+        for variant in [
+            WishlistSource::Scan,
+            WishlistSource::Detail,
+            WishlistSource::Manual,
+        ] {
+            assert_eq!(
+                WishlistSource::from_db(variant.as_str()),
+                Some(variant),
+                "variant {variant:?} did not round-trip through as_str/from_db"
+            );
+        }
+    }
+
+    #[test]
+    fn wishlist_source_from_db_returns_none_for_unrecognized_token() {
+        assert_eq!(WishlistSource::from_db("bogus"), None);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #1264
- Adds happy-path coverage for the 8 `*_for_paths` palette arms (`db/src/palette/{mod,authors,books,series,tags}.rs`), scoping a search/count to a subset of library paths — `db/src/palette/tests.rs`
- Adds `evict_if_over_cap` coverage for `db/src/hls/transcode.rs`, mirroring the FIFO-by-mtime shape of `thumbs::tests::evict_if_over_cap_removes_oldest_files` but scoped to whole `<book_id>/<profile>/` segment dirs
- Adds `extract_isbns` coverage for both the scheme-named-ISBN branch and the bare 10/13-digit heuristic branch (`db/src/suggestions/cascade.rs`)
- Adds direct tests for `contributor_names`, `toggle_dir`, `sort_key_value`, `sort_key_label`, `sort_key_from_value` in `frontend/src/pages/landing/sorting.rs`'s existing inline `mod tests`
- Adds `KindleError::{Smtp,Books,Io}` coverage in `db/src/kindle/tests.rs`, mirroring the existing per-variant tests (the `Smtp` case exercises a real connection-refused against a freshly-dropped ephemeral port so it stays deterministic and fast)
- Adds a `DataError::Decode` test in `frontend/src/data.rs`, gated `#[cfg(any(feature = "mobile", feature = "web"))]` to match the variant's own gate (doesn't compile into the server-only build; verified separately under `--features mobile`)
- Low-severity (best-effort), all completed:
  - `frontend/src/pages/reader/prefs.rs` `font_pct` — direct test via a throwaway `VirtualDom`-driven component, mirroring `contexts::tests::bump_cover_cache_bust_is_observed_by_other_readers_of_the_same_signal`
  - `shared/src/physical.rs` `WishlistSource::{as_str, from_db}` — round-trip test
  - `frontend/src/pages/reader/typography.rs` `save_reader_pref`/`load_reader_pref` — added the "thin wrapper, no test needed" carve-out comment (both need a real `web_sys::window()`, unavailable in unit tests)
- Pure test-addition change; no production logic changed (aside from the one-line carve-out comment).

## Test plan
- [x] `cd /home/user/omnibus-wt-1264 && CARGO_TARGET_DIR=/tmp/omnibus-target-1264 cargo fmt` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1264 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1264 cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1264 cargo clippy -p omnibus-shared --all-targets -- -D warnings` — PASS (touched `shared/src/physical.rs`)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1264 cargo test -p omnibus-db` — PASS (1200 passed, 0 failed; needed `just fixtures` first — see Notes)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1264 cargo test -p omnibus-frontend --features server` — PASS (397 passed, 0 failed)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1264 cargo test -p omnibus-shared` — PASS (171 passed, 0 failed)

## Version
- [x] **No release** — test-only additions.

## Notes
- All Medium-severity acceptance criteria are covered. All three Low-severity bullets are also done (see Summary).
- `cargo test -p omnibus-db` initially failed on an unrelated pre-existing fixture-missing panic (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) because the sandbox hadn't run `just fixtures` yet; running it resolved the failure and is unrelated to this change.
- Verified `DataError::Decode`'s test also compiles and passes under `cargo test -p omnibus-frontend --features mobile` (not one of the prescribed verify commands, but confirms the gate is correct on the other feature side too).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZvPoTt3YLcAaBrbR7GJXS)_