### PR TITLE
refactor: physical/metadata-lookup housekeeping — docs, imports, dead code, test gaps (#1208)

### DIFF
--- a/db/src/metadata_lookup/providers.rs
+++ b/db/src/metadata_lookup/providers.rs
@@ -7,9 +7,8 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::Context;
-use serde::Deserialize;
-
 use omnibus_shared::metadata_lookup::{ExternalBookMeta, MetadataProvider};
+use serde::Deserialize;
 
 /// Per-request timeout for a provider call. A single lookup runs per scan, so
 /// this bounds how long the check-in flow waits on a slow provider.
@@ -31,6 +30,7 @@ pub struct MetadataLookupConfig {
     /// (HTTP 429) — in practice keyless lookups fail more often than they
     /// succeed. Never logged; see [`strip_url`].
     pub googlebooks_api_key: Option<String>,
+    /// Per-request timeout applied to each provider HTTP call.
     pub timeout: Duration,
 }
 

--- a/db/src/metadata_lookup/tests.rs
+++ b/db/src/metadata_lookup/tests.rs
@@ -228,6 +228,44 @@ async fn lookup_rejects_invalid_isbn_without_calling_a_provider() {
     ));
 }
 
+// ── invalid response bodies ──────────────────────────────────────
+
+#[tokio::test]
+async fn openlibrary_lookup_errors_when_response_body_is_invalid_json() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(OL_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+        .mount(&server)
+        .await;
+
+    let err = super::providers::openlibrary_lookup(&config_for(&server), ISBN13)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("not valid json"),
+        "must report a json parse failure, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn googlebooks_lookup_errors_when_response_body_is_invalid_json() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(GB_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+        .mount(&server)
+        .await;
+
+    let err = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("not valid json"),
+        "must report a json parse failure, got: {err}"
+    );
+}
+
 // ── Google Books API key ─────────────────────────────────────────
 
 #[test]

--- a/db/src/physical/copies.rs
+++ b/db/src/physical/copies.rs
@@ -2,9 +2,8 @@
 //! check-in. A copy is shared by all users (like a digital file); a book can
 //! hold many, each individually deletable.
 
-use sqlx::SqlitePool;
-
 use omnibus_shared::physical::PhysicalCopy;
+use sqlx::SqlitePool;
 
 use super::PhysicalError;
 use crate::books::{resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec};

--- a/db/src/physical/mod.rs
+++ b/db/src/physical/mod.rs
@@ -1,11 +1,8 @@
 //! Physical ownership data layer: library-wide physical copies, the per-user
 //! physical wishlist, and fileless book creation from external metadata.
-//!
 //! Copies and wishlist entries soft-reference `books.uuid` (no FK/cascade), so
-//! a reindex that ghosts a book keeps ownership and wishlist intact. Checking
-//! in a copy ([`add_physical_copy`]) fulfills every user's wishlist for that
-//! book atomically. Physical-only books have no file: [`create_fileless_book`]
-//! mints one under a synthetic "Physical" scan root.
+//! a reindex that ghosts a book keeps them intact, and checking in a copy
+//! ([`add_physical_copy`]) fulfills every user's wishlist for that book atomically.
 
 mod copies;
 mod fileless;
