### PR TITLE
fix: delete tags once no book carries them

### DIFF
--- a/db/src/discovery/tags.rs
+++ b/db/src/discovery/tags.rs
@@ -1,8 +1,10 @@
 //! Tag-cloud read: the global tag list with per-tag book counts. Counts
 //! use the merged (override-aware) subject set so user-edited subjects on
-//! a book are reflected here; a tag is visible with either a canonical
-//! `books_tags_link` row or an override membership (the override write
-//! path materializes a `tags` row for every override subject).
+//! a book are reflected here; a tag is visible only while at least one
+//! book effectively carries it — via a canonical `books_tags_link` row or
+//! an override membership (the override write path materializes a `tags`
+//! row for every override subject). A tag with zero effective books never
+//! renders.
 
 use omnibus_shared::TagWeight;
 use sqlx::{Row, SqlitePool};
@@ -22,12 +24,12 @@ const TAG_CLOUD_LIMIT: i64 = 500;
 pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, DiscoveryError> {
     // Counts use the effective (override-aware) subject set, not the raw
     // `books_tags_link` rows — `overrides.subjects` replaces a book's
-    // canonical tag list wholesale when Some. Visibility requires a
-    // canonical link OR an effective override membership: the override
-    // write path materializes a `tags` row for every override subject
-    // (`materialize_tag_rows`), so a tag created via the inline table
-    // editor feeds this cloud — and therefore the editor's own autocomplete
-    // pool — without polluting the scanned link table.
+    // canonical tag list wholesale when Some. Visibility requires an
+    // effective membership: the override write path materializes a `tags`
+    // row for every override subject (`materialize_tag_rows`), so a tag
+    // created via the inline table editor feeds this cloud — and therefore
+    // the editor's own autocomplete pool — without polluting the scanned
+    // link table.
     //
     // The `effective` CTE is `AS MATERIALIZED` (like `matches` in
     // `fetch_search_rows`) so the override extraction — `json_each` over
@@ -36,9 +38,12 @@ pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, Discover
     // columns (arm 1 sets `tag_name = NULL`, arm 2 sets `tag_id = NULL`)
     // and a book with a subjects override is excluded from arm 1, so no
     // single book reaches a tag through both arms — the OR-join in the
-    // final `GROUP BY` sums without double-counting. The `LEFT JOIN`
-    // preserves the prior correlated-subquery `cnt = 0` semantics for a
-    // visible tag whose every canonical book got overridden away. Override
+    // final `GROUP BY` sums without double-counting. The inner JOIN is the
+    // visibility rule: a tag with zero effective members — e.g. every
+    // canonical book overridden away — is hidden, per "a tag with no books
+    // doesn't exist". (Its `tags` row and canonical links survive so
+    // revert-to-scanned still works; rows with no references at all are
+    // physically reaped write-side by `delete_orphan_tags`.) Override
     // names are folded with `lower()` on both sides of the match so a
     // case-variant override ("fiction" against a canonical "Fiction" row)
     // counts toward — and keeps visible — the NOCASE-unique `tags` row it
@@ -65,14 +70,8 @@ pub async fn get_tag_cloud(pool: &SqlitePool) -> Result<Vec<TagWeight>, Discover
            )
            SELECT t.name, COUNT(e.book_id) AS cnt
            FROM tags t
-           LEFT JOIN effective e
+           JOIN effective e
              ON e.tag_id = t.id OR e.tag_name = lower(t.name)
-           WHERE EXISTS (
-             SELECT 1 FROM books_tags_link btl WHERE btl.tag = t.id
-           )
-           OR EXISTS (
-             SELECT 1 FROM effective e2 WHERE e2.tag_name = lower(t.name)
-           )
            GROUP BY t.id, t.name
            ORDER BY cnt DESC, t.name ASC
            LIMIT ?"#,

--- a/db/src/discovery/tests.rs
+++ b/db/src/discovery/tests.rs
@@ -288,15 +288,21 @@ async fn get_tag_cloud_counts_canonical_and_override_subjects_without_double_cou
         essay.count, 2,
         "essay must sum the canonical and override members exactly once each, got {tags:?}",
     );
