### PR TITLE
feat: stats period dropdown in the page title with iOS-style motion

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -7931,9 +7931,9 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .st-range-check { color: var(--accent); }
 
 /* ── Entrance cascade (iOS CascadeIn: fade + 12px lift + settle) ──── */
-/* The period section remounts on every range switch, so these replay
-   then too — the stagger is short and capped, the point is that the
-   page *fills*, not that the user waits for it. */
+/* Page-load only: the cards stay mounted across period switches, so the
+   cascade never replays mid-session — the stagger is short and capped,
+   the point is that the page *fills*, not that the user waits for it. */
 .st-tiles .st-tile,
 .st-compose > *,
 .st-alltime > * {
@@ -7949,12 +7949,31 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .st-compose > *:nth-child(2) { animation-delay: 0.2s; }
 .st-alltime > *:nth-child(2) { animation-delay: 0.06s; }
 
+/* ── Content swap (iOS contentTransition(.numericText()) analogue) ── */
+/* These nodes are keyed on their rendered data, so a period switch
+   remounts just the contents when the new summary lands — the cards
+   around them never move. */
+.st-tile-value,
+.st-donut-body,
+.st-format-pct {
+  animation: st-content-in 0.34s var(--st-ease-settle) both;
+}
+@keyframes st-content-in {
+  from { opacity: 0; transform: translateY(6px); }
+}
+/* The split bar grows/shrinks in place rather than remounting. */
+.st-format-fill { transition: width 0.44s var(--st-ease-settle); }
+
 @media (prefers-reduced-motion: reduce) {
   .st-period-menu,
   .st-tiles .st-tile,
   .st-compose > *,
-  .st-alltime > * { animation: none; }
+  .st-alltime > *,
+  .st-tile-value,
+  .st-donut-body,
+  .st-format-pct { animation: none; }
   .st-period-chevron { transition: none; }
+  .st-format-fill { transition: none; }
 }
 
 /* ── Sections ─────────────────────────────────────────────────────── */

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -7833,9 +7833,12 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
    Stats page (/stats)
 
    Period-scoped modules driven by the Week / Month / Year / Lifetime
-   switcher, then an "All-time" section that never re-queries. Desktop
-   shows the segmented control; the phone breakpoint swaps it for a
-   trigger that opens the shared `.m-sheet-*` bottom sheet.
+   dropdown embedded in the page title (the italic period word is the
+   trigger), then an "All-time" section that never re-queries.
+
+   Motion mirrors the iOS app's vocabulary (omnibus-ios Motion.swift):
+   `settle` for entrances (cascade-in with a capped stagger), `lift` for
+   the dropdown popover, all disabled under prefers-reduced-motion.
    ═══════════════════════════════════════════════════════════════════ */
 
 .st-page {
@@ -7845,70 +7848,114 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   display: flex;
   flex-direction: column;
   gap: 22px;
+  /* iOS Motion.settle (spring 0.44/0.82) and Motion.lift (0.28/0.74),
+     approximated as eased curves with a whisper of overshoot. */
+  --st-ease-settle: cubic-bezier(0.22, 1, 0.36, 1);
+  --st-ease-lift: cubic-bezier(0.2, 0.9, 0.35, 1.08);
 }
 
 /* ── Editorial header ─────────────────────────────────────────────── */
 .st-head { display: flex; flex-direction: column; gap: 8px; }
 .st-title { margin: 0; }
+.st-sub { margin: 0; color: var(--ink-2); }
+
+/* ── In-title period dropdown ─────────────────────────────────────── */
+.st-period-picker { position: relative; display: inline-block; }
+/* The trigger inherits the h1's serif so the period word reads as part
+   of the headline, not as a control bolted next to it. */
+.st-period-trigger {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.28em;
+}
 .st-period-word {
   font-style: italic;
   border-bottom: 2px solid var(--accent);
   padding-bottom: 2px;
 }
-.st-sub { margin: 0; color: var(--ink-2); }
-
-/* ── Period switcher: desktop segmented control ───────────────────── */
-.st-seg {
-  display: flex;
-  gap: 4px;
-  align-self: flex-start;
-  margin-top: 6px;
-  background: var(--bg-1);
-  border: 1px solid var(--line-2);
-  border-radius: 10px;
-  padding: 4px;
+.st-period-chevron {
+  font-size: 0.38em;
+  color: var(--accent);
+  align-self: center;
+  transition: transform 0.28s var(--st-ease-lift);
 }
-.st-seg-btn {
-  border: 0;
-  border-radius: 7px;
-  padding: 5px 14px;
-  background: transparent;
-  color: var(--ink-2);
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
+.st-period-trigger[aria-expanded="true"] .st-period-chevron {
+  transform: rotate(180deg);
 }
-.st-seg-btn.on { background: var(--bg-3); color: var(--ink-0); }
-
-/* ── Period switcher: mobile sheet trigger (hidden on desktop) ────── */
-.st-range-trigger {
-  display: none;
-  align-self: flex-start;
-  align-items: center;
-  gap: 7px;
-  margin-top: 6px;
-  border: 1px solid var(--line-2);
-  border-radius: 999px;
-  padding: 6px 14px;
-  background: var(--bg-1);
-  color: var(--ink-0);
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
+.st-period-scrim {
+  position: fixed; inset: 0; z-index: 60;
+  background: transparent; cursor: default;
 }
-.st-range-chevron { color: var(--accent); }
-.st-range-rows { display: flex; flex-direction: column; gap: 4px; }
+.st-period-menu {
+  position: absolute; top: calc(100% + 10px); left: 0;
+  min-width: 210px; z-index: 61;
+  background: var(--bg-1); border: 1px solid var(--line-2);
+  border-radius: 12px; padding: 6px;
+  display: flex; flex-direction: column; gap: 2px;
+  /* Reset the h1 context the menu inherits from its place in the title. */
+  font-family: var(--sans); font-size: 14px;
+  font-style: normal; font-weight: 400; letter-spacing: normal;
+  box-shadow:
+    0 18px 40px color-mix(in oklch, black 55%, transparent),
+    0 2px 0 color-mix(in oklch, black 25%, transparent);
+  transform-origin: top left;
+  animation: st-menu-in 0.28s var(--st-ease-lift) both;
+}
+@keyframes st-menu-in {
+  from { opacity: 0; transform: translateY(-6px) scale(0.96); }
+}
 .st-range-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
   border: 0;
   border-radius: 8px;
-  padding: 12px 14px;
+  padding: 10px 12px;
   background: transparent;
   color: var(--ink-1);
   font: inherit;
   text-align: left;
   cursor: pointer;
 }
+@media (hover: hover) {
+  .st-range-row:hover { background: var(--bg-2); color: var(--ink-0); }
+}
 .st-range-row.on { background: var(--bg-2); color: var(--ink-0); }
+.st-range-check { color: var(--accent); }
+
+/* ── Entrance cascade (iOS CascadeIn: fade + 12px lift + settle) ──── */
+/* The period section remounts on every range switch, so these replay
+   then too — the stagger is short and capped, the point is that the
+   page *fills*, not that the user waits for it. */
+.st-tiles .st-tile,
+.st-compose > *,
+.st-alltime > * {
+  animation: st-cascade-in 0.44s var(--st-ease-settle) both;
+}
+@keyframes st-cascade-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.985); }
+}
+.st-tiles .st-tile:nth-child(2) { animation-delay: 0.04s; }
+.st-tiles .st-tile:nth-child(3) { animation-delay: 0.08s; }
+.st-tiles .st-tile:nth-child(4) { animation-delay: 0.12s; }
+.st-compose > *:nth-child(1) { animation-delay: 0.16s; }
+.st-compose > *:nth-child(2) { animation-delay: 0.2s; }
+.st-alltime > *:nth-child(2) { animation-delay: 0.06s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .st-period-menu,
+  .st-tiles .st-tile,
+  .st-compose > *,
+  .st-alltime > * { animation: none; }
+  .st-period-chevron { transition: none; }
+}
 
 /* ── Sections ─────────────────────────────────────────────────────── */
 .st-period, .st-alltime { display: flex; flex-direction: column; gap: 16px; }
