### PR TITLE
docs: add root CHANGELOG.md (#1271)

### DIFF
--- a/.claude/rules/99-end-of-session.md
+++ b/.claude/rules/99-end-of-session.md
@@ -7,6 +7,7 @@ Before ending a session where code changed, run this checklist:
    - New dependency in `Cargo.toml` → call it out wherever it's relevant (CLAUDE.md if it affects build commands, the matching rule file if it shifts a convention).
    - New environment variable or configuration key → [.claude/rules/01-dev-environment.md](01-dev-environment.md) and [.env.example](../../.env.example).
    - New or changed convention (error handling, test patterns, etc.) → the matching rule file under [.claude/rules/](.) and the [CLAUDE.md](../../CLAUDE.md) rules index if it's a new file.
+   - Notable user-facing or architectural change landing in the next release → add a bullet under `## [Unreleased]` in [CHANGELOG.md](../../CHANGELOG.md).
 2. **Skill freshness.** Run [98-keep-skills-fresh.md](98-keep-skills-fresh.md) — verify no skill file got stale.
 3. **Nix sync.** If a new system dependency was added, update [flake.nix](../../flake.nix). If the shellHook changed, update [01-dev-environment.md](01-dev-environment.md).
 4. **Format & lint.** Run `just lint` (`cargo fmt --check` + clippy across the crate/feature matrix), or `cargo fmt` + `cargo clippy` on the crates you touched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Releases are cut automatically on merge to `main` (see
-`.github/pull_request_template.md` — unlabeled PRs default to a patch
-release; `minor version` / `patch version` / `no release` labels
-override that), so entries here are curated manually rather than
-generated from the raw commit log.
+`.github/pull_request_template.md`): by default a merge cuts a patch
+release, and the `minor version` / `patch version` / `no release`
+labels override that default. Unlabeled PRs that only touch docs
+(`*.md`, `docs/`) or CI (`.github/`) skip the release automatically.
+Entries here are curated manually rather than generated from the raw
+commit log.
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Releases are cut automatically on merge to `main` (see
+`.github/pull_request_template.md` — unlabeled PRs default to a patch
+release; `minor version` / `patch version` / `no release` labels
+override that), so entries here are curated manually rather than
+generated from the raw commit log.
+
+## [Unreleased]
+
+## [v0.11.4] - 2026-07-24
+
+### Changed
+
+- Added missing row `LIMIT` to `list_wishlist` (#1259)
+- Added test coverage for `ScanError` `Lookup`/`Physical`/`Sqlx` variants (#1263)
+
+## [v0.11.3] - 2026-07-24
+
+### Changed
+
+- Added test coverage for `server::backend::covers` (#1262)
+
+## [v0.11.2] - 2026-07-24
+
+### Fixed
+
+- Fixed `deny.toml` `skip-tree` comment for `rustc-hash` (#1276)
+
+## [v0.11.1] - 2026-07-24
+
+### Changed
+
+- Enforced `-D warnings` and wasm32 clippy in `just lint` (#1270)
+
+## [v0.11.0] - 2026-07-23
+
+### Added
+
+- Added the Google Books API key as a first-class Settings field, used as a
+  fallback rung in the check-in ISBN lookup ladder (#1292)


### PR DESCRIPTION
## Summary
- Adds a root `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format: an `## [Unreleased]` section plus entries for the last five release tags (v0.11.0–v0.11.4), backfilled from actual commit/PR titles.
- Adds a one-line docs-sync reminder to `.claude/rules/99-end-of-session.md` so future notable changes get logged under `## [Unreleased]` going forward.
- Closes #1271

## Test plan
- [x] Docs-only change — no build/test commands apply.
- [x] `git status`/`git diff --stat` confirms only `CHANGELOG.md` and `.claude/rules/99-end-of-session.md` changed.

## Version
- [x] **No release** — docs-only change; unlabeled PRs touching only `*.md`/`docs/` auto-skip the release per the template's own rule.

## Notes
- Entries were curated manually from `git log` / tag history per the issue's suggested approach, not auto-generated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZvPoTt3YLcAaBrbR7GJXS)_