### PR TITLE
test: add VirtualDom component tests for mobile UI (#888)

### DIFF
--- a/frontend/src/components/format_switcher/kindle.rs
+++ b/frontend/src/components/format_switcher/kindle.rs
@@ -203,3 +203,35 @@ mod tests {
         assert!(html.contains("class=\"btn ghost lg\""));
     }
 }
+
+// The mobile arm of `send_to_kindle_action` above is a plain hookless
+// function (no `use_signal`/context), so `test_support::render` can
+// serialize its `Element` directly with no `VirtualDom` needed — unlike the
+// interactive `SendToKindleButton` tests above, this exercises the
+// `#[cfg(feature = "mobile")]` half of the split (rule 07 worked example),
+// so it needs `mobile` *and* `server` together:
+// `cargo test -p omnibus-frontend --features mobile,server` (see
+// `crate::test_support` for the pattern writeup).
+#[cfg(all(test, feature = "mobile", feature = "server"))]
+mod mobile_render_tests {
+    use crate::test_support::render;
+
+    #[test]
+    fn send_to_kindle_action_renders_a_disabled_mobile_placeholder() {
+        let html = render(super::send_to_kindle_action("book-uuid", None, 0));
+        assert!(html.contains("data-testid=\"action-kindle\""));
+        assert!(html.contains("disabled"));
+        assert!(html.contains("Send to Kindle"));
+        assert!(html.contains("Send-to-Kindle on mobile coming soon"));
+    }
+
+    // The mobile placeholder ignores `size_bytes` entirely (no oversize-link
+    // branch on this platform), so a size that would trip the oversize link
+    // off-mobile still renders the same plain disabled button.
+    #[test]
+    fn send_to_kindle_action_ignores_size_bytes_on_mobile() {
+        let html = render(super::send_to_kindle_action("book-uuid", Some(3), i64::MAX));
+        assert!(html.contains("data-testid=\"action-kindle\""));
+        assert!(!html.contains("action-kindle-oversize"));
+    }
+}

--- a/frontend/src/components/format_switcher/kobo/tests.rs
+++ b/frontend/src/components/format_switcher/kobo/tests.rs
@@ -125,3 +125,28 @@ fn kobo_path_segment_leaves_non_reserved_lookalikes_alone() {
     );
     assert_eq!(super::kobo_path_segment("Conan").as_deref(), Some("Conan"));
 }
+
+// `send_to_kobo_action`'s mobile arm is a plain hookless function, so
+// `test_support::render` serializes its `Element` with no `VirtualDom`
+// needed. Exercises the `#[cfg(feature = "mobile")]` half of the split (rule
+// 07 worked example, mirroring `format_switcher::kindle`'s equivalent test);
+// needs `mobile` *and* `server` together:
+// `cargo test -p omnibus-frontend --features mobile,server`.
+#[cfg(all(test, feature = "mobile", feature = "server"))]
+mod mobile_render_tests {
+    use super::super::send_to_kobo_action;
+    use crate::test_support::render;
+
+    #[test]
+    fn send_to_kobo_action_renders_a_disabled_mobile_placeholder() {
+        let html = render(send_to_kobo_action(
+            "book-uuid",
+            "Ada Lovelace",
+            "Notes on the Engine",
+        ));
+        assert!(html.contains("data-testid=\"action-kobo\""));
+        assert!(html.contains("disabled"));
+        assert!(html.contains("Send to Kobo"));
+        assert!(html.contains("Send-to-Kobo coming soon"));
+    }
+}

