### PR TITLE
test: cover the offline module's riskiest untested logic

### DIFF
--- a/frontend/src/offline/downloads/engine/tests.rs
+++ b/frontend/src/offline/downloads/engine/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for `friendly()`'s `DataError` → `DownloadError` mapping —
 //! guards against a raw-error leak into `DownloadStatus::Error` — plus
-//! `download_file`'s byte-range resume/streaming state machine (#1307 AC5).
+//! `download_file`'s byte-range resume/streaming state machine.
 
 use axum::response::IntoResponse;
 

--- a/frontend/src/offline/downloads/engine/tests.rs
+++ b/frontend/src/offline/downloads/engine/tests.rs
@@ -1,5 +1,8 @@
 //! Unit tests for `friendly()`'s `DataError` → `DownloadError` mapping —
-//! guards against a raw-error leak into `DownloadStatus::Error`.
+//! guards against a raw-error leak into `DownloadStatus::Error` — plus
+//! `download_file`'s byte-range resume/streaming state machine (#1307 AC5).
+
+use axum::response::IntoResponse;
 
 use super::*;
 use crate::data::DataError;
@@ -80,4 +83,199 @@ fn download_error_display_never_echoes_a_raw_variant_name() {
     ] {
         assert!(!variant.to_string().is_empty());
     }
+}
+
+// ── download_file: byte-range resume/streaming (#1307 AC5) ─────────────
+
+/// Deterministic filler content so byte-for-byte comparisons are stable.
+fn fixture_content(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+fn planned_file(rel: &str, url_path: &str) -> PlannedFile {
+    PlannedFile {
+        rel: rel.to_string(),
+        url_path: url_path.to_string(),
+        ordinal: None,
+        bytes: None,
+        done: false,
+    }
+}
+
+async fn spawn_router(app: axum::Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::test]
+async fn download_file_streams_a_fresh_file_from_a_full_response() {
+    let content = fixture_content(5000);
+    let app = axum::Router::new().route(
+        "/file",
+        axum::routing::get(move || {
+            let content = content.clone();
+            async move { content }
+        }),
+    );
+    let base = spawn_router(app).await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = planned_file("book.epub", "/file");
+    let mut deltas = Vec::new();
+
+    let written = download_file(&base, dir.path(), &file, &mut |d| deltas.push(d))
+        .await
+        .expect("fresh download must succeed");
+
+    assert_eq!(written, 5000);
+    assert_eq!(deltas.iter().sum::<i64>(), 5000);
+    let final_bytes = tokio::fs::read(dir.path().join("book.epub"))
+        .await
+        .expect("final file must exist");
+    assert_eq!(final_bytes, fixture_content(5000));
+    assert!(
+        tokio::fs::metadata(dir.path().join("book.epub.part"))
+            .await
+            .is_err(),
+        "the .part temp file must be renamed away on completion"
+    );
+}
+
+#[tokio::test]
+async fn download_file_resumes_a_partial_download_via_a_range_request() {
+    let full = fixture_content(5000);
+    let app = axum::Router::new().route(
+        "/file",
+        axum::routing::get(move |headers: axum::http::HeaderMap| {
+            let full = full.clone();
+            async move {
+                let range = headers
+                    .get(axum::http::header::RANGE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default()
+                    .to_string();
+                if range == "bytes=2000-" {
+                    (
+                        axum::http::StatusCode::PARTIAL_CONTENT,
+                        full[2000..].to_vec(),
+                    )
+                        .into_response()
+                } else {
+                    (axum::http::StatusCode::OK, full).into_response()
+                }
+            }
+        }),
+    );
+    let base = spawn_router(app).await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Simulate a prior attempt that got 2000 of the 5000 bytes down.
+    tokio::fs::write(dir.path().join("book.epub.part"), fixture_content(2000))
+        .await
+        .expect("seed partial file");
+    let file = planned_file("book.epub", "/file");
+    let mut deltas = Vec::new();
+
+    let written = download_file(&base, dir.path(), &file, &mut |d| deltas.push(d))
+        .await
+        .expect("resumed download must succeed");
+
+    assert_eq!(written, 5000, "final size must be the full file");
+    // Resumed bytes are the caller's concern (already counted in a prior
+    // session); this call only reports the freshly streamed remainder.
+    assert_eq!(deltas.iter().sum::<i64>(), 3000);
+    let final_bytes = tokio::fs::read(dir.path().join("book.epub"))
+        .await
+        .expect("final file must exist");
+    assert_eq!(final_bytes, fixture_content(5000));
+}
+
+#[tokio::test]
+async fn download_file_restarts_from_scratch_when_the_server_ignores_the_range_request() {
+    let full = fixture_content(500);
+    let app = axum::Router::new().route(
+        "/file",
+        axum::routing::get(move || {
+            let full = full.clone();
+            // Always 200 with the full body — a server that doesn't support
+            // Range at all.
+            async move { full }
+        }),
+    );
+    let base = spawn_router(app).await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    tokio::fs::write(dir.path().join("book.epub.part"), fixture_content(200))
+        .await
+        .expect("seed partial file");
+    let file = planned_file("book.epub", "/file");
+    let mut deltas = Vec::new();
+
+    let written = download_file(&base, dir.path(), &file, &mut |d| deltas.push(d))
+        .await
+        .expect("restart-from-scratch download must succeed");
+
+    assert_eq!(written, 500);
+    // The stale 200 bytes on disk are discarded; the negative delta says so.
+    assert_eq!(deltas[0], -200);
+    assert_eq!(deltas.iter().sum::<i64>(), 300);
+    let final_bytes = tokio::fs::read(dir.path().join("book.epub"))
+        .await
+        .expect("final file must exist");
+    assert_eq!(final_bytes, fixture_content(500));
+}
+
+/// Hand-rolled HTTP/1.1 server (bypassing axum's own framing) so the
+/// response can lie about `Content-Length` — a real proxy/CDN misbehavior,
+/// not something a well-formed axum handler can produce. Whether this
+/// surfaces as `ConnectionLost` (a `resp.chunk()` transport error, since the
+/// connection closes before the promised bytes arrive) or `Interrupted`
+/// (the post-write length check) is a reqwest/hyper implementation detail;
+/// what must hold is the outward contract: an `Err`, and no half-written
+/// file silently promoted to "complete".
+async fn spawn_lying_content_length_server(
+    declared_len: usize,
+    actual_body: &'static [u8],
+) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    tokio::spawn(async move {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf).await;
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {declared_len}\r\nConnection: close\r\n\r\n"
+            );
+            let _ = stream.write_all(head.as_bytes()).await;
+            let _ = stream.write_all(actual_body).await;
+            let _ = stream.shutdown().await;
+        }
+    });
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::test]
+async fn download_file_errors_and_leaves_no_final_file_when_the_response_is_truncated() {
+    let base = spawn_lying_content_length_server(20, b"hello").await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = planned_file("book.epub", "/file");
+
+    let result = download_file(&base, dir.path(), &file, &mut |_| {}).await;
+
+    assert!(
+        result.is_err(),
+        "a body shorter than its declared Content-Length must not report success"
+    );
+    assert!(
+        tokio::fs::metadata(dir.path().join("book.epub"))
+            .await
+            .is_err(),
+        "a truncated transfer must never be renamed into a completed file"
+    );
 }

