### PR TITLE
feat: link Continue Reading cover to details, action to reader

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -2763,7 +2763,7 @@ a.idx-letter-on:focus-visible {
   border-radius: 10px; text-decoration: none; color: inherit;
 }
 @media (hover: hover) {
-  .um-now-reading[href]:hover {
+  .um-now-reading:has([href]:hover) {
     border-color: color-mix(in oklch, var(--accent) 55%, var(--line-2));
   }
 }
@@ -2775,6 +2775,7 @@ a.idx-letter-on:focus-visible {
 }
 .um-now-reading-state.error { color: var(--bad); }
 .um-nr-cover {
+  display: block;
   width: 44px; height: 64px; flex: 0 0 44px;
   background: color-mix(in oklch, var(--accent) 35%, var(--bg-3));
   border-radius: 3px;
@@ -2787,6 +2788,7 @@ a.idx-letter-on:focus-visible {
   height: 100%;
 }
 .um-nr-meta { display: flex; flex-direction: column; gap: 4px; flex: 1 1 auto; min-width: 0; }
+.um-nr-info { display: flex; flex-direction: column; gap: 4px; text-decoration: none; color: inherit; }
 .um-nr-title { font-family: var(--serif); font-style: italic; color: var(--ink-0); font-size: 14px; }
 .um-nr-author { color: var(--ink-2); font-size: 12px; }
 .um-nr-action {
@@ -2794,6 +2796,14 @@ a.idx-letter-on:focus-visible {
   color: var(--ink-2);
   font-family: var(--mono);
   font-size: 10px;
+}
+.um-nr-play {
+  align-self: center; flex: 0 0 34px; width: 34px; height: 34px;
+  border-radius: 999px; display: grid; place-items: center;
+  background: var(--accent); color: var(--accent-ink); text-decoration: none;
+}
+@media (hover: hover) {
+  .um-nr-play:hover { opacity: 0.9; }
 }
 
 /* Stat grid (stubs) */
@@ -4308,13 +4318,17 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 }
 
 /* "Pick up where you left off" card. */
-.m-resume { display: block; margin-bottom: 16px; text-decoration: none; color: inherit; }
+.m-resume { display: block; margin-bottom: 16px; }
 .m-resume-kicker { display: block; margin-bottom: 8px; }
 .m-resume-card {
   display: flex; align-items: stretch; gap: 14px; padding: 12px;
   background: var(--bg-1); border: 1px solid var(--line-2); border-radius: 14px;
 }
-.m-resume:active .m-resume-card { background: var(--bg-2); }
+.m-resume-info {
+  flex: 1; min-width: 0; display: flex; align-items: stretch; gap: 14px;
+  text-decoration: none; color: inherit;
+}
+.m-resume-info:active { opacity: 0.6; }
 .m-resume-cover { width: 54px; flex: 0 0 54px; }
 .m-resume-cover .cover-caption { display: none; }
 .m-resume-body {
@@ -4339,6 +4353,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   display: grid; place-items: center;
   background: var(--accent); color: var(--accent-ink);
 }
+.m-resume-play:active { opacity: 0.85; }
 
 /* Sort & filter sheet internals. */
 .m-sheet-reset {

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -2763,7 +2763,7 @@ a.idx-letter-on:focus-visible {
   border-radius: 10px; text-decoration: none; color: inherit;
 }
 @media (hover: hover) {
-  .um-now-reading:has([href]:hover) {
+  .um-now-reading:hover {
     border-color: color-mix(in oklch, var(--accent) 55%, var(--line-2));
   }
 }

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -309,7 +309,6 @@ fn um_now_reading_row(point: ResumePoint) -> Element {
                 Link {
                     to: detail,
                     class: "um-nr-info",
-                    "aria-label": "View details for {title}",
                     div { class: "um-nr-title", "{title}" }
                     if let Some(author) = author {
                         div { class: "um-nr-author", "{author}" }

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -286,28 +286,72 @@ fn um_now_reading_row(point: ResumePoint) -> Element {
     let uuid = point.record.book_uuid.clone();
     let to = if is_audio {
         Route::BookListen {
-            uuid,
+            uuid: uuid.clone(),
             file_id: None,
         }
     } else {
-        Route::BookRead { uuid }
+        Route::BookRead { uuid: uuid.clone() }
     };
-    let aria_label = format!("{action} {title}");
+    let detail = Route::BookDetail { uuid };
+    let action_label = format!("{action} {title}");
 
     rsx! {
-        Link {
-            to,
+        div {
             class: "um-now-reading",
             "data-testid": "user-menu-now-reading",
-            "aria-label": "{aria_label}",
-            div { class: "um-nr-cover", Cover { book: point.book } }
+            Link {
+                to: detail.clone(),
+                class: "um-nr-cover",
+                "aria-label": "View details for {title}",
+                Cover { book: point.book }
+            }
             div { class: "um-nr-meta",
-                div { class: "um-nr-title", "{title}" }
-                if let Some(author) = author {
-                    div { class: "um-nr-author", "{author}" }
+                Link {
+                    to: detail,
+                    class: "um-nr-info",
+                    "aria-label": "View details for {title}",
+                    div { class: "um-nr-title", "{title}" }
+                    if let Some(author) = author {
+                        div { class: "um-nr-author", "{author}" }
+                    }
                 }
                 div { class: "um-nr-action", "{action}" }
             }
+            Link {
+                to,
+                class: "um-nr-play",
+                "data-testid": "user-menu-now-reading-action",
+                "aria-label": "{action_label}",
+                if is_audio {
+                    {play_glyph()}
+                } else {
+                    {book_glyph()}
+                }
+            }
+        }
+    }
+}
+
+/// Solid play triangle for the "continue listening" affordance.
+#[cfg(any(feature = "web", feature = "server"))]
+fn play_glyph() -> Element {
+    rsx! {
+        svg {
+            width: "14", height: "14", view_box: "0 0 15 15", fill: "currentColor",
+            path { d: "M4 2.5v10l8-5z" }
+        }
+    }
+}
+
+/// Open-book outline for the "continue reading" affordance.
+#[cfg(any(feature = "web", feature = "server"))]
+fn book_glyph() -> Element {
+    rsx! {
+        svg {
+            width: "14", height: "14", view_box: "0 0 24 24", fill: "none",
+            stroke: "currentColor", stroke_width: "2", stroke_linecap: "round", stroke_linejoin: "round",
+            path { d: "M4 19.5A2.5 2.5 0 0 1 6.5 17H20" }
+            path { d: "M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" }
         }
     }
 }

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -252,7 +252,6 @@ fn resume_card(point: &ResumePoint, server_url: &str) -> Element {
                 Link {
                     to: Route::BookDetail { uuid: uuid.clone() },
                     class: "m-resume-info",
-                    "aria-label": "View details for {title}",
                     span { class: "m-resume-cover",
                         Cover { book, src_override: src, sizes: Some("54px".to_string()) }
                     }

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -244,27 +244,34 @@ fn resume_card(point: &ResumePoint, server_url: &str) -> Element {
     let (src, _srcset) = thumb_srcs(&book, &uuid, server_url);
 
     rsx! {
-        Link {
-            to,
+        div {
             class: "m-resume",
             "data-testid": "mobile-resume-card",
-            "aria-label": "Pick up where you left off: {title}",
             span { class: "label m-resume-kicker", "Pick up where you left off" }
             span { class: "m-resume-card",
-                span { class: "m-resume-cover",
-                    Cover { book, src_override: src, sizes: Some("54px".to_string()) }
-                }
-                span { class: "m-resume-body",
-                    span { class: "m-resume-title m-em", "{title}" }
-                    if !author.is_empty() {
-                        span { class: "m-resume-author", "{author}" }
+                Link {
+                    to: Route::BookDetail { uuid: uuid.clone() },
+                    class: "m-resume-info",
+                    "aria-label": "View details for {title}",
+                    span { class: "m-resume-cover",
+                        Cover { book, src_override: src, sizes: Some("54px".to_string()) }
                     }
-                    span { class: "mono m-resume-meta", "{meta}" }
-                    if let Some(pct) = pct {
-                        span { class: "m-resume-bar", i { style: "width:{pct}%" } }
+                    span { class: "m-resume-body",
+                        span { class: "m-resume-title m-em", "{title}" }
+                        if !author.is_empty() {
+                            span { class: "m-resume-author", "{author}" }
+                        }
+                        span { class: "mono m-resume-meta", "{meta}" }
+                        if let Some(pct) = pct {
+                            span { class: "m-resume-bar", i { style: "width:{pct}%" } }
+                        }
                     }
                 }
-                span { class: "m-resume-play",
+                Link {
+                    to,
+                    class: "m-resume-play",
+                    "data-testid": "mobile-resume-play",
+                    "aria-label": "Pick up where you left off: {title}",
                     if is_audio {
                         {play_glyph()}
                     } else {

--- a/ui_tests/playwright/tests/flows/user_menu.spec.ts
+++ b/ui_tests/playwright/tests/flows/user_menu.spec.ts
@@ -149,9 +149,10 @@ for (const sample of [
 
     await gotoReady(page, "/");
     await page.getByTestId("user-menu-trigger").click();
+    const panel = page.getByTestId("user-menu-panel");
 
-    // Only the action link resumes reading/listening.
-    const action = page.getByRole("link", {
+    // Only the action button resumes reading/listening.
+    const action = panel.getByRole("link", {
       name: `${sample.action} ${latest.title}`,
     });
     await expect(action).toBeVisible();
@@ -162,14 +163,11 @@ for (const sample of [
       new RegExp(`^/${sample.path}/${latest.uuid}\\??$`),
     );
 
-    // The cover and title instead route to the book detail page.
-    const details = page.getByRole("link", {
+    // The cover instead routes to the book detail page.
+    const cover = panel.getByRole("link", {
       name: `View details for ${latest.title}`,
     });
-    await expect(details).toHaveCount(2);
-    for (const detail of await details.all()) {
-      await expect(detail).toHaveAttribute("href", `/books/${latest.uuid}`);
-    }
+    await expect(cover).toHaveAttribute("href", `/books/${latest.uuid}`);
   });
 }
 

--- a/ui_tests/playwright/tests/flows/user_menu.spec.ts
+++ b/ui_tests/playwright/tests/flows/user_menu.spec.ts
@@ -150,16 +150,26 @@ for (const sample of [
     await gotoReady(page, "/");
     await page.getByTestId("user-menu-trigger").click();
 
-    const card = page.getByRole("link", {
+    // Only the action link resumes reading/listening.
+    const action = page.getByRole("link", {
       name: `${sample.action} ${latest.title}`,
     });
-    await expect(card).toBeVisible();
+    await expect(action).toBeVisible();
     // The `/listen/:uuid?:file_id` route serializes an unset file_id as a bare
     // trailing `?`, so tolerate it (the `/read` destination stays clean).
-    await expect(card).toHaveAttribute(
+    await expect(action).toHaveAttribute(
       "href",
       new RegExp(`^/${sample.path}/${latest.uuid}\\??$`),
     );
+
+    // The cover and title instead route to the book detail page.
+    const details = page.getByRole("link", {
+      name: `View details for ${latest.title}`,
+    });
+    await expect(details).toHaveCount(2);
+    for (const detail of await details.all()) {
+      await expect(detail).toHaveAttribute("href", `/books/${latest.uuid}`);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- The web and mobile "Continue Reading" cards were one link straight to the reader/player. Split each so the cover (and title) open the book detail page, while a dedicated control resumes reading/listening.
- Mobile resume card: cover + body link to `BookDetail`; the round play/read glyph button routes to `BookRead`/`BookListen`.
- Web now-reading row: cover and title link to `BookDetail`; added a round accent icon button (play/book glyph) that routes to `BookRead`/`BookListen`.

## Test plan
- [x] `cargo clippy` clean on `omnibus-frontend` (server + wasm32 web)
- [x] `cargo fmt --check`, `just lint-css`, `tsc --noEmit`, `biome check` all clean
- [x] Playwright `user_menu` spec updated for the new link contract (action link → reader; two "View details" links → `/books/:uuid`); full E2E runs in CI via `run_ui_tests`

## Version
- [x] **Patch** — default.

## Notes
- Local live-browser verification skipped per the documented Nix-Chromium gap; layout is covered by the updated E2E contract test in CI.