### PR TITLE
docs: fix stale test names, style-guide example, missing env var (#1172)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,14 @@ OMNIBUS_DEV_SEED_USER=admin:omnibus-dev
 # Resize the shared sccache cache (default 20G). Accepts sccache size suffixes.
 #SCCACHE_CACHE_SIZE=20G
 
+# The hot recipes (dev-up, dev-bounce, lint, lint-css, test) run through
+# scripts/with-dev-env.sh, which caches `nix print-dev-env` output keyed on
+# sha256(flake.nix + flake.lock + shell) so they skip paying the per-invocation
+# `nix develop` cost. Set this to bypass the cache and fall back to plain
+# `nix develop` for every invocation — e.g. while debugging a stale/poisoned
+# cache entry the self-heal check didn't catch.
+#OMNIBUS_NO_ENV_CACHE=1
+
 # ── Logging ────────────────────────────────────────────────────────────────
 # Console log filter (standard tracing EnvFilter syntax). The server owns its
 # tracing subscriber, so this works with `cargo run -p omnibus` and `dx serve`

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -572,7 +572,7 @@ async fn delete_metadata_overrides_restores_fts() {
         .is_empty());
 }
 #[tokio::test]
-async fn delete_overrides_reverts_to_scanned() {
+async fn delete_metadata_overrides_reverts_to_scanned() {
     let _covers = CoversTempDir::new("revert");
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
@@ -888,7 +888,7 @@ async fn apply_overrides_unaffected_by_precedence_of_a_different_library() {
 /// Verify that `MetadataOverrides::merge` correctly layers a second edit
 /// on top of a first without losing the first edit's fields.
 #[tokio::test]
-async fn merge_preserves_prior_overrides() {
+async fn metadata_overrides_merge_preserves_prior_overrides() {
     let first = MetadataOverrides {
         title: Some("Edited Title".into()),
         publisher: Some("Edited Publisher".into()),
@@ -908,7 +908,7 @@ async fn merge_preserves_prior_overrides() {
     assert_eq!(merged.language, None);
 }
 #[tokio::test]
-async fn upsert_overrides_materializes_series_link_for_new_series() {
+async fn upsert_metadata_overrides_materializes_series_link_for_new_series() {
     let _covers = CoversTempDir::new("materialize_series");
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
@@ -1115,7 +1115,7 @@ fn write_override_cover_returns_typed_error_when_stale_cleanup_hits_a_directory(
 /// the same transaction as the override row, so the book detail page
 /// never observes a fresh override against a stale link.
 #[tokio::test]
-async fn upsert_overrides_persists_books_series_link_row_for_new_series() {
+async fn upsert_metadata_overrides_persists_books_series_link_row_for_new_series() {
     let _covers = CoversTempDir::new("series_link_row");
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -316,11 +316,10 @@ like `search_books_finds_by_title_and_ranks_by_bm25`,
 
 **Anti-pattern.** [db/src/journals/markdown/tests.rs](../db/src/journals/markdown/tests.rs)
 names like `strips_script_tags` and `strips_event_handler_attributes`
-elide the function-under-test convention entirely — both test `render`
-(the module's sole public function), but neither name says so. Compare
-`renders_basic_markdown` and `render_emits_del_for_strikethrough` a few
-lines above in the same file, which correctly prefix with the function
-they test.
+elide the function-under-test convention entirely — both test `render`,
+the function whose behavior they're checking, but neither name says so.
+Compare `render_emits_del_for_strikethrough` a few lines above in the
+same file, which correctly prefixes with the function it tests.
 
 ---
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -314,10 +314,13 @@ find.
 like `search_books_finds_by_title_and_ranks_by_bm25`,
 `list_books_populates_formats_from_book_files`.
 
-**Anti-pattern.** [db/src/scanner.rs](../db/src/scanner.rs) names
-like `list_files_with_no_path_returns_empty` are *close* but elide
-the function-under-test convention; some tests in the file omit it
-entirely.
+**Anti-pattern.** [db/src/journals/markdown/tests.rs](../db/src/journals/markdown/tests.rs)
+names like `strips_script_tags` and `strips_event_handler_attributes`
+elide the function-under-test convention entirely — both test `render`
+(the module's sole public function), but neither name says so. Compare
+`renders_basic_markdown` and `render_emits_del_for_strikethrough` a few
+lines above in the same file, which correctly prefix with the function
+they test.
 
 ---
 


### PR DESCRIPTION
## Summary
- Renamed 4 tests in `db/src/metadata_overrides/tests.rs` to include their function-under-test prefix (`delete_metadata_overrides_...`, `upsert_metadata_overrides_...`, etc.); one (`merge_preserves_prior_overrides`) is renamed to `metadata_overrides_merge_preserves_prior_overrides` since it actually exercises the `MetadataOverrides::merge` struct method, not a DB function named `merge_metadata_overrides`
- Replaced `docs/style-guide.md`'s stale `db/src/scanner.rs` naming anti-pattern citation (all 9 current tests there are correctly prefixed) with a currently-accurate offender: `db/src/journals/markdown/tests.rs`'s `strips_script_tags` / `strips_event_handler_attributes`, which test `render()` without naming it
- Added the missing `OMNIBUS_NO_ENV_CACHE` entry to `.env.example`, mirroring the existing `OMNIBUS_NO_SCCACHE` entry

Closes #1172

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo test -p omnibus-db metadata_overrides` — PASS
- [x] `cargo test -p omnibus-db` (full crate) — PASS aside from one pre-existing, unrelated failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, missing test fixture in this environment — not caused by this change)

## Version
- [x] **Patch** — the default.

## Notes
- Pure rename/docs/config edits, no logic changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVUdoudfdEerSUphbjJTG7)_