### PR TITLE
fix: recognize file relocation in indexer to stop present/missing flapping (#1534)

### DIFF
--- a/db/src/sync/attach/mod.rs
+++ b/db/src/sync/attach/mod.rs
@@ -35,15 +35,16 @@ pub(super) async fn find_attachment_by_scan_key(
 /// `format` file. Ambiguity (two candidates) returns `None` — better to
 /// surface a duplicate the admin can merge manually than to guess.
 /// Global across libraries: the ebook and audiobook roots are separate
-/// trees.
+/// trees. Returns the candidate's uuid alongside its id so the caller can
+/// test it against this scan's Removed bucket (the relocation check).
 pub(super) async fn find_attach_target(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     title_norm: &str,
     author_norm: &str,
     format: &str,
-) -> Result<Option<i64>, sqlx::Error> {
-    let candidates: Vec<i64> = sqlx::query_scalar(
-        "SELECT b.id FROM books b
+) -> Result<Option<(i64, String)>, sqlx::Error> {
+    let candidates: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT b.id, b.uuid FROM books b
           WHERE b.title_norm = ?1 AND b.author_norm = ?2
             AND NOT EXISTS (SELECT 1 FROM book_files bf
                             WHERE bf.book_id = b.id AND bf.format = ?3)
@@ -54,10 +55,11 @@ pub(super) async fn find_attach_target(
     .bind(format)
     .fetch_all(&mut **tx)
     .await?;
-    Ok(match candidates.as_slice() {
-        [only] => Some(*only),
-        _ => None,
-    })
+    if candidates.len() == 1 {
+        Ok(candidates.into_iter().next())
+    } else {
+        Ok(None)
+    }
 }
 
 /// Return whether another file holds the `(book_id, format)` attachment slot.

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -640,11 +640,12 @@ async fn removing_one_multipart_sibling_keeps_the_other_parts() {
 }
 
 #[tokio::test]
-async fn removed_ebook_goes_fileless_and_audiobook_reattaches() {
-    // F2: removing the ebook file makes its books row fileless (retained, fileless)
-    // rather than deleting it, so the attachment ledger survives. The book's
-    // identity (and any user data on it) is preserved, and re-scanning the
-    // still-present audiobook re-attaches to the same row — now audiobook-only.
+async fn removed_ebook_leaves_attached_audiobook_intact() {
+    // The ebook's own book_files row is dropped when its file goes missing,
+    // but the cross-format M4B — recorded in merged_uuids — is a different
+    // format's file, still present on disk, and must survive rather than
+    // being dropped and re-attached on a later scan (AC5). The old blanket
+    // `book_id IN (...)` delete used to take both rows.
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;
     seed_audiobook(&pool, "Stoker/Dracula.m4b", "Dracula", "Bram Stoker").await;
@@ -664,16 +665,19 @@ async fn removed_ebook_goes_fileless_and_audiobook_reattaches() {
     )
     .await
     .unwrap();
-    // Fileless: the books row + its merged_uuids ledger survive; all file rows
-    // are dropped.
+
+    // The books row and its merged_uuids ledger survive; only the ebook's own
+    // file row is gone — the attached M4B is untouched, no re-attach needed.
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM books").await, 1);
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM merged_uuids").await, 1);
-    assert_eq!(count(&pool, "SELECT COUNT(*) FROM book_files").await, 0);
-
-    // The audiobook is still on disk; the next scan re-attaches it to the
-    // retained row, which becomes file-backed (audiobook-only) again.
-    seed_audiobook(&pool, "Stoker/Dracula.m4b", "Dracula", "Bram Stoker").await;
-    assert_eq!(count(&pool, "SELECT COUNT(*) FROM books").await, 1);
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'EPUB'"
+        )
+        .await,
+        0
+    );
     assert_eq!(
         count(
             &pool,
@@ -681,6 +685,14 @@ async fn removed_ebook_goes_fileless_and_audiobook_reattaches() {
         )
         .await,
         1
+    );
+    // The surviving M4B means the book isn't actually fileless — it must not
+    // be flagged missing (the flag UPDATE is guarded on `NOT EXISTS
+    // book_files`, so a surviving cross-format attachment excludes it).
+    assert_eq!(
+        count(&pool, "SELECT is_missing_files FROM books").await,
+        0,
+        "a book with a surviving cross-format attachment is not flagged missing"
     );
 }
 

--- a/db/src/sync/audiobooks/mod.rs
+++ b/db/src/sync/audiobooks/mod.rs
@@ -96,12 +96,18 @@ pub async fn sync_audiobooks_with_progress(
         },
     )
     .await?;
-    let new_covers =
-        sync_audiobooks_new(&mut tx, library_id, library_path, &plan.new_books, || {
+    let new_covers = sync_audiobooks_new(
+        &mut tx,
+        library_id,
+        library_path,
+        &plan.new_books,
+        &plan.removed_uuids,
+        || {
             processed = processed.saturating_add(1);
             on_progress(processed, total);
-        })
-        .await?;
+        },
+    )
+    .await?;
     backfill_audiobook_stats(&mut tx, library_id, &plan.backfill).await?;
     // Only Changed wipes link rows before re-inserting, so it's the only bucket
     // that can leave an author or series with zero books. See `sync_books`.

--- a/db/src/sync/audiobooks/new.rs
+++ b/db/src/sync/audiobooks/new.rs
@@ -3,7 +3,7 @@
 //! fileless row in place to preserve `books.uuid`, and tries the
 //! cross-format auto-attach heuristic before minting a fresh row.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use sqlx::Transaction;
 
@@ -13,17 +13,24 @@ use super::shared::{insert_new_audiobook, rewrite_audiobook_in_place, try_attach
 /// Apply the New bucket: for each entry try cross-format attach first,
 /// otherwise insert a fresh `books` + `book_files` + parts + chapters +
 /// author-link + FTS row. Returns the post-commit cover triples.
+///
+/// `removed_uuids` is this same sync's Removed-bucket output — passed through
+/// to the attach heuristic so it can tell a relocation (the matched target's
+/// own group just vanished this scan) from a genuine cross-format
+/// attachment.
 pub(super) async fn sync_audiobooks_new(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
     library_path: &str,
     new_books: &[crate::audiobook::IndexedAudiobook],
+    removed_uuids: &[String],
     mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, SyncError> {
     let mut new_covers: Vec<(String, String, Vec<u8>)> = Vec::new();
     if new_books.is_empty() {
         return Ok(new_covers);
     }
+    let removed_this_scan: HashSet<&str> = removed_uuids.iter().map(String::as_str).collect();
     // Pre-fetch every same-scan_key `books` row in one batch (chunked at 499 to
     // stay under SQLite's 999-param cap), keyed on the F2 `scan_key` — mirrors
     // `sync_audiobooks_changed`. New entries carry distinct scan_keys, so each
@@ -54,7 +61,9 @@ pub(super) async fn sync_audiobooks_new(
             on_book_written();
             continue;
         }
-        if try_attach_new_audiobook(tx, library_path, b, &mut new_covers).await? {
+        if try_attach_new_audiobook(tx, library_path, b, &removed_this_scan, &mut new_covers)
+            .await?
+        {
             on_book_written();
             continue;
         }

--- a/db/src/sync/audiobooks/removed.rs
+++ b/db/src/sync/audiobooks/removed.rs
@@ -1,8 +1,11 @@
 //! Removed bucket: mirrors `sync::books::removed` — retain each removed
 //! audiobook's `books` row (metadata, links, FTS, soft-ref user data) and
-//! drop only its `book_files` row (parts/chapters cascade), flagging it
-//! missing so the grid/facets hide it via their `EXISTS book_files` filter.
-//! A returning group re-attaches via the Changed bucket, preserving the uuid.
+//! drop only its own native `book_files` row(s) (parts/chapters cascade) —
+//! a row still recorded in `merged_uuids` is a cross-format attachment and
+//! survives — flagging it missing, unless that surviving attachment means
+//! it isn't actually fileless, so the grid/facets hide it via their
+//! `EXISTS book_files` filter. A returning group re-attaches via the
+//! Changed bucket, preserving the uuid.
 
 use sqlx::Transaction;
 
@@ -71,6 +74,13 @@ pub(super) async fn sync_audiobooks_removed(
 /// on a re-run, and `is_missing_files_override = 0` leaves intentionally-fileless
 /// rows (wishlist) un-flagged. `ids` must be non-empty and within the SQLite
 /// 999-param cap (the caller chunks at 500).
+///
+/// The DELETE excludes any row still recorded in `merged_uuids` — a
+/// cross-format attachment (a different format's file, still present) —
+/// so it survives this book's own group going missing. The UPDATE that
+/// follows is guarded on `NOT EXISTS book_files` too, so a book whose
+/// cross-format attachment survived the delete (and so isn't actually
+/// fileless) is not flagged missing.
 async fn mark_book_files_missing_batch(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     ids: &[i64],
@@ -79,7 +89,16 @@ async fn mark_book_files_missing_batch(
         .collect::<Vec<_>>()
         .join(", ");
 
-    let del_sql = format!("DELETE FROM book_files WHERE book_id IN ({placeholders})");
+    let del_sql = format!(
+        "DELETE FROM book_files
+          WHERE book_id IN ({placeholders})
+            AND NOT EXISTS (
+              SELECT 1 FROM merged_uuids mu
+               WHERE mu.book_id = book_files.book_id
+                 AND mu.format = book_files.format
+                 AND mu.scan_key = book_files.scan_key
+            )"
+    );
     let mut del_q = sqlx::query(&del_sql);
     for id in ids {
         del_q = del_q.bind(id);
@@ -89,7 +108,10 @@ async fn mark_book_files_missing_batch(
     let upd_sql = format!(
         "UPDATE books
             SET is_missing_files = 1, missing_files_since = unixepoch()
-          WHERE id IN ({placeholders}) AND is_missing_files = 0 AND is_missing_files_override = 0"
+          WHERE id IN ({placeholders})
+            AND is_missing_files = 0
+            AND is_missing_files_override = 0
+            AND NOT EXISTS (SELECT 1 FROM book_files WHERE book_files.book_id = books.id)"
     );
     let mut upd_q = sqlx::query(&upd_sql);
     for id in ids {

--- a/db/src/sync/audiobooks/shared.rs
+++ b/db/src/sync/audiobooks/shared.rs
@@ -4,6 +4,8 @@
 //! `insert_chapters`), the rewrite-in-place and cross-format attach paths,
 //! and the author-link writer.
 
+use std::collections::HashSet;
+
 use sqlx::Transaction;
 
 use crate::helpers::{mint_uuid, sanitize_accent_color, stable_uuid};
@@ -70,10 +72,17 @@ pub(super) async fn insert_new_audiobook(
 /// `books::try_attach_new_ebook`: a `merged_uuids` hit attaches
 /// unconditionally; otherwise exactly one normalized title+author match
 /// without this format attaches. Returns `true` when attached.
+///
+/// `removed_this_scan` is the set of uuids this same sync just dropped from
+/// the Removed bucket. When the title+author match lands on one of them,
+/// this group is that book's own native group returning under a new
+/// directory (a relocation), so it's rewritten in place instead of
+/// minting a `merged_uuids` row.
 pub(super) async fn try_attach_new_audiobook(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_path: &str,
     b: &crate::audiobook::IndexedAudiobook,
+    removed_this_scan: &HashSet<&str>,
     covers: &mut Vec<(String, String, Vec<u8>)>,
 ) -> Result<bool, SyncError> {
     if b.error.is_some() {
@@ -96,11 +105,15 @@ pub(super) async fn try_attach_new_audiobook(
         // No author (or empty title): too weak a signal to auto-match.
         return Ok(false);
     };
-    let Some(target_id) =
+    let Some((target_id, target_uuid)) =
         attach::find_attach_target(tx, &title_norm, &author_norm, &b.format).await?
     else {
         return Ok(false);
     };
+    if removed_this_scan.contains(target_uuid.as_str()) {
+        rewrite_audiobook_in_place(tx, target_id, &target_uuid, b, covers).await?;
+        return Ok(true);
+    }
     // find_attach_target already excludes a book that holds this format, so the
     // title+author auto-attach stays one-file-per-format; deliberate multi-part
     // combines come through the manual-merge path, not here.
@@ -436,6 +449,12 @@ async fn insert_audiobook_author_link(
 }
 
 /// UPDATE the `books` row for a Changed audiobook (preserves `books.id`).
+///
+/// Also refreshes `scan_key` from `b.scan_key`. For the Changed bucket and
+/// the New-bucket same-scan_key rewrite this is a no-op (the entry already
+/// matched on that value); it's load-bearing for the New-bucket relocation
+/// rewrite, where the incoming group's directory is the book's *new*
+/// scan_key.
 async fn update_audiobook_row(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
@@ -450,11 +469,12 @@ async fn update_audiobook_row(
 
     sqlx::query(
         "UPDATE books SET \
-            path = ?, title = ?, sort = ?, author_sort = ?, has_cover = ?, \
+            scan_key = ?, path = ?, title = ?, sort = ?, author_sort = ?, has_cover = ?, \
             description = ?, accent_color = ?, title_norm = ?, author_norm = ?, \
             last_modified = strftime('%s','now') \
          WHERE id = ?",
     )
+    .bind(&b.scan_key)
     .bind(&book_path)
     .bind(&b.title)
     .bind(&b.title)

--- a/db/src/sync/audiobooks/tests.rs
+++ b/db/src/sync/audiobooks/tests.rs
@@ -4,12 +4,17 @@
 //! `sync_audiobooks` tests in `sync/tests.rs` cover only the composed happy
 //! path, not these per-helper contracts (attach, re-attach, backfill).
 
+use std::collections::HashSet;
+
 use sqlx::SqlitePool;
 
 use super::backfill_audiobook_stats;
 use super::shared::{attach_audiobook_file, insert_new_audiobook, try_attach_new_audiobook};
 use super::stamp_audiobooks_last_indexed;
-use super::{sync_audiobooks_changed, sync_audiobooks_new, sync_audiobooks_removed};
+use super::{
+    sync_audiobooks, sync_audiobooks_changed, sync_audiobooks_new, sync_audiobooks_removed,
+    AudiobookSyncPlan,
+};
 use crate::pool::init_db;
 use crate::sync::books::SyncError;
 use crate::test_support::{count_rows, indexed_audiobook, seed_synced_ebook, CoversTempDir};
@@ -69,7 +74,7 @@ async fn sync_audiobooks_new_inserts_a_new_audiobook_and_its_rows() {
         Some("Author"),
     )];
     let mut tx = pool.begin().await.unwrap();
-    let covers = sync_audiobooks_new(&mut tx, library_id, "/lib", &new_books, || {})
+    let covers = sync_audiobooks_new(&mut tx, library_id, "/lib", &new_books, &[], || {})
         .await
         .unwrap();
     tx.commit().await.unwrap();
@@ -164,7 +169,7 @@ async fn sync_audiobooks_new_rewrites_a_fileless_book_in_place_when_scan_key_mat
     // … and returned, so the next scan classifies the same scan_key as New.
     let returned = indexed_audiobook("Author/Book.m4b", "Book", Some("Seed Author"));
     let mut tx = pool.begin().await.unwrap();
-    sync_audiobooks_new(&mut tx, library_id, "/lib", &[returned], || {})
+    sync_audiobooks_new(&mut tx, library_id, "/lib", &[returned], &[], || {})
         .await
         .unwrap();
     tx.commit().await.unwrap();
@@ -198,7 +203,7 @@ async fn sync_audiobooks_new_is_a_noop_for_empty_batch() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let library_id = seed_scan_root(&pool).await;
     let mut tx = pool.begin().await.unwrap();
-    let covers = sync_audiobooks_new(&mut tx, library_id, "/lib", &[], || {})
+    let covers = sync_audiobooks_new(&mut tx, library_id, "/lib", &[], &[], || {})
         .await
         .unwrap();
     tx.commit().await.unwrap();
@@ -450,6 +455,78 @@ async fn sync_audiobooks_removed_retains_books_row_and_removes_book_files_row() 
     assert_eq!(flagged, 1, "retained row is flagged missing");
 }
 
+/// A book whose own audiobook group is removed, but which still holds a
+/// cross-format attachment (a different format's file, recorded in
+/// `merged_uuids` and still present), is not flagged missing — the
+/// surviving file means the book isn't actually fileless.
+#[tokio::test]
+async fn sync_audiobooks_removed_does_not_flag_missing_when_a_cross_format_attachment_survives() {
+    let _covers = CoversTempDir::new("ab_sync_removed_survives_attach");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+    let book_id = seed_audiobook_with_file(&pool, library_id, "Author/Book.m4b").await;
+    let uuid: String = sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // Forge a surviving cross-format attachment: a book_files row in a
+    // different format, backed by its own merged_uuids ledger entry.
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch, scan_key)
+         VALUES (?, 'EPUB', 'Book', 1000, 100, 'Author/Book.epub')",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('attached-epub', ?, 'EPUB', '/ebooks', 'Author/Book.epub')",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    sync_audiobooks_removed(&mut tx, library_id, &[uuid])
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    // The M4B row is dropped, the EPUB survives, and the book must not be
+    // flagged missing since it still holds a file.
+    assert_eq!(
+        count_rows(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'M4B'"
+        )
+        .await,
+        0,
+        "the book's own native group row is dropped"
+    );
+    assert_eq!(
+        count_rows(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'EPUB'"
+        )
+        .await,
+        1,
+        "the cross-format attachment survives"
+    );
+    let is_missing: i64 = sqlx::query_scalar("SELECT is_missing_files FROM books WHERE id = ?")
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        is_missing, 0,
+        "a surviving cross-format attachment means the book isn't fileless"
+    );
+}
+
 /// One `sync_audiobooks_removed` call ghosts every uuid in the batch — the
 /// batched resolve + `mark_book_files_missing_batch` covers N groups in a
 /// single invocation.
@@ -667,7 +744,7 @@ async fn try_attach_new_audiobook_attaches_via_recorded_ledger_entry() {
     );
     let mut covers = Vec::new();
     let mut tx = pool.begin().await.unwrap();
-    let attached = try_attach_new_audiobook(&mut tx, "/lib", &b, &mut covers)
+    let attached = try_attach_new_audiobook(&mut tx, "/lib", &b, &HashSet::new(), &mut covers)
         .await
         .unwrap();
     tx.commit().await.unwrap();
@@ -702,7 +779,7 @@ async fn try_attach_new_audiobook_attaches_via_title_author_match_when_no_ledger
     let b = indexed_audiobook("Stoker/Dracula.m4b", "Dracula", Some("Bram Stoker"));
     let mut covers = Vec::new();
     let mut tx = pool.begin().await.unwrap();
-    let attached = try_attach_new_audiobook(&mut tx, "/lib", &b, &mut covers)
+    let attached = try_attach_new_audiobook(&mut tx, "/lib", &b, &HashSet::new(), &mut covers)
         .await
         .unwrap();
     tx.commit().await.unwrap();
@@ -721,7 +798,7 @@ async fn try_attach_new_audiobook_declines_when_no_author_present() {
     let b = indexed_audiobook("Author/NoAuthor.m4b", "No Author", None);
     let mut covers = Vec::new();
     let mut tx = pool.begin().await.unwrap();
-    let attached = try_attach_new_audiobook(&mut tx, "/lib", &b, &mut covers)
+    let attached = try_attach_new_audiobook(&mut tx, "/lib", &b, &HashSet::new(), &mut covers)
         .await
         .unwrap();
     tx.commit().await.unwrap();
@@ -742,7 +819,7 @@ async fn try_attach_new_audiobook_propagates_db_error_when_table_missing() {
         .execute(&mut *tx)
         .await
         .unwrap();
-    let err = try_attach_new_audiobook(&mut tx, "/lib", &b, &mut covers)
+    let err = try_attach_new_audiobook(&mut tx, "/lib", &b, &HashSet::new(), &mut covers)
         .await
         .unwrap_err();
     assert!(matches!(err, SyncError::Db(_)));
@@ -965,4 +1042,64 @@ async fn stamp_audiobooks_last_indexed_sets_scan_roots_last_indexed() {
         after.unwrap_or(0) > 0,
         "last_indexed stamped with wall-clock seconds"
     );
+}
+
+// ── Moved/renamed audiobook group relocation ────────────────────────────
+
+/// AC6: AC1-AC4 hold for an audiobook group directory moved within the
+/// audiobook library. The moved group is classified Removed (old scan_key)
+/// and New (new scan_key) in the same reindex plan; the relocation must be
+/// recognized and rewritten in place — updating `books.scan_key` (AC1),
+/// preserving `books.id`/`books.uuid` (AC4), clearing `is_missing_files`
+/// (AC2), and minting no `merged_uuids` row (AC3) — instead of being
+/// re-bound as a cross-format attachment onto its own just-vacated slot.
+#[tokio::test]
+async fn moved_audiobook_group_relocates_in_place_instead_of_minting_a_merged_uuids_row() {
+    let _covers = CoversTempDir::new("ab_sync_relocation");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+    let book_id = seed_audiobook_with_file(&pool, library_id, "Old/Book").await;
+    let uuid_before: String = sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // One reindex pass observing the move: the old scan_key is Removed, the
+    // new group directory is New — exactly what the real diff produces.
+    sync_audiobooks(
+        &pool,
+        "/lib",
+        AudiobookSyncPlan {
+            new_books: vec![indexed_audiobook("New/Book", "Seeded", Some("Seed Author"))],
+            removed_uuids: vec![uuid_before.clone()],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM books").await,
+        1,
+        "no duplicate book was created"
+    );
+    let (id_after, uuid_after, scan_key_after, is_missing): (i64, String, String, i64) =
+        sqlx::query_as("SELECT id, uuid, scan_key, is_missing_files FROM books")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(id_after, book_id, "AC4: books.id preserved");
+    assert_eq!(uuid_after, uuid_before, "AC4: books.uuid preserved");
+    assert_eq!(scan_key_after, "New/Book", "AC1: scan_key follows the move");
+    assert_eq!(
+        is_missing, 0,
+        "AC2: not flagged missing after the relocation"
+    );
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM merged_uuids").await,
+        0,
+        "AC3: no cross-format ledger row minted for a same-format relocation"
+    );
+    assert_eq!(book_files_count(&pool, book_id).await, 1, "one file row");
 }

--- a/db/src/sync/books/mod.rs
+++ b/db/src/sync/books/mod.rs
@@ -144,10 +144,17 @@ pub async fn sync_books_with_progress(
         },
     )
     .await?;
-    let new_covers = sync_new(&mut tx, library_id, library_path, &plan.new_books, || {
-        processed = processed.saturating_add(1);
-        on_progress(processed, total);
-    })
+    let new_covers = sync_new(
+        &mut tx,
+        library_id,
+        library_path,
+        &plan.new_books,
+        &plan.removed_uuids,
+        || {
+            processed = processed.saturating_add(1);
+            on_progress(processed, total);
+        },
+    )
     .await?;
     super::backfill::backfill_stat_chunks(&mut tx, library_id, &plan.backfill).await?;
     // Changed is the only bucket that drops link rows (`wipe_per_book_link_rows`

--- a/db/src/sync/books/new.rs
+++ b/db/src/sync/books/new.rs
@@ -3,7 +3,7 @@
 //! same-scan_key fileless row in place to preserve `books.uuid`, and tries the
 //! cross-format auto-attach heuristic before minting a fresh row.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use sqlx::Transaction;
 
@@ -16,16 +16,22 @@ use super::shared::{
 
 /// Insert a batch of New entries: canonical `books` + `book_files` row,
 /// metadata link rows, FTS row. Returns the post-commit cover triples.
+///
+/// `removed_uuids` is this same sync's Removed-bucket output — passed through
+/// to the attach heuristic so it can tell a relocation (the matched target's
+/// own file just vanished this scan) from a genuine cross-format attachment.
 pub(super) async fn sync_new(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
     library_path: &str,
     new_books: &[crate::ebook::IndexedBook],
+    removed_uuids: &[String],
     mut on_book_written: impl FnMut(),
 ) -> Result<Vec<(String, String, Vec<u8>)>, sqlx::Error> {
     if new_books.is_empty() {
         return Ok(Vec::new());
     }
+    let removed_this_scan: HashSet<&str> = removed_uuids.iter().map(String::as_str).collect();
 
     // Pre-compute the `scan_key` (relative path, F2) for every New entry so we
     // can batch the "does a `books` row with this scan_key already exist?"
@@ -71,7 +77,7 @@ pub(super) async fn sync_new(
             on_book_written();
             continue;
         }
-        if try_attach_new_ebook(tx, library_path, b, &mut new_covers).await? {
+        if try_attach_new_ebook(tx, library_path, b, &removed_this_scan, &mut new_covers).await? {
             on_book_written();
             continue;
         }

--- a/db/src/sync/books/removed.rs
+++ b/db/src/sync/books/removed.rs
@@ -1,19 +1,22 @@
 //! Removed bucket: every uuid whose file disappeared keeps its `books` row.
-//! One chunked DELETE drops only the `book_files` rows, and one chunked UPDATE
-//! flags each book missing for `missing_files::gc_books_missing_files` — its
-//! metadata, taxonomy links, and FTS row stay, so the book remains in
-//! browse/search; the grid and facets hide it
-//! via their own `EXISTS book_files` filter. Idempotent — a re-run on an
-//! already-fileless row deletes zero `book_files` and the flag UPDATE no-ops
-//! (the `is_missing_files = 0` guard preserves the original
+//! One chunked DELETE drops only the book's own (native) `book_files` rows —
+//! a row still backed by a `merged_uuids` entry is a cross-format attachment
+//! and survives — and one chunked UPDATE flags each book missing for
+//! `missing_files::gc_books_missing_files`. Metadata, taxonomy links, and the
+//! FTS row stay, so the book remains in browse/search; the grid and facets
+//! hide it via their own `EXISTS book_files` filter. Idempotent — a re-run on
+//! an already-fileless row deletes zero `book_files` and the flag UPDATE
+//! no-ops (the `is_missing_files = 0` guard preserves the original
 //! `missing_files_since`).
 
 use sqlx::Transaction;
 
 /// Mark a batch of removed books' files missing. The file is gone, but the
 /// `books` row — its metadata, taxonomy links, FTS row, and every soft-ref
-/// user-data row — is **retained** (only `book_files` is dropped, parts and
-/// chapters cascading), so the book stays in author/series/tag browse and
+/// user-data row — is **retained**; only the book's own native `book_files`
+/// row(s) are dropped (parts and chapters cascading) — a row still recorded
+/// in `merged_uuids` is a cross-format attachment in a different format and
+/// survives — so the book stays in author/series/tag browse and
 /// search while the grid/facets hide it via their `EXISTS book_files` filter. A
 /// returning file re-attaches via the Changed path, preserving the uuid.
 /// Idempotent: a re-run on an already-fileless row deletes zero `book_files`
@@ -56,9 +59,22 @@ pub(super) async fn sync_removed(
             .join(", ");
 
         // One DELETE per chunk: `book_file_parts` + `file_chapters` cascade
-        // off the `book_files` row, so a single sweep drops everything the
-        // file owned.
-        let delete_sql = format!("DELETE FROM book_files WHERE book_id IN ({id_placeholders})");
+        // off the `book_files` row. Scoped to rows with **no** matching
+        // `merged_uuids` entry — a row that IS recorded there is a
+        // cross-format attachment (a different format's file, still present)
+        // and must survive this book's own file going missing; the
+        // old blanket `book_id IN (...)` delete dropped it too, only for it
+        // to re-attach (and re-mint a `book_files` row) on the next scan.
+        let delete_sql = format!(
+            "DELETE FROM book_files
+              WHERE book_id IN ({id_placeholders})
+                AND NOT EXISTS (
+                  SELECT 1 FROM merged_uuids mu
+                   WHERE mu.book_id = book_files.book_id
+                     AND mu.format = book_files.format
+                     AND mu.scan_key = book_files.scan_key
+                )"
+        );
         let mut delete_q = sqlx::query(&delete_sql);
         for id in &ids {
             delete_q = delete_q.bind(id);
@@ -69,13 +85,17 @@ pub(super) async fn sync_removed(
         // clock. The `is_missing_files = 0` guard preserves the original
         // `missing_files_since` on a re-run; the `is_missing_files_override = 0`
         // guard leaves intentionally-fileless rows (wishlist) unflagged so
-        // reads keep showing them.
+        // reads keep showing them. The `NOT EXISTS book_files` guard excludes a
+        // book whose cross-format attachment (a different format's file, still
+        // present) survived the delete above — it isn't actually fileless, so
+        // it must not be flagged missing.
         let update_sql = format!(
             "UPDATE books
                 SET is_missing_files = 1, missing_files_since = unixepoch()
               WHERE id IN ({id_placeholders})
                 AND is_missing_files = 0
-                AND is_missing_files_override = 0"
+                AND is_missing_files_override = 0
+                AND NOT EXISTS (SELECT 1 FROM book_files WHERE book_files.book_id = books.id)"
         );
         let mut update_q = sqlx::query(&update_sql);
         for id in &ids {

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -4,6 +4,8 @@
 //! the rewrite-in-place and cross-format attach paths, and the
 //! post-commit cover materialization + missing-files marker helper.
 
+use std::collections::HashSet;
+
 use omnibus_shared::EbookMetadata;
 use sqlx::Transaction;
 
@@ -52,10 +54,18 @@ pub(super) async fn rewrite_book_in_place(
 /// `true` when the file was attached (the caller skips its normal
 /// insert). Per-file parse errors never attach — their metadata is a
 /// filename fallback, not a real title.
+///
+/// `removed_this_scan` is the set of uuids this same sync just dropped from
+/// the Removed bucket. When the (2) match lands on one of them, the file
+/// isn't a genuine cross-format attachment — it's that book's own native
+/// file returning under a new path (a relocation) — so it's
+/// rewritten in place (updating `books.scan_key`) instead of minting a
+/// `merged_uuids` row.
 pub(super) async fn try_attach_new_ebook(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_path: &str,
     b: &crate::ebook::IndexedBook,
+    removed_this_scan: &HashSet<&str>,
     covers: &mut Vec<(String, String, Vec<u8>)>,
 ) -> Result<bool, sqlx::Error> {
     if b.metadata.error.is_some() {
@@ -97,11 +107,15 @@ pub(super) async fn try_attach_new_ebook(
         // No author (or empty title): too weak a signal to auto-match.
         return Ok(false);
     };
-    let Some(target_id) =
+    let Some((target_id, target_uuid)) =
         attach::find_attach_target(tx, &title_norm, &author_norm, &file_ext).await?
     else {
         return Ok(false);
     };
+    if removed_this_scan.contains(target_uuid.as_str()) {
+        rewrite_book_in_place(tx, target_id, &target_uuid, b, covers).await?;
+        return Ok(true);
+    }
     // A brand-new attachment: mint a stable handle for the ledger row (the
     // lookup above is by scan_key, so this uuid is only an identifier).
     let uuid = stable_uuid(library_path, &m.filename);
@@ -217,6 +231,12 @@ pub(in crate::sync) async fn clear_missing_files_flag(
 /// UPDATE the `books` row for a Changed entry in place (preserving id).
 /// All scalar columns that `insert_book_row` writes get refreshed; the
 /// link tables and FTS row are handled by the caller.
+///
+/// Also refreshes `scan_key` from `b`'s own filename. For the Changed bucket
+/// and the New-bucket same-scan_key rewrite this is a no-op (the entry
+/// already matched on that value); it's load-bearing for the New-bucket
+/// relocation rewrite, where the incoming file's path is the book's *new*
+/// scan_key.
 async fn update_book_row(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
@@ -224,6 +244,7 @@ async fn update_book_row(
 ) -> Result<(), sqlx::Error> {
     let m = &b.metadata;
     let (book_path, _, _) = split_filename(&m.filename);
+    let scan_key = scan_key_for(&m.filename);
     let title = m.display_title();
     let series_index_num = m.series_index.as_deref().and_then(parse_series_index);
     let author_sort = m
@@ -235,12 +256,13 @@ async fn update_book_row(
 
     sqlx::query(
         "UPDATE books SET
-            path = ?, title = ?, sort = ?, author_sort = ?, series_sort = ?, series_index = ?,
-            pubdate = ?, has_cover = ?, description = ?, accent_color = ?,
+            scan_key = ?, path = ?, title = ?, sort = ?, author_sort = ?, series_sort = ?,
+            series_index = ?, pubdate = ?, has_cover = ?, description = ?, accent_color = ?,
             title_norm = ?, author_norm = ?, word_count = ?,
             last_modified = strftime('%s','now')
          WHERE id = ?",
     )
+    .bind(&scan_key)
     .bind(&book_path)
     .bind(&title)
     .bind(&title)

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -8,8 +8,9 @@ use omnibus_shared::{Contributor, EbookMetadata, Identifier};
 use sqlx::SqlitePool;
 
 use super::shared::{insert_book_row, insert_metadata_links};
-use super::{sync_changed, sync_new, sync_removed, wipe_per_book_link_rows};
+use super::{sync_books, sync_changed, sync_new, sync_removed, wipe_per_book_link_rows, SyncPlan};
 use crate::ebook::IndexedBook;
+use crate::indexer::diff_library;
 use crate::pool::init_db;
 use crate::test_support::{count_rows, indexed, CoversTempDir};
 
@@ -123,6 +124,75 @@ async fn sync_removed_retains_books_row_and_removes_book_files_row() {
         .await
         .unwrap();
     assert_eq!(flagged, 1, "retained row is flagged missing");
+}
+
+/// A book whose own ebook file is removed, but which still holds a
+/// cross-format attachment (a different format's file, recorded in
+/// `merged_uuids` and still present), is not flagged missing — the surviving
+/// file means the book isn't actually fileless.
+#[tokio::test]
+async fn sync_removed_does_not_flag_missing_when_a_cross_format_attachment_survives() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+    let book_id = seed_book_with_file(&pool, library_id, "a.epub").await;
+    let uuid: String = sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // Forge a surviving cross-format attachment: a book_files row in a
+    // different format, backed by its own merged_uuids ledger entry.
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch, scan_key)
+         VALUES (?, 'M4B', 'a', 1000, 100, 'a.m4b')",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('attached-m4b', ?, 'M4B', '/audio', 'a.m4b')",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    sync_removed(&mut tx, library_id, &[uuid]).await.unwrap();
+    tx.commit().await.unwrap();
+
+    // The EPUB row is dropped, the M4B survives, and the book must not be
+    // flagged missing since it still holds a file.
+    assert_eq!(
+        count_rows(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'EPUB'"
+        )
+        .await,
+        0,
+        "the book's own native file row is dropped"
+    );
+    assert_eq!(
+        count_rows(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'M4B'"
+        )
+        .await,
+        1,
+        "the cross-format attachment survives"
+    );
+    let is_missing: i64 = sqlx::query_scalar("SELECT is_missing_files FROM books WHERE id = ?")
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        is_missing, 0,
+        "a surviving cross-format attachment means the book isn't fileless"
+    );
 }
 
 /// One `sync_removed` call ghosts every uuid in the batch — proving the
@@ -253,7 +323,7 @@ async fn sync_new_inserts_a_new_book_and_its_link_rows() {
 
     let new_books = vec![book_with_all_links("fresh.epub", "Fresh")];
     let mut tx = pool.begin().await.unwrap();
-    let covers = sync_new(&mut tx, library_id, "/lib", &new_books, || {})
+    let covers = sync_new(&mut tx, library_id, "/lib", &new_books, &[], || {})
         .await
         .unwrap();
     tx.commit().await.unwrap();
@@ -449,6 +519,132 @@ async fn word_count_persists_on_insert_and_refreshes_on_change() {
         .await
         .unwrap();
     assert_eq!(refreshed, Some(2500), "the update refreshes word_count");
+}
+
+// ── Moved/renamed ebook relocation ───────────────────────────────────
+
+/// A moved/renamed ebook is classified Removed (old scan_key) and New (new
+/// scan_key) in the same reindex plan. The relocation must be recognized and
+/// written as the book's own native row — updating `books.scan_key` (AC1),
+/// preserving `books.id`/`books.uuid` (AC4), clearing `is_missing_files`
+/// (AC2), and minting no `merged_uuids` row (AC3) — rather than the
+/// title+author attach heuristic re-binding it as a cross-format attachment
+/// onto its own just-vacated slot.
+#[tokio::test]
+async fn moved_ebook_relocates_in_place_instead_of_minting_a_merged_uuids_row() {
+    let _covers = CoversTempDir::new("sync_books_relocation");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+    let book_id = seed_book_with_file(&pool, library_id, "Old/book.epub").await;
+    let uuid_before: String = sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // One reindex pass observing the move: the old scan_key is Removed, the
+    // new path is New — exactly what the real diff produces.
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            new_books: vec![book_with_all_links("New/book.epub", "Seeded")],
+            removed_uuids: vec![uuid_before.clone()],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM books").await,
+        1,
+        "no duplicate book was created"
+    );
+    let (id_after, uuid_after, scan_key_after, is_missing): (i64, String, String, i64) =
+        sqlx::query_as("SELECT id, uuid, scan_key, is_missing_files FROM books")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(id_after, book_id, "AC4: books.id preserved");
+    assert_eq!(uuid_after, uuid_before, "AC4: books.uuid preserved");
+    assert_eq!(
+        scan_key_after, "New/book.epub",
+        "AC1: scan_key follows the move"
+    );
+    assert_eq!(
+        is_missing, 0,
+        "AC2: not flagged missing after the relocation"
+    );
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM merged_uuids").await,
+        0,
+        "AC3: no cross-format ledger row minted for a same-format relocation"
+    );
+    assert_eq!(book_files_count(&pool, book_id).await, 1, "one file row");
+}
+
+/// AC2: three consecutive reindexes after a move converge. Each pass derives
+/// its plan the way the real indexer does — `diff_library` classifying the
+/// current DB rows against a fixed on-disk state — so a bug that leaves
+/// `books.scan_key` stale (still naming the old path) would keep
+/// reclassifying the book Removed every pass, flapping it between
+/// present and missing forever.
+#[tokio::test]
+async fn three_consecutive_reindexes_after_a_move_converge_on_one_file_backed_row() {
+    let _covers = CoversTempDir::new("sync_books_relocation_convergence");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+    let book_id = seed_book_with_file(&pool, library_id, "Old/book.epub").await;
+
+    let disk = [crate::ebook::StatEntry {
+        filename: "New/book.epub".into(),
+        scan_key: "New/book.epub".into(),
+        mtime_epoch: 0,
+        size_bytes: 0,
+        error: None,
+    }];
+
+    for pass in 0..3 {
+        let db_rows = crate::books::list_indexed_rows_for_formats(&pool, "/lib", &["EPUB"])
+            .await
+            .unwrap();
+        let diff = diff_library(&disk, &db_rows, std::path::Path::new("/lib"), true);
+        let new_books = if diff.new.is_empty() {
+            vec![]
+        } else {
+            vec![book_with_all_links("New/book.epub", "Seeded")]
+        };
+
+        sync_books(
+            &pool,
+            "/lib",
+            SyncPlan {
+                new_books,
+                removed_uuids: diff.removed,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            book_files_count(&pool, book_id).await,
+            1,
+            "pass {pass}: exactly one file row, no flapping"
+        );
+        let is_missing: i64 = sqlx::query_scalar("SELECT is_missing_files FROM books WHERE id = ?")
+            .bind(book_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(is_missing, 0, "pass {pass}: is_missing_files stays 0");
+        assert_eq!(
+            count_rows(&pool, "SELECT COUNT(*) FROM merged_uuids").await,
+            0,
+            "pass {pass}: still no merged_uuids row"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Closes #1534
- Moving/renaming a file inside a library changed its `scan_key`, so the old path landed in Removed and the new path in New. The New-bucket auto-attach heuristic re-bound the file to the same book but never updated `books.scan_key`, and `sync_removed`'s `DELETE` was scoped only by `book_id` — so it dropped the just-attached row (and any cross-format sibling) on the very next scan, flapping the book between present and missing forever.
- `try_attach_new_ebook` / `try_attach_new_audiobook` now recognize a relocation: when the title+author match lands on a book whose own native file this same scan's Removed bucket just dropped, the book is rewritten in place (updating `books.scan_key`/`path`) instead of minting a `merged_uuids` attachment.
- `sync_removed` / `sync_audiobooks_removed` now scope their `DELETE` to a book's own file rows, excluding any row still recorded in `merged_uuids` (a cross-format attachment in a different format, still present on disk) — so it survives a sibling file going missing.
- Updated `removed_ebook_goes_fileless_and_audiobook_reattaches` (renamed `removed_ebook_leaves_attached_audiobook_intact`) to assert the new, better behavior: the attached audiobook survives rather than being dropped and re-attached on the next scan.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1562 passed; 1 unrelated pre-existing failure — `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails only because the downloaded audiobook test fixtures aren't present in this sandbox; unrelated to this change)
- New/updated tests covering AC1–AC6: `sync::books::tests::moved_ebook_relocates_in_place_instead_of_minting_a_merged_uuids_row`, `sync::books::tests::three_consecutive_reindexes_after_a_move_converge_on_one_file_backed_row`, `sync::audiobooks::tests::moved_audiobook_group_relocates_in_place_instead_of_minting_a_merged_uuids_row`, `sync::attach::tests::removed_ebook_leaves_attached_audiobook_intact`

## Notes
- No new environment variables, migrations, or skill changes required — the fix is confined to `db/src/sync/{books,audiobooks,attach}`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYY2wHu8gj3rK7aMHT4M9W)_