### PR TITLE
fix: keep the iOS reader's page ground on the selected theme

### DIFF
--- a/omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js
+++ b/omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js
@@ -305,24 +305,15 @@
       installContentLinkNav();
       installStageResizeWatch(elementId);
 
-      // These body backgrounds are mirrored by the per-theme `--rd-page`
-      // token in atrium.css (the reader-surface ground) — change both
-      // together or the chrome strips stop matching the page.
-      rendition.themes.register("light", {
-        body: { background: "#fcfbfa", color: foregroundColorForTheme("light") },
-      });
-      rendition.themes.register("dark", {
-        body: { background: "#201e1b", color: foregroundColorForTheme("dark") },
-      });
-      // Matches Apple Books' dark reading theme on macOS: a pure-black
-      // #000000 page with bright #ffffff text.
-      rendition.themes.register("black", {
-        body: { background: "#000000", color: foregroundColorForTheme("black") },
-      });
-      rendition.themes.register("sepia", {
-        body: { background: "#ede4d0", color: foregroundColorForTheme("sepia") },
-      });
-      rendition.themes.select(opts.theme || "dark");
+      // The page's colours are the reader's own — see `applyThemeColors` and
+      // the baseline stylesheet — rather than epub.js themes.
+      //
+      // `themes.select` was the wrong tool: it appends a per-theme <style> to
+      // each section head and never removes or reorders one, so the ground came
+      // from whichever theme was appended last, not from the selected one. Once
+      // all four had been visited every later switch left the page on the
+      // fourth one's ground while the ink and the host chrome followed the
+      // selection — Light ink on a black page.
       currentTheme = opts.theme || "dark";
       applyHostGround(currentTheme);
 
@@ -756,10 +747,34 @@
     }
   }
 
+  // Page grounds, keyed by theme token. Mirrored by the per-theme `--rd-page`
+  // token in atrium.css and by `Palette.readerPage` in the iOS design system —
+  // change all three together or the chrome strips stop matching the page.
+  // Black matches Apple Books' dark reading theme on macOS: a pure-black page
+  // under bright #ffffff text.
+  var PAGE_GROUNDS = {
+    light: "#fcfbfa",
+    dark: "#201e1b",
+    black: "#000000",
+    sepia: "#ede4d0",
+  };
+
+  function backgroundColorForTheme(name) {
+    return PAGE_GROUNDS[name] || PAGE_GROUNDS.dark;
+  }
+
   // Push the current theme's reader-owned colours into a section as CSS vars
   // the baseline stylesheet reads. Runs per section and on every theme swap.
