### PR TITLE
refactor: split bulk-edit and hero components under line/prop caps

### DIFF
--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -56,10 +56,7 @@ fn BdWishlistBadge() -> Element {
     }
 }
 
-/// Breadcrumb trail + title-column kicker text, bundled to keep
-/// [`BdHeroSection`] under the 5-prop guideline (mirrors
-/// `physical::BdBookIdentity`, whose doc comment explains the pattern this
-/// one follows).
+/// Breadcrumb trail + title-column kicker text, grouped to keep [`BdHeroSection`] under the 5-prop guideline.
 #[derive(Clone, PartialEq)]
 pub(super) struct BdHeroChrome {
     pub kicker: String,

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -56,17 +56,27 @@ fn BdWishlistBadge() -> Element {
     }
 }
 
+/// Breadcrumb trail + title-column kicker text, bundled to keep
+/// [`BdHeroSection`] under the 5-prop guideline (mirrors
+/// `physical::BdBookIdentity`, whose doc comment explains the pattern this
+/// one follows).
+#[derive(Clone, PartialEq)]
+pub(super) struct BdHeroChrome {
+    pub kicker: String,
+    pub crumbs: Vec<BdCrumbItem>,
+}
+
 /// Hero section: breadcrumb, cover + format badges + tags, title + CTAs, and
 /// the rating rail card (rating, reading status, wishlist slot, shelves).
 #[component]
 pub(super) fn BdHeroSection(
     b: EbookMetadata,
     title: String,
-    kicker: String,
-    crumbs: Vec<BdCrumbItem>,
+    chrome: BdHeroChrome,
     avail: Availability,
     phys: PhysSignals,
 ) -> Element {
+    let BdHeroChrome { kicker, crumbs } = chrome;
     let uuid = b.unique_identifier.clone().unwrap_or_default();
     let on_wishlist = phys.wishlist.read().is_some();
     rsx! {

--- a/frontend/src/pages/book_detail/physical.rs
+++ b/frontend/src/pages/book_detail/physical.rs
@@ -111,6 +111,19 @@ pub(super) fn BdPhysicalPanel(
     }
 }
 
+/// Book-identity + mutation signals the two wishlist rail cards share,
+/// bundled so [`BdWishlistTrackingCard`] and [`BdWishlistAddCard`] each take
+/// one prop beyond their card-specific display fields (mirrors
+/// [`BdBookIdentity`]).
+#[derive(Clone, PartialEq)]
+struct WishlistCardState {
+    uuid: String,
+    server_url: String,
+    wishlist: Signal<Option<WishlistEntry>>,
+    busy: Signal<bool>,
+    err: Signal<Option<String>>,
+}
+
 /// Rail-card wishlist slot the hero embeds under the rating + reading-status
 /// blocks: the tracking card for a wishlisted book, or the add-to-wishlist
 /// affordance for a book with no physical copy. Renders nothing until the
@@ -139,65 +152,115 @@ pub(super) fn BdWishlistRailSlot(identity: BdBookIdentity, phys: PhysSignals) ->
         return rsx! {};
     }
 
