### PR TITLE
fix: revoke sessions on password change (#1402)

### DIFF
--- a/db/src/auth.rs
+++ b/db/src/auth.rs
@@ -20,7 +20,7 @@ pub use login::verify_login;
 pub use password::{hash_password, validate_password, validate_username, verify_password};
 pub use session::{
     create_session, lookup_session, prune_expired_sessions, revoke_all_sessions_for_user,
-    revoke_session, validate_session, SessionAuthError,
+    revoke_all_sessions_for_user_except, revoke_session, validate_session, SessionAuthError,
 };
 pub use session_key::{get_session_key, load_or_create_session_key, put_session_key};
 pub use token::{

--- a/db/src/auth/session.rs
+++ b/db/src/auth/session.rs
@@ -252,13 +252,44 @@ pub async fn revoke_session(pool: &SqlitePool, session_id: i64) -> AuthResult<()
 }
 
 /// Revoke all active sessions for a user; returns the number of rows updated.
-pub async fn revoke_all_sessions_for_user(pool: &SqlitePool, user_id: i64) -> AuthResult<u64> {
+/// Accepts any `sqlx::Executor` so callers can run it inside an existing
+/// transaction (e.g. alongside a password update, so a failure rolls back
+/// both together) or standalone via `&SqlitePool`.
+pub async fn revoke_all_sessions_for_user<'e, E>(executor: E, user_id: i64) -> AuthResult<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
     let r =
         sqlx::query("UPDATE sessions SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL")
             .bind(now_unix())
             .bind(user_id)
-            .execute(pool)
+            .execute(executor)
             .await?;
+    Ok(r.rows_affected())
+}
+
+/// Revoke all of a user's active sessions except `except_session_id`. Used by
+/// the self-service password change so the caller's own session survives the
+/// revocation sweep (they'd otherwise be logged out by the change they just
+/// made). Accepts any `sqlx::Executor`, same rationale as
+/// [`revoke_all_sessions_for_user`].
+pub async fn revoke_all_sessions_for_user_except<'e, E>(
+    executor: E,
+    user_id: i64,
+    except_session_id: i64,
+) -> AuthResult<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let r = sqlx::query(
+        "UPDATE sessions SET revoked_at = ?
+         WHERE user_id = ? AND id != ? AND revoked_at IS NULL",
+    )
+    .bind(now_unix())
+    .bind(user_id)
+    .bind(except_session_id)
+    .execute(executor)
+    .await?;
     Ok(r.rows_affected())
 }
 

--- a/db/src/auth/session/tests.rs
+++ b/db/src/auth/session/tests.rs
@@ -203,6 +203,88 @@ async fn touch_update_does_not_bump_revoked_session() {
 }
 
 #[tokio::test]
