### PR TITLE
test: extract reader indicator logic and open books bare

### DIFF
--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -151,12 +151,19 @@ touch those depend on — page turns still worked because the overlay called
 `next()` itself, which masked the fact that swipe was dead. The host now layers
 nothing interactive over the page.
 
-**Reading chrome follows Apple Books.** The reading view carries almost
-nothing: a `✕` top-right, one menu button bottom-right, and two centred labels
-— "N pages left in chapter" above, "361 of 661" below. The labels never leave;
-only the two buttons come and go on a centre tap, because the position is quiet
-enough to live there permanently. "Pages left in chapter" is the question you
-actually have with a book open, which a raw page number can't answer.
+**Reading chrome follows Apple Books.** A book opens bare — no buttons at all,
+just the page between two centred labels. A centre tap brings up a `✕`
+top-right and one menu button bottom-right; another puts them away.
+
+The labels never leave, but they answer a different question in each state,
+because the two states are different activities (`ReaderIndicators`). Reading,
+they name where you are and nothing else: the **book's title** above, the bare
+**page number** below. With the chrome up you are navigating rather than
+reading, so they widen into "**N pages left in chapter**" and "**361 of 661**"
+— "pages left in chapter" being the question you actually have mid-book, which
+a raw page number can't answer. Both fall back while epub.js's whole-book
+locations pass is still running: the top line to "Chapter N of M", the bottom
+to a percentage, since a page number of 0 would be both wrong and jumpy.
 
 Everything else is behind the one menu, as rows: **Contents · N%**, **Bookmarks
 & Highlights** (with a count), **Themes & Settings**, then a strip of round

