### PR TITLE
refactor: resolve server_connect hosting-docs TODO (#1118)

### DIFF
--- a/frontend/src/pages/server_connect.rs
+++ b/frontend/src/pages/server_connect.rs
@@ -132,7 +132,7 @@ fn server_connect_mobile() -> Element {
                 }
                 p { class: "auth-footer",
                     "Don't have a server? "
-                    // TODO: point at dedicated hosting docs once they exist.
+                    // TODO(#1118): point at dedicated hosting docs once they exist.
                     a {
                         class: "auth-field-action-link",
                         href: "https://github.com/seamus-sloan/omnibus",


### PR DESCRIPTION
## Summary
- Refs #1118
- `frontend/src/pages/server_connect.rs` had a loose `// TODO: point at dedicated hosting docs once they exist.` comment with no tracking issue. Converted it into a tracked reference (`// TODO(#1118): ...`), matching the precedent already set for the analogous untracked-TODO issues #558 and #552.

## Test plan
- [x] `cargo fmt` — PASS (no diff beyond the intended change)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (425 passed; 0 failed)

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- Pure comment change; no logic touched, so no new test was added per the project's testing guidance for trivial changes.
- Per Copilot review: this PR does **not** close #1118 — the issue's acceptance criteria are future-facing (update the link and remove the TODO once dedicated hosting docs actually exist), and its own "suggested approach" says this issue is a tracking vehicle only. #1118 stays open until that future PR lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRCi8VhhaQwzvkKw4Gqt9)_