--- a/frontend/src/pages/listen/mobile/sheets.rs
+++ b/frontend/src/pages/listen/mobile/sheets.rs
@@ -449,6 +449,31 @@ mod tests {
             // has been passed and picks up the check mark.
             assert!(!first.contains("m-ch-trail m-ch-done"));
             assert!(second.contains("m-ch-trail m-ch-done"));
+
+            // The `current` row class and the playing marker sit on whichever
+            // row is `current_index`. HTML preserves chapter order (Intro,
+            // then Part One), so "current appears before Part One" /
+            // "current appears after Intro" pins it to the right row without
+            // needing a DOM query.
+            assert!(first.contains("m-ch-trail m-ch-playing"));
+            let first_current = first
+                .find("m-ch-row current")
+                .expect("current_index 0 should mark a row current");
+            let first_part_one = first.find("Part One").expect("Part One should render");
+            assert!(
+                first_current < first_part_one,
+                "at current_index 0 the current row should be Intro, before Part One"
+            );
+
+            assert!(second.contains("m-ch-trail m-ch-playing"));
+            let second_current = second
+                .find("m-ch-row current")
+                .expect("current_index 1 should mark a row current");
+            let second_intro = second.find("Intro").expect("Intro should render");
+            assert!(
+                second_current > second_intro,
+                "at current_index 1 the current row should be Part One, after Intro"
+            );
         }
     }
 }

--- a/frontend/src/pages/listen/mobile/sheets.rs
+++ b/frontend/src/pages/listen/mobile/sheets.rs
@@ -330,4 +330,125 @@ mod tests {
             0
         ));
     }
+
+    // `VirtualDom`-render tests for the sheet primitives: build a zero-prop
+    // harness component (mirrors `contexts::tests::AssertBustCounter`), drive
+    // it through a real `VirtualDom`, and assert on the SSR'd HTML. This file
+    // only compiles under `mobile` (via the parent `mobile` module's
+    // `#![cfg(feature = "mobile")]`), so these already exercise mobile-only
+    // markup; the `server` gate below is what additionally brings in
+    // `dioxus::ssr` to serialize it — run with
+    // `cargo test -p omnibus-frontend --features mobile,server` (see
+    // `crate::test_support` for the pattern writeup).
+    #[cfg(feature = "server")]
+    mod render {
+        use super::*;
+        use crate::test_support::render_in_vdom;
+
+        fn chapter(ordinal: i64, title: &str, start: f64, dur: f64) -> ChapterInfo {
+            ChapterInfo {
+                ordinal,
+                title: title.into(),
+                start_seconds: start,
+                duration_seconds: dur,
+            }
+        }
+
+        #[test]
+        fn m_sheet_renders_title_testid_and_children_with_no_meta() {
+            fn harness() -> Element {
+                rsx! {
+                    MSheet {
+                        title: "Chapters".to_string(),
+                        testid: "mobile-test-sheet".to_string(),
+                        meta: None,
+                        on_close: move |_| {},
+                        div { "data-testid": "sheet-body", "Body content" }
+                    }
+                }
+            }
+            let html = render_in_vdom(harness);
+            assert!(html.contains("data-testid=\"mobile-test-sheet\""));
+            assert!(html.contains("Chapters"));
+            assert!(html.contains("data-testid=\"sheet-body\""));
+            assert!(html.contains("Body content"));
+        }
+
+        #[test]
+        fn m_sheet_renders_the_meta_slot_when_provided() {
+            fn harness() -> Element {
+                rsx! {
+                    MSheet {
+                        title: "Playback speed".to_string(),
+                        testid: "mobile-speed-sheet".to_string(),
+                        meta: rsx! { span { "1.00\u{00d7}" } },
+                        on_close: move |_| {},
+                        div {}
+                    }
+                }
+            }
+            let html = render_in_vdom(harness);
+            assert!(html.contains("1.00\u{00d7}"));
+        }
+
+        #[test]
+        fn chapters_sheet_renders_every_chapter_and_the_count_meta() {
+            fn harness() -> Element {
+                let list = ChaptersListView {
+                    chapters: vec![
+                        chapter(1, "Intro", 0.0, 300.0),
+                        chapter(2, "Part One", 300.0, 600.0),
+                    ],
+                    current_index: 0,
+                    elapsed: 100.0,
+                    total_label: "15m".to_string(),
+                };
+                rsx! {
+                    ChaptersSheet { list, on_seek: move |_| {}, on_close: move |_| {} }
+                }
+            }
+            let html = render_in_vdom(harness);
+            assert!(html.contains("Intro"));
+            assert!(html.contains("Part One"));
+            assert!(html.contains("2 \u{00b7} 15m"));
+        }
+
+        // Simulates the "chapter advanced" event: `super::view::chapter_index_for_elapsed`
+        // is what a real playback tick would feed into `current_index`, so
+        // re-rendering with it bumped is the VirtualDom-level stand-in for
+        // that state change. Asserts the highlighted row and the completed
+        // marker actually move rather than just checking each render in
+        // isolation.
+        #[test]
+        fn chapters_sheet_moves_the_highlight_when_the_current_chapter_advances() {
+            fn list_at(current_index: usize) -> ChaptersListView {
+                ChaptersListView {
+                    chapters: vec![
+                        chapter(1, "Intro", 0.0, 300.0),
+                        chapter(2, "Part One", 300.0, 600.0),
+                    ],
+                    current_index,
+                    elapsed: 0.0,
+                    total_label: "15m".to_string(),
+                }
+            }
+            fn harness_first() -> Element {
+                rsx! {
+                    ChaptersSheet { list: list_at(0), on_seek: move |_| {}, on_close: move |_| {} }
+                }
+            }
+            fn harness_second() -> Element {
+                rsx! {
+                    ChaptersSheet { list: list_at(1), on_seek: move |_| {}, on_close: move |_| {} }
+                }
+            }
+            let first = render_in_vdom(harness_first);
+            let second = render_in_vdom(harness_second);
+            assert_ne!(first, second);
+            // At index 0 nothing is "done" yet; at index 1 the first chapter
+            // has been passed and picks up the check mark.
+            assert!(!first.contains("m-ch-trail m-ch-done"));
+            assert!(second.contains("m-ch-trail m-ch-done"));
+        }
+    }
 }

