### PR TITLE
feat: single-book OPF export endpoint and edit-page button

### DIFF
--- a/frontend/src/data/books.rs
+++ b/frontend/src/data/books.rs
@@ -6,8 +6,8 @@
 
 use omnibus_shared::{
     AudiobookManifest, BookDeletionManifest, DeleteBookFilesResult, EbookLibrary, EbookMetadata,
-    LibraryContents, LibraryPage, MergeBooksResult, MetadataOverrides, PaletteResults, Settings,
-    SortDir, SortKey, ViewFilters, WorkerStatus,
+    LibraryContents, LibraryPage, MergeBooksResult, MetadataOverrides, OpfExportResult,
+    PaletteResults, Settings, SortDir, SortKey, ViewFilters, WorkerStatus,
 };
 
 #[cfg(not(feature = "mobile"))]
@@ -453,6 +453,20 @@ pub async fn delete_overrides(
     Ok(Some(response.json::<EbookMetadata>().await?))
 }
 
+/// POST `/api/ebooks/{uuid}/export-opf` — write the book's `metadata.opf`
+/// sidecar (mobile).
+#[cfg(feature = "mobile")]
+pub async fn export_opf(server_url: &str, uuid: &str) -> Result<OpfExportResult, DataError> {
+    crate::data::require_online()?;
+    let url = format!("{server_url}/api/ebooks/{uuid}/export-opf");
+    let response = with_bearer(http_client().post(&url)).send().await?;
+    let status = note_status(response.status());
+    if !status.is_success() {
+        return Err(drain_error(response, status).await);
+    }
+    Ok(response.json::<OpfExportResult>().await?)
+}
+
 /// Multipart upload of a replacement cover for a book (mobile). Mirrors
 /// `upload_author_photo`'s mobile REST path against the analogous
 /// `/api/ebooks/:uuid/cover` endpoint.
