### PR TITLE
refactor: fix six rough edges from Kobo Reading Services + landing/reader PRs (#1447)

### DIFF
--- a/db/src/kobo/annotations.rs
+++ b/db/src/kobo/annotations.rs
@@ -1,5 +1,5 @@
 //! Per-(device, book) annotation sync state for the Kobo Reading Services
-//! channel (`kobo_annotations_sync`, #1278): first-PATCH adoption, the
+//! channel (`kobo_annotations_sync`): first-PATCH adoption, the
 //! acked-fingerprint watermark behind `checkforchanges`, and the content
 //! fingerprint itself. Annotation rows live device-agnostic in `annotations`.
 

--- a/frontend/src/pages/listen/chapter_map.rs
+++ b/frontend/src/pages/listen/chapter_map.rs
@@ -131,13 +131,15 @@ pub(super) struct ChapterMapProps {
 }
 
 /// Scrub-state readouts derived for one render of [`ChapterMap`]: the
-/// previewed position, current chapter, remaining time, thumb offset, and
-/// whether a drag is in progress.
+/// previewed position, current chapter, remaining time, thumb offset, the
+/// scrub range's max (duration, or 1.0 to keep the range control non-empty
+/// when duration is unknown), and whether a drag is in progress.
 struct ScrubState {
     effective: f64,
     eff_current: usize,
     eff_remaining: f64,
     thumb: f64,
+    max: f64,
     is_scrubbing: bool,
 }
 
@@ -169,6 +171,7 @@ fn scrub_state(
         eff_current,
         eff_remaining,
         thumb: thumb_pct(effective, max),
+        max,
         is_scrubbing: scrubbing,
     }
 }
@@ -253,6 +256,7 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
         eff_current,
         eff_remaining,
         thumb,
+        max,
         is_scrubbing,
     } = scrub_state(
         &chapters,
@@ -263,7 +267,6 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
         scrubbing(),
         scrub_secs(),
     );
