### PR TITLE
refactor: add anonymous-401 coverage and retry affordance to registration toggle (#1592)

### DIFF
--- a/frontend/src/pages/settings/users.rs
+++ b/frontend/src/pages/settings/users.rs
@@ -149,6 +149,55 @@ fn registration_status_line(enabled: Option<bool>) -> &'static str {
     }
 }
 
+/// Applies the result of `data::registration_status()` to the load signals.
+/// Extracted from the effect (and shared with the retry handler) so the
+/// `Err` branch — and the retry-affordance condition it leaves behind — is
+/// directly testable without a network call.
+fn apply_registration_status(
+    mut confirmed: Signal<Option<bool>>,
+    mut shown: Signal<Option<bool>>,
+    mut error: Signal<Option<String>>,
+    result: Result<bool, String>,
+) {
+    match result {
+        Ok(open) => {
+            confirmed.set(Some(open));
+            shown.set(Some(open));
+            error.set(None);
+        }
+        Err(e) => error.set(Some(e)),
+    }
+}
+
+/// Whether the initial load failed and never resolved — the case that used
+/// to leave the checkbox `disabled` forever with no way to recover. Extracted
+/// as a pure predicate so the retry-button condition is unit-testable.
+fn needs_registration_retry(error: Option<&String>, confirmed: Option<bool>) -> bool {
+    error.is_some() && confirmed.is_none()
+}
+
+/// `onclick` for the retry affordance shown after a failed initial load.
+/// Re-runs the same fetch the mount effect runs and hands the result to
+/// [`apply_registration_status`], so a successful retry re-enables the
+/// checkbox exactly like a successful first load would have.
+fn registration_retry_handler(
+    confirmed: Signal<Option<bool>>,
+    shown: Signal<Option<bool>>,
+    error: Signal<Option<String>>,
+    mut retrying: Signal<bool>,
+) -> impl FnMut(Event<MouseData>) {
+    move |_| {
+        if retrying() {
+            return;
+        }
+        retrying.set(true);
+        spawn(async move {
+            apply_registration_status(confirmed, shown, error, data::registration_status().await);
+            retrying.set(false);
+        });
+    }
+}
+
 /// `onchange` for the self-registration switch, extracted from
 /// [`RegistrationToggle`] so its guards and its failure revert are reachable
 /// from a test without a browser.
