### PR TITLE
fix: require confirmation before deleting a shelf (#1483)

### DIFF
--- a/frontend/src/pages/shelf_detail/header.rs
+++ b/frontend/src/pages/shelf_detail/header.rs
@@ -24,7 +24,7 @@ pub(super) fn ShelfHeader(
 ) -> Element {
     let nav = use_navigator();
     let server_url = use_server_url();
-    let menu_open = use_signal(|| false);
+    let mut menu_open = use_signal(|| false);
     let mut show_delete_confirm = use_signal(|| false);
     let deleting = use_signal(|| false);
 
@@ -48,7 +48,10 @@ pub(super) fn ShelfHeader(
     let shelf_name = shelf.name.clone();
     let syncs_to_kobo = shelf.sync_to_kobo;
 
-    let on_delete = EventHandler::new(move |()| show_delete_confirm.set(true));
+    let on_delete = EventHandler::new(move |()| {
+        menu_open.set(false);
+        show_delete_confirm.set(true);
+    });
     let on_toggle_kobo = build_on_toggle_kobo(
         server_url.clone(),
         id,

--- a/frontend/src/pages/shelf_detail/header.rs
+++ b/frontend/src/pages/shelf_detail/header.rs
@@ -7,7 +7,9 @@ use dioxus_router::{use_navigator, Link};
 use omnibus_shared::{Shelf, ShelfKind, UpdateShelfRequest};
 
 use crate::components::shelf_facets::pencil_glyph;
-use crate::components::ShelfFacets;
+use crate::components::{
+    confirm_modal_body, ConfirmModal, ConfirmModalAction, ConfirmModalTone, ShelfFacets,
+};
 use crate::{data, use_server_url, Route};
 
 /// Header: back link, name + edit pencil, facet row, and the actions menu.
@@ -23,6 +25,8 @@ pub(super) fn ShelfHeader(
     let nav = use_navigator();
     let server_url = use_server_url();
     let menu_open = use_signal(|| false);
+    let mut show_delete_confirm = use_signal(|| false);
+    let deleting = use_signal(|| false);
 
     // Owner/admin gating; `None` until the boot effect resolves the viewer, so
     // controls stay hidden on SSR + first paint (hydration parity, rule 07). The
@@ -41,9 +45,10 @@ pub(super) fn ShelfHeader(
         viewer.as_ref().is_some_and(|u| u.id != owner_id) && shelf.kind != ShelfKind::Wishlist;
 
     let id = shelf.id;
+    let shelf_name = shelf.name.clone();
     let syncs_to_kobo = shelf.sync_to_kobo;
 
-    let on_delete = build_on_delete(server_url.clone(), id, nav);
+    let on_delete = EventHandler::new(move |()| show_delete_confirm.set(true));
     let on_toggle_kobo = build_on_toggle_kobo(
         server_url.clone(),
         id,
@@ -93,20 +98,77 @@ pub(super) fn ShelfHeader(
                 }
             }
         }
+        if show_delete_confirm() {
+            {render_delete_shelf_modal(
+                server_url,
+                id,
+                shelf_name,
+                nav,
+                show_delete_confirm,
+                deleting,
+            )}
+        }
     }
 }
 
-/// Builds the delete-shelf handler: deletes then navigates back to the
-/// library on success.
-fn build_on_delete(server_url: String, id: i64, nav: dioxus_router::Navigator) -> EventHandler<()> {
-    EventHandler::new(move |()| {
+/// The delete-shelf confirm modal: names the shelf, disables the confirm
+/// button while the request is in flight, and can't be dismissed mid-delete.
+/// On success, navigates back to the library (mirrors the old direct-delete
+/// handler's success path).
+fn render_delete_shelf_modal(
+    server_url: String,
+    id: i64,
+    shelf_name: String,
+    nav: dioxus_router::Navigator,
+    mut show_delete_confirm: Signal<bool>,
+    mut deleting: Signal<bool>,
+) -> Element {
+    let is_busy = deleting();
+    let do_delete = move |_| {
+        if deleting() {
+            return;
+        }
+        deleting.set(true);
         let url = server_url.clone();
         spawn(async move {
             if data::delete_shelf(&url, id).await.is_ok() {
                 nav.push(Route::Landing {});
+            } else {
+                deleting.set(false);
             }
         });
-    })
+    };
+    rsx! {
+        ConfirmModal {
+            testid: "shelf-delete-modal".to_string(),
+            aria_label: "Delete shelf?".to_string(),
+            dialog_class: "mg-modal del-modal".to_string(),
+            busy: is_busy,
+            on_dismiss: move |_| show_delete_confirm.set(false),
+            {confirm_modal_body(
+                "Delete shelf?",
+                &format!(
+                    "Deleting \u{201c}{shelf_name}\u{201d} removes it and its rules. This can\u{2019}t be undone."
+                ),
+                vec![
+                    ConfirmModalAction {
+                        testid: "shelf-delete-cancel".to_string(),
+                        label: "Cancel".to_string(),
+                        tone: ConfirmModalTone::Ghost,
+                        disabled: is_busy,
+                        on_click: EventHandler::new(move |_| show_delete_confirm.set(false)),
+                    },
+                    ConfirmModalAction {
+                        testid: "shelf-delete-confirm".to_string(),
+                        label: if is_busy { "Deleting\u{2026}".to_string() } else { "Delete".to_string() },
+                        tone: ConfirmModalTone::Danger,
+                        disabled: is_busy,
+                        on_click: EventHandler::new(do_delete),
+                    },
+                ],
+            )}
+        }
+    }
 }
 
 /// Builds the Kobo sync-opt-in handler: flips `sync_to_kobo` and refetches on

--- a/frontend/src/pages/shelf_detail/mobile.rs
+++ b/frontend/src/pages/shelf_detail/mobile.rs
@@ -12,6 +12,7 @@ use dioxus_router::{use_navigator, Link};
 use omnibus_shared::{EbookMetadata, Shelf, ShelfKind, Visibility};
 
 use crate::components::shelf_facets::rule_text;
+use crate::components::{confirm_modal_body, ConfirmModal, ConfirmModalAction, ConfirmModalTone};
 use crate::pages::landing::mobile_cover_cell;
 use crate::{data, use_server_url, Route};
 
@@ -172,19 +173,12 @@ fn MobileShelfActions(
     let nav = use_navigator();
     let server_url = use_server_url();
     let mut menu_open = use_signal(|| false);
+    let mut show_delete_confirm = use_signal(|| false);
+    let deleting = use_signal(|| false);
 
     let id = shelf.id;
+    let shelf_name = shelf.name.clone();
     let is_manual = shelf.kind == ShelfKind::Manual;
-
-    let del_url = server_url.clone();
-    let on_delete = move |_| {
-        let url = del_url.clone();
-        spawn(async move {
-            if data::delete_shelf(&url, id).await.is_ok() {
-                nav.push(Route::Landing {});
-            }
-        });
-    };
 
     rsx! {
         div { class: "m-shelf-menu-wrap",
@@ -224,11 +218,84 @@ fn MobileShelfActions(
                         r#type: "button",
                         class: "shelf-menu-item shelf-menu-item--danger",
                         "data-testid": "shelf-delete",
-                        onclick: on_delete,
+                        onclick: move |_| {
+                            menu_open.set(false);
+                            show_delete_confirm.set(true);
+                        },
                         "Delete"
                     }
                 }
             }
+        }
+        if show_delete_confirm() {
+            {render_delete_shelf_modal(
+                server_url,
+                id,
+                shelf_name,
+                nav,
+                show_delete_confirm,
+                deleting,
+            )}
+        }
+    }
+}
+
+/// The delete-shelf confirm modal: names the shelf, disables the confirm
+/// button while the request is in flight, and can't be dismissed mid-delete.
+/// On success, navigates back to the library. Mirrors the web header's
+/// version of the same modal (`shelf_detail::header::render_delete_shelf_modal`).
+fn render_delete_shelf_modal(
+    server_url: String,
+    id: i64,
+    shelf_name: String,
+    nav: dioxus_router::Navigator,
+    mut show_delete_confirm: Signal<bool>,
+    mut deleting: Signal<bool>,
+) -> Element {
+    let is_busy = deleting();
+    let do_delete = move |_| {
+        if deleting() {
+            return;
+        }
+        deleting.set(true);
+        let url = server_url.clone();
+        spawn(async move {
+            if data::delete_shelf(&url, id).await.is_ok() {
+                nav.push(Route::Landing {});
+            } else {
+                deleting.set(false);
+            }
+        });
+    };
+    rsx! {
+        ConfirmModal {
+            testid: "shelf-delete-modal".to_string(),
+            aria_label: "Delete shelf?".to_string(),
+            dialog_class: "mg-modal del-modal".to_string(),
+            busy: is_busy,
+            on_dismiss: move |_| show_delete_confirm.set(false),
+            {confirm_modal_body(
+                "Delete shelf?",
+                &format!(
+                    "Deleting \u{201c}{shelf_name}\u{201d} removes it and its rules. This can\u{2019}t be undone."
+                ),
+                vec![
+                    ConfirmModalAction {
+                        testid: "shelf-delete-cancel".to_string(),
+                        label: "Cancel".to_string(),
+                        tone: ConfirmModalTone::Ghost,
+                        disabled: is_busy,
+                        on_click: EventHandler::new(move |_| show_delete_confirm.set(false)),
+                    },
+                    ConfirmModalAction {
+                        testid: "shelf-delete-confirm".to_string(),
+                        label: if is_busy { "Deleting\u{2026}".to_string() } else { "Delete".to_string() },
+                        tone: ConfirmModalTone::Danger,
+                        disabled: is_busy,
+                        on_click: EventHandler::new(do_delete),
+                    },
+                ],
+            )}
         }
     }
 }

--- a/ui_tests/playwright/tests/flows/shelves.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelves.spec.ts
@@ -462,9 +462,21 @@ test("surfaces the delete request in flight and keeps the shelf on failure", asy
   const shelf = (await createResp.json()) as { id: number };
 
   await gotoReady(page, `/shelves/${shelf.id}`);
-  await page.route("**/api/rpc/shelves/delete", (route) =>
-    route.fulfill({ status: 500, body: "boom" }),
-  );
+  // Only intercept the delete for *this* shelf, and hold it open briefly so
+  // the busy state below is actually observed in flight rather than racing
+  // straight to the resolved response.
+  await page.route("**/api/rpc/shelves/delete", async (route) => {
+    if (route.request().postDataJSON()?.id !== shelf.id) {
+      await route.continue();
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: "boom",
+    });
+  });
 
   try {
     await page.getByTestId("shelf-actions").click();
@@ -473,11 +485,24 @@ test("surfaces the delete request in flight and keeps the shelf on failure", asy
     const modal = page.getByTestId("shelf-delete-modal");
     const confirmBtn = modal.getByTestId("shelf-delete-confirm");
 
-    await expectMutation(
+    const mutation = expectMutation(
       page,
-      { method: "POST", url: "/api/rpc/shelves/delete", expectedStatus: 500 },
+      {
+        method: "POST",
+        url: "/api/rpc/shelves/delete",
+        expectedBody: { id: shelf.id },
+        expectedStatus: 500,
+      },
       async () => confirmBtn.click(),
     );
+
+    // While the delayed response is in flight, the confirm button is busy —
+    // disabled and relabeled — and the cancel button is disabled too.
+    await expect(confirmBtn).toBeDisabled();
+    await expect(confirmBtn).toHaveText("Deleting…");
+    await expect(modal.getByTestId("shelf-delete-cancel")).toBeDisabled();
+
+    await mutation;
 
     // The failed delete leaves the shelf, and the modal, in place.
     await expect(modal).toBeVisible();

--- a/ui_tests/playwright/tests/flows/shelves.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelves.spec.ts
@@ -357,3 +357,133 @@ test("surfaces an error when the shelf edit save fails", async ({
   // The header keeps the saved name — the failed edit must not leak in.
   await expect(page.getByTestId("shelf-detail-header")).toContainText(name);
 });
+
+test("cancelling the delete confirmation leaves the shelf intact", async ({
+  page,
+  request,
+}) => {
+  const name = `E2E Delete Cancel ${Date.now()}`;
+  const createResp = await request.post("/api/rpc/shelves/create", {
+    data: {
+      req: {
+        kind: "manual",
+        name,
+        description: null,
+        visibility: "private",
+        match_mode: null,
+        rules: [],
+        book_uuids: [],
+      },
+    },
+  });
+  expect(createResp.status(), "POST /api/rpc/shelves/create failed").toBe(200);
+  const shelf = (await createResp.json()) as { id: number };
+
+  await gotoReady(page, `/shelves/${shelf.id}`);
+  await page.getByTestId("shelf-actions").click();
+  await page.getByTestId("shelf-delete").click();
+
+  const modal = page.getByTestId("shelf-delete-modal");
+  await expect(modal).toBeVisible();
+  await expect(modal).toContainText(name);
+
+  await modal.getByTestId("shelf-delete-cancel").click();
+
+  await expect(modal).not.toBeVisible();
+  // Still on the shelf's page and the shelf still exists.
+  await expect(page.getByTestId("shelf-detail-header")).toContainText(name);
+  expect(new URL(page.url()).pathname).toBe(`/shelves/${shelf.id}`);
+});
+
+test("confirming the delete removes the shelf and returns to the library", async ({
+  page,
+  request,
+}) => {
+  const name = `E2E Delete Confirm ${Date.now()}`;
+  const createResp = await request.post("/api/rpc/shelves/create", {
+    data: {
+      req: {
+        kind: "manual",
+        name,
+        description: null,
+        visibility: "private",
+        match_mode: null,
+        rules: [],
+        book_uuids: [],
+      },
+    },
+  });
+  expect(createResp.status(), "POST /api/rpc/shelves/create failed").toBe(200);
+  const shelf = (await createResp.json()) as { id: number };
+
+  await gotoReady(page, `/shelves/${shelf.id}`);
+  await page.getByTestId("shelf-actions").click();
+  await page.getByTestId("shelf-delete").click();
+
+  const modal = page.getByTestId("shelf-delete-modal");
+  await expect(modal).toBeVisible();
+
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: "/api/rpc/shelves/delete",
+      expectedBody: { id: shelf.id },
+      expectedStatus: 200,
+    },
+    async () => modal.getByTestId("shelf-delete-confirm").click(),
+  );
+
+  await expect(page).toHaveURL("/");
+  await expect(page.getByTestId("gallery-all-books")).toBeVisible();
+  // The deleted shelf's tile is gone from the gallery on the next fetch.
+  await expect(page.getByTestId(`gallery-shelf-${shelf.id}`)).toHaveCount(0);
+});
+
+test("surfaces the delete request in flight and keeps the shelf on failure", async ({
+  page,
+  request,
+}) => {
+  const name = `E2E Delete Fail ${Date.now()}`;
+  const createResp = await request.post("/api/rpc/shelves/create", {
+    data: {
+      req: {
+        kind: "manual",
+        name,
+        description: null,
+        visibility: "private",
+        match_mode: null,
+        rules: [],
+        book_uuids: [],
+      },
+    },
+  });
+  expect(createResp.status(), "POST /api/rpc/shelves/create failed").toBe(200);
+  const shelf = (await createResp.json()) as { id: number };
+
+  await gotoReady(page, `/shelves/${shelf.id}`);
+  await page.route("**/api/rpc/shelves/delete", (route) =>
+    route.fulfill({ status: 500, body: "boom" }),
+  );
+
+  try {
+    await page.getByTestId("shelf-actions").click();
+    await page.getByTestId("shelf-delete").click();
+
+    const modal = page.getByTestId("shelf-delete-modal");
+    const confirmBtn = modal.getByTestId("shelf-delete-confirm");
+
+    await expectMutation(
+      page,
+      { method: "POST", url: "/api/rpc/shelves/delete", expectedStatus: 500 },
+      async () => confirmBtn.click(),
+    );
+
+    // The failed delete leaves the shelf, and the modal, in place.
+    await expect(modal).toBeVisible();
+    await expect(page.getByTestId("shelf-detail-header")).toContainText(name);
+    expect(new URL(page.url()).pathname).toBe(`/shelves/${shelf.id}`);
+  } finally {
+    await page.unroute("**/api/rpc/shelves/delete");
+  }
+});


### PR DESCRIPTION
## Summary
- Closes #1483
- Desktop (`shelf_detail/header.rs`) and mobile (`shelf_detail/mobile.rs`) shelf-delete actions now open the shared `ConfirmModal` (with `confirm_modal_body`), naming the shelf, instead of calling `data::delete_shelf` directly on click.
- The confirm button is busy-gated (disabled, labeled "Deleting…") while the delete request is in flight, and the modal can't be dismissed mid-request — same pattern as `delete_book_dialog.rs` / the physical-copy delete modal in `book_detail/physical.rs`.
- Added Playwright coverage in `ui_tests/playwright/tests/flows/shelves.spec.ts`: cancelling the confirm leaves the shelf intact, confirming deletes it and returns to the library, and a forced 500 leaves the shelf and modal in place.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (537 passed; 0 failed)
- [x] `pnpm run lint` (Biome) — PASS
- [x] `pnpm run typecheck` (`tsc --noEmit`) — PASS
- [ ] `pnpm exec playwright test tests/flows/shelves.spec.ts` — not run in this environment (no dev server/WASM toolchain available here); written by hand following the file's existing conventions (`expectMutation`, `gotoReady`, route-intercept + `try/finally` unroute for the forced-failure case)

## Notes
- Scope kept surgical to the delete-confirmation gap per the issue; did not hoist the desktop/mobile delete-handler duplication into a shared helper (called out in the issue as a nice-to-have, not a blocker).
- `docs/architecture.md` / `CLAUDE.md` untouched — the delete flow's shape didn't change structurally, only its confirmation gating.


---
_Generated by [Claude Code](https://claude.ai/code/session_013MhBULjmcF7E2Px9K2NFW8)_