### PR TITLE
refactor: hoist duplicated interop helpers into shared modules (#1471)

### DIFF
--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -8,6 +8,7 @@
 use dioxus::prelude::*;
 
 use super::suggestion_dropdown::{compute_suggestions, DropdownSelectionState, SuggestionDropdown};
+use crate::focus_after_paint::focus_after_paint;
 
 /// Per-instance handle to the editor's own root DOM node, captured on mount
 /// so a later blur can check whether focus is still somewhere inside this
@@ -557,10 +558,10 @@ fn ChipInput(props: ChipInputProps) -> Element {
             // with. Deferred to the next frame: calling `.focus()`
             // synchronously inside `onmounted` lands before layout
             // finishes and no-ops (same pattern as
-            // `search_palette::focus_palette_input`).
+            // `search_palette::focus_after_paint`).
             onmounted: move |evt: Event<MountedData>| {
                 if autofocus {
-                    focus_chip_input(evt);
+                    focus_after_paint(&evt);
                 }
             },
             onfocus: move |_| on_focus.call(()),
@@ -570,32 +571,6 @@ fn ChipInput(props: ChipInputProps) -> Element {
         }
     }
 }
-
-#[cfg(feature = "web")]
-fn focus_chip_input(evt: Event<MountedData>) {
-    use dioxus::web::WebEventExt;
-    use wasm_bindgen::prelude::*;
-
-    let Some(element) = evt.try_as_web_event() else {
-        return;
-    };
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let cb = Closure::once_into_js(move || {
-        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
-            let _ = html_el.focus();
-        }
-    });
-    let _ = window.request_animation_frame(cb.unchecked_ref());
-}
-
-/// Non-web stub: SSR never paints an interactive input and mobile's touch
-/// keyboard doesn't need the same rAF-deferred focus nudge. Defined so the
-/// `onmounted` handler can call `focus_chip_input` unconditionally (rule
-/// 07: hydration parity — keep cfg gates out of rsx bodies).
-#[cfg(not(feature = "web"))]
-fn focus_chip_input(_evt: Event<MountedData>) {}
 
 /// Rendered chip row — one chip per value with an avatar (optional) and
 /// remove button. Fires `on_remove` with the new full list after each removal.

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -558,7 +558,7 @@ fn ChipInput(props: ChipInputProps) -> Element {
             // with. Deferred to the next frame: calling `.focus()`
             // synchronously inside `onmounted` lands before layout
             // finishes and no-ops (same pattern as
-            // `search_palette::focus_after_paint`).
+            // `crate::focus_after_paint::focus_after_paint`).
             onmounted: move |evt: Event<MountedData>| {
                 if autofocus {
                     focus_after_paint(&evt);

--- a/frontend/src/components/format_switcher/kindle.rs
+++ b/frontend/src/components/format_switcher/kindle.rs
@@ -10,7 +10,7 @@ use omnibus_shared::KindleSendStatus;
 // Only the non-mobile `SendToKindleButton`/`poll_send_result` await the shared
 // sleeper; the mobile action is a disabled placeholder, so gate to match.
 #[cfg(not(feature = "mobile"))]
-use super::async_sleep_ms;
+use crate::platform_sleep::async_sleep_ms;
 
 /// "Send to Kindle" CTA. Web/SSR renders the interactive
 /// [`SendToKindleButton`]; when the EPUB is over Kindle's email cap

--- a/frontend/src/components/format_switcher/kobo.rs
+++ b/frontend/src/components/format_switcher/kobo.rs
@@ -7,7 +7,7 @@ use dioxus::prelude::*;
 // Only the non-mobile `SendToKoboButton` awaits the shared sleeper; the mobile
 // action is a disabled placeholder, so gate the import to match.
 #[cfg(not(feature = "mobile"))]
-use super::async_sleep_ms;
+use crate::platform_sleep::async_sleep_ms;
 
 /// "Send to Kobo" CTA. Web/SSR renders the interactive
 /// [`SendToKoboButton`]; mobile renders a disabled placeholder (the copy-over-

--- a/frontend/src/components/format_switcher/mod.rs
+++ b/frontend/src/components/format_switcher/mod.rs
@@ -241,23 +241,6 @@ fn read_book_action(_uuid: &str) -> Element {
     }
 }
 
-// ── Platform-gated poll sleeper ──────────────────────────────────
-//
-// Mirrors `worker_status`'s helper: web uses `gloo_timers`; the SSR/server
-// build (where the click handler never actually runs — it only needs to
-// compile) falls back to `tokio::time::sleep`. Shared by the Kobo + Kindle
-// send buttons in the sibling submodules.
-
-#[cfg(all(not(feature = "mobile"), feature = "web"))]
-pub(super) async fn async_sleep_ms(ms: u32) {
-    gloo_timers::future::TimeoutFuture::new(ms).await;
-}
-
-#[cfg(all(not(feature = "mobile"), not(feature = "web"), feature = "server"))]
-pub(super) async fn async_sleep_ms(ms: u32) {
-    tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
-}
-
 /// "Listen" CTA for the book-level row.
 #[cfg(not(feature = "mobile"))]
 fn listen_book_action(uuid: &str) -> Element {

--- a/frontend/src/components/merge_dialog.rs
+++ b/frontend/src/components/merge_dialog.rs
@@ -10,6 +10,7 @@ use omnibus_shared::{EbookMetadata, MergeBooksResult};
 
 use crate::components::atrium::Cover;
 use crate::components::ConfirmModal;
+use crate::platform_sleep::async_sleep_ms;
 use crate::{data, use_server_url};
 
 /// Search-and-select signals shared across the dialog's search and
@@ -290,18 +291,6 @@ fn render_search_pane(
             }
         }
     }
-}
-
-// Debounce sleep, platform-gated like search_palette/overlay.rs: the
-// dialog compiles for web (WASM) and server (SSR) targets.
-#[cfg(feature = "web")]
-async fn async_sleep_ms(ms: u32) {
-    gloo_timers::future::TimeoutFuture::new(ms).await;
-}
-
-#[cfg(all(not(feature = "web"), feature = "server"))]
-async fn async_sleep_ms(ms: u32) {
-    tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
 }
 
 /// Pinned "this is the keeper" context shown above the search field: the

