### PR TITLE
refactor: rename 16 more test names to include function-under-test (#863)

### DIFF
--- a/db/src/auth/users/tests.rs
+++ b/db/src/auth/users/tests.rs
@@ -36,7 +36,7 @@ async fn second_user_needs_registration_enabled() {
 }
 
 #[tokio::test]
-async fn username_collision_nocase() {
+async fn create_user_rejects_case_insensitive_username_collision() {
     let p = pool().await;
     create_user(&p, "Alice", "hunter2-real-long").await.unwrap();
     set_registration_enabled(&p, true).await.unwrap();

--- a/db/src/journals/markdown/tests.rs
+++ b/db/src/journals/markdown/tests.rs
@@ -6,7 +6,7 @@
 use super::*;
 
 #[test]
-fn renders_basic_markdown() {
+fn render_emits_strong_and_em_for_bold_and_italic_markdown() {
     let html = render("**bold** and *italic*");
     assert!(html.contains("<strong>bold</strong>"), "got: {html}");
     assert!(html.contains("<em>italic</em>"), "got: {html}");
@@ -19,7 +19,7 @@ fn render_emits_del_for_strikethrough() {
 }
 
 #[test]
-fn strips_script_tags() {
+fn render_strips_script_tags() {
     let html = render("hi <script>alert('x')</script> there");
     assert!(!html.contains("<script"), "script must be stripped: {html}");
     assert!(!html.contains("alert("), "script body removed: {html}");

--- a/db/src/library_layout/tests.rs
+++ b/db/src/library_layout/tests.rs
@@ -15,17 +15,17 @@ fn temp_dir(suffix: &str) -> PathBuf {
 }
 
 #[test]
-fn slugify_basic_ascii() {
+fn slugify_handles_basic_ascii() {
     assert_eq!(slugify("Hello World"), "hello-world");
 }
 
 #[test]
-fn slugify_strips_punctuation() {
+fn slugify_strips_out_punctuation() {
     assert_eq!(slugify("What?! Really..."), "what-really");
 }
 
 #[test]
-fn slugify_collapses_runs() {
+fn slugify_collapses_repeated_separator_runs() {
     assert_eq!(slugify("a---b___c"), "a-b-c");
 }
 
@@ -35,12 +35,12 @@ fn slugify_trims_leading_and_trailing() {
 }
 
 #[test]
-fn slugify_folds_accents() {
+fn slugify_folds_accented_characters_to_ascii() {
     assert_eq!(slugify("Café au Lait"), "cafe-au-lait");
 }
 
 #[test]
-fn slugify_transliterates_cjk() {
+fn slugify_transliterates_cjk_to_ascii() {
     // Locks in deunicode's transliteration. The exact letters matter less
     // than the fact that the result is non-empty ASCII.
     let out = slugify("東京物語");
@@ -56,7 +56,7 @@ fn slugify_transliterates_cjk() {
 }
 
 #[test]
-fn slugify_handles_cyrillic() {
+fn slugify_transliterates_cyrillic_to_ascii() {
     let out = slugify("Война и мир");
     assert!(!out.is_empty());
     assert!(
@@ -84,7 +84,7 @@ fn slugify_caps_at_80_chars() {
 }
 
 #[test]
-fn slugify_preserves_digits() {
+fn slugify_preserves_digits_in_slug() {
     assert_eq!(slugify("Volume 2: The Sequel"), "volume-2-the-sequel");
 }
 
@@ -99,7 +99,7 @@ fn slugify_cap_does_not_leave_trailing_dash() {
 }
 
 #[test]
-fn canonical_path_typical() {
+fn canonical_path_builds_typical_nested_path() {
     let p = canonical_path(
         Path::new("/lib"),
         "Brandon Sanderson",
@@ -113,7 +113,7 @@ fn canonical_path_typical() {
 }
 
 #[test]
-fn canonical_path_apostrophe() {
+fn canonical_path_slugifies_apostrophe_in_author_name() {
     let p = canonical_path(
         Path::new("/lib"),
         "Madeleine L'Engle",

--- a/db/src/sync/tests.rs
+++ b/db/src/sync/tests.rs
@@ -974,7 +974,7 @@ async fn reindex_keeps_fts_row_count_in_sync() {
     );
 }
 #[tokio::test]
-async fn overrides_survive_reindex() {
+async fn replace_books_preserves_metadata_overrides_across_reindex() {
     let _covers = CoversTempDir::new("reindex_survive");
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -315,9 +315,9 @@ like `search_books_finds_by_title_and_ranks_by_bm25`,
 `list_books_populates_formats_from_book_files`.
 
 **Anti-pattern.** [db/src/journals/markdown/tests.rs](../db/src/journals/markdown/tests.rs)
-names like `strips_script_tags` and `strips_event_handler_attributes`
-elide the function-under-test convention entirely — both test `render`,
-the function whose behavior they're checking, but neither name says so.
+has a name like `strips_event_handler_attributes` that elides the
+function-under-test convention entirely — it tests `render`, the
+function whose behavior it's checking, but the name doesn't say so.
 Compare `render_emits_del_for_strikethrough` a few lines above in the
 same file, which correctly prefixes with the function it tests.
 

--- a/server/src/backend/users/tests.rs
+++ b/server/src/backend/users/tests.rs
@@ -351,7 +351,7 @@ async fn post_unlock_returns_403_for_non_admin() {
 }
 
 #[tokio::test]
-async fn unlock_clears_lockout() {
+async fn post_unlock_clears_lockout() {
     let (app, _, pool) = fixture().await;
     let token = admin_token(&pool, "alice").await;
     let bob = auth_test_support::create_user(&pool, "bob").await;
@@ -405,7 +405,7 @@ async fn delete_user_returns_403_for_non_admin() {
 }
 
 #[tokio::test]
-async fn delete_user_succeeds() {
+async fn delete_user_removes_user() {
     let (app, _, pool) = fixture().await;
     let token = admin_token(&pool, "alice").await;
     let bob = auth_test_support::create_user(&pool, "bob").await;

--- a/shared/src/journal/tests.rs
+++ b/shared/src/journal/tests.rs
@@ -97,7 +97,7 @@ fn status_defaults_keep_pre_drafts_payloads_compatible() {
 }
 
 #[test]
-fn status_serializes_lowercase() {
+fn journal_status_serializes_and_parses_lowercase_values() {
     assert_eq!(
         serde_json::to_string(&JournalStatus::Draft).expect("serializes"),
         r#""draft""#


### PR DESCRIPTION
## Summary
- Closes #863. This addresses the **reopened, fresh-batch scope** of the issue (16 test names identified in the 2026-07-27 reopening comment), not the original 10-name batch from the issue body — that batch was already fixed by #1059 / commit `bb1d188`.
- Renames 16 test names across `db/`, `shared/`, and `server/` to include the function/type under test, following the `fn_under_test_does_X_when_Y` naming convention (`.claude/rules/05-rust-style.md` § Tests → Naming).
- Also updates `docs/style-guide.md`'s anti-pattern example, which cited one of the now-renamed names (`strips_script_tags`), so the remaining cited example (`strips_event_handler_attributes`) still applies.

## Test plan
- [x] `cargo test -p omnibus-db --lib` (`CARGO_TARGET_DIR=/tmp/omnibus-target-863`) — 1599 passed, 1 failed. The failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing, environment-only failure (missing audiobook fixture — `run just fixtures`), unrelated to this change. All 13 renamed tests in this crate pass individually.
- [x] `cargo test -p omnibus-shared --lib` — 252 passed, 0 failed. The renamed `journal_status_serializes_and_parses_lowercase_values` passes.
- [x] `cargo test -p omnibus --lib` — 613 passed, 2 failed. Both failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400` and its audiobook variant) are the same pre-existing, environment-only failure documented in #1059's PR notes: the sandbox runs as root, which bypasses the `chmod 0o555` permission check the tests rely on. Unrelated to this change. Both renamed tests (`post_unlock_clears_lockout`, `delete_user_removes_user`) pass individually.
- [x] `cargo fmt --check` — PASS (no diff)

## Notes
- Pure rename, no test bodies or production logic changed.
- Renamed:
  - `db/src/library_layout/tests.rs`: `slugify_basic_ascii` → `slugify_handles_basic_ascii`; `slugify_strips_punctuation` → `slugify_strips_out_punctuation`; `slugify_collapses_runs` → `slugify_collapses_repeated_separator_runs`; `slugify_folds_accents` → `slugify_folds_accented_characters_to_ascii`; `slugify_transliterates_cjk` → `slugify_transliterates_cjk_to_ascii`; `slugify_handles_cyrillic` → `slugify_transliterates_cyrillic_to_ascii`; `slugify_preserves_digits` → `slugify_preserves_digits_in_slug`; `canonical_path_typical` → `canonical_path_builds_typical_nested_path`; `canonical_path_apostrophe` → `canonical_path_slugifies_apostrophe_in_author_name`.
  - `db/src/journals/markdown/tests.rs`: `renders_basic_markdown` → `render_emits_strong_and_em_for_bold_and_italic_markdown`; `strips_script_tags` → `render_strips_script_tags`.
  - `db/src/auth/users/tests.rs`: `username_collision_nocase` → `create_user_rejects_case_insensitive_username_collision`.
  - `db/src/sync/tests.rs`: `overrides_survive_reindex` → `replace_books_preserves_metadata_overrides_across_reindex`.
  - `shared/src/journal/tests.rs`: `status_serializes_lowercase` → `journal_status_serializes_and_parses_lowercase_values`.
  - `server/src/backend/users/tests.rs`: `unlock_clears_lockout` → `post_unlock_clears_lockout`; `delete_user_succeeds` → `delete_user_removes_user`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011kUujohWm91khGGNJgxLTM)_