### PR TITLE
feat: poll for library updates on the iOS home screen

### DIFF
--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -106,9 +106,15 @@ final class LibraryModel {
     }
 
     /// Resume points only. Re-running the whole `reload` would refetch the
-    /// grid and the shelves to update one card.
-    func refreshResume() async {
-        for await points in UserDataService.recentProgress().values() { resume = points }
+    /// grid and the shelves to update one card. `freshOnly` skips the replica
+    /// yield so a background poll doesn't republish an unchanged rail.
+    func refreshResume(freshOnly: Bool = false) async {
+        do {
+            for try await read in UserDataService.recentProgress() {
+                guard read.isFresh || !freshOnly else { continue }
+                resume = read.value
+            }
+        } catch {}
     }
 
     /// One background poll tick: pick up server-side changes (a finished
@@ -125,7 +131,7 @@ final class LibraryModel {
         ) else { return }
 
         async let mirror: Void = LibraryIndex.shared.sync()
-        await refreshResume()
+        await refreshResume(freshOnly: true)
         await revalidateFirstPage()
         await mirror
     }
@@ -253,8 +259,9 @@ struct LibraryView: View {
         // Background poll, mirroring the web client's sync tick. Tied to the
         // view's lifetime, so it pauses whenever the library isn't on screen.
         .task {
-            while !Task.isCancelled {
-                try? await Task.sleep(for: LibraryModel.pollInterval)
+            // `Task.sleep` throws on cancellation — bail out then, rather
+            // than letting a cancelled loop run one last refresh.
+            while (try? await Task.sleep(for: LibraryModel.pollInterval)) != nil {
                 await model.backgroundRefresh()
             }
         }

--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -38,9 +38,15 @@ final class LibraryModel {
     /// so this is the loaded page as-is.
     var visibleBooks: [Book] { books }
 
+    /// Background poll cadence, mirroring the web client's 60 s sync tick.
+    static let pollInterval: Duration = .seconds(60)
+
     private var cursor: String?
     private var reachedEnd = false
     private var loadToken = UUID()
+    /// Once the user has paged past the first screen, a background refresh
+    /// would truncate the grid back to page one — so it stands down.
+    private var hasPaginated = false
 
     func loadIfNeeded() async {
         guard books.isEmpty, !isLoading else { return }
@@ -54,6 +60,7 @@ final class LibraryModel {
         error = nil
         cursor = nil
         reachedEnd = false
+        hasPaginated = false
 
         let sort = sort
         let direction = direction
@@ -104,6 +111,52 @@ final class LibraryModel {
         for await points in UserDataService.recentProgress().values() { resume = points }
     }
 
+    /// One background poll tick: pick up server-side changes (a finished
+    /// import, progress from another device) without requiring a pull.
+    /// Mirrors the web client's sync tick — the mirror sync self-throttles to
+    /// one full pass per five minutes, and the first-page revalidation only
+    /// repaints when the server's answer actually differs.
+    func backgroundRefresh() async {
+        guard Self.shouldPoll(
+            isOnline: Connectivity.shared.isOnline,
+            isLoading: isLoading,
+            isLoadingMore: isLoadingMore,
+            hasPaginated: hasPaginated
+        ) else { return }
+
+        async let mirror: Void = LibraryIndex.shared.sync()
+        await refreshResume()
+        await revalidateFirstPage()
+        await mirror
+    }
+
+    /// Pure poll gate, split out so the guard is testable without a server:
+    /// offline ticks are wasted requests, loading ticks would race the user,
+    /// and a paginated grid must not be truncated back to page one.
+    nonisolated static func shouldPoll(
+        isOnline: Bool, isLoading: Bool, isLoadingMore: Bool, hasPaginated: Bool
+    ) -> Bool {
+        isOnline && !isLoading && !isLoadingMore && !hasPaginated
+    }
+
+    /// Re-reads the first page through the replica cache. `Cache.live` yields
+    /// a fresh value only when the payload changed, so a quiet library never
+    /// re-renders; a failed poll is invisible and the next tick retries.
+    private func revalidateFirstPage() async {
+        let token = loadToken
+        do {
+            for try await read in LibraryService.page(
+                sort: sort, direction: direction, filter: category.filter, cursor: nil
+            ) {
+                guard loadToken == token, !hasPaginated else { return }
+                guard read.isFresh else { continue }
+                books = read.value.books
+                cursor = read.value.nextCursor
+                reachedEnd = read.value.nextCursor == nil
+            }
+        } catch {}
+    }
+
     func loadMoreIfNeeded(currentItem: Book) async {
         guard !reachedEnd, !isLoadingMore, !isLoading, let cursor else { return }
         // Prefetch a page ahead of the end so the grid never shows a gap.
@@ -120,6 +173,7 @@ final class LibraryModel {
             ) {
                 let page = read.value
                 let existing = Set(books.map(\.id))
+                hasPaginated = true
                 books.append(contentsOf: page.books.filter { !existing.contains($0.id) })
                 self.cursor = page.nextCursor
                 reachedEnd = page.nextCursor == nil || page.books.isEmpty
@@ -196,6 +250,14 @@ struct LibraryView: View {
         }
         .environment(\.bookZoomNamespace, bookZoom)
         .task { await model.loadIfNeeded() }
+        // Background poll, mirroring the web client's sync tick. Tied to the
+        // view's lifetime, so it pauses whenever the library isn't on screen.
+        .task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: LibraryModel.pollInterval)
+                await model.backgroundRefresh()
+            }
+        }
         // The reader and player are full-screen covers over the tab view, so
         // closing one neither re-runs `task` nor re-appears this view.
         .onChange(of: presentation.progressToken) { _, _ in

--- a/omnibus-ios/omnibusTests/LibraryPollTests.swift
+++ b/omnibus-ios/omnibusTests/LibraryPollTests.swift
@@ -7,31 +7,31 @@ import Testing
 @testable import omnibus
 
 struct LibraryPollTests {
-    @Test func should_poll_when_online_idle_and_on_first_page() {
+    @Test func pollsWhenOnlineIdleAndOnFirstPage() {
         #expect(LibraryModel.shouldPoll(
             isOnline: true, isLoading: false, isLoadingMore: false, hasPaginated: false
         ))
     }
 
-    @Test func should_not_poll_while_offline() {
+    @Test func skipsWhileOffline() {
         #expect(!LibraryModel.shouldPoll(
             isOnline: false, isLoading: false, isLoadingMore: false, hasPaginated: false
         ))
     }
 
-    @Test func should_not_poll_while_a_reload_is_in_flight() {
+    @Test func skipsWhileAReloadIsInFlight() {
         #expect(!LibraryModel.shouldPoll(
             isOnline: true, isLoading: true, isLoadingMore: false, hasPaginated: false
         ))
     }
 
-    @Test func should_not_poll_while_a_page_fetch_is_in_flight() {
+    @Test func skipsWhileAPageFetchIsInFlight() {
         #expect(!LibraryModel.shouldPoll(
             isOnline: true, isLoading: false, isLoadingMore: true, hasPaginated: false
         ))
     }
 
-    @Test func should_not_poll_once_the_user_has_paginated() {
+    @Test func skipsOnceTheUserHasPaginated() {
         #expect(!LibraryModel.shouldPoll(
             isOnline: true, isLoading: false, isLoadingMore: false, hasPaginated: true
         ))

--- a/omnibus-ios/omnibusTests/LibraryPollTests.swift
+++ b/omnibus-ios/omnibusTests/LibraryPollTests.swift
@@ -1,0 +1,39 @@
+//  LibraryPollTests.swift
+//  The background poll gate: a tick may only refresh when it can't fight the
+//  user (a load in flight, a paginated grid) or waste the radio (offline).
+
+import Testing
+
+@testable import omnibus
+
+struct LibraryPollTests {
+    @Test func should_poll_when_online_idle_and_on_first_page() {
+        #expect(LibraryModel.shouldPoll(
+            isOnline: true, isLoading: false, isLoadingMore: false, hasPaginated: false
+        ))
+    }
+
+    @Test func should_not_poll_while_offline() {
+        #expect(!LibraryModel.shouldPoll(
+            isOnline: false, isLoading: false, isLoadingMore: false, hasPaginated: false
+        ))
+    }
+
+    @Test func should_not_poll_while_a_reload_is_in_flight() {
+        #expect(!LibraryModel.shouldPoll(
+            isOnline: true, isLoading: true, isLoadingMore: false, hasPaginated: false
+        ))
+    }
+
+    @Test func should_not_poll_while_a_page_fetch_is_in_flight() {
+        #expect(!LibraryModel.shouldPoll(
+            isOnline: true, isLoading: false, isLoadingMore: true, hasPaginated: false
+        ))
+    }
+
+    @Test func should_not_poll_once_the_user_has_paginated() {
+        #expect(!LibraryModel.shouldPoll(
+            isOnline: true, isLoading: false, isLoadingMore: false, hasPaginated: true
+        ))
+    }
+}


### PR DESCRIPTION
## Summary
- Ports the Dioxus client's 60-second background sync tick to the SwiftUI home screen: while the library is on screen, online, idle, and un-paginated, it revalidates the first page through `Cache.live`, refreshes the resume rail, and kicks the `LibraryIndex` mirror sync (self-throttled to one pass per 5 minutes).
- `Cache.live` only yields when the server payload differs, so a quiet library never repaints — same "generation bump on change" semantics as the web client.
- The poll gate is a pure function (`LibraryModel.shouldPoll`) with unit coverage for each veto: offline, reload in flight, page fetch in flight, user paginated past page one.

## Test plan
- [x] `omnibusTests` on the iPhone 17 simulator — 100 test cases passed, including the 5 new `LibraryPollTests`.
- [ ] On-device: leave the library open, add a book server-side, and watch it appear within ~a minute without pulling.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The tick lives on the view (`.task`), so it pauses whenever the library tab isn't in the hierarchy — slightly more conservative than the web client's app-wide runtime loop.
- Local unit runs currently need `IPHONEOS_DEPLOYMENT_TARGET=26.4` + `build-for-testing`/`test-without-building`, since the project targets 26.5 but the newest installed simulator runtime is 26.4 (pre-existing mismatch, not introduced here).