### PR TITLE
refactor: clean up shelf-editing Dioxus convention rough edges (#1485)

### DIFF
--- a/frontend/src/components/create_shelf_modal.rs
+++ b/frontend/src/components/create_shelf_modal.rs
@@ -22,11 +22,11 @@ mod tests;
 #[component]
 pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<Shelf>) -> Element {
     let server_url = use_server_url();
-    let mut name = use_signal(String::new);
-    let mut kind = use_signal(|| ShelfKind::Smart);
-    let mut visibility = use_signal(|| Visibility::Private);
-    let mut error = use_signal(|| None::<String>);
-    let mut saving = use_signal(|| false);
+    let name = use_signal(String::new);
+    let kind = use_signal(|| ShelfKind::Smart);
+    let visibility = use_signal(|| Visibility::Private);
+    let error = use_signal(|| None::<String>);
+    let saving = use_signal(|| false);
 
     // Smart-body state.
     let mut match_mode = use_signal(|| MatchMode::All);
@@ -35,31 +35,20 @@ pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<She
     // Hand-picked state.
     let picked = use_signal(Vec::<String>::new);
 
-    let submit_url = server_url.clone();
-    let on_submit = move |_| {
-        if saving() {
-            return;
-        }
-        let req = build_create_request(
-            kind(),
-            name(),
-            visibility(),
-            match_mode(),
-            &rules.read(),
-            &picked.read(),
-        );
-        let url = submit_url.clone();
-        let on_created = on_created;
-        saving.set(true);
-        error.set(None);
-        spawn(async move {
-            match data::create_shelf(&url, req).await {
-                Ok(shelf) => on_created.call(shelf),
-                Err(e) => error.set(Some(e.to_string())),
-            }
-            saving.set(false);
-        });
-    };
+    let on_submit = build_on_submit(
+        server_url.clone(),
+        CreateShelfFormSignals {
+            kind,
+            name,
+            visibility,
+            match_mode,
+            rules,
+            picked,
+            error,
+            saving,
+        },
+        on_created,
+    );
 
     let picked_count = picked.read().len();
     let create_label = create_label(kind(), picked_count);
@@ -73,35 +62,7 @@ pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<She
                 class: "shelf-modal-card",
                 onclick: move |e| e.stop_propagation(),
 
-                div { class: "shelf-modal-head",
-                    input {
-                        r#type: "text",
-                        class: "shelf-name-input",
-                        placeholder: "Shelf name\u{2026}",
-                        "data-testid": "shelf-name-input",
-                        value: "{name}",
-                        oninput: move |e| name.set(e.value()),
-                    }
-                    div { class: "shelf-kind-toggle",
-                        button {
-                            r#type: "button",
-                            class: "shelf-toggle-btn",
-                            "aria-pressed": if kind() == ShelfKind::Smart { "true" } else { "false" },
-                            "data-testid": "shelf-kind-smart",
-                            onclick: move |_| kind.set(ShelfKind::Smart),
-                            "Smart"
-                        }
-                        button {
-                            r#type: "button",
-                            class: "shelf-toggle-btn",
-                            "aria-pressed": if kind() == ShelfKind::Manual { "true" } else { "false" },
-                            "data-testid": "shelf-kind-manual",
-                            onclick: move |_| kind.set(ShelfKind::Manual),
-                            "Hand-picked"
-                        }
-                    }
-                    VisibilityToggle { visibility: visibility(), on_change: move |v| visibility.set(v) }
-                }
+                {create_shelf_head(name, kind, visibility)}
 
                 div { class: "shelf-modal-body",
                     match kind() {
@@ -128,22 +89,134 @@ pub fn CreateShelfModal(on_close: EventHandler<()>, on_created: EventHandler<She
                     }
                 }
 
-                div { class: "shelf-modal-foot",
-                    button {
-                        r#type: "button",
-                        class: "btn shelf-btn-ghost",
-                        onclick: move |_| on_close.call(()),
-                        "Cancel"
-                    }
-                    button {
-                        r#type: "button",
-                        class: "btn shelf-btn-primary",
-                        "data-testid": "shelf-create-submit",
-                        disabled: saving(),
-                        onclick: on_submit,
-                        if saving() { "Creating\u{2026}" } else { "{create_label}" }
-                    }
+                {create_shelf_foot(saving(), create_label, on_close, on_submit)}
+            }
+        }
+    }
+}
+
+/// Form-state signals [`build_on_submit`] reads/writes. `Copy` (Dioxus
+/// signals), so grouping them keeps the function under clippy's
+/// too-many-arguments cap without changing call-site ergonomics.
+#[derive(Clone, Copy)]
+struct CreateShelfFormSignals {
+    kind: Signal<ShelfKind>,
+    name: Signal<String>,
+    visibility: Signal<Visibility>,
+    match_mode: Signal<MatchMode>,
+    rules: Signal<Vec<RuleDraft>>,
+    picked: Signal<Vec<String>>,
+    error: Signal<Option<String>>,
+    saving: Signal<bool>,
+}
+
+/// Builds the create-shelf submit handler: encodes the current form state
+/// via [`build_create_request`], then saves it and reports the result back
+/// through `error`/`saving`/`on_created`.
+fn build_on_submit(
+    server_url: String,
+    sig: CreateShelfFormSignals,
+    on_created: EventHandler<Shelf>,
+) -> EventHandler<MouseEvent> {
+    let CreateShelfFormSignals {
+        kind,
+        name,
+        visibility,
+        match_mode,
+        rules,
+        picked,
+        mut error,
+        mut saving,
+    } = sig;
+    EventHandler::new(move |_| {
+        if saving() {
+            return;
+        }
+        let req = build_create_request(
+            kind(),
+            name(),
+            visibility(),
+            match_mode(),
+            &rules.read(),
+            &picked.read(),
+        );
+        let url = server_url.clone();
+        saving.set(true);
+        error.set(None);
+        spawn(async move {
+            match data::create_shelf(&url, req).await {
+                Ok(shelf) => on_created.call(shelf),
+                Err(e) => error.set(Some(e.to_string())),
+            }
+            saving.set(false);
+        });
+    })
+}
+
+/// Modal head: name input, smart/hand-picked kind toggle, and the shared
+/// visibility toggle. Split out of [`CreateShelfModal`] to keep it under the
+/// line cap, mirroring `shelf_detail::header`'s plain-fn splits.
+fn create_shelf_head(
+    mut name: Signal<String>,
+    mut kind: Signal<ShelfKind>,
+    mut visibility: Signal<Visibility>,
+) -> Element {
+    rsx! {
+        div { class: "shelf-modal-head",
+            input {
+                r#type: "text",
+                class: "shelf-name-input",
+                placeholder: "Shelf name\u{2026}",
+                "data-testid": "shelf-name-input",
+                value: "{name}",
+                oninput: move |e| name.set(e.value()),
+            }
+            div { class: "shelf-kind-toggle",
+                button {
+                    r#type: "button",
+                    class: "shelf-toggle-btn",
+                    "aria-pressed": if kind() == ShelfKind::Smart { "true" } else { "false" },
+                    "data-testid": "shelf-kind-smart",
+                    onclick: move |_| kind.set(ShelfKind::Smart),
+                    "Smart"
                 }
+                button {
+                    r#type: "button",
+                    class: "shelf-toggle-btn",
+                    "aria-pressed": if kind() == ShelfKind::Manual { "true" } else { "false" },
+                    "data-testid": "shelf-kind-manual",
+                    onclick: move |_| kind.set(ShelfKind::Manual),
+                    "Hand-picked"
+                }
+            }
+            VisibilityToggle { visibility: visibility(), on_change: move |v| visibility.set(v) }
+        }
+    }
+}
+
+/// Modal foot: cancel + submit buttons; submit disables and swaps its label
+/// while a save request is in flight.
+fn create_shelf_foot(
+    saving: bool,
+    create_label: String,
+    on_close: EventHandler<()>,
+    on_submit: EventHandler<MouseEvent>,
+) -> Element {
+    rsx! {
+        div { class: "shelf-modal-foot",
+            button {
+                r#type: "button",
+                class: "btn shelf-btn-ghost",
+                onclick: move |_| on_close.call(()),
+                "Cancel"
+            }
+            button {
+                r#type: "button",
+                class: "btn shelf-btn-primary",
+                "data-testid": "shelf-create-submit",
+                disabled: saving,
+                onclick: move |e| on_submit.call(e),
+                if saving { "Creating\u{2026}" } else { "{create_label}" }
             }
         }
     }
@@ -230,10 +303,15 @@ fn PickerBody(picked: Signal<Vec<String>>, server_url: String) -> Element {
 
     use_library_fetch(server_url.clone(), library);
 
-    let filtered: Vec<EbookMetadata> = filter_library(&library.read(), &query.read())
-        .into_iter()
-        .cloned()
-        .collect();
+    // Memoized so filter only reruns when library/query change, not on every render.
+    let filtered = use_memo(move || {
+        let library_books = library.read();
+        filter_library(&library_books, &query.read())
+            .into_iter()
+            .cloned()
+            .collect::<Vec<EbookMetadata>>()
+    });
+    let filtered = filtered();
     let picked_count = picked.read().len();
 
     rsx! {

--- a/frontend/src/components/create_shelf_modal.rs
+++ b/frontend/src/components/create_shelf_modal.rs
@@ -154,8 +154,7 @@ fn build_on_submit(
 }
 
 /// Modal head: name input, smart/hand-picked kind toggle, and the shared
-/// visibility toggle. Split out of [`CreateShelfModal`] to keep it under the
-/// line cap, mirroring `shelf_detail::header`'s plain-fn splits.
+/// visibility toggle.
 fn create_shelf_head(
     mut name: Signal<String>,
     mut kind: Signal<ShelfKind>,

--- a/frontend/src/components/edit_shelf_modal.rs
+++ b/frontend/src/components/edit_shelf_modal.rs
@@ -186,8 +186,7 @@ fn build_on_save(
 }
 
 /// Modal head: name input, read-only kind badge, and the shared visibility
-/// toggle. Split out of [`EditShelfModal`] to keep it under the line cap,
-/// mirroring `create_shelf_modal`'s `create_shelf_head`.
+/// toggle.
 fn edit_shelf_head(
     mut name: Signal<String>,
     kind_label: &'static str,

--- a/frontend/src/components/edit_shelf_modal.rs
+++ b/frontend/src/components/edit_shelf_modal.rs
@@ -29,30 +29,130 @@ pub fn EditShelfModal(
     let server_url = use_server_url();
     let id = shelf.id;
     let is_smart = shelf.kind == ShelfKind::Smart;
-    let kind_label = match shelf.kind {
+    let kind_label = kind_label(shelf.kind);
+    // System shelves reject the Kobo opt-in (`ShelfError::SystemShelf`) — never offer it.
+    let show_kobo = !shelf.kind.is_system();
+    let name = use_signal(|| shelf.name.clone());
+    let visibility = use_signal(|| shelf.visibility);
+    let sync_to_kobo = use_signal(|| shelf.sync_to_kobo);
+    let mut match_mode = use_signal(|| shelf.match_mode.unwrap_or(MatchMode::All));
+    let rules = use_signal(|| initial_rule_drafts(&shelf.rules));
+    let error = use_signal(|| None::<String>);
+    let saving = use_signal(|| false);
+
+    let on_save = build_on_save(
+        server_url.clone(),
+        id,
+        show_kobo,
+        is_smart,
+        EditShelfFormSignals {
+            name,
+            visibility,
+            sync_to_kobo,
+            match_mode,
+            rules,
+            error,
+            saving,
+        },
+        on_saved,
+    );
+
+    rsx! {
+        div {
+            class: "shelf-modal-overlay",
+            "data-testid": "edit-shelf-modal",
+            onclick: move |_| on_close.call(()),
+            div {
+                class: "shelf-modal-card",
+                onclick: move |e| e.stop_propagation(),
+
+                {edit_shelf_head(name, kind_label, visibility)}
+
+                if is_smart {
+                    div { class: "shelf-modal-body",
+                        RuleBuilder {
+                            match_mode: match_mode(),
+                            rules,
+                            on_match_mode: move |m| match_mode.set(m),
+                            server_url: server_url.clone(),
+                        }
+                    }
+                }
+
+                if show_kobo {
+                    {edit_shelf_kobo_toggle(sync_to_kobo)}
+                }
+
+                if let Some(msg) = error() {
+                    p {
+                        role: "alert",
+                        class: "shelf-modal-error",
+                        "data-testid": "edit-shelf-error",
+                        "{msg}"
+                    }
+                }
+
+                {edit_shelf_foot(saving(), on_close, on_save)}
+            }
+        }
+    }
+}
+
+/// Read-only kind badge text for a shelf's kind.
+fn kind_label(kind: ShelfKind) -> &'static str {
+    match kind {
         ShelfKind::Smart => "Smart shelf",
         ShelfKind::Manual => "Hand-picked shelf",
         ShelfKind::Wishlist => "Wishlist",
-    };
-    // System shelves reject the Kobo opt-in (`ShelfError::SystemShelf`) — never offer it.
-    let show_kobo = !shelf.kind.is_system();
-    let mut name = use_signal(|| shelf.name.clone());
-    let mut visibility = use_signal(|| shelf.visibility);
-    let mut sync_to_kobo = use_signal(|| shelf.sync_to_kobo);
-    let mut match_mode = use_signal(|| shelf.match_mode.unwrap_or(MatchMode::All));
-    let rules = use_signal(|| {
-        let drafts: Vec<RuleDraft> = shelf.rules.iter().map(RuleDraft::from_rule).collect();
-        if drafts.is_empty() {
-            vec![RuleDraft::default()]
-        } else {
-            drafts
-        }
-    });
-    let mut error = use_signal(|| None::<String>);
-    let mut saving = use_signal(|| false);
+    }
+}
 
-    let submit_url = server_url.clone();
-    let on_save = move |_| {
+/// Editable rule drafts prefilled from a shelf's saved rules, or one blank
+/// draft for a smart shelf that has none yet.
+fn initial_rule_drafts(rules: &[ShelfRule]) -> Vec<RuleDraft> {
+    let drafts: Vec<RuleDraft> = rules.iter().map(RuleDraft::from_rule).collect();
+    if drafts.is_empty() {
+        vec![RuleDraft::default()]
+    } else {
+        drafts
+    }
+}
+
+/// Form-state signals [`build_on_save`] reads/writes. `Copy` (Dioxus
+/// signals), so grouping them keeps the function under clippy's
+/// too-many-arguments cap without changing call-site ergonomics.
+#[derive(Clone, Copy)]
+struct EditShelfFormSignals {
+    name: Signal<String>,
+    visibility: Signal<Visibility>,
+    sync_to_kobo: Signal<bool>,
+    match_mode: Signal<MatchMode>,
+    rules: Signal<Vec<RuleDraft>>,
+    error: Signal<Option<String>>,
+    saving: Signal<bool>,
+}
+
+/// Builds the save handler: validates via [`build_update_request`], then
+/// saves the whole form in one request and reports the result back through
+/// `error`/`saving`/`on_saved`.
+fn build_on_save(
+    server_url: String,
+    id: i64,
+    show_kobo: bool,
+    is_smart: bool,
+    sig: EditShelfFormSignals,
+    on_saved: EventHandler<Shelf>,
+) -> EventHandler<MouseEvent> {
+    let EditShelfFormSignals {
+        name,
+        visibility,
+        sync_to_kobo,
+        match_mode,
+        rules,
+        mut error,
+        mut saving,
+    } = sig;
+    EventHandler::new(move |_| {
         if saving() {
             return;
         }
@@ -72,8 +172,7 @@ pub fn EditShelfModal(
                 return;
             }
         };
-        let url = submit_url.clone();
-        let on_saved = on_saved;
+        let url = server_url.clone();
         saving.set(true);
         error.set(None);
         spawn(async move {
@@ -83,90 +182,83 @@ pub fn EditShelfModal(
             }
             saving.set(false);
         });
-    };
+    })
+}
 
+/// Modal head: name input, read-only kind badge, and the shared visibility
+/// toggle. Split out of [`EditShelfModal`] to keep it under the line cap,
+/// mirroring `create_shelf_modal`'s `create_shelf_head`.
+fn edit_shelf_head(
+    mut name: Signal<String>,
+    kind_label: &'static str,
+    mut visibility: Signal<Visibility>,
+) -> Element {
     rsx! {
-        div {
-            class: "shelf-modal-overlay",
-            "data-testid": "edit-shelf-modal",
-            onclick: move |_| on_close.call(()),
-            div {
-                class: "shelf-modal-card",
-                onclick: move |e| e.stop_propagation(),
+        div { class: "shelf-modal-head",
+            input {
+                r#type: "text",
+                class: "shelf-name-input",
+                placeholder: "Shelf name\u{2026}",
+                "data-testid": "edit-shelf-name",
+                value: "{name}",
+                oninput: move |e| name.set(e.value()),
+            }
+            span { class: "shelf-badge", "{kind_label}" }
+            VisibilityToggle { visibility: visibility(), on_change: move |v| visibility.set(v) }
+        }
+    }
+}
 
-                div { class: "shelf-modal-head",
-                    input {
-                        r#type: "text",
-                        class: "shelf-name-input",
-                        placeholder: "Shelf name\u{2026}",
-                        "data-testid": "edit-shelf-name",
-                        value: "{name}",
-                        oninput: move |e| name.set(e.value()),
-                    }
-                    span { class: "shelf-badge", "{kind_label}" }
-                    VisibilityToggle { visibility: visibility(), on_change: move |v| visibility.set(v) }
+/// The Kobo sync opt-in row (off/on segmented toggle). Only mounted for
+/// non-system shelves — see `show_kobo` at the call site.
+fn edit_shelf_kobo_toggle(mut sync_to_kobo: Signal<bool>) -> Element {
+    rsx! {
+        div { class: "shelf-modal-kobo",
+            span { class: "shelf-kobo-label", "Sync to Kobo" }
+            div { class: "shelf-kobo-toggle",
+                button {
+                    r#type: "button",
+                    class: "shelf-toggle-btn",
+                    "aria-pressed": if !sync_to_kobo() { "true" } else { "false" },
+                    "data-testid": "edit-shelf-kobo-off",
+                    onclick: move |_| sync_to_kobo.set(false),
+                    "Off"
                 }
+                button {
+                    r#type: "button",
+                    class: "shelf-toggle-btn",
+                    "aria-pressed": if sync_to_kobo() { "true" } else { "false" },
+                    "data-testid": "edit-shelf-kobo-on",
+                    onclick: move |_| sync_to_kobo.set(true),
+                    "On"
+                }
+            }
+        }
+    }
+}
 
-                if is_smart {
-                    div { class: "shelf-modal-body",
-                        RuleBuilder {
-                            match_mode: match_mode(),
-                            rules,
-                            on_match_mode: move |m| match_mode.set(m),
-                            server_url: server_url.clone(),
-                        }
-                    }
-                }
-
-                if show_kobo {
-                    div { class: "shelf-modal-kobo",
-                        span { class: "shelf-kobo-label", "Sync to Kobo" }
-                        div { class: "shelf-kobo-toggle",
-                            button {
-                                r#type: "button",
-                                class: "shelf-toggle-btn",
-                                "aria-pressed": if !sync_to_kobo() { "true" } else { "false" },
-                                "data-testid": "edit-shelf-kobo-off",
-                                onclick: move |_| sync_to_kobo.set(false),
-                                "Off"
-                            }
-                            button {
-                                r#type: "button",
-                                class: "shelf-toggle-btn",
-                                "aria-pressed": if sync_to_kobo() { "true" } else { "false" },
-                                "data-testid": "edit-shelf-kobo-on",
-                                onclick: move |_| sync_to_kobo.set(true),
-                                "On"
-                            }
-                        }
-                    }
-                }
-
-                if let Some(msg) = error() {
-                    p {
-                        role: "alert",
-                        class: "shelf-modal-error",
-                        "data-testid": "edit-shelf-error",
-                        "{msg}"
-                    }
-                }
-
-                div { class: "shelf-modal-foot",
-                    button {
-                        r#type: "button",
-                        class: "btn shelf-btn-ghost",
-                        onclick: move |_| on_close.call(()),
-                        "Cancel"
-                    }
-                    button {
-                        r#type: "button",
-                        class: "btn shelf-btn-primary",
-                        "data-testid": "edit-shelf-save",
-                        disabled: saving(),
-                        onclick: on_save,
-                        if saving() { "Saving\u{2026}" } else { "Save" }
-                    }
-                }
+/// Modal foot: cancel + save buttons; save disables and swaps its label
+/// while a save request is in flight.
+fn edit_shelf_foot(
+    saving: bool,
+    on_close: EventHandler<()>,
+    on_save: EventHandler<MouseEvent>,
+) -> Element {
+    rsx! {
+        div { class: "shelf-modal-foot",
+            button {
+                r#type: "button",
+                class: "btn shelf-btn-ghost",
+                onclick: move |_| on_close.call(()),
+                "Cancel"
+            }
+            button {
+                r#type: "button",
+                class: "btn shelf-btn-primary",
+                "data-testid": "edit-shelf-save",
+                disabled: saving,
+                onclick: move |e| on_save.call(e),
+                if saving { "Saving\u{2026}" } else { "Save" }
             }
         }
     }

--- a/frontend/src/components/shelf_rule_builder.rs
+++ b/frontend/src/components/shelf_rule_builder.rs
@@ -244,21 +244,29 @@ fn render_preview(preview: &Option<RulePreview>, server_url: &str) -> Element {
     }
 }
 
-/// One editable smart-rule condition row.
-#[component]
-fn ConditionRow(
-    index: usize,
-    draft: RuleDraft,
-    can_remove: bool,
-    on_change: EventHandler<RuleDraft>,
-    on_remove: EventHandler<()>,
-) -> Element {
-    let field = draft.field;
-    let op = draft.op;
+/// The five per-row `FormEvent` handlers a [`ConditionRow`] wires up. `Copy`
+/// (Dioxus event handlers), so passing the whole set around — into the rsx
+/// and into [`condition_value_input`] — stays a single value.
+#[derive(Clone, Copy)]
+struct ConditionHandlers {
+    on_field: EventHandler<FormEvent>,
+    on_op: EventHandler<FormEvent>,
+    on_val: EventHandler<FormEvent>,
+    on_val2: EventHandler<FormEvent>,
+    on_unit: EventHandler<FormEvent>,
+}
 
+/// Builds the field/op/value(s)/unit change handlers for one condition row.
+/// Each clones the row's current draft, applies its one field, and reports
+/// the result through the shared `on_change`. Split out of [`ConditionRow`]
+/// to keep it under the line cap.
+fn build_condition_handlers(
+    draft: RuleDraft,
+    on_change: EventHandler<RuleDraft>,
+) -> ConditionHandlers {
     // On a field change, snap the op to the first one the new field accepts.
     let d_field = draft.clone();
-    let on_field = move |e: FormEvent| {
+    let on_field = EventHandler::new(move |e: FormEvent| {
         if let Some(f) = RuleField::from_str(&e.value()) {
             let mut d = d_field.clone();
             d.field = f;
@@ -278,33 +286,55 @@ fn ConditionRow(
             }
             on_change.call(d);
         }
-    };
+    });
     let d_op = draft.clone();
-    let on_op = move |e: FormEvent| {
+    let on_op = EventHandler::new(move |e: FormEvent| {
         if let Some(o) = RuleOp::from_str(&e.value()) {
             let mut d = d_op.clone();
             d.op = o;
             on_change.call(d);
         }
-    };
+    });
     let d_val = draft.clone();
-    let on_val = move |e: FormEvent| {
+    let on_val = EventHandler::new(move |e: FormEvent| {
         let mut d = d_val.clone();
         d.value = e.value();
         on_change.call(d);
-    };
+    });
     let d_val2 = draft.clone();
-    let on_val2 = move |e: FormEvent| {
+    let on_val2 = EventHandler::new(move |e: FormEvent| {
         let mut d = d_val2.clone();
         d.value2 = e.value();
         on_change.call(d);
-    };
+    });
     let d_unit = draft.clone();
-    let on_unit = move |e: FormEvent| {
+    let on_unit = EventHandler::new(move |e: FormEvent| {
         let mut d = d_unit.clone();
         d.unit = e.value();
         on_change.call(d);
-    };
+    });
+
+    ConditionHandlers {
+        on_field,
+        on_op,
+        on_val,
+        on_val2,
+        on_unit,
+    }
+}
+
+/// One editable smart-rule condition row.
+#[component]
+fn ConditionRow(
+    index: usize,
+    draft: RuleDraft,
+    can_remove: bool,
+    on_change: EventHandler<RuleDraft>,
+    on_remove: EventHandler<()>,
+) -> Element {
+    let field = draft.field;
+    let op = draft.op;
+    let handlers = build_condition_handlers(draft.clone(), on_change);
 
     rsx! {
         div { class: "shelf-condition", "data-testid": "condition-row-{index}",
@@ -312,7 +342,7 @@ fn ConditionRow(
                 class: "shelf-select",
                 "data-testid": "condition-field-{index}",
                 value: field.as_str(),
-                onchange: on_field,
+                onchange: move |e| handlers.on_field.call(e),
                 for (f, label) in FIELDS.iter() {
                     option { key: "{f.as_str()}", value: f.as_str(), "{label}" }
                 }
@@ -321,12 +351,12 @@ fn ConditionRow(
                 class: "shelf-select",
                 "data-testid": "condition-op-{index}",
                 value: op.as_str(),
-                onchange: on_op,
+                onchange: move |e| handlers.on_op.call(e),
                 for (o, label) in OPS.iter().filter(|(o, _)| field.accepts(*o)) {
                     option { key: "{o.as_str()}", value: o.as_str(), "{label}" }
                 }
             }
-            {condition_value_input(&draft, on_val, on_val2, on_unit)}
+            {condition_value_input(&draft, handlers)}
             if can_remove {
                 button {
                     r#type: "button",
@@ -342,15 +372,13 @@ fn ConditionRow(
 }
 
 /// Field-aware value input(s) for a condition row.
-fn condition_value_input(
-    draft: &RuleDraft,
-    on_val: impl FnMut(FormEvent) + 'static,
-    on_val2: impl FnMut(FormEvent) + 'static,
-    on_unit: impl FnMut(FormEvent) + 'static,
-) -> Element {
+fn condition_value_input(draft: &RuleDraft, handlers: ConditionHandlers) -> Element {
     let value = draft.value.clone();
     let value2 = draft.value2.clone();
     let unit = draft.unit.clone();
+    let on_val = move |e| handlers.on_val.call(e);
+    let on_val2 = move |e| handlers.on_val2.call(e);
+    let on_unit = move |e| handlers.on_unit.call(e);
 
     // Date fields carry op-specific inputs.
     if draft.field.is_date() {

--- a/frontend/src/components/shelf_rule_builder.rs
+++ b/frontend/src/components/shelf_rule_builder.rs
@@ -258,8 +258,7 @@ struct ConditionHandlers {
 
 /// Builds the field/op/value(s)/unit change handlers for one condition row.
 /// Each clones the row's current draft, applies its one field, and reports
-/// the result through the shared `on_change`. Split out of [`ConditionRow`]
-/// to keep it under the line cap.
+/// the result through the shared `on_change`.
 fn build_condition_handlers(
     draft: RuleDraft,
     on_change: EventHandler<RuleDraft>,

--- a/frontend/src/pages/landing/hero.rs
+++ b/frontend/src/pages/landing/hero.rs
@@ -107,6 +107,7 @@ pub(super) fn ContinueHero(points: Vec<ResumePoint>, server_url: String) -> Elem
                 div { class: "ch-dots",
                     for i in 0..count {
                         button {
+                            key: "{i}",
                             r#type: "button",
                             class: if i == page() { "ch-dot ch-dot--active" } else { "ch-dot" },
                             "data-testid": "hero-dot-{i}",

--- a/frontend/src/pages/landing/shelf_gallery.rs
+++ b/frontend/src/pages/landing/shelf_gallery.rs
@@ -78,9 +78,9 @@ pub(super) fn shelf_meta_line(count: i64, kind: ShelfKind, visibility: Visibilit
     parts.join(" \u{00b7} ")
 }
 
-/// Per-render snapshot of the gallery's data + selection state, grouped to
-/// stay under the 5-prop threshold — mirrors `landing::sections`'
-/// `LandingContentProps`.
+/// Per-render snapshot of the gallery's data + selection state: the shelf
+/// list, which one is picked, the "All books" tile's count/covers, the
+/// server URL for thumbnails, and the select/create callbacks.
 #[derive(Clone, PartialEq, Props)]
 pub(super) struct ShelfGalleryProps {
     pub shelves: Vec<ShelfSummary>,

--- a/frontend/src/pages/landing/shelf_gallery.rs
+++ b/frontend/src/pages/landing/shelf_gallery.rs
@@ -78,18 +78,33 @@ pub(super) fn shelf_meta_line(count: i64, kind: ShelfKind, visibility: Visibilit
     parts.join(" \u{00b7} ")
 }
 
+/// Per-render snapshot of the gallery's data + selection state, grouped to
+/// stay under the 5-prop threshold — mirrors `landing::sections`'
+/// `LandingContentProps`.
+#[derive(Clone, PartialEq, Props)]
+pub(super) struct ShelfGalleryProps {
+    pub shelves: Vec<ShelfSummary>,
+    pub selection: ShelfSelection,
+    pub all_count: Option<i64>,
+    pub all_cover_uuids: Vec<String>,
+    pub server_url: String,
+    pub on_select: EventHandler<ShelfSelection>,
+    pub on_created: EventHandler<()>,
+}
+
 /// The gallery. Tiles are toggle buttons (`aria-pressed` marks the pick);
 /// the create-shelf modal mounts locally, same wiring as the shelf rail.
 #[component]
-pub(super) fn ShelfGallery(
-    shelves: Vec<ShelfSummary>,
-    selection: ShelfSelection,
-    all_count: Option<i64>,
-    all_cover_uuids: Vec<String>,
-    server_url: String,
-    on_select: EventHandler<ShelfSelection>,
-    on_created: EventHandler<()>,
-) -> Element {
+pub(super) fn ShelfGallery(props: ShelfGalleryProps) -> Element {
+    let ShelfGalleryProps {
+        shelves,
+        selection,
+        all_count,
+        all_cover_uuids,
+        server_url,
+        on_select,
+        on_created,
+    } = props;
     let mut show_create = use_signal(|| false);
     let all_active = selection == ShelfSelection::All;
     let all_meta = match all_count {

--- a/frontend/src/pages/shelf_detail/mobile.rs
+++ b/frontend/src/pages/shelf_detail/mobile.rs
@@ -53,72 +53,15 @@ pub(super) fn MobileShelfDetail(props: MobileShelfDetailProps) -> Element {
         .accent
         .clone()
         .unwrap_or_else(|| "var(--accent)".into());
-    let kicker = format!(
-        "{} {} \u{00b7} {}",
-        shelf.book_count,
-        if shelf.book_count == 1 {
-            "book"
-        } else {
-            "books"
-        },
-        if is_smart {
-            "auto-filled"
-        } else {
-            "hand-picked"
-        },
-    );
-    let kind_label = if is_smart { "Smart" } else { "Hand-picked" };
-    let vis_label = match shelf.visibility {
-        Visibility::Private => "Private",
-        Visibility::Public => "Shared",
-    };
 
     rsx! {
         div {
             class: "m-lib m-shelf-detail",
             style: "--accent: {accent};",
             "data-testid": "shelf-detail",
-            header { class: "m-lib-head",
-                div { class: "omn-brand-word m-lib-brand", "Omnibus" }
-                div { class: "m-lib-head-actions",
-                    Link {
-                        to: Route::MobileSearch {},
-                        class: "m-icon-btn",
-                        "aria-label": "Search",
-                        "data-testid": "mobile-search-entry",
-                        {search_glyph()}
-                    }
-                    // System shelves (Wishlist) are locked server-side — don't
-                    // offer edit/delete the server would reject (mirrors web's
-                    // `can_manage` gate).
-                    if !shelf.kind.is_system() {
-                        MobileShelfActions { shelf: shelf.clone(), on_add, on_edit }
-                    }
-                }
-            }
 
-            div { class: "m-lib-title",
-                span { class: "label", "{kicker}" }
-                h2 { class: "m-head-title", span { class: "m-em", "{shelf.name}" } }
-                div { class: "m-shelf-facets",
-                    span { class: "m-shelf-facet-kind",
-                        if is_smart {
-                            {smart_facet_glyph()}
-                        }
-                        "{kind_label}"
-                    }
-                    span { class: "m-shelf-facet-dot", "\u{00b7}" }
-                    span { class: "m-shelf-facet-vis", "{vis_label}" }
-                    if is_smart {
-                        for (i, rule) in shelf.rules.iter().enumerate() {
-                            span { key: "{i}", class: "m-shelf-facet-chip", "{rule_text(rule)}" }
-                        }
-                    }
-                }
-                if let Some(desc) = shelf.description.as_ref() {
-                    p { class: "m-shelf-desc", "{desc}" }
-                }
-            }
+            {mobile_shelf_head(&shelf, on_add, on_edit)}
+            {mobile_shelf_title_block(&shelf, is_smart)}
 
             // Shelves entry — identical to the mobile landing card.
             Link {
@@ -155,6 +98,85 @@ pub(super) fn MobileShelfDetail(props: MobileShelfDetailProps) -> Element {
                     onclick: move |_| on_add.call(()),
                     "\u{FF0B} Add books"
                 }
+            }
+        }
+    }
+}
+
+/// Persistent header: brand word, search entry, and — for non-system
+/// shelves — the actions menu. Split out of [`MobileShelfDetail`] to keep it
+/// under the line cap.
+fn mobile_shelf_head(
+    shelf: &Shelf,
+    on_add: EventHandler<()>,
+    on_edit: EventHandler<()>,
+) -> Element {
+    rsx! {
+        header { class: "m-lib-head",
+            div { class: "omn-brand-word m-lib-brand", "Omnibus" }
+            div { class: "m-lib-head-actions",
+                Link {
+                    to: Route::MobileSearch {},
+                    class: "m-icon-btn",
+                    "aria-label": "Search",
+                    "data-testid": "mobile-search-entry",
+                    {search_glyph()}
+                }
+                // System shelves (Wishlist) are locked server-side — don't
+                // offer edit/delete the server would reject (mirrors web's
+                // `can_manage` gate).
+                if !shelf.kind.is_system() {
+                    MobileShelfActions { shelf: shelf.clone(), on_add, on_edit }
+                }
+            }
+        }
+    }
+}
+
+/// Title block: eyebrow (count + auto-filled/hand-picked), name, the
+/// kind/visibility/rule-chip facet row, and an optional description. Split
+/// out of [`MobileShelfDetail`] to keep it under the line cap.
+fn mobile_shelf_title_block(shelf: &Shelf, is_smart: bool) -> Element {
+    let kicker = format!(
+        "{} {} \u{00b7} {}",
+        shelf.book_count,
+        if shelf.book_count == 1 {
+            "book"
+        } else {
+            "books"
+        },
+        if is_smart {
+            "auto-filled"
+        } else {
+            "hand-picked"
+        },
+    );
+    let kind_label = if is_smart { "Smart" } else { "Hand-picked" };
+    let vis_label = match shelf.visibility {
+        Visibility::Private => "Private",
+        Visibility::Public => "Shared",
+    };
+    rsx! {
+        div { class: "m-lib-title",
+            span { class: "label", "{kicker}" }
+            h2 { class: "m-head-title", span { class: "m-em", "{shelf.name}" } }
+            div { class: "m-shelf-facets",
+                span { class: "m-shelf-facet-kind",
+                    if is_smart {
+                        {smart_facet_glyph()}
+                    }
+                    "{kind_label}"
+                }
+                span { class: "m-shelf-facet-dot", "\u{00b7}" }
+                span { class: "m-shelf-facet-vis", "{vis_label}" }
+                if is_smart {
+                    for (i, rule) in shelf.rules.iter().enumerate() {
+                        span { key: "{i}", class: "m-shelf-facet-chip", "{rule_text(rule)}" }
+                    }
+                }
+            }
+            if let Some(desc) = shelf.description.as_ref() {
+                p { class: "m-shelf-desc", "{desc}" }
             }
         }
     }

--- a/frontend/src/pages/shelf_detail/mobile.rs
+++ b/frontend/src/pages/shelf_detail/mobile.rs
@@ -104,8 +104,7 @@ pub(super) fn MobileShelfDetail(props: MobileShelfDetailProps) -> Element {
 }
 
 /// Persistent header: brand word, search entry, and — for non-system
-/// shelves — the actions menu. Split out of [`MobileShelfDetail`] to keep it
-/// under the line cap.
+/// shelves — the actions menu.
 fn mobile_shelf_head(
     shelf: &Shelf,
     on_add: EventHandler<()>,
@@ -134,8 +133,7 @@ fn mobile_shelf_head(
 }
 
 /// Title block: eyebrow (count + auto-filled/hand-picked), name, the
-/// kind/visibility/rule-chip facet row, and an optional description. Split
-/// out of [`MobileShelfDetail`] to keep it under the line cap.
+/// kind/visibility/rule-chip facet row, and an optional description.
 fn mobile_shelf_title_block(shelf: &Shelf, is_smart: bool) -> Element {
     let kicker = format!(
         "{} {} \u{00b7} {}",


### PR DESCRIPTION
## Summary
- Closes #1485
- Splits the four oversized shelf-editing components (`CreateShelfModal`, `EditShelfModal`, `MobileShelfDetail`, `ConditionRow`) into named helper functions so every function is under the ~80-line soft cap, following the extraction pattern already used in this feature area (plain-fn splits like `shelf_detail::header`/`shelf_detail::body`).
- Wraps `create_shelf_modal.rs`'s `PickerBody` filter computation in `use_memo`, matching `add_books_modal.rs`.
- Groups `ShelfGallery`'s 7 props into a `ShelfGalleryProps` struct, matching the `LandingHeaderView`/`LandingContentProps` pattern in `landing/sections.rs`.
- Adds a stable `key:` to `ContinueHero`'s dot-paging loop.
- No behavior or rendered-output change — pure refactor.

## Test plan
- [x] `cargo fmt --check -p omnibus-frontend` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (557 passed; 0 failed), including the `create_shelf_modal`, `edit_shelf_modal`, `shelf_rule_builder`, and `shelf_gallery` unit/SSR-render tests
- [ ] wasm32 `--features web` clippy — not run; the `wasm32-unknown-unknown` target isn't installed in this environment

## Version
- [ ] **Minor**
- [ ] **Patch**
- [ ] **No release**

## Notes
- Mechanical, behavior-preserving refactor per the issue's acceptance criteria; no schema/behavior changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYY2wHu8gj3rK7aMHT4M9W)_