### PR TITLE
fix: match override-side tags in smart shelf rules

### DIFF
--- a/db/src/shelves/rules.rs
+++ b/db/src/shelves/rules.rs
@@ -4,9 +4,11 @@
 //! alias; the rule set combines with `OR` (match any) or `AND` (match all).
 //! Text fields (tag/author/series/format) match by **name**, case-insensitively
 //! — equality via `COLLATE NOCASE`, substring/prefix via `LIKE` (`contains` /
-//! `starts with`). Owner-scoped fields (`rating`, `status`) bind the shelf
-//! owner's id: `status` matches the owner's read state in `book_read_status`,
-//! treating a missing row as `unread`.
+//! `starts with`). Tag rules match the *effective* (override-aware) tag set,
+//! not just `books_tags_link` — see [`tag_condition`]. Owner-scoped fields
+//! (`rating`, `status`) bind the shelf owner's id: `status` matches the
+//! owner's read state in `book_read_status`, treating a missing row as
+//! `unread`.
 
 use omnibus_shared::{MatchMode, ReadStatus, RuleField, RuleOp, ShelfRule};
 
@@ -66,12 +68,7 @@ fn condition_sql(rule: &ShelfRule, owner_id: i64) -> Result<(String, Vec<Bind>),
     match rule.field {
         // Text fields resolve against the normalized taxonomy `name` columns
         // (all `COLLATE NOCASE`), so the user types a name, not an id.
-        RuleField::Tag => text_condition(
-            rule,
-            "SELECT 1 FROM books_tags_link btl JOIN tags t ON t.id = btl.tag \
-             WHERE btl.book = b.id AND ",
-            "t.name",
-        ),
+        RuleField::Tag => tag_condition(rule),
         RuleField::Author => text_condition(
             rule,
             "SELECT 1 FROM books_authors_link bal JOIN authors a ON a.id = bal.author \
@@ -184,8 +181,8 @@ fn date_condition(rule: &ShelfRule, v: &str) -> Result<(String, Vec<Bind>), Shel
 /// name column.
 ///
 /// `inner` is the subquery up to (but not including) the column comparison, e.g.
-/// `"SELECT 1 FROM books_tags_link btl JOIN tags t ON t.id = btl.tag WHERE
-/// btl.book = b.id AND "`; `col` is the compared column (`"t.name"`). Equality
+/// `"SELECT 1 FROM books_authors_link bal JOIN authors a ON a.id = bal.author
+/// WHERE bal.book = b.id AND "`; `col` is the compared column (`"a.name"`). Equality
 /// (`is`/`is_not`/`includes`) uses `COLLATE NOCASE`; `contains`/`starts_with`
 /// use `LIKE` (case-insensitive for ASCII) with metacharacters escaped so user
 /// text matches literally.
@@ -225,6 +222,58 @@ fn text_condition(
         exists
     };
     Ok((sql, vec![bind]))
+}
+
+/// Build a tag predicate over the book's *effective* tag set.
+///
+/// A `subjects` override replaces a book's scanned tags wholesale, and its
+/// memberships live only in the override JSON — `materialize_tag_rows`
+/// deliberately keeps them out of `books_tags_link` so revert-to-scanned
+/// works. Mirroring `get_tag_cloud`'s membership CTE, a book matches through
+/// exactly one arm: its canonical `books_tags_link` rows when it has no
+/// subjects override, or `json_each` over the override array when it does.
+/// A single-arm canonical predicate both misses override-added tags and
+/// keeps matching scanned tags the override removed.
+fn tag_condition(rule: &ShelfRule) -> Result<(String, Vec<Bind>), ShelfError> {
+    let v = rule.value.trim();
+    let (canonical_cmp, override_cmp, pattern, negate) = match rule.op {
+        RuleOp::Is | RuleOp::IsNot => (
+            "t.name = ? COLLATE NOCASE",
+            "je.value = ? COLLATE NOCASE",
+            v.to_string(),
+            rule.op == RuleOp::IsNot,
+        ),
+        RuleOp::Contains => (
+            "t.name LIKE ? ESCAPE '\\'",
+            "je.value LIKE ? ESCAPE '\\'",
+            format!("%{}%", like_escape(v)),
+            false,
+        ),
+        RuleOp::StartsWith => (
+            "t.name LIKE ? ESCAPE '\\'",
+            "je.value LIKE ? ESCAPE '\\'",
+            format!("{}%", like_escape(v)),
+            false,
+        ),
+        _ => return Err(unsupported(rule)),
+    };
+    let matched = format!(
+        "((NOT EXISTS (SELECT 1 FROM metadata_overrides mo \
+           WHERE mo.book_uuid = b.uuid \
+             AND json_type(mo.overrides, '$.subjects') IS NOT NULL) \
+          AND EXISTS (SELECT 1 FROM books_tags_link btl \
+           JOIN tags t ON t.id = btl.tag \
+           WHERE btl.book = b.id AND {canonical_cmp})) \
+         OR EXISTS (SELECT 1 FROM metadata_overrides mo \
+           JOIN json_each(mo.overrides, '$.subjects') je \
+           WHERE mo.book_uuid = b.uuid AND {override_cmp}))"
+    );
+    let sql = if negate {
+        format!("NOT {matched}")
+    } else {
+        matched
+    };
+    Ok((sql, vec![Bind::Text(pattern.clone()), Bind::Text(pattern)]))
 }
 
 /// Escape `LIKE` metacharacters (`\`, `%`, `_`) so user text matches literally.
@@ -328,7 +377,9 @@ mod rule_tests {
         )
         .unwrap();
         assert!(p.sql.contains(" OR "));
-        assert_eq!(p.binds.len(), 2);
+        // Each tag rule binds its pattern twice: once for the canonical-link
+        // arm, once for the override-JSON arm.
+        assert_eq!(p.binds.len(), 4);
     }
 
     #[test]
