### PR TITLE
fix: drop the redundant breadcrumb from the authors and series index pages

### DIFF
--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -226,7 +226,7 @@ fn authors_index_body<'a>(
     }
 }
 
-/// Header: breadcrumb, hero, filter/sort toolbar, optional A–Z letter strip.
+/// Header: hero, filter/sort toolbar, optional A–Z letter strip.
 #[component]
 fn AuthorsIndexHeader(
     counts: AuthorIndexCounts,
@@ -249,13 +249,6 @@ fn AuthorsIndexHeader(
     } = filter_state;
     rsx! {
         div { class: "idx-header",
-            nav {
-                class: "breadcrumb",
-                aria_label: "breadcrumb",
-                Link { to: Route::Landing {}, "Library" }
-                span { class: "breadcrumb-sep", " › " }
-                span { "Authors" }
-            }
             div { class: "idx-head-row",
                 div {
                     span { class: "label", "Library lens" }

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -142,7 +142,7 @@ struct SeriesHeaderView {
     sort: IndexSort,
 }
 
-/// Header: breadcrumb, hero heading + subtitle, filter input, sort toggles.
+/// Header: hero heading + subtitle, filter input, sort toggles.
 #[component]
 fn SeriesIndexHeader(
     view: SeriesHeaderView,
@@ -157,13 +157,6 @@ fn SeriesIndexHeader(
     } = view;
     rsx! {
         div { class: "idx-header",
-            nav {
-                class: "breadcrumb",
-                aria_label: "breadcrumb",
-                Link { to: Route::Landing {}, "Library" }
-                span { class: "breadcrumb-sep", " › " }
-                span { "Series" }
-            }
             div { class: "idx-head-row",
                 div {
                     span { class: "label", "Library lens" }

--- a/ui_tests/playwright/tests/flows/browse_indices.spec.ts
+++ b/ui_tests/playwright/tests/flows/browse_indices.spec.ts
@@ -21,9 +21,9 @@ test("renders the authors index layout", async ({ page }) => {
   // Hero — "By author."
   await expect(page.getByRole("heading", { level: 1 })).toContainText("author");
 
-  // Breadcrumb has "Library" link.
-  const breadcrumb = page.locator("nav.breadcrumb");
-  await expect(breadcrumb.getByRole("link", { name: "Library" })).toBeVisible();
+  // No breadcrumb — /authors is a top-level route, so the shared nav is the
+  // only wayfinding it needs.
+  await expect(page.locator("nav.breadcrumb")).toHaveCount(0);
 
   // Toolbar — filter input and at least one sort button.
   await expect(page.getByTestId("authors-filter")).toBeVisible();
@@ -112,8 +112,7 @@ test("renders the series index layout", async ({ page }) => {
 
   await expect(page.getByRole("heading", { level: 1 })).toContainText("series");
 
-  const breadcrumb = page.locator("nav.breadcrumb");
-  await expect(breadcrumb.getByRole("link", { name: "Library" })).toBeVisible();
+  await expect(page.locator("nav.breadcrumb")).toHaveCount(0);
 
   await expect(page.getByTestId("series-filter")).toBeVisible();
   await expect(page.getByTestId("series-sort-name")).toBeVisible();


### PR DESCRIPTION
## Summary
- `/authors` and `/series` are top-level routes reached straight from the shared nav, so their `Library › Authors` breadcrumb pointed at a parent the nav already exposes. Removed it from both index headers.
- The shared `.breadcrumb` styles stay — `/search`, book detail, and metadata edit still use them.

## Test plan
- [x] `just lint` (fmt + clippy across the matrix, incl. wasm32) and `just lint-ts` (biome + tsc) clean
- [x] `cargo test -p omnibus-frontend --features server` — 528 passed
- [x] `browse_indices.spec.ts` layout tests now assert `nav.breadcrumb` has count 0 on both pages
- [x] Verified in the browser against a bounced dev server: both headers render with the hero directly under the nav, no console errors

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.