### PR TITLE
chore: rename SwiftUI app bundle id to com.omnibus.mobile

### DIFF
--- a/.github/actions/ios-signing/action.yml
+++ b/.github/actions/ios-signing/action.yml
@@ -1,10 +1,10 @@
 name: "iOS signing setup"
 description: >
   Import an Apple Distribution certificate into a throwaway keychain and install
-  an App Store provisioning profile. Shared by the mobile (WebView) and swiftui
-  (native) TestFlight jobs so the security-sensitive keychain code lives in one
-  place. The keychain persists for the rest of the job; delete it in an
-  always() cleanup step using the `keychain-path` output.
+  an App Store provisioning profile. Used by the TestFlight ios job; kept as a
+  composite action so the security-sensitive keychain code lives in one place.
+  The keychain persists for the rest of the job; delete it in an always()
+  cleanup step using the `keychain-path` output.
 
 inputs:
   cert-p12-base64:

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -54,7 +54,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.ios == 'true' || github.event_name != 'pull_request' }}
     # omnibus-ios needs the Xcode 26 / iOS 26 SDK, only on macos-26 — same
-    # pinning as testflight.yml's swiftui job.
+    # pinning as testflight.yml's ios job.
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/testflight-feedback.yml
+++ b/.github/workflows/testflight-feedback.yml
@@ -1,5 +1,5 @@
 # Opens a GitHub issue for each new TestFlight screenshot feedback submission
-# for the native SwiftUI app (com.omnibus.swiftui).
+# for the native SwiftUI app (com.omnibus.mobile).
 #
 # Runs once a day (and on demand). Reuses the App Store Connect API key already
 # configured for the build-upload workflow (testflight.yml) — no new secrets:
@@ -50,6 +50,6 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
-          BUNDLE_IDS: com.omnibus.swiftui
+          BUNDLE_IDS: com.omnibus.mobile
           DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
         run: python scripts/testflight_feedback_to_issues.py

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -8,7 +8,7 @@ name: TestFlight
 run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.marketing_version) || 'latest tag' }}"
 
 # Manually-triggered iOS build + TestFlight upload for the native SwiftUI app
-# (omnibus-ios/ Xcode project, bundle com.omnibus.swiftui). The Apple side
+# (omnibus-ios/ Xcode project, bundle com.omnibus.mobile). The Apple side
 # (App ID, app record, distribution cert, App Store Connect API key, App Store
 # provisioning profile) must already exist.
 #
@@ -25,7 +25,7 @@ run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.mark
 #     ASC_KEY_ID                        App Store Connect API key ID
 #     ASC_ISSUER_ID                     App Store Connect API issuer ID
 #   Per-app (a profile is bound to one bundle ID):
-#     IOS_SWIFTUI_PROVISION_PROFILE_BASE64   App Store profile for com.omnibus.swiftui
+#     IOS_PROVISIONING_PROFILE_BASE64   App Store profile for com.omnibus.mobile
 
 on:
   workflow_dispatch:
@@ -83,9 +83,9 @@ jobs:
           echo "Marketing version: $version"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
-  # ---- swiftui: native SwiftUI app (com.omnibus.swiftui) ----------------------
-  swiftui:
-    name: swiftui (native · com.omnibus.swiftui)
+  # ---- ios: native SwiftUI app (com.omnibus.mobile) ---------------------------
+  ios:
+    name: ios (native · com.omnibus.mobile)
     needs: version
     # omnibus-ios targets iOS 26.5, so it needs the Xcode 26 / iOS 26 SDK on
     # macos-26. App Store Connect also rejects any upload built with an older
@@ -102,7 +102,7 @@ jobs:
       MARKETING_VERSION: ${{ needs.version.outputs.marketing_version }}
       # The team the omnibus-ios project + the distribution cert belong to.
       DEVELOPMENT_TEAM: "D33VSDXHA6"
-      BUNDLE_ID: com.omnibus.swiftui
+      BUNDLE_ID: com.omnibus.mobile
     steps:
       - uses: actions/checkout@v4
 
@@ -112,7 +112,7 @@ jobs:
         with:
           cert-p12-base64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
           cert-password: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
-          profile-base64: ${{ secrets.IOS_SWIFTUI_PROVISION_PROFILE_BASE64 }}
+          profile-base64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
           expected-team: ${{ env.DEVELOPMENT_TEAM }}
 
       # Archive with manual signing against the installed profile. MARKETING_VERSION
@@ -172,7 +172,7 @@ jobs:
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
           # exportArchive names the .ipa after the product; copy to a stable path.
           IPA="$(ls "$RUNNER_TEMP"/export/*.ipa | head -n1)"
