### PR TITLE
feat: self-service change-password in Settings → Account (#1325)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -28,8 +28,8 @@ pub use token::{
     SESSION_COOKIE_NAME_HOST_PREFIXED,
 };
 pub use users::{
-    create_user, get_kindle_email, get_user_by_id, get_user_by_username, promote_to_admin,
-    registration_enabled, set_kindle_email, set_registration_enabled,
+    change_password, create_user, get_kindle_email, get_user_by_id, get_user_by_username,
+    promote_to_admin, registration_enabled, set_kindle_email, set_registration_enabled,
 };
 
 use sqlx::Row;

--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -2,7 +2,7 @@
 
 use sqlx::{SqliteConnection, SqlitePool};
 
-use super::password::{hash_password, validate_password, validate_username};
+use super::password::{hash_password, validate_password, validate_username, verify_password};
 use super::{row_to_user, AuthError, AuthResult, User};
 
 /// Atomically create a user. The first user created becomes admin; the
@@ -180,6 +180,55 @@ pub async fn get_kindle_email(pool: &SqlitePool, user_id: i64) -> AuthResult<Opt
         .await?
         .flatten();
     Ok(v.filter(|s| !s.trim().is_empty()))
+}
+
+/// Change a user's password. Verifies `current` against the stored hash to
+/// authorize the change, validates `new` against the password policy, then
+/// re-hashes with Argon2id and stamps `password_changed_at` — all in one
+/// transaction so an interrupted call never leaves a half-applied state.
+///
+/// Errors with [`AuthError::InvalidCredentials`] when the current password is
+/// wrong (or the user id no longer exists) and [`AuthError::Validation`] when
+/// the new password fails policy (min length / common-password reject-list).
+/// Only ever touches the row identified by `user_id`.
+pub async fn change_password(
+    pool: &SqlitePool,
+    user_id: i64,
+    current: &str,
+    new: &str,
+) -> AuthResult<()> {
+    let mut tx = pool.begin().await?;
+
+    let phc: Option<String> = sqlx::query_scalar("SELECT password_hash FROM users WHERE id = ?")
+        .bind(user_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+    let Some(phc) = phc else {
+        return Err(AuthError::InvalidCredentials);
+    };
+    if !verify_password(current, &phc)? {
+        return Err(AuthError::InvalidCredentials);
+    }
+
+    // Validate only after authorizing, so an unauthenticated caller can't
+    // probe the policy — and reject before hashing to avoid wasted argon2 work.
+    validate_password(new)?;
+    let new_phc = hash_password(new)?;
+
+    // Stamp `password_changed_at` alongside the new hash (the standing
+    // INVARIANT in `create_user`): downstream "invalidate sessions older than
+    // last password change" logic reads this column.
+    sqlx::query(
+        "UPDATE users SET password_hash = ?, password_changed_at = strftime('%s','now')
+         WHERE id = ?",
+    )
+    .bind(&new_phc)
+    .bind(user_id)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+    Ok(())
 }
 
 /// `OMNIBUS_INITIAL_ADMIN` boot hook: if a user by this username exists,

--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -218,7 +218,7 @@ pub async fn change_password(
     // Stamp `password_changed_at` alongside the new hash (the standing
     // INVARIANT in `create_user`): downstream "invalidate sessions older than
     // last password change" logic reads this column.
-    sqlx::query(
+    let updated = sqlx::query(
         "UPDATE users SET password_hash = ?, password_changed_at = strftime('%s','now')
          WHERE id = ?",
     )
@@ -226,6 +226,13 @@ pub async fn change_password(
     .bind(user_id)
     .execute(&mut *tx)
     .await?;
+
+    // The transaction pins the row we verified above, so a 0-row update
+    // shouldn't happen — but never commit a no-op as success. Treat it as
+    // `InvalidCredentials`, consistent with the missing-user path.
+    if updated.rows_affected() == 0 {
+        return Err(AuthError::InvalidCredentials);
+    }
 
     tx.commit().await?;
     Ok(())

--- a/db/src/auth/users/tests.rs
+++ b/db/src/auth/users/tests.rs
@@ -183,3 +183,85 @@ async fn set_kindle_email_rejects_malformed_address() {
     let err = set_kindle_email(&p, u.id, Some("nope")).await.unwrap_err();
     assert!(matches!(err, AuthError::Validation(_)));
 }
+
+#[tokio::test]
+async fn change_password_updates_hash_and_stamp_and_new_password_logs_in() {
+    use crate::auth::verify_login;
+
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    let before: i64 = sqlx::query_scalar("SELECT password_changed_at FROM users WHERE id = ?")
+        .bind(u.id)
+        .fetch_one(&p)
+        .await
+        .unwrap();
+
+    change_password(&p, u.id, "hunter2-real-long", "brand-new-longpass")
+        .await
+        .unwrap();
+
+    // Old password no longer authenticates; the new one does.
+    assert!(matches!(
+        verify_login(&p, "alice", "hunter2-real-long")
+            .await
+            .unwrap_err(),
+        AuthError::InvalidCredentials
+    ));
+    verify_login(&p, "alice", "brand-new-longpass")
+        .await
+        .unwrap();
+
+    // The stamp advanced (or held steady within the same wall-clock second);
+    // it must never regress.
+    let after: i64 = sqlx::query_scalar("SELECT password_changed_at FROM users WHERE id = ?")
+        .bind(u.id)
+        .fetch_one(&p)
+        .await
+        .unwrap();
+    assert!(after >= before, "password_changed_at must not regress");
+}
+
+#[tokio::test]
+async fn change_password_rejects_wrong_current_and_leaves_hash_intact() {
+    use crate::auth::verify_login;
+
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+
+    let err = change_password(&p, u.id, "wrong-current-pass", "brand-new-longpass")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthError::InvalidCredentials));
+
+    // Nothing changed: the original password still logs in.
+    verify_login(&p, "alice", "hunter2-real-long")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn change_password_rejects_invalid_new_password() {
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+
+    // Too short.
+    let err = change_password(&p, u.id, "hunter2-real-long", "short")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthError::Validation(_)));
+
+    // Common-password reject-list.
+    let err = change_password(&p, u.id, "hunter2-real-long", "password123")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthError::Validation(_)));
+}
+
+#[tokio::test]
+async fn change_password_rejects_unknown_user() {
+    let p = pool().await;
+    let err = change_password(&p, 9999, "anything-here-long", "brand-new-longpass")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthError::InvalidCredentials));
+}

