### PR TITLE
feat: just recipes for omnibus-ios tests and simulator; native ios multiplexer tab

### DIFF
--- a/.claude/rules/01-dev-environment.md
+++ b/.claude/rules/01-dev-environment.md
@@ -27,7 +27,7 @@ nix develop .#audit  --command cargo deny check advisories sources bans
 nix develop .#mobile                  # interactive shell with Android NDK + iOS targets
 ```
 
-`.envrc` resolves `use flake` to `default`, so the editor stays on the slim shell at all times. `just serve` works from default because zellij + process-compose live there; each multiplexer pane internally wraps its command in the right `.#shell` (server → `.#web`, mobile → `.#mobile`, playwright → `.#e2e`), so only the panes you actually start realize their extras. `just dev-up` and `just dev-bounce` self-wrap in `.#web`, so they work straight from default too.
+`.envrc` resolves `use flake` to `default`, so the editor stays on the slim shell at all times. `just serve` works from default because zellij + process-compose live there; each multiplexer pane internally wraps its command in the right `.#shell` (server → `.#web`, android/ios-hybrid → `.#mobile`, playwright → `.#e2e`), so only the panes you actually start realize their extras — except the native `ios` pane, which runs `just ios-sim` on system xcodebuild + simctl and needs no nix shell at all. `just dev-up` and `just dev-bounce` self-wrap in `.#web`, so they work straight from default too.
 
 ## Cached dev-env for hot recipes
 

