### PR TITLE
fix: rework the SwiftUI check-in flow — success screens, covers, note scoping

### DIFF
--- a/omnibus-ios/omnibus/Design/Components/ConfettiView.swift
+++ b/omnibus-ios/omnibus/Design/Components/ConfettiView.swift
@@ -1,0 +1,122 @@
+//  ConfettiView.swift
+//  A one-shot celebratory confetti burst: forty shapes fall once from the top
+//  edge, rotating and fading, on independent delays and speeds. Driven by the
+//  same explicit spring/curve animations as the rest of the app — each piece
+//  is a tiny view animating to "fallen" on appear.
+
+import SwiftUI
+
+/// One piece of confetti. Geometry and timing only — color is an index so the
+/// model stays `Equatable` and the view can resolve palette colors itself.
+struct ConfettiPiece: Equatable {
+    /// Horizontal position as a fraction of the container width.
+    var xFraction: Double
+    /// Seconds before this piece starts falling.
+    var delay: Double
+    /// Seconds the fall takes.
+    var duration: Double
+    /// Base dimension in points; rectangles are `size × size/2`, circles
+    /// render at 0.7 scale.
+    var size: Double
+    var isCircle: Bool
+    var colorIndex: Int
+
+    /// Evenly distributed across the width with jitter, staggered starts,
+    /// varied speeds and sizes; every 4th piece is a circle.
+    static func makePieces(
+        count: Int = 40, using rng: inout some RandomNumberGenerator
+    ) -> [ConfettiPiece] {
+        (0..<count).map { i in
+            ConfettiPiece(
+                xFraction: min(1, max(0, Double(i) / Double(count) + .random(in: -0.04...0.04, using: &rng))),
+                delay: .random(in: 0...0.5, using: &rng),
+                duration: .random(in: 1.5...2.6, using: &rng),
+                size: .random(in: 5...11, using: &rng),
+                isCircle: i % 4 == 0,
+                colorIndex: i
+            )
+        }
+    }
+}
+
+/// The burst. Fires once on appear; renders nothing under Reduce Motion.
+struct ConfettiView: View {
+    var accent: Color
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pieces: [ConfettiPiece] = []
+
+    var body: some View {
+        if !reduceMotion {
+            GeometryReader { geo in
+                ZStack(alignment: .topLeading) {
+                    ForEach(Array(pieces.enumerated()), id: \.offset) { _, piece in
+                        FallingPiece(
+                            piece: piece,
+                            color: colors[piece.colorIndex % colors.count],
+                            bounds: geo.size
+                        )
+                    }
+                }
+            }
+            .clipped()
+            .allowsHitTesting(false)
+            .onAppear {
+                var rng = SystemRandomNumberGenerator()
+                pieces = ConfettiPiece.makePieces(using: &rng)
+            }
+        }
+    }
+
+    /// The book's accent leads; the rest is a fixed festive spread.
+    private var colors: [Color] {
+        [
+            accent,
+            Color(red: 0.70, green: 0.62, blue: 0.25),
+            Color(red: 0.35, green: 0.55, blue: 0.85),
+            Color(red: 0.85, green: 0.72, blue: 0.52),
+            Color(red: 0.15, green: 0.55, blue: 0.45),
+            Color(red: 0.80, green: 0.42, blue: 0.60),
+            .white,
+        ]
+    }
+}
+
+/// One falling shape: starts just above the top edge, lands below the bottom,
+/// rotating ~560° and fading out on the way down. The piece starts off-screen,
+/// so skipping the design's brief fade-in is invisible in practice.
+private struct FallingPiece: View {
+    let piece: ConfettiPiece
+    let color: Color
+    let bounds: CGSize
+
+    @State private var fallen = false
+
+    var body: some View {
+        shape
+            .rotationEffect(.degrees(fallen ? 560 : 0))
+            .opacity(fallen ? 0 : 1)
+            .position(
+                x: piece.xFraction * bounds.width,
+                y: fallen ? bounds.height + piece.size : -piece.size
+            )
+            .onAppear {
+                withAnimation(.easeIn(duration: piece.duration).delay(piece.delay)) {
+                    fallen = true
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var shape: some View {
+        if piece.isCircle {
+            Circle()
+                .fill(color)
+                .frame(width: piece.size * 0.7, height: piece.size * 0.7)
+        } else {
+            Rectangle()
+                .fill(color)
+                .frame(width: piece.size, height: piece.size / 2)
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Design/Components/RemoteImage.swift
+++ b/omnibus-ios/omnibus/Design/Components/RemoteImage.swift
@@ -65,8 +65,13 @@ actor ImageCache {
     /// third party (Google Books, Open Library).
     func externalImage(for url: String) async -> UIImage? {
         if let cached = image(for: url) { return cached }
+        // Provider metadata is untrusted input: only fetch http(s), and only
+        // cache bodies a 2xx actually vouched for.
         guard let remote = URL(string: url),
-              let (data, _) = try? await URLSession.shared.data(from: remote),
+              remote.scheme == "https" || remote.scheme == "http",
+              let (data, response) = try? await URLSession.shared.data(from: remote),
+              let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode),
               let decoded = UIImage(data: data)
         else { return nil }
         store(decoded, data: data, for: url)

--- a/omnibus-ios/omnibus/Design/Components/RemoteImage.swift
+++ b/omnibus-ios/omnibus/Design/Components/RemoteImage.swift
@@ -59,6 +59,20 @@ actor ImageCache {
         store(decoded, data: data, for: key)
     }
 
+    /// Fetch a provider-hosted image (an absolute URL outside the Omnibus
+    /// server). Same cache tiers, but the request must not carry the bearer
+    /// token or wait on the Omnibus server's reachability — the host is a
+    /// third party (Google Books, Open Library).
+    func externalImage(for url: String) async -> UIImage? {
+        if let cached = image(for: url) { return cached }
+        guard let remote = URL(string: url),
+              let (data, _) = try? await URLSession.shared.data(from: remote),
+              let decoded = UIImage(data: data)
+        else { return nil }
+        store(decoded, data: data, for: url)
+        return decoded
+    }
+
     func clearDisk() {
         try? FileManager.default.removeItem(at: directory)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -71,6 +85,35 @@ actor ImageCache {
         ) else { return 0 }
         return contents.reduce(0) { total, url in
             total + Int64((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+        }
+    }
+}
+
+/// Loads a provider-hosted image from an absolute URL, showing `placeholder`
+/// until it lands. A separate type from `RemoteImage` so no call site can
+/// accidentally send the Omnibus bearer token to a third-party host.
+struct ExternalImage<Placeholder: View>: View {
+    let url: String?
+    @ViewBuilder var placeholder: () -> Placeholder
+
+    @State private var image: UIImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .transition(.opacity)
+            } else {
+                placeholder()
+            }
+        }
+        .task(id: url) {
+            guard let url, !url.isEmpty else { return }
+            guard let fetched = await ImageCache.shared.externalImage(for: url) else { return }
+            guard url == self.url else { return }
+            withAnimation(Motion.page) { image = fetched }
         }
     }
 }

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
@@ -42,14 +42,16 @@ struct CheckInSuccess: Equatable {
 /// Pure builders and gates, separated from the view so they're testable
 /// without a server (same pattern as `LibraryModel.shouldPoll`).
 enum CheckInFlow {
-    /// Checked in a physical copy of a library book.
-    static func checkedInSuccess(book: ScanBook) -> CheckInSuccess {
+    /// Checked in a physical copy of a library book. The server answers with
+    /// the *canonical* uuid (merged books resolve to their primary), so the
+    /// success screen links and renders through `ref`, not the scanned book.
+    static func checkedInSuccess(book: ScanBook, ref: BookRef) -> CheckInSuccess {
         CheckInSuccess(
             tone: .celebration,
             headline: "In your physical collection",
             title: book.title,
-            bookUUID: book.uuid,
-            cover: .library(uuid: book.uuid)
+            bookUUID: ref.bookUUID,
+            cover: .library(uuid: ref.bookUUID)
         )
     }
 

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
@@ -1,0 +1,109 @@
+//  CheckInFlow.swift
+//  The check-in flow's stage machine and its pure decision logic — what screen
+//  follows each outcome, and what the success screen shows. Mirrors the web
+//  client's `Stage` enum so both clients resolve a scan the same way.
+
+import Foundation
+
+/// One screen of the check-in sheet. Success is a *stage*, not an annotation
+/// on the outcome screen — once a write lands, the action buttons are gone,
+/// so a second tap (and a duplicate row) is unrepresentable.
+enum CheckInStage: Equatable {
+    case scan
+    case outcome(ScanOutcome)
+    case success(CheckInSuccess)
+}
+
+/// Everything the terminal success screen needs to render.
+struct CheckInSuccess: Equatable {
+    enum Tone: Equatable {
+        /// Owning a book is the joyous occasion — confetti.
+        case celebration
+        /// Wishlisting just tracks it — rings only.
+        case quiet
+    }
+
+    /// Where the cover art comes from: the library thumbnail pipeline, a
+    /// provider-hosted URL, or the lettered fallback plate.
+    enum Cover: Equatable {
+        case library(uuid: String)
+        case external(url: String)
+        case plate
+    }
+
+    var tone: Tone
+    var headline: String
+    var title: String
+    /// "View book" target; nil hides the button.
+    var bookUUID: String?
+    var cover: Cover
+}
+
+/// Pure builders and gates, separated from the view so they're testable
+/// without a server (same pattern as `LibraryModel.shouldPoll`).
+enum CheckInFlow {
+    /// Checked in a physical copy of a library book.
+    static func checkedInSuccess(book: ScanBook) -> CheckInSuccess {
+        CheckInSuccess(
+            tone: .celebration,
+            headline: "In your physical collection",
+            title: book.title,
+            bookUUID: book.uuid,
+            cover: .library(uuid: book.uuid)
+        )
+    }
+
+    /// Added a physical-only book that wasn't in the library. The book is
+    /// brand new, so its server cover may not exist yet — prefer the
+    /// provider's art over the freshly minted uuid.
+    static func addedSuccess(meta: ExternalBookMeta, ref: BookRef) -> CheckInSuccess {
+        CheckInSuccess(
+            tone: .celebration,
+            headline: "In your physical collection",
+            title: meta.title,
+            bookUUID: ref.bookUUID,
+            cover: externalCover(meta)
+        )
+    }
+
+    /// Wishlisted a book that wasn't in the library.
+    static func wishlistedSuccess(meta: ExternalBookMeta, ref: BookRef) -> CheckInSuccess {
+        CheckInSuccess(
+            tone: .quiet,
+            headline: "On your wishlist",
+            title: meta.title,
+            bookUUID: ref.bookUUID,
+            cover: externalCover(meta)
+        )
+    }
+
+    /// The edition note belongs on exactly one screen — the in-library
+    /// check-in confirm — matching the web client.
+    static func showsNoteField(for outcome: ScanOutcome) -> Bool {
+        if case .inLibraryUnowned = outcome { return true }
+        return false
+    }
+
+    /// Outcomes whose card links straight to the book's detail page.
+    static func detailUUID(for outcome: ScanOutcome) -> String? {
+        switch outcome {
+        case let .alreadyOwned(book), let .onWishlist(book):
+            return book.uuid
+        case .inLibraryUnowned, .closeMatch, .notInLibrary, .unresolved:
+            return nil
+        }
+    }
+
+    /// Provider cover URLs are absolute; the library pipeline's are
+    /// server-relative. Only the former may be fetched unauthenticated.
+    static func isExternalURL(_ path: String) -> Bool {
+        path.hasPrefix("https://") || path.hasPrefix("http://")
+    }
+
+    private static func externalCover(_ meta: ExternalBookMeta) -> CheckInSuccess.Cover {
+        if let url = meta.coverURL, isExternalURL(url) {
+            return .external(url: url)
+        }
+        return .plate
+    }
+}

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInSuccessView.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInSuccessView.swift
@@ -1,0 +1,155 @@
+//  CheckInSuccessView.swift
+//  The terminal screen after a check-in flow write lands. Celebration tone
+//  gets confetti + rings around the cover; quiet tone (wishlist) gets rings
+//  only. Both funnel back to the scanner via "Scan another".
+
+import SwiftUI
+
+struct CheckInSuccessView: View {
+    let success: CheckInSuccess
+    var onScanAnother: () -> Void
+    var onViewBook: (String) -> Void
+
+    @Environment(\.palette) private var palette
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var revealed = false
+
+    private static let coverWidth: CGFloat = 130
+    private static let ringDiameter: CGFloat = 236
+
+    var body: some View {
+        ZStack {
+            if success.tone == .celebration {
+                ConfettiView(accent: palette.accentColor)
+            }
+
+            VStack(spacing: 0) {
+                Spacer(minLength: Spacing.lg)
+
+                ZStack {
+                    // Owning a book keeps celebrating; a wishlist add pulses
+                    // once and settles.
+                    if !reduceMotion {
+                        if success.tone == .celebration {
+                            haloRing(delay: 0, repeats: true)
+                            haloRing(delay: 0.55, repeats: true)
+                        } else {
+                            haloRing(delay: 0, repeats: false)
+                        }
+                    }
+                    Circle()
+                        .stroke(palette.accentColor, lineWidth: 2)
+                        .frame(width: Self.ringDiameter, height: Self.ringDiameter)
+                        .shadow(color: palette.accentColor.opacity(0.45), radius: 17)
+                        .scaleEffect(revealed || reduceMotion ? 1 : 0.55)
+                        .opacity(revealed || reduceMotion ? 1 : 0)
+                    coverArt
+                        .frame(width: Self.coverWidth)
+                }
+                .frame(height: Self.ringDiameter + Spacing.lg)
+
+                VStack(spacing: Spacing.sm) {
+                    Text(success.headline.uppercased())
+                        .font(.monoUI(10, weight: .semibold))
+                        .tracking(0.8)
+                        .foregroundStyle(palette.accentColor)
+                    Text(success.title)
+                        .font(.display(24))
+                        .foregroundStyle(palette.ink0Color)
+                        .multilineTextAlignment(.center)
+                    if success.tone == .quiet {
+                        Text("Wishlisting only tracks this book — check in a copy or add a file to move it into your library.")
+                            .font(.ui(12.5))
+                            .foregroundStyle(palette.ink2Color)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+                .padding(.top, Spacing.xl)
+                .opacity(revealed || reduceMotion ? 1 : 0)
+                .offset(y: revealed || reduceMotion ? 0 : 8)
+
+                Spacer(minLength: Spacing.lg)
+
+                VStack(spacing: Spacing.sm) {
+                    Button("Scan another", action: onScanAnother)
+                        .buttonStyle(FilledButtonStyle())
+                    if let uuid = success.bookUUID {
+                        Button {
+                            onViewBook(uuid)
+                        } label: {
+                            // QuietButtonStyle hugs its label; stretching the
+                            // label matches the primary button's width.
+                            Text("View book").frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(QuietButtonStyle())
+                    }
+                }
+            }
+            .screenPadding()
+            .padding(.bottom, Spacing.lg)
+        }
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(Motion.lift) { revealed = true }
+        }
+    }
+
+    /// An expanding, fading pulse centered on the cover — looping for the
+    /// celebration tone, a single pulse for the quiet one.
+    private func haloRing(delay: Double, repeats: Bool) -> some View {
+        HaloRing(delay: delay, repeats: repeats, accent: palette.accentColor)
+            .frame(width: Self.ringDiameter, height: Self.ringDiameter)
+    }
+
+    @ViewBuilder
+    private var coverArt: some View {
+        switch success.cover {
+        case let .library(uuid):
+            BookCover(
+                identity: CoverIdentity(uuid: uuid, title: success.title, hasCover: true),
+                size: .lg
+            )
+        case let .external(url):
+            ExternalImage(url: url) { letterPlate }
+                .aspectRatio(2.0 / 3.0, contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+        case .plate:
+            letterPlate
+        }
+    }
+
+    private var letterPlate: some View {
+        RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+            .fill(palette.coverFallbackBg.color)
+            .aspectRatio(2.0 / 3.0, contentMode: .fit)
+            .overlay {
+                Text(success.title.prefix(1).uppercased())
+                    .font(.display(34))
+                    .foregroundStyle(palette.coverFallbackInk.color.opacity(0.5))
+            }
+    }
+}
+
+/// One halo pulse. Its animation state is private so each ring can run its
+/// own clock with a distinct phase offset. A pulse ends fully expanded at
+/// zero opacity, so a non-repeating ring simply vanishes after one pass.
+private struct HaloRing: View {
+    var delay: Double
+    var repeats: Bool
+    var accent: Color
+
+    @State private var expanded = false
+
+    var body: some View {
+        Circle()
+            .stroke(accent, lineWidth: 2)
+            .scaleEffect(expanded ? 1.85 : 0.62)
+            .opacity(expanded ? 0 : 0.55)
+            .onAppear {
+                let pulse = Animation.easeOut(duration: 1.8).delay(delay)
+                withAnimation(repeats ? pulse.repeatForever(autoreverses: false) : pulse) {
+                    expanded = true
+                }
+            }
+    }
+}

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
@@ -278,6 +278,9 @@ struct CheckInView: View {
                 .foregroundStyle(palette.accentColor)
                 .frame(maxWidth: .infinity)
                 .padding(.top, Spacing.sm)
+                // Restarting mid-write would race the pending POST's stage
+                // swap — a stale success screen for the previous book.
+                .disabled(isWriting)
             }
             .screenPadding()
             .padding(.vertical, Spacing.lg)
@@ -423,17 +426,22 @@ struct CheckInView: View {
         guard beginWrite() else { return }
         defer { isWriting = false }
         do {
-            let _: BookRef = try await APIClient.shared.post(
+            let ref: BookRef = try await APIClient.shared.post(
                 "/api/scan/check-in",
                 body: CheckInRequest(bookUUID: book.uuid, isbn: isbn, note: note.nilIfBlank)
             )
             Haptics.success()
+            // The server answers with the canonical uuid (a merged book
+            // resolves to its primary); bust both keys when they differ.
             await OfflineStore.shared.cacheDelete(CacheKey.book(book.uuid))
+            if ref.bookUUID != book.uuid {
+                await OfflineStore.shared.cacheDelete(CacheKey.book(ref.bookUUID))
+            }
             // Check-in fulfills every user's wishlist for the book, so shelf
             // counts and preview covers are stale too.
             await OfflineStore.shared.cacheDelete(CacheKey.shelves)
             await OfflineStore.shared.cacheDelete(CacheKey.shelfPreviews)
-            withAnimation(Motion.settle) { stage = .success(CheckInFlow.checkedInSuccess(book: book)) }
+            withAnimation(Motion.settle) { stage = .success(CheckInFlow.checkedInSuccess(book: book, ref: ref)) }
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
         }

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
@@ -16,21 +16,36 @@ struct CheckInView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var manualISBN = ""
-    @State private var outcome: ScanOutcome?
+    @State private var stage: CheckInStage = .scan
     @State private var isResolving = false
+    @State private var isWriting = false
     @State private var error: String?
     @State private var scannerAvailable = DataScannerViewController.isSupported
         && DataScannerViewController.isAvailable
     @State private var note = ""
-    @State private var didComplete = false
+    /// Book detail presented full-screen over the sheet, so dismissing it
+    /// lands back on the scanner rather than losing the check-in loop.
+    @State private var detailTarget: DetailTarget?
+
+    private struct DetailTarget: Identifiable {
+        let uuid: String
+        var id: String { uuid }
+    }
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                if outcome == nil {
+                switch stage {
+                case .scan:
                     scannerSection
-                } else {
-                    outcomeSection
+                case let .outcome(outcome):
+                    outcomeSection(outcome)
+                case let .success(success):
+                    CheckInSuccessView(
+                        success: success,
+                        onScanAnother: { restart() },
+                        onViewBook: { detailTarget = DetailTarget(uuid: $0) }
+                    )
                 }
             }
             .background(ScreenBackground())
@@ -40,6 +55,23 @@ struct CheckInView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
                 }
+            }
+        }
+        // Full-screen detail rather than a push inside the sheet; closing it
+        // returns to the check-in flow, so the scan loop is never lost.
+        .fullScreenCover(item: $detailTarget) { target in
+            NavigationStack {
+                BookDetailView(uuid: target.uuid)
+                    .withDestinations()
+                    .toolbar {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button {
+                                detailTarget = nil
+                            } label: {
+                                Image(systemName: "chevron.left")
+                            }
+                        }
+                    }
             }
         }
     }
@@ -126,54 +158,66 @@ struct CheckInView: View {
     // MARK: - Outcome
 
     @ViewBuilder
-    private var outcomeSection: some View {
+    private func outcomeSection(_ outcome: ScanOutcome) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Spacing.lg) {
                 switch outcome {
                 case let .alreadyOwned(book):
                     resultCard(
-                        title: book.title, authors: book.authors, uuid: book.uuid,
+                        title: book.title, authors: book.authors,
+                        cover: .library(uuid: book.uuid),
                         badge: "Already on your shelf", tint: palette.okColor
                     )
                     Text("You've already checked in a physical copy of this book.")
                         .font(.ui(14))
                         .foregroundStyle(palette.ink2Color)
-                    checkInButton(uuid: book.uuid, isbn: book.isbn, label: "Add another copy")
+                    detailsLink(uuid: book.uuid, style: .filled)
 
                 case let .onWishlist(book):
                     resultCard(
-                        title: book.title, authors: book.authors, uuid: book.uuid,
+                        title: book.title, authors: book.authors,
+                        cover: .library(uuid: book.uuid),
                         badge: "On your wishlist", tint: palette.accentColor
                     )
                     Text("Checking a copy in clears this book from your wishlist.")
                         .font(.ui(14))
                         .foregroundStyle(palette.ink2Color)
-                    noteField
-                    checkInButton(uuid: book.uuid, isbn: book.isbn, label: "Check in this copy")
+                    checkInButton(book: book, isbn: book.isbn, label: "Check in this copy")
+                    detailsLink(uuid: book.uuid, style: .quiet)
 
                 case let .inLibraryUnowned(book):
                     resultCard(
-                        title: book.title, authors: book.authors, uuid: book.uuid,
+                        title: book.title, authors: book.authors,
+                        cover: .library(uuid: book.uuid),
                         badge: "In your library", tint: palette.accentColor
                     )
                     noteField
-                    checkInButton(uuid: book.uuid, isbn: book.isbn, label: "Check in this copy")
+                    checkInButton(book: book, isbn: book.isbn, label: "Check in this copy")
 
                 case let .closeMatch(book, scanned):
                     resultCard(
-                        title: book.title, authors: book.authors, uuid: book.uuid,
+                        title: book.title, authors: book.authors,
+                        cover: .library(uuid: book.uuid),
                         badge: "Possible match", tint: palette.warnColor
                     )
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("You scanned")
-                            .font(.ui(12, weight: .medium))
-                            .foregroundStyle(palette.ink3Color)
-                        Text(scanned.title)
-                            .font(.ui(14, weight: .medium))
-                            .foregroundStyle(palette.ink0Color)
-                        Text(scanned.authorDisplay)
-                            .font(.ui(12.5))
-                            .foregroundStyle(palette.ink2Color)
+                    HStack(alignment: .top, spacing: Spacing.md) {
+                        if let cover = scanned.coverURL, CheckInFlow.isExternalURL(cover) {
+                            ExternalImage(url: cover) { Color.clear }
+                                .aspectRatio(2.0 / 3.0, contentMode: .fit)
+                                .frame(width: 40)
+                                .clipShape(RoundedRectangle(cornerRadius: Radius.sm, style: .continuous))
+                        }
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("You scanned")
+                                .font(.ui(12, weight: .medium))
+                                .foregroundStyle(palette.ink3Color)
+                            Text(scanned.title)
+                                .font(.ui(14, weight: .medium))
+                                .foregroundStyle(palette.ink0Color)
+                            Text(scanned.authorDisplay)
+                                .font(.ui(12.5))
+                                .foregroundStyle(palette.ink2Color)
+                        }
                     }
                     .padding(Spacing.md)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -181,43 +225,41 @@ struct CheckInView: View {
                         RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
                             .fill(palette.bg1Color)
                     )
-                    noteField
-                    checkInButton(uuid: book.uuid, isbn: scanned.isbn13, label: "Yes, same book — check in")
+                    checkInButton(book: book, isbn: scanned.isbn13, label: "Yes, same book — check in")
                     Button("No, add as a new physical book") {
                         Task { await addPhysicalOnly(scanned) }
                     }
                     .buttonStyle(QuietButtonStyle())
                     .frame(maxWidth: .infinity)
+                    .disabled(isWriting)
+                    .opacity(isWriting ? 0.55 : 1)
 
                 case let .notInLibrary(online):
                     resultCard(
-                        title: online.title, authors: online.authors, uuid: nil,
-                        badge: "Not in your library", tint: palette.ink2Color,
-                        remoteCover: online.coverURL
+                        title: online.title, authors: online.authors,
+                        cover: externalCover(online),
+                        badge: "Not in your library", tint: palette.ink2Color
                     )
-                    noteField
                     Button("Add as physical book") {
                         Task { await addPhysicalOnly(online) }
                     }
                     .buttonStyle(FilledButtonStyle())
+                    .disabled(isWriting)
+                    .opacity(isWriting ? 0.55 : 1)
                     Button("Add to wishlist") {
                         Task { await addWishlist(online) }
                     }
                     .buttonStyle(QuietButtonStyle())
                     .frame(maxWidth: .infinity)
+                    .disabled(isWriting)
+                    .opacity(isWriting ? 0.55 : 1)
 
-                case .unresolved, .none:
+                case .unresolved:
                     EmptyStateView(
                         icon: "questionmark.circle",
                         title: "Couldn't identify that book",
                         message: "Neither your library nor the online providers recognised that ISBN."
                     )
-                }
-
-                if didComplete {
-                    Label("Saved", systemImage: "checkmark.circle.fill")
-                        .font(.ui(14, weight: .medium))
-                        .foregroundStyle(palette.okColor)
                 }
 
                 // Without this the outcome screen's writes failed in silence —
@@ -230,13 +272,7 @@ struct CheckInView: View {
                 }
 
                 Button("Scan another") {
-                    withAnimation {
-                        outcome = nil
-                        manualISBN = ""
-                        note = ""
-                        didComplete = false
-                        error = nil
-                    }
+                    restart()
                 }
                 .font(.ui(14))
                 .foregroundStyle(palette.accentColor)
@@ -249,28 +285,66 @@ struct CheckInView: View {
     }
 
     private var noteField: some View {
-        TextField("Note (optional)", text: $note, axis: .vertical)
+        TextField("Edition note (optional)", text: $note, axis: .vertical)
             .textFieldStyle(OmnibusFieldStyle())
             .lineLimit(1...3)
     }
 
+    private enum DetailsLinkStyle { case filled, quiet }
+
+    @ViewBuilder
+    private func detailsLink(uuid: String, style: DetailsLinkStyle) -> some View {
+        switch style {
+        case .filled:
+            Button("Go to Book Details") {
+                detailTarget = DetailTarget(uuid: uuid)
+            }
+            .buttonStyle(FilledButtonStyle())
+            .disabled(isWriting)
+        case .quiet:
+            Button {
+                detailTarget = DetailTarget(uuid: uuid)
+            } label: {
+                Text("Go to Book Details").frame(maxWidth: .infinity)
+            }
+            .buttonStyle(QuietButtonStyle())
+            .disabled(isWriting)
+        }
+    }
+
+    private func coverPlate(title: String) -> some View {
+        RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+            .fill(palette.coverFallbackBg.color)
+            .aspectRatio(2.0 / 3.0, contentMode: .fit)
+            .overlay {
+                Text(title.prefix(1).uppercased())
+                    .font(.display(28))
+                    .foregroundStyle(palette.coverFallbackInk.color.opacity(0.5))
+            }
+    }
+
+    private func externalCover(_ meta: ExternalBookMeta) -> CheckInSuccess.Cover {
+        if let url = meta.coverURL, CheckInFlow.isExternalURL(url) {
+            return .external(url: url)
+        }
+        return .plate
+    }
+
     private func resultCard(
-        title: String, authors: [String], uuid: String?,
-        badge: String, tint: Color, remoteCover: String? = nil
+        title: String, authors: [String], cover: CheckInSuccess.Cover,
+        badge: String, tint: Color
     ) -> some View {
         HStack(alignment: .top, spacing: Spacing.md) {
             Group {
-                if let uuid {
+                switch cover {
+                case let .library(uuid):
                     BookCover(identity: CoverIdentity(uuid: uuid, title: title, hasCover: true), size: .md)
-                } else {
-                    RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-                        .fill(palette.coverFallbackBg.color)
+                case let .external(url):
+                    ExternalImage(url: url) { coverPlate(title: title) }
                         .aspectRatio(2.0 / 3.0, contentMode: .fit)
-                        .overlay {
-                            Text(title.prefix(1).uppercased())
-                                .font(.display(28))
-                                .foregroundStyle(palette.coverFallbackInk.color.opacity(0.5))
-                        }
+                        .clipShape(RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+                case .plate:
+                    coverPlate(title: title)
                 }
             }
             .frame(width: 76)
@@ -291,11 +365,18 @@ struct CheckInView: View {
         }
     }
 
-    private func checkInButton(uuid: String, isbn: String?, label: String) -> some View {
-        Button(label) {
-            Task { await checkIn(uuid: uuid, isbn: isbn) }
+    private func checkInButton(book: ScanBook, isbn: String?, label: String) -> some View {
+        Button {
+            Task { await checkIn(book: book, isbn: isbn) }
+        } label: {
+            if isWriting {
+                ProgressView().controlSize(.small)
+            } else {
+                Text(label)
+            }
         }
         .buttonStyle(FilledButtonStyle())
+        .disabled(isWriting)
     }
 
     // MARK: - Actions
@@ -313,62 +394,80 @@ struct CheckInView: View {
             let result: ScanOutcome = try await APIClient.shared.post(
                 "/api/scan/resolve", body: ScanResolveRequest(isbn: isbn)
             )
-            withAnimation { outcome = result }
+            withAnimation(Motion.settle) { stage = .outcome(result) }
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
         }
     }
 
-    /// Drop the previous write's result before starting another. Neither banner
-    /// names the action it came from, so a leftover "Saved" beside a fresh error
-    /// reads as if the write that just failed had succeeded.
-    private func beginWrite() {
-        error = nil
-        withAnimation { didComplete = false }
+    /// Back to the scanner for the next book.
+    private func restart() {
+        withAnimation(Motion.settle) {
+            stage = .scan
+            manualISBN = ""
+            note = ""
+            error = nil
+        }
     }
 
-    private func checkIn(uuid: String, isbn: String?) async {
-        beginWrite()
+    /// One write at a time — the second tap of a double-tap lands while the
+    /// first POST is still in flight, and must not fire another.
+    private func beginWrite() -> Bool {
+        guard !isWriting else { return false }
+        isWriting = true
+        error = nil
+        return true
+    }
+
+    private func checkIn(book: ScanBook, isbn: String?) async {
+        guard beginWrite() else { return }
+        defer { isWriting = false }
         do {
-            let _: Empty = try await APIClient.shared.post(
+            let _: BookRef = try await APIClient.shared.post(
                 "/api/scan/check-in",
-                body: CheckInRequest(bookUUID: uuid, isbn: isbn, note: note.nilIfBlank)
+                body: CheckInRequest(bookUUID: book.uuid, isbn: isbn, note: note.nilIfBlank)
             )
             Haptics.success()
-            withAnimation { didComplete = true }
-            await OfflineStore.shared.cacheDelete(CacheKey.book(uuid))
+            await OfflineStore.shared.cacheDelete(CacheKey.book(book.uuid))
+            // Check-in fulfills every user's wishlist for the book, so shelf
+            // counts and preview covers are stale too.
+            await OfflineStore.shared.cacheDelete(CacheKey.shelves)
+            await OfflineStore.shared.cacheDelete(CacheKey.shelfPreviews)
+            withAnimation(Motion.settle) { stage = .success(CheckInFlow.checkedInSuccess(book: book)) }
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
         }
     }
 
     private func addPhysicalOnly(_ meta: ExternalBookMeta) async {
-        beginWrite()
+        guard beginWrite() else { return }
+        defer { isWriting = false }
         do {
-            let _: Empty = try await APIClient.shared.post(
+            let ref: BookRef = try await APIClient.shared.post(
                 "/api/scan/physical-only",
                 body: AddPhysicalOnlyRequest(meta: meta, note: note.nilIfBlank)
             )
             Haptics.success()
-            withAnimation { didComplete = true }
+            withAnimation(Motion.settle) { stage = .success(CheckInFlow.addedSuccess(meta: meta, ref: ref)) }
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
         }
     }
 
     private func addWishlist(_ meta: ExternalBookMeta) async {
-        beginWrite()
+        guard beginWrite() else { return }
+        defer { isWriting = false }
         do {
-            let _: Empty = try await APIClient.shared.post(
+            let ref: BookRef = try await APIClient.shared.post(
                 "/api/scan/wishlist",
                 body: WishlistAddRequest(bookUUID: nil, meta: meta, source: .scan)
             )
             Haptics.success()
-            withAnimation { didComplete = true }
             // The wishlist is a real shelf whose membership derives from these
             // entries, so its count and preview covers are now stale.
             await OfflineStore.shared.cacheDelete(CacheKey.shelves)
             await OfflineStore.shared.cacheDelete(CacheKey.shelfPreviews)
+            withAnimation(Motion.settle) { stage = .success(CheckInFlow.wishlistedSuccess(meta: meta, ref: ref)) }
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
         }

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1221,7 +1221,7 @@ struct ExternalBookMeta: Codable, Hashable, Sendable {
 }
 
 /// `#[serde(tag = "kind", rename_all = "snake_case")]` on the Rust side.
-enum ScanOutcome: Decodable, Sendable {
+enum ScanOutcome: Decodable, Equatable, Sendable {
     case alreadyOwned(book: ScanBook)
     case onWishlist(book: ScanBook)
     case inLibraryUnowned(book: ScanBook)
@@ -1287,6 +1287,15 @@ struct WishlistAddRequest: Codable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case meta, source
+        case bookUUID = "book_uuid"
+    }
+}
+
+/// `Json(BookRef { book_uuid })` — returned by all three scan writes.
+struct BookRef: Codable, Sendable {
+    var bookUUID: String
+
+    enum CodingKeys: String, CodingKey {
         case bookUUID = "book_uuid"
     }
 }

--- a/omnibus-ios/omnibusTests/CheckInFlowTests.swift
+++ b/omnibus-ios/omnibusTests/CheckInFlowTests.swift
@@ -1,0 +1,86 @@
+//  CheckInFlowTests.swift
+//  The stage machine's pure logic: which success screen each write produces,
+//  where the note field appears, and which covers are provider-hosted.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+private func scanBook(uuid: String = "b-1", title: String = "Babel") -> ScanBook {
+    ScanBook(uuid: uuid, title: title, authors: ["R. F. Kuang"], coverURL: nil, hasPhysical: false, isbn: nil)
+}
+
+private func externalMeta(cover: String? = "https://covers.example/x.jpg") -> ExternalBookMeta {
+    ExternalBookMeta(
+        isbn13: "9781250903440", title: "The Bee Sting", authors: ["Paul Murray"],
+        year: "2023", pages: 656, publisher: nil, description: nil,
+        coverURL: cover, source: "openlibrary"
+    )
+}
+
+struct CheckInFlowTests {
+    @Test func checkedInSuccessIsCelebratoryWithViewBook() {
+        let success = CheckInFlow.checkedInSuccess(book: scanBook())
+        #expect(success.tone == .celebration)
+        #expect(success.headline == "In your physical collection")
+        #expect(success.bookUUID == "b-1")
+        #expect(success.cover == .library(uuid: "b-1"))
+    }
+
+    @Test func addedSuccessUsesReturnedUUIDAndExternalCover() {
+        let success = CheckInFlow.addedSuccess(
+            meta: externalMeta(), ref: BookRef(bookUUID: "new-1")
+        )
+        #expect(success.tone == .celebration)
+        #expect(success.bookUUID == "new-1")
+        #expect(success.cover == .external(url: "https://covers.example/x.jpg"))
+    }
+
+    @Test func addedSuccessFallsBackToPlateWithoutACover() {
+        let success = CheckInFlow.addedSuccess(
+            meta: externalMeta(cover: nil), ref: BookRef(bookUUID: "new-1")
+        )
+        #expect(success.cover == .plate)
+    }
+
+    @Test func wishlistedSuccessIsQuietWithViewBook() {
+        let success = CheckInFlow.wishlistedSuccess(
+            meta: externalMeta(), ref: BookRef(bookUUID: "new-2")
+        )
+        #expect(success.tone == .quiet)
+        #expect(success.headline == "On your wishlist")
+        #expect(success.bookUUID == "new-2")
+    }
+
+    @Test func noteFieldShowsOnlyOnInLibraryUnowned() {
+        #expect(CheckInFlow.showsNoteField(for: .inLibraryUnowned(book: scanBook())))
+        #expect(!CheckInFlow.showsNoteField(for: .alreadyOwned(book: scanBook())))
+        #expect(!CheckInFlow.showsNoteField(for: .onWishlist(book: scanBook())))
+        #expect(!CheckInFlow.showsNoteField(for: .closeMatch(book: scanBook(), scanned: externalMeta())))
+        #expect(!CheckInFlow.showsNoteField(for: .notInLibrary(online: externalMeta())))
+        #expect(!CheckInFlow.showsNoteField(for: .unresolved))
+    }
+
+    @Test func detailUUIDCoversAlreadyOwnedAndOnWishlistOnly() {
+        #expect(CheckInFlow.detailUUID(for: .alreadyOwned(book: scanBook())) == "b-1")
+        #expect(CheckInFlow.detailUUID(for: .onWishlist(book: scanBook())) == "b-1")
+        #expect(CheckInFlow.detailUUID(for: .inLibraryUnowned(book: scanBook())) == nil)
+        #expect(CheckInFlow.detailUUID(for: .notInLibrary(online: externalMeta())) == nil)
+        #expect(CheckInFlow.detailUUID(for: .unresolved) == nil)
+    }
+
+    @Test func externalURLDetectionSplitsAbsoluteFromServerRelative() {
+        #expect(CheckInFlow.isExternalURL("https://books.google.com/x.jpg"))
+        #expect(CheckInFlow.isExternalURL("http://covers.openlibrary.org/x.jpg"))
+        #expect(!CheckInFlow.isExternalURL("/covers/uuid/md"))
+        #expect(!CheckInFlow.isExternalURL("covers/uuid/md"))
+    }
+
+    @Test func bookRefDecodesSnakeCaseBookUUID() throws {
+        let ref = try JSONDecoder().decode(
+            BookRef.self, from: Data(#"{"book_uuid":"b-9"}"#.utf8)
+        )
+        #expect(ref.bookUUID == "b-9")
+    }
+}

--- a/omnibus-ios/omnibusTests/CheckInFlowTests.swift
+++ b/omnibus-ios/omnibusTests/CheckInFlowTests.swift
@@ -21,11 +21,23 @@ private func externalMeta(cover: String? = "https://covers.example/x.jpg") -> Ex
 
 struct CheckInFlowTests {
     @Test func checkedInSuccessIsCelebratoryWithViewBook() {
-        let success = CheckInFlow.checkedInSuccess(book: scanBook())
+        let success = CheckInFlow.checkedInSuccess(
+            book: scanBook(), ref: BookRef(bookUUID: "b-1")
+        )
         #expect(success.tone == .celebration)
         #expect(success.headline == "In your physical collection")
         #expect(success.bookUUID == "b-1")
         #expect(success.cover == .library(uuid: "b-1"))
+    }
+
+    @Test func checkedInSuccessPrefersTheCanonicalUUIDFromTheServer() {
+        // A merged book's check-in answers with the primary's uuid — the
+        // success screen must link and render through it.
+        let success = CheckInFlow.checkedInSuccess(
+            book: scanBook(uuid: "b-merged"), ref: BookRef(bookUUID: "b-primary")
+        )
+        #expect(success.bookUUID == "b-primary")
+        #expect(success.cover == .library(uuid: "b-primary"))
     }
 
     @Test func addedSuccessUsesReturnedUUIDAndExternalCover() {

--- a/omnibus-ios/omnibusTests/ConfettiTests.swift
+++ b/omnibus-ios/omnibusTests/ConfettiTests.swift
@@ -1,0 +1,58 @@
+//  ConfettiTests.swift
+//  The confetti model's contract: pieces stay inside the spec's ranges and
+//  spread evenly across the container width.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+/// Deterministic generator so piece assertions are stable run to run.
+private struct SeededGenerator: RandomNumberGenerator {
+    var state: UInt64
+    mutating func next() -> UInt64 {
+        // SplitMix64 — tiny and plenty for test determinism.
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+private func makePieces(count: Int = 40) -> [ConfettiPiece] {
+    var rng = SeededGenerator(state: 42)
+    return ConfettiPiece.makePieces(count: count, using: &rng)
+}
+
+struct ConfettiTests {
+    @Test func makePiecesProducesFortyPiecesWithinSpecRanges() {
+        let pieces = makePieces()
+        #expect(pieces.count == 40)
+        for piece in pieces {
+            #expect(piece.xFraction >= 0 && piece.xFraction <= 1)
+            #expect(piece.delay >= 0 && piece.delay <= 0.5)
+            #expect(piece.duration >= 1.5 && piece.duration <= 2.6)
+            #expect(piece.size >= 5 && piece.size <= 11)
+        }
+    }
+
+    @Test func everyFourthPieceIsACircle() {
+        let pieces = makePieces()
+        for (i, piece) in pieces.enumerated() {
+            #expect(piece.isCircle == (i % 4 == 0))
+        }
+    }
+
+    @Test func piecesSpreadEvenlyAcrossTheWidth() {
+        let pieces = makePieces()
+        let fractions = pieces.map(\.xFraction)
+        #expect(fractions.min() ?? 1 < 0.1)
+        #expect(fractions.max() ?? 0 > 0.9)
+        // Every tenth of the width holds at least one piece.
+        for bucket in 0..<10 {
+            let lo = Double(bucket) / 10, hi = lo + 0.1
+            #expect(fractions.contains { $0 >= lo && $0 < hi || (bucket == 9 && $0 == 1) })
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Every check-in write now stage-swaps to a success screen (mirroring the web client's `Stage` machine), with an `isWriting` guard while a POST is in flight — a double-tap can no longer insert duplicate physical copies or wishlist rows.
- Check-in / add-physical land on a celebration screen: confetti burst + looping halo rings around the cover; wishlist lands on a quiet variant (single halo pulse, no confetti). Reduce Motion renders no confetti and a static ring.
- External provider covers now render (`ExternalImage` + unauthenticated `ImageCache.externalImage`) — the old `remoteCover` parameter was passed but never read, so not-in-library lookups always drew the letter plate. Provider URLs never receive the Omnibus bearer token.
- Note field scoped to the in-library confirm branch only, relabeled "Edition note (optional)" (web parity); the wishlist branch silently discarded it anyway.
- "View book" / "Go to Book Details" present book details full-screen over the sheet; dismissing lands back in the scan loop. All three scan writes now decode the server's `BookRef` (uuid was being discarded), which is what gives the wishlist success its View book target.

Closes #1477

## Test plan
- [x] `omnibusTests` on the iPhone 17 simulator — full suite green, including 10 new tests (`CheckInFlowTests`, `ConfettiTests`).
- [x] Manual simulator pass over every outcome kind via manual ISBN: external covers render; success screens replace the action buttons; confetti verified visually (slow-motion diagnostic build, then spec timing restored); wishlist pulse runs once; View book opens full-screen and back returns to the scanner; already-owned/on-wishlist cards link to details.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The confetti was rebuilt on explicit per-piece animations after `TimelineView(.animation)` + `Canvas` proved unreliable (and a `try? await Task.sleep` cancellation could freeze the burst at frame zero — the pause task now ignores cancelled sleeps).
- Reader/player presentation from the full-screen book detail two covers deep may conflict with `MainTabView`'s `.fullScreenCover` ("already presenting") — pre-existing constraint, unchanged here.