### PR TITLE
refactor: document intent of two dead-code validation utilities (#857)

### DIFF
--- a/frontend/src/pages/listen/mobile/view.rs
+++ b/frontend/src/pages/listen/mobile/view.rs
@@ -170,9 +170,14 @@ pub fn chapter_prev_seek(chapters: &[ChapterInfo], elapsed: f64, idx: usize) -> 
 }
 
 /// Pick the next playable part after `idx` given a part count. Returns `None`
-/// when `idx` is the last part (playback should stop, not wrap). The runtime
-/// auto-advance runs in the JS `ended` handler ([`super::interop`]); this
-/// mirrors that decision in Rust so the boundary math is unit-tested.
+/// when `idx` is the last part (playback should stop, not wrap).
+///
+/// Intentionally kept unwired: the runtime decision runs synchronously inside
+/// the JS `ended` handler ([`super::interop`]) so the next part's `src` can be
+/// set with zero playback gap — routing through a Rust/WASM round-trip
+/// (`dioxus.send` + a response) would add audible latency at every part
+/// boundary. This mirrors that same `idx + 1 < part_count` check so the
+/// boundary arithmetic stays unit-tested in Rust.
 #[allow(dead_code)]
 pub fn next_part_index(part_count: usize, idx: usize) -> Option<usize> {
     let next = idx + 1;

--- a/server/src/backend/uploads.rs
+++ b/server/src/backend/uploads.rs
@@ -184,9 +184,12 @@ fn require_upload(user: &AuthUser) -> Result<(), UploadError> {
     }
 }
 
-/// Magic-byte + size gate for a fully-buffered upload. Kept as a unit-testable
-/// utility; the streaming path enforces both invariants incrementally inside
-/// [`stream_upload_to_tempfile`].
+/// Magic-byte + size gate for a fully-buffered upload. Intentionally kept
+/// unwired: [`stream_upload_to_tempfile`] enforces the same two invariants
+/// incrementally, chunk-by-chunk, specifically so an upload is never fully
+/// buffered in RAM — swapping this in would mean buffering the whole file
+/// first, defeating that streaming design. Kept as a unit-tested reference
+/// for the two invariants the streaming path must independently uphold.
 #[allow(dead_code)]
 fn validate_file_bytes(bytes: &[u8], cap: usize) -> Result<(), UploadError> {
     if bytes.len() > cap {


### PR DESCRIPTION
## Summary
- Closes #857
- `validate_file_bytes` (`server/src/backend/uploads.rs`) and `next_part_index` (`frontend/src/pages/listen/mobile/view.rs`) are both unit-tested but unwired from their live paths. Per the issue's own guidance, this is a judgment call — for both, I chose option (c): keep them unwired and replace the vague "kept as a unit-testable utility" doc comments with the actual rationale, so the `#[allow(dead_code)]` reads as a deliberate decision rather than debt.
  - `validate_file_bytes` operates on a fully-buffered `&[u8]`, but `stream_upload_to_tempfile` deliberately validates size + magic bytes incrementally, chunk-by-chunk, specifically so an upload is never fully buffered in RAM. Wiring the buffered helper in would mean buffering the whole file first, defeating that streaming design — not a safe drop-in swap.
  - `next_part_index` mirrors the boundary check the JS `ended` handler (`super::interop`) makes at runtime, but that decision has to run synchronously in JS so the next part's `src` can be set with zero playback gap. Routing it through a Rust/WASM round-trip (`dioxus.send` + a response) would add audible latency at every part boundary.
- No behavior change to live upload or playback paths — doc-comment-only diff.

## Test plan
- [x] `cargo fmt --check` (workspace)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings`
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings`
- [x] `cargo test -p omnibus` — 613 passed, 2 pre-existing failures unrelated to this change (`commit_rejects_read_only_library_with_400`, `audiobook_commit_rejects_read_only_library_with_400` fail identically on `main` in this sandbox because the test process runs as root, which bypasses the `chmod 0o555` permission check the tests rely on)
- [x] `cargo test -p omnibus-frontend --features server` — 576 passed, including the existing `validate_file_bytes_*` and `next_part_index_*` unit tests

## Notes
- No code path behavior changed — this PR only replaces two doc comments to record the reasoning behind keeping each function intentionally unwired.


---
_Generated by [Claude Code](https://claude.ai/code/session_011kUujohWm91khGGNJgxLTM)_