-    let content = match entry {
-        Some(e) => {
-            let added = time_ago(now_unix(), e.added_at);
-            let source = source_label(e.source);
-            let find_url = find_a_copy_url(isbn.as_deref(), &title, &author);
-            let remove_url = server_url.clone();
-            let remove_uuid = uuid.clone();
-            rsx! {
-                div { class: "bd-wishlist-rail", "data-testid": "wishlist-card",
-                    p { class: "bd-wishlist-meta",
-                        "Tracking this title \u{00b7} added {added} from {source}"
-                    }
-                    div { class: "bd-wishlist-actions",
-                        a {
-                            class: "btn sm",
-                            "data-testid": "find-a-copy",
-                            href: "{find_url}",
-                            target: "_blank",
-                            rel: "noopener noreferrer",
-                            "Find a copy"
-                        }
-                        button {
-                            class: "btn ghost sm",
-                            "data-testid": "wishlist-remove",
-                            disabled: busy(),
-                            onclick: move |_| {
-                                remove_from_wishlist(
-                                    wishlist, busy, err, remove_url.clone(), remove_uuid.clone(),
-                                )
-                            },
-                            "Remove from wishlist"
-                        }
-                    }
-                }
-            }
-        }
-        None => rsx! {
-            div { class: "bd-wishlist-rail", "data-testid": "wishlist-add-card",
-                p { class: "bd-wishlist-add-blurb", "Track this title to find a physical copy later." }
-                button {
-                    class: "btn sm",
-                    "data-testid": "add-to-wishlist",
-                    disabled: busy(),
-                    onclick: move |_| add_to_wishlist(wishlist, busy, err, server_url.clone(), uuid.clone()),
-                    "Add to physical wishlist"
-                }
-            }
-        },
+    let state = WishlistCardState {
+        uuid,
+        server_url,
+        wishlist,
+        busy,
+        err,
     };
 
     rsx! {
         div { class: "divider" }
         div { class: "label bd-wishlist-head", "Physical wishlist" }
-        {content}
+        {render_wishlist_card(entry, isbn, title, author, state)}
         // Distinct testid from the panel's `physical-error`: both surfaces can
         // error at once (load failure + failed add/remove), and a shared id
         // would make Playwright selectors ambiguous.
         if let Some(e) = err.read().clone() {
             p { role: "alert", class: "bd-phys-error", "data-testid": "wishlist-error", "{e}" }
+        }
+    }
+}
+
+/// Selects the tracking-card view for a wishlisted book, or the
+/// add-affordance view for a book with none.
+fn render_wishlist_card(
+    entry: Option<WishlistEntry>,
+    isbn: Option<String>,
+    title: String,
+    author: String,
+    state: WishlistCardState,
+) -> Element {
+    match entry {
+        Some(e) => {
+            let added = time_ago(now_unix(), e.added_at);
+            let source = source_label(e.source).to_string();
+            let find_url = find_a_copy_url(isbn.as_deref(), &title, &author);
+            rsx! {
+                BdWishlistTrackingCard { added, source, find_url, state }
+            }
+        }
+        None => rsx! {
+            BdWishlistAddCard { state }
+        },
+    }
+}
+
+/// Tracking card for a wishlisted book: relative added-date + source, "Find a
+/// copy" link, and a remove action.
+#[component]
+fn BdWishlistTrackingCard(
+    added: String,
+    source: String,
+    find_url: String,
+    state: WishlistCardState,
+) -> Element {
+    let WishlistCardState {
+        uuid,
+        server_url,
+        wishlist,
+        busy,
+        err,
+    } = state;
+    rsx! {
+        div { class: "bd-wishlist-rail", "data-testid": "wishlist-card",
+            p { class: "bd-wishlist-meta",
+                "Tracking this title \u{00b7} added {added} from {source}"
+            }
+            div { class: "bd-wishlist-actions",
+                a {
+                    class: "btn sm",
+                    "data-testid": "find-a-copy",
+                    href: "{find_url}",
+                    target: "_blank",
+                    rel: "noopener noreferrer",
+                    "Find a copy"
+                }
+                button {
+                    class: "btn ghost sm",
+                    "data-testid": "wishlist-remove",
+                    disabled: busy(),
+                    onclick: move |_| {
+                        remove_from_wishlist(wishlist, busy, err, server_url.clone(), uuid.clone())
+                    },
+                    "Remove from wishlist"
+                }
+            }
+        }
+    }
+}
+
+/// Add-to-wishlist affordance for a book with no tracked entry.
+#[component]
+fn BdWishlistAddCard(state: WishlistCardState) -> Element {
+    let WishlistCardState {
+        uuid,
+        server_url,
+        wishlist,
+        busy,
+        err,
+    } = state;
+    rsx! {
+        div { class: "bd-wishlist-rail", "data-testid": "wishlist-add-card",
+            p { class: "bd-wishlist-add-blurb", "Track this title to find a physical copy later." }
+            button {
+                class: "btn sm",
+                "data-testid": "add-to-wishlist",
+                disabled: busy(),
+                onclick: move |_| add_to_wishlist(wishlist, busy, err, server_url.clone(), uuid.clone()),
+                "Add to physical wishlist"
+            }
         }
     }
 }

