### PR TITLE
feat: keep audiobook miniplayer visible while reading in omnibus-ios

### DIFF
--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -541,7 +541,7 @@ struct MiniPlayerBar: View {
     /// Overrides what tapping the bar body does. The default expands into the
     /// app-global full-screen player; the reader passes its own handler so the
     /// book underneath stays open.
-    var onExpand: (() -> Void)?
+    var onExpand: (() -> Void)? = nil
 
     var body: some View {
         if let book = player.book {

--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -538,6 +538,11 @@ struct MiniPlayerBar: View {
     @Environment(AudioPlayer.self) private var player
     @Environment(\.palette) private var palette
 
+    /// Overrides what tapping the bar body does. The default expands into the
+    /// app-global full-screen player; the reader passes its own handler so the
+    /// book underneath stays open.
+    var onExpand: (() -> Void)?
+
     var body: some View {
         if let book = player.book {
             VStack(spacing: 0) {
@@ -553,7 +558,11 @@ struct MiniPlayerBar: View {
 
                 Button {
                     // The file already playing, so expanding cannot reload it.
-                    Presentation.shared.openPlayer(book, fileID: player.fileID)
+                    if let onExpand {
+                        onExpand()
+                    } else {
+                        Presentation.shared.openPlayer(book, fileID: player.fileID)
+                    }
                 } label: {
                     HStack(spacing: 11) {
                         BookCover(identity: CoverIdentity(book), size: .sm, cornerRadius: 4)

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -29,6 +29,7 @@ struct ReaderView: View {
     @Environment(\.palette) private var palette
     @Environment(\.dismiss) private var dismiss
     @Environment(AppState.self) private var appState
+    @Environment(AudioPlayer.self) private var audio
 
     @State private var controller = ReaderController()
     /// The reading view opens bare, the way a book does — the buttons are one
@@ -77,6 +78,9 @@ struct ReaderView: View {
     /// hours read.
     @State private var sessionStart: Date?
     @State private var lastSave = Date.distantPast
+    /// The full player, raised over the page from the audio dock — a sheet
+    /// rather than the app-global cover, so the book stays open underneath.
+    @State private var showPlayer = false
 
     /// How long a single stretch of reading may run before it is reported as
     /// its own session rather than held until the book closes.
@@ -90,7 +94,10 @@ struct ReaderView: View {
 
             if didConfigure {
                 ReaderWebView(controller: controller, bookUUID: book.uuid)
-                    .ignoresSafeArea()
+                    // Full-bleed alone; with the audio dock up, respecting the
+                    // bottom inset ends the stage above the bar, and the
+                    // glue's ResizeObserver re-paginates to the shorter page.
+                    .ignoresSafeArea(edges: audio.isActive ? [.top, .horizontal] : .all)
                     .opacity(controller.isReady ? 1 : 0)
                     // Fade the first paint in rather than letting a
                     // half-laid-out page flash — the reader is the one surface
@@ -139,6 +146,18 @@ struct ReaderView: View {
             passageMenu
         }
         .animation(Motion.snap, value: passage?.id)
+        // The audio dock: the tab shell's mini bar, kept on screen while
+        // reading so a running audiobook stays controllable — the immersive
+        // read the web reader ships as its docked bar (#1133).
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            VStack(spacing: 0) {
+                if audio.isActive {
+                    MiniPlayerBar(onExpand: { showPlayer = true })
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .animation(Motion.glide, value: audio.isActive)
+        }
         .statusBarHidden(!chromeVisible)
         .persistentSystemOverlays(chromeVisible ? .automatic : .hidden)
         // The status bar sits on the page, so it has to read against the
@@ -204,6 +223,12 @@ struct ReaderView: View {
         .sheet(item: $quoteTarget) { request in
             QuoteCardSheet(quote: request.text, book: book)
                 .preferredColorScheme(appScheme)
+        }
+        .sheet(isPresented: $showPlayer) {
+            if let audioBook = audio.book {
+                PlayerView(book: audioBook, fileID: audio.fileID)
+                    .preferredColorScheme(appScheme)
+            }
         }
         .translationPresentation(isPresented: $showTranslate, text: translateText)
     }

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -192,6 +192,11 @@ struct ReaderView: View {
             controller.display(cfi)
             bridge.pendingCFI = nil
         }
+        // If playback closes while the player sheet is up, the sheet's
+        // content would be empty — take it down with the book.
+        .onChange(of: audio.isActive) { _, active in
+            if !active { showPlayer = false }
+        }
         .onDisappear {
             Task { await finish() }
         }


### PR DESCRIPTION
## Summary
- Docks the existing `MiniPlayerBar` at the bottom of `ReaderView` whenever an audiobook is active, so listening continues (with controls) while reading — parity with the web reader's immersive audio dock (#1133).
- The reader webview respects the bottom inset while the dock is up; the epub glue's stage `ResizeObserver` (already shipped for the web dock) re-paginates to the shorter page.
- Tapping the dock inside the reader raises the full player as a sheet *over* the book — quick speed/sleep changes without closing the reader; the tab shell keeps its full-screen expand.

## Test plan
- [x] Simulator walkthrough: play M4B → open EPUB → dock present with pause/skip/stop; X stops audio and the stage reflows; chrome + page indicators sit above the dock; dock tap opens player sheet, speed changed, dismissed back to the same page.
- [x] `just ios-test` (omnibusTests) green; `just ios-build` clean.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).