--- a/frontend/src/components/search_palette/overlay.rs
+++ b/frontend/src/components/search_palette/overlay.rs
@@ -1,7 +1,7 @@
 //! The floating palette panel itself: dark scrim, centered panel with
 //! autofocused input, meta line, grouped result list, and a footer with
-//! keyboard hints. Owns the debounced FTS5 search task (cancel-on-keystroke)
-//! plus the platform-gated async-sleep + input-focus glue it needs.
+//! keyboard hints. Owns the debounced FTS5 search task (cancel-on-keystroke),
+//! using the shared `platform_sleep`/`focus_after_paint` interop helpers.
 
 use dioxus::core::Task;
 use dioxus::prelude::*;
@@ -12,6 +12,8 @@ use super::keyboard::{make_keydown_handler, KeyboardContext};
 use super::model::{build_flat_items, plural};
 use super::results::SpResultsList;
 use super::PaletteOpen;
+use crate::focus_after_paint::focus_after_paint;
+use crate::platform_sleep::async_sleep_ms;
 use crate::{data, use_server_url};
 
 /// Floating overlay: dark scrim + centered panel with input, results, footer.
@@ -200,7 +202,7 @@ fn SpInputRow(query: Signal<String>, is_loading: bool, on_input: EventHandler<St
                 // appears (this is the timing reason prior
                 // attempts with `set_focus(true)`/`spawn` failed).
                 onmounted: move |evt: MountedEvent| {
-                    focus_palette_input(&evt);
+                    focus_after_paint(&evt);
                 },
                 value: "{query}",
                 oninput: move |evt| on_input.call(evt.value()),
@@ -229,56 +231,4 @@ fn SpFooter() -> Element {
             }
         }
     }
