### PR TITLE
fix: stop re-parsing multi-file books every scan (#1537)

### DIFF
--- a/db/src/books/list.rs
+++ b/db/src/books/list.rs
@@ -116,18 +116,25 @@ pub async fn list_indexed_rows(
     pool: &SqlitePool,
     library_path: &str,
 ) -> Result<Vec<IndexedRow>, super::BooksError> {
+    // Match on `bf.scan_key = b.scan_key` rather than aggregating over every
+    // `book_files` row for the book: a book that carries more than one file
+    // (a manual same-format merge, or a cross-format attach) has one row per
+    // extra file that is *not* this book's own — those are diffed
+    // separately via `merged_uuids` (`list_merged_rows_for_formats`). Folding
+    // them into a MAX/MAX pair here produced a composite that matched
+    // neither file's real stat (#1537).
     let rows = sqlx::query(
         r"
-        SELECT b.uuid                                  AS uuid,
-               COALESCE(b.scan_key, '')                AS scan_key,
-               COALESCE(MAX(bf.mtime_epoch), 0)        AS mtime_epoch,
-               COALESCE(MAX(bf.size_bytes), 0)         AS size_bytes,
-               (COUNT(bf.id) > 0)                      AS has_file
+        SELECT b.uuid                     AS uuid,
+               COALESCE(b.scan_key, '')   AS scan_key,
+               COALESCE(bf.mtime_epoch, 0) AS mtime_epoch,
+               COALESCE(bf.size_bytes, 0)  AS size_bytes,
+               (bf.id IS NOT NULL)         AS has_file
           FROM books b
-          JOIN scan_roots l   ON l.id = b.library_id
-          LEFT JOIN book_files bf ON bf.book_id = b.id
+          JOIN scan_roots l ON l.id = b.library_id
+          LEFT JOIN book_files bf
+                 ON bf.book_id = b.id AND bf.scan_key = b.scan_key
          WHERE l.path = ?
-         GROUP BY b.id, b.uuid
         ",
     )
     .bind(library_path)
@@ -186,21 +193,35 @@ pub async fn list_indexed_rows_for_formats(
     // (`has_file = 0` and it still has files), preserving the cross-format
     // scoping from #328. Bind order: the format placeholders appear before
     // `l.path` in the statement text, so they bind first.
+    //
+    // The join also pins `bf.scan_key = b.scan_key` — this book's *own*
+    // anchor file — instead of aggregating over every matching-format row.
+    // A book carrying more than one file of the scanned formats (a manual
+    // same-format merge, or a cross-format attach) has an extra
+    // `book_files` row per additional file that isn't this book's own; each
+    // is diffed separately via its `merged_uuids` entry
+    // (`list_merged_rows_for_formats`). Aggregating them here with
+    // MAX/MAX produced a composite `(mtime, size)` pair that matched
+    // neither file's real on-disk stat, so the book reclassified Changed on
+    // every scan forever (#1537). The trailing `WHERE` clause carries the
+    // old `HAVING`'s "still return a fully fileless book" branch — with no
+    // `GROUP BY` left, that's now a plain post-join predicate.
     let sql = format!(
         r"
-        SELECT b.uuid                                  AS uuid,
-               COALESCE(b.scan_key, '')                AS scan_key,
-               COALESCE(MAX(bf.mtime_epoch), 0)        AS mtime_epoch,
-               COALESCE(MAX(bf.size_bytes), 0)         AS size_bytes,
-               (COUNT(bf.id) > 0)                      AS has_file
+        SELECT b.uuid                     AS uuid,
+               COALESCE(b.scan_key, '')   AS scan_key,
+               COALESCE(bf.mtime_epoch, 0) AS mtime_epoch,
+               COALESCE(bf.size_bytes, 0)  AS size_bytes,
+               (bf.id IS NOT NULL)         AS has_file
           FROM books b
           JOIN scan_roots l ON l.id = b.library_id
           LEFT JOIN book_files bf
-                 ON bf.book_id = b.id AND bf.format IN ({placeholders})
+                 ON bf.book_id = b.id
+                AND bf.format IN ({placeholders})
+                AND bf.scan_key = b.scan_key
          WHERE l.path = ?
-         GROUP BY b.id
-        HAVING (COUNT(bf.id) > 0)
-            OR NOT EXISTS (SELECT 1 FROM book_files bf2 WHERE bf2.book_id = b.id)
+           AND (bf.id IS NOT NULL
+                OR NOT EXISTS (SELECT 1 FROM book_files bf2 WHERE bf2.book_id = b.id))
         "
     );
     let mut q = sqlx::query(&sql);

--- a/db/src/books/tests.rs
+++ b/db/src/books/tests.rs
@@ -1992,26 +1992,31 @@ async fn list_indexed_rows_for_formats_returns_only_matching_format_rows() {
     .fetch_one(&pool)
     .await
     .unwrap();
+    // Both `books.scan_key` and its anchor `book_files.scan_key` are set to
+    // the same value (matching what `insert_book_row` writes in production)
+    // — that equality is what the per-file anchor match now keys on (#1537).
     let epub_id: i64 = sqlx::query_scalar(
-        "INSERT INTO books (uuid, library_id, path, title, sort) \
-         VALUES ('uuid-epub', ?, '/shared/epub', 'EpubTitle', 'EpubTitle') RETURNING id",
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, sort) \
+         VALUES ('uuid-epub', 'shared/epub/EpubTitle.epub', ?, \
+                 '/shared/epub', 'EpubTitle', 'EpubTitle') RETURNING id",
     )
     .bind(lib_id)
     .fetch_one(&pool)
     .await
     .unwrap();
     let m4b_id: i64 = sqlx::query_scalar(
-        "INSERT INTO books (uuid, library_id, path, title, sort) \
-         VALUES ('uuid-m4b', ?, '/shared/audio', 'AudioTitle', 'AudioTitle') RETURNING id",
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, sort) \
+         VALUES ('uuid-m4b', 'shared/audio/AudioTitle.m4b', ?, \
+                 '/shared/audio', 'AudioTitle', 'AudioTitle') RETURNING id",
     )
     .bind(lib_id)
     .fetch_one(&pool)
     .await
     .unwrap();
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch) \
-         VALUES (?, 'EPUB', 'EpubTitle', 100, 100), \
-                (?, 'M4B',  'AudioTitle', 200, 200)",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch, scan_key) \
+         VALUES (?, 'EPUB', 'EpubTitle', 100, 100, 'shared/epub/EpubTitle.epub'), \
+                (?, 'M4B',  'AudioTitle', 200, 200, 'shared/audio/AudioTitle.m4b')",
     )
     .bind(epub_id)
     .bind(m4b_id)

