### PR TITLE
feat: serve a comic-only book's CBZ from the ebook file endpoint

### DIFF
--- a/.claude/rules/09-content-validators.md
+++ b/.claude/rules/09-content-validators.md
@@ -108,10 +108,10 @@ compare it against a later metadata refresh — `PlannedFile.source_etag` in
   `ORDER BY bf.ordinal LIMIT 1`. Two ways to get this wrong, and both have
   happened: comparing against the wrong row of a two-edition book, and
   matching on the formats a library can *contain* rather than the narrow set
-  a download pulls — `/api/ebooks/{uuid}/file` serves EPUB alone, the
-  audiobook routes M4B/M4A/MP3 alone. A mixed PDF/EPUB book that snapshots
-  the PDF reports staleness about a file the device doesn't hold and misses
-  every change to the one it does.
+  a download pulls — `/api/ebooks/{uuid}/file` serves the EPUB, else the CBZ
+  for a comic-only book; the audiobook routes M4B/M4A/MP3 alone. A mixed
+  PDF/EPUB book that snapshots the PDF reports staleness about a file the
+  device doesn't hold and misses every change to the one it does.
 
 Cached cover bytes carry their own `ETag` sibling and revalidate with
 `If-None-Match` *after* the cached image has been served, never before —

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -258,8 +258,44 @@ async fn resolve_epub_path(
     }
 }
 
-/// Streams the raw EPUB bytes. Accepts optional `?file_id=N` to target
-/// a specific `book_files` row for multi-EPUB books.
+/// Wire mime for a served CBZ archive. The registered comic-book zip type,
+/// which downloaders and shelf apps recognize where a bare
+/// `application/zip` would not say what the bytes are.
+const CBZ_MIME: &str = "application/vnd.comicbook+zip";
+
+/// Resolve the file `/file` streams for `uuid`: the EPUB when the book has
+/// one, else its CBZ archive. The fallback is what lets a comic-only book be
+/// taken offline whole — the per-page endpoint answers reading, not
+/// downloading — while a dual-format book keeps serving the EPUB, matching
+/// the pager's rule that the EPUB stays the primary read. An explicit
+/// `?file_id=` stays EPUB-scoped: multi-file selection exists for
+/// multi-EPUB books and must not silently resolve to an archive.
+async fn resolve_readable_path(
+    state: &AppState,
+    uuid: &str,
+    file_id: Option<i64>,
+) -> Result<(std::path::PathBuf, &'static str), Response> {
+    match resolve_epub_path(state, uuid, file_id).await {
+        Ok(path) => Ok((path, "application/epub+zip")),
+        Err(resp) if file_id.is_none() && resp.status() == StatusCode::NOT_FOUND => {
+            let id = match db::resolve_book_id_by_uuid(&state.pool, uuid).await {
+                Ok(Some(id)) => id,
+                Ok(None) => return Err(StatusCode::NOT_FOUND.into_response()),
+                Err(e) => return Err(internal("resolve_book_id_by_uuid", e)),
+            };
+            match db::book_file_path(&state.pool, id, "CBZ").await {
+                Ok(Some(path)) => Ok((path, CBZ_MIME)),
+                Ok(None) => Err(StatusCode::NOT_FOUND.into_response()),
+                Err(e) => Err(internal("book_file_path", e)),
+            }
+        }
+        Err(resp) => Err(resp),
+    }
+}
+
+/// Streams the raw EPUB bytes — or, for a comic-only book, the CBZ archive
+/// (the whole-file download the offline clients pull). Accepts optional
+/// `?file_id=N` to target a specific `book_files` row for multi-EPUB books.
 ///
 /// Gated by [`MediaAuthUser`] rather than [`AuthUser`]: epub.js fetches this
 /// URL from inside the mobile WebView, which can carry neither a session
@@ -285,9 +321,9 @@ pub(super) async fn get_ebook_file(
     resp
 }
 
-/// Resolve the on-disk EPUB and stream its bytes, or report the resolution
-/// failure as a 404 / 500. CORS is layered on by the caller so it covers
-/// every arm uniformly.
+/// Resolve the book's readable file (EPUB, else CBZ) and stream its bytes,
+/// or report the resolution failure as a 404 / 500. CORS is layered on by
+/// the caller so it covers every arm uniformly.
 ///
 /// Goes through the shared `serve_file` path rather than buffering the whole
 /// book, which is what gives the endpoint `Range` support — without which
