### PR TITLE
feat: rebuild the iOS audiobook player around chapters, Audible-style

### DIFF
--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -257,6 +257,71 @@ stitched into one `AVMutableComposition` so the timeline and seeking stay
 continuous. `MPNowPlayingInfoCenter` + `MPRemoteCommandCenter` give lock-screen,
 Control Center, AirPlay, and CarPlay transport.
 
+**The chapter is the unit of the player, Audible-style.** The layout follows
+Audible's, top to bottom: artwork, then the chapter name left-aligned behind a
+`☰` and tappable straight into the chapter list, then the scrubber, then a
+five-slot transport (chapter back · skip back · play · skip forward · chapter
+forward), then Speed · Car Mode · Sleep · Bookmark.
+
+The scrubber spans the *current chapter*, not the book: on a twelve-hour
+audiobook a whole-book bar puts every chapter boundary within a couple of points
+of its neighbours, so the one gesture the control exists for can't be aimed. The
+three readouts under it are chapter elapsed, **book** remaining, chapter
+remaining — all at once, which is what pays for the chapter-scoped bar without
+needing a mode. The mini bar's hairline stays whole-book for the same reason.
+
+It's a hand-rolled `PlayerScrubber`, not a `Slider`: `Slider` draws a fixed 27pt
+pill thumb and its own inset chrome, and no amount of tinting gets it to the slim
+track every player of this shape uses. The parent owns the drag position so the
+thumb and the readouts can't disagree; a plain tap on the track seeks there too.
+
+The play disc is intrinsically sized rather than taking an equal fifth of the
+transport, so the four steppers split what's left and it can't be squeezed —
+which is what went wrong when chapter-skip first moved into this row.
+
+`ChapterTimeline` owns every bit of the arithmetic — which chapter a position is
+in, how long it runs, where its span starts — as a value type with no AVPlayer
+behind it, because the scrubber, the "Ch N of M" readout, the countdown and the
+prev/next enablement all read the same three functions, so an off-by-one surfaces
+in four places and in none of them obviously. Two cases it exists to pin: a
+chapter that ships `duration_seconds` as 0 (common in real files) measures to the
+next chapter's start, or to the end of the book if it's the last; and a position
+*before* the first chapter's mark resolves to that chapter rather than to `nil`,
+since containers routinely start chapter one a second or two in and "no chapter"
+is not a place you can be listening. A book with no marks at all degrades to a
+whole-book span, and the chapter row and lock-screen chapter commands drop out.
+
+**The artwork gets a share of the screen, not the remainder.** Sizing the cover
+as whatever the transport left over made it resize between books — a title that
+wrapped to two lines cost it 30pt — and on a short phone it drove the layout's
+spacers to zero, wedging the cover against the scrubber. It now takes a fraction
+of the band between the two safe-area insets. The fraction tapers on a short
+screen (0.66 under a 380pt band, 0.76 above): the transport's height is fixed, so
+on a 4.7" phone it claims a far larger share of the screen than on a 6.3" one, and
+holding the tall-screen fraction there re-creates the squeeze.
+
+> **An aspect-fill image in a layout container grows it.** `RemoteImage` renders
+> `.resizable().scaledToFill()`, and a `.fill` aspect ratio *reports* a size
+> larger than the box it fills — that is what filling means. Sat directly in the
+> player's backdrop `ZStack` with no frame and no `.clipped()`, it grew the stack
+> past the screen, and `safeAreaInset` then measured the chrome against those
+> bounds: the top bar landed under the status bar and the utility row's labels
+> fell off the bottom. Nothing errors and nothing logs.
+>
+> It only reproduces on a book with **real cover art** — a generated plate is
+> gradients and `Color`s, all infinitely flexible, so they accept the proposal
+> instead of overriding it. Every generated audiobook fixture is coverless, which
+> is how this shipped: put a cover on one (`POST /api/ebooks/{uuid}/cover`)
+> before trusting a player screenshot. Hold decorative art in a
+> `Color.clear.overlay { … }.clipped()` — an overlay can't grow its parent, which
+> is the same reason `BookCover` puts its art in one.
+
+**Car Mode is a face, not a mode.** It drives the same `AudioPlayer` and adds no
+playback behaviour — five targets none smaller than a thumb, and nothing that
+needs aiming (scrubber, chapter list, speed, bookmarks) reachable from it. It
+holds `isIdleTimerDisabled` while open, since a driver won't tap every 30 seconds
+to keep the screen up and a dark screen is the only reason they'd look down.
+
 **Cached reads have a freshness bound.** `Cache.readThrough` serves the replica
 within `freshnessWindow` (45s) and goes to the network past it, falling back to
 the replica either way when offline. Without the bound, anything changed
@@ -289,4 +354,6 @@ carries a TODO to harden it; this does that.
   read status alone does not populate it. The server also caches stats for 60s,
   so a fresh entry takes up to a minute to appear.
 - Author photo editing, book merging, and the admin log viewer are not ported.
-- No test target yet.
+- Test coverage is limited to the pure logic worth pinning — the offline layer
+  (`omnibusTests/OfflineSyncTests.swift`) and the player's chapter arithmetic
+  (`omnibusTests/ChapterTimelineTests.swift`). No screen-level coverage.

