### PR TITLE
feat: long-press quick edit and tag editing on iOS

### DIFF
--- a/omnibus-ios/omnibus/Features/Discovery/DiscoveryViews.swift
+++ b/omnibus-ios/omnibus/Features/Discovery/DiscoveryViews.swift
@@ -247,6 +247,7 @@ struct AuthorDetailView: View {
                                     BookGridCell(book: book)
                                 }
                                 .buttonStyle(BookPressStyle())
+                                .bookContextMenu(book, onEdited: { Task { await load() } })
                                 .cascadeIn(index: index)
                             }
                         }
@@ -399,6 +400,7 @@ struct SeriesDetailView: View {
                                 bookRow(book, isFirst: index == 0)
                             }
                             .buttonStyle(PressableStyle())
+                            .bookContextMenu(book, onEdited: { Task { await load() } })
                         }
                         RecordRule()
                     }
@@ -411,13 +413,15 @@ struct SeriesDetailView: View {
         .background(ScreenBackground())
         .navigationTitle(detail?.name ?? "Series")
         .navigationBarTitleDisplayMode(.inline)
-        .task {
-            for await value in LibraryService.series(id: id).values() {
-                detail = value
-                isLoading = false
-            }
+        .task { await load() }
+    }
+
+    private func load() async {
+        for await value in LibraryService.series(id: id).values() {
+            detail = value
             isLoading = false
         }
+        isLoading = false
     }
 
     /// The volume number keeps its column whether or not a book carries one, so

--- a/omnibus-ios/omnibus/Features/Library/BookContextMenu.swift
+++ b/omnibus-ios/omnibus/Features/Library/BookContextMenu.swift
@@ -1,0 +1,57 @@
+//  BookContextMenu.swift
+//  Long-press quick actions for a book cell: jump straight into the metadata
+//  editor without the trip through the detail screen. One modifier shared by
+//  every surface that renders a book cell, so a held-down book means the same
+//  thing everywhere.
+
+import SwiftUI
+
+extension View {
+    /// Attach the shared long-press menu to a book cell. `onEdited` runs after
+    /// the editor saves or reverts (not on a cancel), so the surface can
+    /// refresh the rows behind the sheet. `extras` appends surface-specific
+    /// items — e.g. the shelf grid's "Remove from shelf".
+    func bookContextMenu<Extras: View>(
+        _ book: Book,
+        onEdited: (() -> Void)? = nil,
+        @ViewBuilder extras: @escaping () -> Extras = { EmptyView() }
+    ) -> some View {
+        modifier(BookContextMenuModifier(book: book, onEdited: onEdited, extras: extras))
+    }
+}
+
+private struct BookContextMenuModifier<Extras: View>: ViewModifier {
+    let book: Book
+    var onEdited: (() -> Void)?
+    @ViewBuilder var extras: () -> Extras
+
+    @Environment(AppState.self) private var app
+    @State private var showEditor = false
+
+    func body(content: Content) -> some View {
+        content
+            .contextMenu {
+                if app.user?.canEdit == true {
+                    Button {
+                        showEditor = true
+                    } label: {
+                        Label("Edit metadata", systemImage: "pencil")
+                    }
+                }
+                extras()
+            }
+            // A sheet rather than a push: the surfaces this attaches to sit in
+            // four different NavigationStacks, and a sheet needs none of their
+            // paths — edit, save, and you're still where you were.
+            .sheet(isPresented: $showEditor) {
+                NavigationStack {
+                    MetadataEditView(uuid: book.uuid, onSaved: onEdited)
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Cancel") { showEditor = false }
+                            }
+                        }
+                }
+            }
+    }
+}

--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -324,6 +324,7 @@ struct LibraryView: View {
                     BookGridCell(book: book)
                 }
                 .buttonStyle(BookPressStyle())
+                .bookContextMenu(book, onEdited: { Task { await model.reload() } })
                 .bookZoomSource(book.uuid, in: bookZoom)
                 .cascadeIn(index: index)
                 .task { await model.loadMoreIfNeeded(currentItem: book) }

