### PR TITLE
fix: offline outbox no longer wedges on one stuck mutation (#1306)

### DIFF
--- a/frontend/src/components/offline_pill.rs
+++ b/frontend/src/components/offline_pill.rs
@@ -63,6 +63,7 @@ mod tests {
             online,
             pending_ops,
             dropped_ops: 0,
+            stuck_ops: 0,
         }
     }
 

--- a/frontend/src/offline/sync.rs
+++ b/frontend/src/offline/sync.rs
@@ -33,6 +33,11 @@ pub struct NetState {
     /// Ops dropped this session because the server permanently rejected
     /// them (4xx) — surfaced as "N changes couldn't sync".
     pub dropped_ops: usize,
+    /// Ops dropped this session after exhausting their retry budget on
+    /// repeated server errors (5xx) — distinct from `dropped_ops`: these
+    /// were never permanently rejected, they just never got a good answer
+    /// after [`MAX_SERVER_ERROR_ATTEMPTS`] tries. Surfaced next to it.
+    pub stuck_ops: usize,
 }
 
 impl NetState {
@@ -41,6 +46,7 @@ impl NetState {
             online: true,
             pending_ops: 0,
             dropped_ops: 0,
+            stuck_ops: 0,
         }
     }
 }
@@ -104,6 +110,13 @@ pub(crate) async fn refresh_pending() {
 pub(crate) fn note_dropped(n: usize) {
     if n > 0 {
         update(|s| s.dropped_ops += n);
+    }
+}
+
+/// Record ops dropped after exhausting their server-error retry budget.
+pub(crate) fn note_stuck(n: usize) {
+    if n > 0 {
+        update(|s| s.stuck_ops += n);
     }
 }
 
@@ -284,13 +297,31 @@ pub(crate) fn request_drain() {
 enum Outcome {
     /// Replayed (or made moot) — delete the op row.
     Done,
-    /// Permanently rejected by the server — delete and count as dropped.
+    /// Permanently rejected by the server (4xx) — delete and count as
+    /// dropped.
     Rejected,
-    /// Connectivity/5xx failure — keep the op, stop the drain.
+    /// This op's target errored (5xx) or its response failed to decode.
+    /// Unlike [`Outcome::Halt`], this does NOT mean the device is offline —
+    /// keep the op queued, bump its attempt count, and keep draining the
+    /// rest of the queue.
+    ServerError,
+    /// A [`Outcome::ServerError`] that has exhausted
+    /// [`MAX_SERVER_ERROR_ATTEMPTS`] retries — delete and count as stuck
+    /// rather than let it wedge every future drain forever.
+    Stuck,
+    /// Connectivity failure — keep the op, flip the device offline, and
+    /// stop the drain (every other queued op would fail the same way).
     Halt,
     /// Session expired — keep every op for after re-login, stop the drain.
     HaltAuth,
 }
+
+/// Consecutive server-error attempts an op gets before it's treated as
+/// permanently stuck and dropped. Drains are already externally triggered
+/// (reconnect, periodic tick, manual probe) rather than tight-looped, so a
+/// small fixed budget is enough to distinguish "flaky, retry it" from
+/// "this op will never succeed" without needing real exponential backoff.
+const MAX_SERVER_ERROR_ATTEMPTS: i64 = 5;
 
 /// Replay the outbox in enqueue order. One pass per invocation; ops that
 /// arrive mid-drain are picked up by the next trigger.
@@ -301,6 +332,7 @@ async fn drain() {
         return;
     };
     let mut dropped = 0usize;
+    let mut stuck = 0usize;
     let mut resolved = 0usize;
     for row in st.ops_list().await {
         let Ok(op) = serde_json::from_str::<Op>(&row.payload) else {
@@ -310,18 +342,37 @@ async fn drain() {
             dropped += 1;
             continue;
         };
-        match execute_op(&url, op).await {
+        let id = row.id;
+        // A ServerError that has exhausted its retry budget is promoted to
+        // Stuck here (rather than inside `classify`), since only the drain
+        // loop knows the op's attempt history.
+        let outcome = match execute_op(&url, op).await {
+            Outcome::ServerError if row.attempts + 1 >= MAX_SERVER_ERROR_ATTEMPTS => Outcome::Stuck,
+            other => other,
+        };
+        match outcome {
             Outcome::Done => {
-                st.ops_delete_many(vec![row.id]).await;
+                st.ops_delete_many(vec![id]).await;
                 resolved += 1;
             }
             Outcome::Rejected => {
-                st.ops_delete_many(vec![row.id]).await;
+                st.ops_delete_many(vec![id]).await;
                 dropped += 1;
                 resolved += 1;
             }
+            // This op's own target is unhappy — not the device's
+            // connectivity — so keep going rather than break the loop and
+            // wedge every op queued behind it.
+            Outcome::ServerError => {
+                st.ops_bump_attempts(id);
+            }
+            Outcome::Stuck => {
+                st.ops_delete_many(vec![id]).await;
+                stuck += 1;
+                resolved += 1;
+            }
             Outcome::Halt => {
-                st.ops_bump_attempts(row.id);
+                st.ops_bump_attempts(id);
                 note_offline();
                 break;
             }
@@ -329,6 +380,7 @@ async fn drain() {
         }
     }
     note_dropped(dropped);
+    note_stuck(stuck);
     refresh_pending().await;
     if let Some(st) = store::store() {
         st.meta_put("last_sync_at", store::now_secs().to_string());
@@ -347,7 +399,7 @@ fn classify(e: &DataError, target_may_be_gone: bool) -> Outcome {
     match e {
         DataError::Unauthorized => Outcome::HaltAuth,
         DataError::Http { status: 404, .. } if target_may_be_gone => Outcome::Done,
-        DataError::Http { status, .. } if *status >= 500 => Outcome::Halt,
+        DataError::Http { status, .. } if *status >= 500 => Outcome::ServerError,
         DataError::Http { .. } => Outcome::Rejected,
         e if is_offline_error(e) => Outcome::Halt,
         // Decode-class network errors: the server acted but the response

--- a/frontend/src/offline/sync.rs
+++ b/frontend/src/offline/sync.rs
@@ -300,10 +300,9 @@ enum Outcome {
     /// Permanently rejected by the server (4xx) — delete and count as
     /// dropped.
     Rejected,
-    /// This op's target errored (5xx) or its response failed to decode.
-    /// Unlike [`Outcome::Halt`], this does NOT mean the device is offline —
-    /// keep the op queued, bump its attempt count, and keep draining the
-    /// rest of the queue.
+    /// This op's target errored (5xx). Unlike [`Outcome::Halt`], this does
+    /// NOT mean the device is offline — keep the op queued, bump its
+    /// attempt count, and keep draining the rest of the queue.
     ServerError,
     /// A [`Outcome::ServerError`] that has exhausted
     /// [`MAX_SERVER_ERROR_ATTEMPTS`] retries — delete and count as stuck
@@ -371,8 +370,11 @@ async fn drain() {
                 stuck += 1;
                 resolved += 1;
             }
+            // A connectivity halt says nothing about this op's own
+            // reliability — don't consume its ServerError retry budget for
+            // an outage unrelated to its target. It gets retried fresh once
+            // the device is back online.
             Outcome::Halt => {
-                st.ops_bump_attempts(id);
                 note_offline();
                 break;
             }

--- a/frontend/src/offline/sync/tests.rs
+++ b/frontend/src/offline/sync/tests.rs
@@ -157,6 +157,10 @@ async fn mock_server() -> String {
             post(|| async { axum::http::StatusCode::BAD_REQUEST }),
         )
         .route(
+            "/api/account/kindle-email",
+            post(|| async { axum::http::StatusCode::INTERNAL_SERVER_ERROR }),
+        )
+        .route(
             "/api/shelves",
             post(
                 |axum::Json(req): axum::Json<omnibus_shared::CreateShelfRequest>| async move {
@@ -393,6 +397,80 @@ async fn drain_remaps_temp_shelf_ids_across_later_ops() {
             .iter()
             .any(|s| s.id == 55 && s.name == "Drain Shelf"),
         "cache must hold the server-assigned shelf id"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_lets_other_ops_through_when_one_gets_a_server_error() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::SetKindleEmail {
+        email: Some("reader@example.com".into()),
+    });
+    enqueue_raw(&progress_op("drain-book-server-error"));
+    drain().await;
+
+    let st = store::store().expect("store");
+    let remaining = st.ops_list().await;
+    assert_eq!(
+        remaining.len(),
+        1,
+        "the 5xx op stays queued but must not block the other op"
+    );
+    assert_eq!(remaining[0].kind, "SetKindleEmail");
+    assert_eq!(
+        remaining[0].attempts, 1,
+        "a server-error attempt must be recorded"
+    );
+    let cached: Option<Option<ProgressRecord>> =
+        cache::get_json(&cache::keys::progress("drain-book-server-error", "epub")).await;
+    assert!(
+        cached.flatten().is_some(),
+        "the unrelated op behind the stuck one must still drain"
+    );
+    assert!(
+        state().online,
+        "a 5xx from one op's target must not flip the device offline"
+    );
+    clear_ops().await;
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_drops_a_stuck_op_after_exhausting_its_retry_budget() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    let stuck_before = state().stuck_ops;
+    enqueue_raw(&Op::SetKindleEmail {
+        email: Some("reader@example.com".into()),
+    });
+    for _ in 0..super::MAX_SERVER_ERROR_ATTEMPTS {
+        drain().await;
+    }
+
+    let st = store::store().expect("store");
+    assert_eq!(
+        st.ops_count().await,
+        0,
+        "an op that never stops 5xx'ing must eventually be dropped"
+    );
+    assert_eq!(
+        state().stuck_ops,
+        stuck_before + 1,
+        "an exhausted retry budget must count as stuck, not silently vanish"
+    );
+    assert!(
+        state().online,
+        "exhausting a retry budget is still not a connectivity failure"
     );
     note_online();
 }

--- a/frontend/src/pages/account/downloads.rs
+++ b/frontend/src/pages/account/downloads.rs
@@ -98,6 +98,11 @@ pub(super) fn SyncStatusRow() -> Element {
                     "{state.dropped_ops} changes couldn't sync and were discarded."
                 }
             }
+            if state.stuck_ops > 0 {
+                div { class: "m-account-sync-dropped", "data-testid": "account-sync-stuck",
+                    "{state.stuck_ops} changes failed repeatedly and were dropped after retrying."
+                }
+            }
             if let Some(at) = last_sync() {
                 div { class: "m-account-sync-when mono", "Last synced {relative_time(at)}" }
             }


### PR DESCRIPTION
## Summary
- `classify()` in `frontend/src/offline/sync.rs` now distinguishes a server-side 5xx (new `Outcome::ServerError`, keeps draining the rest of the queue) from a genuine connectivity failure (`Outcome::Halt`, now the *only* case that flips `NetState.online`). A single flaky endpoint or edge-case 500 no longer disables sync for the entire device.
- `ServerError` ops are promoted to a new `Outcome::Stuck` once the now-live `attempts` counter exceeds a retry budget (5 consecutive server errors on the same row — a judgment call, documented below).
- Stuck/exhausted ops are tracked via `NetState.stuck_ops` and surfaced in the account Downloads/sync UI (`account-sync-stuck`) alongside the existing `dropped_ops` notice, instead of sitting silently forever.
- New tests in `frontend/src/offline/sync/tests.rs`: a 5xx on one op no longer blocks a subsequent unrelated op from draining; a stuck op is dropped and surfaced after exhausting its retry budget.

Closes #1306

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features mobile` — 476 passed, 0 failed

## Version
- [x] **Patch** — the default.

## Notes
- **Judgment call**: the issue explicitly flags the retry-budget number (N) and whether stuck ops should auto-drop vs. require dismissal as needing product input rather than prescribing one. Picked N=5 consecutive server-errors-on-the-same-row, and auto-drop-with-surfacing (mirroring the existing `dropped_ops` UX) rather than requiring explicit dismissal — reasonable defaults, open to revision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVUdoudfdEerSUphbjJTG7)_