### PR TITLE
refactor: physical collection UI rough edges (#1401)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -731,7 +731,7 @@ html, body { overscroll-behavior: none; }
 }
 .bd-fmt-badge--physical { color: var(--accent); border-color: var(--accent); }
 
-/* Physical collection + wishlist panel (F Physical Check-In, issue #1186) */
+/* Physical collection + wishlist panel */
 .bd-physical-panel {
   max-width: var(--content-w, 1120px);
   margin: 0 auto; padding: 0 24px;

--- a/frontend/src/data/physical.rs
+++ b/frontend/src/data/physical.rs
@@ -1,9 +1,7 @@
-//! Physical-collection + wishlist transport for the book-detail page: a book's
-//! library-wide copies (list / edit-note / delete), the caller's wishlist entry
-//! (get / add / remove), and fileless-book removal. Mobile calls the
-//! `/api/physical/*` REST routes via `reqwest`; web/SSR proxy the RPC server
-//! functions in `crate::rpc`. Each function's public signature is shared across
-//! platforms; the `#[cfg]` gates carry the split.
+//! Physical-collection + wishlist transport for the book-detail page: copies
+//! (list / edit-note / delete), wishlist entry (get / add / remove), and
+//! fileless-book removal. Mobile calls `/api/physical/*` REST routes; web/SSR
+//! proxy the RPC server functions in `crate::rpc` behind a shared signature.
 
 use omnibus_shared::physical::{PhysicalCopy, WishlistEntry};
 

--- a/frontend/src/pages/book_detail/physical.rs
+++ b/frontend/src/pages/book_detail/physical.rs
@@ -1,5 +1,4 @@
 //! Web-only physical-collection + wishlist panel for the book-detail page.
-//!
 //! Renders checked-in copies (edit-note / delete), the wishlist tracking card,
 //! and the add-to-wishlist affordance. Self-loads post-mount for SSR/WASM
 //! hydration parity; bumps the page `refresh` signal after mutations that

--- a/frontend/src/pages/book_detail/physical.rs
+++ b/frontend/src/pages/book_detail/physical.rs
@@ -1,11 +1,9 @@
 //! Web-only physical-collection + wishlist panel for the book-detail page.
 //!
-//! Renders the "In your physical collection" pill with one card per checked-in
-//! copy (edit-note / delete), the wishlist tracking card (Remove / Find a copy),
-//! and the "Add to physical wishlist" affordance for any book without a copy.
-//! Self-loads its data post-mount so SSR and the first WASM paint match
-//! (rule 07); the page `refresh` signal is bumped after mutations that change
-//! the book's physical/visibility state so the hero re-fetches.
+//! Renders checked-in copies (edit-note / delete), the wishlist tracking card,
+//! and the add-to-wishlist affordance. Self-loads post-mount for SSR/WASM
+//! hydration parity; bumps the page `refresh` signal after mutations that
+//! change the book's physical/visibility state.
 
 use dioxus::prelude::*;
 use omnibus_shared::physical::{PhysicalCopy, WishlistEntry, WishlistSource};
@@ -99,13 +97,7 @@ pub(super) fn BdPhysicalPanel(identity: BdBookIdentity, refresh: Signal<u32>) ->
     }
 
     let content = if !copies().is_empty() {
-        render_physical_section(
-            state,
-            server_url.clone(),
-            uuid.clone(),
-            is_fileless,
-            can_edit,
-        )
+        render_physical_section(state, server_url.clone(), is_fileless, can_edit)
     } else if wishlist().is_some() {
         render_wishlist_section(state, server_url.clone(), uuid.clone(), isbn, title, author)
     } else {
@@ -164,7 +156,6 @@ fn use_physical_load_effect(
 fn render_physical_section(
     state: PhysPanelState,
     url: String,
-    uuid: String,
     is_fileless: bool,
     can_edit: bool,
 ) -> Element {
@@ -178,7 +169,7 @@ fn render_physical_section(
         }
         div { class: "bd-phys-copies",
             for copy in copies() {
-                {render_copy_card(state, url.clone(), uuid.clone(), copy, is_fileless, can_edit)}
+                {render_copy_card(state, url.clone(), copy, is_fileless, can_edit)}
             }
         }
     }
@@ -189,7 +180,6 @@ fn render_physical_section(
 fn render_copy_card(
     state: PhysPanelState,
     url: String,
-    _uuid: String,
     copy: PhysicalCopy,
     is_fileless: bool,
     can_edit: bool,
@@ -500,18 +490,22 @@ fn delete_copy_only(state: PhysPanelState, url: String, copy_id: i64) {
     });
 }
 
-/// Last-copy "Remove from library": delete the copy, then the now-fileless
-/// book. The copy is dropped from local state — and the modal closed — the
-/// instant its delete succeeds, so a failed follow-up book-delete can't leave a
-/// phantom card the user would retry into a 404. Bumps `refresh` only on full
-/// success (book gone → the page re-renders not-found).
-fn delete_last_and_remove(state: PhysPanelState, url: String, uuid: String, copy_id: i64) {
+/// Shared shape of the two last-copy actions: delete the copy, drop it from
+/// local state, close the modal, then run `follow_up` for the effect specific
+/// to "remove from library" vs "move to wishlist". The copy leaves local state
+/// the instant its own delete succeeds — before `follow_up` runs — so a failed
+/// follow-up can't resurrect a phantom card or leave a stale one; it can only
+/// drop the panel into a state the user can retry from.
+fn delete_last_copy_then<F, Fut>(state: PhysPanelState, url: String, copy_id: i64, follow_up: F)
+where
+    F: FnOnce() -> Fut + 'static,
+    Fut: std::future::Future<Output = ()> + 'static,
+{
     let PhysPanelState {
         mut copies,
         mut busy,
         mut err,
         mut delete_target,
-        mut refresh,
         ..
     } = state;
     busy.set(true);
@@ -522,46 +516,44 @@ fn delete_last_and_remove(state: PhysPanelState, url: String, uuid: String, copy
             busy.set(false);
             return;
         }
-        // Copy is gone server-side — reflect that locally before the book
-        // delete, whose failure must not resurrect the card.
         copies.with_mut(|l| l.retain(|c| c.id != copy_id));
         delete_target.set(None);
-        match data::delete_fileless_book(&url, &uuid).await {
-            Ok(()) => refresh.with_mut(|r| *r += 1),
-            Err(e) => err.set(Some(e.to_string())),
-        }
+        follow_up().await;
         busy.set(false);
     });
 }
 
-/// Last-copy "Move to wishlist": delete the copy, then wishlist the book. Same
-/// contract as [`delete_last_and_remove`] — the copy leaves local state as soon
-/// as its delete succeeds, so a failed wishlist-add drops the panel into its
-/// "add to wishlist" state (a clean retry) rather than showing a stale card.
-fn delete_last_and_wishlist(state: PhysPanelState, url: String, uuid: String, copy_id: i64) {
+/// Last-copy "Remove from library": delete the copy, then the now-fileless
+/// book. Bumps `refresh` only on full success (book gone → the page re-renders
+/// not-found).
+fn delete_last_and_remove(state: PhysPanelState, url: String, uuid: String, copy_id: i64) {
     let PhysPanelState {
-        mut copies,
-        mut wishlist,
-        mut busy,
+        mut refresh,
         mut err,
-        mut delete_target,
         ..
     } = state;
-    busy.set(true);
-    err.set(None);
-    spawn(async move {
-        if let Err(e) = data::delete_physical_copy(&url, copy_id).await {
-            err.set(Some(e.to_string()));
-            busy.set(false);
-            return;
+    let book_url = url.clone();
+    delete_last_copy_then(state, url, copy_id, move || async move {
+        match data::delete_fileless_book(&book_url, &uuid).await {
+            Ok(()) => refresh.with_mut(|r| *r += 1),
+            Err(e) => err.set(Some(e.to_string())),
         }
-        copies.with_mut(|l| l.retain(|c| c.id != copy_id));
-        delete_target.set(None);
-        match data::add_wishlist_entry(&url, &uuid).await {
+    });
+}
+
+/// Last-copy "Move to wishlist": delete the copy, then wishlist the book.
+fn delete_last_and_wishlist(state: PhysPanelState, url: String, uuid: String, copy_id: i64) {
+    let PhysPanelState {
+        mut wishlist,
+        mut err,
+        ..
+    } = state;
+    let entry_url = url.clone();
+    delete_last_copy_then(state, url, copy_id, move || async move {
+        match data::add_wishlist_entry(&entry_url, &uuid).await {
             Ok(entry) => wishlist.set(Some(entry)),
             Err(e) => err.set(Some(e.to_string())),
         }
-        busy.set(false);
     });
 }
 
@@ -638,8 +630,8 @@ fn source_label(source: WishlistSource) -> &'static str {
     }
 }
 
-/// "Find a copy" target URL. A default web search until the per-user source
-/// setting lands (#1188): the ISBN when present, else title + author.
+/// "Find a copy" target URL: a web search on the ISBN when present, else on
+/// title + author.
 fn find_a_copy_url(isbn: Option<&str>, title: &str, author: &str) -> String {
     let query = match isbn {
         Some(i) if !i.trim().is_empty() => i.trim().to_string(),

--- a/frontend/src/pages/book_detail/physical/tests.rs
+++ b/frontend/src/pages/book_detail/physical/tests.rs
@@ -117,7 +117,7 @@ mod render_tests {
             delete_target: use_signal(|| None),
             refresh: use_signal(|| 0u32),
         };
-        render_physical_section(state, "".to_string(), "u".to_string(), false, true)
+        render_physical_section(state, "".to_string(), false, true)
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Trim both physical module docs (`frontend/src/pages/book_detail/physical.rs`, `frontend/src/data/physical.rs`) to the repo's 5-line `//!` cap.
- Drop the two issue-number references baked into comments (`find_a_copy_url`'s doc comment, `atrium.css`'s panel section header) — they now state the behavior instead of a tracking issue that will rot.
- Remove `render_copy_card`'s unused `_uuid: String` parameter and the matching `uuid.clone()` at its call site (and the now-dead `uuid` param it forced onto `render_physical_section`), so no clone happens on every copy card on every render.
- Factor the ~80%-identical shape of `delete_last_and_remove` and `delete_last_and_wishlist` into a shared `delete_last_copy_then` helper (delete copy → drop from local list → close modal → run the action-specific follow-up).

Closes #1401

## Test plan
- [x] `cargo fmt` — no diff
- [x] `cargo clippy -p omnibus-frontend --features server -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features web --target wasm32-unknown-unknown -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (528 passed; 0 failed)

## Version
- [ ] **Minor**
- [x] **Patch** — default, left unlabeled
- [ ] **No release**

## Notes
- Comment-only change in `frontend/assets/atrium.css`; verified the diff is a single-line comment edit with no brace disruption (no stylelint available without nix in this environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VPCQcEtXzv2WJg7g4Ci3Rn)_