### PR TITLE
fix: keep iOS pull-to-refresh from cancelling its own reads

### DIFF
--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -338,6 +338,18 @@ had the old value and nothing published the update. Resume points are stricter
 still (network-first), because a stale empty list hides the Continue rail
 entirely.
 
+**Pull-to-refresh uses `refreshTask`, never `refreshable`.** SwiftUI cancels a
+`refreshable` action the moment the view it is attached to invalidates, and
+every refresh here publishes as it goes — the replica first, the server's answer
+when it lands. Publishing the replica redrew the view, which cancelled the
+action, which cancelled the request still in flight behind it: a pull re-rendered
+the same stale page, so a book added or removed on the server never showed up
+until the app was relaunched. Changing a filter did pick it up, because that
+reload runs in a task of its own — which is what made this look like a caching
+bug rather than a cancellation one. `View.refreshTask` runs the work
+unstructured and awaits it, detaching it from that cancellation while keeping
+the spinner up until the refresh has settled.
+
 **Offline is Swift-native.** The Rust layer pairs its download registry with a
 loopback HTTP server so the WebView can play a local file. `AVPlayer` and
 `WKWebView` both load `file://` directly, so that hop is gone. The rest is a

--- a/omnibus-ios/omnibus/App/RefreshTask.swift
+++ b/omnibus-ios/omnibus/App/RefreshTask.swift
@@ -12,7 +12,10 @@ import SwiftUI
 /// tested without standing up a view.
 @MainActor
 func runUncancelled(_ action: @escaping @MainActor () async -> Void) async {
-    await Task { await action() }.value
+    // Isolation spelled out rather than left to `Task.init`'s inheritance: the
+    // actor it runs on is not what detaches it — cancellation is — and an
+    // unannotated closure invites a later reader to "fix" the wrong half.
+    await Task { @MainActor in await action() }.value
 }
 
 extension View {

--- a/omnibus-ios/omnibus/App/RefreshTask.swift
+++ b/omnibus-ios/omnibus/App/RefreshTask.swift
@@ -1,0 +1,35 @@
+//  RefreshTask.swift
+//  Pull-to-refresh whose work outlives the redraw it causes.
+
+import SwiftUI
+
+/// Run `action` where the caller's cancellation can't reach it, and wait for it.
+///
+/// An unstructured `Task` inherits priority and task-locals but not
+/// cancellation, and awaiting its value is not itself a cancellation point — so
+/// a cancelled caller still gets a completed action rather than an abandoned
+/// one. Factored out of [`View.refreshTask`] so the property that matters can be
+/// tested without standing up a view.
+@MainActor
+func runUncancelled(_ action: @escaping @MainActor () async -> Void) async {
+    await Task { await action() }.value
+}
+
+extension View {
+    /// `refreshable`, with the work detached from the action's own cancellation.
+    ///
+    /// SwiftUI cancels a `refreshable` action the moment the view it is attached
+    /// to invalidates. Every refresh here publishes as it goes — the replica
+    /// first, the server's answer when it lands — so publishing the replica
+    /// cancelled the action, and with it the request still in flight behind it.
+    /// The pull then redrew the same stale page: a book added elsewhere never
+    /// appeared and a removed one never left, while a filter change picked both
+    /// up immediately because its reload runs in a task of its own.
+    ///
+    /// Awaiting the detached task keeps the spinner up until the refresh has
+    /// actually settled. Prefer this to `refreshable` for anything that writes
+    /// to state the view reads.
+    func refreshTask(_ action: @escaping @MainActor () async -> Void) -> some View {
+        refreshable { await runUncancelled(action) }
+    }
+}

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -153,7 +153,7 @@ struct BookDetailView: View {
         .toolbar { toolbar }
         .bookZoomDestination(uuid, in: bookZoom)
         .task { await model.load(uuid: uuid) }
-        .refreshable { await model.load(uuid: uuid) }
+        .refreshTask { await model.load(uuid: uuid) }
         .sheet(isPresented: $showJournalComposer) {
             if let book = model.book {
                 JournalComposer(book: book, editing: editingJournal) {

--- a/omnibus-ios/omnibus/Features/Discovery/DiscoveryViews.swift
+++ b/omnibus-ios/omnibus/Features/Discovery/DiscoveryViews.swift
@@ -97,7 +97,7 @@ struct AuthorsView: View {
         .background(ScreenBackground())
         .navigationTitle("Authors")
         .searchable(text: $query, prompt: "Filter authors")
-        .refreshable { await load(force: true) }
+        .refreshTask { await load(force: true) }
         .task { await load() }
     }
 

--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -189,7 +189,7 @@ struct LibraryView: View {
             .topEdgeScrim()
             // An explicit pull is the one place the whole-library mirror is
             // worth re-pulling on demand rather than on its own schedule.
-            .refreshable {
+            .refreshTask {
                 async let mirror: Void = LibraryIndex.shared.sync(force: true)
                 await model.reload()
                 await mirror

--- a/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
+++ b/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
@@ -63,7 +63,7 @@ struct ShelvesView: View {
                 Button { showCreate = true } label: { Image(systemName: "plus") }
             }
         }
-        .refreshable { await load(force: true) }
+        .refreshTask { await load(force: true) }
         .sheet(isPresented: $showCreate) {
             CreateShelfSheet { Task { await load(force: true) } }
         }
@@ -187,7 +187,7 @@ struct ShelfDetailView: View {
                 }
             }
         }
-        .refreshable { await load(force: true) }
+        .refreshTask { await load(force: true) }
         .task { await load() }
     }
 

--- a/omnibus-ios/omnibus/Features/Stats/StatsView.swift
+++ b/omnibus-ios/omnibus/Features/Stats/StatsView.swift
@@ -29,7 +29,7 @@ struct StatsView: View {
             // root; a stock large title alongside it would state it twice.
             .toolbar(.hidden, for: .navigationBar)
             .topEdgeScrim()
-            .refreshable { await load(force: true) }
+            .refreshTask { await load(force: true) }
             .withDestinations()
         }
         .task { await load() }

--- a/omnibus-ios/omnibusTests/RefreshTaskTests.swift
+++ b/omnibus-ios/omnibusTests/RefreshTaskTests.swift
@@ -1,0 +1,57 @@
+//  RefreshTaskTests.swift
+//  What `refreshTask` promises: a refresh whose caller is cancelled mid-flight
+//  still finishes.
+//
+//  Worth pinning because the failure is silent. SwiftUI cancels a `refreshable`
+//  action as soon as the view redraws, every refresh redraws it by publishing
+//  the replica, and the cancelled request that followed simply never landed —
+//  a pull that looked like it worked and changed nothing.
+
+import Testing
+
+@testable import omnibus
+
+/// Somewhere for a detached action to record that it ran.
+@MainActor
+private final class Witness {
+    var finished = false
+    var sawCancellation = true
+}
+
+@Suite("Detached refresh work")
+@MainActor
+struct RefreshTaskTests {
+    @Test("action runs to completion after its caller is cancelled")
+    func actionSurvivesCallerCancellation() async {
+        let witness = Witness()
+
+        let caller = Task { @MainActor in
+            await runUncancelled {
+                // Long enough that the cancellation below lands mid-action,
+                // which is exactly when the refresh used to be dropped.
+                try? await Task.sleep(for: .milliseconds(150))
+                witness.sawCancellation = Task.isCancelled
+                witness.finished = true
+            }
+        }
+
+        try? await Task.sleep(for: .milliseconds(20))
+        caller.cancel()
+        await caller.value
+
+        #expect(witness.finished)
+        #expect(!witness.sawCancellation)
+    }
+
+    @Test("the caller waits for the action rather than returning early")
+    func callerWaitsForTheAction() async {
+        let witness = Witness()
+
+        await runUncancelled {
+            try? await Task.sleep(for: .milliseconds(50))
+            witness.finished = true
+        }
+
+        #expect(witness.finished)
+    }
+}


### PR DESCRIPTION
## Description

Pull-to-refresh in the native iOS app never adopted the server's answer. A book added or removed on the server — or a shelf created there — stayed invisible until the app was relaunched, while applying a filter picked it up immediately.

The cause is not caching. SwiftUI **cancels a `refreshable` action the moment the view it is attached to invalidates**, and every refresh here invalidates that view as its first act: `Cache.live` yields the replica, the model publishes it, the body redraws, the action is cancelled, and the `/api/ebooks` request still in flight is cancelled with it.

Instrumented run, before the fix:

```
refreshable fired
reload enter          cancelled=false
child-page enter      cancelled=true      ← already dead
child-page exit
live fetching key=books_page:newest_added.desc.
live ERROR  key=books_page:newest_added.desc. err=CancellationError()
```

Isolated to a single mutation: `model.isLoading = true` alone flips `Task.isCancelled`, while a 550 ms sleep touching nothing does not. The server log is the blunt version — **a pull produced zero completed requests**.

This also explains the two things that made it look like a cache bug:

- **Changing a filter worked** because `category`'s `didSet` runs `Task { await reload() }`, an unstructured task nothing cancels.
- **Search worked** because it never goes through `Cache.live`; it reads the local mirror and calls `/api/search` directly.

## Implementation

New `View.refreshTask` (`omnibus-ios/omnibus/App/RefreshTask.swift`) runs the action through `runUncancelled` — an unstructured `Task`, which inherits priority and task-locals but *not* cancellation — and awaits its value, so the spinner stays up until the refresh has actually settled.

All six pull-to-refresh sites had the identical bug and are switched over: library, shelves list, shelf detail, book detail, authors, stats.

## Affected Crates

None — `omnibus-ios/` only (Xcode project, not a Cargo crate). No server, db, shared, or frontend changes.

## Acceptance Criteria

Verified end-to-end against a local server on a booted simulator, one pull each time:

| Change made server-side | Before | After |
|---|---|---|
| Book added + reindex | 28, unchanged | 31 → 32, new book at top |
| Two books removed + reindex | stale | 32 → 30, both gone |
| Shelf created via `POST /api/shelves` | absent | appears with its mosaic |

- `RefreshTaskTests.swift` pins the contract the fix rests on: a caller cancelled mid-action still gets a completed action (and the action observes no cancellation), and the caller waits rather than returning early.
- Full `xcodebuild test` suite passes.

## Follow-ups (not in this PR)

- **No lint guard against `.refreshable`.** All six sites had this bug because `.refreshable` is the obvious thing to reach for; nothing fails if a seventh screen uses it. A source-scan test would catch it.
- **The iOS test target never runs in CI.** `testflight.yml` is the only workflow touching `omnibus-ios/`, is `workflow_dispatch`-only, and runs `xcodebuild archive` with no `xcodebuild test` anywhere in the repo. So these tests only run locally.
- **`omnibus-ios/README.md` has a stale paragraph** ("Cached reads have a freshness bound") describing `Cache.readThrough` and a 45 s `freshnessWindow`, neither of which still exists — the code is `Cache.live`. Left alone here to keep the diff to the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