--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -78,6 +78,19 @@ final class AudioPlayer {
 
     private init() {
         configureRemoteCommands()
+        syncChapterCommands()
+    }
+
+    /// Point the lock screen's chapter-skip buttons at whether there are chapters
+    /// to skip. A book with no marks would otherwise offer two controls that
+    /// return without doing anything.
+    ///
+    /// Called from every place `timeline` is assigned — that pairing is the whole
+    /// invariant, since the commands are process-wide and outlive any one book.
+    private func syncChapterCommands() {
+        let center = MPRemoteCommandCenter.shared()
+        center.nextTrackCommand.isEnabled = hasChapters
+        center.previousTrackCommand.isEnabled = hasChapters
     }
 
     var isActive: Bool { book != nil }
@@ -171,11 +184,7 @@ final class AudioPlayer {
             // no length of its own measures to the next chapter's start, and the
             // last one has only the end of the book to measure to.
             timeline = ChapterTimeline(chapters: manifest.chapters, bookDuration: duration)
-            // A lock screen offering chapter skip on a book with no chapter marks
-            // gives two buttons that do nothing.
-            let center = MPRemoteCommandCenter.shared()
-            center.nextTrackCommand.isEnabled = hasChapters
-            center.previousTrackCommand.isEnabled = hasChapters
+            syncChapterCommands()
 
             adoptRate(await loadRate(uuid: book.uuid))
 
@@ -479,6 +488,12 @@ final class AudioPlayer {
         // manifest, and leaving this up means the chapter bar spends that window
         // offering to seek inside the book that was just closed.
         timeline = ChapterTimeline()
+        // Paired with the line above so the lock screen's chapter buttons can
+        // never outlive the chapter data they act on. `load` tears down and then
+        // *awaits* the next manifest, so leaving the previous book's enablement
+        // standing offered chapter skip across that whole window — and with an
+        // empty timeline both commands return without doing anything.
+        syncChapterCommands()
         // Closed again so the next book cannot be written to before its own
         // opening position has been settled — this is the one flag whose stale
         // value would be silently destructive rather than merely wrong.
@@ -682,14 +697,10 @@ final class AudioPlayer {
             Task { @MainActor in self?.skip(-15) }
             return .success
         }
-        // Both start disabled and `load` turns them on once it knows whether
-        // this book has chapter marks at all.
-        center.nextTrackCommand.isEnabled = false
         center.nextTrackCommand.addTarget { [weak self] _ in
             Task { @MainActor in self?.nextChapter() }
             return .success
         }
-        center.previousTrackCommand.isEnabled = false
         center.previousTrackCommand.addTarget { [weak self] _ in
             Task { @MainActor in self?.previousChapter() }
             return .success

--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -71,17 +71,47 @@ final class AudioPlayer {
     /// reconcile was still in the middle of correcting, and win.
     private var positionSettled = false
 
+    /// Chapter geometry for the book that's open. Rebuilt once per load — every
+    /// lookup on it runs off a half-second time observer, so it can't afford to
+    /// re-sort per tick.
+    private(set) var timeline = ChapterTimeline()
+
     private init() {
         configureRemoteCommands()
     }
 
-    var chapters: [ChapterInfo] { manifest?.chapters ?? [] }
+    var isActive: Bool { book != nil }
 
-    var currentChapter: ChapterInfo? {
-        chapters.last { position >= $0.startSeconds }
+    // MARK: - Chapters
+
+    var chapters: [ChapterInfo] { timeline.chapters }
+
+    var hasChapters: Bool { !timeline.isEmpty }
+
+    var currentChapterIndex: Int? { timeline.index(at: position) }
+
+    var currentChapter: ChapterInfo? { timeline.chapter(at: position) }
+
+    /// Start of the span the scrubber covers: the current chapter, or the whole
+    /// book when there are no chapters to scope it to.
+    var chapterStart: Double { timeline.span(at: position).start }
+
+    /// Length of that span.
+    var chapterDuration: Double { timeline.span(at: position).duration }
+
+    /// How far into the span playback has got.
+    var chapterOffset: Double { max(0, position - chapterStart) }
+
+    func chapterLength(at index: Int) -> Double { timeline.length(at: index) }
+
+    var canGoNextChapter: Bool {
+        guard let index = currentChapterIndex else { return false }
+        return index + 1 < timeline.count
     }
 
-    var isActive: Bool { book != nil }
+    /// Previous is available in the first chapter too — there it restarts,
+    /// which is the verb the button has in every other player.
+    var canGoPreviousChapter: Bool { hasChapters }
 
     // MARK: - Loading
 
@@ -136,6 +166,16 @@ final class AudioPlayer {
                 duration = 0
             }
             if !duration.isFinite { duration = 0 }
+
+            // Built after `duration`, not with the manifest: a chapter that ships
+            // no length of its own measures to the next chapter's start, and the
+            // last one has only the end of the book to measure to.
+            timeline = ChapterTimeline(chapters: manifest.chapters, bookDuration: duration)
+            // A lock screen offering chapter skip on a book with no chapter marks
+            // gives two buttons that do nothing.
+            let center = MPRemoteCommandCenter.shared()
+            center.nextTrackCommand.isEnabled = hasChapters
+            center.previousTrackCommand.isEnabled = hasChapters
 
             adoptRate(await loadRate(uuid: book.uuid))
 
@@ -332,21 +372,29 @@ final class AudioPlayer {
     }
 
     func seekToChapter(_ chapter: ChapterInfo) {
+        Haptics.tap()
         Task { await seek(to: chapter.startSeconds) }
     }
 
+    /// Seek to an offset inside the current chapter — what the chapter-scoped
+    /// scrubber hands back.
+    func seekWithinChapter(to offset: Double) async {
+        await seek(to: chapterStart + offset)
+    }
+
     func nextChapter() {
-        guard let next = chapters.first(where: { $0.startSeconds > position + 1 }) else { return }
-        seekToChapter(next)
+        guard let index = currentChapterIndex, index + 1 < chapters.count else { return }
+        seekToChapter(chapters[index + 1])
     }
 
     func previousChapter() {
         // Within the first few seconds of a chapter, go to the one before it;
         // otherwise restart the current chapter — the usual player convention.
-        guard let current = currentChapter else { return }
-        if position - current.startSeconds > 3 {
+        guard let index = currentChapterIndex else { return }
+        let current = chapters[index]
+        if position - current.startSeconds > 3 || index == 0 {
             seekToChapter(current)
-        } else if let index = chapters.firstIndex(where: { $0.ordinal == current.ordinal }), index > 0 {
+        } else {
             seekToChapter(chapters[index - 1])
         }
     }
@@ -427,6 +475,10 @@ final class AudioPlayer {
         // checkpoint first, and anything left is not the next book's.
         sessionStart = nil
         listenedSeconds = 0
+        // Cleared with the player, not with the book: `load` awaits the next
+        // manifest, and leaving this up means the chapter bar spends that window
+        // offering to seek inside the book that was just closed.
+        timeline = ChapterTimeline()
         // Closed again so the next book cannot be written to before its own
         // opening position has been settled — this is the one flag whose stale
         // value would be silently destructive rather than merely wrong.
@@ -573,6 +625,10 @@ final class AudioPlayer {
             MPNowPlayingInfoPropertyPlaybackRate: isPlaying ? rate : 0,
             MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.audio.rawValue,
         ]
+        if let index = currentChapterIndex {
+            info[MPNowPlayingInfoPropertyChapterNumber] = index + 1
+            info[MPNowPlayingInfoPropertyChapterCount] = chapters.count
+        }
         if let artwork = currentArtwork {
             info[MPMediaItemPropertyArtwork] = artwork
         }
@@ -626,10 +682,14 @@ final class AudioPlayer {
             Task { @MainActor in self?.skip(-15) }
             return .success
         }
+        // Both start disabled and `load` turns them on once it knows whether
+        // this book has chapter marks at all.
+        center.nextTrackCommand.isEnabled = false
         center.nextTrackCommand.addTarget { [weak self] _ in
             Task { @MainActor in self?.nextChapter() }
             return .success
         }
+        center.previousTrackCommand.isEnabled = false
         center.previousTrackCommand.addTarget { [weak self] _ in
             Task { @MainActor in self?.previousChapter() }
             return .success

--- a/omnibus-ios/omnibus/Features/Player/CarModeView.swift
+++ b/omnibus-ios/omnibus/Features/Player/CarModeView.swift
@@ -16,6 +16,9 @@ struct CarModeView: View {
     @Environment(\.palette) private var palette
     @Environment(\.dismiss) private var dismiss
 
+    /// What the idle timer was set to before Car Mode took it over.
+    @State private var wasIdleTimerDisabled = false
+
     var body: some View {
         VStack(spacing: Spacing.lg) {
             header
@@ -29,8 +32,15 @@ struct CarModeView: View {
         .background(palette.bg0Color.ignoresSafeArea())
         // A driver isn't going to tap every 30 seconds to keep the screen up,
         // and a dark screen is the whole reason they'd look down at all.
-        .onAppear { UIApplication.shared.isIdleTimerDisabled = true }
-        .onDisappear { UIApplication.shared.isIdleTimerDisabled = false }
+        //
+        // Restored to what it was rather than to `false`: the flag is
+        // process-wide, so hard-clearing it on exit would stamp on any other
+        // surface that had a reason to hold the screen awake.
+        .onAppear {
+            wasIdleTimerDisabled = UIApplication.shared.isIdleTimerDisabled
+            UIApplication.shared.isIdleTimerDisabled = true
+        }
+        .onDisappear { UIApplication.shared.isIdleTimerDisabled = wasIdleTimerDisabled }
     }
 
     private var header: some View {

--- a/omnibus-ios/omnibus/Features/Player/CarModeView.swift
+++ b/omnibus-ios/omnibus/Features/Player/CarModeView.swift
@@ -1,0 +1,121 @@
+//  CarModeView.swift
+//  A driving face for the player: five targets, none of them small.
+//
+//  Everything here is the same `AudioPlayer` the full player drives — this adds
+//  no playback behaviour, only a face you can hit without looking. Nothing that
+//  needs aiming (the scrubber, the chapter list, speed, bookmarks) is reachable
+//  from here on purpose.
+
+import SwiftUI
+import UIKit
+
+struct CarModeView: View {
+    let book: Book
+
+    @Environment(AudioPlayer.self) private var player
+    @Environment(\.palette) private var palette
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: Spacing.lg) {
+            header
+            Spacer(minLength: 0)
+            transport
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Spacing.screen)
+        .padding(.vertical, Spacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(palette.bg0Color.ignoresSafeArea())
+        // A driver isn't going to tap every 30 seconds to keep the screen up,
+        // and a dark screen is the whole reason they'd look down at all.
+        .onAppear { UIApplication.shared.isIdleTimerDisabled = true }
+        .onDisappear { UIApplication.shared.isIdleTimerDisabled = false }
+    }
+
+    private var header: some View {
+        VStack(spacing: Spacing.sm) {
+            HStack {
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 19, weight: .semibold))
+                        .foregroundStyle(palette.ink1Color)
+                        .frame(width: 52, height: 52)
+                        .background(Circle().fill(palette.bg2Color))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Leave car mode")
+            }
+
+            Text(player.currentChapter?.title ?? book.displayTitle)
+                .font(.ui(24, weight: .semibold))
+                .foregroundStyle(palette.ink0Color)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+
+            Text(Format.humanDuration(Int64(max(0, player.duration - player.position))) + " left")
+                .font(.ui(16))
+                .monospacedDigit()
+                .foregroundStyle(palette.ink2Color)
+        }
+    }
+
+    private var transport: some View {
+        VStack(spacing: Spacing.md) {
+            HStack(spacing: Spacing.md) {
+                tile("gobackward.15", label: "Back 15 seconds") { player.skip(-15) }
+                tile("goforward.30", label: "Forward 30 seconds") { player.skip(30) }
+            }
+
+            Button { player.toggle() } label: {
+                Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(palette.bg0Color)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 176)
+                    .background(
+                        RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+                            .fill(palette.accentColor)
+                    )
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(player.isPlaying ? "Pause" : "Play")
+
+            HStack(spacing: Spacing.md) {
+                tile(
+                    "backward.end.fill",
+                    label: "Previous chapter",
+                    enabled: player.canGoPreviousChapter
+                ) { player.previousChapter() }
+                tile(
+                    "forward.end.fill",
+                    label: "Next chapter",
+                    enabled: player.canGoNextChapter
+                ) { player.nextChapter() }
+            }
+        }
+    }
+
+    private func tile(
+        _ icon: String, label: String, enabled: Bool = true, action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 38))
+                .foregroundStyle(enabled ? palette.ink0Color : palette.ink3Color)
+                .frame(maxWidth: .infinity)
+                .frame(height: 132)
+                .background(
+                    RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+                        .fill(palette.bg1Color)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .accessibilityLabel(label)
+    }
+}

--- a/omnibus-ios/omnibus/Features/Player/ChapterTimeline.swift
+++ b/omnibus-ios/omnibus/Features/Player/ChapterTimeline.swift
@@ -1,0 +1,60 @@
+//  ChapterTimeline.swift
+//  The chapter arithmetic behind the player's chapter-scoped scrubber.
+//
+//  A value type over the sorted chapter list, so "which chapter is this, how
+//  long does it run, where does its span start" can be pinned by tests without
+//  an AVPlayer behind it. `AudioPlayer` holds one and delegates to it.
+
+import Foundation
+
+struct ChapterTimeline {
+    /// Chapters in timeline order.
+    let chapters: [ChapterInfo]
+
+    /// Whole-book duration. The last chapter's length falls back to it, and it
+    /// is the span reported when there are no chapters at all.
+    let bookDuration: Double
+
+    /// Sorts on the way in: the manifest orders by container ordinal, and every
+    /// lookup here is positional.
+    init(chapters: [ChapterInfo] = [], bookDuration: Double = 0) {
+        self.chapters = chapters.sorted { $0.startSeconds < $1.startSeconds }
+        self.bookDuration = max(0, bookDuration)
+    }
+
+    var isEmpty: Bool { chapters.isEmpty }
+
+    var count: Int { chapters.count }
+
+    /// Index of the chapter `position` falls in.
+    ///
+    /// `nil` only when there are no chapters. A position *before* the first
+    /// chapter's start still resolves to it — some containers put chapter one a
+    /// second or two in, and "no chapter" is not a place you can be listening.
+    func index(at position: Double) -> Int? {
+        guard !chapters.isEmpty else { return nil }
+        return chapters.lastIndex { position >= $0.startSeconds } ?? 0
+    }
+
+    func chapter(at position: Double) -> ChapterInfo? {
+        index(at: position).map { chapters[$0] }
+    }
+
+    /// A chapter's length, falling back to the gap up to the next chapter — a
+    /// good number of real audiobooks ship `duration_seconds` as 0, and a
+    /// zero-length span traps the scrubber at one end.
+    func length(at index: Int) -> Double {
+        guard chapters.indices.contains(index) else { return 0 }
+        let chapter = chapters[index]
+        if chapter.durationSeconds > 0 { return chapter.durationSeconds }
+        let end = index + 1 < chapters.count ? chapters[index + 1].startSeconds : bookDuration
+        return max(0, end - chapter.startSeconds)
+    }
+
+    /// Start and length of the span the scrubber covers at `position`: the
+    /// current chapter, or the whole book when there is nothing to scope it to.
+    func span(at position: Double) -> (start: Double, duration: Double) {
+        guard let index = index(at: position) else { return (0, bookDuration) }
+        return (chapters[index].startSeconds, length(at: index))
+    }
+}

--- a/omnibus-ios/omnibus/Features/Player/PlayerScrubber.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerScrubber.swift
@@ -1,0 +1,74 @@
+//  PlayerScrubber.swift
+//  The slim seek track under the artwork.
+//
+//  `Slider` can't be reshaped this far — it draws a fixed 27pt pill thumb and
+//  its own inset chrome — so this is two capsules and a `DragGesture`. The
+//  parent owns the drag position so the readouts and the thumb can't disagree;
+//  all this keeps locally is whether a finger is down, for the thumb's lift.
+
+import SwiftUI
+
+struct PlayerScrubber: View {
+    /// Where playback is, 0...1.
+    let fraction: Double
+    let tint: Color
+    /// The drag position, reported continuously so the readouts can follow it.
+    let onScrub: (Double) -> Void
+    /// The final position, once the finger lifts.
+    let onCommit: (Double) -> Void
+
+    @Environment(\.palette) private var palette
+
+    @State private var isDragging = false
+
+    private let trackHeight: CGFloat = 4
+    private let thumbSize: CGFloat = 14
+
+    var body: some View {
+        GeometryReader { geo in
+            // The thumb travels between its own radii so it never clips an end,
+            // and the fill tracks the thumb's centre rather than the raw
+            // fraction — otherwise the two disagree by a radius at each end.
+            let travel = max(1, geo.size.width - thumbSize)
+            let centre = thumbSize / 2 + min(1, max(0, fraction)) * travel
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(palette.ink3Color.opacity(0.35))
+                    .frame(height: trackHeight)
+
+                Capsule()
+                    .fill(tint)
+                    .frame(width: centre, height: trackHeight)
+
+                Circle()
+                    .fill(tint)
+                    .frame(width: thumbSize, height: thumbSize)
+                    .scaleEffect(isDragging ? 1.35 : 1)
+                    .offset(x: centre - thumbSize / 2)
+            }
+            .frame(height: geo.size.height)
+            // The whole band takes the touch, not just the 4pt track.
+            .contentShape(Rectangle())
+            .gesture(
+                // `minimumDistance: 0` so a plain tap on the track seeks there
+                // too, which is what every player of this shape does.
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        isDragging = true
+                        onScrub(position(of: value.location.x, travel: travel))
+                    }
+                    .onEnded { value in
+                        isDragging = false
+                        onCommit(position(of: value.location.x, travel: travel))
+                    }
+            )
+            .animation(Motion.snap, value: isDragging)
+        }
+        .frame(height: 28)
+    }
+
+    private func position(of x: CGFloat, travel: CGFloat) -> Double {
+        min(1, max(0, (x - thumbSize / 2) / travel))
+    }
+}

--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -14,29 +14,31 @@ struct PlayerView: View {
     @Environment(\.palette) private var palette
     @Environment(\.dismiss) private var dismiss
 
-    @State private var scrubPosition: Double?
+    /// Offset inside the scrubbed span while a drag is in flight.
+    @State private var scrubOffset: Double?
     @State private var showChapters = false
     @State private var showSleepTimer = false
     @State private var showSpeed = false
     @State private var showBookmarks = false
+    @State private var showCarMode = false
 
     private static let rates: [Double] = [0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0]
+
+    /// Share of the band between the two insets the artwork may take.
+    ///
+    /// It tapers on a short screen. The transport's height is fixed, so on a
+    /// 4.7" phone it eats a much larger fraction of the screen than on a 6.3"
+    /// one, and holding the artwork at the tall-screen share there leaves the
+    /// title with nothing — which is the squeeze this whole layout exists to
+    /// avoid.
+    private static func coverShare(in bandHeight: CGFloat) -> CGFloat {
+        bandHeight < 380 ? 0.66 : 0.76
+    }
 
     var body: some View {
         ZStack {
             backdrop
-
-            // Artwork + titles own the middle; the transport and the top bar
-            // are attached as safe-area insets so they reserve their space
-            // instead of competing for it in one VStack — which silently
-            // compressed them to nothing on a full-screen cover.
-            VStack(spacing: Spacing.lg) {
-                Spacer(minLength: 0)
-                cover
-                titles
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, Spacing.screen)
+            stage
 
             if player.isLoading {
                 LoadingView(label: "Preparing audio")
@@ -61,24 +63,21 @@ struct PlayerView: View {
         .safeAreaInset(edge: .top, spacing: 0) {
             topBar
                 .padding(.horizontal, Spacing.screen)
-                .padding(.vertical, Spacing.sm)
+                .padding(.vertical, Spacing.xs)
                 .containerRelativeFrame(.horizontal)
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            VStack(spacing: Spacing.lg) {
-                scrubber
-                transport
-                secondaryControls
-            }
-            .padding(.horizontal, Spacing.screen)
-            .padding(.top, Spacing.lg)
-            .padding(.bottom, Spacing.sm)
-            .containerRelativeFrame(.horizontal)
+            controls
+                .padding(.horizontal, Spacing.screen)
+                .padding(.top, Spacing.sm)
+                .padding(.bottom, Spacing.xs)
+                .containerRelativeFrame(.horizontal)
         }
         .background(ScreenBackground())
         .task { await player.load(book: book) }
         .sheet(isPresented: $showChapters) { ChapterSheet() }
         .sheet(isPresented: $showBookmarks) { BookmarksSheet(book: book, isAudio: true) }
+        .fullScreenCover(isPresented: $showCarMode) { CarModeView(book: book) }
         .confirmationDialog("Playback speed", isPresented: $showSpeed, titleVisibility: .visible) {
             ForEach(Self.rates, id: \.self) { value in
                 Button(Self.rateLabel(value)) { player.rate = value }
@@ -120,11 +119,25 @@ struct PlayerView: View {
             )
 
             if book.coverURL != nil {
-                RemoteImage(path: "/api/thumbs/\(book.uuid)/md") { Color.clear }
-                    .scaledToFill()
-                    .blur(radius: 70, opaque: true)
-                    .saturation(1.5)
-                    .opacity(0.4)
+                // Held inside a flexible `Color` rather than sat in the stack
+                // directly. An aspect-*fill* image reports a size bigger than
+                // the box it fills — that is what filling means — and as a bare
+                // `ZStack` sibling that grew the stack past the screen, at which
+                // point `safeAreaInset` hung the top bar under the status bar and
+                // pushed the utility row's labels off the bottom edge. An
+                // overlay can't grow its parent, which is the same reason
+                // `BookCover` puts its art in one.
+                //
+                // Only books with real artwork could hit it; a generated plate
+                // is gradients all the way down, and those are flexible.
+                Color.clear
+                    .overlay {
+                        RemoteImage(path: "/api/thumbs/\(book.uuid)/md") { Color.clear }
+                            .blur(radius: 70, opaque: true)
+                            .saturation(1.5)
+                            .opacity(0.4)
+                    }
+                    .clipped()
             }
 
             LinearGradient(
@@ -133,6 +146,26 @@ struct PlayerView: View {
             )
         }
         .ignoresSafeArea()
+    }
+
+    /// Artwork and titles, in the band the two insets leave.
+    ///
+    /// The cover takes a definite share of that band rather than *being* what's
+    /// left of it. As the remainder it resized between books — a title that
+    /// wrapped to two lines cost it 30pt of height — and on a short phone it
+    /// drove both spacers to zero, so the artwork sat wedged against the
+    /// scrubber with no margin anywhere on the screen.
+    private var stage: some View {
+        GeometryReader { band in
+            VStack(spacing: Spacing.md) {
+                Spacer(minLength: 0)
+                cover(maxHeight: max(140, band.size.height * Self.coverShare(in: band.size.height)))
+                titles
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(.horizontal, Spacing.screen)
     }
 
     private var topBar: some View {
@@ -169,16 +202,18 @@ struct PlayerView: View {
         .buttonStyle(.plain)
     }
 
-    private var cover: some View {
-        BookCover(identity: CoverIdentity(uuid: book.uuid, title: book.displayTitle, hasCover: book.coverURL != nil), size: .lg, cornerRadius: Radius.lg)
-        .frame(maxWidth: 320)
-        .shadow(color: .black.opacity(0.5), radius: 28, x: 0, y: 16)
-        .scaleEffect(player.isPlaying ? 1 : 0.94)
-        .animation(Motion.glide, value: player.isPlaying)
+    /// Takes the whole `CoverIdentity`, accent included, so the generated plate
+    /// can't disagree with the wash `backdrop` derives from the same book.
+    private func cover(maxHeight: CGFloat) -> some View {
+        BookCover(identity: CoverIdentity(book), size: .lg, cornerRadius: Radius.lg)
+            .frame(maxWidth: 300, maxHeight: maxHeight)
+            .shadow(color: .black.opacity(0.5), radius: 28, x: 0, y: 16)
+            .scaleEffect(player.isPlaying ? 1 : 0.94)
+            .animation(Motion.glide, value: player.isPlaying)
     }
 
     private var titles: some View {
-        VStack(spacing: 5) {
+        VStack(spacing: 4) {
             Text(book.displayTitle)
                 .font(.display(25))
                 .foregroundStyle(palette.ink0Color)
@@ -188,125 +223,209 @@ struct PlayerView: View {
                 .font(.ui(14))
                 .foregroundStyle(palette.ink2Color)
                 .lineLimit(1)
-            if let chapter = player.currentChapter {
-                Button { showChapters = true } label: {
-                    Label(chapter.title, systemImage: "list.bullet")
-                        .font(.ui(12, weight: .medium))
-                        .foregroundStyle(palette.accentColor)
-                        .lineLimit(1)
-                }
-                .buttonStyle(.plain)
-                .padding(.top, 2)
-            }
         }
     }
 
+    // MARK: - Controls
+
+    private var controls: some View {
+        VStack(spacing: 0) {
+            chapterRow
+            scrubber
+                .padding(.top, Spacing.sm)
+            transport
+                .padding(.top, Spacing.sm)
+            utilityRow
+                .padding(.top, Spacing.md)
+        }
+    }
+
+    /// The chapter name, above the scrubber and tappable straight into the
+    /// chapter list. It carries the most weight of anything down here because
+    /// "where am I" is a chapter name before it's a timestamp.
+    @ViewBuilder
+    private var chapterRow: some View {
+        if let chapter = player.currentChapter {
+            Button { showChapters = true } label: {
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: "list.bullet")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(palette.ink2Color)
+                    Text(chapter.title)
+                        .font(.ui(17, weight: .semibold))
+                        .foregroundStyle(palette.ink0Color)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+                .frame(height: 38)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    /// Scoped to the current chapter: one bar width is one chapter, which is the
+    /// span you can actually aim inside — on a twelve-hour book a whole-book bar
+    /// puts every chapter boundary within a couple of points of its neighbours.
+    ///
+    /// A book with no chapter marks falls back to the whole book, which is what
+    /// `chapterStart` / `chapterDuration` report in that case.
     private var scrubber: some View {
-        VStack(spacing: 4) {
-            Slider(
-                value: Binding(
-                    get: { min(scrubPosition ?? player.position, sliderUpperBound) },
-                    set: { scrubPosition = $0 }
-                ),
-                in: 0...sliderUpperBound,
-                onEditingChanged: { editing in
-                    guard !editing, let target = scrubPosition else { return }
+        VStack(spacing: Spacing.xs) {
+            PlayerScrubber(
+                fraction: displayedOffset / spanUpperBound,
+                tint: palette.accentColor,
+                onScrub: { scrubOffset = $0 * spanUpperBound },
+                onCommit: { target in
+                    let seconds = target * spanUpperBound
+                    scrubOffset = seconds
                     Task {
-                        await player.seek(to: target)
-                        scrubPosition = nil
+                        await player.seekWithinChapter(to: seconds)
+                        scrubOffset = nil
                     }
                 }
             )
-            .tint(palette.accentColor)
 
-            HStack {
-                Text(Format.duration(scrubPosition ?? player.position))
-                Spacer()
-                Text("-" + Format.duration(max(0, player.duration - (scrubPosition ?? player.position))))
+            // Chapter elapsed, book remaining, chapter remaining — all three at
+            // once. The middle one is the whole-book context that a
+            // chapter-scoped bar would otherwise cost you.
+            HStack(spacing: Spacing.sm) {
+                Text(Format.duration(displayedOffset))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if player.hasChapters {
+                    Text(Format.humanDuration(Int64(bookRemaining)) + " left")
+                }
+
+                Text(chapterRemainingLabel)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
             }
-            .font(.monoUI(11))
+            .font(.ui(12))
+            .monospacedDigit()
             .foregroundStyle(palette.ink2Color)
+            .frame(height: 16)
         }
     }
 
-    /// A zero-length range traps `Slider`, and duration is 0 until the asset
-    /// resolves, so the upper bound never drops below one second.
-    private var sliderUpperBound: Double {
-        max(player.duration, 1)
+    /// What the thumb and the left readout should show: the drag in flight when
+    /// there is one, otherwise where playback actually is.
+    private var displayedOffset: Double {
+        min(scrubOffset ?? player.chapterOffset, spanUpperBound)
     }
 
+    /// The span is 0 until the asset resolves, and it divides the scrubber's
+    /// fraction, so the upper bound never drops below one second.
+    private var spanUpperBound: Double {
+        max(player.chapterDuration, 1)
+    }
+
+    private var bookRemaining: Double {
+        max(0, player.duration - (player.chapterStart + displayedOffset))
+    }
+
+    private var chapterRemainingLabel: String {
+        let left = max(0, player.chapterDuration - displayedOffset)
+        // No sign at the end of a chapter: "-0:00" reads as a broken clock.
+        return left < 1 ? "0:00" : "- " + Format.duration(left)
+    }
+
+    /// Five slots: chapter back, skip back, play/pause, skip forward, chapter
+    /// forward. The play disc is intrinsically sized rather than taking an equal
+    /// fifth, so the four steppers split what's left and it can't be squeezed.
     private var transport: some View {
         HStack(spacing: 0) {
-            transportButton("backward.end.fill", size: 20) { player.previousChapter() }
-            transportButton("gobackward.15", size: 29) { player.skip(-15) }
+            transportButton("backward.end.fill", size: 26, enabled: player.canGoPreviousChapter) {
+                player.previousChapter()
+            }
+            transportButton("gobackward.15", size: 32) { player.skip(-15) }
 
             Button { player.toggle() } label: {
                 // Solid rather than hierarchical: hierarchical renders the disc
                 // at a fraction of the ink, which left the one control the
                 // thumb reaches for as the dimmest thing in the transport.
                 Image(systemName: player.isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                    .font(.system(size: 66))
+                    .font(.system(size: 74))
                     .symbolRenderingMode(.palette)
                     .foregroundStyle(palette.bg0Color, palette.ink0Color)
                     .contentTransition(.symbolEffect(.replace))
             }
             .buttonStyle(.plain)
-            .frame(maxWidth: .infinity)
 
-            transportButton("goforward.30", size: 29) { player.skip(30) }
-            transportButton("forward.end.fill", size: 20) { player.nextChapter() }
+            transportButton("goforward.30", size: 32) { player.skip(30) }
+            transportButton("forward.end.fill", size: 26, enabled: player.canGoNextChapter) {
+                player.nextChapter()
+            }
         }
+        .frame(height: 78)
     }
 
     private func transportButton(
-        _ icon: String, size: CGFloat, action: @escaping () -> Void
+        _ icon: String, size: CGFloat, enabled: Bool = true, action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.system(size: size))
-                .foregroundStyle(palette.ink0Color)
+                .foregroundStyle(enabled ? palette.ink0Color : palette.ink3Color)
                 .frame(maxWidth: .infinity)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .disabled(!enabled)
     }
 
-    /// Four evenly-weighted slots. Every entry is a plain `Button` driving a
-    /// confirmation dialog — a `Menu` here silently dropped out of the row.
-    private var secondaryControls: some View {
+    /// Speed · Car Mode · Sleep · Bookmark. Every entry is a plain `Button`
+    /// driving a confirmation dialog or a cover — a `Menu` here silently dropped
+    /// out of the row.
+    private var utilityRow: some View {
         HStack(spacing: 0) {
-            controlChip(Self.rateLabel(player.rate), icon: "speedometer") { showSpeed = true }
-            controlChip("Chapters", icon: "list.bullet") { showChapters = true }
-                .disabled(player.chapters.isEmpty)
-            controlChip("Bookmark", icon: "bookmark") {
-                Task {
-                    await UserDataService.createBookmark(
-                        CreateBookmark(
-                            bookUUID: book.uuid,
-                            position: String(player.position),
-                            title: player.currentChapter?.title
-                        )
-                    )
-                    Haptics.success()
-                }
+            utilityCell("Speed") { showSpeed = true } glyph: {
+                // The rate reads as the icon, so the current speed is legible
+                // without opening anything.
+                Text(Self.rateLabel(player.rate)).font(.ui(19, weight: .semibold))
             }
-            controlChip("Sleep", icon: "moon.zzz") { showSleepTimer = true }
+            utilityCell("Car Mode") { showCarMode = true } glyph: {
+                Image(systemName: "car").font(.system(size: 22))
+            }
+            utilityCell("Sleep") { showSleepTimer = true } glyph: {
+                Image(systemName: "moon.zzz").font(.system(size: 22))
+            }
+            utilityCell("Bookmark") { addBookmark() } glyph: {
+                Image(systemName: "bookmark").font(.system(size: 22))
+            }
         }
     }
 
-    private func controlChip(
-        _ label: String, icon: String, action: @escaping () -> Void
+    private func utilityCell<Glyph: View>(
+        _ label: String,
+        action: @escaping () -> Void,
+        @ViewBuilder glyph: () -> Glyph
     ) -> some View {
         Button(action: action) {
-            VStack(spacing: 4) {
-                Image(systemName: icon).font(.system(size: 16))
-                Text(label).font(.ui(10)).lineLimit(1)
+            VStack(spacing: 5) {
+                glyph()
+                    .frame(height: 26)
+                Text(label)
+                    .font(.ui(11))
+                    .lineLimit(1)
             }
             .foregroundStyle(palette.ink2Color)
             .frame(maxWidth: .infinity)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    private func addBookmark() {
+        Task {
+            await UserDataService.createBookmark(
+                CreateBookmark(
+                    bookUUID: book.uuid,
+                    position: String(player.position),
+                    title: player.currentChapter?.title
+                )
+            )
+            Haptics.success()
+        }
     }
 
     private static func rateLabel(_ value: Double) -> String {
@@ -327,36 +446,19 @@ private struct ChapterSheet: View {
     var body: some View {
         NavigationStack {
             ScrollViewReader { proxy in
-                List(player.chapters) { chapter in
-                    Button {
-                        player.seekToChapter(chapter)
-                        dismiss()
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 3) {
-                                Text(chapter.title)
-                                    .font(.ui(15, weight: .medium))
-                                    .foregroundStyle(palette.ink0Color)
-                                Text(Format.duration(chapter.startSeconds))
-                                    .font(.monoUI(11))
-                                    .foregroundStyle(palette.ink3Color)
-                            }
-                            Spacer()
-                            if player.currentChapter?.ordinal == chapter.ordinal {
-                                Image(systemName: "waveform")
-                                    .foregroundStyle(palette.accentColor)
-                                    .symbolEffect(.variableColor, isActive: player.isPlaying)
-                            }
-                        }
-                    }
-                    .listRowBackground(palette.bg1Color)
-                    .id(chapter.ordinal)
+                // Keyed on position rather than `ordinal`: the ordinal comes out
+                // of the audio container and isn't guaranteed unique, which a
+                // `List` id has to be.
+                List(Array(player.chapters.enumerated()), id: \.offset) { index, chapter in
+                    row(index: index, chapter: chapter)
+                        .listRowBackground(palette.bg1Color)
+                        .id(index)
                 }
                 .scrollContentBackground(.hidden)
                 .background(palette.bg0Color)
                 .onAppear {
-                    guard let current = player.currentChapter else { return }
-                    proxy.scrollTo(current.ordinal, anchor: .center)
+                    guard let current = player.currentChapterIndex else { return }
+                    proxy.scrollTo(current, anchor: .center)
                 }
             }
             .navigationTitle("Chapters")
@@ -367,7 +469,60 @@ private struct ChapterSheet: View {
                 }
             }
         }
-        .presentationDetents([.medium, .large])
+        // Full height, matching the reader's contents sheet — same job, and a
+        // half-height sheet shows four rows of a book that can have a hundred
+        // chapters, which is not enough to navigate by.
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func row(index: Int, chapter: ChapterInfo) -> some View {
+        let isCurrent = player.currentChapterIndex == index
+
+        return Button {
+            player.seekToChapter(chapter)
+            dismiss()
+        } label: {
+            HStack(spacing: Spacing.md) {
+                Text("\(index + 1)")
+                    .font(.monoUI(12))
+                    .foregroundStyle(isCurrent ? palette.accentColor : palette.ink3Color)
+                    .frame(width: 24, alignment: .trailing)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(chapter.title)
+                        .font(.ui(15, weight: isCurrent ? .semibold : .regular))
+                        .foregroundStyle(isCurrent ? palette.ink0Color : palette.ink1Color)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+
+                    // Only the chapter you're in gets a bar. On the others the
+                    // number that answers "should I start this now?" is how
+                    // long it runs, which is the column on the right.
+                    if isCurrent {
+                        ProgressBar(fraction: fraction, tint: palette.accentColor, height: 2)
+                            .frame(height: 2)
+                    }
+                }
+
+                Spacer(minLength: Spacing.sm)
+
+                Text(Format.duration(player.chapterLength(at: index)))
+                    .font(.monoUI(11))
+                    .foregroundStyle(palette.ink3Color)
+            }
+            .padding(.vertical, 3)
+            // Without this only the drawn glyphs take the tap, so the gap
+            // between a short chapter title and its duration was dead — the row
+            // looked tappable across its width and wasn't.
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var fraction: Double {
+        guard player.chapterDuration > 0 else { return 0 }
+        return min(1, max(0, player.chapterOffset / player.chapterDuration))
     }
 }
 
@@ -385,7 +540,9 @@ struct MiniPlayerBar: View {
         if let book = player.book {
             VStack(spacing: 0) {
                 // A hairline of progress along the top edge — the only place
-                // position is visible without opening the player.
+                // position is visible without opening the player. Whole-book,
+                // deliberately: the player's own bar is chapter-scoped, so this
+                // is where the other half of the picture lives.
                 ProgressBar(
                     fraction: player.duration > 0 ? player.position / player.duration : 0,
                     tint: palette.accentColor,

--- a/omnibus-ios/omnibusTests/ChapterTimelineTests.swift
+++ b/omnibus-ios/omnibusTests/ChapterTimelineTests.swift
@@ -1,0 +1,157 @@
+//  ChapterTimelineTests.swift
+//  The chapter geometry the player's chapter-scoped scrubber is built on.
+//
+//  Pure arithmetic over a chapter list, which is the whole reason it's pinned
+//  here: the scrubber, the "Ch N of M" readout, the chapter-remaining countdown
+//  and the prev/next enablement all read the same three functions, so an
+//  off-by-one shows up in four places at once and in none of them obviously.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+/// A chapter with an explicit length, the shape a well-tagged M4B gives.
+private func chapter(_ ordinal: Int64, start: Double, length: Double) -> ChapterInfo {
+    ChapterInfo(ordinal: ordinal, title: "Part \(ordinal)", startSeconds: start, durationSeconds: length)
+}
+
+/// A chapter that ships no length of its own — common enough in real files that
+/// the fallback is load-bearing rather than defensive.
+private func untimed(_ ordinal: Int64, start: Double) -> ChapterInfo {
+    ChapterInfo(ordinal: ordinal, title: "Part \(ordinal)", startSeconds: start, durationSeconds: 0)
+}
+
+@Suite("Chapter timeline")
+struct ChapterTimelineTests {
+    private let timeline = ChapterTimeline(
+        chapters: [
+            chapter(1, start: 0, length: 100),
+            chapter(2, start: 100, length: 200),
+            chapter(3, start: 300, length: 150),
+        ],
+        bookDuration: 450
+    )
+
+    // MARK: - Which chapter
+
+    @Test("index resolves the chapter a position falls inside")
+    func indexResolvesEnclosingChapter() {
+        #expect(timeline.index(at: 0) == 0)
+        #expect(timeline.index(at: 99) == 0)
+        #expect(timeline.index(at: 150) == 1)
+        #expect(timeline.index(at: 449) == 2)
+    }
+
+    @Test("a position exactly on a boundary belongs to the chapter it opens")
+    func boundaryBelongsToTheChapterItOpens() {
+        #expect(timeline.index(at: 100) == 1)
+        #expect(timeline.index(at: 300) == 2)
+    }
+
+    @Test("a position past the end stays in the last chapter")
+    func pastTheEndStaysInTheLastChapter() {
+        #expect(timeline.index(at: 10_000) == 2)
+    }
+
+    /// The case the old lookup returned `nil` for, which left the chapter bar
+    /// blank and both chapter buttons dead for the opening seconds of any book
+    /// whose first mark isn't at zero.
+    @Test("a position before the first chapter's start resolves to that chapter")
+    func beforeTheFirstMarkResolvesToTheFirstChapter() {
+        let late = ChapterTimeline(
+            chapters: [chapter(1, start: 5, length: 95), chapter(2, start: 100, length: 100)],
+            bookDuration: 200
+        )
+        #expect(late.index(at: 0) == 0)
+        #expect(late.chapter(at: 0)?.ordinal == 1)
+    }
+
+    @Test("an empty timeline has no chapter at any position")
+    func emptyTimelineHasNoChapter() {
+        let empty = ChapterTimeline(bookDuration: 500)
+        #expect(empty.isEmpty)
+        #expect(empty.index(at: 0) == nil)
+        #expect(empty.chapter(at: 250) == nil)
+    }
+
+    // MARK: - Ordering
+
+    @Test("chapters are sorted on the way in, whatever order the manifest gave")
+    func chaptersAreSortedOnInit() {
+        let shuffled = ChapterTimeline(
+            chapters: [
+                chapter(3, start: 300, length: 150),
+                chapter(1, start: 0, length: 100),
+                chapter(2, start: 100, length: 200),
+            ],
+            bookDuration: 450
+        )
+        #expect(shuffled.chapters.map(\.ordinal) == [1, 2, 3])
+        #expect(shuffled.index(at: 150) == 1)
+    }
+
+    // MARK: - How long
+
+    @Test("length uses the chapter's own duration when it has one")
+    func lengthUsesDeclaredDuration() {
+        #expect(timeline.length(at: 0) == 100)
+        #expect(timeline.length(at: 1) == 200)
+    }
+
+    @Test("length falls back to the next chapter's start when the file gives none")
+    func lengthFallsBackToNextStart() {
+        let untimedTimeline = ChapterTimeline(
+            chapters: [untimed(1, start: 0), untimed(2, start: 120), untimed(3, start: 400)],
+            bookDuration: 600
+        )
+        #expect(untimedTimeline.length(at: 0) == 120)
+        #expect(untimedTimeline.length(at: 1) == 280)
+    }
+
+    @Test("the last untimed chapter measures to the end of the book")
+    func lastUntimedChapterMeasuresToBookEnd() {
+        let untimedTimeline = ChapterTimeline(
+            chapters: [untimed(1, start: 0), untimed(2, start: 400)],
+            bookDuration: 600
+        )
+        #expect(untimedTimeline.length(at: 1) == 200)
+    }
+
+    @Test("length is zero rather than negative when the book duration is unknown")
+    func lengthNeverGoesNegative() {
+        let noDuration = ChapterTimeline(chapters: [untimed(1, start: 90)], bookDuration: 0)
+        #expect(noDuration.length(at: 0) == 0)
+    }
+
+    @Test("length is zero for an index outside the timeline")
+    func lengthIsZeroOutOfBounds() {
+        #expect(timeline.length(at: -1) == 0)
+        #expect(timeline.length(at: 99) == 0)
+    }
+
+    // MARK: - The scrubbed span
+
+    @Test("span is the enclosing chapter's start and length")
+    func spanIsTheEnclosingChapter() {
+        let span = timeline.span(at: 150)
+        #expect(span.start == 100)
+        #expect(span.duration == 200)
+    }
+
+    /// What keeps a book with no chapter marks scrubbing over its whole self
+    /// instead of over a zero-length span.
+    @Test("span is the whole book when there are no chapters")
+    func spanCoversWholeBookWithoutChapters() {
+        let empty = ChapterTimeline(bookDuration: 500)
+        let span = empty.span(at: 250)
+        #expect(span.start == 0)
+        #expect(span.duration == 500)
+    }
+
+    @Test("an offset inside a span maps back to an absolute position")
+    func offsetMapsBackToAbsolutePosition() {
+        let span = timeline.span(at: 350)
+        #expect(span.start + 20 == 320)
+    }
+}


### PR DESCRIPTION
## Summary
- **The chapter becomes the unit of the player.** The scrubber spans the current chapter rather than the book — on a twelve-hour audiobook a whole-book bar puts every chapter boundary within a couple of points of its neighbours, so the one gesture the control exists for can't be aimed. The three readouts under it are chapter elapsed · **book** remaining · chapter remaining, which is what pays for the narrower span without needing a mode.
- **Layout follows Audible's**: artwork → chapter name (left-aligned behind a `☰`, tappable into the chapter list) → scrubber → five-slot transport (`⏮ ↺15 ▶ ↻30 ⏭`) → Speed · Car Mode · Sleep · Bookmark. The play disc is intrinsically sized rather than taking an equal fifth, so the four steppers split what's left and it can't be squeezed.
- **`PlayerScrubber` replaces `Slider`**, which draws a fixed 27pt pill thumb plus its own inset chrome and can't be tinted down to a slim track. The parent owns the drag position so the thumb and the readouts can't disagree; a tap on the track seeks there.
- **`ChapterTimeline`** extracts the arithmetic as a value type with no `AVPlayer` behind it — the scrubber, the readouts, the countdown and the prev/next enablement all read the same three functions, so an off-by-one surfaces in four places and in none of them obviously. 14 tests.
- **Car Mode** is new (asked for alongside the layout): five targets none smaller than a thumb, nothing that needs aiming, and it holds `isIdleTimerDisabled` while open. It drives the same `AudioPlayer` and adds no playback behaviour.

Deliberately **not** ported from Audible: the Listen / Read & Listen pill and the Clips & notes / Title Details / Listen log chips. The reader and bookmarks affordances stay in the top bar where they already were.

### Bugs fixed along the way

| | |
|---|---|
| `previousChapter()` returned early when the position preceded the first chapter mark — both chapter buttons were dead for the opening seconds of any such book | containers routinely start chapter one a second or two in |
| `nextChapter()` used `first(where:)` over an array it assumed was sorted | finds *a* later chapter, not the *next* one |
| The backdrop's cover wash grew the layout past the screen | see below |
| Chapter rows had no `contentShape` | only the drawn glyphs took the tap; the gap between a short title and its duration was dead |
| The artwork was sized as the *remainder* of the band between the insets | it resized between books (a two-line title cost it 30pt) and drove the spacers to zero on a short screen |
| The player built its `CoverIdentity` without the `accent` | a coverless book drew a title-hash plate under an accent-derived wash |

Lock screen gains `MPNowPlayingInfoPropertyChapterNumber`/`ChapterCount`, and next/previous-track are disabled on books with no chapter marks instead of being dead buttons.

> [!IMPORTANT]
> **An aspect-fill image in a layout container grows it.** `RemoteImage` renders `.resizable().scaledToFill()`, and a `.fill` aspect ratio *reports* a size larger than the box it fills — that is what filling means. Sat directly in the player's backdrop `ZStack` with no frame and no `.clipped()`, it grew the stack past the screen, and `safeAreaInset` then measured the chrome against those bounds: the top bar landed under the status bar and the utility row's labels fell off the bottom. Nothing errors and nothing logs.
>
> It only reproduces on a book with **real cover art** — a generated plate is gradients and `Color`s, all infinitely flexible, so they accept the proposal instead of overriding it. **Every generated audiobook fixture is coverless, which is how this shipped.** The art now lives in a `Color.clear.overlay { … }.clipped()`, the way `BookCover` already does it.

## Test plan
- [x] `xcodebuild test` — full suite green, including 14 new `ChapterTimelineTests` covering chapter resolution (enclosing, boundary, past-the-end, before-the-first-mark, empty), sort-on-init, length fallbacks (declared, gap-to-next, last-to-book-end, unknown duration, out of bounds) and span mapping
- [x] Driven on an iPhone 17 simulator against the full fixture library: chapter-scoped scrubber, drag-to-seek with all three readouts tracking, next/prev chapter (including prev's restart-then-step-back), chapter row → selector, mid-row tap, Car Mode, correct dimming at first/last chapter
- [x] Backdrop overflow **reproduced on a pre-fix build and confirmed fixed**, after putting real cover art on an audiobook fixture (`POST /api/ebooks/{uuid}/cover`) — no coverless fixture can exercise that path
- [x] Audited the other two `RemoteImage` call sites: the author photo has an explicit frame + clip, `BookCover` uses an overlay. The player backdrop was the only unbounded one.
- [ ] **375×667 not verified visually.** The layout is sound by arithmetic and the artwork's share tapers under a 380pt band to give that case headroom, but I could not get a screenshot. Worth a look on an SE before merge.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [x] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

Flagged **minor** as a fairly large UX change to a roadmap surface — the player's controls, scrubbing model and readouts all change, and Car Mode is a new screen. Happy to be talked down to patch.

## Notes
- iOS-only. No Rust crate is touched, so `cargo`/`just` targets and the Playwright suite are unaffected; `mobile/` (the Android WebView shell) is untouched.
- Two new files land in `Features/Player/` and one in `omnibusTests/`. The Xcode project uses `PBXFileSystemSynchronizedRootGroup`, so no `project.pbxproj` change was needed.
- `omnibus-ios/README.md` picks up the layout rationale, the Car Mode note, and a callout for the aspect-fill trap. Its stale "No test target yet" line is corrected.
- Skip intervals are left at **15 back / 30 forward**. Audible defaults to a symmetric 30/30 but that isn't chapter behaviour, so it seemed out of scope to change unasked.
- Title and author stay centered above the now left-aligned chapter row. Audible shows no title text at all in its player, so there was nothing to copy there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