--- a/db/src/identity.rs
+++ b/db/src/identity.rs
@@ -50,16 +50,21 @@ pub async fn backfill_scan_keys(pool: &SqlitePool) -> Result<(), IdentityError> 
 
 /// Fill `book_files.scan_key` (migration 0043) for every row from its own
 /// stored `(path, filename, format)` + part count — the same reconstruction
-/// the `books`/`merged_uuids` backfills use. Attached rows carry their file's
-/// real `path` (the attach writer sets it), so this yields the exact
-/// `scan_key` their `merged_uuids` guard matches on; native rows reconstruct
-/// too (only the merged-join needs an exact value, and that only reads
-/// attachment rows). Idempotent — `scan_key IS NULL` only.
+/// the `books`/`merged_uuids` backfills use. Attached rows carry their
+/// file's real `path` (the attach writer sets it) and reconstruct from it
+/// directly. A **native** row never has `book_files.path` set (only
+/// `books.path` is) — `bf.path` is `NULL` there, so this JOINs `books` and
+/// falls back to the book's own `path` for those rows. Without the JOIN a
+/// native row at `A/one.epub` would backfill to the bare leaf `one.epub`,
+/// losing the directory — which broke the per-file `bf.scan_key = b.scan_key`
+/// anchor match `list_indexed_rows_for_formats` relies on (#1537).
+/// Idempotent — `scan_key IS NULL` only.
 async fn backfill_book_files_scan_keys(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     let rows: Vec<(i64, String, String, String, i64)> = sqlx::query_as(
-        "SELECT bf.id, COALESCE(bf.path, ''), bf.filename, bf.format,
+        "SELECT bf.id, COALESCE(bf.path, b.path), bf.filename, bf.format,
                 (SELECT COUNT(*) FROM book_file_parts p WHERE p.book_file_id = bf.id)
            FROM book_files bf
+           JOIN books b ON b.id = bf.book_id
           WHERE bf.scan_key IS NULL",
     )
     .fetch_all(pool)

--- a/db/src/identity/tests.rs
+++ b/db/src/identity/tests.rs
@@ -136,6 +136,75 @@ async fn backfill_fills_multiple_books_and_a_merged_attachment_in_one_pass() {
 }
 
 #[tokio::test]
+async fn backfill_book_files_scan_keys_uses_books_path_for_native_rows_and_bf_path_for_attachments()
+{
+    // #1537 AC5: a native row has no `book_files.path` of its own (only
+    // `books.path` carries the directory), so reconstructing from
+    // `COALESCE(bf.path, '')` alone dropped the directory — `A/one.epub`
+    // backfilled to the bare leaf `one.epub`, which then never matched the
+    // per-file `bf.scan_key = b.scan_key` anchor the diff relies on.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'Lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    // Native book at `A/one.epub`: pre-0043 row, `book_files.scan_key` and
+    // `book_files.path` both NULL — only `books.path` ('A') carries the dir.
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title) \
+         VALUES ('bk-1', 'A/one.epub', 1, 'A', 'One') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch) \
+         VALUES (?, 'EPUB', 'one', 10, 100)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    // An attachment row on the same book: the attach writer stamps its own
+    // location override (`book_files.path`), unlike the native row above.
+    sqlx::query(
+        "INSERT INTO book_files \
+            (book_id, format, filename, size_bytes, mtime_epoch, library_path, path) \
+         VALUES (?, 'M4B', 'two', 20, 200, '/audio', 'X')",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    backfill_scan_keys(&pool).await.unwrap();
+
+    let keys: Vec<(String, Option<String>)> =
+        sqlx::query_as("SELECT format, scan_key FROM book_files WHERE book_id = ? ORDER BY format")
+            .bind(book_id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        keys,
+        vec![
+            ("EPUB".to_string(), Some("A/one.epub".to_string())),
+            ("M4B".to_string(), Some("X/two.m4b".to_string())),
+        ]
+    );
+
+    // Idempotent: a second pass is a no-op (the `scan_key IS NULL` guard).
+    backfill_scan_keys(&pool).await.unwrap();
+    let keys_again: Vec<(String, Option<String>)> =
+        sqlx::query_as("SELECT format, scan_key FROM book_files WHERE book_id = ? ORDER BY format")
+            .bind(book_id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(keys_again, keys, "second pass must not change anything");
+}
+
+#[tokio::test]
 async fn backfill_scan_keys_propagates_db_error_when_pool_is_closed() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     pool.close().await;

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -4,11 +4,16 @@
 //! cross-format deletion guard.
 
 use super::*;
-use crate::books::{list_books, IndexedRow};
+use crate::books::{
+    list_books, list_indexed_rows_for_formats, list_merged_rows_for_formats, IndexedRow,
+};
 use crate::ebook::StatEntry;
 use crate::pool::init_db;
-use crate::sync::{replace_books, sync_books, SyncPlan};
-use crate::test_support::{count_rows, indexed, make_test_dir, CoversTempDir};
+use crate::sync::{replace_books, sync_audiobooks, sync_books, AudiobookSyncPlan, SyncPlan};
+use crate::test_support::{
+    count_rows, indexed, indexed_audiobook, indexed_with_stat, make_test_dir, uuid_by_scan_key,
+    CoversTempDir,
+};
 
 /// Seed a `scan_roots` row for `path` with an explicit `last_indexed`
 /// epoch-seconds value. There's no public writer for `last_indexed`
@@ -1158,4 +1163,222 @@ async fn is_stale_propagates_db_error_when_pool_is_closed() {
     pool.close().await;
     let err = is_stale(&pool, "/lib").await.unwrap_err();
     assert!(matches!(err, IndexerError::Db(_)));
+}
+
+// ---------- #1537: a multi-file book is diffed per file, not per book ----------
+
+/// Seed two EPUBs through the real `sync_books` write path with distinct
+/// on-disk stats, then merge the second into the first — the exact repro
+/// shape from #1537 (a book left holding two same-format `book_files`
+/// rows). Returns `(target_uuid, source_uuid)`.
+async fn seed_merged_two_epub_book(pool: &SqlitePool) -> (String, String) {
+    sync_books(
+        pool,
+        "/ebooks",
+        SyncPlan {
+            new_books: vec![indexed_with_stat("A/one.epub", Some("One"), 1000, 500)],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let target = uuid_by_scan_key(pool, "A/one.epub").await;
+
+    sync_books(
+        pool,
+        "/ebooks",
+        SyncPlan {
+            new_books: vec![indexed_with_stat("B/two.epub", Some("Two"), 2000, 100)],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let source = uuid_by_scan_key(pool, "B/two.epub").await;
+
+    crate::merge::merge_books(pool, &source, &target, None)
+        .await
+        .unwrap();
+    (target, source)
+}
+
+/// Build the DB side of the diff exactly as `reindex` does for the ebook
+/// pass: the anchor row(s) via `list_indexed_rows_for_formats`, plus every
+/// attached file via `list_merged_rows_for_formats`.
+async fn ebook_db_rows(pool: &SqlitePool, library_path: &str) -> Vec<IndexedRow> {
+    let mut rows = list_indexed_rows_for_formats(pool, library_path, crate::ebook::EBOOK_FORMATS)
+        .await
+        .unwrap();
+    rows.extend(
+        list_merged_rows_for_formats(pool, library_path, crate::ebook::EBOOK_FORMATS)
+            .await
+            .unwrap(),
+    );
+    rows
+}
+
+#[tokio::test]
+async fn multi_file_book_from_merge_classifies_each_file_independently_when_one_changes() {
+    // AC3: modifying only the second file's stat must classify that file
+    // Changed while the first stays Unchanged, and vice versa. Before the
+    // fix, `list_indexed_rows_for_formats` aggregated MAX(mtime)/MAX(size)
+    // across both `book_files` rows, so this book reclassified Changed
+    // regardless of which file (or neither) actually moved.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let (target, source) = seed_merged_two_epub_book(&pool).await;
+    let db_rows = ebook_db_rows(&pool, "/ebooks").await;
+
+    // Only the second file (`B/two.epub`) changed on disk.
+    let disk_second_changed = vec![
+        entry("A/one.epub", "A/one.epub", 1000, 500),
+        entry("B/two.epub", "B/two.epub", 2000, 999),
+    ];
+    let diff = diff_library(&disk_second_changed, &db_rows, Path::new("/ebooks"), true);
+    assert_eq!(diff.unchanged, vec![target.clone()], "{diff:?}");
+    assert_eq!(diff.changed.len(), 1);
+    assert_eq!(diff.changed[0].filename, "B/two.epub");
+
+    // Only the first file (`A/one.epub`) changed on disk.
+    let disk_first_changed = vec![
+        entry("A/one.epub", "A/one.epub", 1000, 999),
+        entry("B/two.epub", "B/two.epub", 2000, 100),
+    ];
+    let diff = diff_library(&disk_first_changed, &db_rows, Path::new("/ebooks"), true);
+    assert_eq!(diff.unchanged, vec![source], "{diff:?}");
+    assert_eq!(diff.changed.len(), 1);
+    assert_eq!(diff.changed[0].filename, "A/one.epub");
+}
+
+/// AC1 + AC2: a book merged from two same-format EPUBs classifies both
+/// files Unchanged on a rescan where neither changed, and stays that way
+/// across three consecutive full reindexes — no re-parse, so each file's
+/// `book_files.id` (and the book's `last_modified`) survives unchanged.
+/// A Changed rewrite always mints a fresh `book_files` row (DELETE +
+/// INSERT), so a stable id is direct evidence no re-parse happened.
+#[tokio::test]
+async fn merged_two_file_book_stays_unchanged_across_three_consecutive_reindexes() {
+    let _covers = CoversTempDir::new("merge-reparse-guard");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = make_test_dir("merge-reparse-guard-lib");
+    let lib_path = lib.to_string_lossy().into_owned();
+
+    seed_ebook_at(&pool, &lib_path, "A/one.epub", "One").await;
+    seed_ebook_at(&pool, &lib_path, "B/two.epub", "Two").await;
+    let target = uuid_by_scan_key(&pool, "A/one.epub").await;
+    let source = uuid_by_scan_key(&pool, "B/two.epub").await;
+    crate::merge::merge_books(&pool, &source, &target, None)
+        .await
+        .unwrap();
+
+    let file_ids_before: Vec<i64> = sqlx::query_scalar("SELECT id FROM book_files ORDER BY id")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        file_ids_before.len(),
+        2,
+        "test precondition: two files merged"
+    );
+    let last_modified_before: i64 =
+        sqlx::query_scalar("SELECT last_modified FROM books WHERE uuid = ?")
+            .bind(&target)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    for pass in 1..=3 {
+        reindex(&pool, &lib_path).await.unwrap();
+        let file_ids_after: Vec<i64> = sqlx::query_scalar("SELECT id FROM book_files ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            file_ids_after, file_ids_before,
+            "reindex pass {pass} re-wrote a book_files row (re-parsed) \
+             instead of classifying Unchanged"
+        );
+        let last_modified_after: i64 =
+            sqlx::query_scalar("SELECT last_modified FROM books WHERE uuid = ?")
+                .bind(&target)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            last_modified_after, last_modified_before,
+            "reindex pass {pass} touched books.last_modified (implies a Changed rewrite)"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&lib);
+}
+
+/// AC6: an audiobook naturally holding two different-format groups under
+/// one book (auto-attached by title+author match — not a manual merge)
+/// classifies both groups Unchanged on a rescan where neither changed.
+#[tokio::test]
+async fn mixed_format_audiobook_group_classifies_both_parts_unchanged_when_nothing_changed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    let mut m4b = indexed_audiobook("A/Dracula.m4b", "Dracula", Some("Stoker"));
+    m4b.max_mtime_epoch = 1000;
+    m4b.total_size_bytes = 500;
+    sync_audiobooks(
+        &pool,
+        "/audio",
+        AudiobookSyncPlan {
+            new_books: vec![m4b],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let target = uuid_by_scan_key(&pool, "A/Dracula.m4b").await;
+
+    // Same title+author, different format — auto-attaches to the M4B book
+    // instead of minting a second `books` row.
+    let mut mp3 = indexed_audiobook("B/Dracula mp3", "Dracula", Some("Stoker"));
+    mp3.format = "MP3".into();
+    mp3.max_mtime_epoch = 2000;
+    mp3.total_size_bytes = 100;
+    sync_audiobooks(
+        &pool,
+        "/audio",
+        AudiobookSyncPlan {
+            new_books: vec![mp3],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM books").await,
+        1,
+        "test precondition: the MP3 group auto-attached rather than minting a new book"
+    );
+    let source = crate::test_support::uuid_by_scan_key(&pool, "B/Dracula mp3").await;
+    assert_ne!(
+        target, source,
+        "the attached group keeps its own ledger uuid"
+    );
+
+    let disk = vec![
+        entry("A/Dracula.m4b", "A/Dracula.m4b", 1000, 500),
+        entry("B/Dracula mp3", "B/Dracula mp3", 2000, 100),
+    ];
+    let mut db_rows =
+        list_indexed_rows_for_formats(&pool, "/audio", crate::audiobook::AUDIOBOOK_FORMATS)
+            .await
+            .unwrap();
+    db_rows.extend(
+        list_merged_rows_for_formats(&pool, "/audio", crate::audiobook::AUDIOBOOK_FORMATS)
+            .await
+            .unwrap(),
+    );
+
+    let diff = diff_library(&disk, &db_rows, Path::new("/audio"), true);
+    assert_eq!(diff.unchanged.len(), 2, "{diff:?}");
+    assert!(diff.unchanged.contains(&target));
+    assert!(diff.unchanged.contains(&source));
+    assert!(diff.new.is_empty(), "{:?}", diff.new);
+    assert!(diff.changed.is_empty(), "{:?}", diff.changed);
 }

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -573,6 +573,82 @@ async fn reindex_diff_classifies_merged_source_file_as_unchanged() {
 }
 
 #[tokio::test]
+async fn merged_two_epub_book_classifies_both_files_unchanged_on_rescan() {
+    // #1537: a book holding two same-format files (created by merging two
+    // EPUB books) used to reclassify Changed on every scan forever — the
+    // DB-side read aggregated MAX(mtime)/MAX(size) across both `book_files`
+    // rows into one composite stat that matched neither file's real stat.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    crate::sync::sync_books(
+        &pool,
+        "/ebooks",
+        crate::sync::SyncPlan {
+            new_books: vec![crate::test_support::indexed_with_stat(
+                "A/one.epub",
+                Some("One"),
+                1000,
+                500,
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let target = crate::test_support::uuid_by_scan_key(&pool, "A/one.epub").await;
+
+    crate::sync::sync_books(
+        &pool,
+        "/ebooks",
+        crate::sync::SyncPlan {
+            new_books: vec![crate::test_support::indexed_with_stat(
+                "B/two.epub",
+                Some("Two"),
+                2000,
+                100,
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let source = crate::test_support::uuid_by_scan_key(&pool, "B/two.epub").await;
+
+    merge_books(&pool, &source, &target, None).await.unwrap();
+
+    let disk = vec![
+        crate::ebook::StatEntry {
+            filename: "A/one.epub".into(),
+            scan_key: "A/one.epub".into(),
+            mtime_epoch: 1000,
+            size_bytes: 500,
+            error: None,
+        },
+        crate::ebook::StatEntry {
+            filename: "B/two.epub".into(),
+            scan_key: "B/two.epub".into(),
+            mtime_epoch: 2000,
+            size_bytes: 100,
+            error: None,
+        },
+    ];
+    let mut db_rows = list_indexed_rows_for_formats(&pool, "/ebooks", crate::ebook::EBOOK_FORMATS)
+        .await
+        .unwrap();
+    db_rows.extend(
+        list_merged_rows_for_formats(&pool, "/ebooks", crate::ebook::EBOOK_FORMATS)
+            .await
+            .unwrap(),
+    );
+
+    let diff = diff_library(&disk, &db_rows, std::path::Path::new("/ebooks"), true);
+    assert_eq!(diff.unchanged.len(), 2, "{diff:?}");
+    assert!(diff.unchanged.contains(&target));
+    assert!(diff.unchanged.contains(&source));
+    assert!(diff.new.is_empty(), "{:?}", diff.new);
+    assert!(diff.changed.is_empty(), "{:?}", diff.changed);
+}
+
+#[tokio::test]
 async fn undo_merge_restores_source_book_and_moves_file_back() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let target = seed_ebook(&pool, "A/Dracula.epub", "Dracula", "Bram Stoker").await;

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -574,10 +574,7 @@ async fn reindex_diff_classifies_merged_source_file_as_unchanged() {
 
 #[tokio::test]
 async fn merged_two_epub_book_classifies_both_files_unchanged_on_rescan() {
-    // #1537: a book holding two same-format files (created by merging two
-    // EPUB books) used to reclassify Changed on every scan forever — the
-    // DB-side read aggregated MAX(mtime)/MAX(size) across both `book_files`
-    // rows into one composite stat that matched neither file's real stat.
+    // Each book_files row must diff against its own stat, not a MAX() composite.
     let pool = init_db("sqlite::memory:").await.unwrap();
     crate::sync::sync_books(
         &pool,

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -359,10 +359,7 @@ pub(super) async fn insert_book_row(
     .bind(&file_stem)
     .bind(b.size_bytes)
     .bind(b.mtime_epoch)
-    // Per-file attachment identity (F#1537): stamp this on insert, matching
-    // `insert_book_file_row`'s sibling write — a NULL here forced every
-    // multi-file book through the boot backfill before the per-file diff
-    // match (`list_indexed_rows_for_formats`) could see this row's own key.
+    // Stamp scan_key on insert, matching `insert_book_file_row`'s sibling write.
     .bind(&scan_key)
     .execute(&mut **tx)
     .await?;

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -351,14 +351,19 @@ pub(super) async fn insert_book_row(
     // `mtime_epoch INTEGER` holds the filesystem stat the incremental diff
     // compares against (migration 0009).
     sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch)
-         VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch, scan_key)
+         VALUES (?, ?, ?, ?, ?, ?)",
     )
     .bind(book_id)
     .bind(&file_ext)
     .bind(&file_stem)
     .bind(b.size_bytes)
     .bind(b.mtime_epoch)
+    // Per-file attachment identity (F#1537): stamp this on insert, matching
+    // `insert_book_file_row`'s sibling write — a NULL here forced every
+    // multi-file book through the boot backfill before the per-file diff
+    // match (`list_indexed_rows_for_formats`) could see this row's own key.
+    .bind(&scan_key)
     .execute(&mut **tx)
     .await?;
 

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -478,6 +478,20 @@ async fn insert_book_row_writes_books_and_book_files_and_mints_uuid() {
         1,
         "exactly one book_files row"
     );
+    // #1537 AC4: the anchor `book_files` row carries its own scan_key
+    // immediately — no boot backfill needed for the per-file diff match
+    // (`list_indexed_rows_for_formats`) to see it.
+    let file_scan_key: Option<String> =
+        sqlx::query_scalar("SELECT scan_key FROM book_files WHERE book_id = ?")
+            .bind(inserted.book_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        file_scan_key.as_deref(),
+        Some("solo.epub"),
+        "book_files.scan_key is set on insert, matching books.scan_key"
+    );
 }
 
 /// `word_count` round-trips through both the insert and the in-place update:

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -478,9 +478,7 @@ async fn insert_book_row_writes_books_and_book_files_and_mints_uuid() {
         1,
         "exactly one book_files row"
     );
-    // #1537 AC4: the anchor `book_files` row carries its own scan_key
-    // immediately — no boot backfill needed for the per-file diff match
-    // (`list_indexed_rows_for_formats`) to see it.
+    // The anchor row's scan_key must be set on insert, not left for a boot backfill.
     let file_scan_key: Option<String> =
         sqlx::query_scalar("SELECT scan_key FROM book_files WHERE book_id = ?")
             .bind(inserted.book_id)


### PR DESCRIPTION
## Summary
- Closes #1537
- `list_indexed_rows_for_formats` (and `list_indexed_rows`) used to project a book's DB-side diff row as `MAX(bf.mtime_epoch)` / `MAX(bf.size_bytes)` aggregated across *every* `book_files` row for that book. A book holding more than one file of the scanned formats — a manual same-format merge (`merge_books`), or a book naturally holding two different-format audiobook groups — produced a composite `(mtime, size)` pair that matched neither file's real on-disk stat, so the book reclassified `Changed` on every single scan forever (unbounded re-parse/re-taxonomy/re-FTS/re-cover churn).
- Fixed the query to match the book's *own* anchor `book_files` row via `bf.scan_key = b.scan_key` instead of aggregating — no `GROUP BY`/`MAX` left. Every other file under the book (attached via `merged_uuids`) is already diffed correctly and independently by `list_merged_rows_for_formats`, which joins per-file on `bf.scan_key`.
- Fixed two upstream scan_key gaps that fed the bug:
  - `insert_book_row` (`db/src/sync/books/shared.rs`) inserted a book's first `book_files` row *without* `scan_key`, leaving it `NULL` until the next boot's backfill — matching the sibling `insert_book_file_row` write.
  - `identity::backfill_book_files_scan_keys` reconstructed a native row's `scan_key` from `COALESCE(bf.path, '')`, but `book_files.path` is only ever set on attachment rows — a native row at `A/one.epub` backfilled to the bare leaf `one.epub`, losing the directory the new anchor match relies on. Now JOINs `books` and falls back to `books.path` for native rows, while attachment rows keep using their own `bf.path`.
- No schema change — `book_files.scan_key` already exists (migration `0043`).

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1537 cargo fmt -p omnibus-db` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1537 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (no warnings)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1537 cargo test -p omnibus-db` — PASS (1556 passed, 1 failed). The one failure, `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, is a pre-existing environment gap (missing public-domain audio fixture — `just fixtures` wasn't run in this sandbox) unrelated to this change; the 7 new tests added by this PR all pass, confirmed individually via a filtered re-run.

New/extended coverage:
- `db/src/books/tests.rs` — updated the `#328` regression seed to carry real `scan_key`s so it exercises the new anchor-match query.
- `db/src/sync/books/tests.rs` — `insert_book_row_writes_books_and_book_files_and_mints_uuid` now also asserts `book_files.scan_key` is set immediately on insert (no boot backfill needed).
- `db/src/identity/tests.rs` — new test proving the backfill reconstructs a native row as `A/one.epub` (not `one.epub`), leaves attachment rows keyed on their own `bf.path`, and stays idempotent.
- `db/src/indexer/tests.rs` — new tests: a merged two-EPUB book classifies both files Unchanged and survives three consecutive real `reindex()` passes with zero re-parse (book_files ids + `books.last_modified` stable); each file of a multi-file book classifies independently when only one changes; a mixed-format audiobook group (auto-attached M4B + MP3) classifies both parts Unchanged.
- `db/src/merge/tests.rs` — new test: the exact `merge_books`-created two-EPUB shape classifies both files Unchanged via the real `list_indexed_rows_for_formats` + `list_merged_rows_for_formats` + `diff_library` path.

## Notes
- The write-path side of "N same-format files under one book" (whether a `Changed` rewrite for an *attached* same-format file could clobber its sibling's `book_files` row via `attach_ebook_file`'s format-wide `DELETE`) is a separate, pre-existing concern not touched here — this PR is scoped to the read/diff-classification side per the issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FEnYBejWkiDP63kY6WetEP)_