### PR TITLE
fix: icon + readable ink on the continue-reading hero CTA

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -116,7 +116,12 @@
      lands the contrast ratio near 3.5:1 — still reads as muted, but legible
      for the small UI text these rails carry. */
   --ink-3: oklch(0.50 0.010 70);
-  --accent-ink: oklch(0.99 0 0);
+  /* Light does not darken `--accent`, so it keeps the 0.78 L amber from
+     `:root`. A near-white ink on that ground is ~2:1 — every accent-filled
+     control (the hero resume pill, primary buttons, active toggles) was
+     unreadable. Sepia can afford white ink because it drops the accent to
+     0.58 L; light has to take the dark ink instead. */
+  --accent-ink: oklch(0.16 0.02 65);
   --cover-fallback-bg:  oklch(0.86 0.004 70);
   --cover-fallback-ink: oklch(0.28 0.006 70);
   --rd-page: #fcfbfa;
@@ -2862,7 +2867,9 @@ a.idx-letter-on:focus-visible {
   font-family: var(--mono);
   font-size: 10px;
 }
-.um-nr-play {
+/* Scoped like `.ch-hero .ch-cta` — a bare class loses `color` to
+   `.atrium a { color: inherit }` and the glyph washes out on the amber disc. */
+.um-now-reading .um-nr-play {
   align-self: center; flex: 0 0 34px; width: 34px; height: 34px;
   border-radius: 999px; display: grid; place-items: center;
   background: var(--accent); color: var(--accent-ink); text-decoration: none;
@@ -6867,8 +6874,14 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .ch-bar + .ch-foot { margin-top: 6px; }
 .ch-hero .ch-body:not(:has(.ch-bar)) .ch-foot { margin-top: auto; }
 .ch-meta { font-size: 11.5px; color: var(--ink-2); }
-.ch-cta {
+/* Scoped under `.ch-hero` to outrank `.atrium a { color: inherit }`, which a
+   bare `.ch-cta` loses to — that left the pill at `--ink-0`, i.e. near-white
+   on the amber ground in the default dark theme. */
+.ch-hero .ch-cta {
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   padding: 7px 13px;
   border-radius: 999px;
   background: var(--accent);
@@ -6878,6 +6891,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   text-decoration: none;
   transition: filter 0.15s;
 }
+.ch-cta svg { display: block; flex-shrink: 0; }
 @media (hover: hover) { .ch-cta:hover { filter: brightness(1.08); } }
 .ch-dots { display: flex; justify-content: center; gap: 6px; }
 .ch-dot {

--- a/frontend/src/components/glyphs.rs
+++ b/frontend/src/components/glyphs.rs
@@ -1,0 +1,29 @@
+//! Inline SVG marks for the "continue reading / listening" affordances — the
+//! user-menu resume row and the landing hero CTA. Shared so both surfaces draw
+//! the same glyph, sized to whatever pill they sit in.
+
+use dioxus::prelude::*;
+
+/// Solid play triangle for the "continue listening" affordance.
+pub fn play_glyph(size: u32) -> Element {
+    rsx! {
+        svg {
+            width: "{size}", height: "{size}", view_box: "0 0 15 15", fill: "currentColor",
+            "aria-hidden": "true",
+            path { d: "M4 2.5v10l8-5z" }
+        }
+    }
+}
+
+/// Open-book outline for the "continue reading" affordance.
+pub fn book_glyph(size: u32) -> Element {
+    rsx! {
+        svg {
+            width: "{size}", height: "{size}", view_box: "0 0 24 24", fill: "none",
+            stroke: "currentColor", stroke_width: "2", stroke_linecap: "round", stroke_linejoin: "round",
+            "aria-hidden": "true",
+            path { d: "M4 19.5A2.5 2.5 0 0 1 6.5 17H20" }
+            path { d: "M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" }
+        }
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -110,6 +110,11 @@ pub mod search_palette;
 #[cfg(not(feature = "mobile"))]
 pub mod worker_status;
 
+// Play / open-book marks shared by the two web "continue reading" surfaces:
+// the user-menu resume row and the landing hero CTA.
+#[cfg(not(feature = "mobile"))]
+pub mod glyphs;
+
 #[cfg(not(feature = "mobile"))]
 mod user_menu;
 

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -8,6 +8,7 @@ use dioxus_router::{use_navigator, Link};
 use omnibus_shared::{ProgressFormat, ResumePoint, UserSummary};
 
 use crate::components::atrium::{persist_theme, Cover, Theme};
+use crate::components::glyphs::{book_glyph, play_glyph};
 use crate::{use_current_user, Route};
 
 /// Derive 1–2 character avatar initials from a username. Empty input falls
@@ -315,35 +316,11 @@ fn um_now_reading_row(point: ResumePoint) -> Element {
                 "data-testid": "user-menu-now-reading-action",
                 "aria-label": "{action_label}",
                 if is_audio {
-                    {play_glyph()}
+                    {play_glyph(14)}
                 } else {
-                    {book_glyph()}
+                    {book_glyph(14)}
                 }
             }
-        }
-    }
-}
-
-/// Solid play triangle for the "continue listening" affordance.
-#[cfg(any(feature = "web", feature = "server"))]
-fn play_glyph() -> Element {
-    rsx! {
-        svg {
-            width: "14", height: "14", view_box: "0 0 15 15", fill: "currentColor",
-            path { d: "M4 2.5v10l8-5z" }
-        }
-    }
-}
-
-/// Open-book outline for the "continue reading" affordance.
-#[cfg(any(feature = "web", feature = "server"))]
-fn book_glyph() -> Element {
-    rsx! {
-        svg {
-            width: "14", height: "14", view_box: "0 0 24 24", fill: "none",
-            stroke: "currentColor", stroke_width: "2", stroke_linecap: "round", stroke_linejoin: "round",
-            path { d: "M4 19.5A2.5 2.5 0 0 1 6.5 17H20" }
-            path { d: "M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" }
         }
     }
 }

--- a/frontend/src/pages/landing/hero.rs
+++ b/frontend/src/pages/landing/hero.rs
@@ -9,6 +9,7 @@ use dioxus_router::Link;
 use omnibus_shared::{ProgressFormat, ResumePoint};
 
 use super::resume_meta::resume_meta;
+use crate::components::glyphs::{book_glyph, play_glyph};
 use crate::Route;
 
 /// Watch the hero cards and report the index of the mostly-visible one, so
@@ -191,7 +192,12 @@ fn HeroCard(point: ResumePoint, server_url: String) -> Element {
                         class: "ch-cta",
                         "data-testid": "hero-resume-{uuid}",
                         aria_label: "{eyebrow}: {title}",
-                        "{cta_label}"
+                        if is_audio {
+                            {play_glyph(11)}
+                        } else {
+                            {book_glyph(11)}
+                        }
+                        span { "{cta_label}" }
                     }
                 }
             }

--- a/omnibus-ios/omnibus/Design/Theme.swift
+++ b/omnibus-ios/omnibus/Design/Theme.swift
@@ -110,7 +110,11 @@ struct Palette: Sendable {
         ink3: OKLCH(0.50, 0.010, 70),
         accent: OKLCH(0.78, 0.13, 65),
         accentSoft: OKLCH(0.30, 0.07, 65),
-        accentInk: OKLCH(0.99, 0, 0),
+        // Light keeps the dark palette's 0.78 L amber accent, so it takes the
+        // dark ink with it — a near-white ink on that ground is ~2:1, which is
+        // what made the Continue-reading capsule unreadable. Sepia can use a
+        // white ink only because it drops the accent to 0.58 L.
+        accentInk: OKLCH(0.16, 0.02, 65),
         coverFallbackBg: OKLCH(0.86, 0.004, 70),
         coverFallbackInk: OKLCH(0.28, 0.006, 70),
         ok: OKLCH(0.78, 0.13, 150),


### PR DESCRIPTION
## Summary
The landing hero's resume CTA rendered as near-white text on the amber pill —
1.44:1 in the default Atrium theme. Two independent causes, both fixed here.

- `.atrium a { color: inherit }` (0,1,1) outranks a bare `.ch-cta` (0,1,0), so
  `color: var(--accent-ink)` never applied and the pill inherited `--ink-0`.
  Scoped the rule under `.ch-hero`; `.um-nr-play` had the identical defect.
- The Light palette keeps `:root`'s 0.78 L amber accent but paired it with a
  near-white `--accent-ink` (~2:1 on *every* accent-filled control). Light now
  takes the dark ink; Sepia is untouched since it drops its accent to 0.58 L.
- The CTA is now icon + label (open book / play triangle), matching what the
  iOS `ContinueHero` capsule already does with `book.fill` / `play.fill`. The
  two glyphs moved out of `user_menu.rs` into `components/glyphs.rs`.
- `Palette.light.accentInk` in the iOS client gets the same token fix — there
  is no `color: inherit` accident masking it there, so Light mode really did
  render white-on-amber.

## Test plan
- [x] Measured contrast in-browser across all four themes: atrium 1.44 → 9.48,
      black 1.46 → 16.7, light 2.0 → 9.48, sepia 4.21 (unchanged).
- [x] Both hero variants checked in Light and Atrium — book glyph + "Read",
      play glyph + "Play"; no console errors, no hydration warnings.
- [x] `cargo test -p omnibus-frontend --features server` — 516 passed.
- [x] `just lint` (fmt + clippy matrix incl. wasm32 + stylelint) clean.
- [x] iOS `xcodebuild -scheme omnibus` succeeds.

## Version
- [ ] **Minor**
- [x] **Patch** — default.
- [ ] **No release**

## Notes
Sepia sits at 4.21:1, just under AA's 4.5 for 12px semibold. Left alone —
it predates this change and fixing it means moving Sepia's accent, not its ink.

Not verified: the iOS app could not be installed on a simulator here. The
project's deployment target is 26.5 and the only installed runtime is 26.4, so
the contrast claim for iOS rests on it using the identical OKLCH token pair as
the measured web case, not on a screenshot.