### PR TITLE
test: add 500-on-db-failure coverage for kobo sync handlers (#1392)

### DIFF
--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -1727,8 +1727,11 @@ async fn download_returns_500_on_db_failure_when_resolving_book_id_fails() {
 
 #[tokio::test]
 async fn download_returns_500_on_db_failure_when_locating_the_epub_file_fails() {
-    // kepubify is absent in the test environment (#1391), so `download`
-    // always takes the plain-EPUB fallback and calls `book_file_path`.
+    // Force kepubify absent so `download` deterministically takes the
+    // plain-EPUB fallback and calls `book_file_path`, regardless of whether
+    // kepubify happens to be installed in the environment running this test.
+    let _kepubify_absent =
+        db::test_support::EnvVarGuard::set("OMNIBUS_KEPUBIFY_PATH", Some("/no/such/kepubify"));
     // Keep `books` intact (the uuid must resolve) and drop `book_files`
     // instead, so this reaches that second `internal(...)` call site
     // rather than the earlier `resolve_book_id_by_uuid` one.

--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -1665,3 +1665,130 @@ async fn library_sync_re_announces_a_status_change_to_a_device_that_holds_the_bo
         .unwrap();
     assert!(body_json(third).await.as_array().unwrap().is_empty());
 }
+
+// --- 500-on-DB-failure coverage (#1392) ---
+//
+// `KoboAuthUser` authenticates via `kobo_devices`, so dropping `books`
+// leaves auth intact and forces the failure inside each handler's own
+// `internal(...)` call site rather than at the extractor.
+
+#[tokio::test]
+async fn library_sync_returns_500_on_db_failure() {
+    // `sync_books` short-circuits to an empty `Ok` when the user has no
+    // opted-in shelf, never touching `books` — so a real opted-in book is
+    // required to actually reach (and fail) that query.
+    let (app, pool, token, uid) = fixture().await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Herbert").await;
+    opt_in(&pool, uid, std::slice::from_ref(&uuid)).await;
+    sqlx::query("DROP TABLE books")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/library/sync")))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn metadata_returns_500_on_db_failure() {
+    let (app, pool, token, _uid) = fixture().await;
+    sqlx::query("DROP TABLE books")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/library/any-uuid/metadata")))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn download_returns_500_on_db_failure_when_resolving_book_id_fails() {
+    let (app, pool, token, _uid) = fixture().await;
+    sqlx::query("DROP TABLE books")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/download/any-uuid")))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn download_returns_500_on_db_failure_when_locating_the_epub_file_fails() {
+    // kepubify is absent in the test environment (#1391), so `download`
+    // always takes the plain-EPUB fallback and calls `book_file_path`.
+    // Keep `books` intact (the uuid must resolve) and drop `book_files`
+    // instead, so this reaches that second `internal(...)` call site
+    // rather than the earlier `resolve_book_id_by_uuid` one.
+    let (app, pool, token, _uid) = fixture().await;
+    let uuid = seed_synced_ebook(&pool, "solaris.epub", "Solaris", "Lem").await;
+    sqlx::query("DROP TABLE book_files")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/download/{uuid}")))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn put_state_returns_500_on_db_failure() {
+    let (app, pool, token, _uid) = fixture().await;
+    sqlx::query("DROP TABLE books")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let body = serde_json::json!({
+        "ReadingStates": [{
+            "StatusInfo": { "Status": "Finished" }
+        }]
+    });
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/kobo/{token}/v1/library/any-uuid/state"))
+                .method("PUT")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn image_returns_500_on_db_failure() {
+    let (app, pool, token, _uid) = fixture().await;
+    sqlx::query("DROP TABLE books")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(get(format!(
+            "/kobo/{token}/v1/books/any-uuid/thumbnail/400/600/100/false/image.jpg"
+        )))
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}


### PR DESCRIPTION
## Summary
- Closes #1392
- The db-layer half of this issue was **already satisfied on `main`** before this PR: `db/src/kobo/tests.rs` already has `book_for_sync_returns_the_row_for_a_known_uuid`, `book_for_sync_reflects_a_saved_title_override_with_no_creators_override`, `book_for_sync_returns_none_for_an_unknown_uuid`, `book_for_sync_propagates_db_error_when_pool_is_closed`, and `sync_books_propagates_db_error_when_pool_is_closed` — confirmed by grep before starting any work.
- This PR's scope is therefore the **server-handler layer only**: adds a 500-on-DB-failure test for each of the 5 Kobo HTTP handlers (`library_sync`, `library/{uuid}/metadata`, `download` — both its `resolve_book_id_by_uuid` and `book_file_path` error arms — `put_state`, `image`) in `server/src/backend/kobo/tests.rs`, which previously had zero tests of this shape across its then-53 tests.
- Each test forces the DB error via `DROP TABLE books` (or `book_files` for `download`'s second arm) rather than `pool.close()` — closing the whole pool would also break the wireless-sync path-token `KoboAuthUser` extractor (it queries `kobo_devices`), masking the handler's own `internal(...)` call site behind an auth failure instead of actually exercising it.

## Test plan
- [x] `cargo fmt -p omnibus --check` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS (0 warnings)
- [x] `cargo test -p omnibus` — 614 passed, 2 failed. The 2 failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400`, `audiobook_commit_rejects_read_only_library_with_400`) are pre-existing and unrelated to this change (confirmed via `git diff --stat origin/main`, which shows only `server/src/backend/kobo/tests.rs` touched): both rely on `chmod 0o555` to force a `PermissionDenied`, which the CI/dev sandbox running as root bypasses entirely (root ignores Unix DAC permission bits).
- [x] All 60 tests in `backend::kobo::tests` (54 pre-existing + 6 new) pass in isolation: `cargo test -p omnibus --lib backend::kobo::tests`
- `db/src/kobo/tests.rs` was not touched, so `cargo test -p omnibus-db` was not required per the issue's own verify list.

## Version
- [x] **No release** — test-only change, no runtime behavior touched.

## Notes
- See the IMPORTANT UPDATE note on #1392 for why the original issue's db-layer acceptance criteria are marked satisfied without new db-layer tests in this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYY2wHu8gj3rK7aMHT4M9W)_