### PR TITLE
fix: fall back to bare-text Google Books query when isbn: search returns empty

### DIFF
--- a/db/src/metadata_lookup/providers.rs
+++ b/db/src/metadata_lookup/providers.rs
@@ -166,10 +166,17 @@ async fn googlebooks_get(
 /// Kept separate so a test can assert the key is attached (and absent when
 /// unset) without a live request.
 pub(super) fn googlebooks_url(config: &MetadataLookupConfig, isbn13: &str) -> String {
-    let base = format!(
-        "{}/books/v1/volumes?q=isbn:{isbn13}",
-        config.googlebooks_base
-    );
+    googlebooks_volumes_url(config, &format!("isbn:{isbn13}"))
+}
+
+/// Build the bare-text variant of the volumes URL (`q=<isbn13>`, no `isbn:`
+/// field restriction) for the fallback in [`googlebooks_lookup`].
+pub(super) fn googlebooks_bare_url(config: &MetadataLookupConfig, isbn13: &str) -> String {
+    googlebooks_volumes_url(config, isbn13)
+}
+
+fn googlebooks_volumes_url(config: &MetadataLookupConfig, q: &str) -> String {
+    let base = format!("{}/books/v1/volumes?q={q}", config.googlebooks_base);
     match config.googlebooks_api_key.as_deref() {
         Some(key) => format!("{base}&key={key}"),
         None => base,
@@ -301,13 +308,50 @@ struct GbImageLinks {
     small_thumbnail: Option<String>,
 }
 
-/// Look up an ISBN-13 against Google Books `volumes?q=isbn:`. `Ok(None)` when no
-/// volume matches; `Err` on transport/parse failure.
+/// Look up an ISBN-13 against Google Books `volumes?q=isbn:`, falling back to
+/// a bare-text `q=<isbn13>` query when the field search answers empty.
+/// `Ok(None)` when no volume matches either way; `Err` on transport/parse
+/// failure of the field query (the bare query is best-effort — see below).
 pub async fn googlebooks_lookup(
     config: &MetadataLookupConfig,
     isbn13: &str,
 ) -> anyhow::Result<Option<ExternalBookMeta>> {
-    let resp = googlebooks_get(config, &googlebooks_url(config, isbn13)).await?;
+    if let Some(meta) = googlebooks_query(config, isbn13, &googlebooks_url(config, isbn13)).await? {
+        return Ok(Some(meta));
+    }
+    // The `isbn:` field search has been observed answering 200/totalItems=0
+    // for volumes the corpus demonstrably holds (2026-08: every field-scoped
+    // query returned empty while the same bare-text query hit). The bare query
+    // may surface a sibling edition, which is acceptable: the scan flow always
+    // confirms with the user, and the stored ISBN is the scanned one either
+    // way (`meta.isbn13` below). A bare-query *failure* degrades to the field
+    // query's clean miss rather than erroring — without this fallback the
+    // outcome would have been a miss anyway.
+    match googlebooks_query(config, isbn13, &googlebooks_bare_url(config, isbn13)).await {
+        Ok(meta) => {
+            if meta.is_some() {
+                tracing::info!(
+                    isbn13,
+                    "google books isbn: search missed but bare-text query hit — field search degraded upstream"
+                );
+            }
+            Ok(meta)
+        }
+        Err(e) => {
+            tracing::warn!(isbn13, "google books bare-text fallback failed: {e:#}");
+            Ok(None)
+        }
+    }
+}
+
+/// Run one volumes query and map its first usable volume. `Ok(None)` when no
+/// volume matches; `Err` on transport/parse failure.
+async fn googlebooks_query(
+    config: &MetadataLookupConfig,
+    isbn13: &str,
+    url: &str,
+) -> anyhow::Result<Option<ExternalBookMeta>> {
+    let resp = googlebooks_get(config, url).await?;
 
     let body: GbResponse = resp
         .json()

--- a/db/src/metadata_lookup/tests.rs
+++ b/db/src/metadata_lookup/tests.rs
@@ -405,7 +405,12 @@ async fn mount_gb_q(server: &MockServer, q: &str, body: serde_json::Value) {
 #[tokio::test]
 async fn googlebooks_falls_back_to_bare_query_when_isbn_search_is_empty() {
     let server = MockServer::start().await;
-    mount_gb_q(&server, &format!("isbn:{ISBN13}"), json!({ "totalItems": 0 })).await;
+    mount_gb_q(
+        &server,
+        &format!("isbn:{ISBN13}"),
+        json!({ "totalItems": 0 }),
+    )
+    .await;
     mount_gb_q(&server, ISBN13, gb_hit()).await;
 
     let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
@@ -448,13 +453,21 @@ async fn googlebooks_hit_never_issues_a_bare_query() {
 #[tokio::test]
 async fn googlebooks_double_miss_is_still_a_clean_miss() {
     let server = MockServer::start().await;
-    mount_gb_q(&server, &format!("isbn:{ISBN13}"), json!({ "totalItems": 0 })).await;
+    mount_gb_q(
+        &server,
+        &format!("isbn:{ISBN13}"),
+        json!({ "totalItems": 0 }),
+    )
+    .await;
     mount_gb_q(&server, ISBN13, json!({ "totalItems": 0 })).await;
 
     let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
         .await
         .unwrap();
-    assert!(meta.is_none(), "double miss must be a clean miss, not an error");
+    assert!(
+        meta.is_none(),
+        "double miss must be a clean miss, not an error"
+    );
     server.verify().await;
 }
 
@@ -464,7 +477,12 @@ async fn googlebooks_bare_query_failure_degrades_to_a_clean_miss() {
     // query answered cleanly, the lookup reports the miss it already had
     // rather than turning a would-be "unresolved" into a user-facing outage.
     let server = MockServer::start().await;
-    mount_gb_q(&server, &format!("isbn:{ISBN13}"), json!({ "totalItems": 0 })).await;
+    mount_gb_q(
+        &server,
+        &format!("isbn:{ISBN13}"),
+        json!({ "totalItems": 0 }),
+    )
+    .await;
     Mock::given(method("GET"))
         .and(path(GB_PATH))
         .and(query_param("q", ISBN13))

--- a/db/src/metadata_lookup/tests.rs
+++ b/db/src/metadata_lookup/tests.rs
@@ -390,12 +390,14 @@ async fn googlebooks_gives_up_after_the_retry_budget() {
 // query hits. The provider retries once as bare text before calling it a miss.
 
 /// Mount a GB mock that only matches a specific `q` value, so the field and
-/// bare queries can answer differently within one test.
+/// bare queries can answer differently within one test. Expects exactly one
+/// request — `server.verify()` then proves the query pattern actually ran.
 async fn mount_gb_q(server: &MockServer, q: &str, body: serde_json::Value) {
     Mock::given(method("GET"))
         .and(path(GB_PATH))
         .and(query_param("q", q))
         .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .expect(1)
         .mount(server)
         .await;
 }
@@ -415,6 +417,7 @@ async fn googlebooks_falls_back_to_bare_query_when_isbn_search_is_empty() {
     // Bare-text search may return a sibling edition; the meta must still carry
     // the *scanned* ISBN so a check-in stores the barcode that was scanned.
     assert_eq!(meta.isbn13, ISBN13);
+    server.verify().await;
 }
 
 #[tokio::test]
@@ -452,10 +455,11 @@ async fn googlebooks_double_miss_is_still_a_clean_miss() {
         .await
         .unwrap();
     assert!(meta.is_none(), "double miss must be a clean miss, not an error");
+    server.verify().await;
 }
 
 #[tokio::test]
-async fn googlebooks_bare_query_failure_degrades_to_the_field_querys_miss() {
+async fn googlebooks_bare_query_failure_degrades_to_a_clean_miss() {
     // The bare query is a bonus attempt: if it fails outright after the field
     // query answered cleanly, the lookup reports the miss it already had
     // rather than turning a would-be "unresolved" into a user-facing outage.
@@ -465,6 +469,8 @@ async fn googlebooks_bare_query_failure_degrades_to_the_field_querys_miss() {
         .and(path(GB_PATH))
         .and(query_param("q", ISBN13))
         .respond_with(ResponseTemplate::new(503))
+        // A 503 is retryable, so the bare query burns the full retry budget.
+        .expect(3)
         .mount(&server)
         .await;
 
@@ -472,6 +478,7 @@ async fn googlebooks_bare_query_failure_degrades_to_the_field_querys_miss() {
         .await
         .unwrap();
     assert!(meta.is_none(), "bare-query failure must degrade to a miss");
+    server.verify().await;
 }
 
 #[test]

--- a/db/src/metadata_lookup/tests.rs
+++ b/db/src/metadata_lookup/tests.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use omnibus_shared::metadata_lookup::MetadataProvider;
@@ -380,6 +380,111 @@ async fn googlebooks_gives_up_after_the_retry_budget() {
     assert!(
         !chain.contains("key="),
         "url must not reach the log: {chain}"
+    );
+}
+
+// ── Google Books bare-text fallback ──────────────────────────────
+//
+// Google's `isbn:` field search has been observed answering 200/totalItems=0
+// for volumes the corpus holds (2026-08), while the same bare-text `q=<isbn>`
+// query hits. The provider retries once as bare text before calling it a miss.
+
+/// Mount a GB mock that only matches a specific `q` value, so the field and
+/// bare queries can answer differently within one test.
+async fn mount_gb_q(server: &MockServer, q: &str, body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path(GB_PATH))
+        .and(query_param("q", q))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn googlebooks_falls_back_to_bare_query_when_isbn_search_is_empty() {
+    let server = MockServer::start().await;
+    mount_gb_q(&server, &format!("isbn:{ISBN13}"), json!({ "totalItems": 0 })).await;
+    mount_gb_q(&server, ISBN13, gb_hit()).await;
+
+    let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+        .await
+        .unwrap()
+        .expect("bare-text fallback must resolve the ISBN");
+    assert_eq!(meta.source, MetadataProvider::GoogleBooks);
+    assert_eq!(meta.title, "Effective Java");
+    // Bare-text search may return a sibling edition; the meta must still carry
+    // the *scanned* ISBN so a check-in stores the barcode that was scanned.
+    assert_eq!(meta.isbn13, ISBN13);
+}
+
+#[tokio::test]
+async fn googlebooks_hit_never_issues_a_bare_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(GB_PATH))
+        .and(query_param("q", format!("isbn:{ISBN13}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(gb_hit()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(GB_PATH))
+        .and(query_param("q", ISBN13))
+        .respond_with(ResponseTemplate::new(200).set_body_json(gb_hit()))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+        .await
+        .unwrap();
+    assert!(meta.is_some());
+    server.verify().await;
+}
+
+#[tokio::test]
+async fn googlebooks_double_miss_is_still_a_clean_miss() {
+    let server = MockServer::start().await;
+    mount_gb_q(&server, &format!("isbn:{ISBN13}"), json!({ "totalItems": 0 })).await;
+    mount_gb_q(&server, ISBN13, json!({ "totalItems": 0 })).await;
+
+    let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+        .await
+        .unwrap();
+    assert!(meta.is_none(), "double miss must be a clean miss, not an error");
+}
+
+#[tokio::test]
+async fn googlebooks_bare_query_failure_degrades_to_the_field_querys_miss() {
+    // The bare query is a bonus attempt: if it fails outright after the field
+    // query answered cleanly, the lookup reports the miss it already had
+    // rather than turning a would-be "unresolved" into a user-facing outage.
+    let server = MockServer::start().await;
+    mount_gb_q(&server, &format!("isbn:{ISBN13}"), json!({ "totalItems": 0 })).await;
+    Mock::given(method("GET"))
+        .and(path(GB_PATH))
+        .and(query_param("q", ISBN13))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+        .await
+        .unwrap();
+    assert!(meta.is_none(), "bare-query failure must degrade to a miss");
+}
+
+#[test]
+fn googlebooks_bare_url_drops_the_field_restriction_and_keeps_the_key() {
+    let keyed = MetadataLookupConfig {
+        openlibrary_base: "http://gb.test".into(),
+        googlebooks_base: "http://gb.test".into(),
+        googlebooks_api_key: Some("sekret".into()),
+        timeout: Duration::from_secs(5),
+    };
+    assert_eq!(
+        super::providers::googlebooks_bare_url(&keyed, ISBN13),
+        format!("http://gb.test/books/v1/volumes?q={ISBN13}&key=sekret")
     );
 }
 


### PR DESCRIPTION
## Summary
- Google Books' `isbn:` field search currently answers `200`/`totalItems: 0` for every ISBN (verified even for identifiers Google itself lists on a volume), so every scan silently degraded to Open Library's sparse data — no descriptions, often no cover, or no result at all.
- `googlebooks_lookup` now retries an empty `isbn:` search once as a bare-text `q=<isbn13>` query before reporting a miss. A bare-text hit may be a sibling edition; the scan flow already confirms with the user, and the stored ISBN stays the scanned one.
- A bare-query failure degrades to the field query's clean miss rather than surfacing an outage; an info line records when the fallback rescues a lookup so upstream breakage stays visible.

## Test plan
- [x] `cargo test -p omnibus-db` — 1687 passed (5 new wiremock tests: fallback hit, no second query on a field hit, double miss, bare-failure degrade, keyed bare URL)
- [x] `cargo clippy -p omnibus-db --all-targets` — clean
- [x] Live repro with the production key: `q=isbn:` returns 0 items for every ISBN tried; bare `q=` resolves the same books (e.g. `9780593982693` → "The Inn at the Foot of Mount Vengeance")

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
>[!NOTE]
> This works around an upstream Google Books regression in field-scoped search; the extra request only fires on an empty `isbn:` result, so it can stay in place harmlessly after Google recovers.