### PR TITLE
refactor: delete dead FetchedBookMetadata::is_empty and cover hardcover resolve-race branches (#1591)

### DIFF
--- a/db/src/metadata_overrides/hardcover_fetch/tests.rs
+++ b/db/src/metadata_overrides/hardcover_fetch/tests.rs
@@ -10,7 +10,7 @@ use omnibus_shared::metadata_fetch::HardcoverFetchResult;
 
 use super::{fetch_hardcover_metadata, fetch_hardcover_metadata_with};
 use crate::pool::init_db;
-use crate::suggestions::hardcover::HardcoverConfig;
+use crate::suggestions::hardcover::{fetch_book_details, HardcoverConfig};
 use crate::test_support::{seed_synced_ebook, EnvVarGuard};
 
 fn config_for(server: &MockServer) -> HardcoverConfig {
@@ -122,4 +122,97 @@ async fn fetch_hardcover_metadata_returns_not_configured_when_no_key_is_set() {
 
     let result = fetch_hardcover_metadata(&pool, &uuid).await.unwrap();
     assert_eq!(result, HardcoverFetchResult::NotConfigured);
+}
+
+/// Resolve-race: `resolve_book` finds a matching id, but that id is deleted
+/// or merged on Hardcover's side before the follow-up detail lookup runs —
+/// the detail query comes back with no rows for it.
+#[tokio::test]
+async fn fetch_hardcover_metadata_with_returns_not_found_when_resolved_id_vanishes_before_detail_fetch(
+) {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_synced_ebook(&pool, "ghost.epub", "Ghost Book", "Ghost Author").await;
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("title: {_eq:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [{
+                "id": 999000, "slug": "ghost-book", "title": "Ghost Book",
+                "contributions": [{ "author": { "name": "Ghost Author" } }],
+                "book_series": [],
+                "image": { "url": "https://example.com/g.jpg" }
+            }] }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("books(where: {id: {_eq: 999000}}"))
+        .and(body_string_contains("description"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [] }
+        })))
+        .mount(&server)
+        .await;
+
+    let result = fetch_hardcover_metadata_with(&pool, &uuid, &config_for(&server))
+        .await
+        .unwrap();
+    assert_eq!(result, HardcoverFetchResult::NotFound);
+}
+
+/// [`fetch_book_details`]'s own miss path, exercised directly rather than
+/// through [`fetch_hardcover_metadata_with`]'s resolve step: the id simply
+/// doesn't resolve to any row.
+#[tokio::test]
+async fn fetch_book_details_returns_none_when_the_book_id_no_longer_resolves() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("books(where: {id: {_eq: 123456}}"))
+        .and(body_string_contains("description"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [] }
+        })))
+        .mount(&server)
+        .await;
+
+    let result = fetch_book_details(&config_for(&server), 123456)
+        .await
+        .unwrap();
+    assert_eq!(result, None);
+}
+
+/// `fetch_primary_isbn13` is private to `suggestions::hardcover`, so its
+/// "no edition carries an ISBN-13" case is exercised through
+/// [`fetch_book_details`], which folds the result into `BookDetails.isbn13`.
+#[tokio::test]
+async fn fetch_book_details_leaves_isbn13_none_when_no_edition_carries_one() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("books(where: {id: {_eq: 555555}}"))
+        .and(body_string_contains("description"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "books": [{
+                "id": 555555, "slug": "no-isbn-book", "title": "No ISBN Book",
+                "contributions": [{ "author": { "name": "Some Author" } }],
+                "book_series": [],
+                "image": { "url": "https://example.com/n.jpg" },
+                "description": "A book with no ISBN listed anywhere."
+            }] }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(body_string_contains("editions(where: {book_id:"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "editions": [] }
+        })))
+        .mount(&server)
+        .await;
+
+    let details = fetch_book_details(&config_for(&server), 555555)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(details.title.as_deref(), Some("No ISBN Book"));
+    assert_eq!(details.isbn13, None);
 }

--- a/shared/src/metadata_fetch.rs
+++ b/shared/src/metadata_fetch.rs
@@ -38,36 +38,3 @@ pub struct FetchedBookMetadata {
     pub series_index: Option<String>,
     pub isbn13: Option<String>,
 }