-}
-
-// ── Async sleep (platform-gated) ─────────────────────────────────
-
-/// Platform-gated async sleep. Web uses `gloo_timers`, server uses `tokio`.
-#[cfg(feature = "web")]
-async fn async_sleep_ms(ms: u32) {
-    gloo_timers::future::TimeoutFuture::new(ms).await;
-}
-
-#[cfg(all(not(feature = "web"), feature = "server"))]
-async fn async_sleep_ms(ms: u32) {
-    tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
-}
-
-// ── Autofocus on overlay mount (platform-gated) ──────────────────
-
-/// Focus the palette input after the browser has painted it.
-///
-/// Replaces a prior `document::eval` + raw JS `requestAnimationFrame` +
-/// `querySelector` workaround with a fully typed `web_sys` path.
-///
-/// The `requestAnimationFrame` indirection is still required. Calling
-/// `.focus()` synchronously inside `onmounted` (or from a `spawn`ed
-/// future) lands before the element is laid out, so the caret never
-/// appears. Scheduling the focus for the next frame matches what the
-/// old eval block did and lets the browser finish layout first.
-#[cfg(feature = "web")]
-fn focus_palette_input(evt: &MountedEvent) {
-    use dioxus::web::WebEventExt;
-    use wasm_bindgen::prelude::*;
-
-    let Some(element) = evt.try_as_web_event() else {
-        return;
-    };
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    // `Closure::once_into_js` hands the callback to JS and frees the Rust
-    // closure (and the captured `element`) after the browser fires it once,
-    // so repeatedly opening/closing the palette doesn't accumulate leaks.
-    let cb = Closure::once_into_js(move || {
-        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
-            let _ = html_el.focus();
-        }
-    });
-    let _ = window.request_animation_frame(cb.unchecked_ref());
-}
-
-#[cfg(not(feature = "web"))]
-fn focus_palette_input(_evt: &MountedEvent) {
-    // No-op on SSR / native: the overlay only opens via web interaction.
 }

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -9,6 +9,7 @@ use omnibus_shared::{ProgressFormat, ResumePoint, UserSummary};
 
 use crate::components::atrium::{persist_theme, Cover, Theme};
 use crate::components::glyphs::{book_glyph, play_glyph};
+use crate::focus_after_paint::focus_after_paint;
 use crate::{use_current_user, Route};
 
 /// Derive 1–2 character avatar initials from a username. Empty input falls
@@ -145,10 +146,10 @@ fn UserMenuPanel(user: UserSummary, open: Signal<bool>) -> Element {
                 // browser has finished layout before `.focus()` lands.
                 //
                 // Hydration parity (rule 07): closure body stays identical
-                // across SSR/WASM; `focus_user_menu_panel` has a non-web
-                // no-op stub so the gate lives at the function definition,
-                // not inside the rsx-attached handler.
-                focus_user_menu_panel(&evt);
+                // across SSR/WASM; `focus_after_paint` has a non-web no-op
+                // stub so the gate lives at the function definition, not
+                // inside the rsx-attached handler.
+                focus_after_paint(&evt);
             },
 
             UmHeader { user }
@@ -461,38 +462,6 @@ fn UmVersion() -> Element {
         }
     }
 }
-
-/// Focus the user-menu panel after the browser has painted it so the
-/// `onkeydown` handler attached to it actually receives ESC. Same
-/// requestAnimationFrame timing pattern as
-/// `search_palette::focus_palette_input`: calling `.focus()` synchronously
-/// inside `onmounted` lands before layout completes and the focus call
-/// no-ops.
-#[cfg(feature = "web")]
-fn focus_user_menu_panel(evt: &MountedEvent) {
-    use dioxus::web::WebEventExt;
-    use wasm_bindgen::prelude::*;
-
-    let Some(element) = evt.try_as_web_event() else {
-        return;
-    };
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let cb = Closure::once_into_js(move || {
-        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
-            let _ = html_el.focus();
-        }
-    });
-    let _ = window.request_animation_frame(cb.unchecked_ref());
-}
-
-/// Non-web stub: SSR never paints the panel and native shells don't
-/// drive the user menu, so there is nothing to focus. Defined so the
-/// `onmounted` handler can call `focus_user_menu_panel` unconditionally
-/// (rule 07: hydration parity — keep cfg gates out of rsx bodies).
-#[cfg(not(feature = "web"))]
-fn focus_user_menu_panel(_evt: &MountedEvent) {}
 
 #[cfg(test)]
 mod tests {

--- a/frontend/src/components/worker_status.rs
+++ b/frontend/src/components/worker_status.rs
@@ -9,6 +9,7 @@
 use dioxus::prelude::*;
 use omnibus_shared::{GhostFilesWarning, ProgressState, TaskKind, TaskProgress, WorkerStatus};
 
+use crate::platform_sleep::async_sleep_ms;
 use crate::{data, use_server_url};
 
 /// Polling cadence in milliseconds. Always 1 s while the component is
@@ -289,24 +290,6 @@ fn ghost_warning_message(warning: &GhostFilesWarning) -> String {
         "{removed} of {total} books lost their files in this scan — \
          check that your library path is mounted."
     )
-}
-
-// ── Platform-gated 1 Hz poll sleeper ─────────────────────────────
-//
-// Web compiles with `gloo_timers` (already a dep under the `web` feature).
-// The server build runs SSR — server functions execute on the server side
-// of the component graph but `use_future` only runs on the client during
-// hydration, so the server-only branch isn't actually exercised. Keep a
-// `tokio::time::sleep` fallback so non-`web` server compilation succeeds.
-
-#[cfg(feature = "web")]
-async fn async_sleep_ms(ms: u32) {
-    gloo_timers::future::TimeoutFuture::new(ms).await;
-}
-
-#[cfg(all(not(feature = "web"), feature = "server"))]
-async fn async_sleep_ms(ms: u32) {
-    tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
 }
 
 #[cfg(test)]

