### PR TITLE
test: add coverage for shelf create/edit modal and rail components (#1486)

### DIFF
--- a/frontend/src/components/create_shelf_modal.rs
+++ b/frontend/src/components/create_shelf_modal.rs
@@ -15,6 +15,9 @@ use crate::components::shelf_rule_builder::{RuleBuilder, RuleDraft};
 use crate::components::LibraryPickerGrid;
 use crate::{data, use_server_url};
 
+#[cfg(test)]
+mod tests;
+
 /// Create-shelf modal. Emits the created shelf via `on_created`.
 #[component]
 pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<Shelf>) -> Element {
@@ -248,95 +251,5 @@ fn PickerBody(picked: Signal<Vec<String>>, server_url: String) -> Element {
             }
             LibraryPickerGrid { books: filtered, server_url: server_url.clone(), picked }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use omnibus_shared::{RuleField, RuleOp};
-
-    use super::*;
-
-    /// A single complete Tag-is-Fantasy draft, the minimal input
-    /// `build_create_request`'s Smart branch needs to emit a rule.
-    fn complete_draft() -> RuleDraft {
-        RuleDraft {
-            field: RuleField::Tag,
-            op: RuleOp::Is,
-            value: "Fantasy".into(),
-            value2: String::new(),
-            unit: "d".into(),
-        }
-    }
-
-    #[test]
-    fn build_create_request_encodes_smart_kind_with_rules_and_no_book_uuids() {
-        let req = build_create_request(
-            ShelfKind::Smart,
-            "Cosy Reads".into(),
-            Visibility::Private,
-            MatchMode::All,
-            &[complete_draft()],
-            &["some-uuid".to_string()],
-        );
-        assert_eq!(req.kind, ShelfKind::Smart);
-        assert_eq!(req.match_mode, Some(MatchMode::All));
-        assert_eq!(
-            req.rules,
-            vec![ShelfRule {
-                field: RuleField::Tag,
-                op: RuleOp::Is,
-                value: "Fantasy".into(),
-            }]
-        );
-        // Smart shelves never carry a picked book list, even if one is passed in.
-        assert!(req.book_uuids.is_empty());
-    }
-
-    #[test]
-    fn build_create_request_encodes_manual_kind_with_picked_books_and_no_rules() {
-        let picked = vec!["uuid-1".to_string(), "uuid-2".to_string()];
-        let req = build_create_request(
-            ShelfKind::Manual,
-            "Hand-picked".into(),
-            Visibility::Public,
-            MatchMode::All,
-            &[complete_draft()],
-            &picked,
-        );
-        assert_eq!(req.kind, ShelfKind::Manual);
-        assert_eq!(req.match_mode, None);
-        assert!(req.rules.is_empty());
-        assert_eq!(req.book_uuids, picked);
-    }
-
-    #[test]
-    fn build_create_request_folds_wishlist_kind_into_manual() {
-        // The kind toggle only offers Smart/Manual, but the request builder is
-        // also defensive against a Wishlist value reaching it.
-        let req = build_create_request(
-            ShelfKind::Wishlist,
-            "Wishlist".into(),
-            Visibility::Private,
-            MatchMode::All,
-            &[],
-            &[],
-        );
-        assert_eq!(req.kind, ShelfKind::Manual);
-    }
-
-    #[test]
-    fn create_label_is_plain_for_smart_shelves() {
-        assert_eq!(create_label(ShelfKind::Smart, 4), "Create");
-    }
-
-    #[test]
-    fn create_label_shows_picked_count_for_manual_shelves() {
-        assert_eq!(create_label(ShelfKind::Manual, 3), "Create \u{b7} 3");
-    }
-
-    #[test]
-    fn create_label_shows_picked_count_for_wishlist_kind_too() {
-        assert_eq!(create_label(ShelfKind::Wishlist, 0), "Create \u{b7} 0");
     }
 }

