### PR TITLE
feat: auto-mark reading and finished from the native iOS readers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,8 +256,11 @@ Offline/            — Cache (read-through policies), OfflineStore (SQLite
                       mutation outbox — see rule 08), Connectivity
 Reader/             — SwiftUI reader chrome, the host-drawn selection layer,
                       the passage menu, the typography sheet and the quote-card
-                      composer, over Web/ (vendored epub.js + JSZip + glue,
-                      hosted in a WKWebView)
+                      composer, and ReadStatusAuto (the readers' automatic
+                      read-status transitions — unread marks reading on open,
+                      the book's end marks finished, never a downgrade; the
+                      comic pager drives the same tracker), over Web/ (vendored
+                      epub.js + JSZip + glue, hosted in a WKWebView)
 Comic/              — the native CBZ pager: ComicReaderView (paged TabView +
                       UIScrollView zoom per page), ComicPages (per-page server
                       reads online, ZIPFoundation over the downloaded archive

--- a/omnibus-ios/omnibus/Comic/ComicReaderView.swift
+++ b/omnibus-ios/omnibus/Comic/ComicReaderView.swift
@@ -35,6 +35,9 @@ struct ComicReaderView: View {
     @State private var sessionStart: Date?
     @State private var lastSave = Date.distantPast
     @State private var showPlayer = false
+    /// Auto read-status for the open comic — unread marks reading on open,
+    /// the last page marks finished. Created in `prepare`, driven by turns.
+    @State private var autoStatus: ReadStatusAuto?
 
     /// How long a single stretch of reading may run before it is reported
     /// as its own session rather than held until the book closes.
@@ -79,6 +82,9 @@ struct ComicReaderView: View {
             Task {
                 await pages?.prefetch(around: newPage)
                 await persist(force: false)
+                if let count = pages?.count, count > 0 {
+                    await autoStatus?.positionChanged(atEnd: newPage == count - 1)
+                }
             }
         }
         .onChange(of: audio.isActive) { _, active in
@@ -256,6 +262,21 @@ struct ComicReaderView: View {
         page = start
         pages = source
         sessionStart = Date()
+
+        // Auto read-status, the same lifecycle the EPUB reader drives: opening
+        // an unread comic marks it reading, landing on the last page marks it
+        // finished, and a failed status fetch keeps it inert. The opening page
+        // is fed first — a comic restored onto its last page never turns a
+        // page, so `onChange` alone would miss the finish. Spawned so opening
+        // never waits on the fetch.
+        let tracker = ReadStatusAuto(uuid: book.uuid)
+        autoStatus = tracker
+        let openedAtEnd = start == source.count - 1
+        Task {
+            await tracker.positionChanged(atEnd: openedAtEnd)
+            await tracker.bookOpened()
+        }
+
         await source.prefetch(around: start)
 
         LifecycleSync.shared.register(source) {

--- a/omnibus-ios/omnibus/Reader/ReadStatusAuto.swift
+++ b/omnibus-ios/omnibus/Reader/ReadStatusAuto.swift
@@ -1,0 +1,78 @@
+//  ReadStatusAuto.swift
+//  Automatic read-status transitions driven by the readers: opening an
+//  unread book marks it reading, and reaching the end marks it finished —
+//  the reader-side sibling of the audio player's finish-on-playback-end,
+//  and the native port of the web readers' `read_status_auto`.
+
+import Foundation
+
+/// One book's automatic transitions, owned by the reader that has it open.
+///
+/// The stored status is fetched once per open, and `nil` — the fetch failed —
+/// keeps every transition inert: a decision is never made against a guessed
+/// status, because writing `reading` over an unfetched `finished` would be a
+/// downgrade. Writes take the same outbox path as the detail screen's manual
+/// chip (`UserDataService.setReadStatus`), so they queue offline like any
+/// other content-state write.
+@MainActor
+final class ReadStatusAuto {
+    /// `nil` until the fetch lands — and stays `nil` when it fails.
+    private var status: ReadStatus?
+    private var atEnd = false
+    private let fetch: () async -> ReadStatus?
+    private let write: (ReadStatus) async -> Void
+
+    /// The production wiring for one book, over `UserDataService`.
+    convenience init(uuid: String) {
+        self.init(
+            fetch: { await UserDataService.storedReadStatus(uuid: uuid) },
+            write: { await UserDataService.setReadStatus(uuid: uuid, status: $0) }
+        )
+    }
+
+    init(
+        fetch: @escaping () async -> ReadStatus?,
+        write: @escaping (ReadStatus) async -> Void
+    ) {
+        self.fetch = fetch
+        self.write = write
+    }
+
+    /// The status to write for a book whose stored state is `current`,
+    /// observed either at the reader's end position (`atEnd`) or merely open.
+    /// `nil` means no write: opening never downgrades a finished book back to
+    /// reading, and re-reaching the end of a finished book is a no-op.
+    nonisolated static func transition(current: ReadStatus, atEnd: Bool) -> ReadStatus? {
+        if atEnd {
+            return current == .finished ? nil : .finished
+        }
+        return current == .unread ? .reading : nil
+    }
+
+    /// Fetch the stored status and apply the open transition. Call once per
+    /// open, off the reader's critical path — the fetch may cost a round trip.
+    func bookOpened() async {
+        status = await fetch()
+        await applyIfNeeded()
+    }
+
+    /// Tell the tracker whether the reader is at the book's end position.
+    /// Cheap on every relocate or page turn; an end observed before the fetch
+    /// lands is applied when it does.
+    func positionChanged(atEnd: Bool) async {
+        guard atEnd != self.atEnd else { return }
+        self.atEnd = atEnd
+        await applyIfNeeded()
+    }
+
+    private func applyIfNeeded() async {
+        guard let current = status,
+              let next = Self.transition(current: current, atEnd: atEnd)
+        else { return }
+        // Optimistic: move the tracked status before the write, so the next
+        // observation settles on no-transition instead of repeating a write
+        // that is still queued.
+        status = next
+        await write(next)
+    }
+}

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -78,6 +78,9 @@ struct ReaderView: View {
     /// hours read.
     @State private var sessionStart: Date?
     @State private var lastSave = Date.distantPast
+    /// Auto read-status for the open book — unread marks reading on open, the
+    /// book's end marks finished. Created in `prepare`, driven by relocates.
+    @State private var autoStatus: ReadStatusAuto?
     /// The full player, raised over the page from the audio dock — a sheet
     /// rather than the app-global cover, so the book stays open underneath.
     @State private var showPlayer = false
@@ -177,6 +180,9 @@ struct ReaderView: View {
         }
         .onChange(of: controller.location?.cfi) { _, _ in
             Task { await persist(force: false) }
+        }
+        .onChange(of: controller.location?.atEnd) { _, atEnd in
+            Task { await autoStatus?.positionChanged(atEnd: atEnd ?? false) }
         }
         // A handle drag ends when the finger lifts — unless the selection goes
         // out from under it first, which a re-pagination does (the glue drops
@@ -654,6 +660,14 @@ struct ReaderView: View {
         controller.configure(book: book, startCFI: startCFI, highlights: highlights)
         didConfigure = true
         sessionStart = Date()
+
+        // Auto read-status, the same lifecycle the web reader drives: opening
+        // an unread book marks it reading, the first relocate that reaches the
+        // book's end marks it finished, and a failed status fetch keeps it
+        // inert. Spawned so opening never waits on the fetch.
+        let tracker = ReadStatusAuto(uuid: book.uuid)
+        autoStatus = tracker
+        Task { await tracker.bookOpened() }
 
         LifecycleSync.shared.register(controller) {
             await persist(force: true)

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -88,6 +88,10 @@ struct RelocateData: Codable {
     var page: Int = 0
     var totalPages: Int = 0
     var pct: Int = 0
+    /// True when the rendered range reaches the book's end (epub.js
+    /// `location.atEnd`) — the auto `finished` trigger. `pct` can't stand in:
+    /// it tracks the start of the visible range, so it tops out below 100.
+    var atEnd: Bool = false
     var chapter: Int = 0
     var totalChapters: Int = 0
     var chapterTitle: String = ""

--- a/omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js
+++ b/omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js
@@ -237,6 +237,10 @@
       page: page + 1,
       totalPages: totalPages,
       pct: pct,
+      // epub.js sets `atEnd` when the displayed range reaches the last page
+      // of the last spine item — `pct` alone tops out below 100 because it
+      // tracks the *start* of the visible range.
+      atEnd: !!(location && location.atEnd),
       chapter: ch ? ch.index : 0,
       totalChapters: ch ? ch.total : tocFlat.length,
       chapterTitle: ch ? ch.title : "",

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -206,6 +206,31 @@ enum UserDataService {
         }
     }
 
+    /// The stored status the readers' auto transitions decide against.
+    ///
+    /// The replica answers when a queued write makes it the newest truth, and
+    /// again when the server can't be asked; otherwise the server does, where
+    /// `null` is a real answer — a book nobody has marked is `unread`. (The
+    /// `readStatus` stream can't carry that distinction: it decodes the record
+    /// non-optionally, so "no row" and "no answer" fail alike.) `nil` here
+    /// means nothing is known, and the caller must stay inert — acting on a
+    /// guess could downgrade an unfetched `finished`.
+    static func storedReadStatus(uuid: String) async -> ReadStatus? {
+        let key = CacheKey.readStatus(uuid)
+        let cached: ReadStatusRecord? = await Cache.cachedOnly(key)
+        // Same guard as `Cache.live`'s revalidation: with a write queued for
+        // this book, the server's answer predates the replica.
+        if await Cache.isBlocked(key) { return cached?.status }
+        do {
+            let fresh: ReadStatusRecord? = try await APIClient.shared.get(
+                "/api/read-status/\(uuid)"
+            )
+            return fresh?.status ?? .unread
+        } catch {
+            return cached?.status
+        }
+    }
+
     static func setReadStatus(uuid: String, status: ReadStatus) async {
         let update = SetReadStatus(bookUUID: uuid, status: status)
         await Cache.write(

--- a/omnibus-ios/omnibusTests/ReadStatusAutoTests.swift
+++ b/omnibus-ios/omnibusTests/ReadStatusAutoTests.swift
@@ -1,0 +1,111 @@
+//  ReadStatusAutoTests.swift
+//  The readers' automatic read-status transitions: the pure decision table,
+//  and the tracker's fetch-then-apply sequencing — inert on a failed fetch,
+//  settled against repeat observations, never a downgrade.
+//
+//  The decision table mirrors the web reader's `read_status_auto` tests, so
+//  the two clients agree on when a reader may move the chip on its own.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+@Suite("Read-status auto transition")
+struct ReadStatusTransitionTests {
+    @Test("an unread book is marked reading on open")
+    func unreadBecomesReadingOnOpen() {
+        #expect(ReadStatusAuto.transition(current: .unread, atEnd: false) == .reading)
+    }
+
+    @Test("reading and finished are left untouched on open")
+    func openNeverRewritesStartedBooks() {
+        #expect(ReadStatusAuto.transition(current: .reading, atEnd: false) == nil)
+        #expect(ReadStatusAuto.transition(current: .finished, atEnd: false) == nil)
+    }
+
+    @Test("any unfinished book is marked finished at the end")
+    func endFinishesUnfinishedBooks() {
+        #expect(ReadStatusAuto.transition(current: .unread, atEnd: true) == .finished)
+        #expect(ReadStatusAuto.transition(current: .reading, atEnd: true) == .finished)
+    }
+
+    @Test("an already finished book is never rewritten")
+    func endNeverRewritesFinished() {
+        #expect(ReadStatusAuto.transition(current: .finished, atEnd: true) == nil)
+    }
+}
+
+@Suite("Read-status auto tracker")
+@MainActor
+struct ReadStatusAutoTrackerTests {
+    /// What the tracker wrote, in order — the whole observable surface.
+    private final class Log {
+        var writes: [ReadStatus] = []
+    }
+
+    private func tracker(stored: ReadStatus?, log: Log) -> ReadStatusAuto {
+        ReadStatusAuto(
+            fetch: { stored },
+            write: { log.writes.append($0) }
+        )
+    }
+
+    @Test("opening an unread book writes reading once")
+    func openWritesReading() async {
+        let log = Log()
+        let auto = tracker(stored: .unread, log: log)
+        await auto.bookOpened()
+        #expect(log.writes == [.reading])
+    }
+
+    @Test("reaching the end after opening writes finished")
+    func endWritesFinished() async {
+        let log = Log()
+        let auto = tracker(stored: .unread, log: log)
+        await auto.bookOpened()
+        await auto.positionChanged(atEnd: true)
+        #expect(log.writes == [.reading, .finished])
+    }
+
+    @Test("a finished book is untouched by opening and re-reaching the end")
+    func finishedIsNeverDowngraded() async {
+        let log = Log()
+        let auto = tracker(stored: .finished, log: log)
+        await auto.bookOpened()
+        await auto.positionChanged(atEnd: true)
+        #expect(log.writes.isEmpty)
+    }
+
+    @Test("a failed status fetch keeps every transition inert")
+    func failedFetchStaysInert() async {
+        let log = Log()
+        let auto = tracker(stored: nil, log: log)
+        await auto.bookOpened()
+        await auto.positionChanged(atEnd: true)
+        #expect(log.writes.isEmpty)
+    }
+
+    @Test("an end observed before the fetch lands is applied when it does")
+    func endBeforeFetchStillFinishes() async {
+        // The comic restored onto its last page: the opening position is fed
+        // before the status fetch settles.
+        let log = Log()
+        let auto = tracker(stored: .reading, log: log)
+        await auto.positionChanged(atEnd: true)
+        #expect(log.writes.isEmpty)
+        await auto.bookOpened()
+        #expect(log.writes == [.finished])
+    }
+
+    @Test("paging back and forth past the end writes finished once")
+    func endWritesAreSettled() async {
+        let log = Log()
+        let auto = tracker(stored: .reading, log: log)
+        await auto.bookOpened()
+        await auto.positionChanged(atEnd: true)
+        await auto.positionChanged(atEnd: false)
+        await auto.positionChanged(atEnd: true)
+        #expect(log.writes == [.finished])
+    }
+}


### PR DESCRIPTION
## Summary
- Ports the web readers' automatic read-status transitions (#1603) to the native iOS app: opening an unread book marks it **reading**, reaching the end marks it **finished**, and a finished book is never downgraded.
- One `ReadStatusAuto` tracker drives both readers — the EPUB reader off epub.js `location.atEnd` (passed through the iOS glue fork), the CBZ pager off its last page.
- New `UserDataService.storedReadStatus` fetches the status the decision runs against: server `null` reads as unread, the replica answers when a queued write or an unreachable server makes it the newest truth, and an unknown status keeps every transition inert.
- Writes take the detail screen's manual-chip outbox path (`setReadStatus`, coalesced `read_status:<uuid>` kind — already declared per rule 08).

## Test plan
- [x] `just ios-test` — 154 passed / 0 failed (10 new in `ReadStatusAutoTests.swift`)
- [x] `just ios-build`

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The decision-table tests mirror the web's `read_status_auto` tests one-for-one, so the two clients agree on when a reader may move the chip on its own.