### PR TITLE
refactor: memoize filter/sort derived state in three Dioxus pages (#1254)

### DIFF
--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -17,6 +17,15 @@ struct AuthorIndexCounts {
     total_books: usize,
 }
 
+/// Owned output of the filter/sort/group-by-letter pipeline, memoized as a
+/// single unit (mirrors `landing.rs`'s `visible = use_memo(...)`) so none of
+/// the three steps reruns on a render the filter/sort/source didn't touch.
+#[derive(Clone, PartialEq)]
+struct AuthorGroups {
+    filtered: Vec<AuthorSummary>,
+    letters: Vec<(char, Vec<AuthorSummary>)>,
+}
+
 /// Filter + sort + alphabet-strip state for the header. The strip's
 /// visibility, glyphs, and footnote totals all change together as the
 /// filtered set changes, so they ride the same struct.
@@ -63,25 +72,31 @@ pub fn AuthorsIndexPage() -> Element {
     // `&Vec<AuthorSummary>` and the rsx! tree only needs borrowed views.
     let all = authors.read();
     let total_authors = all.len();
-    let total_books: usize = all.iter().map(|a| a.book_count).sum();
+    let any_in_library = !all.is_empty();
+    drop(all);
 
-    // Memoized so filter/sort only reruns when authors/filter/sort change, not on every render.
-    let filtered = use_memo(move || {
+    // Memoized separately from the filter/sort/group-by pipeline below: this
+    // total is unaffected by the filter text or sort key, so tying it to
+    // that memo would recompute it on every keystroke for no reason.
+    let total_books = use_memo(move || authors.read().iter().map(|a| a.book_count).sum::<usize>());
+
+    // Group by first letter of sort key (last name when available, else
+    // name); only meaningful when sorting by name. Folded into the same
+    // memo as filter/sort so none of the three steps reruns on a render
+    // that didn't touch authors/filter/sort (mirrors `landing.rs`'s
+    // `visible = use_memo(...)`).
+    let show_letters = matches!(sort(), IndexSort::Name);
+    let groups = use_memo(move || {
         let all = authors.read();
         let q = filter.read().to_lowercase();
         let mut filtered = filter_authors(&all, &q);
-        sort_authors(&mut filtered, sort());
-        filtered
-            .into_iter()
-            .cloned()
-            .collect::<Vec<AuthorSummary>>()
+        let sort_value = sort();
+        sort_authors(&mut filtered, sort_value);
+        let filtered: Vec<AuthorSummary> = filtered.into_iter().cloned().collect();
+        let letters = group_by_letter(&filtered, matches!(sort_value, IndexSort::Name));
+        AuthorGroups { filtered, letters }
     });
-    let filtered = filtered();
-
-    // Group by first letter of sort key (last name when available, else name).
-    // Only meaningful when sorting by name.
-    let show_letters = matches!(sort(), IndexSort::Name);
-    let letters = group_by_letter(&filtered, show_letters);
+    let AuthorGroups { filtered, letters } = groups();
 
     // Alphabet strip: A–Z followed by a single '#' bucket for any
     // authors whose surname-equivalent doesn't start with an ASCII
@@ -92,11 +107,9 @@ pub fn AuthorsIndexPage() -> Element {
     let present_letters: std::collections::HashSet<char> =
         letters.iter().map(|(l, _)| *l).collect();
 
-    let any_in_library = !all.is_empty();
-
     let counts = AuthorIndexCounts {
         total_authors,
-        total_books,
+        total_books: total_books(),
     };
     let filter_state = AuthorIndexFilter {
         filter: filter(),
@@ -161,18 +174,20 @@ fn sort_authors(filtered: &mut [&AuthorSummary], sort: IndexSort) {
     }
 }
 
-/// Buckets `filtered` by first letter of `sort_key`; empty when `show_letters` is false.
+/// Buckets `filtered` by first letter of `sort_key`; empty when `show_letters`
+/// is false. Owned (not borrowed) so the result can live inside the
+/// `use_memo` pipeline in `AuthorsIndexPage` alongside `filtered`.
 fn group_by_letter(
     filtered: &[AuthorSummary],
     show_letters: bool,
-) -> Vec<(char, Vec<&AuthorSummary>)> {
-    let mut letters: Vec<(char, Vec<&AuthorSummary>)> = Vec::new();
+) -> Vec<(char, Vec<AuthorSummary>)> {
+    let mut letters: Vec<(char, Vec<AuthorSummary>)> = Vec::new();
     if show_letters {
         for a in filtered {
             let l = first_letter(a);
             match letters.last_mut() {
-                Some((existing, group)) if *existing == l => group.push(a),
-                _ => letters.push((l, vec![a])),
+                Some((existing, group)) if *existing == l => group.push(a.clone()),
+                _ => letters.push((l, vec![a.clone()])),
             }
         }
     }
@@ -183,7 +198,7 @@ fn group_by_letter(
 /// and `letters` directly instead of cloning them again for a child prop).
 fn authors_index_body<'a>(
     filtered: &'a [AuthorSummary],
-    letters: &[(char, Vec<&'a AuthorSummary>)],
+    letters: &'a [(char, Vec<AuthorSummary>)],
     show_letters: bool,
     any_in_library: bool,
     server_url: &str,

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -96,7 +96,8 @@ pub fn AuthorsIndexPage() -> Element {
         let letters = group_by_letter(&filtered, matches!(sort_value, IndexSort::Name));
         AuthorGroups { filtered, letters }
     });
-    let AuthorGroups { filtered, letters } = groups();
+    let groups_ref = groups.read();
+    let AuthorGroups { filtered, letters } = &*groups_ref;
 
     // Alphabet strip: A–Z followed by a single '#' bucket for any
     // authors whose surname-equivalent doesn't start with an ASCII
@@ -134,7 +135,7 @@ pub fn AuthorsIndexPage() -> Element {
                     index_prefs::save(&prefs);
                 },
             }
-            {authors_index_body(&filtered, &letters, show_letters, any_in_library, &server_url_for_cards)}
+            {authors_index_body(filtered, letters, show_letters, any_in_library, &server_url_for_cards)}
         }
     }
 }

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -59,7 +59,7 @@ pub fn SeriesIndexPage() -> Element {
             .cloned()
             .collect::<Vec<SeriesSummary>>()
     });
-    let filtered = filtered();
+    let filtered = filtered.read();
 
     rsx! {
         div { class: "idx-page",

--- a/frontend/src/pages/series_index.rs
+++ b/frontend/src/pages/series_index.rs
@@ -39,7 +39,13 @@ pub fn SeriesIndexPage() -> Element {
     // on every keystroke would be wasted work).
     let all = series.read();
     let total_series = all.len();
-    let total_books: usize = all.iter().map(|s| s.book_count).sum();
+    let library_empty = all.is_empty();
+    drop(all);
+
+    // Memoized separately from the filter/sort pipeline below: this total is
+    // unaffected by the filter text or sort key, so tying it to that memo
+    // would recompute it on every keystroke for no reason.
+    let total_books = use_memo(move || series.read().iter().map(|s| s.book_count).sum::<usize>());
 
     let filter_text = filter();
     let current_sort = sort();
@@ -60,7 +66,7 @@ pub fn SeriesIndexPage() -> Element {
             SeriesIndexHeader {
                 view: SeriesHeaderView {
                     total_series,
-                    total_books,
+                    total_books: total_books(),
                     filter: filter_text,
                     sort: current_sort,
                 },
@@ -72,7 +78,7 @@ pub fn SeriesIndexPage() -> Element {
                     index_prefs::save(&prefs);
                 },
             }
-            {render_series_body(&filtered, all.is_empty())}
+            {render_series_body(&filtered, library_empty)}
         }
     }
 }


### PR DESCRIPTION
## Summary
- Closes #1254
- The original three call sites (`authors_index.rs`, `series_index.rs`, `shelf_detail.rs`'s Add-books `filter_library`) were already wrapped in `use_memo` on `main`, matching the historical fix for this issue — no change needed there.
- The issue was reopened by a follow-up sweep that found the same root cause recurring nearby: `authors_index.rs`'s `total_books` sum and `series_index.rs`'s `total_books` sum were still recomputed inline every render, and `authors_index.rs`'s `group_by_letter` call sat outside the existing filter/sort `use_memo` instead of inside it.
- `authors_index.rs`: added a separate `use_memo` for `total_books` (keyed only on the `authors` signal, since it doesn't depend on filter/sort), and folded `group_by_letter` into the same `use_memo` as `filter_authors`/`sort_authors` via a new owned `AuthorGroups { filtered, letters }` struct (mirrors `landing.rs`'s `visible = use_memo(...)`).
- `series_index.rs`: added a `use_memo` for `total_books`, same rationale.

## Test plan
- [x] `cargo fmt -p omnibus-frontend --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [ ] `cargo clippy -p omnibus-frontend --features web --target wasm32-unknown-unknown -- -D warnings` — SKIPPED (wasm32 target not installed in this sandbox)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (555 passed; 0 failed)

## Notes
- Behavior-preserving: rendered filtered/sorted/grouped content and order are unchanged; this only changes when the derivations recompute.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FEnYBejWkiDP63kY6WetEP)_