### PR TITLE
feat: gate Add books entry point and page on can_upload

### DIFF
--- a/frontend/src/components/top_nav.rs
+++ b/frontend/src/components/top_nav.rs
@@ -30,6 +30,7 @@ pub fn TopNav() -> Element {
     let is_authors = matches!(route, Route::AuthorsIndex {} | Route::AuthorDetail { .. });
     let is_series = matches!(route, Route::SeriesIndex {} | Route::SeriesDetail { .. });
     let is_stats = matches!(route, Route::Stats {});
+    let can_upload = crate::use_can_upload();
 
     rsx! {
         nav { class: "atrium-topbar", aria_label: "Primary",
@@ -72,17 +73,79 @@ pub fn TopNav() -> Element {
                     onclick: move |_| check_in_open.set(true),
                     "Check in"
                 }
-                button {
-                    class: "btn primary sm",
-                    r#type: "button",
-                    "data-testid": "add-books-button",
-                    onclick: move |_| {
+                AddBooksButton {
+                    can_upload: can_upload(),
+                    on_click: move |_| {
                         nav.push(Route::AddBooks {});
                     },
-                    "Add books"
                 }
                 UserMenu {}
             }
         }
+    }
+}
+
+/// The "Add books" nav entry, gated on `can_upload` — the server's
+/// `require_upload` (`server/src/backend/uploads.rs`) is the real boundary;
+/// this only keeps the entry point off a screen a non-uploader would 403 on.
+/// Split out from [`TopNav`] so both render states are unit-testable without
+/// a router/context (mirrors `SettingsSidebar`'s bool-prop shape in
+/// `pages::settings`).
+#[component]
+fn AddBooksButton(can_upload: bool, on_click: EventHandler<MouseEvent>) -> Element {
+    if !can_upload {
+        return rsx! {};
+    }
+    rsx! {
+        button {
+            class: "btn primary sm",
+            r#type: "button",
+            "data-testid": "add-books-button",
+            onclick: move |e| on_click.call(e),
+            "Add books"
+        }
+    }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+
+    // `AddBooksButton` takes an `EventHandler` prop, and building one via
+    // `Callback::new` asserts a Dioxus runtime is active — true inside a
+    // component body mid-render, but not in a bare `rsx! { .. }` built
+    // directly in a `#[test]` fn. So each harness constructs the button from
+    // inside its own component body and the test drives it through a real
+    // `VirtualDom`, mirroring `contexts::tests::AssertBustCounter`.
+    #[component]
+    fn AllowedHarness() -> Element {
+        rsx! {
+            AddBooksButton { can_upload: true, on_click: move |_| {} }
+        }
+    }
+
+    #[component]
+    fn ForbiddenHarness() -> Element {
+        rsx! {
+            AddBooksButton { can_upload: false, on_click: move |_| {} }
+        }
+    }
+
+    #[test]
+    fn add_books_button_omits_markup_when_can_upload_is_false() {
+        let mut dom = VirtualDom::new(ForbiddenHarness);
+        dom.rebuild_in_place();
+        let html = dioxus::ssr::render(&dom);
+        assert!(!html.contains("add-books-button"));
+        assert!(!html.contains("Add books"));
+    }
+
+    #[test]
+    fn add_books_button_renders_when_can_upload_is_true() {
+        let mut dom = VirtualDom::new(AllowedHarness);
+        dom.rebuild_in_place();
+        let html = dioxus::ssr::render(&dom);
+        assert!(html.contains("data-testid=\"add-books-button\""));
+        assert!(html.contains("Add books"));
     }
 }

--- a/frontend/src/components/top_nav.rs
+++ b/frontend/src/components/top_nav.rs
@@ -85,12 +85,7 @@ pub fn TopNav() -> Element {
     }
 }
 
