### PR TITLE
refactor: shrink BdPhysicalPanel's prop count and body, key its copy cards (#1399)

### DIFF
--- a/frontend/src/pages/book_detail/physical.rs
+++ b/frontend/src/pages/book_detail/physical.rs
@@ -38,26 +38,38 @@ struct PhysPanelState {
     refresh: Signal<u32>,
 }
 
-/// Physical-collection + wishlist panel. `is_fileless` is `b.formats.is_empty()`
-/// (no ebook/audiobook files); `isbn`/`title`/`author` feed the "Find a copy"
-/// search. `refresh` is the page's book-refetch signal.
+/// Book-identity fields the panel needs, bundled to keep `BdPhysicalPanel`
+/// under the 5-prop guideline (mirrors `body::BdPageCtx`). `is_fileless` is
+/// `b.formats.is_empty()` (no ebook/audiobook files); `isbn`/`title`/`author`
+/// feed the "Find a copy" search.
+#[derive(Clone, PartialEq, Props)]
+pub(super) struct BdBookIdentity {
+    pub uuid: String,
+    pub is_fileless: bool,
+    pub isbn: Option<String>,
+    pub title: String,
+    pub author: String,
+}
+
+/// Physical-collection + wishlist panel. `refresh` is the page's book-refetch
+/// signal.
 #[component]