@@ -8188,8 +8235,6 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 
 @media (max-width: 720px) {
   .st-page { padding-top: 8px; }
-  .st-seg { display: none; }
-  .st-range-trigger { display: inline-flex; }
 
   /* Tiles collapse to a 2×2 grid; the hero pair (Finished, Avg rating)
      stays larger, per the converged design. */

--- a/frontend/src/pages/stats/donut.rs
+++ b/frontend/src/pages/stats/donut.rs
@@ -86,10 +86,14 @@ pub(super) fn GenreDonut(summary: StatsSummary) -> Element {
     }
     let percents = percentages(&folded.iter().map(|(_, c)| *c).collect::<Vec<_>>());
     let gradient = donut_gradient(&percents);
+    // Content-derived key: when a period switch lands a different mix, the
+    // body remounts and replays the content-swap animation while the card
+    // stays put. Same data → same key → no motion.
+    let content_key = format!("{books_active}|{gradient}|{folded:?}");
     rsx! {
         div { class: "card st-donut-card", "data-testid": "stats-genre-donut",
             div { class: "label", "What you read" }
-            div { class: "st-donut-body",
+            div { key: "{content_key}", class: "st-donut-body",
                 div { class: "st-donut", style: "background: {gradient};", role: "img",
                     aria_label: "Genre share by book count",
                     div { class: "st-donut-hole",
@@ -137,7 +141,10 @@ pub(super) fn FormatSplit(summary: StatsSummary) -> Element {
                 div { class: "st-format-row",
                     div { class: "st-format-row-head",
                         span { class: "st-format-name", {label} }
-                        span { class: "st-format-pct mono", "{pct}%" }
+                        // Keyed so a changed share fades the number in; the
+                        // bar below animates its width via CSS transition
+                        // instead (the row itself never remounts).
+                        span { key: "{pct}", class: "st-format-pct mono", "{pct}%" }
                     }
                     div { class: "st-format-track",
                         div { class: "st-format-fill", style: "width: {pct}%; background: {var};" }

--- a/frontend/src/pages/stats/mod.rs
+++ b/frontend/src/pages/stats/mod.rs
@@ -68,13 +68,11 @@ pub fn StatsPage() -> Element {
             if empty {
                 StatsEmpty {}
             } else {
-                // Keyed on the range so a period switch remounts the section
-                // and replays the cascade-in entrance (the web analogue of the
-                // iOS screen's settle-on-change motion).
-                section {
-                    key: "{range().label()}",
-                    class: "st-period",
-                    "data-testid": "stats-period-section",
+                // Deliberately not keyed on the range: a period switch keeps
+                // the cards mounted (the entrance cascade plays on page load
+                // only) and each card's *contents* transition when the new
+                // summary lands — the web analogue of iOS numericText.
+                section { class: "st-period", "data-testid": "stats-period-section",
                     PeriodSummary { period, expanded }
                 }
                 div { class: "st-divider",
@@ -196,6 +194,7 @@ fn StatsHeader(range: Signal<StatsRange>, menu_open: Signal<bool>) -> Element {
                         "data-testid": "stats-range-trigger",
                         "aria-haspopup": "dialog",
                         "aria-expanded": "{menu_open()}",
+                        "aria-describedby": "st-period-hint",
                         onclick: move |_| {
                             let next = !menu_open();
                             menu_open.set(next);
@@ -213,6 +212,13 @@ fn StatsHeader(range: Signal<StatsRange>, menu_open: Signal<bool>) -> Element {
                     }
                 }
             }
+            // aria-describedby target, outside the h1 so the hint text never
+            // joins the heading's accessible name ("Your reading month", not
+            // "Your reading Change period month"). An aria-label on the
+            // trigger would replace the period word as the button's name and
+            // distort the heading the same way — a description adds the
+            // action without touching either name.
+            span { id: "st-period-hint", class: "sr-only", "Change period" }
             p { class: "st-sub", "Reading & listening, tracked over time." }
         }
     }

--- a/frontend/src/pages/stats/mod.rs
+++ b/frontend/src/pages/stats/mod.rs
@@ -1,7 +1,7 @@
-//! Reading-stats page (`/stats`). Period-scoped modules up top driven by a
-//! Week / Month / Year / Lifetime switcher, then an explicitly separated
-//! All-time section that never re-queries on switcher change. Mirrors the
-//! converged Stats design (`screens/stats-converged.jsx`).
+//! Reading-stats page (`/stats`). Period-scoped modules up top driven by the
+//! Week / Month / Year / Lifetime dropdown embedded in the page title, then an
+//! explicitly separated All-time section that never re-queries on period
+//! change. Mirrors the converged Stats design (`screens/stats-converged.jsx`).
 
 use dioxus::prelude::*;
 use omnibus_shared::{StatsRange, StatsSummary, STATS_TTL_SECS};
@@ -43,7 +43,9 @@ pub fn StatsPage() -> Element {
     let all_time: Signal<Option<StatsSummary>> = use_signal(|| None);
     let loading = use_signal(|| true);
     let error: Signal<Option<String>> = use_signal(|| None);
-    let sheet_open = use_signal(|| false);
+    // Seeded closed on every target (rule 07): the title dropdown only ever
+    // opens from a client click.
+    let menu_open = use_signal(|| false);
     // Which tile's drill-in is open, if any — seeded closed on every target
     // (rule 07): the sheet/modal only ever opens from a client click.
     let expanded: Signal<Option<Metric>> = use_signal(|| None);
@@ -62,11 +64,17 @@ pub fn StatsPage() -> Element {
 
     rsx! {
         div { class: "st-page",
-            StatsHeader { range, sheet_open }
+            StatsHeader { range, menu_open }
             if empty {
                 StatsEmpty {}
             } else {
-                section { class: "st-period", "data-testid": "stats-period-section",
+                // Keyed on the range so a period switch remounts the section
+                // and replays the cascade-in entrance (the web analogue of the
+                // iOS screen's settle-on-change motion).
+                section {
+                    key: "{range().label()}",
+                    class: "st-period",
+                    "data-testid": "stats-period-section",
                     PeriodSummary { period, expanded }
                 }
                 div { class: "st-divider",
@@ -76,9 +84,6 @@ pub fn StatsPage() -> Element {
                 section { class: "st-alltime", "data-testid": "stats-alltime-section",
                     AllTimeSummary { all_time }
                 }
-            }
-            if sheet_open() {
-                RangeSheet { range, sheet_open }
             }
             if let (Some(metric), Some(summary)) = (expanded(), period.read().clone()) {
                 DrillIn { metric, summary, range: range(), expanded }
@@ -174,75 +179,114 @@ fn use_all_time_fetch_effect(
     });
 }
 
-/// Editorial header: title with the italic period word, subtitle, and the
-/// period switcher (desktop segmented control + mobile sheet trigger — CSS
-/// picks one per form factor, never `cfg`-gated rsx).
+/// Editorial header: the title's italic period word doubles as the period
+/// switcher — a trigger that drops the Week / Month / Year / Lifetime menu
+/// straight out of the headline, one control across every form factor.
 #[component]
-fn StatsHeader(range: Signal<StatsRange>, sheet_open: Signal<bool>) -> Element {
+fn StatsHeader(range: Signal<StatsRange>, menu_open: Signal<bool>) -> Element {
     let current = range();
     rsx! {
         header { class: "st-head",
             h1 { class: "st-title",
                 "Your reading "
-                span { class: "st-period-word", {period_word(current)} }
-            }
-            p { class: "st-sub", "Reading & listening, tracked over time." }
-            div { class: "st-seg", role: "group", "aria-label": "Period",
-                for r in StatsRange::ALL {
+                span { class: "st-period-picker",
                     button {
-                        class: if r == current { "st-seg-btn on" } else { "st-seg-btn" },
+                        class: "st-period-trigger",
                         r#type: "button",
-                        "aria-pressed": if r == current { "true" } else { "false" },
-                        onclick: move |_| range.set(r),
-                        {r.label()}
+                        "data-testid": "stats-range-trigger",
+                        "aria-haspopup": "dialog",
+                        "aria-expanded": "{menu_open()}",
+                        onclick: move |_| {
+                            let next = !menu_open();
+                            menu_open.set(next);
+                        },
+                        span { class: "st-period-word", {period_word(current)} }
+                        span { class: "st-period-chevron", aria_hidden: "true", "\u{25BE}" }
+                    }
+                    if menu_open() {
+                        div {
+                            class: "st-period-scrim",
+                            "data-testid": "stats-range-scrim",
+                            onclick: move |_| menu_open.set(false),
+                        }
+                        RangeMenu { range, menu_open }
                     }
                 }
             }
-            button {
-                class: "st-range-trigger",
-                r#type: "button",
-                "data-testid": "stats-range-trigger",
-                onclick: move |_| sheet_open.set(true),
-                {current.label()}
-                span { class: "st-range-chevron", aria_hidden: "true", "\u{25BE}" }
+            p { class: "st-sub", "Reading & listening, tracked over time." }
+        }
+    }
+}
+
+/// The open period dropdown, anchored under the title's period word.
+///
+/// `role="dialog"` (not `role="menu"`) to match the user-menu / export
+/// dropdowns: a scrim-dismissed popover with plain buttons, not an ARIA menu
+/// with roving-tabindex navigation.
+#[component]
+fn RangeMenu(range: Signal<StatsRange>, menu_open: Signal<bool>) -> Element {
+    let current = range();
+    let mut menu_open = menu_open;
+    let on_keydown = move |evt: Event<KeyboardData>| {
+        if evt.key() == Key::Escape {
+            evt.prevent_default();
+            menu_open.set(false);
+        }
+    };
+    rsx! {
+        div {
+            class: "st-period-menu",
+            role: "dialog",
+            "aria-label": "Period",
+            "data-testid": "stats-range-menu",
+            tabindex: "-1",
+            onkeydown: on_keydown,
+            onmounted: move |evt: MountedEvent| focus_range_menu(&evt),
+            for r in StatsRange::ALL {
+                button {
+                    class: if r == current { "st-range-row on" } else { "st-range-row" },
+                    r#type: "button",
+                    "aria-pressed": if r == current { "true" } else { "false" },
+                    onclick: move |_| {
+                        range.set(r);
+                        menu_open.set(false);
+                    },
+                    span { class: "st-range-row-label", {r.label()} }
+                    if r == current {
+                        span { class: "st-range-check", aria_hidden: "true", "\u{2713}" }
+                    }
+                }
             }
         }
     }
 }
 
-/// Mobile bottom sheet listing the four period options.
-#[component]
-fn RangeSheet(range: Signal<StatsRange>, sheet_open: Signal<bool>) -> Element {
-    let current = range();
-    rsx! {
-        div {
-            class: "m-sheet-scrim",
-            "data-testid": "stats-range-sheet",
-            onclick: move |_| sheet_open.set(false),
-            div { class: "m-sheet", onclick: move |e| e.stop_propagation(),
-                div { class: "m-sheet-grabber" }
-                div { class: "m-sheet-head",
-                    h4 { "Period" }
-                }
-                div { class: "m-sheet-body",
-                    div { class: "st-range-rows",
-                        for r in StatsRange::ALL {
-                            button {
-                                class: if r == current { "st-range-row on" } else { "st-range-row" },
-                                r#type: "button",
-                                onclick: move |_| {
-                                    range.set(r);
-                                    sheet_open.set(false);
-                                },
-                                {r.label()}
-                            }
-                        }
-                    }
-                }
-            }
+/// Focus the menu after paint so its `onkeydown` receives ESC — same
+/// requestAnimationFrame timing as the user-menu and export panels. Web-only;
+/// SSR never paints the menu, so the gate lives at the fn definition to keep
+/// the `onmounted` handler body identical across targets (rule 07).
+#[cfg(feature = "web")]
+fn focus_range_menu(evt: &MountedEvent) {
+    use dioxus::web::WebEventExt;
+    use wasm_bindgen::prelude::*;
+
+    let Some(element) = evt.try_as_web_event() else {
+        return;
+    };
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let cb = Closure::once_into_js(move || {
+        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
+            let _ = html_el.focus();
         }
-    }
+    });
+    let _ = window.request_animation_frame(cb.unchecked_ref());
 }
+
+/// Non-web stub (SSR): nothing to focus before hydration.
+#[cfg(not(feature = "web"))]
+fn focus_range_menu(_evt: &MountedEvent) {}
 
 /// The period-scoped module stack: headline tiles, then the composition row
 /// (genre donut + format split). A placeholder card until the first fetch

--- a/frontend/src/pages/stats/tiles.rs
+++ b/frontend/src/pages/stats/tiles.rs
@@ -149,7 +149,11 @@ fn StatTile(
             r#type: "button",
             "aria-label": "Expand {label} details",
             onclick: move |_| onexpand.call(()),
-            div { class: "st-tile-value",
+            // Keyed on the rendered value so a period switch remounts just
+            // this node when the new summary lands — replaying the content
+            // swap animation while the tile itself stays put (iOS
+            // numericText analogue). An unchanged value doesn't animate.
+            div { key: "{value}", class: "st-tile-value",
                 {value}
                 if let Some(u) = unit {
                     span { class: "st-tile-unit", {u} }

--- a/ui_tests/playwright/tests/flows/stats.spec.ts
+++ b/ui_tests/playwright/tests/flows/stats.spec.ts
@@ -1,6 +1,6 @@
 // Reading-stats page (/stats): layout, the Week / Month / Year / Lifetime
-// period switcher, the all-time section's immunity to switcher changes, and
-// the zero-activity empty state.
+// dropdown embedded in the page title, the all-time section's immunity to
+// period changes, and the zero-activity empty state.
 //
 // Sessions are seeded once in beforeAll — before the first /stats visit — so
 // the server-side 60s stats cache never captures an empty summary for the
@@ -8,6 +8,7 @@
 // indexed book, so the library is seeded first and sessions ride a real
 // fixture uuid.
 
+import type { Page } from "@playwright/test";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expect, test } from "../fixtures/test";
 import { expectMutation } from "../utils/api";
@@ -22,6 +23,14 @@ test.describe.configure({ mode: "serial" });
 
 /** Late-2023 anchor: inside Lifetime, outside the week/month/year windows. */
 const OLD_SESSION_AT = 1_700_000_000;
+
+/** Open the in-title period dropdown and return its dialog locator. */
+async function openPeriodMenu(page: Page) {
+  await page.getByTestId("stats-range-trigger").click();
+  const menu = page.getByRole("dialog", { name: "Period" });
+  await expect(menu).toBeVisible();
+  return menu;
+}
 
 test.beforeAll(async ({ request }) => {
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
@@ -86,15 +95,23 @@ test("renders the stats page layout", async ({ page }) => {
     page.getByRole("heading", { name: "Your reading month" }),
   ).toBeVisible();
 
-  // The switcher offers all four periods with Month pre-selected.
-  const seg = page.getByRole("group", { name: "Period" });
+  // The title's period word opens the dropdown, which offers all four
+  // periods with Month pre-selected.
+  const menu = await openPeriodMenu(page);
   for (const label of ["Week", "Month", "Year", "Lifetime"]) {
-    await expect(seg.getByRole("button", { name: label })).toBeVisible();
+    await expect(menu.getByRole("button", { name: label })).toBeVisible();
   }
-  await expect(seg.getByRole("button", { name: "Month" })).toHaveAttribute(
+  await expect(menu.getByRole("button", { name: "Month" })).toHaveAttribute(
     "aria-pressed",
     "true",
   );
+
+  // The scrim dismisses it without changing the period.
+  await page.getByTestId("stats-range-scrim").click();
+  await expect(menu).toHaveCount(0);
+  await expect(
+    page.getByRole("heading", { name: "Your reading month" }),
+  ).toBeVisible();
 
   // Period-scoped section above, explicitly divided all-time section below.
   await expect(page.getByTestId("stats-period-section")).toBeVisible();
@@ -144,12 +161,10 @@ test("a tile's grip opens its drill-in and the close button dismisses it", async
   await page.getByTestId("stats-drill-close").click();
   await expect(drillIn).toHaveCount(0);
 
-  // The period switcher underneath is untouched by opening/closing (AC4).
+  // The selected period is untouched by opening/closing (AC4).
   await expect(
-    page
-      .getByRole("group", { name: "Period" })
-      .getByRole("button", { name: "Month" }),
-  ).toHaveAttribute("aria-pressed", "true");
+    page.getByRole("heading", { name: "Your reading month" }),
+  ).toBeVisible();
 });
 
 test("the Finished drill-in lists the books completed in the window", async ({
@@ -171,7 +186,7 @@ test("switching the period re-queries and updates the period section", async ({
   page,
 }) => {
   await gotoReady(page, "/stats");
-  const seg = page.getByRole("group", { name: "Period" });
+  const menu = await openPeriodMenu(page);
 
   await expectMutation(
     page,
@@ -181,20 +196,25 @@ test("switching the period re-queries and updates the period section", async ({
       expectedBody: { range: "week" },
       expectedStatus: 200,
     },
-    async () => seg.getByRole("button", { name: "Week" }).click(),
+    async () => menu.getByRole("button", { name: "Week" }).click(),
   );
 
-  await expect(seg.getByRole("button", { name: "Week" })).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
-  await expect(seg.getByRole("button", { name: "Month" })).toHaveAttribute(
-    "aria-pressed",
-    "false",
-  );
+  // Picking a period closes the menu and rewrites the title.
+  await expect(menu).toHaveCount(0);
   await expect(
     page.getByRole("heading", { name: "Your reading week" }),
   ).toBeVisible();
+
+  // Reopening shows the new selection.
+  const reopened = await openPeriodMenu(page);
+  await expect(reopened.getByRole("button", { name: "Week" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(reopened.getByRole("button", { name: "Month" })).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
 });
 
 test("the heatmap and genre donut render from seeded activity", async ({
@@ -246,7 +266,7 @@ test("the all-time section does not change with the switcher", async ({
   await expect(allTime).toBeVisible();
   const before = await allTime.textContent();
 
-  const seg = page.getByRole("group", { name: "Period" });
+  const menu = await openPeriodMenu(page);
   await expectMutation(
     page,
     {
@@ -255,7 +275,7 @@ test("the all-time section does not change with the switcher", async ({
       expectedBody: { range: "year" },
       expectedStatus: 200,
     },
-    async () => seg.getByRole("button", { name: "Year" }).click(),
+    async () => menu.getByRole("button", { name: "Year" }).click(),
   );
 
   await expect(

--- a/ui_tests/playwright/tests/flows/stats.spec.ts
+++ b/ui_tests/playwright/tests/flows/stats.spec.ts
@@ -113,6 +113,15 @@ test("renders the stats page layout", async ({ page }) => {
     page.getByRole("heading", { name: "Your reading month" }),
   ).toBeVisible();
 
+  // ESC dismisses it too (the menu takes focus on mount), also without
+  // changing the period.
+  const reopened = await openPeriodMenu(page);
+  await reopened.press("Escape");
+  await expect(reopened).toHaveCount(0);
+  await expect(
+    page.getByRole("heading", { name: "Your reading month" }),
+  ).toBeVisible();
+
   // Period-scoped section above, explicitly divided all-time section below.
   await expect(page.getByTestId("stats-period-section")).toBeVisible();
   await expect(page.getByText("Not tied to the period above.")).toBeVisible();


### PR DESCRIPTION
## Summary
- The stats page's Week / Month / Year / Lifetime switcher is now a dropdown on the italic period word in the "Your reading ___" title (accent underline + rotating chevron), replacing both the desktop segmented control and the mobile bottom sheet — one control on every form factor, following the export-menu/user-menu popover pattern (scrim dismiss, ESC, focus-on-mount, sr-only `aria-describedby` action hint).
- Ports the iOS motion vocabulary (`omnibus-ios/Design/Motion.swift`) to CSS: staggered cascade-in entrance for tiles/cards on page load (settle curve), lift-curve spring for the dropdown, all disabled under `prefers-reduced-motion`.
- Period switches never remount the cards — content nodes (tile values, donut body, split percentages) are keyed on their rendered data so only the contents transition when the new summary lands, and the split bars tween width in place — the web analogue of iOS `contentTransition(.numericText())`.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` (528 passed)
- [x] All 9 `stats.spec.ts` Playwright tests pass against a live dev server (specs updated to drive the dropdown, incl. scrim- and ESC-dismiss coverage)
- [x] `clippy -D warnings` (native + wasm32 web), `cargo fmt`, `just lint-css`, `just lint-ts`
- [x] Manual browser check: menu open/close, period switch refetch + title rewrite, cards stay mounted across switches, clean console (no hydration errors)

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)