--- a/omnibus-ios/omnibus/Reader/ReaderIndicators.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderIndicators.swift
@@ -1,0 +1,100 @@
+//  ReaderIndicators.swift
+//  The two centred labels above and below the page, and what each of them says.
+//
+//  They answer a different question depending on whether the chrome is up.
+//  Reading, the questions are "which book am I in" and "which page am I on".
+//  With the menu out you are navigating rather than reading, so the chapter's
+//  remaining pages and the page count are what's worth the space.
+
+import SwiftUI
+
+/// What the labels above and below the page read, for one reader state.
+///
+/// Split out of the view so the wording is testable without a rendered
+/// hierarchy — four states of `chapterPagesLeft` alone decide the top line.
+struct ReaderIndicators {
+    let location: RelocateData?
+    /// The book's title, which is the top line while reading.
+    let title: String
+    /// Whether the reader's buttons — the close button and the menu — are up.
+    let chromeVisible: Bool
+
+    /// The label above the page.
+    ///
+    /// Reading, that's the book you're in. With the chrome up it becomes how
+    /// much further to a natural place to stop — the question you actually have
+    /// mid-book, which a raw page number can't answer. Falls back to the
+    /// chapter's own position until epub.js's whole-book locations pass lands.
+    ///
+    /// Both forms wait on a location so the two labels arrive together rather
+    /// than the title hanging over the loading view on its own.
+    var top: String? {
+        guard let location else { return nil }
+        guard chromeVisible else { return title.nilIfBlank }
+
+        let left = location.chapterPagesLeft
+        if left > 0 {
+            return left == 1
+                ? "1 page left in chapter"
+                : "\(left) pages left in chapter"
+        }
+        // `chapter` is 0 when the current href matched no TOC entry (common in
+        // front matter) — omit rather than showing a meaningless "Ch. 0".
+        guard location.chapter > 0, location.totalChapters > 0 else { return nil }
+        return "Chapter \(location.chapter) of \(location.totalChapters)"
+    }
+
+    /// The label below the page: which page you're on, and — with the chrome up
+    /// — how many there are.
+    ///
+    /// Page numbers need epub.js's whole-book locations pass, which lands
+    /// seconds after the first paint; percent stands in until then rather than
+    /// a placeholder that jumps.
+    var bottom: String? {
+        guard let location else { return nil }
+        guard location.hasPageNumbers else {
+            return location.pct > 0 ? "\(location.pct)%" : nil
+        }
+        return chromeVisible
+            ? "\(location.page) of \(location.totalPages)"
+            : "\(location.page)"
+    }
+}
+
+/// The two labels, which stay put whether the buttons are showing or not.
+///
+/// They sit in the bands `#stage` reserves via `env(safe-area-inset-*)`, so
+/// they never overlap prose, and they take no touches so the page keeps every
+/// gesture. Only the buttons come and go on a centre tap — the position is
+/// quiet enough to live there permanently.
+struct ReaderIndicatorLabels: View {
+    let indicators: ReaderIndicators
+    let ink: Color
+
+    var body: some View {
+        VStack(spacing: 0) {
+            label(indicators.top)
+                .padding(.top, Spacing.xs)
+
+            Spacer(minLength: 0)
+
+            label(indicators.bottom)
+                .padding(.bottom, Spacing.xs)
+        }
+        .allowsHitTesting(false)
+    }
+
+    /// Given the button's own box rather than its own text height, so a label
+    /// sits centred on the line its buttons are on however the type resolves.
+    @ViewBuilder
+    private func label(_ text: String?) -> some View {
+        if let text {
+            Text(text)
+                .font(.ui(12.5))
+                .foregroundStyle(ink.opacity(0.5))
+                .lineLimit(1)
+                .frame(height: ReaderMenu.buttonSize)
+                .padding(.horizontal, 72)
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -23,7 +23,10 @@ struct ReaderView: View {
     @Environment(AppState.self) private var appState
 
     @State private var controller = ReaderController()
-    @State private var chromeVisible = true
+    /// The reading view opens bare, the way a book does — the buttons are one
+    /// centre tap away, and opening onto them puts chrome over the first page
+    /// of every book for someone who only wanted to read.
+    @State private var chromeVisible = false
     @State private var showSettings = false
     @State private var showContents = false
     @State private var contentsTab: ReaderContentsSheet.Tab = .contents
@@ -241,65 +244,17 @@ struct ReaderView: View {
         }
     }
 
-    /// The two labels, which stay put whether the buttons are showing or not.
-    ///
-    /// They sit in the bands `#stage` reserves via `env(safe-area-inset-*)`, so
-    /// they never overlap prose, and they take no touches so the page keeps
-    /// every gesture. Only the buttons come and go on a centre tap — the
-    /// position is quiet enough to live there permanently.
+    /// The two labels above and below the page. See `ReaderIndicators` for what
+    /// each one says, which depends on whether the chrome is up.
     private var persistentIndicators: some View {
-        VStack(spacing: 0) {
-            indicator(chapterLabel)
-                .padding(.top, Spacing.xs)
-
-            Spacer(minLength: 0)
-
-            indicator(positionLabel)
-                .padding(.bottom, Spacing.xs)
-        }
-        .allowsHitTesting(false)
-    }
-
-    /// Given the button's own box rather than its own text height, so a label
-    /// sits centred on the line its buttons are on however the type resolves.
-    @ViewBuilder
-    private func indicator(_ label: String?) -> some View {
-        if let label {
-            Text(label)
-                .font(.ui(12.5))
-                .foregroundStyle(barInk.opacity(0.5))
-                .lineLimit(1)
-                .frame(height: ReaderMenu.buttonSize)
-                .padding(.horizontal, 72)
-        }
-    }
-
-    /// How much further to a natural place to stop — the question you have with
-    /// a book open, which a raw page number can't answer. Falls back to the
-    /// chapter's own position until epub.js's whole-book locations pass lands.
-    private var chapterLabel: String? {
-        guard let location = controller.location else { return nil }
-        let left = location.chapterPagesLeft
-        if left > 0 {
-            return left == 1
-                ? "1 page left in chapter"
-                : "\(left) pages left in chapter"
-        }
-        // `chapter` is 0 when the current href matched no TOC entry (common in
-        // front matter) — omit rather than showing a meaningless "Ch. 0".
-        guard location.chapter > 0, location.totalChapters > 0 else { return nil }
-        return "Chapter \(location.chapter) of \(location.totalChapters)"
-    }
-
-    /// Page numbers need epub.js's whole-book locations pass, which lands
-    /// seconds after the first paint; percent stands in until then rather than
-    /// a placeholder that jumps.
-    private var positionLabel: String? {
-        guard let location = controller.location else { return nil }
-        if location.hasPageNumbers {
-            return "\(location.page) of \(location.totalPages)"
-        }
-        return location.pct > 0 ? "\(location.pct)%" : nil
+        ReaderIndicatorLabels(
+            indicators: ReaderIndicators(
+                location: controller.location,
+                title: book.displayTitle,
+                chromeVisible: chromeVisible
+            ),
+            ink: barInk
+        )
     }
 
     @ViewBuilder

--- a/omnibus-ios/omnibusTests/ReaderIndicatorsTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderIndicatorsTests.swift
@@ -1,0 +1,131 @@
+//  ReaderIndicatorsTests.swift
+//  What the reader's two centred labels say, per chrome state.
+//
+//  Pinned here because the wording is the whole feature: the same two lines
+//  serve reading (title, page) and navigating (pages left, page of total), and
+//  each has its own fallback for the seconds before epub.js's locations pass
+//  lands. Rendered, all of that is one 12.5pt line that is easy to eyeball as
+//  fine while showing the wrong half of it.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+/// A relocate with whole-book page numbers — what the reader reports once
+/// epub.js's locations pass has run.
+private func located(
+    page: Int = 361, totalPages: Int = 661, pct: Int = 55,
+    chapter: Int = 7, totalChapters: Int = 24, chapterPagesLeft: Int = 12
+) -> RelocateData {
+    RelocateData(
+        cfi: "epubcfi(/6/14!/4/2/2)", page: page, totalPages: totalPages, pct: pct,
+        chapter: chapter, totalChapters: totalChapters, chapterTitle: "The Moor",
+        chapterPagesLeft: chapterPagesLeft
+    )
+}
+
+/// The first seconds of a book: a position is known, page numbers are not.
+private func unlocated(pct: Int = 3) -> RelocateData {
+    RelocateData(
+        cfi: "epubcfi(/6/2!/4/2)", page: 0, totalPages: 0, pct: pct,
+        chapter: 1, totalChapters: 24, chapterTitle: "Mr. Sherlock Holmes",
+        chapterPagesLeft: 0
+    )
+}
+
+private func indicators(
+    _ location: RelocateData?, title: String = "The Hound of the Baskervilles",
+    chromeVisible: Bool
+) -> ReaderIndicators {
+    ReaderIndicators(location: location, title: title, chromeVisible: chromeVisible)
+}
+
+@Suite("Reader indicators while reading")
+struct ReaderIndicatorsHiddenChromeTests {
+    @Test("the top line is the book's title when the chrome is down")
+    func topIsTheTitle() {
+        #expect(indicators(located(), chromeVisible: false).top == "The Hound of the Baskervilles")
+    }
+
+    @Test("the bottom line is the bare page number when the chrome is down")
+    func bottomIsTheBarePage() {
+        #expect(indicators(located(), chromeVisible: false).bottom == "361")
+    }
+
+    /// The title is the only line that has nothing to fall back to, so a book
+    /// filed under a blank title has to leave the band empty rather than paint
+    /// an empty label.
+    @Test("a blank title leaves the top line empty rather than showing whitespace")
+    func blankTitleShowsNothing() {
+        #expect(indicators(located(), title: "  ", chromeVisible: false).top == nil)
+    }
+
+    /// The page number is still 0 in the seconds before the locations pass
+    /// lands, so "0" would be both wrong and jumpy — percent is the honest
+    /// stand-in, chrome or no chrome.
+    @Test("the bottom line falls back to percent before page numbers exist")
+    func bottomFallsBackToPercent() {
+        #expect(indicators(unlocated(pct: 3), chromeVisible: false).bottom == "3%")
+    }
+
+    @Test("nothing shows before the first relocate, so both labels arrive together")
+    func nothingBeforeTheFirstRelocate() {
+        let labels = indicators(nil, chromeVisible: false)
+        #expect(labels.top == nil)
+        #expect(labels.bottom == nil)
+    }
+}
+
+@Suite("Reader indicators with the menu up")
+struct ReaderIndicatorsVisibleChromeTests {
+    @Test("the top line counts the pages left in the chapter")
+    func topCountsPagesLeft() {
+        #expect(
+            indicators(located(chapterPagesLeft: 12), chromeVisible: true).top
+                == "12 pages left in chapter"
+        )
+    }
+
+    @Test("the last page of a chapter reads in the singular")
+    func onePageLeftIsSingular() {
+        #expect(
+            indicators(located(chapterPagesLeft: 1), chromeVisible: true).top
+                == "1 page left in chapter"
+        )
+    }
+
+    @Test("the top line falls back to the chapter's position when no pages are left to count")
+    func topFallsBackToChapterPosition() {
+        #expect(
+            indicators(located(chapterPagesLeft: 0), chromeVisible: true).top
+                == "Chapter 7 of 24"
+        )
+    }
+
+    /// Front matter routinely matches no TOC entry, which lands here as chapter
+    /// 0 — a "Chapter 0 of 24" nobody can act on.
+    @Test("the top line is empty in front matter, which belongs to no chapter")
+    func topIsEmptyInFrontMatter() {
+        #expect(
+            indicators(located(chapter: 0, chapterPagesLeft: 0), chromeVisible: true).top == nil
+        )
+    }
+
+    @Test("the bottom line carries the page count as well as the page")
+    func bottomCarriesTheTotal() {
+        #expect(indicators(located(), chromeVisible: true).bottom == "361 of 661")
+    }
+
+    @Test("the bottom line falls back to percent before page numbers exist")
+    func bottomFallsBackToPercent() {
+        #expect(indicators(unlocated(pct: 3), chromeVisible: true).bottom == "3%")
+    }
+
+    /// Percent is 0 for the whole first page of a book, and "0%" reads as a
+    /// stall rather than a position.
+    @Test("the bottom line is empty when there is neither a page nor a percent")
+    func bottomIsEmptyAtZero() {
+        #expect(indicators(unlocated(pct: 0), chromeVisible: true).bottom == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Extract the reader's two centred labels into a testable `ReaderIndicators` struct, and change the default chrome state so books open bare (buttons hidden) rather than with the menu visible.

The labels answer different questions depending on whether the chrome is up:
- **Reading (chrome hidden):** book title above, bare page number below
- **Navigating (chrome visible):** pages left in chapter above, page count below

Both fall back gracefully while epub.js's locations pass is still running.

## Changes

- **New `ReaderIndicators.swift`:** Extracted label logic from `ReaderView` into a testable struct. The wording is the whole feature — four states of `chapterPagesLeft` alone decide the top line, and the fallback chain (page numbers → percent → nothing) is subtle enough to warrant pinning in tests.

- **New `ReaderIndicatorsTests.swift`:** 131 lines of test coverage for all label combinations: both chrome states, fallbacks before page numbers exist, singular/plural handling, front matter edge cases, and blank title handling.

- **`ReaderView.swift`:** Changed default `chromeVisible` from `true` to `false` so books open bare — the way a physical book does. Replaced inline label logic with a call to `ReaderIndicatorLabels`, which composes the new `ReaderIndicators` struct.

- **`README.md`:** Updated to reflect the new reading chrome behavior and the dual-purpose label design.

## Test plan

- [x] Added comprehensive unit tests covering all label states and fallback chains
- [x] Existing reader integration tests pass with the new chrome default

## Version

- [ ] **Patch** — straightforward refactor + UX polish (opening bare is a better default, matching Apple Books)

## Notes

The label logic was previously inline in `ReaderView`, making it hard to test the wording without rendering. Extracting it into `ReaderIndicators` lets us pin the exact text for each state — important because the labels are the whole feature: they serve both reading and navigating, and each has its own fallback for the seconds before epub.js's locations pass lands.

https://claude.ai/code/session_01Mq6GqQcCvfLaU7vgUq5htZ