### PR TITLE
fix: stop leaking absolute filesystem path from OPF export

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -16,10 +16,10 @@ mod tests;
 
 pub use facets::library_facets;
 pub use get::{
-    book_file_path, book_file_path_by_id, book_file_paths, get_book, get_book_by_uuid,
-    get_book_files, get_book_files_exec, get_book_uuid_by_scan_key, resolve_book_id_by_uuid,
-    resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
-    resolve_canonical_book_uuids_bulk_exec,
+    book_file_path, book_file_path_by_id, book_file_paths, book_file_relative_dir, get_book,
+    get_book_by_uuid, get_book_files, get_book_files_exec, get_book_uuid_by_scan_key,
+    resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid,
+    resolve_canonical_book_uuid_exec, resolve_canonical_book_uuids_bulk_exec,
 };
 pub use list::{
     collect_paths, count_books, count_books_for_paths, library_from_db, library_from_db_combined,

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -396,6 +396,32 @@ pub async fn book_file_path(
     }))
 }
 
+/// Resolve the library-relative directory of a book's file for the given
+/// format (e.g. "EPUB") — the on-disk path with the owning scan root's
+/// absolute prefix stripped. Used where a caller must not echo the server's
+/// absolute filesystem layout back to the client (e.g. the OPF export
+/// response) but still wants to show where the file lives *within* the
+/// library. Same lowest-`ordinal` tie-break as [`book_file_path`]. `Ok(None)`
+/// when absent.
+pub async fn book_file_relative_dir(
+    pool: &SqlitePool,
+    id: i64,
+    format: &str,
+) -> Result<Option<std::path::PathBuf>, super::BooksError> {
+    let row = sqlx::query_as::<_, (String,)>(
+        "SELECT COALESCE(bf.path, b.path) \
+         FROM books b \
+         JOIN book_files bf ON bf.book_id = b.id \
+         WHERE b.id = ? AND bf.format = ? COLLATE NOCASE \
+         ORDER BY bf.ordinal LIMIT 1",
+    )
+    .bind(id)
+    .bind(format)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(dir,)| std::path::PathBuf::from(dir)))
+}
+
 /// Resolve the on-disk path for a specific `book_files.id`, verifying
 /// it belongs to the given book. When `format` is `Some`, also
 /// validates the file's format matches (case-insensitive) — returns

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -396,13 +396,12 @@ pub async fn book_file_path(
     }))
 }
 
-/// Resolve the library-relative directory of a book's file for the given
-/// format (e.g. "EPUB") — the on-disk path with the owning scan root's
-/// absolute prefix stripped. Used where a caller must not echo the server's
-/// absolute filesystem layout back to the client (e.g. the OPF export
-/// response) but still wants to show where the file lives *within* the
-/// library. Same lowest-`ordinal` tie-break as [`book_file_path`]. `Ok(None)`
-/// when absent.
+/// Resolve the scan-root-relative directory of a book's file for the given
+/// format (e.g. "EPUB"), as stored verbatim in `book_files.path` /
+/// `books.path`. Used where a caller must not echo the server's absolute
+/// filesystem layout back to the client (e.g. the OPF export response) but
+/// still wants to show where the file lives *within* the library. Same
+/// lowest-`ordinal` tie-break as [`book_file_path`]. `Ok(None)` when absent.
 pub async fn book_file_relative_dir(
     pool: &SqlitePool,
     id: i64,

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -1780,6 +1780,47 @@ async fn book_file_path_returns_absolute_path_for_epub() {
 }
 
 #[tokio::test]
+async fn book_file_relative_dir_returns_library_relative_directory_for_epub() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let book_id = sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title) \
+         VALUES ('uuid-epub-rel', ?, 'sub/dir', 'Some Book')",
+    )
+    .bind(lib_id)
+    .execute(&pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'some-book', 0)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let dir = book_file_relative_dir(&pool, book_id, "EPUB")
+        .await
+        .unwrap();
+    // Relative to the scan root only — never includes `/lib`, unlike
+    // `book_file_path`.
+    assert_eq!(dir, Some(std::path::PathBuf::from("sub/dir")));
+}
+
+#[tokio::test]
+async fn book_file_relative_dir_returns_none_for_missing_book() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let dir = book_file_relative_dir(&pool, 9999, "EPUB").await.unwrap();
+    assert!(dir.is_none());
+}
+
+#[tokio::test]
 async fn book_file_path_returns_none_for_missing_book() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let path = book_file_path(&pool, 9999, "EPUB").await.unwrap();