@@ -300,11 +336,11 @@ async fn read_ebook_file(
     file_id: Option<i64>,
     req: Request,
 ) -> Response {
-    let path = match resolve_epub_path(state, uuid, file_id).await {
-        Ok(p) => p,
+    let (path, mime) = match resolve_readable_path(state, uuid, file_id).await {
+        Ok(resolved) => resolved,
         Err(resp) => return resp,
     };
-    super::serve_file(req, &path, "application/epub+zip", None).await
+    super::serve_file(req, &path, mime, None).await
 }
 
 /// Serve one page image out of the book's CBZ archive, extracted

--- a/server/src/backend/ebooks/tests.rs
+++ b/server/src/backend/ebooks/tests.rs
@@ -503,6 +503,103 @@ async fn api_get_ebook_file_returns_200_with_query_token() {
     std::fs::remove_dir_all(&tmp).ok();
 }
 
+/// The whole-file fallback for comic-only books: with no EPUB row, `/file`
+/// streams the CBZ archive itself under the comic mime — the download the
+/// offline clients pull, as opposed to the per-page reads the pager makes.
+#[tokio::test]
+async fn api_get_ebook_file_serves_cbz_when_book_has_no_epub() {
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let (uuid, tmp) = seed_cbz_on_disk(&pool).await;
+    let archive = std::fs::read(tmp.join("alpha.cbz")).unwrap();
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    let res = app
+        .oneshot(get_with_bearer(&format!("/api/ebooks/{uuid}/file"), &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/vnd.comicbook+zip"),
+    );
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&bytes[..], &archive[..]);
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+/// A dual-format book keeps serving the EPUB — the fallback is only for
+/// books with nothing else to read, matching the pager's rule that the
+/// EPUB stays the primary read.
+#[tokio::test]
+async fn api_get_ebook_file_prefers_epub_when_book_has_both_formats() {
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let (uuid, tmp) = seed_cbz_on_disk(&pool).await;
+    std::fs::write(tmp.join("alpha.epub"), b"PK\x03\x04 fake-epub").unwrap();
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?")
+        .bind(&uuid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'alpha', 0)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    let res = app
+        .oneshot(get_with_bearer(&format!("/api/ebooks/{uuid}/file"), &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/epub+zip"),
+    );
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&bytes[..], b"PK\x03\x04 fake-epub");
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+/// `?file_id=` exists for multi-EPUB selection, so on a comic-only book it
+/// stays a 404 rather than silently resolving to the archive.
+#[tokio::test]
+async fn api_get_ebook_file_with_file_id_returns_404_for_comic_only_book() {
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let (uuid, tmp) = seed_cbz_on_disk(&pool).await;
+    let file_id: i64 = sqlx::query_scalar("SELECT id FROM book_files WHERE format = 'CBZ'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/ebooks/{uuid}/file?file_id={file_id}"),
+            &token,
+        ))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
 /// Drives the first `internal(...)` arm of `get_ebook_file`: when
 /// `db::resolve_book_id_by_uuid` returns `Err`, the handler must
 /// surface 500 (not 404). The induce-sqlx-error idiom is to drop


### PR DESCRIPTION
## Summary
- `GET /api/ebooks/{uuid}/file` now falls back to the book's CBZ archive (`application/vnd.comicbook+zip`) when it has no EPUB, giving the offline clients a whole-file download for comic-only books.
- A dual-format book keeps serving the EPUB, and `?file_id=` stays EPUB-scoped (multi-EPUB selection must not silently resolve to an archive).
- Rule 09's served-format wording updated to match.

Part of #1565 — base of a two-PR stack; `feat/1565-ios-comic-pager-2` carries the iOS pager that consumes this.

## Test plan
- [x] `cargo test -p omnibus` — 630 passed (3 new `/file` CBZ tests: fallback, EPUB preference, `file_id` guard)
- [x] `cargo fmt` + `cargo clippy -D warnings`

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.