### PR TITLE
refactor: group Dioxus props/args exceeding the 5-field threshold (#1543)

### DIFF
--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -604,10 +604,12 @@ fn mobile_landing_body(
         mobile::MobileLanding {
             book_count: view.book_count,
             books: view.visible_books,
-            is_loading: view.is_loading,
-            has_more: view.has_more,
-            is_loading_more: view.is_loading_more,
-            on_load_more: handlers.on_load_more,
+            paging: mobile::MobileLandingPaging {
+                is_loading: view.is_loading,
+                has_more: view.has_more,
+                is_loading_more: view.is_loading_more,
+                on_load_more: handlers.on_load_more,
+            },
             prefs: (sigs.prefs)(),
             on_prefs_change: handlers.on_prefs_change_header,
             server_url,

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -40,8 +40,9 @@ const COVERS_DECODE_JS: &str = r#"
 "#;
 
 /// Load-more paging state for the mobile cover grid: whether the first page
-/// is still loading, whether more pages remain, and the fetch-more handler.
-/// Grouped so [`MobileLandingProps`] stays under the prop cap.
+/// is still loading, whether more pages remain, whether a load-more fetch is
+/// in flight, and the fetch-more handler. Grouped so [`MobileLandingProps`]
+/// stays under the prop cap.
 #[derive(Clone, PartialEq)]
 pub(super) struct MobileLandingPaging {
     /// True while the first page is still loading.

--- a/frontend/src/pages/landing/mobile.rs
+++ b/frontend/src/pages/landing/mobile.rs
@@ -39,14 +39,11 @@ const COVERS_DECODE_JS: &str = r#"
 })();
 "#;
 
-/// Props for [`MobileLanding`] — the already-derived view state handed
-/// down from [`super::LandingPage`].
-#[derive(Props, Clone, PartialEq)]
-pub(super) struct MobileLandingProps {
-    /// Total book count shown in the "N books" label.
-    pub book_count: usize,
-    /// The page of books to render as cover cells.
-    pub books: Vec<EbookMetadata>,
+/// Load-more paging state for the mobile cover grid: whether the first page
+/// is still loading, whether more pages remain, and the fetch-more handler.
+/// Grouped so [`MobileLandingProps`] stays under the prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct MobileLandingPaging {
     /// True while the first page is still loading.
     pub is_loading: bool,
     /// True when more pages remain to load.
@@ -55,6 +52,18 @@ pub(super) struct MobileLandingProps {
     pub is_loading_more: bool,
     /// Fired when the "Load more" button is pressed.
     pub on_load_more: EventHandler<()>,
+}
+
+/// Props for [`MobileLanding`] — the already-derived view state handed
+/// down from [`super::LandingPage`].
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct MobileLandingProps {
+    /// Total book count shown in the "N books" label.
+    pub book_count: usize,
+    /// The page of books to render as cover cells.
+    pub books: Vec<EbookMetadata>,
+    /// Load-more paging state for the cover grid.
+    pub paging: MobileLandingPaging,
     /// Current sort/filter prefs, driving the pill + sheet.
     pub prefs: ViewPrefs,
     /// Fired with updated prefs on every sheet interaction.
@@ -198,14 +207,17 @@ pub(super) fn MobileLanding(props: MobileLandingProps) -> Element {
     let MobileLandingProps {
         book_count,
         books,
-        is_loading,
-        has_more,
-        is_loading_more,
-        on_load_more,
+        paging,
         prefs,
         on_prefs_change,
         server_url,
     } = props;
+    let MobileLandingPaging {
+        is_loading,
+        has_more,
+        is_loading_more,
+        on_load_more,
+    } = paging;
 
     let mut sheet_open = use_signal(|| false);
     let resume = use_resume_point(server_url.clone());

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -169,13 +169,16 @@ pub(super) fn RowTitleCell(title: String, error: Option<String>, ctx: CellEditCt
     } = ctx;
     rsx! {
         EditableCell {
-            col_class: "ebook-col-title".to_string(),
-            cell_testid: "ebook-cell-title".to_string(),
+            display: EditableCellDisplay {
+                col_class: "ebook-col-title".to_string(),
+                cell_testid: "ebook-cell-title".to_string(),
+                display_value: title,
+                placeholder: "Title".to_string(),
+                ..Default::default()
+            },
             field: EditField::Title,
-            display_value: title,
             is_admin,
             editing,
-            placeholder: "Title".to_string(),
             on_save: move |v: String| save_field.call((EditField::Title, v)),
             error,
         }
@@ -193,14 +196,16 @@ pub(super) fn RowSeriesCell(series_line: String, series_text: String, ctx: CellE
     } = ctx;
     rsx! {
         EditableCell {
-            col_class: "ebook-col-series".to_string(),
-            cell_testid: "ebook-cell-series".to_string(),
+            display: EditableCellDisplay {
+                col_class: "ebook-col-series".to_string(),
+                cell_testid: "ebook-cell-series".to_string(),
+                display_value: series_line,
+                edit_value: Some(series_text),
+                placeholder: "Series".to_string(),
+            },
             field: EditField::Series,
-            display_value: series_line,
-            edit_value: Some(series_text),
             is_admin,
             editing,
-            placeholder: "Series".to_string(),
             on_save: move |v: String| save_field.call((EditField::Series, v)),
             error: None,
         }
@@ -238,13 +243,16 @@ pub(super) fn RowScalarCell(
     } = ctx;
     rsx! {
         EditableCell {
-            col_class,
-            cell_testid,
+            display: EditableCellDisplay {
+                col_class,
+                cell_testid,
+                display_value: value,
+                placeholder,
+                ..Default::default()
+            },
             field,
-            display_value: value,
             is_admin,
             editing,
-            placeholder,
             on_save: move |v: String| save_field.call((field, v)),
             error: None,
         }
@@ -317,12 +325,13 @@ pub(super) fn EbookRowFormatsCell(formats: Vec<String>, has_physical: bool) -> E
     }
 }
 
-/// Props for the [`EditableCell`] component.
-#[derive(Props, Clone, PartialEq)]
-pub(super) struct EditableCellProps {
+/// Grouped display fields (column class, testid, value, placeholder) for an
+/// [`EditableCell`]. Mirrors [`RowScalarCellDisplay`] so both cell types
+/// stay under the prop cap.
+#[derive(Clone, PartialEq, Default)]
+pub(super) struct EditableCellDisplay {
     pub col_class: String,
     pub cell_testid: String,
-    pub field: EditField,
     pub display_value: String,
     /// Separate value used to seed the input when edit mode opens.
     /// Some cells render a richer display string than the underlying
@@ -330,11 +339,17 @@ pub(super) struct EditableCellProps {
     /// is the series-name override. Pass `Some(bare_value)` so the
     /// input seeds (and the blur-comparison runs against) the editable
     /// scalar, not the rendered text. Defaults to `display_value`.
-    #[props(default)]
     pub edit_value: Option<String>,
+    pub placeholder: String,
+}
+
+/// Props for the [`EditableCell`] component.
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct EditableCellProps {
+    pub display: EditableCellDisplay,
+    pub field: EditField,
     pub is_admin: bool,
     pub editing: Signal<Option<EditField>>,
-    pub placeholder: String,
     pub on_save: EventHandler<String>,
     pub error: Option<String>,
 }
@@ -347,17 +362,20 @@ pub(super) struct EditableCellProps {
 #[component]
 pub(super) fn EditableCell(props: EditableCellProps) -> Element {
     let EditableCellProps {
-        col_class,
-        cell_testid,
+        display,
         field,
-        display_value,
-        edit_value,
         is_admin,
         editing,
-        placeholder,
         on_save,
         error,
     } = props;
+    let EditableCellDisplay {
+        col_class,
+        cell_testid,
+        display_value,
+        edit_value,
+        placeholder,
+    } = display;
     let mut editing = editing;
     let mut draft = use_signal(String::new);
     let is_editing = editing() == Some(field);
@@ -501,7 +519,12 @@ impl ChipCellDisplay {
     }
 }
 
-/// Props for the [`ChipCell`] component.
+/// Props for the [`ChipCell`] component. Already groups its static config
+/// into [`ChipCellDisplay`]; the remaining 6 fields are each a distinct
+/// piece of live state (admin gate, editing signal, draft, suggestions,
+/// change handler) with no further natural grouping, so this sits at the
+/// same accepted-at-6 precedent as `RowScalarCell` (#853) rather than
+/// forcing an arbitrary split.
 #[derive(Props, Clone, PartialEq)]
 pub(super) struct ChipCellProps {
     /// Field/column/testid/options config for this cell.

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -325,9 +325,9 @@ pub(super) fn EbookRowFormatsCell(formats: Vec<String>, has_physical: bool) -> E
     }
 }
 
-/// Grouped display fields (column class, testid, value, placeholder) for an
-/// [`EditableCell`]. Mirrors [`RowScalarCellDisplay`] so both cell types
-/// stay under the prop cap.
+/// Grouped display fields (column class, testid, display/edit value,
+/// placeholder) for an [`EditableCell`]. Mirrors [`RowScalarCellDisplay`] so
+/// both cell types stay under the prop cap.
 #[derive(Clone, PartialEq, Default)]
 pub(super) struct EditableCellDisplay {
     pub col_class: String,
@@ -519,12 +519,9 @@ impl ChipCellDisplay {
     }
 }
 
-/// Props for the [`ChipCell`] component. Already groups its static config
-/// into [`ChipCellDisplay`]; the remaining 6 fields are each a distinct
-/// piece of live state (admin gate, editing signal, draft, suggestions,
-/// change handler) with no further natural grouping, so this sits at the
-/// same accepted-at-6 precedent as `RowScalarCell` (#853) rather than
-/// forcing an arbitrary split.
+/// Props for the [`ChipCell`] component. `display` already groups the static
+/// config; the other 5 fields are each distinct live state with no further
+/// natural grouping — accepted at 6 total, same precedent as `RowScalarCell`.
 #[derive(Props, Clone, PartialEq)]
 pub(super) struct ChipCellProps {
     /// Field/column/testid/options config for this cell.

--- a/frontend/src/pages/reader/annotations_sheet.rs
+++ b/frontend/src/pages/reader/annotations_sheet.rs
@@ -124,19 +124,31 @@ fn render_annotations_filter_row(active: AnnFilter, filter: Signal<AnnFilter>) -
     }
 }
 
-/// Drawer body: empty state, or the filtered bookmark + highlight rows.
-#[allow(clippy::too_many_arguments)]
-fn render_annotations_body(
-    empty: bool,
-    show_bookmarks: bool,
-    marks: Vec<Bookmark>,
-    shown_highlights: Vec<Highlight>,
+/// The bookmark/highlight lists plus the callbacks forwarded to each row.
+/// Grouped so [`render_annotations_body`] stays under the arg cap.
+struct AnnotationsBodyCtx {
     bookmarks: Signal<Vec<Bookmark>>,
     highlights: Signal<Vec<Highlight>>,
     on_navigate: EventHandler<String>,
     on_quote: EventHandler<Highlight>,
     on_edit_note: EventHandler<Highlight>,
+}
+
+/// Drawer body: empty state, or the filtered bookmark + highlight rows.
+fn render_annotations_body(
+    empty: bool,
+    show_bookmarks: bool,
+    marks: Vec<Bookmark>,
+    shown_highlights: Vec<Highlight>,
+    ctx: AnnotationsBodyCtx,
 ) -> Element {
+    let AnnotationsBodyCtx {
+        bookmarks,
+        highlights,
+        on_navigate,
+        on_quote,
+        on_edit_note,
+    } = ctx;
     rsx! {
         div { class: "rd-drawer-body",
             if empty {
@@ -256,11 +268,13 @@ pub(super) fn AnnotationsSheet(props: AnnotationsSheetProps) -> Element {
                     show_bookmarks,
                     marks,
                     shown_highlights,
-                    bookmarks,
-                    highlights,
-                    on_navigate,
-                    on_quote,
-                    on_edit_note,
+                    AnnotationsBodyCtx {
+                        bookmarks,
+                        highlights,
+                        on_navigate,
+                        on_quote,
+                        on_edit_note,
+                    },
                 )
             }
         }

--- a/frontend/src/pages/reader/overlays.rs
+++ b/frontend/src/pages/reader/overlays.rs
@@ -250,20 +250,34 @@ fn render_bookmarks_overlay(
     }
 }
 
-/// Combined phone annotations sheet, shown while `show_annotations` is set.
-#[allow(clippy::too_many_arguments)]
-fn render_annotations_overlay(
-    show_annotations: Signal<bool>,
+/// Book identity/position plus the shared annotation state the combined
+/// phone annotations sheet renders and mutates. Grouped so
+/// [`render_annotations_overlay`] stays under the arg cap.
+struct AnnotationsOverlayCtx {
     uuid: String,
     current_cfi: String,
     chapter_title: String,
     highlights: Signal<Vec<Highlight>>,
     quote_target: Signal<Option<Highlight>>,
     note_target: Signal<Option<Highlight>>,
+}
+
+/// Combined phone annotations sheet, shown while `show_annotations` is set.
+fn render_annotations_overlay(
+    show_annotations: Signal<bool>,
+    ctx: AnnotationsOverlayCtx,
 ) -> Element {
     if !show_annotations() {
         return rsx! {};
     }
+    let AnnotationsOverlayCtx {
+        uuid,
+        current_cfi,
+        chapter_title,
+        highlights,
+        quote_target,
+        note_target,
+    } = ctx;
     rsx! {
         AnnotationsSheet {
             uuid,
@@ -383,12 +397,14 @@ pub(super) fn ReaderOverlays(meta: OverlayMeta, panels: ReaderPanelSignals) -> E
         {
             render_annotations_overlay(
                 show_annotations,
-                uuid,
-                current_cfi,
-                chapter_title,
-                highlights,
-                quote_target,
-                note_target,
+                AnnotationsOverlayCtx {
+                    uuid,
+                    current_cfi,
+                    chapter_title,
+                    highlights,
+                    quote_target,
+                    note_target,
+                },
             )
         }
         {render_quote_target_overlay(quote_target, book_author, book_title, book_accent)}


### PR DESCRIPTION
## Summary
- Closes #1543
- `MobileLandingProps` (`frontend/src/pages/landing/mobile.rs`): grouped the load-more paging fields (`is_loading`, `has_more`, `is_loading_more`, `on_load_more`) into a new `MobileLandingPaging` sub-struct, mirroring how `sections.rs` groups `LandingContentHandlers`/`BooksView`. Down from 9 fields to 6 (`book_count`, `books`, `paging`, `prefs`, `on_prefs_change`, `server_url`); updated the one call site in `frontend/src/pages/landing.rs`.
- `EditableCellProps` (`frontend/src/pages/landing/table/cells.rs`): grouped the display-only fields (`col_class`, `cell_testid`, `display_value`, `edit_value`, `placeholder`) into a new `EditableCellDisplay`, mirroring the existing `RowScalarCellDisplay` pattern in the same file. Down from 10 fields to 6 (`display`, `field`, `is_admin`, `editing`, `on_save`, `error`); updated all three call sites (`RowTitleCell`, `RowSeriesCell`, `RowScalarCell`).
- `ChipCellProps` (same file): already sits at exactly 6 fields with its static config already grouped into `ChipCellDisplay` from a prior pass. Rather than force an arbitrary further split of the remaining 6 independent pieces of live state (admin gate, editing signal, draft, suggestions, change handler), I documented it as an accepted-at-6 case with a one-line comment, following the `RowScalarCell`-at-6 precedent from #853 — no further change here.
- `render_annotations_overlay` (`frontend/src/pages/reader/overlays.rs`): converted its 7 params into a `Signal<bool>` gate plus a new private `AnnotationsOverlayCtx` struct (uuid/current_cfi/chapter_title/highlights/quote_target/note_target), dropping `#[allow(clippy::too_many_arguments)]`.
- `render_annotations_body` (`frontend/src/pages/reader/annotations_sheet.rs`): converted its 9 params into the 4 already-distinct data params (`empty`, `show_bookmarks`, `marks`, `shown_highlights`) plus a new private `AnnotationsBodyCtx` struct bundling the bookmarks/highlights signals and the three row callbacks, dropping `#[allow(clippy::too_many_arguments)]`.

Pure signature/structure refactor — no behavior change to any of the four call sites' rendered output; both reader helpers keep the same rsx bodies, just destructured from the new context structs.

## Test plan
- [x] `cargo fmt -p omnibus-frontend` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS (clean, no warnings)
- [ ] `cargo clippy -p omnibus-frontend --features web --target wasm32-unknown-unknown -- -D warnings` — SKIP (wasm32-unknown-unknown target not installed in this sandbox)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (555 passed; 0 failed)

## Notes
- No behavior change; this is purely a signature/struct-shape refactor to bring the four flagged sites in line with the repo's existing prop-grouping convention (see `RowScalarCell`/`RowScalarCellDisplay` and `CellEditCtx`/`RowContext` in `frontend/src/pages/landing/table/cells.rs` for the established pattern this mirrors).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FEnYBejWkiDP63kY6WetEP)_