### PR TITLE
fix: book deletion TOCTOU + missing DeleteError test coverage (#1309)

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -17,7 +17,7 @@ mod tests;
 pub use facets::library_facets;
 pub use get::{
     book_file_path, book_file_path_by_id, book_file_paths, get_book, get_book_by_uuid,
-    get_book_files, get_book_uuid_by_scan_key, resolve_book_id_by_uuid,
+    get_book_files, get_book_files_exec, get_book_uuid_by_scan_key, resolve_book_id_by_uuid,
     resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
     resolve_canonical_book_uuids_bulk_exec,
 };

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -440,6 +440,20 @@ pub async fn get_book_files(
     pool: &SqlitePool,
     book_id: i64,
 ) -> Result<Vec<omnibus_shared::BookFileInfo>, super::BooksError> {
+    get_book_files_exec(pool, book_id).await
+}
+
+/// Executor-generic counterpart to [`get_book_files`], so a caller already
+/// holding an open transaction (e.g. book deletion's count-inside-the-tx fix)
+/// reads on the same connection its writes will run on. Pass `&pool` for a
+/// standalone read or `&mut *tx` from within a transaction.
+pub async fn get_book_files_exec<'e, E>(
+    executor: E,
+    book_id: i64,
+) -> Result<Vec<omnibus_shared::BookFileInfo>, super::BooksError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     let rows = sqlx::query_as::<
         _,
         (
@@ -456,7 +470,7 @@ pub async fn get_book_files(
          WHERE book_id = ? ORDER BY format, ordinal",
     )
     .bind(book_id)
-    .fetch_all(pool)
+    .fetch_all(executor)
     .await?;
     Ok(rows
         .into_iter()

--- a/db/src/deletion/mod.rs
+++ b/db/src/deletion/mod.rs
@@ -212,7 +212,7 @@ pub async fn delete_book_items(
 async fn selection_total_delete(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
-    uuid: &str,
+    canonical_uuid: &str,
     file_ids: &[i64],
     copy_ids: &[i64],
 ) -> Result<Option<bool>, DeleteError> {
@@ -223,7 +223,8 @@ async fn selection_total_delete(
     {
         return Err(DeleteError::FileNotFound(*unknown));
     }
-    let existing_copies = list_physical_copies_by_canonical_uuid_exec(&mut **tx, uuid).await?;
+    let existing_copies =
+        list_physical_copies_by_canonical_uuid_exec(&mut **tx, canonical_uuid).await?;
     if let Some(unknown) = copy_ids
         .iter()
         .find(|id| !existing_copies.iter().any(|c| c.id == **id))

--- a/db/src/deletion/mod.rs
+++ b/db/src/deletion/mod.rs
@@ -15,7 +15,10 @@ use sqlx::SqlitePool;
 use omnibus_shared::physical::PhysicalCopy;
 use omnibus_shared::BookFileInfo;
 
-use crate::books::{book_file_path_by_id, get_book_files, resolve_book_id_by_uuid};
+use crate::books::{
+    book_file_path_by_id, get_book_files, get_book_files_exec, resolve_book_id_by_uuid,
+};
+use crate::physical::list_physical_copies_by_canonical_uuid_exec;
 
 /// Errors from the deletion path.
 #[derive(Debug, thiserror::Error)]
@@ -110,6 +113,13 @@ pub async fn book_deletion_manifest(
 /// flight can re-insert a file it snapshotted before the unlink (as a fresh
 /// book with a new uuid); the next scan won't, so that's left to resolve
 /// itself rather than locking against the worker.
+///
+/// The item count that decides `total_delete` is read and acted on inside one
+/// `BEGIN IMMEDIATE` transaction (see [`selection_total_delete`]), so two
+/// concurrent calls on the same book with disjoint selections can't both
+/// observe the pre-delete count and both leave a zero-item `books` row
+/// behind: `BEGIN IMMEDIATE` takes the RESERVED write lock up front, so the
+/// second call blocks until the first commits, then counts fresh.
 pub async fn delete_book_items(
     pool: &SqlitePool,
     book_uuid: &str,
@@ -128,31 +138,26 @@ pub async fn delete_book_items(
     let file_ids = &dedup(file_ids);
     let copy_ids = &dedup(copy_ids);
 
-    let existing_files = get_book_files(pool, book_id).await?;
-    if let Some(unknown) = file_ids
-        .iter()
-        .find(|id| !existing_files.iter().any(|f| f.id == **id))
-    {
-        return Err(DeleteError::FileNotFound(*unknown));
-    }
-    let existing_copies = crate::physical::list_physical_copies(pool, &uuid).await?;
-    if let Some(unknown) = copy_ids
-        .iter()
-        .find(|id| !existing_copies.iter().any(|c| c.id == **id))
-    {
-        return Err(DeleteError::CopyNotFound(*unknown));
-    }
-
-    let item_count = existing_files.len() + existing_copies.len();
-    let selected = file_ids.len() + copy_ids.len();
+    // `BEGIN IMMEDIATE` takes the RESERVED write lock at open time, before
+    // the count below runs, matching `auth::users::create_user`'s guard
+    // against the same class of race. A plain `pool.begin()` issues a
+    // DEFERRED `BEGIN` that acquires the lock lazily on first write, which
+    // would leave the count read outside the lock and reopen the TOCTOU
+    // window this closes.
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     // Selecting nothing on a book that still has items is a no-op; the same
-    // call on a book with no items at all is the "delete this record" case.
-    if selected == 0 && item_count > 0 {
+    // call on a book with no items at all is the "delete this record" case
+    // `total_delete` handles below.
+    let Some(total_delete) =
+        selection_total_delete(&mut tx, book_id, &uuid, file_ids, copy_ids).await?
+    else {
         return Ok(DeleteOutcome::default());
-    }
-    let total_delete = selected == item_count;
+    };
 
     // Resolve on-disk paths before the rows they're derived from disappear.
+    // Read on the pool rather than the tx: the rows aren't deleted until the
+    // writes below, so a separate connection still sees them, and a plain
+    // `SELECT` never contends with the tx's RESERVED write lock under WAL.
     let mut paths = Vec::with_capacity(file_ids.len());
     for id in file_ids {
         if let Some(path) = book_file_path_by_id(pool, book_id, *id, None).await? {
@@ -166,7 +171,6 @@ pub async fn delete_book_items(
         Vec::new()
     };
 
-    let mut tx = pool.begin().await?;
     purge::delete_file_rows(&mut tx, book_id, file_ids).await?;
     purge::delete_copy_rows(&mut tx, &uuid, copy_ids).await?;
     if total_delete {
@@ -193,6 +197,46 @@ pub async fn delete_book_items(
         deleted_copy_ids: copy_ids.to_vec(),
         book_deleted: total_delete,
     })
+}
+
+/// Validate `file_ids`/`copy_ids` against the book's *current* items and
+/// decide whether every item is being removed. Reads on `tx`'s own
+/// connection, so they run under the `BEGIN IMMEDIATE` RESERVED lock the
+/// caller opened — the fix for the TOCTOU where two concurrent deletes with
+/// disjoint selections could each read the pre-transaction item count and
+/// both conclude `total_delete = false`, leaving a zero-item `books` row
+/// neither call purges.
+///
+/// Returns `None` for the no-op case (nothing selected on a book that still
+/// has items); otherwise `Some(total_delete)`.
+async fn selection_total_delete(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    uuid: &str,
+    file_ids: &[i64],
+    copy_ids: &[i64],
+) -> Result<Option<bool>, DeleteError> {
+    let existing_files = get_book_files_exec(&mut **tx, book_id).await?;
+    if let Some(unknown) = file_ids
+        .iter()
+        .find(|id| !existing_files.iter().any(|f| f.id == **id))
+    {
+        return Err(DeleteError::FileNotFound(*unknown));
+    }
+    let existing_copies = list_physical_copies_by_canonical_uuid_exec(&mut **tx, uuid).await?;
+    if let Some(unknown) = copy_ids
+        .iter()
+        .find(|id| !existing_copies.iter().any(|c| c.id == **id))
+    {
+        return Err(DeleteError::CopyNotFound(*unknown));
+    }
+
+    let item_count = existing_files.len() + existing_copies.len();
+    let selected = file_ids.len() + copy_ids.len();
+    if selected == 0 && item_count > 0 {
+        return Ok(None);
+    }
+    Ok(Some(selected == item_count))
 }
 
 /// Copy of `ids` with duplicates removed, order-independent (the caller only

--- a/db/src/deletion/tests.rs
+++ b/db/src/deletion/tests.rs
@@ -382,6 +382,99 @@ async fn delete_book_items_resolves_a_ledger_uuid_to_its_target_book() {
     assert_eq!(count_rows(&pool, "SELECT COUNT(*) FROM books").await, 0);
 }
 
+// --- concurrency -------------------------------------------------------
+
+#[tokio::test]
+async fn delete_book_items_never_orphans_a_zero_item_book_row_under_concurrent_disjoint_deletes() {
+    // Regression test for the TOCTOU this module used to have: two concurrent
+    // calls deleting disjoint files must not both read the pre-delete item
+    // count and both decide `total_delete = false` — that would leave
+    // `book_files` at 0 rows with the `books` row never purged, a state
+    // nothing else cleans up. `BEGIN IMMEDIATE` serializes the two calls on
+    // the RESERVED write lock, so whichever runs second recomputes the count
+    // fresh (against the first call's already-committed delete) and sees the
+    // true remaining total.
+    let dir = temp_dir("concurrent");
+    let _env = cache_env(&dir);
+    let pool = pool().await;
+    let lib = seed_root(&pool, "/lib").await;
+    let book = seed_book(&pool, lib, "uuid-a", "Raced").await;
+    let a = seed_file(&pool, book, "/lib", "a", "a", "EPUB").await;
+    let b = seed_file(&pool, book, "/lib", "a", "a", "M4B").await;
+
+    let p1 = pool.clone();
+    let p2 = pool.clone();
+    let t1 = tokio::spawn(async move { delete_book_items(&p1, "uuid-a", &[a], &[]).await });
+    let t2 = tokio::spawn(async move { delete_book_items(&p2, "uuid-a", &[b], &[]).await });
+
+    let r1 = t1.await.unwrap().unwrap();
+    let r2 = t2.await.unwrap().unwrap();
+
+    // Whichever call ran second sees the other's file already gone, so
+    // exactly one of the two — never both, never neither — purges the book.
+    assert_eq!(
+        [r1.book_deleted, r2.book_deleted]
+            .iter()
+            .filter(|d| **d)
+            .count(),
+        1,
+        "exactly one of the two racing deletes must purge the now-empty book"
+    );
+    assert_eq!(count_rows(&pool, "SELECT COUNT(*) FROM books").await, 0);
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM book_files").await,
+        0
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// --- DeleteError variants ------------------------------------------------
+
+#[tokio::test]
+async fn delete_book_items_wraps_a_books_error_when_the_pool_is_closed() {
+    // `resolve_book_id_by_uuid` is the first DB touch in `delete_book_items`,
+    // so closing the pool up front guarantees it's the call that fails,
+    // giving a deterministic `DeleteError::Books`.
+    let pool = pool().await;
+    let lib = seed_root(&pool, "/lib").await;
+    seed_book(&pool, lib, "uuid-a", "Doomed").await;
+    pool.close().await;
+
+    let err = delete_book_items(&pool, "uuid-a", &[], &[])
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, DeleteError::Books(_)));
+}
+
+#[tokio::test]
+async fn canonical_uuid_propagates_a_sqlx_error_when_the_pool_is_closed() {
+    let pool = pool().await;
+    pool.close().await;
+
+    let err = canonical_uuid(&pool, 1).await.unwrap_err();
+
+    assert!(matches!(err, DeleteError::Sqlx(_)));
+}
+
+#[tokio::test]
+async fn delete_error_wraps_a_physical_error_when_the_copy_lookup_fails() {
+    // Both `delete_book_items` and `book_deletion_manifest` convert a
+    // `physical::PhysicalError` via `?`. Isolating that specific call inside
+    // either multi-step orchestrator isn't possible with a closed-pool
+    // trigger alone (an earlier DB touch would fail first and mask it), so
+    // this drives the conversion directly against the same real DB failure.
+    let pool = pool().await;
+    pool.close().await;
+
+    let physical_err = crate::physical::list_physical_copies(&pool, "uuid-a")
+        .await
+        .unwrap_err();
+    let err: DeleteError = physical_err.into();
+
+    assert!(matches!(err, DeleteError::Physical(_)));
+}
+
 // --- errors ----------------------------------------------------------------
 
 #[tokio::test]

--- a/db/src/deletion/tests.rs
+++ b/db/src/deletion/tests.rs
@@ -394,37 +394,54 @@ async fn delete_book_items_never_orphans_a_zero_item_book_row_under_concurrent_d
     // the RESERVED write lock, so whichever runs second recomputes the count
     // fresh (against the first call's already-committed delete) and sees the
     // true remaining total.
+    //
+    // `tokio::spawn` scheduling isn't guaranteed to interleave the two calls
+    // at the exact snapshot-vs-commit window a regression would need to slip
+    // through — a single run could pass by luck even on a reintroduced bug.
+    // Repeating the race against a fresh book each time makes a regression
+    // extremely likely to surface within the loop.
     let dir = temp_dir("concurrent");
     let _env = cache_env(&dir);
     let pool = pool().await;
     let lib = seed_root(&pool, "/lib").await;
-    let book = seed_book(&pool, lib, "uuid-a", "Raced").await;
-    let a = seed_file(&pool, book, "/lib", "a", "a", "EPUB").await;
-    let b = seed_file(&pool, book, "/lib", "a", "a", "M4B").await;
 
-    let p1 = pool.clone();
-    let p2 = pool.clone();
-    let t1 = tokio::spawn(async move { delete_book_items(&p1, "uuid-a", &[a], &[]).await });
-    let t2 = tokio::spawn(async move { delete_book_items(&p2, "uuid-a", &[b], &[]).await });
+    for i in 0..25 {
+        let uuid = format!("uuid-race-{i}");
+        let book = seed_book(&pool, lib, &uuid, "Raced").await;
+        let a = seed_file(&pool, book, "/lib", "a", &format!("a{i}"), "EPUB").await;
+        let b = seed_file(&pool, book, "/lib", "a", &format!("a{i}"), "M4B").await;
 
-    let r1 = t1.await.unwrap().unwrap();
-    let r2 = t2.await.unwrap().unwrap();
+        let p1 = pool.clone();
+        let p2 = pool.clone();
+        let u1 = uuid.clone();
+        let u2 = uuid.clone();
+        let t1 = tokio::spawn(async move { delete_book_items(&p1, &u1, &[a], &[]).await });
+        let t2 = tokio::spawn(async move { delete_book_items(&p2, &u2, &[b], &[]).await });
 
-    // Whichever call ran second sees the other's file already gone, so
-    // exactly one of the two — never both, never neither — purges the book.
-    assert_eq!(
-        [r1.book_deleted, r2.book_deleted]
-            .iter()
-            .filter(|d| **d)
-            .count(),
-        1,
-        "exactly one of the two racing deletes must purge the now-empty book"
-    );
-    assert_eq!(count_rows(&pool, "SELECT COUNT(*) FROM books").await, 0);
-    assert_eq!(
-        count_rows(&pool, "SELECT COUNT(*) FROM book_files").await,
-        0
-    );
+        let r1 = t1.await.unwrap().unwrap();
+        let r2 = t2.await.unwrap().unwrap();
+
+        // Whichever call ran second sees the other's file already gone, so
+        // exactly one of the two — never both, never neither — purges the
+        // book.
+        assert_eq!(
+            [r1.book_deleted, r2.book_deleted]
+                .iter()
+                .filter(|d| **d)
+                .count(),
+            1,
+            "exactly one of the two racing deletes must purge the now-empty book (iteration {i})"
+        );
+        assert_eq!(
+            count_rows(
+                &pool,
+                &format!("SELECT COUNT(*) FROM books WHERE uuid = '{uuid}'")
+            )
+            .await,
+            0,
+            "iteration {i}"
+        );
+    }
     std::fs::remove_dir_all(&dir).ok();
 }
 

--- a/db/src/physical/copies.rs
+++ b/db/src/physical/copies.rs
@@ -83,14 +83,30 @@ pub async fn list_physical_copies(
     let Some(canonical) = resolve_canonical_book_uuid(pool, book_uuid).await? else {
         return Ok(Vec::new());
     };
+    list_physical_copies_by_canonical_uuid_exec(pool, &canonical).await
+}
+
+/// Executor-generic counterpart to [`list_physical_copies`] for a uuid
+/// already resolved to canonical, so a caller holding an open transaction
+/// (e.g. book deletion's count-inside-the-tx fix) reads on the same
+/// connection its writes will run on, without a second `merged_uuids`
+/// resolution. Pass `&pool` for a standalone read or `&mut *tx` from within
+/// a transaction.
+pub async fn list_physical_copies_by_canonical_uuid_exec<'e, E>(
+    executor: E,
+    canonical_uuid: &str,
+) -> Result<Vec<PhysicalCopy>, PhysicalError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     let rows = sqlx::query_as::<_, CopyRow>(
         "SELECT id, book_uuid, isbn, added_by_user_id, checked_in_at, note
            FROM physical_copies
           WHERE book_uuid = ?1
           ORDER BY checked_in_at, id",
     )
-    .bind(&canonical)
-    .fetch_all(pool)
+    .bind(canonical_uuid)
+    .fetch_all(executor)
     .await?;
     Ok(rows.into_iter().map(map_copy).collect())
 }

--- a/db/src/physical/mod.rs
+++ b/db/src/physical/mod.rs
@@ -16,7 +16,8 @@ mod wishlist;
 mod tests;
 
 pub use copies::{
-    add_physical_copy, delete_physical_copy, list_physical_copies, update_physical_copy_note,
+    add_physical_copy, delete_physical_copy, list_physical_copies,
+    list_physical_copies_by_canonical_uuid_exec, update_physical_copy_note,
 };
 pub use fileless::{create_fileless_book, FilelessBook, FilelessCover};
 pub use remove::delete_fileless_book;


### PR DESCRIPTION
## Summary
- `delete_book_items` (`db/src/deletion/mod.rs`) now recomputes `item_count`/`total_delete` **inside** the same transaction its deletes run in, instead of from a pre-transaction snapshot — closing the TOCTOU window where two concurrent calls with disjoint item selections could each observe a stale full `item_count`, each compute `total_delete = false`, and leave a `books` row with zero files/copies that nothing ever cleans up.
- New executor-generic helpers `get_book_files_exec` (`db/src/books/get.rs`) and `list_physical_copies_by_canonical_uuid_exec` (`db/src/physical/copies.rs`) let the transaction-scoped count read run on the same connection as the writes that follow.
- New regression test spawns two concurrent, disjoint-selection `delete_book_items` calls against the same book and asserts the book is never left orphaned (zero items, undeleted row).
- Added direct tests for `DeleteError::Books`/`::Physical`/`::Sqlx`, following the crate's established closed-pool DB-failure-injection pattern.

Closes #1309

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — 1264 passed; 2 failed, both pre-existing/environmental and unrelated to this change (confirmed by re-running each in isolation): `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` (missing audiobook test fixture — needs `just fixtures`, unavailable in this environment) and `ebook::accent::tests::extract_accent_completes_within_budget` (a 2s wall-clock timing budget test that flaked under the heavy concurrent CPU load from this session running several other crates' builds in parallel — passes cleanly in isolation)

## Version
- [x] **Patch** — the default.

## Notes
- **Judgment call**: the acceptance criterion around book-purge cache-cleanup recovery (reconciling covers/HLS/kepub cache against live `books.uuid`s, or giving `db/src/covers.rs` the same FIFO cap eviction thumbnails/HLS already have) is **not** included in this PR. The issue explicitly allows splitting this into a follow-up if the TOCTOU fix + test coverage alone is the cleaner first PR — that's the call made here. Flagging as a distinct follow-up rather than scope-creeping this PR.
- **Merge-order heads-up**: this PR and #1331 (issue #1208) both touch `db/src/physical/copies.rs` and `db/src/physical/mod.rs`, but in different regions (import ordering/docs vs. a new `_exec` helper) — should merge cleanly in either order, but whichever lands second may want a quick rebase-and-recheck.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVUdoudfdEerSUphbjJTG7)_