### PR TITLE
fix: keep HardcoverFetchPanel hook order stable across availability transition (#1590)

### DIFF
--- a/frontend/src/pages/metadata_edit/hardcover_fetch.rs
+++ b/frontend/src/pages/metadata_edit/hardcover_fetch.rs
@@ -17,6 +17,9 @@ use omnibus_shared::metadata_fetch::{FetchedBookMetadata, HardcoverFetchResult};
 use super::form_grid::FormFields;
 use crate::{data, use_server_url};
 
+#[cfg(test)]
+mod tests;
+
 /// What the fetch action is currently doing.
 #[derive(Clone, PartialEq)]
 enum FetchState {
@@ -34,6 +37,13 @@ enum FetchState {
 pub(super) fn HardcoverFetchPanel(uuid: String, fields: FormFields) -> Element {
     let server_url = use_server_url();
     let mut available = use_signal(|| false);
+    // Declared unconditionally, before the `available` gate below, so this
+    // scope calls the same number of hooks in the same order on every
+    // render — the gate only skips the visible markup, never a hook
+    // (rule 07; #1590 was this component calling one hook pre-availability
+    // and three post-availability on the same mounted instance).
+    let mut state = use_signal(|| FetchState::Idle);
+    let mut busy = use_signal(|| false);
 
     let url = server_url.clone();
     use_effect(move || {
@@ -49,8 +59,6 @@ pub(super) fn HardcoverFetchPanel(uuid: String, fields: FormFields) -> Element {
         return rsx! {};
     }
 
-    let mut state = use_signal(|| FetchState::Idle);
-    let mut busy = use_signal(|| false);
     let on_fetch = move |_| {
         if busy() {
             return;

--- a/frontend/src/pages/metadata_edit/hardcover_fetch.rs
+++ b/frontend/src/pages/metadata_edit/hardcover_fetch.rs
@@ -17,7 +17,7 @@ use omnibus_shared::metadata_fetch::{FetchedBookMetadata, HardcoverFetchResult};
 use super::form_grid::FormFields;
 use crate::{data, use_server_url};
 
-#[cfg(test)]
+#[cfg(all(test, feature = "server"))]
 mod tests;
 
 /// What the fetch action is currently doing.

--- a/frontend/src/pages/metadata_edit/hardcover_fetch/tests.rs
+++ b/frontend/src/pages/metadata_edit/hardcover_fetch/tests.rs
@@ -1,0 +1,79 @@
+//! Regression coverage for #1590: `HardcoverFetchPanel`'s `available` gate
+//! must never change the number/order of hooks a render calls.
+//!
+//! The real component resolves `available` through a `dioxus::fullstack`
+//! server function whose extractors (`pool: PoolExt`, `user: AuthUser`) need
+//! a live axum request context to resolve — there's no seam in this crate's
+//! test harness to drive that from a bare `VirtualDom` (unlike
+//! `rpc::overrides`'s tests, which call an *extracted* pool-taking body
+//! directly; this rpc is a one-line lookup with nothing to extract). So this
+//! harness mirrors `HardcoverFetchPanel`'s exact fixed hook shape — every
+//! `use_signal` declared before the `if !available() { return }` gate — and
+//! drives the false-to-true transition with a real `Signal<bool>` published
+//! back to the test via `use_hook`, then flips it and forces a second render
+//! the same way `dioxus`'s own signal-write scheduling does in production
+//! (`dom.in_runtime(|| available.set(true))`, then `render_immediate`).
+//!
+//! This build of Dioxus (v0.7.9) does not hard-panic on the specific
+//! *monotonic-growth* hook mismatch #1590 described (a render that calls
+//! strictly more hooks than the previous one just extends the hook list) —
+//! confirmed by running the pre-fix shape through this same harness during
+//! development, which completed without panicking. That is exactly why the
+//! bug shipped unnoticed rather than crashing CI: rule 07's "same hook
+//! count/order on every render" is a hazard that can silently misattribute
+//! state (a *different* hook shrinking or reordering) rather than a
+//! guaranteed crash on *this* one-directional transition, so the test below
+//! asserts the fixed shape's rendered *content* is correct after the flip,
+//! not just that it avoided a panic.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use dioxus::prelude::*;
+
+/// Publishes its internal `available` signal back to the test via `slot`,
+/// so the test can flip it the same way a real `use_effect` resolution
+/// would, then forces a second render to prove the hook table survives.
+#[derive(Clone)]
+struct HarnessProps {
+    slot: Rc<RefCell<Option<Signal<bool>>>>,
+}
+
+/// Mirrors `HardcoverFetchPanel`'s fixed shape: `state`/`busy` declared
+/// unconditionally, before the `available` gate.
+fn fixed_shape_harness(props: HarnessProps) -> Element {
+    let available = use_signal(|| false);
+    use_hook(|| *props.slot.borrow_mut() = Some(available));
+    let mut state = use_signal(|| 0i32);
+    let mut busy = use_signal(|| false);
+
+    if !available() {
+        return rsx! {};
+    }
+
+    state += 1;
+    busy.set(true);
+    rsx! { div { "{state()}-{busy()}" } }
+}
+
+#[test]
+fn hook_order_survives_an_availability_flip_from_false_to_true() {
+    let slot: Rc<RefCell<Option<Signal<bool>>>> = Rc::new(RefCell::new(None));
+    let mut dom =
+        VirtualDom::new_with_props(fixed_shape_harness, HarnessProps { slot: slot.clone() });
+    dom.rebuild_in_place();
+    // Before the flip: same hook shape as the real panel's pre-availability
+    // render, and its early return renders nothing.
+    assert_eq!(dioxus::ssr::render(&dom), "");
+
+    let mut available = slot
+        .borrow_mut()
+        .take()
+        .expect("harness publishes its signal on first render");
+    dom.in_runtime(|| available.set(true));
+    // Must not panic, and the post-flip render must show the *correct*
+    // state — not just avoid crashing, in case a hook mismatch silently
+    // wired `busy`'s slot to `state`'s value or vice versa.
+    dom.render_immediate(&mut dioxus::core::NoOpMutations);
+    assert_eq!(dioxus::ssr::render(&dom), "<div>1-true</div>");
+}

--- a/frontend/src/pages/metadata_edit/hardcover_fetch/tests.rs
+++ b/frontend/src/pages/metadata_edit/hardcover_fetch/tests.rs
@@ -51,7 +51,7 @@ fn fixed_shape_harness(props: HarnessProps) -> Element {
         return rsx! {};
     }
 
-    state += 1;
+    state.with_mut(|v| *v += 1);
     busy.set(true);
     rsx! { div { "{state()}-{busy()}" } }
 }


### PR DESCRIPTION
## Summary
- Closes #1590
- `HardcoverFetchPanel` declared `state`/`busy` via `use_signal` *after* the `if !available() { return rsx! {}; }` early return, so the component called a different number of hooks before vs. after the async availability check resolved on the same mounted instance — a hook-order violation of rule 07 (`.claude/rules/07-hydration.md`), not merely SSR/hydration parity.
- Fix: move both `use_signal` declarations above the `available` gate, exactly per the issue's suggested approach. Hook count/order is now identical on every render; the gate still short-circuits only the visible markup.
- Added a regression test (`frontend/src/pages/metadata_edit/hardcover_fetch/tests.rs`) that mounts a harness mirroring the fixed hook shape in a real `VirtualDom`, publishes its `available` `Signal<bool>` back to the test via `use_hook`, flips it `false -> true` through `dom.in_runtime(|| available.set(true))` (the same signal-write scheduling path production uses), forces a second render with `render_immediate`, and asserts the *rendered content* is correct post-flip (not just that nothing panicked).

## Note on test scope
The real `HardcoverFetchPanel`'s availability check goes through a `dioxus::fullstack` server function whose extractors (`pool: PoolExt`, `user: AuthUser`) need a live axum request context to resolve — there's no seam in this crate's existing test harness to drive that resolution from a bare `VirtualDom` (unlike `rpc::overrides`'s tests, which call an *extracted* pool-taking body directly; this rpc is a one-line lookup with nothing to extract). The added test instead mirrors the panel's exact hook-declaration shape and drives the identical false→true transition with a real `Signal<bool>`, which exercises the actual Dioxus hook-slot invariant rule 07 requires.

Also worth noting: this build of Dioxus (v0.7.9) does not hard-panic on this specific *monotonic-growth* hook-count change (a render calling strictly more hooks than the previous one just extends the hook list) — confirmed by running the pre-fix shape through the same harness during development, which completed without panicking. That's consistent with the issue's own wording ("risking a panic or silently misattributed signal state") — the invariant in rule 07 exists independent of whether this exact transition crashes on this exact Dioxus build, and the added test guards the *content* correctness of the fixed shape, not just crash-freedom.

## Test plan
- [x] `cargo fmt -p omnibus-frontend` — clean
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 618 passed; 0 failed

## Version
- [x] **Patch** — left unlabeled (default)

## Notes
- Manual verification via `ui-validate` was not run for this change (the fix is a hook-declaration reorder with identical visible behavior); the new unit test exercises the exact false→true transition the issue describes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DhPxqqQHT7EfpDyhQGZHWx)_