### PR TITLE
test: add non-admin/anon regression tests for admin user endpoints (#1403)

### DIFF
--- a/server/src/backend/users/tests.rs
+++ b/server/src/backend/users/tests.rs
@@ -169,6 +169,36 @@ async fn create_user_returns_422_on_weak_password() {
 // ── Permissions ──────────────────────────────────────────────────
 
 #[tokio::test]
+async fn patch_permissions_returns_401_when_anonymous() {
+    let (app, _, _) = fixture().await;
+    let res = app
+        .oneshot(anon("PATCH", "/api/users/1/permissions"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn patch_permissions_returns_403_for_non_admin() {
+    let (app, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let bob = auth_test_support::create_user(&pool, "bob").await;
+    let res = app
+        .oneshot(req(
+            "PATCH",
+            &format!("/api/users/{}/permissions", bob.id),
+            &token,
+            Some(serde_json::json!({
+                "is_admin": false, "can_upload": true, "can_edit": true, "can_download": false,
+            })),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn patch_permissions_updates_flags() {
     let (app, _, pool) = fixture().await;
     let token = admin_token(&pool, "alice").await;
@@ -233,6 +263,34 @@ async fn patch_permissions_returns_404_for_unknown_user() {
 // ── Password reset ───────────────────────────────────────────────
 
 #[tokio::test]
+async fn post_password_returns_401_when_anonymous() {
+    let (app, _, _) = fixture().await;
+    let res = app
+        .oneshot(anon("POST", "/api/users/1/password"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn post_password_returns_403_for_non_admin() {
+    let (app, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let bob = auth_test_support::create_user(&pool, "bob").await;
+    let res = app
+        .oneshot(req(
+            "POST",
+            &format!("/api/users/{}/password", bob.id),
+            &token,
+            Some(serde_json::json!({ "password": "reset-by-admin-99" })),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn reset_password_succeeds_and_rejects_weak() {
     let (app, _, pool) = fixture().await;
     let token = admin_token(&pool, "alice").await;
@@ -265,6 +323,34 @@ async fn reset_password_succeeds_and_rejects_weak() {
 // ── Unlock ───────────────────────────────────────────────────────
 
 #[tokio::test]
+async fn post_unlock_returns_401_when_anonymous() {
+    let (app, _, _) = fixture().await;
+    let res = app
+        .oneshot(anon("POST", "/api/users/1/unlock"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn post_unlock_returns_403_for_non_admin() {
+    let (app, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let bob = auth_test_support::create_user(&pool, "bob").await;
+    let res = app
+        .oneshot(req(
+            "POST",
+            &format!("/api/users/{}/unlock", bob.id),
+            &token,
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn unlock_clears_lockout() {
     let (app, _, pool) = fixture().await;
     let token = admin_token(&pool, "alice").await;
@@ -292,6 +378,31 @@ async fn unlock_clears_lockout() {
 }
 
 // ── Delete ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn delete_user_returns_401_when_anonymous() {
+    let (app, _, _) = fixture().await;
+    let res = app.oneshot(anon("DELETE", "/api/users/1")).await.unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn delete_user_returns_403_for_non_admin() {
+    let (app, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let bob = auth_test_support::create_user(&pool, "bob").await;
+    let res = app
+        .oneshot(req(
+            "DELETE",
+            &format!("/api/users/{}", bob.id),
+            &token,
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
 
 #[tokio::test]
 async fn delete_user_succeeds() {


### PR DESCRIPTION
## Summary
- Closes #1403
- Adds `returns_401_when_anonymous` / `returns_403_for_non_admin` regression tests for the 4 admin-only user-management handlers that lacked them: `patch_permissions`, `post_password`, `post_unlock`, `delete_user` — mirroring the existing pattern already used for `list_users` and `create_user` in `server/src/backend/users/tests.rs`.
- Purely additive: no production code changed, only test coverage.

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1403 cargo fmt -p omnibus` — PASS (no diff)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1403 cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1403 cargo test -p omnibus` — all 22 tests in `backend::users::tests` pass, including the 8 new ones (`patch_permissions_returns_401_when_anonymous`, `patch_permissions_returns_403_for_non_admin`, `post_password_returns_401_when_anonymous`, `post_password_returns_403_for_non_admin`, `post_unlock_returns_401_when_anonymous`, `post_unlock_returns_403_for_non_admin`, `delete_user_returns_401_when_anonymous`, `delete_user_returns_403_for_non_admin`)

## Notes
- Full-suite `cargo test -p omnibus` in this sandbox shows 2 pre-existing, unrelated failures — `backend::uploads::tests::commit_rejects_read_only_library_with_400` and `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`. Both assert a 400 when writing to a read-only directory, but this sandbox runs as root, which bypasses the OS read-only-directory permission check the test relies on. Not related to this change (no `uploads` code touched).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELJGEUULbpCwMYLBaHqPw8)_