### PR TITLE
test: add coverage for offline revalidation offline-skip and multi-file-format check (#1513)

### DIFF
--- a/frontend/src/offline/media/tests.rs
+++ b/frontend/src/offline/media/tests.rs
@@ -1,6 +1,12 @@
 //! Loopback media server tests — real HTTP round-trips against a
 //! port-0 instance, plus the pure helper functions.
 
+// The state-lock guard is deliberately held across awaits: it serializes
+// whole async test bodies against process-global state, and each test owns
+// its own thread + runtime, so there is no interleaving to deadlock on.
+// Mirrors `offline::sync::tests`.
+#![allow(clippy::await_holding_lock)]
+
 use super::*;
 
 /// Boot the router on a random port with a temp downloads/img dir; returns
@@ -400,6 +406,41 @@ async fn img_does_not_revalidate_an_entry_with_no_stored_validator() {
         .expect("get");
     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     assert_eq!(hits.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn img_does_not_revalidate_while_the_client_is_offline() {
+    // The fourth documented skip condition on `revalidate_in_background`:
+    // spawning a check-back the device has no way to complete would just
+    // burn a task on every offline render of a stale-enough cover.
+    let _guard = crate::offline::sync::test_state_lock()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    crate::offline::sync::note_offline();
+
+    let (base, token, dir) = boot(&[]).await;
+    let img_dir = dir.path().join("imgcache");
+    seed_cache_entry(&img_dir, "/api/covers/u1", b"cached-cover", Some("\"v1\""));
+    let (hits, _seen) = spawn_upstream(axum::http::StatusCode::OK, b"new", "\"v2\"").await;
+
+    let encoded = urlencode("/api/covers/u1");
+    let resp = reqwest::get(format!("{base}/img?path={encoded}&token={token}"))
+        .await
+        .expect("get");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.bytes().await.expect("body").as_ref(),
+        b"cached-cover",
+        "the cached copy still serves instantly while offline"
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        0,
+        "offline must not fire a background revalidation"
+    );
+
+    crate::offline::sync::note_online();
 }
 
 #[tokio::test]

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -486,3 +486,45 @@ fn thumb_srcs(
         (None, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(format: &str, ordinal: i64) -> BookFileInfo {
+        BookFileInfo {
+            id: ordinal,
+            format: format.to_string(),
+            filename: format!("part-{ordinal}.{}", format.to_lowercase()),
+            ordinal,
+            label: None,
+            size_bytes: 0,
+            path: None,
+            etag: None,
+        }
+    }
+
+    #[test]
+    fn has_multi_file_format_is_false_for_an_empty_file_list() {
+        assert!(!has_multi_file_format(&[]));
+    }
+
+    #[test]
+    fn has_multi_file_format_is_false_when_every_format_has_one_file() {
+        assert!(!has_multi_file_format(&[file("EPUB", 0), file("M4B", 1)]));
+    }
+
+    #[test]
+    fn has_multi_file_format_is_true_when_a_format_has_two_files() {
+        assert!(has_multi_file_format(&[file("M4B", 0), file("M4B", 1)]));
+    }
+
+    #[test]
+    fn has_multi_file_format_is_true_when_only_one_of_several_formats_has_duplicates() {
+        assert!(has_multi_file_format(&[
+            file("EPUB", 0),
+            file("M4B", 1),
+            file("M4B", 2),
+        ]));
+    }
+}

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -527,4 +527,9 @@ mod tests {
             file("M4B", 2),
         ]));
     }
+
+    #[test]
+    fn has_multi_file_format_matches_formats_that_differ_only_by_ascii_case() {
+        assert!(has_multi_file_format(&[file("M4B", 0), file("m4b", 1)]));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds direct unit test coverage for two pure-logic functions that shipped
  untested in the #1490-#1505 batch: `revalidate_in_background`'s offline
  skip branch in `frontend/src/offline/media.rs`, and `has_multi_file_format`
  in `frontend/src/pages/book_detail/mobile.rs`.
- Closes #1513.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1513 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1513 cargo test -p omnibus-frontend --features server` — PASS (537 passed; 0 failed)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1513 cargo clippy -p omnibus-frontend --all-targets --features mobile -- -D warnings` — PASS (both new tests live in `mobile`-gated modules — `offline::media` and `book_detail::mobile` — so this is the feature flag that actually compiles them; `--features server` alone doesn't reach either)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1513 cargo test -p omnibus-frontend --features mobile img_does_not_revalidate_while_the_client_is_offline` and `has_multi_file_format` — PASS, both reliable across repeated runs

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Test-only change, no production behavior modified.
- The two new tests live in modules gated `#[cfg(feature = "mobile")]`
  (`frontend/src/offline/mod.rs`, `frontend/src/pages/book_detail/mod.rs`), so
  they aren't compiled by `--features server` alone — verified them under
  `--features mobile` as well, matching how `just test` already runs the
  frontend crate twice (once per feature set).
- `frontend/src/offline/media/tests.rs` gained a file-level
  `#[allow(clippy::await_holding_lock)]`, mirroring the existing one in
  `frontend/src/offline/sync/tests.rs`: the new offline test holds
  `offline::sync::test_state_lock()` across awaits by design, since each
  `#[tokio::test]` owns its own thread + runtime and there's no interleaving
  to deadlock on.
- Under plain `cargo test --features mobile` (no `cargo-nextest` available in
  this sandbox — no `nix`), two pre-existing, unrelated tests in the same
  file — `img_keeps_the_cached_copy_when_the_server_answers_not_modified` and
  `img_serves_the_cached_copy_then_replaces_it_when_the_cover_changed` —
  intermittently fail. Confirmed via `git stash` that this reproduces on
  unmodified `main` too, independent of this change: they share process-global
  state (`set_upstream`, the write-lock map) that only `cargo-nextest`'s
  process-per-test isolation (what CI and `just test` actually use) protects
  against. Not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeD9AEWg7ptJesSu1CmLqs)_