### PR TITLE
feat: native iOS CBZ comic pager with offline support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -277,6 +277,11 @@ Reader/             — SwiftUI reader chrome, the host-drawn selection layer,
                       the passage menu, the typography sheet and the quote-card
                       composer, over Web/ (vendored epub.js + JSZip + glue,
                       hosted in a WKWebView)
+Comic/              — the native CBZ pager: ComicReaderView (paged TabView +
+                      UIScrollView zoom per page), ComicPages (per-page server
+                      reads online, ZIPFoundation over the downloaded archive
+                      offline), ComicPosition (the `comic-page:N` anchor ↔
+                      progress-record mapping shared with the web pager)
 Services/           — AuthService, LibraryService, UserDataService
 ```
 
@@ -287,6 +292,14 @@ generation compatibly. Assets and book bytes are served over a custom
 `omnibus-reader://` scheme so epub.js sees one same-origin space and needs no
 cookie. Everything around it — chrome, gestures, sheets, persistence — is
 native.
+
+**Comics skip the WebView entirely.** A CBZ is images, so `Comic/` pages them
+natively (pinch zoom, paged `TabView`) against the server's per-page endpoint,
+or against the downloaded archive via **ZIPFoundation** — the app's only Swift
+package dependency, pinned in the project's `Package.resolved`. Positions ride
+the same Epub-format progress row as every reader, as a `comic-page:N` anchor
+plus the cross-surface percent (`omnibus_shared::comic_page_anchor`), and a
+downloaded archive is CRC-verified before it replaces anything on disk.
 
 **Selection is drawn by the app, not by WebKit.** The iOS glue disables
 WebKit's own touch selection inside each section (`user-select: none` in the

--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -62,6 +62,7 @@ to scope an exception to.
 | `omnibus/Services/` | Read/write facades over the API + cache |
 | `omnibus/Features/` | One folder per screen |
 | `omnibus/Reader/` | EPUB reader: native chrome over the vendored epub.js engine |
+| `omnibus/Comic/` | CBZ comic pager: paged `TabView` + `UIScrollView` zoom, no WebView |
 
 ## Shell
 
@@ -158,6 +159,20 @@ against exactly the contract the server expects. `Reader/Web/` is a copy of
 gestures, persistence — is native. Assets and the book are served over a custom
 `omnibus-reader://` scheme so epub.js sees one same-origin space and needs no
 cookie.
+
+**Comics are native, and the WebView host stays EPUB-only.** A CBZ is a zip of
+images, so `Comic/ComicReaderView` pages them in a `TabView` with a
+`UIScrollView` zoom wrapper per page — pinch, pan-while-zoomed, double-tap, and
+deference at 1x (an unzoomed page must not claim the horizontal drag that turns
+pages) all come from the platform. Online it reads
+`GET /api/ebooks/{uuid}/pages/{n}` with an n±1 prefetch; offline the whole CBZ
+comes down through the ordinary download machinery (`/file` serves the archive
+for a comic-only book) and **ZIPFoundation** — the app's only SPM dependency —
+reads pages out of it in the same natural-sort order the server uses, CRC-checked
+per entry. A saved position is the shared `comic-page:N` anchor in the
+Epub-format progress row plus a whole-book percent, so comics resume across
+devices and surface on Continue Reading with a real progress bar, with no
+comic-specific server state.
 
 **The glue owns gestures, not SwiftUI.** `epub-reader-glue.js` already
 implements swipe-to-turn (the page tracks your finger, with velocity and

--- a/omnibus-ios/omnibus.xcodeproj/project.pbxproj
+++ b/omnibus-ios/omnibus.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		9FC0DEC3301436B1004AB003 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 9FC0DEC2301436B1004AB002 /* ZIPFoundation */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		9F0BACB4301436B1004AB339 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -52,6 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9FC0DEC3301436B1004AB003 /* ZIPFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,6 +117,7 @@
 			);
 			name = omnibus;
 			packageProductDependencies = (
+				9FC0DEC2301436B1004AB002 /* ZIPFoundation */,
 			);
 			productName = omnibus;
 			productReference = 9F0BACA6301436B0004AB339 /* omnibus.app */;
@@ -195,6 +201,9 @@
 			);
 			mainGroup = 9F0BAC9D301436B0004AB339;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				9FC0DEC1301436B1004AB001 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9F0BACA7301436B0004AB339 /* Products */;
 			projectDirPath = "";
@@ -615,6 +624,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9FC0DEC1301436B1004AB001 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/weichsel/ZIPFoundation.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.19;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9FC0DEC2301436B1004AB002 /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9FC0DEC1301436B1004AB001 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9F0BAC9E301436B0004AB339 /* Project object */;
 }