--- a/frontend/src/components/auth/mod.rs
+++ b/frontend/src/components/auth/mod.rs
@@ -11,4 +11,4 @@ mod strength;
 pub use banner::{Banner, BannerKind};
 pub use field::Field;
 pub use shell::AuthShell;
-pub use strength::{StrengthMeter, StrengthScore};
+pub use strength::{score_password, PasswordRequirements, StrengthMeter, StrengthScore};

--- a/frontend/src/components/auth/strength.rs
+++ b/frontend/src/components/auth/strength.rs
@@ -79,9 +79,141 @@ pub fn StrengthMeter(score: StrengthScore, #[props(default)] label: Option<Strin
     }
 }
 
+/// Presentational password scoring — the server still enforces policy (the
+/// 10-char minimum + common-password reject-list). Returns the meter score
+/// (0..=4), a short label, and the three checklist booleans (length≥10,
+/// mixed case, number-or-symbol) so a page renders both the meter and the
+/// requirements list from one pass. Shared by the register page and the
+/// Settings → Account change-password form.
+pub fn score_password(pw: &str) -> (StrengthScore, &'static str, [bool; 3]) {
+    let len = pw.chars().count();
+    let has_lower = pw.chars().any(|c| c.is_ascii_lowercase());
+    let has_upper = pw.chars().any(|c| c.is_ascii_uppercase());
+    let mixed_case = has_lower && has_upper;
+    let has_number_or_symbol = pw
+        .chars()
+        .any(|c| c.is_ascii_digit() || !c.is_alphanumeric());
+    let len_ok = len >= 10;
+
+    let mut raw: u8 = 0;
+    if len >= 4 {
+        raw = raw.saturating_add(1);
+    }
+    if len >= 8 {
+        raw = raw.saturating_add(1);
+    }
+    if mixed_case {
+        raw = raw.saturating_add(1);
+    }
+    if has_number_or_symbol {
+        raw = raw.saturating_add(1);
+    }
+    if len_ok {
+        raw = raw.saturating_add(1);
+    }
+    let score = StrengthScore::new(raw.min(StrengthScore::MAX));
+    // "empty" only when nothing was typed; a non-empty score-0 input
+    // (1–3 chars, no special chars) is still weak, not empty.
+    let label = if pw.is_empty() {
+        "empty"
+    } else {
+        match score.value() {
+            0 | 1 => "weak",
+            2 => "fair",
+            3 => "good",
+            _ => "strong",
+        }
+    };
+    (score, label, [len_ok, mixed_case, has_number_or_symbol])
+}
+
+/// The three-rule password requirements checklist rendered under the strength
+/// meter: length, mixed case, and one number-or-symbol. Pass the `rules`
+/// triple from [`score_password`]; each row shows met/unmet with an
+/// SR-only status so the dot color isn't the only signal.
+#[component]
+pub fn PasswordRequirements(rules: [bool; 3]) -> Element {
+    rsx! {
+        div { class: "auth-requirements",
+            div { class: "auth-requirements-title", "Password needs" }
+            PasswordRequirementRow { ok: rules[0], text: "At least 10 characters" }
+            PasswordRequirementRow { ok: rules[1], text: "Mixed case" }
+            PasswordRequirementRow { ok: rules[2], text: "One number or symbol" }
+        }
+    }
+}
+
+#[component]
+fn PasswordRequirementRow(ok: bool, text: String) -> Element {
+    let cls = if ok { "auth-req ok" } else { "auth-req" };
+    let status = if ok { "met" } else { "not met" };
+    rsx! {
+        div { class: "{cls}",
+            span { class: "auth-req-dot", aria_hidden: "true" }
+            span { "{text}" }
+            // Screen-reader-only status — the dot color alone isn't
+            // perceivable to assistive tech, so announce met/unmet.
+            span { class: "sr-only", ": {status}" }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn score_password_empty_is_zero() {
+        let (score, label, rules) = score_password("");
+        assert_eq!(score.value(), 0);
+        assert_eq!(label, "empty");
+        assert_eq!(rules, [false, false, false]);
+    }
+
+    #[test]
+    fn score_password_grows_with_length_and_classes() {
+        let (s, _, _) = score_password("abcd");
+        assert_eq!(s.value(), 1);
+        let (s, _, _) = score_password("AbCdEfGh");
+        assert_eq!(s.value(), 3);
+        let (s, label, rules) = score_password("AbCdEfGh1!2x");
+        assert_eq!(s.value(), 4);
+        assert_eq!(label, "strong");
+        assert_eq!(rules, [true, true, true]);
+    }
+
+    #[test]
+    fn score_password_rules_track_thresholds() {
+        let (_, _, rules) = score_password("Ab1");
+        assert_eq!(rules, [false, true, true]);
+        let (_, _, rules) = score_password("abcdefghijk1");
+        assert_eq!(rules, [true, false, true]);
+    }
+
+    #[test]
+    fn score_password_length_rule_boundary() {
+        // Right at the server-policy boundary (10 chars). 9-char inputs
+        // must report length-not-met; 10-char inputs must report met.
+        let (_, _, rules) = score_password("abcdefgh1");
+        assert!(!rules[0], "9-char input must not satisfy len_ok");
+        let (_, _, rules) = score_password("abcdefghi1");
+        assert!(rules[0], "10-char input must satisfy len_ok");
+        let (_, _, rules) = score_password("abcdefghij1");
+        assert!(rules[0], "11-char input must satisfy len_ok");
+    }
+
+    #[test]
+    fn score_password_label_distinguishes_empty_from_short() {
+        // Empty -> "empty"; any non-empty input -> at least "weak"
+        // (covers the 1–3 char range where score=0 but typed content
+        // exists, so the meter shouldn't lie about being empty).
+        let (_, label, _) = score_password("");
+        assert_eq!(label, "empty");
+        let (_, label, _) = score_password("a");
+        assert_eq!(label, "weak");
+        let (_, label, _) = score_password("ab");
+        assert_eq!(label, "weak");
+    }
 
     #[test]
     fn clamps_above_max() {

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -767,16 +767,18 @@ pub mod web_auth_state {
 /// skip the redirect ping — there's no client to redirect.
 #[cfg(not(feature = "mobile"))]
 pub(crate) fn note_server_fn_err(e: dioxus::CapturedError) -> DataError {
-    if let Some(sfn_err) = e.0.downcast_ref::<dioxus::fullstack::ServerFnError>() {
-        let code = match sfn_err {
-            dioxus::fullstack::ServerFnError::ServerError { code, .. } => *code,
-            _ => 0,
-        };
-        if code == 401 {
+    if let Some(dioxus::fullstack::ServerFnError::ServerError { code, message, .. }) =
+        e.0.downcast_ref::<dioxus::fullstack::ServerFnError>()
+    {
+        if *code == 401 {
             #[cfg(feature = "web")]
             web_auth_state::notify_unauthorized();
             return DataError::Unauthorized;
         }
+        // Surface the handler's own `ServerFnError::new(msg)` text rather than
+        // the `CapturedError` Display, which wraps it as "error running server
+        // function: <msg> (details: None)" — noise for an inline form error.
+        return DataError::Other(message.clone());
     }
     DataError::Other(e.to_string())
 }

--- a/frontend/src/data/kindle.rs
+++ b/frontend/src/data/kindle.rs
@@ -131,6 +131,24 @@ pub(crate) async fn set_kindle_email_online(
     Ok(())
 }
 
+// ── Change password ──────────────────────────────────────────────
+
+/// Web/SSR: change the authenticated user's password. The returned
+/// [`DataError`] carries the server's message (wrong current password / policy
+/// rejection) so the Account form can surface it inline. Web-only — the change
+/// happens through the same `/api/rpc` server function; mobile has no Account
+/// section (its Settings shell is a flat admin form).
+#[cfg(not(feature = "mobile"))]
+pub async fn change_password(
+    _server_url: &str,
+    current: String,
+    new: String,
+) -> Result<(), DataError> {
+    crate::rpc::rpc_change_password(current, new)
+        .await
+        .map_err(note_server_fn_err)
+}
+
 // ── SMTP config (admin settings) ─────────────────────────────────
 
 /// Web/SSR: read the masked SMTP config status.

--- a/frontend/src/pages/account.rs
+++ b/frontend/src/pages/account.rs
@@ -12,6 +12,8 @@ use dioxus::prelude::*;
 mod downloads;
 
 #[cfg(not(feature = "mobile"))]
+use crate::components::auth::{score_password, PasswordRequirements, StrengthMeter};
+#[cfg(not(feature = "mobile"))]
 use crate::{data, use_server_url};
 
 #[cfg(feature = "mobile")]
@@ -282,6 +284,124 @@ fn kindle_account_body(embedded: bool) -> Element {
                 p {
                     role: "status",
                     "data-testid": "kindle-email-status",
+                    class: if msg_is_error() { "settings-status error" } else { "settings-status success" },
+                    "{m}"
+                }
+            }
+        }
+
+        ChangePasswordCard {}
+    }
+}
+
+/// Self-service change-password card (web Account section). Requires the
+/// current password to authorize, validates the new one against the same
+/// policy as registration (strength meter + requirements are advisory; the
+/// server is authoritative), and surfaces the server's inline error for a
+/// wrong current password or a policy rejection without clearing the form.
+#[cfg(not(feature = "mobile"))]
+#[component]
+fn ChangePasswordCard() -> Element {
+    let server_url = use_server_url();
+    let mut current = use_signal(String::new);
+    let mut new_password = use_signal(String::new);
+    let mut msg = use_signal(|| None::<String>);
+    let mut msg_is_error = use_signal(|| false);
+    let mut in_flight = use_signal(|| false);
+
+    let pw = new_password();
+    let (score, score_label, rules) = score_password(&pw);
+
+    let on_submit = move |evt: Event<FormData>| {
+        evt.prevent_default();
+        let cur = current();
+        let next = new_password();
+        if cur.is_empty() || next.is_empty() {
+            msg.set(Some("Enter your current and new password.".to_string()));
+            msg_is_error.set(true);
+            return;
+        }
+        let url = server_url.clone();
+        in_flight.set(true);
+        spawn(async move {
+            match data::change_password(&url, cur, next).await {
+                Ok(()) => {
+                    current.set(String::new());
+                    new_password.set(String::new());
+                    msg.set(Some("Password changed.".to_string()));
+                    msg_is_error.set(false);
+                }
+                Err(e) => {
+                    msg.set(Some(e.to_string()));
+                    msg_is_error.set(true);
+                }
+            }
+            in_flight.set(false);
+        });
+    };
+
+    rsx! {
+        section { class: "card", "data-testid": "account-password-card",
+            h2 { "Password" }
+            p { class: "subtitle", "Change the password you use to sign in." }
+
+            form {
+                id: "change-password-form",
+                class: "settings-form",
+                onsubmit: on_submit,
+                div { class: "settings-field",
+                    label { r#for: "current-password", "Current password" }
+                    input {
+                        r#type: "password",
+                        id: "current-password",
+                        name: "current_password",
+                        "data-testid": "current-password-input",
+                        autocomplete: "current-password",
+                        autocapitalize: "none",
+                        autocorrect: "off",
+                        spellcheck: "false",
+                        value: "{current}",
+                        oninput: move |e| {
+                            current.set(e.value());
+                            msg.set(None);
+                        },
+                    }
+                }
+                div { class: "settings-field",
+                    label { r#for: "new-password", "New password" }
+                    input {
+                        r#type: "password",
+                        id: "new-password",
+                        name: "new_password",
+                        "data-testid": "new-password-input",
+                        autocomplete: "new-password",
+                        autocapitalize: "none",
+                        autocorrect: "off",
+                        spellcheck: "false",
+                        value: "{new_password}",
+                        oninput: move |e| {
+                            new_password.set(e.value());
+                            msg.set(None);
+                        },
+                    }
+                }
+                StrengthMeter { score, label: Some(score_label.to_string()) }
+                PasswordRequirements { rules }
+                div { class: "settings-actions",
+                    button {
+                        r#type: "submit",
+                        class: "btn",
+                        disabled: in_flight(),
+                        "data-testid": "change-password-submit",
+                        "Change password"
+                    }
+                }
+            }
+
+            if let Some(m) = msg() {
+                p {
+                    role: "status",
+                    "data-testid": "change-password-status",
                     class: if msg_is_error() { "settings-status error" } else { "settings-status success" },
                     "{m}"
                 }

--- a/frontend/src/pages/auth/register.rs
+++ b/frontend/src/pages/auth/register.rs
@@ -6,7 +6,9 @@ use dioxus_router::{use_navigator, Link};
 
 #[cfg(not(feature = "mobile"))]
 use crate::components::auth::AuthShell;
-use crate::components::auth::{Banner, BannerKind, Field, StrengthMeter, StrengthScore};
+use crate::components::auth::{
+    score_password, Banner, BannerKind, Field, PasswordRequirements, StrengthMeter,
+};
 use crate::{use_server_url, Route};
 
 #[cfg(feature = "mobile")]
@@ -287,27 +289,7 @@ fn PasswordSection(
             score: score,
             label: Some(score_label.to_string()),
         }
-        div { class: "auth-requirements",
-            div { class: "auth-requirements-title", "Password needs" }
-            PasswordRequirementRow { ok: rules[0], text: "At least 10 characters" }
-            PasswordRequirementRow { ok: rules[1], text: "Mixed case" }
-            PasswordRequirementRow { ok: rules[2], text: "One number or symbol" }
-        }
-    }
-}
-
-#[component]
-fn PasswordRequirementRow(ok: bool, text: String) -> Element {
-    let cls = if ok { "auth-req ok" } else { "auth-req" };
-    let status = if ok { "met" } else { "not met" };
-    rsx! {
-        div { class: "{cls}",
-            span { class: "auth-req-dot", aria_hidden: "true" }
-            span { "{text}" }
-            // Screen-reader-only status — the dot color alone isn't
-            // perceivable to assistive tech, so announce met/unmet.
-            span { class: "sr-only", ": {status}" }
-        }
+        PasswordRequirements { rules }
     }
 }
 
@@ -331,52 +313,6 @@ fn classify_register_error(raw: &str) -> RegisterError {
     } else {
         RegisterError::Other(raw.to_string())
     }
-}
-
-/// Presentational password scoring — server still enforces policy (10-char
-/// minimum). Returns the meter score (0..=4), a short label, and the three
-/// checklist booleans (length≥10, mixed case, number-or-symbol) so the
-/// page renders both the meter and the requirements list from one pass.
-fn score_password(pw: &str) -> (StrengthScore, &'static str, [bool; 3]) {
-    let len = pw.chars().count();
-    let has_lower = pw.chars().any(|c| c.is_ascii_lowercase());
-    let has_upper = pw.chars().any(|c| c.is_ascii_uppercase());
-    let mixed_case = has_lower && has_upper;
-    let has_number_or_symbol = pw
-        .chars()
-        .any(|c| c.is_ascii_digit() || !c.is_alphanumeric());
-    let len_ok = len >= 10;
-
-    let mut raw: u8 = 0;
-    if len >= 4 {
-        raw = raw.saturating_add(1);
-    }
-    if len >= 8 {
-        raw = raw.saturating_add(1);
-    }
-    if mixed_case {
-        raw = raw.saturating_add(1);
-    }
-    if has_number_or_symbol {
-        raw = raw.saturating_add(1);
-    }
-    if len_ok {
-        raw = raw.saturating_add(1);
-    }
-    let score = StrengthScore::new(raw.min(StrengthScore::MAX));
-    // "empty" only when nothing was typed; a non-empty score-0 input
-    // (1–3 chars, no special chars) is still weak, not empty.
-    let label = if pw.is_empty() {
-        "empty"
-    } else {
-        match score.value() {
-            0 | 1 => "weak",
-            2 => "fair",
-            3 => "good",
-            _ => "strong",
-        }
-    };
-    (score, label, [len_ok, mixed_case, has_number_or_symbol])
 }
 
 #[cfg(test)]

--- a/frontend/src/pages/auth/register/tests.rs
+++ b/frontend/src/pages/auth/register/tests.rs
@@ -1,57 +1,7 @@
+// Password-scoring coverage lives with the shared helper in
+// `components::auth::strength`; these tests cover only register-specific
+// error routing.
 use super::*;
-
-#[test]
-fn score_password_empty_is_zero() {
-    let (score, label, rules) = score_password("");
-    assert_eq!(score.value(), 0);
-    assert_eq!(label, "empty");
-    assert_eq!(rules, [false, false, false]);
-}
-
-#[test]
-fn score_password_grows_with_length_and_classes() {
-    let (s, _, _) = score_password("abcd");
-    assert_eq!(s.value(), 1);
-    let (s, _, _) = score_password("AbCdEfGh");
-    assert_eq!(s.value(), 3);
-    let (s, label, rules) = score_password("AbCdEfGh1!2x");
-    assert_eq!(s.value(), 4);
-    assert_eq!(label, "strong");
-    assert_eq!(rules, [true, true, true]);
-}
-
-#[test]
-fn score_password_rules_track_thresholds() {
-    let (_, _, rules) = score_password("Ab1");
-    assert_eq!(rules, [false, true, true]);
-    let (_, _, rules) = score_password("abcdefghijk1");
-    assert_eq!(rules, [true, false, true]);
-}
-
-#[test]
-fn score_password_length_rule_boundary() {
-    // Right at the server-policy boundary (10 chars). 9-char inputs
-    // must report length-not-met; 10-char inputs must report met.
-    let (_, _, rules) = score_password("abcdefgh1");
-    assert!(!rules[0], "9-char input must not satisfy len_ok");
-    let (_, _, rules) = score_password("abcdefghi1");
-    assert!(rules[0], "10-char input must satisfy len_ok");
-    let (_, _, rules) = score_password("abcdefghij1");
-    assert!(rules[0], "11-char input must satisfy len_ok");
-}
-
-#[test]
-fn score_password_label_distinguishes_empty_from_short() {
-    // Empty -> "empty"; any non-empty input -> at least "weak"
-    // (covers the 1–3 char range where score=0 but typed content
-    // exists, so the meter shouldn't lie about being empty).
-    let (_, label, _) = score_password("");
-    assert_eq!(label, "empty");
-    let (_, label, _) = score_password("a");
-    assert_eq!(label, "weak");
-    let (_, label, _) = score_password("ab");
-    assert_eq!(label, "weak");
-}
 
 #[test]
 fn classify_register_error_routes_username() {

--- a/frontend/src/rpc/account.rs
+++ b/frontend/src/rpc/account.rs
@@ -1,5 +1,6 @@
-//! Per-user account server functions. Currently just the Send-to-Kindle
-//! destination address, editable from the `/account` page.
+//! Per-user account server functions: the Send-to-Kindle destination address
+//! and the self-service change-password flow, both editable from the Account
+//! section of `/settings`.
 
 use dioxus::fullstack::post;
 use dioxus::prelude::*;
@@ -18,5 +19,21 @@ pub async fn rpc_set_kindle_email(email: Option<String>) -> Result<()> {
         Ok(()) => Ok(()),
         Err(AuthError::Validation(msg)) => Err(ServerFnError::new(msg).into()),
         Err(e) => Err(internal_rpc_error("set kindle email", e).into()),
+    }
+}
+
+/// Change the authenticated user's own password. The `AuthUser` extractor
+/// scopes the change to the caller's own account (AC4). Surfaces a wrong
+/// current password and a policy-failing new password as distinct client
+/// errors the form renders inline; opaque failures fold to a generic message.
+#[post("/api/rpc/account/change-password", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_change_password(current_password: String, new_password: String) -> Result<()> {
+    match db::auth::change_password(&pool.0, user.id, &current_password, &new_password).await {
+        Ok(()) => Ok(()),
+        Err(AuthError::InvalidCredentials) => {
+            Err(ServerFnError::new("current password is incorrect").into())
+        }
+        Err(AuthError::Validation(msg)) => Err(ServerFnError::new(msg).into()),
+        Err(e) => Err(internal_rpc_error("change password", e).into()),
     }
 }

--- a/ui_tests/playwright/tests/flows/account.spec.ts
+++ b/ui_tests/playwright/tests/flows/account.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures/test";
 import { expectMutation } from "../utils/api";
+import { TEST_PASSWORD } from "../utils/auth";
 import { expectNavVisible, gotoReady } from "../utils/nav";
 
 // F4.3 — the Send-to-Kindle destination address lives in the Account section
@@ -12,6 +13,10 @@ import { expectNavVisible, gotoReady } from "../utils/nav";
 const ACCOUNT = "/settings?section=account";
 
 const emailInput = (page: Page) => page.getByTestId("kindle-email-input");
+const currentPassword = (page: Page) =>
+  page.getByTestId("current-password-input");
+const newPassword = (page: Page) => page.getByTestId("new-password-input");
+const changeStatus = (page: Page) => page.getByTestId("change-password-status");
 
 test("renders the account section layout", async ({ page }) => {
   await gotoReady(page, ACCOUNT);
@@ -23,6 +28,16 @@ test("renders the account section layout", async ({ page }) => {
   await expect(emailInput(page)).toBeVisible();
   await expect(page.getByTestId("kindle-email-save")).toBeVisible();
   await expect(page.getByTestId("kindle-email-connected")).toBeAttached();
+
+  // The change-password card sits below the Kindle card in the same section.
+  await expect(
+    page.getByRole("heading", { level: 2, name: "Password" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("account-password-card")).toBeVisible();
+  await expect(currentPassword(page)).toBeVisible();
+  await expect(newPassword(page)).toBeVisible();
+  await expect(page.getByTestId("change-password-submit")).toBeVisible();
+
   await expectNavVisible(page);
 });
 
@@ -90,4 +105,104 @@ test("shows an error status when saving the Kindle email fails", async ({
   );
 
   await expect(page.getByTestId("kindle-email-status")).toHaveClass(/error/);
+});
+
+// Change-password (#1325). The success test mocks the mutation: the suite
+// reuses this admin's credentials across every spec, so an actual password
+// change would strand later `ensureLoggedIn` calls. The real DB behavior
+// (verify current, validate new, stamp `password_changed_at`) is covered by
+// the `omnibus-db` unit tests; the rejection tests below hit the live server
+// and are safe because both reject *before* the write.
+
+test("changes the password and clears the form on success", async ({
+  page,
+}) => {
+  await gotoReady(page, ACCOUNT);
+
+  await page.route("**/api/rpc/account/change-password", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "null",
+      });
+    }
+    return route.continue();
+  });
+
+  await currentPassword(page).fill(TEST_PASSWORD);
+  await newPassword(page).fill("Brand-New-Valid-9x");
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/rpc/account/change-password",
+      expectedBody: {
+        current_password: TEST_PASSWORD,
+        new_password: "Brand-New-Valid-9x",
+      },
+      expectedStatus: 200,
+    },
+    async () => page.getByTestId("change-password-submit").click(),
+  );
+
+  await expect(changeStatus(page)).toHaveText("Password changed.");
+  await expect(changeStatus(page)).toHaveClass(/success/);
+  await expect(currentPassword(page)).toHaveValue("");
+  await expect(newPassword(page)).toHaveValue("");
+});
+
+test("rejects a wrong current password and leaves the form untouched", async ({
+  page,
+}) => {
+  await gotoReady(page, ACCOUNT);
+
+  await currentPassword(page).fill("definitely-not-the-password");
+  await newPassword(page).fill("Brand-New-Valid-9x");
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/rpc/account/change-password",
+      expectedBody: {
+        current_password: "definitely-not-the-password",
+        new_password: "Brand-New-Valid-9x",
+      },
+      expectedStatus: 500,
+    },
+    async () => page.getByTestId("change-password-submit").click(),
+  );
+
+  await expect(changeStatus(page)).toHaveClass(/error/);
+  await expect(changeStatus(page)).toContainText(
+    "current password is incorrect",
+  );
+  // Inputs keep their values so the user can correct just the current field.
+  await expect(currentPassword(page)).toHaveValue(
+    "definitely-not-the-password",
+  );
+});
+
+test("rejects an invalid new password", async ({ page }) => {
+  await gotoReady(page, ACCOUNT);
+
+  // Correct current password authorizes; the too-short new password fails
+  // policy on the server before any write happens.
+  await currentPassword(page).fill(TEST_PASSWORD);
+  await newPassword(page).fill("short");
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/rpc/account/change-password",
+      expectedBody: { current_password: TEST_PASSWORD, new_password: "short" },
+      expectedStatus: 500,
+    },
+    async () => page.getByTestId("change-password-submit").click(),
+  );
+
+  await expect(changeStatus(page)).toHaveClass(/error/);
 });