--- a/frontend/src/focus_after_paint.rs
+++ b/frontend/src/focus_after_paint.rs
@@ -1,9 +1,6 @@
 //! Shared "focus this panel after paint" helper, used by every dismissible
 //! overlay/menu whose `onmounted` handler needs the mounted element to hold
 //! focus (so `onkeydown` picks up ESC without a prior click).
-//!
-//! Replaces a prior `document::eval` + raw JS `requestAnimationFrame` +
-//! `querySelector` workaround with a fully typed `web_sys` path.
 
 use dioxus::prelude::*;
 

--- a/frontend/src/focus_after_paint.rs
+++ b/frontend/src/focus_after_paint.rs
@@ -1,0 +1,45 @@
+//! Shared "focus this panel after paint" helper, used by every dismissible
+//! overlay/menu whose `onmounted` handler needs the mounted element to hold
+//! focus (so `onkeydown` picks up ESC without a prior click).
+//!
+//! Replaces a prior `document::eval` + raw JS `requestAnimationFrame` +
+//! `querySelector` workaround with a fully typed `web_sys` path.
+
+use dioxus::prelude::*;
+
+/// Focus the mounted element on the next animation frame.
+///
+/// The `requestAnimationFrame` hop is required: calling `.focus()`
+/// synchronously inside `onmounted` (or from a `spawn`ed future) lands
+/// before the element is laid out, so the caret/focus ring never appears.
+/// Scheduling the focus for the next frame lets the browser finish layout
+/// first.
+#[cfg(feature = "web")]
+pub fn focus_after_paint(evt: &MountedEvent) {
+    use dioxus::web::WebEventExt;
+    use wasm_bindgen::prelude::*;
+
+    let Some(element) = evt.try_as_web_event() else {
+        return;
+    };
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    // `Closure::once_into_js` hands the callback to JS and frees the Rust
+    // closure (and the captured `element`) after the browser fires it once,
+    // so repeatedly mounting/unmounting the panel doesn't accumulate leaks.
+    let cb = Closure::once_into_js(move || {
+        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
+            let _ = html_el.focus();
+        }
+    });
+    let _ = window.request_animation_frame(cb.unchecked_ref());
+}
+
+/// Non-web stub: SSR never paints the panel and native shells don't drive
+/// these overlays through a browser focus ring, so there is nothing to
+/// focus. Defined so an `onmounted` handler can call `focus_after_paint`
+/// unconditionally (rule 07: hydration parity — keep cfg gates out of rsx
+/// bodies).
+#[cfg(not(feature = "web"))]
+pub fn focus_after_paint(_evt: &MountedEvent) {}

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -12,6 +12,7 @@ pub mod client_store;
 pub mod components;
 pub mod contexts;
 pub mod data;
+pub mod focus_after_paint;
 pub mod format;
 pub mod index_prefs;
 pub mod js_interop;
@@ -20,6 +21,7 @@ pub(crate) mod native_share;
 #[cfg(feature = "mobile")]
 pub mod offline;
 pub mod pages;
+pub mod platform_sleep;
 pub mod reader_progress;
 pub mod routes;
 pub mod rpc;
@@ -31,6 +33,7 @@ pub mod shelf_selection;
 // too — otherwise the wasm `web --all-targets` lint would compile it and fail.
 #[cfg(all(any(test, feature = "test-support"), feature = "server"))]
 pub mod test_support;
+pub mod time;
 pub mod version;
 pub mod view_prefs;
 