--- a/frontend/src/components/create_shelf_modal.rs
+++ b/frontend/src/components/create_shelf_modal.rs
@@ -37,32 +37,14 @@ pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<She
         if saving() {
             return;
         }
-        let req = match kind() {
-            ShelfKind::Smart => {
-                let wire: Vec<ShelfRule> =
-                    rules.read().iter().filter_map(RuleDraft::to_rule).collect();
-                CreateShelfRequest {
-                    kind: ShelfKind::Smart,
-                    name: name(),
-                    description: None,
-                    visibility: visibility(),
-                    match_mode: Some(match_mode()),
-                    rules: wire,
-                    book_uuids: Vec::new(),
-                }
-            }
-            // The modal's toggle only offers Smart/Manual — Wishlist is a
-            // system shelf, never user-created — so it falls in with Manual.
-            ShelfKind::Manual | ShelfKind::Wishlist => CreateShelfRequest {
-                kind: ShelfKind::Manual,
-                name: name(),
-                description: None,
-                visibility: visibility(),
-                match_mode: None,
-                rules: Vec::new(),
-                book_uuids: picked.read().clone(),
-            },
-        };
+        let req = build_create_request(
+            kind(),
+            name(),
+            visibility(),
+            match_mode(),
+            &rules.read(),
+            &picked.read(),
+        );
         let url = submit_url.clone();
         let on_created = on_created;
         saving.set(true);
@@ -77,11 +59,7 @@ pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<She
     };
 
     let picked_count = picked.read().len();
-    let create_label = match kind() {
-        ShelfKind::Smart => "Create".to_string(),
-        // Wishlist can't be reached by the toggle; grouped with Manual.
-        ShelfKind::Manual | ShelfKind::Wishlist => format!("Create \u{b7} {picked_count}"),
-    };
+    let create_label = create_label(kind(), picked_count);
 
     rsx! {
         div {
@@ -168,6 +146,53 @@ pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<She
     }
 }
 
+/// Build the create-shelf request for the current form state. Smart shelves
+/// carry the encoded rule set and no book list; Manual — and Wishlist, which
+/// the kind toggle can never reach since it's system-provisioned — carry the
+/// picked book list and no rules.
+fn build_create_request(
+    kind: ShelfKind,
+    name: String,
+    visibility: Visibility,
+    match_mode: MatchMode,
+    rules: &[RuleDraft],
+    picked: &[String],
+) -> CreateShelfRequest {
+    match kind {
+        ShelfKind::Smart => {
+            let wire: Vec<ShelfRule> = rules.iter().filter_map(RuleDraft::to_rule).collect();
+            CreateShelfRequest {
+                kind: ShelfKind::Smart,
+                name,
+                description: None,
+                visibility,
+                match_mode: Some(match_mode),
+                rules: wire,
+                book_uuids: Vec::new(),
+            }
+        }
+        ShelfKind::Manual | ShelfKind::Wishlist => CreateShelfRequest {
+            kind: ShelfKind::Manual,
+            name,
+            description: None,
+            visibility,
+            match_mode: None,
+            rules: Vec::new(),
+            book_uuids: picked.to_vec(),
+        },
+    }
+}
+
+/// Submit-button label: plain for a smart shelf, a running picked-count for a
+/// hand-picked one.
+fn create_label(kind: ShelfKind, picked_count: usize) -> String {
+    match kind {
+        ShelfKind::Smart => "Create".to_string(),
+        // Wishlist can't be reached by the toggle; grouped with Manual.
+        ShelfKind::Manual | ShelfKind::Wishlist => format!("Create \u{b7} {picked_count}"),
+    }
+}
+
 /// Private/Public segmented control shared by the create- and edit-shelf
 /// modal headers.
 #[component]
@@ -223,5 +248,95 @@ fn PickerBody(picked: Signal<Vec<String>>, server_url: String) -> Element {
             }
             LibraryPickerGrid { books: filtered, server_url: server_url.clone(), picked }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use omnibus_shared::{RuleField, RuleOp};
