### PR TITLE
fix: chunk download-validator sweeps above the 500-entry server limit (#1503)

### DIFF
--- a/frontend/src/offline/downloads.rs
+++ b/frontend/src/offline/downloads.rs
@@ -731,8 +731,8 @@ fn last_stale_check() -> &'static std::sync::atomic::AtomicI64 {
     &AT
 }
 
-/// Refresh the "Update available" flags for every completed download in
-/// **one** request.
+/// Refresh the "Update available" flags for every completed download, in as
+/// few requests as the server's per-request cap allows.
 ///
 /// Driven by the online background tick, so the Downloads list learns about
 /// a replaced file without the reader opening each book. Two properties are
@@ -759,13 +759,36 @@ pub(super) async fn refresh_stale_flags(server_url: &str) {
         last_stale_check().store(now, Ordering::Relaxed);
         return;
     }
-    let Ok(answers) = crate::data::download_validators(server_url, &queries).await else {
-        // Leave the timestamp alone so the next tick retries rather than
-        // waiting out a TTL on a request that never landed.
-        return;
-    };
-    last_stale_check().store(now, Ordering::Relaxed);
-    apply_validators(&answers);
+    if sweep_validators(server_url, &queries).await {
+        last_stale_check().store(now, Ordering::Relaxed);
+    }
+    // A chunk that failed leaves the timestamp alone so the next tick
+    // retries the whole sweep, rather than waiting out a TTL on a sweep
+    // that never finished.
+}
+
+/// Ask about every completed download in chunks of at most
+/// `MAX_VALIDATOR_QUERY` — the server rejects a single request over that
+/// size with `422` (`post_download_validators`), and a device can easily
+/// hold more downloads than that cap.
+///
+/// Each chunk's answers are applied as soon as they arrive rather than
+/// buffered for one final apply, so a later chunk failing still leaves the
+/// earlier chunks' flags updated. Returns whether every chunk succeeded;
+/// [`refresh_stale_flags`] only advances the TTL timestamp on a full `true`,
+/// so a partial sweep is retried in full on the next tick rather than being
+/// recorded as done.
+async fn sweep_validators(
+    server_url: &str,
+    queries: &[omnibus_shared::DownloadValidatorQuery],
+) -> bool {
+    for chunk in queries.chunks(omnibus_shared::MAX_VALIDATOR_QUERY) {
+        let Ok(answers) = crate::data::download_validators(server_url, chunk).await else {
+            return false;
+        };
+        apply_validators(&answers);
+    }
+    true
 }
 
 /// One query per completed download, naming the file it actually came from.

--- a/frontend/src/offline/downloads/engine/tests.rs
+++ b/frontend/src/offline/downloads/engine/tests.rs
@@ -6,7 +6,7 @@ use axum::response::IntoResponse;
 
 use super::*;
 use crate::data::DataError;
-use crate::offline::test_support::{connect_refused_error, decode_error};
+use crate::offline::test_support::{connect_refused_error, decode_error, spawn_router};
 
 #[test]
 fn friendly_maps_offline_to_the_offline_message() {
@@ -123,17 +123,6 @@ async fn download_file_ignoring_etag(
     on_delta: &mut (dyn FnMut(i64) + Send),
 ) -> anyhow::Result<Fetched> {
     download_file(base, dir, file, &mut |_| {}, on_delta).await
-}
-
-async fn spawn_router(app: axum::Router) -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().expect("addr").port();
-    tokio::spawn(async move {
-        let _ = axum::serve(listener, app).await;
-    });
-    format!("http://127.0.0.1:{port}")
 }
 
 #[tokio::test]

--- a/frontend/src/offline/downloads/tests.rs
+++ b/frontend/src/offline/downloads/tests.rs
@@ -1,8 +1,18 @@
 //! Unit tests for the download registry, plan builders, and AC4 isolation.
 
+// Held across awaits in the `refresh_stale_flags` tests to serialize their
+// use of the process-global `last_stale_check` timestamp; safe since each
+// test owns its own thread + runtime.
+#![allow(clippy::await_holding_lock)]
+
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+
+use axum::response::IntoResponse;
 use omnibus_shared::{BookFileInfo, EbookMetadata, ManifestPart};
 
 use super::*;
