### PR TITLE
refactor: cap kobo_devices list and document ebooks pagination default (#1453)

### DIFF
--- a/db/src/kobo_devices.rs
+++ b/db/src/kobo_devices.rs
@@ -13,10 +13,7 @@ use crate::auth::generate_token;
 const COLS: &str =
     "id, user_id, token, name, kobo_device_id, sync_cursor, created_at, last_seen_at";
 
-/// Hard cap on how many devices `list_devices` returns for a single user.
-/// Matches `LIST_SHELVES_LIMIT`/`LIST_BOOKMARKS_LIMIT` — a real reader
-/// registers only a handful of Koboes, but the cap keeps the response bounded
-/// regardless.
+/// Hard cap on devices `list_devices` returns for one user (matches `LIST_SHELVES_LIMIT`/`LIST_BOOKMARKS_LIMIT`).
 pub const LIST_DEVICES_LIMIT: i64 = 100;
 
 /// One registered Kobo: its owning user, the re-displayable path token, a

--- a/db/src/kobo_devices.rs
+++ b/db/src/kobo_devices.rs
@@ -13,6 +13,12 @@ use crate::auth::generate_token;
 const COLS: &str =
     "id, user_id, token, name, kobo_device_id, sync_cursor, created_at, last_seen_at";
 
+/// Hard cap on how many devices `list_devices` returns for a single user.
+/// Matches `LIST_SHELVES_LIMIT`/`LIST_BOOKMARKS_LIMIT` — a real reader
+/// registers only a handful of Koboes, but the cap keeps the response bounded
+/// regardless.
+pub const LIST_DEVICES_LIMIT: i64 = 100;
+
 /// One registered Kobo: its owning user, the re-displayable path token, a
 /// user-visible label, the learned `x-kobo-deviceid` (once seen), the opaque
 /// per-device delta cursor, and timestamps.
@@ -77,9 +83,11 @@ pub async fn list_devices(
     let rows = sqlx::query(&format!(
         "SELECT {COLS} FROM kobo_devices
          WHERE user_id = ?
-         ORDER BY created_at ASC, id ASC"
+         ORDER BY created_at ASC, id ASC
+         LIMIT ?"
     ))
     .bind(user_id)
+    .bind(LIST_DEVICES_LIMIT)
     .fetch_all(pool)
     .await?;
     Ok(rows.iter().map(row_to_device).collect())

--- a/db/src/kobo_devices/tests.rs
+++ b/db/src/kobo_devices/tests.rs
@@ -272,6 +272,38 @@ async fn resolve_device_by_hardware_id_propagates_db_error_when_pool_is_closed()
     assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
 }
 
+/// Seed `count` devices directly via SQL (bypassing `create_device`'s token
+/// generation, which is unnecessarily expensive at this volume).
+async fn seed_devices_raw(pool: &SqlitePool, user_id: i64, count: i64) {
+    sqlx::query(
+        "WITH RECURSIVE n(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
+        )
+        INSERT INTO kobo_devices (user_id, token, name, created_at)
+        SELECT ?, 'tok-' || i, 'Kobo ' || i, i FROM n",
+    )
+    .bind(count)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn list_devices_caps_response_at_hard_limit() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "reader").await;
+    let over_cap = LIST_DEVICES_LIMIT + 50;
+    seed_devices_raw(&pool, user, over_cap).await;
+
+    let listed = list_devices(&pool, user).await.unwrap();
+    assert_eq!(
+        listed.len() as i64,
+        LIST_DEVICES_LIMIT,
+        "list_devices must not return more than LIST_DEVICES_LIMIT rows",
+    );
+}
+
 #[tokio::test]
 async fn deleting_the_user_cascades_the_device() {
     let pool = init_db("sqlite::memory:").await.unwrap();


### PR DESCRIPTION
## Summary
- `db/src/kobo_devices.rs::list_devices` had no `LIMIT`, unlike every sibling list function in `db/src` (`LIST_SHELVES_LIMIT`, `LIST_BOOKMARKS_LIMIT`, `LIST_HIGHLIGHTS_LIMIT`, `LIST_WISHLIST_LIMIT`). Added an explicit `LIST_DEVICES_LIMIT` constant (100, mirroring `bookmarks::LIST_BOOKMARKS_LIMIT`'s pattern) and an `ORDER BY … LIMIT ?` clause.
- Investigated the `server/src/backend/ebooks.rs::get_ebooks` no-params default (falls through to `respond_full_library`). It already carries an in-code comment explaining the full-library fallback is intentional back-compat, and confirmed by reading callers that this is genuinely required: `frontend/src/data/books.rs::get_ebooks` (built under the `mobile` feature, used by the Android shell's `library_picker_grid.rs` and `account.rs`) calls `GET /api/ebooks` with no query params and expects the full payload. Real keyset pagination (`respond_keyset_page`) is opt-in via `sort`/`dir`/`cursor`/`limit`/`formats`, as F5b intended. No code change was needed here — the acceptance criterion ("documents in-code why a full-library response is intentional for back-compat") was already satisfied.
- Closes #1453

## Test plan
- [x] `cargo fmt` — no diff
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 1467 passed (new `list_devices_caps_response_at_hard_limit` included); 1 unrelated pre-existing flake (`worker::tests::poisoned_progress_lock_recovers_instead_of_panicking`, passes in isolation — a known parallel-thread flake, not touched by this change)
- [x] `cargo test -p omnibus` — 547 passed; 2 unrelated pre-existing failures in `backend::uploads::tests` (`commit_rejects_read_only_library_with_400`, `audiobook_commit_rejects_read_only_library_with_400`) caused by the sandbox running tests as `root`, which bypasses the read-only-directory permission check those tests rely on — same class as the known `uploads inspect_allows_non_admin` flake, unrelated to `db/src/kobo_devices.rs`
- [x] `cargo test -p omnibus backend::kobo` — all 76 Kobo-route server tests pass

## Version
- [x] **Patch** — the default; leaving unlabeled (tech-debt label applied separately)

## Notes
- Scope is intentionally narrow: only `db/src/kobo_devices.rs` and its sibling `db/src/kobo_devices/tests.rs` changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VPCQcEtXzv2WJg7g4Ci3Rn)_