+
+    use super::*;
+
+    /// A single complete Tag-is-Fantasy draft, the minimal input
+    /// `build_create_request`'s Smart branch needs to emit a rule.
+    fn complete_draft() -> RuleDraft {
+        RuleDraft {
+            field: RuleField::Tag,
+            op: RuleOp::Is,
+            value: "Fantasy".into(),
+            value2: String::new(),
+            unit: "d".into(),
+        }
+    }
+
+    #[test]
+    fn build_create_request_encodes_smart_kind_with_rules_and_no_book_uuids() {
+        let req = build_create_request(
+            ShelfKind::Smart,
+            "Cosy Reads".into(),
+            Visibility::Private,
+            MatchMode::All,
+            &[complete_draft()],
+            &["some-uuid".to_string()],
+        );
+        assert_eq!(req.kind, ShelfKind::Smart);
+        assert_eq!(req.match_mode, Some(MatchMode::All));
+        assert_eq!(
+            req.rules,
+            vec![ShelfRule {
+                field: RuleField::Tag,
+                op: RuleOp::Is,
+                value: "Fantasy".into(),
+            }]
+        );
+        // Smart shelves never carry a picked book list, even if one is passed in.
+        assert!(req.book_uuids.is_empty());
+    }
+
+    #[test]
+    fn build_create_request_encodes_manual_kind_with_picked_books_and_no_rules() {
+        let picked = vec!["uuid-1".to_string(), "uuid-2".to_string()];
+        let req = build_create_request(
+            ShelfKind::Manual,
+            "Hand-picked".into(),
+            Visibility::Public,
+            MatchMode::All,
+            &[complete_draft()],
+            &picked,
+        );
+        assert_eq!(req.kind, ShelfKind::Manual);
+        assert_eq!(req.match_mode, None);
+        assert!(req.rules.is_empty());
+        assert_eq!(req.book_uuids, picked);
+    }
+
+    #[test]
+    fn build_create_request_folds_wishlist_kind_into_manual() {
+        // The kind toggle only offers Smart/Manual, but the request builder is
+        // also defensive against a Wishlist value reaching it.
+        let req = build_create_request(
+            ShelfKind::Wishlist,
+            "Wishlist".into(),
+            Visibility::Private,
+            MatchMode::All,
+            &[],
+            &[],
+        );
+        assert_eq!(req.kind, ShelfKind::Manual);
+    }
+
+    #[test]
+    fn create_label_is_plain_for_smart_shelves() {
+        assert_eq!(create_label(ShelfKind::Smart, 4), "Create");
+    }
+
+    #[test]
+    fn create_label_shows_picked_count_for_manual_shelves() {
+        assert_eq!(create_label(ShelfKind::Manual, 3), "Create \u{b7} 3");
+    }
+
+    #[test]
+    fn create_label_shows_picked_count_for_wishlist_kind_too() {
+        assert_eq!(create_label(ShelfKind::Wishlist, 0), "Create \u{b7} 0");
     }
 }

