### PR TITLE
refactor: key the LogStream loop and test settings save/maintenance handlers (#1346)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,6 +4522,7 @@ dependencies = [
  "axum",
  "base64",
  "dioxus",
+ "dioxus-html",
  "dioxus-router",
  "getrandom 0.2.17",
  "gloo-net 0.7.0",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -112,6 +112,12 @@ ndk-context = { version = "0.1", optional = true }
 [dev-dependencies]
 # Sandboxed temp dirs for the mobile `token_store` / `app_dirs` file tests.
 tempfile.workspace = true
+# `SerializedFormData`/`SerializedMouseData` — synthetic `FormEvent`/`MouseEvent`
+# construction for tests that call a signal-driven handler directly (e.g.
+# `settings::library`'s `save_settings_handler`/`scan_library_handler`). Not a
+# target-gated dev-dep: `VirtualDom`-backed handler tests compile and run on
+# wasm32 too, so this needs to be in the unification unit for every target.
+dioxus-html = { version = "0.7", features = ["serialize"] }
 
 # In-memory pool + seed fixtures for the `server`-gated rpc tests. Gated off
 # wasm32: those tests only compile under the (native) `server` feature, and an

--- a/frontend/src/pages/logs.rs
+++ b/frontend/src/pages/logs.rs
@@ -283,7 +283,7 @@ fn LogResults(
 fn LogStream(records: Vec<LogRecord>) -> Element {
     rsx! {
         div { class: "logs-stream mono", "data-testid": "logs-table", role: "region", "aria-label": "Server log stream",
-            for (i , record) in records.into_iter().enumerate() {
+            for (i, record) in records.into_iter().enumerate() {
                 LogLine { key: "{record.timestamp}-{i}", record }
             }
         }

--- a/frontend/src/pages/logs.rs
+++ b/frontend/src/pages/logs.rs
@@ -283,8 +283,8 @@ fn LogResults(
 fn LogStream(records: Vec<LogRecord>) -> Element {
     rsx! {
         div { class: "logs-stream mono", "data-testid": "logs-table", role: "region", "aria-label": "Server log stream",
-            for record in records {
-                LogLine { record }
+            for (i , record) in records.into_iter().enumerate() {
+                LogLine { key: "{record.timestamp}-{i}", record }
             }
         }
     }

--- a/frontend/src/pages/settings/library.rs
+++ b/frontend/src/pages/settings/library.rs
@@ -270,6 +270,37 @@ fn ScanIntervalField(mut scan_interval_hours: Signal<String>) -> Element {
     }
 }
 
+/// Returns the "Scan Library" button's `onclick` handler: flips
+/// `scan_in_flight` immediately (so the button disables before the request
+/// even lands), then reports the queued scan — or its failure — once the
+/// request resolves.
+fn scan_library_handler(
+    url: String,
+    mut status: Signal<Option<String>>,
+    mut status_is_error: Signal<bool>,
+    mut scan_in_flight: Signal<bool>,
+    mut library_refresh: Signal<u32>,
+) -> impl FnMut(MouseEvent) {
+    move |_evt: MouseEvent| {
+        let url = url.clone();
+        scan_in_flight.set(true);
+        spawn(async move {
+            match data::scan_library(&url).await {
+                Ok(()) => {
+                    status.set(Some("Library scan queued.".into()));
+                    status_is_error.set(false);
+                    library_refresh.set(library_refresh() + 1);
+                }
+                Err(e) => {
+                    status.set(Some(format!("Failed to start library scan: {e}")));
+                    status_is_error.set(true);
+                }
+            }
+            scan_in_flight.set(false);
+        });
+    }
+}
+
 /// Ghost buttons for one-off maintenance jobs (library rescan, author photo
 /// refetch, chapter backfill).
 #[component]
@@ -278,13 +309,19 @@ fn MaintenanceActions(
     mut status_is_error: Signal<bool>,
     mut refetch_in_flight: Signal<bool>,
     mut backfill_in_flight: Signal<bool>,
-    mut scan_in_flight: Signal<bool>,
-    mut library_refresh: Signal<u32>,
+    scan_in_flight: Signal<bool>,
+    library_refresh: Signal<u32>,
 ) -> Element {
     let server_url = use_server_url();
-    let url_for_scan = server_url.clone();
     let url_for_refetch = server_url.clone();
-    let url_for_backfill = server_url;
+    let url_for_backfill = server_url.clone();
+    let on_scan = scan_library_handler(
+        server_url,
+        status,
+        status_is_error,
+        scan_in_flight,
+        library_refresh,
+    );
 
     rsx! {
         button {
@@ -292,24 +329,7 @@ fn MaintenanceActions(
             class: "btn ghost",
             disabled: scan_in_flight(),
             "data-testid": "scan-library",
-            onclick: move |_| {
-                let url = url_for_scan.clone();
-                scan_in_flight.set(true);
-                spawn(async move {
-                    match data::scan_library(&url).await {
-                        Ok(()) => {
-                            status.set(Some("Library scan queued.".into()));
-                            status_is_error.set(false);
-                            library_refresh.set(library_refresh() + 1);
-                        }
-                        Err(e) => {
-                            status.set(Some(format!("Failed to start library scan: {e}")));
-                            status_is_error.set(true);
-                        }
-                    }
-                    scan_in_flight.set(false);
-                });
-            },
+            onclick: on_scan,
             "Scan Library"
         }
         button {
@@ -409,28 +429,4 @@ fn LibrarySummary(testid: String, section: LibrarySection) -> Element {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn section(total: usize, counts: &[(&str, usize)]) -> LibrarySection {
-        LibrarySection {
-            path: Some("/lib".into()),
-            total_files: total,
-            counts_by_ext: counts.iter().map(|(e, c)| (e.to_string(), *c)).collect(),
-            error: None,
-        }
-    }
-
-    #[test]
-    fn summary_line_reports_total_only_when_no_ext_breakdown() {
-        assert_eq!(library_summary_line(&section(3, &[])), "3 file(s) found.");
-    }
-
-    #[test]
-    fn summary_line_appends_a_clause_per_extension() {
-        let line = library_summary_line(&section(5, &[("epub", 4), ("pdf", 1)]));
-        assert!(line.starts_with("5 file(s) found."));
-        assert!(line.contains("4 .epub found."));
-        assert!(line.contains("1 .pdf found."));
-    }
-}
+mod tests;

--- a/frontend/src/pages/settings/library/tests.rs
+++ b/frontend/src/pages/settings/library/tests.rs
@@ -1,0 +1,160 @@
+//! Tests for the pure library-summary formatter, the settings-save
+//! rescan-interval guard, and the "Scan Library" maintenance handler.
+//!
+//! `Signal::new`/`spawn` need a live Dioxus runtime, and `save_settings_handler`
+//! takes a real `FormEvent` (`scan_library_handler` a real `MouseEvent`), so
+//! those two run inside a throwaway zero-prop component driven by
+//! `VirtualDom::new(...).rebuild_in_place()` — the pattern established in
+//! `frontend/src/pages/reader/prefs/tests.rs` and `frontend/src/contexts.rs`.
+//! The handlers only ever call `prevent_default()`/ignore the event, so a
+//! bare `SerializedFormData`/`SerializedMouseData` is enough — no real
+//! browser event is needed. Neither test lets the spawned save/scan future
+//! run (it's queued but never polled), so no network call actually fires;
+//! each test only observes the synchronous guard/in-flight behavior before
+//! the request would be sent.
+
+use std::rc::Rc;
+
+use dioxus::prelude::*;
+
+use super::*;
+
+fn section(total: usize, counts: &[(&str, usize)]) -> LibrarySection {
+    LibrarySection {
+        path: Some("/lib".into()),
+        total_files: total,
+        counts_by_ext: counts.iter().map(|(e, c)| (e.to_string(), *c)).collect(),
+        error: None,
+    }
+}
+
+#[test]
+fn summary_line_reports_total_only_when_no_ext_breakdown() {
+    assert_eq!(library_summary_line(&section(3, &[])), "3 file(s) found.");
+}
+
+#[test]
+fn summary_line_appends_a_clause_per_extension() {
+    let line = library_summary_line(&section(5, &[("epub", 4), ("pdf", 1)]));
+    assert!(line.starts_with("5 file(s) found."));
+    assert!(line.contains("4 .epub found."));
+    assert!(line.contains("1 .pdf found."));
+}
+
+/// A no-op `FormEvent` — `save_settings_handler` never reads the form's own
+/// values, so a blank `SerializedFormData` is enough to call it.
+fn blank_form_event() -> FormEvent {
+    Event::new(
+        Rc::new(FormData::new(SerializedFormData::new(
+            String::new(),
+            vec![],
+        ))),
+        false,
+    )
+}
+
+/// A no-op `MouseEvent` — `scan_library_handler` ignores its argument.
+fn blank_mouse_event() -> MouseEvent {
+    Event::new(
+        Rc::new(MouseData::new(SerializedMouseData::default())),
+        false,
+    )
+}
+
+#[test]
+fn save_settings_handler_rejects_non_numeric_interval_without_saving() {
+    #[component]
+    fn AssertRejects() -> Element {
+        let ebook_path = Signal::new(String::new());
+        let audiobook_path = Signal::new(String::new());
+        let scan_interval_hours = Signal::new("soon".to_string());
+        let status = Signal::new(None::<String>);
+        let status_is_error = Signal::new(false);
+        let library_refresh = Signal::new(0u32);
+
+        let mut handler = save_settings_handler(
+            "http://127.0.0.1:0".to_string(),
+            ebook_path,
+            audiobook_path,
+            scan_interval_hours,
+            status,
+            status_is_error,
+            library_refresh,
+        );
+        handler(blank_form_event());
+
+        assert_eq!(
+            status(),
+            Some("Automatic rescan interval must be a whole number of hours.".to_string())
+        );
+        assert!(status_is_error());
+        // The guard returned before spawning the save, so the
+        // only-bumped-on-success refresh counter is untouched.
+        assert_eq!(library_refresh(), 0);
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertRejects).rebuild_in_place();
+}
+
+#[test]
+fn save_settings_handler_accepts_a_blank_interval_and_proceeds_to_save() {
+    #[component]
+    fn AssertAccepts() -> Element {
+        let ebook_path = Signal::new(String::new());
+        let audiobook_path = Signal::new(String::new());
+        let scan_interval_hours = Signal::new(String::new());
+        let status = Signal::new(None::<String>);
+        let status_is_error = Signal::new(false);
+        let library_refresh = Signal::new(0u32);
+
+        let mut handler = save_settings_handler(
+            "http://127.0.0.1:0".to_string(),
+            ebook_path,
+            audiobook_path,
+            scan_interval_hours,
+            status,
+            status_is_error,
+            library_refresh,
+        );
+        handler(blank_form_event());
+
+        // The guard didn't reject a blank interval, so no rejection message
+        // was set synchronously — it went on to spawn the actual save,
+        // whose result lands asynchronously (covered end-to-end by
+        // Playwright's settings flow).
+        assert_eq!(status(), None);
+        assert!(!status_is_error());
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertAccepts).rebuild_in_place();
+}
+
+#[test]
+fn scan_library_handler_flips_in_flight_immediately_on_click() {
+    #[component]
+    fn AssertScanInFlight() -> Element {
+        let status = Signal::new(None::<String>);
+        let status_is_error = Signal::new(false);
+        let scan_in_flight = Signal::new(false);
+        let library_refresh = Signal::new(0u32);
+
+        let mut handler = scan_library_handler(
+            "http://127.0.0.1:0".to_string(),
+            status,
+            status_is_error,
+            scan_in_flight,
+            library_refresh,
+        );
+        assert!(!scan_in_flight());
+        handler(blank_mouse_event());
+
+        // The in-flight flag flips synchronously, before the scan request
+        // itself ever resolves — that's what disables the button on click.
+        assert!(scan_in_flight());
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertScanInFlight).rebuild_in_place();
+}

--- a/frontend/src/pages/settings/library/tests.rs
+++ b/frontend/src/pages/settings/library/tests.rs
@@ -1,17 +1,10 @@
 //! Tests for the pure library-summary formatter, the settings-save
-//! rescan-interval guard, and the "Scan Library" maintenance handler.
-//!
-//! `Signal::new`/`spawn` need a live Dioxus runtime, and `save_settings_handler`
-//! takes a real `FormEvent` (`scan_library_handler` a real `MouseEvent`), so
-//! those two run inside a throwaway zero-prop component driven by
-//! `VirtualDom::new(...).rebuild_in_place()` — the pattern established in
-//! `frontend/src/pages/reader/prefs/tests.rs` and `frontend/src/contexts.rs`.
-//! The handlers only ever call `prevent_default()`/ignore the event, so a
-//! bare `SerializedFormData`/`SerializedMouseData` is enough — no real
-//! browser event is needed. Neither test lets the spawned save/scan future
-//! run (it's queued but never polled), so no network call actually fires;
-//! each test only observes the synchronous guard/in-flight behavior before
-//! the request would be sent.
+//! rescan-interval guard, and the "Scan Library" maintenance handler. The
+//! latter two run inside a `VirtualDom::new(...).rebuild_in_place()` (the
+//! pattern in `frontend/src/pages/reader/prefs/tests.rs`) so `Signal::new`
+//! has a runtime, driven by a synthetic `FormEvent`/`MouseEvent` built from
+//! `SerializedFormData`/`SerializedMouseData` — the futures they spawn are
+//! never polled, so no network call actually fires.
 
 use std::rc::Rc;
 


### PR DESCRIPTION
## Summary
- `LogStream`'s record loop (`frontend/src/pages/logs.rs`) was the only unkeyed data-driven loop in the settings-redesign family; it's now keyed off `"{record.timestamp}-{i}"` (from an `enumerate()`) since `LogRecord` has no natural id.
- Extracted the "Scan Library" maintenance action (`frontend/src/pages/settings/library.rs`) into a named `scan_library_handler`, mirroring the existing `save_settings_handler` shape, so it can be driven directly in a test.
- Added direct unit tests for `save_settings_handler`'s rescan-interval validation guard (happy path + the non-numeric rejection case) and for `scan_library_handler` (in-flight flag flips synchronously on click), in the new sibling `frontend/src/pages/settings/library/tests.rs`. Both drive the real handler closures via `VirtualDom::new(...).rebuild_in_place()` with a synthetic `FormEvent`/`MouseEvent` (`SerializedFormData`/`SerializedMouseData`), so `frontend/Cargo.toml` gained a `dioxus-html` dev-dependency with the `serialize` feature to construct those.

Closes #1346

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1346 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, no warnings
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1346 cargo test -p omnibus-frontend --features server` — PASS, 476 passed; 0 failed (includes the 4 new/moved tests in `settings::library::tests`)

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- No behavior change to rendering (hydration-parity preserved per `.claude/rules/07-hydration.md`) — only a `key:` prop was added to the existing loop.
- The two new handler tests never let the spawned save/scan future actually poll, so no network call fires in tests; they only assert the synchronous guard/in-flight behavior before the request would be sent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EFzc12hKmVQqsGwyHoC7nC)_