### PR TITLE
refactor: split 5 oversized reader/account/landing components (#1472)

### DIFF
--- a/frontend/src/pages/account/kobo.rs
+++ b/frontend/src/pages/account/kobo.rs
@@ -15,7 +15,7 @@ fn endpoint_url(server_url: &str, token: &str) -> String {
     format!("{}/kobo/{token}", server_url.trim_end_matches('/'))
 }
 
-/// The three-step "how to connect" list at the top of the card.
+/// The numbered "how to connect" list at the top of the card.
 fn render_kobo_setup_steps() -> Element {
     rsx! {
         ol { class: "subtitle kobo-setup-steps", "data-testid": "kobo-setup-steps",
@@ -104,11 +104,11 @@ fn render_kobo_device_list(
     }
     rsx! {
         ul { class: "kobo-device-list", "data-testid": "kobo-device-list",
-            for dev in device_list.iter().cloned() {
+            for dev in device_list.iter() {
                 KoboDeviceRow {
                     key: "{dev.id}",
-                    device: dev.clone(),
                     endpoint: endpoint_url(server_url, &dev.token),
+                    device: dev.clone(),
                     disabled: in_flight,
                     on_regenerate,
                     on_remove,

--- a/frontend/src/pages/account/kobo.rs
+++ b/frontend/src/pages/account/kobo.rs
@@ -15,6 +15,147 @@ fn endpoint_url(server_url: &str, token: &str) -> String {
     format!("{}/kobo/{token}", server_url.trim_end_matches('/'))
 }
 
+/// The three-step "how to connect" list at the top of the card.
+fn render_kobo_setup_steps() -> Element {
+    rsx! {
+        ol { class: "subtitle kobo-setup-steps", "data-testid": "kobo-setup-steps",
+            li {
+                "Give your Kobo a name and click "
+                b { "Add a Kobo" }
+            }
+            li {
+                "Copy the device's wireless sync endpoint URL. ("
+                code { "/kobo/<token>" }
+                ")"
+            }
+            li { "Connect the Kobo over USB," }
+            li {
+                "Edit "
+                code { ".kobo/Kobo/Kobo eReader.conf" }
+                " and set "
+                code { "api_endpoint=" }
+                " under "
+                code { "[OneStoreServices]" }
+                " to "
+                code { "<your_omnibus_server_url>/kobo/<token>" }
+                "."
+            }
+            li { "Eject safely. Your next sync on the device talks to Omnibus." }
+        }
+    }
+}
+
+/// The unconditional first-sync data-loss warning, with backup tool links.
+fn render_kobo_warning() -> Element {
+    rsx! {
+        div { class: "kobo-warning", "data-testid": "kobo-data-loss-warning",
+            p { class: "kobo-warning-title", "First sync can erase your Kobo's highlights" }
+            p {
+                "An improper sync can potentially wipe data on the Kobo like your "
+                "annotations, notes, bookmarks, reading progress, and books."
+            }
+            p {
+                "It is highly recommended to back up your device before attempting "
+                "a sync with one of these tools:"
+            }
+            ul { class: "kobo-warning-tools",
+                li {
+                    a {
+                        href: "https://github.com/seamus-sloan/kobo-backup#kobo-backup",
+                        target: "_blank",
+                        rel: "noopener noreferrer",
+                        "seamus-sloan/kobo-backup"
+                    }
+                }
+                li {
+                    a {
+                        href: "https://github.com/karlicoss/kobuddy#usage",
+                        target: "_blank",
+                        rel: "noopener noreferrer",
+                        "karlicoss/kobuddy"
+                    }
+                }
+            }
+            p {
+                "At minimum, copy "
+                code { ".kobo/KoboReader.sqlite" }
+                " off the device over USB."
+            }
+        }
+    }
+}
+
+/// Registered-device list, or the empty-state line when there are none yet.
+fn render_kobo_device_list(
+    device_list: &[KoboDeviceView],
+    server_url: &str,
+    in_flight: bool,
+    on_regenerate: Callback<i64>,
+    on_remove: Callback<i64>,
+) -> Element {
+    if device_list.is_empty() {
+        return rsx! {
+            p {
+                class: "settings-status",
+                "data-testid": "kobo-devices-empty",
+                "No Kobo registered yet."
+            }
+        };
+    }
+    rsx! {
+        ul { class: "kobo-device-list", "data-testid": "kobo-device-list",
+            for dev in device_list.iter().cloned() {
+                KoboDeviceRow {
+                    key: "{dev.id}",
+                    device: dev.clone(),
+                    endpoint: endpoint_url(server_url, &dev.token),
+                    disabled: in_flight,
+                    on_regenerate,
+                    on_remove,
+                }
+            }
+        }
+    }
+}
+
+/// The "Add a Kobo" name form.
+fn render_kobo_add_form(
+    name_input: Signal<String>,
+    in_flight: bool,
+    on_add: impl FnMut(Event<FormData>) + 'static,
+) -> Element {
+    rsx! {
+        form {
+            id: "kobo-add-form",
+            class: "settings-form",
+            onsubmit: on_add,
+            div { class: "settings-field",
+                label { r#for: "kobo-device-name", "Device name" }
+                input {
+                    r#type: "text",
+                    id: "kobo-device-name",
+                    name: "kobo_device_name",
+                    "data-testid": "kobo-device-name-input",
+                    autocomplete: "off",
+                    placeholder: "Kobo Clara",
+                    maxlength: "100",
+                    value: "{name_input}",
+                    oninput: move |e| { let mut name_input = name_input; name_input.set(e.value()) },
+                }
+            }
+            div { class: "settings-actions",
+                button {
+                    r#type: "submit",
+                    class: "btn",
+                    disabled: in_flight,
+                    "data-testid": "kobo-device-add",
+                    "Add a Kobo"
+                }
+            }
+        }
+    }
+}
+
 /// Card body: device list + add form. Every mutation re-fetches the list so the
 /// rendered state always matches the server.
 #[component]
@@ -117,116 +258,11 @@ pub fn KoboDevicesCard() -> Element {
     rsx! {
         section { class: "card", "data-testid": "kobo-devices-card",
             h2 { "Kobo wireless sync" }
-            ol { class: "subtitle kobo-setup-steps", "data-testid": "kobo-setup-steps",
-                li {
-                    "Give your Kobo a name and click "
-                    b { "Add a Kobo" }
-                }
-                li {
-                    "Copy the device's wireless sync endpoint URL. ("
-                    code { "/kobo/<token>" }
-                    ")"
-                }
-                li { "Connect the Kobo over USB," }
-                li {
-                    "Edit "
-                    code { ".kobo/Kobo/Kobo eReader.conf" }
-                    " and set "
-                    code { "api_endpoint=" }
-                    " under "
-                    code { "[OneStoreServices]" }
-                    " to "
-                    code { "<your_omnibus_server_url>/kobo/<token>" }
-                    "."
-                }
-                li { "Eject safely. Your next sync on the device talks to Omnibus." }
-            }
-
+            {render_kobo_setup_steps()}
             // Unconditional: the hazard applies the moment a URL is copied.
-            div { class: "kobo-warning", "data-testid": "kobo-data-loss-warning",
-                p { class: "kobo-warning-title", "First sync can erase your Kobo's highlights" }
-                p {
-                    "An improper sync can potentially wipe data on the Kobo like your "
-                    "annotations, notes, bookmarks, reading progress, and books."
-                }
-                p {
-                    "It is highly recommended to back up your device before attempting "
-                    "a sync with one of these tools:"
-                }
-                ul { class: "kobo-warning-tools",
-                    li {
-                        a {
-                            href: "https://github.com/seamus-sloan/kobo-backup#kobo-backup",
-                            target: "_blank",
-                            rel: "noopener noreferrer",
-                            "seamus-sloan/kobo-backup"
-                        }
-                    }
-                    li {
-                        a {
-                            href: "https://github.com/karlicoss/kobuddy#usage",
-                            target: "_blank",
-                            rel: "noopener noreferrer",
-                            "karlicoss/kobuddy"
-                        }
-                    }
-                }
-                p {
-                    "At minimum, copy "
-                    code { ".kobo/KoboReader.sqlite" }
-                    " off the device over USB."
-                }
-            }
-
-            if device_list.is_empty() {
-                p {
-                    class: "settings-status",
-                    "data-testid": "kobo-devices-empty",
-                    "No Kobo registered yet."
-                }
-            } else {
-                ul { class: "kobo-device-list", "data-testid": "kobo-device-list",
-                    for dev in device_list.iter().cloned() {
-                        KoboDeviceRow {
-                            key: "{dev.id}",
-                            device: dev.clone(),
-                            endpoint: endpoint_url(&server_url, &dev.token),
-                            disabled: in_flight(),
-                            on_regenerate,
-                            on_remove,
-                        }
-                    }
-                }
-            }
-
-            form {
-                id: "kobo-add-form",
-                class: "settings-form",
-                onsubmit: on_add,
-                div { class: "settings-field",
-                    label { r#for: "kobo-device-name", "Device name" }
-                    input {
-                        r#type: "text",
-                        id: "kobo-device-name",
-                        name: "kobo_device_name",
-                        "data-testid": "kobo-device-name-input",
-                        autocomplete: "off",
-                        placeholder: "Kobo Clara",
-                        maxlength: "100",
-                        value: "{name_input}",
-                        oninput: move |e| name_input.set(e.value()),
-                    }
-                }
-                div { class: "settings-actions",
-                    button {
-                        r#type: "submit",
-                        class: "btn",
-                        disabled: in_flight(),
-                        "data-testid": "kobo-device-add",
-                        "Add a Kobo"
-                    }
-                }
-            }
+            {render_kobo_warning()}
+            {render_kobo_device_list(&device_list, &server_url, in_flight(), on_regenerate, on_remove)}
+            {render_kobo_add_form(name_input, in_flight(), on_add)}
 
             if let Some(m) = msg() {
                 p {

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -63,6 +63,134 @@ pub(super) struct MobileLandingProps {
     pub server_url: String,
 }
 
+/// "Pick up where you left off" — the most recent progress row, fetched per
+/// mount and re-read when a background cache revalidation lands.
+fn use_resume_point(server_url: String) -> Signal<Option<ResumePoint>> {
+    let mut resume = use_signal(|| None::<ResumePoint>);
+    let generation = crate::use_cache_generation();
+    use_effect(move || {
+        let _ = generation();
+        let url = server_url.clone();
+        spawn(async move {
+            if let Ok(points) = crate::data::recent_progress(&url, 1).await {
+                resume.set(points.into_iter().next());
+            }
+        });
+    });
+    resume
+}
+
+/// Settled reveal: hold the screen invisible until the first page fetch lands
+/// (the offline cache answers within tens of ms) AND the above-the-fold cover
+/// images have decoded, so the enter transition plays once over finished
+/// content — no cold "Loading" skeleton fading in, no covers popping over
+/// placeholder tiles mid-flight. Every wait is bounded: the decode eval times
+/// out internally, and the floor reveals unconditionally so a slow first load
+/// falls back to the ordinary Loading state updating in place.
+fn use_settled_reveal(is_loading: bool, books_empty: bool) -> bool {
+    let mut reveal_floor = use_signal(|| false);
+    use_future(move || async move {
+        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+        reveal_floor.set(true);
+    });
+    let mut covers_ready = use_signal(|| false);
+    let mut decode_eval = use_hook(|| dioxus::document::eval(COVERS_DECODE_JS));
+    use_future(move || async move {
+        if decode_eval.recv::<i32>().await.is_ok() {
+            covers_ready.set(true);
+        }
+    });
+    (!is_loading && (covers_ready() || books_empty)) || reveal_floor()
+}
+
+/// Slim header: brand word + search entry. Account/settings lives on the
+/// bottom-nav "You" tab.
+fn render_mobile_header() -> Element {
+    rsx! {
+        header { class: "m-lib-head",
+            div { class: "omn-brand-word m-lib-brand", "Omnibus" }
+            div { class: "m-lib-head-actions",
+                Link {
+                    to: Route::MobileSearch {},
+                    class: "m-icon-btn",
+                    "aria-label": "Search",
+                    "data-testid": "mobile-search-entry",
+                    {search_glyph()}
+                }
+            }
+        }
+    }
+}
+
+/// "All Books" title + the sort/filter pill that opens [`MobileSortFilterSheet`].
+fn render_mobile_title_row(
+    book_count: usize,
+    pill_label: &str,
+    pill_arrow: &str,
+    filter_count: usize,
+    sheet_open: Signal<bool>,
+) -> Element {
+    let mut sheet_open = sheet_open;
+    rsx! {
+        div { class: "m-lib-title",
+            div { class: "m-lib-title-text",
+                span { class: "label", "{book_count} books" }
+                h2 { class: "m-head-title",
+                    "All "
+                    span { class: "m-em", "Books" }
+                }
+            }
+            button {
+                r#type: "button",
+                class: "m-sort-pill",
+                "aria-label": "Sort & filter",
+                "data-testid": "mobile-sort-pill",
+                onclick: move |_| sheet_open.set(true),
+                {filter_glyph()}
+                span { class: "m-sort-pill-label", "{pill_label}" }
+                span { class: "m-sort-pill-arrow", "{pill_arrow}" }
+                if filter_count > 0 {
+                    span { class: "m-sort-pill-badge mono", "{filter_count}" }
+                }
+            }
+        }
+    }
+}
+
+/// The cover grid (or the loading line before the first page lands) plus the
+/// "Load more" pager.
+fn render_mobile_grid(
+    is_loading: bool,
+    is_loading_more: bool,
+    has_more: bool,
+    books: Vec<EbookMetadata>,
+    server_url: String,
+    on_load_more: EventHandler<()>,
+) -> Element {
+    if is_loading && books.is_empty() {
+        return rsx! {
+            p { class: "subtitle m-lib-loading", "Loading\u{2026}" }
+        };
+    }
+    rsx! {
+        div { class: "m-cover-grid", "data-testid": "mobile-lib-grid", role: "list",
+            for book in books.into_iter() {
+                {cover_cell(book, &server_url)}
+            }
+        }
+        if has_more {
+            button {
+                r#type: "button",
+                class: "btn m-load-more",
+                "data-testid": "mobile-load-more",
+                disabled: is_loading_more,
+                onclick: move |_| on_load_more.call(()),
+                if is_loading_more { "Loading\u{2026}" } else { "Load more" }
+            }
+        }
+    }
+}
+
 /// Mobile landing surface. Fed the already-derived view state from
 /// [`super::LandingPage`] so the data path stays shared across targets.
 #[component]
@@ -80,47 +208,14 @@ pub(super) fn MobileLanding(props: MobileLandingProps) -> Element {
     } = props;
 
     let mut sheet_open = use_signal(|| false);
-
-    // "Pick up where you left off" — the most recent progress row, fetched
-    // per mount and re-read when a background cache revalidation lands.
-    let mut resume = use_signal(|| None::<ResumePoint>);
-    let resume_url = server_url.clone();
-    let generation = crate::use_cache_generation();
-    use_effect(move || {
-        let _ = generation();
-        let url = resume_url.clone();
-        spawn(async move {
-            if let Ok(points) = crate::data::recent_progress(&url, 1).await {
-                resume.set(points.into_iter().next());
-            }
-        });
-    });
+    let resume = use_resume_point(server_url.clone());
 
     let pill_label = sort_pill_label(prefs.sort_key);
     let pill_arrow = dir_arrow(prefs.sort_dir);
     let filter_count = prefs.filters.formats.len();
 
-    // Settled reveal: hold the screen invisible until the first page fetch
-    // lands (the offline cache answers within tens of ms) AND the
-    // above-the-fold cover images have decoded, so the enter transition
-    // plays once over finished content — no cold "Loading" skeleton fading
-    // in, no covers popping over placeholder tiles mid-flight. Every wait
-    // is bounded: the decode eval times out internally, and the floor
-    // reveals unconditionally so a slow first load falls back to the
-    // ordinary Loading state updating in place.
-    let mut reveal_floor = use_signal(|| false);
-    use_future(move || async move {
-        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
-        reveal_floor.set(true);
-    });
-    let mut covers_ready = use_signal(|| false);
-    let mut decode_eval = use_hook(|| dioxus::document::eval(COVERS_DECODE_JS));
-    use_future(move || async move {
-        if decode_eval.recv::<i32>().await.is_ok() {
-            covers_ready.set(true);
-        }
-    });
-    let settled = (!is_loading && (covers_ready() || books.is_empty())) || reveal_floor();
+    let books_empty = books.is_empty();
+    let settled = use_settled_reveal(is_loading, books_empty);
     let root_class = if settled {
         "m-lib m-lib-ready"
     } else {
@@ -134,43 +229,8 @@ pub(super) fn MobileLanding(props: MobileLandingProps) -> Element {
             div { class: "m-ptr", "aria-hidden": "true",
                 span { class: "m-ptr-arrow", "↓" }
             }
-            header { class: "m-lib-head",
-                div { class: "omn-brand-word m-lib-brand", "Omnibus" }
-                div { class: "m-lib-head-actions",
-                    // Search entry — opens the mobile-native search screen.
-                    // Account/settings lives on the bottom-nav "You" tab.
-                    Link {
-                        to: Route::MobileSearch {},
-                        class: "m-icon-btn",
-                        "aria-label": "Search",
-                        "data-testid": "mobile-search-entry",
-                        {search_glyph()}
-                    }
-                }
-            }
-
-            div { class: "m-lib-title",
-                div { class: "m-lib-title-text",
-                    span { class: "label", "{book_count} books" }
-                    h2 { class: "m-head-title",
-                        "All "
-                        span { class: "m-em", "Books" }
-                    }
-                }
-                button {
-                    r#type: "button",
-                    class: "m-sort-pill",
-                    "aria-label": "Sort & filter",
-                    "data-testid": "mobile-sort-pill",
-                    onclick: move |_| sheet_open.set(true),
-                    {filter_glyph()}
-                    span { class: "m-sort-pill-label", "{pill_label}" }
-                    span { class: "m-sort-pill-arrow", "{pill_arrow}" }
-                    if filter_count > 0 {
-                        span { class: "m-sort-pill-badge mono", "{filter_count}" }
-                    }
-                }
-            }
+            {render_mobile_header()}
+            {render_mobile_title_row(book_count, pill_label, pill_arrow, filter_count, sheet_open)}
 
             if let Some(point) = resume() {
                 {resume_card(&point, &server_url)}
@@ -188,25 +248,7 @@ pub(super) fn MobileLanding(props: MobileLandingProps) -> Element {
                 span { class: "m-shelves-entry-chevron", {chevron()} }
             }
 
-            if is_loading && books.is_empty() {
-                p { class: "subtitle m-lib-loading", "Loading\u{2026}" }
-            } else {
-                div { class: "m-cover-grid", "data-testid": "mobile-lib-grid", role: "list",
-                    for book in books.into_iter() {
-                        {cover_cell(book, &server_url)}
-                    }
-                }
-                if has_more {
-                    button {
-                        r#type: "button",
-                        class: "btn m-load-more",
-                        "data-testid": "mobile-load-more",
-                        disabled: is_loading_more,
-                        onclick: move |_| on_load_more.call(()),
-                        if is_loading_more { "Loading\u{2026}" } else { "Load more" }
-                    }
-                }
-            }
+            {render_mobile_grid(is_loading, is_loading_more, has_more, books, server_url.clone(), on_load_more)}
 
             if sheet_open() {
                 MobileSortFilterSheet {

--- a/frontend/src/pages/reader/annotations_sheet.rs
+++ b/frontend/src/pages/reader/annotations_sheet.rs
@@ -57,6 +57,117 @@ pub(super) struct AnnotationsSheetProps {
     pub on_close: EventHandler<()>,
 }
 
+/// Drawer head: title + count, "+ Bookmark", and close button.
+fn render_annotations_header(
+    counts: String,
+    can_add: bool,
+    on_add: impl FnMut(Event<MouseData>) + 'static,
+    on_close: EventHandler<()>,
+) -> Element {
+    rsx! {
+        div { class: "rd-drawer-head",
+            h4 { class: "rd-drawer-title",
+                "Annotations "
+                span { class: "rd-drawer-count", "{counts}" }
+            }
+            div { class: "rd-drawer-head-actions",
+                button {
+                    class: "btn sm",
+                    r#type: "button",
+                    "data-testid": "reader-annotations-add",
+                    disabled: !can_add,
+                    onclick: on_add,
+                    "+ Bookmark"
+                }
+                button {
+                    class: "rd-x",
+                    r#type: "button",
+                    "aria-label": "Close",
+                    onclick: move |_| on_close.call(()),
+                    "\u{00d7}"
+                }
+            }
+        }
+    }
+}
+
+/// Kind/color filter chip row: All, Bookmarks, then one chip per highlight color.
+fn render_annotations_filter_row(active: AnnFilter, filter: Signal<AnnFilter>) -> Element {
+    let mut filter = filter;
+    rsx! {
+        div { class: "rd-filter-row",
+            button {
+                class: if active == AnnFilter::All { "rd-chip on" } else { "rd-chip" },
+                r#type: "button",
+                onclick: move |_| filter.set(AnnFilter::All),
+                "All"
+            }
+            button {
+                class: if active == AnnFilter::Bookmarks { "rd-chip on" } else { "rd-chip" },
+                r#type: "button",
+                "data-testid": "annotations-filter-bookmarks",
+                onclick: move |_| filter.set(AnnFilter::Bookmarks),
+                "Bookmarks"
+            }
+            span { class: "rd-filter-div" }
+            for (color, name) in PALETTE {
+                button {
+                    key: "{name}",
+                    class: if active == AnnFilter::Color(color) { "rd-chip on" } else { "rd-chip" },
+                    r#type: "button",
+                    "aria-label": "Filter {name}",
+                    onclick: move |_| filter.set(AnnFilter::Color(color)),
+                    span { class: "rd-chip-dot", "data-color": "{name}" }
+                }
+            }
+        }
+    }
+}
+
+/// Drawer body: empty state, or the filtered bookmark + highlight rows.
+#[allow(clippy::too_many_arguments)]
+fn render_annotations_body(
+    empty: bool,
+    show_bookmarks: bool,
+    marks: Vec<Bookmark>,
+    shown_highlights: Vec<Highlight>,
+    bookmarks: Signal<Vec<Bookmark>>,
+    highlights: Signal<Vec<Highlight>>,
+    on_navigate: EventHandler<String>,
+    on_quote: EventHandler<Highlight>,
+    on_edit_note: EventHandler<Highlight>,
+) -> Element {
+    rsx! {
+        div { class: "rd-drawer-body",
+            if empty {
+                div { class: "rd-drawer-empty",
+                    "Nothing here yet. Highlight a passage or tap + Bookmark to save your place."
+                }
+            } else {
+                if show_bookmarks {
+                    for mark in marks.iter() {
+                        AnnotationBookmarkRow {
+                            key: "bm-{mark.id}",
+                            bookmark: mark.clone(),
+                            on_navigate,
+                            list: bookmarks,
+                        }
+                    }
+                }
+                for h in shown_highlights.iter() {
+                    HighlightRow {
+                        key: "{h.id}",
+                        highlight: h.clone(),
+                        highlights,
+                        on_quote,
+                        on_edit_note,
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// The combined annotations bottom sheet.
 #[component]
 pub(super) fn AnnotationsSheet(props: AnnotationsSheetProps) -> Element {
@@ -70,7 +181,7 @@ pub(super) fn AnnotationsSheet(props: AnnotationsSheetProps) -> Element {
         on_navigate,
         on_close,
     } = props;
-    let mut filter = use_signal(|| AnnFilter::All);
+    let filter = use_signal(|| AnnFilter::All);
     let bookmarks = use_signal(Vec::<Bookmark>::new);
     let server_url = crate::contexts::use_server_url();
 
@@ -137,81 +248,20 @@ pub(super) fn AnnotationsSheet(props: AnnotationsSheetProps) -> Element {
         div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
         div { class: "rd-drawer", "data-testid": "reader-annotations-drawer",
             div { class: "rd-grabber" }
-            div { class: "rd-drawer-head",
-                h4 { class: "rd-drawer-title",
-                    "Annotations "
-                    span { class: "rd-drawer-count", "{counts}" }
-                }
-                div { class: "rd-drawer-head-actions",
-                    button {
-                        class: "btn sm",
-                        r#type: "button",
-                        "data-testid": "reader-annotations-add",
-                        disabled: !can_add,
-                        onclick: add,
-                        "+ Bookmark"
-                    }
-                    button {
-                        class: "rd-x",
-                        r#type: "button",
-                        "aria-label": "Close",
-                        onclick: move |_| on_close.call(()),
-                        "\u{00d7}"
-                    }
-                }
-            }
-            div { class: "rd-filter-row",
-                button {
-                    class: if active == AnnFilter::All { "rd-chip on" } else { "rd-chip" },
-                    r#type: "button",
-                    onclick: move |_| filter.set(AnnFilter::All),
-                    "All"
-                }
-                button {
-                    class: if active == AnnFilter::Bookmarks { "rd-chip on" } else { "rd-chip" },
-                    r#type: "button",
-                    "data-testid": "annotations-filter-bookmarks",
-                    onclick: move |_| filter.set(AnnFilter::Bookmarks),
-                    "Bookmarks"
-                }
-                span { class: "rd-filter-div" }
-                for (color, name) in PALETTE {
-                    button {
-                        key: "{name}",
-                        class: if active == AnnFilter::Color(color) { "rd-chip on" } else { "rd-chip" },
-                        r#type: "button",
-                        "aria-label": "Filter {name}",
-                        onclick: move |_| filter.set(AnnFilter::Color(color)),
-                        span { class: "rd-chip-dot", "data-color": "{name}" }
-                    }
-                }
-            }
-            div { class: "rd-drawer-body",
-                if empty {
-                    div { class: "rd-drawer-empty",
-                        "Nothing here yet. Highlight a passage or tap + Bookmark to save your place."
-                    }
-                } else {
-                    if show_bookmarks {
-                        for mark in marks.iter() {
-                            AnnotationBookmarkRow {
-                                key: "bm-{mark.id}",
-                                bookmark: mark.clone(),
-                                on_navigate,
-                                list: bookmarks,
-                            }
-                        }
-                    }
-                    for h in shown_highlights.iter() {
-                        HighlightRow {
-                            key: "{h.id}",
-                            highlight: h.clone(),
-                            highlights,
-                            on_quote,
-                            on_edit_note,
-                        }
-                    }
-                }
+            {render_annotations_header(counts, can_add, add, on_close)}
+            {render_annotations_filter_row(active, filter)}
+            {
+                render_annotations_body(
+                    empty,
+                    show_bookmarks,
+                    marks,
+                    shown_highlights,
+                    bookmarks,
+                    highlights,
+                    on_navigate,
+                    on_quote,
+                    on_edit_note,
+                )
             }
         }
     }

--- a/frontend/src/pages/reader/overlays.rs
+++ b/frontend/src/pages/reader/overlays.rs
@@ -126,6 +126,227 @@ pub(super) struct OverlayMeta {
     pub contents_progress: String,
 }
 
+/// Contents (table-of-contents) drawer, shown while `show_toc` is set.
+fn render_toc_overlay(
+    show_toc: Signal<bool>,
+    toc: Signal<Vec<super::toc_drawer::TocEntry>>,
+    chapter_title: String,
+    contents_progress: String,
+) -> Element {
+    if !show_toc() {
+        return rsx! {};
+    }
+    rsx! {
+        TocDrawer {
+            entries: toc.read().clone(),
+            current_title: chapter_title.clone(),
+            progress_label: contents_progress.clone(),
+            on_navigate: move |href: String| {
+                #[cfg(any(feature = "web", feature = "mobile"))]
+                super::reader_call_json("display", &href);
+                let _ = &href;
+                let mut show_toc = show_toc;
+                show_toc.set(false);
+            },
+            on_close: move |_| {
+                let mut show_toc = show_toc;
+                show_toc.set(false);
+            },
+        }
+    }
+}
+
+/// Highlights drawer, shown while `show_highlights` is set.
+fn render_highlights_overlay(
+    show_highlights: Signal<bool>,
+    highlights: Signal<Vec<Highlight>>,
+    quote_target: Signal<Option<Highlight>>,
+    note_target: Signal<Option<Highlight>>,
+) -> Element {
+    if !show_highlights() {
+        return rsx! {};
+    }
+    rsx! {
+        HighlightsDrawer {
+            highlights,
+            on_quote: move |h: Highlight| {
+                let mut quote_target = quote_target;
+                let mut show_highlights = show_highlights;
+                quote_target.set(Some(h));
+                show_highlights.set(false);
+            },
+            on_edit_note: move |h: Highlight| {
+                let mut note_target = note_target;
+                let mut show_highlights = show_highlights;
+                note_target.set(Some(h));
+                show_highlights.set(false);
+            },
+            on_close: move |_| {
+                let mut show_highlights = show_highlights;
+                show_highlights.set(false);
+            },
+        }
+    }
+}
+
+/// Full-text search drawer, shown while `show_search` is set.
+fn render_search_overlay(
+    show_search: Signal<bool>,
+    search_results: Signal<Vec<super::search_panel::SearchResult>>,
+) -> Element {
+    if !show_search() {
+        return rsx! {};
+    }
+    rsx! {
+        SearchPanel {
+            results: search_results,
+            on_query: move |q: String| {
+                #[cfg(any(feature = "web", feature = "mobile"))]
+                super::reader_call_json("search", &q);
+                let _ = &q;
+            },
+            on_navigate: move |cfi: String| {
+                #[cfg(any(feature = "web", feature = "mobile"))]
+                super::reader_call_json("display", &cfi);
+                let _ = &cfi;
+                let mut show_search = show_search;
+                show_search.set(false);
+            },
+            on_close: move |_| {
+                let mut show_search = show_search;
+                show_search.set(false);
+            },
+        }
+    }
+}
+
+/// Bookmarks drawer (desktop), shown while `show_bookmarks` is set.
+fn render_bookmarks_overlay(
+    show_bookmarks: Signal<bool>,
+    uuid: String,
+    current_cfi: String,
+    chapter_title: String,
+) -> Element {
+    if !show_bookmarks() {
+        return rsx! {};
+    }
+    rsx! {
+        ReaderBookmarksDrawer {
+            uuid: uuid.clone(),
+            current_cfi: current_cfi.clone(),
+            current_label: chapter_title.clone(),
+            on_navigate: move |cfi: String| {
+                #[cfg(any(feature = "web", feature = "mobile"))]
+                super::reader_call_json("display", &cfi);
+                let _ = &cfi;
+                let mut show_bookmarks = show_bookmarks;
+                show_bookmarks.set(false);
+            },
+            on_close: move |_| {
+                let mut show_bookmarks = show_bookmarks;
+                show_bookmarks.set(false);
+            },
+        }
+    }
+}
+
+/// Combined phone annotations sheet, shown while `show_annotations` is set.
+#[allow(clippy::too_many_arguments)]
+fn render_annotations_overlay(
+    show_annotations: Signal<bool>,
+    uuid: String,
+    current_cfi: String,
+    chapter_title: String,
+    highlights: Signal<Vec<Highlight>>,
+    quote_target: Signal<Option<Highlight>>,
+    note_target: Signal<Option<Highlight>>,
+) -> Element {
+    if !show_annotations() {
+        return rsx! {};
+    }
+    rsx! {
+        AnnotationsSheet {
+            uuid: uuid.clone(),
+            current_cfi: current_cfi.clone(),
+            current_label: chapter_title.clone(),
+            highlights,
+            on_quote: move |h: Highlight| {
+                let mut quote_target = quote_target;
+                let mut show_annotations = show_annotations;
+                quote_target.set(Some(h));
+                show_annotations.set(false);
+            },
+            on_edit_note: move |h: Highlight| {
+                let mut note_target = note_target;
+                let mut show_annotations = show_annotations;
+                note_target.set(Some(h));
+                show_annotations.set(false);
+            },
+            on_navigate: move |cfi: String| {
+                #[cfg(any(feature = "web", feature = "mobile"))]
+                super::reader_call_json("display", &cfi);
+                let _ = &cfi;
+                let mut show_annotations = show_annotations;
+                show_annotations.set(false);
+            },
+            on_close: move |_| {
+                let mut show_annotations = show_annotations;
+                show_annotations.set(false);
+            },
+        }
+    }
+}
+
+/// Quote-card panel, shown while a highlight is targeted for a quote card.
+fn render_quote_target_overlay(
+    quote_target: Signal<Option<Highlight>>,
+    book_author: String,
+    book_title: String,
+    book_accent: String,
+) -> Element {
+    let Some(h) = quote_target.read().clone() else {
+        return rsx! {};
+    };
+    rsx! {
+        QuotePanel {
+            quote_text: h.text.clone().unwrap_or_default(),
+            author: book_author.clone(),
+            subtitle: book_title.clone(),
+            accent: book_accent.clone(),
+            on_close: move |_| {
+                let mut quote_target = quote_target;
+                quote_target.set(None);
+            },
+        }
+    }
+}
+
+/// Note composer, shown while a highlight is targeted for note editing.
+fn render_note_target_overlay(
+    note_target: Signal<Option<Highlight>>,
+    highlights: Signal<Vec<Highlight>>,
+) -> Element {
+    let Some(h) = note_target.read().clone() else {
+        return rsx! {};
+    };
+    rsx! {
+        NoteComposer {
+            highlight: h,
+            on_saved: move |(id, note): (i64, Option<String>)| {
+                let mut highlights = highlights;
+                let idx = highlights.read().iter().position(|x| x.id == id);
+                if let Some(i) = idx {
+                    highlights.write()[i].note = note;
+                }
+            },
+            on_close: move |_| {
+                let mut note_target = note_target;
+                note_target.set(None);
+            },
+        }
+    }
+}
+
 /// The toggleable reader overlays: contents, highlights, search, bookmarks
 /// drawers plus the quote panel and note composer. Each renders only when its
 /// backing signal is set.
@@ -155,148 +376,22 @@ pub(super) fn ReaderOverlays(meta: OverlayMeta, panels: ReaderPanelSignals) -> E
     } = panels;
 
     rsx! {
-        if show_toc() {
-            TocDrawer {
-                entries: toc.read().clone(),
-                current_title: chapter_title.clone(),
-                progress_label: contents_progress.clone(),
-                on_navigate: move |href: String| {
-                    #[cfg(any(feature = "web", feature = "mobile"))]
-                    super::reader_call_json("display", &href);
-                    let _ = &href;
-                    let mut show_toc = show_toc;
-                    show_toc.set(false);
-                },
-                on_close: move |_| {
-                    let mut show_toc = show_toc;
-                    show_toc.set(false);
-                },
-            }
-        }
-
-        if show_highlights() {
-            HighlightsDrawer {
+        {render_toc_overlay(show_toc, toc, chapter_title.clone(), contents_progress)}
+        {render_highlights_overlay(show_highlights, highlights, quote_target, note_target)}
+        {render_search_overlay(show_search, search_results)}
+        {render_bookmarks_overlay(show_bookmarks, uuid.clone(), current_cfi.clone(), chapter_title.clone())}
+        {
+            render_annotations_overlay(
+                show_annotations,
+                uuid,
+                current_cfi,
+                chapter_title,
                 highlights,
-                on_quote: move |h: Highlight| {
-                    let mut quote_target = quote_target;
-                    let mut show_highlights = show_highlights;
-                    quote_target.set(Some(h));
-                    show_highlights.set(false);
-                },
-                on_edit_note: move |h: Highlight| {
-                    let mut note_target = note_target;
-                    let mut show_highlights = show_highlights;
-                    note_target.set(Some(h));
-                    show_highlights.set(false);
-                },
-                on_close: move |_| {
-                    let mut show_highlights = show_highlights;
-                    show_highlights.set(false);
-                },
-            }
+                quote_target,
+                note_target,
+            )
         }
-
-        if show_search() {
-            SearchPanel {
-                results: search_results,
-                on_query: move |q: String| {
-                    #[cfg(any(feature = "web", feature = "mobile"))]
-                    super::reader_call_json("search", &q);
-                    let _ = &q;
-                },
-                on_navigate: move |cfi: String| {
-                    #[cfg(any(feature = "web", feature = "mobile"))]
-                    super::reader_call_json("display", &cfi);
-                    let _ = &cfi;
-                    let mut show_search = show_search;
-                    show_search.set(false);
-                },
-                on_close: move |_| {
-                    let mut show_search = show_search;
-                    show_search.set(false);
-                },
-            }
-        }
-
-        if show_bookmarks() {
-            ReaderBookmarksDrawer {
-                uuid: uuid.clone(),
-                current_cfi: current_cfi.clone(),
-                current_label: chapter_title.clone(),
-                on_navigate: move |cfi: String| {
-                    #[cfg(any(feature = "web", feature = "mobile"))]
-                    super::reader_call_json("display", &cfi);
-                    let _ = &cfi;
-                    let mut show_bookmarks = show_bookmarks;
-                    show_bookmarks.set(false);
-                },
-                on_close: move |_| {
-                    let mut show_bookmarks = show_bookmarks;
-                    show_bookmarks.set(false);
-                },
-            }
-        }
-
-        if show_annotations() {
-            AnnotationsSheet {
-                uuid: uuid.clone(),
-                current_cfi: current_cfi.clone(),
-                current_label: chapter_title.clone(),
-                highlights,
-                on_quote: move |h: Highlight| {
-                    let mut quote_target = quote_target;
-                    let mut show_annotations = show_annotations;
-                    quote_target.set(Some(h));
-                    show_annotations.set(false);
-                },
-                on_edit_note: move |h: Highlight| {
-                    let mut note_target = note_target;
-                    let mut show_annotations = show_annotations;
-                    note_target.set(Some(h));
-                    show_annotations.set(false);
-                },
-                on_navigate: move |cfi: String| {
-                    #[cfg(any(feature = "web", feature = "mobile"))]
-                    super::reader_call_json("display", &cfi);
-                    let _ = &cfi;
-                    let mut show_annotations = show_annotations;
-                    show_annotations.set(false);
-                },
-                on_close: move |_| {
-                    let mut show_annotations = show_annotations;
-                    show_annotations.set(false);
-                },
-            }
-        }
-
-        if let Some(h) = quote_target.read().clone() {
-            QuotePanel {
-                quote_text: h.text.clone().unwrap_or_default(),
-                author: book_author.clone(),
-                subtitle: book_title.clone(),
-                accent: book_accent.clone(),
-                on_close: move |_| {
-                    let mut quote_target = quote_target;
-                    quote_target.set(None);
-                },
-            }
-        }
-
-        if let Some(h) = note_target.read().clone() {
-            NoteComposer {
-                highlight: h,
-                on_saved: move |(id, note): (i64, Option<String>)| {
-                    let mut highlights = highlights;
-                    let idx = highlights.read().iter().position(|x| x.id == id);
-                    if let Some(i) = idx {
-                        highlights.write()[i].note = note;
-                    }
-                },
-                on_close: move |_| {
-                    let mut note_target = note_target;
-                    note_target.set(None);
-                },
-            }
-        }
+        {render_quote_target_overlay(quote_target, book_author, book_title, book_accent)}
+        {render_note_target_overlay(note_target, highlights)}
     }
 }

--- a/frontend/src/pages/reader/overlays.rs
+++ b/frontend/src/pages/reader/overlays.rs
@@ -139,8 +139,8 @@ fn render_toc_overlay(
     rsx! {
         TocDrawer {
             entries: toc.read().clone(),
-            current_title: chapter_title.clone(),
-            progress_label: contents_progress.clone(),
+            current_title: chapter_title,
+            progress_label: contents_progress,
             on_navigate: move |href: String| {
                 #[cfg(any(feature = "web", feature = "mobile"))]
                 super::reader_call_json("display", &href);
@@ -232,9 +232,9 @@ fn render_bookmarks_overlay(
     }
     rsx! {
         ReaderBookmarksDrawer {
-            uuid: uuid.clone(),
-            current_cfi: current_cfi.clone(),
-            current_label: chapter_title.clone(),
+            uuid,
+            current_cfi,
+            current_label: chapter_title,
             on_navigate: move |cfi: String| {
                 #[cfg(any(feature = "web", feature = "mobile"))]
                 super::reader_call_json("display", &cfi);
@@ -266,9 +266,9 @@ fn render_annotations_overlay(
     }
     rsx! {
         AnnotationsSheet {
-            uuid: uuid.clone(),
-            current_cfi: current_cfi.clone(),
-            current_label: chapter_title.clone(),
+            uuid,
+            current_cfi,
+            current_label: chapter_title,
             highlights,
             on_quote: move |h: Highlight| {
                 let mut quote_target = quote_target;
@@ -310,9 +310,9 @@ fn render_quote_target_overlay(
     rsx! {
         QuotePanel {
             quote_text: h.text.clone().unwrap_or_default(),
-            author: book_author.clone(),
-            subtitle: book_title.clone(),
-            accent: book_accent.clone(),
+            author: book_author,
+            subtitle: book_title,
+            accent: book_accent,
             on_close: move |_| {
                 let mut quote_target = quote_target;
                 quote_target.set(None);

--- a/frontend/src/pages/reader/quote_panel.rs
+++ b/frontend/src/pages/reader/quote_panel.rs
@@ -56,6 +56,162 @@ fn ink_for(hex: &str) -> &'static str {
     }
 }
 
+/// Drawer head: kicker + title + close button.
+fn render_quote_header(on_close: EventHandler<()>) -> Element {
+    rsx! {
+        div { class: "rd-drawer-head",
+            div {
+                div { class: "rd-quote-kicker", "From your highlight" }
+                h4 { class: "rd-drawer-title", "Make a quote card" }
+            }
+            button {
+                class: "rd-x",
+                r#type: "button",
+                "aria-label": "Close",
+                onclick: move |_| on_close.call(()),
+                "\u{00d7}"
+            }
+        }
+    }
+}
+
+/// The live quote-card preview, styled with the current background/ink/ratio.
+fn render_quote_preview(
+    preview_style: &str,
+    quote_text: &str,
+    author: &str,
+    subtitle: &str,
+) -> Element {
+    rsx! {
+        div { class: "rd-quote-card", style: "{preview_style}",
+            div { class: "rd-quote-card-head", "OMNIBUS \u{00b7} QUOTE" }
+            div { class: "rd-quote-card-body", "\u{201c}{quote_text}\u{201d}" }
+            div { class: "rd-quote-card-foot",
+                div { class: "rd-quote-card-author", "{author}" }
+                div { class: "rd-quote-card-sub", "{subtitle}" }
+            }
+        }
+    }
+}
+
+/// Background swatches (book accent + fixed presets + custom color picker).
+fn render_background_swatches(
+    accent: &str,
+    bg: Signal<String>,
+    ink: Signal<String>,
+    custom: Signal<String>,
+) -> Element {
+    let mut bg = bg;
+    let mut ink = ink;
+    let mut custom = custom;
+    rsx! {
+        div { class: "rd-quote-label", "Background" }
+        div { class: "rd-quote-swatches",
+            button {
+                class: "rd-quote-swatch",
+                r#type: "button",
+                style: "background:{accent};",
+                "aria-label": "Book accent",
+                onclick: {
+                    let accent = accent.to_string();
+                    move |_| {
+                        bg.set(accent.clone());
+                        ink.set("#f5f0e8".into());
+                    }
+                },
+            }
+            for p in PRESETS.iter() {
+                button {
+                    key: "{p.bg}",
+                    class: "rd-quote-swatch",
+                    r#type: "button",
+                    style: "background:{p.bg};",
+                    "aria-label": "Background {p.bg}",
+                    onclick: move |_| {
+                        bg.set(p.bg.to_string());
+                        ink.set(p.ink.to_string());
+                    },
+                }
+            }
+            label { class: "rd-quote-custom",
+                input {
+                    r#type: "color",
+                    "aria-label": "Custom background color",
+                    value: "{custom}",
+                    oninput: move |e| {
+                        let hex = e.value();
+                        custom.set(hex.clone());
+                        ink.set(ink_for(&hex).to_string());
+                        bg.set(hex);
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// Aspect-ratio chip row.
+fn render_ratio_controls(ratio: Signal<String>, cur_ratio: &str) -> Element {
+    let mut ratio = ratio;
+    rsx! {
+        div { class: "rd-quote-label", "Aspect" }
+        div { class: "rd-quote-ratios",
+            for r in RATIOS {
+                button {
+                    key: "{r}",
+                    class: if cur_ratio == r { "rd-chip on" } else { "rd-chip" },
+                    r#type: "button",
+                    onclick: move |_| ratio.set(r.to_string()),
+                    "{r}"
+                }
+            }
+        }
+    }
+}
+
+/// Export actions: download (desktop), copy/share (phone), composer (disabled).
+fn render_quote_actions(
+    download: impl FnMut(Event<MouseData>) + 'static,
+    copy_image: impl FnMut(Event<MouseData>) + 'static,
+    share: impl FnMut(Event<MouseData>) + 'static,
+) -> Element {
+    rsx! {
+        div { class: "rd-quote-actions",
+            button {
+                class: "btn primary rd-desktop-only",
+                r#type: "button",
+                "data-testid": "quote-download",
+                onclick: download,
+                "Download PNG"
+            }
+            button {
+                class: "btn rd-phone-only",
+                r#type: "button",
+                "data-testid": "quote-copy-image",
+                onclick: copy_image,
+                "Copy image"
+            }
+            // Phone primary action: the OS share sheet takes the
+            // rendered PNG (glue falls back to a download where
+            // Web Share can't carry files).
+            button {
+                class: "btn primary rd-phone-only",
+                r#type: "button",
+                "data-testid": "quote-share",
+                onclick: share,
+                "Share"
+            }
+            button {
+                class: "btn rd-desktop-only",
+                r#type: "button",
+                disabled: true,
+                title: "Journal & quote cards ship in a later phase",
+                "Open in composer \u{2192}"
+            }
+        }
+    }
+}
+
 #[component]
 pub(super) fn QuotePanel(
     quote_text: String,
@@ -64,10 +220,10 @@ pub(super) fn QuotePanel(
     accent: String,
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut bg = use_signal(|| accent.clone());
-    let mut ink = use_signal(|| "#f5f0e8".to_string());
-    let mut ratio = use_signal(|| "1:1".to_string());
-    let mut custom = use_signal(|| "#6b4f8a".to_string());
+    let bg = use_signal(|| accent.clone());
+    let ink = use_signal(|| "#f5f0e8".to_string());
+    let ratio = use_signal(|| "1:1".to_string());
+    let custom = use_signal(|| "#6b4f8a".to_string());
 
     let cur_bg = bg();
     let cur_ink = ink();
@@ -130,119 +286,13 @@ pub(super) fn QuotePanel(
         div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
         div { class: "rd-drawer rd-quote-drawer", "data-testid": "reader-quote-drawer",
             div { class: "rd-grabber" }
-            div { class: "rd-drawer-head",
-                div {
-                    div { class: "rd-quote-kicker", "From your highlight" }
-                    h4 { class: "rd-drawer-title", "Make a quote card" }
-                }
-                button {
-                    class: "rd-x",
-                    r#type: "button",
-                    "aria-label": "Close",
-                    onclick: move |_| on_close.call(()),
-                    "\u{00d7}"
-                }
-            }
+            {render_quote_header(on_close)}
             div { class: "rd-drawer-body",
-                div { class: "rd-quote-card", style: "{preview_style}",
-                    div { class: "rd-quote-card-head", "OMNIBUS \u{00b7} QUOTE" }
-                    div { class: "rd-quote-card-body", "\u{201c}{quote_text}\u{201d}" }
-                    div { class: "rd-quote-card-foot",
-                        div { class: "rd-quote-card-author", "{author}" }
-                        div { class: "rd-quote-card-sub", "{subtitle}" }
-                    }
-                }
-
+                {render_quote_preview(&preview_style, &quote_text, &author, &subtitle)}
                 div { class: "rd-quote-controls",
-                    div { class: "rd-quote-label", "Background" }
-                    div { class: "rd-quote-swatches",
-                        button {
-                            class: "rd-quote-swatch",
-                            r#type: "button",
-                            style: "background:{accent};",
-                            "aria-label": "Book accent",
-                            onclick: {
-                                let accent = accent.clone();
-                                move |_| {
-                                    bg.set(accent.clone());
-                                    ink.set("#f5f0e8".into());
-                                }
-                            },
-                        }
-                        for p in PRESETS.iter() {
-                            button {
-                                key: "{p.bg}",
-                                class: "rd-quote-swatch",
-                                r#type: "button",
-                                style: "background:{p.bg};",
-                                "aria-label": "Background {p.bg}",
-                                onclick: move |_| {
-                                    bg.set(p.bg.to_string());
-                                    ink.set(p.ink.to_string());
-                                },
-                            }
-                        }
-                        label { class: "rd-quote-custom",
-                            input {
-                                r#type: "color",
-                                "aria-label": "Custom background color",
-                                value: "{custom}",
-                                oninput: move |e| {
-                                    let hex = e.value();
-                                    custom.set(hex.clone());
-                                    ink.set(ink_for(&hex).to_string());
-                                    bg.set(hex);
-                                },
-                            }
-                        }
-                    }
-
-                    div { class: "rd-quote-label", "Aspect" }
-                    div { class: "rd-quote-ratios",
-                        for r in RATIOS {
-                            button {
-                                key: "{r}",
-                                class: if cur_ratio == r { "rd-chip on" } else { "rd-chip" },
-                                r#type: "button",
-                                onclick: move |_| ratio.set(r.to_string()),
-                                "{r}"
-                            }
-                        }
-                    }
-
-                    div { class: "rd-quote-actions",
-                        button {
-                            class: "btn primary rd-desktop-only",
-                            r#type: "button",
-                            "data-testid": "quote-download",
-                            onclick: download,
-                            "Download PNG"
-                        }
-                        button {
-                            class: "btn rd-phone-only",
-                            r#type: "button",
-                            "data-testid": "quote-copy-image",
-                            onclick: copy_image,
-                            "Copy image"
-                        }
-                        // Phone primary action: the OS share sheet takes the
-                        // rendered PNG (glue falls back to a download where
-                        // Web Share can't carry files).
-                        button {
-                            class: "btn primary rd-phone-only",
-                            r#type: "button",
-                            "data-testid": "quote-share",
-                            onclick: share,
-                            "Share"
-                        }
-                        button {
-                            class: "btn rd-desktop-only",
-                            r#type: "button",
-                            disabled: true,
-                            title: "Journal & quote cards ship in a later phase",
-                            "Open in composer \u{2192}"
-                        }
-                    }
+                    {render_background_swatches(&accent, bg, ink, custom)}
+                    {render_ratio_controls(ratio, &cur_ratio)}
+                    {render_quote_actions(download, copy_image, share)}
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Closes #1472
- Splits the five oversized Dioxus components the issue named — `QuotePanel`, `KoboDevicesCard`, `ReaderOverlays`, `AnnotationsSheet`, and `MobileLanding` — into named sub-render helper functions, following the pattern the codebase already uses for this family (#763/#1078/#1351).
- Pure extraction: no markup, class names, testids, or behavior changes. Each component's own body now sits well under the ~150-line family cap (85 / 116 / 44 / 96 / 67 lines respectively, down from 191 / 220 / 170 / 157 / 153).

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (537 passed; 0 failed)

## Notes
- No Playwright specs needed updating — no selectors, roles, or testids changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MhBULjmcF7E2Px9K2NFW8)_