### PR TITLE
fix: batch bulk metadata-override merge queries to bound write-lock hold time

### DIFF
--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -1887,3 +1887,90 @@ async fn bulk_merge_metadata_overrides_rebuilds_fts_for_each_book() {
         );
     }
 }
+
+#[tokio::test]
+async fn bulk_merge_metadata_overrides_applies_correctly_across_a_batch_past_the_chunk_boundary() {
+    // #1576: both the pre-tx effective-subjects fetch and the in-tx
+    // metadata_overrides read are chunked at 500 uuids. Seed one book past a
+    // single chunk (520) so this exercises the two-chunk path for both
+    // batch queries, not just the common single-chunk case.
+    //
+    // sqlx has no query-counter hook to assert round-trip *count* directly,
+    // so this test asserts the batched implementation's *correctness* at
+    // chunk-boundary scale instead — every one of the 520 books, including
+    // one that straddles the chunk boundary with a pre-existing override,
+    // must come out right. This is the accepted approach per #1576's
+    // acceptance criteria (an exact query-count assertion was judged
+    // impractical without new test-only instrumentation).
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    const BOOK_COUNT: usize = 520;
+    let books: Vec<_> = (0..BOOK_COUNT)
+        .map(|i| {
+            indexed(
+                &format!("book-{i:04}.epub"),
+                Some(&format!("Title {i}")),
+                &["Old Author"],
+                &["shared"],
+                None,
+                None,
+            )
+        })
+        .collect();
+    replace_books(&pool, "/lib", books).await.unwrap();
+    let mut seeded = list_books(&pool, "/lib").await.unwrap();
+    seeded.sort_by(|a, b| a.filename.cmp(&b.filename));
+    assert_eq!(seeded.len(), BOOK_COUNT);
+    let uuids: Vec<String> = seeded
+        .iter()
+        .map(|b| b.unique_identifier.clone().unwrap())
+        .collect();
+
+    // Give one book past the first 500-uuid chunk boundary a pre-existing
+    // override with its own subjects, so the in-tx override-row batch read
+    // (not just the pre-tx effective-subjects fetch) is exercised for a
+    // second-chunk uuid too.
+    let boundary_uuid = uuids[510].clone();
+    merge_metadata_overrides(
+        &pool,
+        &boundary_uuid,
+        &MetadataOverrides {
+            subjects: Some(vec!["preexisting".into()]),
+            ..Default::default()
+        },
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let edit = BulkMetadataEdit {
+        publisher: Some("Batch House".into()),
+        add_tags: vec!["bulklabel".into()],
+        remove_tags: vec!["shared".into(), "preexisting".into()],
+        ..Default::default()
+    };
+    bulk_merge_metadata_overrides(&pool, &uuids, &edit, user_id)
+        .await
+        .unwrap();
+
+    let merged = list_books(&pool, "/lib").await.unwrap();
+    assert_eq!(merged.len(), BOOK_COUNT);
+    for book in &merged {
+        assert_eq!(
+            book.publisher,
+            Some("Batch House".into()),
+            "book {:?} missed the bulk publisher edit",
+            book.unique_identifier
+        );
+        assert_eq!(
+            book.subjects,
+            vec!["bulklabel".to_string()],
+            "book {:?} has the wrong effective subjects after the bulk tag delta",
+            book.unique_identifier
+        );
+    }
+}

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -1890,18 +1890,8 @@ async fn bulk_merge_metadata_overrides_rebuilds_fts_for_each_book() {
 
 #[tokio::test]
 async fn bulk_merge_metadata_overrides_applies_correctly_across_a_batch_past_the_chunk_boundary() {
-    // #1576: both the pre-tx effective-subjects fetch and the in-tx
-    // metadata_overrides read are chunked at 500 uuids. Seed one book past a
-    // single chunk (520) so this exercises the two-chunk path for both
-    // batch queries, not just the common single-chunk case.
-    //
-    // sqlx has no query-counter hook to assert round-trip *count* directly,
-    // so this test asserts the batched implementation's *correctness* at
-    // chunk-boundary scale instead — every one of the 520 books, including
-    // one that straddles the chunk boundary with a pre-existing override,
-    // must come out right. This is the accepted approach per #1576's
-    // acceptance criteria (an exact query-count assertion was judged
-    // impractical without new test-only instrumentation).
+    // Both batch fetches chunk at 500 uuids; 520 books exercises the
+    // two-chunk path for each, including a boundary-straddling override.
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
         .await

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -339,10 +339,9 @@ async fn merge_one_in_tx(
 /// would have created the override row this transaction reads, so the
 /// pre-tx fetch cannot serve a stale base). Both the pre-tx effective-subjects
 /// fetch and the in-tx override-row read are batched via chunked `IN (...)`
-/// queries (mirroring [`load_overrides_bulk`]) rather than looped per uuid,
-/// so a 2000-book selection holds the write lock for a handful of round
-/// trips instead of one per book (#1576). FTS rebuilds run best-effort per
-/// book after commit, matching [`merge_metadata_overrides`].
+/// queries (mirroring [`load_overrides_bulk`]) rather than looped per uuid.
+/// FTS rebuilds run best-effort per book after commit, matching
+/// [`merge_metadata_overrides`].
 pub async fn bulk_merge_metadata_overrides(
     pool: &SqlitePool,
     uuids: &[String],
@@ -365,9 +364,10 @@ pub async fn bulk_merge_metadata_overrides(
         if has_tag_deltas {
             // The in-tx override row wins as the tag base; the pre-tx fetch
             // only covers books with no subjects override at all.
-            let override_subjects = override_rows.get(uuid).and_then(|ov| ov.subjects.clone());
+            let override_subjects = override_rows
+                .get(uuid)
+                .and_then(|ov| ov.subjects.as_deref());
             let base = override_subjects
-                .as_deref()
                 .or(effective_subjects.get(uuid).map(Vec::as_slice))
                 .unwrap_or_default();
             let subjects = edit.apply_tags(base);
@@ -393,13 +393,11 @@ pub async fn bulk_merge_metadata_overrides(
 
 /// Batch-resolve the effective (scanned + override-merged) `subjects` for a
 /// whole uuid set, for [`bulk_merge_metadata_overrides`]'s pre-transaction
-/// tag-delta base. Two chunked bulk queries regardless of batch size —
+/// tag-delta base. Chunked bulk queries regardless of batch size —
 /// [`resolve_book_ids_bulk`] then [`get_books_by_ids`], the same
-/// join-in-memory pattern [`super::fts::rebuild_fts_for_books_batch`] uses —
-/// replacing the former `get_book_by_uuid` call per uuid. A uuid absent from
-/// either step (unknown, or resolved to a book row that vanished
-/// concurrently) fails the whole call with `BookNotFound`, matching the
-/// former per-uuid loop's behavior.
+/// join-in-memory pattern [`super::fts::rebuild_fts_for_books_batch`] uses.
+/// A uuid absent from either step (unknown, or resolved to a book row that
+/// vanished concurrently) fails the whole call with `BookNotFound`.
 async fn effective_subjects_bulk(
     pool: &SqlitePool,
     uuids: &[String],
@@ -434,9 +432,7 @@ async fn effective_subjects_bulk(
 /// `metadata_overrides.overrides` for a whole uuid set on the caller's open
 /// transaction, chunked the same way, so [`bulk_merge_metadata_overrides`]'s
 /// per-book tag-delta base comes from one pre-loaded `HashMap` instead of a
-/// `SELECT … WHERE book_uuid = ?` per uuid — the second half of #1576's
-/// fix, bounding the `BEGIN IMMEDIATE` write-lock hold time instead of
-/// letting it scale linearly with the selection size.
+/// `SELECT … WHERE book_uuid = ?` per uuid.
 async fn load_overrides_bulk_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     uuids: &[String],

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use omnibus_shared::{BulkMetadataEdit, EbookMetadata, MetadataOverrides, MetadataSource};
 use sqlx::{Executor, SqliteConnection, SqlitePool};
 
-use crate::books::resolve_book_id_by_uuid_exec;
+use crate::books::{get_books_by_ids, resolve_book_id_by_uuid_exec, resolve_book_ids_bulk};
 use crate::normalize::{normalize_author, normalize_title};
 use crate::sync::upsert_fts;
 
@@ -337,38 +337,35 @@ async fn merge_one_in_tx(
 /// metadata fetched just before the transaction (equal to the scanned
 /// subjects when no override exists — and any concurrent subjects write
 /// would have created the override row this transaction reads, so the
-/// pre-tx fetch cannot serve a stale base). FTS rebuilds run best-effort
-/// per book after commit, matching [`merge_metadata_overrides`].
+/// pre-tx fetch cannot serve a stale base). Both the pre-tx effective-subjects
+/// fetch and the in-tx override-row read are batched via chunked `IN (...)`
+/// queries (mirroring [`load_overrides_bulk`]) rather than looped per uuid,
+/// so a 2000-book selection holds the write lock for a handful of round
+/// trips instead of one per book (#1576). FTS rebuilds run best-effort per
+/// book after commit, matching [`merge_metadata_overrides`].
 pub async fn bulk_merge_metadata_overrides(
     pool: &SqlitePool,
     uuids: &[String],
     edit: &BulkMetadataEdit,
     user_id: i64,
 ) -> Result<(), MetadataOverridesError> {
-    let mut effective_subjects = HashMap::with_capacity(uuids.len());
-    for uuid in uuids {
-        let book = crate::books::get_book_by_uuid(pool, uuid)
-            .await?
-            .ok_or_else(|| MetadataOverridesError::BookNotFound(uuid.clone()))?;
-        effective_subjects.insert(uuid.clone(), book.subjects);
-    }
+    let effective_subjects = effective_subjects_bulk(pool, uuids).await?;
 
     let has_tag_deltas = !edit.add_tags.is_empty() || !edit.remove_tags.is_empty();
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+    // Pre-loaded once for the whole batch, chunked, instead of a
+    // `SELECT … WHERE book_uuid = ?` per uuid inside the loop below.
+    let override_rows = if has_tag_deltas {
+        load_overrides_bulk_tx(&mut tx, uuids).await?
+    } else {
+        HashMap::new()
+    };
     for uuid in uuids {
         let mut incoming = edit.scalar_overrides();
         if has_tag_deltas {
             // The in-tx override row wins as the tag base; the pre-tx fetch
             // only covers books with no subjects override at all.
-            let row_subjects: Option<String> =
-                sqlx::query_scalar("SELECT overrides FROM metadata_overrides WHERE book_uuid = ?")
-                    .bind(uuid.as_str())
-                    .fetch_optional(&mut *tx)
-                    .await?;
-            let override_subjects = match row_subjects {
-                Some(json) => serde_json::from_str::<MetadataOverrides>(&json)?.subjects,
-                None => None,
-            };
+            let override_subjects = override_rows.get(uuid).and_then(|ov| ov.subjects.clone());
             let base = override_subjects
                 .as_deref()
                 .or(effective_subjects.get(uuid).map(Vec::as_slice))
@@ -392,6 +389,85 @@ pub async fn bulk_merge_metadata_overrides(
         }
     }
     Ok(())
+}
+
+/// Batch-resolve the effective (scanned + override-merged) `subjects` for a
+/// whole uuid set, for [`bulk_merge_metadata_overrides`]'s pre-transaction
+/// tag-delta base. Two chunked bulk queries regardless of batch size —
+/// [`resolve_book_ids_bulk`] then [`get_books_by_ids`], the same
+/// join-in-memory pattern [`super::fts::rebuild_fts_for_books_batch`] uses —
+/// replacing the former `get_book_by_uuid` call per uuid. A uuid absent from
+/// either step (unknown, or resolved to a book row that vanished
+/// concurrently) fails the whole call with `BookNotFound`, matching the
+/// former per-uuid loop's behavior.
+async fn effective_subjects_bulk(
+    pool: &SqlitePool,
+    uuids: &[String],
+) -> Result<HashMap<String, Vec<String>>, MetadataOverridesError> {
+    let id_map = resolve_book_ids_bulk(pool, uuids).await?;
+    let mut ids: Vec<i64> = id_map.values().copied().collect();
+    ids.sort_unstable();
+    ids.dedup();
+
+    let subjects_by_id: HashMap<i64, Vec<String>> = get_books_by_ids(pool, &ids)
+        .await?
+        .into_iter()
+        .map(|b| (b.id, b.subjects))
+        .collect();
+
+    let mut out = HashMap::with_capacity(uuids.len());
+    for uuid in uuids {
+        let id = id_map
+            .get(uuid)
+            .copied()
+            .ok_or_else(|| MetadataOverridesError::BookNotFound(uuid.clone()))?;
+        let subjects = subjects_by_id
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| MetadataOverridesError::BookNotFound(uuid.clone()))?;
+        out.insert(uuid.clone(), subjects);
+    }
+    Ok(out)
+}
+
+/// Tx-scoped counterpart to [`load_overrides_bulk`]: batch-read
+/// `metadata_overrides.overrides` for a whole uuid set on the caller's open
+/// transaction, chunked the same way, so [`bulk_merge_metadata_overrides`]'s
+/// per-book tag-delta base comes from one pre-loaded `HashMap` instead of a
+/// `SELECT … WHERE book_uuid = ?` per uuid — the second half of #1576's
+/// fix, bounding the `BEGIN IMMEDIATE` write-lock hold time instead of
+/// letting it scale linearly with the selection size.
+async fn load_overrides_bulk_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    uuids: &[String],
+) -> Result<HashMap<String, MetadataOverrides>, sqlx::Error> {
+    let mut map = HashMap::with_capacity(uuids.len());
+    for chunk in uuids.chunks(500) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT book_uuid, overrides FROM metadata_overrides WHERE book_uuid IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String, String)>(&sql);
+        for uuid in chunk {
+            q = q.bind(uuid);
+        }
+        let rows = q.fetch_all(&mut **tx).await?;
+        for (uuid, json) in rows {
+            match serde_json::from_str::<MetadataOverrides>(&json) {
+                Ok(ov) => {
+                    map.insert(uuid, ov);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        book_uuid = %uuid,
+                        error = %e,
+                        "corrupt metadata_overrides JSON — skipping row"
+                    );
+                }
+            }
+        }
+    }
+    Ok(map)
 }
 
 /// Load overrides for a single book UUID. Returns `None` if no overrides


### PR DESCRIPTION
## Summary
- `bulk_merge_metadata_overrides` (bulk edit on the landing table) previously ran a sequential per-uuid query loop both **before** and **inside** a single `BEGIN IMMEDIATE` transaction: one `get_book_by_uuid` call per uuid to build the pre-tx `effective_subjects` map, and one `SELECT overrides FROM metadata_overrides WHERE book_uuid = ?` per uuid inside the transaction for tag-delta bases. For a 2000-book selection that's ~2000+ round trips held under SQLite's single-writer lock, blocking every other writer for the duration.
- Replaced both loops with chunked `IN (...)` batch fetches (500 uuids/chunk), mirroring the existing `load_overrides_bulk` pattern a few functions above it in the same file:
  - The pre-tx effective-subjects fetch now goes through a new `effective_subjects_bulk` helper, composing the already-existing `resolve_book_ids_bulk` + `get_books_by_ids` bulk primitives (the same join-in-memory pattern `metadata_overrides::fts::rebuild_fts_for_books_batch` already uses) instead of `get_book_by_uuid` per uuid.
  - The in-tx per-uuid override-row read is now a new `load_overrides_bulk_tx` helper that batch-loads every `metadata_overrides` row for the whole selection into a `HashMap` right after `BEGIN IMMEDIATE`, so the per-uuid loop reads from memory instead of issuing a query per book. This keeps the read inside the same write-locked critical section as before (so it still can't race a concurrent writer creating an override row mid-batch), it's just 1–4 chunked queries instead of up to 2000.
- `merge_one_in_tx` (shared with the single-book `merge_metadata_overrides` path) is untouched — it still runs once per book inside the loop, as expected.

## Test plan
- [x] `cargo fmt --check -p omnibus-db` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1654 passed, 1 unrelated pre-existing failure: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails because the `test_data/audiobooks/public_domain` fixture asset isn't present in this environment — a `just fixtures` download, unrelated to this change)
- [x] New test `bulk_merge_metadata_overrides_applies_correctly_across_a_batch_past_the_chunk_boundary` seeds 520 books (past the 500-uuid chunk boundary for both new batch helpers), gives one book past the boundary a pre-existing override so the in-tx batch read is exercised on a second-chunk uuid too, then asserts every book's scalar + tag-delta result is correct after the bulk edit. sqlx has no query-counter hook to assert round-trip *count* directly, so this asserts the batched implementation's *correctness* at chunk-boundary scale instead (documented inline in the test).

Closes #1576

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Known pre-existing local flakes if seen in CI (not from this change): `worker::tests::poisoned_completions/progress_lock_recovers_*`, `backend::uploads::tests::inspect_allows_non_admin_with_can_upload`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REKzzanmr82ABC9ZSVY9tH)_