### PR TITLE
refactor: dedupe web/mobile scrub-position derivation and shrink ChapterMap (#1351)

### DIFF
--- a/frontend/src/pages/listen/chapter_map.rs
+++ b/frontend/src/pages/listen/chapter_map.rs
@@ -1,11 +1,9 @@
 //! Segmented chapter progress bar doubling as a draggable seek scrubber.
 //!
-//! Each chapter is a flex segment sized by `flex: {duration_seconds}`; the
-//! played portion fills proportionally with accent colour. A transparent
-//! full-width `<input type="range">` layered on top captures click / drag /
-//! keyboard seeking (the visible playhead is drawn separately). Dragging
-//! previews the target position on the bar and only seeks the audio on
-//! release, so a scrub across a multi-part book doesn't thrash `el.src`.
+//! Each chapter is a flex segment sized by `flex: {duration_seconds}`; a
+//! transparent `<input type="range">` layered on top captures click / drag /
+//! keyboard seeking. See [`helpers::effective_scrub_position`] for the
+//! drag-preview contract.
 
 #![cfg(not(feature = "mobile"))]
 
@@ -13,7 +11,7 @@ use dioxus::prelude::*;
 use omnibus_shared::ChapterInfo;
 
 use super::chapter_nav::chapter_index_for_elapsed;
-use super::helpers::format_hms;
+use super::helpers::{self, format_hms};
 
 /// Fill percentage for a chapter segment in the progress bar.
 /// `i` is the segment index, `current` is the active chapter index.
@@ -132,6 +130,105 @@ pub(super) struct ChapterMapProps {
     pub on_seek: EventHandler<f64>,
 }
 
+/// Scrub-state readouts derived for one render of [`ChapterMap`]: the
+/// previewed position, current chapter, remaining time, thumb offset, and
+/// whether a drag is in progress.
+struct ScrubState {
+    effective: f64,
+    eff_current: usize,
+    eff_remaining: f64,
+    thumb: f64,
+    is_scrubbing: bool,
+}
+
+/// Derive [`ScrubState`] from the raw `scrubbing` / `scrub_secs` signal pair
+/// via the shared [`helpers::effective_scrub_position`] (web's bool+f64 pair
+/// normalizes to that function's `Option<f64>` shape at this one call site).
+fn scrub_state(
+    chapters: &[ChapterInfo],
+    elapsed: f64,
+    duration: f64,
+    current_chapter_index: usize,
+    remaining: f64,
+    scrubbing: bool,
+    scrub_secs: f64,
+) -> ScrubState {
+    let scrub = scrubbing.then_some(scrub_secs);
+    let (effective, eff_current, eff_remaining) = helpers::effective_scrub_position(
+        chapters,
+        elapsed,
+        duration,
+        current_chapter_index,
+        remaining,
+        scrub,
+        chapter_index_for_elapsed,
+    );
+    let max = if duration > 0.0 { duration } else { 1.0 };
+    ScrubState {
+        effective,
+        eff_current,
+        eff_remaining,
+        thumb: thumb_pct(effective, max),
+        is_scrubbing: scrubbing,
+    }
+}
+
+/// Render the segmented chapter bar: one flex segment per chapter (or a
+/// single fallback segment when there are no chapter markers), each filled
+/// proportionally to how much of it has played. Pure visual — the range
+/// overlay in [`ChapterMap`] owns pointer interaction (`pointer-events: none`
+/// in CSS).
+fn segment_bar(
+    chapters: &[ChapterInfo],
+    eff_current: usize,
+    effective: f64,
+    duration: f64,
+) -> Element {
+    rsx! {
+        div { class: "lp-chapter-seg-row", "data-testid": "chapter-map",
+            if chapters.is_empty() {
+                div { class: "lp-chapter-seg", style: "flex: 1;",
+                    div {
+                        class: "lp-chapter-seg-fill",
+                        style: "width: {no_chapter_fill_pct(effective, duration):.1}%;",
+                    }
+                }
+            } else {
+                for (i, ch) in chapters.iter().enumerate() {
+                    {
+                        let flex_val = ch.duration_seconds.max(0.1);
+                        let fill = chapter_fill_pct(
+                            i,
+                            eff_current,
+                            effective,
+                            ch.start_seconds,
+                            ch.duration_seconds,
+                        );
+                        let class_name = if i == eff_current {
+                            "lp-chapter-seg current"
+                        } else {
+                            "lp-chapter-seg"
+                        };
+                        let title = ch.title.clone();
+                        rsx! {
+                            div {
+                                key: "{ch.ordinal}",
+                                class: "{class_name}",
+                                style: "flex: {flex_val};",
+                                title: "{title}",
+                                div {
+                                    class: "lp-chapter-seg-fill",
+                                    style: "width: {fill:.1}%;",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// The chapter progress map / seek scrubber component.
 #[component]
 pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
@@ -145,31 +242,28 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
     } = props;
 
     // Local scrub state. While the user drags, the segments / thumb / time
-    // readouts preview `scrub_secs`; the audio element is only seeked on
-    // release so dragging across a multi-part book doesn't thrash `el.src`.
+    // readouts preview `scrub_secs` (see `scrub_state`); the audio element is
+    // only seeked on release so dragging across a multi-part book doesn't
+    // thrash `el.src`.
     let mut scrubbing = use_signal(|| false);
     let mut scrub_secs = use_signal(|| 0.0_f64);
 
+    let ScrubState {
+        effective,
+        eff_current,
+        eff_remaining,
+        thumb,
+        is_scrubbing,
+    } = scrub_state(
+        &chapters,
+        elapsed,
+        duration,
+        current_chapter_index,
+        remaining,
+        scrubbing(),
+        scrub_secs(),
+    );
     let max = if duration > 0.0 { duration } else { 1.0 };
-    let is_scrubbing = scrubbing();
-    let effective = if is_scrubbing {
-        scrub_secs().clamp(0.0, max)
-    } else {
-        elapsed
-    };
-    // Track the current chapter from the preview so segment fills follow the
-    // thumb mid-drag; fall back to the parent's index at rest.
-    let eff_current = if is_scrubbing {
-        chapter_index_for_elapsed(&chapters, effective)
-    } else {
-        current_chapter_index
-    };
-    let eff_remaining = if is_scrubbing {
-        (duration - effective).max(0.0)
-    } else {
-        remaining
-    };
-    let thumb = thumb_pct(effective, max);
 
     let on_input = move |evt: Event<FormData>| {
         if let Ok(v) = evt.value().parse::<f64>() {
@@ -193,49 +287,7 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
     rsx! {
         div { class: "lp-chapter-map",
             div { class: "{scrub_class}",
-                // Segmented bar — pure visual; the range overlay owns pointer
-                // interaction (`pointer-events: none` in CSS).
-                div { class: "lp-chapter-seg-row", "data-testid": "chapter-map",
-                    if chapters.is_empty() {
-                        div { class: "lp-chapter-seg", style: "flex: 1;",
-                            div {
-                                class: "lp-chapter-seg-fill",
-                                style: "width: {no_chapter_fill_pct(effective, duration):.1}%;",
-                            }
-                        }
-                    } else {
-                        for (i, ch) in chapters.iter().enumerate() {
-                            {
-                                let flex_val = ch.duration_seconds.max(0.1);
-                                let fill = chapter_fill_pct(
-                                    i,
-                                    eff_current,
-                                    effective,
-                                    ch.start_seconds,
-                                    ch.duration_seconds,
-                                );
-                                let class_name = if i == eff_current {
-                                    "lp-chapter-seg current"
-                                } else {
-                                    "lp-chapter-seg"
-                                };
-                                let title = ch.title.clone();
-                                rsx! {
-                                    div {
-                                        key: "{ch.ordinal}",
-                                        class: "{class_name}",
-                                        style: "flex: {flex_val};",
-                                        title: "{title}",
-                                        div {
-                                            class: "lp-chapter-seg-fill",
-                                            style: "width: {fill:.1}%;",
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                {segment_bar(&chapters, eff_current, effective, duration)}
 
                 // Visible playhead + drag-time bubble.
                 div { class: "lp-chapter-thumb", style: "left: {thumb:.3}%;" }

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -1,17 +1,46 @@
 //! Shared helpers for the listen page: timestamp formatting, the audio
 //! progress POST shim, the audited `window.OmnibusAudio` poke, the
-//! transport click-handler builders, and the volume load/save/apply trio
-//! shared by the mini-dock and full player. Consumed by `listen.rs`,
-//! `controls`, `speed_panel`, `sleep`, `ready_player`, and `bootstrap`.
+//! transport click-handler builders, the volume load/save/apply trio
+//! shared by the mini-dock and full player, and the scrub-drag preview
+//! math shared by the web and mobile players.
 
 // Imported for `Asset`/`MouseEvent`; the audio helpers below that use it are
 // all gated to non-mobile targets, so the import is too (unused on mobile).
 #[cfg(not(feature = "mobile"))]
 use dioxus::prelude::*;
+use omnibus_shared::ChapterInfo;
 #[cfg(not(feature = "mobile"))]
 use omnibus_shared::{
     MAX_AUDIOBOOK_PLAYBACK_RATE as MAX_RATE, MIN_AUDIOBOOK_PLAYBACK_RATE as MIN_RATE,
 };
+
+/// Effective (position, chapter index, remaining) derivation shared by the
+/// web and mobile players' scrub bars: while dragging (`scrub` is `Some`)
+/// every readout previews the target position instead of the real playback
+/// state; at rest (`None`) `elapsed` / `current_chapter_index` / `remaining`
+/// pass through unchanged. `chapter_index_fn` is threaded in rather than
+/// called directly because each target keeps its own
+/// `chapter_index_for_elapsed` under its own cfg gate (`chapter_nav` on web,
+/// `mobile::view` on mobile) — this is the one place the "preview while
+/// dragging, commit on release" math itself lives, so the two can't diverge.
+pub(super) fn effective_scrub_position(
+    chapters: &[ChapterInfo],
+    elapsed: f64,
+    duration: f64,
+    current_chapter_index: usize,
+    remaining: f64,
+    scrub: Option<f64>,
+    chapter_index_fn: impl Fn(&[ChapterInfo], f64) -> usize,
+) -> (f64, usize, f64) {
+    let Some(target) = scrub else {
+        return (elapsed, current_chapter_index, remaining);
+    };
+    let max = if duration > 0.0 { duration } else { 1.0 };
+    let effective = target.clamp(0.0, max);
+    let eff_current = chapter_index_fn(chapters, effective);
+    let eff_remaining = (duration - effective).max(0.0);
+    (effective, eff_current, eff_remaining)
+}
 
 /// Vendored hls.js for the HLS fallback path.
 #[cfg(feature = "web")]
@@ -217,7 +246,70 @@ pub(super) fn post_audio_progress(uuid: String, seconds: f64) {
 
 #[cfg(test)]
 mod tests {
-    use super::format_hms;
+    use omnibus_shared::ChapterInfo;
+
+    use super::{effective_scrub_position, format_hms};
+
+    fn ch(ordinal: i64, title: &str, start: f64, dur: f64) -> ChapterInfo {
+        ChapterInfo {
+            ordinal,
+            title: title.into(),
+            start_seconds: start,
+            duration_seconds: dur,
+        }
+    }
+
+    /// Mirrors the shape of the real per-target `chapter_index_for_elapsed`
+    /// implementations (`chapter_nav` / `mobile::view`) without depending on
+    /// either — this module compiles on both cfg configurations.
+    fn idx_of(chapters: &[ChapterInfo], elapsed: f64) -> usize {
+        chapters
+            .partition_point(|c| c.start_seconds <= elapsed)
+            .saturating_sub(1)
+    }
+
+    #[test]
+    fn effective_scrub_position_passes_through_when_not_scrubbing() {
+        let chs = vec![ch(1, "Intro", 0.0, 300.0), ch(2, "Part 1", 300.0, 600.0)];
+        let (effective, idx, remaining) =
+            effective_scrub_position(&chs, 120.0, 900.0, 0, 780.0, None, idx_of);
+        assert!((effective - 120.0).abs() < f64::EPSILON);
+        assert_eq!(idx, 0);
+        assert!((remaining - 780.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn effective_scrub_position_overrides_with_drag_target_when_scrubbing() {
+        let chs = vec![ch(1, "Intro", 0.0, 300.0), ch(2, "Part 1", 300.0, 600.0)];
+        // Parent still reports elapsed=120/chapter 0/remaining=780, but the
+        // drag is previewing 500s — every readout should follow the drag.
+        let (effective, idx, remaining) =
+            effective_scrub_position(&chs, 120.0, 900.0, 0, 780.0, Some(500.0), idx_of);
+        assert!((effective - 500.0).abs() < f64::EPSILON);
+        assert_eq!(idx, 1);
+        assert!((remaining - 400.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn effective_scrub_position_recomputes_chapter_at_a_boundary() {
+        let chs = vec![ch(1, "Intro", 0.0, 300.0), ch(2, "Part 1", 300.0, 600.0)];
+        // Dragging to exactly the chapter-2 boundary should flip the index.
+        let (_, idx_before, _) =
+            effective_scrub_position(&chs, 0.0, 900.0, 0, 900.0, Some(299.9), idx_of);
+        let (_, idx_after, _) =
+            effective_scrub_position(&chs, 0.0, 900.0, 0, 900.0, Some(300.0), idx_of);
+        assert_eq!(idx_before, 0);
+        assert_eq!(idx_after, 1);
+    }
+
+    #[test]
+    fn effective_scrub_position_clamps_drag_target_to_the_book_bounds() {
+        let chs = vec![ch(1, "Intro", 0.0, 300.0)];
+        let (effective, _, remaining) =
+            effective_scrub_position(&chs, 0.0, 300.0, 0, 300.0, Some(999.0), idx_of);
+        assert!((effective - 300.0).abs() < f64::EPSILON);
+        assert!((remaining - 0.0).abs() < f64::EPSILON);
+    }
 
     #[test]
     fn format_hms_under_one_hour_renders_mm_ss() {

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -23,6 +23,15 @@ use omnibus_shared::{
 /// `chapter_index_for_elapsed` under its own cfg gate (`chapter_nav` on web,
 /// `mobile::view` on mobile) — this is the one place the "preview while
 /// dragging, commit on release" math itself lives, so the two can't diverge.
+///
+/// Note the `target.clamp(0.0, max)` below is a deliberate, small behavior
+/// change on mobile: the pre-refactor mobile derivation used the raw drag
+/// value unclamped (`scrub().unwrap_or(elapsed)`), while web already
+/// clamped. A stale drag value that outlives a mid-drag `duration` change
+/// (or any other out-of-range input) now clamps into range on both
+/// platforms instead of only on web — intentionally aligning mobile with
+/// web's existing, safer edge-case behavior rather than preserving mobile's
+/// unguarded one.
 pub(super) fn effective_scrub_position(
     chapters: &[ChapterInfo],
     elapsed: f64,
@@ -303,12 +312,25 @@ mod tests {
     }
 
     #[test]
-    fn effective_scrub_position_clamps_drag_target_to_the_book_bounds() {
+    fn effective_scrub_position_clamps_a_drag_target_past_the_end() {
         let chs = vec![ch(1, "Intro", 0.0, 300.0)];
         let (effective, _, remaining) =
             effective_scrub_position(&chs, 0.0, 300.0, 0, 300.0, Some(999.0), idx_of);
         assert!((effective - 300.0).abs() < f64::EPSILON);
         assert!((remaining - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn effective_scrub_position_clamps_a_negative_drag_target_to_zero() {
+        // A stale/out-of-range scrub value (e.g. one that outlives a
+        // mid-drag `duration` change) clamps into range on both platforms —
+        // this is the mobile-alignment fix noted on `effective_scrub_position`.
+        let chs = vec![ch(1, "Intro", 0.0, 300.0)];
+        let (effective, idx, remaining) =
+            effective_scrub_position(&chs, 120.0, 300.0, 0, 180.0, Some(-50.0), idx_of);
+        assert!((effective - 0.0).abs() < f64::EPSILON);
+        assert_eq!(idx, 0);
+        assert!((remaining - 300.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -10,6 +10,7 @@ use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};
 use omnibus_shared::{EbookMetadata, ProgressFormat, ProgressUpdate};
 
+use super::helpers::effective_scrub_position;
 use crate::components::atrium::Cover;
 use crate::contexts::use_server_url;
 use crate::data;
@@ -317,13 +318,18 @@ fn render_player(p: PlayerProps) -> Element {
     // While dragging, every readout previews the drag position and the current
     // chapter is re-derived from it, so the bar/times track the thumb; at rest
     // `effective` is the true elapsed. The transport handlers below still act
-    // on the real `elapsed` / `chapter_index`, never the preview.
-    let effective = scrub().unwrap_or(elapsed);
-    let disp_index = if scrub().is_some() {
-        chapter_index_for_elapsed(&view.chapters, effective)
-    } else {
-        chapter_index
-    };
+    // on the real `elapsed` / `chapter_index`, never the preview. Shared with
+    // the web player via `effective_scrub_position` so the two derivations
+    // can't silently diverge.
+    let (effective, disp_index, eff_remaining) = effective_scrub_position(
+        &view.chapters,
+        elapsed,
+        duration,
+        chapter_index,
+        (duration - elapsed).max(0.0),
+        scrub(),
+        chapter_index_for_elapsed,
+    );
     let current = view.chapters.get(disp_index);
     let chapter_no = disp_index + 1;
     let chapter_count = view.chapters.len();
@@ -335,7 +341,7 @@ fn render_player(p: PlayerProps) -> Element {
         view::remaining_in_chapter(&view.chapters, disp_index, effective),
         rate,
     );
-    let remaining_book = remaining_at_rate((duration - effective).max(0.0), rate);
+    let remaining_book = remaining_at_rate(eff_remaining, rate);
     let scrub_max = if duration > 0.0 { duration } else { 1.0 };
 
     let accent_style = view


### PR DESCRIPTION
## Summary
- Closes #1351. Extracts the "preview while dragging, commit on release" derivation shared by the web and mobile audiobook scrubbers into one `effective_scrub_position()` in `frontend/src/pages/listen/helpers.rs` (a module compiled on both mobile and non-mobile targets), so the two players' bool+f64 / `Option<f64>` signal shapes both funnel through the same math instead of hand-duplicating it.
- Shrinks `ChapterMap` in `frontend/src/pages/listen/chapter_map.rs` from ~138 lines to 94 by extracting the scrub-state derivation into a `scrub_state()` helper and the segmented-bar markup into a `segment_bar()` helper.
- Trims `chapter_map.rs`'s module `//!` doc from 8 lines to 6 (5 content lines), per the ~5-line convention, pointing to the new shared helper for the drag-preview contract detail.
- Mostly a behavior-preserving refactor, with **one small, deliberate exception** flagged by review (see Notes): mobile's drag target is now clamped to `[0, duration]`, matching web's pre-existing clamp, instead of the prior unclamped mobile behavior.

## Test plan
- [x] `cargo fmt -p omnibus-frontend -- --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1351 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (0 warnings)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1351 cargo test -p omnibus-frontend --features server` — PASS (478 passed; 0 failed), including 6 direct unit tests on `effective_scrub_position`: not-scrubbing passthrough, scrubbing-active override, a chapter-boundary transition, an overshoot-past-the-end clamp, and a negative/underflow clamp.
- [ ] wasm32 clippy (`--target wasm32-unknown-unknown --features web`) — skipped, target not installed in this environment; no wasm-specific code was touched (the new helper is plain `f64`/`usize` arithmetic with no `web`/`wasm` cfg gates).

## Version
- [x] **Patch** — the default; internal refactor plus one small, intentional edge-case behavior alignment (see Notes), no user-facing feature change.

## Notes
- The pre-existing duplication of `chapter_index_for_elapsed` itself (one copy in `chapter_nav.rs` gated `not(mobile)`, one in `mobile/view.rs` gated `mobile`) is left as-is — the issue's shared-helper ask was specifically the "effective position while dragging" derivation, and the two `chapter_index_for_elapsed` copies are threaded into the new shared helper as an `impl Fn` parameter rather than merged, to avoid a larger cross-cfg restructuring outside this issue's scope.
- **Behavior note (from Copilot review):** the shared `effective_scrub_position()` clamps the drag target to `[0, duration]`. Web already did this pre-refactor; mobile's prior derivation used the raw scrub value unclamped (`scrub().unwrap_or(elapsed)`). This is now a deliberate, small behavior fix — aligning mobile with web's existing, safer edge-case handling for a stale/out-of-range drag value (e.g. one that outlives a mid-drag `duration` change) — documented in a comment on `effective_scrub_position` and covered by a new dedicated test (`effective_scrub_position_clamps_a_negative_drag_target_to_zero`).