@@ -205,28 +254,24 @@ fn registration_toggle_handler(
 /// leave the box sitting in a state the server refused.
 #[component]
 fn RegistrationToggle() -> Element {
-    let mut confirmed = use_signal(|| Option::<bool>::None);
-    let mut shown = use_signal(|| Option::<bool>::None);
-    let mut error = use_signal(|| None::<String>);
+    let confirmed = use_signal(|| Option::<bool>::None);
+    let shown = use_signal(|| Option::<bool>::None);
+    let error = use_signal(|| None::<String>);
     let saving = use_signal(|| false);
+    let retrying = use_signal(|| false);
 
     use_effect(move || {
         spawn(async move {
-            match data::registration_status().await {
-                Ok(open) => {
-                    confirmed.set(Some(open));
-                    shown.set(Some(open));
-                    error.set(None);
-                }
-                Err(e) => error.set(Some(e)),
-            }
+            apply_registration_status(confirmed, shown, error, data::registration_status().await);
         });
     });
 
     let toggle = registration_toggle_handler(confirmed, shown, error, saving);
+    let retry = registration_retry_handler(confirmed, shown, error, retrying);
 
     let is_on = shown() == Some(true);
     let status = registration_status_line(confirmed());
+    let show_retry = needs_registration_retry(error().as_ref(), confirmed());
 
     rsx! {
         section { class: "card", "data-testid": "registration-card",
@@ -252,6 +297,16 @@ fn RegistrationToggle() -> Element {
                     class: "settings-status error",
                     "data-testid": "registration-error",
                     "{err}"
+                }
+            }
+            if show_retry {
+                button {
+                    r#type: "button",
+                    class: "btn ghost sm",
+                    "data-testid": "registration-retry",
+                    disabled: retrying(),
+                    onclick: retry,
+                    if retrying() { "Retrying\u{2026}" } else { "Retry" }
                 }
             }
         }

--- a/frontend/src/pages/settings/users.rs
+++ b/frontend/src/pages/settings/users.rs
@@ -271,7 +271,8 @@ fn RegistrationToggle() -> Element {
 
     let is_on = shown() == Some(true);
     let status = registration_status_line(confirmed());
-    let show_retry = needs_registration_retry(error().as_ref(), confirmed());
+    let load_err = error();
+    let show_retry = needs_registration_retry(load_err.as_ref(), confirmed());
 
     rsx! {
         section { class: "card", "data-testid": "registration-card",
@@ -291,7 +292,7 @@ fn RegistrationToggle() -> Element {
                     span { "Allow new users to register" }
                 }
             }
-            if let Some(err) = error() {
+            if let Some(err) = load_err {
                 p {
                     role: "alert",
                     class: "settings-status error",

--- a/frontend/src/pages/settings/users/tests.rs
+++ b/frontend/src/pages/settings/users/tests.rs
@@ -168,3 +168,139 @@ fn registration_toggle_handler_moves_the_checkbox_but_not_the_subtitle() {
     }
     VirtualDom::new(AssertSplit).rebuild_in_place();
 }
+
+// ── Retry after a failed initial load ───────────────────────────────────
+//
+// `data::registration_status()` is stubbed to always return `Ok(true)` under
+// `--features server` (the SSR/native test target never actually runs the
+// web fetch — see the stub's doc comment in `frontend/src/data/auth.rs`), so
+// these drive `apply_registration_status` and `registration_retry_handler`
+// directly with a synthetic `Result` rather than a real network failure.
+
+#[test]
+fn needs_registration_retry_is_true_only_when_load_failed_and_never_resolved() {
+    assert!(!needs_registration_retry(None, None));
+    assert!(needs_registration_retry(Some(&"boom".to_string()), None));
+    // A stale error alongside an already-confirmed value shouldn't occur in
+    // practice (`apply_registration_status` clears `error` on success), but
+    // the predicate must still favor "resolved" if it ever does.
+    assert!(!needs_registration_retry(
+        Some(&"boom".to_string()),
+        Some(true)
+    ));
+    assert!(!needs_registration_retry(None, Some(false)));
+}
+
+#[cfg(feature = "server")]
+#[test]
+fn apply_registration_status_sets_error_and_leaves_the_checkbox_unresolved_on_err() {
+    #[component]
+    fn AssertErr() -> Element {
+        let confirmed = Signal::new(None::<bool>);
+        let shown = Signal::new(None::<bool>);
+        let error = Signal::new(None::<String>);
+
+        apply_registration_status(confirmed, shown, error, Err("network error".to_string()));
+
+        assert_eq!(
+            confirmed(),
+            None,
+            "an errored load must not resolve a value"
+        );
+        assert_eq!(shown(), None);
+        assert_eq!(error(), Some("network error".to_string()));
+        assert!(
+            needs_registration_retry(error().as_ref(), confirmed()),
+            "the failure must leave the retry affordance visible"
+        );
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertErr).rebuild_in_place();
+}
+
+#[cfg(feature = "server")]
+#[test]
+fn apply_registration_status_clears_a_prior_error_and_enables_the_checkbox_on_retry_success() {
+    #[component]
+    fn AssertRetrySucceeds() -> Element {
+        // Start where a failed initial load leaves things: unresolved and
+        // errored — this is the state the new retry button appears in.
+        let confirmed = Signal::new(None::<bool>);
+        let shown = Signal::new(None::<bool>);
+        let error = Signal::new(Some("network error".to_string()));
+
+        apply_registration_status(confirmed, shown, error, Ok(true));
+
+        assert_eq!(
+            confirmed(),
+            Some(true),
+            "retry must resolve the confirmed value"
+        );
+        assert_eq!(shown(), Some(true), "retry must re-enable the checkbox");
+        assert_eq!(
+            error(),
+            None,
+            "a successful retry must clear the prior error"
+        );
+        assert!(!needs_registration_retry(error().as_ref(), confirmed()));
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertRetrySucceeds).rebuild_in_place();
+}
+
+/// A no-op `MouseEvent` — `registration_retry_handler` ignores its argument.
+#[cfg(feature = "server")]
+fn blank_mouse_event() -> MouseEvent {
+    use dioxus::prelude::SerializedMouseData;
+
+    Event::new(
+        std::rc::Rc::new(MouseData::new(SerializedMouseData::default())),
+        false,
+    )
+}
+
+#[cfg(feature = "server")]
+#[test]
+fn registration_retry_handler_flips_retrying_immediately_on_click() {
+    #[component]
+    fn AssertRetryInFlight() -> Element {
+        let confirmed = Signal::new(None::<bool>);
+        let shown = Signal::new(None::<bool>);
+        let error = Signal::new(Some("network error".to_string()));
+        let retrying = Signal::new(false);
+
+        let mut handler = registration_retry_handler(confirmed, shown, error, retrying);
+        handler(blank_mouse_event());
+
+        // Disables synchronously, before the retried fetch resolves — same
+        // shape as `scan_library_handler_flips_in_flight_immediately_on_click`.
+        assert!(retrying());
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertRetryInFlight).rebuild_in_place();
+}
+
+#[cfg(feature = "server")]
+#[test]
+fn registration_retry_handler_ignores_a_click_while_a_retry_is_in_flight() {
+    #[component]
+    fn AssertIgnores() -> Element {
+        let confirmed = Signal::new(None::<bool>);
+        let shown = Signal::new(None::<bool>);
+        let error = Signal::new(Some("network error".to_string()));
+        let retrying = Signal::new(true);
+
+        let mut handler = registration_retry_handler(confirmed, shown, error, retrying);
+        handler(blank_mouse_event());
+
+        // A second click must not queue a second fetch on top of the one
+        // already in flight.
+        assert!(retrying());
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertIgnores).rebuild_in_place();
+}

--- a/server/src/backend/settings/tests.rs
+++ b/server/src/backend/settings/tests.rs
@@ -829,6 +829,34 @@ async fn api_post_registration_reopens_self_registration_for_admin() {
 }
 
 #[tokio::test]
+async fn api_post_registration_returns_401_when_anonymous() {
+    let (app, _state, pool) = fixture().await;
+    omnibus_db::auth::set_registration_enabled(&pool, true)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/settings/registration")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "enabled": false }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        omnibus_db::auth::registration_enabled(&pool).await.unwrap(),
+        "an unauthenticated request must not have changed the setting"
+    );
+}
+
+#[tokio::test]
 async fn api_post_registration_rejects_non_admin() {
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "reader").await;


### PR DESCRIPTION
## Summary
- Closes #1592
- Adds `api_post_registration_returns_401_when_anonymous` to `server/src/backend/settings/tests.rs`, matching the sibling `_returns_401_when_anonymous` pattern already covering `/api/reindex`, `/api/scan-library`, `/api/fts/rebuild`, and `/api/settings`.
- Gives `RegistrationToggle` (`frontend/src/pages/settings/users.rs`) a retry affordance: extracted `apply_registration_status` (shared by the mount effect and the new retry handler) and a pure `needs_registration_retry` predicate, so a failed initial `data::registration_status()` load now surfaces a "Retry" button instead of permanently disabling the checkbox.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus` — 642 passed; 2 pre-existing failures unrelated to this change (`backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` — these `chmod`-based read-only-library simulations fail under a root test runner, which ignores file permission bits; `uploads.rs` is untouched by this PR)
- [x] `cargo test -p omnibus-frontend --features server` — 622 passed; 0 failed (includes the new `apply_registration_status_*`, `needs_registration_retry_*`, and `registration_retry_handler_*` tests)

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- Not security-relevant: the server-side gate (`AdminUser` + `require_auth`) was already correct; this closes a test-coverage gap and a UX robustness gap per the issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DhPxqqQHT7EfpDyhQGZHWx)_