### PR TITLE
feat: default the landing library view to Grid

### DIFF
--- a/frontend/src/pages/landing/toolbar.rs
+++ b/frontend/src/pages/landing/toolbar.rs
@@ -131,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn toolbar_renders_the_view_toggle_with_table_pressed_by_default() {
+    fn toolbar_renders_the_view_toggle_with_grid_pressed_by_default() {
         let html = render_toolbar(ViewPrefs::default());
 
         assert!(html.contains("data-testid=\"lib-toolbar\""));
@@ -140,22 +140,25 @@ mod tests {
         assert!(html.contains("data-testid=\"view-toggle-grid\""));
         assert!(html.contains("Table"));
         assert!(html.contains("Grid"));
-        // Default view mode is Table, so its button is the pressed one and the
-        // grid-only sort controls stay out of the markup.
+        // Default view mode is Grid, so its button is the pressed one and the
+        // grid-only sort controls are part of the default markup.
         assert!(html.contains("aria-pressed=\"true\""));
-        assert!(!html.contains("data-testid=\"lib-sort-select\""));
+        assert!(html.contains("data-testid=\"lib-sort-select\""));
+        assert!(html.contains("data-testid=\"lib-sort-dir\""));
+        assert!(html.contains("Sort by"));
     }
 
     #[test]
-    fn toolbar_reveals_the_sort_controls_in_grid_mode() {
+    fn toolbar_hides_the_sort_controls_in_table_mode() {
         let prefs = ViewPrefs {
-            view_mode: ViewMode::Grid,
+            view_mode: ViewMode::Table,
             ..ViewPrefs::default()
         };
         let html = render_toolbar(prefs);
 
-        assert!(html.contains("data-testid=\"lib-sort-select\""));
-        assert!(html.contains("data-testid=\"lib-sort-dir\""));
-        assert!(html.contains("Sort by"));
+        // Table view sorts via its own column headers, so the grid-only sort
+        // dropdown stays out of the markup.
+        assert!(!html.contains("data-testid=\"lib-sort-select\""));
+        assert!(!html.contains("data-testid=\"lib-sort-dir\""));
     }
 }

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -49,7 +49,7 @@ mod ssr_tests {
     #[test]
     fn save_is_a_noop_and_does_not_affect_subsequent_loads() {
         let prefs = ViewPrefs {
-            view_mode: ViewMode::Grid,
+            view_mode: ViewMode::Table,
             sort_key: SortKey::Author,
             sort_dir: SortDir::Desc,
             filters: ViewFilters {
@@ -65,10 +65,10 @@ mod ssr_tests {
 
     #[test]
     fn default_prefs_match_documented_shape() {
-        // First-hydration markup depends on these defaults: Table view, sorted
+        // First-hydration markup depends on these defaults: Grid view, sorted
         // by Title ascending, no active filters, sidebar closed.
         let d = ViewPrefs::default();
-        assert_eq!(d.view_mode, ViewMode::Table);
+        assert_eq!(d.view_mode, ViewMode::Grid);
         assert_eq!(d.sort_key, SortKey::Title);
         assert_eq!(d.sort_dir, SortDir::Asc);
         assert!(d.filters.is_empty());

--- a/shared/src/view_prefs.rs
+++ b/shared/src/view_prefs.rs
@@ -13,8 +13,8 @@ mod tests;
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ViewMode {
-    #[default]
     Table,
+    #[default]
     Grid,
 }
 

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -9,7 +9,11 @@ import {
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expect, test } from "../fixtures/test";
 import { expectMutation } from "../utils/api";
-import { fetchBookUuidByTitle, getRow } from "../utils/ebooks";
+import {
+  fetchBookUuidByTitle,
+  getRow,
+  switchToTableView,
+} from "../utils/ebooks";
 import { withLock } from "../utils/lock";
 import { gotoReady } from "../utils/nav";
 import {
@@ -230,6 +234,7 @@ test("navigates from a landing row to the detail page and back", async ({
   page,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   // Click the row's cover cell to follow the SPA navigation. We target the
   // cover specifically because the seeded admin sees inline-editable cells
@@ -248,7 +253,8 @@ test("navigates from a landing row to the detail page and back", async ({
   await expect(backLink).toBeVisible();
 
   // The back link must return us to the landing route, not just visually
-  // re-render — assert URL plus that the table comes back.
+  // re-render — assert URL plus that the table view (persisted above) comes
+  // back.
   await backLink.click();
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByTestId("ebook-table")).toBeVisible();
@@ -358,12 +364,12 @@ test("renders the detail contents for the selected book", async ({
     page.getByRole("heading", { name: "Suggested for you" }),
   ).toBeVisible();
 
-  // Back link still navigates to landing
+  // Back link still navigates to landing (default Grid view)
   const backLink = page.getByRole("link", { name: "Back to library" });
   await expect(backLink).toBeVisible();
   await backLink.click();
   await expect(page).toHaveURL(/\/$/);
-  await expect(page.getByTestId("ebook-table")).toBeVisible();
+  await expect(page.getByTestId("lib-grid")).toBeVisible();
 });
 
 // Action — Send to Kobo (F4.1 KEPUB direct write / download fallback)

--- a/ui_tests/playwright/tests/flows/landing.spec.ts
+++ b/ui_tests/playwright/tests/flows/landing.spec.ts
@@ -1,6 +1,6 @@
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expect, test } from "../fixtures/test";
-import { expectRowMatches } from "../utils/ebooks";
+import { expectRowMatches, switchToTableView } from "../utils/ebooks";
 import { expectNavVisible, gotoReady } from "../utils/nav";
 import { fixturesDir, seedLibrary } from "../utils/seed";
 
@@ -24,7 +24,8 @@ test("renders the landing page layout", async ({ page }) => {
   await expect(
     page.getByRole("heading", { level: 1, name: "Your Library" }),
   ).toBeVisible();
-  await expect(page.getByTestId("ebook-table")).toBeVisible();
+  // Grid is the default view mode; the table is opt-in via the toolbar.
+  await expect(page.getByTestId("lib-grid")).toBeVisible();
   await expect(page.getByTestId("lib-toolbar")).toBeVisible();
   // The shelf gallery replaced the left rail on the landing: an "All Books"
   // tile (selected by default) plus a New-shelf tile. In-place selection is
@@ -39,6 +40,7 @@ test("renders every fixture book with the expected metadata", async ({
   page,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   // Every ebook fixture must appear; audiobooks may also be present when
   // parallel specs have seeded the audiobook library on the shared server.
@@ -61,37 +63,38 @@ test("browse fits the fixture library in one keyset page (no Load more)", async 
   // 100-book page size, so the first page contains the whole library and the
   // pagination sentinel must not render. (Above the page size, a
   // `lib-load-more` button appears and appends further pages.)
-  await expect(page.getByTestId(/^ebook-row-/).first()).toBeVisible();
-  const rowCount = await page.getByTestId(/^ebook-row-/).count();
-  expect(rowCount).toBeGreaterThanOrEqual(FIXTURE_BOOKS.length);
+  await expect(page.getByTestId(/^ebook-tile-/).first()).toBeVisible();
+  const tileCount = await page.getByTestId(/^ebook-tile-/).count();
+  expect(tileCount).toBeGreaterThanOrEqual(FIXTURE_BOOKS.length);
   await expect(page.getByTestId("lib-load-more")).toHaveCount(0);
 });
 
-test("toggles to grid view and persists across reload", async ({ page }) => {
+test("toggles to table view and persists across reload", async ({ page }) => {
   await gotoReady(page, "/");
 
-  await expect(page.getByTestId("ebook-table")).toBeVisible();
-  await page.getByTestId("view-toggle-grid").click();
-
   await expect(page.getByTestId("lib-grid")).toBeVisible();
-  await expect(page.getByTestId("ebook-table")).toHaveCount(0);
-  const tileCount = await page.getByTestId(/^ebook-tile-/).count();
-  expect(tileCount).toBeGreaterThanOrEqual(FIXTURE_BOOKS.length);
-  await expect(page.getByTestId("view-toggle-grid")).toHaveAttribute(
+  await page.getByTestId("view-toggle-table").click();
+
+  await expect(page.getByTestId("ebook-table")).toBeVisible();
+  await expect(page.getByTestId("lib-grid")).toHaveCount(0);
+  const rowCount = await page.getByTestId(/^ebook-row-/).count();
+  expect(rowCount).toBeGreaterThanOrEqual(FIXTURE_BOOKS.length);
+  await expect(page.getByTestId("view-toggle-table")).toHaveAttribute(
     "aria-pressed",
     "true",
   );
 
   await page.reload();
   await page.waitForLoadState("networkidle");
-  await expect(page.getByTestId("lib-grid")).toBeVisible();
-  await expect(page.getByTestId("ebook-table")).toHaveCount(0);
+  await expect(page.getByTestId("ebook-table")).toBeVisible();
+  await expect(page.getByTestId("lib-grid")).toHaveCount(0);
 });
 
 test("sorts by title descending when the Title header is clicked", async ({
   page,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   // Default sort is title asc — click once to flip to desc.
   await page.getByRole("button", { name: /^Title( ↑| ↓)?$/ }).click();

--- a/ui_tests/playwright/tests/flows/landing_inline_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/landing_inline_edit.spec.ts
@@ -1,7 +1,7 @@
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expect, test } from "../fixtures/test";
 import { expectMutation } from "../utils/api";
-import { fetchBookIdByTitle } from "../utils/ebooks";
+import { fetchBookIdByTitle, switchToTableView } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
 import { fixturesDir, seedLibrary } from "../utils/seed";
 
@@ -29,6 +29,7 @@ test("renders editable cell affordances on the landing table for admins", async 
   page,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   const titleCell = page
     .getByTestId(`ebook-row-${TARGET.slug}`)
@@ -45,6 +46,7 @@ test("edits a title inline and saves the override via rpc_save_overrides", async
   request,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
   const titleCell = row.getByTestId("ebook-cell-title");
@@ -87,6 +89,7 @@ test("inline edit save error keeps the row showing the prior value", async ({
   page,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
   const titleCell = row.getByTestId("ebook-cell-title");
@@ -130,6 +133,7 @@ test("clicking the Authors cell renders the chip editor inline", async ({
   page,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
   const authorsCell = row.getByTestId("ebook-cell-author");
@@ -163,6 +167,7 @@ test("clicking away from an open Authors cell editor closes it", async ({
   page,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
   const authorsCell = row.getByTestId("ebook-cell-author");
@@ -184,6 +189,7 @@ test("Tab from the chip input reaches a chip's Remove button without closing the
   page,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
   const authorsCell = row.getByTestId("ebook-cell-author");
@@ -212,6 +218,7 @@ test("selecting an author suggestion keeps the editor open; a later click away c
   request,
 }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   const row = page.getByTestId(`ebook-row-${TARGET.slug}`);
   const authorsCell = row.getByTestId("ebook-cell-author");

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -491,15 +491,10 @@ test("shows the mini-dock on the immersive reader while an audiobook is loaded",
   // way — a native page load at any hop would remount `App` and drop the
   // in-memory playback context the dock reads from.
   await spaNavigateToLibrary(page);
-  // Click the cover cell, not the bare row: a plain `.click()` on the `<tr>`
-  // lands at its horizontal center, which is one of the inline-editable
-  // cells (authors/series/etc.) — those stop propagation on click, so the
-  // row's own navigate-on-click handler never fires. The cover cell has no
-  // click handler of its own and safely bubbles to the row.
-  await page
-    .getByTestId(`ebook-row-${READER_BOOK.slug}`)
-    .getByTestId("ebook-cell-cover")
-    .click();
+  // The default Grid view's tiles navigate via `nav.push` (SPA), so clicking
+  // one keeps the in-memory playback context alive — no editable-cell click
+  // interception to route around like the table rows have.
+  await page.getByTestId(`ebook-tile-${READER_BOOK.slug}`).click();
   await expect(page).toHaveURL(new RegExp(`/books/${readerUuid}$`));
   await page.getByTestId("start-reading").click();
   await expect(page).toHaveURL(new RegExp(`/read/${readerUuid}$`));

--- a/ui_tests/playwright/tests/flows/mini-dock.spec.ts
+++ b/ui_tests/playwright/tests/flows/mini-dock.spec.ts
@@ -493,8 +493,11 @@ test("shows the mini-dock on the immersive reader while an audiobook is loaded",
   await spaNavigateToLibrary(page);
   // The default Grid view's tiles navigate via `nav.push` (SPA), so clicking
   // one keeps the in-memory playback context alive — no editable-cell click
-  // interception to route around like the table rows have.
-  await page.getByTestId(`ebook-tile-${READER_BOOK.slug}`).click();
+  // interception to route around like the table rows have. Assert the tile
+  // rendered before clicking so the click can't race the landing paint.
+  const readerTile = page.getByTestId(`ebook-tile-${READER_BOOK.slug}`);
+  await expect(readerTile).toBeVisible();
+  await readerTile.click();
   await expect(page).toHaveURL(new RegExp(`/books/${readerUuid}$`));
   await page.getByTestId("start-reading").click();
   await expect(page).toHaveURL(new RegExp(`/read/${readerUuid}$`));

--- a/ui_tests/playwright/tests/flows/persistence.spec.ts
+++ b/ui_tests/playwright/tests/flows/persistence.spec.ts
@@ -137,9 +137,8 @@ test("library scroll position is restored after opening a book", async ({
   await gotoReady(page, "/");
 
   // Grid tiles navigate on click with no editable cells (unlike admin table
-  // rows, where clicking the title cell enters edit mode). Grid view persists
-  // via view_prefs, so it survives the back-navigation too.
-  await page.getByTestId("view-toggle-grid").click();
+  // rows, where clicking the title cell enters edit mode). Grid is the
+  // default view mode, so the tiles are already on screen.
   await expect(page.getByTestId(/^ebook-tile-/).first()).toBeVisible();
 
   const savedY = await page.evaluate(() => {

--- a/ui_tests/playwright/tests/flows/shelf_gallery.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelf_gallery.spec.ts
@@ -3,7 +3,7 @@ import type { APIRequestContext } from "@playwright/test";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expect, test } from "../fixtures/test";
 import { expectMutation } from "../utils/api";
-import { fetchBookUuidByTitle } from "../utils/ebooks";
+import { fetchBookUuidByTitle, switchToTableView } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
 import { fixturesDir, seedLibrary } from "../utils/seed";
 
@@ -49,6 +49,7 @@ test("selects a shelf in place: glow moves, list filters, URL stays put", async 
   const shelfId = await createManualShelf(request, name, [alphaUuid]);
 
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   // All Books glows (is selected) by default.
   await expect(page.getByTestId("gallery-all-books")).toHaveAttribute(
@@ -87,6 +88,7 @@ test("persists the selected shelf across a reload", async ({
   const shelfId = await createManualShelf(request, name, [alphaUuid]);
 
   await gotoReady(page, "/");
+  await switchToTableView(page);
   const tile = page.getByTestId(`gallery-shelf-${shelfId}`);
   await expectMutation(
     page,
@@ -120,6 +122,7 @@ test("returns to All Books and restores the full library", async ({
   const shelfId = await createManualShelf(request, name, [alphaUuid]);
 
   await gotoReady(page, "/");
+  await switchToTableView(page);
   await expectMutation(
     page,
     { method: "POST", url: "/api/rpc/shelves/page", expectedStatus: 200 },

--- a/ui_tests/playwright/tests/flows/thumbnails.spec.ts
+++ b/ui_tests/playwright/tests/flows/thumbnails.spec.ts
@@ -1,5 +1,6 @@
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expect, test } from "../fixtures/test";
+import { switchToTableView } from "../utils/ebooks";
 import { gotoReady } from "../utils/nav";
 import { fixturesDir, seedLibrary } from "../utils/seed";
 
@@ -12,6 +13,7 @@ test.beforeAll(async ({ request }) => {
 
 test("renders book grid with srcset cover images", async ({ page }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   // Pick a fixture book that has a cover and target its row directly by slug.
   // Earlier this filtered by `ebook-cell-cover`, but every row has that
@@ -41,6 +43,7 @@ test("renders book grid with srcset cover images", async ({ page }) => {
 
 test("thumb endpoint serves an image", async ({ page, request }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   // Extract a real book ID from the srcset of the first cover <img> in the grid.
   const coverImg = page
@@ -84,6 +87,7 @@ test("thumb endpoint serves an image", async ({ page, request }) => {
 
 test("books without covers render fallback dash", async ({ page }) => {
   await gotoReady(page, "/");
+  await switchToTableView(page);
 
   // "gamma" is the fixture book with hasCover=false.
   const bookWithoutCover = FIXTURE_BOOKS.find((b) => !b.hasCover);

--- a/ui_tests/playwright/tests/flows/thumbnails.spec.ts
+++ b/ui_tests/playwright/tests/flows/thumbnails.spec.ts
@@ -11,7 +11,7 @@ test.beforeAll(async ({ request }) => {
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
 });
 
-test("renders book grid with srcset cover images", async ({ page }) => {
+test("renders table cover images with a srcset", async ({ page }) => {
   await gotoReady(page, "/");
   await switchToTableView(page);
 
@@ -45,7 +45,7 @@ test("thumb endpoint serves an image", async ({ page, request }) => {
   await gotoReady(page, "/");
   await switchToTableView(page);
 
-  // Extract a real book ID from the srcset of the first cover <img> in the grid.
+  // Extract a real book UUID from the srcset of the first table row's cover <img>.
   const coverImg = page
     .getByTestId(/^ebook-row-/)
     .filter({ has: page.getByRole("img", { name: /^Cover of/ }) })

--- a/ui_tests/playwright/tests/utils/ebooks.ts
+++ b/ui_tests/playwright/tests/utils/ebooks.ts
@@ -71,6 +71,15 @@ export function getRow(page: Page, slug: string): Locator {
   return page.getByTestId(`ebook-row-${slug}`);
 }
 
+/**
+ * Switch the landing library to the table view. Grid is the default view
+ * mode, so any spec that asserts against table rows/cells must opt in first.
+ */
+export async function switchToTableView(page: Page): Promise<void> {
+  await page.getByTestId("view-toggle-table").click();
+  await expect(page.getByTestId("ebook-table")).toBeVisible();
+}
+
 /** Expected text for the series cell, mirroring the Rust formatter:
  *  `${name} #${idx}` when both are present, just `${name}` when no index,
  *  empty string otherwise. */


### PR DESCRIPTION
## Summary
- Grid is now the default landing view (`ViewMode::Grid` default); saved per-library view prefs are untouched, so only first-time visitors see the change.
- Fixes a scroll-restore bug the grid default exposed: on back-nav, Chromium's native restoration fires a scroll clamped against the outgoing page's DOM after `location.pathname` has already flipped, so the recorder clobbered the saved offset before restore read it. The singleton now snapshots the saved offset at `popstate`.
- Playwright specs that assumed the table renders at `/` now opt in via a shared `switchToTableView` helper.

Stacked base (`-1`); `u/sloan/tags-column-2` builds on this.

## Test plan
- [x] `just check` green — full lint matrix (incl. wasm32 clippy) + 3,300+ tests across the crate matrix.
- [x] Flipped unit tests pin the new default (`view_prefs`, toolbar SSR render).
- [x] Affected Playwright flows run against a live dev server: landing, landing_inline_edit, thumbnails, book_detail, shelf_gallery, persistence, mini-dock (scroll-restore test now passes deterministically).

## Version
- [ ] **Minor**
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
- [ ] **No release**

## Notes
- The toolbar's grid-only sort controls are now part of the default markup; table mode still hides them.