--- a/frontend/src/pages/book_detail/export_menu.rs
+++ b/frontend/src/pages/book_detail/export_menu.rs
@@ -7,6 +7,7 @@ use dioxus::prelude::*;
 use omnibus_shared::{kindle_email_oversize, KINDLE_WEB_UPLOAD_URL};
 
 use crate::components::{SendToKindleButton, SendToKoboButton};
+use crate::focus_after_paint::focus_after_paint;
 
 /// The "Export" trigger + dropdown panel. Renders the download links for
 /// whichever formats the book has, the interactive Send-to-Kindle button,
@@ -79,7 +80,7 @@ fn BdExportPanel(
             "data-testid": "hero-export-panel",
             tabindex: "-1",
             onkeydown: on_keydown,
-            onmounted: move |evt: MountedEvent| focus_export_panel(&evt),
+            onmounted: move |evt: MountedEvent| focus_after_paint(&evt),
 
             if has_ebook {
                 // Plain anchor (not a router Link) so the browser performs a
@@ -172,30 +173,3 @@ fn KindleOversizeItem(open: Signal<bool>) -> Element {
         }
     }
 }
-
-/// Focus the panel after paint so its `onkeydown` receives ESC — same
-/// requestAnimationFrame timing as the user-menu panel. Web-only; SSR
-/// never paints the panel, so the gate lives at the fn definition to keep
-/// the `onmounted` handler body identical across targets (rule 07).
-#[cfg(feature = "web")]
-fn focus_export_panel(evt: &MountedEvent) {
-    use dioxus::web::WebEventExt;
-    use wasm_bindgen::prelude::*;
-
-    let Some(element) = evt.try_as_web_event() else {
-        return;
-    };
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let cb = Closure::once_into_js(move || {
-        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
-            let _ = html_el.focus();
-        }
-    });
-    let _ = window.request_animation_frame(cb.unchecked_ref());
-}
-
-/// Non-web stub (SSR): nothing to focus before hydration.
-#[cfg(not(feature = "web"))]
-fn focus_export_panel(_evt: &MountedEvent) {}

--- a/frontend/src/pages/book_detail/file_picker.rs
+++ b/frontend/src/pages/book_detail/file_picker.rs
@@ -8,6 +8,8 @@ use dioxus::prelude::*;
 use dioxus_router::Link;
 use omnibus_shared::BookFileInfo;
 
+use crate::focus_after_paint::focus_after_paint;
+
 /// Which action the picker's rows perform — drives the route prefix, the
 /// dialog's accessible label, and the stable testids.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -154,7 +156,7 @@ fn BdFilePickerPanel(
             "data-testid": "{testid}-panel",
             tabindex: "-1",
             onkeydown: on_keydown,
-            onmounted: move |evt: MountedEvent| focus_file_picker_panel(&evt),
+            onmounted: move |evt: MountedEvent| focus_after_paint(&evt),
 
             div {
                 class: "label bd-file-picker-heading",
@@ -187,35 +189,6 @@ fn BdFilePickerPanel(
         }
     }
 }
-
-/// Focus the panel after paint so its `onkeydown` receives ESC — same
-/// requestAnimationFrame timing as `export_menu::focus_export_panel` and
-/// `user_menu::focus_user_menu_panel`.
-#[cfg(feature = "web")]
-fn focus_file_picker_panel(evt: &MountedEvent) {
-    use dioxus::web::WebEventExt;
-    use wasm_bindgen::prelude::*;
-
-    let Some(element) = evt.try_as_web_event() else {
-        return;
-    };
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let cb = Closure::once_into_js(move || {
-        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
-            let _ = html_el.focus();
-        }
-    });
-    let _ = window.request_animation_frame(cb.unchecked_ref());
-}
-
-/// Non-web stub: SSR never paints the panel, and the mobile native shell has
-/// no `web_sys` to focus through, so there is nothing to focus. Defined so
-/// the `onmounted` handler can call `focus_file_picker_panel` unconditionally
-/// (rule 07: hydration parity — keep cfg gates out of rsx bodies).
-#[cfg(not(feature = "web"))]
-fn focus_file_picker_panel(_evt: &MountedEvent) {}
 
 #[cfg(test)]
 mod tests {

--- a/frontend/src/pages/book_detail/journal/composer.rs
+++ b/frontend/src/pages/book_detail/journal/composer.rs
@@ -8,6 +8,7 @@ use omnibus_shared::{CreateJournalEntry, Highlight, JournalStatus, UpdateJournal
 
 use crate::data;
 use crate::pages::book_detail::journal_editor::*;
+use crate::platform_sleep::async_sleep_ms;
 
 /// Draft-composer signals owned by [`BdJournalComposer`] and threaded into
 /// its footer. Grouped so the composer sub-components stay under the prop cap.
@@ -597,17 +598,4 @@ fn BdJournalComposerFoot(
             }
         }
     }
