### PR TITLE
feat: add Worker::metrics() accessor for queue depth and completion timings

### DIFF
--- a/db/src/worker.rs
+++ b/db/src/worker.rs
@@ -20,12 +20,15 @@
 //! * [`handlers`] — `Worker::execute` per-task-kind handlers.
 //! * [`progress`] — `progress_snapshot` + retention/eviction +
 //!   `report_progress` + the terminal-state writer.
+//! * [`metrics`] — `Worker::metrics`: per-task-type queue depth and a
+//!   bounded recent-completions window, for a future admin health page.
 //! * [`periodic_scan`] — the testable "read settings, decide, post" step
 //!   behind the configurable periodic library rescan; the timer loop that
 //!   drives it lives in `server::main`.
 
 mod exec;
 mod handlers;
+mod metrics;
 mod periodic_scan;
 mod progress;
 mod queue;
@@ -34,5 +37,6 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+pub use metrics::WorkerMetrics;
 pub use periodic_scan::{periodic_scan_tick, PERIODIC_SCAN_RECHECK};
 pub use types::{Task, TaskId, TaskOutcome, Worker, WorkerConfig};

--- a/db/src/worker/metrics.rs
+++ b/db/src/worker/metrics.rs
@@ -1,0 +1,78 @@
+//! Aggregate worker metrics for a future admin health page (issue #953,
+//! part of the "Admin Server Health" epic alongside #952/#954/#955): a
+//! per-task-type queue depth plus a bounded window of recent completion
+//! timings. Distinct from [`super::progress`]'s `progress_snapshot`, which
+//! is a live per-task feed — this module summarizes across every
+//! currently-tracked task by [`TaskKind`] and never mutates or evicts the
+//! progress map's own state.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use omnibus_shared::TaskKind;
+
+use super::types::{lock_unpoison, Worker};
+
+/// Recent-completions window kept per [`TaskKind`]. Small and fixed so the
+/// in-memory window stays bounded no matter how long the worker has been
+/// running; 20 is enough for a health page to render a meaningful recent
+/// spread (e.g. min/median/max) without unbounded bookkeeping cost.
+pub(super) const RECENT_COMPLETIONS_CAP: usize = 20;
+
+/// Aggregate, per-task-type snapshot of worker queue state: how many tasks
+/// of each [`TaskKind`] are currently queued or running, and how long the
+/// most recently completed tasks of each kind took. Returned by
+/// [`Worker::metrics`]; unlike [`Worker::progress_snapshot`](super::Worker::progress_snapshot)
+/// (a live per-task feed) this is a coarse summary meant for cheap,
+/// periodic polling.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct WorkerMetrics {
+    /// Count of non-terminal (queued or running) tasks per [`TaskKind`].
+    /// A kind with no live tasks is simply absent rather than mapped to 0.
+    pub queue_depth: HashMap<TaskKind, usize>,
+    /// Durations of the most recent completions per [`TaskKind`], oldest
+    /// first, capped at [`RECENT_COMPLETIONS_CAP`] entries per kind.
+    /// Recorded on every terminal transition (`Done` or `Failed`) — this
+    /// reports how long tasks are taking, not whether they succeeded.
+    pub recent_completions: HashMap<TaskKind, Vec<Duration>>,
+}
+
+impl Worker {
+    /// Cheap, read-only snapshot of per-task-type queue depth and recent
+    /// completion timings, for a future admin health page. Two short lock
+    /// scopes, neither of which is the write path `progress_snapshot`
+    /// relies on for eviction, so calling this never disturbs the live
+    /// progress feed.
+    pub fn metrics(&self) -> WorkerMetrics {
+        let mut queue_depth: HashMap<TaskKind, usize> = HashMap::new();
+        for entry in lock_unpoison(&self.progress).values() {
+            if entry.terminal_at.is_none() {
+                *queue_depth.entry(entry.progress.kind).or_insert(0) += 1;
+            }
+        }
+
+        let recent_completions = lock_unpoison(&self.completion_timings)
+            .iter()
+            .map(|(kind, timings)| (*kind, timings.iter().copied().collect()))
+            .collect();
+
+        WorkerMetrics {
+            queue_depth,
+            recent_completions,
+        }
+    }
+
+    /// Record one task's completion duration into its [`TaskKind`]'s
+    /// bounded recent-completions window, evicting the oldest entry once
+    /// [`RECENT_COMPLETIONS_CAP`] is exceeded. Called from
+    /// [`super::progress::write_terminal_progress`] so every terminal
+    /// transition counts as one completion.
+    pub(super) fn record_completion(&self, kind: TaskKind, duration: Duration) {
+        let mut map = lock_unpoison(&self.completion_timings);
+        let window = map.entry(kind).or_default();
+        window.push_back(duration);
+        if window.len() > RECENT_COMPLETIONS_CAP {
+            window.pop_front();
+        }
+    }
+}