-    let max = if duration > 0.0 { duration } else { 1.0 };
 
     let on_input = move |evt: Event<FormData>| {
         if let Ok(v) = evt.value().parse::<f64>() {

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -7,6 +7,9 @@ use dioxus::prelude::*;
 
 use omnibus_shared::{Highlight, HighlightColor};
 
+#[cfg(test)]
+mod tests;
+
 pub(super) const PALETTE: [(HighlightColor, &str); 5] = [
     (HighlightColor::Amber, "amber"),
     (HighlightColor::Green, "green"),

--- a/frontend/src/pages/reader/highlights_drawer/tests.rs
+++ b/frontend/src/pages/reader/highlights_drawer/tests.rs
@@ -3,6 +3,7 @@
 //! to, but recolor and delete must still be offered. Needs the `server`
 //! feature (`dioxus::ssr`).
 
+#[cfg(feature = "server")]
 use super::*;
 
 #[cfg(feature = "server")]

--- a/frontend/src/pages/reader/highlights_drawer/tests.rs
+++ b/frontend/src/pages/reader/highlights_drawer/tests.rs
@@ -1,0 +1,74 @@
+//! SSR render-smoke coverage for `HighlightRow`'s anchorless (no-CFI)
+//! branch: a Kobo-origin highlight has nothing painted in the viewer to jump
+//! to, but recolor and delete must still be offered. Needs the `server`
+//! feature (`dioxus::ssr`).
+
+use super::*;
+
+#[cfg(feature = "server")]
+mod render_tests {
+    use super::*;
+    use crate::test_support::render_in_vdom;
+
+    fn seeded(cfi: Option<&str>) -> Highlight {
+        Highlight {
+            id: 7,
+            book_uuid: "book-uuid".to_string(),
+            epub_cfi_range: cfi.map(str::to_string),
+            color: HighlightColor::Violet,
+            note: None,
+            text: Some("the highlighted passage".to_string()),
+            client_id: None,
+            created_at: 1_779_019_200,
+        }
+    }
+
+    fn anchored_row() -> Element {
+        rsx! {
+            HighlightRow {
+                highlight: seeded(Some("epubcfi(/6/14[chap03]!/4/2,/1:0,/1:12)")),
+                highlights: use_signal(Vec::new),
+                on_quote: move |_| {},
+                on_edit_note: move |_| {},
+            }
+        }
+    }
+
+    fn anchorless_row() -> Element {
+        rsx! {
+            HighlightRow {
+                highlight: seeded(None),
+                highlights: use_signal(Vec::new),
+                on_quote: move |_| {},
+                on_edit_note: move |_| {},
+            }
+        }
+    }
+
+    /// Pull the opening tag for the first match of `testid_or_class` so a
+    /// `disabled` assertion doesn't accidentally match a sibling element.
+    fn opening_tag<'a>(html: &'a str, needle: &str) -> &'a str {
+        let start = html.find(needle).expect("element rendered");
+        let end = html[start..].find('>').expect("tag closes") + start;
+        &html[start..end]
+    }
+
+    #[test]
+    fn highlight_row_disables_the_quote_jump_for_an_anchorless_kobo_highlight() {
+        // No CFI, nowhere to navigate: the quote button still shows the
+        // passage but can't jump to it.
+        let html = render_in_vdom(anchorless_row);
+        assert!(opening_tag(&html, "rd-hl-quote").contains("disabled"));
+        assert!(html.contains("the highlighted passage"));
+        // Recolor and delete are unaffected — a Kobo row still supports
+        // both even with nothing painted in the viewer to repaint/remove.
+        assert!(html.contains("data-testid=\"reader-highlight-recolor-amber\""));
+        assert!(html.contains("data-testid=\"highlight-delete\""));
+    }
+
+    #[test]
+    fn highlight_row_enables_the_quote_jump_for_an_anchored_highlight() {
+        let html = render_in_vdom(anchored_row);
+        assert!(!opening_tag(&html, "rd-hl-quote").contains("disabled"));
+    }
+}

--- a/server/src/backend/kobo/reading_services.rs
+++ b/server/src/backend/kobo/reading_services.rs
@@ -1,15 +1,8 @@
-//! Kobo Reading Services — the wireless annotation channel (#1278), served at
-//! the bare origin (`/api/v3/content/*`) because `reading_services_host` in
-//! the initialization map is a host, not a path. No session and no path
-//! token: every route authenticates via the `x-kobo-deviceid` header
-//! ([`KoboHardwareUser`]). Exempted from `require_auth` in `auth::gate`.
-//!
-//! Protocol quirks this module honors: the device never echoes a real ETag
-//! (always `If-None-Match: W/"0"`) and drives change detection through
-//! `checkforchanges`; deletions propagate **by omission** (anything absent
-//! from a GET body is removed on-device — tombstone flags are ignored); and
-//! a (device, book) pair is answered `304` until its first clean PATCH, so a
-//! first sync can never wipe highlights made before wireless sync existed.
+//! Kobo Reading Services — the wireless annotation channel, served at the
+//! bare origin (`/api/v3/content/*`) since `reading_services_host` in the
+//! initialization map is a host, not a path. Every route authenticates via
+//! the `x-kobo-deviceid` header ([`KoboHardwareUser`]) rather than a session
+//! or path token, and is exempted from `require_auth` in `auth::gate`.
 
 use axum::{
     body::{Body, Bytes},
@@ -67,10 +60,67 @@ async fn get_annotations(
     if let Some(reject) = reject_oversized_uuid(uuid) {
         return reject;
     }
+
+    let (canonical, served) = match resolve_adopted_served(&state, &auth, uuid).await {
+        Ok(Some(pair)) => pair,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(NotAdopted) => {
+            return (
+                StatusCode::NOT_MODIFIED,
+                [(header::ETAG, "W/\"0\"".to_string())],
+            )
+                .into_response();
+        }
+        Err(Failed(response)) => return response,
+    };
+
+    let fingerprint = db::kobo::annotations::fingerprint(&served);
+    let etag = format!("W/\"{fingerprint}\"");
+    if if_none_match_matches(&headers, &etag) {
+        return not_modified_and_ack(&state, auth.device_id, &canonical, &fingerprint, etag).await;
+    }
+
+    let body = match serde_json::to_vec(&dto::AnnotationsResponse {
+        annotations: served.iter().map(dto::AnnotationOut::from_served).collect(),
+        next_page_offset_token: None,
+    }) {
+        Ok(b) => Bytes::from(b),
+        Err(e) => return internal("reading-services serialize", e),
+    };
+
+    stream_annotations(
+        state.pool().clone(),
+        auth.device_id,
+        canonical,
+        fingerprint,
+        etag,
+        body,
+    )
+}
+
+/// Outcome of [`resolve_adopted_served`] when the pair isn't ready to serve.
+enum Unready {
+    /// No prior PATCH and nothing to serve — the AC5 first-sync guard.
+    NotAdopted,
+    /// A resolve/fetch/adoption-check db call failed; already an HTTP response.
+    Failed(Response),
+}
+use Unready::{Failed, NotAdopted};
+
+/// Resolve `uuid` to its canonical book, fetch the served annotation set, and
+/// check first-PATCH adoption — the second driver stage: canonical-uuid
+/// resolution plus the adoption gate that must run before any ETag is
+/// computed. `Ok(None)` is an unknown book (404); `Err(NotAdopted)` is the
+/// AC5 guard against wiping a device's pre-wireless backlog by omission.
+async fn resolve_adopted_served(
+    state: &AppState,
+    auth: &KoboHardwareUser,
+    uuid: &str,
+) -> Result<Option<(String, Vec<db::annotations::ServedKoboAnnotation>)>, Unready> {
     let canonical = match db::resolve_canonical_book_uuid(state.pool(), uuid).await {
         Ok(Some(c)) => c,
-        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
-        Err(e) => return internal("reading-services resolve uuid", e),
+        Ok(None) => return Ok(None),
+        Err(e) => return Err(Failed(internal("reading-services resolve uuid", e))),
     };
 
     let served = match db::annotations::served_kobo_annotations(
@@ -81,7 +131,7 @@ async fn get_annotations(
     .await
     {
         Ok(s) => s,
-        Err(e) => return internal("reading-services served set", e),
+        Err(e) => return Err(Failed(internal("reading-services served set", e))),
     };
 
     // A pair no device has uploaded for — and with nothing to serve from
@@ -92,47 +142,45 @@ async fn get_annotations(
     let adopted =
         match db::kobo::annotations::is_adopted(state.pool(), auth.device_id, &canonical).await {
             Ok(a) => a || !served.is_empty(),
-            Err(e) => return internal("reading-services adoption check", e),
+            Err(e) => return Err(Failed(internal("reading-services adoption check", e))),
         };
     if !adopted {
-        return (
-            StatusCode::NOT_MODIFIED,
-            [(header::ETAG, "W/\"0\"".to_string())],
-        )
-            .into_response();
+        return Err(NotAdopted);
     }
+    Ok(Some((canonical, served)))
+}
 
-    let fingerprint = db::kobo::annotations::fingerprint(&served);
-    let etag = format!("W/\"{fingerprint}\"");
-
-    // Firmware always sends `If-None-Match: W/"0"`, so this arm is
-    // theoretical — but a correct 304 is cheap, and it still acks: a matched
-    // ETag means the device already holds exactly this set.
-    if if_none_match_matches(&headers, &etag) {
-        if let Err(e) = db::kobo::annotations::ack_served(
-            state.pool(),
-            auth.device_id,
-            &canonical,
-            &fingerprint,
-        )
-        .await
-        {
-            tracing::warn!(error = %e, "reading-services 304 ack failed");
-        }
-        return (StatusCode::NOT_MODIFIED, [(header::ETAG, etag)]).into_response();
+/// `If-None-Match` matched: ack what the device already holds and answer
+/// `304`. Firmware always sends `If-None-Match: W/"0"`, so this path is
+/// theoretical — but a correct 304 is cheap, and it still acks: a matched
+/// ETag means the device already holds exactly this set.
+async fn not_modified_and_ack(
+    state: &AppState,
+    device_id: i64,
+    canonical: &str,
+    fingerprint: &str,
+    etag: String,
+) -> Response {
+    if let Err(e) =
+        db::kobo::annotations::ack_served(state.pool(), device_id, canonical, fingerprint).await
+    {
+        tracing::warn!(error = %e, "reading-services 304 ack failed");
     }
+    (StatusCode::NOT_MODIFIED, [(header::ETAG, etag)]).into_response()
+}
 
-    let response = dto::AnnotationsResponse {
-        annotations: served.iter().map(dto::AnnotationOut::from_served).collect(),
-        next_page_offset_token: None,
-    };
-    let body = match serde_json::to_vec(&response) {
-        Ok(b) => Bytes::from(b),
-        Err(e) => return internal("reading-services serialize", e),
-    };
-
-    let pool = state.pool().clone();
-    let device_id = auth.device_id;
+/// Stream `body` as the `200` response, acking on the final poll — the same
+/// pattern as `library_sync`'s snapshot commit: a connection dropped
+/// mid-body never acks, so `checkforchanges` re-reports the book, which is
+/// the protocol's only redelivery mechanism.
+fn stream_annotations(
+    pool: sqlx::SqlitePool,
+    device_id: i64,
+    canonical: String,
+    fingerprint: String,
+    etag: String,
+    body: Bytes,
+) -> Response {
     let stream = stream::unfold(
         (Some(body), canonical, fingerprint, false),
         move |(body, canonical, fingerprint, acked)| {

--- a/server/src/backend/kobo/reading_services/tests.rs
+++ b/server/src/backend/kobo/reading_services/tests.rs
@@ -190,6 +190,22 @@ async fn get_annotations_answers_not_modified_for_an_unadopted_pair() {
 }
 
 #[tokio::test]
+async fn patch_annotations_rejects_an_oversized_content_id_with_400() {
+    let (app, _pool, _user, _device) = fixture().await;
+    let oversized = "u".repeat(omnibus_shared::BOOK_UUID_MAX_LEN + 1);
+    let res = app
+        .oneshot(request(
+            "PATCH",
+            &annotations_uri(&oversized),
+            Some(HW_ID),
+            Some(&upload_body("kobo-ann-1", "yellow", None)),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn patch_then_get_round_trips_a_device_highlight_with_a_weak_etag() {
     let (app, pool, _user, _device) = fixture().await;
     let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Herbert").await;


### PR DESCRIPTION
## Summary
- Closes #1447.
- Addressed 5 of the 6 tech-debt items from PR #1438/#1436:
  1. Dropped the `#1278` issue-number references from the module docs in `server/src/backend/kobo/reading_services.rs` and `db/src/kobo/annotations.rs`; trimmed `reading_services.rs`'s doc to the ≤5-line cap.
  2. Split `get_annotations` (was ~124 lines) into `resolve_adopted_served`, `not_modified_and_ack`, and `stream_annotations` helpers — the driver function is now ~40 lines, under the ~80-line soft cap.
  3. Added `patch_annotations_rejects_an_oversized_content_id_with_400`, mirroring the existing `get_annotations` coverage for the same `reject_oversized_uuid` check.
  4. Added SSR render-smoke coverage for the anchorless (no-CFI) Kobo-origin highlight row in `frontend/src/pages/reader/highlights_drawer.rs` (new `highlights_drawer/tests.rs`): asserts the quote-jump button is disabled with no CFI and enabled with one, mirroring the pattern in `book_detail/highlights/tests.rs`.
  5. Deduped the repeated `let max = if duration > 0.0 { duration } else { 1.0 };` in `frontend/src/pages/listen/chapter_map.rs` — `scrub_state` now returns `max` as part of `ScrubState` instead of the caller recomputing it.
- Item 6 (`ShelfGallery`'s prop count) needed **no change**: it already groups its 7 fields into a `ShelfGalleryProps` struct (landed separately in #1485 / PR #1540), so this PR is a no-op there.

## Test plan
- [x] `cargo fmt --check -p omnibus -p omnibus-frontend -p omnibus-db` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus` — 609 passed, 2 failed (`backend::uploads::tests::{commit_rejects_read_only_library_with_400,audiobook_commit_rejects_read_only_library_with_400}`) — pre-existing sandbox artifact: these tests `chmod 0o555` a temp dir to force a `PermissionDenied` write, which the sandbox's root user bypasses; unrelated to this change (`uploads.rs` untouched) and reproduces identically on a clean checkout in this environment.
- [x] `cargo test -p omnibus-db` — 1552 passed, 0 failed
- [x] `cargo test -p omnibus-frontend --features server` — 557 passed, 0 failed (includes the 2 new `highlights_drawer` render tests)

## Notes
- All six items were independent per the issue; landed together in one small PR as instructed.
- Known CI flakes (`worker::tests::poisoned_{completions,progress}_lock_recovers_*`, `backend::uploads::tests::inspect_allows_non_admin_with_can_upload`) were not observed in this run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FEnYBejWkiDP63kY6WetEP)_