### PR TITLE
fix: bound zip-entry decompression in export rewrite (#1394)

### DIFF
--- a/db/src/epub_rewrite/archive.rs
+++ b/db/src/epub_rewrite/archive.rs
@@ -8,8 +8,36 @@ use std::io::{Read, Write};
 use std::path::Path;
 
 use anyhow::Context;
+use zip::read::ZipFile;
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+/// Hard cap on the bytes read from any single zip entry. A crafted EPUB can
+/// declare an arbitrary (and false) [`ZipFile::size`], or rely on deflate's
+/// ~1000:1 worst-case ratio to make a small archive decompress to gigabytes
+/// (a "zip bomb") — this bounds memory regardless of what the entry claims
+/// or how well it compresses. 200 MiB comfortably covers any real EPUB
+/// resource (fonts, images, video) while staying far below an OOM.
+const MAX_ENTRY_BYTES: u64 = 200 * 1024 * 1024;
+
+/// Read `entry` fully into memory, capped at [`MAX_ENTRY_BYTES`] regardless
+/// of the entry's declared (attacker-controlled) size. Errors if the entry's
+/// actual decompressed content exceeds the cap.
+fn read_entry_bounded<R: Read>(entry: &mut ZipFile<'_, R>, name: &str) -> anyhow::Result<Vec<u8>> {
+    let hint = entry.size().min(MAX_ENTRY_BYTES) as usize;
+    let mut raw = Vec::with_capacity(hint);
+    // Take one byte past the cap so an entry that lands exactly on the
+    // boundary reads clean, while anything larger is distinguishable from a
+    // legitimately-sized entry.
+    let read = entry
+        .take(MAX_ENTRY_BYTES + 1)
+        .read_to_end(&mut raw)
+        .with_context(|| format!("read entry {name}"))?;
+    if read as u64 > MAX_ENTRY_BYTES {
+        anyhow::bail!("zip entry {name} exceeds {MAX_ENTRY_BYTES} byte cap");
+    }
+    Ok(raw)
+}
 
 /// Rewrite `src` into `dst`, replacing the `opf_path` entry with the output of
 /// `opf_transform` and — when `cover` is `Some((path, bytes))` — the cover
@@ -35,8 +63,7 @@ pub(super) fn rewrite_archive(
     // even when the source stored it out of order (we can't rely on the source
     // iteration order); the main loop then skips it.
     if let Ok(mut mt) = archive.by_name("mimetype") {
-        let mut raw = Vec::with_capacity(mt.size() as usize);
-        mt.read_to_end(&mut raw).context("read mimetype entry")?;
+        let raw = read_entry_bounded(&mut mt, "mimetype")?;
         drop(mt);
         writer
             .start_file(
@@ -67,18 +94,13 @@ pub(super) fn rewrite_archive(
         let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
 
         let bytes = if name == opf_path {
-            let mut raw = Vec::with_capacity(entry.size() as usize);
-            entry.read_to_end(&mut raw).context("read OPF entry")?;
+            let raw = read_entry_bounded(&mut entry, "OPF entry")?;
             opf_transform(&raw)?
         } else if cover.as_ref().is_some_and(|(p, _)| *p == name) {
             // Safe: matched the guard above.
             cover.as_ref().map(|(_, b)| b.clone()).unwrap_or_default()
         } else {
-            let mut raw = Vec::with_capacity(entry.size() as usize);
-            entry
-                .read_to_end(&mut raw)
-                .with_context(|| format!("read entry {name}"))?;
-            raw
+            read_entry_bounded(&mut entry, &name)?
         };
 
         writer

--- a/db/src/epub_rewrite/archive.rs
+++ b/db/src/epub_rewrite/archive.rs
@@ -18,13 +18,26 @@ use zip::{CompressionMethod, ZipArchive, ZipWriter};
 /// (a "zip bomb") — this bounds memory regardless of what the entry claims
 /// or how well it compresses. 200 MiB comfortably covers any real EPUB
 /// resource (fonts, images, video) while staying far below an OOM.
-const MAX_ENTRY_BYTES: u64 = 200 * 1024 * 1024;
+#[cfg(not(test))]
+pub(super) const MAX_ENTRY_BYTES: u64 = 200 * 1024 * 1024;
+/// Test builds use a much smaller cap so the zip-bomb regression test isn't
+/// streaming 200 MiB of I/O and compression on every run — the bounded-read
+/// behavior under test doesn't depend on the cap's exact value.
+#[cfg(test)]
+pub(super) const MAX_ENTRY_BYTES: u64 = 64 * 1024;
+
+/// Ceiling on the up-front `Vec` allocation for a zip entry, independent of
+/// [`MAX_ENTRY_BYTES`]. `ZipFile::size()` is attacker-controlled, so trusting
+/// it for `Vec::with_capacity` would let a crafted entry force a large
+/// allocation immediately — even though the read itself is capped — and
+/// concurrent rewrites would multiply that cost.
+const PREALLOC_HINT_BYTES: usize = 64 * 1024;
 
 /// Read `entry` fully into memory, capped at [`MAX_ENTRY_BYTES`] regardless
 /// of the entry's declared (attacker-controlled) size. Errors if the entry's
 /// actual decompressed content exceeds the cap.
 fn read_entry_bounded<R: Read>(entry: &mut ZipFile<'_, R>, name: &str) -> anyhow::Result<Vec<u8>> {
-    let hint = entry.size().min(MAX_ENTRY_BYTES) as usize;
+    let hint = (entry.size().min(MAX_ENTRY_BYTES) as usize).min(PREALLOC_HINT_BYTES);
     let mut raw = Vec::with_capacity(hint);
     // Take one byte past the cap so an entry that lands exactly on the
     // boundary reads clean, while anything larger is distinguishable from a
@@ -94,7 +107,7 @@ pub(super) fn rewrite_archive(
         let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
 
         let bytes = if name == opf_path {
-            let raw = read_entry_bounded(&mut entry, "OPF entry")?;
+            let raw = read_entry_bounded(&mut entry, &name)?;
             opf_transform(&raw)?
         } else if cover.as_ref().is_some_and(|(p, _)| *p == name) {
             // Safe: matched the guard above.

--- a/db/src/epub_rewrite/tests.rs
+++ b/db/src/epub_rewrite/tests.rs
@@ -291,11 +291,13 @@ fn rewrite_archive_errors_on_entry_that_decompresses_past_the_size_cap() {
     let dst = tmp.path().join("out.epub");
 
     // Zip-bomb-style fixture: `huge.bin` decompresses to one byte past the
-    // 200 MiB per-entry read cap, but — being all zeros — deflates to a few
-    // KB on disk, exactly the "small compressed, huge decompressed" shape a
-    // hostile EPUB upload could exploit. Streamed via `io::repeat` so
-    // *building* the fixture never materializes 200 MiB in memory either.
-    const OVER_CAP: u64 = 200 * 1024 * 1024 + 1;
+    // per-entry read cap (test builds use a much smaller `MAX_ENTRY_BYTES`
+    // than production so this regression stays fast), but — being all zeros
+    // — deflates to a few bytes on disk, exactly the "small compressed, huge
+    // decompressed" shape a hostile EPUB upload could exploit. Streamed via
+    // `io::repeat` so *building* the fixture never materializes the cap's
+    // worth of bytes in memory either.
+    const OVER_CAP: u64 = super::archive::MAX_ENTRY_BYTES + 1;
     let file = std::fs::File::create(&src).unwrap();
     let mut writer = zip::ZipWriter::new(file);
     writer

--- a/db/src/epub_rewrite/tests.rs
+++ b/db/src/epub_rewrite/tests.rs
@@ -1,6 +1,6 @@
 //! Tests for the export-with-overrides EPUB rewrite (F5.8 #1372).
 
-use std::io::Cursor;
+use std::io::{Cursor, Read};
 
 use epub::doc::EpubDoc;
 use image::{DynamicImage, ImageFormat, RgbImage};
@@ -280,6 +280,46 @@ fn rewrite_blocking_bakes_metadata_without_cover_override() {
     super::rewrite_blocking(&src, &dst, &book).unwrap();
     let doc = EpubDoc::new(&dst).unwrap();
     assert_eq!(epub_title(&doc).as_deref(), Some("Text Only Edit"));
+}
+
+// --- rewrite_archive (zip-entry size bound, #1394) ---------------------
+
+#[test]
+fn rewrite_archive_errors_on_entry_that_decompresses_past_the_size_cap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("bomb.epub");
+    let dst = tmp.path().join("out.epub");
+
+    // Zip-bomb-style fixture: `huge.bin` decompresses to one byte past the
+    // 200 MiB per-entry read cap, but — being all zeros — deflates to a few
+    // KB on disk, exactly the "small compressed, huge decompressed" shape a
+    // hostile EPUB upload could exploit. Streamed via `io::repeat` so
+    // *building* the fixture never materializes 200 MiB in memory either.
+    const OVER_CAP: u64 = 200 * 1024 * 1024 + 1;
+    let file = std::fs::File::create(&src).unwrap();
+    let mut writer = zip::ZipWriter::new(file);
+    writer
+        .start_file(
+            "huge.bin",
+            zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated),
+        )
+        .unwrap();
+    std::io::copy(&mut std::io::repeat(0).take(OVER_CAP), &mut writer).unwrap();
+    writer.finish().unwrap();
+
+    let err = super::archive::rewrite_archive(
+        &src,
+        &dst,
+        "nonexistent.opf",
+        |raw| Ok(raw.to_vec()),
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("exceeds") && err.to_string().contains("byte cap"),
+        "expected a size-cap error, got: {err}"
+    );
 }
 
 // --- rewritten_epub_path (DB-integrated) -------------------------------


### PR DESCRIPTION
## Summary
- Closes #1394
- `rewrite_archive` in `db/src/epub_rewrite/archive.rs` trusted each zip entry's declared (attacker-controlled) `size()` for both the `Vec::with_capacity` hint and the `read_to_end` call. A crafted EPUB with a huge declared-but-fake size, or a genuine zip bomb (small compressed payload, huge decompressed output), could exhaust server memory on the "Send to Kobo" / export-with-overrides rewrite path.
- Added a `read_entry_bounded` helper that caps every zip-entry read (the capacity hint *and* the actual bytes read) at a 200 MiB ceiling via `Read::take`, applied consistently at all three read sites in the file: the `mimetype` entry, the OPF entry, and the general copy-through entry in the main loop.

## Test plan
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1394 cargo fmt -p omnibus-db` — PASS
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1394 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1394 cargo test -p omnibus-db` — PASS (1327/1328; see Notes for the one unrelated pre-existing failure)
- Added `rewrite_archive_errors_on_entry_that_decompresses_past_the_size_cap` in `db/src/epub_rewrite/tests.rs`: builds a zip-bomb-style fixture (an all-zero entry that deflates to a few KB on disk but decompresses to one byte past the 200 MiB cap, streamed via `io::repeat` so the fixture itself never materializes 200 MiB in memory) and asserts `rewrite_archive` returns an error instead of allocating unbounded memory.

## Notes
- One pre-existing, unrelated test failure in this run: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` panics because the `test_data/audiobooks/public_domain/` fixture asset isn't present in this worktree (`just fixtures` wasn't run; `just`/`nix` weren't available in this environment). Unrelated to the `epub_rewrite` change — all `epub_rewrite` tests pass.
- Kept the fix as a plain `anyhow::bail!` inside `archive.rs` rather than adding a new `thiserror` variant to `EpubRewriteError` — that enum already collapses every foreign-system (zip/XML/image/filesystem) failure from this path into its `Failed(#[from] anyhow::Error)` variant, and no caller branches on this specific failure mode, so a new variant wouldn't buy anything per the coarse-grained error-handling convention in `.claude/rules/02-error-handling.md`.
- 200 MiB is a per-entry cap, comfortably above any real EPUB resource (text, image, font, video) while well below a memory-exhaustion threshold.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELJGEUULbpCwMYLBaHqPw8)_