### PR TITLE
fix: move Kobo image handler last-modified lookup into db crate (#1488)

### DIFF
--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -17,8 +17,8 @@ mod tests;
 pub use facets::library_facets;
 pub use get::{
     book_file_path, book_file_path_by_id, book_file_paths, book_file_relative_dir,
-    download_validators, get_book, get_book_by_uuid, get_book_files, get_book_files_exec,
-    get_book_uuid_by_scan_key, last_modified_for, resolve_book_id_by_uuid,
+    book_last_modified_for, download_validators, get_book, get_book_by_uuid, get_book_files,
+    get_book_files_exec, get_book_uuid_by_scan_key, resolve_book_id_by_uuid,
     resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
     resolve_canonical_book_uuids_bulk_exec,
 };

--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -18,8 +18,8 @@ pub use facets::library_facets;
 pub use get::{
     book_file_path, book_file_path_by_id, book_file_paths, book_file_relative_dir,
     download_validators, get_book, get_book_by_uuid, get_book_files, get_book_files_exec,
-    get_book_uuid_by_scan_key, resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec,
-    resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
+    get_book_uuid_by_scan_key, last_modified_for, resolve_book_id_by_uuid,
+    resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
     resolve_canonical_book_uuids_bulk_exec,
 };
 pub use list::{

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -181,7 +181,7 @@ where
 /// column is NULL. Used by the Kobo cover-image handler to derive a weak
 /// `ETag` from `(book id, last_modified)`; callers are expected to have
 /// already confirmed `id` exists (e.g. via [`resolve_book_id_by_uuid`]).
-pub async fn last_modified_for(pool: &SqlitePool, id: i64) -> Result<i64, super::BooksError> {
+pub async fn book_last_modified_for(pool: &SqlitePool, id: i64) -> Result<i64, super::BooksError> {
     Ok(sqlx::query_scalar(
         "SELECT CAST(COALESCE(last_modified, 0) AS INTEGER) FROM books WHERE id = ?",
     )

--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -177,6 +177,19 @@ where
     .await?)
 }
 
+/// Return `books.last_modified` (unix seconds), defaulting to `0` when the
+/// column is NULL. Used by the Kobo cover-image handler to derive a weak
+/// `ETag` from `(book id, last_modified)`; callers are expected to have
+/// already confirmed `id` exists (e.g. via [`resolve_book_id_by_uuid`]).
+pub async fn last_modified_for(pool: &SqlitePool, id: i64) -> Result<i64, super::BooksError> {
+    Ok(sqlx::query_scalar(
+        "SELECT CAST(COALESCE(last_modified, 0) AS INTEGER) FROM books WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await?)
+}
+
 /// Bulk counterpart to [`resolve_book_id_by_uuid`]: map each input uuid to
 /// its current `books.id`, replicating the `merged_uuids` fallback so a
 /// merged/attached uuid still resolves to the surviving book. UUIDs that

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -56,6 +56,47 @@ async fn get_book_formats_machine_timestamps_as_fixed_width_iso() {
 }
 
 #[tokio::test]
+async fn last_modified_for_returns_the_stored_epoch() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, last_modified) \
+         VALUES ('bk', 'b', 1, '/lib/bk', 'Book', 1700000000) \
+         RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let last_modified = last_modified_for(&pool, id).await.unwrap();
+    assert_eq!(last_modified, 1700000000);
+}
+
+#[tokio::test]
+async fn last_modified_for_defaults_to_zero_when_column_is_null() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await;
+    let id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = 'uuid-1'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let last_modified = last_modified_for(&pool, id).await.unwrap();
+    assert_eq!(last_modified, 0);
+}
+
+#[tokio::test]
+async fn last_modified_for_returns_db_error_for_unknown_id() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let err = last_modified_for(&pool, 999).await.unwrap_err();
+    assert!(matches!(err, BooksError::Db(_)));
+}
+
+#[tokio::test]
 async fn get_book_reports_epub_size_from_lowest_ordinal_epub() {
     // `epub_size_bytes` drives the export menu's Kindle size gate. It must
     // mirror what the hero send delivers — the lowest-ordinal EPUB — and ignore

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -56,7 +56,7 @@ async fn get_book_formats_machine_timestamps_as_fixed_width_iso() {
 }
 
 #[tokio::test]
-async fn last_modified_for_returns_the_stored_epoch() {
+async fn book_last_modified_for_returns_the_stored_epoch() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     sqlx::query("INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib')")
         .execute(&pool)
@@ -71,12 +71,12 @@ async fn last_modified_for_returns_the_stored_epoch() {
     .await
     .unwrap();
 
-    let last_modified = last_modified_for(&pool, id).await.unwrap();
+    let last_modified = book_last_modified_for(&pool, id).await.unwrap();
     assert_eq!(last_modified, 1700000000);
 }
 
 #[tokio::test]
-async fn last_modified_for_defaults_to_zero_when_column_is_null() {
+async fn book_last_modified_for_defaults_to_zero_when_column_is_null() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_minimal_books(&pool, 1).await;
     let id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = 'uuid-1'")
@@ -84,15 +84,15 @@ async fn last_modified_for_defaults_to_zero_when_column_is_null() {
         .await
         .unwrap();
 
-    let last_modified = last_modified_for(&pool, id).await.unwrap();
+    let last_modified = book_last_modified_for(&pool, id).await.unwrap();
     assert_eq!(last_modified, 0);
 }
 
 #[tokio::test]
-async fn last_modified_for_returns_db_error_for_unknown_id() {
+async fn book_last_modified_for_returns_db_error_for_unknown_id() {
     let pool = init_db("sqlite::memory:").await.unwrap();
 
-    let err = last_modified_for(&pool, 999).await.unwrap_err();
+    let err = book_last_modified_for(&pool, 999).await.unwrap_err();
     assert!(matches!(err, BooksError::Db(_)));
 }
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -66,13 +66,14 @@ pub use books::{
     book_file_path, book_file_path_by_id, book_file_paths, collect_paths, count_books,
     count_books_for_paths, count_books_page, count_search_books, count_search_books_for_paths,
     download_validators, get_book, get_book_by_uuid, get_book_files, get_book_uuid_by_scan_key,
-    library_facets, library_from_db, library_from_db_combined, library_from_db_with_total,
-    library_from_db_with_total_combined, list_books, list_books_for_paths, list_books_page,
-    list_indexed_rows, list_indexed_rows_for_formats, list_merged_rows_for_formats,
-    resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec, resolve_canonical_book_uuid,
-    resolve_canonical_book_uuid_exec, resolve_canonical_book_uuids_bulk_exec, search_books,
-    search_books_for_paths, search_books_for_paths_with_total, search_books_with_total, BookPage,
-    BooksError, CursorError, IndexedRow, PageCursor, MAX_BOOKS_RETURNED,
+    last_modified_for, library_facets, library_from_db, library_from_db_combined,
+    library_from_db_with_total, library_from_db_with_total_combined, list_books,
+    list_books_for_paths, list_books_page, list_indexed_rows, list_indexed_rows_for_formats,
+    list_merged_rows_for_formats, resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec,
+    resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec,
+    resolve_canonical_book_uuids_bulk_exec, search_books, search_books_for_paths,
+    search_books_for_paths_with_total, search_books_with_total, BookPage, BooksError, CursorError,
+    IndexedRow, PageCursor, MAX_BOOKS_RETURNED,
 };
 pub use browse::*;
 pub use covers::{covers_dir, get_cover, get_last_modified_epoch, CoversError};

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -63,10 +63,10 @@ pub mod worker;
 pub use author_photos_data::*;
 pub use book_summary::{fetch_summary, summary_source_plan};
 pub use books::{
-    book_file_path, book_file_path_by_id, book_file_paths, collect_paths, count_books,
-    count_books_for_paths, count_books_page, count_search_books, count_search_books_for_paths,
-    download_validators, get_book, get_book_by_uuid, get_book_files, get_book_uuid_by_scan_key,
-    last_modified_for, library_facets, library_from_db, library_from_db_combined,
+    book_file_path, book_file_path_by_id, book_file_paths, book_last_modified_for, collect_paths,
+    count_books, count_books_for_paths, count_books_page, count_search_books,
+    count_search_books_for_paths, download_validators, get_book, get_book_by_uuid, get_book_files,
+    get_book_uuid_by_scan_key, library_facets, library_from_db, library_from_db_combined,
     library_from_db_with_total, library_from_db_with_total_combined, list_books,
     list_books_for_paths, list_books_page, list_indexed_rows, list_indexed_rows_for_formats,
     list_merged_rows_for_formats, resolve_book_id_by_uuid, resolve_book_id_by_uuid_exec,

--- a/server/src/backend/kobo.rs
+++ b/server/src/backend/kobo.rs
@@ -503,7 +503,7 @@ async fn image(
     // Cheap freshness probe before the cover bytes are ever loaded: the cover
     // changes only through paths that bump `books.last_modified` (override
     // save, reindex), so the pair is an honest validator.
-    let last_modified = match db::last_modified_for(state.pool(), id).await {
+    let last_modified = match db::book_last_modified_for(state.pool(), id).await {
         Ok(lm) => lm,
         Err(e) => return internal("kobo image last_modified", e),
     };

--- a/server/src/backend/kobo.rs
+++ b/server/src/backend/kobo.rs
@@ -503,13 +503,7 @@ async fn image(
     // Cheap freshness probe before the cover bytes are ever loaded: the cover
     // changes only through paths that bump `books.last_modified` (override
     // save, reindex), so the pair is an honest validator.
-    let last_modified: i64 = match sqlx::query_scalar(
-        "SELECT CAST(COALESCE(last_modified, 0) AS INTEGER) FROM books WHERE id = ?",
-    )
-    .bind(id)
-    .fetch_one(state.pool())
-    .await
-    {
+    let last_modified = match db::last_modified_for(state.pool(), id).await {
         Ok(lm) => lm,
         Err(e) => return internal("kobo image last_modified", e),
     };


### PR DESCRIPTION
## Summary
- Closes #1488
- `server/src/backend/kobo.rs`'s `image` handler ran a raw `sqlx::query_scalar` directly against `state.pool()` to fetch a book's `last_modified` epoch for its weak `ETag` — the second ad hoc SQL call site outside the db crate (after #1454's `author_photos.rs` evidence).
- Added `omnibus_db::last_modified_for(pool, id) -> Result<i64, BooksError>` in `db/src/books/get.rs` (same SQL, same `COALESCE(last_modified, 0)` default, same `fetch_one` semantics) and switched the handler to call it, mapping the error through the handler's existing `internal(...)` path — no raw `sqlx::Error` crosses the module boundary (`BooksError::Db` wraps it via `#[error(transparent)] #[from]`).

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1491 passed; 0 failed)
- [x] `cargo test -p omnibus` — PASS for all kobo/image-handler-relevant tests (`backend::kobo::tests::image_returns_304_when_the_if_none_match_etag_is_current`, `image_serves_the_body_when_the_etag_is_stale`, `image_returns_404_for_unknown_uuid` all `ok`, unmodified — same ETag/304 semantics). Two unrelated pre-existing failures in `backend::uploads::tests` (`commit_rejects_read_only_library_with_400`, `audiobook_commit_rejects_read_only_library_with_400`) are environment artifacts of running the test suite as root, which bypasses the `chmod 0o555` permission check those tests rely on — untouched by this change.

## Notes
- Added `last_modified_for_returns_the_stored_epoch`, `last_modified_for_defaults_to_zero_when_column_is_null`, and `last_modified_for_returns_db_error_for_unknown_id` in `db/src/books/tests.rs` per the repo's per-`thiserror`-variant coverage rule.
- Issue #1454 remains open and separately covers `kobo.rs`'s `put_state` transaction loop and `author_photos.rs`'s `author_exists` — left a comment there noting this second raw-SQL site (kobo.rs:486, from #1488's evidence) is now resolved.


---
_Generated by [Claude Code](https://claude.ai/code/session_013MhBULjmcF7E2Px9K2NFW8)_