+use crate::offline::test_support::spawn_router;
 
 fn bf(id: i64, format: &str, ordinal: i64, size_bytes: i64) -> BookFileInfo {
     BookFileInfo {
@@ -686,5 +696,250 @@ fn completed_validator_queries_names_the_file_each_download_came_from() {
         mine.file_id,
         Some(9),
         "asking about the default row would report a two-edition book stale when it isn't"
+    );
+}
+
+// ── Chunked validator sweeps (#1503) ────────────────────────────────────
+//
+// The server caps one `POST /api/downloads/validators` request at
+// `MAX_VALIDATOR_QUERY` (422 above it). A device with more completed
+// downloads than that must split the sweep into multiple requests, none
+// over the cap, and must not record the sweep as done unless every chunk
+// answered.
+
+fn validator_query(uuid: &str) -> omnibus_shared::DownloadValidatorQuery {
+    omnibus_shared::DownloadValidatorQuery {
+        book_uuid: uuid.into(),
+        format: omnibus_shared::DownloadFormat::Epub,
+        file_id: None,
+    }
+}
+
+/// A `/validators` mock that records each request's file count and answers
+/// every query "can't tell" (`etag: None`) — enough for tests that only care
+/// how the client splits the batch, not the answer content.
+async fn spawn_counting_validator_server() -> (String, Arc<Mutex<Vec<usize>>>) {
+    let sizes: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+    let recorded = sizes.clone();
+    let app = axum::Router::new().route(
+        "/api/downloads/validators",
+        axum::routing::post(
+            move |axum::Json(req): axum::Json<omnibus_shared::DownloadValidatorRequest>| {
+                let recorded = recorded.clone();
+                async move {
+                    recorded.lock().expect("lock").push(req.files.len());
+                    axum::Json(omnibus_shared::DownloadValidatorResponse { files: vec![] })
+                }
+            },
+        ),
+    );
+    let base = spawn_router(app).await;
+    (base, sizes)
+}
+
+#[tokio::test]
+async fn sweep_validators_sends_exactly_one_request_for_the_500_entry_limit() {
+    let (base, sizes) = spawn_counting_validator_server().await;
+    let queries: Vec<_> = (0..omnibus_shared::MAX_VALIDATOR_QUERY)
+        .map(|i| validator_query(&format!("u-cap-{i}")))
+        .collect();
+
+    let ok = sweep_validators(&base, &queries).await;
+
+    assert!(ok, "a batch at the cap must succeed");
+    assert_eq!(
+        sizes.lock().expect("lock").clone(),
+        vec![omnibus_shared::MAX_VALIDATOR_QUERY],
+        "exactly 500 entries must fit in one request"
+    );
+}
+
+#[tokio::test]
+async fn sweep_validators_splits_501_entries_into_two_requests_neither_over_the_limit() {
+    let (base, sizes) = spawn_counting_validator_server().await;
+    let queries: Vec<_> = (0..omnibus_shared::MAX_VALIDATOR_QUERY + 1)
+        .map(|i| validator_query(&format!("u-over-{i}")))
+        .collect();
+
+    let ok = sweep_validators(&base, &queries).await;
+
+    assert!(ok);
+    let sent = sizes.lock().expect("lock").clone();
+    assert_eq!(sent.len(), 2, "501 entries must take two requests");
+    assert!(
+        sent.iter()
+            .all(|&n| n <= omnibus_shared::MAX_VALIDATOR_QUERY),
+        "neither request may exceed the server's cap: {sent:?}"
+    );
+    assert_eq!(sent, vec![omnibus_shared::MAX_VALIDATOR_QUERY, 1]);
+}
+
+#[tokio::test]
+async fn sweep_validators_applies_answers_from_every_chunk() {
+    let first_uuid = "u-multi-chunk-first";
+    let second_uuid = "u-multi-chunk-second";
+    seed_complete_download(first_uuid, DlFormat::Epub, Some("\"old-first\""));
+    seed_complete_download(second_uuid, DlFormat::Epub, Some("\"old-second\""));
+
+    // `first_uuid` lands in the first chunk, `second_uuid` in the second —
+    // one query per remaining slot in between keeps the boundary exact.
+    let mut queries = vec![validator_query(first_uuid)];
+    queries.extend(
+        (1..omnibus_shared::MAX_VALIDATOR_QUERY).map(|i| validator_query(&format!("u-fill-{i}"))),
+    );
+    queries.push(validator_query(second_uuid));
+
+    let app = axum::Router::new().route(
+        "/api/downloads/validators",
+        axum::routing::post(
+            |axum::Json(req): axum::Json<omnibus_shared::DownloadValidatorRequest>| async move {
+                let files = req
+                    .files
+                    .iter()
+                    .map(|q| omnibus_shared::DownloadValidator {
+                        book_uuid: q.book_uuid.clone(),
+                        format: q.format,
+                        file_id: q.file_id,
+                        etag: match q.book_uuid.as_str() {
+                            "u-multi-chunk-first" => Some("\"new-first\"".into()),
+                            "u-multi-chunk-second" => Some("\"new-second\"".into()),
+                            _ => None,
+                        },
+                    })
+                    .collect();
+                axum::Json(omnibus_shared::DownloadValidatorResponse { files })
+            },
+        ),
+    );
+    let base = spawn_router(app).await;
+
+    let ok = sweep_validators(&base, &queries).await;
+
+    assert!(ok);
+    assert!(
+        is_marked_stale(first_uuid, DlFormat::Epub),
+        "the first chunk's answer must be applied"
+    );
+    assert!(
+        is_marked_stale(second_uuid, DlFormat::Epub),
+        "the second chunk's answer must be applied too"
+    );
+}
+
+#[tokio::test]
+async fn sweep_validators_returns_false_when_a_chunk_fails_but_keeps_earlier_answers() {
+    let first_uuid = "u-chunk-fail-first";
+    seed_complete_download(first_uuid, DlFormat::Epub, Some("\"old\""));
+
+    // The first request (containing `first_uuid`) succeeds; the second
+    // (the lone entry pushed past the cap) fails every time.
+    let mut queries = vec![validator_query(first_uuid)];
+    queries.extend(
+        (1..omnibus_shared::MAX_VALIDATOR_QUERY)
+            .map(|i| validator_query(&format!("u-fail-fill-{i}"))),
+    );
+    queries.push(validator_query("u-chunk-fail-second"));
+
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let counted = calls.clone();
+    let app = axum::Router::new().route(
+        "/api/downloads/validators",
+        axum::routing::post(
+            move |axum::Json(req): axum::Json<omnibus_shared::DownloadValidatorRequest>| {
+                let counted = counted.clone();
+                async move {
+                    let call = counted.fetch_add(1, Ordering::SeqCst);
+                    if call == 0 {
+                        let files = req
+                            .files
+                            .iter()
+                            .map(|q| omnibus_shared::DownloadValidator {
+                                book_uuid: q.book_uuid.clone(),
+                                format: q.format,
+                                file_id: q.file_id,
+                                etag: if q.book_uuid == "u-chunk-fail-first" {
+                                    Some("\"new\"".into())
+                                } else {
+                                    None
+                                },
+                            })
+                            .collect();
+                        axum::Json(omnibus_shared::DownloadValidatorResponse { files })
+                            .into_response()
+                    } else {
+                        (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response()
+                    }
+                }
+            },
+        ),
+    );
+    let base = spawn_router(app).await;
+
+    let ok = sweep_validators(&base, &queries).await;
+
+    assert!(
+        !ok,
+        "a failed chunk must not report the sweep as successful"
+    );
+    assert!(
+        is_marked_stale(first_uuid, DlFormat::Epub),
+        "the chunk that succeeded before the failure must still be applied"
+    );
+}
+
+#[tokio::test]
+async fn refresh_stale_flags_leaves_the_timestamp_alone_when_the_sweep_fails() {
+    // `last_stale_check` is a single process-wide static; serialize with the
+    // other test that touches it so the two can't race each other's resets.
+    let _guard = crate::offline::sync::test_state_lock().lock().unwrap();
+    last_stale_check().store(0, Ordering::Relaxed);
+    seed_complete_download("u-refresh-fail", DlFormat::Epub, Some("\"old\""));
+
+    let app = axum::Router::new().route(
+        "/api/downloads/validators",
+        axum::routing::post(|| async { (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom") }),
+    );
+    let base = spawn_router(app).await;
+
+    refresh_stale_flags(&base).await;
+
+    assert_eq!(
+        last_stale_check().load(Ordering::Relaxed),
+        0,
+        "a failed sweep must not be recorded as done, so the next tick retries in full"
+    );
+}
+
+#[tokio::test]
+async fn refresh_stale_flags_advances_the_timestamp_after_a_successful_sweep() {
+    let _guard = crate::offline::sync::test_state_lock().lock().unwrap();
+    last_stale_check().store(0, Ordering::Relaxed);
+    seed_complete_download("u-refresh-ok", DlFormat::Epub, Some("\"old\""));
+
+    let app = axum::Router::new().route(
+        "/api/downloads/validators",
+        axum::routing::post(
+            |axum::Json(req): axum::Json<omnibus_shared::DownloadValidatorRequest>| async move {
+                let files = req
+                    .files
+                    .into_iter()
+                    .map(|q| omnibus_shared::DownloadValidator {
+                        book_uuid: q.book_uuid,
+                        format: q.format,
+                        file_id: q.file_id,
+                        etag: None,
+                    })
+                    .collect();
+                axum::Json(omnibus_shared::DownloadValidatorResponse { files })
+            },
+        ),
+    );
+    let base = spawn_router(app).await;
+
+    refresh_stale_flags(&base).await;
+
+    assert!(
+        last_stale_check().load(Ordering::Relaxed) > 0,
+        "a fully successful sweep must advance the TTL timestamp"
     );
 }

--- a/frontend/src/offline/test_support.rs
+++ b/frontend/src/offline/test_support.rs
@@ -23,9 +23,9 @@ pub(crate) async fn connect_refused_error() -> DataError {
 pub(crate) async fn decode_error() -> DataError {
     use axum::routing::get;
     let app = axum::Router::new().route("/j", get(|| async { "not-json" }));
-    let port = spawn_router(app).await;
+    let base_url = spawn_router(app).await;
     let err = crate::data::http_client()
-        .get(format!("{port}/j"))
+        .get(format!("{base_url}/j"))
         .send()
         .await
         .expect("send")

--- a/frontend/src/offline/test_support.rs
+++ b/frontend/src/offline/test_support.rs
@@ -23,15 +23,9 @@ pub(crate) async fn connect_refused_error() -> DataError {
 pub(crate) async fn decode_error() -> DataError {
     use axum::routing::get;
     let app = axum::Router::new().route("/j", get(|| async { "not-json" }));
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().expect("addr").port();
-    tokio::spawn(async move {
-        let _ = axum::serve(listener, app).await;
-    });
+    let port = spawn_router(app).await;
     let err = crate::data::http_client()
-        .get(format!("http://127.0.0.1:{port}/j"))
+        .get(format!("{port}/j"))
         .send()
         .await
         .expect("send")
@@ -39,6 +33,20 @@ pub(crate) async fn decode_error() -> DataError {
         .await
         .expect_err("decode must fail");
     DataError::from(err)
+}
+
+/// Serve `app` on a loopback port and return its base URL. Shared by every
+/// test in the `offline` tree that needs a real socket to drive a `reqwest`
+/// call against — download resume, decode errors, batched validator sweeps.
+pub(crate) async fn spawn_router(app: axum::Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://127.0.0.1:{port}")
 }
 
 /// A structurally valid ZIP holding one stored (uncompressed) entry with a


### PR DESCRIPTION
## Summary
- PR #1496 replaced the per-download metadata polling loop with a batched `POST /api/downloads/validators` request, but the client sent every completed download-format entry in a single request. The server caps a request at `MAX_VALIDATOR_QUERY` (500, in `shared/src/ebook/validator.rs`), so a device with more than 500 completed downloads got a `422` on every attempt.
- Because the failed request never advanced `last_stale_check`, that device retried the same oversized request on every 60-second background tick and staleness flags never updated.
- `completed_validator_queries`/`refresh_stale_flags` in `frontend/src/offline/downloads.rs` now split the sweep into chunks of at most `MAX_VALIDATOR_QUERY` via a new `sweep_validators` helper, applying each chunk's answers as they arrive. The TTL timestamp is only advanced once every chunk succeeds, so a partial failure is retried in full on the next tick rather than being recorded as done. No metadata is fetched and no cache rows are written, matching the existing "asking about many files is one request" constraint in `.claude/rules/09-content-validators.md`.
- Also hoisted a duplicated `spawn_router` axum test helper (used to mock the validator endpoint) into the shared `frontend/src/offline/test_support.rs`, and updated `frontend/src/offline/downloads/engine/tests.rs` to reuse it instead of keeping its own copy.
- Closes #1503

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1503 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1503 cargo clippy -p omnibus-frontend --all-targets --features mobile -- -D warnings` — PASS (the changed `offline` module only compiles under the `mobile` feature, so this is the feature set that actually lints/tests this change; `server` alone would silently skip it)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1503 cargo test -p omnibus-frontend --features server` — PASS (537 passed; 0 failed)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1503 cargo test -p omnibus-frontend --features mobile` — 607 passed, 2 failed. The 2 failures (`offline::media::tests::img_serves_the_cached_copy_then_replaces_it_when_the_cover_changed`, `offline::media::tests::img_keeps_the_cached_copy_when_the_server_answers_not_modified`) are **pre-existing and unrelated**: they reproduce identically on a clean `main` checkout (verified via `git stash`) with no files from this PR touched, and appear to be timing-sensitive (`eventually(...)` polling) under parallel test execution — the exact failure count varies between runs (2 or 3) even on unmodified `main`.
- New tests added in `frontend/src/offline/downloads/tests.rs` cover the acceptance criteria directly: exactly 500 entries → one request, 501 entries → two requests neither exceeding the cap, results applied from every chunk (including right at the chunk boundary), a failed chunk returning `false` while keeping earlier chunks' answers applied, and `refresh_stale_flags` correctly leaving/advancing the TTL timestamp on failure/success.

## Version
- [ ] **Minor**
- [ ] **Patch**
- [ ] **No release**

## Notes
- The two `offline::media::tests` failures under `--features mobile` are pre-existing/flaky and not caused by this change (see Test plan above) — flagging for visibility, not asking for a separate fix here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeD9AEWg7ptJesSu1CmLqs)_