-}
-
-// Platform-gated async sleep for the autosave debounce + indicator ticker:
-// web uses `gloo_timers`; mobile and the SSR/server build use `tokio::time`
-// (mirrors `search_palette::overlay`).
-#[cfg(feature = "web")]
-async fn async_sleep_ms(ms: u32) {
-    gloo_timers::future::TimeoutFuture::new(ms).await;
-}
-
-#[cfg(not(feature = "web"))]
-async fn async_sleep_ms(ms: u32) {
-    tokio::time::sleep(std::time::Duration::from_millis(u64::from(ms))).await;
 }

--- a/frontend/src/pages/book_detail/physical.rs
+++ b/frontend/src/pages/book_detail/physical.rs
@@ -8,6 +8,7 @@ use dioxus::prelude::*;
 use omnibus_shared::physical::{PhysicalCopy, WishlistEntry, WishlistSource};
 
 use crate::components::{confirm_modal_body, ConfirmModal, ConfirmModalAction, ConfirmModalTone};
+use crate::time::now_unix;
 use crate::{data, use_server_url};
 
 use super::BdSectionHead;
@@ -652,23 +653,6 @@ fn encode_query(s: &str) -> String {
         }
     }
     out
-}
-
-/// Current unix seconds. Only ever called client-side (labels render after the
-/// post-mount load), so SSR never invokes the JS clock. Mirrors
-/// `rating::now_unix`.
-fn now_unix() -> i64 {
-    #[cfg(feature = "web")]
-    {
-        (js_sys::Date::now() / 1000.0) as i64
-    }
-    #[cfg(not(feature = "web"))]
-    {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0)
-    }
 }
 
 #[cfg(test)]

--- a/frontend/src/pages/book_detail/rating.rs
+++ b/frontend/src/pages/book_detail/rating.rs
@@ -8,6 +8,7 @@
 use dioxus::prelude::*;
 use omnibus_shared::{AttributedRating, RatingRecord, RatingUpdate};
 
+use crate::time::now_unix;
 use crate::{data, use_server_url};
 
 /// Live rating signals shared between [`BdRatingWidget`] and each
@@ -347,23 +348,6 @@ fn rated_ago(now: i64, updated_at: i64) -> String {
     } else {
         let d = secs / 86_400;
         format!("rated {d} day{} ago", plural(d))
-    }
-}
-
-/// Current unix time in seconds. Only ever called client-side (the relative
-/// timestamp renders after the post-mount load, and the optimistic write runs
-/// on click), so SSR never invokes the JS clock.
-fn now_unix() -> i64 {
-    #[cfg(feature = "web")]
-    {
-        (js_sys::Date::now() / 1000.0) as i64
-    }
-    #[cfg(not(feature = "web"))]
-    {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0)
     }
 }
 

--- a/frontend/src/pages/book_detail/read_status.rs
+++ b/frontend/src/pages/book_detail/read_status.rs
@@ -7,6 +7,7 @@
 use dioxus::prelude::*;
 use omnibus_shared::{ReadStatus, ReadStatusRecord, SetReadStatus};
 
+use crate::time::now_unix;
 use crate::{data, use_server_url};
 
 /// The three selectable states, in display order, with their labels + testids.
@@ -174,23 +175,6 @@ fn ago(now: i64, then: i64) -> String {
     } else {
         let d = secs / 86_400;
         format!("{d} day{} ago", plural(d))
-    }
-}
-
-/// Current unix time in seconds. Only ever called client-side (the relative
-/// timestamp renders after the post-mount load; the optimistic write runs on
-/// click), so SSR never invokes the JS clock.
-fn now_unix() -> i64 {
-    #[cfg(feature = "web")]
-    {
-        (js_sys::Date::now() / 1000.0) as i64
-    }
-    #[cfg(not(feature = "web"))]
-    {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0)
     }
 }
 

--- a/frontend/src/pages/check_in/mod.rs
+++ b/frontend/src/pages/check_in/mod.rs
@@ -17,6 +17,7 @@ use omnibus_shared::{
     ScanBook, ScanOutcome, WishlistAddRequest, WishlistSource,
 };
 
