### PR TITLE
refactor: document CBZ hidden-entry filter scope, close page-endpoint test gap (#1594)

### DIFF
--- a/db/src/comic.rs
+++ b/db/src/comic.rs
@@ -196,16 +196,31 @@ fn indexed_book_from(
 fn page_names<R: Read + std::io::Seek>(archive: &zip::ZipArchive<R>) -> Vec<String> {
     let mut pages: Vec<String> = archive
         .file_names()
-        .filter(|name| !name.ends_with('/') && !is_hidden_name(name) && is_page_name(name))
+        .filter(|name| {
+            if name.ends_with('/') {
+                return false;
+            }
+            if is_hidden_name(name) {
+                // Fires on every legitimate AppleDouble fork too, so this is
+                // routine noise, not a problem to warn about — `debug!`
+                // keeps it out of the default log level.
+                tracing::debug!(entry = %name, "comic page list: excluding hidden entry");
+                return false;
+            }
+            is_page_name(name)
+        })
         .map(str::to_string)
         .collect();
     pages.sort_by(|a, b| natural_cmp(a, b));
     pages
 }
 
-/// `true` when any path segment starts with `.` — macOS AppleDouble forks
-/// (`__MACOSX/._p001.jpg`) and other hidden junk carry image extensions but
-/// aren't pages, and their sort keys would land them ahead of the real cover.
+/// `true` when any path segment starts with `.` — broader than just macOS
+/// AppleDouble forks (`__MACOSX/._p001.jpg`): it excludes every dot-prefixed
+/// segment, including a legitimately named `.chapter1/` directory or page.
+/// Kept broad deliberately: narrowing to an AppleDouble-only pattern risks
+/// letting some other archiver's leading-dot junk resurface as a page, and
+/// no known CBZ producer needs a leading dot for real content.
 fn is_hidden_name(name: &str) -> bool {
     name.split('/').any(|segment| segment.starts_with('.'))
 }

--- a/db/src/comic.rs
+++ b/db/src/comic.rs
@@ -219,8 +219,7 @@ fn page_names<R: Read + std::io::Seek>(archive: &zip::ZipArchive<R>) -> Vec<Stri
 /// AppleDouble forks (`__MACOSX/._p001.jpg`): it excludes every dot-prefixed
 /// segment, including a legitimately named `.chapter1/` directory or page.
 /// Kept broad deliberately: narrowing to an AppleDouble-only pattern risks
-/// letting some other archiver's leading-dot junk resurface as a page, and
-/// no known CBZ producer needs a leading dot for real content.
+/// letting some other archiver's leading-dot junk resurface as a page.
 fn is_hidden_name(name: &str) -> bool {
     name.split('/').any(|segment| segment.starts_with('.'))
 }

--- a/db/src/comic/tests.rs
+++ b/db/src/comic/tests.rs
@@ -192,6 +192,35 @@ fn list_pages_returns_images_in_natural_sort_order() {
 }
 
 #[test]
+fn list_pages_excludes_plain_dot_prefixed_names_same_as_appledouble_forks() {
+    let dir = make_test_dir("comic-pages-hidden-broad");
+    let path = write_cbz(
+        &dir,
+        "book.cbz",
+        &[
+            // The canonical case this filter was written for: a macOS
+            // AppleDouble resource fork sitting next to a real page.
+            ("__MACOSX/._page1.jpg", b"appledouble fork"),
+            // Not AppleDouble at all — a directory an archiver could
+            // plausibly name for real content — but excluded too, since
+            // `is_hidden_name` treats any leading dot as hidden.
+            (".chapter1/page1.jpg", b"legit dot-prefixed name"),
+            ("page1.jpg", b"real page"),
+        ],
+    );
+
+    let pages = list_pages(&path).unwrap();
+
+    assert_eq!(
+        pages,
+        vec!["page1.jpg"],
+        "both the AppleDouble fork and the plain dot-prefixed name are excluded"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn list_pages_excludes_hidden_entries_and_appledouble_forks() {
     let dir = make_test_dir("comic-pages-hidden");
     let path = write_cbz(

--- a/server/src/backend/ebooks/tests.rs
+++ b/server/src/backend/ebooks/tests.rs
@@ -2027,6 +2027,59 @@ async fn api_get_ebook_page_returns_500_when_resolve_book_id_by_uuid_fails() {
     assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
+/// Drives `get_ebook_page`'s second `internal(...)` arm — the sibling of
+/// `api_get_ebook_file_returns_500_when_book_file_path_fails`: when
+/// `db::resolve_book_id_by_uuid` returns `Ok(Some(_))` but
+/// `db::book_file_path` returns `Err`, the handler must surface 500. Seed a
+/// book row so the first call succeeds, then drop `book_files` so the
+/// second call's JOIN errors out.
+#[tokio::test]
+async fn api_get_ebook_page_returns_500_when_book_file_path_fails() {
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind("/lib")
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let uuid = "66666666-6666-6666-6666-666666666666";
+    sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, 'B')")
+        .bind(uuid)
+        .bind(lib_id)
+        .bind("/lib")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // FKs off because `book_file_parts` references `book_files`; we want
+    // the single DROP to succeed without cascading further. PRAGMA + DROP
+    // pinned to a single connection — see the `/file` sibling test above
+    // for the rationale.
+    let mut conn = pool.acquire().await.unwrap();
+    sqlx::query("PRAGMA foreign_keys = OFF")
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+    sqlx::query("DROP TABLE book_files")
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+    drop(conn);
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/ebooks/{uuid}/pages/0"),
+            &token,
+        ))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
 /// A `book_files` row that points at bytes which aren't a zip archive is a
 /// server-side failure, not a client error.
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Corrected `is_hidden_name`'s doc comment in `db/src/comic.rs` to state the true, broader rule it implements — any dot-prefixed path segment is treated as hidden, not just macOS AppleDouble forks — and explained why that breadth is intentional (narrowing risks resurfacing junk from archivers this filter hasn't been tested against).
- Added a `tracing::debug!` log in `page_names` when the hidden-entry filter excludes an entry, matching this feature's existing per-problem logging convention elsewhere in the module. `debug!` (not `warn!`) because this fires on every legitimate AppleDouble fork too, so it would otherwise be noise at the default log level.
- Added `list_pages_excludes_plain_dot_prefixed_names_same_as_appledouble_forks` to `db/src/comic/tests.rs`, distinguishing a real AppleDouble fork (`__MACOSX/._page1.jpg`) from a legitimately dot-prefixed directory (`.chapter1/page1.jpg`) and asserting both are excluded under the documented broad rule.
- Added `api_get_ebook_page_returns_500_when_book_file_path_fails` to `server/src/backend/ebooks/tests.rs`, covering `get_ebook_page`'s `book_file_path`-failure arm — the one 5xx arm this handler was missing relative to its `/file` sibling's matrix.

Closes #1594.

**Judgment call**: the issue flagged one open question — narrow `is_hidden_name` to AppleDouble-only, or document the broader "any dot-prefixed segment" behavior as intentional. I went with document-the-broader-behavior, per the issue's own steer: narrowing is a behavior change with no report of it causing a real problem, and it risks silently letting some other archiver's leading-dot junk (which this filter has never been tested against) resurface as a page. Documenting what the code actually does, plus a debug log so an operator can see it firing, is the safer default.

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1594 cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1594 cargo clippy -p omnibus-db -p omnibus --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1594 cargo test -p omnibus-db` — PASS (1696 passed, 0 failed)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1594 cargo test -p omnibus` — PASS on every test this change could affect (642 passed); 2 pre-existing failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400` and its audiobook sibling) are unrelated to this change — they rely on chmod'd read-only directories to trigger a `PermissionDenied`, which doesn't hold when the test process runs as root (this sandbox's user), and I confirmed both fail identically on `main` before this change.

## Version
- [ ] Minor
- [ ] Patch
- [ ] No release

## Notes
- No behavior change to what counts as a hidden entry — this is a documentation + observability + test-coverage change only.
- The two pre-existing `read_only_library` test failures are a root-user sandbox artifact, not something introduced here; see Test plan above.


---
_Generated by [Claude Code](https://claude.ai/code/session_014S8Ts6ZqELQenSjFEjvj3B)_