### PR TITLE
refactor: address review feedback on offline progress reporting (#1311)

### DIFF
--- a/frontend/src/offline/downloads.rs
+++ b/frontend/src/offline/downloads.rs
@@ -372,23 +372,17 @@ pub(super) fn update_progress_bytes(
 ) {
     let downloaded = downloaded.max(0);
     let now = store::now_secs();
-    let found = registry()
-        .write()
-        .ok()
-        .map(
-            |mut guard| match guard.get_mut(&(uuid.to_string(), format)) {
-                Some(entry) => {
-                    entry.status = DownloadStatus::Downloading { downloaded, total };
-                    entry.updated_at = now;
-                    true
-                }
-                None => false,
-            },
-        )
-        .unwrap_or(false);
-    if !found {
+    let Ok(mut guard) = registry().write() else {
         return;
-    }
+    };
+    let Some(entry) = guard.get_mut(&(uuid.to_string(), format)) else {
+        return;
+    };
+    entry.status = DownloadStatus::Downloading { downloaded, total };
+    entry.updated_at = now;
+    // Release the lock before the DB write — persistence never needs to
+    // hold it.
+    drop(guard);
     persist_progress(uuid, format, downloaded, total, now);
     bump();
 }
@@ -404,11 +398,11 @@ fn persist_progress(
     let uuid = uuid.to_string();
     let format = format.as_str();
     store.run_detached(move |conn| {
-        let _ = conn.execute(
+        store::log_err(conn.execute(
             "UPDATE downloads SET downloaded_bytes = ?1, total_bytes = ?2, updated_at = ?3
              WHERE book_uuid = ?4 AND format = ?5",
             rusqlite::params![downloaded, total, updated_at, uuid, format],
-        );
+        ));
     });
 }
 

--- a/frontend/src/offline/store.rs
+++ b/frontend/src/offline/store.rs
@@ -547,8 +547,9 @@ impl Store {
 }
 
 /// Log-and-continue for best-effort writes: the offline layer must never
-/// take the app down over a cache write.
-fn log_err(r: Result<usize, rusqlite::Error>) {
+/// take the app down over a cache write. `pub(super)` so sibling `offline`
+/// modules (e.g. `downloads`) share this instead of swallowing the error.
+pub(super) fn log_err(r: Result<usize, rusqlite::Error>) {
     if let Err(e) = r {
         tracing::warn!(error = %e, "offline store write failed");
     }


### PR DESCRIPTION
## Summary
- Refs #1311 (follow-up to the already-merged #1375)
- #1375 landed `downloads::update_progress_bytes` for #1311, but its Copilot review feedback finished after the PR was already merged, so the fix commit was orphaned on the deleted branch. This PR lands that fix on top of current `main`.
- `update_progress_bytes`'s write-lock handling rewritten from a `write().ok().map(...).unwrap_or(false)` chain to an explicit `let Ok(mut guard) = registry().write() else { return; }` + `let Some(entry) = guard.get_mut(...) else { return; }`, with an explicit `drop(guard)` before the DB write — matches the rest of the file's style and makes it clear persistence never runs while the lock is held.
- `persist_progress`'s SQLite write now routes through `store::log_err` (promoted from private to `pub(super)`) instead of silently discarding a failed `UPDATE` with `let _ = ...`.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features mobile` — PASS (488 passed, 0 failed)

## Version
- [x] **Patch** — the default.

## Notes
- Pure internal robustness/readability refactor of code already merged in #1375; no behavior change to what a progress observer sees.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRCi8VhhaQwzvkKw4Gqt9)_