@@ -489,7 +540,15 @@ mod rule_tests {
             "sql was {}",
             c.sql
         );
-        assert_eq!(c.binds, vec![Bind::Text("%sci%".into())]);
+        assert!(
+            c.sql.contains("je.value LIKE ? ESCAPE '\\'"),
+            "sql was {}",
+            c.sql
+        );
+        assert_eq!(
+            c.binds,
+            vec![Bind::Text("%sci%".into()), Bind::Text("%sci%".into())]
+        );
 
         let s = membership_predicate(
             &[rule(RuleField::Author, RuleOp::StartsWith, "Le")],
@@ -512,6 +571,48 @@ mod rule_tests {
             1,
         )
         .unwrap();
-        assert_eq!(p.binds, vec![Bind::Text("%50\\%%".into())]);
+        assert_eq!(
+            p.binds,
+            vec![Bind::Text("%50\\%%".into()), Bind::Text("%50\\%%".into())]
+        );
+    }
+
+    #[test]
+    fn tag_condition_is_override_aware() {
+        // Both membership arms must be present: canonical links gated on "no
+        // subjects override", and json_each over the override array.
+        let p = membership_predicate(
+            &[rule(RuleField::Tag, RuleOp::StartsWith, "Sea")],
+            MatchMode::Any,
+            1,
+        )
+        .unwrap();
+        assert!(
+            p.sql
+                .contains("json_type(mo.overrides, '$.subjects') IS NOT NULL"),
+            "sql was {}",
+            p.sql
+        );
+        assert!(
+            p.sql.contains("json_each(mo.overrides, '$.subjects')"),
+            "sql was {}",
+            p.sql
+        );
+        assert_eq!(
+            p.binds,
+            vec![Bind::Text("Sea%".into()), Bind::Text("Sea%".into())]
+        );
+    }
+
+    #[test]
+    fn tag_is_not_negates_the_effective_match() {
+        let p = membership_predicate(
+            &[rule(RuleField::Tag, RuleOp::IsNot, "fiction")],
+            MatchMode::Any,
+            1,
+        )
+        .unwrap();
+        assert!(p.sql.starts_with("(NOT ("), "sql was {}", p.sql);
+        assert!(p.sql.contains("je.value = ? COLLATE NOCASE"));
     }
 }