@@ -777,6 +791,14 @@ pub async fn delete_overrides(
     uuid: &str,
 ) -> Result<Option<EbookMetadata>, DataError> {
     crate::rpc::rpc_delete_overrides(uuid.to_string())
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Web/SSR `export_opf` — server-function wrapper that proxies to `rpc_export_opf`.
+#[cfg(not(feature = "mobile"))]
+pub async fn export_opf(_server_url: &str, uuid: &str) -> Result<OpfExportResult, DataError> {
+    crate::rpc::rpc_export_opf(uuid.to_string())
         .await
         .map_err(note_server_fn_err)
 }

--- a/frontend/src/pages/metadata_edit/sidebar.rs
+++ b/frontend/src/pages/metadata_edit/sidebar.rs
@@ -1,13 +1,14 @@
 //! Sticky right-column sidebar for the metadata edit page: cover
 //! upload/revert (delegated to `cover_editor::CoverEditor`), identifiers,
-//! and the override-active card. Full-override revert bubbles to the
-//! parent `MetadataEditForm`; cover-only revert stays local, updating
-//! `live_book` so the "Override active" card tracks it.
+//! the OPF-export card, and the override-active card. Full-override revert
+//! bubbles to the parent `MetadataEditForm`; cover-only revert stays local,
+//! updating `live_book` so the "Override active" card tracks it.
 
 use dioxus::prelude::*;
-use omnibus_shared::EbookMetadata;
+use omnibus_shared::{EbookMetadata, OpfExportResult};
 
 use super::cover_editor::CoverEditor;
+use crate::{data, use_server_url};
 
 /// Cover preview + identifiers + override-status sidebar.
 #[component]
@@ -17,6 +18,7 @@ pub(super) fn Sidebar(
     on_revert: EventHandler<()>,
 ) -> Element {
     let uuid = book.unique_identifier.clone().unwrap_or_default();
+    let export_uuid = uuid.clone();
     let identifiers = book.identifiers.clone();
     // Tracks the merged book returned by a cover upload/revert so the
     // "Override active" card reflects a cover-only change immediately —
@@ -54,6 +56,8 @@ pub(super) fn Sidebar(
                 }
             }
 
+            ExportCard { uuid: export_uuid, saving }
+
             // Override status
             if has_override {
                 div { class: "card me-sidebar-card",
@@ -70,6 +74,70 @@ pub(super) fn Sidebar(
                         "Revert to scanned values"
                     }
                 }
+            }
+        }
+    }
+}
+
+/// "Export to OPF" card: writes the book's merged metadata to its
+/// `metadata.opf` sidecar and reports the resulting path / backup status.
+/// Not dirty-dependent, so it owns its own state instead of touching the
+/// parent form's save flow.
+#[component]
+fn ExportCard(uuid: String, saving: Signal<bool>) -> Element {
+    let server_url = use_server_url();
+    let mut exporting = use_signal(|| false);
+    let mut status: Signal<Option<Result<OpfExportResult, String>>> = use_signal(|| None);
+
+    let on_export = move |_| {
+        let uuid = uuid.clone();
+        let server_url = server_url.clone();
+        exporting.set(true);
+        status.set(None);
+        spawn(async move {
+            let result = data::export_opf(&server_url, &uuid)
+                .await
+                .map_err(|e| format!("Export failed: {e}"));
+            status.set(Some(result));
+            exporting.set(false);
+        });
+    };
+
+    rsx! {
+        div { class: "card me-sidebar-card",
+            div { class: "label", style: "margin-bottom: 8px;", "Export" }
+            p { class: "mono", style: "font-size: 11px; color: var(--ink-2);",
+                "Write a metadata.opf sidecar next to the book's EPUB with the current (scanned + override) metadata."
+            }
+            button {
+                class: "btn ghost sm",
+                style: "margin-top: 10px; width: 100%; justify-content: center;",
+                "data-testid": "me-export-opf",
+                disabled: exporting() || saving(),
+                onclick: on_export,
+                if exporting() { "Exporting\u{2026}" } else { "Export to OPF" }
+            }
+            match status() {
+                Some(Ok(result)) => rsx! {
+                    p {
+                        class: "mono",
+                        "data-testid": "me-export-status",
+                        style: "font-size: 11px; color: var(--ink-2); margin-top: 8px;",
+                        "Wrote {result.path}"
+                        if result.backed_up {
+                            " (previous file backed up to metadata.opf.bak)"
+                        }
+                    }
+                },
+                Some(Err(msg)) => rsx! {
+                    p {
+                        class: "mono",
+                        "data-testid": "me-export-status",
+                        style: "font-size: 11px; color: var(--bad); margin-top: 8px;",
+                        "{msg}"
+                    }
+                },
+                None => rsx! {},
             }
         }
     }

--- a/frontend/src/rpc/overrides.rs
+++ b/frontend/src/rpc/overrides.rs
@@ -2,7 +2,7 @@
 
 use dioxus::fullstack::post;
 use dioxus::prelude::*;
-use omnibus_shared::{EbookMetadata, MetadataOverrides};
+use omnibus_shared::{EbookMetadata, MetadataOverrides, OpfExportResult};
 
 #[cfg(feature = "server")]
 use omnibus_db as db;
@@ -33,6 +33,33 @@ pub async fn rpc_save_overrides(
     Ok(db::get_book_by_uuid(&pool.0, &uuid)
         .await
         .map_err(|e| internal_rpc_error("get ebook", e))?)
+}
+
+/// Export a book's merged metadata to its `metadata.opf` sidecar. Requires
+/// `can_edit` or admin. Returns the written path and whether an existing
+/// sidecar was backed up.
+#[post("/api/rpc/ebook/export-opf", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_export_opf(uuid: String) -> Result<OpfExportResult> {
+    if !user.is_admin && !user.can_edit {
+        return Err(ServerFnError::new("forbidden: edit permission required").into());
+    }
+    let Some(book_id) = db::resolve_book_id_by_uuid(&pool.0, &uuid)
+        .await
+        .map_err(|e| internal_rpc_error("resolve book id", e))?
+    else {
+        return Err(ServerFnError::new("book not found").into());
+    };
+    match db::export_opf(&pool.0, book_id).await {
+        Ok(export) => Ok(OpfExportResult {
+            path: export.path.display().to_string(),
+            backed_up: export.backed_up,
+        }),
+        // These are user-renderable resource-state errors, not internal faults.
+        Err(e @ (db::OpfExportError::BookNotFound(_) | db::OpfExportError::NoEpubFile(_))) => {
+            Err(ServerFnError::new(e.to_string()).into())
+        }
+        Err(e) => Err(internal_rpc_error("export opf", e).into()),
+    }
 }
 
 /// Delete metadata overrides for a book, reverting to scanned values.

--- a/frontend/src/rpc/overrides.rs
+++ b/frontend/src/rpc/overrides.rs
@@ -54,9 +54,14 @@ pub async fn rpc_export_opf(uuid: String) -> Result<OpfExportResult> {
             path: export.path.display().to_string(),
             backed_up: export.backed_up,
         }),
