### PR TITLE
feat: move reading status + wishlist into the book-detail rating rail

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -766,13 +766,16 @@ html, body { overscroll-behavior: none; }
 .bd-phys-note-actions { display: flex; gap: 8px; }
 .bd-phys-error { color: var(--bad); margin: 0; }
 
-.bd-wishlist-card, .bd-wishlist-add { padding: 14px 16px; }
-.bd-wishlist-meta { margin: 0 0 10px; color: var(--ink-2); }
-.bd-wishlist-actions, .bd-wishlist-add {
-  display: flex; gap: 8px; align-items: center;
+/* Wishlist slot inside the hero rating card (tracking meta + actions, or the
+   add affordance). Narrow column, so actions wrap instead of overflowing. */
+.bd-wishlist-rail {
+  display: flex; flex-direction: column; gap: 10px; align-items: flex-start;
 }
-.bd-wishlist-add { justify-content: space-between; flex-wrap: wrap; }
-.bd-wishlist-add-blurb { margin: 4px 0 0; color: var(--ink-2); }
+.bd-wishlist-meta { margin: 0; color: var(--ink-2); }
+.bd-wishlist-actions {
+  display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+}
+.bd-wishlist-add-blurb { margin: 0; color: var(--ink-2); }
 
 /* Title column */
 .bd-title-col { min-width: 0; }
@@ -949,14 +952,8 @@ html, body { overscroll-behavior: none; }
   max-width: calc(100vw - 24px);
 }
 
-.bd-progress-meta { margin-top: 22px; max-width: 460px; }
-.bd-progress-line {
-  display: flex; justify-content: space-between;
-  font-size: 11px; color: var(--ink-2); margin-bottom: 6px;
-}
-
 /* Read/unread segmented control. Three equal segments in a pill; the active
-   one carries the accent. Mirrors the pbar's width but reads as a control. */
+   one carries the accent. Lives in the hero rating card under its own label. */
 .bd-readstatus { display: flex; flex-direction: column; gap: 8px; }
 .bd-readstatus-seg {
   display: inline-flex; align-self: flex-start;
@@ -980,6 +977,8 @@ html, body { overscroll-behavior: none; }
   display: flex; gap: 8px; flex-wrap: wrap;
   list-style: none; padding: 0; margin: 22px 0 0;
 }
+/* Under the cover, tags sit tight against the format badges. */
+.bd-cover-col .bd-tag-list { margin-top: 12px; }
 
 /* Rating + actions card */
 .bd-rating-card {
@@ -1037,29 +1036,7 @@ html, body { overscroll-behavior: none; }
 .bd-other-rating-star-slot {
   position: relative; display: inline-block; width: 1em; height: 1em;
 }
-.bd-action-head, .bd-shelves-head { margin-bottom: 8px; }
-.bd-actions {
-  display: flex; flex-direction: column; gap: 4px;
-}
-.bd-action-row {
-  display: flex; align-items: center; justify-content: space-between;
-  width: 100%; height: 36px; padding: 0 10px;
-  border-radius: 8px;
-}
-/* The action rows ship disabled until F3.x wires the real handlers, and the
-   browser's default `button[disabled]` styling drops their opacity, which
-   tanks contrast on Light theme (was the second half of #289 — "Mark as
-   finished" reading as a washed-out grey). Pin our own disabled style so
-   the row reads as muted-but-legible in every theme. The non-disabled state
-   intentionally inherits `.btn.ghost` so the row is ready for the wired
-   future without extra rules. */
-.bd-action-row[disabled],
-.bd-action-row:disabled {
-  opacity: 1;
-  color: var(--ink-2);
-  cursor: not-allowed;
-}
-.bd-action-row-arrow { color: var(--ink-3); }
+.bd-readstatus-head, .bd-wishlist-head, .bd-shelves-head { margin-bottom: 8px; }
 .bd-shelves { display: flex; gap: 6px; flex-wrap: wrap; }
 
 /* Body grid */

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -1,4 +1,6 @@
-//! Hero section of the book-detail page — breadcrumb, cover with format badges, title row, CTAs, tag chips, rating card.
+//! Hero section of the book-detail page — breadcrumb, cover with format badges
+//! and tag chips, title row, CTAs, and the rating rail card (rating,
+//! reading status, wishlist slot, shelves).
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
@@ -12,9 +14,10 @@ use crate::{data, use_server_url, Route};
 use super::export_menu::BdExportMenu;
 use super::file_picker::{is_audio_book_file, BdFilePickerMenu, FilePickerKind};
 use super::immersive::BdImmersiveButton;
+use super::physical::{BdBookIdentity, BdWishlistRailSlot};
 use super::rating::BdRatingWidget;
 use super::read_status::BdReadStatusControl;
-use super::{BdCrumb, BdCrumbItem, BdFormatBadge};
+use super::{BdCrumb, BdCrumbItem, BdFormatBadge, PhysSignals};
 
 /// Which formats this book has, driving the hero's CTA buttons and format badges.
 #[derive(Clone, Copy, PartialEq)]
@@ -37,7 +40,24 @@ fn BdPhysBadge() -> Element {
     }
 }
 
