### PR TITLE
test: add DB-failure-path coverage for Kobo reading services, merge, and device helpers (#1487)

### DIFF
--- a/db/src/browse/tests.rs
+++ b/db/src/browse/tests.rs
@@ -506,6 +506,14 @@ async fn list_authors_propagates_db_error_when_pool_is_closed() {
     assert!(matches!(err, BrowseError::Db(_)));
 }
 
+#[tokio::test]
+async fn list_series_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = list_series(&pool, &["/lib"]).await.unwrap_err();
+    assert!(matches!(err, BrowseError::Db(_)));
+}
+
 // -----------------------------------------------------------------
 // Physical-only visibility — #1181
 // -----------------------------------------------------------------

--- a/db/src/kobo/tests.rs
+++ b/db/src/kobo/tests.rs
@@ -472,6 +472,17 @@ async fn reading_state_for_is_scoped_to_the_requesting_user() {
 }
 
 #[tokio::test]
+async fn reading_state_for_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+
+    assert!(matches!(
+        reading_state_for(&pool, 1, &["any-uuid".to_string()]).await,
+        Err(KoboError::Sqlx(_))
+    ));
+}
+
+#[tokio::test]
 async fn reading_state_for_returns_empty_for_no_uuids() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = make_user(&pool, "reader").await;

--- a/db/src/kobo_devices/tests.rs
+++ b/db/src/kobo_devices/tests.rs
@@ -36,6 +36,14 @@ async fn create_device_mints_a_token_and_lists_it() {
 }
 
 #[tokio::test]
+async fn create_device_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = create_device(&pool, 1, "Kobo").await;
+    assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
+}
+
+#[tokio::test]
 async fn create_device_mints_unique_tokens_per_device() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = seed_user(&pool, "reader").await;
@@ -44,6 +52,22 @@ async fn create_device_mints_unique_tokens_per_device() {
     let b = create_device(&pool, user, "Kobo Two").await.unwrap();
     assert_ne!(a.token, b.token);
     assert_eq!(list_devices(&pool, user).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn list_devices_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = list_devices(&pool, 1).await;
+    assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
+}
+
+#[tokio::test]
+async fn get_device_for_user_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = get_device_for_user(&pool, 1, 1).await;
+    assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
 }
 
 #[tokio::test]
@@ -73,6 +97,14 @@ async fn resolve_device_by_token_returns_none_for_unknown_token() {
 }
 
 #[tokio::test]
+async fn regenerate_token_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = regenerate_token(&pool, 1, 1).await;
+    assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
+}
+
+#[tokio::test]
 async fn regenerate_token_rotates_the_token_and_invalidates_the_old() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = seed_user(&pool, "reader").await;
@@ -92,6 +124,14 @@ async fn regenerate_token_rotates_the_token_and_invalidates_the_old() {
         .await
         .unwrap()
         .is_some());
+}
+
+#[tokio::test]
+async fn resolve_device_by_token_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = resolve_device_by_token(&pool, "some-token").await;
+    assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
 }
 
 #[tokio::test]
@@ -121,6 +161,14 @@ async fn regenerate_token_rejects_a_device_owned_by_another_user() {
         .await
         .unwrap()
         .is_some());
+}
+
+#[tokio::test]
+async fn revoke_device_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = revoke_device(&pool, 1, 1).await;
+    assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
 }
 
 #[tokio::test]
@@ -169,6 +217,22 @@ async fn list_devices_is_scoped_to_the_owner() {
         .await
         .unwrap()
         .is_none());
+}
+
+#[tokio::test]
+async fn learn_kobo_device_id_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = learn_kobo_device_id(&pool, 1, "hw-abc").await;
+    assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
+}
+
+#[tokio::test]
+async fn set_sync_cursor_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = set_sync_cursor(&pool, 1, "cursor-1").await;
+    assert!(matches!(err, Err(KoboDeviceError::Sqlx(_))));
 }
 
 #[tokio::test]

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -265,6 +265,19 @@ async fn merge_books_rejects_same_book() {
 }
 
 #[tokio::test]