-        // These are user-renderable resource-state errors, not internal faults.
-        Err(e @ (db::OpfExportError::BookNotFound(_) | db::OpfExportError::NoEpubFile(_))) => {
-            Err(ServerFnError::new(e.to_string()).into())
+        // Stable, user-renderable messages that don't leak the internal
+        // numeric book id (which `OpfExportError`'s Display carries) — mirror
+        // the REST handler's strings.
+        Err(db::OpfExportError::BookNotFound(_)) => {
+            Err(ServerFnError::new("book not found").into())
+        }
+        Err(db::OpfExportError::NoEpubFile(_)) => {
+            Err(ServerFnError::new("book has no EPUB file to export next to").into())
         }
         Err(e) => Err(internal_rpc_error("export opf", e).into()),
     }

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -26,6 +26,7 @@ mod authors;
 mod bookmarks;
 mod covers;
 mod ebooks;
+mod export_opf;
 mod health;
 mod highlights;
 mod image_upload;
@@ -306,6 +307,10 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
         .route(
             "/api/ebooks/{uuid}/overrides",
             post(overrides::post_ebook_overrides).delete(overrides::delete_ebook_overrides),
+        )
+        .route(
+            "/api/ebooks/{uuid}/export-opf",
+            post(export_opf::post_export_opf),
         )
         // Cover-only revert. Carries no upload body (unlike the POST in
         // `upload_router`), so it stays outside the upload rate limiter —