--- a/frontend/src/pages/book_detail/view.rs
+++ b/frontend/src/pages/book_detail/view.rs
@@ -233,8 +233,7 @@ pub(super) fn render_loaded(
                 BdHeroSection {
                     b: b.clone(),
                     title: title.clone(),
-                    kicker,
-                    crumbs,
+                    chrome: hero::BdHeroChrome { kicker, crumbs },
                     avail: hero::Availability {
                         has_ebook,
                         has_audio,

--- a/frontend/src/pages/landing.rs
+++ b/frontend/src/pages/landing.rs
@@ -775,8 +775,10 @@ fn web_landing_body(
                 bulk_edit::BulkEditModal {
                     uuids: bulk_uuids,
                     selected_books: bulk_books,
-                    author_suggestions: author_pool,
-                    tag_suggestions: tag_pool,
+                    suggestions: bulk_edit::BulkEditSuggestions {
+                        author_suggestions: author_pool,
+                        tag_suggestions: tag_pool,
+                    },
                     on_close: move |_| bulk_modal_open.set(false),
                     on_saved: move |updated: Vec<EbookMetadata>| {
                         install_updated_books(&mut books_sig, &mut shelf_books_sig, &updated);

--- a/frontend/src/pages/landing/bulk_edit.rs
+++ b/frontend/src/pages/landing/bulk_edit.rs
@@ -38,10 +38,7 @@ pub(super) fn BulkEditBar(
     }
 }
 
-/// The two suggestion pools the modal's chip editors read, bundled to keep
-/// [`BulkEditModal`] under the 5-prop guideline (mirrors
-/// `book_detail::physical::BdBookIdentity`, whose doc comment explains the
-/// pattern this one follows).
+/// The two suggestion pools the modal's chip editors read, grouped to keep [`BulkEditModal`] under the 5-prop guideline.
 #[derive(Clone, Copy, PartialEq)]
 pub(super) struct BulkEditSuggestions {
     pub author_suggestions: ReadSignal<Vec<SuggestionItem>>,

--- a/frontend/src/pages/landing/bulk_edit.rs
+++ b/frontend/src/pages/landing/bulk_edit.rs
@@ -38,6 +38,16 @@ pub(super) fn BulkEditBar(
     }
 }
 
+/// The two suggestion pools the modal's chip editors read, bundled to keep
+/// [`BulkEditModal`] under the 5-prop guideline (mirrors
+/// `book_detail::physical::BdBookIdentity`, whose doc comment explains the
+/// pattern this one follows).
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct BulkEditSuggestions {
+    pub author_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    pub tag_suggestions: ReadSignal<Vec<SuggestionItem>>,
+}
+
 /// The bulk-edit modal. Blank scalar fields leave every book unchanged;
 /// authors replace each book's full list; tags are add/remove deltas.
 /// On success fires `on_saved` with the server's merged metadata for every
@@ -46,8 +56,7 @@ pub(super) fn BulkEditBar(
 pub(super) fn BulkEditModal(
     uuids: Vec<String>,
     selected_books: Vec<EbookMetadata>,
-    author_suggestions: ReadSignal<Vec<SuggestionItem>>,
-    tag_suggestions: ReadSignal<Vec<SuggestionItem>>,
+    suggestions: BulkEditSuggestions,
     on_close: EventHandler<()>,
     on_saved: EventHandler<Vec<EbookMetadata>>,
 ) -> Element {
@@ -60,8 +69,8 @@ pub(super) fn BulkEditModal(
         add_tags: use_signal(Vec::<String>::new),
         remove_tags: use_signal(Vec::<String>::new),
     };
-    let mut busy = use_signal(|| false);
-    let mut error = use_signal(|| None::<String>);
+    let busy = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
 
     // Remove-tag candidates: the union of the selected books' current tags,
     // with per-tag counts — removing a tag no book carries is meaningless.
@@ -73,31 +82,7 @@ pub(super) fn BulkEditModal(
     let nothing_to_apply = fields.current_edit().is_empty();
     let count = uuids.len();
     let noun = if count == 1 { "book" } else { "books" };
-
-    let on_submit = move |_| {
-        if busy() {
-            return;
-        }
-        let edit = fields.current_edit();
-        if edit.is_empty() {
-            return;
-        }
-        if let Err(msg) = edit.validate() {
-            error.set(Some(msg));
-            return;
-        }
-        let url = server_url.clone();
-        let uuids = uuids.clone();
-        busy.set(true);
-        error.set(None);
-        spawn(async move {
-            match data::bulk_save_overrides(&url, uuids, &edit).await {
-                Ok(updated) => on_saved.call(updated),
-                Err(e) => error.set(Some(format!("Save failed: {e}"))),
-            }
-            busy.set(false);
-        });
-    };
+    let on_submit = build_bulk_edit_submit(server_url, uuids, fields, busy, error, on_saved);
 
     rsx! {
         ConfirmModal {
@@ -110,8 +95,8 @@ pub(super) fn BulkEditModal(
             p { class: "bulk-edit-hint", "Blank fields are left unchanged on every book." }
             BulkEditFields {
                 fields,
-                author_suggestions,
-                tag_suggestions,
+                author_suggestions: suggestions.author_suggestions,
+                tag_suggestions: suggestions.tag_suggestions,
                 removable_pool,
             }
             if let Some(msg) = error() {
@@ -137,6 +122,44 @@ pub(super) fn BulkEditModal(
             }
         }
     }
+}
+
+/// Builds the bulk-edit submit handler: snapshots and validates the current
+/// field state, then saves it and reports the merged metadata back through
+/// `error`/`busy`/`on_saved`. Mirrors
+/// `create_shelf_modal::build_on_submit`.
+fn build_bulk_edit_submit(
+    server_url: String,
+    uuids: Vec<String>,
+    fields: BulkEditFieldSignals,
+    mut busy: Signal<bool>,
+    mut error: Signal<Option<String>>,
+    on_saved: EventHandler<Vec<EbookMetadata>>,
+) -> EventHandler<MouseEvent> {
+    EventHandler::new(move |_| {
+        if busy() {
+            return;
+        }
+        let edit = fields.current_edit();
+        if edit.is_empty() {
+            return;
+        }
+        if let Err(msg) = edit.validate() {
+            error.set(Some(msg));
+            return;
+        }
+        let url = server_url.clone();
+        let uuids = uuids.clone();
+        busy.set(true);
+        error.set(None);
+        spawn(async move {
+            match data::bulk_save_overrides(&url, uuids, &edit).await {
+                Ok(updated) => on_saved.call(updated),
+                Err(e) => error.set(Some(format!("Save failed: {e}"))),
+            }
+            busy.set(false);
+        });
+    })
 }
 
 /// The modal's six field signals, grouped so [`BulkEditModal`] and


### PR DESCRIPTION
## Summary
- `BulkEditModal` (`frontend/src/pages/landing/bulk_edit.rs`) was ~95 lines with 6 props; its submit handler is now `build_bulk_edit_submit` (mirrors `create_shelf_modal::build_on_submit`), and the two suggestion `ReadSignal`s are grouped into a new `BulkEditSuggestions` struct. The component is now 70 lines / 5 props.
- `BdWishlistRailSlot` (`frontend/src/pages/book_detail/physical.rs`) was ~84 lines with both the "tracking this title" and "add to wishlist" rsx branches inline; they're now split into `BdWishlistTrackingCard` and `BdWishlistAddCard`, sharing a `WishlistCardState` grouping struct. The slot itself is now 42 lines.
- `BdHeroSection` (`frontend/src/pages/book_detail/hero.rs`) had 6 props; `kicker` + `crumbs` are now grouped into a new `BdHeroChrome` struct, landing at 5 props.
- Both new grouping structs (`BulkEditSuggestions`, `WishlistCardState`, `BdHeroChrome`) follow the existing `BdBookIdentity` pattern already documented in `physical.rs`.
- Pure refactor — no behavior change, no markup/testid changes.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (596 passed; 0 failed)

Closes #1577

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- No functional/markup change — every rsx `data-testid` and CSS class is preserved verbatim, so no Playwright spec needed updating.

---
_Generated by [Claude Code](https://claude.ai/code/session_01REKzzanmr82ABC9ZSVY9tH)_