-/// Hero section: breadcrumb, cover + format badges, title + CTAs, rating card.
+/// "Physical Wishlist" badge shown in the format-badge row when the book is on
+/// the caller's wishlist. Client-only by construction: the wishlist signal is
+/// `None` on SSR and the first WASM paint, so it appears after the post-mount
+/// load (rule 07 holds).
+#[component]
+fn BdWishlistBadge() -> Element {
+    rsx! {
+        span {
+            class: "bd-fmt-badge bd-fmt-badge--physical",
+            "data-testid": "format-badge-wishlist",
+            title: "On your physical wishlist",
+            "Physical Wishlist"
+        }
+    }
+}
+
+/// Hero section: breadcrumb, cover + format badges + tags, title + CTAs, and
+/// the rating rail card (rating, reading status, wishlist slot, shelves).
 #[component]
 pub(super) fn BdHeroSection(
     b: EbookMetadata,
@@ -45,21 +65,33 @@ pub(super) fn BdHeroSection(
     kicker: String,
     crumbs: Vec<BdCrumbItem>,
     avail: Availability,
+    phys: PhysSignals,
 ) -> Element {
     let uuid = b.unique_identifier.clone().unwrap_or_default();
+    let on_wishlist = phys.wishlist.read().is_some();
     rsx! {
         section { class: "bd-hero",
             BdCrumb { items: crumbs }
             div { class: "bd-hero-grid",
                 div { class: "bd-cover-col",
                     Cover { book: b.clone() }
-                    if !b.formats.is_empty() || b.has_physical {
+                    if !b.formats.is_empty() || b.has_physical || on_wishlist {
                         div { class: "bd-format-badges",
                             for f in b.formats.iter() {
                                 BdFormatBadge { key: "{f}", fmt: f.clone() }
                             }
                             if b.has_physical {
                                 BdPhysBadge {}
+                            }
+                            if on_wishlist {
+                                BdWishlistBadge {}
+                            }
+                        }
+                    }
+                    if !b.subjects.is_empty() {
+                        ul { class: "bd-tag-list",
+                            for tag in b.subjects.iter() {
+                                li { key: "{tag}", class: "chip", "{tag}" }
                             }
                         }
                     }
@@ -75,21 +107,17 @@ pub(super) fn BdHeroSection(
                     div { class: "label", "Your rating" }
                     BdRatingWidget { uuid: uuid.clone() }
                     div { class: "divider" }
-                    div { class: "label bd-action-head", "Actions" }
-                    div { class: "bd-actions",
-                        a { class: "btn ghost bd-action-row", href: "#journal",
-                            "data-testid": "hero-write-journal",
-                            span { "Write a journal entry" }
-                            span { class: "bd-action-row-arrow", "\u{2192}" }
-                        }
-                        button { class: "btn ghost bd-action-row", disabled: true,
-                            span { "Add a highlight" }
-                            span { class: "bd-action-row-arrow", "\u{2192}" }
-                        }
-                        button { class: "btn ghost bd-action-row", disabled: true,
-                            span { "Share or export\u{2026}" }
-                            span { class: "bd-action-row-arrow", "\u{2192}" }
-                        }
+                    div { class: "label bd-readstatus-head", "Reading status" }
+                    BdReadStatusControl { uuid: uuid.clone() }
+                    BdWishlistRailSlot {
+                        identity: BdBookIdentity {
+                            uuid: uuid.clone(),
+                            has_physical: b.has_physical,
+                            isbn: b.isbn13.clone(),
+                            title: title.clone(),
+                            author: b.creators.first().map(|c| c.name.clone()).unwrap_or_default(),
+                        },
+                        phys,
                     }
                     div { class: "divider" }
                     div { class: "label bd-shelves-head", "On your shelves" }
@@ -194,16 +222,6 @@ fn BdTitleCol(
                     epub_size_bytes: b.epub_size_bytes,
                     book_files: b.book_files.clone(),
                 },
-            }
-            div { class: "bd-progress-meta",
-                BdReadStatusControl { uuid: uuid.clone() }
-            }
-            if !b.subjects.is_empty() {
-                ul { class: "bd-tag-list",
-                    for tag in b.subjects.iter() {
-                        li { key: "{tag}", class: "chip", "{tag}" }
-                    }
-                }
             }
         }
     }
@@ -371,5 +389,12 @@ mod tests {
         let html = dioxus::ssr::render_element(rsx! { BdPhysBadge {} });
         assert!(html.contains("data-testid=\"format-badge-physical\""));
         assert!(html.contains("Physical"));
+    }
+
+    #[test]
+    fn wishlist_badge_renders_its_testid_and_label() {
+        let html = dioxus::ssr::render_element(rsx! { BdWishlistBadge {} });
+        assert!(html.contains("data-testid=\"format-badge-wishlist\""));
+        assert!(html.contains("Physical Wishlist"));
     }
 }

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -6,6 +6,7 @@
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
+use omnibus_shared::physical::WishlistEntry;
 use omnibus_shared::{EbookMetadata, MergeBooksResult, SuggestionsResponse};
 
 use crate::components::{PageError, PageLoading, PageNotFound};
@@ -86,6 +87,15 @@ pub fn BookDetailPage(uuid: String) -> Element {
     // Delete-dialog state, declared unconditionally for the same reason.
     let delete_open = use_signal(|| false);
 
+    // Physical-wishlist state, lifted here because two web sections share it:
+    // the hero (cover chip + rail wishlist slot) and the physical panel (whose
+    // post-mount load populates it, and whose last-copy delete can write it).
+    // Declared unconditionally per rule 07; mobile discards it.
+    let phys = PhysSignals {
+        wishlist: use_signal(|| None::<WishlistEntry>),
+        loaded: use_signal(|| false),
+    };
+
     // Fetch Summary override (mobile only). Declared unconditionally per
     // rule 07 — `render_loaded_mobile` is a plain fn with no hook scope,
     // reached only past the early returns below. `epoch` is bumped
@@ -134,6 +144,7 @@ pub fn BookDetailPage(uuid: String) -> Element {
         PageSignals {
             description,
             delete_open,
+            phys,
         },
         author_books(),
         suggestions(),
@@ -161,6 +172,17 @@ struct DescriptionSignals {
 struct PageSignals {
     description: DescriptionSignals,
     delete_open: Signal<bool>,
+    phys: PhysSignals,
+}
+
+/// Shared physical-wishlist state: the entry itself plus the loaded flag for
+/// the panel's post-mount copies+wishlist fetch. Both the hero (chip + rail
+/// slot) and the physical panel hold the same signals, so a mutation in either
+/// place is immediately visible in the other.
+#[derive(Clone, Copy, PartialEq)]
+struct PhysSignals {
+    wishlist: Signal<Option<WishlistEntry>>,
+    loaded: Signal<bool>,
 }
 
 /// The book-page data signals written by the fetch effects. `Copy` (Dioxus
@@ -244,6 +266,7 @@ fn render_book_shell(
     let PageSignals {
         description,
         delete_open,
+        phys,
     } = page;
 
     // `is_admin` starts at `false` and only flips to `true` on the web
@@ -314,6 +337,7 @@ fn render_book_shell(
             server_url,
             is_admin: is_admin_flag,
             refresh: merge.refresh,
+            phys,
         },
     );
     rsx! {

--- a/frontend/src/pages/book_detail/physical.rs
+++ b/frontend/src/pages/book_detail/physical.rs
@@ -193,8 +193,11 @@ pub(super) fn BdWishlistRailSlot(identity: BdBookIdentity, phys: PhysSignals) ->
         div { class: "divider" }
         div { class: "label bd-wishlist-head", "Physical wishlist" }
         {content}
+        // Distinct testid from the panel's `physical-error`: both surfaces can
+        // error at once (load failure + failed add/remove), and a shared id
+        // would make Playwright selectors ambiguous.
         if let Some(e) = err.read().clone() {
-            p { role: "alert", class: "bd-phys-error", "data-testid": "physical-error", "{e}" }
+            p { role: "alert", class: "bd-phys-error", "data-testid": "wishlist-error", "{e}" }
         }
     }
 }

--- a/frontend/src/pages/book_detail/physical.rs
+++ b/frontend/src/pages/book_detail/physical.rs
@@ -1,8 +1,8 @@
-//! Web-only physical-collection + wishlist panel for the book-detail page.
-//! Renders checked-in copies (edit-note / delete), the wishlist tracking card,
-//! and the add-to-wishlist affordance. Self-loads post-mount for SSR/WASM
-//! hydration parity; bumps the page `refresh` signal after mutations that
-//! change the book's physical/visibility state.
+//! Web-only physical-collection + wishlist UI for the book-detail page: the
+//! full-width checked-in-copies panel (edit-note / delete) and the rail-card
+//! wishlist slot (tracking card / add-to-wishlist affordance) the hero embeds.
+//! Self-loads post-mount for SSR/WASM hydration parity; bumps the page
+//! `refresh` signal after mutations that change physical/visibility state.
 
 use dioxus::prelude::*;
 use omnibus_shared::physical::{PhysicalCopy, WishlistEntry, WishlistSource};
@@ -11,7 +11,7 @@ use crate::components::{confirm_modal_body, ConfirmModal, ConfirmModalAction, Co
 use crate::time::now_unix;
 use crate::{data, use_server_url};
 
-use super::BdSectionHead;
+use super::{BdSectionHead, PhysSignals};
 
 /// A pending copy deletion awaiting confirmation. `last_fileless` marks the
 /// only copy of a book with no files — deleting it needs the remove-or-wishlist
@@ -37,37 +37,37 @@ struct PhysPanelState {
     refresh: Signal<u32>,
 }
 
-/// Book-identity fields the panel needs, bundled to keep `BdPhysicalPanel`
-/// under the 5-prop guideline (mirrors `body::BdPageCtx`). `is_fileless` is
-/// `b.formats.is_empty()` (no ebook/audiobook files); `isbn`/`title`/`author`
-/// feed the "Find a copy" search.
+/// Book-identity fields the rail wishlist slot needs, bundled to keep
+/// [`BdWishlistRailSlot`] under the 5-prop guideline (mirrors
+/// `body::BdPageCtx`). `isbn`/`title`/`author` feed the "Find a copy" search;
+/// `has_physical` suppresses the add affordance for an already-owned book.
 #[derive(Clone, PartialEq, Props)]
 pub(super) struct BdBookIdentity {
     pub uuid: String,
-    pub is_fileless: bool,
+    pub has_physical: bool,
     pub isbn: Option<String>,
     pub title: String,
     pub author: String,
 }
 
-/// Physical-collection + wishlist panel. `refresh` is the page's book-refetch
-/// signal.
+/// Checked-in physical-copies panel. Owns the post-mount copies+wishlist load
+/// (writing the shared `phys` signals the hero's chip and rail slot read);
+/// the wishlist UI itself lives in [`BdWishlistRailSlot`]. `refresh` is the
+/// page's book-refetch signal.
 #[component]
-pub(super) fn BdPhysicalPanel(identity: BdBookIdentity, refresh: Signal<u32>) -> Element {
-    let BdBookIdentity {
-        uuid,
-        is_fileless,
-        isbn,
-        title,
-        author,
-    } = identity;
+pub(super) fn BdPhysicalPanel(
+    uuid: String,
+    is_fileless: bool,
+    refresh: Signal<u32>,
+    phys: PhysSignals,
+) -> Element {
     let server_url = use_server_url();
     let user = crate::use_current_user_summary();
     let can_edit = user().map(|u| u.is_admin || u.can_edit).unwrap_or(false);
 
     let copies = use_signal(Vec::<PhysicalCopy>::new);
-    let wishlist = use_signal(|| None::<WishlistEntry>);
-    let loaded = use_signal(|| false);
+    let wishlist = phys.wishlist;
+    let loaded = phys.loaded;
     let err = use_signal(|| None::<String>);
     let state = PhysPanelState {
         copies,
@@ -90,27 +90,111 @@ pub(super) fn BdPhysicalPanel(identity: BdBookIdentity, refresh: Signal<u32>) ->
     );
 
     // First paint (SSR + first WASM) renders nothing; the post-mount load fills
-    // it in. No hooks past this point, so the early return keeps hook order
-    // fixed across the empty and loaded renders (rule 07).
-    if !loaded() {
+    // it in. No hooks past this point, so the early returns keep hook order
+    // fixed across the empty and loaded renders (rule 07). A copy-less book
+    // without a load error renders nothing here either — its wishlist state
+    // shows in the hero rail instead.
+    if !loaded() || (copies().is_empty() && state.err.read().is_none()) {
         return rsx! {};
     }
 
-    let content = if !copies().is_empty() {
-        render_physical_section(state, server_url.clone(), is_fileless, can_edit)
-    } else if wishlist().is_some() {
-        render_wishlist_section(state, server_url.clone(), uuid.clone(), isbn, title, author)
-    } else {
-        render_add_wishlist(state, server_url.clone(), uuid.clone())
-    };
-
     rsx! {
         section { class: "bd-physical-panel", "data-testid": "bd-physical-panel",
-            {content}
+            if !copies().is_empty() {
+                {render_physical_section(state, server_url.clone(), is_fileless, can_edit)}
+            }
             if let Some(e) = state.err.read().clone() {
                 p { role: "alert", class: "bd-phys-error", "data-testid": "physical-error", "{e}" }
             }
             {render_delete_modal(state, server_url, uuid)}
+        }
+    }
+}
+
+/// Rail-card wishlist slot the hero embeds under the rating + reading-status
+/// blocks: the tracking card for a wishlisted book, or the add-to-wishlist
+/// affordance for a book with no physical copy. Renders nothing until the
+/// panel's shared post-mount load resolves (rule 07 — SSR and first WASM
+/// paint both empty), and nothing for a book already in the collection.
+#[component]
+pub(super) fn BdWishlistRailSlot(identity: BdBookIdentity, phys: PhysSignals) -> Element {
+    let BdBookIdentity {
+        uuid,
+        has_physical,
+        isbn,
+        title,
+        author,
+    } = identity;
+    let server_url = use_server_url();
+    let wishlist = phys.wishlist;
+    let busy = use_signal(|| false);
+    let err = use_signal(|| None::<String>);
+
+    // No hooks past this point (rule 07).
+    if !(phys.loaded)() {
+        return rsx! {};
+    }
+    let entry = wishlist.read().clone();
+    if entry.is_none() && has_physical {
+        return rsx! {};
+    }
+
+    let content = match entry {
+        Some(e) => {
+            let added = time_ago(now_unix(), e.added_at);
+            let source = source_label(e.source);
+            let find_url = find_a_copy_url(isbn.as_deref(), &title, &author);
+            let remove_url = server_url.clone();
+            let remove_uuid = uuid.clone();
+            rsx! {
+                div { class: "bd-wishlist-rail", "data-testid": "wishlist-card",
+                    p { class: "bd-wishlist-meta",
+                        "Tracking this title \u{00b7} added {added} from {source}"
+                    }
+                    div { class: "bd-wishlist-actions",
+                        a {
+                            class: "btn sm",
+                            "data-testid": "find-a-copy",
+                            href: "{find_url}",
+                            target: "_blank",
+                            rel: "noopener noreferrer",
+                            "Find a copy"
+                        }
+                        button {
+                            class: "btn ghost sm",
+                            "data-testid": "wishlist-remove",
+                            disabled: busy(),
+                            onclick: move |_| {
+                                remove_from_wishlist(
+                                    wishlist, busy, err, remove_url.clone(), remove_uuid.clone(),
+                                )
+                            },
+                            "Remove from wishlist"
+                        }
+                    }
+                }
+            }
+        }
+        None => rsx! {
+            div { class: "bd-wishlist-rail", "data-testid": "wishlist-add-card",
+                p { class: "bd-wishlist-add-blurb", "Track this title to find a physical copy later." }
+                button {
+                    class: "btn sm",
+                    "data-testid": "add-to-wishlist",
+                    disabled: busy(),
+                    onclick: move |_| add_to_wishlist(wishlist, busy, err, server_url.clone(), uuid.clone()),
+                    "Add to physical wishlist"
+                }
+            }
+        },
+    };
+
+    rsx! {
+        div { class: "divider" }
+        div { class: "label bd-wishlist-head", "Physical wishlist" }
+        {content}
+        if let Some(e) = err.read().clone() {
+            p { role: "alert", class: "bd-phys-error", "data-testid": "physical-error", "{e}" }
         }
     }
 }
@@ -270,76 +354,6 @@ fn render_note_editor(state: PhysPanelState, url: String, copy_id: i64) -> Eleme
                     onclick: move |_| editing.set(None),
                     "Cancel"
                 }
-            }
-        }
-    }
-}
-
-/// Wishlisted-book state: pill + tracking card with Remove and Find a copy.
-fn render_wishlist_section(
-    state: PhysPanelState,
-    url: String,
-    uuid: String,
-    isbn: Option<String>,
-    title: String,
-    author: String,
-) -> Element {
-    let busy = state.busy;
-    let entry = state.wishlist.read().clone();
-    let added = entry
-        .as_ref()
-        .map(|e| time_ago(now_unix(), e.added_at))
-        .unwrap_or_default();
-    let source = entry.map(|e| source_label(e.source)).unwrap_or("a scan");
-    let find_url = find_a_copy_url(isbn.as_deref(), &title, &author);
-    rsx! {
-        BdSectionHead { kicker: "Wishlist", title: "On your wishlist" }
-        div { class: "bd-phys-pill-row",
-            span { class: "chip bd-phys-pill bd-wishlist-pill", "data-testid": "wishlist-pill",
-                "On your wishlist"
-            }
-        }
-        div { class: "card bd-wishlist-card", "data-testid": "wishlist-card",
-            p { class: "bd-wishlist-meta",
-                "Tracking this title \u{00b7} added {added} from {source}"
-            }
-            div { class: "bd-wishlist-actions",
-                a {
-                    class: "btn sm",
-                    "data-testid": "find-a-copy",
-                    href: "{find_url}",
-                    target: "_blank",
-                    rel: "noopener noreferrer",
-                    "Find a copy"
-                }
-                button {
-                    class: "btn ghost sm",
-                    "data-testid": "wishlist-remove",
-                    disabled: busy(),
-                    onclick: move |_| remove_from_wishlist(state, url.clone(), uuid.clone()),
-                    "Remove from wishlist"
-                }
-            }
-        }
-    }
-}
-
-/// The "Add to physical wishlist" affordance, shown for any book without a
-/// physical copy — including one owned only digitally.
-fn render_add_wishlist(state: PhysPanelState, url: String, uuid: String) -> Element {
-    let busy = state.busy;
-    rsx! {
-        div { class: "card bd-wishlist-add", "data-testid": "wishlist-add-card",
-            div { class: "bd-wishlist-add-text",
-                div { class: "label bd-section-kicker", "Physical wishlist" }
-                p { class: "bd-wishlist-add-blurb", "Track this title to find a physical copy later." }
-            }
-            button {
-                class: "btn sm",
-                "data-testid": "add-to-wishlist",
-                disabled: busy(),
-                onclick: move |_| add_to_wishlist(state, url.clone(), uuid.clone()),
-                "Add to physical wishlist"
             }
         }
     }
@@ -557,14 +571,15 @@ fn delete_last_and_wishlist(state: PhysPanelState, url: String, uuid: String, co
     });
 }
 
-/// Add the book to the caller's wishlist.
-fn add_to_wishlist(state: PhysPanelState, url: String, uuid: String) {
-    let PhysPanelState {
-        mut wishlist,
-        mut busy,
-        mut err,
-        ..
-    } = state;
+/// Add the book to the caller's wishlist. Takes the individual signals (not
+/// `PhysPanelState`) because its caller is the rail slot, not the panel.
+fn add_to_wishlist(
+    mut wishlist: Signal<Option<WishlistEntry>>,
+    mut busy: Signal<bool>,
+    mut err: Signal<Option<String>>,
+    url: String,
+    uuid: String,
+) {
     busy.set(true);
     err.set(None);
     spawn(async move {
@@ -576,14 +591,15 @@ fn add_to_wishlist(state: PhysPanelState, url: String, uuid: String) {
     });
 }
 
-/// Remove the book from the caller's wishlist.
-fn remove_from_wishlist(state: PhysPanelState, url: String, uuid: String) {
-    let PhysPanelState {
-        mut wishlist,
-        mut busy,
-        mut err,
-        ..
-    } = state;
+/// Remove the book from the caller's wishlist. Same signal-taking shape as
+/// [`add_to_wishlist`].
+fn remove_from_wishlist(
+    mut wishlist: Signal<Option<WishlistEntry>>,
+    mut busy: Signal<bool>,
+    mut err: Signal<Option<String>>,
+    url: String,
+    uuid: String,
+) {
     busy.set(true);
     err.set(None);
     spawn(async move {
@@ -630,14 +646,14 @@ fn source_label(source: WishlistSource) -> &'static str {
     }
 }
 
-/// "Find a copy" target URL: a web search on the ISBN when present, else on
-/// title + author.
+/// "Find a copy" target URL: an Amazon search on the ISBN when present, else
+/// on title + author.
 fn find_a_copy_url(isbn: Option<&str>, title: &str, author: &str) -> String {
     let query = match isbn {
         Some(i) if !i.trim().is_empty() => i.trim().to_string(),
         _ => format!("{title} {author}").trim().to_string(),
     };
-    format!("https://www.google.com/search?q={}", encode_query(&query))
+    format!("https://www.amazon.com/s?k={}", encode_query(&query))
 }
 
 /// Percent-encode a query string (RFC 3986 unreserved kept literal, the rest

--- a/frontend/src/pages/book_detail/physical/tests.rs
+++ b/frontend/src/pages/book_detail/physical/tests.rs
@@ -40,7 +40,7 @@ fn source_label_covers_every_variant() {
 #[test]
 fn find_a_copy_url_prefers_isbn_when_present() {
     let url = find_a_copy_url(Some("9780451524935"), "1984", "George Orwell");
-    assert_eq!(url, "https://www.google.com/search?q=9780451524935");
+    assert_eq!(url, "https://www.amazon.com/s?k=9780451524935");
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn find_a_copy_url_falls_back_to_title_and_author() {
     let url = find_a_copy_url(None, "Brave New World", "Aldous Huxley");
     assert_eq!(
         url,
-        "https://www.google.com/search?q=Brave%20New%20World%20Aldous%20Huxley"
+        "https://www.amazon.com/s?k=Brave%20New%20World%20Aldous%20Huxley"
     );
 }
 
@@ -70,18 +70,42 @@ mod render_tests {
     use super::*;
     use crate::test_support::render_in_vdom;
 
+    /// Build the shared wishlist signals a preview needs, seeded to a state.
+    fn seeded_phys(entry: Option<WishlistEntry>, loaded: bool) -> PhysSignals {
+        PhysSignals {
+            wishlist: use_signal(move || entry.clone()),
+            loaded: use_signal(move || loaded),
+        }
+    }
+
+    fn sample_entry() -> WishlistEntry {
+        WishlistEntry {
+            id: 1,
+            user_id: 1,
+            book_uuid: "u".to_string(),
+            added_at: 0,
+            source: WishlistSource::Detail,
+        }
+    }
+
+    fn slot_identity(has_physical: bool) -> BdBookIdentity {
+        BdBookIdentity {
+            uuid: "u".to_string(),
+            has_physical,
+            isbn: None,
+            title: "Dune".to_string(),
+            author: "Frank Herbert".to_string(),
+        }
+    }
+
     /// The panel's first paint, before the post-mount load resolves.
     fn panel_first_paint() -> Element {
         rsx! {
             BdPhysicalPanel {
-                identity: BdBookIdentity {
-                    uuid: "book-uuid".to_string(),
-                    is_fileless: false,
-                    isbn: None,
-                    title: "Dracula".to_string(),
-                    author: "Bram Stoker".to_string(),
-                },
+                uuid: "book-uuid".to_string(),
+                is_fileless: false,
                 refresh: use_signal(|| 0u32),
+                phys: seeded_phys(None, false),
             }
         }
     }
@@ -93,6 +117,26 @@ mod render_tests {
         // against (rule 07).
         let html = render_in_vdom(panel_first_paint);
         assert!(!html.contains("data-testid=\"bd-physical-panel\""));
+    }
+
+    /// A loaded, copy-less book: wishlist state lives in the hero rail, so the
+    /// full-width panel renders nothing at all.
+    fn panel_loaded_copyless() -> Element {
+        rsx! {
+            BdPhysicalPanel {
+                uuid: "book-uuid".to_string(),
+                is_fileless: false,
+                refresh: use_signal(|| 0u32),
+                phys: seeded_phys(Some(sample_entry()), true),
+            }
+        }
+    }
+
+    #[test]
+    fn panel_renders_nothing_for_a_loaded_book_without_copies() {
+        let html = render_in_vdom(panel_loaded_copyless);
+        assert!(!html.contains("data-testid=\"bd-physical-panel\""));
+        assert!(!html.contains("data-testid=\"wishlist-card\""));
     }
 
     /// Seed a state with one copy and render the physical section directly, so
@@ -132,44 +176,77 @@ mod render_tests {
         assert!(html.contains("data-testid=\"copy-delete\""));
     }
 
-    /// Seed a wishlisted state and render its section (pill + tracking card).
-    fn wishlist_section_preview() -> Element {
-        let state = PhysPanelState {
-            copies: use_signal(Vec::new),
-            wishlist: use_signal(|| {
-                Some(WishlistEntry {
-                    id: 1,
-                    user_id: 1,
-                    book_uuid: "u".to_string(),
-                    added_at: 0,
-                    source: WishlistSource::Detail,
-                })
-            }),
-            busy: use_signal(|| false),
-            err: use_signal(|| None),
-            editing: use_signal(|| None),
-            note_draft: use_signal(String::new),
-            delete_target: use_signal(|| None),
-            refresh: use_signal(|| 0u32),
-        };
-        render_wishlist_section(
-            state,
-            "".to_string(),
-            "u".to_string(),
-            None,
-            "Dune".to_string(),
-            "Frank Herbert".to_string(),
-        )
+    /// The rail slot for a wishlisted book (tracking card + actions).
+    fn wishlisted_slot_preview() -> Element {
+        rsx! {
+            BdWishlistRailSlot {
+                identity: slot_identity(false),
+                phys: seeded_phys(Some(sample_entry()), true),
+            }
+        }
     }
 
     #[test]
-    fn wishlist_section_renders_pill_tracking_card_and_find_a_copy() {
-        let html = render_in_vdom(wishlist_section_preview);
-        assert!(html.contains("data-testid=\"wishlist-pill\""));
-        assert!(html.contains("On your wishlist"));
+    fn wishlist_slot_renders_tracking_card_and_find_a_copy_when_wishlisted() {
+        let html = render_in_vdom(wishlisted_slot_preview);
+        assert!(html.contains("Physical wishlist"));
         assert!(html.contains("data-testid=\"wishlist-card\""));
+        assert!(html.contains("Tracking this title"));
         assert!(html.contains("data-testid=\"wishlist-remove\""));
         assert!(html.contains("data-testid=\"find-a-copy\""));
+    }
+
+    /// The rail slot for a book that is neither wishlisted nor owned
+    /// physically (the add affordance).
+    fn add_slot_preview() -> Element {
+        rsx! {
+            BdWishlistRailSlot {
+                identity: slot_identity(false),
+                phys: seeded_phys(None, true),
+            }
+        }
+    }
+
+    #[test]
+    fn wishlist_slot_offers_add_when_not_wishlisted() {
+        let html = render_in_vdom(add_slot_preview);
+        assert!(html.contains("data-testid=\"wishlist-add-card\""));
+        assert!(html.contains("data-testid=\"add-to-wishlist\""));
+    }
+
+    /// The rail slot for a book already in the physical collection.
+    fn physical_owned_slot_preview() -> Element {
+        rsx! {
+            BdWishlistRailSlot {
+                identity: slot_identity(true),
+                phys: seeded_phys(None, true),
+            }
+        }
+    }
+
+    #[test]
+    fn wishlist_slot_renders_nothing_for_a_physically_owned_book() {
+        let html = render_in_vdom(physical_owned_slot_preview);
+        assert!(!html.contains("Physical wishlist"));
+        assert!(!html.contains("data-testid=\"add-to-wishlist\""));
+    }
+
+    /// The rail slot before the shared load resolves — must be empty so the
+    /// SSR and first-hydration paints match (rule 07).
+    fn unloaded_slot_preview() -> Element {
+        rsx! {
+            BdWishlistRailSlot {
+                identity: slot_identity(false),
+                phys: seeded_phys(None, false),
+            }
+        }
+    }
+
+    #[test]
+    fn wishlist_slot_renders_nothing_before_the_load_resolves() {
+        let html = render_in_vdom(unloaded_slot_preview);
+        assert!(!html.contains("Physical wishlist"));
+        assert!(!html.contains("data-testid=\"wishlist-add-card\""));
     }
 
     fn state_with_target(last_fileless: bool) -> PhysPanelState {

--- a/frontend/src/pages/book_detail/view.rs
+++ b/frontend/src/pages/book_detail/view.rs
@@ -22,7 +22,7 @@ use super::hero::{self, BdHeroSection};
 use super::mobile;
 #[cfg(not(feature = "mobile"))]
 use super::physical;
-use super::{BdCrumbItem, DescriptionSignals};
+use super::{BdCrumbItem, DescriptionSignals, PhysSignals};
 
 fn kicker_label(year: &str) -> String {
     if year.is_empty() {
@@ -163,6 +163,7 @@ pub(super) struct LoadedCtx {
     pub(super) server_url: String,
     pub(super) is_admin: bool,
     pub(super) refresh: Signal<u32>,
+    pub(super) phys: PhysSignals,
 }
 
 /// Render the fully-loaded book detail view.
@@ -178,6 +179,7 @@ pub(super) fn render_loaded(
         server_url,
         is_admin,
         refresh,
+        phys,
     } = ctx;
     // Mobile re-flows the same loaded data into a single column; the web body
     // (hero + rail + suggestions + merge UI) isn't rendered there.
@@ -185,9 +187,10 @@ pub(super) fn render_loaded(
     let out = {
         // The merge and delete affordances stay web-only; the discovery blocks
         // (author cluster + suggestions) now render on mobile too. The physical
-        // panel is web-only too (issue #1186 scope), so `refresh` is unused here.
+        // panel + wishlist rail are web-only too (issue #1186 scope), so
+        // `refresh` and `phys` are unused here.
         let _ = rail;
-        let _ = refresh;
+        let _ = (refresh, phys);
         mobile::render_loaded_mobile(mobile::MobileBookView {
             b,
             author_books,
@@ -224,8 +227,6 @@ pub(super) fn render_loaded(
         let uuid = b.unique_identifier.clone().unwrap_or_default();
         // Extract the physical-panel inputs before `b` is moved into the rail.
         let is_fileless = b.formats.is_empty();
-        let isbn13 = b.isbn13.clone();
-        let panel_author = primary_author.clone();
         let accent = b.accent.clone();
         rsx! {
             div { class: "bd-root", style: "{accent_style}",
@@ -238,16 +239,13 @@ pub(super) fn render_loaded(
                         has_ebook,
                         has_audio,
                     },
+                    phys,
                 }
                 physical::BdPhysicalPanel {
-                    identity: physical::BdBookIdentity {
-                        uuid: uuid.clone(),
-                        is_fileless,
-                        isbn: isbn13,
-                        title: title.clone(),
-                        author: panel_author,
-                    },
+                    uuid: uuid.clone(),
+                    is_fileless,
                     refresh,
+                    phys,
                 }
                 section { class: "bd-body-grid",
                     BdBodyMain {

--- a/ui_tests/playwright/tests/flows/physical_collection.spec.ts
+++ b/ui_tests/playwright/tests/flows/physical_collection.spec.ts
@@ -13,6 +13,11 @@ import { fixturesDir, seedLibrary } from "../utils/seed";
 // keeps the suite race-free: nothing here mutates library-wide physical copies
 // or the admin's real wishlist, so no parallel spec's assertions are disturbed
 // and no extra book leaks into any count.
+//
+// Layout note: the wishlist UI (tracking card / add affordance) lives in the
+// hero's rating rail card, and a wishlisted book shows a "Physical Wishlist"
+// badge next to the cover's format facets. The full-width panel below the
+// hero renders only checked-in physical copies.
 
 // A plain single-format ebook to land on. Which book is immaterial — the
 // physical endpoints are mocked — but a real uuid exercises the real SSR +
@@ -80,7 +85,7 @@ test.beforeAll(async ({ request }) => {
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
 });
 
-test("renders the physical panel with the add-to-wishlist default state", async ({
+test("renders the add-to-wishlist default state in the hero rail", async ({
   page,
   request,
 }) => {
@@ -92,10 +97,11 @@ test("renders the physical panel with the add-to-wishlist default state", async 
   await gotoReady(page, `/books/${uuid}`);
   await expectNavVisible(page);
 
-  await expect(page.getByTestId("bd-physical-panel")).toBeVisible();
   await expect(page.getByTestId("add-to-wishlist")).toBeVisible();
-  // Nothing checked in, so no physical pill.
+  // Nothing checked in, so no physical pill — and the full-width copies
+  // panel renders nothing at all for a copy-less book.
   await expect(page.getByTestId("physical-pill")).toBeHidden();
+  await expect(page.getByTestId("bd-physical-panel")).toBeHidden();
 });
 
 test("adds then removes a wishlist entry", async ({ page, request }) => {
@@ -122,7 +128,9 @@ test("adds then removes a wishlist entry", async ({ page, request }) => {
     async () => page.getByTestId("add-to-wishlist").click(),
   );
 
-  await expect(page.getByTestId("wishlist-pill")).toBeVisible();
+  // Wishlisted: the cover badge row gains the "Physical Wishlist" facet and
+  // the rail slot shows the tracking card.
+  await expect(page.getByTestId("format-badge-wishlist")).toBeVisible();
   await expect(page.getByTestId("wishlist-card")).toBeVisible();
   await expect(page.getByTestId("find-a-copy")).toBeVisible();
 

--- a/ui_tests/playwright/tests/flows/physical_collection.spec.ts
+++ b/ui_tests/playwright/tests/flows/physical_collection.spec.ts
@@ -179,7 +179,7 @@ test("surfaces an error when the wishlist add fails", async ({
     async () => page.getByTestId("add-to-wishlist").click(),
   );
 
-  await expect(page.getByTestId("physical-error")).toBeVisible();
+  await expect(page.getByTestId("wishlist-error")).toBeVisible();
   // The optimistic state reverted — still offering to add.
   await expect(page.getByTestId("add-to-wishlist")).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Book-detail hero rework: the reading-status control moves into the rating rail card (below "Your rating"), the Actions card (journal / highlight / share) is removed, and tag chips move under the cover next to the format facets.
- Wishlist UI leaves the full-width panel: a wishlisted book now shows a "Physical Wishlist" chip beside the format facets, and the tracking card (Find a copy / Remove) lives in the rail slot where Actions was, with the add affordance in the same slot.
- Wishlist state is lifted to the page level and shared between the hero (chip + rail slot) and the physical panel, which now renders only checked-in copies.
- "Find a copy" now targets an Amazon search (ISBN preferred, title+author fallback).

## Test plan
- [x] `just lint` (fmt + clippy matrix incl. wasm32 + stylelint) clean
- [x] `just test` matrix green (one pre-existing month-end date flake in `omnibus-db` stats, unrelated — tracked separately)
- [x] Updated unit tests: wishlist rail slot states, panel empty-states, badge, Amazon URL helpers
- [x] `physical_collection.spec.ts` + `book_detail.spec.ts` pass against a live dev server
- [x] Manual browser pass: add/remove wishlist, chip appears, rail order, tags under cover, no hydration errors

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).