--- a/frontend/src/offline/replica/tests.rs
+++ b/frontend/src/offline/replica/tests.rs
@@ -1,4 +1,5 @@
 //! Pure replica pagination / sorting / search tests.
+#![allow(clippy::await_holding_lock)]
 
 use omnibus_shared::Contributor;
 
@@ -123,6 +124,270 @@ fn page_from_replica_returns_empty_page_past_the_end() {
     );
     assert!(page.books.is_empty());
     assert_eq!(page.next_cursor, None);
+}
+
+fn book_with_series(
+    title: &str,
+    series: Option<&str>,
+    series_index: Option<&str>,
+) -> EbookMetadata {
+    EbookMetadata {
+        title: Some(title.to_string()),
+        filename: format!("{title}.epub"),
+        series: series.map(str::to_string),
+        series_index: series_index.map(str::to_string),
+        unique_identifier: Some(format!("uuid-{title}")),
+        ..Default::default()
+    }
+}
+
+fn book_with_dates(title: &str, added_at: Option<&str>, modified: Option<&str>) -> EbookMetadata {
+    EbookMetadata {
+        title: Some(title.to_string()),
+        filename: format!("{title}.epub"),
+        added_at: added_at.map(str::to_string),
+        modified: modified.map(str::to_string),
+        unique_identifier: Some(format!("uuid-{title}")),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn sort_books_orders_by_series_then_title_with_no_series_sorting_last() {
+    let mut books = vec![
+        book_with_series("Solo", None, None),
+        book_with_series("Second In Series", Some("Wheel"), Some("2")),
+        book_with_series("First In Series", Some("Wheel"), Some("1")),
+        book_with_series("Another Series", Some("Annals"), Some("1")),
+    ];
+    sort_books(&mut books, SortKey::Series, SortDir::Asc);
+    let titles: Vec<&str> = books.iter().map(|b| b.title.as_deref().unwrap()).collect();
+    assert_eq!(
+        titles,
+        vec![
+            "Another Series",   // Annals, index 1
+            "First In Series",  // Wheel, index 1
+            "Second In Series", // Wheel, index 2
+            "Solo",             // no series — sorts last
+        ]
+    );
+}
+
+#[test]
+fn sort_books_orders_by_last_updated_and_newest_added_on_the_same_date_key() {
+    let mut books = vec![
+        book_with_dates("No Date", None, None),
+        book_with_dates("Older", Some("2024-01-01"), None),
+        book_with_dates("Modified Only", None, Some("2024-06-01")),
+    ];
+    sort_books(&mut books, SortKey::LastUpdated, SortDir::Asc);
+    let titles: Vec<&str> = books.iter().map(|b| b.title.as_deref().unwrap()).collect();
+    // Empty date keys sort first; `NewestAdded` shares the exact same
+    // comparator (see `sort_books`'s match arm), so it must agree too.
+    assert_eq!(titles, vec!["No Date", "Older", "Modified Only"]);
+    let mut same = vec![
+        book_with_dates("No Date", None, None),
+        book_with_dates("Older", Some("2024-01-01"), None),
+        book_with_dates("Modified Only", None, Some("2024-06-01")),
+    ];
+    sort_books(&mut same, SortKey::NewestAdded, SortDir::Asc);
+    let same_titles: Vec<&str> = same.iter().map(|b| b.title.as_deref().unwrap()).collect();
+    assert_eq!(same_titles, titles);
+}
+
+#[test]
+fn series_key_truncates_the_float_cast_toward_zero_at_the_millesimal_boundary() {
+    let just_under_two = book_with_series("A", Some("S"), Some("1.9999"));
+    let exactly_two = book_with_series("B", Some("S"), Some("2.0"));
+    // `1.9999 * 1000.0 == 1999.9`, cast to i64 truncates to 1999 — not 2000 —
+    // so it must still sort strictly before the exact "2.0" (2000) index.
+    assert_eq!(series_key(&just_under_two), (false, "s".to_string(), 1999));
+    assert_eq!(series_key(&exactly_two), (false, "s".to_string(), 2000));
+}
+
+#[test]
+fn series_key_falls_back_to_zero_for_missing_or_unparsable_index() {
+    let no_index = book_with_series("A", Some("S"), None);
+    let bad_index = book_with_series("B", Some("S"), Some("not-a-number"));
+    assert_eq!(series_key(&no_index).2, 0);
+    assert_eq!(series_key(&bad_index).2, 0);
+}
+
+#[test]
+fn series_key_marks_books_without_a_series_to_sort_after_every_series() {
+    let with_series = book_with_series("A", Some("S"), Some("1"));
+    let without_series = book_with_series("B", None, None);
+    assert!(!series_key(&with_series).0);
+    assert!(series_key(&without_series).0);
+}
+
+#[test]
+fn date_key_prefers_added_at_then_modified_then_empty() {
+    let both = book_with_dates("A", Some("2024-01-01"), Some("2024-06-01"));
+    let modified_only = book_with_dates("B", None, Some("2024-06-01"));
+    let neither = book_with_dates("C", None, None);
+    assert_eq!(date_key(&both), "2024-01-01");
+    assert_eq!(date_key(&modified_only), "2024-06-01");
+    assert_eq!(date_key(&neither), "");
+}
+
+// ── ensure_fresh / sync_replica: TTL gate, paging, discard ─────────────
+
+use axum::response::IntoResponse;
+
+use crate::offline::sync::test_state_lock;
+use crate::offline::{cache, store};
+
+/// Bind a one-shot axum router on an ephemeral loopback port and return its
+/// base URL — mirrors the `sync/tests.rs` `mock_server` helper.
+async fn spawn_router(app: axum::Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://127.0.0.1:{port}")
+}
+
+/// Clear the replica's global cache row so each test starts from "no replica
+/// synced yet", regardless of what an earlier test left behind.
+async fn reset_replica_cache() {
+    let st = store::store().expect("test store");
+    st.kv_delete(&cache::keys::ebooks_all());
+    // Land the delete before the test's own writes race it on the same
+    // worker channel.
+    let _ = st.kv_get(&cache::keys::ebooks_all()).await;
+}
+
+#[tokio::test]
+async fn sync_replica_skips_refetch_when_the_cached_replica_is_still_fresh() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    reset_replica_cache().await;
+    let st = store::store().expect("test store");
+    let seeded = vec![book("Fresh", "Author", &["EPUB"])];
+    st.kv_put(
+        &cache::keys::ebooks_all(),
+        serde_json::to_string(&seeded).expect("serialize"),
+    );
+    let _ = st.kv_get(&cache::keys::ebooks_all()).await;
+
+    // If the TTL gate did not short-circuit, this server's distinct payload
+    // would land in the cache instead of the seeded one.
+    let app = axum::Router::new().route(
+        "/api/ebooks",
+        axum::routing::get(|| async {
+            axum::Json(EbookLibrary {
+                path: None,
+                books: vec![book("ShouldNotAppear", "Other", &["EPUB"])],
+                error: None,
+                total: Some(1),
+            })
+        }),
+    );
+    let base = spawn_router(app).await;
+    sync_replica(&base).await;
+
+    let cached: Vec<EbookMetadata> = cache::get_json(&cache::keys::ebooks_all())
+        .await
+        .expect("cache untouched");
+    assert_eq!(titles_of(&cached), vec!["Fresh"]);
+}
+
+fn titles_of(books: &[EbookMetadata]) -> Vec<String> {
+    books
+        .iter()
+        .map(|b| b.title.clone().unwrap_or_default())
+        .collect()
+}
+
+#[tokio::test]
+async fn sync_replica_pages_through_the_cursor_loop_and_stores_the_full_replica() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    reset_replica_cache().await;
+
+    let app = axum::Router::new().route(
+        "/api/ebooks",
+        axum::routing::get(
+            |axum::extract::Query(params): axum::extract::Query<
+                std::collections::HashMap<String, String>,
+            >| async move {
+                let mut headers = axum::http::HeaderMap::new();
+                let books = match params.get("cursor").map(String::as_str) {
+                    None => {
+                        headers.insert("X-Next-Cursor", "p2".parse().unwrap());
+                        vec![book("One", "A", &["EPUB"]), book("Two", "B", &["EPUB"])]
+                    }
+                    Some("p2") => vec![book("Three", "C", &["EPUB"])],
+                    _ => vec![],
+                };
+                (
+                    headers,
+                    axum::Json(EbookLibrary {
+                        path: None,
+                        books,
+                        error: None,
+                        total: None,
+                    }),
+                )
+            },
+        ),
+    );
+    let base = spawn_router(app).await;
+    sync_replica(&base).await;
+
+    let cached: Vec<EbookMetadata> = cache::get_json(&cache::keys::ebooks_all())
+        .await
+        .expect("replica stored after a successful multi-page sync");
+    let mut titles = titles_of(&cached);
+    titles.sort();
+    assert_eq!(titles, vec!["One", "Three", "Two"]);
+}
+
+#[tokio::test]
+async fn sync_replica_discards_everything_when_a_later_page_fails() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    reset_replica_cache().await;
+
+    let app = axum::Router::new().route(
+        "/api/ebooks",
+        axum::routing::get(
+            |axum::extract::Query(params): axum::extract::Query<
+                std::collections::HashMap<String, String>,
+            >| async move {
+                match params.get("cursor").map(String::as_str) {
+                    None => {
+                        let mut headers = axum::http::HeaderMap::new();
+                        headers.insert("X-Next-Cursor", "p2".parse().unwrap());
+                        (
+                            axum::http::StatusCode::OK,
+                            headers,
+                            axum::Json(EbookLibrary {
+                                path: None,
+                                books: vec![book("Partial", "A", &["EPUB"])],
+                                error: None,
+                                total: None,
+                            }),
+                        )
+                            .into_response()
+                    }
+                    _ => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response(),
+                }
+            },
+        ),
+    );
+    let base = spawn_router(app).await;
+    sync_replica(&base).await;
+
+    let cached: Option<Vec<EbookMetadata>> = cache::get_json(&cache::keys::ebooks_all()).await;
+    assert!(
+        cached.is_none(),
+        "a mid-page failure must discard the partial page rather than caching it"
+    );
 }
 
 #[test]

