### PR TITLE
fix: anchor stats month arithmetic at month start so month-end days don't collapse windows

### DIFF
--- a/db/src/stats/mod.rs
+++ b/db/src/stats/mod.rs
@@ -550,8 +550,11 @@ async fn prev_window_bounds(
             "strftime('%s', 'now', '-6 days', 'start of day')",
         )),
         StatsRange::Month => Some((
-            "strftime('%s', strftime('%Y-%m-01 00:00:00', 'now', '-1 month'))",
-            "strftime('%s', strftime('%Y-%m-01 00:00:00', 'now'))",
+            // Month arithmetic runs on a month-start anchor: applying
+            // '-1 month' to a month-end 'now' (e.g. July 31) normalizes to
+            // day 1 of the *current* month and collapses the window.
+            "strftime('%s', 'now', 'start of month', '-1 month')",
+            "strftime('%s', 'now', 'start of month')",
         )),
         StatsRange::Year => Some((
             "strftime('%s', strftime('%Y-01-01 00:00:00', 'now', '-1 year'))",
@@ -692,7 +695,7 @@ async fn listening_daily(
 async fn rating_monthly(pool: &SqlitePool, user_id: i64) -> Result<Vec<TrendPoint>, StatsError> {
     let rows = sqlx::query(
         "WITH RECURSIVE months(month) AS (
-             SELECT strftime('%Y-%m', 'now', '-11 months')
+             SELECT strftime('%Y-%m', 'now', 'start of month', '-11 months')
              UNION ALL
              SELECT strftime('%Y-%m', month || '-01', '+1 month')
              FROM months
@@ -734,7 +737,7 @@ async fn rating_monthly(pool: &SqlitePool, user_id: i64) -> Result<Vec<TrendPoin
 async fn books_per_month(pool: &SqlitePool, user_id: i64) -> Result<Vec<MonthCount>, StatsError> {
     let sql = format!(
         "WITH RECURSIVE months(month) AS (
-             SELECT strftime('%Y-%m', 'now', '-11 months')
+             SELECT strftime('%Y-%m', 'now', 'start of month', '-11 months')
              UNION ALL
              SELECT strftime('%Y-%m', month || '-01', '+1 month')
              FROM months

--- a/db/src/stats/tests.rs
+++ b/db/src/stats/tests.rs
@@ -117,7 +117,9 @@ async fn rate_book(pool: &SqlitePool, user: i64, uuid: &str, half_stars: i64, up
 /// recursive CTE anchors on, regardless of day-of-month clamping.
 async fn months_ago_secs(pool: &SqlitePool, months: i64) -> i64 {
     sqlx::query_scalar(&format!(
-        "SELECT CAST(strftime('%s', 'now', '-{months} months') AS INTEGER)"
+        // Mid-month anchor: naive '-N months' from a month-end 'now'
+        // (July 31 → "June 31" → July 1) lands the seed in the wrong month.
+        "SELECT CAST(strftime('%s', 'now', 'start of month', '-{months} months', '+14 days') AS INTEGER)"
     ))
     .fetch_one(pool)
     .await


### PR DESCRIPTION
## Summary
- CI went red repo-wide at 00:02 UTC on July 31: `previous_period_month_sums_only_last_calendar_months_activity` fails on month-end days because SQLite normalizes `'2026-07-31','-1 month'` (June 31) to July 1.
- The production window math had the same hazard: `previous_bounds`' Month arm applied `-1 month` to `'now'` *before* truncating to the month start, so on the 29th–31st the "previous month" boundary collapsed into the current month; the two trailing-12 CTE anchors had the month-end variant. All three now run month arithmetic on a `'start of month'` anchor.
- The `months_ago_secs` test helper now anchors mid-month (`start of month, -N months, +14 days`), so seeds land in the intended month on any date.
- The existing test suite is the regression coverage — today's CI runs on the boundary date itself.

## Test plan
- [x] `cargo test -p omnibus-db stats` — 46 passing, run while 'now' is July 31 UTC (the exact failing condition).
- [x] fmt + clippy clean.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.