--- a/db/src/worker/metrics.rs
+++ b/db/src/worker/metrics.rs
@@ -1,10 +1,8 @@
-//! Aggregate worker metrics for a future admin health page (issue #953,
-//! part of the "Admin Server Health" epic alongside #952/#954/#955): a
-//! per-task-type queue depth plus a bounded window of recent completion
-//! timings. Distinct from [`super::progress`]'s `progress_snapshot`, which
-//! is a live per-task feed — this module summarizes across every
-//! currently-tracked task by [`TaskKind`] and never mutates or evicts the
-//! progress map's own state.
+//! Aggregate worker metrics: per-task-type queue depth plus a bounded
+//! window of recent completion timings. Distinct from [`super::progress`]'s
+//! `progress_snapshot`, which is a live per-task feed — this module
+//! summarizes across every currently-tracked task by [`TaskKind`] and never
+//! mutates or evicts the progress map's own state.
 
 use std::collections::HashMap;
 use std::time::Duration;

--- a/db/src/worker/progress.rs
+++ b/db/src/worker/progress.rs
@@ -93,13 +93,29 @@ impl Worker {
 
     /// Internal terminal write. Called from `run` (Ok/Err) and from the
     /// `ProgressTerminalGuard` (panic). The `terminal_at` Instant is
-    /// monotonic so eviction is robust to wall-clock drift.
+    /// monotonic so eviction is robust to wall-clock drift. Also records
+    /// this task's wall-clock run duration into
+    /// [`Worker::record_completion`]'s per-kind window, backing
+    /// [`Worker::metrics`] — the two mutexes involved (`progress` and
+    /// `completion_timings`) are never held at once, so this can't
+    /// introduce a lock-order deadlock with `metrics()`.
     pub(super) fn write_terminal_progress(&self, id: TaskId, state: ProgressState) {
-        let mut map = lock_unpoison(&self.progress);
-        if let Some(entry) = map.get_mut(&id) {
-            entry.progress.last_update_ms = wall_clock_ms();
-            entry.progress.state = state;
-            entry.terminal_at = Some(Instant::now());
+        let recorded = {
+            let mut map = lock_unpoison(&self.progress);
+            map.get_mut(&id).map(|entry| {
+                let now_ms = wall_clock_ms();
+                entry.progress.last_update_ms = now_ms;
+                entry.progress.state = state;
+                entry.terminal_at = Some(Instant::now());
+                let elapsed_ms = now_ms.saturating_sub(entry.progress.started_at_ms).max(0);
+                (
+                    entry.progress.kind,
+                    Duration::from_millis(elapsed_ms as u64),
+                )
+            })
+        };
+        if let Some((kind, duration)) = recorded {
+            self.record_completion(kind, duration);
         }
     }
 

--- a/db/src/worker/tests.rs
+++ b/db/src/worker/tests.rs
@@ -1017,7 +1017,7 @@ async fn metrics_bounds_the_recent_completions_window_per_kind() {
     let w = make_worker_default(pool().await);
     // One more than the cap (20) so eviction must have kicked in at least
     // once; each task is posted and awaited serially so ordering is stable.
-    for i in 0..21 {
+    for _ in 0..21 {
         let id = w.post(Task::Test {
             tag: "bound",
             latency_ms: 0,
@@ -1027,7 +1027,6 @@ async fn metrics_bounds_the_recent_completions_window_per_kind() {
             on_done: None,
         });
         let _ = w.await_completion(id).await;
-        let _ = i;
     }
 
     let m = w.metrics();

--- a/db/src/worker/tests.rs
+++ b/db/src/worker/tests.rs
@@ -915,3 +915,161 @@ async fn task_scan_reports_ghost_warning_in_the_warn_band_below_abort() {
 
     let _ = std::fs::remove_dir_all(&lib);
 }
+
+// ---------- #953: `Worker::metrics` (queue depth + recent completions) ----------
+
+/// `metrics().queue_depth` reflects a task's own [`TaskKind`] while it's
+/// still queued/running, and drops back to zero once it completes — mirrors
+/// `queued_task_shows_as_running_immediately`'s use of `progress_snapshot`
+/// but asserts the aggregate accessor instead.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_reports_queue_depth_for_in_flight_tasks() {
+    let w = make_worker_default(pool().await);
+    let id = w.post(Task::Test {
+        tag: "depth",
+        latency_ms: 80,
+        resource: Some("depth".into()),
+        route_through_scan_sem: false,
+        on_run: None,
+        on_done: None,
+    });
+
+    // Test tasks report as TaskKind::Scan (see `Task::kind`'s doc comment).
+    let m = w.metrics();
+    assert_eq!(m.queue_depth.get(&TaskKind::Scan), Some(&1));
+
+    let _ = w.await_completion(id).await;
+    let m_after = w.metrics();
+    assert_eq!(
+        m_after
+            .queue_depth
+            .get(&TaskKind::Scan)
+            .copied()
+            .unwrap_or(0),
+        0,
+        "a completed task must not still count against queue depth"
+    );
+}
+
+/// Two concurrently queued tasks of the same kind both count toward that
+/// kind's depth — the accessor aggregates, not just reports presence.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_aggregates_queue_depth_across_same_kind_tasks() {
+    let w = make_worker_default(pool().await);
+    let mk = |key: &'static str| {
+        w.post(Task::Test {
+            tag: key,
+            latency_ms: 80,
+            resource: Some(key.into()),
+            route_through_scan_sem: false,
+            on_run: None,
+            on_done: None,
+        })
+    };
+    let id1 = mk("m1");
+    let id2 = mk("m2");
+
+    let m = w.metrics();
+    assert_eq!(m.queue_depth.get(&TaskKind::Scan), Some(&2));
+
+    let _ = tokio::join!(w.await_completion(id1), w.await_completion(id2));
+}
+
+/// A completed task's duration lands in `recent_completions` for its
+/// `TaskKind`, and `progress_snapshot` keeps reporting the same terminal
+/// state unchanged — `metrics()` is purely additive.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_records_a_recent_completion_timing_without_disturbing_progress() {
+    let w = make_worker_default(pool().await);
+    let id = w.post(Task::Test {
+        tag: "timing",
+        latency_ms: 20,
+        resource: None,
+        route_through_scan_sem: false,
+        on_run: None,
+        on_done: None,
+    });
+    let _ = w.await_completion(id).await;
+
+    let m = w.metrics();
+    let timings = m
+        .recent_completions
+        .get(&TaskKind::Scan)
+        .expect("one completion recorded for TaskKind::Scan");
+    assert_eq!(timings.len(), 1);
+
+    // progress_snapshot is unaffected: the terminal entry is still present
+    // and still Done, same as before metrics() was ever called.
+    let snap = w.progress_snapshot();
+    let entry = snap
+        .recent_complete
+        .iter()
+        .find(|p| p.task_id == id)
+        .expect("terminal entry still present in progress_snapshot");
+    assert!(matches!(entry.state, ProgressState::Done { .. }));
+}
+
+/// The recent-completions window per `TaskKind` is bounded: posting more
+/// than the cap evicts the oldest entries, keeping only the most recent
+/// `RECENT_COMPLETIONS_CAP` durations.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_bounds_the_recent_completions_window_per_kind() {
+    let w = make_worker_default(pool().await);
+    // One more than the cap (20) so eviction must have kicked in at least
+    // once; each task is posted and awaited serially so ordering is stable.
+    for i in 0..21 {
+        let id = w.post(Task::Test {
+            tag: "bound",
+            latency_ms: 0,
+            resource: None,
+            route_through_scan_sem: false,
+            on_run: None,
+            on_done: None,
+        });
+        let _ = w.await_completion(id).await;
+        let _ = i;
+    }
+
+    let m = w.metrics();
+    let timings = m
+        .recent_completions
+        .get(&TaskKind::Scan)
+        .expect("completions recorded for TaskKind::Scan");
+    assert_eq!(
+        timings.len(),
+        20,
+        "recent-completions window must stay capped at 20 entries"
+    );
+}
+
+/// Different task kinds keep independent queue-depth and recent-completion
+/// buckets — a burst of one kind must not appear under another's key.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_keeps_separate_buckets_per_task_kind() {
+    let w = make_worker_default(pool().await);
+    let scan_id = w.post(Task::Test {
+        tag: "scan-kind",
+        latency_ms: 0,
+        resource: None,
+        route_through_scan_sem: false,
+        on_run: None,
+        on_done: None,
+    });
+    let _ = w.await_completion(scan_id).await;
+
+    let thumb_id = w.post(Task::GenerateThumbs {
+        book_id: 1,
+        last_modified_epoch: 0,
+    });
+    let _ = w.await_completion(thumb_id).await;
+
+    let m = w.metrics();
+    assert!(
+        m.recent_completions.contains_key(&TaskKind::Scan),
+        "Test task should record under TaskKind::Scan"
+    );
+    assert!(
+        m.recent_completions.contains_key(&TaskKind::GenerateThumbs),
+        "GenerateThumbs task should record under its own TaskKind"
+    );
+}

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -4,7 +4,7 @@
 //! struct, `ProgressEntry`, `TERMINAL_RETENTION`, and the `lock_unpoison` /
 //! `wall_clock_ms` helpers the sibling modules share.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -296,6 +296,13 @@ pub struct Worker {
     /// paths are `post` (initial Running) and `run` (terminal Done/Failed,
     /// plus the panic-safety guard).
     pub(super) progress: Arc<StdMutex<BTreeMap<TaskId, ProgressEntry>>>,
