### PR TITLE
docs: refresh dependency-audit.md inventory (#1100)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -232,6 +232,20 @@ skip = [
     # 0.26 from sqlx-core; 1.0 from hyper-rustls (reqwest).
     # Collapses when sqlx bumps its rustls deps.
     { name = "webpki-roots", version = "0.26.11" },
+
+    # --- Dioxus git-pin lag (axum-extra / tower-http / reqwest) ---
+    # dioxus-fullstack 0.7.9's git-pinned Dioxus tag carries older copies of
+    # these three crates than our own server crate/workspace pin. See
+    # docs/dependency-audit.md for full source chains (issue #1100).
+    { name = "axum-extra", version = "0.10.3" },
+    # tower-http 0.6.11 also arrives via reqwest 0.12.28 AND reqwest 0.13.4
+    # (each vendors its own copy) — not purely a Dioxus-lag issue; persists
+    # until reqwest itself upgrades to tower-http 0.7.
+    { name = "tower-http", version = "0.6.11" },
+    # reqwest: two *major* versions (0.12 vs 0.13), the largest gap in this
+    # list. 0.12.28 is the dioxus-fullstack git-pin copy; 0.13.4 is the
+    # workspace-pinned version (Cargo.toml [workspace.dependencies]).
+    { name = "reqwest", version = "0.12.28" },
 ]
 
 # ---------------------------------------------------------------------------

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -1,6 +1,6 @@
 # Dependency Audit — Cargo.lock Duplicate Families
 
-Last updated: 2026-07-23 (issue #1268; previously issues #1147, #643).
+Last updated: 2026-07-25 (issue #1100; previously issues #1268, #1147, #643).
 
 Run `cargo tree -d` and inspect the output any time Dioxus or Axum are bumped.
 The `deny.toml` `[bans]` section has matching `skip` entries for all accepted
@@ -26,7 +26,7 @@ this list.
 | `reqwest` | 0.12.28, 0.13.4 | 0.12.28 via `dioxus-fullstack` 0.7.9 (the git-pinned Dioxus tag); 0.13.4 via `omnibus-db`, `omnibus-frontend`, `omnibus-mobile` — the workspace-pinned version per `Cargo.toml`'s `[workspace.dependencies] reqwest = { version = "0.13", ... }` | **blocked by upstream** | Two-*major*-version split, the largest gap in this table (the rest is minor-version churn). Exists because `dioxus-fullstack`'s git-pinned tag hasn't caught up to the `reqwest 0.13` the workspace standardized on. Should collapse on the next Dioxus bump, same caveat as the `tungstenite`/`const-serialize` rows. |
 | `digest` | 0.10.7 (×2) | Both consumers are `sha1` (axum/tungstenite) + `blake2`/`sha2` (argon2/sqlx) | N/A — same version | `cargo tree -d` shows two entry paths to the same version (different consumers). No actual duplicate in the lockfile. |
 | `rustc-hash` | 1.1.0, 2.1.2 | 1.1.0 via `sledgehammer_utils` (pulled in by `dioxus-interpreter-js`, which both `dioxus-web` and `dioxus-server` depend on); 2.1.2 as a direct dependency of `dioxus-core` | **blocked by upstream** | Verified with `cargo tree -i rustc-hash@1.1.0` / `@2.1.2` (not assumed): both versions are reachable from the default, non-mobile build via `dioxus-core`/`dioxus-server`/`dioxus-web`, which `omnibus` and `omnibus-frontend` depend on directly — i.e. **inside** the shipped web/WASM bundle, not confined to the `wry`/`tao` mobile native-shell subtree (despite that subtree's skip-tree comment in `deny.toml` also naming `rustc-hash` among its duplicates — the mobile subtree apparently resolves to one of these same two versions rather than introducing a third). Collapses when Dioxus unifies its internal `rustc-hash` pin. |
-| `bytes`, `futures-*`, `num-traits`, `tokio`, `manganis-core` | (shown ×2 each) | Multiple downstream consumers | N/A — same version | Same pattern as `digest`: one version, multiple reverse-dependency entry points in the `cargo tree -d` output. Not true duplicates. |
+| `bytes`, `futures-*`, `num-traits`, `tokio`, `manganis-core`, `log`, `fastrand`, `sqlx-sqlite` | (shown ×2 each) | Multiple downstream consumers | N/A — same version | Same pattern as `digest`: one version, multiple reverse-dependency entry points in the `cargo tree -d` output. Not true duplicates. |
 
 ## First-party skew resolved in this PR
 


### PR DESCRIPTION
## Summary
- Closes #1100.
- `docs/dependency-audit.md` already had accurate rows for `axum-extra`, `tower-http`, and `reqwest` (landed in a prior PR), but `deny.toml`'s `[bans] skip` list was never updated to match — exactly the gap this issue's reopening comment flagged. Adds the three missing skip entries (`axum-extra` 0.10.3, `tower-http` 0.6.11, `reqwest` 0.12.28 — the older Dioxus git-pin copy of each pair, mirroring the existing `webpki-roots`/`tokio-tungstenite` N-1 skip pattern), with source-chain comments matching the doc's rows.
- Bumped the doc's "Last updated" line to reference #1100.
- Folded three newly-confirmed same-version, multi-path crates (`log`, `fastrand`, `sqlx-sqlite`) into the existing "N/A — same version" catch-all row, found while re-verifying the whole inventory against current `Cargo.lock`.

## Test plan
- Verified current state against reality before editing: `cargo tree -d -e normal,build,dev --workspace --target=all` (the full picture cargo-deny scans, since `omnibus-mobile` and target-gated deps are excluded from a bare `cargo tree -d`) confirms every row in `docs/dependency-audit.md`'s inventory table — including `axum-extra`/`tower-http`/`reqwest` — matches `Cargo.lock` exactly. PASS
- `cargo deny --version` — not installed in this environment; reconciled `deny.toml`'s `[bans] skip` list manually against the doc and `Cargo.lock` instead, and validated the edited TOML parses correctly with `python3 -c "import tomllib; tomllib.load(...)"`. PASS
- `cargo check --workspace --exclude omnibus-mobile` (CARGO_TARGET_DIR=/root/.cache/cargo-target/omnibus-routine) — sanity check after touching `deny.toml`, even though it's not consumed by `cargo build`/`check`. PASS

## Notes
- Docs-only + `deny.toml` config change; no `Cargo.toml`/`Cargo.lock` edits, no dependency version changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oRCi8VhhaQwzvkKw4Gqt9)_