--- a/frontend/src/components/create_shelf_modal/tests.rs
+++ b/frontend/src/components/create_shelf_modal/tests.rs
@@ -1,0 +1,90 @@
+//! Coverage for `create_shelf_modal`'s pure request-construction helpers:
+//! `build_create_request`'s Smart vs Manual/Wishlist kind-branch, and
+//! `create_label`'s formatting.
+
+use omnibus_shared::{RuleField, RuleOp};
+
+use super::*;
+
+/// A single complete Tag-is-Fantasy draft, the minimal input
+/// `build_create_request`'s Smart branch needs to emit a rule.
+fn complete_draft() -> RuleDraft {
+    RuleDraft {
+        field: RuleField::Tag,
+        op: RuleOp::Is,
+        value: "Fantasy".into(),
+        value2: String::new(),
+        unit: "d".into(),
+    }
+}
+
+#[test]
+fn build_create_request_encodes_smart_kind_with_rules_and_no_book_uuids() {
+    let req = build_create_request(
+        ShelfKind::Smart,
+        "Cosy Reads".into(),
+        Visibility::Private,
+        MatchMode::All,
+        &[complete_draft()],
+        &["some-uuid".to_string()],
+    );
+    assert_eq!(req.kind, ShelfKind::Smart);
+    assert_eq!(req.match_mode, Some(MatchMode::All));
+    assert_eq!(
+        req.rules,
+        vec![ShelfRule {
+            field: RuleField::Tag,
+            op: RuleOp::Is,
+            value: "Fantasy".into(),
+        }]
+    );
+    // Smart shelves never carry a picked book list, even if one is passed in.
+    assert!(req.book_uuids.is_empty());
+}
+
+#[test]
+fn build_create_request_encodes_manual_kind_with_picked_books_and_no_rules() {
+    let picked = vec!["uuid-1".to_string(), "uuid-2".to_string()];
+    let req = build_create_request(
+        ShelfKind::Manual,
+        "Hand-picked".into(),
+        Visibility::Public,
+        MatchMode::All,
+        &[complete_draft()],
+        &picked,
+    );
+    assert_eq!(req.kind, ShelfKind::Manual);
+    assert_eq!(req.match_mode, None);
+    assert!(req.rules.is_empty());
+    assert_eq!(req.book_uuids, picked);
+}
+
+#[test]
+fn build_create_request_folds_wishlist_kind_into_manual() {
+    // The kind toggle only offers Smart/Manual, but the request builder is
+    // also defensive against a Wishlist value reaching it.
+    let req = build_create_request(
+        ShelfKind::Wishlist,
+        "Wishlist".into(),
+        Visibility::Private,
+        MatchMode::All,
+        &[],
+        &[],
+    );
+    assert_eq!(req.kind, ShelfKind::Manual);
+}
+
+#[test]
+fn create_label_is_plain_for_smart_shelves() {
+    assert_eq!(create_label(ShelfKind::Smart, 4), "Create");
+}
+
+#[test]
+fn create_label_shows_picked_count_for_manual_shelves() {
+    assert_eq!(create_label(ShelfKind::Manual, 3), "Create \u{b7} 3");
+}
+
+#[test]
+fn create_label_shows_picked_count_for_wishlist_kind_too() {
+    assert_eq!(create_label(ShelfKind::Wishlist, 0), "Create \u{b7} 0");
+}

--- a/frontend/src/components/edit_shelf_modal.rs
+++ b/frontend/src/components/edit_shelf_modal.rs
@@ -5,7 +5,7 @@
 //! pencil, the web `ShelfHeader` pencil, and the mobile shelf-detail menu.
 
 use dioxus::prelude::*;
-use omnibus_shared::{MatchMode, Shelf, ShelfKind, ShelfRule, UpdateShelfRequest};
+use omnibus_shared::{MatchMode, Shelf, ShelfKind, ShelfRule, UpdateShelfRequest, Visibility};
 
 use crate::components::create_shelf_modal::VisibilityToggle;
 use crate::components::shelf_rule_builder::{RuleBuilder, RuleDraft};
@@ -56,28 +56,22 @@ pub fn EditShelfModal(
         if saving() {
             return;
         }
-        let trimmed = name().trim().to_string();
-        if trimmed.is_empty() {
-            error.set(Some("Name is required.".into()));
-            return;
-        }
-        let mut req = UpdateShelfRequest {
-            name: Some(trimmed),
-            visibility: Some(visibility()),
-            ..Default::default()
-        };
-        if show_kobo {
-            req.sync_to_kobo = Some(sync_to_kobo());
-        }
-        if is_smart {
-            let wire: Vec<ShelfRule> = rules.read().iter().filter_map(RuleDraft::to_rule).collect();
-            if wire.is_empty() {
-                error.set(Some("Add at least one condition.".into()));
+        let req = build_update_request(
+            &name(),
+            visibility(),
+            show_kobo,
+            sync_to_kobo(),
+            is_smart,
+            match_mode(),
+            &rules.read(),
+        );
+        let req = match req {
+            Ok(req) => req,
+            Err(msg) => {
+                error.set(Some(msg));
                 return;
             }
-            req.match_mode = Some(match_mode());
-            req.rules = Some(wire);
-        }
+        };
         let url = submit_url.clone();
         let on_saved = on_saved;
         saving.set(true);
@@ -176,4 +170,40 @@ pub fn EditShelfModal(
             }
         }
     }