--- a/frontend/src/test_support.rs
+++ b/frontend/src/test_support.rs
@@ -6,6 +6,20 @@
 //! otherwise touch the runtime) before rendering. Both exist only under the
 //! `server` feature, where `dioxus::ssr` is available and where these tests
 //! count toward llvm-cov.
+//!
+//! **Testing `#[cfg(feature = "mobile")]`-only markup** needs both cfgs at
+//! once — `mobile` to compile the gated component, `server` for this
+//! module's `dioxus::ssr` backing — so those tests run under
+//! `cargo test -p omnibus-frontend --features mobile,server`, a combination
+//! neither CI feature-matrix leg (`frontend` / `frontend-mobile`) exercises
+//! on its own. Gate such a test module on `#[cfg(all(test, feature =
+//! "server"))]` inside a file the `mobile` feature already pulls in (e.g. a
+//! submodule of `pages::listen::mobile`, or a `#[cfg(feature = "mobile")]`
+//! function's own module) — the surrounding file's mobile-only compilation
+//! is what supplies the other half. See `pages::listen::mobile::sheets` and
+//! `components::format_switcher::kindle` for worked examples: build a
+//! zero-prop harness component (or a bare `Element` for a hookless
+//! function), render it, and assert on substrings of the HTML.
 
 use dioxus::prelude::*;
 

--- a/frontend/src/test_support.rs
+++ b/frontend/src/test_support.rs
@@ -12,14 +12,37 @@
 //! module's `dioxus::ssr` backing — so those tests run under
 //! `cargo test -p omnibus-frontend --features mobile,server`, a combination
 //! neither CI feature-matrix leg (`frontend` / `frontend-mobile`) exercises