-
-impl FetchedBookMetadata {
-    /// `true` when every field is empty — nothing a preview panel could show
-    /// or a user could apply.
-    pub fn is_empty(&self) -> bool {
-        self.title.is_none()
-            && self.authors.is_empty()
-            && self.description.is_none()
-            && self.series.is_none()
-            && self.series_index.is_none()
-            && self.isbn13.is_none()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn is_empty_is_true_only_when_every_field_is_absent() {
-        assert!(FetchedBookMetadata::default().is_empty());
-        assert!(!FetchedBookMetadata {
-            title: Some("Fourth Wing".to_string()),
-            ..Default::default()
-        }
-        .is_empty());
-        assert!(!FetchedBookMetadata {
-            authors: vec!["Rebecca Yarros".to_string()],
-            ..Default::default()
-        }
-        .is_empty());
-    }
-}


### PR DESCRIPTION
## Summary
- Delete `FetchedBookMetadata::is_empty()` (`shared/src/metadata_fetch.rs`) — it was never called from production code, and its no-whitespace-trim semantics disagreed with the frontend's own `non_empty()` check in `frontend/src/pages/metadata_edit/hardcover_fetch.rs`, which remains the single source of truth for "is there anything to preview/apply." Its unit test goes with it.
- Add the three tests rule 03 flagged as missing coverage for documented branches:
  - `fetch_hardcover_metadata_with_returns_not_found_when_resolved_id_vanishes_before_detail_fetch` — the resolve-then-detail-miss race named in the inline comment on `db/src/metadata_overrides/hardcover_fetch.rs`.
  - `fetch_book_details_returns_none_when_the_book_id_no_longer_resolves` — `fetch_book_details`'s own `Ok(None)` path.
  - `fetch_book_details_leaves_isbn13_none_when_no_edition_carries_one` — `fetch_primary_isbn13`'s "no edition carries an ISBN-13" case, exercised through `fetch_book_details` since `fetch_primary_isbn13` is private to `suggestions::hardcover`.

## Acceptance criteria (#1591)
- [x] `is_empty()` deleted along with its test — the UI-side `non_empty()` check remains the single source of truth (chose "delete" over "wire in", since folding an all-empty `Found` into `NotFound` server-side would just be a second, differently-behaved copy of a check the frontend already does correctly).
- [x] N/A — the two checks no longer coexist, so there's nothing left to disagree.
- [x] All three missing tests added.
- [x] Series/series-index checkbox judgment call: keeping them **independently selectable** (current behavior, unchanged). A reader who wants "Book #3 of an untitled series" applied is a real, if narrow, case — a user manually filling in the series name later while keeping the fetched index. Coupling them into one checkbox would take away a working per-field selection for a case (index without name) that isn't a UI or data-integrity bug, just an unusual combination. No code change made.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p omnibus-db -p omnibus-shared -p omnibus-frontend --features server --all-targets -- -D warnings`
- [x] `cargo test -p omnibus-db` — 1698 passed
- [x] `cargo test -p omnibus-shared` — 254 passed
- [x] `cargo test -p omnibus-frontend --features server` — 617 passed
- [x] `cargo test -p omnibus` — 641 passed, 2 pre-existing failures unrelated to this change (see Notes)

## Version
- [x] **Patch** — leaving unlabeled (test-only + dead-code removal, no behavior change).

## Notes
- `cargo test -p omnibus` has 2 failures — `commit_rejects_read_only_library_with_400` and `audiobook_commit_rejects_read_only_library_with_400` in `server/src/backend/uploads/tests.rs` — but that file is untouched by this branch (identical to `main`) and the failures are a sandbox artifact: those tests `chmod 0o555` a directory to force `PermissionDenied`, which root (this CI sandbox runs tests as root) bypasses entirely. The codebase already has an established root-guard pattern for this exact class of test elsewhere (`db/src/indexer/tests.rs`, `db/src/scanner/tests.rs`, `db/src/ebook/cover/tests.rs` — "running as root, perms don't bite; skip"), just not applied to these two. Pre-existing gap, out of scope for this PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014S8Ts6ZqELQenSjFEjvj3B


---
_Generated by [Claude Code](https://claude.ai/code/session_014S8Ts6ZqELQenSjFEjvj3B)_