@@ -40,8 +37,10 @@ pub enum PhysicalError {
     /// A cover file could not be written for a fileless book.
     #[error("cover write failed: {0}")]
     Cover(#[from] std::io::Error),
+    /// A book-layer failure surfaced from `crate::books`.
     #[error(transparent)]
     Books(#[from] crate::books::BooksError),
+    /// A database error not covered by a more specific variant above.
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
 }

--- a/db/src/physical/tests.rs
+++ b/db/src/physical/tests.rs
@@ -491,6 +491,70 @@ async fn create_fileless_book_links_authors_above_the_sqlite_bind_cap() {
     assert_eq!(linked, authors);
 }
 
+#[tokio::test]
+async fn create_fileless_book_returns_cover_error_when_cover_dir_path_is_a_file() {
+    let covers = CoversTempDir::new("fileless_cover_error");
+    // Occupy the covers-dir path with a regular file so `write_cover_file`'s
+    // `create_dir_all` fails — the io-failure path `PhysicalError::Cover` wraps.
+    std::fs::write(&covers.path, b"not a directory").unwrap();
+    let pool = pool().await;
+
+    let err = create_fileless_book(
+        &pool,
+        FilelessBook {
+            title: "Broken Cover".into(),
+            authors: vec![],
+            isbn: None,
+            pubdate: None,
+            description: None,
+            cover: Some(FilelessCover {
+                mime: "image/gif".into(),
+                bytes: GIF_1X1.to_vec(),
+            }),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, PhysicalError::Cover(_)));
+    // The whole transaction rolls back rather than leaving a `has_cover` row
+    // with no file on disk.
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM books").await, 0);
+}
+
+#[tokio::test]
+async fn create_fileless_book_is_searchable_via_fts() {
+    let _covers = CoversTempDir::new("fileless_fts");
+    let pool = pool().await;
+
+    let uuid = create_fileless_book(
+        &pool,
+        FilelessBook {
+            title: "Unsearchable No More".into(),
+            authors: vec!["Fts Author".into()],
+            isbn: None,
+            pubdate: None,
+            description: None,
+            cover: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?1")
+        .bind(&uuid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let hits: Vec<i64> = sqlx::query_scalar("SELECT rowid FROM books_fts WHERE books_fts MATCH ?1")
+        .bind("Unsearchable")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(hits, vec![book_id]);
+}
+
 /// Minimal valid 1x1 GIF87a — enough for `image` to sniff and write `<uuid>.gif`.
 const GIF_1X1: &[u8] = &[
     0x47, 0x49, 0x46, 0x38, 0x37, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/db/src/physical/tests.rs
+++ b/db/src/physical/tests.rs
@@ -520,6 +520,11 @@ async fn create_fileless_book_returns_cover_error_when_cover_dir_path_is_a_file(
     // The whole transaction rolls back rather than leaving a `has_cover` row
     // with no file on disk.
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM books").await, 0);
+
+    // `covers.path` is a regular file here, not a directory, so
+    // `CoversTempDir`'s `Drop` (`remove_dir_all`) can't clean it up — remove
+    // it explicitly to avoid leaking a stray file into the OS temp dir.
+    let _ = std::fs::remove_file(&covers.path);
 }
 
 #[tokio::test]

--- a/db/src/physical/wishlist.rs
+++ b/db/src/physical/wishlist.rs
@@ -2,9 +2,8 @@
 //! a user can wishlist a book whose EPUB they already have. Unique per
 //! `(user_id, book_uuid)`, so re-wishlisting is idempotent.
 
-use sqlx::SqlitePool;
-
 use omnibus_shared::physical::{WishlistEntry, WishlistSource};
+use sqlx::SqlitePool;
 
 use super::PhysicalError;
 use crate::books::resolve_canonical_book_uuid;


### PR DESCRIPTION
## Summary
- Trim `db/src/physical/mod.rs` module doc to ≤5 lines (was an 8-line, two-paragraph `//!`)
- Add missing one-line `///` docs on `PhysicalError::Books`/`::Sqlx` and `MetadataLookupConfig::timeout`, matching sibling doc style
- Collapse split external-crate import blocks in `copies.rs`, `wishlist.rs`, and `providers.rs` to the standard std/external/crate three-block shape
- Remove redundant `.clone()` + dead `.unwrap_or(new)` fallback in `providers::client()` (once `CLIENT.set` runs, `CLIENT.get()` can never subsequently return `None`)
- Add tests: `PhysicalError::Cover` io-failure path in `create_fileless_book`, fileless-book FTS searchability after creation, and one invalid-JSON-body parse-failure test per metadata provider (OpenLibrary, Google Books)

Closes #1208

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — 1265 passed, 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` — fails because the audiobook test fixture isn't present in this environment; requires `just fixtures`, which needs the Nix dev shell not available here)

## Version
- [x] **Patch** — the default.

## Notes
- Pure mechanical housekeeping, no behavior change apart from the two new-test additions and the `client()` dead-code removal (still returns the same value on every path).
- Left `frontend/src/components/user_menu.rs`'s cfg-gated `UserMenu` alone per the issue's own note — it's explicitly flagged as a separate maintainer judgment call, not part of this issue's acceptance criteria.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVUdoudfdEerSUphbjJTG7)_