### PR TITLE
docs: add pin-rationale comments for zip and sqlx (#1529)

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -11,11 +11,14 @@ license.workspace = true
 
 [dependencies]
 omnibus-shared = { path = "../shared" }
-# held at 0.8: 0.9 requires `impl SqlSafeStr` on every `query*()` call — the ~55
-# dynamic-SQL sites here (`sqlx::query(&sql)` / `&format!(...)`) would each need
-# an `AssertSqlSafe(...)` wrap, and the combined `runtime-tokio-rustls` feature
-# is split into `runtime-tokio` + `tls-rustls-*`. That's a nontrivial migration,
-# out of scope for this staleness bump; track it as a follow-up.
+# PIN RATIONALE (#1529): held at 0.8 — 0.9 requires `impl SqlSafeStr` on every
+# `query*()` call — the ~55 dynamic-SQL sites here (`sqlx::query(&sql)` /
+# `&format!(...)`) would each need an `AssertSqlSafe(...)` wrap, and the
+# combined `runtime-tokio-rustls` feature is split into `runtime-tokio` +
+# `tls-rustls-*`. That's a nontrivial migration, out of scope for this
+# staleness bump; lifting it means doing that migration deliberately, in
+# lockstep across `server/`, `db/`, and `frontend/` (see their matching
+# comments) — track it as a follow-up.
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "process", "io-util"] }
 anyhow = "1"
@@ -28,6 +31,14 @@ thiserror.workspace = true
 futures = "0.3"
 epub = "2"
 
+# PIN RATIONALE (#1529): frozen at v3 (current stable is several majors
+# ahead) pending a deliberate audit of the v4-v9 changelog against this
+# crate's untrusted-input parsing path — it reads user-uploaded EPUB and
+# audiobook zip archives via the "add your own books" path. Lifting it
+# means that audit plus re-verifying the `deflate-flate2`/`deflate` feature
+# names still resolve (they've moved across `zip` majors before), done in
+# lockstep with the `frontend/Cargo.toml` copy below so both stay unified.
+#
 # F5.8 export-with-overrides (#1372): the `epub` crate is read-only, so baking
 # DB metadata/cover overrides *into* the exported EPUB needs a zip *writer*. We
 # read-through the source archive and rewrite only the OPF + cover entries.

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -1,6 +1,6 @@
 # Dependency Audit — Cargo.lock Duplicate Families
 
-Last updated: 2026-07-30 (issue #1530; previously issues #1100, #1268, #1147, #643).
+Last updated: 2026-07-31 (issue #1529; previously issues #1530, #1100, #1268, #1147, #643).
 
 Run `cargo tree -d` and inspect the output any time Dioxus or Axum are bumped.
 The `deny.toml` `[bans]` section has matching `skip` entries for all accepted
@@ -44,6 +44,14 @@ this list.
 
 ## Policy
 
+- **Plain version-currency pins** (issue #1529): a dependency frozen behind
+  current stable earns a `# PIN RATIONALE: ...` comment at its pin site even
+  when it isn't part of a duplicate-family split — the same "explain, don't
+  silently drift" principle this doc has always applied to duplicates, now
+  extended to any deliberately-stale single-version pin (`zip`, `sqlx`,
+  `rusqlite`, `argon2`, etc.). State *why* the freeze is intentional and
+  *what* would need to change to lift it, so the next person to touch that
+  line doesn't have to reconstruct the reasoning from a git-blame.
 - **Adding a new crate:** check `cargo tree -d` after `cargo update`; any new duplicate must be classified here before the PR lands.
 - **Bumping Dioxus:** re-run this audit. The websocket and const-serialize clusters will be the first to collapse.
 - **Promoting `getrandom`:** when `argon2`/`password-hash` ship a version that supports `getrandom@0.3`, consolidate the 0.2 + 0.3 entries. Until then the three-way split is intentional.

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -48,8 +48,9 @@ js-sys = { version = "0.3", optional = true }
 # pulled in with no default features so each consuming feature opts into
 # only what it needs — mobile gets `sync` for `watch`, server gets the
 # multi-thread runtime + macros for `#[tokio::main]`-style usage in rpc.rs.
-# held at 0.8: see db/Cargo.toml — 0.9's SqlSafeStr requirement is a nontrivial
-# migration across the db crate; keep all three crates on 0.8 in lockstep.
+# PIN RATIONALE (#1529): held at 0.8 — see db/Cargo.toml for the full
+# SqlSafeStr migration rationale; keep all three crates (`server/`, `db/`,
+# `frontend/`) on 0.8 in lockstep, lifted only when that migration lands.
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"], optional = true }
 tokio = { workspace = true, optional = true }
 # Server-side structured logging for #[cfg(feature = "server")] code paths
@@ -78,6 +79,11 @@ tokio-util = { version = "0.7", default-features = false, features = ["io"], opt
 # version already resolved in Cargo.lock (avoids adding a third duplicate).
 getrandom = { version = "0.2", optional = true }
 
+# PIN RATIONALE (#1529): frozen at v3, same reasoning as db/Cargo.toml's zip
+# pin — mirrors the version already resolved transitively via `epub`, so
+# bumping here alone would just reintroduce the duplicate this pin avoids.
+# Lift both crates' `zip` deps together, after the v4-v9 changelog audit.
+#
 # Real ZIP validation for a downloaded EPUB: reading each member to EOF is
 # what checks the CRC-32 the central directory recorded for it, which is the
 # only thing that catches a same-length splice preserving the archive's

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -80,9 +80,12 @@ tokio-util = { version = "0.7", default-features = false, features = ["io"], opt
 getrandom = { version = "0.2", optional = true }
 
 # PIN RATIONALE (#1529): frozen at v3, same reasoning as db/Cargo.toml's zip
-# pin — mirrors the version already resolved transitively via `epub`, so
-# bumping here alone would just reintroduce the duplicate this pin avoids.
-# Lift both crates' `zip` deps together, after the v4-v9 changelog audit.
+# pin. This crate's `mobile` feature enables `dep:zip` directly, without
+# `dep:omnibus-db` — but building the workspace (or this crate's `server`
+# feature, which does pull in `omnibus-db`) resolves one shared `zip` via
+# Cargo's version unification, so bumping here alone, out of step with
+# `db/Cargo.toml`, would reintroduce that duplicate. Lift both crates' `zip`
+# deps together, after the v4-v9 changelog audit.
 #
 # Real ZIP validation for a downloaded EPUB: reading each member to EOF is
 # what checks the CRC-32 the central directory recorded for it, which is the

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,8 +24,9 @@ tower-http = { version = "0.7", features = ["trace", "timeout", "set-header", "f
 tower = { version = "0.5", optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-# held at 0.8: see db/Cargo.toml — 0.9's SqlSafeStr requirement is a nontrivial
-# migration across the db crate; keep all three crates on 0.8 in lockstep.
+# PIN RATIONALE (#1529): held at 0.8 — see db/Cargo.toml for the full
+# SqlSafeStr migration rationale; keep all three crates (`server/`, `db/`,
+# `frontend/`) on 0.8 in lockstep, lifted only when that migration lands.
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"], optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"], optional = true }
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
- Closes #1529
- `zip` (`db/Cargo.toml`, `frontend/Cargo.toml`) and `sqlx` (`server/Cargo.toml`, `db/Cargo.toml`, `frontend/Cargo.toml`) were pinned several majors/minors behind current stable with no documented rationale, unlike every other version-frozen dependency in this workspace (Dioxus, `rusqlite`, `lettre`, `pulldown-cmark`, `lofty`).
- Took the "smallest first" path the issue itself suggests: added `# PIN RATIONALE: ...` comments at all 5 pin sites (mirroring the existing `rusqlite` comment's style) explaining why each freeze is intentional and what would need to change to lift it. No version bumps — `zip` sits on an untrusted-input parsing boundary (user-uploaded EPUB/audiobook archives) and a major bump deserves its own dedicated PR with real upload-path testing, which this sandbox can't run.
- Bumped `docs/dependency-audit.md`'s "Last updated" line to reference #1529 and added a Policy note establishing that plain version-currency pins (not just duplicate families) get a rationale comment going forward.

## Test plan
- [x] `cargo fmt --check` — clean (comment-only change)
- [x] `cargo metadata --no-deps` — all three `Cargo.toml` files still parse correctly

## Notes
- Comment-only diff; no dependency versions changed. A follow-up PR to actually bump `zip`/`sqlx` (if desired) is out of scope here per the issue's own guidance that it needs dedicated upload-path testing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011kUujohWm91khGGNJgxLTM)_