+}
+
+/// Validate the current form state and build the save request, or return the
+/// message the modal renders inline. Two branches reject before any network
+/// call: an empty (post-trim) name, and — for a smart shelf only — an empty
+/// encoded rule set.
+fn build_update_request(
+    name: &str,
+    visibility: Visibility,
+    show_kobo: bool,
+    sync_to_kobo: bool,
+    is_smart: bool,
+    match_mode: MatchMode,
+    rules: &[RuleDraft],
+) -> Result<UpdateShelfRequest, String> {
+    let trimmed = name.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("Name is required.".into());
+    }
+    let mut req = UpdateShelfRequest {
+        name: Some(trimmed),
+        visibility: Some(visibility),
+        ..Default::default()
+    };
+    if show_kobo {
+        req.sync_to_kobo = Some(sync_to_kobo);
+    }
+    if is_smart {
+        let wire: Vec<ShelfRule> = rules.iter().filter_map(RuleDraft::to_rule).collect();
+        if wire.is_empty() {
+            return Err("Add at least one condition.".into());
+        }
+        req.match_mode = Some(match_mode);
+        req.rules = Some(wire);
+    }
+    Ok(req)
 }

--- a/frontend/src/components/edit_shelf_modal/tests.rs
+++ b/frontend/src/components/edit_shelf_modal/tests.rs
@@ -1,8 +1,9 @@
-//! SSR render-smoke coverage for the edit-shelf modal: the Kobo sync opt-in
-//! toggle renders for owner-editable shelves (prefilled from the shelf), and
-//! never for system shelves. Needs the `server` feature (`dioxus::ssr`).
+//! Coverage for the edit-shelf modal: SSR render-smoke of the Kobo sync
+//! opt-in toggle (prefilled from the shelf, never shown for system shelves),
+//! plus `build_update_request`'s save-validation branches. Needs the
+//! `server` feature (`dioxus::ssr`).
 
-use omnibus_shared::Visibility;
+use omnibus_shared::{RuleField, RuleOp, ShelfRule, Visibility};
 
 use super::*;
 use crate::test_support::render;