--- a/.zellij/layout.kdl
+++ b/.zellij/layout.kdl
@@ -26,6 +26,16 @@ layout {
         }
     }
     tab name="ios" {
+        // Native SwiftUI app (omnibus-ios/): boot the newest iPhone simulator,
+        // build, install, launch. System xcodebuild — no nix shell; `just`
+        // comes from the direnv slim shell this session inherits.
+        pane command="just" start_suspended=true {
+            args "ios-sim"
+        }
+    }
+    tab name="ios-hybrid" {
+        // Hybrid WebView shell (mobile/ crate) on iOS — what the maestro tab
+        // drives. The native app above is the iOS surface going forward.
         pane command="nix" start_suspended=true {
             args "develop" ".#mobile" "--command" "dx" "serve" "--platform" "ios" "--package" "omnibus-mobile"
         }
@@ -36,7 +46,8 @@ layout {
         }
     }
     tab name="maestro" {
-        // Mobile E2E suite, one run per Enter. Prereqs: the ios tab's app
+        // Mobile E2E suite, one run per Enter. Prereqs: the ios-hybrid tab's
+        // app (Maestro drives the hybrid WebView shell, not the native app)
         // installed on a booted simulator, and the server tab running —
         // OMNIBUS_PORT=3000 pins the flows at that tab's fixed port (the
         // e2e-mobile recipe would otherwise read a stale dev-up env.sh).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Do not use Chrome DevTools MCP or Claude in Chrome for routine agent verificatio
 
 Five-crate Cargo workspace: `shared/` (serde types), `db/` (data layer + indexer), `frontend/` (Dioxus UI + server functions), `server/` (fullstack binary + REST router), `mobile/` (thin native shell).
 
-Alongside it, `omnibus-ios/` is a native SwiftUI client — an Xcode project, not a Cargo crate, so no `cargo`/`just` target builds or tests it. It is the iOS surface going forward; `mobile/` remains the Android shell. It speaks the same `/api/*` REST surface.
+Alongside it, `omnibus-ios/` is a native SwiftUI client — an Xcode project, not a Cargo crate; `just ios-build` / `ios-test` / `ios-test-ui` / `ios-sim` wrap xcodebuild + simctl for it (no cargo target touches it). It is the iOS surface going forward; `mobile/` remains the Android shell. It speaks the same `/api/*` REST surface.
 
 Full crate descriptions, per-crate module maps, request flow diagrams, and mobile-auth details live in [docs/architecture.md](docs/architecture.md).
 
@@ -57,7 +57,7 @@ Operator-specific conventions (ticket prefixes, standing workspace names) live i
 ## Quick commands
 
 ```bash
-# Multiplexed dev stack (server + ios + android + playwright panes)
+# Multiplexed dev stack (server + native ios + ios-hybrid + android + playwright panes)
 just serve                                                  # Zellij
 just serve-pc                                               # process-compose
 
@@ -97,7 +97,13 @@ cd ui_tests/playwright && pnpm install                      # first time
 cd ui_tests/playwright && pnpm exec playwright test         # run all
 just lint-ts                                                # biome + typecheck (TS project)
 
-# Mobile
+# Native iOS app (omnibus-ios/; system xcodebuild + simctl, no nix shell)
+just ios-build                                              # compile check (generic simulator destination)
+just ios-test                                               # omnibusTests unit suite — same script CI runs
+just ios-test-ui                                            # omnibusUITests
+just ios-sim                                                # boot newest iPhone sim, build, install, launch
+
+# Hybrid mobile shell (mobile/ crate — Android surface; iOS build survives as ios-hybrid pane)
 cargo build -p omnibus-mobile
 xcrun simctl boot "iPhone 17" 2>/dev/null; dx serve --platform ios --package omnibus-mobile
 dx serve --platform android --package omnibus-mobile

--- a/Justfile
+++ b/Justfile
@@ -1,10 +1,12 @@
-# Launch the dev multiplexer with Zellij. Server tab auto-starts; android/ios/playwright
-# tabs are preloaded with their commands suspended — press Enter in the pane to start them.
+# Launch the dev multiplexer with Zellij. Server tab auto-starts; the
+# android/ios/ios-hybrid/playwright/maestro tabs are preloaded with their
+# commands suspended — press Enter in the pane to start them.
 serve:
     zellij --layout .zellij/layout.kdl
 
 # Launch the dev multiplexer with process-compose. Server process auto-starts;
-# android/ios/playwright are disabled by default — select one in the TUI and press F7 to start.
+# android/ios/ios-hybrid/playwright/maestro are disabled by default — select
+# one in the TUI and press F7 to start.
 serve-pc:
     process-compose up
 
@@ -171,3 +173,36 @@ ios-icon app="":
 # and installs. Pass a device name to disambiguate. See scripts/install-ios.sh.
 install-ios device="":
     nix develop .#mobile --command scripts/install-ios.sh "{{device}}"
+
+# --- Native SwiftUI app (omnibus-ios/, scheme `omnibus`). xcodebuild + simctl
+# are system Xcode, so none of these wrap in a nix shell — the opposite: the
+# `env -u LD -u CC -u CXX` prefixes strip the nix dev shell's toolchain exports
+# (direnv loads them into every interactive shell), because xcodebuild adopts
+# $LD as the linker driver and raw ld can't parse the clang-style args it then
+# receives. Derived data lives under ~/.cache/omnibus-ios-derived/<worktree> —
+# outside the repo, same philosophy as CARGO_TARGET_DIR.
+
+# Compile check against a generic simulator destination — no booted device
+# needed. Shares derived data with `ios-sim`, so a later sim run reuses it.
+ios-build:
+    env -u LD -u CC -u CXX xcodebuild build \
+        -project omnibus-ios/omnibus.xcodeproj -scheme omnibus \
+        -configuration Debug \
+        -destination 'generic/platform=iOS Simulator' \
+        -derivedDataPath "${OMNIBUS_IOS_DERIVED_DIR:-$HOME/.cache/omnibus-ios-derived/$(basename "$PWD")}"
+
+# Unit tests (omnibusTests) via scripts/ios-test.sh — the exact invocation CI
+# runs (.github/workflows/ios-tests.yml), so local and CI agree. Results land
+# as .claude/runtime/ios-tests/<suite>.xcresult.
+ios-test:
+    env -u LD -u CC -u CXX scripts/ios-test.sh unit
+
+# UI tests (omnibusUITests), same script/invocation as CI.
+ios-test-ui:
+    env -u LD -u CC -u CXX scripts/ios-test.sh ui
+
+# Boot the newest iPhone simulator, build, install, and launch the native app.
+# Prints this workspace's dev-server URL (from `just dev-up`'s env.sh) as a
+# hint for the Connect screen. See scripts/ios-sim.sh.
+ios-sim:
+    scripts/ios-sim.sh

--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -15,6 +15,23 @@ avoidance, or lock-screen audio. This app talks to the same server over the same
 
 ## Running it
 
+Quickest path, from the repo root (system xcodebuild + simctl — no nix shell):
+
+```bash
+just ios-sim       # boot the newest iPhone simulator, build, install, launch
+just ios-build     # compile check only (generic simulator destination)
+just ios-test      # omnibusTests — the same scripts/ios-test.sh invocation CI runs
+just ios-test-ui   # omnibusUITests
+```
+
+`ios-sim` builds into `~/.cache/omnibus-ios-derived/<worktree>` (build artifacts
+stay out of the tree, like `CARGO_TARGET_DIR`) and, when `just dev-up` has run,
+prints this workspace's dev-server URL to enter on the Connect screen. Pin a
+simulator with `OMNIBUS_IOS_SIM_UDID`; test results land as
+`.claude/runtime/ios-tests/<suite>.xcresult`.
+
+Or through Xcode:
+
 1. Start a server the simulator can reach, pointed at the full fixture set:
 
 ```bash

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -13,6 +13,14 @@ processes:
     disabled: true
 
   ios:
+    # Native SwiftUI app (omnibus-ios/): boot the newest iPhone simulator,
+    # build, install, launch. System xcodebuild — no nix shell.
+    command: just ios-sim
+    disabled: true
+
+  ios-hybrid:
+    # Hybrid WebView shell (mobile/ crate) on iOS — what the maestro process
+    # drives. The native `ios` process above is the iOS surface going forward.
     command: nix develop .#mobile --command dx serve --platform ios --package omnibus-mobile
     disabled: true
 
@@ -22,8 +30,9 @@ processes:
     disabled: true
 
   maestro:
-    # Mobile E2E suite, one run per F7. Prereqs: the ios process's app
-    # installed on a booted simulator, and the server process running —
+    # Mobile E2E suite, one run per F7. Prereqs: the ios-hybrid process's app
+    # (Maestro drives the hybrid WebView shell, not the native app) installed
+    # on a booted simulator, and the server process running —
     # OMNIBUS_PORT pins the flows at its fixed :3000 (the e2e-mobile recipe
     # would otherwise read a stale dev-up env.sh).
     command: just e2e-mobile

--- a/scripts/ios-sim.sh
+++ b/scripts/ios-sim.sh
@@ -23,6 +23,11 @@ unset LD CC CXX
 if [ -n "${OMNIBUS_IOS_SIM_UDID:-}" ]; then
   udid="$OMNIBUS_IOS_SIM_UDID"
 else
+  # Preflight like ios-test.sh: fail actionably instead of mid-pipeline.
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ios-sim.sh: jq is required to auto-pick a simulator (brew install jq), or set OMNIBUS_IOS_SIM_UDID" >&2
+    exit 1
+  fi
   # Newest installed iOS runtime that has an iPhone device. Duplicated from
   # scripts/ios-test.sh (which CI owns) rather than shared — keep in sync.
   # xcodebuild's destination matcher silently omits simulators whose runtime

--- a/scripts/ios-sim.sh
+++ b/scripts/ios-sim.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Boot the newest available iPhone simulator, build the native SwiftUI app
+# (omnibus-ios/, scheme `omnibus`), install it, and launch it. Backs the
+# `just ios-sim` recipe and the `ios` multiplexer pane. xcodebuild + simctl
+# are system Xcode — no nix shell involved.
+#
+# Env: OMNIBUS_IOS_SIM_UDID     pin a specific simulator instead of
+#                               auto-picking the newest iPhone runtime
+#      OMNIBUS_IOS_DERIVED_DIR  override the derived-data path (default
+#                               ~/.cache/omnibus-ios-derived/<worktree> —
+#                               outside the repo, same philosophy as
+#                               CARGO_TARGET_DIR)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+derived="${OMNIBUS_IOS_DERIVED_DIR:-$HOME/.cache/omnibus-ios-derived/$(basename "$repo_root")}"
+
+# The nix dev shell (direnv-loaded into most local shells) exports LD/CC/CXX;
+# xcodebuild adopts $LD as the linker driver and raw ld can't parse the
+# clang-style args it then receives, so strip them before any xcodebuild call.
+unset LD CC CXX
+
+if [ -n "${OMNIBUS_IOS_SIM_UDID:-}" ]; then
+  udid="$OMNIBUS_IOS_SIM_UDID"
+else
+  # Newest installed iOS runtime that has an iPhone device. Duplicated from
+  # scripts/ios-test.sh (which CI owns) rather than shared — keep in sync.
+  # xcodebuild's destination matcher silently omits simulators whose runtime
+  # is older than the project's IPHONEOS_DEPLOYMENT_TARGET, so pick a
+  # concrete UDID ourselves and fail with a message naming the real cause.
+  udid="$(xcrun simctl list --json devices available | jq -r '
+    .devices | to_entries
+    | map(select(.key | test("SimRuntime\\.iOS")))
+    | map({ver: (.key | sub(".*iOS-"; "") | gsub("-"; ".")),
+           devs: [.value[] | select(.name | startswith("iPhone"))]})
+    | map(select(.devs | length > 0))
+    | sort_by(.ver | split(".") | map(tonumber))
+    | if length == 0 then empty else last.devs[0].udid end')"
+fi
+if [ -z "$udid" ]; then
+  echo "ios-sim.sh: no available iPhone simulator; if 'xcrun simctl list devices' shows iPhones, their iOS runtime is older than the project's IPHONEOS_DEPLOYMENT_TARGET" >&2
+  exit 1
+fi
+
+# -b boots the device if it's shut down and blocks until it finishes booting;
+# on an already-booted device it returns immediately.
+xcrun simctl bootstatus "$udid" -b
+open -a Simulator
+
+# -configuration Debug pinned explicitly: the shared scheme's Run action is
+# Release, and the install step below needs a deterministic product path.
+xcodebuild build \
+  -project "$repo_root/omnibus-ios/omnibus.xcodeproj" \
+  -scheme omnibus \
+  -configuration Debug \
+  -destination "platform=iOS Simulator,id=$udid" \
+  -derivedDataPath "$derived"
+
+app="$derived/Build/Products/Debug-iphonesimulator/omnibus.app"
+if [ ! -d "$app" ]; then
+  echo "ios-sim.sh: built app not found at $app" >&2
+  exit 1
+fi
+
+# Read the bundle id off the built product rather than hardcoding it, so a
+# project-level rename can't silently break the launch step.
+bundle_id="$(/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' "$app/Info.plist")"
+
+xcrun simctl install "$udid" "$app"
+xcrun simctl launch "$udid" "$bundle_id"
+
+# The app has no baked-in server URL — hint at this workspace's dev server
+# (written by `just dev-up`) for the Connect screen.
+if [ -f "$repo_root/.claude/runtime/env.sh" ]; then
+  # shellcheck disable=SC1091
+  source "$repo_root/.claude/runtime/env.sh"
+  echo "Dev server for this workspace: http://localhost:${OMNIBUS_PORT:-3000} — enter it on the Connect screen."
+fi


### PR DESCRIPTION
## Summary
- New recipes: `just ios-build` (compile check, generic simulator destination), `just ios-test` / `just ios-test-ui` (thin wrappers over `scripts/ios-test.sh`, so local and CI run the identical invocation), and `just ios-sim` (new `scripts/ios-sim.sh`: boot newest iPhone simulator, Debug build, install, launch, print this workspace's dev-server URL as a login hint).
- The `ios` tab in `just serve` and the `ios` process in `just serve-pc` now launch the native SwiftUI app via `just ios-sim`; the hybrid `dx serve --platform ios` invocation survives as `ios-hybrid` since Maestro's mobile E2E still drives that app — prereq comments updated to match.
- Docs: CLAUDE.md quick commands + architecture wording, rule 01 multiplexer notes, `omnibus-ios/README.md`.
- The `ios-build`/`ios-test*` recipes and `ios-sim.sh` neutralize the nix shells' `LD`/`CC`/`CXX` exports, which otherwise break xcodebuild's link step from a direnv-loaded shell.

Closes #1508

## Test plan
- [x] `just ios-build` — BUILD SUCCEEDED.
- [x] `just ios-test` — 99/99 passed (verified via `xcresulttool`).
- [x] `just ios-sim` — simulator booted, app installed (`simctl listapps` shows `com.omnibus.swiftui`), launched, Connect screen screenshot-confirmed; dev-server hint printed.
- [x] `just --list` parses; `bash -n` on `ios-sim.sh`; process-compose.yaml parses (keys: server, android, ios, ios-hybrid, playwright, maestro).

## Version
- [ ] **Minor**
- [x] **Patch** — the default.
- [ ] **No release**

## Notes
`ios-sim.sh` pins `-configuration Debug` explicitly — the shared scheme's Run action is Release, so an unpinned build lands in `Release-iphonesimulator` and the install step would miss the Debug product path. Derived data goes to `~/.cache/omnibus-ios-derived/<worktree>` (per-worktree, mirroring `CARGO_TARGET_DIR`).