-/// The "Add books" nav entry, gated on `can_upload` — the server's
-/// `require_upload` (`server/src/backend/uploads.rs`) is the real boundary;
-/// this only keeps the entry point off a screen a non-uploader would 403 on.
-/// Split out from [`TopNav`] so both render states are unit-testable without
-/// a router/context (mirrors `SettingsSidebar`'s bool-prop shape in
-/// `pages::settings`).
+/// The "Add books" nav entry, shown only when `can_upload` is true.
 #[component]
 fn AddBooksButton(can_upload: bool, on_click: EventHandler<MouseEvent>) -> Element {
     if !can_upload {

--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -207,6 +207,27 @@ pub fn use_is_admin() -> ReadSignal<bool> {
     ReadSignal::new(use_signal(|| false))
 }
 
+/// Derive `can_upload` from the app-wide [`CurrentUser`] context, same
+/// shape as [`use_is_admin`]: an admin implicitly may upload even with the
+/// flag unset (mirrors `require_upload` in
+/// `server/src/backend/uploads.rs`, the real enforcement boundary this
+/// only pre-empts in the UI). Web-only: see [`use_is_admin`] for why the
+/// other targets take the fallback below.
+#[cfg(feature = "web")]
+pub fn use_can_upload() -> ReadSignal<bool> {
+    let user_ctx = use_current_user().0;
+    ReadSignal::new(use_memo(
+        move || matches!(user_ctx(), Some(Some(ref u)) if u.is_admin || u.can_upload),
+    ))
+}
+
+/// Non-web fallback for [`use_can_upload`] — same reasoning as
+/// [`use_is_admin`]'s fallback.
+#[cfg(not(feature = "web"))]
+pub fn use_can_upload() -> ReadSignal<bool> {
+    ReadSignal::new(use_signal(|| false))
+}
+
 /// Derive the resolved current user from the app-wide [`CurrentUser`]
 /// context — a pure function of its value, so `use_memo` recomputes it
 /// inline with no extra render pass, flattening "not yet resolved" and

--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -207,12 +207,7 @@ pub fn use_is_admin() -> ReadSignal<bool> {
     ReadSignal::new(use_signal(|| false))
 }
 
-/// Derive `can_upload` from the app-wide [`CurrentUser`] context, same
-/// shape as [`use_is_admin`]: an admin implicitly may upload even with the
-/// flag unset (mirrors `require_upload` in
-/// `server/src/backend/uploads.rs`, the real enforcement boundary this
-/// only pre-empts in the UI). Web-only: see [`use_is_admin`] for why the
-/// other targets take the fallback below.
+/// Derive `can_upload` (admin implies it) from [`CurrentUser`] — mirrors [`use_is_admin`].
 #[cfg(feature = "web")]
 pub fn use_can_upload() -> ReadSignal<bool> {
     let user_ctx = use_current_user().0;

--- a/frontend/src/contexts.rs
+++ b/frontend/src/contexts.rs
@@ -344,7 +344,9 @@ mod tests {
 
     use dioxus::prelude::*;
 
-    use super::{append_cache_bust, bump_cover_cache_bust, cover_bust_for, format_page_title};
+    use super::{
+        append_cache_bust, bump_cover_cache_bust, cover_bust_for, format_page_title, use_can_upload,
+    };
 
     #[test]
     fn format_page_title_prefixes_subtitle_and_omits_when_none() {
@@ -406,5 +408,22 @@ mod tests {
             rsx! {}
         }
         VirtualDom::new(AssertBustCounter).rebuild_in_place();
+    }
+
+    // The `web` arm (which derives the real value from `CurrentUser`) needs
+    // the wasm32 target and isn't compiled for this native run, so only the
+    // non-web fallback is exercisable here — same blind spot `use_is_admin`
+    // already has. It's still worth pinning: this is the value SSR and the
+    // first WASM paint both render before the boot effect resolves the real
+    // permission (rule 07), so a regression here would flash the upload UI.
+    #[test]
+    fn use_can_upload_defaults_to_false_on_the_non_web_fallback() {
+        #[component]
+        fn AssertCanUpload() -> Element {
+            let can_upload = use_can_upload();
+            assert!(!can_upload());
+            rsx! {}
+        }
+        VirtualDom::new(AssertCanUpload).rebuild_in_place();
     }
 }

--- a/frontend/src/pages/add_books.rs
+++ b/frontend/src/pages/add_books.rs
@@ -1,12 +1,8 @@
-//! Add-books page (`/add-books`) — upload an EPUB or audiobook into the library.
-//! Users pick a file; the server parses it for an editable confirm step, then
-//! files it into the canonical folder and redirects to the new book. Ebooks
-//! take one `.epub`; audiobooks one `.m4a`/`.m4b` or a set of `.mp3` parts. The
-//! rsx is target-agnostic — file interop runs only in the post-mount `spawn`.
-//!
-//! Gated on `can_upload`: the real boundary is the server's `require_upload`
-//! (`server/src/backend/uploads.rs`); this just keeps the form off a screen
-//! the submit would 403 on, mirroring `pages::logs`'s `use_is_admin` gate.
+//! Add-books page (`/add-books`) — upload an EPUB or audiobook into the
+//! library, gated on `can_upload` (server's `require_upload` remains the real
+//! boundary). Users pick a file; the server parses it for an editable confirm
+//! step, then files it into the canonical folder and redirects to the new
+//! book. rsx is target-agnostic — file interop runs only in `spawn`.
 
 use dioxus::prelude::*;
 use dioxus_router::use_navigator;

--- a/frontend/src/pages/add_books.rs
+++ b/frontend/src/pages/add_books.rs
@@ -3,6 +3,10 @@
 //! files it into the canonical folder and redirects to the new book. Ebooks
 //! take one `.epub`; audiobooks one `.m4a`/`.m4b` or a set of `.mp3` parts. The
 //! rsx is target-agnostic — file interop runs only in the post-mount `spawn`.
+//!
+//! Gated on `can_upload`: the real boundary is the server's `require_upload`
+//! (`server/src/backend/uploads.rs`); this just keeps the form off a screen
+//! the submit would 403 on, mirroring `pages::logs`'s `use_is_admin` gate.
 
 use dioxus::prelude::*;
 use dioxus_router::use_navigator;
@@ -58,6 +62,10 @@ impl UploadState {
 /// Upload form: pick a file, confirm/correct the auto-extracted metadata, file it.
 #[component]
 pub fn AddBooksPage() -> Element {
+    // All hooks run unconditionally on every render — only the rsx output
+    // below branches on `can_upload` — so the hook call order stays stable
+    // once the boot effect resolves the real permission (rule 07).
+    let can_upload = crate::use_can_upload();
     let server_url = use_server_url();
     let nav = use_navigator();
 
@@ -79,6 +87,10 @@ pub fn AddBooksPage() -> Element {
     let on_file = make_on_file(server_url.clone(), state);
     let on_submit = make_on_submit(server_url, state, nav);
     let is_audiobook = (state.mode)() == UploadMode::Audiobook;
+
+    if !can_upload() {
+        return rsx! { AddBooksForbidden {} };
+    }
 
     rsx! {
         section { class: "card",
@@ -110,6 +122,22 @@ pub fn AddBooksPage() -> Element {
                     class: if (state.status_is_error)() { "settings-status error" } else { "settings-status success" },
                     "{msg}"
                 }
+            }
+        }
+    }
+}
+
+/// Not-authorized state shown in place of the form to a user without
+/// `can_upload`. Split out (no props, no hooks) so it's directly
+/// render-testable without `AddBooksPage`'s router dependency
+/// (`use_navigator` panics outside a `Router` ancestor).
+#[component]
+fn AddBooksForbidden() -> Element {
+    rsx! {
+        section { class: "card",
+            h1 { "Add books" }
+            p { class: "settings-status error", "data-testid": "add-books-forbidden",
+                "You don't have permission to add books to this library."
             }
         }
     }
@@ -520,5 +548,22 @@ fn ConfirmForm(state: UploadState, audiobook: bool, on_submit: EventHandler<Form
                 }
             }
         }
+    }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod render_tests {
+    use super::*;
+
+    /// A user without `can_upload` sees the not-authorized state, not the
+    /// upload form — the markup `AddBooksPage` returns via `AddBooksForbidden`
+    /// when its `use_can_upload` gate is (the SSR/pre-hydration default) false.
+    #[test]
+    fn add_books_forbidden_renders_not_authorized_message_not_the_form() {
+        let html = dioxus::ssr::render_element(rsx! { AddBooksForbidden {} });
+        assert!(html.contains("data-testid=\"add-books-forbidden\""));
+        assert!(html.contains("have permission to add books"));
+        assert!(!html.contains("add-books-file-input"));
+        assert!(!html.contains("add-books-submit"));
     }
 }


### PR DESCRIPTION
## Summary
- Closes #945
- Hide the top-nav "Add books" button (`AddBooksButton` in `frontend/src/components/top_nav.rs`) unless the current user has `can_upload` (or is admin), via a new `use_can_upload` accessor in `frontend/src/contexts.rs` mirroring the existing `use_is_admin` pattern.
- Guard `/add-books` (`frontend/src/pages/add_books.rs`) so a user without the permission sees a not-authorized state (`AddBooksForbidden`) instead of the upload form, mirroring the `use_is_admin` gate already used on `pages::logs`.
- Server-side `require_upload` (`server/src/backend/uploads.rs`) is untouched and remains the real enforcement boundary — this change only keeps the client UI in sync with it (defense in depth).
- Both new gates default to `false` on SSR/first paint (matching `use_is_admin`'s existing bootstrapping convention) so the upload UI never flashes for an unauthorized user before the real permission resolves post-hydration.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (520 passed, including 3 new tests: `AddBooksButton` omits/renders markup by `can_upload`, `AddBooksForbidden` renders the not-authorized state instead of the form)
- [ ] Playwright — not run in this environment (no server available); the nav button and a new `add-books-forbidden` testid may warrant a follow-up E2E spec under `ui_tests/playwright/tests/flows/`.

## Notes
- 


---
_Generated by [Claude Code](https://claude.ai/code/session_01NQoAFicPp9dtT7RTJWz56G)_