### PR TITLE
refactor: offline module gains thiserror/anyhow discipline (#1308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ commit log.
 ### Fixed
 
 - Scanning a book already on your wishlist now opens its detail page instead of the "you already have this one digitally" check-in screen
+- The account Downloads page no longer surfaces a raw transport/decode error message on a failed download; it now shows a fixed, user-safe reason while the original error is logged for diagnosis (#1308)
 
 ## [v0.11.4] - 2026-07-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4514,6 +4514,7 @@ dependencies = [
 name = "omnibus-frontend"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "base64",
  "dioxus",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -19,6 +19,10 @@ serde_json.workspace = true
 # the derive must be available in all builds (including the no-feature
 # default-members check). Version matches `omnibus-db`.
 thiserror.workspace = true
+# Foreign-failure-space errors for the mobile-only `offline` module (network,
+# filesystem) per `.claude/rules/02-error-handling.md`. Optional, enabled by
+# `mobile` — not needed by the web/server builds. Version matches `omnibus-db`.
+anyhow = { version = "1", optional = true }
 reqwest = { workspace = true, optional = true, features = ["multipart"] }
 gloo-net = { version = "0.7", default-features = false, features = ["http", "json"], optional = true }
 gloo-timers = { version = "0.4", features = ["futures"], optional = true }
@@ -155,6 +159,7 @@ mobile = [
     "tokio/fs",
     "tokio/io-util",
     "dep:tracing",
+    "dep:anyhow",
     "dep:jni",
     "dep:ndk-context",
     "dep:base64",

--- a/frontend/src/offline.rs
+++ b/frontend/src/offline.rs
@@ -11,6 +11,7 @@ pub mod outbox;
 pub mod replica;
 pub mod store;
 pub mod sync;
+mod test_support;
 
 /// Initialize the offline layer. Called once from the native shell's
 /// `main()` before `dioxus::launch`, right after `token_store::load_from_disk`.

--- a/frontend/src/offline/downloads/engine.rs
+++ b/frontend/src/offline/downloads/engine.rs
@@ -212,6 +212,10 @@ async fn download_file(
         DownloadError::ConnectionLost
     })?;
     let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        tracing::warn!(status = status.as_u16(), url = %file.url_path, "offline download: request was unauthorized");
+        return Err(DownloadError::Unauthorized.into());
+    }
     if !status.is_success() {
         tracing::warn!(status = status.as_u16(), url = %file.url_path, "offline download: server returned a non-success status");
         return Err(DownloadError::ServerError.into());

--- a/frontend/src/offline/downloads/engine.rs
+++ b/frontend/src/offline/downloads/engine.rs
@@ -6,6 +6,8 @@
 
 use omnibus_shared::{AudiobookManifest, EbookMetadata, ManifestPart};
 
+use anyhow::Context;
+
 use crate::data;
 use crate::offline::{cache, media};
 
@@ -14,12 +16,45 @@ use super::{DlFormat, DownloadEntry, DownloadStatus, PlannedFile};
 /// Flush registry progress every this many streamed bytes.
 const PROGRESS_FLUSH_BYTES: i64 = 1024 * 1024;
 
+/// Fixed, user-safe download failure reasons. Every other fallible step in
+/// this module (filesystem, network I/O) is wrapped with a safe
+/// `.context(...)` message instead, so no raw `io`/`reqwest` `Display` ever
+/// reaches [`DownloadStatus::Error`] — see
+/// `.claude/rules/02-error-handling.md`'s boundary rule.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+enum DownloadError {
+    #[error("You're offline — connect to download")]
+    Offline,
+    #[error("Book not found")]
+    NotFound,
+    #[error("This audiobook's format isn't supported offline")]
+    UnsupportedFormat,
+    #[error("Nothing to download for this format")]
+    NothingToDownload,
+    #[error("Offline storage unavailable")]
+    StorageUnavailable,
+    #[error("Connection lost")]
+    ConnectionLost,
+    #[error("Server returned an unexpected response")]
+    ServerError,
+    #[error("Network error — check your connection and try again")]
+    NetworkError,
+    #[error("You need to sign in again")]
+    Unauthorized,
+    #[error("Download was interrupted — tap to resume")]
+    Interrupted,
+}
+
 /// Run one download to completion (or error). The registry entry was
 /// already put in `Downloading` by `downloads::start`.
 pub(super) async fn run(server_url: String, uuid: String, format: DlFormat, file_id: Option<i64>) {
-    match run_inner(&server_url, &uuid, format, file_id).await {
-        Ok(()) => {}
-        Err(message) => super::set_error(&uuid, format, message),
+    if let Err(err) = run_inner(&server_url, &uuid, format, file_id).await {
+        // `err`'s `Display` is always a safe, pre-authored message (see
+        // `DownloadError` and the `.context(...)` calls below); the full
+        // chain — which can include raw io/reqwest text — is logged here
+        // for diagnosis and never forwarded to the UI.
+        tracing::warn!(error = ?err, book_uuid = %uuid, "offline download failed");
+        super::set_error(&uuid, format, err.to_string());
     }
 }
 
@@ -28,13 +63,13 @@ async fn run_inner(
     uuid: &str,
     format: DlFormat,
     file_id: Option<i64>,
-) -> Result<(), String> {
+) -> anyhow::Result<()> {
     // The raw `_online` variant: starting a download while offline must
     // fail loudly, never silently plan from a stale cached book.
     let book = data::get_ebook_online(server_url, uuid)
         .await
         .map_err(|e| friendly(&e))?
-        .ok_or_else(|| "Book not found".to_string())?;
+        .ok_or(DownloadError::NotFound)?;
     cache::put_json(&cache::keys::ebook(uuid), &book);
     let title = book
         .title
@@ -54,7 +89,7 @@ async fn run_inner(
                 AudiobookManifest::Hls { .. } => {
                     // The mobile player can't play HLS-only books either, so
                     // there is nothing useful to store.
-                    return Err("This audiobook's format isn't supported offline".into());
+                    return Err(DownloadError::UnsupportedFormat.into());
                 }
             };
             // The offline player reads the manifest from this cache row.
@@ -63,15 +98,15 @@ async fn run_inner(
         }
     };
     if plan.is_empty() {
-        return Err("Nothing to download for this format".into());
+        return Err(DownloadError::NothingToDownload.into());
     }
 
     let dir = media::downloads_root()
         .map(|r| r.join(uuid))
-        .ok_or_else(|| "Offline storage unavailable".to_string())?;
+        .ok_or(DownloadError::StorageUnavailable)?;
     tokio::fs::create_dir_all(&dir)
         .await
-        .map_err(|e| format!("Could not create download dir: {e}"))?;
+        .context("Offline storage unavailable")?;
 
     // Merge prior completion state (resume of a partly-finished download).
     // Stat asynchronously — this future shares the loopback runtime with the
@@ -155,7 +190,7 @@ async fn download_file(
     dir: &std::path::Path,
     file: &PlannedFile,
     on_delta: &mut (dyn FnMut(i64) + Send),
-) -> Result<i64, String> {
+) -> anyhow::Result<i64> {
     use tokio::io::AsyncWriteExt;
 
     let part_path = dir.join(format!("{}.part", file.rel));
@@ -172,13 +207,14 @@ async fn download_file(
     if resumed > 0 {
         req = req.header(reqwest::header::RANGE, format!("bytes={resumed}-"));
     }
-    let mut resp = req
-        .send()
-        .await
-        .map_err(|_| "Connection lost".to_string())?;
+    let mut resp = req.send().await.map_err(|e| {
+        tracing::warn!(error = %e, url = %file.url_path, "offline download: request failed");
+        DownloadError::ConnectionLost
+    })?;
     let status = resp.status();
     if !status.is_success() {
-        return Err(format!("Server returned {}", status.as_u16()));
+        tracing::warn!(status = status.as_u16(), url = %file.url_path, "offline download: server returned a non-success status");
+        return Err(DownloadError::ServerError.into());
     }
 
     // 206 → append after the existing bytes; 200 → the server ignored the
@@ -194,7 +230,7 @@ async fn download_file(
         .truncate(!appending)
         .open(&part_path)
         .await
-        .map_err(|e| format!("Could not write download: {e}"))?;
+        .context("Could not save the download to this device")?;
     if appending {
         on_delta(0);
     } else if resumed > 0 {
@@ -206,33 +242,36 @@ async fn download_file(
         let chunk = match resp.chunk().await {
             Ok(Some(chunk)) => chunk,
             Ok(None) => break,
-            Err(_) => return Err("Connection lost".into()),
+            Err(e) => {
+                tracing::warn!(error = %e, url = %file.url_path, "offline download: chunk read failed");
+                return Err(DownloadError::ConnectionLost.into());
+            }
         };
         out.write_all(&chunk)
             .await
-            .map_err(|e| format!("Could not write download: {e}"))?;
+            .context("Could not save the download to this device")?;
         on_delta(chunk.len() as i64);
     }
     out.flush()
         .await
-        .map_err(|e| format!("Could not write download: {e}"))?;
+        .context("Could not save the download to this device")?;
     out.sync_all()
         .await
-        .map_err(|e| format!("Could not write download: {e}"))?;
+        .context("Could not save the download to this device")?;
     drop(out);
 
     let written = tokio::fs::metadata(&part_path)
         .await
         .map(|m| m.len() as i64)
-        .map_err(|e| format!("Could not verify download: {e}"))?;
+        .context("Could not verify the downloaded file")?;
     if let Some(expected) = expected_total {
         if written != expected as i64 {
-            return Err("Download was interrupted — tap to resume".into());
+            return Err(DownloadError::Interrupted.into());
         }
     }
     tokio::fs::rename(&part_path, &final_path)
         .await
-        .map_err(|e| format!("Could not finalize download: {e}"))?;
+        .context("Could not finalize the download")?;
     Ok(written)
 }
 
@@ -359,11 +398,28 @@ fn publish_progress(uuid: &str, format: DlFormat, downloaded: i64, total: Option
     super::upsert(entry);
 }
 
-/// Short, user-facing message for a download failure.
-fn friendly(e: &crate::data::DataError) -> String {
+/// Maps a [`crate::data::DataError`] to a fixed, user-safe [`DownloadError`].
+/// The original error's `Display` (which can carry raw `reqwest`/
+/// `serde_json` transport/decode text) is logged via `tracing::warn!` for
+/// diagnosis but never returned — only the fixed variant reaches the UI.
+fn friendly(e: &crate::data::DataError) -> DownloadError {
+    tracing::warn!(error = %e, "offline download: data fetch failed");
     if crate::offline::sync::is_offline_error(e) {
-        "You're offline — connect to download".into()
-    } else {
-        e.to_string()
+        return DownloadError::Offline;
+    }
+    use crate::data::DataError;
+    match e {
+        DataError::Offline => DownloadError::Offline,
+        DataError::Unauthorized => DownloadError::Unauthorized,
+        // A `Network` variant that *is* a decode failure means the server
+        // was reachable but returned a malformed body — same bucket as an
+        // explicit `Decode`/`Http`, not a connectivity problem.
+        DataError::Network(re) if re.is_decode() => DownloadError::ServerError,
+        DataError::Network(_) => DownloadError::NetworkError,
+        DataError::Http { .. } | DataError::Decode(_) => DownloadError::ServerError,
+        DataError::Other(_) => DownloadError::NetworkError,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/frontend/src/offline/downloads/engine/tests.rs
+++ b/frontend/src/offline/downloads/engine/tests.rs
@@ -1,0 +1,83 @@
+//! Unit tests for `friendly()`'s `DataError` → `DownloadError` mapping —
+//! the fix for the raw-error leak into `DownloadStatus::Error` (#1308).
+
+use super::*;
+use crate::data::DataError;
+use crate::offline::test_support::{connect_refused_error, decode_error};
+
+#[test]
+fn friendly_maps_offline_to_the_offline_message() {
+    assert_eq!(friendly(&DataError::Offline), DownloadError::Offline);
+}
+
+#[test]
+fn friendly_maps_unauthorized_to_the_sign_in_again_message() {
+    assert_eq!(
+        friendly(&DataError::Unauthorized),
+        DownloadError::Unauthorized
+    );
+}
+
+#[test]
+fn friendly_maps_http_to_the_server_error_message() {
+    let e = DataError::Http {
+        status: 503,
+        body: "upstream exploded in a way a user should never see".into(),
+    };
+    let mapped = friendly(&e);
+    assert_eq!(mapped, DownloadError::ServerError);
+    assert!(!mapped.to_string().contains("upstream exploded"));
+}
+
+#[test]
+fn friendly_maps_decode_to_the_server_error_message() {
+    let src = serde_json::from_str::<i64>("not json").expect_err("must fail");
+    let e = DataError::from(src);
+    assert_eq!(friendly(&e), DownloadError::ServerError);
+}
+
+#[test]
+fn friendly_maps_other_to_the_network_error_message() {
+    assert_eq!(
+        friendly(&DataError::Other("raw internal detail".into())),
+        DownloadError::NetworkError
+    );
+}
+
+#[tokio::test]
+async fn friendly_maps_a_connect_refused_network_error_to_offline() {
+    // Connect-refused classifies as offline via `is_offline_error`, checked
+    // before the per-variant match.
+    let e = connect_refused_error().await;
+    assert_eq!(friendly(&e), DownloadError::Offline);
+}
+
+#[tokio::test]
+async fn friendly_maps_a_decode_class_network_error_to_server_error_not_offline() {
+    // A `Network` error that IS a decode failure means the server was
+    // reachable — must not be classified as offline.
+    let e = decode_error().await;
+    let mapped = friendly(&e);
+    assert_eq!(mapped, DownloadError::ServerError);
+    assert!(!mapped.to_string().to_lowercase().contains("offline"));
+}
+
+#[test]
+fn download_error_display_never_echoes_a_raw_variant_name() {
+    // Every fixed message is a full sentence a user could read — not a
+    // bare enum tag or a `{:?}`-style debug dump.
+    for variant in [
+        DownloadError::Offline,
+        DownloadError::NotFound,
+        DownloadError::UnsupportedFormat,
+        DownloadError::NothingToDownload,
+        DownloadError::StorageUnavailable,
+        DownloadError::ConnectionLost,
+        DownloadError::ServerError,
+        DownloadError::NetworkError,
+        DownloadError::Unauthorized,
+        DownloadError::Interrupted,
+    ] {
+        assert!(!variant.to_string().is_empty());
+    }
+}

--- a/frontend/src/offline/downloads/engine/tests.rs
+++ b/frontend/src/offline/downloads/engine/tests.rs
@@ -1,5 +1,5 @@
 //! Unit tests for `friendly()`'s `DataError` → `DownloadError` mapping —
-//! the fix for the raw-error leak into `DownloadStatus::Error` (#1308).
+//! guards against a raw-error leak into `DownloadStatus::Error`.
 
 use super::*;
 use crate::data::DataError;

--- a/frontend/src/offline/store.rs
+++ b/frontend/src/offline/store.rs
@@ -46,6 +46,20 @@ pub struct DownloadRow {
     pub updated_at: i64,
 }
 
+/// Failure opening or preparing the offline SQLite store. Wraps the raw
+/// `rusqlite::Error` so it never crosses this module's boundary directly
+/// (see `.claude/rules/02-error-handling.md`'s boundary rule).
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    /// Any `rusqlite` failure opening the connection, setting pragmas, or
+    /// applying the schema.
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+    /// The OS refused to spawn the dedicated worker thread.
+    #[error("could not spawn the offline store worker thread: {0}")]
+    WorkerSpawn(#[source] std::io::Error),
+}
+
 type Job = Box<dyn FnOnce(&Connection) + Send>;
 
 /// Handle to the store worker. Cheap to clone; the tokio unbounded sender is
@@ -106,7 +120,7 @@ impl Store {
     /// Open (or create) the database at `path` and spawn the worker thread.
     /// The connection and schema are prepared on the caller's thread so open
     /// failures surface immediately instead of as silent no-op sends.
-    pub fn open(path: PathBuf) -> Result<Store, rusqlite::Error> {
+    pub fn open(path: PathBuf) -> Result<Store, StoreError> {
         let conn = Connection::open(&path)?;
         // WAL keeps readers (none today, but cheap insurance) from blocking
         // the worker's writes; NORMAL sync is durable enough for a cache +
@@ -124,9 +138,7 @@ impl Store {
                     job(&conn);
                 }
             })
-            .map_err(|e| {
-                rusqlite::Error::InvalidPath(PathBuf::from(format!("worker spawn failed: {e}")))
-            })?;
+            .map_err(StoreError::WorkerSpawn)?;
         Ok(Store { tx })
     }
 

--- a/frontend/src/offline/store/tests.rs
+++ b/frontend/src/offline/store/tests.rs
@@ -138,6 +138,23 @@ async fn next_temp_id_decrements_and_survives_reopen() {
 }
 
 #[tokio::test]
+async fn open_returns_sqlite_error_when_path_is_a_directory() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let result = Store::open(dir.path().to_path_buf());
+    assert!(matches!(result, Err(StoreError::Sqlite(_))));
+}
+
+#[test]
+fn store_error_worker_spawn_variant_carries_the_source_message() {
+    let io_err = std::io::Error::other("boom");
+    let err = StoreError::WorkerSpawn(io_err);
+    assert_eq!(
+        err.to_string(),
+        "could not spawn the offline store worker thread: boom"
+    );
+}
+
+#[tokio::test]
 async fn meta_round_trips_values() {
     let (_dir, store) = open_temp();
     assert!(store.meta_get("last_sync_at").await.is_none());

--- a/frontend/src/offline/sync/tests.rs
+++ b/frontend/src/offline/sync/tests.rs
@@ -9,39 +9,7 @@
 #![allow(clippy::await_holding_lock)]
 
 use super::*;
-
-/// A real connect-refused `DataError::Network` (port 1 is never listening).
-async fn connect_refused_error() -> DataError {
-    let err = crate::data::http_client()
-        .get("http://127.0.0.1:1/nope")
-        .send()
-        .await
-        .expect_err("connect must fail");
-    DataError::from(err)
-}
-
-/// A real decode-class `DataError::Network`: the server answers 200 with a
-/// body that isn't the expected JSON shape.
-async fn decode_error() -> DataError {
-    use axum::routing::get;
-    let app = axum::Router::new().route("/j", get(|| async { "not-json" }));
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().expect("addr").port();
-    tokio::spawn(async move {
-        let _ = axum::serve(listener, app).await;
-    });
-    let err = crate::data::http_client()
-        .get(format!("http://127.0.0.1:{port}/j"))
-        .send()
-        .await
-        .expect("send")
-        .json::<Vec<i64>>()
-        .await
-        .expect_err("decode must fail");
-    DataError::from(err)
-}
+use crate::offline::test_support::{connect_refused_error, decode_error};
 
 #[tokio::test]
 async fn is_offline_error_accepts_connect_failures() {

--- a/frontend/src/offline/test_support.rs
+++ b/frontend/src/offline/test_support.rs
@@ -1,0 +1,43 @@
+//! Shared test-only fixtures for the `offline` module tree: real `reqwest`
+//! errors produced against live sockets (a refused connect for the offline
+//! class, a garbage-body response for the decode class) so classifiers are
+//! exercised on the exact error values production sees. In-crate only (no
+//! `test-support` feature — nothing outside `omnibus-frontend` depends on
+//! this crate's test fixtures), so a plain `cfg(test)` is enough.
+
+#![cfg(test)]
+
+use crate::data::DataError;
+
+/// A real connect-refused `DataError::Network` (port 1 is never listening).
+pub(crate) async fn connect_refused_error() -> DataError {
+    let err = crate::data::http_client()
+        .get("http://127.0.0.1:1/nope")
+        .send()
+        .await
+        .expect_err("connect must fail");
+    DataError::from(err)
+}
+
+/// A real decode-class `DataError::Network`: the server answers 200 with a
+/// body that isn't the expected JSON shape.
+pub(crate) async fn decode_error() -> DataError {
+    use axum::routing::get;
+    let app = axum::Router::new().route("/j", get(|| async { "not-json" }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let err = crate::data::http_client()
+        .get(format!("http://127.0.0.1:{port}/j"))
+        .send()
+        .await
+        .expect("send")
+        .json::<Vec<i64>>()
+        .await
+        .expect_err("decode must fail");
+    DataError::from(err)
+}

--- a/frontend/src/offline/test_support.rs
+++ b/frontend/src/offline/test_support.rs
@@ -1,9 +1,7 @@
 //! Shared test-only fixtures for the `offline` module tree: real `reqwest`
-//! errors produced against live sockets (a refused connect for the offline
-//! class, a garbage-body response for the decode class) so classifiers are
-//! exercised on the exact error values production sees. In-crate only (no
-//! `test-support` feature — nothing outside `omnibus-frontend` depends on
-//! this crate's test fixtures), so a plain `cfg(test)` is enough.
+//! errors produced against live sockets (refused-connect for the offline
+//! class, garbage-body for the decode class) so classifiers are exercised
+//! on the exact error values production sees.
 
 #![cfg(test)]
 


### PR DESCRIPTION
## Summary
- `frontend/src/offline/downloads/engine.rs`'s `run_inner`/`download_file` now return `anyhow::Result` with contextual messages instead of hand-rolled `Result<_, String>`, using a local `DownloadError` `thiserror` enum for the enumerable outcomes (offline, not found, unsupported format, storage unavailable, connection lost, server error, interrupted, unauthorized, network error).
- `friendly()` now maps every `DataError` variant to that fixed, user-safe set instead of forwarding the raw transport/decode `Display` — the original error is logged via `tracing::warn!` for diagnosis but never reaches `DownloadStatus::Error`, closing the leak into the account Downloads page.
- `Store::open` now returns a module-local `StoreError` (`#[error(transparent)] #[from] rusqlite::Error` + a `WorkerSpawn` variant) instead of the raw `rusqlite::Error`, matching the `02-error-handling.md` boundary rule.
- Extracted the `connect_refused_error`/`decode_error` real-socket test fixtures (previously private to `sync/tests.rs`) into a shared `offline::test_support` module so the new `engine` tests can reuse them without duplicating helpers.

Closes #1308.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features mobile` — PASS (485 passed; 0 failed)

## Version
- [x] **Patch**

## Notes
- Scoped to `engine.rs`/`friendly()` + `Store::open` per the issue's own "Notes for the implementer" — the rest of the `offline/` module (cache.rs, outbox.rs, replica.rs, sync.rs, media.rs) still uses ad-hoc error handling and is left for a follow-up if desired.
- `anyhow` is a new optional dependency on `omnibus-frontend`, gated behind the `mobile` feature only (the `offline` module's own gate) — no effect on the `web`/`server`/default builds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SzYzELgFNfUJ3w1Nm37MsV)_