### PR TITLE
refactor: dedupe title-or-filename fallback into EbookMetadata::display_title (#1256)

### DIFF
--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -89,7 +89,7 @@ pub(super) async fn try_attach_new_ebook(
         return Ok(false);
     }
 
-    let title = m.title.clone().unwrap_or_else(|| m.filename.clone());
+    let title = m.display_title();
     let (Some(title_norm), Some(author_norm)) = (
         normalize_title(&title),
         m.creators.first().and_then(|c| normalize_author(&c.name)),
@@ -224,7 +224,7 @@ async fn update_book_row(
 ) -> Result<(), sqlx::Error> {
     let m = &b.metadata;
     let (book_path, _, _) = split_filename(&m.filename);
-    let title = m.title.clone().unwrap_or_else(|| m.filename.clone());
+    let title = m.display_title();
     let series_index_num = m.series_index.as_deref().and_then(parse_series_index);
     let author_sort = m
         .creators
@@ -286,7 +286,7 @@ pub(super) async fn insert_book_row(
     let uuid = mint_uuid();
     let scan_key = scan_key_for(&m.filename);
     let (book_path, file_stem, file_ext) = split_filename(&m.filename);
-    let title = m.title.clone().unwrap_or_else(|| m.filename.clone());
+    let title = m.display_title();
     let series_index_num = m.series_index.as_deref().and_then(parse_series_index);
     let author_sort = m
         .creators

--- a/frontend/src/components/merge_dialog.rs
+++ b/frontend/src/components/merge_dialog.rs
@@ -356,7 +356,7 @@ fn render_candidate(
     target_series: Option<String>,
     mut selected: Signal<Option<EbookMetadata>>,
 ) -> Element {
-    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    let title = book.display_title();
     // Primary author only — joining every creator surfaces calibre's
     // book-producer contributor ("calibre (x.y) [url]") as junk, and the
     // keeper rail above already shows just the lead author.

--- a/frontend/src/components/merge_dialog.rs
+++ b/frontend/src/components/merge_dialog.rs
@@ -45,10 +45,7 @@ pub fn MergeDialog(
 ) -> Element {
     let server_url = use_server_url();
     let target_uuid = target.unique_identifier.clone().unwrap_or_default();
-    let target_title = target
-        .title
-        .clone()
-        .unwrap_or_else(|| target.filename.clone());
+    let target_title = target.display_title();
 
     let signals = use_merge_dialog_signals();
     let busy = signals.busy;
@@ -425,10 +422,7 @@ fn render_confirm(
 ) -> Element {
     let mut on_confirm = on_confirm;
     let mut on_back = on_back;
-    let source_title = source
-        .title
-        .clone()
-        .unwrap_or_else(|| source.filename.clone());
+    let source_title = source.display_title();
     rsx! {
         div { class: "mg-confirm",
             p { class: "mg-confirm-copy",

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -355,7 +355,7 @@ fn author_body(series_groups: SeriesGroups, standalone: Vec<EbookMetadata>) -> E
 /// before `book` moves into `Cover`, which needs ownership.
 fn author_book_tile(book: EbookMetadata, series_index: Option<String>) -> Element {
     let uuid = book.unique_identifier.clone().unwrap_or_default();
-    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    let title = book.display_title();
     let book_id = book.id;
     rsx! {
         Link {

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -297,7 +297,7 @@ fn render_book_shell(
         delete_open,
         merge.refresh,
         b.unique_identifier.clone().unwrap_or_default(),
-        b.title.clone().unwrap_or_else(|| b.filename.clone()),
+        b.display_title(),
     );
     #[cfg(feature = "mobile")]
     let delete_ui: Option<Element> = {
@@ -545,7 +545,7 @@ struct LoadedBookView {
 
 /// Compute the per-section display fields from the loaded book.
 fn derive_loaded_view(b: &EbookMetadata) -> LoadedBookView {
-    let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
+    let title = b.display_title();
     let primary_author = b
         .creators
         .first()

--- a/frontend/src/pages/listen/mini_dock/mod.rs
+++ b/frontend/src/pages/listen/mini_dock/mod.rs
@@ -59,7 +59,7 @@ pub fn MiniDock() -> Element {
     let idx = chapter_index_for_elapsed(&chapters, elapsed);
     let chapter_sub = chapter_sub_text(&chapters, idx);
     let sub = dock_sub_text(chapter_sub, elapsed, duration, rate);
-    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    let title = book.display_title();
     let fill = format!("width: {:.1}%", progress_pct(elapsed, duration));
     // Book-accent theming, mirroring the full player's `accent_style`.
     let accent_style = book

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -118,7 +118,7 @@ pub(super) fn ReadyPlayer(
         bookmarks.create(*elapsed.peek(), &chs_now);
     };
 
-    let title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    let title = book.display_title();
     let author = book
         .creators
         .first()

--- a/frontend/src/pages/metadata_edit/state.rs
+++ b/frontend/src/pages/metadata_edit/state.rs
@@ -128,7 +128,7 @@ fn use_field_signals(book: &EbookMetadata) -> FormFields {
 /// title, primary author name + id, and the CSS custom-property style
 /// string for the page's accent color.
 fn header_strings(book: &EbookMetadata) -> (String, String, Option<i64>, String) {
-    let display_title = book.title.clone().unwrap_or_else(|| book.filename.clone());
+    let display_title = book.display_title();
     let (primary_author, primary_author_id) = book
         .creators
         .first()

--- a/shared/src/ebook/metadata.rs
+++ b/shared/src/ebook/metadata.rs
@@ -124,6 +124,13 @@ pub struct EbookMetadata {
     pub epub_size_bytes: Option<i64>,
 }
 
+impl EbookMetadata {
+    /// The book's own title, or its filename when the title is unset.
+    pub fn display_title(&self) -> String {
+        self.title.clone().unwrap_or_else(|| self.filename.clone())
+    }
+}
+
 /// One `book_files` row — a single physical file on disk. Exposed to the
 /// frontend so the format switcher can offer a file picker when N > 1.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/shared/src/ebook/tests.rs
+++ b/shared/src/ebook/tests.rs
@@ -7,6 +7,28 @@ fn contributor(name: &str) -> Contributor {
     }
 }
 
+// --- EbookMetadata::display_title() ------------------------------------
+
+#[test]
+fn display_title_returns_title_when_present() {
+    let m = EbookMetadata {
+        filename: "book.epub".into(),
+        title: Some("The Actual Title".into()),
+        ..Default::default()
+    };
+    assert_eq!(m.display_title(), "The Actual Title");
+}
+
+#[test]
+fn display_title_falls_back_to_filename_when_title_is_none() {
+    let m = EbookMetadata {
+        filename: "untitled.epub".into(),
+        title: None,
+        ..Default::default()
+    };
+    assert_eq!(m.display_title(), "untitled.epub");
+}
+
 // --- validate() --------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary
- Hoists the `title.clone().unwrap_or_else(|| filename.clone())` idiom — duplicated at 10 call sites across `db` and `frontend` — into a single `EbookMetadata::display_title(&self) -> String` method in `shared::ebook::metadata`, which both crates already depend on.
- Replaces all 10 call sites (`db/src/sync/books/shared.rs` x3, and 7 in `frontend`: `author.rs`, `book_detail/mod.rs` x2, `listen/mini_dock/mod.rs`, `listen/ready_player.rs`, `metadata_edit/state.rs`, `components/merge_dialog.rs`) with `.display_title()`.
- Pure refactor, no behavior change.

Closes #1256

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-shared` — 214 passed (incl. 2 new tests for `display_title`)
- [x] `cargo test -p omnibus-db` — 1324 passed, 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` — missing binary test fixture in this environment; requires `just fixtures`, not available here)
- [x] `cargo test -p omnibus-frontend --features server` — 457 passed

## Notes
- The `db/src/sync/books/shared.rs` failing-test note above is a pre-existing environment gap (audiobook fixtures aren't checked into git and this sandbox has no `just fixtures` bootstrap), not something introduced by this change — `db/src/audiobook/cover.rs` isn't touched here.
- `frontend/src/pages/author.rs` originally had two duplicate call sites per the issue text; the module has since been refactored so there's now a single shared `author_book_tile` helper with one occurrence — updated that one site.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvCHBVqzjjCxcuCyFRTFYo)_