### PR TITLE
refactor: resolve download-validator uuids via bulk lookup (#1512)

### DIFF
--- a/db/src/books/get.rs
+++ b/db/src/books/get.rs
@@ -580,16 +580,15 @@ pub async fn download_validators(
     use std::collections::HashMap;
 
     // uuid → books.id, merged-uuid aware so an attached format still
-    // resolves (migration 0016).
-    let mut ids: HashMap<&str, i64> = HashMap::new();
-    for query in queries {
-        if ids.contains_key(query.book_uuid.as_str()) {
-            continue;
-        }
-        if let Some(id) = crate::resolve_book_id_by_uuid(pool, &query.book_uuid).await? {
-            ids.insert(query.book_uuid.as_str(), id);
-        }
-    }
+    // resolves (migration 0016). Resolved in one bulk pass over the distinct
+    // uuid set rather than looping the single-uuid lookup (#1512).
+    let distinct_uuids: Vec<String> = {
+        let mut v: Vec<String> = queries.iter().map(|q| q.book_uuid.clone()).collect();
+        v.sort_unstable();
+        v.dedup();
+        v
+    };
+    let ids: HashMap<String, i64> = resolve_book_ids_bulk(pool, &distinct_uuids).await?;
 
     // One pass over every candidate row, chunked under SQLite's 999-param cap.
     let distinct: Vec<i64> = {


### PR DESCRIPTION
## Summary
- Closes #1512
- `download_validators` (`db/src/books/get.rs`) resolved each distinct book uuid with a separate `resolve_book_id_by_uuid` call in a loop, even though the bulk counterpart `resolve_book_ids_bulk` (defined ~380 lines above in the same file) already does the same merged-uuid-aware uuid→id resolution in chunked bulk queries.
- Replaced the per-uuid loop with a single `resolve_book_ids_bulk` call over the deduplicated uuid set. `ids` is now `HashMap<String, i64>` (owned keys) instead of `HashMap<&str, i64>` (borrowed) — downstream lookups (`ids.get(query.book_uuid.as_str())`) are unaffected since `String: Borrow<str>` makes the existing `&str` lookup key still work as-is.
- No new `sqlx::query` call sites introduced; purely reuses the existing bulk helper. Non-behavior-changing refactor — all existing `download_validators` tests (merged-uuid resolution, missing uuid, mixed formats, batch ordering) pass unchanged.

## Test plan
- [x] `cargo fmt` — PASS (no changes needed beyond the edit)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1512 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (clean, no warnings)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1512 cargo test -p omnibus-db` — PASS for all `download_validators` tests (5/5) and 1513/1514 total; 1 pre-existing, unrelated failure: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails in this environment because the `just fixtures` audio test fixture isn't present (this sandbox has no `nix`/`just` to fetch it) — unrelated to `db/src/books/get.rs` and not touched by this change.

<!--
Generally, patch versions are sufficient. Minor versions should only be used in
one of the following different cases:
1. There was a change that will not allow older versions of the mobile app to 
work with the new server version.
2. There was a fairly large UX change (i.e. a roadmap feature was complete).
3. There was a large architectural shift introduced in the PR.
-->

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Pre-existing, unrelated test failure observed in this sandbox: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails because the audio test fixture isn't present (no `nix`/`just` available to run `just fixtures` here). Not caused by, or related to, this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeD9AEWg7ptJesSu1CmLqs)_