### PR TITLE
fix: persist author/series/publisher edits from grid view (#1085)

### DIFF
--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -105,6 +105,91 @@ async fn merge_metadata_overrides_creates_row_when_absent() {
     assert_eq!(loaded.title, Some("Fresh".into()));
     assert!(!has_cover, "a brand-new merged row has no cover override");
 }
+
+/// #1085 regression: a grid quick-edit "clear this field" save must land
+/// as a real clear, not a silent no-op. `merge_metadata_overrides` reads
+/// an incoming `None` as "untouched — keep whatever override already
+/// exists" (that's what lets an edit that only touches one field
+/// preserve the rest), so a caller that represents "the user cleared
+/// series/publisher" as `None` can never actually clear it — the prior
+/// override value survives forever. The correct clear payload is
+/// `Some("")` (the same sentinel `apply_overrides` already special-cases
+/// for `isbn13`, and what the full metadata-edit page's `build_overrides`
+/// already emits): `Option::or` always prefers a `Some`, even an empty
+/// one, so it overwrites the prior value and the book reads back
+/// cleared. This is what `frontend::pages::landing::table::cells::field_override`
+/// now sends for the grid's quick-edit cells (AC2/AC3).
+#[tokio::test]
+async fn merge_metadata_overrides_treats_none_as_untouched_but_empty_string_as_clear() {
+    let _covers = CoversTempDir::new("clear_field_1085");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed(
+            "clear.epub",
+            Some("Scanned Title"),
+            &["Author"],
+            &[],
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let uuid = books[0].unique_identifier.clone().unwrap();
+    let id = books[0].id;
+
+    let initial = MetadataOverrides {
+        series: Some("Foundation".into()),
+        publisher: Some("Gnome Press".into()),
+        ..Default::default()
+    };
+    merge_metadata_overrides(&pool, &uuid, &initial, user_id)
+        .await
+        .unwrap();
+    let with_overrides = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(with_overrides.series.as_deref(), Some("Foundation"));
+    assert_eq!(with_overrides.publisher.as_deref(), Some("Gnome Press"));
+
+    // A `None`-based "clear" (the pre-fix grid payload) is a no-op: the
+    // prior override values survive the merge untouched.
+    let none_clear = MetadataOverrides::default();
+    merge_metadata_overrides(&pool, &uuid, &none_clear, user_id)
+        .await
+        .unwrap();
+    let after_none = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(
+        after_none.series.as_deref(),
+        Some("Foundation"),
+        "a None-based clear payload must not be able to clear series (#1085)"
+    );
+    assert_eq!(
+        after_none.publisher.as_deref(),
+        Some("Gnome Press"),
+        "a None-based clear payload must not be able to clear publisher (#1085)"
+    );
+
+    // The `Some("")` sentinel actually clears.
+    let real_clear = MetadataOverrides {
+        series: Some(String::new()),
+        publisher: Some(String::new()),
+        ..Default::default()
+    };
+    merge_metadata_overrides(&pool, &uuid, &real_clear, user_id)
+        .await
+        .unwrap();
+    let after_clear = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(after_clear.series.as_deref(), Some(""));
+    assert_eq!(after_clear.publisher.as_deref(), Some(""));
+}
+
 /// Two concurrent saves to the same book (e.g. the edit form open in two
 /// tabs, or a network retry firing twice) each touch a different field.
 /// Because the rpc/REST save paths route through `merge_metadata_overrides`

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -106,19 +106,22 @@ async fn merge_metadata_overrides_creates_row_when_absent() {
     assert!(!has_cover, "a brand-new merged row has no cover override");
 }
 
-/// #1085 regression: a grid quick-edit "clear this field" save must land
-/// as a real clear, not a silent no-op. `merge_metadata_overrides` reads
-/// an incoming `None` as "untouched — keep whatever override already
-/// exists" (that's what lets an edit that only touches one field
-/// preserve the rest), so a caller that represents "the user cleared
-/// series/publisher" as `None` can never actually clear it — the prior
-/// override value survives forever. The correct clear payload is
-/// `Some("")` (the same sentinel `apply_overrides` already special-cases
-/// for `isbn13`, and what the full metadata-edit page's `build_overrides`
-/// already emits): `Option::or` always prefers a `Some`, even an empty
-/// one, so it overwrites the prior value and the book reads back
-/// cleared. This is what `frontend::pages::landing::table::cells::field_override`
-/// now sends for the grid's quick-edit cells (AC2/AC3).
+/// A grid quick-edit "clear this field" save must land as a real clear,
+/// not a silent no-op. `merge_metadata_overrides` reads an incoming
+/// `None` as "untouched — keep whatever override already exists" (that's
+/// what lets an edit that only touches one field preserve the rest), so
+/// a caller that represents "the user cleared series/publisher" as
+/// `None` can never actually clear it — the prior override value
+/// survives forever. The correct clear payload is `Some("")`:
+/// `Option::or` always prefers a `Some`, even an empty one, so the merge
+/// overwrites the prior override value. Unlike `isbn13` — which
+/// `apply_overrides` special-cases to read back as `None` — series and
+/// publisher have no such special-casing, so the field reads back as a
+/// literal empty string (`Some("")`), not `None`; that's still what the
+/// UI (and the full metadata-edit page's `build_overrides`) treats as
+/// "cleared". This is what
+/// `frontend::pages::landing::table::cells::field_override` now sends
+/// for the grid's quick-edit cells.
 #[tokio::test]
 async fn merge_metadata_overrides_treats_none_as_untouched_but_empty_string_as_clear() {
     let _covers = CoversTempDir::new("clear_field_1085");

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -36,11 +36,40 @@ pub(super) struct RowContext {
     pub save_authors: EventHandler<Vec<String>>,
 }
 
-/// Build the common per-cell save callback. Empty strings clear the
-/// override (None — the scanned value re-surfaces); non-empty strings
-/// persist as `Some(value)`. The server-side merge in `rpc_save_overrides`
-/// returns the canonical merged metadata which we install verbatim into
-/// the optimistic `book_state` signal.
+/// Build the single-field override payload for a grid quick-edit save.
+///
+/// `EditableCell` only invokes the save callback when the trimmed value
+/// differs from the cell's prior value (see its `onkeydown`/`onblur`
+/// guards), so by the time this runs the field has genuinely changed —
+/// including changing to empty (the user cleared it). That means the
+/// override must always carry `Some(trimmed)`, **never `None`**: `None`
+/// is what `MetadataOverrides::merge` (and `merge_metadata_overrides`'s
+/// read-merge-write) reads as "untouched, keep whatever override already
+/// exists", so a `None`-based "clear" is a silent no-op. `Some("")` is
+/// the established clear sentinel — the same one the full metadata-edit
+/// page's `build_overrides` already emits (see
+/// `frontend::pages::metadata_edit::build_overrides`) — and the merge +
+/// `apply_overrides` read path already understands it (#1085).
+pub(super) fn field_override(field: EditField, value: &str) -> MetadataOverrides {
+    let mut overrides = MetadataOverrides::default();
+    let value = Some(value.trim().to_string());
+    match field {
+        EditField::Title => overrides.title = value,
+        EditField::Series => overrides.series = value,
+        EditField::Publisher => overrides.publisher = value,
+        EditField::Published => overrides.published = value,
+        EditField::Language => overrides.language = value,
+        // Authors edits go through `build_save_authors` so they can set
+        // the `creators` override instead of a scalar.
+        EditField::Authors => {}
+    }
+    overrides
+}
+
+/// Build the common per-cell save callback. Delegates the payload shape to
+/// [`field_override`]; the server-side merge in `rpc_save_overrides` returns
+/// the canonical merged metadata which we install verbatim into the
+/// optimistic `book_state` signal.
 pub(super) fn build_save_field(
     uuid: String,
     server_url: String,
@@ -48,26 +77,13 @@ pub(super) fn build_save_field(
 ) -> impl FnMut((EditField, String)) + 'static {
     move |args: (EditField, String)| {
         let (field, value) = args;
+        if field == EditField::Authors {
+            return;
+        }
         let uuid = uuid.clone();
         let url = server_url.clone();
         spawn(async move {
-            let mut overrides = MetadataOverrides::default();
-            let trimmed = value.trim();
-            let value = if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            };
-            match field {
-                EditField::Title => overrides.title = value,
-                EditField::Series => overrides.series = value,
-                EditField::Publisher => overrides.publisher = value,
-                EditField::Published => overrides.published = value,
-                EditField::Language => overrides.language = value,
-                // Authors edits go through `build_save_authors` so they
-                // can set the `creators` override instead of a scalar.
-                EditField::Authors => return,
-            }
+            let overrides = field_override(field, &value);
             if overrides.validate().is_err() {
                 // F5.1 length caps rejected the payload. The display
                 // reverts on the next refetch; a toast / inline error
@@ -489,3 +505,6 @@ pub(super) fn AuthorsCell(props: AuthorsCellProps) -> Element {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/frontend/src/pages/landing/table/cells/tests.rs
+++ b/frontend/src/pages/landing/table/cells/tests.rs
@@ -1,4 +1,4 @@
-//! Tests for the grid quick-edit save payload construction (#1085).
+//! Tests for the grid quick-edit save payload construction.
 
 use super::*;
 

--- a/frontend/src/pages/landing/table/cells/tests.rs
+++ b/frontend/src/pages/landing/table/cells/tests.rs
@@ -1,0 +1,49 @@
+//! Tests for the grid quick-edit save payload construction (#1085).
+
+use super::*;
+
+#[test]
+fn field_override_sends_empty_string_sentinel_when_series_is_cleared() {
+    // `EditableCell` only calls the save handler once the value has
+    // actually changed, so an empty input here means "the user cleared
+    // this field" — the payload must carry `Some("")` (the clear
+    // sentinel `merge_metadata_overrides` understands), not `None`
+    // (which reads as "untouched" and silently keeps whatever override
+    // already exists — the #1085 bug for AC2).
+    let ov = field_override(EditField::Series, "");
+    assert_eq!(ov.series, Some(String::new()));
+}
+
+#[test]
+fn field_override_sends_empty_string_sentinel_when_publisher_is_cleared() {
+    // Same contract as the series case, covering AC3.
+    let ov = field_override(EditField::Publisher, "  ");
+    assert_eq!(ov.publisher, Some(String::new()));
+}
+
+#[test]
+fn field_override_trims_and_sets_value_when_field_is_edited() {
+    let ov = field_override(EditField::Title, "  New Title  ");
+    assert_eq!(ov.title, Some("New Title".to_string()));
+    // Untouched scalar fields stay `None` so a merge preserves them.
+    assert_eq!(ov.series, None);
+    assert_eq!(ov.publisher, None);
+}
+
+#[test]
+fn field_override_only_sets_the_targeted_scalar_field() {
+    let ov = field_override(EditField::Published, "2024");
+    assert_eq!(ov.published, Some("2024".to_string()));
+    assert_eq!(ov.title, None);
+    assert_eq!(ov.language, None);
+}
+
+#[test]
+fn field_override_is_noop_for_authors_field() {
+    // Authors edits are routed through `build_save_authors`/`creators`
+    // instead — `build_save_field` returns early for this variant, but
+    // `field_override` itself must also stay a no-op if ever called
+    // directly with it.
+    let ov = field_override(EditField::Authors, "Someone");
+    assert_eq!(ov, MetadataOverrides::default());
+}

--- a/frontend/src/pages/landing/table/row.rs
+++ b/frontend/src/pages/landing/table/row.rs
@@ -66,18 +66,9 @@ fn use_row_state(
     let mut book_state: Signal<EbookMetadata> = use_signal(|| book.clone());
     let editing: Signal<Option<EditField>> = use_signal(|| None);
     use_effect(use_reactive!(|book| {
-        // `editing.peek()` deliberately does *not* subscribe this effect
-        // to the `editing` signal (only `use_reactive!`'s `book` dependency
-        // does). Reading it reactively (`editing()`) used to re-run this
-        // resync on every edit-close transition — including a chip-editor
-        // close that lands *after* an in-flight save already applied the
-        // fresh `book_state` (`build_save_authors`'s `book_state.set(merged)`
-        // in cells.rs) — clobbering the just-saved optimistic value back to
-        // this stale outer `book` prop until the next full library refetch
-        // (#1085 AC1: an author edit "requires a refresh" to show up).
-        // `.peek()` still reads the *current* value to gate the resync so an
-        // upstream `book` change mid-edit doesn't stomp an open draft; it
-        // just no longer treats "editing closed" as its own trigger.
+        // `.peek()` avoids subscribing this effect to `editing`, so a save
+        // that resolves after edit-close (e.g. the chip editor) can't have
+        // its fresh `book_state` clobbered by a spurious resync.
         if editing.peek().is_none() {
             // `book` here is `use_reactive!`'s per-run dependency snapshot
             // (already an owned clone produced by the macro), not the

--- a/frontend/src/pages/landing/table/row.rs
+++ b/frontend/src/pages/landing/table/row.rs
@@ -66,7 +66,19 @@ fn use_row_state(
     let mut book_state: Signal<EbookMetadata> = use_signal(|| book.clone());
     let editing: Signal<Option<EditField>> = use_signal(|| None);
     use_effect(use_reactive!(|book| {
-        if editing().is_none() {
+        // `editing.peek()` deliberately does *not* subscribe this effect
+        // to the `editing` signal (only `use_reactive!`'s `book` dependency
+        // does). Reading it reactively (`editing()`) used to re-run this
+        // resync on every edit-close transition — including a chip-editor
+        // close that lands *after* an in-flight save already applied the
+        // fresh `book_state` (`build_save_authors`'s `book_state.set(merged)`
+        // in cells.rs) — clobbering the just-saved optimistic value back to
+        // this stale outer `book` prop until the next full library refetch
+        // (#1085 AC1: an author edit "requires a refresh" to show up).
+        // `.peek()` still reads the *current* value to gate the resync so an
+        // upstream `book` change mid-edit doesn't stomp an open draft; it
+        // just no longer treats "editing closed" as its own trigger.
+        if editing.peek().is_none() {
             // `book` here is `use_reactive!`'s per-run dependency snapshot
             // (already an owned clone produced by the macro), not the
             // outer `book` parameter — safe to move straight into the


### PR DESCRIPTION
## Summary
- Closes #1085. The library grid's inline quick-edit cells could not reliably persist author/series/publisher edits.
- Root cause (AC2/AC3, clearing series/publisher silently no-ops): `frontend/src/pages/landing/table/cells.rs`'s `build_save_field` sent `None` for a cleared scalar field. `merge_metadata_overrides`'s read-merge-write (`MetadataOverrides::merge`) reads an incoming `None` as "untouched — keep whatever override already exists" (that's what lets a single-field edit preserve the rest), so a `None`-based "clear" could never actually clear anything — the prior value survived forever. The fix sends `Some("")` instead, the same clear sentinel the full metadata-edit page's `build_overrides` already emits and that `merge`/`apply_overrides` already understand. The payload construction is now a pure, unit-tested helper (`field_override`).
- Root cause (AC1, an author edit not showing until refresh): the row's `book_state` resync effect in `frontend/src/pages/landing/table/row.rs` read `editing()` reactively, so it re-ran (and reset `book_state` back to the stale `book` prop) on *every* edit-close transition — not just on an actual upstream `book` prop change. For scalar `EditableCell` fields this was harmless (the close happens synchronously, before the save's network round trip resolves, so the save's `book_state.set(merged)` always landed last). For the Authors chip editor, `editing` only closes on blur/Escape, which can land *after* the save already resolved — clobbering the just-saved optimistic state back to stale data until a full refresh. Switched the resync to `editing.peek()` so it only re-runs on a genuine `book` prop change, preserving the "don't stomp an open draft" gating without treating "editing just closed" as its own trigger.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1288 passed, 1 pre-existing failure unrelated to this change: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` needs a `just fixtures` download not available in this environment; the new `metadata_overrides` regression test passes)
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (429 passed, 0 failed, including the 5 new `field_override` tests)

New regression coverage:
- `db/src/metadata_overrides/tests.rs`: `merge_metadata_overrides_treats_none_as_untouched_but_empty_string_as_clear` — proves a `None`-based clear payload is a no-op while `Some("")` actually clears series/publisher end-to-end through `get_book`.
- `frontend/src/pages/landing/table/cells/tests.rs`: `field_override_*` — proves the grid's per-cell save payload always sends `Some(trimmed)` (never `None`) for a genuine edit or clear, and is a no-op for the `Authors` field (routed separately).

## Notes
- The `use_row_state` reactivity fix (AC1) is inherently timing-dependent and not practically unit-testable without a full Dioxus render harness (none exists in this codebase yet), so it's covered by a detailed code comment explaining the race instead of an automated test.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oRCi8VhhaQwzvkKw4Gqt9)_