### PR TITLE
fix: OPF export - cover untested error variants and atomic-write rollback (#1339)

### DIFF
--- a/db/src/opf_export.rs
+++ b/db/src/opf_export.rs
@@ -87,6 +87,26 @@ pub async fn export_opf(pool: &SqlitePool, book_id: i64) -> Result<OpfExport, Op
 /// place. A concurrent reader never sees a torn document (the final step is a
 /// single atomic rename).
 async fn write_sidecar(book_dir: &Path, xml: &str) -> Result<bool, std::io::Error> {
+    write_sidecar_inner(book_dir, xml, false).await
+}
+
+/// Test-only seam: identical to [`write_sidecar`] but forces the final
+/// promotion rename to fail, so a test can assert the `.bak` rollback
+/// actually restores the pre-existing sidecar. A real filesystem fault can't
+/// be injected between the two renames without racing, hence the flag.
+#[cfg(test)]
+async fn write_sidecar_forcing_promote_failure(
+    book_dir: &Path,
+    xml: &str,
+) -> Result<bool, std::io::Error> {
+    write_sidecar_inner(book_dir, xml, true).await
+}
+
+async fn write_sidecar_inner(
+    book_dir: &Path,
+    xml: &str,
+    force_promote_failure: bool,
+) -> Result<bool, std::io::Error> {
     let opf = book_dir.join("metadata.opf");
     let bak = book_dir.join("metadata.opf.bak");
     let tmp = book_dir.join(".metadata.opf.tmp");
@@ -102,7 +122,15 @@ async fn write_sidecar(book_dir: &Path, xml: &str) -> Result<bool, std::io::Erro
         }
     };
 
-    if let Err(e) = tokio::fs::rename(&tmp, &opf).await {
+    let promoted = if force_promote_failure {
+        Err(std::io::Error::other(
+            "forced promotion failure (test seam)",
+        ))
+    } else {
+        tokio::fs::rename(&tmp, &opf).await
+    };
+
+    if let Err(e) = promoted {
         // Promotion failed after the backup — restore the original so the
         // book isn't left without a sidecar.
         if backed_up {

--- a/db/src/opf_export/tests.rs
+++ b/db/src/opf_export/tests.rs
@@ -318,6 +318,69 @@ async fn export_opf_returns_no_epub_file_for_audiobook_only_book() {
     assert!(matches!(err, OpfExportError::NoEpubFile(_)));
 }
 
+#[tokio::test]
+async fn export_opf_returns_books_error_when_book_files_table_is_missing() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = tempfile::tempdir().unwrap();
+    let (book_id, _uuid) = seed_epub_book_at(&pool, lib.path()).await;
+    // get_book's final step (get_book_files) queries book_files; dropping it
+    // forces the crate::books::BooksError this exercises.
+    sqlx::query("DROP TABLE book_files")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let err = export_opf(&pool, book_id).await.unwrap_err();
+    assert!(matches!(err, OpfExportError::Books(_)));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn export_opf_returns_io_error_when_book_directory_is_not_writable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = tempfile::tempdir().unwrap();
+    let (book_id, _uuid) = seed_epub_book_at(&pool, lib.path()).await;
+    let dir = lib.path().join("sub");
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    // Skip if the chmod didn't take (e.g. running as root in some CI
+    // containers), same guard as db/src/ebook/cover/tests.rs.
+    if std::fs::write(dir.join("write_probe"), b"x").is_ok() {
+        std::fs::remove_file(dir.join("write_probe")).ok();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        return;
+    }
+
+    let err = export_opf(&pool, book_id).await.unwrap_err();
+
+    // Restore perms so the tempdir can clean itself up.
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(matches!(err, OpfExportError::Io(_)));
+}
+
+#[tokio::test]
+async fn write_sidecar_restores_backup_when_promotion_rename_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("metadata.opf"), b"ORIGINAL SIDECAR").unwrap();
+
+    let err = write_sidecar_forcing_promote_failure(dir.path(), "<new/>")
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+
+    // The pre-existing sidecar must be restored, not left missing, and no
+    // stray backup/temp file should remain.
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("metadata.opf")).unwrap(),
+        "ORIGINAL SIDECAR"
+    );
+    assert!(!dir.path().join("metadata.opf.bak").exists());
+    assert!(!dir.path().join(".metadata.opf.tmp").exists());
+}
+
 /// Encode a 1×1 red image in `format` for the cover-copy tests.
 fn encode_test_image(format: image::ImageFormat) -> Vec<u8> {
     let img = image::RgbImage::from_pixel(1, 1, image::Rgb([255, 0, 0]));

--- a/server/src/backend/export_opf/tests.rs
+++ b/server/src/backend/export_opf/tests.rs
@@ -96,6 +96,28 @@ async fn api_export_opf_writes_sidecar_and_returns_path_and_backed_up() {
 }
 
 #[tokio::test]
+async fn api_export_opf_returns_500_on_db_failure() {
+    let (app, _state, pool) = fixture().await;
+    let lib = tempfile::tempdir().unwrap();
+    let (_id, uuid) = db::test_support::seed_epub_book_at(&pool, lib.path()).await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+    // get_book's final step queries book_files; dropping it forces the
+    // db::OpfExportError::Books catch-all path to 500, mirroring
+    // read_status's api_get_read_status_returns_500_on_db_failure.
+    sqlx::query("DROP TABLE book_files")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(post_export(&uuid, Some(&token)))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
 async fn api_export_opf_returns_409_when_book_has_no_epub() {
     let (app, _state, pool) = fixture().await;
     let admin = auth_test_support::create_admin(&pool, "admin").await;


### PR DESCRIPTION
## Summary
- `db/src/opf_export.rs`: split `write_sidecar` into a thin wrapper plus `write_sidecar_inner`, adding a `#[cfg(test)]`-only seam (`write_sidecar_forcing_promote_failure`) that forces the final promotion rename to fail, so a test can assert the `.bak` rollback actually restores the pre-existing sidecar rather than leaving the book without one.
- `db/src/opf_export/tests.rs`: added `export_opf_returns_books_error_when_book_files_table_is_missing` (drops `book_files` to force the `OpfExportError::Books` bubble-up from `get_book`), `export_opf_returns_io_error_when_book_directory_is_not_writable` (chmod 555 on the book dir, unix-only, with the same root-container skip guard used elsewhere in the crate), and `write_sidecar_restores_backup_when_promotion_rename_fails`.
- `server/src/backend/export_opf/tests.rs`: added `api_export_opf_returns_500_on_db_failure`, mirroring `read_status`'s `api_get_read_status_returns_500_on_db_failure` pattern (drop `book_files`, assert 500).

Closes #1339

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db opf_export` — PASS (15 passed, 0 failed)
- [x] `cargo test -p omnibus export_opf` — PASS (6 passed, 0 failed)

## Version
- [x] **Patch** — the default.

## Notes
- None of this changes runtime behavior — it's coverage-only, per the issue's own framing ("none of this is a live bug today").


---
_Generated by [Claude Code](https://claude.ai/code/session_01SzYzELgFNfUJ3w1Nm37MsV)_