### PR TITLE
fix: check every store path in dev-env cache staleness check (#1421)

### DIFF
--- a/scripts/tests/with-dev-env-cache-is-stale.test.sh
+++ b/scripts/tests/with-dev-env-cache-is-stale.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Regression test for with-dev-env.sh's cache_is_stale() staleness check
+# (issue #1421): a partial `nix store gc` can collect a later-referenced
+# store path while an earlier one survives, and the check must still report
+# the cache stale — not just spot-check the first path.
+#
+# No nix, no network: the function is extracted verbatim from the real
+# script (so this tracks the shipped implementation, not a hand-copied
+# duplicate) and exercised against synthetic cache files. Real /nix/store
+# entries already present on this machine (from the Nix installer itself)
+# stand in for "path exists"; fabricated paths stand in for "GC'd".
+#
+# Usage: scripts/tests/with-dev-env-cache-is-stale.test.sh
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+script="$repo_root/scripts/with-dev-env.sh"
+
+func_src="$(sed -n '/^cache_is_stale() {/,/^}/p' "$script")"
+if [ -z "$func_src" ]; then
+  echo "FAIL: could not extract cache_is_stale() from $script" >&2
+  exit 1
+fi
+eval "$func_src"
+
+# Two store paths that genuinely exist on this box, standing in for
+# survived-GC paths. A fabricated suffix stands in for a collected one.
+existing_paths=(/nix/store/*/)
+if [ "${#existing_paths[@]}" -lt 2 ]; then
+  echo "SKIP: fewer than two /nix/store entries on this machine; cannot build fixtures" >&2
+  exit 0
+fi
+exists_a="${existing_paths[0]%/}"
+exists_b="${existing_paths[1]%/}"
+missing="/nix/store/0000000000000000000000000000000-omnibus-1421-gc-test"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+check() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $desc (expected $expected, got $actual)" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+verdict() {
+  # cache_is_stale returns 0 (true) for "stale" and 1 (false) for "fresh",
+  # matching its `if cache_is_stale; then rebuild; fi` call site.
+  if cache_is_stale; then echo stale; else echo fresh; fi
+}
+
+# No cache file at all -> stale (nothing to spot-check).
+cache_file="$tmp/missing.env.bash"
+check "missing cache file is stale" stale "$(verdict)"
+
+# Every referenced path survives -> fresh.
+cache_file="$tmp/all-present.env.bash"
+printf 'export PATH="%s:%s:$PATH"\n' "$exists_a" "$exists_b" >"$cache_file"
+check "cache with only surviving paths is fresh" fresh "$(verdict)"
+
+# First path survives, a LATER path was collected -> stale. This is the
+# exact regression from #1421: the old check only looked at the first path
+# (`head -1`) and would have reported "fresh" here.
+cache_file="$tmp/later-missing.env.bash"
+printf 'export PATH="%s:%s:$PATH"\n' "$exists_a" "$missing" >"$cache_file"
+check "cache with a later collected path is stale" stale "$(verdict)"
+
+# Only path was collected -> stale.
+cache_file="$tmp/only-missing.env.bash"
+printf 'export PATH="%s/bin:$PATH"\n' "$missing" >"$cache_file"
+check "cache with its only path collected is stale" stale "$(verdict)"
+
+echo "---"
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/tests/with-dev-env-cache-is-stale.test.sh
+++ b/scripts/tests/with-dev-env-cache-is-stale.test.sh
@@ -25,7 +25,7 @@ eval "$func_src"
 
 # Two store paths that genuinely exist on this box, standing in for
 # survived-GC paths. A fabricated suffix stands in for a collected one.
-existing_paths=(/nix/store/*/)
+mapfile -t existing_paths < <(compgen -G '/nix/store/*/' | head -n 2)
 if [ "${#existing_paths[@]}" -lt 2 ]; then
   echo "SKIP: fewer than two /nix/store entries on this machine; cannot build fixtures" >&2
   exit 0

--- a/scripts/with-dev-env.sh
+++ b/scripts/with-dev-env.sh
@@ -61,7 +61,7 @@ cache_is_stale() {
   local p
   while IFS= read -r p; do
     [ -e "$p" ] || return 0
-  done < <(grep -o '/nix/store/[^"'\'' :]*' "$cache_file" | sort -u)
+  done < <(grep -o '/nix/store/[^"'\'' :]*' "$cache_file")
   return 1
 }
 

--- a/scripts/with-dev-env.sh
+++ b/scripts/with-dev-env.sh
@@ -52,12 +52,17 @@ key="$( (cat "$repo_root/flake.nix" "$repo_root/flake.lock"; echo "$shell") | sh
 cache_file="$cache_dir/$shell-$key.env.bash"
 
 # Self-heal: a `nix store gc` can collect a store path the cached env
-# references, leaving a poisoned cache. Spot-check the first /nix/store path.
+# references, leaving a poisoned cache. Check every unique /nix/store path —
+# a partial GC can collect a later path while an earlier one survives, so a
+# spot-check of just the first path would report "still valid" and a command
+# would run with a silently incomplete PATH.
 cache_is_stale() {
   [ ! -f "$cache_file" ] && return 0
   local p
-  p="$(grep -o '/nix/store/[^\"'\'' :]*' "$cache_file" | head -1 || true)"
-  [ -n "$p" ] && [ ! -e "$p" ]
+  while IFS= read -r p; do
+    [ -e "$p" ] || return 0
+  done < <(grep -o '/nix/store/[^"'\'' :]*' "$cache_file" | sort -u)
+  return 1
 }
 
 if cache_is_stale; then


### PR DESCRIPTION
## Summary
- Closes #1421
- `cache_is_stale()` in `scripts/with-dev-env.sh` only spot-checked the **first** `/nix/store` path referenced by the cached env file. A partial `nix store gc` can collect a *later* referenced path (e.g. the pinned `wasm-bindgen-cli`) while an earlier one survives (e.g. `dioxus-cli`), so the check reported "still valid" and a command ran with a silently incomplete `PATH` — `dx` then fell back to `dioxus-cli`'s bundled `wasm-bindgen`, which mismatched the project's pinned version and broke `dx serve`/`just dev-up`.
- Hardened the check to walk every unique `/nix/store` path in the cache file and return stale on the first missing one, matching the fix proposed in the issue.

## Test plan
- Added `scripts/tests/with-dev-env-cache-is-stale.test.sh`, a nix-free bash regression test: it extracts `cache_is_stale()` verbatim from the shipped script (so it tracks the real implementation, not a hand-copied duplicate) and exercises it against synthetic cache files, using real pre-existing `/nix/store` entries on the box to stand in for "survived GC" and a fabricated path for "collected by GC". Covers: no cache file, all paths present, **a later (non-first) path missing — the exact #1421 regression**, and only path missing.
- Ran it directly: `bash scripts/tests/with-dev-env-cache-is-stale.test.sh` → `4 passed, 0 failed`.
- `bash -n scripts/with-dev-env.sh` and `bash -n scripts/tests/with-dev-env-cache-is-stale.test.sh` → both syntax-clean.
- No nix available in this environment, so `just dev-up` / AC2's end-to-end "partial GC then dev-up succeeds" scenario was verified by manual trace-through of the new `cache_is_stale()` logic rather than a live run: it iterates every unique `/nix/store/...` substring extracted from the cache file via `grep -o ... | sort -u` and returns stale (`return 0`) as soon as any one is missing, so a GC'd path anywhere in the file — not just the first — now forces a rebuild. AC3 (warm-cache overhead) is unchanged in shape: still zero `nix` invocations on a hit, just additional `[ -e ]` stat calls (a few hundred at most), which was already called out as negligible in the issue.
- This is a bash-only change with no cargo crate involved, so `cargo fmt`/`clippy`/`test` don't apply.

## Notes
- No unrelated refactoring — the header comment above `cache_is_stale()` was updated to describe the new "check every path" behavior; `.claude/rules/01-dev-environment.md`'s existing self-heal description was already generic enough ("the wrapper spot-checks and self-heals") that it didn't need a change.


---
_Generated by [Claude Code](https://claude.ai/code/session_0154iwVM7UPK47c5LV7SZDEW)_