### PR TITLE
refactor: avoid full-entry clone in offline download progress reporting

### DIFF
--- a/frontend/src/offline/downloads.rs
+++ b/frontend/src/offline/downloads.rs
@@ -359,6 +359,59 @@ pub(super) fn get_entry(uuid: &str, format: DlFormat) -> Option<DownloadEntry> {
         .and_then(|m| m.get(&(uuid.to_string(), format)).cloned())
 }
 
+/// Mid-stream progress bump: mutates the byte-count fields on the existing
+/// registry entry in place (no full-entry/`Vec<PlannedFile>` clone) and
+/// mirrors just those columns to SQLite via a targeted `UPDATE`, skipping
+/// the JSON `files` re-serialize a full [`upsert`] pays. No-op if the entry
+/// isn't registered yet (a progress tick racing a `remove`).
+pub(super) fn update_progress_bytes(
+    uuid: &str,
+    format: DlFormat,
+    downloaded: i64,
+    total: Option<i64>,
+) {
+    let downloaded = downloaded.max(0);
+    let now = store::now_secs();
+    let found = registry()
+        .write()
+        .ok()
+        .map(
+            |mut guard| match guard.get_mut(&(uuid.to_string(), format)) {
+                Some(entry) => {
+                    entry.status = DownloadStatus::Downloading { downloaded, total };
+                    entry.updated_at = now;
+                    true
+                }
+                None => false,
+            },
+        )
+        .unwrap_or(false);
+    if !found {
+        return;
+    }
+    persist_progress(uuid, format, downloaded, total, now);
+    bump();
+}
+
+fn persist_progress(
+    uuid: &str,
+    format: DlFormat,
+    downloaded: i64,
+    total: Option<i64>,
+    updated_at: i64,
+) {
+    let Some(store) = store::store() else { return };
+    let uuid = uuid.to_string();
+    let format = format.as_str();
+    store.run_detached(move |conn| {
+        let _ = conn.execute(
+            "UPDATE downloads SET downloaded_bytes = ?1, total_bytes = ?2, updated_at = ?3
+             WHERE book_uuid = ?4 AND format = ?5",
+            rusqlite::params![downloaded, total, updated_at, uuid, format],
+        );
+    });
+}
+
 pub(super) fn set_error(uuid: &str, format: DlFormat, message: String) {
     let Some(mut entry) = get_entry(uuid, format) else {
         return;

--- a/frontend/src/offline/downloads/engine.rs
+++ b/frontend/src/offline/downloads/engine.rs
@@ -389,17 +389,11 @@ fn publish(
     });
 }
 
-/// Cheap mid-stream progress bump that keeps the existing file list.
+/// Cheap mid-stream progress bump that keeps the existing file list — see
+/// [`super::update_progress_bytes`] for why this avoids the full-entry
+/// clone + JSON re-serialize `publish`/`upsert` pay on a status change.
 fn publish_progress(uuid: &str, format: DlFormat, downloaded: i64, total: Option<i64>) {
-    let Some(mut entry) = super::get_entry(uuid, format) else {
-        return;
-    };
-    entry.status = DownloadStatus::Downloading {
-        downloaded: downloaded.max(0),
-        total,
-    };
-    entry.updated_at = crate::offline::store::now_secs();
-    super::upsert(entry);
+    super::update_progress_bytes(uuid, format, downloaded, total);
 }
 
 /// Maps a [`crate::data::DataError`] to a fixed, user-safe [`DownloadError`].

--- a/frontend/src/offline/downloads/tests.rs
+++ b/frontend/src/offline/downloads/tests.rs
@@ -168,6 +168,79 @@ fn registry_status_and_downloaded_uuids_reflect_upserts() {
     assert!(downloaded_uuids().contains(uuid));
 }
 
+#[test]
+fn update_progress_bytes_mutates_status_in_place_and_preserves_files() {
+    let uuid = "u-progress-update";
+    let files = vec![PlannedFile {
+        rel: "part-0.m4b".into(),
+        url_path: "/x".into(),
+        ordinal: Some(0),
+        bytes: None,
+        done: false,
+    }];
+    upsert(DownloadEntry {
+        book_uuid: uuid.into(),
+        format: DlFormat::Audio,
+        title: "T".into(),
+        file_id: None,
+        status: DownloadStatus::Downloading {
+            downloaded: 0,
+            total: Some(100),
+        },
+        files: files.clone(),
+        updated_at: 1,
+    });
+
+    update_progress_bytes(uuid, DlFormat::Audio, 42, Some(100));
+
+    assert_eq!(
+        status(uuid, DlFormat::Audio),
+        DownloadStatus::Downloading {
+            downloaded: 42,
+            total: Some(100)
+        }
+    );
+    let entry = get_entry(uuid, DlFormat::Audio).expect("entry");
+    assert_eq!(
+        entry.files, files,
+        "file list must be untouched by a progress bump"
+    );
+}
+
+#[test]
+fn update_progress_bytes_is_a_noop_when_the_entry_is_not_registered() {
+    let uuid = "u-progress-missing";
+    update_progress_bytes(uuid, DlFormat::Epub, 10, None);
+    assert_eq!(status(uuid, DlFormat::Epub), DownloadStatus::NotDownloaded);
+}
+
+#[test]
+fn update_progress_bytes_clamps_negative_downloaded_to_zero() {
+    let uuid = "u-progress-clamp";
+    upsert(DownloadEntry {
+        book_uuid: uuid.into(),
+        format: DlFormat::Epub,
+        title: "T".into(),
+        file_id: None,
+        status: DownloadStatus::Downloading {
+            downloaded: 5,
+            total: None,
+        },
+        files: vec![],
+        updated_at: 1,
+    });
+
+    update_progress_bytes(uuid, DlFormat::Epub, -3, None);
+
+    assert_eq!(
+        status(uuid, DlFormat::Epub),
+        DownloadStatus::Downloading {
+            downloaded: 0,
+            total: None
+        }
+    );
+}
+
 #[tokio::test]
 async fn remove_format_files_deletes_only_the_named_formats_files() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
- Closes #1311
- `publish_progress` (in `frontend/src/offline/downloads/engine.rs`) fired on every ~1 MiB streamed and cloned the full `DownloadEntry` (including its `Vec<PlannedFile>`) via `get_entry`, then round-tripped it through `upsert`, which JSON-re-serialized the whole entry and did a blocking `INSERT...ON CONFLICT UPDATE` — for a multi-hundred-MB/GB download that's roughly a thousand full clone+serialize+DB-round-trip cycles.
- Added `downloads::update_progress_bytes`, which mutates only the `status`/`updated_at` fields on the already-registered entry in place (no entry/`Vec` clone) and mirrors just the byte-count columns to SQLite via a targeted `UPDATE downloads SET downloaded_bytes = ?, total_bytes = ?, updated_at = ? WHERE book_uuid = ? AND format = ?`, skipping the `files` JSON re-serialize entirely. `engine::publish_progress` now delegates to it; behavior (what a progress observer reads from `status`/`get_entry`) is unchanged — only the internal path got cheaper.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test -p omnibus-frontend --features mobile` — PASS (488 passed, 0 failed), including 3 new tests covering `update_progress_bytes`: mutates status in place while leaving `files` untouched, no-ops when the entry isn't registered, and clamps a negative `downloaded` to zero.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- Pure internal refactor of the progress-reporting path; no change to `DownloadStatus`/`DownloadEntry`'s public shape or to what a progress observer (registry `status()`/`list()`) sees.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oRCi8VhhaQwzvkKw4Gqt9)_