### PR TITLE
fix: repaint reader highlight panes after reflow and queue pre-init adds

### DIFF
--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -85,6 +85,13 @@
   // otherwise leave the last line of prose clipped behind stale pagination.
   var stageResizeObserver = null;
   var stageResizeTimer = null;
+  // addAnnotation calls that arrived before init() built the rendition — the
+  // host seeds saved highlights in parallel with the bootstrap poll, so the
+  // highlight list can win that race. Flushed (and emptied) by init(); not
+  // cleared in teardown(), because init() tears down first and must still
+  // flush adds that raced it.
+  var pendingAnnotations = [];
+  var annotationRepaintTimer = null;
 
   function emitStatus(state) {
     if (typeof window.__omnibusOnStatus === "function") {
@@ -104,6 +111,10 @@
     if (stageResizeTimer) {
       clearTimeout(stageResizeTimer);
       stageResizeTimer = null;
+    }
+    if (annotationRepaintTimer) {
+      clearTimeout(annotationRepaintTimer);
+      annotationRepaintTimer = null;
     }
     if (stageResizeObserver) {
       try {
@@ -280,6 +291,20 @@
     } catch (e) {
       emitStatus("error");
       return;
+    }
+
+    // Saved highlights seeded while the bootstrap poll was still waiting on
+    // this init now have a rendition to land in; without this flush they
+    // were silently dropped and never painted. Guarded per-add so one
+    // unparseable CFI can't abort the rest of init.
+    var queued = pendingAnnotations;
+    pendingAnnotations = [];
+    for (var qi = 0; qi < queued.length; qi++) {
+      try {
+        addAnnotation(queued[qi].cfiRange, queued[qi].color);
+      } catch (e) {
+        /* skip the bad CFI, keep the rest */
+      }
     }
 
     // The whole-book `pct` figure comes from epub.js "locations" — a
@@ -784,6 +809,14 @@
 
       applyThemeColors(doc);
 
+      // Webfont activation reflows the prose without changing the section's
+      // quantized width, so epub.js never reframes — repaint the marks once
+      // the section's fonts settle or highlights sit where the fallback-font
+      // text used to be.
+      if (doc.fonts && doc.fonts.ready && doc.fonts.ready.then) {
+        doc.fonts.ready.then(scheduleAnnotationRepaint, function () {});
+      }
+
       // Reader baseline / override layer. The split mirrors Apple Books and
       // Kindle: the reading system owns colour (and font, size, spacing,
       // margins, justification — set elsewhere), while the publisher keeps
@@ -1224,6 +1257,7 @@
   function setFontSize(px) {
     if (!rendition) return;
     rendition.themes.fontSize(px + "px");
+    scheduleAnnotationRepaint();
   }
 
   function setTheme(name) {
@@ -1243,22 +1277,26 @@
   function setFont(family) {
     if (!rendition) return;
     rendition.themes.font(family);
+    scheduleAnnotationRepaint();
   }
 
   function setLineHeight(value) {
     if (!rendition) return;
     rendition.themes.override("line-height", value);
+    scheduleAnnotationRepaint();
   }
 
   function setMargins(maxWidth) {
     if (!rendition) return;
     rendition.themes.override("max-width", maxWidth);
     rendition.themes.override("margin", "0 auto");
+    scheduleAnnotationRepaint();
   }
 
   function setJustify(on) {
     if (!rendition) return;
     rendition.themes.override("text-align", on ? "justify" : "start");
+    scheduleAnnotationRepaint();
   }
 
   // Single vs two-page spread. "none" forces one column; "auto" lets epub.js
@@ -1270,6 +1308,41 @@
     } catch (e) {
       /* older epub.js builds may not expose spread() */
     }
+    scheduleAnnotationRepaint();
+  }
+
+  // Re-render every attached view's marks pane from live range rects.
+  // epub.js only repaints marks inside a view reframe, and expand() skips
+  // the reframe whenever a reflow lands on the same quantized column count —
+  // so a font-size step (or webfont swap) that keeps the page count leaves
+  // every highlight frozen at the previous layout's pixel rects.
+  function repaintAnnotations() {
+    if (!rendition || !rendition.manager || !rendition.manager.views) return;
+    var views = rendition.manager.views;
+    var all = typeof views.all === "function" ? views.all() : [];
+    for (var i = 0; i < all.length; i++) {
+      var pane = all[i] && all[i].pane;
+      if (!pane) continue;
+      try {
+        pane.render();
+      } catch (e) {
+        /* view mid-teardown */
+      }
+    }
+  }
+
+  // Repaint once the pending reflow has settled: after the next paint
+  // (double rAF), plus a timer backstop for settles the frame pass runs
+  // ahead of (webfont activation, epub.js's own debounced expand).
+  function scheduleAnnotationRepaint() {
+    requestAnimationFrame(function () {
+      requestAnimationFrame(repaintAnnotations);
+    });
+    if (annotationRepaintTimer) clearTimeout(annotationRepaintTimer);
+    annotationRepaintTimer = setTimeout(function () {
+      annotationRepaintTimer = null;
+      repaintAnnotations();
+    }, 450);
   }
 
   // Solid fills — transparency is applied once via the `fill-opacity`
@@ -1284,7 +1357,10 @@
   };
 
   function addAnnotation(cfiRange, color) {
-    if (!rendition) return;
+    if (!rendition) {
+      pendingAnnotations.push({ cfiRange: cfiRange, color: color });
+      return;
+    }
     var fill = HIGHLIGHT_COLORS[color] || HIGHLIGHT_COLORS.amber;
     rendition.annotations.add(
       "highlight", cfiRange, {}, undefined,
@@ -1294,11 +1370,15 @@
   }
 
   function removeAnnotation(cfiRange) {
+    pendingAnnotations = pendingAnnotations.filter(function (p) {
+      return p.cfiRange !== cfiRange;
+    });
     if (!rendition) return;
     rendition.annotations.remove(cfiRange, "highlight");
   }
 
   function clearAnnotations() {
+    pendingAnnotations = [];
     if (!rendition || !rendition.annotations) return;
     var store = rendition.annotations._annotations;
     if (!store) return;

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -24,6 +24,10 @@ const NOTE_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "gamma")!;
 // A fourth book for the recolor test so its seeded highlight is isolated from
 // the other highlight specs running in parallel.
 const RECOLOR_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "pioneers-3")!;
+// A fifth book, reserved for the highlight-overlay regression: it asserts on
+// where the highlight SVG is painted, so no other spec may write highlights
+// or drive typography on it.
+const OVERLAY_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "standalone-river")!;
 // Reserved books for the progress-restore tests (see fixtures/epubs.ts):
 // saved position is per-book state on the shared server, so any other spec
 // opening these in the reader would race the restore assertions. They must