@@ -68,4 +69,90 @@ fn edit_shelf_modal_hides_the_kobo_toggle_for_system_shelves() {
     let html = render(rsx! { Harness { kind: ShelfKind::Wishlist, sync_to_kobo: false } });
     assert!(!html.contains("Sync to Kobo"));
     assert!(!html.contains("edit-shelf-kobo-on"));
+}
+
+/// A single complete Tag-is-Fantasy draft — the minimal input a smart shelf
+/// needs to encode a non-empty rule set.
+fn complete_draft() -> RuleDraft {
+    RuleDraft {
+        field: RuleField::Tag,
+        op: RuleOp::Is,
+        value: "Fantasy".into(),
+        value2: String::new(),
+        unit: "d".into(),
+    }
+}
+
+#[test]
+fn build_update_request_rejects_an_empty_name_before_any_other_check() {
+    let err = build_update_request(
+        "   ",
+        Visibility::Private,
+        true,
+        false,
+        true,
+        MatchMode::All,
+        &[complete_draft()],
+    )
+    .unwrap_err();
+    assert_eq!(err, "Name is required.");
+}
+
+#[test]
+fn build_update_request_rejects_a_smart_shelf_with_no_complete_rules() {
+    // An incomplete draft (empty value) encodes to no wire rule at all.
+    let incomplete = RuleDraft::default();
+    let err = build_update_request(
+        "Cosy Reads",
+        Visibility::Private,
+        true,
+        false,
+        true,
+        MatchMode::All,
+        &[incomplete],
+    )
+    .unwrap_err();
+    assert_eq!(err, "Add at least one condition.");
+}
+
+#[test]
+fn build_update_request_accepts_a_manual_shelf_with_no_rules() {
+    // Manual shelves skip the rule-set check entirely (`is_smart == false`).
+    let req = build_update_request(
+        "Cosy Reads",
+        Visibility::Public,
+        true,
+        true,
+        false,
+        MatchMode::All,
+        &[],
+    )
+    .expect("manual shelves don't need any rules");
+    assert_eq!(req.name, Some("Cosy Reads".to_string()));
+    assert_eq!(req.visibility, Some(Visibility::Public));
+    assert_eq!(req.sync_to_kobo, Some(true));
+    assert_eq!(req.rules, None);
+}
+
+#[test]
+fn build_update_request_accepts_a_smart_shelf_with_a_complete_rule() {
+    let req = build_update_request(
+        "Cosy Reads",
+        Visibility::Private,
+        true,
+        false,
+        true,
+        MatchMode::Any,
+        &[complete_draft()],
+    )
+    .expect("a complete draft encodes a rule");
+    assert_eq!(req.match_mode, Some(MatchMode::Any));
+    assert_eq!(
+        req.rules,
+        Some(vec![ShelfRule {
+            field: RuleField::Tag,
+            op: RuleOp::Is,
+            value: "Fantasy".into(),
+        }])
+    );
 }

--- a/frontend/src/components/shelves_rail.rs
+++ b/frontend/src/components/shelves_rail.rs
@@ -11,6 +11,9 @@ use omnibus_shared::{ShelfKind, ShelfSummary, Visibility};
 use crate::components::CreateShelfModal;
 use crate::{data, use_server_url, Route};
 
