### PR TITLE
fix: keep mini player from overlapping scroll content

### DIFF
--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -103,6 +103,7 @@ struct BookDetailView: View {
 
     @Environment(\.palette) private var palette
     @Environment(AppState.self) private var app
+    @Environment(AudioPlayer.self) private var player
     @Environment(\.bookZoomNamespace) private var bookZoom
     @State private var model = BookDetailModel()
     @State private var showJournalComposer = false
@@ -229,7 +230,15 @@ struct BookDetailView: View {
                     }
                     .screenPadding()
                     .padding(.top, Spacing.xl)
-                    .padding(.bottom, 48)
+                    // 48 clears the docked tab bar on its own; that fixed
+                    // value doesn't grow when the audio mini player docks
+                    // above it mid-navigation, so the last section (often
+                    // Journal) renders under the bar with no gap (#1482).
+                    // Reserving the bar's own height here — rather than
+                    // trusting it to arrive via the ancestor `TabView`'s
+                    // `safeAreaInset` — is what `ReaderView` already does
+                    // for the same bar.
+                    .padding(.bottom, 48 + (player.isActive ? MiniPlayerBar.reservedHeight : 0))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(palette.bg0Color)
                 }

--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -543,6 +543,14 @@ struct MiniPlayerBar: View {
     /// book underneath stays open.
     var onExpand: (() -> Void)? = nil
 
+    /// The bar's own on-screen height: the 2pt progress rail, plus the button
+    /// row's 9+9 vertical padding, plus its tallest element — the 34pt-wide
+    /// cover at its native 2:3 aspect (51pt). Screens that reserve their own
+    /// clearance for the docked bar rather than trusting an ancestor
+    /// `safeAreaInset` to reach them (see `BookDetailView`, #1482) use this
+    /// so the two never drift apart.
+    static let reservedHeight: CGFloat = 72
+
     var body: some View {
         if let book = player.book {
             VStack(spacing: 0) {

--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -543,13 +543,28 @@ struct MiniPlayerBar: View {
     /// book underneath stays open.
     var onExpand: (() -> Void)? = nil
 
-    /// The bar's own on-screen height: the 2pt progress rail, plus the button
-    /// row's 9+9 vertical padding, plus its tallest element — the 34pt-wide
-    /// cover at its native 2:3 aspect (51pt). Screens that reserve their own
-    /// clearance for the docked bar rather than trusting an ancestor
-    /// `safeAreaInset` to reach them (see `BookDetailView`, #1482) use this
-    /// so the two never drift apart.
-    static let reservedHeight: CGFloat = 72
+    /// Height of the hairline progress rail along the top edge.
+    private static let progressRailHeight: CGFloat = 2
+    /// Top and bottom padding around the button row's content.
+    private static let buttonRowVerticalPadding: CGFloat = 9
+    /// Width the cover is pinned to in the button row.
+    private static let coverWidth: CGFloat = 34
+    /// `BookCover`'s fixed width:height aspect (see `BookCover`'s
+    /// `.aspectRatio(2.0 / 3.0, contentMode: .fit)`) — the cover is the
+    /// button row's tallest element, so this is what actually sets its height.
+    private static let coverAspectRatio: CGFloat = 2.0 / 3.0
+
+    /// The bar's own on-screen height, derived from the same constants its
+    /// `body` lays out with — the progress rail, the button row's vertical
+    /// padding, and the cover's height at its fixed aspect ratio — so a later
+    /// tweak to any of those moves this with it instead of drifting out of
+    /// sync. Screens that reserve their own clearance for the docked bar
+    /// rather than trusting an ancestor `safeAreaInset` to reach them (see
+    /// `BookDetailView`, #1482) use this.
+    static let reservedHeight: CGFloat =
+        progressRailHeight
+        + buttonRowVerticalPadding * 2
+        + coverWidth / coverAspectRatio
 
     var body: some View {
         if let book = player.book {
@@ -561,7 +576,7 @@ struct MiniPlayerBar: View {
                 ProgressBar(
                     fraction: player.duration > 0 ? player.position / player.duration : 0,
                     tint: palette.accentColor,
-                    height: 2
+                    height: Self.progressRailHeight
                 )
 
                 Button {
@@ -574,7 +589,7 @@ struct MiniPlayerBar: View {
                 } label: {
                     HStack(spacing: 11) {
                         BookCover(identity: CoverIdentity(book), size: .sm, cornerRadius: 4)
-                            .frame(width: 34)
+                            .frame(width: Self.coverWidth)
 
                         VStack(alignment: .leading, spacing: 1) {
                             Text(book.displayTitle)
@@ -598,7 +613,7 @@ struct MiniPlayerBar: View {
                             .accessibilityLabel("Stop playback")
                     }
                     .padding(.horizontal, Spacing.screen)
-                    .padding(.vertical, 9)
+                    .padding(.vertical, Self.buttonRowVerticalPadding)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Root cause: `BookDetailView`'s scrollable content (`omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift`) reserved a fixed `.padding(.bottom, 48)` below its last section, sized only for the docked `OmnibusTabBar`. That fixed value never grows when the audio `MiniPlayerBar` docks above the tab bar mid-navigation (e.g. you start listening from the very book detail page you're on), so the last section — often the "Start a journal" card — renders with no gap and gets visually cut off/obscured by the bar, exactly as reported on TestFlight build 50.
- `BookDetailView` is pushed via `NavigationStack.navigationDestination` (not a `.sheet`/`.fullScreenCover`), so in principle it inherits `MainTabView`'s `TabView`-level `.safeAreaInset(edge: .bottom)`. But `ReaderView` — which docks the *same* `MiniPlayerBar` — does not rely on that inheritance either; it declares its own local `.safeAreaInset` for it (see `omnibus-ios/omnibus/Reader/ReaderView.swift`, added for #1531/#1133) precisely because it's presented via `.fullScreenCover`, a boundary that resets inherited safe area. `BookDetailView` had no equivalent local reservation at all, and a fixed constant that predates the mini player feature is the concrete, verifiable gap: it accounts for the tab bar only, never for the bar's own height, regardless of what does or doesn't propagate down through the push.
- Fix: `BookDetailView` now reads `AudioPlayer.isActive` directly (same `@Environment(AudioPlayer.self)` used by `MainTabView`/`ReaderView`/`MiniPlayerBar` itself) and adds `MiniPlayerBar.reservedHeight` (a new documented constant on `MiniPlayerBar`, derived from its own layout: 2pt progress rail + 9+9pt button-row padding + its tallest element, the 34pt-wide cover at its native 2:3 aspect ≈ 51pt) to the existing bottom padding whenever the player is docked. This mirrors the pattern `ReaderView` already established for the same bar, and is additive-only: in the (expected-safe) case where the ancestor's `safeAreaInset` already does reserve enough room, this only adds a little extra breathing room at the very bottom of the scroll content — it can't reduce the space Book Detail had before, and it directly targets the reported overlap.

## Test plan
- **No local Xcode/simulator available in this environment — verified by code review only** (traced the view hierarchy from `MainTabView`'s `TabView` → `NavigationStack` → `navigationDestination(.book)` → `BookDetailView`, confirmed brace/paren balance in both edited files, and cross-checked the fix against the existing `ReaderView` precedent for the same `MiniPlayerBar`). CI's `ios-tests.yml` (`omnibusTests` / `omnibusUITests` on a real simulator) is the real build/compile gate for this change, along with a manual TestFlight check that the "Start a journal" card (and any other trailing section) is fully visible and scrollable clear of the docked mini player on a book detail page while an audiobook is playing.

Closes #1482

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Follow-up worth considering (out of scope here): other pushed destinations under the tab shell (author/series/tags/etc.) share the same `TabView`-level `safeAreaInset` dependency and could, in principle, exhibit the same class of issue if their content reaches the very bottom of the screen while the mini player is docked. This PR fixes the specific reported screen; a broader fix (e.g. a shared environment value every scrollable screen reads) would be a separate change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REKzzanmr82ABC9ZSVY9tH)_