--- a/omnibus-ios/omnibus/Features/Search/SearchView.swift
+++ b/omnibus-ios/omnibus/Features/Search/SearchView.swift
@@ -295,6 +295,7 @@ struct SearchResultsView: View {
                                 BookGridCell(book: book)
                             }
                             .buttonStyle(BookPressStyle())
+                            .bookContextMenu(book, onEdited: { Task { await load() } })
                             .cascadeIn(index: index)
                         }
                     }
@@ -307,12 +308,14 @@ struct SearchResultsView: View {
         .background(ScreenBackground())
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
-        .task {
-            for await hits in LibraryService.searchFull(query: query) {
-                books = hits
-                isLoading = false
-            }
+        .task { await load() }
+    }
+
+    private func load() async {
+        for await hits in LibraryService.searchFull(query: query) {
+            books = hits
             isLoading = false
         }
+        isLoading = false
     }
 }

--- a/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
@@ -103,7 +103,7 @@ enum ChipEntry {
     /// web chip editor — a duplicate tag means nothing, while two credited
     /// contributors can legitimately share a name.
     static func committed(from entry: String, existing: [String], deduplicating: Bool) -> String? {
-        let trimmed = entry.trimmingCharacters(in: .whitespaces)
+        let trimmed = entry.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         if deduplicating {
             let lowered = trimmed.lowercased()

--- a/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
@@ -1,0 +1,114 @@
+//  MetadataDraft.swift
+//  The metadata editor's editable snapshot and its wire payload: one
+//  comparable value for "has anything changed", plus the changed-fields-only
+//  overrides body a save posts. Kept out of the view so the diff and
+//  chip-commit logic are testable.
+
+import Foundation
+
+/// Every editable value on the editor screen, as one comparable value.
+///
+/// Kept as a single struct rather than ten `@State` strings so "has anything
+/// changed" is a plain `!=` against the loaded snapshot — which is what lets
+/// Save disable itself until there's something to save, and what drives the
+/// per-field edited markers.
+struct MetadataDraft: Equatable {
+    var title = ""
+    /// A real list, not a comma-joined string: authors are structured on the
+    /// wire, and asking someone to maintain delimiters by hand made the one
+    /// genuinely multi-value field the most error-prone on the screen.
+    var authors: [String] = []
+    /// Tags (the server's `subjects`), as the same chip list authors use.
+    var tags: [String] = []
+    var series = ""
+    var seriesIndex = ""
+    var publisher = ""
+    var published = ""
+    var language = ""
+    var isbn13 = ""
+    var description = ""
+
+    init() {}
+
+    /// Snapshot of a book's current effective metadata — the baseline the
+    /// per-field edited markers and the save diff compare against.
+    init(book: Book) {
+        title = book.title ?? ""
+        authors = book.creators.map(\.name)
+        tags = book.subjects
+        series = book.series ?? ""
+        seriesIndex = book.seriesIndex ?? ""
+        publisher = book.publisher ?? ""
+        published = book.published ?? ""
+        language = book.language ?? ""
+        isbn13 = book.isbn13 ?? ""
+        description = book.description ?? ""
+    }
+
+    /// The changed-fields-only body for `POST /api/ebooks/{uuid}/overrides`.
+    ///
+    /// Sending every field on every save wrote overrides for fields nobody
+    /// touched, pinning scanned values so a later rescan could no longer
+    /// update them. The endpoint merges, so omitting a field leaves it as it
+    /// was, and an empty string clears an existing override.
+    func payload(since loaded: MetadataDraft) -> MetadataOverridesPayload {
+        func changed(_ key: KeyPath<MetadataDraft, String>) -> String? {
+            self[keyPath: key] == loaded[keyPath: key] ? nil : self[keyPath: key]
+        }
+        return MetadataOverridesPayload(
+            title: changed(\.title),
+            creators: authors == loaded.authors
+                ? nil : authors.map(MetadataOverridesPayload.Creator.init),
+            subjects: tags == loaded.tags ? nil : tags,
+            series: changed(\.series),
+            series_index: changed(\.seriesIndex),
+            publisher: changed(\.publisher),
+            published: changed(\.published),
+            language: changed(\.language),
+            isbn13: changed(\.isbn13),
+            description: changed(\.description)
+        )
+    }
+}
+
+/// Body for `POST /api/ebooks/{uuid}/overrides`. Field names match the wire.
+struct MetadataOverridesPayload: Encodable, Equatable {
+    /// `creators` is a list of Contributor *objects* on the wire, not bare
+    /// strings: sending `["E. M. Forster"]` fails the server's JSON
+    /// extraction outright, so every save with a non-empty Authors field
+    /// was rejected before it reached validation.
+    struct Creator: Encodable, Equatable {
+        var name: String
+    }
+
+    var title: String?
+    var creators: [Creator]?
+    /// Replaces the whole tag list when present — the server's `subjects`
+    /// override is a wholesale replace, never an append.
+    var subjects: [String]?
+    var series: String?
+    var series_index: String?
+    var publisher: String?
+    var published: String?
+    var language: String?
+    var isbn13: String?
+    var description: String?
+}
+
+/// Chip-entry commit semantics shared by the authors and tags fields — and by
+/// the save path, which flushes a value still sitting in an entry field.
+enum ChipEntry {
+    /// The chip an entry commits: trimmed, or `nil` when blank. Deduplicating
+    /// fields also refuse a value already present ignoring case, matching the
+    /// web chip editor — a duplicate tag means nothing, while two credited
+    /// contributors can legitimately share a name.
+    static func committed(from entry: String, existing: [String], deduplicating: Bool) -> String? {
+        let trimmed = entry.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        if deduplicating {
+            let lowered = trimmed.lowercased()
+            guard !existing.contains(where: { $0.lowercased() == lowered }) else { return nil }
+        }
+        return trimmed
+    }
+}

--- a/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
@@ -9,32 +9,15 @@
 
 import SwiftUI
 
-/// Every editable value on the screen, as one comparable value.
-///
-/// Kept as a single struct rather than nine `@State` strings so "has anything
-/// changed" is a plain `!=` against the loaded snapshot — which is what lets
-/// Save disable itself until there's something to save, and what drives the
-/// per-field edited markers.
-private struct MetadataDraft: Equatable {
-    var title = ""
-    /// A real list, not a comma-joined string: authors are structured on the
-    /// wire, and asking someone to maintain delimiters by hand made the one
-    /// genuinely multi-value field the most error-prone on the screen.
-    var authors: [String] = []
-    var series = ""
-    var seriesIndex = ""
-    var publisher = ""
-    var published = ""
-    var language = ""
-    var isbn13 = ""
-    var description = ""
-}
-
 struct MetadataEditView: View {
     let uuid: String
+    /// Runs after a save or revert lands, before the editor dismisses — the
+    /// long-press entry points use it to refresh the grid behind their sheet.
+    var onSaved: (() -> Void)?
 
-    init(uuid: String) {
+    init(uuid: String, onSaved: (() -> Void)? = nil) {
         self.uuid = uuid
+        self.onSaved = onSaved
     }
 
     @Environment(\.palette) private var palette
@@ -47,14 +30,22 @@ struct MetadataEditView: View {
     @State private var isSaving = false
     @State private var error: String?
     /// An author typed into the add field but not yet committed to a chip.
-    /// Held here rather than inside `AuthorsField` so saving can flush it.
+    /// Held here rather than inside the chip field so saving can flush it.
     @State private var pendingAuthor = ""
+    /// Same, for the tags field.
+    @State private var pendingTag = ""
 
     private var pendingAuthorName: String {
         pendingAuthor.trimmingCharacters(in: .whitespaces)
     }
 
-    private var isDirty: Bool { draft != loaded || !pendingAuthorName.isEmpty }
+    private var pendingTagName: String {
+        pendingTag.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var isDirty: Bool {
+        draft != loaded || !pendingAuthorName.isEmpty || !pendingTagName.isEmpty
+    }
 
     var body: some View {
         Group {
@@ -79,8 +70,10 @@ struct MetadataEditView: View {
                 group("Title & authors") {
                     Plate {
                         field("Title", \.title, isFirst: true)
-                        AuthorsField(
-                            authors: $draft.authors,
+                        ChipListField(
+                            label: "Authors",
+                            placeholder: "Add an author",
+                            values: $draft.authors,
                             entry: $pendingAuthor,
                             isEdited: draft.authors != loaded.authors
                         )
@@ -100,6 +93,20 @@ struct MetadataEditView: View {
                         field("Published", \.published, hint: "YYYY-MM-DD")
                         field("Language", \.language, hint: "e.g. en")
                         field("ISBN-13", \.isbn13, keyboard: .numberPad)
+                    }
+                }
+
+                group("Tags") {
+                    Plate {
+                        ChipListField(
+                            label: "Tags",
+                            placeholder: "Add a tag",
+                            values: $draft.tags,
+                            entry: $pendingTag,
+                            isEdited: draft.tags != loaded.tags,
+                            deduplicates: true,
+                            isFirst: true
+                        )
                     }
                 }
 
@@ -225,30 +232,9 @@ struct MetadataEditView: View {
             isLoading = false
             return
         }
-        loaded = MetadataDraft(
-            title: book.title ?? "",
-            authors: book.creators.map(\.name),
-            series: book.series ?? "",
-            seriesIndex: book.seriesIndex ?? "",
-            publisher: book.publisher ?? "",
-            published: book.published ?? "",
-            language: book.language ?? "",
-            isbn13: book.isbn13 ?? "",
-            description: book.description ?? ""
-        )
+        loaded = MetadataDraft(book: book)
         draft = loaded
         isLoading = false
-    }
-
-    /// A field's value, but only when the user actually changed it.
-    ///
-    /// Sending every field on every save wrote overrides for fields nobody
-    /// touched, pinning scanned values so a later rescan could no longer update
-    /// them. The endpoint merges, so omitting a field leaves it as it was, and
-    /// an empty string clears an existing override.
-    private func changed(_ key: KeyPath<MetadataDraft, String>) -> String? {
-        let value = draft[keyPath: key]
-        return value == loaded[keyPath: key] ? nil : value
     }
 
     private func save() async {
@@ -256,50 +242,29 @@ struct MetadataEditView: View {
         error = nil
         defer { isSaving = false }
 
-        // A name typed into the add field but never committed to a chip is
+        // A value typed into an add field but never committed to a chip is
         // still what the user meant to save; dropping it silently is worse
         // than accepting it.
-        if !pendingAuthorName.isEmpty {
-            draft.authors.append(pendingAuthorName)
-            pendingAuthor = ""
+        if let chip = ChipEntry.committed(
+            from: pendingAuthor, existing: draft.authors, deduplicating: false
+        ) {
+            draft.authors.append(chip)
         }
-
-        // `creators` is a list of Contributor *objects* on the wire, not bare
-        // strings: sending `["E. M. Forster"]` fails the server's JSON
-        // extraction outright, so every save with a non-empty Authors field
-        // was rejected before it reached validation.
-        struct Creator: Encodable {
-            var name: String
+        pendingAuthor = ""
+        if let chip = ChipEntry.committed(
+            from: pendingTag, existing: draft.tags, deduplicating: true
+        ) {
+            draft.tags.append(chip)
         }
-
-        struct Overrides: Encodable {
-            var title: String?
-            var creators: [Creator]?
-            var series: String?
-            var series_index: String?
-            var publisher: String?
-            var published: String?
-            var language: String?
-            var isbn13: String?
-            var description: String?
-        }
-
-        let payload = Overrides(
-            title: changed(\.title),
-            creators: draft.authors == loaded.authors ? nil : draft.authors.map(Creator.init),
-            series: changed(\.series),
-            series_index: changed(\.seriesIndex),
-            publisher: changed(\.publisher),
-            published: changed(\.published),
-            language: changed(\.language),
-            isbn13: changed(\.isbn13),
-            description: changed(\.description)
-        )
+        pendingTag = ""
 
         do {
-            let _: Empty = try await APIClient.shared.post("/api/ebooks/\(uuid)/overrides", body: payload)
+            let _: Empty = try await APIClient.shared.post(
+                "/api/ebooks/\(uuid)/overrides", body: draft.payload(since: loaded)
+            )
             await OfflineStore.shared.cacheDelete(CacheKey.book(uuid))
             Haptics.success()
+            onSaved?()
             dismiss()
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
@@ -311,6 +276,7 @@ struct MetadataEditView: View {
             let _: Empty = try await APIClient.shared.delete("/api/ebooks/\(uuid)/overrides")
             await OfflineStore.shared.cacheDelete(CacheKey.book(uuid))
             Haptics.success()
+            onSaved?()
             dismiss()
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
@@ -318,26 +284,36 @@ struct MetadataEditView: View {
     }
 }
 
-/// Authors as removable chips plus an add field.
-///
-/// Order is meaningful (it's the byline), so entries append and can be removed
-/// individually rather than being re-typed as one delimited string.
-private struct AuthorsField: View {
-    @Binding var authors: [String]
+/// A list-valued field: removable chips plus an add field. Authors and tags
+/// share it — order is meaningful in both (the byline; the tag order the
+/// server stores), so entries append and can be removed individually rather
+/// than being re-typed as one delimited string.
+private struct ChipListField: View {
+    let label: String
+    let placeholder: String
+    @Binding var values: [String]
     @Binding var entry: String
     var isEdited = false
+    /// Tags refuse an exact re-add (ignoring case) the way the web chip
+    /// editor does; authors keep duplicates because two credited
+    /// contributors can legitimately share a name.
+    var deduplicates = false
+    /// First row of its plate — no leading hairline.
+    var isFirst = false
 
     @Environment(\.palette) private var palette
 
     var body: some View {
         VStack(spacing: 0) {
-            Rectangle()
-                .fill(palette.line2.color)
-                .frame(height: 0.5)
+            if !isFirst {
+                Rectangle()
+                    .fill(palette.line2.color)
+                    .frame(height: 0.5)
+            }
 
             VStack(alignment: .leading, spacing: 9) {
                 HStack(spacing: 6) {
-                    Text("AUTHORS")
+                    Text(label.uppercased())
                         .font(.monoUI(10, weight: .medium))
                         .tracking(0.7)
                         .foregroundStyle(isEdited ? palette.accentColor : palette.ink3Color)
@@ -352,11 +328,11 @@ private struct AuthorsField: View {
                     Spacer(minLength: 0)
                 }
 
-                if !authors.isEmpty {
+                if !values.isEmpty {
                     FlowLayout(spacing: 6, lineSpacing: 6) {
-                        // Index-identified: two contributors can legitimately
-                        // share a name, and the name is also what changes.
-                        ForEach(Array(authors.enumerated()), id: \.offset) { index, name in
+                        // Index-identified: authors can legitimately repeat a
+                        // name, and the name is also what changes.
+                        ForEach(Array(values.enumerated()), id: \.offset) { index, name in
                             chip(name, at: index)
                         }
                     }
@@ -367,7 +343,7 @@ private struct AuthorsField: View {
                         .font(.system(size: 14))
                         .foregroundStyle(palette.ink3Color)
 
-                    TextField("Add an author", text: $entry)
+                    TextField(placeholder, text: $entry)
                         .font(.ui(15))
                         .foregroundStyle(palette.ink0Color)
                         .textInputAutocapitalization(.words)
@@ -386,7 +362,7 @@ private struct AuthorsField: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
             .animation(Motion.snap, value: isEdited)
-            .animation(Motion.snap, value: authors)
+            .animation(Motion.snap, value: values)
         }
     }
 
@@ -398,7 +374,7 @@ private struct AuthorsField: View {
 
             Button {
                 Haptics.tap()
-                authors.remove(at: index)
+                values.remove(at: index)
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 9, weight: .bold))
@@ -415,10 +391,13 @@ private struct AuthorsField: View {
     }
 
     private func commit() {
-        let name = entry.trimmingCharacters(in: .whitespaces)
-        guard !name.isEmpty else { return }
+        // A refused duplicate still clears the field: the input was
+        // understood, and leaving the text sitting there reads as a failure.
+        defer { entry = "" }
+        guard let chip = ChipEntry.committed(
+            from: entry, existing: values, deduplicating: deduplicates
+        ) else { return }
         Haptics.select()
-        authors.append(name)
-        entry = ""
+        values.append(chip)
     }
 }

--- a/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
@@ -36,11 +36,11 @@ struct MetadataEditView: View {
     @State private var pendingTag = ""
 
     private var pendingAuthorName: String {
-        pendingAuthor.trimmingCharacters(in: .whitespaces)
+        pendingAuthor.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private var pendingTagName: String {
-        pendingTag.trimmingCharacters(in: .whitespaces)
+        pendingTag.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private var isDirty: Bool {
@@ -352,7 +352,7 @@ private struct ChipListField: View {
                         .tint(palette.accentColor)
                         .onSubmit(commit)
 
-                    if !entry.trimmingCharacters(in: .whitespaces).isEmpty {
+                    if !entry.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         Button("Add", action: commit)
                             .font(.ui(13, weight: .semibold))
                             .foregroundStyle(palette.accentColor)

--- a/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
+++ b/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
@@ -132,7 +132,7 @@ struct ShelfDetailView: View {
                                     }
                                     .buttonStyle(BookPressStyle())
                                     .cascadeIn(index: index)
-                                    .contextMenu {
+                                    .bookContextMenu(book, onEdited: { Task { await load() } }) {
                                         if shelf?.kind == .manual {
                                             Button(role: .destructive) {
                                                 Task {

--- a/omnibus-ios/omnibusTests/MetadataDraftTests.swift
+++ b/omnibus-ios/omnibusTests/MetadataDraftTests.swift
@@ -1,0 +1,115 @@
+//  MetadataDraftTests.swift
+//  The metadata editor's pure logic: which fields a save actually sends,
+//  and what a typed entry commits as a chip.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+private func gatsby() -> Book {
+    var book = Book(id: 7, filename: "gatsby.epub")
+    book.title = "The Great Gatsby"
+    book.creators = [Contributor(name: "F. Scott Fitzgerald")]
+    book.subjects = ["Classics", "Novel"]
+    book.series = "—"
+    book.publisher = "Scribner"
+    book.language = "en"
+    return book
+}
+
+struct MetadataDraftTests {
+    @Test func draftFromBookCarriesSubjectsAsTags() {
+        let draft = MetadataDraft(book: gatsby())
+        #expect(draft.tags == ["Classics", "Novel"])
+        #expect(draft.authors == ["F. Scott Fitzgerald"])
+        #expect(draft.title == "The Great Gatsby")
+    }
+
+    @Test func payloadSendsOnlyTheFieldsThatChanged() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.title = "Trimalchio"
+        draft.tags = ["Classics", "Novel", "Jazz Age"]
+
+        let payload = draft.payload(since: loaded)
+        #expect(payload.title == "Trimalchio")
+        #expect(payload.subjects == ["Classics", "Novel", "Jazz Age"])
+        // Untouched fields stay absent so the merge endpoint leaves them
+        // alone — sending them would pin scanned values against a rescan.
+        #expect(payload.creators == nil)
+        #expect(payload.series == nil)
+        #expect(payload.publisher == nil)
+        #expect(payload.language == nil)
+        #expect(payload.description == nil)
+    }
+
+    @Test func payloadOmitsTagsWhenTheListIsUntouched() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.publisher = "Modern Library"
+
+        let payload = draft.payload(since: loaded)
+        #expect(payload.subjects == nil)
+        #expect(payload.publisher == "Modern Library")
+    }
+
+    @Test func payloadSendsTheWholeTagListWhenOneTagIsRemoved() {
+        // The server's subjects override replaces wholesale, so a removal is
+        // expressed as the surviving list — not a delta.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.tags = ["Classics"]
+
+        #expect(draft.payload(since: loaded).subjects == ["Classics"])
+    }
+
+    @Test func payloadClearsAScalarFieldWithAnEmptyString() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.publisher = ""
+
+        #expect(draft.payload(since: loaded).publisher == "")
+    }
+
+    @Test func payloadReplacesTheWholeCreatorListWhenAuthorsChange() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.authors = ["F. Scott Fitzgerald", "Zelda Fitzgerald"]
+
+        #expect(draft.payload(since: loaded).creators == [
+            MetadataOverridesPayload.Creator(name: "F. Scott Fitzgerald"),
+            MetadataOverridesPayload.Creator(name: "Zelda Fitzgerald"),
+        ])
+    }
+}
+
+struct ChipEntryTests {
+    @Test func committedTrimsSurroundingWhitespace() {
+        let chip = ChipEntry.committed(from: "  Jazz Age  ", existing: [], deduplicating: true)
+        #expect(chip == "Jazz Age")
+    }
+
+    @Test func committedRefusesABlankEntry() {
+        #expect(ChipEntry.committed(from: "   ", existing: [], deduplicating: false) == nil)
+        #expect(ChipEntry.committed(from: "", existing: [], deduplicating: true) == nil)
+    }
+
+    @Test func committedRefusesADuplicateTagIgnoringCase() {
+        let chip = ChipEntry.committed(
+            from: "classics", existing: ["Classics", "Novel"], deduplicating: true
+        )
+        #expect(chip == nil)
+    }
+
+    @Test func committedAllowsADuplicateAuthorName() {
+        // Two credited contributors can legitimately share a name, so the
+        // authors field does not deduplicate.
+        let chip = ChipEntry.committed(
+            from: "F. Scott Fitzgerald",
+            existing: ["F. Scott Fitzgerald"],
+            deduplicating: false
+        )
+        #expect(chip == "F. Scott Fitzgerald")
+    }
+}

--- a/omnibus-ios/omnibusTests/MetadataDraftTests.swift
+++ b/omnibus-ios/omnibusTests/MetadataDraftTests.swift
@@ -93,6 +93,15 @@ struct ChipEntryTests {
     @Test func committedRefusesABlankEntry() {
         #expect(ChipEntry.committed(from: "   ", existing: [], deduplicating: false) == nil)
         #expect(ChipEntry.committed(from: "", existing: [], deduplicating: true) == nil)
+        // Pasted values commonly carry a trailing newline; newline-only input
+        // is still blank.
+        #expect(ChipEntry.committed(from: "\n", existing: [], deduplicating: true) == nil)
+        #expect(ChipEntry.committed(from: " \n ", existing: [], deduplicating: false) == nil)
+    }
+
+    @Test func committedTrimsATrailingNewlineFromAPastedValue() {
+        let chip = ChipEntry.committed(from: "Jazz Age\n", existing: [], deduplicating: true)
+        #expect(chip == "Jazz Age")
     }
 
     @Test func committedRefusesADuplicateTagIgnoringCase() {


### PR DESCRIPTION
## Summary
- Long-pressing a book cell anywhere on iOS (library grid, shelf grids, author pages, series rows, search results) now offers **Edit metadata** — the existing editor opens as a sheet, gated on `can_edit`, with each surface refreshing itself after a save.
- The metadata editor gains a **Tags** section: the authors chip field is generalized into a shared `ChipListField`; tags dedupe an exact re-add ignoring case (matching the web chip editor) while authors still allow duplicate names.
- Saves send `subjects` only when the list actually changed, through the existing `POST /api/ebooks/{uuid}/overrides` merge endpoint — untouched fields stay un-pinned.
- The draft snapshot, changed-fields-only payload diff, and chip-commit rules moved out of the view into `MetadataDraft.swift` so they're unit-testable.

## Test plan
- [x] `just ios-build` — compile check passes.
- [x] `just ios-test` — 164/164, including 10 new `MetadataDraftTests`/`ChipEntryTests` cases covering the payload diff and chip-commit semantics.
- [ ] Manual: long-press a cover in the library grid → Edit metadata → add/remove tags → Save; grid reflects the change.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.