-    // "fiction" loses its only member to the override; the tag stays
-    // visible via its canonical link but its merged count drops to 0.
-    let fiction = tags
-        .iter()
-        .find(|t| t.name == "fiction")
-        .expect("fiction stays visible via canonical link");
+    // "fiction" loses its only member to the override; with zero effective
+    // books it drops out of the cloud entirely. Its `tags` row and canonical
+    // link survive underneath (revert-to-scanned needs them) — hidden, not
+    // deleted.
+    assert!(
+        !tags.iter().any(|t| t.name == "fiction"),
+        "a fully-overridden-away tag must be hidden from the cloud, got {tags:?}",
+    );
+    let fiction_row: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tags WHERE name = 'fiction'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
     assert_eq!(
-        fiction.count, 0,
-        "a fully-overridden-away tag stays visible at cnt=0, got {tags:?}",
+        fiction_row, 1,
+        "the canonical tags row must survive for revert-to-scanned"
     );
 }
 #[tokio::test]

--- a/db/src/metadata_overrides/links.rs
+++ b/db/src/metadata_overrides/links.rs
@@ -49,10 +49,10 @@ pub(super) async fn materialize_series_link(
 /// link table is the sole record of a book's *scanned* tags, so writing
 /// override memberships into it would make "delete overrides → revert to
 /// scanned" impossible. Memberships stay in the override JSON, which
-/// `get_tag_cloud` already counts via `json_each`. A row whose every
-/// membership is override-side can still be reaped by
-/// `delete_orphan_taxonomy` after an unrelated book delete — it resurfaces
-/// on the next subjects-override save that names it.
+/// `get_tag_cloud` already counts via `json_each`. The orphan sweep
+/// (`delete_orphan_tags`) counts those memberships too, so a materialized
+/// row lives exactly as long as a canonical link or a live book's override
+/// still names it — and is deleted the moment neither does.
 pub(super) async fn materialize_tag_rows(
     conn: &mut SqliteConnection,
     overrides: &MetadataOverrides,

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -1174,9 +1174,9 @@ async fn upsert_metadata_overrides_materializes_tag_links_for_new_tags() {
     .await
     .unwrap();
 
-    // `get_tag_cloud` only surfaces tags with a canonical `books_tags_link`
-    // row, so the override-created tag appearing here proves the
-    // materialization — this is what feeds the inline-edit autocomplete pool.
+    // `get_tag_cloud` selects FROM `tags`, so the override-created tag
+    // appearing here proves the materialized row and its override membership
+    // joined up — this is what feeds the inline-edit autocomplete pool.
     let cloud = crate::get_tag_cloud(&pool).await.unwrap();
     assert!(
         cloud.iter().any(|t| t.name == "Brand New Tag"),
@@ -1188,6 +1188,185 @@ async fn upsert_metadata_overrides_materializes_tag_links_for_new_tags() {
         cloud.iter().all(|t| !t.name.trim().is_empty()),
         "blank subjects must not materialize tag rows"
     );
+}
+
+/// Count `tags` rows matching `name` (NOCASE column, so case variants match).
+async fn tag_row_count(pool: &sqlx::SqlitePool, name: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM tags WHERE name = ?")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// Seed one scanned book under `/lib` with the given canonical tags and
+/// return its `(uuid, id)`.
+async fn seed_one_book_with_tags(pool: &sqlx::SqlitePool, tags: &[&str]) -> (String, i64) {
+    replace_books(
+        pool,
+        "/lib",
+        vec![indexed(
+            "book.epub",
+            Some("Book"),
+            &["Author"],
+            tags,
+            None,
+            None,
+        )],
+    )
+    .await
+    .unwrap();
+    let books = list_books(pool, "/lib").await.unwrap();
+    (books[0].unique_identifier.clone().unwrap(), books[0].id)
+}
+
+#[tokio::test]
+async fn upsert_metadata_overrides_deletes_a_tag_orphaned_by_dropping_its_last_membership() {
+    let _covers = CoversTempDir::new("reap_tag_upsert");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let (uuid, _) = seed_one_book_with_tags(&pool, &[]).await;
+
+    let with_subjects = |subjects: &[&str]| MetadataOverrides {
+        subjects: Some(subjects.iter().map(|s| s.to_string()).collect()),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &with_subjects(&["keep", "drop"]),
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+    assert_eq!(tag_row_count(&pool, "drop").await, 1);
+
+    upsert_metadata_overrides(&pool, &uuid, &with_subjects(&["keep"]), false, user_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        tag_row_count(&pool, "drop").await,
+        0,
+        "the save dropped the tag's last membership, so the row must be reaped"
+    );
+    assert_eq!(tag_row_count(&pool, "keep").await, 1);
+}
+
+#[tokio::test]
+async fn upsert_metadata_overrides_keeps_canonical_tag_rows_shadowed_by_an_override() {
+    let _covers = CoversTempDir::new("reap_tag_shadowed");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let (uuid, id) = seed_one_book_with_tags(&pool, &["scanned"]).await;
+
+    // Clear-all override: the tag's every *effective* membership is gone,
+    // but its canonical link row is the scanned truth — reaping it would
+    // make revert-to-scanned lossy.
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            subjects: Some(vec![]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+    assert_eq!(tag_row_count(&pool, "scanned").await, 1);
+    let links: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM books_tags_link")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(links, 1, "the canonical link row must survive the override");
+
+    delete_metadata_overrides(&pool, &uuid).await.unwrap();
+    let reverted = get_book(&pool, id).await.unwrap().unwrap();
+    assert_eq!(
+        reverted.subjects,
+        vec!["scanned"],
+        "revert-to-scanned must still restore the tag"
+    );
+}
+
+#[tokio::test]
+async fn delete_metadata_overrides_deletes_tags_that_existed_only_through_the_override() {
+    let _covers = CoversTempDir::new("reap_tag_delete");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let (uuid, _) = seed_one_book_with_tags(&pool, &[]).await;
+
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            subjects: Some(vec!["solo".into()]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+    assert_eq!(tag_row_count(&pool, "solo").await, 1);
+
+    delete_metadata_overrides(&pool, &uuid).await.unwrap();
+    assert_eq!(
+        tag_row_count(&pool, "solo").await,
+        0,
+        "reverting to scanned must reap the override-only tag"
+    );
+}
+
+#[tokio::test]
+async fn merge_metadata_overrides_deletes_a_tag_dropped_by_the_replacing_subjects_list() {
+    let _covers = CoversTempDir::new("reap_tag_merge");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let (uuid, _) = seed_one_book_with_tags(&pool, &[]).await;
+
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            subjects: Some(vec!["a".into(), "b".into()]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    // `merge` replaces m2m fields wholesale when `Some` — "b" loses its
+    // only membership.
+    merge_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            subjects: Some(vec!["a".into()]),
+            ..Default::default()
+        },
+        user_id,
+    )
+    .await
+    .unwrap();
+    assert_eq!(tag_row_count(&pool, "b").await, 0, "dropped tag reaped");
+    assert_eq!(tag_row_count(&pool, "a").await, 1);
 }
 
 /// The batch FTS rebuild resolves and rewrites more than one uuid in a
@@ -1714,6 +1893,47 @@ async fn bulk_merge_metadata_overrides_uses_existing_override_subjects_as_the_ta
         vec!["ov2", "new"],
         "base must be the prior override subjects, not the scanned list"
     );
+}
+
+#[tokio::test]
+async fn bulk_merge_metadata_overrides_deletes_tags_orphaned_by_a_remove_delta() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let seeded = seed_two_books_for_bulk(&pool).await;
+    let (uuid, _) = seeded[0].clone();
+
+    merge_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            subjects: Some(vec!["ov1".into(), "ov2".into()]),
+            ..Default::default()
+        },
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let edit = BulkMetadataEdit {
+        remove_tags: vec!["ov1".into()],
+        ..Default::default()
+    };
+    bulk_merge_metadata_overrides(&pool, std::slice::from_ref(&uuid), &edit, user_id)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        tag_row_count(&pool, "ov1").await,
+        0,
+        "the remove delta dropped ov1's last membership — row reaped"
+    );
+    assert_eq!(tag_row_count(&pool, "ov2").await, 1);
+    // a.epub's canonical tags are shadowed by the override but still
+    // linked — scanned truth survives for revert.
+    assert_eq!(tag_row_count(&pool, "scifi").await, 1);
 }
 
 #[tokio::test]

--- a/db/src/metadata_overrides/upsert.rs
+++ b/db/src/metadata_overrides/upsert.rs
@@ -248,6 +248,9 @@ pub async fn upsert_metadata_overrides(
     materialize_series_link(&mut tx, book_uuid, overrides).await?;
     materialize_tag_rows(&mut tx, overrides).await?;
     touch_book_last_modified(&mut tx, book_uuid).await?;
+    // A subjects replacement may have dropped a tag's last membership — reap
+    // orphans in the same tx so no surface ever serves a bookless tag.
+    crate::taxonomy::delete_orphan_tags(&mut tx).await?;
     tx.commit().await?;
 
     if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
@@ -279,6 +282,9 @@ pub async fn merge_metadata_overrides(
     // cleanup.
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     merge_one_in_tx(&mut tx, book_uuid, incoming, user_id).await?;
+    // The merged subjects may have dropped a tag's last membership (m2m
+    // fields replace wholesale when `Some`) — reap orphans before commit.
+    crate::taxonomy::delete_orphan_tags(&mut tx).await?;
     tx.commit().await?;
 
     if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
@@ -381,6 +387,9 @@ pub async fn bulk_merge_metadata_overrides(
         }
         merge_one_in_tx(&mut tx, uuid, &incoming, user_id).await?;
     }
+    // One sweep for the whole batch, not per book: a `remove_tags` delta can
+    // drop a tag's last membership anywhere in the set.
+    crate::taxonomy::delete_orphan_tags(&mut tx).await?;
     tx.commit().await?;
 
     for uuid in uuids {
@@ -519,6 +528,9 @@ pub async fn delete_metadata_overrides(
         upsert_fts(&mut tx, id).await?;
     }
     touch_book_last_modified(&mut tx, book_uuid).await?;
+    // Reverting to scanned drops every override membership this row held —
+    // tags that existed only through it are now orphans.
+    crate::taxonomy::delete_orphan_tags(&mut tx).await?;
     tx.commit().await?;
 
     // The override state is now fully cleared, so any cached rewritten

--- a/db/src/taxonomy.rs
+++ b/db/src/taxonomy.rs
@@ -79,9 +79,11 @@ pub(crate) async fn delete_orphan_taxonomy(
 /// override write paths, which can orphan a tag without touching any link
 /// row (a subjects save dropping the tag's last membership, or an override
 /// delete). The membership match mirrors `get_tag_cloud`'s override arm:
-/// scoped to live `books` rows and case-folded with `lower()` on both sides.
-/// A JSON-null or absent `$.subjects` yields no matching `json_each` rows,
-/// so such overrides protect nothing.
+/// scoped to live `books` rows, filtered to overrides that actually set
+/// `$.subjects`, and compared `COLLATE NOCASE` — equivalent to the cloud's
+/// `lower()` fold (both are ASCII-only) without recomputing `lower()` per
+/// row. A JSON-null or absent `$.subjects` yields no matching `json_each`
+/// rows, so such overrides protect nothing.
 pub(crate) async fn delete_orphan_tags(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
 ) -> Result<(), sqlx::Error> {
@@ -93,7 +95,8 @@ pub(crate) async fn delete_orphan_tags(
                 FROM books b
                 JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
                 JOIN json_each(mo.overrides, '$.subjects') je
-               WHERE lower(je.value) = lower(tags.name)
+               WHERE json_type(mo.overrides, '$.subjects') IS NOT NULL
+                 AND je.value = tags.name COLLATE NOCASE
             )",
     )
     .execute(&mut **tx)

--- a/db/src/taxonomy.rs
+++ b/db/src/taxonomy.rs
@@ -42,23 +42,22 @@ resolve_or_insert_simple!(resolve_or_insert_tag, "tags", "name");
 resolve_or_insert_simple!(resolve_or_insert_publisher, "publishers", "name");
 resolve_or_insert_simple!(resolve_or_insert_language, "languages", "code");
 
-/// Delete taxonomy rows (`authors`, `series`, `tags`, `publishers`,
-/// `languages`) no longer referenced by any book. Run wherever the last link
-/// to a taxonomy row can disappear — the missing-files GC purge, the merge
-/// source delete, and the indexer's Changed bucket, which wipes a book's link
-/// rows before re-inserting them from the re-parsed file — so an author or
-/// series left with zero books doesn't linger. `author_photos`
-/// cascades on the author delete; the link tables have no taxonomy-side
-/// cascade, so a row is only deletable once its last link is gone, which is
-/// exactly the set this targets. Table/column names are compile-time literals,
-/// not caller input.
+/// Delete taxonomy rows (`authors`, `series`, `publishers`, `languages`)
+/// no longer referenced by any book, then reap orphaned tags via
+/// [`delete_orphan_tags`]. Run wherever the last link to a taxonomy row can
+/// disappear — the missing-files GC purge, the merge source delete, and the
+/// indexer's Changed bucket, which wipes a book's link rows before
+/// re-inserting them from the re-parsed file — so an author or series left
+/// with zero books doesn't linger. `author_photos` cascades on the author
+/// delete; the link tables have no taxonomy-side cascade, so a row is only
+/// deletable once its last link is gone, which is exactly the set this
+/// targets. Table/column names are compile-time literals, not caller input.
 pub(crate) async fn delete_orphan_taxonomy(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
 ) -> Result<(), sqlx::Error> {
     for (table, link, col) in [
         ("authors", "books_authors_link", "author"),
         ("series", "books_series_link", "series"),
-        ("tags", "books_tags_link", "tag"),
         ("publishers", "books_publishers_link", "publisher"),
         ("languages", "books_languages_link", "language"),
     ] {
@@ -68,6 +67,37 @@ pub(crate) async fn delete_orphan_taxonomy(
         );
         sqlx::query(&sql).execute(&mut **tx).await?;
     }
+    delete_orphan_tags(tx).await
+}
+
+/// Delete `tags` rows with no book left to justify them: no canonical
+/// `books_tags_link` row **and** no subjects-override membership on a live
+/// book. Tags need the second clause because override memberships live in
+/// `metadata_overrides` JSON rather than the link table (see
+/// `materialize_tag_rows`) — a link-only check would reap a tag an override
+/// still names. Called from [`delete_orphan_taxonomy`] and directly from the
+/// override write paths, which can orphan a tag without touching any link
+/// row (a subjects save dropping the tag's last membership, or an override
+/// delete). The membership match mirrors `get_tag_cloud`'s override arm:
+/// scoped to live `books` rows and case-folded with `lower()` on both sides.
+/// A JSON-null or absent `$.subjects` yields no matching `json_each` rows,
+/// so such overrides protect nothing.
+pub(crate) async fn delete_orphan_tags(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "DELETE FROM tags
+          WHERE NOT EXISTS (SELECT 1 FROM books_tags_link WHERE tag = tags.id)
+            AND NOT EXISTS (
+              SELECT 1
+                FROM books b
+                JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+                JOIN json_each(mo.overrides, '$.subjects') je
+               WHERE lower(je.value) = lower(tags.name)
+            )",
+    )
+    .execute(&mut **tx)
+    .await?;
     Ok(())
 }
 

--- a/db/src/taxonomy/tests.rs
+++ b/db/src/taxonomy/tests.rs
@@ -2,10 +2,17 @@
 //! macro generates the three resolvers, so all three contracts (insert,
 //! idempotency, case-insensitivity) are covered on `series` and spot-checked
 //! on `publishers` / `languages` to catch a bad expansion.
-//! `delete_orphan_taxonomy` gets its own drop/keep pair.
+//! `delete_orphan_taxonomy` gets its own drop/keep pair;
+//! `delete_orphan_tags` adds the override-aware keep/drop cases.
+
+use omnibus_shared::MetadataOverrides;
 
 use super::*;
+use crate::books::list_books;
+use crate::metadata_overrides::upsert_metadata_overrides;
 use crate::pool::init_db;
+use crate::sync::replace_books;
+use crate::test_support::{indexed, CoversTempDir};
 
 #[tokio::test]
 async fn resolve_or_insert_series_inserts_and_returns_id() {
@@ -174,4 +181,121 @@ async fn delete_orphan_taxonomy_keeps_rows_that_still_have_a_linked_book() {
         .await
         .unwrap();
     assert_eq!(authors, 1, "linked author retained");
+}
+
+#[tokio::test]
+async fn delete_orphan_tags_keeps_a_tag_named_only_by_a_live_books_override() {
+    let _covers = CoversTempDir::new("orphan_tags_override_keep");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed("a.epub", Some("A"), &["X"], &[], None, None)],
+    )
+    .await
+    .unwrap();
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let uuid = books[0].unique_identifier.clone().unwrap();
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            subjects: Some(vec!["Keeper".into()]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    delete_orphan_tags(&mut tx).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tags WHERE name = 'Keeper'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(kept, 1, "an override membership must protect the tag row");
+}
+
+#[tokio::test]
+async fn delete_orphan_tags_matches_override_subjects_case_insensitively() {
+    let _covers = CoversTempDir::new("orphan_tags_case_fold");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    // A linkless canonical-cased row, protected only by a lower-cased
+    // override subject on a live book — the NOCASE tags unique means the
+    // override materializes no second row, so the sweep's membership match
+    // must fold case or the row is wrongly reaped.
+    let mut tx = pool.begin().await.unwrap();
+    resolve_or_insert_tag(&mut tx, "Fiction").await.unwrap();
+    tx.commit().await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed("a.epub", Some("A"), &["X"], &[], None, None)],
+    )
+    .await
+    .unwrap();
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let uuid = books[0].unique_identifier.clone().unwrap();
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            subjects: Some(vec!["fiction".into()]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    delete_orphan_tags(&mut tx).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tags WHERE name = 'Fiction'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        kept, 1,
+        "a case-variant override membership must protect the row"
+    );
+}
+
+#[tokio::test]
+async fn delete_orphan_tags_ignores_override_rows_whose_book_no_longer_exists() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    // An override row keyed to a uuid with no live `books` row — e.g. left
+    // behind by an out-of-band delete — must not keep its tags alive. The
+    // membership check joins to `books`, mirroring `get_tag_cloud`.
+    sqlx::query(
+        r#"INSERT INTO metadata_overrides (book_uuid, overrides)
+           VALUES ('no-such-book', '{"subjects":["Ghosted"]}')"#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    let mut tx = pool.begin().await.unwrap();
+    resolve_or_insert_tag(&mut tx, "Ghosted").await.unwrap();
+    delete_orphan_tags(&mut tx).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tags WHERE name = 'Ghosted'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(n, 0, "a dead book's override must not protect a tag row");
 }


### PR DESCRIPTION
## Summary
- Orphaned tags are now deleted the moment their last reference disappears: new `delete_orphan_tags` reaps `tags` rows with no canonical link **and** no subjects-override membership on a live book, and runs from every override write path (save / merge / bulk edit / revert-to-scanned) plus the existing delete/reindex sweeps.
- The tag cloud hides tags with zero effective books instead of showing them at count 0.
- Override-only tags are no longer wrongly reaped by unrelated book deletes (the old "resurfaces on next save" flaw).
- Invariant: canonical `books_tags_link` rows shadowed by an override are never deleted — revert-to-scanned stays lossless; such tags are hidden, not dropped.

## Test plan
- [x] `cargo test -p omnibus-db` — 1670 passed (8 new: 3 for `delete_orphan_tags`, 5 for the override write-path reap/keep behavior)
- [x] Full matrix green: `-p omnibus` (640), `-p omnibus-frontend --features server` (613), `-p omnibus-shared` (255)
- [x] `just lint` clean

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The command-palette tag search still keys off canonical links (deliberate — override-only tags have no navigable id there), so a fully-shadowed tag can still surface in palette results; happy to align it with the cloud in a follow-up if wanted.