+use crate::focus_after_paint::focus_after_paint;
 use crate::{data, use_server_url, Route};
 use entry::EntryScreen;
 use scan::ScanScreen;
@@ -87,7 +88,7 @@ fn CheckInModal() -> Element {
                 // Move focus into the dialog on open so keyboard users land
                 // inside the modal and the panel's Escape handler fires without
                 // a prior click. Mirrors the search palette's input focus.
-                onmounted: move |evt: MountedEvent| focus_overlay_panel(&evt),
+                onmounted: move |evt: MountedEvent| focus_after_paint(&evt),
                 // Clicks inside the card must not reach the scrim's close.
                 onclick: move |e| e.stop_propagation(),
                 onkeydown: move |e| {
@@ -108,35 +109,6 @@ fn CheckInModal() -> Element {
         }
     }
 }
-
-/// Focus the dialog panel after the browser paints it, so the modal opens with
-/// focus inside it and Escape works without a prior click. The
-/// `requestAnimationFrame` hop lets layout finish first — a synchronous
-/// `.focus()` inside `onmounted` lands before the element is laid out and
-/// no-ops. Mirrors `focus_palette_input` in the search palette.
-#[cfg(feature = "web")]
-fn focus_overlay_panel(evt: &MountedEvent) {
-    use dioxus::web::WebEventExt;
-    use wasm_bindgen::prelude::*;
-
-    let Some(element) = evt.try_as_web_event() else {
-        return;
-    };
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let cb = Closure::once_into_js(move || {
-        if let Some(html_el) = element.dyn_ref::<web_sys::HtmlElement>() {
-            let _ = html_el.focus();
-        }
-    });
-    let _ = window.request_animation_frame(cb.unchecked_ref());
-}
-
-/// No-op on SSR / native: the panel only needs programmatic focus on the web
-/// client, and mobile has no hardware Escape key.
-#[cfg(not(feature = "web"))]
-fn focus_overlay_panel(_evt: &MountedEvent) {}
 
 /// Where the flow currently sits. One variant per leaf of the design's
 /// decision tree, plus the three transient states (scan, entry, resolving).

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -14,6 +14,7 @@ use super::helpers::effective_scrub_position;
 use crate::components::atrium::Cover;
 use crate::contexts::use_server_url;
 use crate::data;
+use crate::time::now_unix;
 use crate::Route;
 
 mod bookmarks_sheet;
@@ -219,18 +220,6 @@ fn persist_position(uuid: &str, file_id: Option<i64>, server_url: &str, seconds:
         };
         let _ = data::save_progress(&server_url, update).await;
     });
-}
-
-/// Current unix time in seconds from the device clock — stamped onto every
-/// `ProgressUpdate` so most-recent-wins resolves on client event time
-/// rather than server receipt time (issue #1362). This module only
-/// compiles under `feature = "mobile"` (native, not wasm32), so the
-/// platform clock is always `std::time::SystemTime`.
-fn now_unix() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
 }
 
 /// Marquee-ready title markup: `.m-player-title` is the fixed-width clipping

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -12,6 +12,7 @@ use dioxus::prelude::*;
 use omnibus_shared::{Highlight, ProgressFormat, ProgressUpdate};
 
 use crate::data;
+use crate::time::now_unix;
 
 use super::prefs::ReaderPrefs;
 use super::search_panel::SearchResult;
@@ -297,16 +298,4 @@ fn persist_progress(uuid: &str, server_url: &str, cfi: String) {
         };
         let _ = data::save_progress(&server_url, update).await;
     });
-}
-
-/// Current unix time in seconds from the device clock — stamped onto every
-/// `ProgressUpdate` so most-recent-wins resolves on client event time
-/// rather than server receipt time (issue #1362). This module only
-/// compiles under `feature = "mobile"` (native, not wasm32), so the
-/// platform clock is always `std::time::SystemTime`.
-fn now_unix() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
 }

--- a/frontend/src/platform_sleep.rs
+++ b/frontend/src/platform_sleep.rs
@@ -1,19 +1,32 @@
-//! Shared platform-gated async sleep: web awaits `gloo_timers`, every other
-//! build (server SSR compile, mobile native) awaits `tokio::time`.
+//! Shared platform-gated async sleep: web awaits `gloo_timers`, the server
+//! and mobile builds (the only other targets `tokio` is enabled for) await
+//! `tokio::time`. A no-feature build has neither, so it gets a no-op stub.
 
 /// Sleep for `ms` milliseconds, yielding to the browser event loop on web or