-          cp "$IPA" "$GITHUB_WORKSPACE/omnibus-swiftui.ipa"
+          cp "$IPA" "$GITHUB_WORKSPACE/omnibus-ios.ipa"
 
       - name: Upload to TestFlight
         env:
@@ -184,7 +184,7 @@ jobs:
           mkdir -p "$HOME/.appstoreconnect/private_keys"
           KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
           echo "$ASC_API_KEY_BASE64" | base64 -D > "$KEY_PATH"
-          xcrun altool --upload-app -f "$GITHUB_WORKSPACE/omnibus-swiftui.ipa" -t ios \
+          xcrun altool --upload-app -f "$GITHUB_WORKSPACE/omnibus-ios.ipa" -t ios \
             --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
           rm -f "$KEY_PATH"
 
@@ -192,8 +192,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: omnibus-swiftui-ipa
-          path: omnibus-swiftui.ipa
+          name: omnibus-ios-ipa
+          path: omnibus-ios.ipa
           if-no-files-found: ignore
 
       - name: Clean up signing keychain

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -270,7 +270,7 @@ Services/           — AuthService, LibraryService, UserDataService
 `.github/workflows/testflight.yml` (workflow_dispatch, `macos-26` runner —
 Xcode 26 / iOS 26 SDK, which App Store Connect now requires) archives the
 Xcode project with manual signing (`xcodebuild archive` +
-`-exportArchive`, bundle `com.omnibus.swiftui`) and uploads the `.ipa`
+`-exportArchive`, bundle `com.omnibus.mobile`) and uploads the `.ipa`
 with `xcrun altool`, stamping the marketing version from the latest `v*`
 release tag so TestFlight tracks the server release. Signing is six
 CI-only repo secrets (distribution cert + password, provisioning profile,

--- a/omnibus-ios/omnibus.xcodeproj/project.pbxproj
+++ b/omnibus-ios/omnibus.xcodeproj/project.pbxproj
@@ -422,8 +422,8 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.swiftui;
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.omnibus.swiftui;
+				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.omnibus.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -469,8 +469,8 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.swiftui;
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.omnibus.swiftui;
+				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.omnibus.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -496,7 +496,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.swiftui.omnibusTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile.omnibusTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -521,7 +521,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.swiftui.omnibusTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile.omnibusTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -545,7 +545,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.swiftui.omnibusUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile.omnibusUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -569,7 +569,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.swiftui.omnibusUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile.omnibusUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/scripts/testflight_feedback_to_issues.py
+++ b/scripts/testflight_feedback_to_issues.py
@@ -35,7 +35,7 @@ ASC_BASE = "https://api.appstoreconnect.apple.com"
 GH_BASE = "https://api.github.com"
 DRY_RUN = os.environ.get("DRY_RUN") == "1"
 # Bundle id -> the name shown in the issue title and Environment block.
-APP_NAMES = {"com.omnibus.swiftui": "SwiftUI"}
+APP_NAMES = {"com.omnibus.mobile": "SwiftUI"}
 BUNDLE_IDS = [b.strip() for b in
               os.environ.get("BUNDLE_IDS", ",".join(APP_NAMES.keys())).split(",") if b.strip()]
 ASSET_BRANCH = os.environ.get("ASSET_BRANCH", "testflight-feedback")


### PR DESCRIPTION
## Summary
- Renames the native SwiftUI app's bundle id from `com.omnibus.swiftui` to `com.omnibus.mobile` (test bundles follow: `.omnibusTests` / `.omnibusUITests`).
- The TestFlight `ios` job now signs with `IOS_PROVISIONING_PROFILE_BASE64` — the existing App Store profile for `com.omnibus.mobile` — so `IOS_SWIFTUI_PROVISION_PROFILE_BASE64` is no longer referenced.
- The feedback poller now attributes `com.omnibus.mobile` feedback to the SwiftUI app.

Closes #1558

## Test plan
- [x] `grep -r com.omnibus.swiftui` over the repo returns nothing
- [x] `just ios-test` — omnibusTests pass on a simulator under the renamed test-bundle ids
- [x] `just ios-sim` — app builds, installs, and launches as `com.omnibus.mobile`
- [ ] TestFlight dispatch uploads under `com.omnibus.mobile` (after the ASC-side cleanup in Notes)

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — add the `no release` label to skip cutting a release.

## Notes
- Uploads under `com.omnibus.mobile` land on the old Dioxus app record and inherit its build-number history — if the first upload is rejected for a low build number, dispatch with an explicit `build_number`.
- Repo secrets `IOS_SWIFTUI_PROVISION_PROFILE_BASE64` and `IOS_SIGNING_IDENTITY` are now unreferenced and can be deleted; the orphaned `com.omnibus.swiftui` App ID / app record can be retired in App Store Connect.