--- a/server/src/backend/export_opf.rs
+++ b/server/src/backend/export_opf.rs
@@ -1,0 +1,54 @@
+//! Per-book OPF export handler (REST, mobile-facing).
+//!
+//! An edit-permitted user `POST`s against a book's uuid to write its
+//! `metadata.opf` sidecar; the response reports the path and whether an
+//! existing sidecar was backed up. Mounted on the REST router in
+//! [`super::rest_router`].
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use omnibus_db::{self as db};
+use omnibus_shared::OpfExportResult;
+
+use super::{internal, AppState};
+use crate::auth::AuthUser;
+
+/// Export a book's merged metadata to its `metadata.opf` sidecar. Requires
+/// `can_edit` or admin.
+pub(super) async fn post_export_opf(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(uuid): Path<String>,
+) -> Response {
+    if !user.is_admin && !user.can_edit {
+        return (StatusCode::FORBIDDEN, "edit permission required").into_response();
+    }
+    let id = match db::resolve_book_id_by_uuid(&state.pool, &uuid).await {
+        Ok(Some(id)) => id,
+        Ok(None) => return (StatusCode::NOT_FOUND, "book not found").into_response(),
+        Err(e) => return internal("resolve_book_id_by_uuid", e),
+    };
+    match db::export_opf(&state.pool, id).await {
+        Ok(export) => Json(OpfExportResult {
+            path: export.path.display().to_string(),
+            backed_up: export.backed_up,
+        })
+        .into_response(),
+        Err(db::OpfExportError::BookNotFound(_)) => {
+            (StatusCode::NOT_FOUND, "book not found").into_response()
+        }
+        Err(db::OpfExportError::NoEpubFile(_)) => (
+            StatusCode::CONFLICT,
+            "book has no EPUB file to export next to",
+        )
+            .into_response(),
+        Err(e) => internal("export_opf", e),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/src/backend/export_opf/tests.rs
+++ b/server/src/backend/export_opf/tests.rs
@@ -1,0 +1,136 @@
+//! Integration tests for the single-book OPF export endpoint.
+//!
+//! The RPC variant (`rpc_export_opf`) shares the same db call and is covered
+//! transitively by `db::opf_export` unit tests; these cover the REST entry
+//! point the mobile client uses — auth, permission, resolution, and the
+//! written-sidecar success path.
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header::AUTHORIZATION, Request, StatusCode},
+};
+use omnibus_shared::OpfExportResult;
+use tower::ServiceExt;
+
+use super::*;
+use crate::auth::test_support as auth_test_support;
+use crate::backend::test_support::*;
+
+fn post_export(uuid: &str, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .uri(format!("/api/ebooks/{uuid}/export-opf"))
+        .method("POST");
+    if let Some(token) = token {
+        builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+#[tokio::test]
+async fn api_export_opf_requires_auth() {
+    let (app, _state, _pool) = fixture().await;
+    let res = app
+        .oneshot(post_export("uuid-1", None))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_export_opf_returns_403_for_user_without_edit_permission() {
+    let (app, _state, pool) = fixture().await;
+    let lib = tempfile::tempdir().unwrap();
+    let (_id, uuid) = db::test_support::seed_epub_book_at(&pool, lib.path()).await;
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let res = app
+        .oneshot(post_export(&uuid, Some(&token)))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    assert!(
+        !lib.path().join("sub").join("metadata.opf").exists(),
+        "403 path must not write a sidecar"
+    );
+}
+
+#[tokio::test]
+async fn api_export_opf_returns_404_for_unknown_uuid() {
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let res = app
+        .oneshot(post_export("does-not-exist", Some(&token)))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn api_export_opf_writes_sidecar_and_returns_path_and_backed_up() {
+    let (app, _state, pool) = fixture().await;
+    let lib = tempfile::tempdir().unwrap();
+    let (_id, uuid) = db::test_support::seed_epub_book_at(&pool, lib.path()).await;
+    // A can_edit non-admin user must be able to export (AC3).
+    let user = auth_test_support::create_user(&pool, "editor").await;
+    sqlx::query("UPDATE users SET can_edit = 1 WHERE id = ?")
+        .bind(user.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let res = app
+        .oneshot(post_export(&uuid, Some(&token)))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let result: OpfExportResult = serde_json::from_slice(&bytes).unwrap();
+    assert!(result.path.ends_with("sub/metadata.opf"), "{}", result.path);
+    assert!(!result.backed_up);
+
+    let written = std::fs::read_to_string(lib.path().join("sub").join("metadata.opf")).unwrap();
+    assert!(written.contains("<dc:title>Title</dc:title>"));
+}
+
+#[tokio::test]
+async fn api_export_opf_returns_409_when_book_has_no_epub() {
+    let (app, _state, pool) = fixture().await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    // An audiobook-only book: a books row with only an M4B file.
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/audio', 'lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, last_modified)
+         VALUES ('uuid-ab', 'sub/audio', 1, 'sub', 'Audio', '2000-01-01 00:00:00')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = 'uuid-ab'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch)
+         VALUES (?, 'M4B', 'audio', 4, 1)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let res = app
+        .oneshot(post_export("uuid-ab", Some(&token)))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::CONFLICT);
+}

--- a/server/src/backend/export_opf/tests.rs
+++ b/server/src/backend/export_opf/tests.rs
@@ -1,9 +1,7 @@
-//! Integration tests for the single-book OPF export endpoint.
-//!
-//! The RPC variant (`rpc_export_opf`) shares the same db call and is covered
-//! transitively by `db::opf_export` unit tests; these cover the REST entry
-//! point the mobile client uses — auth, permission, resolution, and the
-//! written-sidecar success path.
+//! Integration tests for the single-book OPF export REST endpoint: auth,
+//! `can_edit` permission, uuid resolution, the audiobook-only 409, and the
+//! written-sidecar success path. The `rpc_export_opf` variant shares the same
+//! db call and is covered transitively by `db::opf_export` unit tests.
 
 use axum::{
     body::{to_bytes, Body},

--- a/shared/src/ebook/export.rs
+++ b/shared/src/ebook/export.rs
@@ -1,0 +1,13 @@
+//! Wire shape for the OPF-export action result (F5.8).
+
+use serde::{Deserialize, Serialize};
+
+/// Result of exporting a book's metadata to its `metadata.opf` sidecar.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpfExportResult {
+    /// Absolute path of the written `metadata.opf`.
+    pub path: String,
+    /// Whether an existing `metadata.opf` was backed up to
+    /// `metadata.opf.bak` before writing.
+    pub backed_up: bool,
+}

--- a/shared/src/ebook/export.rs
+++ b/shared/src/ebook/export.rs
@@ -1,4 +1,4 @@
-//! Wire shape for the OPF-export action result (F5.8).
+//! Wire shape for the OPF-export action result.
 
 use serde::{Deserialize, Serialize};
 

--- a/shared/src/ebook/mod.rs
+++ b/shared/src/ebook/mod.rs
@@ -5,11 +5,13 @@
 //! layer persisted in `metadata_overrides.overrides` and merged on read.
 //! Re-exports flatten so callers keep `omnibus_shared::EbookMetadata` etc.
 
+mod export;
 mod metadata;
 mod overrides;
 
 #[cfg(test)]
 mod tests;
 
+pub use export::OpfExportResult;
 pub use metadata::{BookFileInfo, Contributor, EbookMetadata, Identifier};
 pub use overrides::MetadataOverrides;

--- a/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
@@ -73,6 +73,9 @@ test("renders the metadata edit form with pre-populated fields", async ({ page, 
   await expect(page.getByTestId("me-save")).toBeVisible();
   await expect(page.getByTestId("me-discard")).toBeVisible();
 
+  // Export-to-OPF control is present in the sidebar.
+  await expect(page.getByTestId("me-export-opf")).toBeVisible();
+
   // Save is initially disabled (no dirty fields).
   await expect(page.getByTestId("me-save")).toBeDisabled();
 });
@@ -269,6 +272,40 @@ test("surfaces error and stays on edit form when save mutation fails", async ({ 
   // Save button has come out of its "Saving…" state and is re-enabled so
   // the user can retry. `toBeEnabled` auto-retries until the signal settles.
   await expect(page.getByTestId("me-save")).toBeEnabled();
+});
+
+// ---------------------------------------------------------------------------
+// OPF export — force a 500 on the export RPC and assert the sidebar surfaces
+// the failure and re-enables the button. Intercept-only: a real export would
+// write a metadata.opf into the committed fixture library; the success path
+// is covered by the db + server Rust tests.
+// ---------------------------------------------------------------------------
+
+test("surfaces error when the OPF export mutation fails", async ({ page, request }) => {
+  const id = await fetchBookIdByTitle(request, TARGET.title);
+  await gotoReady(page, `/books/${id}/edit`);
+
+  const exportBtn = page.getByTestId("me-export-opf");
+  await expect(exportBtn).toBeEnabled();
+
+  await page.route("**/api/rpc/ebook/export-opf", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ status: 500, contentType: "text/plain", body: "forced failure" });
+    }
+    return route.continue();
+  });
+
+  await expectMutation(
+    page,
+    { method: "POST", url: /\/api\/rpc\/ebook\/export-opf$/, expectedStatus: 500 },
+    async () => exportBtn.click(),
+  );
+
+  // Sidebar status line surfaces the failure; the button re-enables for retry.
+  await expect(page.getByTestId("me-export-status")).toContainText("Export failed");
+  await expect(exportBtn).toBeEnabled();
+
+  await page.unroute("**/api/rpc/ebook/export-opf");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Exposes the #957 OPF writer as a per-book action, available to non-admin `can_edit` users:
  - REST: `POST /api/ebooks/{uuid}/export-opf` (`server/src/backend/export_opf.rs`) — 403 without edit permission, 404 unknown uuid, **409** for an audiobook-only book with no EPUB, 200 → `{ path, backed_up }`.
  - RPC: `rpc_export_opf` (`frontend/src/rpc/overrides.rs`) — same gate; typed `NoEpubFile`/`BookNotFound` surface as user-renderable messages, everything else through `internal_rpc_error`.
  - Shared DTO `OpfExportResult { path, backed_up }` (`shared/src/ebook/export.rs`).
  - Unified `data::export_opf` wrapper (mobile REST + web/SSR RPC variants).
- Adds an **Export to OPF** card to the book metadata edit page sidebar (`me-export-opf`) that calls the action and shows the written path plus a "backed up to metadata.opf.bak" note on success, or the error inline.
- Stacked on #1319 (#957) — **base branch is `feat/957-opf-writer-1`**; review/merge that first.

## Test plan
- [x] `cargo test -p omnibus export_opf` — 5 integration tests: 401 anon, 403 non-`can_edit` (asserts no sidecar written), 404 unknown uuid, 409 audiobook-only, 200 success by a `can_edit` non-admin (deserializes `OpfExportResult`, asserts the file was written).
- [x] `cargo test -p omnibus-frontend --features server` — 406 passing; frontend compiles for server, `web`/wasm, and `mobile`.
- [x] Playwright `metadata_edit.spec.ts` — 15/15 passing against a rebuilt dev server, incl. the new "Export button visible" layout assertion and a forced-500 error-path test (intercept-only, so no real write dirties the committed fixtures).
- [x] `just lint` clean across the matrix.

## Version
- [x] **Minor** — completes the F5.8 OPF Export roadmap feature (new user-facing surface + REST endpoint).

## Notes
- Playwright covers only button-visibility + the failure path; the success path is proven by the db + server Rust tests (a real browser export would write into the committed `test_data/epubs/generated/` fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)