-/// the tokio runtime elsewhere.
+/// the tokio runtime on server/mobile.
 #[cfg(feature = "web")]
 pub async fn async_sleep_ms(ms: u32) {
     gloo_timers::future::TimeoutFuture::new(ms).await;
 }
 
-#[cfg(not(feature = "web"))]
+// `tokio` is an optional dep enabled only by `server` and `mobile` — gate
+// on those explicitly rather than a bare `not(web)`, which would try to
+// link `tokio` in a plain no-feature build and fail.
+#[cfg(all(not(feature = "web"), any(feature = "server", feature = "mobile")))]
 pub async fn async_sleep_ms(ms: u32) {
     tokio::time::sleep(std::time::Duration::from_millis(u64::from(ms))).await;
 }
 
-#[cfg(all(test, not(feature = "web")))]
+/// No-feature stub: neither `gloo_timers` nor `tokio` is available, and
+/// nothing calls this helper on that target anyway.
+#[cfg(not(any(feature = "web", feature = "server", feature = "mobile")))]
+pub async fn async_sleep_ms(_ms: u32) {}
+
+#[cfg(all(
+    test,
+    not(feature = "web"),
+    any(feature = "server", feature = "mobile")
+))]
 mod tests {
     use super::*;
 

--- a/frontend/src/platform_sleep.rs
+++ b/frontend/src/platform_sleep.rs
@@ -1,0 +1,26 @@
+//! Shared platform-gated async sleep: web awaits `gloo_timers`, every other
+//! build (server SSR compile, mobile native) awaits `tokio::time`.
+
+/// Sleep for `ms` milliseconds, yielding to the browser event loop on web or
+/// the tokio runtime elsewhere.
+#[cfg(feature = "web")]
+pub async fn async_sleep_ms(ms: u32) {
+    gloo_timers::future::TimeoutFuture::new(ms).await;
+}
+
+#[cfg(not(feature = "web"))]
+pub async fn async_sleep_ms(ms: u32) {
+    tokio::time::sleep(std::time::Duration::from_millis(u64::from(ms))).await;
+}
+
+#[cfg(all(test, not(feature = "web")))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn async_sleep_ms_waits_at_least_the_requested_duration() {
+        let start = std::time::Instant::now();
+        async_sleep_ms(10).await;
+        assert!(start.elapsed().as_millis() >= 10);
+    }
+}

--- a/frontend/src/time.rs
+++ b/frontend/src/time.rs
@@ -1,0 +1,30 @@
+//! Client-side wall-clock time: the JS clock on web, `SystemTime` elsewhere.
+//! Used for optimistic-write timestamps and relative-time labels that only
+//! ever run client-side (SSR never invokes the JS clock, so there's no
+//! cross-target consistency requirement to worry about here).
+
+/// Current unix time in seconds.
+pub fn now_unix() -> i64 {
+    #[cfg(feature = "web")]
+    {
+        (js_sys::Date::now() / 1000.0) as i64
+    }
+    #[cfg(not(feature = "web"))]
+    {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_unix_returns_a_plausible_recent_timestamp() {
+        // Any unix-seconds value after 2020-01-01T00:00:00Z.
+        assert!(now_unix() > 1_577_836_800);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #1471
- Hoists three interop helpers each duplicated 5-6 times across the frontend crate into single shared modules: `async_sleep_ms` → `frontend/src/platform_sleep.rs`, `focus_*_panel` → one `frontend/src/focus_after_paint.rs` (call sites now call `focus_after_paint` directly instead of a per-file wrapper name), and `now_unix` → `frontend/src/time.rs`.
- Every call site named in the issue now imports the shared helper instead of redefining it; done in the suggested order (now_unix, then async_sleep_ms, then focus_*_panel). Pure mechanical dedupe — no behavior change, same `#[cfg(feature = "web")]`/non-web split each original used.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1471 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1471 cargo test -p omnibus-frontend --features server` — PASS (539 passed; 0 failed), including new unit tests for `platform_sleep::async_sleep_ms` and `time::now_unix`
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1471 cargo clippy -p omnibus-frontend --features mobile -- -D warnings` — PASS

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- No pre-existing unrelated failures observed in any of the above runs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeD9AEWg7ptJesSu1CmLqs)_