### PR DESCRIPTION
## Summary
- Adds a self-service **change-password** form to Settings → Account (web), sitting below the existing Kindle-email card. Reuses the registration strength meter + requirements checklist.
- New DB layer `omnibus_db::auth::change_password` — verifies the current password to authorize, validates the new one against the same policy as registration (min 10 chars + common-password reject-list), re-hashes with Argon2id, and stamps `password_changed_at` in one transaction (closes the standing TODO in `db/src/auth/users.rs`).
- New authenticated web server function `POST /api/rpc/account/change-password` (`AuthUser`-scoped, so it only ever changes the caller's own password). A wrong current password → `InvalidCredentials`; a policy-failing new password → `Validation`; both surface as distinct inline errors.
- Refactor: extracted `score_password` + a shared `PasswordRequirements` component into `components::auth::strength` so register and the new form share one source of truth (no duplicated scoring/markup).
- Cleaner inline errors: `note_server_fn_err` now surfaces the handler's own `ServerFnError` message instead of the `CapturedError` wrapper ("error running server function: … (details: None)").

Implements #1325 (part of #1323).

## Test plan
- [x] `just test` — full matrix green (db 1269, server 436, frontend 421, shared 485; 0 failures). New `omnibus-db` tests cover the happy path (old password stops logging in, new one works, `password_changed_at` advances), wrong current password, invalid new password (too-short + common), and unknown user.
- [x] `just lint` — fmt-check + full clippy matrix (incl. wasm32 web + mobile) + stylelint clean.
- [x] `just lint-ts` — Biome + tsc clean.
- [x] Playwright `account.spec.ts` — 7/7 pass: layout, mocked success (form clears), real wrong-current-password rejection (inline "current password is incorrect"), real invalid-new-password rejection. Success is mocked so the shared admin credential is never actually changed.
- [x] Manual browser verification (SSR + hydration): card renders, strength meter + checklist react to input, wrong current password shows a clean `settings-status error`, register page still renders the shared meter/checklist.

## Version
- [x] **Patch** — additive feature, no schema migration, no mobile-compat break.

## Notes
- Web-only by design — the mobile Settings shell has no Account section (mobile AC unchecked on the issue).
- No migration: `password_changed_at` already exists (migration `0004`); this is the first writer of it. No session-invalidation logic consumes the column yet, so existing sessions stay valid after a change.