+  //
+  // A variable rather than a stylesheet swap is the whole point: one rule reads
+  // it, so a theme change is a value changing in place and can never turn into
+  // a cascade race between the ground the reader left and the one it picked.
   function applyThemeColors(doc) {
     if (doc && doc.documentElement) {
+      doc.documentElement.style.setProperty(
+        "--omn-bg",
+        backgroundColorForTheme(currentTheme)
+      );
       doc.documentElement.style.setProperty(
         "--omn-fg",
         foregroundColorForTheme(currentTheme)
@@ -807,18 +822,22 @@
       // margins, justification — set elsewhere), while the publisher keeps
       // structure — weight, style, headings, alignment, indents, small-caps.
       //
-      // Appended last, and `!important` on colour so a publisher hue can't
-      // override the theme. Include `body` itself: descendants inheriting from
-      // a publisher-coloured, classed body otherwise stay black in Black/Dark
-      // themes. Only *real* links — `a` with an `href` — get the reader's
-      // accent. Scoping to `[href]` also spares body text that Gutenberg wraps
-      // in a self-closing *named* anchor (`<a id="chapN"/>`, no href), which
-      // the HTML parser leaves open across the chapter.
+      // Appended last, and `!important` on both ground and ink so a publisher
+      // hue can't override the theme. Include `body` itself: descendants
+      // inheriting from a publisher-coloured, classed body otherwise stay black
+      // in Black/Dark themes. Only *real* links — `a` with an `href` — get the
+      // reader's accent. Scoping to `[href]` also spares body text that
+      // Gutenberg wraps in a self-closing *named* anchor (`<a id="chapN"/>`, no
+      // href), which the HTML parser leaves open across the chapter.
+      //
+      // The ground is one rule over `html,body` only — never `body *`, which
+      // would paint every element its own opaque box.
       if (!doc.getElementById("__omnibus_baseline")) {
         var style = doc.createElement("style");
         style.id = "__omnibus_baseline";
         style.textContent =
           "html,body{-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto;}" +
+          "html,body{background:var(--omn-bg,#201e1b)!important;}" +
           "body,body *{color:var(--omn-fg,#f5f3f0)!important;}" +
           "a:not([href]){cursor:auto;}" +
           "a[href]{color:var(--omn-link,#4a86d8)!important;text-decoration:none;}" +
@@ -1746,15 +1765,6 @@
     applyMarkStyles();
   }
 
-  // Page grounds, keyed by theme token. Mirrors the `themes.register` bodies
-  // above — change both together.
-  var HOST_GROUNDS = {
-    light: "#fcfbfa",
-    dark: "#201e1b",
-    black: "#000000",
-    sepia: "#ede4d0",
-  };
-
   // Paint the *host* document the same ground as the page.
   //
   // The stage is inset from the safe areas, so the bands above and below it are
@@ -1762,14 +1772,15 @@
   // dark behind a white page — which reads as a broken frame around the prose
   // now that the chrome floats over those bands instead of covering them.
   function applyHostGround(name) {
-    var ground = HOST_GROUNDS[name];
-    if (!ground || !document.documentElement) return;
-    document.documentElement.style.setProperty("--page", ground);
+    if (!document.documentElement) return;
+    document.documentElement.style.setProperty(
+      "--page",
+      backgroundColorForTheme(name)
+    );
   }
 
   function setTheme(name) {
     if (!rendition) return;
-    rendition.themes.select(name);
     currentTheme = name;
     applyHostGround(name);
     applyMarkStyles();


### PR DESCRIPTION
## Problem

Switching reading themes in the iOS reader stops changing the page once all four have been visited. Reported as "switching between all the themes quickly breaks things" — speed isn't the trigger, **revisiting** a theme is.

Pick Light → Sepia → Dark → Black and each one lands correctly. Pick any of them a second time and the page keeps Black's ground, while the ink (`--omn-fg`) and the host chrome/safe-area bands do follow the selection. The result is Light's near-black ink on a black page.

## Root cause

`setTheme` drove `rendition.themes.select(name)`. epub.js implements that by appending a `<style id="epubjs-inserted-css-{theme}">` into the section's `<head>` — and it never removes, empties, or reorders one. The id appears **exactly once** in the whole vendored bundle, inside `_getStylesheetNode`, which only ever get-or-creates:

```js
_getStylesheetNode(t){var e;return t="epubjs-inserted-css-"+(t||""),
  !!this.document&&((e=this.document.getElementById(t))||
  ((e=this.document.createElement("style")).id=t,this.document.head.appendChild(e)),e)}
```

So the page ground came from **document order of style nodes** — the order the themes were *first* visited — not from the current selection. Revisiting a theme re-inserted its rule into a node that was no longer last in the cascade, so it lost to a theme the reader had already left.

Replaying the sequence against the real vendored `Contents` class:

| selected | computed body background |
|---|---|
| dark | `#201e1b` ✅ |
| light | `#fcfbfa` ✅ |
| sepia | `#ede4d0` ✅ |
| black | `#000000` ✅ |
| **light** | **`#000000`** ❌ |
| **dark** | **`#000000`** ❌ |
| **sepia** | **`#000000`** ❌ |

## Fix

The reader now owns the page ground the same way it already owned ink and link colour: an `--omn-bg` custom property set by `applyThemeColors`, read by one `!important` rule in `__omnibus_baseline`. A theme change becomes a value changing in place, so there is no node ordering left to get wrong and nothing accumulates in the section head on repeated switches.

- `themes.register` × 4 and `themes.select` removed — that mechanism is what carried the defect.
- `HOST_GROUNDS` folded into a single `PAGE_GROUNDS` map, now read by both the page (`applyThemeColors`) and the host's safe-area bands (`applyHostGround`), so the two can't drift.
- Ground is scoped to `html,body` only — never `body *`, which would paint every element its own opaque box.

## Verification

Replaying nine switches through the patched mechanism — with an adversarial publisher `body{background:#fff}` **and** a stale `epubjs-inserted-css-black` node appended *after* the baseline — ground and ink track the selection on every switch, including all revisits.

**Not verified on device.** The build succeeds and installs, but signing the simulator into a server needs credentials entered by hand, so the reader itself wasn't driven through a theme cycle. Worth a manual pass before merge.

## Notes

- **The web reader has the same bug.** `frontend/assets/vendor/epub-reader-glue.js` has the identical `themes.register`/`themes.select` structure. Left out of this PR — it needs its own Playwright pass.
- No test added: the glue is untested JS on both surfaces, with no JS runner in either project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