-//! on its own. Gate such a test module on `#[cfg(all(test, feature =
-//! "server"))]` inside a file the `mobile` feature already pulls in (e.g. a
-//! submodule of `pages::listen::mobile`, or a `#[cfg(feature = "mobile")]`
-//! function's own module) — the surrounding file's mobile-only compilation
-//! is what supplies the other half. See `pages::listen::mobile::sheets` and
-//! `components::format_switcher::kindle` for worked examples: build a
-//! zero-prop harness component (or a bare `Element` for a hookless
-//! function), render it, and assert on substrings of the HTML.
+//! on its own. The exact `#[cfg(...)]` to write on the test module depends
+//! on whether the *file* is already mobile-only:
+//!
+//! - **A mobile-only file** — one whose module root already sits behind
+//!   `#![cfg(feature = "mobile")]` (e.g. `pages::listen::mobile` and its
+//!   submodules) — only needs `server` spelled out on the test module itself;
+//!   the file-level gate already supplies the `mobile` half:
+//!   ```ignore
+//!   #[cfg(feature = "server")]
+//!   mod render {
+//!       use crate::test_support::render_in_vdom;
+//!       // ... build a harness, call render_in_vdom, assert on the HTML
+//!   }
+//!   ```
+//!   Worked example: `pages::listen::mobile::sheets`.
+//! - **A shared file**, where only some items are `#[cfg(feature =
+//!   "mobile")]` and the rest of the file compiles on every target (e.g.
+//!   `components::format_switcher::kindle`, which also has a non-mobile
+//!   `SendToKindleButton`) — the test module needs both cfgs spelled out
+//!   explicitly, since nothing upstream of it implies `mobile`:
+//!   ```ignore
+//!   #[cfg(all(test, feature = "mobile", feature = "server"))]
+//!   mod mobile_render_tests {
+//!       use crate::test_support::render;
+//!       // ... render the mobile-only fn's Element, assert on the HTML
+//!   }
+//!   ```
+//!   Worked example: `components::format_switcher::kindle`.
+//!
+//! Either way: build a zero-prop harness component (or a bare `Element` for
+//! a hookless function), render it, and assert on substrings of the HTML.
 
 use dioxus::prelude::*;
 


### PR DESCRIPTION
## Summary
- Closes #888
- Adds Rust-level `VirtualDom` render tests for mobile-only UI, the Maestro/E2E complement the issue asks for: fast, in-process component tests with no emulator.
- Covers 4 small, self-contained mobile-gated components across 2 files:
  - `MSheet` and `ChaptersSheet` (`frontend/src/pages/listen/mobile/sheets.rs`) — the shared bottom-sheet frame and the chapter list, including a test that re-renders with an advanced `current_index` and asserts the highlighted row and "done" marker actually move (the event-simulation case from the issue).
  - `send_to_kindle_action` / `send_to_kobo_action` mobile placeholders (`frontend/src/components/format_switcher/{kindle.rs,kobo/tests.rs}`) — asserts the `#[cfg(feature = "mobile")]` arm renders a disabled placeholder, mirroring the existing non-mobile `SendToKindleButton` SSR tests.
- Documents the pattern in `frontend/src/test_support.rs`'s module doc: testing `#[cfg(feature = "mobile")]`-only markup needs `dioxus::ssr` (only available under `server`) *and* the `mobile` cfg together, so those tests run under `cargo test -p omnibus-frontend --features mobile,server` — a combination neither CI feature-matrix leg (`frontend` / `frontend-mobile`) exercises alone. New tests are gated accordingly so they're inert (not dead code, just excluded) under either CI leg on its own.
- Investigated first per the issue's own instruction: `VirtualDom`-driven tests already existed in this crate (`contexts::tests`, `pages::reader::prefs::tests`, `pages::settings::library::tests`, `components::top_nav`) for constructing `Signal`s and calling handlers, but none of them actually rendered a `#[cfg(feature = "mobile")]`-only component's markup to HTML and asserted on it — that gap is what this PR fills.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS, 0 warnings
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — PASS, 0 warnings
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 596/596
- [x] `cargo test -p omnibus-frontend --features mobile,server` — the new tests all pass; the run also surfaces 11 pre-existing failures in files this PR does not touch (`offline::media`, `create_shelf_modal`, `edit_shelf_modal`, `shelves_rail`, `pages::book_detail::rating`, `pages::book_detail::read_status`, `pages::reader::highlights_drawer`). Confirmed pre-existing/environmental: `cargo test -p omnibus-frontend --features server` alone is 100% green, and 2 of the `offline::media` cases still fail in isolation under `--features mobile` alone (single-threaded, no other feature combined) — timing-sensitive tests unrelated to this change's mobile-render work.

## Notes
- Scope stayed off `frontend/src/pages/metadata_edit.rs`, `series.rs`, `settings/*`, `db/src/worker/*`, and `server/src/backend/kobo/*` per the run's instructions (other agents were working those areas).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPVSaxqfUWhjzgTPkrxic7)_