### PR TITLE
feat: audiobook file selection in the native iOS app

### DIFF
--- a/omnibus-ios/omnibus/App/MainTabView.swift
+++ b/omnibus-ios/omnibus/App/MainTabView.swift
@@ -71,7 +71,7 @@ struct MainTabView: View {
             ReaderView(book: session.book)
         }
         .fullScreenCover(item: playerBinding) { session in
-            PlayerView(book: session.book)
+            PlayerView(book: session.book, fileID: session.fileID)
         }
         // Presented here rather than at each Read/Listen button: the surfaces
         // being refused live above the tabs, and every entry point into them
@@ -129,6 +129,10 @@ final class TabReselect {
 /// A book opened into an immersive surface.
 struct ReaderSession: Identifiable, Equatable {
     let book: Book
+    /// The audiobook file to open, when a specific one was chosen or
+    /// resumed. `nil` lets the player resolve it (saved position, then the
+    /// server default). Reader sessions never set it.
+    var fileID: Int64?
     var id: String { book.uuid }
 }
 
@@ -167,13 +171,13 @@ final class Presentation {
         reader = ReaderSession(book: book)
     }
 
-    func openPlayer(_ book: Book) {
+    func openPlayer(_ book: Book, fileID: Int64? = nil) {
         guard canOpen(book, kind: .audio) else {
             unavailable = UnavailableBook(title: book.displayTitle, kind: .audio)
             return
         }
         reader = nil
-        player = ReaderSession(book: book)
+        player = ReaderSession(book: book, fileID: fileID)
     }
 
     /// Whether this format can actually be opened: the file is on the device,

--- a/omnibus-ios/omnibus/Features/BookDetail/AudioFilePicker.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/AudioFilePicker.swift
@@ -1,0 +1,106 @@
+//  AudioFilePicker.swift
+//  Choosing which audiobook file of a book to listen to — a book can carry
+//  more than one (two narrations, an abridged edition), and they don't share
+//  a timeline.
+
+import SwiftUI
+
+/// Lists a book's audiobook files and reports the one tapped. The caller
+/// presents the player from its own `onDismiss` — presenting a full-screen
+/// cover while this sheet is still up would be refused.
+struct AudioFilePickerSheet: View {
+    let book: Book
+    let onPick: (BookFileInfo) -> Void
+
+    @Environment(\.palette) private var palette
+    @Environment(\.dismiss) private var dismiss
+
+    /// The file the saved listening position was taken in, so the row can
+    /// say which choice continues and which starts over. Read from the
+    /// replica only — this must answer instantly, offline included.
+    @State private var inProgressFileID: Int64?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: Spacing.sm) {
+                    ForEach(book.audioFiles) { file in
+                        fileRow(file)
+                    }
+                }
+                .screenPadding()
+                .padding(.top, Spacing.md)
+            }
+            .background(ScreenBackground())
+            .navigationTitle("Choose a file")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .task {
+            let saved = await UserDataService.localProgress(uuid: book.uuid, format: .audio)
+            inProgressFileID = saved?.bookFileID
+        }
+    }
+
+    private func fileRow(_ file: BookFileInfo) -> some View {
+        Button {
+            Haptics.tap()
+            onPick(file)
+            dismiss()
+        } label: {
+            HStack(spacing: Spacing.md) {
+                Image(systemName: "headphones")
+                    .font(.system(size: 20, weight: .light))
+                    .foregroundStyle(palette.accentColor)
+                    .frame(width: 38)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(file.label?.nilIfBlank ?? file.filename)
+                        .font(.ui(15.5, weight: .medium))
+                        .foregroundStyle(palette.ink0Color)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                    Text(detail(for: file))
+                        .font(.ui(12.5))
+                        .foregroundStyle(palette.ink3Color)
+                }
+
+                Spacer(minLength: 0)
+
+                if file.id == inProgressFileID {
+                    Text("In progress")
+                        .font(.ui(11, weight: .semibold))
+                        .foregroundStyle(palette.accentColor)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(palette.accentColor.opacity(0.14)))
+                }
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(palette.ink3Color)
+            }
+            .padding(Spacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                    .fill(palette.bg1Color)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                    .strokeBorder(palette.line2.color, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(PressableStyle())
+    }
+
+    private func detail(for file: BookFileInfo) -> String {
+        var parts = [file.format.uppercased()]
+        if file.sizeBytes > 0 { parts.append(Format.bytes(file.sizeBytes)) }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -108,6 +108,11 @@ struct BookDetailView: View {
     @State private var showJournalComposer = false
     @State private var showShelfPicker = false
     @State private var showBookmarks = false
+    @State private var showAudioFilePicker = false
+    /// The file chosen in the picker, opened from the sheet's `onDismiss` —
+    /// presenting the full-screen player while the sheet is still up would
+    /// be refused.
+    @State private var pickedAudioFile: BookFileInfo?
     @State private var showDeleteConfirm = false
     @State private var scrollY: CGFloat = 0
     @State private var aboutExpanded = false
@@ -172,6 +177,20 @@ struct BookDetailView: View {
                 BookmarksSheet(book: book, isAudio: book.hasAudiobook)
             }
         }
+        .sheet(isPresented: $showAudioFilePicker, onDismiss: openPickedAudioFile) {
+            if let book = model.book {
+                AudioFilePickerSheet(book: book) { file in
+                    pickedAudioFile = file
+                }
+            }
+        }
+    }
+
+    /// Open the player on the file the picker chose, once its sheet is gone.
+    private func openPickedAudioFile() {
+        guard let file = pickedAudioFile, let book = model.book else { return }
+        pickedAudioFile = nil
+        Presentation.shared.openPlayer(book, fileID: file.id)
     }
 
     private func content(_ book: Book) -> some View {
@@ -293,13 +312,25 @@ struct BookDetailView: View {
                 if book.hasAudiobook {
                     Button {
                         Haptics.tap()
-                        Presentation.shared.openPlayer(book)
+                        listen(book)
                     } label: {
                         Label("Listen", systemImage: "headphones")
                     }
                     .buttonStyle(FilledButtonStyle(prominent: !book.hasEbook))
                 }
             }
+        }
+    }
+
+    /// A book with one audiobook file opens straight into the player; one
+    /// with several asks which — they don't share a timeline, so "Listen"
+    /// alone can't say where to put the needle. The player resolves the
+    /// saved-position file on its own for the single-file case.
+    private func listen(_ book: Book) {
+        if book.audioFiles.count > 1 {
+            showAudioFilePicker = true
+        } else {
+            Presentation.shared.openPlayer(book)
         }
     }
 

