### PR TITLE
refactor: use shared ConfirmModal for author and user delete dialogs (#1484)

### DIFF
--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -487,7 +487,7 @@ fn AuthorDeleteModal(
     rsx! {
         ConfirmModal {
             testid: "author-delete-modal".to_string(),
-            aria_label: "Delete {author_name}".to_string(),
+            aria_label: format!("Delete {author_name}"),
             dialog_class: "author-delete-modal".to_string(),
             busy,
             on_dismiss: move |_| show_confirm.set(false),

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -10,6 +10,8 @@ use omnibus_shared::{AuthorDetail, EbookMetadata};
 
 use crate::components::atrium::Cover;
 use crate::components::author_photo_edit::AuthorPhotoEditOverlay;
+#[cfg(not(feature = "mobile"))]
+use crate::components::{confirm_modal_body, ConfirmModal, ConfirmModalAction, ConfirmModalTone};
 use crate::components::{PageError, PageLoading, PageNotFound};
 use crate::{data, use_server_url, Route};
 
@@ -437,7 +439,9 @@ struct AuthorDeleteState {
 /// navigates back to `/authors`. The blocklist insert is what makes the
 /// delete durable across reindexes — without it the next `Task::Scan`
 /// would silently recreate the row from the OPF metadata. Web-only;
-/// mobile admins fall back to the per-book metadata edit page.
+/// mobile admins fall back to the per-book metadata edit page. Built on
+/// the shared `ConfirmModal` shell (see `components::confirm_modal`)
+/// rather than hand-rolling its own backdrop/busy-gate markup.
 #[cfg(not(feature = "mobile"))]
 #[component]
 fn AuthorDeleteModal(
@@ -448,80 +452,68 @@ fn AuthorDeleteModal(
     state: AuthorDeleteState,
 ) -> Element {
     let AuthorDeleteState {
-        show_confirm,
-        deleting,
-        delete_error,
+        mut show_confirm,
+        mut deleting,
+        mut delete_error,
     } = state;
-    let mut show_confirm = show_confirm;
-    let mut deleting = deleting;
-    let mut delete_error = delete_error;
     let nav = use_navigator();
     let busy = deleting();
     let book_count_label = if book_count == 1 { "book" } else { "books" };
+    let title = format!("Delete \"{author_name}\"?");
+    let body = format!(
+        "This will un-link the author from {book_count} {book_count_label} \
+         and prevent the name from being re-added on future library scans. \
+         The books themselves are not deleted."
+    );
 
-    rsx! {
-        div {
-            class: "author-delete-modal-backdrop",
-            role: "dialog",
-            aria_modal: "true",
-            aria_label: "Delete {author_name}",
-            "data-testid": "author-delete-modal",
-            onclick: move |_| {
-                if !busy {
+    let confirm_delete = move |_| {
+        let server_url = server_url.clone();
+        spawn(async move {
+            deleting.set(true);
+            delete_error.set(None);
+            match data::delete_author(&server_url, author_id).await {
+                Ok(_) => {
                     show_confirm.set(false);
+                    nav.push(Route::AuthorsIndex {});
                 }
-            },
-            div {
-                class: "author-delete-modal",
-                onclick: move |evt| evt.stop_propagation(),
-                h2 { class: "author-delete-modal__title", "Delete \"{author_name}\"?" }
-                p { class: "author-delete-modal__body",
-                    "This will un-link the author from {book_count} {book_count_label} "
-                    "and prevent the name from being re-added on future library scans. "
-                    "The books themselves are not deleted."
-                }
-                if let Some(msg) = delete_error() {
-                    p { role: "alert", class: "error author-delete-modal__error", "⚠ {msg}" }
-                }
-                div { class: "author-delete-modal__actions",
-                    button {
-                        class: "btn",
-                        "data-testid": "author-delete-cancel",
-                        disabled: busy,
-                        onclick: move |_| {
-                            show_confirm.set(false);
-                        },
-                        "Cancel"
-                    }
-                    button {
-                        class: "btn primary author-delete-confirm",
-                        "data-testid": "author-delete-confirm",
-                        disabled: busy,
-                        onclick: {
-                            let server_url = server_url.clone();
-                            move |_| {
-                                let server_url = server_url.clone();
-                                let nav = nav;
-                                spawn(async move {
-                                    deleting.set(true);
-                                    delete_error.set(None);
-                                    match data::delete_author(&server_url, author_id).await {
-                                        Ok(_) => {
-                                            show_confirm.set(false);
-                                            nav.push(Route::AuthorsIndex {});
-                                        }
-                                        Err(e) => {
-                                            delete_error.set(Some(e.to_string()));
-                                        }
-                                    }
-                                    deleting.set(false);
-                                });
-                            }
-                        },
-                        if busy { "Deleting\u{2026}" } else { "Delete" }
-                    }
+                Err(e) => {
+                    delete_error.set(Some(e.to_string()));
                 }
             }
+            deleting.set(false);
+        });
+    };
+
+    rsx! {
+        ConfirmModal {
+            testid: "author-delete-modal".to_string(),
+            aria_label: "Delete {author_name}".to_string(),
+            dialog_class: "author-delete-modal".to_string(),
+            busy,
+            on_dismiss: move |_| show_confirm.set(false),
+            if let Some(msg) = delete_error() {
+                p { role: "alert", class: "error author-delete-modal__error", "⚠ {msg}" }
+            }
+            {confirm_modal_body(
+                &title,
+                &body,
+                vec![
+                    ConfirmModalAction {
+                        testid: "author-delete-cancel".to_string(),
+                        label: "Cancel".to_string(),
+                        tone: ConfirmModalTone::Ghost,
+                        disabled: busy,
+                        on_click: EventHandler::new(move |_| show_confirm.set(false)),
+                    },
+                    ConfirmModalAction {
+                        testid: "author-delete-confirm".to_string(),
+                        label: if busy { "Deleting\u{2026}".to_string() } else { "Delete".to_string() },
+                        tone: ConfirmModalTone::Danger,
+                        disabled: busy,
+                        on_click: EventHandler::new(confirm_delete),
+                    },
+                ],
+            )}
         }
     }
 }

--- a/frontend/src/pages/settings/users.rs
+++ b/frontend/src/pages/settings/users.rs
@@ -8,6 +8,7 @@ use dioxus_router::use_navigator;
 use omnibus_shared::{AdminUserRow, CreateUserRequest, UserPermissions};
 
 use crate::components::auth::{score_password, PasswordRequirements, StrengthMeter};
+use crate::components::{confirm_modal_body, ConfirmModal, ConfirmModalAction, ConfirmModalTone};
 use crate::{data, Route};
 
 /// Which modal, if any, is open over the Users table.
@@ -463,6 +464,9 @@ fn EditUserModal(
 
 /// Delete-confirmation modal. Warns when the admin is deleting their own
 /// account; the last-admin guard is enforced server-side and surfaced inline.
+/// Built on the shared `ConfirmModal` shell (see `components::confirm_modal`)
+/// rather than `ModalShell`, so the backdrop can't be dismissed mid-delete —
+/// `ModalShell`'s own backdrop has no busy gate at all.
 #[component]
 fn DeleteUserModal(
     user: AdminUserRow,
@@ -473,6 +477,12 @@ fn DeleteUserModal(
     let uid = user.id;
     let mut error = use_signal(|| None::<String>);
     let mut deleting = use_signal(|| false);
+    let busy = deleting();
+    let title = format!("Delete {}", user.username);
+    let body = format!(
+        "Permanently delete {} and all of their reading data. This can't be undone.",
+        user.username
+    );
 
     let confirm = move |_| {
         if deleting() {
@@ -490,29 +500,38 @@ fn DeleteUserModal(
     };
 
     rsx! {
-        ModalShell { title: "Delete {user.username}", testid: "users-delete-modal", on_close,
-            p {
-                "Permanently delete "
-                b { "{user.username}" }
-                " and all of their reading data. This can't be undone."
-            }
+        ConfirmModal {
+            testid: "users-delete-modal".to_string(),
+            aria_label: title.clone(),
+            dialog_class: "users-modal-card".to_string(),
+            busy,
+            on_dismiss: move |_| on_close.call(()),
             if is_self {
                 p { class: "settings-status error", "data-testid": "delete-self-warning",
                     "This is your own account — you'll be signed out."
                 }
             }
             ModalError { error: error() }
-            div { class: "settings-actions",
-                button {
-                    r#type: "button",
-                    class: "btn users-danger",
-                    "data-testid": "delete-user-confirm",
-                    disabled: deleting(),
-                    onclick: confirm,
-                    "Delete user"
-                }
-                button { r#type: "button", class: "btn ghost", onclick: move |_| on_close.call(()), "Cancel" }
-            }
+            {confirm_modal_body(
+                &title,
+                &body,
+                vec![
+                    ConfirmModalAction {
+                        testid: "delete-user-cancel".to_string(),
+                        label: "Cancel".to_string(),
+                        tone: ConfirmModalTone::Ghost,
+                        disabled: busy,
+                        on_click: EventHandler::new(move |_| on_close.call(())),
+                    },
+                    ConfirmModalAction {
+                        testid: "delete-user-confirm".to_string(),
+                        label: if busy { "Deleting\u{2026}".to_string() } else { "Delete user".to_string() },
+                        tone: ConfirmModalTone::Danger,
+                        disabled: busy,
+                        on_click: EventHandler::new(confirm),
+                    },
+                ],
+            )}
         }
     }
 }

--- a/ui_tests/playwright/tests/flows/users.spec.ts
+++ b/ui_tests/playwright/tests/flows/users.spec.ts
@@ -97,6 +97,61 @@ test("creates a user then deletes it", async ({ page }) => {
   await expect(tempRow(page)).toHaveCount(0);
 });
 
+test("a backdrop click during an in-flight delete does not dismiss the modal or lose the result", async ({
+  page,
+}) => {
+  // #1484 — DeleteUserModal used to sit on a hand-rolled `ModalShell` whose
+  // backdrop had no busy gate at all, so a stray click while the delete was
+  // in flight closed the modal before the admin saw the outcome. It now
+  // shares `ConfirmModal`, which refuses to dismiss while `busy`.
+  await gotoReady(page, USERS);
+
+  const tempName = `e2e_backdrop_${Date.now()}`;
+  await page.getByTestId("users-new").click();
+  await page.getByTestId("new-user-username").fill(tempName);
+  await page.getByTestId("new-user-password").fill(TEMP_PASSWORD);
+  await expectMutation(
+    page,
+    { method: "POST", url: "/api/users", expectedStatus: 201 },
+    async () => page.getByTestId("new-user-submit").click(),
+  );
+  const row = table(page).locator("tr", { hasText: tempName });
+  await expect(row).toBeVisible();
+
+  // Delay the DELETE response so the modal is provably still busy when the
+  // backdrop click lands.
+  await page.route("**/api/users/*", async (route) => {
+    if (route.request().method() !== "DELETE") return route.continue();
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return route.continue();
+  });
+
+  await row.getByRole("button", { name: "Delete" }).click();
+  const modal = page.getByTestId("users-delete-modal");
+  await expect(modal).toBeVisible();
+
+  const requestPromise = page.waitForRequest(
+    (r) => r.method() === "DELETE" && r.url().includes("/api/users/"),
+  );
+  const responsePromise = page.waitForResponse(
+    (r) => r.request().method() === "DELETE" && r.url().includes("/api/users/"),
+  );
+  await page.getByTestId("delete-user-confirm").click();
+  await requestPromise;
+
+  // Click the backdrop well away from the centered panel while the delete
+  // is still in flight — the modal must stay open.
+  await modal.click({ position: { x: 5, y: 5 } });
+  await expect(modal).toBeVisible();
+
+  const response = await responsePromise;
+  expect(response.status()).toBe(204);
+
+  await expect(modal).toHaveCount(0);
+  await expect(row).toHaveCount(0);
+  await page.unroute("**/api/users/*");
+});
+
 test("surfaces a 409 when creating a duplicate username", async ({ page }) => {
   await gotoReady(page, USERS);
   await page.getByTestId("users-new").click();

--- a/ui_tests/playwright/tests/flows/users.spec.ts
+++ b/ui_tests/playwright/tests/flows/users.spec.ts
@@ -118,38 +118,37 @@ test("a backdrop click during an in-flight delete does not dismiss the modal or 
   const row = table(page).locator("tr", { hasText: tempName });
   await expect(row).toBeVisible();
 
+  await row.getByRole("button", { name: "Delete" }).click();
+  const modal = page.getByTestId("users-delete-modal");
+  await expect(modal).toBeVisible();
+
   // Delay the DELETE response so the modal is provably still busy when the
-  // backdrop click lands.
+  // backdrop click lands mid-request.
   await page.route("**/api/users/*", async (route) => {
     if (route.request().method() !== "DELETE") return route.continue();
     await new Promise((resolve) => setTimeout(resolve, 400));
     return route.continue();
   });
 
-  await row.getByRole("button", { name: "Delete" }).click();
-  const modal = page.getByTestId("users-delete-modal");
-  await expect(modal).toBeVisible();
-
-  const requestPromise = page.waitForRequest(
-    (r) => r.method() === "DELETE" && r.url().includes("/api/users/"),
-  );
-  const responsePromise = page.waitForResponse(
-    (r) => r.request().method() === "DELETE" && r.url().includes("/api/users/"),
-  );
-  await page.getByTestId("delete-user-confirm").click();
-  await requestPromise;
-
-  // Click the backdrop well away from the centered panel while the delete
-  // is still in flight — the modal must stay open.
-  await modal.click({ position: { x: 5, y: 5 } });
-  await expect(modal).toBeVisible();
-
-  const response = await responsePromise;
-  expect(response.status()).toBe(204);
+  try {
+    await expectMutation(
+      page,
+      { method: "DELETE", url: "/api/users/", expectedStatus: 204 },
+      async () => {
+        await page.getByTestId("delete-user-confirm").click();
+        // Click the backdrop well away from the centered panel while the
+        // delete is still in flight (the route above delays the response) —
+        // the modal must stay open and the request must still complete.
+        await modal.click({ position: { x: 5, y: 5 } });
+        await expect(modal).toBeVisible();
+      },
+    );
+  } finally {
+    await page.unroute("**/api/users/*");
+  }
 
   await expect(modal).toHaveCount(0);
   await expect(row).toHaveCount(0);
-  await page.unroute("**/api/users/*");
 });
 
 test("surfaces a 409 when creating a duplicate username", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Closes #1484
- `AuthorDeleteModal` (`frontend/src/pages/author.rs`) now uses the shared `ConfirmModal` + `confirm_modal_body` instead of hand-rolling its own backdrop/panel/busy-gate markup.
- `DeleteUserModal` (`frontend/src/pages/settings/users.rs`) now uses `ConfirmModal` + `confirm_modal_body` too, with `busy` wired to the in-flight `delete_user` request — fixing the actual bug: `ModalShell`'s backdrop had no busy check at all, so a stray click during an in-flight delete silently closed the modal before the admin saw the result.
- `ModalShell` is kept as-is, scoped to `NewUserModal`/`EditUserModal` — those are multi-field forms, not "confirm one thing" dialogs, so they don't belong on `ConfirmModal`.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (537 passed; 0 failed)
- [x] Added a Playwright case in `ui_tests/playwright/tests/flows/users.spec.ts` asserting a backdrop click during an in-flight delete does not dismiss `DeleteUserModal` or lose the result (regression coverage for the busy-gate bug).

## Notes
- Existing `author-delete-*` / `delete-user-*` / `users-delete-modal` test ids are unchanged, so `author_delete.spec.ts` and the rest of `users.spec.ts` need no updates.


---
_Generated by [Claude Code](https://claude.ai/code/session_013MhBULjmcF7E2Px9K2NFW8)_