+    /// Bounded per-[`TaskKind`] window of recent completion durations,
+    /// backing [`Worker::metrics`]. Written once per terminal transition by
+    /// [`super::progress::write_terminal_progress`]; capped at
+    /// [`super::metrics::RECENT_COMPLETIONS_CAP`] entries per kind. A
+    /// separate `StdMutex` from `progress` so reading metrics never
+    /// contends with the live progress feed's own lock.
+    pub(super) completion_timings: Arc<StdMutex<HashMap<TaskKind, VecDeque<Duration>>>>,
     pub(super) next_id: std::sync::atomic::AtomicU64,
 }
 
@@ -355,6 +362,7 @@ impl Worker {
             resource_locks: Arc::new(Mutex::new(HashMap::new())),
             completions: Arc::new(StdMutex::new(HashMap::new())),
             progress: Arc::new(StdMutex::new(BTreeMap::new())),
+            completion_timings: Arc::new(StdMutex::new(HashMap::new())),
             next_id: std::sync::atomic::AtomicU64::new(1),
         })
     }

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -300,8 +300,10 @@ pub struct Worker {
     /// backing [`Worker::metrics`]. Written once per terminal transition by
     /// [`super::progress::write_terminal_progress`]; capped at
     /// [`super::metrics::RECENT_COMPLETIONS_CAP`] entries per kind. A
-    /// separate `StdMutex` from `progress` so reading metrics never
-    /// contends with the live progress feed's own lock.
+    /// separate `StdMutex` from `progress`, so recording a completion
+    /// releases the `progress` lock first rather than extending its hold
+    /// time — `Worker::metrics` still takes `progress` separately to
+    /// compute queue depth.
     pub(super) completion_timings: Arc<StdMutex<HashMap<TaskKind, VecDeque<Duration>>>>,
     pub(super) next_id: std::sync::atomic::AtomicU64,
 }


### PR DESCRIPTION
## Summary
- Closes #953
- Adds a `WorkerMetrics` struct and `Worker::metrics()` accessor in `db/src/worker/` so a future admin health page can report background-worker queue state: per-`TaskKind` queue depth (non-terminal tasks currently tracked) and a bounded window of recent completion durations per kind.
- `metrics()` is purely additive — it reads the existing `progress` map and a new `completion_timings` map, and never mutates or evicts `progress_snapshot`'s live state, so the existing progress feed is unchanged.
- This is one of several sub-issues under the "Admin Server Health" epic (#951), alongside #952/#954/#955 which build a health page / ring-buffer / polling on top of this. Per #953's own Affected Crates scope, this PR only adds the `db`-crate accessor — no `server`/`frontend` plumbing.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-db --lib worker::` — 46 passed (5 new `metrics_*` tests covering queue depth for in-flight tasks, aggregation across same-kind tasks, recorded completion timings without disturbing `progress_snapshot`, the bounded 20-entry window, and per-kind bucket separation)
- [x] `cargo test -p omnibus-db` — full suite passes except one pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, which needs downloaded test fixtures not available in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_011kUujohWm91khGGNJgxLTM)_