### PR TITLE
fix: apply metadata overrides to Kobo sync metadata and downloads (#1391)

### DIFF
--- a/db/src/kobo.rs
+++ b/db/src/kobo.rs
@@ -132,6 +132,7 @@ pub async fn sync_books(pool: &SqlitePool, user_id: i64) -> Result<Vec<KoboBookR
     // chunks; sorting here keeps newest-modified-first over the whole set
     // rather than within each chunk.
     rows.sort_by_key(|r| std::cmp::Reverse(r.last_modified_epoch));
+    apply_title_author_overrides(pool, &mut rows).await?;
     Ok(rows)
 }
 
@@ -150,7 +151,69 @@ pub async fn book_for_sync(
         .bind(&canonical)
         .fetch_optional(pool)
         .await?;
-    Ok(row.as_ref().map(row_to_book))
+    let Some(mut book) = row.as_ref().map(row_to_book) else {
+        return Ok(None);
+    };
+    apply_title_author_overrides(pool, std::slice::from_mut(&mut book)).await?;
+    Ok(Some(book))
+}
+
+/// Overlay each row's title/author with its saved `metadata_overrides` (the
+/// same [`crate::metadata_overrides::apply_overrides`] merge `db::get_book`
+/// runs for every other book-detail surface), gated by the owning scan
+/// root's configured source precedence (#972). A no-op for rows whose uuid
+/// has no override row.
+async fn apply_title_author_overrides(
+    pool: &SqlitePool,
+    rows: &mut [KoboBookRow],
+) -> Result<(), KoboError> {
+    let uuids: Vec<String> = rows.iter().map(|r| r.uuid.clone()).collect();
+    let overrides = crate::metadata_overrides::load_overrides_bulk(pool, &uuids).await?;
+    if overrides.is_empty() {
+        return Ok(());
+    }
+    let precedence = crate::settings::metadata_precedence_by_uuid(pool, &uuids).await?;
+    for row in rows.iter_mut() {
+        let Some((ov, has_cover_override)) = overrides.get(&row.uuid) else {
+            continue;
+        };
+        let prec = precedence
+            .get(&row.uuid)
+            .cloned()
+            .unwrap_or_else(|| omnibus_shared::DEFAULT_METADATA_PRECEDENCE.to_vec());
+        // A throwaway `EbookMetadata` seeded with this row's current
+        // title/author lets `apply_overrides` do the real merge (title
+        // replace, precedence gate, creators-list replace) instead of
+        // re-deriving those rules here.
+        let mut book = omnibus_shared::EbookMetadata {
+            title: Some(row.title.clone()),
+            creators: if row.author.is_empty() {
+                Vec::new()
+            } else {
+                vec![omnibus_shared::Contributor {
+                    name: row.author.clone(),
+                    ..Default::default()
+                }]
+            },
+            ..Default::default()
+        };
+        crate::metadata_overrides::apply_overrides(
+            &mut book,
+            &row.uuid,
+            ov,
+            *has_cover_override,
+            &prec,
+        );
+        if let Some(title) = book.title {
+            row.title = title;
+        }
+        row.author = book
+            .creators
+            .first()
+            .map(|c| c.name.clone())
+            .unwrap_or_default();
+    }
+    Ok(())
 }
 
 fn row_to_book(row: &sqlx::sqlite::SqliteRow) -> KoboBookRow {

--- a/db/src/kobo.rs
+++ b/db/src/kobo.rs
@@ -172,7 +172,8 @@ async fn apply_title_author_overrides(
     if overrides.is_empty() {
         return Ok(());
     }
-    let precedence = crate::settings::metadata_precedence_by_uuid(pool, &uuids).await?;
+    let overridden_uuids: Vec<String> = overrides.keys().cloned().collect();
+    let precedence = crate::settings::metadata_precedence_by_uuid(pool, &overridden_uuids).await?;
     for row in rows.iter_mut() {
         let Some((ov, has_cover_override)) = overrides.get(&row.uuid) else {
             continue;

--- a/db/src/kobo/tests.rs
+++ b/db/src/kobo/tests.rs
@@ -1,9 +1,13 @@
-use omnibus_shared::{CreateShelfRequest, MatchMode, RuleField, RuleOp, ShelfKind, ShelfRule};
+use omnibus_shared::{
+    Contributor, CreateShelfRequest, MatchMode, MetadataOverrides, RuleField, RuleOp, ShelfKind,
+    ShelfRule,
+};
 
 use super::*;
 use crate::init_db;
 use crate::shelves::{create_shelf, update_shelf};
 use crate::test_support::seed_synced_ebook;
+use crate::upsert_metadata_overrides;
 
 async fn make_user(pool: &SqlitePool, username: &str) -> i64 {
     sqlx::query_scalar::<_, i64>(
@@ -279,6 +283,36 @@ async fn sync_books_deduplicates_a_book_on_two_opted_in_shelves() {
 }
 
 #[tokio::test]
+async fn sync_books_reflects_a_saved_title_and_author_override() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = make_user(&pool, "reader").await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Frank Herbert").await;
+    synced_manual_shelf(&pool, user, "Kobo", std::slice::from_ref(&uuid)).await;
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            title: Some("Dune (Corrected)".into()),
+            creators: Some(vec![Contributor {
+                name: "F. Herbert".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        },
+        false,
+        user,
+    )
+    .await
+    .unwrap();
+
+    let rows = sync_books(&pool, user).await.unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].title, "Dune (Corrected)");
+    assert_eq!(rows[0].author, "F. Herbert");
+}
+
+#[tokio::test]
 async fn sync_books_propagates_db_error_when_pool_is_closed() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = make_user(&pool, "reader").await;
@@ -299,6 +333,32 @@ async fn book_for_sync_returns_the_row_for_a_known_uuid() {
 
     assert_eq!(row.uuid, uuid);
     assert_eq!(row.title, "Dune");
+    assert_eq!(row.author, "Frank Herbert");
+}
+
+#[tokio::test]
+async fn book_for_sync_reflects_a_saved_title_override_with_no_creators_override() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = make_user(&pool, "reader").await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Frank Herbert").await;
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            title: Some("Dune (Corrected)".into()),
+            ..Default::default()
+        },
+        false,
+        user,
+    )
+    .await
+    .unwrap();
+
+    let row = book_for_sync(&pool, &uuid).await.unwrap().unwrap();
+
+    assert_eq!(row.title, "Dune (Corrected)");
+    // Author has no override in this test — the scanned value must survive
+    // the merge unchanged rather than being blanked.
     assert_eq!(row.author, "Frank Herbert");
 }
 

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -408,8 +408,10 @@ pub(super) async fn get_ebook_download(
 
 /// The override-baked export EPUB for `book_id` when the book has edits, else
 /// `source` unchanged. A rewrite failure logs and falls back to `source` — an
-/// export must always download *something*.
-async fn rewritten_or_source(
+/// export must always download *something*. `pub(super)` so the Kobo plain-
+/// EPUB download fallback (`backend::kobo::download`) shares it rather than
+/// serving the raw on-disk file when overrides exist.
+pub(super) async fn rewritten_or_source(
     state: &AppState,
     book_id: i64,
     source: std::path::PathBuf,

--- a/server/src/backend/kobo.rs
+++ b/server/src/backend/kobo.rs
@@ -333,11 +333,15 @@ async fn download(
     let path = if kepub_ready(&state, id).await {
         db::kepub_path(id)
     } else {
-        match db::book_file_path(state.pool(), id, "EPUB").await {
+        // Still override-baked — same fallback `get_ebook_kepub` uses — so a
+        // Kobo device without kepubify support (or after a conversion
+        // failure) sees the user's edits rather than the raw scanned file.
+        let source = match db::book_file_path(state.pool(), id, "EPUB").await {
             Ok(Some(p)) => p,
             Ok(None) => return StatusCode::NOT_FOUND.into_response(),
             Err(e) => return internal("kobo book_file_path", e),
-        }
+        };
+        super::ebooks::rewritten_or_source(&state, id, source).await
     };
     serve_download(req, &path, "application/epub+zip").await
 }

--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -975,6 +975,87 @@ async fn download_returns_404_for_unknown_uuid() {
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
 
+/// #1391: kepubify is absent in the test environment, so `download` takes its
+/// plain-EPUB fallback arm — which must still route through
+/// `rewritten_or_source` (mirrors `api_get_ebook_download_bakes_metadata_override_into_epub`
+/// in `ebooks/tests.rs`) rather than serving the raw on-disk file.
+#[tokio::test]
+async fn download_bakes_a_metadata_override_into_the_plain_epub_fallback() {
+    use std::io::Cursor;
+
+    let (app, pool, token, uid) = fixture().await;
+
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp = std::env::temp_dir().join(format!("omnibus_kobo_dl_override_{pid}_{nanos}"));
+    let export = tmp.join("export");
+    std::fs::create_dir_all(&export).unwrap();
+    // Isolate the export cache so the rewrite doesn't land in ./data.
+    let _env =
+        db::test_support::EnvVarGuard::set_os("OMNIBUS_EXPORT_EPUB_DIR", Some(export.as_os_str()));
+
+    // Copy a real fixture EPUB so the rewrite has a valid container to parse.
+    let fixture_epub = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../test_data/epubs/generated/alpha.epub");
+    let stem = "alpha";
+    std::fs::copy(&fixture_epub, tmp.join(format!("{stem}.epub"))).unwrap();
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(tmp.to_str().unwrap())
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let uuid = "55555555-5555-5555-5555-555555555555";
+    sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title, last_modified) \
+         VALUES (?, ?, ?, 'Alpha', 1)",
+    )
+    .bind(uuid)
+    .bind(lib_id)
+    .bind(tmp.to_str().unwrap())
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES ((SELECT id FROM books WHERE uuid = ?), 'EPUB', ?, 0)",
+    )
+    .bind(uuid)
+    .bind(stem)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let overrides = omnibus_shared::MetadataOverrides {
+        title: Some("Stormlight #1".into()),
+        ..Default::default()
+    };
+    db::upsert_metadata_overrides(&pool, uuid, &overrides, false, uid)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/download/{uuid}")))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+
+    let doc = epub::doc::EpubDoc::from_reader(Cursor::new(bytes.to_vec()))
+        .expect("downloaded bytes are a valid EPUB");
+    assert_eq!(
+        doc.mdata("title").map(|m| m.value.clone()),
+        Some("Stormlight #1".to_string()),
+        "kobo download fallback must carry the baked title override"
+    );
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
 #[tokio::test]
 async fn library_tags_returns_an_empty_collection() {
     let (app, _pool, token, _uid) = fixture().await;


### PR DESCRIPTION
## Summary
- Closes #1391
- `sync_books`/`book_for_sync` (`db/src/kobo.rs`) now overlay saved title/author metadata overrides before returning rows to the device, via a new `apply_title_author_overrides` helper that reuses the same `apply_overrides` merge (and scan-root precedence gate) that `db::get_book` already uses for every other book-detail surface.
- The Kobo `download` handler's plain-EPUB fallback (`server/src/backend/kobo.rs`) now routes through `rewritten_or_source` — the same override-baking helper `get_ebook_kepub`'s fallback already uses in `server/src/backend/ebooks.rs` — instead of serving the raw on-disk file when overrides exist. `rewritten_or_source` was widened from private to `pub(super)` so the sibling `kobo` module can share it.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS, no warnings
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus-db` — PASS except one pre-existing, unrelated failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) caused by a missing binary audio fixture not committed to git in this sandbox (`just fixtures` needs network access unavailable here); added `sync_books_reflects_a_saved_title_and_author_override` and `book_for_sync_reflects_a_saved_title_override_with_no_creators_override`, both PASS
- [x] `cargo test -p omnibus` — PASS except two pre-existing, unrelated failures (`backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400`) caused by running as root in this sandbox, where `chmod 0o555` doesn't actually block writes; added `download_bakes_a_metadata_override_into_the_plain_epub_fallback`, which PASSes and asserts the downloaded bytes are a valid EPUB whose internal OPF carries the baked title override

## Notes
- Both fixes are localized call-site fixes per the issue's suggested approach — no new override-merge logic, just extending the existing `metadata_overrides` machinery to two call sites that had bypassed it.


---
_Generated by [Claude Code](https://claude.ai/code/session_0154iwVM7UPK47c5LV7SZDEW)_