### PR TITLE
fix: surface actual server error message on OPF export failure (#1342)

### DIFF
--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -123,12 +123,14 @@ impl DataError {
     }
 }
 
-/// Flatten a [`DataError`] into the user-facing diagnostic text a caller
-/// should display. For an HTTP failure this splices the server's response
-/// body back in — `DataError`'s own `Display` deliberately omits it (see the
-/// `Http` variant's doc comment) — so a 409/403 renders its actual reason
-/// instead of a bare status code. Every other variant falls back to its own
-/// `Display`.
+/// Flatten a [`DataError`] into diagnostic text for a UI surface that
+/// already treats the server body as user-facing. For an HTTP failure this
+/// splices the server's response body back in — `DataError`'s own `Display`
+/// deliberately omits it (see the `Http` variant's doc comment) — so a
+/// 409/403 renders its actual reason instead of a bare status code. Every
+/// other variant falls back to its own `Display`. Not a default for every
+/// caller: some contexts (e.g. offline downloads) deliberately avoid echoing
+/// raw server bodies to the user.
 pub fn server_error_message(err: &DataError) -> String {
     match err {
         DataError::Http { status, body } if !body.is_empty() => format!("{status}: {body}"),

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -123,6 +123,19 @@ impl DataError {
     }
 }
 
+/// Flatten a [`DataError`] into the user-facing diagnostic text a caller
+/// should display. For an HTTP failure this splices the server's response
+/// body back in — `DataError`'s own `Display` deliberately omits it (see the
+/// `Http` variant's doc comment) — so a 409/403 renders its actual reason
+/// instead of a bare status code. Every other variant falls back to its own
+/// `Display`.
+pub fn server_error_message(err: &DataError) -> String {
+    match err {
+        DataError::Http { status, body } if !body.is_empty() => format!("{status}: {body}"),
+        other => other.to_string(),
+    }
+}
+
 /// Dioxus context wrapper holding the backend base URL for mobile clients.
 ///
 /// Reactive: the pre-login Connect screen rewrites this signal, and every
@@ -823,6 +836,33 @@ mod tests {
         let err = DataError::Other("missing value field".into());
         assert!(!err.is_unauthorized());
         assert_eq!(err.to_string(), "missing value field");
+    }
+
+    #[test]
+    fn server_error_message_splices_the_body_back_in_for_http_errors() {
+        let err = DataError::Http {
+            status: 409,
+            body: "book has no EPUB file to export next to".into(),
+        };
+        assert_eq!(
+            server_error_message(&err),
+            "409: book has no EPUB file to export next to"
+        );
+    }
+
+    #[test]
+    fn server_error_message_falls_back_to_display_for_an_empty_body() {
+        let err = DataError::Http {
+            status: 500,
+            body: String::new(),
+        };
+        assert_eq!(server_error_message(&err), "server returned 500");
+    }
+
+    #[test]
+    fn server_error_message_falls_back_to_display_for_non_http_variants() {
+        let err = DataError::Other("book not found".into());
+        assert_eq!(server_error_message(&err), "book not found");
     }
 
     // `Decode` only exists on the web/mobile builds that link `serde_json`

--- a/frontend/src/pages/auth/mod.rs
+++ b/frontend/src/pages/auth/mod.rs
@@ -97,19 +97,15 @@ async fn submit_register(
 }
 
 /// Flatten a [`crate::data::DataError`] into the user-facing string the auth
-/// pages surface. For an HTTP failure we splice the server's diagnostic body
-/// back in — `DataError`'s own `Display` deliberately omits it, but the
-/// register-error classifier keys on "username"/"password" substrings, so the
-/// mobile path must keep the body to route field errors correctly (mirrors
-/// the pre-#96 `"{status}: {body}"` string).
+/// pages surface. Delegates to [`crate::data::server_error_message`], which
+/// splices the server's diagnostic body back into an HTTP failure —
+/// `DataError`'s own `Display` deliberately omits it, but the register-error
+/// classifier keys on "username"/"password" substrings, so the mobile path
+/// must keep the body to route field errors correctly (mirrors the pre-#96
+/// `"{status}: {body}"` string).
 #[cfg(feature = "mobile")]
 fn data_error_message(err: crate::data::DataError) -> String {
-    match err {
-        crate::data::DataError::Http { status, body } if !body.is_empty() => {
-            format!("{status}: {body}")
-        }
-        other => other.to_string(),
-    }
+    crate::data::server_error_message(&err)
 }
 
 /// Best-effort device name for the bearer-login `device_name` field. The

--- a/frontend/src/pages/metadata_edit/sidebar.rs
+++ b/frontend/src/pages/metadata_edit/sidebar.rs
@@ -97,7 +97,7 @@ fn ExportCard(uuid: String, saving: Signal<bool>) -> Element {
         spawn(async move {
             let result = data::export_opf(&server_url, &uuid)
                 .await
-                .map_err(|e| format!("Export failed: {e}"));
+                .map_err(|e| export_error_message(&e));
             status.set(Some(result));
             exporting.set(false);
         });
@@ -140,5 +140,42 @@ fn ExportCard(uuid: String, saving: Signal<bool>) -> Element {
                 None => rsx! {},
             }
         }
+    }
+}
+
+/// Build the status-line message for a failed export, splicing in the
+/// server's actual diagnostic text (via [`data::server_error_message`])
+/// instead of `DataError`'s status-only `Display` — a 409/403 should read
+/// as its real reason, not "server returned {status}".
+fn export_error_message(err: &data::DataError) -> String {
+    format!("Export failed: {}", data::server_error_message(err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_error_message_surfaces_the_servers_diagnostic_body() {
+        let err = data::DataError::Http {
+            status: 409,
+            body: "book has no EPUB file to export next to".into(),
+        };
+        assert_eq!(
+            export_error_message(&err),
+            "Export failed: 409: book has no EPUB file to export next to"
+        );
+    }
+
+    #[test]
+    fn export_error_message_falls_back_to_display_when_the_body_is_empty() {
+        let err = data::DataError::Http {
+            status: 500,
+            body: String::new(),
+        };
+        assert_eq!(
+            export_error_message(&err),
+            "Export failed: server returned 500"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Closes #1342
- The OPF export button's error handler formatted `DataError`'s own `Display`, which deliberately omits the response body (see the doc comment on `DataError::Http` in `frontend/src/data.rs`), so every 4xx from the export endpoint — a 409 ("book has no EPUB file to export next to") or a 403 ("edit permission required") — collapsed to an uninformative `Export failed: server returned 409` / `Export failed: server returned 403` on both web and mobile.
- Extracted the body-recovering match arm from `frontend/src/pages/auth/mod.rs`'s `data_error_message` into a new `data::server_error_message(err: &DataError) -> String` helper, and used it from `sidebar.rs`'s export error handler (now `export_error_message`) so the actual server-provided text is surfaced instead of the bare status code. `auth/mod.rs`'s mobile-only `data_error_message` now delegates to the shared helper instead of duplicating the match arm.

## Test plan
- [x] `cargo fmt -p omnibus-frontend -- --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (533 passed; 0 failed), including 5 new tests:
  - `data::tests::server_error_message_splices_the_body_back_in_for_http_errors`
  - `data::tests::server_error_message_falls_back_to_display_for_an_empty_body`
  - `data::tests::server_error_message_falls_back_to_display_for_non_http_variants`
  - `pages::metadata_edit::sidebar::tests::export_error_message_surfaces_the_servers_diagnostic_body`
  - `pages::metadata_edit::sidebar::tests::export_error_message_falls_back_to_display_when_the_body_is_empty`

## Version
- [ ] **Minor**
- [ ] **Patch** — default, unlabeled (leaving as default patch release)
- [ ] **No release**

## Notes
- Scoped to the one confirmed call site (`sidebar.rs`) per the issue. A quick grep found no other misuse of `DataError`'s bare `Display` outside `auth/mod.rs` (which already handled it correctly and now shares the same helper) and this one.
- The existing Playwright spec (`ui_tests/playwright/tests/flows/metadata_edit.spec.ts`, "surfaces error when the OPF export mutation fails") only forces a raw 500 at the network-route level against the server-function transport and asserts the generic "Export failed" prefix — it doesn't (and can't, without a live server) exercise the specific 409/403 server-provided message, so the acceptance criterion for a message-specific assertion is covered instead by the new Rust-level unit tests on `export_error_message` / `server_error_message`, mirroring the exact 409 "book has no EPUB file to export next to" wording from `server/src/backend/export_opf.rs`. This spec was not run in this environment (no nix/pnpm/playwright available here).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPCQcEtXzv2WJg7g4Ci3Rn)_