--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -88,6 +88,75 @@ async fn create_smart_shelf_membership_matches_tag_rule() {
 }
 
 #[tokio::test]
+async fn smart_shelf_tag_rule_matches_override_added_subjects() {
+    let (pool, _covers) = seed_discovery_fixture().await;
+    let owner = make_user(&pool, "owner", false).await;
+
+    // "Other Story" is scanned as "nonfiction"; the user retags it through a
+    // subjects override, so the tag exists only in the override JSON — never
+    // in `books_tags_link` (see `materialize_tag_rows`).
+    let uuid = uuid_by_title(&pool, "Other Story").await;
+    let overrides = omnibus_shared::MetadataOverrides {
+        subjects: Some(vec!["Seamus".into()]),
+        ..Default::default()
+    };
+    crate::upsert_metadata_overrides(&pool, &uuid, &overrides, false, owner)
+        .await
+        .unwrap();
+
+    // `starts with` and case-insensitive `is` both reach the override arm.
+    let prefix = ShelfRule {
+        field: RuleField::Tag,
+        op: RuleOp::StartsWith,
+        value: "Sea".into(),
+    };
+    let shelf = create_shelf(
+        &pool,
+        owner,
+        &smart_req("Seamus Books", MatchMode::Any, vec![prefix]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(shelf.book_count, 1);
+
+    let shelf = create_shelf(
+        &pool,
+        owner,
+        &smart_req("Seamus Eq", MatchMode::Any, vec![tag_rule("seamus")]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(shelf.book_count, 1);
+}
+
+#[tokio::test]
+async fn smart_shelf_tag_rule_skips_scanned_tags_replaced_by_override() {
+    let (pool, _covers) = seed_discovery_fixture().await;
+    let owner = make_user(&pool, "owner", false).await;
+
+    // Both Saga books are scanned "fiction". A subjects override replaces
+    // Book Two's tag list wholesale, so only Book One may still match — the
+    // canonical link row must not shine through the override.
+    let uuid = uuid_by_title(&pool, "Saga: Book Two").await;
+    let overrides = omnibus_shared::MetadataOverrides {
+        subjects: Some(vec!["romance".into()]),
+        ..Default::default()
+    };
+    crate::upsert_metadata_overrides(&pool, &uuid, &overrides, false, owner)
+        .await
+        .unwrap();
+
+    let shelf = create_shelf(
+        &pool,
+        owner,
+        &smart_req("Fiction", MatchMode::Any, vec![tag_rule("fiction")]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(shelf.book_count, 1);
+}
+
+#[tokio::test]
 async fn smart_shelf_date_added_rules_match_epoch_column() {
     // `books.timestamp` is INTEGER unix-seconds (migration 0038); the date-rule
     // SQL must compare it as an epoch (`date(col,'unixepoch')`, numeric


### PR DESCRIPTION
## Summary
- Smart-shelf `Tag` conditions only queried `books_tags_link`, so tags added via the inline editor (stored in the `subjects` override JSON, never in the link table) matched nothing — a "Tag starts with" rule over 50+ override-tagged books previewed 0 matches.
- The tag predicate now matches the effective tag set, mirroring `get_tag_cloud`'s membership: canonical link rows when the book has no subjects override, `json_each` over the override array when it does.
- This also stops scanned tags that an override removed from still matching (an override replaces the tag list wholesale).

## Test plan
- [x] New db tests: override-added tags match (`is` + `starts with`), overridden-away scanned tags no longer match, and SQL-shape/bind unit tests in `rules.rs`.
- [x] `just check` (full lint + test matrix) green.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.