### PR TITLE
fix: de-race db test-support so covers/periodic-scan tests stop flaking CI

### DIFF
--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -131,17 +131,13 @@ impl Drop for EnvVarGuard {
 // Covers env guard
 // ---------------------------------------------------------------------------
 
-/// Process-wide lock for `OMNIBUS_COVERS_DIR`. Tests that touch the
-/// covers directory must serialize, since the env var is global.
-///
-/// Prefer `EnvVarGuard` + `ENV_LOCK` for new callers. This alias is
-/// retained for test code that still references it directly.
-pub static COVERS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 /// RAII guard that points `OMNIBUS_COVERS_DIR` at a unique temp dir for
 /// the lifetime of the test, then restores the previous value (and
-/// removes the temp dir) on drop. Holds `COVERS_ENV_LOCK` so parallel
-/// `cargo test` runs don't stomp on each other.
+/// removes the temp dir) on drop. Holds the shared [`ENV_LOCK`] — the
+/// same lock `EnvVarGuard` uses — so it serializes against *every* other
+/// env-var mutation in the crate, not just other `CoversTempDir`s. A
+/// prior split lock let a test setting `OMNIBUS_COVERS_DIR` via
+/// `EnvVarGuard` run concurrently with one here and stomp the value.
 pub struct CoversTempDir {
     pub path: PathBuf,
     prev: Option<String>,
@@ -150,7 +146,7 @@ pub struct CoversTempDir {
 
 impl CoversTempDir {
     pub fn new(tag: &str) -> Self {
-        let guard = COVERS_ENV_LOCK
+        let guard = ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let pid = std::process::id();
@@ -161,7 +157,7 @@ impl CoversTempDir {
         let path = std::env::temp_dir().join(format!("omnibus_covers_{tag}_{pid}_{seq}"));
         let _ = std::fs::remove_dir_all(&path);
         let prev = std::env::var("OMNIBUS_COVERS_DIR").ok();
-        // SAFETY: COVERS_ENV_LOCK is held; no other thread mutates the env.
+        // SAFETY: ENV_LOCK is held; no other thread mutates the env.
         unsafe {
             std::env::set_var("OMNIBUS_COVERS_DIR", &path);
         }
@@ -176,7 +172,7 @@ impl CoversTempDir {
 impl Drop for CoversTempDir {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.path);
-        // SAFETY: COVERS_ENV_LOCK is still held via `_guard`.
+        // SAFETY: ENV_LOCK is still held via `_guard`.
         unsafe {
             match self.prev.take() {
                 Some(v) => std::env::set_var("OMNIBUS_COVERS_DIR", v),

--- a/db/src/worker/periodic_scan/tests.rs
+++ b/db/src/worker/periodic_scan/tests.rs
@@ -101,8 +101,12 @@ async fn periodic_scan_tick_posts_only_the_configured_library_path() {
     let _ = periodic_scan_tick(&p, &w).await;
 
     assert!(find_by_resource(&w, "/ebooks"));
+    // Count across both buckets: the /ebooks scan of a nonexistent path can
+    // fail fast and move from `active` to `recent_complete` before we snapshot,
+    // so asserting `active.len() == 1` alone races that completion.
+    let snap = w.progress_snapshot();
     assert_eq!(
-        w.progress_snapshot().active.len(),
+        snap.active.len() + snap.recent_complete.len(),
         1,
         "no audiobook path configured, so only one scan should be posted"
     );


### PR DESCRIPTION
## Summary
Two test-only isolation bugs in the `db` crate were intermittently reddening the `test (db)` CI job on unrelated PRs. Both are fixed here.

- **`covers::tests::cover_returns_override_when_flag_set` race.** `CoversTempDir` guarded `OMNIBUS_COVERS_DIR` with its own `COVERS_ENV_LOCK` — a *different* mutex from the `ENV_LOCK` that `EnvVarGuard` holds. `ENV_LOCK`'s own doc says "a single lock is used so guards for different variables still serialize … env-var space is process-global", but `CoversTempDir` opted out of it. So a test setting `OMNIBUS_COVERS_DIR` via `EnvVarGuard` (e.g. `deletion::tests`) could run concurrently with a `CoversTempDir` test and stomp the value — a genuine `set_var`/`set_var` data race (UB) — making `get_cover` read the wrong dir and return `None` (`left: None, right: Some(("image/png", …OVERRIDE…))`). `CoversTempDir` now holds the shared `ENV_LOCK`; the now-dead `COVERS_ENV_LOCK` is removed. Verified no test holds both an `EnvVarGuard` and a `CoversTempDir` simultaneously, so unifying the lock introduces no deadlock.

- **`periodic_scan_tick_posts_only_the_configured_library_path` race.** It asserted `active.len() == 1`, but the scan of the nonexistent `/ebooks` path can fail fast and move from `active` to `recent_complete` before the snapshot (`left: 0, right: 1`). It now counts across both buckets — the same race-safe pattern the sibling `find_by_resource` helper already uses for the other periodic-scan tests.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db --lib worker::periodic_scan::` — 6/6 passed, repeated 3× (multi-thread runtime, no flake)
- [x] `cargo test -p omnibus-db --lib` (full suite, exercises covers + deletion + settings concurrently) — 1199 passed across 3 consecutive runs; the sole failure each time is the pre-existing fixture-dependent `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, which needs `just fixtures` (not runnable in this environment) and is unrelated to this change.

## Version
- [x] **No release** — test-only change; no production code or behavior touched.

## Notes
- Pure test-support change: `db/src/test_support.rs` (lock unification) and `db/src/worker/periodic_scan/tests.rs` (assertion). No production logic changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZvPoTt3YLcAaBrbR7GJXS)_