### PR TITLE
fix: answer Kobo gettests POST and unknown store paths; correct setup copy (#1499)

### DIFF
--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -66,18 +66,29 @@ to get KEPUB output. See [.env.example](../.env.example).
 ## About wireless sync (experimental)
 
 *Wireless* Kobo sync — where the device talks to Omnibus over Wi-Fi instead of a
-USB cable — is **under construction**. **Account → Kobo wireless sync** will hand
-you an endpoint URL, but the protocol behind it is incomplete. Treat it as
-experimental and do not point a device you care about at it yet.
+USB cable — is functional but **experimental**: the protocol implementation is
+complete, but it has not yet passed verification against real devices. Back up
+first (below), then expect rough edges.
 
 > [!WARNING]
 > **The first wireless sync can erase your Kobo's highlights and notes.**
-> A Kobo clears its own annotations when the server it syncs with does not answer
-> Kobo's annotation channel. Omnibus does not answer that channel yet, and does
-> **not** store what the device erases — anything lost this way is gone.
+> A Kobo clears its own annotations when the server it syncs with mishandles
+> Kobo's annotation channel. Omnibus answers that channel, but until real-device
+> verification passes, assume a first sync can still wipe on-device annotations —
+> and Omnibus does **not** store what the device erases.
 
-**Back up your annotations before the first wireless sync.** They live in a
-single file on the device:
+**Back up your device before the first wireless sync.** Two tools cover this
+properly:
+
+- [**kobo-backup**](https://github.com/seamus-sloan/kobo-backup) — snapshots the
+  entire device over USB into a verified zip (books, annotations, reading
+  progress, settings, databases) and can restore the Kobo to exactly that point
+  in time. The most complete option: a wipe becomes a non-event.
+- [**kobuddy**](https://github.com/karlicoss/kobuddy) — exports your highlights,
+  annotations, and reading history from the device database into plain data you
+  keep.
+
+At minimum, copy the device database off by hand:
 
 1. Connect the Kobo over USB and tap **Connect**. It appears as a USB drive.
 2. Copy `.kobo/KoboReader.sqlite` off the drive to somewhere safe. (`.kobo` is a
@@ -88,12 +99,32 @@ single file on the device:
 That file holds every highlight and note on the device. Keeping a copy means a
 wipe is recoverable.
 
-**If your Omnibus version offers a Kobo annotation import, run it before the
-first wireless sync** — that pulls the device's highlights and notes into your
-library, so a wipe costs you nothing. That import is still in development
-([#933](https://github.com/seamus-sloan/omnibus/issues/933)); until it ships,
-the file copy above is the backup, and it is one you keep yourself rather than
-something Omnibus can read back.
+### Setting up wireless sync
+
+There is **no on-device setting** for a custom sync server — the endpoint is set
+by editing a config file on the Kobo over USB:
+
+1. In Omnibus, open **Account → Kobo wireless sync**, name your device, and
+   click **Add a Kobo**. Omnibus mints it a private sync URL
+   (`https://<your-server>/kobo/<token>`); the token authorizes only your
+   library, and **Regenerate** revokes it.
+2. Copy the device's **wireless sync endpoint** URL from the card.
+3. Connect the Kobo over USB and tap **Connect**. Open the hidden
+   `.kobo/Kobo/Kobo eReader.conf` file in a text editor.
+4. In the `[OneStoreServices]` section, set `api_endpoint=` to the copied URL:
+
+   ```ini
+   [OneStoreServices]
+   api_endpoint=https://your-server.example.com/kobo/<token>
+   ```
+
+5. Save, eject the Kobo safely, and unplug. The next sync on the device
+   (**Sync** from the home screen) talks to Omnibus: books from shelves marked
+   **Sync to Kobo** appear on the device, and reading position, read status,
+   and highlights round-trip back.
+
+Only shelves you've opted in are synced — mark a shelf **Sync to Kobo** in its
+settings to include it.
 
 The wired **Send to Kobo** transfer described above carries none of this risk and
-stays the safe choice.
+stays the safe choice for simply putting books on the device.

--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -66,65 +66,37 @@ to get KEPUB output. See [.env.example](../.env.example).
 ## About wireless sync (experimental)
 
 *Wireless* Kobo sync — where the device talks to Omnibus over Wi-Fi instead of a
-USB cable — is functional but **experimental**: the protocol implementation is
-complete, but it has not yet passed verification against real devices. Back up
-first (below), then expect rough edges.
+USB cable — is functional but **experimental**: it has not yet passed
+verification against real devices.
 
 > [!WARNING]
-> **The first wireless sync can erase your Kobo's highlights and notes.**
-> A Kobo clears its own annotations when the server it syncs with mishandles
-> Kobo's annotation channel. Omnibus answers that channel, but until real-device
-> verification passes, assume a first sync can still wipe on-device annotations —
-> and Omnibus does **not** store what the device erases.
-
-**Back up your device before the first wireless sync.** Two tools cover this
-properly:
-
-- [**kobo-backup**](https://github.com/seamus-sloan/kobo-backup) — snapshots the
-  entire device over USB into a verified zip (books, annotations, reading
-  progress, settings, databases) and can restore the Kobo to exactly that point
-  in time. The most complete option: a wipe becomes a non-event.
-- [**kobuddy**](https://github.com/karlicoss/kobuddy) — exports your highlights,
-  annotations, and reading history from the device database into plain data you
-  keep.
-
-At minimum, copy the device database off by hand:
-
-1. Connect the Kobo over USB and tap **Connect**. It appears as a USB drive.
-2. Copy `.kobo/KoboReader.sqlite` off the drive to somewhere safe. (`.kobo` is a
-   hidden folder — on macOS press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>.</kbd> in Finder
-   to reveal it; on Windows enable **Hidden items** in Explorer's View tab.)
-3. Eject the Kobo safely.
-
-That file holds every highlight and note on the device. Keeping a copy means a
-wipe is recoverable.
+> **First sync can erase your Kobo's highlights**
+>
+> An improper sync can potentially wipe data on the Kobo like your annotations,
+> notes, bookmarks, reading progress, and books.
+>
+> It is highly recommended to back up your device before attempting a sync with
+> one of these tools:
+>
+> - [seamus-sloan/kobo-backup](https://github.com/seamus-sloan/kobo-backup#kobo-backup)
+> - [karlicoss/kobuddy](https://github.com/karlicoss/kobuddy#usage)
+>
+> At minimum, copy `.kobo/KoboReader.sqlite` off the device over USB.
 
 ### Setting up wireless sync
 
-There is **no on-device setting** for a custom sync server — the endpoint is set
-by editing a config file on the Kobo over USB:
+From **Account → Kobo wireless sync**:
 
-1. In Omnibus, open **Account → Kobo wireless sync**, name your device, and
-   click **Add a Kobo**. Omnibus mints it a private sync URL
-   (`https://<your-server>/kobo/<token>`); the token authorizes only your
-   library, and **Regenerate** revokes it.
-2. Copy the device's **wireless sync endpoint** URL from the card.
-3. Connect the Kobo over USB and tap **Connect**. Open the hidden
-   `.kobo/Kobo/Kobo eReader.conf` file in a text editor.
-4. In the `[OneStoreServices]` section, set `api_endpoint=` to the copied URL:
+1. Give your Kobo a name and click **Add a Kobo**
+2. Copy the device's wireless sync endpoint URL. (`/kobo/<token>`)
+3. Connect the Kobo over USB,
+4. Edit `.kobo/Kobo/Kobo eReader.conf` and set `api_endpoint=` under
+   `[OneStoreServices]` to `<your_omnibus_server_url>/kobo/<token>`.
+5. Eject safely. Your next sync on the device talks to Omnibus.
 
-   ```ini
-   [OneStoreServices]
-   api_endpoint=https://your-server.example.com/kobo/<token>
-   ```
-
-5. Save, eject the Kobo safely, and unplug. The next sync on the device
-   (**Sync** from the home screen) talks to Omnibus: books from shelves marked
-   **Sync to Kobo** appear on the device, and reading position, read status,
-   and highlights round-trip back.
+(`.kobo` is a hidden folder — on macOS press
+<kbd>⌘</kbd><kbd>⇧</kbd><kbd>.</kbd> in Finder to reveal it; on Windows enable
+**Hidden items** in Explorer's View tab.)
 
 Only shelves you've opted in are synced — mark a shelf **Sync to Kobo** in its
 settings to include it.
-
-The wired **Send to Kobo** transfer described above carries none of this risk and
-stays the safe choice for simply putting books on the device.

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4944,6 +4944,7 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   color: var(--ink-1);
 }
 .kobo-warning p { margin: 0 0 0.5rem; }
+.kobo-warning ul { margin: 0 0 0.5rem; padding-left: 1.25rem; }
 .kobo-warning p:last-child { margin-bottom: 0; }
 .kobo-warning-title { font-weight: 600; color: #f87171; }
 .kobo-warning code { font-family: var(--mono, ui-monospace, monospace); font-size: 0.8rem; }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -4921,6 +4921,16 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 .btn.ghost.danger { color: #f87171; }
 @media (hover: hover) { .btn.ghost.danger:hover { background: var(--bg-1); color: #fca5a5; } }
 
+/* Kobo wireless-sync setup steps (#1499). */
+.kobo-setup-steps {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.kobo-setup-steps code { font-family: var(--mono, ui-monospace, monospace); font-size: 0.8rem; }
+
 /* Kobo annotation data-loss warning (#927). */
 .kobo-warning {
   margin-top: 1rem;

--- a/frontend/src/pages/account/kobo.rs
+++ b/frontend/src/pages/account/kobo.rs
@@ -118,25 +118,51 @@ pub fn KoboDevicesCard() -> Element {
         section { class: "card", "data-testid": "kobo-devices-card",
             h2 { "Kobo wireless sync" }
             p { class: "subtitle",
-                "Register a Kobo, then set its "
-                b { "wireless sync endpoint" }
-                " (Settings \u{2192} Beta Features on the device) to the URL below. "
-                "The token authorizes only your library."
+                "There is no on-device setting for this \u{2014} the endpoint is set "
+                "by editing a config file on the Kobo over USB:"
+            }
+            ol { class: "subtitle kobo-setup-steps", "data-testid": "kobo-setup-steps",
+                li {
+                    "Name your Kobo below and click "
+                    b { "Add a Kobo" }
+                    ". Omnibus mints it a private sync URL \u{2014} the token inside "
+                    "authorizes only your library."
+                }
+                li { "Copy the device's " b { "wireless sync endpoint" } " URL." }
+                li {
+                    "Connect the Kobo over USB, open the hidden "
+                    code { ".kobo/Kobo/Kobo eReader.conf" }
+                    " file, and set "
+                    code { "api_endpoint=" }
+                    " under "
+                    code { "[OneStoreServices]" }
+                    " to that URL."
+                }
+                li { "Eject safely. The next sync on the device talks to Omnibus." }
             }
 
             // Unconditional: the hazard applies the moment a URL is copied.
             div { class: "kobo-warning", "data-testid": "kobo-data-loss-warning",
                 p { class: "kobo-warning-title", "First sync can erase your Kobo's highlights" }
                 p {
-                    "A Kobo clears its own highlights and notes when the server it syncs with "
-                    "does not answer Kobo's annotation channel. Omnibus does not answer that "
-                    "channel yet, and does not store what the device erases."
+                    "A Kobo clears its own highlights and notes when the server it syncs "
+                    "with mishandles Kobo's annotation channel. Omnibus answers that "
+                    "channel, but it has not yet been verified against real devices \u{2014} "
+                    "treat wireless sync as experimental and assume the first sync can "
+                    "still wipe them."
                 }
                 p {
-                    "Copy "
+                    "Back up the device fully before you point it here \u{2014} "
+                    a { href: "https://github.com/seamus-sloan/kobo-backup", target: "_blank",
+                        "kobo-backup"
+                    }
+                    " snapshots and restores the whole device, and "
+                    a { href: "https://github.com/karlicoss/kobuddy", target: "_blank",
+                        "kobuddy"
+                    }
+                    " exports highlights and reading history. At minimum, copy "
                     code { ".kobo/KoboReader.sqlite" }
-                    " off the device over USB before you point it here. Wireless sync is "
-                    "incomplete \u{2014} treat it as experimental."
+                    " off the device over USB."
                 }
             }
 
@@ -314,6 +340,18 @@ mod render_tests {
         assert!(html.contains("data-testid=\"kobo-data-loss-warning\""));
         assert!(html.contains("First sync can erase your Kobo&#39;s highlights"));
         assert!(html.contains("KoboReader.sqlite"));
+    }
+
+    /// The setup steps must name the real procedure — the USB edit of
+    /// `Kobo eReader.conf` — and never a nonexistent on-device setting
+    /// (the pre-#1499 copy pointed at "Settings → Beta Features").
+    #[test]
+    fn kobo_card_walks_through_the_conf_file_setup() {
+        let html = render_in_vdom(card);
+        assert!(html.contains("data-testid=\"kobo-setup-steps\""));
+        assert!(html.contains("Kobo eReader.conf"));
+        assert!(html.contains("api_endpoint="));
+        assert!(!html.contains("Beta Features"));
     }
 
     /// The warning must not be gated on having registered a device — a user

--- a/frontend/src/pages/account/kobo.rs
+++ b/frontend/src/pages/account/kobo.rs
@@ -123,44 +123,60 @@ pub fn KoboDevicesCard() -> Element {
             }
             ol { class: "subtitle kobo-setup-steps", "data-testid": "kobo-setup-steps",
                 li {
-                    "Name your Kobo below and click "
+                    "Give your Kobo a name and click "
                     b { "Add a Kobo" }
-                    ". Omnibus mints it a private sync URL \u{2014} the token inside "
-                    "authorizes only your library."
                 }
-                li { "Copy the device's " b { "wireless sync endpoint" } " URL." }
                 li {
-                    "Connect the Kobo over USB, open the hidden "
+                    "Copy the device's wireless sync endpoint URL. ("
+                    code { "/kobo/<token>" }
+                    ")"
+                }
+                li { "Connect the Kobo over USB," }
+                li {
+                    "Edit "
                     code { ".kobo/Kobo/Kobo eReader.conf" }
-                    " file, and set "
+                    " and set "
                     code { "api_endpoint=" }
                     " under "
                     code { "[OneStoreServices]" }
-                    " to that URL."
+                    " to "
+                    code { "<your_omnibus_server_url>/kobo/<token>" }
+                    "."
                 }
-                li { "Eject safely. The next sync on the device talks to Omnibus." }
+                li { "Eject safely. Your next sync on the device talks to Omnibus." }
             }
 
             // Unconditional: the hazard applies the moment a URL is copied.
             div { class: "kobo-warning", "data-testid": "kobo-data-loss-warning",
                 p { class: "kobo-warning-title", "First sync can erase your Kobo's highlights" }
                 p {
-                    "A Kobo clears its own highlights and notes when the server it syncs "
-                    "with mishandles Kobo's annotation channel. Omnibus answers that "
-                    "channel, but it has not yet been verified against real devices \u{2014} "
-                    "treat wireless sync as experimental and assume the first sync can "
-                    "still wipe them."
+                    "An improper sync can potentially wipe data on the Kobo like your "
+                    "annotations, notes, bookmarks, reading progress, and books."
                 }
                 p {
-                    "Back up the device fully before you point it here \u{2014} "
-                    a { href: "https://github.com/seamus-sloan/kobo-backup", target: "_blank",
-                        "kobo-backup"
+                    "It is highly recommended to back up your device before attempting "
+                    "a sync with one of these tools:"
+                }
+                ul { class: "kobo-warning-tools",
+                    li {
+                        a {
+                            href: "https://github.com/seamus-sloan/kobo-backup#kobo-backup",
+                            target: "_blank",
+                            rel: "noopener noreferrer",
+                            "seamus-sloan/kobo-backup"
+                        }
                     }
-                    " snapshots and restores the whole device, and "
-                    a { href: "https://github.com/karlicoss/kobuddy", target: "_blank",
-                        "kobuddy"
+                    li {
+                        a {
+                            href: "https://github.com/karlicoss/kobuddy#usage",
+                            target: "_blank",
+                            rel: "noopener noreferrer",
+                            "karlicoss/kobuddy"
+                        }
                     }
-                    " exports highlights and reading history. At minimum, copy "
+                }
+                p {
+                    "At minimum, copy "
                     code { ".kobo/KoboReader.sqlite" }
                     " off the device over USB."
                 }

--- a/frontend/src/pages/account/kobo.rs
+++ b/frontend/src/pages/account/kobo.rs
@@ -117,10 +117,6 @@ pub fn KoboDevicesCard() -> Element {
     rsx! {
         section { class: "card", "data-testid": "kobo-devices-card",
             h2 { "Kobo wireless sync" }
-            p { class: "subtitle",
-                "There is no on-device setting for this \u{2014} the endpoint is set "
-                "by editing a config file on the Kobo over USB:"
-            }
             ol { class: "subtitle kobo-setup-steps", "data-testid": "kobo-setup-steps",
                 li {
                     "Give your Kobo a name and click "

--- a/server/src/backend/kobo.rs
+++ b/server/src/backend/kobo.rs
@@ -10,7 +10,7 @@ use axum::{
     extract::{Path, Request, State},
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
-    routing::{get, post, put},
+    routing::{any, get, post, put},
     Extension, Json, Router,
 };
 use futures_util::stream;
@@ -57,9 +57,10 @@ pub fn kobo_router(state: AppState) -> Router {
             "/kobo/{token}/v1/analytics/event",
             post(analytics::analytics_event),
         )
+        // Real firmware POSTs gettests despite it being a fetch; serve both.
         .route(
             "/kobo/{token}/v1/analytics/gettests",
-            get(analytics::analytics_gettests),
+            get(analytics::analytics_gettests).post(analytics::analytics_gettests),
         )
         .route("/kobo/{token}/v1/library/sync", get(library_sync))
         .route(
@@ -73,8 +74,21 @@ pub fn kobo_router(state: AppState) -> Router {
             "/kobo/{token}/v1/books/{uuid}/thumbnail/{w}/{h}/{quality}/{greyscale}/image.jpg",
             get(image),
         )
+        // Registered routes win over the wildcard; only unhandled paths land here.
+        .route("/kobo/{token}/{*rest}", any(store_stub))
         .with_state(state)
         .layer(Extension(pool))
+}
+
+/// Benign `200 {}` for store paths the firmware derives from `api_endpoint`
+/// itself (`v1/user/profile`, `v1/deals`, …), bypassing the initialization
+/// resources map that points them at Kobo. A 404 on any of them makes the
+/// device abort the whole sync before `library/sync`; Calibre-Web answers the
+/// same paths with an empty object. The log line doubles as capture data for
+/// the #928 golden fixture.
+async fn store_stub(_auth: KoboAuthUser, Path((_token, rest)): Path<(String, String)>) -> Response {
+    tracing::info!(path = %rest, "kobo store path answered with empty stub");
+    Json(serde_json::json!({})).into_response()
 }
 
 /// `GET v1/initialization` — the handshake that redirects a device at this

--- a/server/src/backend/kobo.rs
+++ b/server/src/backend/kobo.rs
@@ -86,8 +86,14 @@ pub fn kobo_router(state: AppState) -> Router {
 /// device abort the whole sync before `library/sync`; Calibre-Web answers the
 /// same paths with an empty object. The log line doubles as capture data for
 /// the #928 golden fixture.
-async fn store_stub(_auth: KoboAuthUser, Path((_token, rest)): Path<(String, String)>) -> Response {
-    tracing::info!(path = %rest, "kobo store path answered with empty stub");
+async fn store_stub(auth: KoboAuthUser, Path((_token, rest)): Path<(String, String)>) -> Response {
+    // `?rest` (Debug) escapes control chars the router percent-decodes into
+    // the path; device_id makes multi-device captures attributable.
+    tracing::info!(
+        device_id = auth.device_id,
+        path = ?rest,
+        "kobo store path answered with empty stub"
+    );
     Json(serde_json::json!({})).into_response()
 }
 

--- a/server/src/backend/kobo/analytics.rs
+++ b/server/src/backend/kobo/analytics.rs
@@ -82,8 +82,9 @@ pub async fn analytics_event(
     Json(serde_json::json!({ "Result": "Success" })).into_response()
 }
 
-/// `GET v1/analytics/gettests` — the A/B-test flag fetch the initialization
-/// map points here. No tests to run; an empty result is a valid answer.
+/// `GET`/`POST v1/analytics/gettests` — the A/B-test flag fetch the
+/// initialization map points here (real firmware POSTs it). No tests to run;
+/// an empty result is a valid answer.
 pub async fn analytics_gettests(_auth: KoboAuthUser) -> Response {
     Json(serde_json::json!({ "Result": "Success", "TestKey": "", "Tests": {} })).into_response()
 }

--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -691,6 +691,67 @@ async fn analytics_gettests_answers_the_initialization_pointer() {
 }
 
 #[tokio::test]
+async fn analytics_gettests_answers_the_post_a_real_device_sends() {
+    // Real firmware POSTs gettests even though it's a fetch; a 405 here aborts
+    // the device's whole sync before `library/sync` is ever attempted.
+    let (app, _pool, token, _uid) = fixture().await;
+    let res = app
+        .oneshot(post_json(
+            format!("/kobo/{token}/v1/analytics/gettests"),
+            serde_json::json!({}),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(body_json(res).await["Result"], "Success");
+}
+
+#[tokio::test]
+async fn store_stub_answers_firmware_hardcoded_paths_with_an_empty_object() {
+    // The device derives these from `api_endpoint` directly, bypassing the
+    // resources map; each must get a benign 200 or the sync aborts.
+    let (app, _pool, token, _uid) = fixture().await;
+    for path in [
+        "v1/user/profile",
+        "v1/user/loyalty/benefits",
+        "v1/products/books/subscriptions",
+        "v1/deals",
+    ] {
+        let res = app
+            .clone()
+            .oneshot(get(format!("/kobo/{token}/{path}")))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "{path}");
+        assert_eq!(body_json(res).await, serde_json::json!({}), "{path}");
+    }
+}
+
+#[tokio::test]
+async fn store_stub_rejects_an_invalid_token() {
+    let (app, _pool, _token, _uid) = fixture().await;
+    let res = app
+        .oneshot(get("/kobo/not-a-real-token/v1/user/profile".to_owned()))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn store_stub_does_not_shadow_registered_routes() {
+    // The wildcard must lose to every registered route: initialization keeps
+    // its real payload rather than the stub's empty object.
+    let (app, _pool, token, _uid) = fixture().await;
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/initialization")))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert!(body_json(res).await.get("Resources").is_some());
+}
+
+#[tokio::test]
 async fn analytics_rejects_an_invalid_token() {
     let (app, _pool, _token, _uid) = fixture().await;
     let res = app


### PR DESCRIPTION
## Summary
- The first real-device smoke (#1499) against a production instance failed with "Sync Failed" before `library/sync` was ever attempted.
- Register `v1/analytics/gettests` for **POST** as well as GET: real firmware POSTs it, and the initialization resources map points `get_tests_request` at this server, so the 405 aborted the device's whole sync.
- Add a token-authenticated catch-all under `/kobo/{token}/` answering `200 {}` for store paths the firmware derives from `api_endpoint` directly (`v1/user/profile`, `v1/user/loyalty/benefits`, `v1/products/books/subscriptions`, `v1/deals`), matching Calibre-Web's dummy response; the log line doubles as capture data for the #928 golden fixture.
- Rewrite the settings-card setup copy: the old text pointed at a nonexistent on-device setting ("Settings → Beta Features"); the real procedure is editing `api_endpoint` under `[OneStoreServices]` in `.kobo/Kobo/Kobo eReader.conf` over USB. The card now walks through name → copy URL → conf edit.
- Refresh `docs/kobo.md`'s wireless section with the full setup walkthrough, correct the stale "Omnibus does not answer the annotation channel" / #933 claims (superseded by #1278), and recommend full-device backups via [kobo-backup](https://github.com/seamus-sloan/kobo-backup) or [kobuddy](https://github.com/karlicoss/kobuddy) before a first sync.

Closes #1499

## Test plan
- [x] `cargo test -p omnibus kobo` — 81 pass, including four new tests: gettests POST 200, firmware-hardcoded paths get `200 {}`, invalid token still 401, wildcard doesn't shadow registered routes.
- [x] `cargo test -p omnibus-frontend --features server kobo` — 20 pass, including a new render test asserting the conf-file walkthrough and the absence of "Beta Features".
- [x] Verified live against the dev server: registered a device via the UI, then `POST gettests` → 200, `GET user/profile` → `200 {}`, bad token → 401, `initialization` still serves its real resources map.
- [x] `just lint-css`, `cargo fmt`, `cargo clippy -p omnibus -p omnibus-frontend --features server` clean.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
>[!NOTE]
> The wildcard route relies on axum's static-over-wildcard precedence, covered by `store_stub_does_not_shadow_registered_routes`. Unknown-path hits are logged at INFO with the path — field data for the #928 golden fixture and smoke checklist.
