### PR TITLE
fix: apply length-cap validation to 3 request types that skipped it

### DIFF
--- a/frontend/src/rpc/physical.rs
+++ b/frontend/src/rpc/physical.rs
@@ -11,6 +11,9 @@ use omnibus_db as db;
 // Only the server-side body names the source; the client half never sees it.
 #[cfg(feature = "server")]
 use omnibus_shared::physical::WishlistSource;
+// Only the server-side body constructs one to reuse its `validate()`.
+#[cfg(feature = "server")]
+use omnibus_shared::physical::UpdateCopyNoteRequest;
 
 #[cfg(feature = "server")]
 use super::{internal_rpc_error, AuthUser, PoolExt};
@@ -57,8 +60,12 @@ pub async fn rpc_update_physical_copy_note(
     note: Option<String>,
 ) -> Result<PhysicalCopy> {
     require_edit(&user)?;
+    let req = UpdateCopyNoteRequest { note };
+    if let Err(msg) = req.validate() {
+        return Err(ServerFnError::new(msg).into());
+    }
     Ok(
-        db::update_physical_copy_note(&pool.0, copy_id, note.as_deref())
+        db::update_physical_copy_note(&pool.0, copy_id, req.note.as_deref())
             .await
             .map_err(|e| map_physical_error("update physical copy note", e))?,
     )

--- a/frontend/src/rpc/scan.rs
+++ b/frontend/src/rpc/scan.rs
@@ -41,6 +41,9 @@ fn map_scan_err(e: db::ScanError) -> ServerFnError {
 /// user may resolve; ownership is library-wide.
 #[post("/api/rpc/scan/resolve", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_resolve_scan(req: ResolveRequest) -> Result<ScanOutcome> {
+    if let Err(msg) = req.validate() {
+        return Err(ServerFnError::new(msg).into());
+    }
     // Saved settings key wins over `GOOGLE_BOOKS_API_KEY`; both absent is a
     // keyless (shared-quota) lookup.
     let key = db::effective_google_books_api_key(&pool.0)

--- a/server/src/backend/physical.rs
+++ b/server/src/backend/physical.rs
@@ -62,6 +62,9 @@ pub(super) async fn patch_copy_note(
     if let Some(denied) = require_edit(&user) {
         return denied;
     }
+    if let Err(msg) = req.validate() {
+        return (StatusCode::BAD_REQUEST, msg).into_response();
+    }
     match db::update_physical_copy_note(&state.pool, copy_id, req.note.as_deref()).await {
         Ok(copy) => Json(copy).into_response(),
         Err(e) => physical_error("update_physical_copy_note", e),

--- a/server/src/backend/physical/tests.rs
+++ b/server/src/backend/physical/tests.rs
@@ -150,6 +150,28 @@ async fn api_patch_copy_note_rejects_a_user_without_edit_permission() {
 }
 
 #[tokio::test]
+async fn api_patch_copy_note_returns_400_for_an_oversized_note() {
+    let _covers = CoversDirGuard::new("phys_patch_400");
+    let (app, _state, pool) = fixture().await;
+    let (_uuid, copy_id) = seed_physical_only(&pool, "Paper Only").await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let oversized = "x".repeat(omnibus_shared::physical::UpdateCopyNoteRequest::NOTE_MAX_LEN + 1);
+    let res = app
+        .oneshot(req(
+            "PATCH",
+            &format!("/api/physical/copies/{copy_id}"),
+            &token,
+            Some(serde_json::json!({ "note": oversized })),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn api_patch_copy_note_returns_404_for_unknown_copy() {
     let (app, _state, pool) = fixture().await;
     let admin = auth_test_support::create_admin(&pool, "admin").await;

--- a/server/src/backend/read_status/tests.rs
+++ b/server/src/backend/read_status/tests.rs
@@ -54,6 +54,22 @@ async fn api_put_read_status_rejects_blank_uuid() {
 }
 
 #[tokio::test]
+async fn api_put_read_status_rejects_an_oversized_uuid() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let oversized = "u".repeat(omnibus_shared::BOOK_UUID_MAX_LEN + 1);
+    let res = app
+        .oneshot(put_status_req(
+            &token,
+            serde_json::json!({ "book_uuid": oversized, "status": "reading" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn api_put_read_status_returns_404_for_unknown_book() {
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;

--- a/server/src/backend/scan.rs
+++ b/server/src/backend/scan.rs
@@ -50,6 +50,9 @@ pub(super) async fn post_resolve(
     State(state): State<AppState>,
     Json(req): Json<ResolveRequest>,
 ) -> Response {
+    if let Err(msg) = req.validate() {
+        return (StatusCode::BAD_REQUEST, msg).into_response();
+    }
     // Saved settings key wins over `GOOGLE_BOOKS_API_KEY`; both absent is a
     // keyless (shared-quota) lookup.
     let key = match db::effective_google_books_api_key(&state.pool).await {

--- a/server/src/backend/scan/tests.rs
+++ b/server/src/backend/scan/tests.rs
@@ -116,6 +116,23 @@ async fn api_scan_resolve_rejects_invalid_isbn() {
 }
 
 #[tokio::test]
+async fn api_scan_resolve_rejects_an_oversized_isbn() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let oversized = "1".repeat(omnibus_shared::scan::ISBN_MAX_LEN + 1);
+    let res = app
+        .oneshot(post(
+            "/api/scan/resolve",
+            &token,
+            serde_json::json!({ "isbn": oversized }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn api_scan_resolve_exact_hit_returns_in_library_unowned() {
     let (app, _state, pool) = fixture().await;
     let uuid = seed_book_with_isbn(&pool, "Effective Java", ISBN).await;

--- a/shared/src/physical.rs
+++ b/shared/src/physical.rs
@@ -60,6 +60,24 @@ pub struct UpdateCopyNoteRequest {
     pub note: Option<String>,
 }
 
+impl UpdateCopyNoteRequest {
+    /// Maximum length (in chars) of a physical copy's free-text note. Mirrors
+    /// `omnibus_shared::highlight::UpdateHighlightNote::NOTE_MAX_LEN`.
+    pub const NOTE_MAX_LEN: usize = 4096;
+
+    /// Validate the note length. `None` clears the note and is always
+    /// permitted. Returns `Err` with a human-readable message when the cap is
+    /// exceeded. Handlers translate `Err(_)` into 400.
+    pub fn validate(&self) -> Result<(), String> {
+        if let Some(ref note) = self.note {
+            if note.chars().count() > Self::NOTE_MAX_LEN {
+                return Err(format!("note exceeds {} characters", Self::NOTE_MAX_LEN));
+            }
+        }
+        Ok(())
+    }
+}
+
 /// A book on one user's physical wishlist. Unique per `(user_id, book_uuid)`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WishlistEntry {
@@ -71,26 +89,4 @@ pub struct WishlistEntry {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn wishlist_source_round_trips_through_the_db_string_for_every_variant() {
-        for variant in [
-            WishlistSource::Scan,
-            WishlistSource::Detail,
-            WishlistSource::Manual,
-        ] {
-            assert_eq!(
-                WishlistSource::from_db(variant.as_str()),
-                Some(variant),
-                "variant {variant:?} did not round-trip through as_str/from_db"
-            );
-        }
-    }
-
-    #[test]
-    fn wishlist_source_from_db_returns_none_for_unrecognized_token() {
-        assert_eq!(WishlistSource::from_db("bogus"), None);
-    }
-}
+mod tests;

--- a/shared/src/physical/tests.rs
+++ b/shared/src/physical/tests.rs
@@ -1,0 +1,47 @@
+//! Serde/token round-trip tests plus `UpdateCopyNoteRequest::validate` length-cap
+//! coverage (issue #1338).
+
+use super::*;
+
+#[test]
+fn wishlist_source_round_trips_through_the_db_string_for_every_variant() {
+    for variant in [
+        WishlistSource::Scan,
+        WishlistSource::Detail,
+        WishlistSource::Manual,
+    ] {
+        assert_eq!(
+            WishlistSource::from_db(variant.as_str()),
+            Some(variant),
+            "variant {variant:?} did not round-trip through as_str/from_db"
+        );
+    }
+}
+
+#[test]
+fn wishlist_source_from_db_returns_none_for_unrecognized_token() {
+    assert_eq!(WishlistSource::from_db("bogus"), None);
+}
+
+#[test]
+fn update_copy_note_request_validate_accepts_a_missing_note() {
+    let req = UpdateCopyNoteRequest { note: None };
+    assert!(req.validate().is_ok());
+}
+
+#[test]
+fn update_copy_note_request_validate_accepts_a_well_formed_note() {
+    let req = UpdateCopyNoteRequest {
+        note: Some("1st edition, dust jacket a little worn.".into()),
+    };
+    assert!(req.validate().is_ok());
+}
+
+#[test]
+fn update_copy_note_request_validate_rejects_an_oversized_note() {
+    let req = UpdateCopyNoteRequest {
+        note: Some("x".repeat(UpdateCopyNoteRequest::NOTE_MAX_LEN + 1)),
+    };
+    let err = req.validate().expect_err("oversized note must be rejected");
+    assert!(err.contains("note"), "got: {err}");
+}

--- a/shared/src/physical/tests.rs
+++ b/shared/src/physical/tests.rs
@@ -1,5 +1,5 @@
 //! Serde/token round-trip tests plus `UpdateCopyNoteRequest::validate` length-cap
-//! coverage (issue #1338).
+//! coverage.
 
 use super::*;
 

--- a/shared/src/read_status.rs
+++ b/shared/src/read_status.rs
@@ -62,10 +62,18 @@ pub struct SetReadStatus {
 }
 
 impl SetReadStatus {
-    /// Reject an empty uuid. Handlers translate `Err(_)` into 400.
+    /// Reject an empty or oversized `book_uuid`, mirroring the same cap
+    /// applied to every other `book_uuid`-carrying request (e.g.
+    /// `CheckInRequest::validate`). Handlers translate `Err(_)` into 400.
     pub fn validate(&self) -> Result<(), String> {
         if self.book_uuid.trim().is_empty() {
             return Err("book_uuid is required".into());
+        }
+        if self.book_uuid.len() > crate::BOOK_UUID_MAX_LEN {
+            return Err(format!(
+                "book uuid must be ≤ {} bytes",
+                crate::BOOK_UUID_MAX_LEN
+            ));
         }
         Ok(())
     }

--- a/shared/src/read_status/tests.rs
+++ b/shared/src/read_status/tests.rs
@@ -58,6 +58,18 @@ fn set_read_status_validate_accepts_nonblank_uuid() {
 }
 
 #[test]
+fn set_read_status_validate_rejects_an_oversized_uuid() {
+    let req = SetReadStatus {
+        book_uuid: "u".repeat(crate::BOOK_UUID_MAX_LEN + 1),
+        status: ReadStatus::Reading,
+    };
+    let err = req
+        .validate()
+        .expect_err("oversized book_uuid must be rejected");
+    assert!(err.contains("bytes"), "got: {err}");
+}
+
+#[test]
 fn record_omits_null_finished_at_from_wire() {
     let json = serde_json::to_string(&ReadStatusRecord {
         book_uuid: "abc".into(),

--- a/shared/src/scan.rs
+++ b/shared/src/scan.rs
@@ -55,6 +55,20 @@ pub struct ResolveRequest {
     pub isbn: String,
 }
 
+impl ResolveRequest {
+    /// Reject an empty/oversized `isbn`, mirroring the same cap applied to
+    /// [`CheckInRequest::isbn`]. Handlers translate `Err(_)` into 400.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.isbn.trim().is_empty() {
+            return Err("isbn is required".into());
+        }
+        if self.isbn.chars().count() > ISBN_MAX_LEN {
+            return Err(format!("isbn exceeds {ISBN_MAX_LEN} characters"));
+        }
+        Ok(())
+    }
+}
+
 /// Maximum length (in chars) for a free-text physical check-in `note` field.
 /// Mirrors `omnibus_shared::highlight::UpdateHighlightNote::NOTE_MAX_LEN`.
 pub const NOTE_MAX_LEN: usize = 4096;

--- a/shared/src/scan/tests.rs
+++ b/shared/src/scan/tests.rs
@@ -188,3 +188,27 @@ fn wishlist_add_request_validate_ignores_an_invalid_meta_when_book_uuid_is_prese
     };
     assert!(req.validate().is_ok());
 }
+
+#[test]
+fn resolve_request_validate_accepts_a_well_formed_isbn() {
+    let req = ResolveRequest {
+        isbn: "9780141439518".into(),
+    };
+    assert!(req.validate().is_ok());
+}
+
+#[test]
+fn resolve_request_validate_rejects_a_blank_isbn() {
+    let req = ResolveRequest { isbn: "   ".into() };
+    let err = req.validate().expect_err("blank isbn must be rejected");
+    assert!(err.contains("isbn"), "got: {err}");
+}
+
+#[test]
+fn resolve_request_validate_rejects_an_oversized_isbn() {
+    let req = ResolveRequest {
+        isbn: "1".repeat(ISBN_MAX_LEN + 1),
+    };
+    let err = req.validate().expect_err("oversized isbn must be rejected");
+    assert!(err.contains("isbn"), "got: {err}");
+}


### PR DESCRIPTION
## Summary
- Closes #1338. `UpdateCopyNoteRequest`, `ResolveRequest`, and `SetReadStatus` accepted unbounded free-text fields with no defensive length cap at the shared-type `validate()` layer, unlike sibling request types elsewhere in `shared/` (e.g. `CheckInRequest`, `MetadataOverrides`, `UpdateHighlightNote`).
- `UpdateCopyNoteRequest` gains `NOTE_MAX_LEN` (mirrors `UpdateHighlightNote::NOTE_MAX_LEN`), enforced in `patch_copy_note` (REST) and `rpc_update_physical_copy_note` (RPC).
- `ResolveRequest` gains a `validate()` capping `isbn` at the existing `ISBN_MAX_LEN` used by `CheckInRequest`, enforced in `post_resolve` (REST) and `rpc_resolve_scan` (RPC).
- `SetReadStatus::validate` now also caps `book_uuid` at `BOOK_UUID_MAX_LEN` (previously only rejected a blank uuid), mirroring `CheckInRequest`/`WishlistAddRequest`.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-shared` — PASS (210 passed) — new regression tests cover oversized `note`/`isbn`/`book_uuid` rejection for all 3 types
- [x] `cargo test -p omnibus-db` — PASS (1288 passed, after fetching test fixtures)
- [x] `cargo test -p omnibus --features server` — 451 passed, 2 failed; both failures (`commit_rejects_read_only_library_with_400`, `audiobook_commit_rejects_read_only_library_with_400`) are pre-existing and unrelated to this change — they `chmod 0o555` a directory to simulate a read-only library and this sandbox runs tests as root, which ignores the write-permission bit. Confirmed unrelated: this PR never touches `server/src/backend/uploads.rs`.
- [x] `cargo test -p omnibus-frontend --features server` — PASS (424 passed)

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Reused the existing length-cap convention throughout rather than inventing a new one: `NOTE_MAX_LEN`/`ISBN_MAX_LEN` constants next to the struct, a `validate()` method returning `Result<(), String>`, called at both the RPC and REST entry points before any DB work — matching `CheckInRequest`, `MetadataOverrides`, and `UpdateHighlightNote`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oRCi8VhhaQwzvkKw4Gqt9)_