### PR TITLE
fix: redirect to login on admin self-delete (#1404)

### DIFF
--- a/frontend/src/pages/settings/users.rs
+++ b/frontend/src/pages/settings/users.rs
@@ -122,9 +122,7 @@ pub fn UsersSection() -> Element {
                         on_close: move |_| modal.set(Modal::None),
                         on_deleted: move |_| {
                             modal.set(Modal::None);
-                            // A self-delete invalidates the session server-side, so
-                            // refetching the table would just 401 — send the admin
-                            // to login instead of reloading now-inaccessible data.
+                            // Self-delete invalidates the session; reloading would just 401.
                             if is_self {
                                 nav.replace(Route::Login {});
                             } else {

--- a/frontend/src/pages/settings/users.rs
+++ b/frontend/src/pages/settings/users.rs
@@ -4,10 +4,11 @@
 //! empty list (rule 07); the post-mount effect loads the real rows.
 
 use dioxus::prelude::*;
+use dioxus_router::use_navigator;
 use omnibus_shared::{AdminUserRow, CreateUserRequest, UserPermissions};
 
 use crate::components::auth::{score_password, PasswordRequirements, StrengthMeter};
-use crate::data;
+use crate::{data, Route};
 
 /// Which modal, if any, is open over the Users table.
 #[derive(Clone, PartialEq)]
@@ -29,6 +30,7 @@ pub fn UsersSection() -> Element {
     let mut reload = use_signal(|| 0u32);
     let mut modal = use_signal(|| Modal::None);
     let current = crate::use_current_user_summary();
+    let nav = use_navigator();
 
     // Reload whenever the counter bumps (initial mount + after each mutation).
     use_effect(move || {
@@ -118,7 +120,17 @@ pub fn UsersSection() -> Element {
                         user: row,
                         is_self,
                         on_close: move |_| modal.set(Modal::None),
-                        on_deleted: move |_| { modal.set(Modal::None); reload.with_mut(|n| *n += 1); },
+                        on_deleted: move |_| {
+                            modal.set(Modal::None);
+                            // A self-delete invalidates the session server-side, so
+                            // refetching the table would just 401 — send the admin
+                            // to login instead of reloading now-inaccessible data.
+                            if is_self {
+                                nav.replace(Route::Login {});
+                            } else {
+                                reload.with_mut(|n| *n += 1);
+                            }
+                        },
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Closes #1404
- The delete-user modal's `on_deleted` callback in `frontend/src/pages/settings/users.rs` always closed the modal and bumped the reload counter, even when the admin deleted their own account. A self-delete invalidates the session server-side, so the subsequent users-table refetch 401'd and left the UI in a broken state.
- `UsersSection` already computes `is_self` (comparing the row's id against `crate::use_current_user_summary()`) for the delete-confirmation warning, so the fix reuses that flag in `on_deleted`: when `is_self` is true, navigate to `/login` via `use_navigator().replace(Route::Login {})` (the same pattern `user_menu.rs`'s sign-out handler uses) instead of reloading the now-inaccessible table; otherwise the existing reload behavior is unchanged.

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1404 cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1404 cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1404 cargo test -p omnibus-frontend --features server` — PASS (465 passed)

## Notes
- Change is scoped to `frontend/src/pages/settings/users.rs` only; no new files, no test-infra added since the page's only existing test coverage pattern (`frontend/src/pages/settings/users/tests.rs`) covers pure helpers (`fmt_date`, `civil_from_days`), not interactive/router logic.
- No hydration concerns: the branch (`is_self` check) is plain logic inside an existing event-handler closure, not gated on `web`/`server`/`mobile`, and doesn't change the component's rsx body.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELJGEUULbpCwMYLBaHqPw8)_