@@ -313,6 +317,89 @@ test("recolors an existing highlight from the drawer", async ({
   await expect(
     row.getByTestId("reader-highlight-recolor-amber"),
   ).toHaveAttribute("aria-pressed", "false");
+});
+
+test("keeps a seeded highlight glued to its text across font-size changes", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, OVERLAY_BOOK.title);
+
+  // Seed a mid-paragraph range (chars 20–40): its painted position genuinely
+  // moves when the font grows, so a stale overlay can't pass by accident the
+  // way a range anchored at the paragraph origin would.
+  const quote = `overlay passage ${Date.now()}`;
+  const created = await request.post("/api/highlights", {
+    data: {
+      book_uuid: uuid,
+      epub_cfi_range: "epubcfi(/6/4!/4/2,/1:20,/1:40)",
+      color: "amber",
+      text: quote,
+    },
+  });
+  expect(created.status(), "seed highlight").toBe(200);
+
+  await gotoReady(page, `/read/${uuid}`);
+  await expect(page.getByTestId("reader-viewer")).toBeVisible();
+
+  // Intentional exception to the "never assert on rendered EPUB text" rule
+  // (same rationale as the black-theme regression above): the defect under
+  // test is epub.js painting the highlight SVG at a stale layout's pixel
+  // rects, so the assertion must compare the painted overlay against the
+  // rendered prose itself. Returns the worst axis drift between the SVG
+  // union box and the live range's union box; Infinity while unmeasurable.
+  const overlayDrift = (): Promise<number> =>
+    page.evaluate(() => {
+      const view = document.querySelector("#omnibus-viewer .epub-view");
+      const iframe = view?.querySelector("iframe");
+      const rects = view
+        ? Array.from(view.querySelectorAll(":scope > svg rect"))
+        : [];
+      const doc = iframe?.contentDocument;
+      const text = doc?.body?.firstElementChild?.firstChild;
+      if (
+        !iframe ||
+        !doc ||
+        rects.length === 0 ||
+        !text ||
+        text.nodeType !== Node.TEXT_NODE
+      ) {
+        return Number.POSITIVE_INFINITY;
+      }
+      const range = doc.createRange();
+      const len = (text as Text).data.length;
+      range.setStart(text, Math.min(20, len));
+      range.setEnd(text, Math.min(40, len));
+      const t = range.getBoundingClientRect();
+      const ifr = iframe.getBoundingClientRect();
+      const union = rects
+        .map((r) => r.getBoundingClientRect())
+        .reduce(
+          (a, b) => ({
+            left: Math.min(a.left, b.left),
+            top: Math.min(a.top, b.top),
+          }),
+          { left: Number.POSITIVE_INFINITY, top: Number.POSITIVE_INFINITY },
+        );
+      return Math.max(
+        Math.abs(union.left - (t.left + ifr.left)),
+        Math.abs(union.top - (t.top + ifr.top)),
+      );
+    });
+
+  // Painted over the prose on first open, with no font-size nudge — the add
+  // used to be dropped entirely when it raced the epub.js bootstrap.
+  await expect.poll(overlayDrift, { timeout: 20_000 }).toBeLessThan(3);
+
+  // Grow the text twice (18 → 20px). Each step reflows the prose without
+  // changing the section's one-spread width — exactly the case where
+  // epub.js skips the reframe that would have repositioned the marks.
+  await page.getByTestId("reader-aa").click();
+  await expect(page.getByTestId("reader-font-increase")).toBeVisible();
+  await page.getByTestId("reader-font-increase").click();
+  await page.getByTestId("reader-font-increase").click();
+
+  await expect.poll(overlayDrift, { timeout: 10_000 }).toBeLessThan(3);
 });
 
 test("opens the reader from the book detail Read action", async ({

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -325,14 +325,17 @@ test("keeps a seeded highlight glued to its text across font-size changes", asyn
 }) => {
   const uuid = await fetchBookUuidByTitle(request, OVERLAY_BOOK.title);
 
-  // Seed a mid-paragraph range (chars 20–40): its painted position genuinely
-  // moves when the font grows, so a stale overlay can't pass by accident the
-  // way a range anchored at the paragraph origin would.
+  // Seed a mid-paragraph range — chars 10–24 of the `<p>` (`/4/4`, after the
+  // `<h1>` at `/4/2`) in the single-item spine (`/6/2`). Its painted position
+  // genuinely moves when the font grows, so a stale overlay can't pass by
+  // accident the way a range anchored at the paragraph origin would. (The
+  // drawer specs above seed `/6/4!/4/2` anchors, but those are never
+  // resolved against the DOM — this one is, so it must be exact.)
   const quote = `overlay passage ${Date.now()}`;
   const created = await request.post("/api/highlights", {
     data: {
       book_uuid: uuid,
-      epub_cfi_range: "epubcfi(/6/4!/4/2,/1:20,/1:40)",
+      epub_cfi_range: "epubcfi(/6/2!/4/4,/1:10,/1:24)",
       color: "amber",
       text: quote,
     },
@@ -356,7 +359,8 @@ test("keeps a seeded highlight glued to its text across font-size changes", asyn
         ? Array.from(view.querySelectorAll(":scope > svg rect"))
         : [];
       const doc = iframe?.contentDocument;
-      const text = doc?.body?.firstElementChild?.firstChild;
+      // The seeded CFI targets the <p> after the <h1> — mirror it exactly.
+      const text = doc?.body?.querySelector("p")?.firstChild;
       if (
         !iframe ||
         !doc ||
@@ -368,8 +372,8 @@ test("keeps a seeded highlight glued to its text across font-size changes", asyn
       }
       const range = doc.createRange();
       const len = (text as Text).data.length;
-      range.setStart(text, Math.min(20, len));
-      range.setEnd(text, Math.min(40, len));
+      range.setStart(text, Math.min(10, len));
+      range.setEnd(text, Math.min(24, len));
       const t = range.getBoundingClientRect();
       const ifr = iframe.getBoundingClientRect();
       const union = rects


### PR DESCRIPTION
## Summary
- epub.js only repaints highlight SVG panes inside a view reframe, and `expand()` skips the reframe whenever a reflow lands on the same quantized spread count — font-size steps (40%/45% = 20/21px) and webfont swaps left highlights frozen at the previous layout's pixel rects, floating off-text.
- The glue now re-renders every view's marks pane after each typography change and once a section's webfonts settle (double-rAF + 450ms backstop).
- `addAnnotation` calls that raced the epub.js bootstrap were silently dropped; they now queue and flush at init, so saved highlights always paint on first open.

## Test plan
- [x] Reproduced against a copy of the production DB (Elantris, Kobo-synced highlight): pre-fix, drawn SVG rects stayed frozen across 18→22px while the text moved; post-fix, drawn rects equal the live range rects exactly at 19/20/21/22px in both Editorial and EB Garamond, and the highlight paints on first open with no size nudge.
- [x] New E2E regression `keeps a seeded highlight glued to its text across font-size changes` (reader.spec.ts, reserves `standalone-river`); mid-paragraph range so a stale overlay can't pass by accident.
- [x] `just lint-ts`, `node --check` on the glue.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.