### PR TITLE
fix: re-apply audiobook playback rate after media load on web

### DIFF
--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -31,6 +31,7 @@ pub(super) fn control_surface_js(rate_lit: &str, vol_lit: &str, uuid_lit: &str) 
 {hls_init}
 
       _uuid: {uuid_lit},
+      _rate: {rate_lit},
     }};
   }}
   mount();
@@ -60,7 +61,10 @@ fn transport_controls_js() -> &'static str {
       play:    function(){ var p = el.play(); if (p && p.catch) p.catch(function(){}); },
       pause:   function(){ el.pause(); },
       toggle:  function(){ if (el.paused) { this.play(); } else { this.pause(); } },
-      setRate: function(r){ try { el.playbackRate = r; } catch(_) {} },
+      // Track the rate on the shim as well as the element: a media `load()`
+      // (new src / part swap / HLS attach) resets `el.playbackRate` to 1.0,
+      // and the `loadedmetadata` listener re-applies this tracked value.
+      setRate: function(r){ try { el.playbackRate = r; this._rate = r; } catch(_) {} },
       // User volume slider + sleep-timer fade both drive this. Clamps to
       // [0,1]; the Rust countdown ramps it down over the final seconds and
       // restores the user's chosen volume (not always 1.0) on cancel/expiry.
@@ -165,6 +169,12 @@ fn listeners_js() -> &'static str {
       // duration. For direct mode we always report the book-level total
       // so a part change does not collapse the scrub bar to per-part.
       var oa = window.OmnibusAudio;
+      // A media `load()` resets playbackRate to defaultPlaybackRate (1.0),
+      // so re-apply the tracked rate on every load — otherwise a restored
+      // speed shows in the UI but plays at 1.0 until the user re-picks it.
+      if (oa && typeof oa._rate === 'number') {
+        try { el.playbackRate = oa._rate; } catch(_) {}
+      }
       if (window.__omnibusOnAudioDuration) {
         var d = (oa && oa._mode === 'direct' && oa._totalDuration > 0)
           ? oa._totalDuration
@@ -318,6 +328,16 @@ mod tests {
         assert!(js.contains("el.playbackRate = 1.25;"));
         assert!(js.contains("el.volume = 0.6;"));
         assert!(js.contains("_uuid: \"abc-123\","));
+        // The shim tracks the rate so a media `load()` reset can be undone.
+        assert!(js.contains("_rate: 1.25,"), "initial _rate seed missing");
+        assert!(
+            js.contains("el.playbackRate = oa._rate;"),
+            "loadedmetadata rate re-apply missing"
+        );
+        assert!(
+            js.contains("this._rate = r;"),
+            "setRate does not track _rate"
+        );
         // Each pure JS segment contributed its signature substring.
         assert!(
             js.contains("SPA-nav from another page"),

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -165,6 +165,31 @@ test("persists playback speed per audiobook across reloads", async ({
   await waitForPlayerReady(page);
   await expect(page.getByTestId("listen-rate")).toHaveText("1.50×");
 
+  // The UI label alone is not proof of restored speed: the regression was
+  // that the label showed 1.50× while the audio element played at 1.0,
+  // because a media load() resets playbackRate to its default. Assert the
+  // element's actual rate — it only survives if the shim re-applies the
+  // tracked rate on loadedmetadata.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            (
+              document.getElementById(
+                "omnibus-audio",
+              ) as HTMLAudioElement | null
+            )?.playbackRate ?? null,
+        ),
+      {
+        message:
+          "audio element should actually play at the restored 1.5× after reload",
+        timeout: 10_000,
+        intervals: [50, 100, 250, 500],
+      },
+    )
+    .toBe(1.5);
+
   await gotoReady(page, `/listen/${uuidB}`);
   await waitForPlayerReady(page);
   await expect(page.getByTestId("listen-rate")).toHaveText("1.00×");


### PR DESCRIPTION
## Summary
- The web audio shim set `el.playbackRate` before `el.src` / `el.load()`, but the HTML media load algorithm resets `playbackRate` to its default (1.0) on every `load()`, and nothing re-applied it. After a reload the saved speed showed in the UI while audio played at 1.0× until the user re-picked a speed.
- Mirror the existing mobile fix: track the rate on `window.OmnibusAudio` (`_rate`, updated by `setRate`) and re-apply it in the `loadedmetadata` listener, which fires on every load (initial, direct part-swap, HLS attach).

## Test plan
- [x] Extended the `listen.spec.ts` reload test to assert the real `#omnibus-audio` `playbackRate` (1.5×) after reload — not just the UI label, which was the gap that let this ship. Verified it goes red with the re-apply disabled and green with it restored.
- [x] `listen.spec.ts` (16) + `mini-dock.spec.ts` (11) pass on a fresh DB.
- [x] `control_surface_js` unit test covers the `_rate` seed, `setRate` tracking, and the re-apply. `cargo fmt` / `clippy` clean on `omnibus-frontend`.

## Version
- [x] **Patch** — default.

## Notes
- N/A