--- a/db/src/opf_export.rs
+++ b/db/src/opf_export.rs
@@ -14,9 +14,9 @@ use omnibus_shared::EbookMetadata;
 /// Result of a successful export.
 #[derive(Debug)]
 pub struct OpfExport {
-    /// Library-relative path of the written `metadata.opf` (the owning scan
-    /// root's absolute filesystem prefix stripped) — callers must not echo
-    /// the server's absolute directory layout back to a `can_edit`-but-not-
+    /// Scan-root-relative path of the written `metadata.opf`, as stored in
+    /// the DB (`book_file_relative_dir`) — callers must not echo the
+    /// server's absolute directory layout back to a `can_edit`-but-not-
     /// admin client.
     pub path: PathBuf,
     /// Whether a pre-existing `metadata.opf` was renamed to
@@ -65,8 +65,9 @@ pub async fn export_opf(pool: &SqlitePool, book_id: i64) -> Result<OpfExport, Op
     let book_dir = epub_path
         .parent()
         .ok_or(OpfExportError::NoEpubFile(book_id))?;
-    // Library-relative directory for the *returned* path — never expose the
-    // server's absolute filesystem layout to a can_edit-but-not-admin client.
+    // Scan-root-relative directory (as stored in the DB) for the *returned*
+    // path — never expose the server's absolute filesystem layout to a
+    // can_edit-but-not-admin client.
     let relative_dir = crate::books::book_file_relative_dir(pool, book_id, "EPUB")
         .await?
         .unwrap_or_default();

--- a/db/src/opf_export.rs
+++ b/db/src/opf_export.rs
@@ -14,7 +14,10 @@ use omnibus_shared::EbookMetadata;
 /// Result of a successful export.
 #[derive(Debug)]
 pub struct OpfExport {
-    /// Absolute path of the written `metadata.opf`.
+    /// Library-relative path of the written `metadata.opf` (the owning scan
+    /// root's absolute filesystem prefix stripped) — callers must not echo
+    /// the server's absolute directory layout back to a `can_edit`-but-not-
+    /// admin client.
     pub path: PathBuf,
     /// Whether a pre-existing `metadata.opf` was renamed to
     /// `metadata.opf.bak` before writing.
@@ -62,6 +65,11 @@ pub async fn export_opf(pool: &SqlitePool, book_id: i64) -> Result<OpfExport, Op
     let book_dir = epub_path
         .parent()
         .ok_or(OpfExportError::NoEpubFile(book_id))?;
+    // Library-relative directory for the *returned* path — never expose the
+    // server's absolute filesystem layout to a can_edit-but-not-admin client.
+    let relative_dir = crate::books::book_file_relative_dir(pool, book_id, "EPUB")
+        .await?
+        .unwrap_or_default();
 
     let xml = render_opf(&book);
     let backed_up = write_sidecar(book_dir, &xml).await?;
@@ -73,7 +81,7 @@ pub async fn export_opf(pool: &SqlitePool, book_id: i64) -> Result<OpfExport, Op
     }
 
     Ok(OpfExport {
-        path: book_dir.join("metadata.opf"),
+        path: relative_dir.join("metadata.opf"),
         backed_up,
     })
 }

--- a/db/src/opf_export/tests.rs
+++ b/db/src/opf_export/tests.rs
@@ -177,6 +177,22 @@ async fn export_opf_writes_snapshot_of_scanned_metadata_when_no_overrides() {
 }
 
 #[tokio::test]