+async fn revoke_all_sessions_for_user_revokes_every_active_session() {
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    let a = create_session(&p, u.id, None, SessionKind::Cookie, 3600)
+        .await
+        .unwrap();
+    let b = create_session(&p, u.id, None, SessionKind::Bearer, 3600)
+        .await
+        .unwrap();
+
+    let revoked = revoke_all_sessions_for_user(&p, u.id).await.unwrap();
+    assert_eq!(revoked, 2);
+
+    assert!(matches!(
+        lookup_session(&p, &a.raw_token).await.unwrap_err(),
+        AuthError::SessionNotFound
+    ));
+    assert!(matches!(
+        lookup_session(&p, &b.raw_token).await.unwrap_err(),
+        AuthError::SessionNotFound
+    ));
+}
+
+#[tokio::test]
+async fn revoke_all_sessions_for_user_is_scoped_to_the_target_user() {
+    let p = pool().await;
+    let alice = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    // Registration auto-disables after the first user; re-enable for bob.
+    crate::auth::set_registration_enabled(&p, true).await.unwrap();
+    let bob = create_user(&p, "bob", "bunker9-longer-pass").await.unwrap();
+    let alices = create_session(&p, alice.id, None, SessionKind::Cookie, 3600)
+        .await
+        .unwrap();
+    let bobs = create_session(&p, bob.id, None, SessionKind::Cookie, 3600)
+        .await
+        .unwrap();
+
+    let revoked = revoke_all_sessions_for_user(&p, alice.id).await.unwrap();
+    assert_eq!(revoked, 1);
+
+    assert!(matches!(
+        lookup_session(&p, &alices.raw_token).await.unwrap_err(),
+        AuthError::SessionNotFound
+    ));
+    lookup_session(&p, &bobs.raw_token)
+        .await
+        .expect("bob's session must be untouched by alice's revocation");
+}
+
+#[tokio::test]
+async fn revoke_all_sessions_for_user_except_preserves_only_the_named_session() {
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    let keep = create_session(&p, u.id, None, SessionKind::Cookie, 3600)
+        .await
+        .unwrap();
+    let drop_a = create_session(&p, u.id, None, SessionKind::Bearer, 3600)
+        .await
+        .unwrap();
+    let drop_b = create_session(&p, u.id, None, SessionKind::Cookie, 3600)
+        .await
+        .unwrap();
+
+    let revoked = revoke_all_sessions_for_user_except(&p, u.id, keep.session.id)
+        .await
+        .unwrap();
+    assert_eq!(revoked, 2);
+
+    lookup_session(&p, &keep.raw_token)
+        .await
+        .expect("the excluded session must remain live");
+    assert!(matches!(
+        lookup_session(&p, &drop_a.raw_token).await.unwrap_err(),
+        AuthError::SessionNotFound
+    ));
+    assert!(matches!(
+        lookup_session(&p, &drop_b.raw_token).await.unwrap_err(),
+        AuthError::SessionNotFound
+    ));
+}
+
+#[tokio::test]
 async fn unknown_token_is_rejected() {
     let p = pool().await;
     let err = lookup_session(&p, "not-a-real-token").await.unwrap_err();

--- a/db/src/auth/session/tests.rs
+++ b/db/src/auth/session/tests.rs
@@ -231,7 +231,9 @@ async fn revoke_all_sessions_for_user_is_scoped_to_the_target_user() {
     let p = pool().await;
     let alice = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
     // Registration auto-disables after the first user; re-enable for bob.
-    crate::auth::set_registration_enabled(&p, true).await.unwrap();
+    crate::auth::set_registration_enabled(&p, true)
+        .await
+        .unwrap();
     let bob = create_user(&p, "bob", "bunker9-longer-pass").await.unwrap();
     let alices = create_session(&p, alice.id, None, SessionKind::Cookie, 3600)
         .await

--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -4,6 +4,7 @@ use omnibus_shared::{AdminUserRow, UserPermissions};
 use sqlx::{Row, SqliteConnection, SqlitePool};
 
 use super::password::{hash_password, validate_password, validate_username, verify_password};
+use super::session::{revoke_all_sessions_for_user, revoke_all_sessions_for_user_except};
 use super::{now_unix, row_to_user, AuthError, AuthResult, User};
 
 /// Atomically create a user. The first user created becomes admin; the
@@ -187,6 +188,10 @@ pub async fn get_kindle_email(pool: &SqlitePool, user_id: i64) -> AuthResult<Opt
 /// authorize the change, validates `new` against the password policy, then
 /// re-hashes with Argon2id and stamps `password_changed_at` — all in one
 /// transaction so an interrupted call never leaves a half-applied state.
+/// Also revokes every other active session for the user in the same
+/// transaction (#1402), except `except_session_id` — the caller's own
+/// session, which stays live so a self-service change doesn't immediately
+/// log the caller out.
 ///
 /// Errors with [`AuthError::InvalidCredentials`] when the current password is
 /// wrong (or the user id no longer exists) and [`AuthError::Validation`] when
@@ -197,6 +202,7 @@ pub async fn change_password(
     user_id: i64,
     current: &str,
     new: &str,
+    except_session_id: i64,
 ) -> AuthResult<()> {
     let mut tx = pool.begin().await?;
 
@@ -234,6 +240,11 @@ pub async fn change_password(
     if updated.rows_affected() == 0 {
         return Err(AuthError::InvalidCredentials);
     }
+
+    // Kick out anyone else holding a session for this account (e.g. an
+    // attacker with a stolen cookie) — but leave the caller's own session
+    // live, since they authenticated this very request with it.
+    revoke_all_sessions_for_user_except(&mut *tx, user_id, except_session_id).await?;
 
     tx.commit().await?;
     Ok(())
@@ -406,8 +417,11 @@ pub async fn update_user_permissions(
 }
 
 /// Admin-reset a user's password: validate + re-hash + stamp
-/// `password_changed_at`. No current-password check — this is the admin
-/// override path, distinct from the self-service [`change_password`].
+/// `password_changed_at`, then revoke every active session for the target
+/// user in the same transaction (#1402) — unlike the self-service
+/// [`change_password`], there is no caller session to exclude, since the
+/// admin isn't the affected account. No current-password check — this is
+/// the admin override path.
 /// [`AuthError::UserNotFound`] for an unknown id; [`AuthError::Validation`]
 /// when the new password fails policy.
 pub async fn admin_set_password(
@@ -417,17 +431,24 @@ pub async fn admin_set_password(
 ) -> AuthResult<()> {
     validate_password(new_password)?;
     let phc = hash_password(new_password)?;
+
+    let mut tx = pool.begin().await?;
+
     let updated = sqlx::query(
         "UPDATE users SET password_hash = ?, password_changed_at = strftime('%s','now')
          WHERE id = ?",
     )
     .bind(&phc)
     .bind(user_id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
     if updated.rows_affected() == 0 {
         return Err(AuthError::UserNotFound);
     }
+
+    revoke_all_sessions_for_user(&mut *tx, user_id).await?;
+
+    tx.commit().await?;
     Ok(())
 }
 

--- a/db/src/auth/users/tests.rs
+++ b/db/src/auth/users/tests.rs
@@ -196,7 +196,7 @@ async fn change_password_updates_hash_and_stamp_and_new_password_logs_in() {
         .await
         .unwrap();
 
-    change_password(&p, u.id, "hunter2-real-long", "brand-new-longpass")
+    change_password(&p, u.id, "hunter2-real-long", "brand-new-longpass", -1)
         .await
         .unwrap();
 
@@ -228,7 +228,7 @@ async fn change_password_rejects_wrong_current_and_leaves_hash_intact() {
     let p = pool().await;
     let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
 
-    let err = change_password(&p, u.id, "wrong-current-pass", "brand-new-longpass")
+    let err = change_password(&p, u.id, "wrong-current-pass", "brand-new-longpass", -1)
         .await
         .unwrap_err();
     assert!(matches!(err, AuthError::InvalidCredentials));
@@ -245,13 +245,13 @@ async fn change_password_rejects_invalid_new_password() {
     let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
 
     // Too short.
-    let err = change_password(&p, u.id, "hunter2-real-long", "short")
+    let err = change_password(&p, u.id, "hunter2-real-long", "short", -1)
         .await
         .unwrap_err();
     assert!(matches!(err, AuthError::Validation(_)));
 
     // Common-password reject-list.
-    let err = change_password(&p, u.id, "hunter2-real-long", "password123")
+    let err = change_password(&p, u.id, "hunter2-real-long", "password123", -1)
         .await
         .unwrap_err();
     assert!(matches!(err, AuthError::Validation(_)));
@@ -260,10 +260,47 @@ async fn change_password_rejects_invalid_new_password() {
 #[tokio::test]
 async fn change_password_rejects_unknown_user() {
     let p = pool().await;
-    let err = change_password(&p, 9999, "anything-here-long", "brand-new-longpass")
+    let err = change_password(&p, 9999, "anything-here-long", "brand-new-longpass", -1)
         .await
         .unwrap_err();
     assert!(matches!(err, AuthError::InvalidCredentials));
+}
+
+#[tokio::test]
+async fn change_password_keeps_callers_own_session_but_revokes_others() {
+    // #1402: a self-service password change must not immediately log the
+    // caller out of the session they used to make the change, but any other
+    // live session for the account (e.g. a stolen cookie) must die with it.
+    use crate::auth::{create_session, lookup_session, SessionKind};
+
+    let p = pool().await;
+    let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+
+    let callers_session = create_session(&p, u.id, None, SessionKind::Cookie, 3600)
+        .await
+        .unwrap();
+    let other_session = create_session(&p, u.id, None, SessionKind::Bearer, 3600)
+        .await
+        .unwrap();
+
+    change_password(
+        &p,
+        u.id,
+        "hunter2-real-long",
+        "brand-new-longpass",
+        callers_session.session.id,
+    )
+    .await
+    .unwrap();
+
+    lookup_session(&p, &callers_session.raw_token)
+        .await
+        .expect("the caller's own session must survive the password change");
+
+    let err = lookup_session(&p, &other_session.raw_token)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthError::SessionNotFound));
 }
 
 // ── Admin user management (F5.4) ─────────────────────────────────────
@@ -425,6 +462,39 @@ async fn admin_set_password_resets_and_new_password_logs_in() {
     crate::auth::verify_login(&p, "bob", "reset-by-admin-99")
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn admin_set_password_revokes_all_sessions_for_target_user() {
+    // #1402: an admin-initiated reset has no caller session on the target
+    // account to preserve — every existing session for that user must die.
+    use crate::auth::{create_session, lookup_session, SessionKind};
+
+    let p = pool().await;
+    create_user(&p, "alice", "hunter2-real-long").await.unwrap();
+    let bob = admin_create_user(&p, "bob", "bunker9-longer-pass", READER)
+        .await
+        .unwrap();
+
+    let bobs_cookie = create_session(&p, bob.id, None, SessionKind::Cookie, 3600)
+        .await
+        .unwrap();
+    let bobs_bearer = create_session(&p, bob.id, None, SessionKind::Bearer, 3600)
+        .await
+        .unwrap();
+
+    admin_set_password(&p, bob.id, "reset-by-admin-99")
+        .await
+        .unwrap();
+
+    let err = lookup_session(&p, &bobs_cookie.raw_token)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthError::SessionNotFound));
+    let err = lookup_session(&p, &bobs_bearer.raw_token)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthError::SessionNotFound));
 }
 
 #[tokio::test]

--- a/frontend/src/rpc/account.rs
+++ b/frontend/src/rpc/account.rs
@@ -28,7 +28,15 @@ pub async fn rpc_set_kindle_email(email: Option<String>) -> Result<()> {
 /// errors the form renders inline; opaque failures fold to a generic message.
 #[post("/api/rpc/account/change-password", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_change_password(current_password: String, new_password: String) -> Result<()> {
-    match db::auth::change_password(&pool.0, user.id, &current_password, &new_password).await {
+    match db::auth::change_password(
+        &pool.0,
+        user.id,
+        &current_password,
+        &new_password,
+        user.session_id,
+    )
+    .await
+    {
         Ok(()) => Ok(()),
         Err(AuthError::InvalidCredentials) => {
             Err(ServerFnError::new("current password is incorrect").into())

--- a/frontend/src/rpc/mod.rs
+++ b/frontend/src/rpc/mod.rs
@@ -110,6 +110,10 @@ mod server_auth {
         /// Metadata edit permission. `true` for the first user (admin) and
         /// any user explicitly granted `can_edit`.
         pub can_edit: bool,
+        /// The live session this request authenticated with. Threaded into
+        /// `db::auth::change_password` so a self-service password change can
+        /// exclude the caller's own session from its revocation sweep (#1402).
+        pub session_id: i64,
     }
 
     /// Admin-only wrapper. Extracting this returns 403 for non-admin users
@@ -150,10 +154,11 @@ mod server_auth {
                 .get(header::COOKIE)
                 .and_then(|v| v.to_str().ok());
             match auth_db::validate_session(&pool, authorization, cookie_header).await {
-                Ok((user, _session)) => Ok(AuthUser {
+                Ok((user, session)) => Ok(AuthUser {
                     id: user.id,
                     is_admin: user.is_admin,
                     can_edit: user.can_edit,
+                    session_id: session.id,
                 }),
                 Err(SessionAuthError::Unauthenticated) => Err(unauthorized()),
                 Err(SessionAuthError::Internal(e)) => Err(internal(e)),


### PR DESCRIPTION
## Summary
- Closes #1402
- `revoke_all_sessions_for_user` (`db/src/auth/session.rs`) existed but was never called from either password-change path, so a stolen session cookie stayed valid after the account owner changed their password.
- `db::auth::change_password` (self-service) now revokes every other active session for the user in the same transaction as the password update, via a new `revoke_all_sessions_for_user_except` that excludes the caller's own session (threaded through as a new `except_session_id` parameter, sourced from the `AuthUser` rpc extractor's session id — the extractor gained a `session_id` field for this).
- `db::auth::admin_set_password` now wraps its update in a transaction and revokes **all** sessions for the target user (no exclusion — the admin is never the affected account).

## Test plan
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1402 cargo fmt -p omnibus-db` — PASS (no diff)
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1402 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1402 cargo test -p omnibus-db` — PASS (all `auth::` tests, including new coverage; one unrelated pre-existing audiobook-fixture failure, see Notes)
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1402 cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1402 cargo test -p omnibus-frontend --features server` — PASS
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1402 cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- `CARGO_TARGET_DIR=/tmp/omnibus-target-1402 cargo test -p omnibus` — PASS (463/465; 2 unrelated pre-existing failures, see Notes)

New tests added:
- `db/src/auth/session/tests.rs`: `revoke_all_sessions_for_user_revokes_every_active_session`, `revoke_all_sessions_for_user_is_scoped_to_the_target_user`, `revoke_all_sessions_for_user_except_preserves_only_the_named_session`
- `db/src/auth/users/tests.rs`: `change_password_keeps_callers_own_session_but_revokes_others`, `admin_set_password_revokes_all_sessions_for_target_user`

## Notes
- Sandbox-environment pre-existing failures unrelated to this change (confirmed against a clean checkout of the same tree):
  - `omnibus-db`: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails because this sandbox has no `test_data/` fixture assets (`just fixtures` not run here).
  - `omnibus`: `backend::uploads::tests::commit_rejects_read_only_library_with_400` and `audiobook_commit_rejects_read_only_library_with_400` fail because they assert a `chmod 0o555` directory rejects writes, but this sandbox runs as root, which bypasses Unix permission checks.
- `change_password`'s new `except_session_id: i64` parameter and `admin_set_password`'s new internal transaction are both additive/internal — no REST route calls `change_password` directly (only the `/api/rpc/account/change-password` Dioxus server function does), and `admin_set_password`'s external signature is unchanged so `server/src/backend/users.rs` needed no edits.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELJGEUULbpCwMYLBaHqPw8)_