+#[cfg(test)]
+mod tests;
+
 /// Which rail row is currently active — drives the highlight.
 #[derive(Clone, Copy, PartialEq)]
 pub enum RailActive {
@@ -98,17 +101,14 @@ pub fn ShelvesRail(active: RailActive) -> Element {
 /// count, visibility icon.
 fn render_shelf_row(s: &ShelfSummary, active: RailActive, viewer_id: Option<i64>) -> Element {
     let id = s.id;
-    let is_active = matches!(active, RailActive::Shelf(other) if other == id);
+    let is_active = is_row_active(active, id);
     let class = if is_active {
         "shelf-row shelf-row--active"
     } else {
         "shelf-row"
     };
     let accent = s.accent.clone().unwrap_or_else(|| "var(--accent)".into());
-    // Attribute a shelf that isn't the viewer's (only once the viewer is known);
-    // a wishlist's name already opens with the owner, so the chip would repeat it.
-    let not_mine =
-        viewer_id.is_some_and(|vid| vid != s.owner_user_id) && s.kind != ShelfKind::Wishlist;
+    let not_mine = shows_owner_attribution(viewer_id, s.owner_user_id, s.kind);
 
     rsx! {
         Link {
@@ -143,6 +143,19 @@ fn render_shelf_row(s: &ShelfSummary, active: RailActive, viewer_id: Option<i64>
             }
         }
     }
+}
+
+/// `true` when `id` is the rail's currently active shelf row.
+fn is_row_active(active: RailActive, id: i64) -> bool {
+    matches!(active, RailActive::Shelf(other) if other == id)
+}
+
+/// `true` when a row should show "by <owner>" attribution: the shelf isn't
+/// the viewer's own (only once the viewer is known — `None` withholds
+/// attribution rather than guessing), and it isn't the Wishlist, whose name
+/// already opens with the owner so the chip would repeat it.
+fn shows_owner_attribution(viewer_id: Option<i64>, owner_user_id: i64, kind: ShelfKind) -> bool {
+    viewer_id.is_some_and(|vid| vid != owner_user_id) && kind != ShelfKind::Wishlist
 }
 
 /// Stack-of-books glyph for the "All books" row.

--- a/frontend/src/components/shelves_rail/tests.rs
+++ b/frontend/src/components/shelves_rail/tests.rs
@@ -1,0 +1,47 @@
+//! Coverage for `render_shelf_row`'s owner-attribution and active-row
+//! branching, exercised via the pure helpers it delegates to
+//! (`shows_owner_attribution`, `is_row_active`) rather than a full render:
+//! `render_shelf_row` mounts a router `Link`, which needs a live Dioxus
+//! runtime + router context that a bare SSR string render doesn't provide.
+
+use omnibus_shared::ShelfKind;
+
+use super::*;
+
+#[test]
+fn shows_owner_attribution_is_false_for_the_viewers_own_shelf() {
+    assert!(!shows_owner_attribution(Some(1), 1, ShelfKind::Manual));
+}
+
+#[test]
+fn shows_owner_attribution_is_true_for_a_shelf_the_viewer_does_not_own() {
+    assert!(shows_owner_attribution(Some(1), 2, ShelfKind::Manual));
+}
+
+#[test]
+fn shows_owner_attribution_is_false_for_a_wishlist_even_when_not_owned() {
+    // A wishlist's name already opens with the owner, so the chip would repeat it.
+    assert!(!shows_owner_attribution(Some(1), 2, ShelfKind::Wishlist));
+}
+
+#[test]
+fn shows_owner_attribution_is_false_while_the_viewer_is_still_unknown() {
+    // `viewer_id` is `None` until the boot effect resolves (SSR + first
+    // paint); attribution must not show up before we know who's looking.
+    assert!(!shows_owner_attribution(None, 2, ShelfKind::Manual));
+}
+
+#[test]
+fn is_row_active_is_true_when_the_active_shelf_matches_this_row() {
+    assert!(is_row_active(RailActive::Shelf(7), 7));
+}
+
+#[test]
+fn is_row_active_is_false_for_a_different_shelf_id() {
+    assert!(!is_row_active(RailActive::Shelf(99), 7));
+}
+
+#[test]
+fn is_row_active_is_false_when_the_all_books_row_is_active() {
+    assert!(!is_row_active(RailActive::All, 7));
+}


### PR DESCRIPTION
## Summary
- Closes #1486
- `create_shelf_modal.rs` had no tests for the Smart vs Manual/Wishlist request-construction branch or `create_label` formatting. Extracted both into pure helpers (`build_create_request`, `create_label`) and added one test per shelf-kind branch plus label-formatting tests.
- `edit_shelf_modal.rs` had no tests for the save-validation branches (empty name, empty rule set). Extracted the validation + request-building logic into a pure `build_update_request` helper and added a test per distinct error message, plus happy-path tests for manual and smart shelves.
- `shelves_rail.rs` had no tests for `render_shelf_row`'s owner-attribution / active-row branching. That logic lived inline inside an `rsx!` body that also mounts a router `Link` — rendering it directly needs a live Dioxus runtime + router context that a bare SSR string render doesn't provide, so per the issue's suggested fallback I extracted the two branch conditions into pure helpers (`shows_owner_attribution`, `is_row_active`) and test those directly, mirroring the `shelf_facets.rs` / `shelf_rule_builder.rs` pattern already used elsewhere in this feature.
- Coverage-only change — no production behavior differs; the extracted helpers are called with the exact same inputs the old inline code used.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1486 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (no warnings)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1486 cargo test -p omnibus-frontend --features server` — PASS (554 passed; 0 failed)

## Version
- [x] **Patch** — the default; leaving unlabeled (test-only change, no behavior difference).

## Notes
- Pure code motion only, following the pattern the issue itself points at (`shelf_facets.rs`/`shelf_rule_builder.rs`): test the extracted helper functions directly rather than rendering full component trees.
- No unrelated pre-existing failures encountered; the full `omnibus-frontend --features server` suite is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeD9AEWg7ptJesSu1CmLqs)_