-pub(super) fn BdPhysicalPanel(
-    uuid: String,
-    is_fileless: bool,
-    isbn: Option<String>,
-    title: String,
-    author: String,
-    refresh: Signal<u32>,
-) -> Element {
+pub(super) fn BdPhysicalPanel(identity: BdBookIdentity, refresh: Signal<u32>) -> Element {
+    let BdBookIdentity {
+        uuid,
+        is_fileless,
+        isbn,
+        title,
+        author,
+    } = identity;
     let server_url = use_server_url();
     let user = crate::use_current_user_summary();
     let can_edit = user().map(|u| u.is_admin || u.can_edit).unwrap_or(false);
 
-    let mut copies = use_signal(Vec::<PhysicalCopy>::new);
-    let mut wishlist = use_signal(|| None::<WishlistEntry>);
-    let mut loaded = use_signal(|| false);
-    let mut err = use_signal(|| None::<String>);
+    let copies = use_signal(Vec::<PhysicalCopy>::new);
+    let wishlist = use_signal(|| None::<WishlistEntry>);
+    let loaded = use_signal(|| false);
+    let err = use_signal(|| None::<String>);
     let state = PhysPanelState {
         copies,
         wishlist,
@@ -69,33 +81,14 @@ pub(super) fn BdPhysicalPanel(
         refresh,
     };
 
-    let load_url = server_url.clone();
-    use_effect(use_reactive!(|uuid| {
-        // Reset on (re)navigation so a previous book's copies/wishlist don't
-        // flash under the new book before its load resolves.
-        copies.set(Vec::new());
-        wishlist.set(None);
-        err.set(None);
-        loaded.set(false);
-        if uuid.is_empty() {
-            return;
-        }
-        let load_url = load_url.clone();
-        let uuid = uuid.clone();
-        spawn(async move {
-            // Surface a read failure rather than silently degrading to the
-            // empty "add to wishlist" state (which would mask a 500/transient).
-            match data::list_physical_copies(&load_url, &uuid).await {
-                Ok(c) => copies.set(c),
-                Err(e) => err.set(Some(e.to_string())),
-            }
-            match data::get_wishlist_entry(&load_url, &uuid).await {
-                Ok(w) => wishlist.set(w),
-                Err(e) => err.set(Some(e.to_string())),
-            }
-            loaded.set(true);
-        });
-    }));
+    use_physical_load_effect(
+        uuid.clone(),
+        server_url.clone(),
+        copies,
+        wishlist,
+        err,
+        loaded,
+    );
 
     // First paint (SSR + first WASM) renders nothing; the post-mount load fills
     // it in. No hooks past this point, so the early return keeps hook order
@@ -127,6 +120,43 @@ pub(super) fn BdPhysicalPanel(
             {render_delete_modal(state, server_url, uuid)}
         }
     }
+}
+
+/// Install the uuid-reactive load effect: fetch this book's physical copies
+/// and wishlist entry post-mount, resetting state first so a previous book's
+/// copies/wishlist don't flash under the new book before its load resolves.
+fn use_physical_load_effect(
+    uuid: String,
+    load_url: String,
+    mut copies: Signal<Vec<PhysicalCopy>>,
+    mut wishlist: Signal<Option<WishlistEntry>>,
+    mut err: Signal<Option<String>>,
+    mut loaded: Signal<bool>,
+) {
+    use_effect(use_reactive!(|uuid| {
+        copies.set(Vec::new());
+        wishlist.set(None);
+        err.set(None);
+        loaded.set(false);
+        if uuid.is_empty() {
+            return;
+        }
+        let load_url = load_url.clone();
+        let uuid = uuid.clone();
+        spawn(async move {
+            // Surface a read failure rather than silently degrading to the
+            // empty "add to wishlist" state (which would mask a 500/transient).
+            match data::list_physical_copies(&load_url, &uuid).await {
+                Ok(c) => copies.set(c),
+                Err(e) => err.set(Some(e.to_string())),
+            }
+            match data::get_wishlist_entry(&load_url, &uuid).await {
+                Ok(w) => wishlist.set(w),
+                Err(e) => err.set(Some(e.to_string())),
+            }
+            loaded.set(true);
+        });
+    }));
 }
 
 /// The checked-in-copies section: pill + one card per copy.
@@ -173,7 +203,10 @@ fn render_copy_card(
     let note_val = copy.note.clone().unwrap_or_default();
     let note_is_empty = note_val.trim().is_empty();
     rsx! {
-        div { class: "card bd-phys-copy", "data-testid": "physical-copy-card",
+        div {
+            key: "{copy.id}",
+            class: "card bd-phys-copy",
+            "data-testid": "physical-copy-card",
             div { class: "bd-phys-copy-head",
                 span { class: "bd-phys-copy-date", "{checked_in}" }
                 if let Some(isbn) = copy.isbn.clone() {

--- a/frontend/src/pages/book_detail/physical/tests.rs
+++ b/frontend/src/pages/book_detail/physical/tests.rs
@@ -74,11 +74,13 @@ mod render_tests {
     fn panel_first_paint() -> Element {
         rsx! {
             BdPhysicalPanel {
-                uuid: "book-uuid".to_string(),
-                is_fileless: false,
-                isbn: None,
-                title: "Dracula".to_string(),
-                author: "Bram Stoker".to_string(),
+                identity: BdBookIdentity {
+                    uuid: "book-uuid".to_string(),
+                    is_fileless: false,
+                    isbn: None,
+                    title: "Dracula".to_string(),
+                    author: "Bram Stoker".to_string(),
+                },
                 refresh: use_signal(|| 0u32),
             }
         }

--- a/frontend/src/pages/book_detail/view.rs
+++ b/frontend/src/pages/book_detail/view.rs
@@ -239,11 +239,13 @@ pub(super) fn render_loaded(
                     },
                 }
                 physical::BdPhysicalPanel {
-                    uuid: uuid.clone(),
-                    is_fileless,
-                    isbn: isbn13,
-                    title: title.clone(),
-                    author: panel_author,
+                    identity: physical::BdBookIdentity {
+                        uuid: uuid.clone(),
+                        is_fileless,
+                        isbn: isbn13,
+                        title: title.clone(),
+                        author: panel_author,
+                    },
                     refresh,
                 }
                 section { class: "bd-body-grid",


### PR DESCRIPTION
## Summary
- Closes #1399
- Bundle `BdPhysicalPanel`'s book-identity props (`uuid`, `is_fileless`, `isbn`, `title`, `author`) into a new `BdBookIdentity` struct, mirroring the `body::BdPageCtx` bundling pattern; `refresh` stays its own prop.
- Extract the load effect into a named helper, `use_physical_load_effect(...)`, mirroring `mod.rs`'s `use_book_data_effects` — the component body is now ~35 lines, well under the 80-line cap.
- Give `render_copy_card`'s root element a stable `key: "{copy.id}"`, matching every other keyed loop in this feature (`hero.rs`).
- The fourth acceptance item (inline test modules moved to a sibling `tests.rs`) was already done by #1423's file-length split — `physical/tests.rs` already existed as a sibling of the flat `physical.rs`, so no further move was needed there; only the one preview helper inside it was updated to build the new `BdBookIdentity` prop shape.

Pure refactor — no behavior change. No new tests were added/removed/renamed; one existing render-test helper was updated to match the new prop shape.

## Test plan
- [x] `cargo fmt` — clean (formatted `physical.rs`)
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — clean, no warnings
- [x] `cargo test -p omnibus-frontend --features server` — 517 passed, 0 failed (same suite; only one test's fixture-construction was updated for the new prop shape)
- [ ] wasm32 `frontend-web` clippy target — **not run**, this environment has no `nix`/`dx` tooling to invoke the `.#web` shell's wasm32 target; the change only touches component-prop shape and a hook-free helper extraction, not any `#[cfg(feature = "web")]` path, so risk is low, but flagging as unverified per the task instructions.

## Notes
- No functional/behavioral change. `BdBookIdentity` derives `Clone, PartialEq, Props` per Dioxus component-prop convention, matching `body::BdPageCtx`/`BdAuthorCluster`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0154iwVM7UPK47c5LV7SZDEW)_