+async fn export_opf_returns_library_relative_path_not_absolute_directory() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = tempfile::tempdir().unwrap();
+    let (book_id, _uuid) = seed_epub_book_at(&pool, lib.path()).await;
+
+    let result = export_opf(&pool, book_id).await.unwrap();
+    assert_eq!(
+        result.path,
+        std::path::Path::new("sub").join("metadata.opf")
+    );
+    assert!(!result.path.is_absolute());
+    let absolute_lib_path = lib.path().to_string_lossy().to_string();
+    assert!(!result.path.to_string_lossy().contains(&absolute_lib_path));
+}
+
+#[tokio::test]
 async fn export_opf_merges_overrides_into_written_snapshot() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user_id = seed_user(&pool).await;

--- a/server/src/backend/export_opf/tests.rs
+++ b/server/src/backend/export_opf/tests.rs
@@ -96,6 +96,34 @@ async fn api_export_opf_writes_sidecar_and_returns_path_and_backed_up() {
 }
 
 #[tokio::test]
+async fn api_export_opf_returns_library_relative_path_not_absolute_filesystem_path() {
+    let (app, _state, pool) = fixture().await;
+    let lib = tempfile::tempdir().unwrap();
+    let (_id, uuid) = db::test_support::seed_epub_book_at(&pool, lib.path()).await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let res = app
+        .oneshot(post_export(&uuid, Some(&token)))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let result: OpfExportResult = serde_json::from_slice(&bytes).unwrap();
+    // The exact library-relative path — not the absolute path underneath
+    // `lib`, which would leak the server's filesystem layout to any
+    // can_edit-but-not-admin client.
+    assert_eq!(result.path, "sub/metadata.opf");
+    let absolute_lib_path = lib.path().to_string_lossy().to_string();
+    assert!(
+        !result.path.contains(&absolute_lib_path),
+        "response leaked the server's absolute filesystem path: {}",
+        result.path
+    );
+}
+
+#[tokio::test]
 async fn api_export_opf_returns_500_on_db_failure() {
     let (app, _state, pool) = fixture().await;
     let lib = tempfile::tempdir().unwrap();

--- a/shared/src/ebook/export.rs
+++ b/shared/src/ebook/export.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 /// Result of exporting a book's metadata to its `metadata.opf` sidecar.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OpfExportResult {
-    /// Absolute path of the written `metadata.opf`.
+    /// Library-relative path of the written `metadata.opf` (the server's
+    /// absolute filesystem prefix is never sent to the client — a `can_edit`
+    /// user isn't necessarily an admin).
     pub path: String,
     /// Whether an existing `metadata.opf` was backed up to
     /// `metadata.opf.bak` before writing.


### PR DESCRIPTION
## Summary
- Closes #1341
- `OpfExportResult.path` returned the server's absolute filesystem path to any `can_edit` (not necessarily admin) client — inconsistent with the same function's deliberate choice not to leak the internal numeric book id via `OpfExportError`'s `Display`.
- `db::export_opf` now returns the library-relative path (owning scan root's absolute prefix stripped) via a new `book_file_relative_dir` helper in `db/src/books/get.rs`. The REST (`/api/ebooks/{uuid}/export-opf`) and RPC (`rpc_export_opf`) responses, and the metadata-edit sidebar's "Wrote ..." message, now show a path relative to the library root instead of the server's directory layout.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-shared` — PASS (203 passed)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (424 passed)
- [x] `cargo test -p omnibus` — 449 passed, 2 failed. The 2 failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400`, `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`) are pre-existing and unrelated to this change: they `chmod 0o555` a temp dir expecting a `PermissionDenied` write failure, which doesn't occur when tests run as root (root bypasses the write-permission bit). This diff never touches `uploads.rs` or permission logic.
- New regression tests added: `db::opf_export::tests::export_opf_returns_library_relative_path_not_absolute_directory`, `server::backend::export_opf::tests::api_export_opf_returns_library_relative_path_not_absolute_filesystem_path`, and `db::books::tests::book_file_relative_dir_returns_library_relative_directory_for_epub` / `..._returns_none_for_missing_book` — all assert the response path is relative and never contains the absolute library directory.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled.

## Notes
- Judgment call per the issue: chose "library-relative path" over "no path at all" since the relative path is still useful for a self-hosted admin/editor to confirm where the sidecar landed, without disclosing the server's absolute directory layout.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oRCi8VhhaQwzvkKw4Gqt9)_