--- a/frontend/src/offline/replica/tests.rs
+++ b/frontend/src/offline/replica/tests.rs
@@ -1,4 +1,7 @@
 //! Pure replica pagination / sorting / search tests.
+// The state-lock guard is deliberately held across awaits: it serializes
+// whole async test bodies against process-global state, and each test owns
+// its own thread + runtime, so there is no interleaving to deadlock on.
 #![allow(clippy::await_holding_lock)]
 
 use omnibus_shared::Contributor;

--- a/frontend/src/offline/store/tests.rs
+++ b/frontend/src/offline/store/tests.rs
@@ -181,6 +181,77 @@ async fn downloads_upsert_is_keyed_per_uuid_and_format() {
 }
 
 #[tokio::test]
+async fn kv_delete_removes_only_the_named_key() {
+    let (_dir, store) = open_temp();
+    store.kv_put("a", "1".to_string());
+    store.kv_put("b", "2".to_string());
+    store.kv_delete("a");
+    assert!(store.kv_get("a").await.is_none());
+    assert_eq!(store.kv_get("b").await.expect("row").payload, "2");
+}
+
+#[tokio::test]
+async fn kv_prefix_returns_only_matching_key_payload_pairs() {
+    let (_dir, store) = open_temp();
+    store.kv_put("progress:u1:epub", "1".to_string());
+    store.kv_put("progress:u2:epub", "2".to_string());
+    store.kv_put("shelves", "3".to_string());
+    let mut rows = store.kv_prefix("progress:").await;
+    rows.sort();
+    assert_eq!(
+        rows,
+        vec![
+            ("progress:u1:epub".to_string(), "1".to_string()),
+            ("progress:u2:epub".to_string(), "2".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn kv_prefix_blocking_returns_only_matching_key_payload_pairs() {
+    let (_dir, store) = open_temp();
+    store.kv_put("rating:u1", "4.5".to_string());
+    store.kv_put("rating:u2", "3.0".to_string());
+    store.kv_put("shelves", "x".to_string());
+    // The put calls above go through the async worker channel; force them to
+    // land before the blocking read races the same queue.
+    let _ = store.kv_get("shelves").await;
+    let mut rows = store.kv_prefix_blocking("rating:");
+    rows.sort();
+    assert_eq!(
+        rows,
+        vec![
+            ("rating:u1".to_string(), "4.5".to_string()),
+            ("rating:u2".to_string(), "3.0".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn run_blocking_returns_the_closures_value_from_the_worker_thread() {
+    let (_dir, store) = open_temp();
+    let result = store.run_blocking(|_conn| 42i64);
+    assert_eq!(result, Some(42));
+}
+
+#[tokio::test]
+async fn ops_bump_attempts_increments_only_the_named_op() {
+    let (_dir, store) = open_temp();
+    store.ops_append("A", "1".to_string(), None);
+    store.ops_append("B", "2".to_string(), None);
+    let ops = store.ops_list().await;
+    let a_id = ops.iter().find(|o| o.kind == "A").expect("op A").id;
+    store.ops_bump_attempts(a_id);
+    // Force the detached write to land before reading it back.
+    let _ = store.ops_count().await;
+    let ops = store.ops_list().await;
+    let a = ops.iter().find(|o| o.id == a_id).expect("op A");
+    let b = ops.iter().find(|o| o.kind == "B").expect("op B");
+    assert_eq!(a.attempts, 1);
+    assert_eq!(b.attempts, 0);
+}
+
+#[tokio::test]
 async fn downloads_delete_removes_only_the_named_format() {
     let (_dir, store) = open_temp();
     store.downloads_upsert(download_row("u1", "epub")).await;

--- a/frontend/src/offline/sync/tests.rs
+++ b/frontend/src/offline/sync/tests.rs
@@ -239,9 +239,7 @@ async fn mock_server() -> String {
             "/api/account/kindle-email",
             post(
                 |axum::Json(body): axum::Json<serde_json::Value>| async move {
-                    // Two of the earlier tests assert the 5xx / retry-budget
-                    // path against this exact address — keep that behavior
-                    // and give every other address a normal success reply.
+                    // Preserve the 5xx/retry-budget behavior earlier tests assert for this address.
                     if body.get("email").and_then(|v| v.as_str()) == Some("reader@example.com") {
                         axum::http::StatusCode::INTERNAL_SERVER_ERROR
                     } else {

--- a/frontend/src/offline/sync/tests.rs
+++ b/frontend/src/offline/sync/tests.rs
@@ -95,7 +95,7 @@ fn enqueue_raw(op: &Op) {
 
 /// Mock server covering the drain-test routes; returns its base URL.
 async fn mock_server() -> String {
-    use axum::routing::{delete, get, post};
+    use axum::routing::{delete, get, patch, post, put};
     let progress_record = |update: ProgressUpdate| ProgressRecord {
         book_uuid: update.book_uuid,
         format: update.format,
@@ -121,16 +121,138 @@ async fn mock_server() -> String {
             ),
         )
         .route(
+            "/api/progress/sessions",
+            post(
+                |axum::Json(reports): axum::Json<Vec<omnibus_shared::SessionReport>>| async move {
+                    axum::Json(serde_json::json!({ "recorded": reports.len() }))
+                },
+            ),
+        )
+        .route(
+            "/api/audiobooks/{uuid}/playback-rate",
+            put(
+                |axum::extract::Path(uuid): axum::extract::Path<String>,
+                 axum::Json(update): axum::Json<omnibus_shared::AudiobookPlaybackRateUpdate>| async move {
+                    axum::Json(omnibus_shared::AudiobookPlaybackRateRecord {
+                        book_uuid: uuid,
+                        playback_rate: update.playback_rate,
+                        updated_at: 333,
+                    })
+                },
+            ),
+        )
+        .route(
+            "/api/ratings/{uuid}",
+            delete(|| async { axum::http::StatusCode::OK }),
+        )
+        .route(
+            "/api/highlights",
+            post(
+                |axum::Json(input): axum::Json<omnibus_shared::CreateHighlight>| async move {
+                    axum::Json(omnibus_shared::Highlight {
+                        id: 55,
+                        book_uuid: input.book_uuid,
+                        epub_cfi_range: Some(input.epub_cfi_range),
+                        color: input.color,
+                        note: None,
+                        text: input.text,
+                        client_id: input.client_id,
+                        created_at: 222,
+                    })
+                },
+            ),
+        )
+        .route(
+            "/api/highlights/{id}/color",
+            patch(|| async { axum::http::StatusCode::OK }),
+        )
+        .route(
+            "/api/highlights/{id}/note",
+            patch(|| async { axum::http::StatusCode::OK }),
+        )
+        .route(
             "/api/highlights/{id}",
             delete(|| async { axum::http::StatusCode::NOT_FOUND }),
         )
         .route(
-            "/api/ratings",
-            post(|| async { axum::http::StatusCode::BAD_REQUEST }),
+            "/api/bookmarks",
+            post(
+                |axum::Json(input): axum::Json<omnibus_shared::CreateBookmark>| async move {
+                    axum::Json(omnibus_shared::Bookmark {
+                        id: 55,
+                        book_uuid: input.book_uuid,
+                        position: input.position,
+                        title: input.title,
+                        client_id: input.client_id,
+                        created_at: 111,
+                    })
+                },
+            ),
+        )
+        .route(
+            "/api/bookmarks/{id}",
+            put(|| async { axum::http::StatusCode::OK }).delete(|| async { axum::http::StatusCode::OK }),
+        )
+        .route(
+            "/api/journals",
+            post(
+                |axum::Json(input): axum::Json<omnibus_shared::CreateJournalEntry>| async move {
+                    axum::Json(omnibus_shared::JournalEntry {
+                        id: 55,
+                        book_uuid: input.book_uuid,
+                        author_id: 1,
+                        author_name: "elena".into(),
+                        body_html: format!("<p>{}</p>", input.body_md),
+                        body_md: input.body_md,
+                        progress: input.progress,
+                        status: input.status,
+                        client_id: input.client_id,
+                        created_at: 444,
+                        updated_at: 444,
+                    })
+                },
+            ),
+        )
+        .route(
+            "/api/journals/{id}",
+            patch(
+                |axum::extract::Path(id): axum::extract::Path<i64>,
+                 axum::Json(input): axum::Json<omnibus_shared::UpdateJournalEntry>| async move {
+                    axum::Json(omnibus_shared::JournalEntry {
+                        id,
+                        book_uuid: "journal-book".into(),
+                        author_id: 1,
+                        author_name: "elena".into(),
+                        body_html: format!("<p>{}</p>", input.body_md),
+                        body_md: input.body_md,
+                        progress: input.progress,
+                        status: input.status.unwrap_or_default(),
+                        client_id: None,
+                        created_at: 444,
+                        updated_at: 555,
+                    })
+                },
+            )
+            .delete(|| async { axum::http::StatusCode::OK }),
         )
         .route(
             "/api/account/kindle-email",
-            post(|| async { axum::http::StatusCode::INTERNAL_SERVER_ERROR }),
+            post(
+                |axum::Json(body): axum::Json<serde_json::Value>| async move {
+                    // Two of the earlier tests assert the 5xx / retry-budget
+                    // path against this exact address — keep that behavior
+                    // and give every other address a normal success reply.
+                    if body.get("email").and_then(|v| v.as_str()) == Some("reader@example.com") {
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+                    } else {
+                        axum::http::StatusCode::OK
+                    }
+                },
+            ),
+        )
+        .route(
+            "/api/ratings",
+            post(|| async { axum::http::StatusCode::BAD_REQUEST }),
         )
         .route(
             "/api/shelves",
@@ -154,6 +276,29 @@ async fn mock_server() -> String {
             ),
         )
         .route(
+            "/api/shelves/{id}",
+            patch(
+                |axum::extract::Path(id): axum::extract::Path<i64>,
+                 axum::Json(req): axum::Json<omnibus_shared::UpdateShelfRequest>| async move {
+                    axum::Json(omnibus_shared::Shelf {
+                        id,
+                        owner_user_id: 1,
+                        owner_username: "elena".into(),
+                        kind: omnibus_shared::ShelfKind::Manual,
+                        name: req.name.unwrap_or_else(|| "Shelf".into()),
+                        description: req.description,
+                        visibility: req.visibility.unwrap_or(omnibus_shared::Visibility::Private),
+                        accent: None,
+                        match_mode: req.match_mode,
+                        rules: req.rules.unwrap_or_default(),
+                        book_count: 0,
+                        sync_to_kobo: req.sync_to_kobo.unwrap_or(false),
+                    })
+                },
+            )
+            .delete(|| async { axum::http::StatusCode::OK }),
+        )
+        .route(
             "/api/shelves/{id}/books",
             post(
                 |axum::extract::Path(id): axum::extract::Path<i64>| async move {
@@ -165,6 +310,10 @@ async fn mock_server() -> String {
                     }
                 },
             ),
+        )
+        .route(
+            "/api/shelves/{id}/books/{uuid}",
+            delete(|| async { axum::http::StatusCode::OK }),
         );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -449,6 +598,386 @@ async fn drain_drops_a_stuck_op_after_exhausting_its_retry_budget() {
     assert!(
         state().online,
         "exhausting a retry budget is still not a connectivity failure"
+    );
+    note_online();
+}
+
+// ── drain integration: remaining Op variants (#1307 AC4) ───────────────
+
+#[tokio::test]
+async fn drain_replays_set_playback_rate_and_caches_the_server_record() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::SetPlaybackRate {
+        uuid: "rate-book".into(),
+        update: omnibus_shared::AudiobookPlaybackRateUpdate { playback_rate: 1.5 },
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(st.ops_count().await, 0, "replayed op must be removed");
+    let cached: Option<Option<omnibus_shared::AudiobookPlaybackRateRecord>> =
+        cache::get_json(&cache::keys::playback_rate("rate-book")).await;
+    let record = cached.flatten().expect("server record cached after drain");
+    assert_eq!(record.playback_rate, 1.5);
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_replays_record_sessions_and_clears_the_queue() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::RecordSessions {
+        reports: vec![omnibus_shared::SessionReport {
+            book_uuid: "session-book".into(),
+            format: ProgressFormat::Audio,
+            started_at: 1,
+            ended_at: 2,
+            progress_units: 60,
+            device_id: None,
+            client_id: Some("dev-1".into()),
+        }],
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(
+        st.ops_count().await,
+        0,
+        "a recorded session batch must be removed once replayed"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_replays_clear_rating_and_clears_the_queue() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::ClearRating {
+        uuid: "clear-rating-book".into(),
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(st.ops_count().await, 0, "a cleared rating must be removed");
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_remaps_temp_bookmark_id_after_create() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    cache::put_json(
+        &cache::keys::bookmarks("bm-book"),
+        &vec![omnibus_shared::Bookmark {
+            id: -90,
+            book_uuid: "bm-book".into(),
+            position: "epubcfi(/6/4!/4/2/1:0)".into(),
+            title: Some("Draft".into()),
+            client_id: None,
+            created_at: 100,
+        }],
+    );
+    enqueue_raw(&Op::CreateBookmark {
+        temp_id: -90,
+        input: omnibus_shared::CreateBookmark {
+            book_uuid: "bm-book".into(),
+            position: "epubcfi(/6/4!/4/2/1:0)".into(),
+            title: Some("Draft".into()),
+            client_id: None,
+        },
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(st.ops_count().await, 0);
+    let bookmarks: Vec<omnibus_shared::Bookmark> =
+        cache::get_json(&cache::keys::bookmarks("bm-book"))
+            .await
+            .unwrap_or_default();
+    assert!(
+        bookmarks.iter().any(|b| b.id == 55),
+        "cache must hold the server-assigned bookmark id"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_replays_update_bookmark_and_delete_bookmark() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::UpdateBookmark {
+        id: 55,
+        book_uuid: "bm-book-2".into(),
+        title: Some("Renamed".into()),
+    });
+    enqueue_raw(&Op::DeleteBookmark {
+        id: 56,
+        book_uuid: "bm-book-2".into(),
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(
+        st.ops_count().await,
+        0,
+        "both a real-id update and delete must replay and clear"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_remaps_temp_highlight_id_after_create() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    cache::put_json(
+        &cache::keys::highlights("hl-book"),
+        &vec![omnibus_shared::Highlight {
+            id: -91,
+            book_uuid: "hl-book".into(),
+            epub_cfi_range: Some("epubcfi(/6/4!/4/2/1:0,/1:5)".into()),
+            color: omnibus_shared::HighlightColor::Amber,
+            note: None,
+            text: Some("a passage".into()),
+            client_id: None,
+            created_at: 100,
+        }],
+    );
+    enqueue_raw(&Op::CreateHighlight {
+        temp_id: -91,
+        input: omnibus_shared::CreateHighlight {
+            book_uuid: "hl-book".into(),
+            epub_cfi_range: "epubcfi(/6/4!/4/2/1:0,/1:5)".into(),
+            color: omnibus_shared::HighlightColor::Amber,
+            text: Some("a passage".into()),
+            client_id: None,
+        },
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(st.ops_count().await, 0);
+    let highlights: Vec<omnibus_shared::Highlight> =
+        cache::get_json(&cache::keys::highlights("hl-book"))
+            .await
+            .unwrap_or_default();
+    assert!(
+        highlights.iter().any(|h| h.id == 55),
+        "cache must hold the server-assigned highlight id"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_replays_update_highlight_color_and_note() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::UpdateHighlightColor {
+        id: 55,
+        book_uuid: "hl-book-2".into(),
+        color: omnibus_shared::HighlightColor::Green,
+    });
+    enqueue_raw(&Op::UpdateHighlightNote {
+        id: 55,
+        book_uuid: "hl-book-2".into(),
+        note: Some("worth rereading".into()),
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(
+        st.ops_count().await,
+        0,
+        "both color and note edits must replay and clear"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_remaps_temp_journal_id_after_create() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    cache::put_json(
+        &cache::keys::journals("journal-book-1"),
+        &vec![omnibus_shared::JournalEntry {
+            id: -92,
+            book_uuid: "journal-book-1".into(),
+            author_id: 1,
+            author_name: "elena".into(),
+            body_md: "draft".into(),
+            body_html: "<p>draft</p>".into(),
+            progress: Some(10),
+            status: omnibus_shared::JournalStatus::Published,
+            client_id: None,
+            created_at: 100,
+            updated_at: 100,
+        }],
+    );
+    enqueue_raw(&Op::CreateJournal {
+        temp_id: -92,
+        input: omnibus_shared::CreateJournalEntry {
+            book_uuid: "journal-book-1".into(),
+            body_md: "draft".into(),
+            progress: Some(10),
+            status: omnibus_shared::JournalStatus::Published,
+            client_id: None,
+        },
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(st.ops_count().await, 0);
+    let entries: Vec<omnibus_shared::JournalEntry> =
+        cache::get_json(&cache::keys::journals("journal-book-1"))
+            .await
+            .unwrap_or_default();
+    assert!(
+        entries.iter().any(|e| e.id == 55),
+        "cache must hold the server-assigned journal id"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_replays_update_journal_and_delete_journal() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::UpdateJournal {
+        id: 55,
+        book_uuid: "journal-book-2".into(),
+        input: omnibus_shared::UpdateJournalEntry {
+            body_md: "revised".into(),
+            progress: Some(50),
+            status: None,
+        },
+    });
+    enqueue_raw(&Op::DeleteJournal {
+        id: 56,
+        book_uuid: "journal-book-2".into(),
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(
+        st.ops_count().await,
+        0,
+        "both a real-id journal edit and delete must replay and clear"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_replays_set_kindle_email_success_path() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::SetKindleEmail {
+        email: Some("new-address@example.com".into()),
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(
+        st.ops_count().await,
+        0,
+        "an address distinct from the fixed 5xx one must succeed and clear"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_replays_update_shelf_and_delete_shelf() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::UpdateShelf {
+        id: 55,
+        req: omnibus_shared::UpdateShelfRequest {
+            name: Some("Renamed Shelf".into()),
+            description: None,
+            visibility: None,
+            match_mode: None,
+            rules: None,
+            sync_to_kobo: None,
+        },
+    });
+    enqueue_raw(&Op::DeleteShelf { id: 56 });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(
+        st.ops_count().await,
+        0,
+        "both a real-id shelf edit and delete must replay and clear"
+    );
+    note_online();
+}
+
+#[tokio::test]
+async fn drain_replays_add_and_remove_shelf_books() {
+    store::init_global_for_tests();
+    let _guard = test_state_lock().lock().unwrap();
+    clear_ops().await;
+    let base = mock_server().await;
+    set_server_url(&base);
+
+    enqueue_raw(&Op::AddShelfBooks {
+        shelf_id: 55,
+        book_uuids: vec!["u1".into(), "u2".into()],
+    });
+    enqueue_raw(&Op::RemoveShelfBook {
+        shelf_id: 55,
+        book_uuid: "u1".into(),
+    });
+    drain().await;
+
+    let st = store::store().expect("store");
+    assert_eq!(
+        st.ops_count().await,
+        0,
+        "both a membership add and remove must replay and clear"
     );
     note_online();
 }


### PR DESCRIPTION
## Summary
- Adds test coverage for all five gaps called out in #1307 — the stateful, failure-prone cores of `frontend/src/offline/` that had no direct tests.
- Closes #1307

## Coverage by acceptance criterion

1. **`download_file` byte-range resume/streaming** (`downloads/engine/tests.rs`) — fresh full-response download, resume via a `Range` request against a partial `.part` file, restart-from-scratch when the server ignores `Range` (200 instead of 206), and a truncated/lying-`Content-Length` transfer via a hand-rolled raw-TCP server that surfaces as an `Err` rather than a silently-corrupted "complete" file. `run_inner`'s outer orchestration (the `data::get_ebook_online`/manifest-fetch wrapper) is not separately tested — see Known limitations below.
2. **`execute_op` replay dispatch** (`sync/tests.rs`) — extended `mock_server` to cover all 14 previously-untested `Op` variants: `SetPlaybackRate`, `RecordSessions`, `ClearRating`, `CreateBookmark`/`UpdateBookmark`/`DeleteBookmark`, `CreateHighlight`/`UpdateHighlightColor`/`UpdateHighlightNote`, `CreateJournal`/`UpdateJournal`/`DeleteJournal`, `SetKindleEmail`, `UpdateShelf`/`DeleteShelf`, `AddShelfBooks`/`RemoveShelfBook`. The three `Create*` variants are exercised through the existing temp-id-remap tests, which already drive that code path.
3. **`sync_replica`/`ensure_fresh`** (`replica/tests.rs`) — TTL-gated no-op, a successful multi-page cursor-loop sync, and discard-on-partial-failure (a later page erroring must not leave a half-written replica).
4. **`sort_books` + `series_key`/`date_key`** (`replica/tests.rs`) — `Series`/`LastUpdated`/`NewestAdded` sort branches, plus the `series_key`/`date_key` fallbacks, including the float→i64 boundary cast at the millesimal edge that #1307 flagged by name.
5. **`store.rs` gaps** (`store/tests.rs`) — happy-path tests for `kv_delete`, `kv_prefix`, `kv_prefix_blocking`, `run_blocking`, and `ops_bump_attempts`.

## Known limitations
- `run_inner` (the top-level download orchestration: book fetch, manifest fetch, plan-merge, warm-related-caches) isn't directly tested — only `download_file`, the actual I/O state machine `run_inner` delegates to, which is where the resume/streaming risk actually lives.
- The truncated-transfer test surfaces as an `Err` (documented in the test as either `ConnectionLost` from a `resp.chunk()` transport error, or `Interrupted` from the post-write length check, depending on reqwest/hyper's handling of the premature close) rather than pinning the literal `DownloadError::Interrupted` variant. Under compliant HTTP framing, a body that legitimately completes with `written != expected_total` is effectively unreachable — any Content-Length lie either self-truncates to match (client only reads what's declared) or surfaces as a transport error before the length check runs. The test asserts the externally-observable contract instead: an `Err`, and no half-written file renamed into a completed one.

## Test plan
- [x] `cargo fmt -p omnibus-frontend -- --check`
- [x] `cargo clippy -p omnibus-frontend --features mobile --tests -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --features server -- -D warnings`
- [x] `cargo test -p omnibus-frontend --features mobile` — 551 passed
- [x] `cargo test -p omnibus-frontend --features server` — 528 passed

## Notes
- Test-only change; no production code touched.

- [x] **No release** — tests only, doesn't warrant a version bump.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VPCQcEtXzv2WJg7g4Ci3Rn)_