+async fn merge_books_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let target = seed_ebook(&pool, "A/Dracula.epub", "Dracula", "Bram Stoker").await;
+    let source = seed_audiobook(&pool, "B/Drakula.m4b", "Drakula", "Bram Stoker").await;
+    pool.close().await;
+
+    let err = merge_books(&pool, &source, &target, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, MergeError::Db(_)));
+}
+
+#[tokio::test]
 async fn merge_books_rejects_unknown_uuid() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let uuid = seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;

--- a/server/src/backend/kobo/reading_services/tests.rs
+++ b/server/src/backend/kobo/reading_services/tests.rs
@@ -586,6 +586,57 @@ async fn user_storage_metadata_returns_the_empty_stub() {
     );
 }
 
+#[tokio::test]
+async fn get_annotations_returns_500_when_pool_is_closed() {
+    let (app, pool, _user, _device) = fixture().await;
+    pool.close().await;
+
+    let res = app
+        .oneshot(request(
+            "GET",
+            &annotations_uri("any-book-uuid"),
+            Some(HW_ID),
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn patch_annotations_returns_500_when_pool_is_closed() {
+    let (app, pool, _user, _device) = fixture().await;
+    pool.close().await;
+
+    let res = app
+        .oneshot(request(
+            "PATCH",
+            &annotations_uri("any-book-uuid"),
+            Some(HW_ID),
+            Some(&upload_body("kobo-ann-1", "yellow", None)),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn check_for_changes_returns_500_when_pool_is_closed() {
+    let (app, pool, _user, _device) = fixture().await;
+    pool.close().await;
+
+    let res = app
+        .oneshot(request(
+            "POST",
+            "/api/v3/content/checkforchanges",
+            Some(HW_ID),
+            Some(&json!([])),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
 mod dto_tests {
     use super::super::dto::*;
     use omnibus_shared::HighlightColor;


### PR DESCRIPTION
## Summary
- Closes #1487
- Adds the missing DB-failure-path (`pool_is_closed`) tests called out by #1487, mirroring the pattern already used by their siblings in the same files: the 3 Kobo Reading Services HTTP handlers (`get_annotations`, `patch_annotations`, `check_for_changes`), `merge_books`' untested `MergeError::Db` variant, all 8 `kobo_devices.rs` functions still missing it, `db::kobo::reading_state_for`, and `db::browse::list_series`.
- Coverage-only change — no production code touched.

## Test plan
- [x] `cargo fmt --check` — PASS (clean)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1487 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1487 cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1487 cargo test -p omnibus-db` — 1524 passed, 1 pre-existing failure unrelated to this change: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` (missing audio fixture in this sandbox — `just fixtures` wasn't run; not a file touched by this PR)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1487 cargo test -p omnibus` — 601 passed, 2 pre-existing failures unrelated to this change: `backend::uploads::tests::commit_rejects_read_only_library_with_400` and `audiobook_commit_rejects_read_only_library_with_400` (these `chmod 0o555` a temp dir to simulate a read-only library; the sandbox runs as root, which bypasses Unix permission bits, so the write the test expects to fail instead succeeds — `server/src/backend/uploads.rs` is not touched by this PR)
- All newly-added tests (grepped from the run logs) pass, including the 3 Reading Services 500-on-DB-failure tests and every new `*_propagates_db_error_when_pool_is_closed` test.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- The three Reading Services handler tests close the pool before the request; since `KoboHardwareUser`'s own extractor also queries the pool, the closed-pool 500 is observed at the extractor boundary rather than deep inside each handler's own DB call — this matches the acceptance criteria's literal ask ("a test that closes the pool and asserts a 500 response") and is the same shape used elsewhere in this PR.
- Pre-existing failures noted above are environmental (missing test fixtures / running as root) and unrelated to the files this PR touches; flagging per the task's guidance rather than trying to fix them here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeD9AEWg7ptJesSu1CmLqs)_