### PR TITLE
refactor: dedupe redundant work across 3 recent PRs, cover downsync failure path (#1614)

### DIFF
--- a/db/src/annotations/downsync.rs
+++ b/db/src/annotations/downsync.rs
@@ -19,6 +19,23 @@ fn inflight_downsyncs() -> &'static Mutex<HashSet<(i64, String)>> {
     INFLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
+/// Removes its key from [`inflight_downsyncs`] on drop, not just on the
+/// task's normal-completion path — so a panic inside the task, or the task
+/// being aborted, still releases the key instead of permanently suppressing
+/// future downsyncs for it.
+struct InflightGuard {
+    key: (i64, String),
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        inflight_downsyncs()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&self.key);
+    }
+}
+
 /// What one materialization pass accomplished, for logs.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct DownsyncStats {
@@ -146,13 +163,10 @@ pub fn spawn_kobo_downsync(pool: SqlitePool, user_id: i64, book_uuid: String) {
         }
     }
     tokio::spawn(async move {
+        let _guard = InflightGuard { key };
         if let Err(e) = downsync_book_annotations(&pool, user_id, &book_uuid).await {
             tracing::warn!(user_id, book_uuid, error = %e, "annotation downsync failed");
         }
-        inflight_downsyncs()
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .remove(&key);
     });
 }
 

--- a/db/src/annotations/downsync.rs
+++ b/db/src/annotations/downsync.rs
@@ -4,9 +4,20 @@
 //! device. The serving queries never change — a materialized row simply
 //! starts matching `kobo_location IS NOT NULL`.
 
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
 use sqlx::SqlitePool;
 
 use crate::kobo_position::annotation_locations;
+
+/// Process-wide guard for [`spawn_kobo_downsync`]: the key of every
+/// `(user_id, book_uuid)` pair with a materialization task currently
+/// in flight.
+fn inflight_downsyncs() -> &'static Mutex<HashSet<(i64, String)>> {
+    static INFLIGHT: OnceLock<Mutex<HashSet<(i64, String)>>> = OnceLock::new();
+    INFLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
+}
 
 /// What one materialization pass accomplished, for logs.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -114,11 +125,34 @@ pub async fn downsync_all_kobo_annotations(pool: &SqlitePool) -> anyhow::Result<
 /// Fire-and-forget materialization after a highlight write. Callers stay
 /// on their own latency budget — a highlight create never waits on an
 /// EPUB walk.
+///
+/// Coalesced per `(user_id, book_uuid)` via [`inflight_downsyncs`]: several
+/// highlights written on the same book in quick succession would otherwise
+/// each fan out their own full-book recompute, since every call re-walks
+/// every still-unresolved row on the book rather than just its own row. A
+/// call that finds one already running for the same key skips the spawn —
+/// this is a best-effort guard, not a correctness one: a row written after
+/// the in-flight task has already read its worklist stays unresolved until
+/// the *next* highlight write or the boot-time [`downsync_all_kobo_annotations`]
+/// pass, rather than being covered by the task it skipped spawning behind.
 pub fn spawn_kobo_downsync(pool: SqlitePool, user_id: i64, book_uuid: String) {
+    let key = (user_id, book_uuid.clone());
+    {
+        let mut inflight = inflight_downsyncs()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !inflight.insert(key.clone()) {
+            return;
+        }
+    }
     tokio::spawn(async move {
         if let Err(e) = downsync_book_annotations(&pool, user_id, &book_uuid).await {
             tracing::warn!(user_id, book_uuid, error = %e, "annotation downsync failed");
         }
+        inflight_downsyncs()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&key);
     });
 }
 

--- a/db/src/annotations/downsync/tests.rs
+++ b/db/src/annotations/downsync/tests.rs
@@ -287,7 +287,7 @@ async fn downsync_all_kobo_annotations_continues_past_a_failing_book_and_reports
         build_test_kepub(&[("c1.xhtml", KEPUB_C1)]),
     )
     .unwrap();
-    let _guard = EnvVarGuard::set("OMNIBUS_KEPUB_DIR", Some(kepub_dir.to_str().unwrap()));
+    let _guard = EnvVarGuard::set_os("OMNIBUS_KEPUB_DIR", Some(kepub_dir.as_os_str()));
     create_highlight(&pool, alice, &web_highlight(&uuid, WEB_CFI, None))
         .await
         .unwrap();

