### PR TITLE
feat: warn about Kobo annotation data loss before exposing the device URL (#927)

### DIFF
--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -86,9 +86,14 @@ single file on the device:
 3. Eject the Kobo safely.
 
 That file holds every highlight and note on the device. Keeping a copy means a
-wipe is recoverable. Importing one back into Omnibus is planned, not yet built
-([#933](https://github.com/seamus-sloan/omnibus/issues/933)) — for now the copy
-is a backup you keep, not something Omnibus can read.
+wipe is recoverable.
+
+**If your Omnibus version offers a Kobo annotation import, run it before the
+first wireless sync** — that pulls the device's highlights and notes into your
+library, so a wipe costs you nothing. That import is still in development
+([#933](https://github.com/seamus-sloan/omnibus/issues/933)); until it ships,
+the file copy above is the backup, and it is one you keep yourself rather than
+something Omnibus can read back.
 
 The wired **Send to Kobo** transfer described above carries none of this risk and
 stays the safe choice.

--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -14,8 +14,8 @@ and you copy it over yourself. Both are described below.
 > **cannot delete or change anything already on your Kobo** — not your books,
 > not your highlights, not your notes. Omnibus only ever *adds* a book file; it
 > never touches the device's internal database. (That is *not* true of wireless
-> "sync", which is a different feature Omnibus does not yet offer — see the note
-> at the bottom.)
+> sync, a separate and still-incomplete feature — see
+> [About wireless sync](#about-wireless-sync-experimental).)
 
 ## Chrome / Edge — one-click write
 
@@ -63,11 +63,32 @@ just a bit slower. The official Docker image ships `kepubify`; if you build from
 source, install `kepubify` on the server's `PATH` (or set `OMNIBUS_KEPUBIFY_PATH`)
 to get KEPUB output. See [.env.example](../.env.example).
 
-## About wireless sync (not yet available)
+## About wireless sync (experimental)
 
-Some servers offer *wireless* Kobo sync, where the device talks to the server
-over Wi-Fi. Omnibus does **not** do this yet. It's worth knowing why the wired
-copy above is the safe choice in the meantime: pointing a Kobo's wireless sync at
-a server that doesn't fully implement Kobo's protocol can make the **device erase
-its own highlights and notes**. The manual USB copy has no such risk. If wireless
-sync is added later, Omnibus will warn you clearly before you enable it.
+*Wireless* Kobo sync — where the device talks to Omnibus over Wi-Fi instead of a
+USB cable — is **under construction**. **Account → Kobo wireless sync** will hand
+you an endpoint URL, but the protocol behind it is incomplete. Treat it as
+experimental and do not point a device you care about at it yet.
+
+> [!WARNING]
+> **The first wireless sync can erase your Kobo's highlights and notes.**
+> A Kobo clears its own annotations when the server it syncs with does not answer
+> Kobo's annotation channel. Omnibus does not answer that channel yet, and does
+> **not** store what the device erases — anything lost this way is gone.
+
+**Back up your annotations before the first wireless sync.** They live in a
+single file on the device:
+
+1. Connect the Kobo over USB and tap **Connect**. It appears as a USB drive.
+2. Copy `.kobo/KoboReader.sqlite` off the drive to somewhere safe. (`.kobo` is a
+   hidden folder — on macOS press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>.</kbd> in Finder
+   to reveal it; on Windows enable **Hidden items** in Explorer's View tab.)
+3. Eject the Kobo safely.
+
+That file holds every highlight and note on the device. Keeping a copy means a
+wipe is recoverable. Importing one back into Omnibus is planned, not yet built
+([#933](https://github.com/seamus-sloan/omnibus/issues/933)) — for now the copy
+is a backup you keep, not something Omnibus can read.
+
+The wired **Send to Kobo** transfer described above carries none of this risk and
+stays the safe choice.

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4895,6 +4895,23 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .btn.ghost.danger { color: #f87171; }
 @media (hover: hover) { .btn.ghost.danger:hover { background: var(--bg-1); color: #fca5a5; } }
 
+/* Kobo annotation data-loss warning (#927). */
+.kobo-warning {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid #f8717155;
+  border-left-width: 3px;
+  border-left-color: #f87171;
+  border-radius: 8px;
+  background: var(--bg-1);
+  font-size: 0.85rem;
+  color: var(--ink-1);
+}
+.kobo-warning p { margin: 0 0 0.5rem; }
+.kobo-warning p:last-child { margin-bottom: 0; }
+.kobo-warning-title { font-weight: 600; color: #f87171; }
+.kobo-warning code { font-family: var(--mono, ui-monospace, monospace); font-size: 0.8rem; }
+
 /* F5.1 per-library metadata-source precedence editor (#972). */
 .metadata-precedence-list {
   display: flex;

--- a/frontend/src/pages/account/kobo.rs
+++ b/frontend/src/pages/account/kobo.rs
@@ -124,9 +124,7 @@ pub fn KoboDevicesCard() -> Element {
                 "The token authorizes only your library."
             }
 
-            // Rendered unconditionally and non-dismissably: the hazard applies
-            // the moment a URL is copied, so it must not be possible to see an
-            // endpoint without it (#927).
+            // Unconditional: the hazard applies the moment a URL is copied.
             div { class: "kobo-warning", "data-testid": "kobo-data-loss-warning",
                 p { class: "kobo-warning-title", "First sync can erase your Kobo's highlights" }
                 p {

--- a/frontend/src/pages/account/kobo.rs
+++ b/frontend/src/pages/account/kobo.rs
@@ -124,6 +124,24 @@ pub fn KoboDevicesCard() -> Element {
                 "The token authorizes only your library."
             }
 
+            // Rendered unconditionally and non-dismissably: the hazard applies
+            // the moment a URL is copied, so it must not be possible to see an
+            // endpoint without it (#927).
+            div { class: "kobo-warning", "data-testid": "kobo-data-loss-warning",
+                p { class: "kobo-warning-title", "First sync can erase your Kobo's highlights" }
+                p {
+                    "A Kobo clears its own highlights and notes when the server it syncs with "
+                    "does not answer Kobo's annotation channel. Omnibus does not answer that "
+                    "channel yet, and does not store what the device erases."
+                }
+                p {
+                    "Copy "
+                    code { ".kobo/KoboReader.sqlite" }
+                    " off the device over USB before you point it here. Wireless sync is "
+                    "incomplete \u{2014} treat it as experimental."
+                }
+            }
+
             if device_list.is_empty() {
                 p {
                     class: "settings-status",
@@ -253,5 +271,67 @@ mod tests {
             endpoint_url("http://localhost:3000/", "abc"),
             "http://localhost:3000/kobo/abc"
         );
+    }
+}
+
+// SSR render-smoke coverage. These need the `server` feature (`dioxus::ssr`).
+#[cfg(all(test, feature = "server"))]
+mod render_tests {
+    use super::*;
+    use crate::test_support::render_in_vdom;
+
+    fn card() -> Element {
+        rsx! {
+            KoboDevicesCard {}
+        }
+    }
+
+    /// `Callback::new` needs a live runtime, so the row is built inside the
+    /// throwaway `VirtualDom` rather than via a bare `render`.
+    fn device_row() -> Element {
+        rsx! {
+            KoboDeviceRow {
+                device: KoboDeviceView {
+                    id: 1,
+                    name: "Kobo Clara".to_string(),
+                    token: "tok123".to_string(),
+                    created_at: 0,
+                    last_seen_at: 0,
+                },
+                endpoint: "https://omni.example.com/kobo/tok123".to_string(),
+                disabled: false,
+                on_regenerate: Callback::new(|_| {}),
+                on_remove: Callback::new(|_| {}),
+            }
+        }
+    }
+
+    /// The warning sits at card level, above the list, so it is present on the
+    /// very first paint — before any device row (and therefore any endpoint
+    /// URL) can render. `KoboDeviceRow` is only ever mounted inside this card,
+    /// so covering the card covers every path that shows a URL (#927 AC1/AC4).
+    #[test]
+    fn kobo_card_renders_the_data_loss_warning_on_first_paint() {
+        let html = render_in_vdom(card);
+        assert!(html.contains("data-testid=\"kobo-data-loss-warning\""));
+        assert!(html.contains("First sync can erase your Kobo&#39;s highlights"));
+        assert!(html.contains("KoboReader.sqlite"));
+    }
+
+    /// The warning must not be gated on having registered a device — a user
+    /// reads it *before* adding their first Kobo, not after.
+    #[test]
+    fn kobo_card_warns_even_with_no_devices_registered() {
+        let html = render_in_vdom(card);
+        assert!(html.contains("data-testid=\"kobo-devices-empty\""));
+        assert!(html.contains("data-testid=\"kobo-data-loss-warning\""));
+    }
+
+    /// The row is what actually exposes the endpoint URL; assert it renders so
+    /// the card-level warning test above is anchored to a real URL surface.
+    #[test]
+    fn kobo_device_row_renders_the_endpoint_url() {
+        let html = render_in_vdom(device_row);
+        assert!(html.contains("https://omni.example.com/kobo/tok123"));
     }
 }


### PR DESCRIPTION
## Summary
- The Account → Kobo card shipped in #1387 hands out a live `wireless sync endpoint` URL with **no warning attached**, while [docs/kobo.md](docs/kobo.md) still told users wireless sync was "not yet available" and promised "Omnibus will warn you clearly before you enable it." This closes that gap.
- Adds a non-dismissable data-loss warning rendered unconditionally at card level, above the device list — so it is present on first paint, before any endpoint URL can render, and before a user adds their first Kobo.
- Rewrites the docs' wireless-sync section: `not yet available` → `experimental`, a `[!WARNING]` callout, and step-by-step instructions for backing up `.kobo/KoboReader.sqlite` over USB before the first wireless sync.

Closes #927.

### On AC2
The AC asks the docs to recommend the F4.4 USB import before first wireless sync. That import (#933) **is not built yet**, so pointing users at it would be a false promise. The docs instead walk through copying `KoboReader.sqlite` off the device by hand — same protection, honest about what exists — and link #933 as planned.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server kobo` — 19 passed, incl. 3 new render tests (warning on first paint; warning with zero devices; row renders the endpoint URL).
- [x] `cargo fmt --check` clean; `cargo clippy -p omnibus-frontend --features server --all-targets -D warnings` clean.
- [x] `just lint-css` clean.
- [ ] **Browser verification not run** — `just dev-up` fails on this workspace with `Incorrect wasm-bindgen-cli version: project requires version 0.2.122 but version 0.2.118 is installed`. Pre-existing flake drift on `main`, unrelated to this change; the warning is static markup covered by the SSR render tests above. Flagging separately.

## Version
- [x] **Patch** — frontend copy + docs, no migration, no API change.

## Notes
- `KoboDeviceRow` is only ever mounted inside `KoboDevicesCard`, so a card-level warning covers every path that can display a URL — that reasoning is captured in the test doc comment rather than duplicating the warning per row.
- Copy deliberately claims nothing about preserving on-device annotations (AC3): it states plainly that Omnibus does not answer Kobo's annotation channel and does not store what the device erases.
- This is the **interim** safeguard. The durable fix is speaking the Reading Services annotation channel (#1278), after which this copy should soften.
