### PR TITLE
fix: clearer barcode-scanner copy in the SwiftUI check-in flow

### DIFF
--- a/omnibus-ios/omnibus/Features/AddBooks/AddBooksSheet.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/AddBooksSheet.swift
@@ -28,8 +28,8 @@ struct AddBooksSheet: View {
 
                     actionCard(
                         icon: "barcode.viewfinder",
-                        title: "Check in a physical book",
-                        subtitle: "Scan the barcode to log a copy you own on paper."
+                        title: "Scan a barcode",
+                        subtitle: "Check in a physical copy you own on paper."
                     ) { showCheckIn = true }
 
                     if !uploads.isEmpty {

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
@@ -61,6 +61,17 @@ struct CheckInView: View {
                     RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
                         .strokeBorder(palette.lineColor, lineWidth: 1)
                 )
+                // VisionKit's guidance text ("Find nearby barcodes") isn't
+                // customizable, so guidance is disabled and drawn here instead.
+                .overlay(alignment: .top) {
+                    Text("Move barcode into view")
+                        .font(.ui(13, weight: .medium))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, Spacing.md)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(.black.opacity(0.55)))
+                        .padding(.top, Spacing.md)
+                }
                 .screenPadding()
                 .padding(.top, Spacing.lg)
 
@@ -377,6 +388,7 @@ struct BarcodeScannerView: UIViewControllerRepresentable {
             qualityLevel: .balanced,
             recognizesMultipleItems: false,
             isHighFrameRateTrackingEnabled: false,
+            isGuidanceEnabled: false,
             isHighlightingEnabled: true
         )
         controller.delegate = context.coordinator


### PR DESCRIPTION
## Summary
- Renames the Add Books action card from "Check in a physical book" to "Scan a barcode" (subtitle now carries the check-in framing).
- Replaces VisionKit's built-in scanner guidance ("Find nearby barcodes") with an in-frame "Move barcode into view" pill — the system string isn't customizable, so guidance is disabled and drawn by the app.

Closes #1479
Closes #1480

## Test plan
- [x] `xcodebuild build -scheme omnibus -destination 'generic/platform=iOS Simulator'` — builds clean (pre-existing Swift 6 warnings only).
- [ ] TestFlight/simulator: open Add Books → card reads "Scan a barcode"; open the scanner → pill reads "Move barcode into view".

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.