### PR TITLE
docs: strip stale roadmap/issue tags from doc comments, add missing tests.rs module docs (#1473)

### DIFF
--- a/db/src/audiobook/group/tests.rs
+++ b/db/src/audiobook/group/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for audiobook file grouping: which stat entries collapse into one
+//! book (an mp3 folder, a lone m4b) versus stay separate (multiple m4bs
+//! sharing a base stem, mixed m4b/m4a in one dir), and error passthrough.
+
 use super::*;
 use crate::audiobook::stat::AudiobookStatEntry;
 

--- a/db/src/audiobook/tests.rs
+++ b/db/src/audiobook/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for audiobook scanning and parsing: directory stat walks, m4b/mp3
+//! grouping into books, tag-derived title/metadata extraction (including
+//! error rows for unreadable or undecodable files), and duration formatting.
+
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/db/src/auth/password/tests.rs
+++ b/db/src/auth/password/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for password hashing and policy: Argon2id hash/verify
+//! round-tripping (including a compatibility guard against a stored PHC
+//! string from an earlier dependency version), and username/password
+//! validation rules.
+
 use super::*;
 
 #[test]

--- a/db/src/auth/session/tests.rs
+++ b/db/src/auth/session/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for session lifecycle: create/lookup round-tripping, expiry and
+//! idle-timeout enforcement, revocation (single, all, all-except-current),
+//! last-used touch throttling, and cookie/bearer token resolution.
+
 use super::*;
 use crate::auth::test_support::pool;
 use crate::auth::token::SESSION_COOKIE_NAME;

--- a/db/src/auth/users/tests.rs
+++ b/db/src/auth/users/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for user account management: first-user admin promotion and
+//! registration lockout, username collision/validation, password changes
+//! (including session revocation on change), and the admin user projection.
+
 use super::*;
 use crate::auth::test_support::pool;
 

--- a/db/src/author_photos_data/tests.rs
+++ b/db/src/author_photos_data/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for author photo storage: manual-upload round-tripping, upsert
+//! replacing an existing row, delete clearing it, and author deletion
+//! cascading (links removed, blocklist entry inserted, FTS rebuilt) while
+//! surviving a reindex.
+
 use super::*;
 use crate::books::list_books;
 use crate::pool::init_db;

--- a/db/src/discovery/tags.rs
+++ b/db/src/discovery/tags.rs
@@ -17,54 +17,32 @@ const TAG_CLOUD_LIMIT: i64 = 500;
 /// Return up to [`TAG_CLOUD_LIMIT`] tags with their book counts, ordered
 /// by count descending then name ascending. Used by the tag cloud page.
 ///
-/// Currently returns results across all users (single-tenant). When F4.x
-/// per-user ACL lands, add a `user_id: i64` parameter and scope the query
-/// to books accessible to that user.
+/// Currently returns results across all users (single-tenant); scoping to a
+/// per-user `user_id` is a future extension, not yet needed.
 pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, DiscoveryError> {
-    // TODO: scope by `user_id` once per-user ACLs land (single-tenant today).
-    //
-    // F5.1: counts use the effective (override-aware) subject set, not
-    // the raw `books_tags_link` rows — `overrides.subjects` replaces a
-    // book's canonical tag list wholesale when Some. Visibility requires a
+    // Counts use the effective (override-aware) subject set, not the raw
+    // `books_tags_link` rows — `overrides.subjects` replaces a book's
+    // canonical tag list wholesale when Some. Visibility requires a
     // canonical link OR an effective override membership: the override
     // write path materializes a `tags` row for every override subject
     // (`materialize_tag_rows`), so a tag created via the inline table
-    // editor feeds this cloud — and therefore the editor's own
-    // autocomplete pool — without polluting the scanned link table. The
-    // single-library, single-tenant scope means the cloud is global;
-    // if/when per-library scoping lands this picks up a path filter
-    // alongside the existing `WHERE EXISTS`.
+    // editor feeds this cloud — and therefore the editor's own autocomplete
+    // pool — without polluting the scanned link table.
     //
-    // Issue #154: counts are taken from an `effective` membership CTE —
-    // the UNION of (1) canonical `books_tags_link` rows whose book has no
-    // `subjects` override and (2) override-extracted `(tag_name, book_id)`
-    // pairs from `json_each(mo.overrides, '$.subjects')`. The CTE is
-    // `AS MATERIALIZED` (like `matches` in `fetch_search_rows`) so the
-    // override extraction — `json_each` over every `metadata_overrides`
-    // row — is built once per call rather than re-scanned per tag. Counts
-    // come from a single `GROUP BY` pass: `effective` is `LEFT JOIN`ed to
-    // `tags` on the OR predicate (`e.tag_id = t.id OR e.tag_name = t.name`)
-    // and aggregated with `COUNT(e.book_id)`. The `LEFT JOIN` preserves the
-    // prior correlated-subquery `cnt = 0` semantics for a visible tag whose
-    // every canonical book got overridden away (the `EXISTS` keeps it
-    // visible while `COUNT(e.book_id)` over zero matched rows yields 0).
-    // The two arms are disjoint on the key columns (arm 1 sets
-    // `tag_name = NULL`, arm 2 sets `tag_id = NULL`), and a book with a
-    // subjects override is excluded from arm 1, so no single book reaches a
-    // tag through both arms — the OR-join sums without double-counting.
-    // The empty-array clear-all case falls out naturally: a `Some([])`
-    // override drops the book from arm (1) and yields no rows from
-    // `json_each` in arm (2). UNION (not ALL) in arm (2) dedupes duplicate
-    // subject strings within one override array so a book tagged
-    // `["fiction","fiction"]` still counts once. Override names are folded
-    // with `lower()` on both sides of the match so a case-variant override
-    // ("fiction" typed against a canonical "Fiction" row) counts toward —
-    // and keeps visible — the NOCASE-unique `tags` row it already
-    // deduplicated into at materialize time; the same fold also collapses
-    // case-variant duplicates within one override array through the UNION.
-    // A canonically-linked tag whose every book got overridden away stays
-    // visible with `cnt = 0` (first EXISTS arm), matching the prior
-    // semantics; an override-only tag surfaces through the second arm.
+    // The `effective` CTE is `AS MATERIALIZED` (like `matches` in
+    // `fetch_search_rows`) so the override extraction — `json_each` over
+    // every `metadata_overrides` row — is built once per call rather than
+    // re-scanned per tag. The two UNION arms are disjoint on the key
+    // columns (arm 1 sets `tag_name = NULL`, arm 2 sets `tag_id = NULL`)
+    // and a book with a subjects override is excluded from arm 1, so no
+    // single book reaches a tag through both arms — the OR-join in the
+    // final `GROUP BY` sums without double-counting. The `LEFT JOIN`
+    // preserves the prior correlated-subquery `cnt = 0` semantics for a
+    // visible tag whose every canonical book got overridden away. Override
+    // names are folded with `lower()` on both sides of the match so a
+    // case-variant override ("fiction" against a canonical "Fiction" row)
+    // counts toward — and keeps visible — the NOCASE-unique `tags` row it
+    // already deduplicated into at materialize time.
     let rows = sqlx::query(
         r#"WITH effective AS MATERIALIZED (
              -- (1) Canonical tag memberships with no subjects override.

--- a/db/src/ebook/cover/tests.rs
+++ b/db/src/ebook/cover/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for EPUB cover extraction: sidecar-over-embedded precedence,
+//! opt-in sidecar materialization and its reuse on a second scan, repairing
+//! or falling back from an unreadable/failed materialization, and leaving
+//! an unrelated existing sidecar untouched.
+
 use crate::ebook::test_support::*;
 use crate::ebook::{scan_ebook_library, scan_ebook_library_with, ScanOptions};
 

--- a/db/src/ebook/parse/tests.rs
+++ b/db/src/ebook/parse/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for EPUB OPF metadata parsing: refinement lookup, contributor
+//! role/file-as extraction across EPUB3 refinements and legacy attributes,
+//! and series extraction from both the EPUB3 `belongs-to-collection` form
+//! and the legacy Calibre series meta.
+
 use std::io::Cursor;
 
 use epub::doc::{EpubDoc, MetadataRefinement};

--- a/db/src/ebook/stat/tests.rs
+++ b/db/src/ebook/stat/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for the EPUB library stat walk: missing/empty path handling,
+//! non-EPUB filtering, subdirectory recursion (including continuing past
+//! an unreadable subdirectory), and the `saw_any_file`/completeness flags
+//! `stat_ebook_library` reports for the scan-progress UI.
+
 use crate::ebook::scan_ebook_library;
 use crate::ebook::stat::stat_ebook_library;
 use crate::ebook::test_support::*;

--- a/db/src/epub_rewrite/archive.rs
+++ b/db/src/epub_rewrite/archive.rs
@@ -1,5 +1,5 @@
 //! Copy a source EPUB zip to a new archive, swapping only the OPF and cover
-//! entries (F5.8 #1372). Every other entry — text, styles, fonts, nav — is
+//! entries. Every other entry — text, styles, fonts, nav — is
 //! copied through unchanged, and the `mimetype` entry is re-emitted first and
 //! uncompressed per the EPUB OCF spec so the result stays a valid container.
 

--- a/db/src/epub_rewrite/cover.rs
+++ b/db/src/epub_rewrite/cover.rs
@@ -1,5 +1,5 @@
 //! Re-encode a user's override cover to match the format of the EPUB's
-//! existing cover resource (F5.8 #1372). The in-place rewrite swaps only the
+//! existing cover resource. The in-place rewrite swaps only the
 //! *bytes* of the cover entry, so the replacement must decode to the same
 //! image format the manifest already declares — otherwise the entry's
 //! `media-type` and href extension would lie about its contents.

--- a/db/src/epub_rewrite/mod.rs
+++ b/db/src/epub_rewrite/mod.rs
@@ -1,6 +1,6 @@
 //! Bake a book's effective metadata + cover override *into* a copy of its
-//! EPUB (F5.8 #1372), so exports (Send-to-Kobo KEPUB, plain download) carry the
-//! user's edits instead of shipping the untouched source file. This writes
+//! EPUB, so exports (Send-to-Kobo KEPUB, plain download) carry the user's
+//! edits instead of shipping the untouched source file. This writes
 //! inside the `.epub` container, which is the only metadata a Kobo / kepubify
 //! actually reads.
 //!

--- a/db/src/epub_rewrite/opf.rs
+++ b/db/src/epub_rewrite/opf.rs
@@ -1,4 +1,4 @@
-//! In-place OPF `<metadata>` rewrite (F5.8 #1372). Copies the source OPF
+//! In-place OPF `<metadata>` rewrite. Copies the source OPF
 //! through byte-for-byte via quick-xml events, dropping the descriptive
 //! `<dc:*>` elements (and the two `calibre:series` metas) and re-emitting them
 //! from the book's effective metadata. Everything else — the package

--- a/db/src/identity/tests.rs
+++ b/db/src/identity/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for book-identity scan-key handling: `reconstruct_scan_key`'s
+//! extension rules per format, and the idempotent, error-propagating
+//! `backfill_scan_keys` boot pass for rows with a `NULL` scan key.
+
 use super::*;
 use crate::pool::init_db;
 

--- a/db/src/journals/markdown/tests.rs
+++ b/db/src/journals/markdown/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for journal markdown rendering: basic formatting and strikethrough,
+//! HTML sanitization (script tags, event-handler attributes, non-checkbox
+//! inputs), spoiler-marker wrapping, task-list checkboxes, and image
+//! handling (captioned figures, offsite-source stripping).
+
 use super::*;
 
 #[test]

--- a/db/src/kobo/delta/tests.rs
+++ b/db/src/kobo/delta/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for `sync_delta`: per-device entitlement change tracking — new,
+//! changed, and removed books since the last snapshot, ordering (removals
+//! after adds/changes), idempotent recording, snapshot clearing, and
+//! cascading cleanup when a device is deleted.
+
 use omnibus_shared::{CreateShelfRequest, ShelfKind};
 
 use super::*;

--- a/db/src/kobo/tests.rs
+++ b/db/src/kobo/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for `sync_books`: which books a Kobo sync surfaces from opted-in
+//! manual and smart shelves, per-user scoping, dedup across shelves,
+//! ordering, chunk-boundary and no-cap enumeration, and override reflection.
+
 use omnibus_shared::{
     Contributor, CreateShelfRequest, MatchMode, MetadataOverrides, RuleField, RuleOp, ShelfKind,
     ShelfRule,

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -486,7 +486,7 @@ pub(crate) async fn load_overrides_bulk(
 
 /// Apply a `MetadataOverrides` to an `EbookMetadata`, mutating it in place,
 /// gated by whether `precedence` (the owning scan root's configured
-/// metadata-source order, F5.1 #972) ranks `OmnibusOverrides` above
+/// metadata-source order) ranks `OmnibusOverrides` above
 /// `EmbeddedTags` — the two sources with a real data provider today (see
 /// [`overrides_outrank_embedded`]). Scalar fields are replaced when `Some`;
 /// m2m fields (`creators`, `subjects`) replace entirely when present.

--- a/db/src/normalize/tests.rs
+++ b/db/src/normalize/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for title/author normalization: casefolding, punctuation
+//! collapsing, diacritic folding, last/first-name swapping, idempotence
+//! and panic-safety over varied Unicode input, and the `_norm` column
+//! boot backfill's error propagation.
+
 use super::*;
 use crate::pool::init_db;
 

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -37,12 +37,14 @@ pub async fn search_tags_for_paths(
     // when Some — including the empty array, which clears all tags.
     // Visibility still requires at least one canonical link in this
     // library so we don't list tags that exist only inside override JSON
-    // (no navigable id). The per-tag count comes from a single-pass
-    // `effective` membership CTE (scoped to the library up front) rather
-    // than a per-tag correlated `COUNT(*)`. The override match stays
-    // BINARY (`je.value = t.name`, no COLLATE); the empty-array clear-all
-    // case falls out naturally since a `Some([])` override drops the book
-    // from the canonical arm and yields no `json_each` rows either.
+    // (no navigable id). `effective` is scoped to the library once up
+    // front, but `book_count` is still a per-tag correlated `COUNT(*)`
+    // over it. The `e.tag_name = t.name` override-arm match stays BINARY
+    // even though `tags.name` is `COLLATE NOCASE`: `tag_name` is a CTE
+    // column with no explicit collation, and SQLite's column-collation
+    // precedence favors the left operand, so BINARY wins. The empty-array
+    // clear-all case falls out naturally since a `Some([])` override drops
+    // the book from the canonical arm and yields no `json_each` rows either.
     let rows = sqlx::query(
         r"
         WITH effective AS (

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -31,24 +31,18 @@ pub async fn search_tags_for_paths(
     if library_paths.is_empty() {
         return Ok(Vec::new());
     }
-    // F5.1: the count uses the effective (override-aware) subject set,
-    // not the raw `books_tags_link` rows. `MetadataOverrides.subjects`
+    // The count uses the effective (override-aware) subject set, not the
+    // raw `books_tags_link` rows. `MetadataOverrides.subjects`
     // (Option<Vec<String>>) replaces the canonical tag list wholesale
     // when Some — including the empty array, which clears all tags.
     // Visibility still requires at least one canonical link in this
-    // library so we don't list tags that exist only inside override
-    // JSON (no navigable id).
-    //
-    // Issue #154: the per-tag correlated `COUNT(*)` is replaced with a
-    // single-pass `effective` membership CTE (scoped to the library up
-    // front) — the UNION of (1) canonical `books_tags_link` rows whose book
-    // has no `subjects` override and (2) override-extracted subject strings
-    // from `json_each(mo.overrides, '$.subjects')`. UNION (not ALL) dedupes
-    // duplicate subject strings within one override array, matching the
-    // prior `EXISTS` semantics. The override match stays BINARY
-    // (`je.value = t.name`, no COLLATE). The empty-array clear-all case
-    // falls out: a `Some([])` override drops the book from arm (1) and
-    // yields no `json_each` rows in arm (2).
+    // library so we don't list tags that exist only inside override JSON
+    // (no navigable id). The per-tag count comes from a single-pass
+    // `effective` membership CTE (scoped to the library up front) rather
+    // than a per-tag correlated `COUNT(*)`. The override match stays
+    // BINARY (`je.value = t.name`, no COLLATE); the empty-array clear-all
+    // case falls out naturally since a `Some([])` override drops the book
+    // from the canonical arm and yields no `json_each` rows either.
     let rows = sqlx::query(
         r"
         WITH effective AS (

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -276,7 +276,7 @@ async fn run_legacy_cover_purge() {
     })
     .await
     {
-        tracing::error!("issue #94: legacy cover purge spawn_blocking failed: {join_err}");
+        tracing::error!("legacy cover purge spawn_blocking failed: {join_err}");
     }
 }
 
@@ -324,7 +324,7 @@ fn purge_legacy_covers_once(dir: &Path) {
             tracing::warn!(
                 covers_dir = %dir.display(),
                 error = %err,
-                "issue #94: could not read covers dir to purge legacy files; skipping",
+                "could not read covers dir to purge legacy files; skipping",
             );
             return;
         }
@@ -343,7 +343,7 @@ fn purge_legacy_covers_once(dir: &Path) {
             tracing::warn!(
                 path = %path.display(),
                 error = %err,
-                "issue #94: failed to remove legacy cover file",
+                "failed to remove legacy cover file",
             );
         } else {
             removed += 1;
@@ -354,13 +354,13 @@ fn purge_legacy_covers_once(dir: &Path) {
         tracing::warn!(
             sentinel = %sentinel.display(),
             error = %err,
-            "issue #94: failed to write covers-scheme sentinel; will retry on next boot",
+            "failed to write covers-scheme sentinel; will retry on next boot",
         );
     } else {
         tracing::info!(
             covers_dir = %dir.display(),
             removed,
-            "issue #94: purged legacy cover files and wrote v5 sentinel",
+            "purged legacy cover files and wrote v5 sentinel",
         );
     }
 }

--- a/db/src/pool/tests.rs
+++ b/db/src/pool/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for pool init and migrations: `init_db` error surfacing on a bad
+//! URL or a tampered applied-migration checksum, and per-migration
+//! correctness checks (schema cleanup, timestamp coercion, orphan
+//! row handling) run against a fresh `sqlite::memory:` database.
+
 use super::*;
 
 use crate::test_support::count_rows as count;

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -68,11 +68,11 @@ fn parse_format(raw: &str) -> ProgressFormat {
 /// stores/keys on it.
 ///
 /// The conflict resolution is conditional on `client_updated_at`, not
-/// unconditional last-write-wins on receipt order (issue #1362): the stored
+/// unconditional last-write-wins on receipt order: the stored
 /// `MIN(update.client_updated_at, now)` — clamping a fast client clock so it
 /// can't pin itself as permanently newest — only overwrites the row when it
 /// is `>=` the value already stored. A write with no `client_updated_at`
-/// (older client) is treated as "now", matching the pre-#1362 behaviour. A
+/// (older client) is treated as "now", matching plain last-write-wins. A
 /// rejected (older) write still re-reads and returns the row that won, so
 /// the caller learns it is behind rather than seeing its own rejected
 /// payload echoed back.
@@ -317,7 +317,7 @@ pub async fn get_playback_rate(
 /// The user's most recent progress rows across both formats, newest first
 /// by **client event time** — `COALESCE(client_updated_at, updated_at)`, so
 /// a queued offline replay landing late doesn't jump a week-old book to the
-/// top (issue #1362). Feeds the "pick up where you left off" surfaces via
+/// top. Feeds the "pick up where you left off" surfaces via
 /// [`resume_points`].
 pub async fn recent_progress(
     pool: &SqlitePool,

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -1,3 +1,8 @@
+//! Tests for cross-format book attachment: matching a new audiobook/ebook
+//! to an existing book of the other format by normalized title + author
+//! (including last/first name order), and the ambiguity/ownership guards
+//! that skip a match rather than clobbering an existing attachment.
+
 use crate::books::list_merged_rows_for_formats;
 use crate::indexer::diff_library;
 use crate::pool::init_db;

--- a/frontend/src/components/barcode_scanner/tests.rs
+++ b/frontend/src/components/barcode_scanner/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for `ScanStatus`: mapping the JS camera-glue status strings to the
+//! enum (with an error default for unrecognized values), and which states
+//! are terminal (the camera is out for good).
+
 use super::*;
 
 #[test]

--- a/frontend/src/components/format_switcher/kobo/tests.rs
+++ b/frontend/src/components/format_switcher/kobo/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for `kobo_outcome`: mapping the web Send-to-Kobo picker's outcome
+//! strings (device write, download fallback, cancellation) to a status
+//! message, or `None` when there is nothing to report.
+
 #[cfg(not(feature = "mobile"))]
 #[test]
 fn kobo_outcome_reports_success_for_device_write() {

--- a/frontend/src/data/users.rs
+++ b/frontend/src/data/users.rs
@@ -1,4 +1,4 @@
-//! Admin user-management client wrappers (F5.4). Web hits the AdminUser-gated
+//! Admin user-management client wrappers. Web hits the AdminUser-gated
 //! `/api/users*` REST routes via `gloo-net` (same-origin cookie session,
 //! mirroring `data::auth`); SSR builds get no-op stubs so the Users settings
 //! page compiles and hydrates with identical markup. Mobile has no admin

--- a/frontend/src/pages/auth/register/tests.rs
+++ b/frontend/src/pages/auth/register/tests.rs
@@ -1,6 +1,8 @@
-// Password-scoring coverage lives with the shared helper in
-// `components::auth::strength`; these tests cover only register-specific
-// error routing.
+//! Tests for `classify_register_error`: routing a server error string to
+//! the matching `RegisterError` variant. Password-scoring coverage lives
+//! with the shared helper in `components::auth::strength`; these tests
+//! cover only register-specific error routing.
+
 use super::*;
 
 #[test]

--- a/frontend/src/pages/authors_index/tests.rs
+++ b/frontend/src/pages/authors_index/tests.rs
@@ -1,3 +1,6 @@
+//! Tests for the authors-index sort/grouping helpers: `sort_key` prefers
+//! the explicit sort field, and `first_letter` groups by that same key.
+
 use super::*;
 
 fn author(name: &str, sort: Option<&str>) -> AuthorSummary {

--- a/frontend/src/pages/book_detail/body/tests.rs
+++ b/frontend/src/pages/book_detail/body/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for `bd_identifier_key`: the rendered-list key for a book's
+//! identifiers must stay unique across same-scheme, schemeless, and
+//! delimiter-containing values so React/Dioxus keying never collides.
+
 use super::*;
 
 #[test]

--- a/frontend/src/pages/book_detail/highlights/tests.rs
+++ b/frontend/src/pages/book_detail/highlights/tests.rs
@@ -1,3 +1,6 @@
+//! Tests for `highlight_locator`: naming the spine section a highlight's
+//! epub.js CFI falls in, for both range and point CFI forms.
+
 use super::locator::highlight_locator;
 use super::*;
 

--- a/frontend/src/pages/check_in/tests.rs
+++ b/frontend/src/pages/check_in/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for the check-in flow's pure helpers: ISBN cleaning and check-digit
+//! rejection, keypad entry, wizard stage selection per lookup outcome, and
+//! the byline/notes formatting used by the confirm screens.
+
 use super::entry::apply_key;
 use super::screens::byline;
 use super::*;

--- a/frontend/src/pages/landing/filtering/tests.rs
+++ b/frontend/src/pages/landing/filtering/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for the landing-page book filters: facet AND-across-groups /
+//! OR-within-group semantics for tags, formats, and series, including
+//! case-insensitive format matching and the empty-filter passthrough.
+
 use super::*;
 use omnibus_shared::Contributor;
 

--- a/frontend/src/pages/listen/mobile/view/tests.rs
+++ b/frontend/src/pages/listen/mobile/view/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for the mobile audiobook player's pure helpers: time formatting,
+//! locating the chapter at an elapsed position, remaining-time math at a
+//! playback rate, and prev/next chapter and part seek targets.
+
 use super::*;
 
 fn ch(ordinal: i64, title: &str, start: f64, dur: f64) -> ChapterInfo {

--- a/frontend/src/pages/metadata_edit/tests.rs
+++ b/frontend/src/pages/metadata_edit/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for `build_overrides`: diffing an edited form against the source
+//! book to emit only the changed fields, clearing a populated field as an
+//! empty string, and replacing creator/subject lists wholesale.
+
 use super::*;
 
 fn book_with(title: Option<&str>, creators: &[&str], subjects: &[&str]) -> EbookMetadata {

--- a/frontend/src/pages/series_index/tests.rs
+++ b/frontend/src/pages/series_index/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for the series-index sort/filter helpers: `sort_key`'s leading-
+//! "The" stripping and explicit-sort-field preference, and
+//! `apply_filter_and_sort`'s name/author search and book-count ordering.
+
 use super::*;
 
 fn summary(name: &str, sort: Option<&str>) -> SeriesSummary {

--- a/frontend/src/pages/settings/users.rs
+++ b/frontend/src/pages/settings/users.rs
@@ -1,4 +1,4 @@
-//! Users settings section (F5.4) — the admin table plus the New / Edit /
+//! Users settings section — the admin table plus the New / Edit /
 //! Delete modals and inline Unlock. Admin-only; rendered as the `users`
 //! section of `/settings`. SSR and the first WASM paint both start from an
 //! empty list (rule 07); the post-mount effect loads the real rows.

--- a/frontend/src/pages/settings/users/tests.rs
+++ b/frontend/src/pages/settings/users/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for the Users settings section's date helpers: `fmt_date`
+//! formatting known epochs in UTC and staying stable within a civil day,
+//! and `civil_from_days` round-tripping the epoch.
+
 use super::*;
 
 #[test]

--- a/server/src/backend/kobo/store_resources/tests.rs
+++ b/server/src/backend/kobo/store_resources/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for `resources_for`: the Kobo store-resources map repoints only
+//! the overridden keys at this server (with the path token attached) and
+//! leaves the rest of the map, including non-string entries, untouched.
+
 use super::*;
 
 const BASE: &str = "https://omni.test";

--- a/server/src/backend/users.rs
+++ b/server/src/backend/users.rs
@@ -1,4 +1,4 @@
-//! Admin user-management REST handlers (F5.4). Every route is `AdminUser`-gated
+//! Admin user-management REST handlers. Every route is `AdminUser`-gated
 //! (403 for non-admins): list, create, update permissions, reset password,
 //! unlock, and delete — with the last-admin guardrails enforced by the db
 //! layer surfaced as `409 Conflict`.

--- a/server/src/metrics/tests.rs
+++ b/server/src/metrics/tests.rs
@@ -1,3 +1,6 @@
+//! Tests for the Prometheus metrics endpoint: request-labeled histograms
+//! render with grouped id-path labels rather than raw per-resource paths.
+
 use super::*;
 use axum::{
     body::{to_bytes, Body},

--- a/server/src/security_headers/tests.rs
+++ b/server/src/security_headers/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for the security-headers middleware: baseline headers present on
+//! every response, CSP permissiveness for Dioxus hydration and fonts,
+//! handler-supplied overrides winning over the baseline, and HSTS toggling.
+
 use super::*;
 use axum::{
     body::{to_bytes, Body},

--- a/shared/src/ebook/tests.rs
+++ b/shared/src/ebook/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for `EbookMetadata` and `MetadataOverrides`: title/description
+//! display fallbacks, override validation (length caps measured in chars,
+//! ISBN-13 shape, subject/creator/tag limits), and override-merge layering.
+
 use super::*;
 
 fn contributor(name: &str) -> Contributor {

--- a/shared/src/isbn/tests.rs
+++ b/shared/src/isbn/tests.rs
@@ -1,3 +1,6 @@
+//! Tests for ISBN normalization: ISBN-10 to ISBN-13 conversion, check-digit
+//! validation, and rejection of malformed or non-ASCII-digit input.
+
 use super::*;
 
 const ISBN13: &str = "9780134685991";

--- a/shared/src/progress/tests.rs
+++ b/shared/src/progress/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for `ProgressUpdate` and `SessionReport` validation: cross-format
+//! field rejection, CFI/percent length and range caps, `client_updated_at`
+//! and `book_file_id` handling, and backward-compatible payload decoding.
+
 use super::*;
 
 #[test]

--- a/shared/src/shelves/tests.rs
+++ b/shared/src/shelves/tests.rs
@@ -1,3 +1,7 @@
+//! Tests for shelf wire types: rule field/op token round-tripping, smart
+//! and manual shelf create/update validation, and length/count caps on
+//! rules, descriptions, names, and book uuid lists.
+
 use super::*;
 
 #[test]


### PR DESCRIPTION
## Summary
- Closes #1473. Strips stale roadmap-phase / issue-number tags (`F5.8 #1372`, `F5.4`, `F4.x`, `F5.1 #972`, `issue #1362`, `issue #94`) from module and function doc comments across `db/`, `server/`, and `frontend/`, keeping the substantive "why" prose intact per rule 05's "Comments & docs" — no roadmap-phase or issue-number references belong in doc comments.
- Trims `get_tag_cloud` (`db/src/discovery/tags.rs`) and `search_tags_for_paths` (`db/src/palette/tags.rs`) from a ~35/~15-line line-by-line SQL narration down to why-only prose (the CTE/UNION/JOIN reasoning), removing the what-narration.
- Adds a missing module `//!` doc to all 35 `tests.rs` sibling files that had none, matching the `db/src/books/tests.rs` model (one-line-per-topic summary of what the file covers).

This is a pure documentation change — no logic, no behavior change (the five `issue #94:` prefixes stripped from `db/src/pool.rs` were tracing log-message text, not comments, but were explicitly called out in the issue as an inline-comment-style site to fix).

## Test plan
- [x] `cargo fmt --all` — PASS (no changes needed beyond the edits made)
- [x] `cargo doc --workspace --no-deps --exclude omnibus-mobile` — PASS (only pre-existing rustdoc warnings unrelated to this change; `omnibus-mobile` excluded because this sandbox lacks the GTK3/WebKitGTK system libs it needs to build, a pre-existing environment gap unrelated to this PR)
- [x] `cargo build --workspace --exclude omnibus-mobile` — PASS
- [x] Manual grep confirming every roadmap/issue tag from the issue's Part 1 list is gone from its named file, and no `tests.rs` file lacks a `//!` doc

## Notes
- Docs-only change (`db/`, `server/`, `frontend/` doc comments and `tests.rs` module docs) — no release-relevant code touched, so it auto-skips the release per this repo's own convention (unlabeled PRs touching only comments carry no functional diff).
- `db/src/opf_export.rs` (named in the issue as an `F5.8 #1372` site) no longer exists — it was removed in a prior PR (#1373/#1542) that superseded the OPF sidecar export; nothing to fix there.
- Scope was kept to the files the issue explicitly named plus the `tests.rs` grep results, to avoid overlapping with #1171's file set, per the issue's own guidance.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FEnYBejWkiDP63kY6WetEP)_