--- a/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
+++ b/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
@@ -63,7 +63,9 @@ private struct HeroCard: View {
         Button {
             Haptics.tap()
             if isAudio {
-                Presentation.shared.openPlayer(book)
+                // Reopen the file the position was taken in, not the book's
+                // first one — two narrations don't share a timeline.
+                Presentation.shared.openPlayer(book, fileID: point.record.bookFileID)
             } else {
                 Presentation.shared.openReader(book)
             }

--- a/omnibus-ios/omnibus/Features/Library/ContinueReadingRail.swift
+++ b/omnibus-ios/omnibus/Features/Library/ContinueReadingRail.swift
@@ -40,7 +40,9 @@ struct ContinueReadingRail: View {
     private func open(_ point: ResumePoint) {
         switch point.record.format {
         case .audio:
-            Presentation.shared.openPlayer(point.book)
+            // Reopen the file the position was taken in, not the book's
+            // first one — two narrations don't share a timeline.
+            Presentation.shared.openPlayer(point.book, fileID: point.record.bookFileID)
         case .epub:
             Presentation.shared.openReader(point.book)
         }

--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -19,6 +19,11 @@ final class AudioPlayer {
 
     private(set) var book: Book?
     private(set) var manifest: AudiobookManifest?
+    /// The `book_files` row playback was built against. Resolved on load —
+    /// an explicit pick, else the file the saved position was taken in, else
+    /// the server's default — and carried on every position write so a
+    /// resume reopens this file rather than the book's first one.
+    private(set) var fileID: Int64?
     private(set) var isPlaying = false
     private(set) var isLoading = false
     private(set) var duration: Double = 0
@@ -85,9 +90,13 @@ final class AudioPlayer {
 
     // MARK: - Loading
 
-    func load(book: Book, autoplay: Bool = true) async {
-        // Re-opening the book that's already loaded should not restart it.
-        if self.book?.uuid == book.uuid, player != nil {
+    func load(book: Book, fileID requestedFileID: Int64? = nil, autoplay: Bool = true) async {
+        // Re-opening the book that's already loaded should not restart it —
+        // unless a different file of it was explicitly asked for. A `nil`
+        // request means "whatever is right", and what's already playing is.
+        if self.book?.uuid == book.uuid, player != nil,
+           requestedFileID == nil || requestedFileID == fileID
+        {
             if autoplay, !isPlaying { play() }
             return
         }
@@ -119,8 +128,15 @@ final class AudioPlayer {
         position = 0
         duration = 0
 
+        // The saved position is read before the manifest because it also
+        // names the file to open: an explicit pick wins, else the file the
+        // position was taken in, else the server's default (first by
+        // ordinal). Resolved up front — the manifest is built per file.
+        let local = await UserDataService.localProgress(uuid: book.uuid, format: .audio)
+        fileID = requestedFileID ?? local?.bookFileID ?? book.audioFiles.first?.id
+
         do {
-            let manifest = try await LibraryService.audiobookManifest(uuid: book.uuid)
+            let manifest = try await loadManifest(for: book)
             self.manifest = manifest
             let item = try await makeItem(for: manifest, uuid: book.uuid)
 
@@ -149,12 +165,11 @@ final class AudioPlayer {
             // elsewhere was overwritten by a stale local one before the
             // listener had heard a word. Reading first is what makes the
             // handoff work in the direction it was always claimed to.
-            let local = await UserDataService.localProgress(uuid: book.uuid, format: .audio)
             let remote = Task { @MainActor in
                 await PositionSync.newerRemote(uuid: book.uuid, format: .audio, than: local)
             }
             let opening = await firstResult(of: remote, within: PositionSync.openDeadline) ?? local
-            if let saved = opening?.audioPositionSeconds, saved > 1 {
+            if let saved = opening?.audioPositionSeconds, saved > 1, matchesLoadedFile(opening) {
                 await seek(to: saved)
             }
             // Only now may the observer write. Before this the position is
@@ -185,6 +200,38 @@ final class AudioPlayer {
         isAdoptingRate = false
     }
 
+    /// The manifest for the resolved file, falling back to the server's
+    /// default when a remembered id has gone stale — `book_files` rows churn
+    /// on reindex, so a position saved before one can name a file the book
+    /// no longer has.
+    private func loadManifest(for book: Book) async throws -> AudiobookManifest {
+        do {
+            return try await LibraryService.audiobookManifest(uuid: book.uuid, fileID: fileID)
+        } catch let error as APIError {
+            guard case .http(status: 404, message: _) = error, fileID != nil else { throw error }
+            fileID = book.audioFiles.first?.id
+            return try await LibraryService.audiobookManifest(uuid: book.uuid)
+        }
+    }
+
+    /// Whether a stored position belongs to the file being played. A record
+    /// carrying no file id predates selection (or came from an older server)
+    /// and applies to whatever is loaded — the pre-selection behaviour.
+    private func matchesLoadedFile(_ record: ProgressRecord?) -> Bool {
+        guard let recorded = record?.bookFileID, let fileID else { return true }
+        return recorded == fileID
+    }
+
+    /// Whether the resolved file is the one the server picks with no
+    /// `file_id` at all — the first audio file by ordinal. Answered `true`
+    /// when the cached `Book` doesn't carry its files: refusing the local
+    /// copy on missing data would break offline playback of a downloaded
+    /// book, which is worse than opening a mis-remembered selection.
+    private var isDefaultFileSelected: Bool {
+        guard let fileID, let defaultID = book?.audioFiles.first?.id else { return true }
+        return fileID == defaultID
+    }
+
     /// Surface a position that landed after the open deadline, if it is still
     /// ahead of where this listener has got to.
     ///
@@ -197,6 +244,7 @@ final class AudioPlayer {
             guard let record = await remote.value,
                   let seconds = record.audioPositionSeconds,
                   book?.uuid == uuid,
+                  matchesLoadedFile(record),
                   seconds > position + 1
             else { return }
             withAnimation(Motion.settle) { syncOffer = seconds }
@@ -240,7 +288,10 @@ final class AudioPlayer {
     /// remote part streams directly; multiple parts are stitched into one
     /// composition so the timeline and seeking stay continuous.
     private func makeItem(for manifest: AudiobookManifest, uuid: String) async throws -> AVPlayerItem {
-        if let local = DownloadManager.shared.localURL(for: uuid, kind: .audio) {
+        // The downloaded copy is the server's default file (the download
+        // endpoint takes no file id), so it can only stand in for that
+        // selection — any other file of the book streams.
+        if isDefaultFileSelected, let local = DownloadManager.shared.localURL(for: uuid, kind: .audio) {
             return AVPlayerItem(asset: AVURLAsset(url: local))
         }
 
@@ -389,11 +440,13 @@ final class AudioPlayer {
         // until the network answers.
         let closing = book
         let finalPosition = position
+        let finalFileID = fileID
         let pending = takePendingReport()
 
         teardown()
         book = nil
         manifest = nil
+        fileID = nil
         position = 0
         duration = 0
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
@@ -404,7 +457,8 @@ final class AudioPlayer {
                 await UserDataService.saveProgress(
                     ProgressUpdate(
                         bookUUID: closing.uuid, format: .audio,
-                        epubCFI: nil, audioPositionSeconds: finalPosition
+                        epubCFI: nil, audioPositionSeconds: finalPosition,
+                        bookFileID: finalFileID
                     )
                 )
             }
@@ -482,7 +536,8 @@ final class AudioPlayer {
         lastPersist = Date()
         await UserDataService.saveProgress(
             ProgressUpdate(
-                bookUUID: book.uuid, format: .audio, epubCFI: nil, audioPositionSeconds: position
+                bookUUID: book.uuid, format: .audio, epubCFI: nil,
+                audioPositionSeconds: position, bookFileID: fileID
             ),
             push: force
         )

--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -5,9 +5,11 @@ import SwiftUI
 
 struct PlayerView: View {
     let book: Book
+    let fileID: Int64?
 
-    init(book: Book) {
+    init(book: Book, fileID: Int64? = nil) {
         self.book = book
+        self.fileID = fileID
     }
 
     @Environment(AudioPlayer.self) private var player
@@ -76,7 +78,7 @@ struct PlayerView: View {
             .containerRelativeFrame(.horizontal)
         }
         .background(ScreenBackground())
-        .task { await player.load(book: book) }
+        .task { await player.load(book: book, fileID: fileID) }
         .sheet(isPresented: $showChapters) { ChapterSheet() }
         .sheet(isPresented: $showBookmarks) { BookmarksSheet(book: book, isAudio: true) }
         .confirmationDialog("Playback speed", isPresented: $showSpeed, titleVisibility: .visible) {
@@ -393,7 +395,8 @@ struct MiniPlayerBar: View {
                 )
 
                 Button {
-                    Presentation.shared.openPlayer(book)
+                    // The file already playing, so expanding cannot reload it.
+                    Presentation.shared.openPlayer(book, fileID: player.fileID)
                 } label: {
                     HStack(spacing: 11) {
                         BookCover(identity: CoverIdentity(book), size: .sm, cornerRadius: 4)

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -393,7 +393,7 @@ struct ProgressUpdate: Codable, Sendable {
     var clientUpdatedAt: Int64 = Int64(Date().timeIntervalSince1970)
     /// The `book_files` row the position was taken in, when the client knows
     /// it. `nil` encodes as an absent field, so a server that predates the
-    /// column (migration 0056) sees the same payload it always has.
+    /// column sees the same payload it always has.
     var bookFileID: Int64?
 
     enum CodingKeys: String, CodingKey {

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -133,6 +133,20 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
 
     static let ebookFormats: Set<String> = ["epub", "kepub", "pdf", "mobi", "azw3", "cbz", "cbr"]
     static let audioFormats: Set<String> = ["m4b", "m4a", "mp3", "aac", "flac", "ogg", "opus", "wav"]
+
+    /// The formats the server's manifest resolver admits for playback —
+    /// `resolve_audiobook_file` in `db/src/hls/query.rs` filters on exactly
+    /// these, so offering any other format as a selection would 404.
+    static let selectableAudioFormats: Set<String> = ["m4b", "m4a", "mp3"]
+
+    /// The audiobook files a listener can choose between, in the order the
+    /// server resolves them — its default (no `file_id`) is the first of
+    /// these by ordinal.
+    var audioFiles: [BookFileInfo] {
+        bookFiles
+            .filter { Self.selectableAudioFormats.contains($0.format.lowercased()) }
+            .sorted { $0.ordinal < $1.ordinal }
+    }
 }
 
 struct EbookLibrary: Codable, Sendable {
@@ -377,6 +391,10 @@ struct ProgressUpdate: Codable, Sendable {
     /// read further. The server keeps whichever position carries the later
     /// clock, so a replayed position can no longer overwrite a newer one.
     var clientUpdatedAt: Int64 = Int64(Date().timeIntervalSince1970)
+    /// The `book_files` row the position was taken in, when the client knows
+    /// it. `nil` encodes as an absent field, so a server that predates the
+    /// column (migration 0056) sees the same payload it always has.
+    var bookFileID: Int64?
 
     enum CodingKeys: String, CodingKey {
         case format
@@ -384,6 +402,7 @@ struct ProgressUpdate: Codable, Sendable {
         case epubCFI = "epub_cfi"
         case audioPositionSeconds = "audio_position_seconds"
         case clientUpdatedAt = "client_updated_at"
+        case bookFileID = "book_file_id"
     }
 }
 
@@ -399,6 +418,9 @@ struct ProgressRecord: Codable, Sendable {
     /// `nil` only against a server too old to send it. Prefer
     /// [`orderingClock`] over reading either field directly.
     var clientUpdatedAt: Int64?
+    /// The `book_files` row the position was taken in. `nil` for positions
+    /// saved before the column existed, and against older servers.
+    var bookFileID: Int64?
 
     /// The clock two positions may be compared on.
     ///
@@ -419,6 +441,7 @@ struct ProgressRecord: Codable, Sendable {
         case audioPositionSeconds = "audio_position_seconds"
         case updatedAt = "updated_at"
         case clientUpdatedAt = "client_updated_at"
+        case bookFileID = "book_file_id"
     }
 }
 

--- a/omnibus-ios/omnibus/Offline/Cache.swift
+++ b/omnibus-ios/omnibus/Offline/Cache.swift
@@ -35,7 +35,13 @@ enum CacheKey {
     static func ratingsOthers(_ uuid: String) -> String { "ratings_others:\(uuid)" }
     static func readStatus(_ uuid: String) -> String { "read_status:\(uuid)" }
     static func stats(_ range: StatsRange) -> String { "stats:\(range.rawValue)" }
-    static func manifest(_ uuid: String) -> String { "manifest:\(uuid)" }
+    /// Scoped by file as well as book when a specific `book_files` row is
+    /// requested: each file lays out its own timeline, so a manifest cached
+    /// for one narration must never answer for another. The no-file key is
+    /// unchanged so manifests cached before selection existed stay valid.
+    static func manifest(_ uuid: String, fileID: Int64? = nil) -> String {
+        fileID.map { "manifest:\(uuid):\($0)" } ?? "manifest:\(uuid)"
+    }
     static func libraryPage(_ signature: String) -> String { "books_page:\(signature)" }
     static func playbackRate(_ uuid: String) -> String { "audio_rate:\(uuid)" }
     static func suggestions(_ uuid: String) -> String { "suggestions:\(uuid)" }

--- a/omnibus-ios/omnibus/Services/LibraryService.swift
+++ b/omnibus-ios/omnibus/Services/LibraryService.swift
@@ -299,9 +299,17 @@ enum LibraryService {
     /// device goes offline — the audio file alone doesn't say how to lay it
     /// out on a timeline, so a downloaded audiobook whose manifest had never
     /// been fetched could not be opened without a network.
-    static func audiobookManifest(uuid: String) async throws -> AudiobookManifest {
-        try await Cache.settled(CacheKey.manifest(uuid)) {
-            try await APIClient.shared.get("/api/audiobooks/\(uuid)/manifest")
+    /// `fileID` targets one `book_files` row of a multi-file book; `nil` is
+    /// the server's default (first audio file by ordinal). The server 404s an
+    /// id that no longer names a file of this book — `book_files` rows churn
+    /// on reindex — and the caller decides whether to fall back.
+    static func audiobookManifest(uuid: String, fileID: Int64? = nil) async throws
+        -> AudiobookManifest
+    {
+        var query: [String: String?] = [:]
+        if let fileID { query["file_id"] = String(fileID) }
+        return try await Cache.settled(CacheKey.manifest(uuid, fileID: fileID)) {
+            try await APIClient.shared.get("/api/audiobooks/\(uuid)/manifest", query: query)
         }
     }
 

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -74,7 +74,8 @@ enum UserDataService {
             // unset here would make the optimistic row the one thing in the
             // replica that couldn't be compared against a server answer.
             updatedAt: update.clientUpdatedAt,
-            clientUpdatedAt: update.clientUpdatedAt
+            clientUpdatedAt: update.clientUpdatedAt,
+            bookFileID: update.bookFileID
         )
         await Cache.write(key, optimistic)
         await noteResumePoint(optimistic)

--- a/omnibus-ios/omnibusTests/OfflineSyncTests.swift
+++ b/omnibus-ios/omnibusTests/OfflineSyncTests.swift
@@ -342,7 +342,7 @@ struct ProgressFileIdentityTests {
 
     @Test("an unknown file encodes as an absent field, not null")
     func unknownFileIsOmitted() throws {
-        // A server that predates migration 0056 must see the payload it always
+        // A server that predates the column must see the payload it always
         // has — the web client omits the field the same way.
         let update = ProgressUpdate(
             bookUUID: "book-1", format: .audio,

--- a/omnibus-ios/omnibusTests/OfflineSyncTests.swift
+++ b/omnibus-ios/omnibusTests/OfflineSyncTests.swift
@@ -317,6 +317,110 @@ struct ProgressClockTests {
     }
 }
 
+// MARK: - Audiobook file selection
+
+@Suite("Progress file identity")
+struct ProgressFileIdentityTests {
+    private func encoded(_ update: ProgressUpdate) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(update)
+        return try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+    }
+
+    @Test("a position carries the file it was taken in")
+    func fileIdIsOnTheWire() throws {
+        // Two narrations of one book don't share a timeline; without the file
+        // id every resume lands the saved timestamp in the book's first file.
+        let update = ProgressUpdate(
+            bookUUID: "book-1", format: .audio,
+            epubCFI: nil, audioPositionSeconds: 42, bookFileID: 917
+        )
+        let object = try encoded(update)
+        #expect(object["book_file_id"] as? Int64 == 917)
+    }
+
+    @Test("an unknown file encodes as an absent field, not null")
+    func unknownFileIsOmitted() throws {
+        // A server that predates migration 0056 must see the payload it always
+        // has — the web client omits the field the same way.
+        let update = ProgressUpdate(
+            bookUUID: "book-1", format: .audio,
+            epubCFI: nil, audioPositionSeconds: 42
+        )
+        let object = try encoded(update)
+        #expect(object["book_file_id"] == nil)
+    }
+
+    @Test("a record decodes the file id, and its absence")
+    func recordDecodesTheFileId() throws {
+        let with = """
+            {"book_uuid":"b","format":"audio","audio_position_seconds":42,
+             "updated_at":7000,"book_file_id":917}
+            """
+        let without = """
+            {"book_uuid":"b","format":"audio","audio_position_seconds":42,
+             "updated_at":7000}
+            """
+        let recorded = try JSONDecoder().decode(ProgressRecord.self, from: Data(with.utf8))
+        let legacy = try JSONDecoder().decode(ProgressRecord.self, from: Data(without.utf8))
+        #expect(recorded.bookFileID == 917)
+        #expect(legacy.bookFileID == nil)
+    }
+}
+
+@Suite("Selectable audio files")
+struct AudioFileSelectionTests {
+    private func file(
+        _ id: Int64, format: String, ordinal: Int64
+    ) -> BookFileInfo {
+        BookFileInfo(
+            id: id, format: format, filename: "file-\(id).\(format.lowercased())",
+            ordinal: ordinal
+        )
+    }
+
+    @Test("only formats the manifest resolver admits are offered")
+    func onlyStreamableFormatsAreOffered() {
+        // `resolve_audiobook_file` filters on M4B / M4A / MP3 — offering a
+        // FLAC (or the epub of a dual-format book) as a choice would 404 the
+        // moment it was picked.
+        var book = Book(id: 1, filename: "b.epub")
+        book.bookFiles = [
+            file(1, format: "EPUB", ordinal: 0),
+            file(2, format: "M4B", ordinal: 0),
+            file(3, format: "FLAC", ordinal: 1),
+            file(4, format: "MP3", ordinal: 2),
+        ]
+        #expect(book.audioFiles.map(\.id) == [2, 4])
+    }
+
+    @Test("files come back in the order the server resolves them")
+    func filesAreOrderedByOrdinal() {
+        // The first of these is the server's default (no `file_id`), which is
+        // what makes "is the downloaded copy usable for this selection"
+        // answerable at all.
+        var book = Book(id: 1, filename: "b.m4b")
+        book.bookFiles = [
+            file(9, format: "M4B", ordinal: 2),
+            file(7, format: "M4B", ordinal: 0),
+            file(8, format: "M4A", ordinal: 1),
+        ]
+        #expect(book.audioFiles.map(\.id) == [7, 8, 9])
+    }
+
+    @Test("a manifest is cached per file, and the default key is unchanged")
+    func manifestKeysAreFileScoped() {
+        // One narration's timeline must never answer for another's — and the
+        // no-file key has to keep its old shape so manifests cached before
+        // selection existed (the download prefetch path) stay valid.
+        #expect(CacheKey.manifest("u") == "manifest:u")
+        #expect(CacheKey.manifest("u", fileID: nil) == "manifest:u")
+        #expect(CacheKey.manifest("u", fileID: 5) == "manifest:u:5")
+        #expect(CacheKey.manifest("u", fileID: 5) != CacheKey.manifest("u", fileID: 6))
+    }
+}
+
 // MARK: - Account scoping
 
 @Suite("User-scoped cache wipe")
@@ -366,8 +470,8 @@ struct UserScopedPrefixTests {
         // wiping them would re-download the whole mirror on every sign-in.
         for key in [
             CacheKey.library, CacheKey.authors, CacheKey.series, CacheKey.tags,
-            CacheKey.book(uuid), CacheKey.manifest(uuid), CacheKey.suggestions(uuid),
-            CacheKey.libraryPage("title.asc."),
+            CacheKey.book(uuid), CacheKey.manifest(uuid), CacheKey.manifest(uuid, fileID: 9),
+            CacheKey.suggestions(uuid), CacheKey.libraryPage("title.asc."),
         ] {
             let covered = OfflineStore.userScopedPrefixes.contains { key.hasPrefix($0) }
             #expect(!covered, "library-wide key \"\(key)\" is being wiped on account switch")


### PR DESCRIPTION
## Summary
- Book Detail's Listen action now opens a picker when a book carries more than one streamable audiobook file (label, format, size, and an "In progress" tag on the file the saved position was taken in); single-file books open the player directly as before.
- The player resolves which `book_files` row to open — explicit pick, else the file the saved position names, else the server default — fetches the manifest with `?file_id=`, and falls back to the default when a remembered id has gone stale.
- Positions are written and restored with `book_file_id`: `ProgressUpdate`/`ProgressRecord` carry it (omitted when unknown, so pre-0056 servers see the payload they always have), Continue surfaces reopen the recorded file, and positions from a different file are never applied to the loaded one.
- Manifests are cached per file; the downloaded copy only stands in for the default selection (any other file streams).

Closes #1422

## Test plan
- [x] `xcodebuild test` (omnibusTests, iPhone 17 simulator) — 36/36 passed, including 6 new tests covering the progress wire contract (`book_file_id` present/omitted/decoded), the selectable-format filter + ordering, and per-file manifest cache keys.
- [x] Full app target compiles as part of the test build.

## Version
- [ ] **Minor**
- [x] **Patch** — default
- [ ] **No release**

## Notes
>[!NOTE]
> Pairs with #1416, which adds the server-side `book_file_id` column on `reading_progress` and the re-resolved id on `resume_points`. This PR is file-disjoint from it and degrades gracefully against a server without it (the field is ignored on POST and absent on reads), but AC3 of #1422 — resuming the exact narration — only takes full effect once #1416 lands.