### PR TITLE
refactor: transact kobo put_state writes and move author_exists into db crate (#1454)

### DIFF
--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -55,11 +55,7 @@ impl AuthorPhotoSource {
     }
 }
 
-/// Returns `true` when an `authors` row with `id` exists. Used as a
-/// preflight by the admin author-photo mutation handlers (upload, URL fetch,
-/// scan) so a typo'd id fails fast with 404 rather than doing side-effecting
-/// work first; a future change (e.g. a soft-delete column) then has exactly
-/// one query to touch.
+/// Returns `true` when an `authors` row with `id` exists.
 pub async fn author_exists(pool: &SqlitePool, id: i64) -> Result<bool, AuthorPhotosDataError> {
     Ok(
         sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")

--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -55,6 +55,21 @@ impl AuthorPhotoSource {
     }
 }
 
+/// Returns `true` when an `authors` row with `id` exists. Used as a
+/// preflight by the admin author-photo mutation handlers (upload, URL fetch,
+/// scan) so a typo'd id fails fast with 404 rather than doing side-effecting
+/// work first; a future change (e.g. a soft-delete column) then has exactly
+/// one query to touch.
+pub async fn author_exists(pool: &SqlitePool, id: i64) -> Result<bool, AuthorPhotosDataError> {
+    Ok(
+        sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .map(|v| v != 0)?,
+    )
+}
+
 /// Fetch a cached profile photo for the given author. Returns `None` when no
 /// row exists or the row is a `'letter'` negative-cache marker — both cases
 /// should produce a 404 from the GET handler so the frontend keeps rendering

--- a/db/src/author_photos_data/tests.rs
+++ b/db/src/author_photos_data/tests.rs
@@ -303,6 +303,23 @@ async fn get_author_photo_propagates_db_error_when_pool_is_closed() {
 }
 
 #[tokio::test]
+async fn author_exists_is_true_for_a_known_author_and_false_for_an_unknown_id() {
+    let (pool, _guard) = seed_discovery_fixture().await;
+    let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;
+
+    assert!(author_exists(&pool, ada_id).await.unwrap());
+    assert!(!author_exists(&pool, ada_id + 1_000_000).await.unwrap());
+}
+
+#[tokio::test]
+async fn author_exists_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = author_exists(&pool, 1).await.unwrap_err();
+    assert!(matches!(err, AuthorPhotosDataError::Db(_)));
+}
+
+#[tokio::test]
 async fn author_photo_status_bulk_matches_per_author_lookups_and_omits_unset() {
     let (pool, _guard) = seed_discovery_fixture().await;
     let ada_id = author_id_by_name(&pool, "Ada Lovelace").await;

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -89,7 +89,22 @@ pub async fn upsert_progress(
     user_id: i64,
     update: &ProgressUpdate,
 ) -> Result<ProgressRecord, ProgressError> {
-    let book_uuid = resolve_canonical_book_uuid(pool, &update.book_uuid)
+    let mut tx = pool.begin().await?;
+    let record = upsert_progress_tx(&mut tx, user_id, update).await?;
+    tx.commit().await?;
+    Ok(record)
+}
+
+/// Transaction-scoped [`upsert_progress`], for callers that batch it with
+/// other writes (e.g. the Kobo `put_state` handler) inside one shared
+/// `Transaction` so a mid-batch failure rolls back every entry, not just the
+/// one that failed. The caller is responsible for committing or rolling back.
+pub async fn upsert_progress_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    update: &ProgressUpdate,
+) -> Result<ProgressRecord, ProgressError> {
+    let book_uuid = resolve_canonical_book_uuid_exec(&mut **tx, &update.book_uuid)
         .await?
         .ok_or(ProgressError::BookNotFound)?;
     let fmt = format_str(update.format);
@@ -135,7 +150,7 @@ pub async fn upsert_progress(
     )
     .bind(update.book_file_id)
     .bind(update.client_updated_at)
-    .execute(pool)
+    .execute(&mut **tx)
     .await?;
 
     let row = sqlx::query(
@@ -148,7 +163,7 @@ pub async fn upsert_progress(
     .bind(user_id)
     .bind(&book_uuid)
     .bind(fmt)
-    .fetch_one(pool)
+    .fetch_one(&mut **tx)
     .await?;
     Ok(ProgressRecord {
         book_uuid,

--- a/db/src/read_status/mod.rs
+++ b/db/src/read_status/mod.rs
@@ -5,9 +5,9 @@
 //! aggregations can window completions like the journal path windows `created_at`.
 
 use omnibus_shared::{ReadStatus, ReadStatusRecord, SetReadStatus};
-use sqlx::{Row, SqlitePool};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
-use crate::resolve_canonical_book_uuid;
+use crate::{resolve_canonical_book_uuid, resolve_canonical_book_uuid_exec};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ReadStatusError {
@@ -57,7 +57,22 @@ pub async fn set_read_status(
     user_id: i64,
     update: &SetReadStatus,
 ) -> Result<ReadStatusRecord, ReadStatusError> {
-    let book_uuid = resolve_canonical_book_uuid(pool, &update.book_uuid)
+    let mut tx = pool.begin().await?;
+    let record = set_read_status_tx(&mut tx, user_id, update).await?;
+    tx.commit().await?;
+    Ok(record)
+}
+
+/// Transaction-scoped [`set_read_status`], for callers that batch it with
+/// other writes (e.g. the Kobo `put_state` handler) inside one shared
+/// `Transaction` so a mid-batch failure rolls back every entry, not just the
+/// one that failed. The caller is responsible for committing or rolling back.
+pub async fn set_read_status_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    update: &SetReadStatus,
+) -> Result<ReadStatusRecord, ReadStatusError> {
+    let book_uuid = resolve_canonical_book_uuid_exec(&mut **tx, &update.book_uuid)
         .await?
         .ok_or(ReadStatusError::BookNotFound)?;
     let status = update.status.as_str();
@@ -81,7 +96,7 @@ pub async fn set_read_status(
     .bind(&book_uuid)
     .bind(status)
     .bind(status)
-    .execute(pool)
+    .execute(&mut **tx)
     .await?;
 
     let row = sqlx::query(
@@ -90,7 +105,7 @@ pub async fn set_read_status(
     )
     .bind(user_id)
     .bind(&book_uuid)
-    .fetch_one(pool)
+    .fetch_one(&mut **tx)
     .await?;
     Ok(record_from_row(book_uuid, &row)?)
 }

--- a/server/src/backend/author_photos.rs
+++ b/server/src/backend/author_photos.rs
@@ -14,23 +14,10 @@ use axum::{
 use omnibus_db::{self as db, worker::Task};
 use omnibus_shared::detect_image_format;
 use serde::Deserialize;
-use sqlx::SqlitePool;
 
 use super::image_upload::extract_validated_image;
 use super::{internal, AppState};
 use crate::auth::{AdminUser, MediaAuthUser};
-
-/// Returns `true` when an `authors` row with `id` exists. Extracted because
-/// the three admin-mutation handlers below all need an "author exists?"
-/// preflight before doing any side-effecting work; a future change (e.g.
-/// a soft-delete column) then has exactly one query to touch.
-async fn author_exists(pool: &SqlitePool, id: i64) -> Result<bool, sqlx::Error> {
-    sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM authors WHERE id = ?)")
-        .bind(id)
-        .fetch_one(pool)
-        .await
-        .map(|v| v != 0)
-}
 
 /// Serve a cached author profile photo. Returns 404 when no photo is cached
 /// (including `'letter'` negative-cache markers) — the frontend keeps the
@@ -79,7 +66,7 @@ pub(super) async fn put_author_photo(
 ) -> Response {
     // Confirm the author exists before reading multipart so a malformed
     // upload to a missing id fails fast with 404 (not 400).
-    let exists = match author_exists(&state.pool, id).await {
+    let exists = match db::author_exists(&state.pool, id).await {
         Ok(v) => v,
         Err(e) => return internal("author exists check", e),
     };
@@ -136,7 +123,7 @@ pub(super) async fn post_author_photo_scan(
 ) -> Response {
     // Verify the author exists first so a typo on the id gets a 404 instead
     // of a successful no-op scan.
-    let exists = match author_exists(&state.pool, id).await {
+    let exists = match db::author_exists(&state.pool, id).await {
         Ok(v) => v,
         Err(e) => return internal("author exists check", e),
     };
@@ -194,7 +181,7 @@ pub(super) async fn put_author_photo_url(
     Path(id): Path<i64>,
     Json(body): Json<AuthorPhotoUrlBody>,
 ) -> Response {
-    let exists = match author_exists(&state.pool, id).await {
+    let exists = match db::author_exists(&state.pool, id).await {
         Ok(v) => v,
         Err(e) => return internal("author exists check", e),
     };

--- a/server/src/backend/kobo.rs
+++ b/server/src/backend/kobo.rs
@@ -19,6 +19,7 @@ use omnibus_db::{
     worker::{Task, TaskOutcome},
 };
 use omnibus_shared::{ProgressFormat, ProgressUpdate, ReadStatus, SetReadStatus};
+use sqlx::{Sqlite, Transaction};
 
 use super::{internal, serve_download, AppState};
 
@@ -488,6 +489,12 @@ async fn download(
 /// position lands in `reading_progress` as percent + verbatim `KoboSpan`
 /// plus a server-derived `epub_cfi` when the cached KEPUB allows it
 /// (#925), stamped with the device's own event time when it sends one.
+///
+/// The whole batch's read-status and bookmark writes share one transaction
+/// (begun before the loop, committed after it), so a mid-batch DB failure
+/// rolls back every entry rather than leaving the sync half-applied — a
+/// `BookNotFound` for one entry is not such a failure and is logged and
+/// skipped within the same transaction.
 async fn put_state(
     auth: KoboAuthUser,
     State(state): State<AppState>,
@@ -500,13 +507,17 @@ async fn put_state(
     if let Some(rejected) = reject_oversized_state_request(&body) {
         return rejected;
     }
+    let mut tx = match state.pool().begin().await {
+        Ok(tx) => tx,
+        Err(e) => return internal("kobo put_state begin", e),
+    };
     for entry in &body.reading_states {
         if let Some(info) = &entry.status_info {
             let update = SetReadStatus {
                 book_uuid: uuid.clone(),
                 status: map_status(&info.status),
             };
-            match db::read_status::set_read_status(state.pool(), auth.user_id, &update).await {
+            match db::read_status::set_read_status_tx(&mut tx, auth.user_id, &update).await {
                 Ok(_) => {}
                 // A state push for a book the server never indexed is not fatal
                 // to the sync — log and keep the success envelope.
@@ -529,7 +540,7 @@ async fn put_state(
                 .or(entry.last_modified.as_deref())
                 .or(entry.priority_timestamp.as_deref())
                 .and_then(dto::parse_kobo_timestamp);
-            match persist_bookmark(&state, auth.user_id, &uuid, bookmark, event_ts).await {
+            match persist_bookmark(&state, &mut tx, auth.user_id, &uuid, bookmark, event_ts).await {
                 Ok(()) => {}
                 Err(db::progress::ProgressError::BookNotFound) => {
                     tracing::warn!(%uuid, "kobo position PUT for unknown book");
@@ -545,6 +556,9 @@ async fn put_state(
             tracing::debug!(%uuid, "kobo statistics received");
         }
     }
+    if let Err(e) = tx.commit().await {
+        return internal("kobo put_state commit", e);
+    }
     Json(dto::StateResponse::success(uuid)).into_response()
 }
 
@@ -558,8 +572,13 @@ async fn put_state(
 /// forward clamp bounds a fast device clock. A bookmark carrying neither
 /// percent nor location is a no-op rather than a validation error — the
 /// device sends the field either way.
+///
+/// The final write goes through `tx` so it shares [`put_state`]'s batch
+/// transaction; the CFI derivation above it only reads (via `state.pool()`),
+/// so it stays outside the transaction rather than blocking it.
 async fn persist_bookmark(
     state: &AppState,
+    tx: &mut Transaction<'_, Sqlite>,
     user_id: i64,
     uuid: &str,
     bookmark: &dto::CurrentBookmark,
@@ -604,7 +623,7 @@ async fn persist_bookmark(
         tracing::debug!(%uuid, "kobo bookmark carried no usable position");
         return Ok(());
     }
-    db::progress::upsert_progress(state.pool(), user_id, &update).await?;
+    db::progress::upsert_progress_tx(tx, user_id, &update).await?;
     Ok(())
 }
 

--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -1206,6 +1206,57 @@ async fn put_state_persists_the_current_bookmark_position() {
     assert!(loc.contains("kobo.9.1"), "got: {loc}");
 }
 
+#[tokio::test]
+async fn put_state_batch_transaction_rolls_back_a_read_status_write_when_a_later_write_fails() {
+    // `put_state` shares one `Transaction` across a batch's read-status and
+    // bookmark writes and returns without calling `.commit()` on the first
+    // genuine DB error — reproduced here directly against the `_tx`
+    // primitives it composes, since neither write is reachable from a
+    // malformed HTTP body (both are guarded by application-level
+    // validation before any query runs). A cross-format `ProgressUpdate`
+    // (`Audio` format carrying an `epub_cfi`) trips the `reading_progress`
+    // CHECK constraint, standing in for whatever mid-batch DB error a real
+    // device push could hit.
+    let (_app, pool, _token, uid) = fixture().await;
+    let uuid = seed_synced_ebook(&pool, "hyperion.epub", "Hyperion", "Simmons").await;
+
+    let mut tx = pool.begin().await.unwrap();
+    db::read_status::set_read_status_tx(
+        &mut tx,
+        uid,
+        &omnibus_shared::SetReadStatus {
+            book_uuid: uuid.clone(),
+            status: ReadStatus::Finished,
+        },
+    )
+    .await
+    .unwrap();
+
+    let bad_update = omnibus_shared::ProgressUpdate {
+        book_uuid: uuid.clone(),
+        format: omnibus_shared::ProgressFormat::Audio,
+        epub_cfi: Some("epubcfi(/6/4)".into()),
+        audio_position_seconds: Some(10.0),
+        progress_percent: None,
+        kobo_location: None,
+        book_file_id: None,
+        client_updated_at: None,
+    };
+    let err = db::progress::upsert_progress_tx(&mut tx, uid, &bad_update)
+        .await
+        .expect_err("an audio row carrying an epub_cfi violates the reading_progress CHECK");
+    assert!(matches!(err, db::progress::ProgressError::Sqlx(_)));
+    drop(tx); // no `.commit()` — implicit rollback, matching `put_state`'s early return
+
+    let status = db::read_status::get_read_status(&pool, uid, &uuid)
+        .await
+        .unwrap();
+    assert!(
+        status.is_none(),
+        "the read-status write from the same batch must not survive the rollback"
+    );
+}
+
 /// Source/kepub fixture pair used by the derivation tests: single-chapter
 /// book where span kobo.2.1 starts the second paragraph.
 const STATE_SOURCE_C1: &str = r#"<?xml version="1.0" encoding="utf-8"?>

--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -1208,15 +1208,8 @@ async fn put_state_persists_the_current_bookmark_position() {
 
 #[tokio::test]
 async fn put_state_batch_transaction_rolls_back_a_read_status_write_when_a_later_write_fails() {
-    // `put_state` shares one `Transaction` across a batch's read-status and
-    // bookmark writes and returns without calling `.commit()` on the first
-    // genuine DB error — reproduced here directly against the `_tx`
-    // primitives it composes, since neither write is reachable from a
-    // malformed HTTP body (both are guarded by application-level
-    // validation before any query runs). A cross-format `ProgressUpdate`
-    // (`Audio` format carrying an `epub_cfi`) trips the `reading_progress`
-    // CHECK constraint, standing in for whatever mid-batch DB error a real
-    // device push could hit.
+    // Drives the `_tx` primitives directly, since a genuine mid-batch DB
+    // error isn't reachable through a malformed HTTP body.
     let (_app, pool, _token, uid) = fixture().await;
     let uuid = seed_synced_ebook(&pool, "hyperion.epub", "Hyperion", "Simmons").await;
 


### PR DESCRIPTION
## Summary
- Closes #1454
- `server/src/backend/kobo.rs`'s `put_state` handler now begins one `Transaction` before its per-entry loop and commits once after it. `db::read_status::set_read_status` and `db::progress::upsert_progress` each gained a `_tx` sibling (`set_read_status_tx` / `upsert_progress_tx`, taking `&mut Transaction<'_, Sqlite>`) mirroring the existing `record_session`/`record_session_tx` convention in `db/src/progress.rs`; the pool-based functions are now thin wrappers over them. `persist_bookmark` takes the shared `tx` for its final write (the CFI-derivation reads above it stay on the pool, since they don't need the transaction). A mid-batch `BookNotFound` is still logged and skipped (unchanged behavior); a genuine DB error now rolls back the whole batch instead of leaving a partially-applied sync.
- `server/src/backend/author_photos.rs`'s hand-rolled `author_exists(pool: &SqlitePool, id: i64) -> Result<bool, sqlx::Error>` moved into `omnibus_db` as `pub async fn author_exists(...) -> Result<bool, AuthorPhotosDataError>` in `db/src/author_photos_data.rs` (the module the issue suggested), closing the layering violation and the raw-`sqlx::Error`-across-a-module-boundary gap (rule 02). All three server call sites now call `db::author_exists` and propagate the typed error via the existing `internal(...)` mapping.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — 1561 passed, 1 failed. The one failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing, unrelated environment gap in this sandbox: the public-domain audio fixtures aren't checked out (`just fixtures` wasn't run / isn't available here), confirmed by the test's own panic message and `test_data/audiobooks/public_domain` being absent.
- [x] `cargo test -p omnibus` — 609 passed, 2 failed. Both failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400`, `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`) are pre-existing and unrelated: they `chmod 0o555` a temp dir expecting a `PermissionDenied`, but the sandbox's test process runs as root, which bypasses POSIX write-permission bits. Neither touches kobo or author_photos.
- [x] Added `put_state_batch_transaction_rolls_back_a_read_status_write_when_a_later_write_fails` in `server/src/backend/kobo/tests.rs` — drives the exact `_tx` composition `put_state` uses (a successful `set_read_status_tx` followed by an `upsert_progress_tx` that trips the `reading_progress` CHECK constraint) and asserts the first write is not visible after the transaction is dropped without `.commit()`, matching `put_state`'s early-return-on-error path.
- [x] Added `author_exists_is_true_for_a_known_author_and_false_for_an_unknown_id` / `author_exists_propagates_db_error_when_pool_is_closed` in `db/src/author_photos_data/tests.rs`.
- [x] Full existing kobo (91 tests) and author_photos (26 tests) suites re-verified green in isolation.

## Notes
- No schema/migration changes — low blast radius as called out in the issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYY2wHu8gj3rK7aMHT4M9W)_