--- a/omnibus-ios/omnibus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/omnibus-ios/omnibus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "b26c070fd1f0b029780331f3cefa3909a6d58ea6b3ae242bffe49d6011fe06fe",
+  "pins" : [
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/omnibus-ios/omnibus/App/MainTabView.swift
+++ b/omnibus-ios/omnibus/App/MainTabView.swift
@@ -68,7 +68,15 @@ struct MainTabView: View {
             AddBooksSheet()
         }
         .fullScreenCover(item: readerBinding) { session in
-            ReaderView(book: session.book)
+            // Comic-only books get the native pager; everything else the
+            // epub.js host. A book carrying both formats keeps the EPUB as
+            // its primary read, matching the web pager and the server's
+            // `/file` resolution.
+            if session.book.opensAsComic {
+                ComicReaderView(book: session.book)
+            } else {
+                ReaderView(book: session.book)
+            }
         }
         .fullScreenCover(item: playerBinding) { session in
             PlayerView(book: session.book, fileID: session.fileID)

--- a/omnibus-ios/omnibus/Comic/ComicArchive.swift
+++ b/omnibus-ios/omnibus/Comic/ComicArchive.swift
@@ -1,0 +1,178 @@
+//  ComicArchive.swift
+//  Local CBZ page reads for a downloaded comic.
+//
+//  Mirror of the server's `db::comic` reader: the page list, its ordering,
+//  and the hidden-file rules must match exactly, because a saved
+//  `comic-page:N` anchor is an index into that order — a device that sorted
+//  differently would resume on the wrong page. Every read checks the entry's
+//  recorded CRC-32 (ZIPFoundation verifies on extract), which is what makes
+//  a downloaded CBZ part of the CRC-backed tier of integrity checking.
+
+import Foundation
+import ZIPFoundation
+
+enum ComicArchiveError: LocalizedError {
+    case unreadable(String)
+    case pageOutOfRange(Int)
+    case pageTooLarge(String)
+    case pageDamaged(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unreadable(detail): "This comic couldn't be opened. \(detail)"
+        case let .pageOutOfRange(index): "Page \(index + 1) doesn't exist in this comic."
+        case let .pageTooLarge(name): "Page \(name) is too large to display."
+        case let .pageDamaged(name): "Page \(name) is damaged and couldn't be read."
+        }
+    }
+}
+
+final class ComicArchive {
+    /// Image-entry extensions that count as comic pages — the same set the
+    /// server's scanner and page endpoint admit.
+    static let pageExtensions: Set<String> = ["png", "jpg", "jpeg", "webp", "gif"]
+
+    /// Hard cap on a single decompressed page, mirroring the server's
+    /// zip-bomb bound: a crafted entry can claim a false size or lean on
+    /// deflate's worst-case ratio, so the consumer counts real bytes.
+    static let maxPageBytes = 64 * 1024 * 1024
+
+    /// The archive's page entry names in natural-sort reading order. The
+    /// list's length is the page count; index N is the page the server's
+    /// `/pages/N` would serve.
+    let pages: [String]
+
+    private let archive: Archive
+
+    init(url: URL) throws {
+        do {
+            archive = try Archive(url: url, accessMode: .read)
+        } catch {
+            throw ComicArchiveError.unreadable(String(describing: error))
+        }
+        pages = Self.pageNames(in: archive)
+    }
+
+    /// Read page `index` (0-based, in [`pages`] order), CRC-checked as it
+    /// decompresses. Bounded by [`maxPageBytes`] so a hostile archive can't
+    /// balloon in memory.
+    ///
+    /// The CRC comparison is explicit: ZIPFoundation's `extract` *computes*
+    /// the checksum but leaves comparing it against the entry's recorded one
+    /// to the caller (only its whole-directory `unzipItem` compares).
+    func page(at index: Int) throws -> Data {
+        guard pages.indices.contains(index) else {
+            throw ComicArchiveError.pageOutOfRange(index)
+        }
+        let name = pages[index]
+        guard let entry = archive[name] else {
+            throw ComicArchiveError.unreadable("missing entry \(name)")
+        }
+        var bytes = Data()
+        let checksum = try archive.extract(entry, skipCRC32: false) { chunk in
+            guard bytes.count + chunk.count <= Self.maxPageBytes else {
+                throw ComicArchiveError.pageTooLarge(name)
+            }
+            bytes.append(chunk)
+        }
+        guard checksum == entry.checksum else {
+            throw ComicArchiveError.pageDamaged(name)
+        }
+        return bytes
+    }
+
+    /// Whether every entry in the archive reads clean against its recorded
+    /// CRC-32 — the post-download integrity check. Reading each entry to EOF
+    /// is what performs the comparison; structure alone would pass a
+    /// same-length splice whose offsets all still resolve.
+    static func verify(url: URL) -> Bool {
+        guard let archive = try? Archive(url: url, accessMode: .read) else { return false }
+        let pages = pageNames(in: archive)
+        // An archive with nothing to show is a broken download, not an
+        // intact empty book — the scanner refuses to index one either.
+        guard !pages.isEmpty else { return false }
+        for entry in archive where entry.type == .file {
+            // Same explicit comparison as `page(at:)` — extract only
+            // computes the checksum, it never judges it.
+            guard let checksum = try? archive.extract(entry, skipCRC32: false, consumer: { _ in }),
+                  checksum == entry.checksum
+            else { return false }
+        }
+        return true
+    }
+
+    /// List the archive's page entries the way the server does: image
+    /// extensions only, no directories, no hidden segments (macOS
+    /// AppleDouble junk like `__MACOSX/._p001.jpg` carries an image
+    /// extension but isn't a page), natural-sorted.
+    private static func pageNames(in archive: Archive) -> [String] {
+        var names: [String] = []
+        for entry in archive where entry.type == .file {
+            let path = entry.path
+            guard !isHiddenName(path), isPageName(path) else { continue }
+            names.append(path)
+        }
+        names.sort { naturalCompare($0, $1) == .orderedAscending }
+        return names
+    }
+
+    /// `true` when any path segment starts with `.`.
+    static func isHiddenName(_ name: String) -> Bool {
+        name.split(separator: "/", omittingEmptySubsequences: false)
+            .contains { $0.hasPrefix(".") }
+    }
+
+    static func isPageName(_ name: String) -> Bool {
+        let ext = (name as NSString).pathExtension.lowercased()
+        return pageExtensions.contains(ext)
+    }
+
+    /// Natural-sort comparison for page order, ported from the server's
+    /// `natural_cmp`: digit runs compare numerically ("p2" < "p10"),
+    /// everything else compares case-insensitively, and numeric ties fall
+    /// back to run length so "007" and "7" order deterministically.
+    static func naturalCompare(_ a: String, _ b: String) -> ComparisonResult {
+        var ac = Array(a)[...]
+        var bc = Array(b)[...]
+        while true {
+            switch (ac.first, bc.first) {
+            case (nil, nil): return .orderedSame
+            case (nil, _): return .orderedAscending
+            case (_, nil): return .orderedDescending
+            case let (x?, y?) where x.isASCII && x.isNumber && y.isASCII && y.isNumber:
+                let da = takeDigits(&ac)
+                let db = takeDigits(&bc)
+                // Compare stripped of leading zeros: more digits wins, then
+                // lexical (same length ⇒ digit-wise is numeric ordering).
+                let sa = String(da.drop { $0 == "0" })
+                let sb = String(db.drop { $0 == "0" })
+                if sa.count != sb.count {
+                    return sa.count < sb.count ? .orderedAscending : .orderedDescending
+                }
+                if sa != sb {
+                    return sa < sb ? .orderedAscending : .orderedDescending
+                }
+                if da.count != db.count {
+                    return da.count < db.count ? .orderedAscending : .orderedDescending
+                }
+            case let (x?, y?):
+                let lx = String(x).lowercased()
+                let ly = String(y).lowercased()
+                if lx != ly {
+                    return lx < ly ? .orderedAscending : .orderedDescending
+                }
+                ac = ac.dropFirst()
+                bc = bc.dropFirst()
+            }
+        }
+    }
+
+    private static func takeDigits(_ chars: inout ArraySlice<Character>) -> [Character] {
+        var digits: [Character] = []
+        while let c = chars.first, c.isASCII, c.isNumber {
+            digits.append(c)
+            chars = chars.dropFirst()
+        }
+        return digits
+    }
+}

--- a/omnibus-ios/omnibus/Comic/ComicArchive.swift
+++ b/omnibus-ios/omnibus/Comic/ComicArchive.swift
@@ -4,8 +4,9 @@
 //  Mirror of the server's `db::comic` reader: the page list, its ordering,
 //  and the hidden-file rules must match exactly, because a saved
 //  `comic-page:N` anchor is an index into that order — a device that sorted
-//  differently would resume on the wrong page. Every read checks the entry's
-//  recorded CRC-32 (ZIPFoundation verifies on extract), which is what makes
+//  differently would resume on the wrong page. Every read compares the
+//  entry's recorded CRC-32 against the checksum ZIPFoundation computes on
+//  extract (the comparison is ours — see `page(at:)`), which is what makes
 //  a downloaded CBZ part of the CRC-backed tier of integrity checking.
 
 import Foundation
@@ -81,24 +82,41 @@ final class ComicArchive {
         return bytes
     }
 
-    /// Whether every entry in the archive reads clean against its recorded
-    /// CRC-32 — the post-download integrity check. Reading each entry to EOF
-    /// is what performs the comparison; structure alone would pass a
-    /// same-length splice whose offsets all still resolve.
+    /// Whether every page entry reads clean against its recorded CRC-32 —
+    /// the post-download integrity check. Reading each to EOF is what
+    /// performs the comparison; structure alone would pass a same-length
+    /// splice whose offsets all still resolve.
+    ///
+    /// Pages only, under the same per-entry decompression bound as a read:
+    /// the verdict is about whether the comic can be *read* offline, and
+    /// extracting arbitrary non-page entries unbounded would hand a crafted
+    /// archive a zip-bomb lever in the very check meant to reject it.
     static func verify(url: URL) -> Bool {
         guard let archive = try? Archive(url: url, accessMode: .read) else { return false }
         let pages = pageNames(in: archive)
         // An archive with nothing to show is a broken download, not an
         // intact empty book — the scanner refuses to index one either.
         guard !pages.isEmpty else { return false }
-        for entry in archive where entry.type == .file {
-            // Same explicit comparison as `page(at:)` — extract only
-            // computes the checksum, it never judges it.
-            guard let checksum = try? archive.extract(entry, skipCRC32: false, consumer: { _ in }),
-                  checksum == entry.checksum
-            else { return false }
+        for name in pages {
+            guard let entry = archive[name], entryReadsClean(archive, entry) else {
+                return false
+            }
         }
         return true
+    }
+
+    /// Extract `entry` to EOF under [`maxPageBytes`] and answer whether its
+    /// bytes match the recorded CRC-32. The comparison is ours — extract
+    /// only computes the checksum, it never judges it.
+    private static func entryReadsClean(_ archive: Archive, _ entry: Entry) -> Bool {
+        var seen = 0
+        let checksum = try? archive.extract(entry, skipCRC32: false) { chunk in
+            seen += chunk.count
+            guard seen <= maxPageBytes else {
+                throw ComicArchiveError.pageTooLarge(entry.path)
+            }
+        }
+        return checksum == entry.checksum
     }
 
     /// List the archive's page entries the way the server does: image

--- a/omnibus-ios/omnibus/Comic/ComicPageView.swift
+++ b/omnibus-ios/omnibus/Comic/ComicPageView.swift
@@ -1,0 +1,144 @@
+//  ComicPageView.swift
+//  One comic page: a UIScrollView zoom wrapper around the page image.
+//
+//  UIKit rather than SwiftUI gestures because a comic page needs the whole
+//  scroll-view contract at once — pinch to zoom about the pinch point,
+//  pan while zoomed, double-tap to zoom, and *deference* while zoomed out
+//  (an unzoomed page must not claim horizontal drags, or the TabView pager
+//  behind it could never turn a page). UIScrollView gets all of that right
+//  by construction; rebuilding it from MagnifyGesture does not.
+
+import SwiftUI
+import UIKit
+
+/// Where a single tap landed, in page-turn terms.
+enum ComicTapZone {
+    case previous, toggle, next
+}
+
+/// The zoomable page image. Single taps report their zone (outer quarters
+/// turn pages, the centre toggles chrome — the EPUB reader's gutter
+/// contract); a double tap zooms in about the tap, or back out.
+struct ComicPageView: UIViewRepresentable {
+    let image: UIImage
+    let onTap: (ComicTapZone) -> Void
+
+    func makeUIView(context: Context) -> ComicZoomView {
+        let view = ComicZoomView()
+        view.onTap = onTap
+        return view
+    }
+
+    func updateUIView(_ view: ComicZoomView, context: Context) {
+        view.onTap = onTap
+        view.display(image)
+    }
+}
+
+/// The scroll-view host: owns fit-to-screen sizing, zoom centring, and the
+/// tap recognizers.
+final class ComicZoomView: UIScrollView, UIScrollViewDelegate {
+    var onTap: ((ComicTapZone) -> Void)?
+
+    private let imageView = UIImageView()
+    /// Bounds the fit scale was computed against, so a rotation re-fits
+    /// while ordinary layout passes leave the reader's zoom alone.
+    private var fittedSize: CGSize = .zero
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        delegate = self
+        showsVerticalScrollIndicator = false
+        showsHorizontalScrollIndicator = false
+        contentInsetAdjustmentBehavior = .never
+        // No bounce at 1x: a page that springs back on a horizontal drag
+        // would swallow the exact gesture that should turn to the next one.
+        bounces = false
+        bouncesZoom = true
+        backgroundColor = .black
+
+        imageView.contentMode = .scaleAspectFill
+        addSubview(imageView)
+
+        let doubleTap = UITapGestureRecognizer(target: self, action: #selector(didDoubleTap))
+        doubleTap.numberOfTapsRequired = 2
+        addGestureRecognizer(doubleTap)
+
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(didSingleTap))
+        singleTap.require(toFail: doubleTap)
+        addGestureRecognizer(singleTap)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    func display(_ image: UIImage) {
+        guard imageView.image !== image else { return }
+        imageView.image = image
+        imageView.frame = CGRect(origin: .zero, size: image.size)
+        contentSize = image.size
+        fittedSize = .zero
+        setNeedsLayout()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let image = imageView.image, bounds.size != .zero else { return }
+        if bounds.size != fittedSize {
+            fittedSize = bounds.size
+            fitToBounds(image)
+        }
+        centerContent()
+    }
+
+    /// Fit the page inside the viewport and make that the floor of the zoom
+    /// range — zooming out past "whole page visible" serves nothing.
+    private func fitToBounds(_ image: UIImage) {
+        let fit = min(
+            bounds.width / max(image.size.width, 1),
+            bounds.height / max(image.size.height, 1)
+        )
+        minimumZoomScale = fit
+        maximumZoomScale = max(fit * 4, 1)
+        zoomScale = fit
+    }
+
+    /// Keep a page smaller than the viewport centred rather than pinned to
+    /// the top-left, in both axes and at every zoom level.
+    private func centerContent() {
+        let x = max((bounds.width - contentSize.width) / 2, 0)
+        let y = max((bounds.height - contentSize.height) / 2, 0)
+        contentInset = UIEdgeInsets(top: y, left: x, bottom: y, right: x)
+    }
+
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? { imageView }
+
+    func scrollViewDidZoom(_ scrollView: UIScrollView) {
+        centerContent()
+    }
+
+    @objc private func didSingleTap(_ gesture: UITapGestureRecognizer) {
+        // Location relative to the viewport, not the (offset) content.
+        let x = (gesture.location(in: self).x - contentOffset.x) / max(bounds.width, 1)
+        if x < 0.25 {
+            onTap?(.previous)
+        } else if x > 0.75 {
+            onTap?(.next)
+        } else {
+            onTap?(.toggle)
+        }
+    }
+
+    @objc private func didDoubleTap(_ gesture: UITapGestureRecognizer) {
+        if zoomScale > minimumZoomScale * 1.01 {
+            setZoomScale(minimumZoomScale, animated: true)
+            return
+        }
+        // Zoom in about the tap, so the panel under the finger is what grows.
+        let target = zoomScale * 2.5
+        let point = gesture.location(in: imageView)
+        let size = CGSize(width: bounds.width / target, height: bounds.height / target)
+        let origin = CGPoint(x: point.x - size.width / 2, y: point.y - size.height / 2)
+        zoom(to: CGRect(origin: origin, size: size), animated: true)
+    }
+}

--- a/omnibus-ios/omnibus/Comic/ComicPages.swift
+++ b/omnibus-ios/omnibus/Comic/ComicPages.swift
@@ -1,0 +1,101 @@
+//  ComicPages.swift
+//  The pager's page source: one actor, two backings.
+//
+//  Online, pages come one at a time from `GET /api/ebooks/{uuid}/pages/{n}`
+//  — the server extracts entries so the client never downloads the archive
+//  to read. Offline, the downloaded CBZ answers through `ComicArchive`, in
+//  the same page order, so a saved page index means the same thing on both.
+
+import Foundation
+
+actor ComicPages {
+    /// Recently-read pages held for instant back-and-forth turns. Small on
+    /// purpose — scanned pages run megabytes each, and the pager only ever
+    /// needs the neighbourhood of the current page.
+    private static let cacheLimit = 8
+
+    let count: Int
+
+    private enum Backing {
+        case remote(uuid: String)
+        case local(ComicArchive)
+    }
+
+    private let backing: Backing
+    private var cache: [Int: Data] = [:]
+    /// Insertion order for eviction, oldest first.
+    private var order: [Int] = []
+    /// One fetch per page however many views ask — a turn plus a prefetch
+    /// land on the same task rather than the same request twice.
+    private var inflight: [Int: Task<Data, Error>] = [:]
+
+    /// A source over the server's per-page endpoint. `count` comes from the
+    /// detail payload's `page_count`.
+    init(uuid: String, count: Int) {
+        backing = .remote(uuid: uuid)
+        self.count = count
+    }
+
+    /// A source over a downloaded archive. The archive itself is the page
+    /// count, so a shrunken re-download can't leave the pager aiming past
+    /// the end.
+    init(localURL: URL) throws {
+        let archive = try ComicArchive(url: localURL)
+        backing = .local(archive)
+        count = archive.pages.count
+    }
+
+    /// The bytes of page `index`, from cache, an in-flight fetch, or the
+    /// backing.
+    func page(_ index: Int) async throws -> Data {
+        if let cached = cache[index] { return cached }
+        if let running = inflight[index] { return try await running.value }
+
+        let task = Task { try await self.read(index) }
+        inflight[index] = task
+        defer { inflight[index] = nil }
+        let bytes = try await task.value
+        store(bytes, at: index)
+        return bytes
+    }
+
+    /// Warm the neighbours of `index` — the n±1 prefetch that makes a page
+    /// turn instant. Failures are dropped; the page is fetched again with a
+    /// real error path when it's actually turned to.
+    func prefetch(around index: Int) {
+        for neighbour in [index + 1, index - 1]
+        where (0..<count).contains(neighbour) && cache[neighbour] == nil
+            && inflight[neighbour] == nil
+        {
+            let task = Task { try await self.read(neighbour) }
+            inflight[neighbour] = task
+            Task {
+                defer { self.inflight[neighbour] = nil }
+                guard let bytes = try? await task.value else { return }
+                self.store(bytes, at: neighbour)
+            }
+        }
+    }
+
+    private func store(_ bytes: Data, at index: Int) {
+        if cache[index] == nil { order.append(index) }
+        cache[index] = bytes
+        while order.count > Self.cacheLimit {
+            let evicted = order.removeFirst()
+            cache[evicted] = nil
+        }
+    }
+
+    /// One page read against the backing. Actor-isolated on purpose: local
+    /// extracts share one `Archive` (a seeking file handle that must never
+    /// see two readers at once), while a remote read suspends on the network
+    /// and leaves the actor free.
+    private func read(_ index: Int) async throws -> Data {
+        switch backing {
+        case let .remote(uuid):
+            return try await APIClient.shared.data(for: "/api/ebooks/\(uuid)/pages/\(index)")
+        case let .local(archive):
+            return try archive.page(at: index)
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Comic/ComicPosition.swift
+++ b/omnibus-ios/omnibus/Comic/ComicPosition.swift
@@ -21,10 +21,16 @@ enum ComicPosition {
 
     /// Parse an [`anchor(page:)`] back to its 0-based page index. `nil` for
     /// anything else — including a real EPUB CFI — so callers can fall back
-    /// to `progress_percent` without misreading a foreign position.
+    /// to `progress_percent` without misreading a foreign position. A
+    /// negative index is malformed, not a page: `startPage`'s clamp only
+    /// bounds the top end, so letting one through would aim the pager at a
+    /// selection that doesn't exist.
     static func parseAnchor(_ anchor: String) -> Int? {
-        guard anchor.hasPrefix(anchorPrefix) else { return nil }
-        return Int(anchor.dropFirst(anchorPrefix.count))
+        guard anchor.hasPrefix(anchorPrefix),
+              let page = Int(anchor.dropFirst(anchorPrefix.count)),
+              page >= 0
+        else { return nil }
+        return page
     }
 
     /// Whole-book percent for a 0-based `page` of `count` — the

--- a/omnibus-ios/omnibus/Comic/ComicPosition.swift
+++ b/omnibus-ios/omnibus/Comic/ComicPosition.swift
@@ -1,0 +1,53 @@
+//  ComicPosition.swift
+//  How a comic page maps onto the shared progress record.
+//
+//  Mirror of `omnibus_shared::{comic_page_anchor, parse_comic_page_anchor}`
+//  and the web pager's percent/start-page math. Comics reuse the Epub-format
+//  progress row: the `epub_cfi` slot holds a self-describing `comic-page:N`
+//  anchor and `progress_percent` carries the cross-surface half, so Continue
+//  Reading and cross-device sync work unchanged. Every client round-trips
+//  positions through these helpers rather than inventing its own encoding.
+
+import Foundation
+
+enum ComicPosition {
+    private static let anchorPrefix = "comic-page:"
+
+    /// Position anchor for a 0-based comic page, stored in the `epub_cfi`
+    /// slot of an Epub-format progress row.
+    static func anchor(page: Int) -> String {
+        "\(anchorPrefix)\(page)"
+    }
+
+    /// Parse an [`anchor(page:)`] back to its 0-based page index. `nil` for
+    /// anything else — including a real EPUB CFI — so callers can fall back
+    /// to `progress_percent` without misreading a foreign position.
+    static func parseAnchor(_ anchor: String) -> Int? {
+        guard anchor.hasPrefix(anchorPrefix) else { return nil }
+        return Int(anchor.dropFirst(anchorPrefix.count))
+    }
+
+    /// Whole-book percent for a 0-based `page` of `count` — the
+    /// cross-surface half of the saved position. Last page reads as 100.
+    static func percent(page: Int, count: Int) -> Int64 {
+        guard count > 0 else { return 0 }
+        return Int64((Double((page + 1) * 100) / Double(count)).rounded())
+    }
+
+    /// The 0-based page a saved record resumes at: the exact anchor when
+    /// present, else the inverse of [`percent(page:count:)`], else page 0.
+    /// Clamped so a shrunken re-scan of the archive can't land out of range.
+    static func startPage(anchor: String?, percent: Int64?, count: Int) -> Int {
+        guard count > 0 else { return 0 }
+        let last = count - 1
+        if let anchor, let page = parseAnchor(anchor) {
+            return min(page, last)
+        }
+        if let percent {
+            let clamped = Double(min(max(percent, 0), 100))
+            let approx = Int((clamped / 100 * Double(count)).rounded())
+            return min(max(approx - 1, 0), last)
+        }
+        return 0
+    }
+}

--- a/omnibus-ios/omnibus/Comic/ComicReaderView.swift
+++ b/omnibus-ios/omnibus/Comic/ComicReaderView.swift
@@ -1,0 +1,429 @@
+//  ComicReaderView.swift
+//  The native CBZ pager: a paged TabView of zoomable pages inside the
+//  reader's chrome contract — bare on open, close button and a page slider
+//  one centre tap away, the same indicator labels above and below the page.
+//
+//  The EPUB reader's WKWebView + epub.js host stays EPUB-only; comics are
+//  images, so the platform pager and scroll view do everything the web
+//  stack was carrying. Positions ride the same Epub-format progress row as
+//  every other reader via `ComicPosition`, so Continue Reading and
+//  cross-device sync need no comic-specific server state.
+
+import SwiftUI
+
+struct ComicReaderView: View {
+    let book: Book
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(AppState.self) private var appState
+    @Environment(AudioPlayer.self) private var audio
+
+    /// The page source, once the archive or the detail read has resolved.
+    /// Doubles as the LifecycleSync registration token.
+    @State private var pages: ComicPages?
+    @State private var failureMessage: String?
+    @State private var page = 0
+    @State private var chromeVisible = false
+    /// The record the pager opened on, so a later server answer can be
+    /// judged newer or older than what this device knew.
+    @State private var openedProgress: ProgressRecord?
+    /// A further page another device reached, waiting on the reader to
+    /// accept it. Never applied on its own.
+    @State private var syncOfferPage: Int?
+    /// When the current stretch of reading began, or `nil` while the app is
+    /// in the background — same reading-time clock as the EPUB reader.
+    @State private var sessionStart: Date?
+    @State private var lastSave = Date.distantPast
+    @State private var showPlayer = false
+
+    /// How long a single stretch of reading may run before it is reported
+    /// as its own session rather than held until the book closes.
+    private static let sessionCheckpointInterval: TimeInterval = 300
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            if let pages {
+                pager(pages)
+            } else if failureMessage == nil {
+                LoadingView(label: "Opening \(book.displayTitle)")
+            }
+
+            if let failureMessage {
+                ErrorStateView(message: failureMessage) { dismiss() }
+            }
+
+            indicators
+
+            if let offered = syncOfferPage {
+                SyncOfferBanner(
+                    onGo: {
+                        withAnimation(Motion.page) { page = offered }
+                        dismissSyncOffer()
+                    },
+                    onDismiss: dismissSyncOffer
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
+            chrome
+        }
+        .statusBarHidden(!chromeVisible)
+        .persistentSystemOverlays(chromeVisible ? .automatic : .hidden)
+        // The stage is black whatever the app theme, so the status bar and
+        // any glass chrome have to resolve against a dark page.
+        .preferredColorScheme(.dark)
+        .task { await prepare() }
+        .onChange(of: page) { _, newPage in
+            Task {
+                await pages?.prefetch(around: newPage)
+                await persist(force: false)
+            }
+        }
+        .onChange(of: audio.isActive) { _, active in
+            if !active { showPlayer = false }
+        }
+        .onDisappear {
+            Task { await finish() }
+        }
+        // The audio dock: playback stays controllable while reading, same
+        // as the EPUB reader's immersive-read contract.
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            VStack(spacing: 0) {
+                if audio.isActive {
+                    MiniPlayerBar(onExpand: { showPlayer = true })
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .animation(Motion.glide, value: audio.isActive)
+        }
+        .sheet(isPresented: $showPlayer) {
+            if let audioBook = audio.book {
+                PlayerView(book: audioBook, fileID: audio.fileID)
+                    .preferredColorScheme(appState.theme.colorScheme)
+            }
+        }
+    }
+
+    // MARK: - Pager
+
+    private func pager(_ pages: ComicPages) -> some View {
+        TabView(selection: $page) {
+            ForEach(0..<pages.count, id: \.self) { index in
+                ComicPageCell(index: index, pages: pages, onTap: handleTap)
+                    .tag(index)
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .ignoresSafeArea()
+    }
+
+    private func handleTap(_ zone: ComicTapZone) {
+        switch zone {
+        case .previous:
+            guard page > 0 else { return }
+            withAnimation(Motion.page) { page -= 1 }
+        case .next:
+            guard let pages, page < pages.count - 1 else { return }
+            withAnimation(Motion.page) { page += 1 }
+        case .toggle:
+            withAnimation(Motion.settle) { chromeVisible.toggle() }
+        }
+    }
+
+    // MARK: - Chrome
+
+    /// The two centred labels: the book above, the page below — the page
+    /// count joining in while the chrome (navigation, not reading) is up.
+    /// Same bands and type as the EPUB reader's `ReaderIndicatorLabels`.
+    private var indicators: some View {
+        VStack(spacing: 0) {
+            indicatorLabel(pages == nil ? nil : book.displayTitle)
+                .padding(.top, Spacing.xs)
+            Spacer(minLength: 0)
+            indicatorLabel(pageLabel)
+                .padding(.bottom, Spacing.xs)
+        }
+        .allowsHitTesting(false)
+    }
+
+    private var pageLabel: String? {
+        guard let pages, pages.count > 0 else { return nil }
+        return chromeVisible ? "\(page + 1) of \(pages.count)" : "\(page + 1)"
+    }
+
+    @ViewBuilder
+    private func indicatorLabel(_ text: String?) -> some View {
+        if let text {
+            Text(text)
+                .font(.ui(12.5))
+                .foregroundStyle(.white.opacity(0.5))
+                .lineLimit(1)
+                .frame(height: ReaderMenu.buttonSize)
+                .padding(.horizontal, 72)
+        }
+    }
+
+    @ViewBuilder
+    private var chrome: some View {
+        if chromeVisible {
+            VStack {
+                HStack {
+                    Spacer()
+                    ReaderGlassButton(
+                        icon: "xmark",
+                        label: "Close book",
+                        ink: .white,
+                        diameter: ReaderMenu.buttonSize
+                    ) {
+                        dismiss()
+                    }
+                }
+                .padding(.horizontal, ReaderMenu.inset)
+                .padding(.top, Spacing.xs)
+
+                Spacer()
+
+                if let pages, pages.count > 1 {
+                    pageSlider(pages)
+                        .padding(.bottom, 34)
+                }
+            }
+            .transition(.opacity)
+        }
+    }
+
+    /// The whole-book scrubber: one slider row, page-stepped. Comics have no
+    /// chapters or locations pass, so unlike the EPUB reader the range is
+    /// exact from the first paint.
+    private func pageSlider(_ pages: ComicPages) -> some View {
+        Slider(
+            value: Binding(
+                get: { Double(page) },
+                set: { page = Int($0.rounded()) }
+            ),
+            in: 0...Double(pages.count - 1),
+            step: 1
+        )
+        .tint(.white.opacity(0.85))
+        .padding(.horizontal, 18)
+        .frame(width: ReaderMenu.width, height: ReaderMenu.rowHeight)
+        .glassEffect(.regular, in: .capsule)
+        .accessibilityLabel("Page")
+        .accessibilityValue("Page \(page + 1) of \(pages.count)")
+    }
+
+    /// Declining is as final as accepting — re-offering the same page on the
+    /// next turn would nag through the whole book.
+    private func dismissSyncOffer() {
+        withAnimation(Motion.settle) { syncOfferPage = nil }
+    }
+
+    // MARK: - Lifecycle
+
+    private func prepare() async {
+        guard pages == nil, failureMessage == nil else { return }
+
+        // Open from what this device already knows, with no network in the
+        // path — a downloaded comic must open with the server gone.
+        let local = await UserDataService.localProgress(uuid: book.uuid, format: .epub)
+        openedProgress = local
+
+        let source = await resolveSource()
+        guard let source else { return }
+        guard source.count > 0 else {
+            failureMessage = "This comic has no pages."
+            return
+        }
+
+        var start = ComicPosition.startPage(
+            anchor: local?.epubCFI,
+            percent: local?.progressPercent,
+            count: source.count
+        )
+
+        // A position from another device, folded into the first paint when
+        // it answers within the deadline and offered as a jump when it
+        // lands later — the EPUB reader's open contract.
+        let remote = Task { @MainActor in
+            await PositionSync.newerRemote(uuid: book.uuid, format: .epub, than: local)
+        }
+        if let settled = await firstResult(of: remote, within: PositionSync.openDeadline) {
+            start = resumePage(of: settled, count: source.count)
+        }
+
+        page = start
+        pages = source
+        sessionStart = Date()
+        await source.prefetch(around: start)
+
+        LifecycleSync.shared.register(source) {
+            await persist(force: true)
+            await checkpointSession()
+        } resume: {
+            // Only when the flush actually stopped the clock — an
+            // `.inactive` blip comes back through here without ever having
+            // backgrounded.
+            if sessionStart == nil { sessionStart = Date() }
+        }
+        LifecycleSync.shared.didOpenBook()
+
+        guard let record = await remote.value else { return }
+        let offered = resumePage(of: record, count: source.count)
+        if offered != page {
+            withAnimation(Motion.settle) { syncOfferPage = offered }
+        }
+    }
+
+    /// The downloaded archive when this book is on the device, else the
+    /// server's per-page endpoint sized by the detail read's `page_count`.
+    private func resolveSource() async -> ComicPages? {
+        if let local = DownloadManager.shared.localURL(for: book.uuid, kind: .ebook),
+           local.pathExtension.lowercased() == "cbz"
+        {
+            do {
+                return try ComicPages(localURL: local)
+            } catch {
+                // A damaged download must not dead-end the book while the
+                // server can still serve it page by page.
+                guard Connectivity.shared.isOnline else {
+                    failureMessage = error.localizedDescription
+                    return nil
+                }
+            }
+        }
+        if let count = book.pageCount, count > 0 {
+            return ComicPages(uuid: book.uuid, count: Int(count))
+        }
+        // Opened from a surface whose payload has no page count (the resume
+        // rail's projection) — the detail read carries it.
+        if let detail = try? await LibraryService.settledBook(uuid: book.uuid),
+           let count = detail.pageCount, count > 0
+        {
+            return ComicPages(uuid: book.uuid, count: Int(count))
+        }
+        failureMessage = "This comic couldn't be opened."
+        return nil
+    }
+
+    /// The page a saved record resumes at, via the shared anchor-then-percent
+    /// fallback.
+    private func resumePage(of record: ProgressRecord, count: Int) -> Int {
+        ComicPosition.startPage(
+            anchor: record.epubCFI,
+            percent: record.progressPercent,
+            count: count
+        )
+    }
+
+    /// Record where the reader is. `force` marks the moments worth a round
+    /// trip of their own — a close, a backgrounding — while page turns queue
+    /// and go out with the next push, exactly like the EPUB reader's CFI
+    /// trickle.
+    private func persist(force: Bool) async {
+        guard let pages, pages.count > 0 else { return }
+        guard force || Date().timeIntervalSince(lastSave) > 4 else { return }
+        lastSave = Date()
+        let clamped = min(max(page, 0), pages.count - 1)
+        await UserDataService.saveProgress(
+            ProgressUpdate(
+                bookUUID: book.uuid,
+                format: .epub,
+                epubCFI: ComicPosition.anchor(page: clamped),
+                audioPositionSeconds: nil,
+                progressPercent: ComicPosition.percent(page: clamped, count: pages.count)
+            ),
+            push: force
+        )
+        await checkpointSessionIfStale()
+    }
+
+    private func checkpointSessionIfStale() async {
+        guard let start = sessionStart,
+              Date().timeIntervalSince(start) >= Self.sessionCheckpointInterval
+        else { return }
+        await checkpointSession(restarting: true)
+    }
+
+    /// Report the stretch of reading that just ended — same rules as the
+    /// EPUB reader: disjoint spans across backgroundings, own client id per
+    /// report, sub-5-second stretches returned to the clock.
+    private func checkpointSession(restarting: Bool = false) async {
+        guard let start = sessionStart else { return }
+        let end = Date()
+        sessionStart = restarting ? end : nil
+        let elapsed = Int64(end.timeIntervalSince(start))
+        guard elapsed >= 5 else {
+            if restarting { sessionStart = start }
+            return
+        }
+        await UserDataService.reportSessions([
+            SessionReport(
+                bookUUID: book.uuid,
+                format: .epub,
+                startedAt: Int64(start.timeIntervalSince1970),
+                endedAt: Int64(end.timeIntervalSince1970),
+                progressUnits: elapsed,
+                deviceId: nil
+            )
+        ])
+    }
+
+    private func finish() async {
+        if let pages { LifecycleSync.shared.unregister(pages) }
+        await persist(force: true)
+        await checkpointSession()
+        Presentation.shared.noteProgressPersisted()
+        // Last, so the position and the session report are both queued
+        // before the drain goes looking for them.
+        LifecycleSync.shared.didCloseBook()
+    }
+}
+
+/// One page of the pager: spinner while the bytes come, the zoomable image
+/// once decoded, and a tappable retry when a fetch fails.
+private struct ComicPageCell: View {
+    let index: Int
+    let pages: ComicPages
+    let onTap: (ComicTapZone) -> Void
+
+    @State private var image: UIImage?
+    @State private var failed = false
+
+    var body: some View {
+        ZStack {
+            if let image {
+                ComicPageView(image: image, onTap: onTap)
+            } else if failed {
+                ErrorStateView(message: "This page couldn't be loaded.") {
+                    failed = false
+                    Task { await load() }
+                }
+            } else {
+                ProgressView()
+                    .controlSize(.large)
+                    .tint(.white.opacity(0.6))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+        .task(id: index) { await load() }
+    }
+
+    private func load() async {
+        guard image == nil else { return }
+        do {
+            let bytes = try await pages.page(index)
+            guard let decoded = UIImage(data: bytes) else {
+                failed = true
+                return
+            }
+            // Decode off the render path — a multi-megapixel page decoded
+            // lazily at draw time stutters the turn that revealed it.
+            image = await decoded.byPreparingForDisplay() ?? decoded
+        } catch {
+            failed = true
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
+++ b/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
@@ -106,9 +106,14 @@ private struct HeroCard: View {
 
     private var isAudio: Bool { format == .audio }
 
-    /// Only a listening position has an honest fraction, and only while the card
-    /// is still presenting itself as one.
-    private var fraction: Double? { isAudio ? point.fraction : nil }
+    /// The record's own honest fraction — audio's position over its duration,
+    /// or a reading record's cross-surface percent (a comic position always
+    /// carries one; a CFI-only EPUB save never does) — but not a listening
+    /// fraction on a card no longer presenting itself as one.
+    private var fraction: Double? {
+        if isAudio != point.isAudio { return nil }
+        return point.fraction
+    }
 
     private var washTone: OKLCH {
         OKLCH(palette.bg0.l > 0.5 ? 0.93 : 0.24, tone.c * 0.6, tone.h)
@@ -154,8 +159,8 @@ private struct HeroCard: View {
 
                     Spacer(minLength: 4)
 
-                    // An EPUB resume point carries a CFI, not a percentage, so
-                    // there is no honest bar to draw for one. The band the bar
+                    // A CFI-only EPUB resume point has no honest percentage,
+                    // so there is no bar to draw for one. The band the bar
                     // would occupy goes to when you left off instead of sitting
                     // empty — which is what made the card read as underfilled.
                     if let fraction {

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -93,6 +93,10 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
     var hasCoverOverride: Bool = false
     var bookFiles: [BookFileInfo] = []
     var epubSizeBytes: Int64?
+    /// Page count of the book's CBZ archive, attached by the detail read for
+    /// comic books only — the pager's slider range and progress mapping.
+    /// `nil` on every other payload (list projections, non-comics).
+    var pageCount: Int64?
 
     enum CodingKeys: String, CodingKey {
         case id, filename, title, description, publisher, published, modified
@@ -108,6 +112,7 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
         case hasCoverOverride = "has_cover_override"
         case bookFiles = "book_files"
         case epubSizeBytes = "epub_size_bytes"
+        case pageCount = "page_count"
     }
 
     /// Stable identity used for every `/books/:uuid` and `/api/covers/:uuid`
@@ -136,6 +141,19 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
         formats.contains { Self.audioFormats.contains($0.lowercased()) }
     }
 
+    var hasEpub: Bool {
+        formats.contains { $0.caseInsensitiveCompare("epub") == .orderedSame }
+    }
+
+    var hasComic: Bool {
+        formats.contains { $0.caseInsensitiveCompare("cbz") == .orderedSame }
+    }
+
+    /// Whether "Read" opens the native comic pager rather than the EPUB
+    /// reader. A book carrying both keeps the EPUB as its primary read —
+    /// the same rule the web pager and the server's `/file` resolution use.
+    var opensAsComic: Bool { hasComic && !hasEpub }
+
     static let ebookFormats: Set<String> = ["epub", "kepub", "pdf", "mobi", "azw3", "cbz", "cbr"]
     static let audioFormats: Set<String> = ["m4b", "m4a", "mp3", "aac", "flac", "ogg", "opus", "wav"]
 
@@ -143,16 +161,6 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
     /// `resolve_audiobook_file` in `db/src/hls/query.rs` filters on exactly
     /// these, so offering any other format as a selection would 404.
     static let selectableAudioFormats: Set<String> = ["m4b", "m4a", "mp3"]
-
-    /// The ebook formats a download actually pulls.
-    ///
-    /// `/api/ebooks/{uuid}/file` resolves `book_file_path(id, "EPUB")` — EPUB
-    /// and nothing else — so this is deliberately narrower than
-    /// ``ebookFormats``, which is the set the library *contains*. Snapshotting
-    /// a validator against the broader set means a mixed PDF/EPUB book records
-    /// the PDF's tag while downloading the EPUB, and then reports staleness
-    /// about the wrong file in both directions.
-    static let downloadableEbookFormats: Set<String> = ["epub"]
 
     /// The audiobook files a listener can choose between, in the order the
     /// server resolves them — its default (no `file_id`) is the first of
@@ -399,6 +407,10 @@ struct ProgressUpdate: Codable, Sendable {
     var format: ProgressFormat
     var epubCFI: String?
     var audioPositionSeconds: Double?
+    /// Whole-book percent, 0...100 — the cross-surface half of a position.
+    /// Set by the comic pager (whose `epubCFI` is a page anchor, not a CFI)
+    /// so the landing surfaces can draw a bar without parsing the anchor.
+    var progressPercent: Int64?
     /// When the reader actually moved here, by this device's clock.
     ///
     /// Stamped at the gesture rather than left to the server, because a write
@@ -416,6 +428,7 @@ struct ProgressUpdate: Codable, Sendable {
         case bookUUID = "book_uuid"
         case epubCFI = "epub_cfi"
         case audioPositionSeconds = "audio_position_seconds"
+        case progressPercent = "progress_percent"
         case clientUpdatedAt = "client_updated_at"
         case bookFileID = "book_file_id"
     }
@@ -426,6 +439,10 @@ struct ProgressRecord: Codable, Sendable {
     var format: ProgressFormat
     var epubCFI: String?
     var audioPositionSeconds: Double?
+    /// Whole-book percent, 0...100, when the write carried one — a comic
+    /// position always does, a Kobo's percent-only write does, a CFI-only
+    /// EPUB save does not.
+    var progressPercent: Int64?
     /// When the server stored this row, on the *server's* clock.
     var updatedAt: Int64
     /// When the reader moved here, on the clock of the device that moved them.
@@ -454,6 +471,7 @@ struct ProgressRecord: Codable, Sendable {
         case bookUUID = "book_uuid"
         case epubCFI = "epub_cfi"
         case audioPositionSeconds = "audio_position_seconds"
+        case progressPercent = "progress_percent"
         case updatedAt = "updated_at"
         case clientUpdatedAt = "client_updated_at"
         case bookFileID = "book_file_id"
@@ -493,13 +511,20 @@ struct ResumePoint: Codable, Sendable, Identifiable {
 
     /// Fraction complete for the progress bar, when the format supports one.
     ///
-    /// Audio only — an EPUB position is a CFI, and there is no honest
-    /// percentage to derive from one. The format check is what keeps a reading
-    /// card from borrowing the listening card's bar.
+    /// Audio derives it from the position over the whole-book duration. A
+    /// reading record has one only when it carries the cross-surface percent
+    /// — a comic position always does, a CFI-only EPUB save does not, and
+    /// there is no honest percentage to derive from a bare CFI. The format
+    /// check is what keeps a reading card from borrowing the listening
+    /// card's bar.
     var fraction: Double? {
-        guard isAudio, let total = totalDurationSeconds, total > 0,
-              let position = record.audioPositionSeconds else { return nil }
-        return min(1, max(0, position / total))
+        if isAudio {
+            guard let total = totalDurationSeconds, total > 0,
+                  let position = record.audioPositionSeconds else { return nil }
+            return min(1, max(0, position / total))
+        }
+        guard let percent = record.progressPercent else { return nil }
+        return min(1, max(0, Double(percent) / 100))
     }
 }
 

--- a/omnibus-ios/omnibus/Offline/DownloadManager.swift
+++ b/omnibus-ios/omnibus/Offline/DownloadManager.swift
@@ -131,18 +131,28 @@ final class DownloadManager: NSObject {
     ///
     /// The narrow format sets matter. `Book.ebookFormats` and
     /// `Book.audioFormats` describe what a library can *contain*; the
-    /// endpoints serve EPUB, and M4B/M4A/MP3. Matching on the broad sets lets
-    /// a mixed book — a PDF at ordinal 0, the EPUB at ordinal 1 — snapshot
-    /// the PDF's validator while downloading the EPUB, which then reports a
-    /// stale download whenever the PDF changes and misses every change to the
-    /// file actually on the device.
+    /// endpoints serve EPUB (else CBZ for a comic-only book), and
+    /// M4B/M4A/MP3. Matching on the broad sets lets a mixed book — a PDF at
+    /// ordinal 0, the EPUB at ordinal 1 — snapshot the PDF's validator while
+    /// downloading the EPUB, which then reports a stale download whenever
+    /// the PDF changes and misses every change to the file actually on the
+    /// device.
     nonisolated static func targetFile(_ book: Book, kind: DownloadKind) -> BookFileInfo? {
-        let formats = kind == .audio
-            ? Book.selectableAudioFormats
-            : Book.downloadableEbookFormats
-        return book.bookFiles
-            .filter { formats.contains($0.format.lowercased()) }
-            .min { $0.ordinal < $1.ordinal }
+        if kind == .audio {
+            return book.bookFiles
+                .filter { Book.selectableAudioFormats.contains($0.format.lowercased()) }
+                .min { $0.ordinal < $1.ordinal }
+        }
+        // Mirror `/file`'s two-step resolution exactly: the EPUB wins when
+        // the book has one, and the CBZ answers only after that — not the
+        // lowest ordinal across both, which would snapshot the CBZ's
+        // validator on a dual-format book whose EPUB is what downloads.
+        func lowest(_ format: String) -> BookFileInfo? {
+            book.bookFiles
+                .filter { $0.format.lowercased() == format }
+                .min { $0.ordinal < $1.ordinal }
+        }
+        return lowest("epub") ?? lowest("cbz")
     }
 
     /// Whether the library file has moved under a downloaded copy — the
@@ -214,7 +224,8 @@ final class DownloadManager: NSObject {
     }
 
     /// Begin (or restart) a download. `kind` picks the endpoint: an ebook pulls
-    /// `/api/ebooks/{uuid}/file`, an audiobook `/api/audiobooks/{uuid}/download`.
+    /// `/api/ebooks/{uuid}/file` (the EPUB, or a comic-only book's CBZ), an
+    /// audiobook `/api/audiobooks/{uuid}/download`.
     ///
     /// `replacing` carries the completed record this download is standing in
     /// for, so the book stays readable throughout and is restored on failure.
@@ -223,9 +234,13 @@ final class DownloadManager: NSObject {
         let path = kind == .audio
             ? "/api/audiobooks/\(uuid)/download"
             : "/api/ebooks/\(uuid)/file"
+        // The stored format names the file the endpoint will actually send —
+        // it becomes the local file's extension, which is how the comic
+        // reader recognises a downloaded archive.
         let format = kind == .audio
             ? (book.formats.first { Book.audioFormats.contains($0.lowercased()) } ?? "m4b")
-            : "epub"
+            : (Self.targetFile(book, kind: .ebook)?.format.lowercased()
+                ?? (book.opensAsComic ? "cbz" : "epub"))
 
         guard let url = await APIClient.shared.absoluteURL(path) else { return }
         var request = URLRequest(url: url)
@@ -394,6 +409,28 @@ extension DownloadManager: URLSessionDownloadDelegate {
             }
 
             guard let record = self.records[key] else { return }
+
+            // CBZ integrity check *before* the swap, so a damaged transfer
+            // never replaces a readable copy: every zip entry carries a
+            // recorded CRC-32, and reading each to EOF verifies it — the
+            // CRC-backed tier of rule 09's post-download backstop. Only
+            // comics get this today; the EPUB/audio formats have no
+            // verifier on this client yet.
+            if record.format.lowercased() == "cbz" {
+                let intact = await Task.detached(priority: .utility) {
+                    ComicArchive.verify(url: staged)
+                }.value
+                guard intact else {
+                    try? FileManager.default.removeItem(at: staged)
+                    if await self.restoreReplaced(key: key) { return }
+                    await self.update(key: key) { record in
+                        record.state = .failed
+                        record.error = "The download failed its integrity check."
+                    }
+                    return
+                }
+            }
+
             let name = "\(record.bookUUID).\(record.kind.rawValue).\(record.format)"
             let destination = OfflineStore.downloadsDirectory.appendingPathComponent(name)
             try? FileManager.default.removeItem(at: destination)

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -69,6 +69,7 @@ enum UserDataService {
             format: update.format,
             epubCFI: update.epubCFI,
             audioPositionSeconds: update.audioPositionSeconds,
+            progressPercent: update.progressPercent,
             // The device clock on both, because that is what this write will
             // be ordered on when it reaches the server. Leaving `clientUpdatedAt`
             // unset here would make the optimistic row the one thing in the

--- a/omnibus-ios/omnibusTests/ComicArchiveTests.swift
+++ b/omnibus-ios/omnibusTests/ComicArchiveTests.swift
@@ -207,6 +207,27 @@ struct ComicArchiveVerifyTests {
         #expect(!ComicArchive.verify(url: url))
     }
 
+    @Test("the verdict is about the pages — damaged metadata doesn't fail it")
+    func nonPageEntriesAreNotVerified() throws {
+        // Corrupt a *non-page* entry and leave the page clean: the comic is
+        // still fully readable offline, so the download must not be refused
+        // for it — and verifying only pages is also what keeps a crafted
+        // non-page entry from becoming a zip-bomb lever in the check.
+        var bytes = buildStoredZip([
+            ("p1.jpg", pageOne),
+            ("ComicInfo.xml", Data("<ComicInfo/>".utf8)),
+        ])
+        let junk = Data("<ComicInfo/>".utf8)
+        let range = bytes.range(of: junk)!
+        bytes[range.lowerBound] ^= 0xFF
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("comic-junk-\(UUID().uuidString).cbz")
+        try bytes.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(ComicArchive.verify(url: url))
+    }
+
     @Test("an archive with no pages is a broken download, not an empty book")
     func pagelessArchiveIsDamage() throws {
         let url = try writeCBZ([("ComicInfo.xml", Data("<ComicInfo/>".utf8))])

--- a/omnibus-ios/omnibusTests/ComicArchiveTests.swift
+++ b/omnibus-ios/omnibusTests/ComicArchiveTests.swift
@@ -1,0 +1,225 @@
+//  ComicArchiveTests.swift
+//  The local CBZ page source: page ordering, CRC-checked reads, and the
+//  post-download integrity verdict.
+//
+//  The zip fixtures are built by hand (a port of `db::test_support`'s
+//  `build_stored_zip`) rather than through ZIPFoundation, so a test can
+//  corrupt a byte and know the recorded CRC no longer matches — and so the
+//  ordering cases are byte-for-byte the ones the server's own comic tests
+//  pin. Index N here must be the page `/pages/N` would serve.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+// MARK: - Stored-zip fixture builder
+
+/// CRC-32 (IEEE), the checksum zip records per entry.
+private func crc32(_ data: Data) -> UInt32 {
+    var crc: UInt32 = 0xFFFF_FFFF
+    for byte in data {
+        crc ^= UInt32(byte)
+        for _ in 0..<8 {
+            crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB8_8320 : crc >> 1
+        }
+    }
+    return ~crc
+}
+
+/// Minimal stored (uncompressed) zip: local headers, data, central
+/// directory, EOCD. Port of `db::test_support::build_stored_zip`.
+private func buildStoredZip(_ entries: [(String, Data)]) -> Data {
+    var out = Data()
+    var central = Data()
+
+    func append<T: FixedWidthInteger>(_ value: T, to data: inout Data) {
+        withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    for (name, bytes) in entries {
+        let offset = UInt32(out.count)
+        let crc = crc32(bytes)
+        let nameBytes = Data(name.utf8)
+        let size = UInt32(bytes.count)
+
+        append(UInt32(0x0403_4B50), to: &out)
+        append(UInt16(20), to: &out) // version needed
+        append(UInt16(0), to: &out) // flags
+        append(UInt16(0), to: &out) // method: stored
+        append(UInt16(0), to: &out) // mod time
+        append(UInt16(0), to: &out) // mod date
+        append(crc, to: &out)
+        append(size, to: &out) // compressed size
+        append(size, to: &out) // uncompressed size
+        append(UInt16(nameBytes.count), to: &out)
+        append(UInt16(0), to: &out) // extra len
+        out.append(nameBytes)
+        out.append(bytes)
+
+        append(UInt32(0x0201_4B50), to: &central)
+        append(UInt16(20), to: &central) // version made by
+        append(UInt16(20), to: &central) // version needed
+        append(UInt16(0), to: &central) // flags
+        append(UInt16(0), to: &central) // method
+        append(UInt16(0), to: &central) // mod time
+        append(UInt16(0), to: &central) // mod date
+        append(crc, to: &central)
+        append(size, to: &central)
+        append(size, to: &central)
+        append(UInt16(nameBytes.count), to: &central)
+        append(UInt16(0), to: &central) // extra
+        append(UInt16(0), to: &central) // comment
+        append(UInt16(0), to: &central) // disk start
+        append(UInt16(0), to: &central) // internal attrs
+        append(UInt32(0), to: &central) // external attrs
+        append(offset, to: &central)
+        central.append(nameBytes)
+    }
+
+    let cdOffset = UInt32(out.count)
+    out.append(central)
+    append(UInt32(0x0605_4B50), to: &out)
+    append(UInt16(0), to: &out) // this disk
+    append(UInt16(0), to: &out) // cd start disk
+    append(UInt16(entries.count), to: &out)
+    append(UInt16(entries.count), to: &out)
+    append(UInt32(central.count), to: &out)
+    append(cdOffset, to: &out)
+    append(UInt16(0), to: &out) // comment len
+    return out
+}
+
+/// Write a fixture archive to a scratch file the test cleans up.
+private func writeCBZ(_ entries: [(String, Data)]) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("comic-test-\(UUID().uuidString).cbz")
+    try buildStoredZip(entries).write(to: url)
+    return url
+}
+
+private let pageOne = Data("PAGE-ONE-BYTES".utf8)
+private let pageTwo = Data("PAGE-TWO-BYTES".utf8)
+
+@Suite("Comic archive page listing")
+struct ComicArchiveListingTests {
+    @Test("pages come out in natural-sort order, junk excluded")
+    func pagesAreNaturallyOrderedAndFiltered() throws {
+        // Same shape the server's comic tests seed: entry order is not page
+        // order, AppleDouble forks carry image extensions but aren't pages,
+        // and ComicInfo.xml is metadata, not a page.
+        let url = try writeCBZ([
+            ("p10.jpg", pageTwo),
+            ("p2.jpg", pageOne),
+            ("__MACOSX/._p2.jpg", Data("junk".utf8)),
+            ("ComicInfo.xml", Data("<ComicInfo/>".utf8)),
+        ])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let archive = try ComicArchive(url: url)
+        // Numeric ordering — "p2" before "p10" — is the whole reason the
+        // sort is natural rather than lexical.
+        #expect(archive.pages == ["p2.jpg", "p10.jpg"])
+    }
+
+    @Test("numeric ties order deterministically, like the server")
+    func naturalCompareMatchesTheServer() {
+        // "007" vs "7": equal numerically, so the run length breaks the tie.
+        #expect(ComicArchive.naturalCompare("p7.jpg", "p007.jpg") == .orderedAscending)
+        #expect(ComicArchive.naturalCompare("P2.jpg", "p10.jpg") == .orderedAscending)
+        #expect(ComicArchive.naturalCompare("b1.png", "a2.png") == .orderedDescending)
+        #expect(ComicArchive.naturalCompare("same.png", "same.png") == .orderedSame)
+    }
+
+    @Test("a file that is not a zip refuses to open")
+    func garbageRefusesToOpen() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("not-a-zip-\(UUID().uuidString).cbz")
+        try Data("not a zip at all".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(throws: ComicArchiveError.self) {
+            _ = try ComicArchive(url: url)
+        }
+    }
+}
+
+@Suite("Comic archive page reads")
+struct ComicArchiveReadTests {
+    @Test("a page reads back its exact bytes by natural-sort index")
+    func pageReadsByIndex() throws {
+        let url = try writeCBZ([("p2.png", pageTwo), ("p1.jpg", pageOne)])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let archive = try ComicArchive(url: url)
+        #expect(try archive.page(at: 0) == pageOne)
+        #expect(try archive.page(at: 1) == pageTwo)
+    }
+
+    @Test("an out-of-range index is an error, not a crash")
+    func outOfRangeThrows() throws {
+        let url = try writeCBZ([("p1.jpg", pageOne)])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let archive = try ComicArchive(url: url)
+        #expect(throws: ComicArchiveError.self) {
+            _ = try archive.page(at: 1)
+        }
+    }
+
+    @Test("a corrupted page fails its CRC on read")
+    func corruptionFailsTheRead() throws {
+        var bytes = buildStoredZip([("p1.jpg", pageOne)])
+        // Flip one byte inside the page data — structure intact, CRC not.
+        let range = bytes.range(of: pageOne)!
+        bytes[range.lowerBound] ^= 0xFF
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("comic-corrupt-\(UUID().uuidString).cbz")
+        try bytes.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let archive = try ComicArchive(url: url)
+        #expect(throws: Error.self) {
+            _ = try archive.page(at: 0)
+        }
+    }
+}
+
+@Suite("Comic archive integrity verdict")
+struct ComicArchiveVerifyTests {
+    @Test("a clean archive verifies intact")
+    func cleanArchiveIsIntact() throws {
+        let url = try writeCBZ([("p1.jpg", pageOne), ("p2.png", pageTwo)])
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(ComicArchive.verify(url: url))
+    }
+
+    @Test("a flipped byte is provably damage — structure alone would pass it")
+    func corruptionIsDamage() throws {
+        var bytes = buildStoredZip([("p1.jpg", pageOne)])
+        let range = bytes.range(of: pageOne)!
+        bytes[range.lowerBound] ^= 0xFF
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("comic-damaged-\(UUID().uuidString).cbz")
+        try bytes.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(!ComicArchive.verify(url: url))
+    }
+
+    @Test("an archive with no pages is a broken download, not an empty book")
+    func pagelessArchiveIsDamage() throws {
+        let url = try writeCBZ([("ComicInfo.xml", Data("<ComicInfo/>".utf8))])
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(!ComicArchive.verify(url: url))
+    }
+
+    @Test("a file that is not an archive at all is damage")
+    func garbageIsDamage() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("garbage-\(UUID().uuidString).cbz")
+        try Data("garbage".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(!ComicArchive.verify(url: url))
+    }
+}

--- a/omnibus-ios/omnibusTests/ComicPositionTests.swift
+++ b/omnibus-ios/omnibusTests/ComicPositionTests.swift
@@ -1,0 +1,118 @@
+//  ComicPositionTests.swift
+//  The comic page ↔ progress record mapping — the arithmetic every device
+//  agrees on.
+//
+//  These mirror the web pager's tests for the same math: the anchor
+//  round-trip, the percent's endpoint behaviour, and the resume fallback
+//  chain. A divergence here is a book that resumes on a different page than
+//  the one the other client saved.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+@Suite("Comic page anchor")
+struct ComicAnchorTests {
+    @Test("an anchor round-trips through its parser")
+    func anchorRoundTrips() {
+        #expect(ComicPosition.anchor(page: 0) == "comic-page:0")
+        #expect(ComicPosition.parseAnchor(ComicPosition.anchor(page: 12)) == 12)
+    }
+
+    @Test("a real EPUB CFI is not misread as a page")
+    func foreignPositionsAreRejected() {
+        // The prefix is what makes the anchor self-describing — a CFI or
+        // garbage must fall through to the percent fallback, never parse.
+        #expect(ComicPosition.parseAnchor("epubcfi(/6/4!/4/2)") == nil)
+        #expect(ComicPosition.parseAnchor("comic-page:") == nil)
+        #expect(ComicPosition.parseAnchor("comic-page:12b") == nil)
+        #expect(ComicPosition.parseAnchor("") == nil)
+    }
+}
+
+@Suite("Comic percent")
+struct ComicPercentTests {
+    @Test("first and last pages map to the ends of the bar")
+    func endpointsMapToEnds() {
+        // Same cases the web pager pins: page 0 of a long book reads as 0,
+        // the last page as 100, a single-page book as 100, and an empty
+        // archive degrades to 0 rather than dividing by zero.
+        #expect(ComicPosition.percent(page: 0, count: 219) == 0)
+        #expect(ComicPosition.percent(page: 218, count: 219) == 100)
+        #expect(ComicPosition.percent(page: 0, count: 1) == 100)
+        #expect(ComicPosition.percent(page: 0, count: 0) == 0)
+    }
+
+    @Test("the midpoint rounds like the web pager")
+    func midpointMatchesTheWebMath() {
+        // (10+1)*100/20 = 55 — the +1 is what makes the last page 100.
+        #expect(ComicPosition.percent(page: 10, count: 20) == 55)
+    }
+}
+
+@Suite("Comic resume page")
+struct ComicStartPageTests {
+    @Test("the exact anchor wins over the percent")
+    func anchorWins() {
+        let page = ComicPosition.startPage(
+            anchor: ComicPosition.anchor(page: 7), percent: 100, count: 20
+        )
+        #expect(page == 7)
+    }
+
+    @Test("an anchor past the end of a shrunken re-scan is clamped")
+    func anchorIsClamped() {
+        let page = ComicPosition.startPage(
+            anchor: ComicPosition.anchor(page: 50), percent: nil, count: 20
+        )
+        #expect(page == 19)
+    }
+
+    @Test("the percent inverts when there is no anchor")
+    func percentFallsBack() {
+        // A CFI is not an anchor, so a foreign position falls through to
+        // the percent — round(50/100 × 10) − 1 = 4.
+        #expect(
+            ComicPosition.startPage(anchor: "epubcfi(/6/4)", percent: 50, count: 10) == 4
+        )
+        #expect(ComicPosition.startPage(anchor: nil, percent: 0, count: 10) == 0)
+        #expect(ComicPosition.startPage(anchor: nil, percent: 100, count: 10) == 9)
+    }
+
+    @Test("no position at all opens on page one")
+    func bareOpenStartsAtZero() {
+        #expect(ComicPosition.startPage(anchor: nil, percent: nil, count: 10) == 0)
+        #expect(ComicPosition.startPage(anchor: nil, percent: nil, count: 0) == 0)
+    }
+}
+
+@Suite("Resume card fraction")
+struct ComicResumeFractionTests {
+    private func record(percent: Int64?) -> ProgressRecord {
+        ProgressRecord(
+            bookUUID: "u1", format: .epub, epubCFI: ComicPosition.anchor(page: 3),
+            audioPositionSeconds: nil, progressPercent: percent,
+            updatedAt: 100, clientUpdatedAt: 100, bookFileID: nil
+        )
+    }
+
+    private func point(percent: Int64?) -> ResumePoint {
+        ResumePoint(
+            record: record(percent: percent),
+            book: Book(id: 1, filename: "c.cbz"),
+            totalDurationSeconds: nil, chapterNumber: nil, chapterCount: nil
+        )
+    }
+
+    @Test("a comic record's percent drives the card's bar")
+    func percentBecomesTheFraction() {
+        #expect(point(percent: 40).fraction == 0.4)
+        #expect(point(percent: 100).fraction == 1.0)
+    }
+
+    @Test("a CFI-only reading record still has no honest fraction")
+    func cfiOnlyRecordsStayBarless() {
+        #expect(point(percent: nil).fraction == nil)
+    }
+}

--- a/omnibus-ios/omnibusTests/ComicPositionTests.swift
+++ b/omnibus-ios/omnibusTests/ComicPositionTests.swift
@@ -28,6 +28,9 @@ struct ComicAnchorTests {
         #expect(ComicPosition.parseAnchor("comic-page:") == nil)
         #expect(ComicPosition.parseAnchor("comic-page:12b") == nil)
         #expect(ComicPosition.parseAnchor("") == nil)
+        // A negative index is malformed, not a page — `startPage` only
+        // clamps the top end, so parsing one would aim below page zero.
+        #expect(ComicPosition.parseAnchor("comic-page:-1") == nil)
     }
 }
 

--- a/omnibus-ios/omnibusTests/OfflineSyncTests.swift
+++ b/omnibus-ios/omnibusTests/OfflineSyncTests.swift
@@ -652,14 +652,44 @@ struct DownloadTargetFileTests {
 
     @Test("a book with no servable file of that kind has nothing to compare")
     func unservableKindsAreUnanswerable() {
-        // Every ebook-ish format except the one the endpoint serves.
-        let noEpub = book([
-            file(1, format: "PDF", ordinal: 0, etag: "\"pdf\""),
-            file(2, format: "CBZ", ordinal: 1, etag: "\"cbz\""),
-        ])
-        #expect(DownloadManager.targetFile(noEpub, kind: .ebook) == nil)
+        // Every ebook-ish format except the ones the endpoint serves.
+        let noServable = book([file(1, format: "PDF", ordinal: 0, etag: "\"pdf\"")])
+        #expect(DownloadManager.targetFile(noServable, kind: .ebook) == nil)
         #expect(
-            DownloadManager.staleness(snapshot: "\"old\"", against: noEpub, kind: .ebook) == nil
+            DownloadManager.staleness(snapshot: "\"old\"", against: noServable, kind: .ebook) == nil
         )
+    }
+
+    @Test("a comic-only book targets its CBZ — the file `/file` falls back to")
+    func comicOnlyBookTargetsTheArchive() {
+        let comic = book([
+            file(1, format: "PDF", ordinal: 0, etag: "\"pdf\""),
+            file(2, format: "CBZ", ordinal: 2, etag: "\"cbz-v1\""),
+            file(3, format: "CBZ", ordinal: 1, etag: "\"cbz-first\""),
+        ])
+        // Lowest-ordinal CBZ, same as `db::book_file_path(id, "CBZ")`.
+        #expect(DownloadManager.targetFile(comic, kind: .ebook)?.id == 3)
+        // The wire etag drives staleness for the archive like any other
+        // downloaded format.
+        #expect(
+            DownloadManager.staleness(snapshot: "\"cbz-old\"", against: comic, kind: .ebook)
+                == true
+        )
+        #expect(
+            DownloadManager.staleness(snapshot: "\"cbz-first\"", against: comic, kind: .ebook)
+                == false
+        )
+    }
+
+    @Test("a dual-format book keeps the EPUB as the served file")
+    func epubStillWinsOverAComicSibling() {
+        // `/file` resolves the EPUB first however the ordinals fall, so the
+        // snapshot must not follow a lower-ordinal CBZ — that would report
+        // staleness about the archive while the device holds the EPUB.
+        let dual = book([
+            file(1, format: "CBZ", ordinal: 0, etag: "\"cbz\""),
+            file(2, format: "EPUB", ordinal: 1, etag: "\"epub\""),
+        ])
+        #expect(DownloadManager.targetFile(dual, kind: .ebook)?.id == 2)
     }
 }


### PR DESCRIPTION
## Summary
- Native SwiftUI comic reader (`omnibus/Comic/`): paged `TabView` with a `UIScrollView` zoom wrapper per page — pinch, double-tap, pan-while-zoomed, gutter-tap page turns, centre-tap chrome with a page slider. Comic-only books route here; the EPUB reader path is untouched.
- Online, pages come from `GET /api/ebooks/{uuid}/pages/{n}` with n±1 prefetch; offline, the whole CBZ downloads through the existing machinery and ZIPFoundation (the app's first and only SPM dependency) reads it in the server's exact natural-sort page order, CRC-checked per entry, with a pre-swap integrity verification in `DownloadManager`.
- Positions ride the shared `comic-page:N` anchor + whole-book percent on the Epub-format progress row, coalesced through the existing `progress:<uuid>:epub` outbox op — so resume syncs both ways, queues offline, and the Continue rail draws a real bar for comics.
- Wire-etag staleness now snapshots the file `/file` actually serves (EPUB, else CBZ), same rule as the server.

Closes #1565. Stacked on #1595 (`-1`, the server-side CBZ fallback).

## Test plan
- [x] `just ios-test` — 143 passed (new `ComicPositionTests` + `ComicArchiveTests` incl. CRC-corruption cases, updated download-selection/staleness suites)
- [x] `just ios-build`
- [ ] Manual: `just ios-sim` against a server seeded with the `aurora-station-*` CBZ fixtures — page turns, pinch zoom, offline open after download

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
>[!NOTE]
> ZIPFoundation is pinned via the committed `Package.resolved` (0.9.20); its `extract` computes but does not compare CRCs, so `ComicArchive` does the comparison explicitly — the corruption tests pin that.