--- a/db/src/annotations/downsync/tests.rs
+++ b/db/src/annotations/downsync/tests.rs
@@ -278,6 +278,94 @@ async fn downsync_all_kobo_annotations_converts_every_users_pending_rows() {
 }
 
 #[tokio::test]
+async fn downsync_all_kobo_annotations_continues_past_a_failing_book_and_reports_the_rest() {
+    let (pool, alice, book_id, uuid, dir) = fixture("bootfail_good").await;
+    let kepub_dir = dir.join("kepub");
+    std::fs::create_dir_all(&kepub_dir).unwrap();
+    std::fs::write(
+        kepub_dir.join(format!("{book_id}.kepub.epub")),
+        build_test_kepub(&[("c1.xhtml", KEPUB_C1)]),
+    )
+    .unwrap();
+    let _guard = EnvVarGuard::set("OMNIBUS_KEPUB_DIR", Some(kepub_dir.to_str().unwrap()));
+    create_highlight(&pool, alice, &web_highlight(&uuid, WEB_CFI, None))
+        .await
+        .unwrap();
+
+    // A second book whose kepub cache file exists but isn't a valid zip:
+    // `annotation_locations` errors opening it, so its
+    // `downsync_book_annotations` call returns `Err` and must not abort the
+    // pass before the first (good) book is processed.
+    let bad_dir = make_test_dir("annotation_downsync_bootfail_bad");
+    std::fs::write(
+        bad_dir.join("bad.epub"),
+        build_test_epub(&[("c1.xhtml", SOURCE_C1)]),
+    )
+    .unwrap();
+    crate::replace_books(
+        &pool,
+        bad_dir.to_str().unwrap(),
+        vec![crate::ebook::IndexedBook {
+            metadata: EbookMetadata {
+                filename: "bad.epub".into(),
+                title: Some("Bad Book".into()),
+                ..Default::default()
+            },
+            cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
+            word_count: None,
+        }],
+    )
+    .await
+    .unwrap();
+    let bad_book = crate::list_books(&pool, bad_dir.to_str().unwrap())
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    let bad_uuid = bad_book.unique_identifier.clone().unwrap();
+    std::fs::write(
+        kepub_dir.join(format!("{}.kepub.epub", bad_book.id)),
+        b"not a zip file",
+    )
+    .unwrap();
+    create_highlight(&pool, alice, &web_highlight(&bad_uuid, WEB_CFI, None))
+        .await
+        .unwrap();
+
+    let stats = downsync_all_kobo_annotations(&pool).await.unwrap();
+
+    // Only the good book's row is counted — the failing book's error was
+    // caught and logged, not folded into the pass's stats.
+    assert_eq!(
+        stats,
+        DownsyncStats {
+            derived: 1,
+            unresolved: 0
+        }
+    );
+    assert_eq!(
+        served_kobo_annotations(&pool, alice, &uuid)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    // The failing book's row is untouched — proof the loop reached it and
+    // moved on, rather than the pass having stopped before it.
+    let (kobo_location,): (Option<String>,) =
+        sqlx::query_as("SELECT kobo_location FROM annotations WHERE user_id = ? AND book_uuid = ?")
+            .bind(alice)
+            .bind(&bad_uuid)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(kobo_location.is_none());
+}
+
+#[tokio::test]
 async fn downsync_book_annotations_propagates_db_error_when_pool_is_closed() {
     let (pool, user, _book_id, uuid, _dir) = fixture("dberr").await;
     pool.close().await;

--- a/db/src/metadata_lookup/providers.rs
+++ b/db/src/metadata_lookup/providers.rs
@@ -309,15 +309,24 @@ struct GbImageLinks {
 }
 
 /// Look up an ISBN-13 against Google Books `volumes?q=isbn:`, falling back to
-/// a bare-text `q=<isbn13>` query when the field search answers empty.
-/// `Ok(None)` when no volume matches either way; `Err` on transport/parse
-/// failure of the field query (the bare query is best-effort — see below).
+/// a bare-text `q=<isbn13>` query when the field search answers empty and a
+/// key is configured. `Ok(None)` when no volume matches either way (or the
+/// fallback is skipped keyless); `Err` on transport/parse failure of the
+/// field query (the bare query is best-effort — see below).
 pub async fn googlebooks_lookup(
     config: &MetadataLookupConfig,
     isbn13: &str,
 ) -> anyhow::Result<Option<ExternalBookMeta>> {
     if let Some(meta) = googlebooks_query(config, isbn13, &googlebooks_url(config, isbn13)).await? {
         return Ok(Some(meta));
+    }
+    // Keyless requests share Google's anonymous daily quota (see
+    // .claude/rules/01-dev-environment.md) and exhaust it almost
+    // immediately, so doubling every miss into a second request is a cost
+    // only a keyed instance can afford — gate the fallback on one being
+    // configured.
+    if config.googlebooks_api_key.is_none() {
+        return Ok(None);
     }
     // The `isbn:` field search has been observed answering 200/totalItems=0
     // for volumes the corpus demonstrably holds (2026-08: every field-scoped

--- a/db/src/metadata_lookup/tests.rs
+++ b/db/src/metadata_lookup/tests.rs
@@ -29,6 +29,16 @@ fn config_for(server: &MockServer) -> MetadataLookupConfig {
     }
 }
 
+/// Same as [`config_for`] but with a key configured — the bare-text fallback
+/// gate requires one (#1614: keyless requests share Google's anonymous
+/// quota, so the fallback only fires when a key is present).
+fn keyed_config_for(server: &MockServer) -> MetadataLookupConfig {
+    MetadataLookupConfig {
+        googlebooks_api_key: Some("k".into()),
+        ..config_for(server)
+    }
+}
+
 async fn mount_ol(server: &MockServer, body: serde_json::Value) {
     Mock::given(method("GET"))
         .and(path(OL_PATH))
@@ -413,7 +423,7 @@ async fn googlebooks_falls_back_to_bare_query_when_isbn_search_is_empty() {
     .await;
     mount_gb_q(&server, ISBN13, gb_hit()).await;
 
-    let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+    let meta = super::providers::googlebooks_lookup(&keyed_config_for(&server), ISBN13)
         .await
         .unwrap()
         .expect("bare-text fallback must resolve the ISBN");
@@ -422,6 +432,33 @@ async fn googlebooks_falls_back_to_bare_query_when_isbn_search_is_empty() {
     // Bare-text search may return a sibling edition; the meta must still carry
     // the *scanned* ISBN so a check-in stores the barcode that was scanned.
     assert_eq!(meta.isbn13, ISBN13);
+    server.verify().await;
+}
+
+#[tokio::test]
+async fn googlebooks_lookup_skips_the_bare_query_without_a_key() {
+    // Keyless requests share Google's anonymous daily quota (#1614), so a
+    // field-search miss must stay a clean miss rather than doubling into a
+    // second request.
+    let server = MockServer::start().await;
+    mount_gb_q(
+        &server,
+        &format!("isbn:{ISBN13}"),
+        json!({ "totalItems": 0 }),
+    )
+    .await;
+    Mock::given(method("GET"))
+        .and(path(GB_PATH))
+        .and(query_param("q", ISBN13))
+        .respond_with(ResponseTemplate::new(200).set_body_json(gb_hit()))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+        .await
+        .unwrap();
+    assert!(meta.is_none(), "keyless miss must not issue a bare query");
     server.verify().await;
 }
 
@@ -461,7 +498,7 @@ async fn googlebooks_double_miss_is_still_a_clean_miss() {
     .await;
     mount_gb_q(&server, ISBN13, json!({ "totalItems": 0 })).await;
 
-    let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+    let meta = super::providers::googlebooks_lookup(&keyed_config_for(&server), ISBN13)
         .await
         .unwrap();
     assert!(
@@ -492,7 +529,7 @@ async fn googlebooks_bare_query_failure_degrades_to_a_clean_miss() {
         .mount(&server)
         .await;
 
-    let meta = super::providers::googlebooks_lookup(&config_for(&server), ISBN13)
+    let meta = super::providers::googlebooks_lookup(&keyed_config_for(&server), ISBN13)
         .await
         .unwrap();
     assert!(meta.is_none(), "bare-query failure must degrade to a miss");

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -209,18 +209,20 @@ async fn attach_comic_page_count(state: &AppState, book: &mut omnibus_shared::Eb
 }
 
 /// Resolve the on-disk EPUB path for `uuid`, honouring an optional
-/// `?file_id=N` (multi-EPUB books). Returns the error `Response`
-/// (404 / 500) already formed on the failure paths so callers can `?`-style
-/// early-return with `Err`.
+/// `?file_id=N` (multi-EPUB books). Returns the resolved book id alongside
+/// the path on success so callers that need it (the override-baked download,
+/// the CBZ fallback) don't re-resolve uuid→id. On failure the error carries
+/// the id too, when it was resolved before the failure — `None` only when
+/// the uuid itself didn't match a book.
 async fn resolve_epub_path(
     state: &AppState,
     uuid: &str,
     file_id: Option<i64>,
-) -> Result<std::path::PathBuf, Response> {
+) -> Result<(std::path::PathBuf, i64), (Response, Option<i64>)> {
     let id = match db::resolve_book_id_by_uuid(&state.pool, uuid).await {
         Ok(Some(id)) => id,
-        Ok(None) => return Err(axum::http::StatusCode::NOT_FOUND.into_response()),
-        Err(e) => return Err(internal("resolve_book_id_by_uuid", e)),
+        Ok(None) => return Err((axum::http::StatusCode::NOT_FOUND.into_response(), None)),
+        Err(e) => return Err((internal("resolve_book_id_by_uuid", e), None)),
     };
     // Carry the context alongside the chosen query so a 500 points at the
     // call that actually failed rather than always blaming `book_file_path`.
@@ -236,9 +238,9 @@ async fn resolve_epub_path(
         )
     };
     match resolved {
-        Ok(Some(p)) => Ok(p),
-        Ok(None) => Err(axum::http::StatusCode::NOT_FOUND.into_response()),
-        Err(e) => Err(internal(ctx, e)),
+        Ok(Some(p)) => Ok((p, id)),
+        Ok(None) => Err((axum::http::StatusCode::NOT_FOUND.into_response(), Some(id))),
+        Err(e) => Err((internal(ctx, e), Some(id))),
     }
 }
 
@@ -260,20 +262,17 @@ async fn resolve_readable_path(
     file_id: Option<i64>,
 ) -> Result<(std::path::PathBuf, &'static str), Response> {
     match resolve_epub_path(state, uuid, file_id).await {
-        Ok(path) => Ok((path, "application/epub+zip")),
-        Err(resp) if file_id.is_none() && resp.status() == StatusCode::NOT_FOUND => {
-            let id = match db::resolve_book_id_by_uuid(&state.pool, uuid).await {
-                Ok(Some(id)) => id,
-                Ok(None) => return Err(StatusCode::NOT_FOUND.into_response()),
-                Err(e) => return Err(internal("resolve_book_id_by_uuid", e)),
-            };
+        Ok((path, _id)) => Ok((path, "application/epub+zip")),
+        // The uuid resolved to a book (we have `id`) but it has no EPUB —
+        // reuse that id rather than re-querying `resolve_book_id_by_uuid`.
+        Err((resp, Some(id))) if file_id.is_none() && resp.status() == StatusCode::NOT_FOUND => {
             match db::book_file_path(&state.pool, id, "CBZ").await {
                 Ok(Some(path)) => Ok((path, CBZ_MIME)),
                 Ok(None) => Err(StatusCode::NOT_FOUND.into_response()),
                 Err(e) => Err(internal("book_file_path", e)),
             }
         }
-        Err(resp) => Err(resp),
+        Err((resp, _)) => Err(resp),
     }
 }
 
@@ -500,17 +499,14 @@ pub(super) async fn get_ebook_download(
     Query(query): Query<EbookFileQuery>,
     req: Request,
 ) -> Response {
-    let source = match resolve_epub_path(&state, &uuid, query.file_id).await {
-        Ok(p) => p,
-        Err(resp) => return resp,
+    let (source, id) = match resolve_epub_path(&state, &uuid, query.file_id).await {
+        Ok(resolved) => resolved,
+        Err((resp, _)) => return resp,
     };
     // A saved download must carry the user's metadata/cover edits (F5.8 #1372),
     // so serve the override-baked EPUB when the book has any; otherwise the
     // source verbatim.
-    let path = match db::resolve_book_id_by_uuid(&state.pool, &uuid).await {
-        Ok(Some(id)) => rewritten_or_source(&state, id, source).await,
-        _ => source,
-    };
+    let path = rewritten_or_source(&state, id, source).await;
     // The validator is taken from whichever file is actually sent. For an
     // override-having book that is the export-cache copy, whose own stat
     // moves when `books.last_modified` invalidates it — so it tracks the


### PR DESCRIPTION
## Summary

Four independent, small items from #1614 — tech debt introduced across PRs #1595, #1602, #1605.

1. **`resolve_readable_path` resolved uuid→id twice.** `resolve_epub_path` (`server/src/backend/ebooks.rs`) now returns `(PathBuf, book_id)` on success and `(Response, Option<book_id>)` on failure — carrying the id whenever it was resolved before the failure, not just on success. `resolve_readable_path`'s CBZ fallback reuses that id instead of re-querying `db::resolve_book_id_by_uuid`. Bonus: `get_ebook_download` had the identical redundant second call for the override-baked-download id — fixed the same way, for free, since it's the other caller of `resolve_epub_path`. Pure refactor, no behavior change; covered transitively by the existing 62 `backend::ebooks::tests`.

2. **`spawn_kobo_downsync` fanned out one full-book recompute per highlight write, uncoalesced.** Judgment call (issue flagged this as needing one): the issue's suggested shape was a `Mutex<HashSet>` guard on `AppState`, but `AppState` only backs the mobile REST router — the web UI's highlight-create path is `frontend::rpc::highlights::rpc_create_highlight`, which calls the same `db::annotations::spawn_kobo_downsync` directly and has no `AppState`. An `AppState`-scoped guard would have left the primary (web) path unfixed. Instead the in-flight guard (`Mutex<HashSet<(i64, String)>>` behind a `OnceLock`) lives in `db/src/annotations/downsync.rs` itself, inside `spawn_kobo_downsync`, so it coalesces both callers uniformly with no signature change and no new call-site plumbing. It's explicitly best-effort (documented on the function): a highlight written after the in-flight task already read its worklist stays unresolved until the next write or the boot-time pass, not perfect coverage — matches the issue's "doesn't need to be perfect, just stop the worst-case pile-up."

3. **Google Books bare-text fallback doubled provider requests, ungated.** `MetadataLookupConfig` already carries `googlebooks_api_key: Option<String>` — the "known parameter" the issue anticipated — so gating `googlebooks_lookup`'s bare-text fallback on `config.googlebooks_api_key.is_some()` was a 6-line change, no threading needed. Went with the full fix rather than the comment-only fallback since it turned out to be the smaller change. Updated the existing bare-text-fallback tests to use a keyed config (that's what they're testing) and added a new test (`googlebooks_lookup_skips_the_bare_query_without_a_key`) asserting the keyless gate itself.

4. **`downsync_all_kobo_annotations`'s per-book failure resilience was untested.** Added `downsync_all_kobo_annotations_continues_past_a_failing_book_and_reports_the_rest`: seeds one good book and one book whose kepub cache file exists but isn't a valid zip (so `annotation_locations` errors opening it), runs the boot pass, and asserts the good book's row still derives (stats reflect only it) while the bad book's row is left untouched — proof the loop reached and moved past the failing entry rather than the pass having stopped before it.

## Test plan

All run with `CARGO_TARGET_DIR=/tmp/omnibus-target-1614`, foreground, from `/home/user/omnibus-wt-1614`:

- `cargo fmt --check` — PASS
- `cargo clippy -p omnibus -p omnibus-db --all-targets -- -D warnings` — PASS
- `cargo test -p omnibus-db` — PASS (1697/1697, incl. the new downsync + googlebooks-gate tests)
- `cargo test -p omnibus` — PASS except 2 known-environmental failures unrelated to this change (see Notes)

## Notes

- **Judgment calls (items 2 & 3):** see the reasoning inline in the Summary above — both landed on the "simplest reasonable fix" the issue asked for, in each case slightly reshaped from the issue's suggested shape once the actual call sites were read (item 2: guard lives in `db/` not `AppState` since there are two producers, not one; item 3: full key-gate rather than a comment, since the key was already threaded through).
- **Unrelated pre-existing test failures:** `backend::uploads::tests::commit_rejects_read_only_library_with_400` and `audiobook_commit_rejects_read_only_library_with_400` fail in this sandbox because it runs as `root` (uid 0) — `chmod` read-only permission checks are bypassed by the kernel for root, so the "write to a read-only library rejects with 400" assertion never gets the read-only condition it's testing. Confirmed unrelated: both live in `server/src/backend/uploads/`, a module untouched by this PR, and every other test in `-p omnibus` (641/641) and `-p omnibus-db` (1697/1697) passes.
- Test fixtures (`test_data/{epubs,audiobooks}/public_domain/`) weren't present in this fresh worktree; fetched via `scripts/fetch-fixtures.sh` (no `just` binary available in this environment, so called the underlying script directly) before running the db suite.

## Version
- [ ] **Minor**
- [ ] **Patch**
- [ ] **No release**


---
_Generated by [Claude Code](https://claude.ai/code/session_014S8Ts6ZqELQenSjFEjvj3B)_