### PR TITLE
fix: flush ebook upload tempfile before parse to prevent spurious 415

### DIFF
--- a/server/src/backend/uploads.rs
+++ b/server/src/backend/uploads.rs
@@ -261,6 +261,21 @@ async fn stream_upload_to_tempfile(
             .map_err(|e| UploadError::internal("write upload chunk", e))?;
     }
 
+    // Flush + fsync before the path is handed to a separate reader (`EpubDoc`
+    // in a `spawn_blocking`, or `std::fs::copy` on commit). `tokio::fs::File`
+    // batches writes on a background thread pool and does NOT flush on drop, so
+    // without this the parser can reopen the tempfile before the streamed writes
+    // are durably visible and reads a truncated ZIP → a spurious 415. Mirrors
+    // the audiobook path's `stream_audio_to_tempfile`, which already fixed the
+    // same race (surfaced under CI's Linux filesystem timing).
+    f.flush()
+        .await
+        .map_err(|e| UploadError::internal("flush upload tempfile", e))?;
+    f.sync_all()
+        .await
+        .map_err(|e| UploadError::internal("sync upload tempfile", e))?;
+    drop(f);
+
     if magic_prefix.is_empty() {
         return Err(UploadError::MissingFile);
     }


### PR DESCRIPTION
## Summary
- The ebook upload path (`stream_upload_to_tempfile`) streamed the file to a `tokio::fs::File` but returned **without flushing**. `tokio::fs::File` batches writes on a background thread pool and does not flush on drop, so the parser (`EpubDoc::new`, via a separate reopened handle) could read a **truncated ZIP** and reject a valid EPUB as **415** under load.
- Flush + `sync_all` before handing the tempfile back — mirroring `stream_audio_to_tempfile` in `uploads/audiobooks.rs`, which already carries this exact fix (with a comment noting it surfaced under CI's Linux filesystem timing).

## Test plan
- [x] `cargo test -p omnibus --lib backend::uploads` passes; `cargo clippy -p omnibus -- -D warnings` clean.
- [x] Root cause verified against the audiobook path, which already flushes+fsyncs for the identical reopen-before-durable race.

## Version
- [x] **Patch** — bug fix, no schema or API change.

## Notes
> [!NOTE]
> Surfaced as a flaky failure of `backend::uploads::tests::inspect_*` (intermittent 415 ≠ 200) on the required `test (server)` gate — it fails only under parallel load, so it can intermittently block unrelated PRs until this lands. Not reproducible in isolation (the write lands before the read when uncontended).