### PR TITLE
fix: reserve a dedicated fixture book for the journal insert-highlight spec

### DIFF
--- a/ui_tests/playwright/tests/fixtures/epubs.ts
+++ b/ui_tests/playwright/tests/fixtures/epubs.ts
@@ -339,6 +339,10 @@ export const FIXTURE_BOOKS: readonly ExpectedBook[] = [
     language: "en",
     hasCover: false,
   },
+  // Reserved for the journal insert-from-highlights spec (`journal.spec.ts`):
+  // it seeds a highlight on this book, and highlights are per-(user, book)
+  // server state that survives the run, so any spec asserting an empty
+  // highlights state on it would race that seed. No other spec may read it.
   {
     slug: "standalone-meadow",
     filename: "standalone-meadow.epub",

--- a/ui_tests/playwright/tests/flows/journal.spec.ts
+++ b/ui_tests/playwright/tests/flows/journal.spec.ts
@@ -18,6 +18,15 @@ test.beforeAll(async ({ request }) => {
 
 const TARGET = FIXTURE_BOOKS.find((b) => b.slug === "alpha")!;
 
+// Reserved for the insert-from-highlights test (see fixtures/epubs.ts): a
+// seeded highlight is per-(user, book) state on the shared, persistent dev
+// server, so seeding one on TARGET would break reader.spec.ts's empty
+// highlights-drawer assertion on the same book. `standalone-meadow`
+// (Claude Shannon) is read by no other spec.
+const HIGHLIGHT_BOOK = FIXTURE_BOOKS.find(
+  (b) => b.slug === "standalone-meadow",
+)!;
+
 type Page = import("@playwright/test").Page;
 
 // The Write surface is a live-formatting `contenteditable` (testid
@@ -153,7 +162,9 @@ test("inserts a saved highlight into the draft as a blockquote", async ({
   page,
   request,
 }) => {
-  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  // HIGHLIGHT_BOOK, not TARGET: the seeded highlight below outlives the test's
+  // page, so it must land on a book no other spec reads.
+  const uuid = await fetchBookUuidByTitle(request, HIGHLIGHT_BOOK.title);
 
   // Seed a highlight via the REST API (bearer-authed request fixture); a unique
   // passage keeps the assertion robust against the shared, persistent dev DB.
@@ -167,6 +178,7 @@ test("inserts a saved highlight into the draft as a blockquote", async ({
     },
   });
   expect(created.status(), "seed highlight").toBe(200);
+  const highlightId = (await created.json()).id as number;
 
   await gotoReady(page, `/books/${uuid}`);
   await page.getByTestId("journal-open-composer").click();
@@ -186,6 +198,11 @@ test("inserts a saved highlight into the draft as a blockquote", async ({
   await expect(page.getByTestId("journal-highlights-pop")).toHaveCount(0);
 
   await cancelComposerDiscardingDraft(page);
+
+  // Delete the seeded highlight so it doesn't outlive the run in the shared
+  // dev DB (204 No Content, unlike the 200 on create).
+  const removed = await request.delete(`/api/highlights/${highlightId}`);
+  expect(removed.status(), "clean up seeded highlight").toBe(204);
 });
 
 // ---------------------------------------------------------------------------

--- a/ui_tests/playwright/tests/flows/journal.spec.ts
+++ b/ui_tests/playwright/tests/flows/journal.spec.ts
@@ -180,29 +180,32 @@ test("inserts a saved highlight into the draft as a blockquote", async ({
   expect(created.status(), "seed highlight").toBe(200);
   const highlightId = (await created.json()).id as number;
 
-  await gotoReady(page, `/books/${uuid}`);
-  await page.getByTestId("journal-open-composer").click();
+  // `finally`, so a mid-test assertion failure still cleans up: the seeded row
+  // would otherwise outlive the run in the shared dev DB.
+  try {
+    await gotoReady(page, `/books/${uuid}`);
+    await page.getByTestId("journal-open-composer").click();
 
-  // Open the inserter, pick the seeded passage → it lands as a `> ` blockquote
-  // with attribution, and the popover closes.
-  await page.getByTestId("journal-insert-highlight").click();
-  await expect(page.getByTestId("journal-highlights-pop")).toBeVisible();
-  await page
-    .getByTestId("journal-highlight-item")
-    .filter({ hasText: quote })
-    .click();
+    // Open the inserter, pick the seeded passage → it lands as a `> `
+    // blockquote with attribution, and the popover closes.
+    await page.getByTestId("journal-insert-highlight").click();
+    await expect(page.getByTestId("journal-highlights-pop")).toBeVisible();
+    await page
+      .getByTestId("journal-highlight-item")
+      .filter({ hasText: quote })
+      .click();
 
-  await expect(editorMarkdown(page)).toHaveValue(
-    new RegExp(`> ${quote}[\\s\\S]*saved from highlights`),
-  );
-  await expect(page.getByTestId("journal-highlights-pop")).toHaveCount(0);
+    await expect(editorMarkdown(page)).toHaveValue(
+      new RegExp(`> ${quote}[\\s\\S]*saved from highlights`),
+    );
+    await expect(page.getByTestId("journal-highlights-pop")).toHaveCount(0);
 
-  await cancelComposerDiscardingDraft(page);
-
-  // Delete the seeded highlight so it doesn't outlive the run in the shared
-  // dev DB (204 No Content, unlike the 200 on create).
-  const removed = await request.delete(`/api/highlights/${highlightId}`);
-  expect(removed.status(), "clean up seeded highlight").toBe(204);
+    await cancelComposerDiscardingDraft(page);
+  } finally {
+    // 204 No Content, unlike the 200 on create.
+    const removed = await request.delete(`/api/highlights/${highlightId}`);
+    expect(removed.status(), "clean up seeded highlight").toBe(204);
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `journal.spec.ts`'s insert-from-highlights test seeded a highlight on `alpha` and never deleted it. Highlights are per-(user, book) state that outlives the run on the shared dev server, so `reader.spec.ts`'s `No highlights yet` assertion — same book — failed whenever journal.spec ran first, and the row stayed dirty across later runs.
- Moves the seed to `standalone-meadow`, now reserved in `fixtures/epubs.ts` alongside the existing `frankenstein` / `great-gatsby` / `standalone-canyon` reservations, and deletes it via `DELETE /api/highlights/{id}` at the end of the test.
- Pre-existing; unrelated to the saved-passages work on `973/book-detail-highlights`.

## Test plan
- [x] `pnpm exec playwright test journal.spec.ts reader.spec.ts book_detail.spec.ts --workers=1` — 46 passed, run order put journal before reader (the ordering that used to fail).
- [x] `just lint-ts` — Biome + `tsc --noEmit` clean.
- [x] Post-run DB check: no highlight left on `alpha`.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — add the `no release` label to skip cutting a release.

## Notes
- `standalone-meadow` (Claude Shannon) was picked because its slug, title, and author appear in no other spec — verified by grep across `tests/`.