### PR TITLE
refactor: extract helpers from 20 functions exceeding the 80-line cap (#1251)

### DIFF
--- a/db/src/audiobook/stat.rs
+++ b/db/src/audiobook/stat.rs
@@ -72,6 +72,36 @@ pub fn stat_audiobook_library(
         };
     }
 
+    match walk_audiobook_tree(dir) {
+        Ok((mut entries, incomplete, saw_any_file)) => {
+            entries.sort_by(|a, b| a.filename.cmp(&b.filename));
+            AudiobookStatScanResult {
+                path: Some(path_str.to_string()),
+                entries,
+                error: None,
+                incomplete,
+                saw_any_file,
+            }
+        }
+        // A read failure on the root is fatal (unlike a subdir, which
+        // becomes a synthetic placeholder row inside the walk instead).
+        Err(e) => AudiobookStatScanResult {
+            path: Some(path_str.to_string()),
+            entries: vec![],
+            error: Some(format!("could not read directory: {e}")),
+            incomplete: true,
+            saw_any_file: false,
+        },
+    }
+}
+
+/// Depth-first walk of the tree rooted at `dir`, stat-ing every accepted
+/// file. Returns `(entries, incomplete, saw_any_file)`; a root `read_dir`
+/// failure is the only case that aborts the walk (`Err`) — a subdir
+/// failure instead flags `incomplete` and continues.
+fn walk_audiobook_tree(
+    dir: &Path,
+) -> Result<(Vec<AudiobookStatEntry>, bool, bool), std::io::Error> {
     let mut entries: Vec<AudiobookStatEntry> = Vec::new();
     // Set when any subdir read fails — partial enumeration; see the
     // ebook walker for the rationale.
@@ -84,16 +114,8 @@ pub fn stat_audiobook_library(
         let read = match std::fs::read_dir(&current) {
             Ok(e) => e,
             Err(e) => {
-                // A read failure on the root is fatal; on a subdir it becomes a
-                // synthetic placeholder row the diff classifier ignores.
                 if current == dir {
-                    return AudiobookStatScanResult {
-                        path: Some(path_str.to_string()),
-                        entries: vec![],
-                        error: Some(format!("could not read directory: {e}")),
-                        incomplete: true,
-                        saw_any_file: false,
-                    };
+                    return Err(e);
                 }
                 incomplete = true;
                 entries.push(unreadable_subdir_entry(dir, &current, &e));
@@ -129,16 +151,7 @@ pub fn stat_audiobook_library(
             }
         }
     }
-
-    entries.sort_by(|a, b| a.filename.cmp(&b.filename));
-
-    AudiobookStatScanResult {
-        path: Some(path_str.to_string()),
-        entries,
-        error: None,
-        incomplete,
-        saw_any_file,
-    }
+    Ok((entries, incomplete, saw_any_file))
 }
 
 /// Build the empty-uuid placeholder row for a subdirectory that couldn't be

--- a/db/src/browse.rs
+++ b/db/src/browse.rs
@@ -74,18 +74,34 @@ pub async fn list_authors(
     pool: &SqlitePool,
     library_paths: &[&str],
 ) -> Result<Vec<AuthorSummary>, BrowseError> {
-    let ph = placeholders(library_paths.len());
+    let sql = list_authors_sql(library_paths.len());
+    let mut q = sqlx::query(&sql);
+    for path in library_paths {
+        q = q.bind(*path);
+    }
+    q = q.bind(INDEX_LIMIT);
+    let rows = q.fetch_all(pool).await?;
+
+    Ok(rows.iter().map(map_author_row).collect())
+}
+
+/// Build the `list_authors` query text for an `n`-entry `library_paths`
+/// binding. Split out from [`list_authors`] because the SQL, not the
+/// bind/fetch/map plumbing, is the bulk of that function's length.
+///
+/// `effective(author_id, book_id)` is the override-aware membership set,
+/// built once: arm (1) canonical link rows whose book has no creators
+/// override, arm (2) override-derived `(authors.id, book_id)` pairs. A
+/// single `GROUP BY author_id` over it replaces the old per-author
+/// correlated `COUNT(*)` subquery, so the books table is scanned once
+/// rather than once per author. UNION (not ALL) collapses a duplicate
+/// author name inside one override array. The inner `JOIN counts` is also
+/// what enforces the `book_count > 0` invariant.
+fn list_authors_sql(n: usize) -> String {
+    let ph = placeholders(n);
     let vis = visible("b", "l");
     let vis2 = visible("b2", "l2");
-    // `effective(author_id, book_id)` is the override-aware membership set,
-    // built once: arm (1) canonical link rows whose book has no creators
-    // override, arm (2) override-derived `(authors.id, book_id)` pairs.
-    // A single `GROUP BY author_id` over it replaces the old per-author
-    // correlated `COUNT(*)` subquery, so the books table is scanned once
-    // rather than once per author. UNION (not ALL) collapses a duplicate
-    // author name inside one override array. The inner `JOIN counts` is also
-    // what enforces the `book_count > 0` invariant.
-    let sql = format!(
+    format!(
         r"
         WITH lib_paths(p) AS (VALUES {ph}),
         effective AS (
@@ -137,25 +153,19 @@ pub async fn list_authors(
         ORDER BY COALESCE(a.sort, a.name) COLLATE NOCASE ASC
         LIMIT ?
         "
-    );
-    let mut q = sqlx::query(&sql);
-    for path in library_paths {
-        q = q.bind(*path);
-    }
-    q = q.bind(INDEX_LIMIT);
-    let rows = q.fetch_all(pool).await?;
+    )
+}
 
-    Ok(rows
-        .iter()
-        .map(|r| AuthorSummary {
-            id: r.get("id"),
-            name: r.get("name"),
-            sort: r.get("sort"),
-            book_count: usize::try_from(r.get::<i64, _>("book_count")).unwrap_or(0),
-            accent: r.get("accent"),
-            has_photo: r.get::<i64, _>("has_photo") != 0,
-        })
-        .collect())
+/// Map one `list_authors` result row to the wire type.
+fn map_author_row(r: &sqlx::sqlite::SqliteRow) -> AuthorSummary {
+    AuthorSummary {
+        id: r.get("id"),
+        name: r.get("name"),
+        sort: r.get("sort"),
+        book_count: usize::try_from(r.get::<i64, _>("book_count")).unwrap_or(0),
+        accent: r.get("accent"),
+        has_photo: r.get::<i64, _>("has_photo") != 0,
+    }
 }
 
 /// Return every series with book count, primary author, and an optional

--- a/db/src/deletion/mod.rs
+++ b/db/src/deletion/mod.rs
@@ -138,20 +138,63 @@ pub async fn delete_book_items(
     let file_ids = &dedup(file_ids);
     let copy_ids = &dedup(copy_ids);
 
-    // `BEGIN IMMEDIATE` takes the RESERVED write lock at open time, before
-    // the count below runs, matching `auth::users::create_user`'s guard
-    // against the same class of race. A plain `pool.begin()` issues a
-    // DEFERRED `BEGIN` that acquires the lock lazily on first write, which
-    // would leave the count read outside the lock and reopen the TOCTOU
-    // window this closes.
-    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
-    // Selecting nothing on a book that still has items is a no-op; the same
-    // call on a book with no items at all is the "delete this record" case
-    // `total_delete` handles below.
-    let Some(total_delete) =
-        selection_total_delete(&mut tx, book_id, &uuid, file_ids, copy_ids).await?
-    else {
+    let Some(committed) = run_deletion_tx(pool, book_id, &uuid, file_ids, copy_ids).await? else {
         return Ok(DeleteOutcome::default());
+    };
+
+    // Post-commit, so an image another book's entry still embeds survives.
+    let journal_images = purge::orphaned_images(pool, committed.journal_images).await?;
+
+    fs::cleanup(fs::Cleanup {
+        paths: committed.paths,
+        library_roots: committed.library_roots,
+        book: committed.total_delete.then_some(fs::BookCleanup {
+            book_id,
+            uuid,
+            journal_images,
+        }),
+    })
+    .await;
+
+    Ok(DeleteOutcome {
+        deleted_file_ids: file_ids.to_vec(),
+        deleted_copy_ids: copy_ids.to_vec(),
+        book_deleted: committed.total_delete,
+    })
+}
+
+/// What a committed [`run_deletion_tx`] hands back for the post-commit,
+/// best-effort filesystem cleanup.
+struct CommittedDeletion {
+    total_delete: bool,
+    paths: Vec<std::path::PathBuf>,
+    library_roots: Vec<String>,
+    journal_images: Vec<String>,
+}
+
+/// Open the `BEGIN IMMEDIATE` transaction, decide `total_delete`, resolve
+/// the on-disk state the caller needs after commit, and write the row
+/// deletions. Returns `None` for the no-op case (nothing selected on a book
+/// that still has items).
+///
+/// `BEGIN IMMEDIATE` takes the RESERVED write lock at open time, before the
+/// count inside `selection_total_delete` runs, matching
+/// `auth::users::create_user`'s guard against the same class of race. A
+/// plain `pool.begin()` issues a DEFERRED `BEGIN` that acquires the lock
+/// lazily on first write, which would leave the count read outside the lock
+/// and reopen the TOCTOU window this closes.
+async fn run_deletion_tx(
+    pool: &SqlitePool,
+    book_id: i64,
+    uuid: &str,
+    file_ids: &[i64],
+    copy_ids: &[i64],
+) -> Result<Option<CommittedDeletion>, DeleteError> {
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+    let Some(total_delete) =
+        selection_total_delete(&mut tx, book_id, uuid, file_ids, copy_ids).await?
+    else {
+        return Ok(None);
     };
 
     // Resolve on-disk paths before the rows they're derived from disappear.
@@ -166,37 +209,24 @@ pub async fn delete_book_items(
     }
     let library_roots = library_roots(pool).await?;
     let journal_images = if total_delete {
-        purge::journal_image_names(pool, &uuid).await?
+        purge::journal_image_names(pool, uuid).await?
     } else {
         Vec::new()
     };
 
     purge::delete_file_rows(&mut tx, book_id, file_ids).await?;
-    purge::delete_copy_rows(&mut tx, &uuid, copy_ids).await?;
+    purge::delete_copy_rows(&mut tx, uuid, copy_ids).await?;
     if total_delete {
-        purge::purge_book(&mut tx, book_id, &uuid).await?;
+        purge::purge_book(&mut tx, book_id, uuid).await?;
     }
     tx.commit().await?;
 
-    // Post-commit, so an image another book's entry still embeds survives.
-    let journal_images = purge::orphaned_images(pool, journal_images).await?;
-
-    fs::cleanup(fs::Cleanup {
+    Ok(Some(CommittedDeletion {
+        total_delete,
         paths,
         library_roots,
-        book: total_delete.then_some(fs::BookCleanup {
-            book_id,
-            uuid,
-            journal_images,
-        }),
-    })
-    .await;
-
-    Ok(DeleteOutcome {
-        deleted_file_ids: file_ids.to_vec(),
-        deleted_copy_ids: copy_ids.to_vec(),
-        book_deleted: total_delete,
-    })
+        journal_images,
+    }))
 }
 
 /// Validate `file_ids`/`copy_ids` against the book's *current* items and

--- a/db/src/shelves/read/summary.rs
+++ b/db/src/shelves/read/summary.rs
@@ -15,12 +15,45 @@ use super::{
 };
 use crate::shelves::rules::{membership_predicate, Bind};
 
+struct VisibleShelfRow {
+    id: i64,
+    owner_user_id: i64,
+    owner_username: String,
+    kind: ShelfKind,
+    name: String,
+    visibility: Visibility,
+    accent: Option<String>,
+    match_mode: Option<String>,
+}
+
+/// Per-kind id groups used to fan the batch loaders out to the right query
+/// (smart shelves count via their rule predicate, manual/wishlist via a
+/// single `GROUP BY`).
+struct ShelfIdGroups {
+    smart_ids: Vec<i64>,
+    manual_ids: Vec<i64>,
+    wishlist_owner_ids: Vec<i64>,
+}
+
 /// Every shelf `viewer_id` can see: own + public, or all when `is_admin`.
 pub async fn list_visible_shelves(
     pool: &SqlitePool,
     viewer_id: i64,
     is_admin: bool,
 ) -> Result<Vec<ShelfSummary>, ShelfError> {
+    let (parsed, groups) = fetch_visible_shelf_rows(pool, viewer_id, is_admin).await?;
+    let (counts, covers) = load_shelf_batches(pool, &parsed, &groups).await?;
+    Ok(assemble_shelf_summaries(parsed, counts, covers))
+}
+
+/// Run the visibility-scoped shelf query and parse each row into a
+/// [`VisibleShelfRow`], grouping ids by kind for the batch loaders that
+/// follow.
+async fn fetch_visible_shelf_rows(
+    pool: &SqlitePool,
+    viewer_id: i64,
+    is_admin: bool,
+) -> Result<(Vec<VisibleShelfRow>, ShelfIdGroups), ShelfError> {
     let rows = sqlx::query(
         "SELECT s.id, s.owner_user_id, u.username AS owner_username,
                 s.kind, s.name, s.visibility, s.accent, s.match_mode
@@ -36,16 +69,6 @@ pub async fn list_visible_shelves(
     .fetch_all(pool)
     .await?;
 
-    struct VisibleShelfRow {
-        id: i64,
-        owner_user_id: i64,
-        owner_username: String,
-        kind: ShelfKind,
-        name: String,
-        visibility: Visibility,
-        accent: Option<String>,
-        match_mode: Option<String>,
-    }
     let mut parsed = Vec::with_capacity(rows.len());
     let mut smart_ids = Vec::new();
     let mut manual_ids = Vec::new();
@@ -72,44 +95,95 @@ pub async fn list_visible_shelves(
             match_mode: r.try_get("match_mode")?,
         });
     }
+    Ok((
+        parsed,
+        ShelfIdGroups {
+            smart_ids,
+            manual_ids,
+            wishlist_owner_ids,
+        },
+    ))
+}
 
-    let mut rules_by_shelf = load_rules_batch(pool, &smart_ids).await?;
-    let manual_counts = count_manual_batch(pool, &manual_ids).await?;
-    let wishlist_counts = count_wishlist_batch(pool, &wishlist_owner_ids).await?;
-    let mut manual_covers = covers_manual_batch(pool, &manual_ids).await?;
-    let mut wishlist_covers = covers_wishlist_batch(pool, &wishlist_owner_ids).await?;
+/// Per-kind book counts, keyed to match how each kind's batch loader groups
+/// its rows (shelf id for smart/manual, owner id for wishlist).
+struct ShelfCounts {
+    smart: HashMap<i64, i64>,
+    manual: HashMap<i64, i64>,
+    wishlist: HashMap<i64, i64>,
+}
 
-    // Each smart shelf's membership predicate is unique, so unlike the manual
-    // counts above these can't fold into one `GROUP BY` — fan them out
-    // concurrently instead of one sequential query per shelf.
-    let mut smart_inputs = Vec::with_capacity(smart_ids.len());
-    for row in &parsed {
+/// Per-kind mosaic cover uuids, same keying convention as [`ShelfCounts`].
+struct ShelfCovers {
+    smart: HashMap<i64, Vec<String>>,
+    manual: HashMap<i64, Vec<String>>,
+    wishlist: HashMap<i64, Vec<String>>,
+}
+
+/// Run every count/cover batch loader, fanning the smart-shelf ones out
+/// concurrently since each shelf's membership predicate is unique and can't
+/// fold into one `GROUP BY` like manual/wishlist can.
+async fn load_shelf_batches(
+    pool: &SqlitePool,
+    parsed: &[VisibleShelfRow],
+    groups: &ShelfIdGroups,
+) -> Result<(ShelfCounts, ShelfCovers), ShelfError> {
+    let mut rules_by_shelf = load_rules_batch(pool, &groups.smart_ids).await?;
+    let manual_counts = count_manual_batch(pool, &groups.manual_ids).await?;
+    let wishlist_counts = count_wishlist_batch(pool, &groups.wishlist_owner_ids).await?;
+    let manual_covers = covers_manual_batch(pool, &groups.manual_ids).await?;
+    let wishlist_covers = covers_wishlist_batch(pool, &groups.wishlist_owner_ids).await?;
+
+    let mut smart_inputs = Vec::with_capacity(groups.smart_ids.len());
+    for row in parsed {
         if row.kind == ShelfKind::Smart {
             let mode = parse_mode(row.match_mode.clone());
             let rules = rules_by_shelf.remove(&row.id).unwrap_or_default();
             smart_inputs.push((row.id, row.owner_user_id, mode, rules));
         }
     }
-    let mut smart_covers = covers_smart_fan_out(pool, &smart_inputs).await?;
+    let smart_covers = covers_smart_fan_out(pool, &smart_inputs).await?;
     let smart_counts = count_smart_fan_out(pool, smart_inputs).await?;
 
+    Ok((
+        ShelfCounts {
+            smart: smart_counts,
+            manual: manual_counts,
+            wishlist: wishlist_counts,
+        },
+        ShelfCovers {
+            smart: smart_covers,
+            manual: manual_covers,
+            wishlist: wishlist_covers,
+        },
+    ))
+}
+
+/// Zip parsed rows with their batch-loaded counts/covers into the wire type.
+fn assemble_shelf_summaries(
+    parsed: Vec<VisibleShelfRow>,
+    counts: ShelfCounts,
+    mut covers: ShelfCovers,
+) -> Vec<ShelfSummary> {
     let mut out = Vec::with_capacity(parsed.len());
     for row in parsed {
         let book_count = match row.kind {
-            ShelfKind::Smart => smart_counts.get(&row.id).copied().unwrap_or(0),
-            ShelfKind::Manual => manual_counts.get(&row.id).copied().unwrap_or(0),
-            ShelfKind::Wishlist => wishlist_counts
+            ShelfKind::Smart => counts.smart.get(&row.id).copied().unwrap_or(0),
+            ShelfKind::Manual => counts.manual.get(&row.id).copied().unwrap_or(0),
+            ShelfKind::Wishlist => counts
+                .wishlist
                 .get(&row.owner_user_id)
                 .copied()
                 .unwrap_or(0),
         };
         let cover_uuids = match row.kind {
-            ShelfKind::Smart => smart_covers.remove(&row.id).unwrap_or_default(),
-            ShelfKind::Manual => manual_covers.remove(&row.id).unwrap_or_default(),
+            ShelfKind::Smart => covers.smart.remove(&row.id).unwrap_or_default(),
+            ShelfKind::Manual => covers.manual.remove(&row.id).unwrap_or_default(),
             // Two visible rows can share an owner's wishlist covers only if the
             // same user somehow owned two wishlists; `remove` keeps the map
             // drain simple and the first row wins.
-            ShelfKind::Wishlist => wishlist_covers
+            ShelfKind::Wishlist => covers
+                .wishlist
                 .remove(&row.owner_user_id)
                 .unwrap_or_default(),
         };
@@ -125,7 +199,7 @@ pub async fn list_visible_shelves(
             cover_uuids,
         });
     }
-    Ok(out)
+    out
 }
 
 /// Load rules for every shelf id in `shelf_ids` in one query, keyed by shelf

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -69,28 +69,7 @@ fn kepub_outcome(result: Result<std::path::PathBuf, crate::kepub::KepubError>) -
 impl Worker {
     pub(super) async fn execute(self: &Arc<Self>, task: Task, id: TaskId) -> TaskOutcome {
         match task {
-            Task::Scan { library_path } => {
-                match crate::indexer::reindex_with_progress(
-                    &self.pool,
-                    &library_path,
-                    |processed, total| {
-                        self.report_progress(id, processed, Some(total));
-                    },
-                )
-                .await
-                {
-                    Ok(stats) => {
-                        // Fill word counts for any pre-0049 rows this library
-                        // still carries. Same resource key as the scan, so it
-                        // waits for this task to fully finish; the post itself
-                        // is instant. Mirrors the audiobook chapter backfill.
-                        let warning = stats.ghost_warning();
-                        self.post(Task::BackfillWordCounts { library_path });
-                        TaskOutcome::Ok(warning)
-                    }
-                    Err(e) => sanitized_err("library scan", e),
-                }
-            }
+            Task::Scan { library_path } => self.handle_scan(library_path, id).await,
             Task::ScanAudiobooks { library_path } => {
                 self.handle_scan_audiobooks(library_path, id).await
             }
@@ -114,16 +93,7 @@ impl Worker {
                 "author photo lookup",
                 crate::author_photos::resolve(&self.pool, author_id).await,
             ),
-            Task::RefetchAuthorPhotos => {
-                match crate::author_photos::refetch_all(&self.pool, |processed, total| {
-                    self.report_progress(id, processed, total);
-                })
-                .await
-                {
-                    Ok(()) => TaskOutcome::Ok(None),
-                    Err(e) => sanitized_err("author photo refetch", e),
-                }
-            }
+            Task::RefetchAuthorPhotos => self.handle_refetch_author_photos(id).await,
             Task::BackfillChapters { library_path } => anyhow_outcome(
                 "chapter backfill",
                 crate::indexer::backfill_chapters(&self.pool, &library_path, |processed, total| {
@@ -175,6 +145,42 @@ impl Worker {
                 on_done,
                 ..
             } => handle_test_task(latency_ms, on_run, on_done).await,
+        }
+    }
+
+    /// Reindex an ebook library, then (on success) post the follow-up
+    /// word-count backfill task for any pre-0049 rows this library still
+    /// carries. Same resource key as the scan, so it waits for this task to
+    /// fully finish; the post itself is instant. Mirrors the audiobook
+    /// chapter backfill.
+    async fn handle_scan(self: &Arc<Self>, library_path: String, id: TaskId) -> TaskOutcome {
+        match crate::indexer::reindex_with_progress(
+            &self.pool,
+            &library_path,
+            |processed, total| {
+                self.report_progress(id, processed, Some(total));
+            },
+        )
+        .await
+        {
+            Ok(stats) => {
+                let warning = stats.ghost_warning();
+                self.post(Task::BackfillWordCounts { library_path });
+                TaskOutcome::Ok(warning)
+            }
+            Err(e) => sanitized_err("library scan", e),
+        }
+    }
+
+    /// Re-resolve every author's photo, reporting progress as it goes.
+    async fn handle_refetch_author_photos(self: &Arc<Self>, id: TaskId) -> TaskOutcome {
+        match crate::author_photos::refetch_all(&self.pool, |processed, total| {
+            self.report_progress(id, processed, total);
+        })
+        .await
+        {
+            Ok(()) => TaskOutcome::Ok(None),
+            Err(e) => sanitized_err("author photo refetch", e),
         }
     }
 

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -125,22 +125,48 @@ pub struct ChipEditorProps {
     pub options: ChipEditorOptions,
 }
 
+/// Local reactive state for one [`ChipEditor`] instance. A custom-hook-style
+/// helper — called unconditionally so Dioxus's per-scope hook-order tracking
+/// sees the same `use_signal` sequence every render — so [`ChipEditor`]
+/// itself starts from the derived selection instead of a wall of signal
+/// declarations.
+///
+/// `focused` seeds from `autofocus`: the browser's autofocus does not always
+/// emit `onfocus` for a freshly-mounted node (e.g. the landing cell's
+/// editor, mounted on click), so without seeding the open-on-focus dropdown
+/// never surfaces. `suppress_open` flips true after a commit so the
+/// just-emptied input does not instantly re-surface the pool; any keystroke
+/// / fresh focus clears it. `root_el` is captured by the wrapper's
+/// `onmounted` in [`ChipEditor`]'s rsx; read by
+/// `close_unless_focus_stayed_inside` on blur.
+struct ChipEditorState {
+    input: Signal<String>,
+    highlight: Signal<Option<usize>>,
+    focused: Signal<bool>,
+    suppress_open: Signal<bool>,
+    root_el: Signal<Option<ChipEditorRoot>>,
+}
+
+fn use_chip_editor_state(autofocus: bool) -> ChipEditorState {
+    ChipEditorState {
+        input: use_signal(String::new),
+        highlight: use_signal(|| None),
+        focused: use_signal(|| autofocus),
+        suppress_open: use_signal(|| false),
+        root_el: use_signal(|| None),
+    }
+}
+
 /// Add/remove chip editor with autocomplete dropdown.
 #[component]
 pub fn ChipEditor(props: ChipEditorProps) -> Element {
-    // Seed `focused` from `autofocus`: the browser's autofocus does not
-    // always emit `onfocus` for a freshly-mounted node (e.g. the landing
-    // cell's editor, mounted on click), so without seeding the
-    // open-on-focus dropdown never surfaces. `suppress_open` flips true
-    // after a commit so the just-emptied input does not instantly
-    // re-surface the pool; any keystroke / fresh focus clears it.
-    let mut input = use_signal(String::new);
-    let mut highlight = use_signal::<Option<usize>>(|| None);
-    let mut focused = use_signal(|| props.options.autofocus);
-    let mut suppress_open = use_signal(|| false);
-    // Captured by the wrapper's `onmounted` below; read by
-    // `close_unless_focus_stayed_inside` on blur.
-    let mut root_el = use_signal(|| None::<ChipEditorRoot>);
+    let ChipEditorState {
+        mut input,
+        mut highlight,
+        mut focused,
+        mut suppress_open,
+        mut root_el,
+    } = use_chip_editor_state(props.options.autofocus);
 
     let selection = compute_selection(&props, input(), focused(), suppress_open());
     let selection_kd = selection.clone();

--- a/frontend/src/components/delete_book_dialog.rs
+++ b/frontend/src/components/delete_book_dialog.rs
@@ -157,6 +157,52 @@ fn build_do_delete(
     }
 }
 
+/// Precomputed copy/state for the choose-step body, so [`render_choose`]
+/// itself only has the rsx tree left to build.
+struct ChooseLabels {
+    /// The continue button's label — names the action rather than a count
+    /// while nothing is picked, since the button is disabled at zero.
+    action: String,
+    intro: &'static str,
+    /// With copies in play the count would misread as the item total, so
+    /// the section header drops it (as the design's variant does).
+    files_head: String,
+    all_picked: bool,
+}
+
+/// Compute [`ChooseLabels`] from the manifest and the current selection
+/// count.
+fn choose_labels(manifest: &BookDeletionManifest, has_copies: bool, picked: usize) -> ChooseLabels {
+    // "1 item…" once physical copies are in play, since not every row is a file.
+    let noun = match (has_copies, picked) {
+        (true, 1) => "item",
+        (true, _) => "items",
+        (false, 1) => "file",
+        (false, _) => "files",
+    };
+    let action = if picked == 0 {
+        format!("Delete {noun}\u{2026}")
+    } else {
+        format!("Delete {picked} {noun}\u{2026}")
+    };
+    let intro = if has_copies {
+        "Choose what to remove. Files are deleted from disk; a physical copy is only un-recorded."
+    } else {
+        "Choose the files to remove. Each one is deleted from disk and from the library database. This cannot be undone."
+    };
+    let files_head = match (has_copies, manifest.files.len()) {
+        (true, _) => "FILES ON DISK".to_string(),
+        (false, 1) => "1 FILE ON DISK".to_string(),
+        (false, n) => format!("{n} FILES ON DISK"),
+    };
+    ChooseLabels {
+        action,
+        intro,
+        files_head,
+        all_picked: picked == manifest.item_count(),
+    }
+}
+
 /// Step 1 — the item checklist, files first and physical copies below.
 fn render_choose(
     title: String,
@@ -172,47 +218,22 @@ fn render_choose(
     } = signals;
     let picked = files.read().len() + copies.read().len();
     let has_copies = !manifest.copies.is_empty();
-    // "1 item…" once physical copies are in play, since not every row is a file.
-    let noun = match (has_copies, picked) {
-        (true, 1) => "item",
-        (true, _) => "items",
-        (false, 1) => "file",
-        (false, _) => "files",
-    };
-    // The button is disabled at zero, so it names the action rather than a count.
-    let action = if picked == 0 {
-        format!("Delete {noun}\u{2026}")
-    } else {
-        format!("Delete {picked} {noun}\u{2026}")
-    };
-    let all_picked = picked == manifest.item_count();
-    let intro = if has_copies {
-        "Choose what to remove. Files are deleted from disk; a physical copy is only un-recorded."
-    } else {
-        "Choose the files to remove. Each one is deleted from disk and from the library database. This cannot be undone."
-    };
-    let files_head = match (has_copies, manifest.files.len()) {
-        // With copies in play the count would misread as the item total, so
-        // the section header drops it (as the design's variant does).
-        (true, _) => "FILES ON DISK".to_string(),
-        (false, 1) => "1 FILE ON DISK".to_string(),
-        (false, n) => format!("{n} FILES ON DISK"),
-    };
-    let select_all = build_select_all(&manifest, signals, all_picked);
+    let labels = choose_labels(&manifest, has_copies, picked);
+    let select_all = build_select_all(&manifest, signals, labels.all_picked);
 
     rsx! {
         div { class: "del-body",
             h2 { class: "del-title", "Delete files from \u{201c}{title}\u{201d}?" }
-            p { class: "del-copy", "{intro}" }
+            p { class: "del-copy", "{labels.intro}" }
 
             div { class: "del-section-head",
-                span { class: "label del-section-label", "{files_head}" }
+                span { class: "label del-section-label", "{labels.files_head}" }
                 button {
                     class: "del-select-all",
                     "data-testid": "delete-select-all",
                     r#type: "button",
                     onclick: select_all,
-                    if all_picked { "Clear selection" } else { "Select all" }
+                    if labels.all_picked { "Clear selection" } else { "Select all" }
                 }
             }
             ul { class: "del-items",
@@ -242,7 +263,7 @@ fn render_choose(
                     r#type: "button",
                     disabled: picked == 0,
                     onclick: move |_| stage.set(Stage::Confirm),
-                    "{action}"
+                    "{labels.action}"
                 }
             }, on_close, signals.busy)}
         }
@@ -373,24 +394,27 @@ fn render_item_row(row: ItemRow) -> Element {
     }
 }
 
-/// Step 2 — the confirm pane. Three shapes: no items at all, a partial
-/// delete the book survives, and a total delete that takes the book.
-fn render_confirm(
-    title: String,
-    manifest: BookDeletionManifest,
+/// Precomputed copy/state for the confirm-step body, so [`render_confirm`]
+/// itself only has the rsx tree left to build. Three shapes: no items at
+/// all, a partial delete the book survives, and a total delete that takes
+/// the book.
+struct ConfirmLabels {
+    heading: String,
+    copy: String,
+    action: String,
+    /// Only a total delete takes the uuid-keyed user data with it.
+    losses: Option<Vec<String>>,
+    empty: bool,
+}
+
+/// Compute [`ConfirmLabels`] from the manifest, current selection, and
+/// pick counts.
+fn confirm_labels(
+    title: &str,
+    manifest: &BookDeletionManifest,
     signals: DeleteDialogSignals,
-    on_confirm: impl FnMut(()) + 'static,
-    on_close: EventHandler<()>,
-) -> Element {
-    let DeleteDialogSignals {
-        files,
-        copies,
-        mut stage,
-        busy,
-        ..
-    } = signals;
-    let mut on_confirm = on_confirm;
-    let picked = files.read().len() + copies.read().len();
+    picked: usize,
+) -> ConfirmLabels {
     let empty = manifest.item_count() == 0;
     let total = empty || picked == manifest.item_count();
     let remaining = manifest.item_count().saturating_sub(picked);
@@ -421,23 +445,50 @@ fn render_confirm(
             (false, 1) => "item",
             (false, _) => "items",
         };
-        format!("{} will be deleted from disk and removed from this book. {title} stays in your library with its {remaining} remaining {left}.", picked_label(&manifest, signals))
+        format!("{} will be deleted from disk and removed from this book. {title} stays in your library with its {remaining} remaining {left}.", picked_label(manifest, signals))
     };
     let action = match (empty, total, noun) {
         (true, _, _) => "Delete record".to_string(),
         (_, true, _) => "Delete book".to_string(),
         (_, _, n) => format!("Delete {n}"),
     };
-    // Only a total delete takes the uuid-keyed user data with it.
     let losses = total
         .then(|| manifest.impact.losses())
         .filter(|l| !l.is_empty());
 
+    ConfirmLabels {
+        heading,
+        copy,
+        action,
+        losses,
+        empty,
+    }
+}
+
+/// Step 2 — the confirm pane.
+fn render_confirm(
+    title: String,
+    manifest: BookDeletionManifest,
+    signals: DeleteDialogSignals,
+    on_confirm: impl FnMut(()) + 'static,
+    on_close: EventHandler<()>,
+) -> Element {
+    let DeleteDialogSignals {
+        files,
+        copies,
+        mut stage,
+        busy,
+        ..
+    } = signals;
+    let mut on_confirm = on_confirm;
+    let picked = files.read().len() + copies.read().len();
+    let labels = confirm_labels(&title, &manifest, signals, picked);
+
     rsx! {
         div { class: "del-body",
-            h2 { class: "del-title", "{heading}" }
-            p { class: "del-copy", "data-testid": "delete-confirm-copy", "{copy}" }
-            if let Some(losses) = losses {
+            h2 { class: "del-title", "{labels.heading}" }
+            p { class: "del-copy", "data-testid": "delete-confirm-copy", "{labels.copy}" }
+            if let Some(losses) = &labels.losses {
                 p { class: "del-copy del-losses", "data-testid": "delete-losses",
                     "Also deleted: {losses.join(\", \")}."
                 }
@@ -446,7 +497,7 @@ fn render_confirm(
                 p { role: "alert", class: "bd-merge-error", "{msg}" }
             }
             {render_actions(rsx! {
-                if !empty {
+                if !labels.empty {
                     button {
                         class: "del-btn-ghost",
                         "data-testid": "delete-back",
@@ -462,7 +513,7 @@ fn render_confirm(
                     r#type: "button",
                     disabled: busy(),
                     onclick: move |_| on_confirm(()),
-                    if busy() { "Deleting\u{2026}" } else { "{action}" }
+                    if busy() { "Deleting\u{2026}" } else { "{labels.action}" }
                 }
             }, on_close, signals.busy)}
         }

--- a/frontend/src/data/books/library.rs
+++ b/frontend/src/data/books/library.rs
@@ -68,32 +68,57 @@ pub async fn get_ebooks_page(
     // the TTL-gated background sync on every online browse.
     crate::offline::replica::ensure_fresh(server_url.to_string());
     if cursor.is_none() {
-        // First page: cache-first via the SWR policy, so landing paints
-        // instantly (server-exact ordering as of the last visit) and
-        // revalidates in the background.
-        let key = crate::offline::cache::keys::ebooks_first(
-            sort_key.as_wire(),
-            sort_dir.as_wire(),
-            &filters.formats.join(","),
-        );
-        let url = server_url.to_string();
-        let f = filters.clone();
-        let result = crate::offline::cache::read_through(key, async move {
-            get_ebooks_page_online(&url, sort_key, sort_dir, f, None, limit).await
-        })
-        .await;
-        return match result {
-            // Went offline mid-request with a cold first-page cache — the
-            // full replica may still save the paint.
-            Err(e) if crate::offline::sync::is_offline_error(&e) => {
-                crate::offline::replica::page_from_cache(sort_key, sort_dir, &filters, None, limit)
-                    .await
-                    .ok_or(e)
-            }
-            r => r,
-        };
+        first_page_ebooks(server_url, sort_key, sort_dir, filters, limit).await
+    } else {
+        cursor_page_ebooks(server_url, sort_key, sort_dir, filters, cursor, limit).await
     }
-    // Cursor pages ("load more"): network-first with replica fallback.
+}
+
+/// First page: cache-first via the SWR policy, so landing paints instantly
+/// (server-exact ordering as of the last visit) and revalidates in the
+/// background. Falls back to the full replica if the network attempt itself
+/// went offline against a cold first-page cache.
+#[cfg(feature = "mobile")]
+async fn first_page_ebooks(
+    server_url: &str,
+    sort_key: SortKey,
+    sort_dir: SortDir,
+    filters: ViewFilters,
+    limit: i64,
+) -> Result<LibraryPage, DataError> {
+    let key = crate::offline::cache::keys::ebooks_first(
+        sort_key.as_wire(),
+        sort_dir.as_wire(),
+        &filters.formats.join(","),
+    );
+    let url = server_url.to_string();
+    let f = filters.clone();
+    let result = crate::offline::cache::read_through(key, async move {
+        get_ebooks_page_online(&url, sort_key, sort_dir, f, None, limit).await
+    })
+    .await;
+    match result {
+        // Went offline mid-request with a cold first-page cache — the full
+        // replica may still save the paint.
+        Err(e) if crate::offline::sync::is_offline_error(&e) => {
+            crate::offline::replica::page_from_cache(sort_key, sort_dir, &filters, None, limit)
+                .await
+                .ok_or(e)
+        }
+        r => r,
+    }
+}
+
+/// Cursor pages ("load more"): network-first with replica fallback.
+#[cfg(feature = "mobile")]
+async fn cursor_page_ebooks(
+    server_url: &str,
+    sort_key: SortKey,
+    sort_dir: SortDir,
+    filters: ViewFilters,
+    cursor: Option<String>,
+    limit: i64,
+) -> Result<LibraryPage, DataError> {
     let attempt = get_ebooks_page_online(
         server_url,
         sort_key,

--- a/frontend/src/offline/sync.rs
+++ b/frontend/src/offline/sync.rs
@@ -10,6 +10,10 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{OnceLock, RwLock};
 
+use omnibus_shared::{
+    AudiobookPlaybackRateUpdate, CreateBookmark, CreateHighlight, CreateJournalEntry,
+    CreateShelfRequest, ProgressUpdate, RatingUpdate, UpdateJournalEntry,
+};
 use tokio::sync::watch;
 
 use crate::data::{self, DataError};
@@ -423,59 +427,22 @@ fn ok_or<T>(result: Result<T, DataError>, target_may_be_gone: bool) -> (Option<T
 }
 
 /// Replay one op against the server, applying remaps / cache refreshes on
-/// success.
+/// success. Each variant's real work lives in a per-variant `exec_*` helper
+/// below; guard arms (negative temp ids that never reached the server) stay
+/// inline since they're a single `Outcome::Done`.
 async fn execute_op(url: &str, op: Op) -> Outcome {
     match op {
         Op::SaveProgress {
             update,
             captured_at,
-        } => {
-            // LWW stale guard: if another device wrote a *newer* position
-            // while this one was offline, keep the server's copy.
-            if let Ok(Some(server)) =
-                data::get_progress_online(url, &update.book_uuid, update.format).await
-            {
-                if server.updated_at > captured_at {
-                    outbox::apply::progress_saved(&server).await;
-                    return Outcome::Done;
-                }
-            }
-            let (record, outcome) = ok_or(data::save_progress_online(url, update).await, false);
-            if let Some(record) = record {
-                outbox::apply::progress_saved(&record).await;
-            }
-            outcome
-        }
-        Op::SetPlaybackRate { uuid, update } => {
-            let (record, outcome) = ok_or(
-                data::set_playback_rate_online(url, &uuid, update).await,
-                false,
-            );
-            if let Some(record) = record {
-                super::cache::put_json(&super::cache::keys::playback_rate(&uuid), &Some(record));
-            }
-            outcome
-        }
+        } => exec_save_progress(url, update, captured_at).await,
+        Op::SetPlaybackRate { uuid, update } => exec_set_playback_rate(url, uuid, update).await,
         Op::RecordSessions { reports } => {
             ok_or(data::record_sessions_online(url, reports).await, false).1
         }
-        Op::SetRating { update } => {
-            let uuid = update.book_uuid.clone();
-            let (record, outcome) = ok_or(data::set_rating_online(url, update).await, false);
-            if let Some(record) = record {
-                super::cache::put_json(&super::cache::keys::rating(&uuid), &Some(record));
-            }
-            outcome
-        }
+        Op::SetRating { update } => exec_set_rating(url, update).await,
         Op::ClearRating { uuid } => ok_or(data::clear_rating_online(url, &uuid).await, true).1,
-        Op::CreateHighlight { temp_id, input } => {
-            let (created, outcome) = ok_or(data::create_highlight_online(url, input).await, false);
-            if let Some(created) = created {
-                outbox::apply::highlight_remapped(temp_id, &created).await;
-                outbox::remap_queued(temp_id, created.id).await;
-            }
-            outcome
-        }
+        Op::CreateHighlight { temp_id, input } => exec_create_highlight(url, temp_id, input).await,
         Op::UpdateHighlightColor { id, .. } if id < 0 => Outcome::Done,
         Op::UpdateHighlightColor { id, color, .. } => {
             ok_or(
@@ -496,28 +463,14 @@ async fn execute_op(url: &str, op: Op) -> Outcome {
         Op::DeleteHighlight { id, .. } => {
             ok_or(data::delete_highlight_online(url, id).await, true).1
         }
-        Op::CreateBookmark { temp_id, input } => {
-            let (created, outcome) = ok_or(data::create_bookmark_online(url, input).await, false);
-            if let Some(created) = created {
-                outbox::apply::bookmark_remapped(temp_id, &created).await;
-                outbox::remap_queued(temp_id, created.id).await;
-            }
-            outcome
-        }
+        Op::CreateBookmark { temp_id, input } => exec_create_bookmark(url, temp_id, input).await,
         Op::UpdateBookmark { id, .. } if id < 0 => Outcome::Done,
         Op::UpdateBookmark { id, title, .. } => {
             ok_or(data::update_bookmark_online(url, id, title).await, true).1
         }
         Op::DeleteBookmark { id, .. } if id < 0 => Outcome::Done,
         Op::DeleteBookmark { id, .. } => ok_or(data::delete_bookmark_online(url, id).await, true).1,
-        Op::CreateShelf { temp_id, req } => {
-            let (created, outcome) = ok_or(data::create_shelf_online(url, req).await, false);
-            if let Some(created) = created {
-                outbox::apply::shelf_remapped(temp_id, &created).await;
-                outbox::remap_queued(temp_id, created.id).await;
-            }
-            outcome
-        }
+        Op::CreateShelf { temp_id, req } => exec_create_shelf(url, temp_id, req).await,
         Op::UpdateShelf { id, .. } if id < 0 => Outcome::Done,
         Op::UpdateShelf { id, req } => ok_or(data::update_shelf_online(url, id, req).await, true).1,
         Op::DeleteShelf { id } if id < 0 => Outcome::Done,
@@ -544,26 +497,9 @@ async fn execute_op(url: &str, op: Op) -> Outcome {
             )
             .1
         }
-        Op::CreateJournal { temp_id, input } => {
-            let (created, outcome) =
-                ok_or(data::create_journal_entry_online(url, input).await, false);
-            if let Some(created) = created {
-                outbox::apply::journal_remapped(temp_id, &created).await;
-                outbox::remap_queued(temp_id, created.id).await;
-            }
-            outcome
-        }
+        Op::CreateJournal { temp_id, input } => exec_create_journal(url, temp_id, input).await,
         Op::UpdateJournal { id, .. } if id < 0 => Outcome::Done,
-        Op::UpdateJournal { id, input, .. } => {
-            let (updated, outcome) = ok_or(
-                data::update_journal_entry_online(url, id, input).await,
-                true,
-            );
-            if let Some(updated) = updated {
-                outbox::apply::journal_remapped(id, &updated).await;
-            }
-            outcome
-        }
+        Op::UpdateJournal { id, input, .. } => exec_update_journal(url, id, input).await,
         Op::DeleteJournal { id, .. } if id < 0 => Outcome::Done,
         Op::DeleteJournal { id, .. } => {
             ok_or(data::delete_journal_entry_online(url, id).await, true).1
@@ -572,6 +508,105 @@ async fn execute_op(url: &str, op: Op) -> Outcome {
             ok_or(data::set_kindle_email_online(url, email).await, true).1
         }
     }
+}
+
+/// Replay a queued progress write, honoring the LWW stale guard: if another
+/// device wrote a *newer* position while this one was offline, keep the
+/// server's copy instead of overwriting it.
+async fn exec_save_progress(url: &str, update: ProgressUpdate, captured_at: i64) -> Outcome {
+    if let Ok(Some(server)) = data::get_progress_online(url, &update.book_uuid, update.format).await
+    {
+        if server.updated_at > captured_at {
+            outbox::apply::progress_saved(&server).await;
+            return Outcome::Done;
+        }
+    }
+    let (record, outcome) = ok_or(data::save_progress_online(url, update).await, false);
+    if let Some(record) = record {
+        outbox::apply::progress_saved(&record).await;
+    }
+    outcome
+}
+
+/// Replay a queued playback-rate write, refreshing the cached rate on
+/// success.
+async fn exec_set_playback_rate(
+    url: &str,
+    uuid: String,
+    update: AudiobookPlaybackRateUpdate,
+) -> Outcome {
+    let (record, outcome) = ok_or(
+        data::set_playback_rate_online(url, &uuid, update).await,
+        false,
+    );
+    if let Some(record) = record {
+        super::cache::put_json(&super::cache::keys::playback_rate(&uuid), &Some(record));
+    }
+    outcome
+}
+
+/// Replay a queued rating write, refreshing the cached rating on success.
+async fn exec_set_rating(url: &str, update: RatingUpdate) -> Outcome {
+    let uuid = update.book_uuid.clone();
+    let (record, outcome) = ok_or(data::set_rating_online(url, update).await, false);
+    if let Some(record) = record {
+        super::cache::put_json(&super::cache::keys::rating(&uuid), &Some(record));
+    }
+    outcome
+}
+
+/// Replay a queued highlight creation, remapping the client-minted temp id
+/// to the server-assigned one so later ops against the same handle land.
+async fn exec_create_highlight(url: &str, temp_id: i64, input: CreateHighlight) -> Outcome {
+    let (created, outcome) = ok_or(data::create_highlight_online(url, input).await, false);
+    if let Some(created) = created {
+        outbox::apply::highlight_remapped(temp_id, &created).await;
+        outbox::remap_queued(temp_id, created.id).await;
+    }
+    outcome
+}
+
+/// Replay a queued bookmark creation, remapping the client-minted temp id.
+async fn exec_create_bookmark(url: &str, temp_id: i64, input: CreateBookmark) -> Outcome {
+    let (created, outcome) = ok_or(data::create_bookmark_online(url, input).await, false);
+    if let Some(created) = created {
+        outbox::apply::bookmark_remapped(temp_id, &created).await;
+        outbox::remap_queued(temp_id, created.id).await;
+    }
+    outcome
+}
+
+/// Replay a queued shelf creation, remapping the client-minted temp id.
+async fn exec_create_shelf(url: &str, temp_id: i64, req: CreateShelfRequest) -> Outcome {
+    let (created, outcome) = ok_or(data::create_shelf_online(url, req).await, false);
+    if let Some(created) = created {
+        outbox::apply::shelf_remapped(temp_id, &created).await;
+        outbox::remap_queued(temp_id, created.id).await;
+    }
+    outcome
+}
+
+/// Replay a queued journal creation, remapping the client-minted temp id.
+async fn exec_create_journal(url: &str, temp_id: i64, input: CreateJournalEntry) -> Outcome {
+    let (created, outcome) = ok_or(data::create_journal_entry_online(url, input).await, false);
+    if let Some(created) = created {
+        outbox::apply::journal_remapped(temp_id, &created).await;
+        outbox::remap_queued(temp_id, created.id).await;
+    }
+    outcome
+}
+
+/// Replay a queued journal edit, refreshing the cached entry with the
+/// server-rendered body on success.
+async fn exec_update_journal(url: &str, id: i64, input: UpdateJournalEntry) -> Outcome {
+    let (updated, outcome) = ok_or(
+        data::update_journal_entry_online(url, id, input).await,
+        true,
+    );
+    if let Some(updated) = updated {
+        outbox::apply::journal_remapped(id, &updated).await;
+    }
+    outcome
 }
 
 /// Serializes tests (across offline test modules) that assert on the

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -53,104 +53,118 @@ use view::{derive_loaded_view, LoadedBookView};
 #[component]
 pub fn BookDetailPage(uuid: String) -> Element {
     let server_url = use_server_url();
-    let book: Signal<Option<EbookMetadata>> = use_signal(|| None);
+    let sig = use_book_detail_signals();
     // Reflect the loaded book title in the browser tab (e.g. "Omnibus | Dracula").
+    let book = sig.book;
     crate::use_page_title(move || book.read().as_ref().and_then(|b| b.title.clone()));
-    let author_books: Signal<Vec<EbookMetadata>> = use_signal(Vec::new);
-    // F3.3 suggestions. Starts `None` on both SSR and the first WASM paint so
-    // hydration markup matches (rule 07); the client effect below populates it.
-    let suggestions: Signal<Option<SuggestionsResponse>> = use_signal(|| None);
-    // Epoch guard so a poll loop left over from a previous book can't write its
-    // result onto the current book after navigation (mirrors landing's
-    // `fetch_epoch`).
-    let suggestions_epoch = use_signal(|| 0u64);
-    let loading = use_signal(|| true);
-    let error: Signal<Option<String>> = use_signal(|| None);
-    // Bumped after a merge/undo so the effect below refetches the book
-    // (signals read inside `use_effect` re-arm it).
-    let refresh = use_signal(|| 0u32);
-
-    // Admin gating for the "Merge with…" affordance — derived from the
-    // app-wide `CurrentUser` context (`crate::use_is_admin`) instead of an
-    // independent per-mount `/api/auth/me` fetch. Mobile/SSR stay at the
-    // `false` default since the context is web-only; the server-side
-    // `AdminUser` extractor on `rpc_merge_books` is the actual security
-    // boundary.
-    let is_admin = crate::use_is_admin();
-
-    // Merge dialog state. Declared unconditionally per rule 07 so the hook
-    // count is identical on every target — mobile compiles the signals but
-    // `render_book_shell` stubs the builders that read them.
-    let merge_open = use_signal(|| false);
-    let merge_result: Signal<Option<MergeBooksResult>> = use_signal(|| None);
-    let undo_error: Signal<Option<String>> = use_signal(|| None);
-    // Delete-dialog state, declared unconditionally for the same reason.
-    let delete_open = use_signal(|| false);
-
-    // Physical-wishlist state, lifted here because two web sections share it:
-    // the hero (cover chip + rail wishlist slot) and the physical panel (whose
-    // post-mount load populates it, and whose last-copy delete can write it).
-    // Declared unconditionally per rule 07; mobile discards it.
-    let phys = PhysSignals {
-        wishlist: use_signal(|| None::<WishlistEntry>),
-        loaded: use_signal(|| false),
-    };
-
-    // Fetch Summary override (mobile only). Declared unconditionally per
-    // rule 07 — `render_loaded_mobile` is a plain fn with no hook scope,
-    // reached only past the early returns below. `epoch` is bumped
-    // alongside `value` on every fresh book load; the Fetch Summary save in
-    // `render_loaded_mobile` checks it's unchanged before writing, so a save
-    // left over from a since-navigated-away book can't clobber the new
-    // book's description.
-    let description = DescriptionSignals {
-        value: use_signal(String::new),
-        epoch: use_signal(|| 0u64),
-    };
 
     use_book_data_effects(
         uuid.clone(),
         server_url.clone(),
         BookDataSignals {
-            book,
-            author_books,
-            loading,
-            error,
-            refresh,
-            suggestions_epoch,
-            suggestions,
-            description,
+            book: sig.book,
+            author_books: sig.author_books,
+            loading: sig.loading,
+            error: sig.error,
+            refresh: sig.merge.refresh,
+            suggestions_epoch: sig.suggestions_epoch,
+            suggestions: sig.suggestions,
+            description: sig.description,
         },
     );
 
-    if loading() {
+    if (sig.loading)() {
         return rsx! { PageLoading {} };
     }
-    if let Some(msg) = error() {
+    if let Some(msg) = (sig.error)() {
         return rsx! { PageError { message: msg, back_to: Route::Landing {} } };
     }
-    let Some(b) = book() else {
+    let Some(b) = (sig.book)() else {
         return rsx! { PageNotFound { subject: "Book", back_to: Route::Landing {} } };
     };
 
     render_book_shell(
         b,
-        MergeSignals {
-            open: merge_open,
-            result: merge_result,
-            undo_error,
-            refresh,
-        },
+        sig.merge,
         PageSignals {
-            description,
-            delete_open,
-            phys,
+            description: sig.description,
+            delete_open: sig.delete_open,
+            phys: sig.phys,
         },
-        author_books(),
-        suggestions(),
-        is_admin,
+        (sig.author_books)(),
+        (sig.suggestions)(),
+        sig.is_admin,
         server_url,
     )
+}
+
+/// Every signal [`BookDetailPage`] owns, declared unconditionally (rule 07)
+/// so the hook count and order stay identical on every platform target.
+/// Bundled into one custom-hook-style helper — called unconditionally, so
+/// Dioxus's per-scope hook-order tracking sees the same sequence of
+/// `use_signal` calls every render — so the component body reads as a
+/// data-fetch + dispatch shell instead of a wall of hook declarations.
+struct BookDetailSignals {
+    book: Signal<Option<EbookMetadata>>,
+    author_books: Signal<Vec<EbookMetadata>>,
+    // F3.3 suggestions. Starts `None` on both SSR and the first WASM paint so
+    // hydration markup matches (rule 07); the client effect below populates it.
+    suggestions: Signal<Option<SuggestionsResponse>>,
+    // Epoch guard so a poll loop left over from a previous book can't write
+    // its result onto the current book after navigation (mirrors landing's
+    // `fetch_epoch`).
+    suggestions_epoch: Signal<u64>,
+    loading: Signal<bool>,
+    error: Signal<Option<String>>,
+    // Admin gating for the "Merge with…" affordance — derived from the
+    // app-wide `CurrentUser` context instead of an independent per-mount
+    // `/api/auth/me` fetch. Mobile/SSR stay at the `false` default since the
+    // context is web-only; the server-side `AdminUser` extractor on
+    // `rpc_merge_books` is the actual security boundary.
+    is_admin: ReadSignal<bool>,
+    // Merge-dialog state; mobile compiles the signals but `render_book_shell`
+    // stubs the builders that read them.
+    merge: MergeSignals,
+    // Delete-dialog state, declared unconditionally for the same reason.
+    delete_open: Signal<bool>,
+    // Physical-wishlist state, lifted here because two web sections share it:
+    // the hero (cover chip + rail wishlist slot) and the physical panel
+    // (whose post-mount load populates it, and whose last-copy delete can
+    // write it). Mobile discards it.
+    phys: PhysSignals,
+    // Fetch Summary override (mobile only); reached only past the early
+    // returns below. `epoch` bumps alongside `value` on every fresh book
+    // load, so the Fetch Summary save in `render_loaded_mobile` can detect
+    // and drop a result left over from a since-navigated-away book.
+    description: DescriptionSignals,
+}
+
+fn use_book_detail_signals() -> BookDetailSignals {
+    let refresh = use_signal(|| 0u32);
+    BookDetailSignals {
+        book: use_signal(|| None),
+        author_books: use_signal(Vec::new),
+        suggestions: use_signal(|| None),
+        suggestions_epoch: use_signal(|| 0u64),
+        loading: use_signal(|| true),
+        error: use_signal(|| None),
+        is_admin: crate::use_is_admin(),
+        merge: MergeSignals {
+            open: use_signal(|| false),
+            result: use_signal(|| None),
+            undo_error: use_signal(|| None),
+            refresh,
+        },
+        delete_open: use_signal(|| false),
+        phys: PhysSignals {
+            wishlist: use_signal(|| None::<WishlistEntry>),
+            loaded: use_signal(|| false),
+        },
+        description: DescriptionSignals {
+            value: use_signal(String::new),
+            epoch: use_signal(|| 0u64),
+        },
+    }
 }
 
 /// Fetch Summary override signals (mobile only): the effective description
@@ -274,55 +288,9 @@ fn render_book_shell(
     // returns `false` during SSR and for non-admins on every platform.
     let is_admin_flag = is_admin();
 
-    // Rail "Merge with…" button (admin, web only) — threaded down as a
-    // prebuilt Element so the rail component stays platform-agnostic.
-    #[cfg(not(feature = "mobile"))]
-    let merge_button: Option<Element> = merge::build_merge_button(is_admin_flag, merge.open);
-    #[cfg(feature = "mobile")]
-    let merge_button: Option<Element> = merge::build_merge_button(is_admin_flag);
-
-    #[cfg(not(feature = "mobile"))]
-    let merge_ui: Option<Element> = merge::build_merge_ui(
-        merge.open,
-        merge.result,
-        merge.undo_error,
-        merge.refresh,
-        server_url.clone(),
-        b.clone(),
-    );
-    #[cfg(feature = "mobile")]
-    let merge_ui: Option<Element> = {
-        // Mobile's builders take no args; read every field so the signals
-        // (declared unconditionally in `BookDetailPage` for hook parity)
-        // aren't flagged as never-read on this target.
-        let MergeSignals {
-            open,
-            result,
-            undo_error,
-            refresh,
-        } = merge;
-        let _ = (open, result, undo_error, refresh);
-        merge::build_merge_ui()
-    };
-
-    // Rail "Delete files…" button + its dialog, same web-only shape as merge.
-    #[cfg(not(feature = "mobile"))]
-    let delete_button: Option<Element> = delete::build_delete_button(is_admin_flag, delete_open);
-    #[cfg(feature = "mobile")]
-    let delete_button: Option<Element> = delete::build_delete_button(is_admin_flag);
-
-    #[cfg(not(feature = "mobile"))]
-    let delete_ui: Option<Element> = delete::build_delete_ui(
-        delete_open,
-        merge.refresh,
-        b.unique_identifier.clone().unwrap_or_default(),
-        b.display_title(),
-    );
-    #[cfg(feature = "mobile")]
-    let delete_ui: Option<Element> = {
-        let _ = delete_open;
-        delete::build_delete_ui()
-    };
+    let (merge_button, merge_ui) = build_merge_pieces(is_admin_flag, merge, &server_url, &b);
+    let (delete_button, delete_ui) =
+        build_delete_pieces(is_admin_flag, delete_open, merge.refresh, &b);
 
     let body = render_loaded(
         b,
@@ -345,6 +313,76 @@ fn render_book_shell(
         {merge_ui}
         {delete_ui}
     }
+}
+
+/// Rail "Merge with…" button (admin, web only) plus its dialog, threaded down
+/// as prebuilt `Element`s so the rail component stays platform-agnostic.
+fn build_merge_pieces(
+    is_admin_flag: bool,
+    merge: MergeSignals,
+    server_url: &str,
+    b: &EbookMetadata,
+) -> (Option<Element>, Option<Element>) {
+    #[cfg(not(feature = "mobile"))]
+    let merge_button: Option<Element> = merge::build_merge_button(is_admin_flag, merge.open);
+    #[cfg(feature = "mobile")]
+    let merge_button: Option<Element> = merge::build_merge_button(is_admin_flag);
+
+    #[cfg(not(feature = "mobile"))]
+    let merge_ui: Option<Element> = merge::build_merge_ui(
+        merge.open,
+        merge.result,
+        merge.undo_error,
+        merge.refresh,
+        server_url.to_string(),
+        b.clone(),
+    );
+    #[cfg(feature = "mobile")]
+    let merge_ui: Option<Element> = {
+        // Mobile's builders take no args; read every field (plus the
+        // web-only params) so the signals — declared unconditionally in
+        // `BookDetailPage` for hook parity — aren't flagged as never-read
+        // on this target.
+        let MergeSignals {
+            open,
+            result,
+            undo_error,
+            refresh,
+        } = merge;
+        let _ = (open, result, undo_error, refresh, server_url, b);
+        merge::build_merge_ui()
+    };
+
+    (merge_button, merge_ui)
+}
+
+/// Rail "Delete files…" button + its dialog, same web-only shape as
+/// [`build_merge_pieces`].
+fn build_delete_pieces(
+    is_admin_flag: bool,
+    delete_open: Signal<bool>,
+    refresh: Signal<u32>,
+    b: &EbookMetadata,
+) -> (Option<Element>, Option<Element>) {
+    #[cfg(not(feature = "mobile"))]
+    let delete_button: Option<Element> = delete::build_delete_button(is_admin_flag, delete_open);
+    #[cfg(feature = "mobile")]
+    let delete_button: Option<Element> = delete::build_delete_button(is_admin_flag);
+
+    #[cfg(not(feature = "mobile"))]
+    let delete_ui: Option<Element> = delete::build_delete_ui(
+        delete_open,
+        refresh,
+        b.unique_identifier.clone().unwrap_or_default(),
+        b.display_title(),
+    );
+    #[cfg(feature = "mobile")]
+    let delete_ui: Option<Element> = {
+        let _ = (delete_open, refresh, b);
+        delete::build_delete_ui()
+    };
+
+    (delete_button, delete_ui)
 }
 
 // View helpers — the loaded-book case is the only thing rendered, so the

--- a/frontend/src/pages/book_detail/view.rs
+++ b/frontend/src/pages/book_detail/view.rs
@@ -170,10 +170,8 @@ pub(super) struct LoadedCtx {
 }
 
 /// Render the fully-loaded book detail view — mobile re-flow into a single
-/// column via [`mobile::render_loaded_mobile`]. The merge and delete
-/// affordances stay web-only; the discovery blocks (author cluster +
-/// suggestions) render on mobile too. The physical panel + wishlist rail
-/// are web-only too (issue #1186 scope), so `rail`/`refresh`/`phys` are
+/// column via [`mobile::render_loaded_mobile`]. Merge/delete and the
+/// physical/wishlist rail stay web-only, so `rail`/`refresh`/`phys` are
 /// unused here.
 #[cfg(feature = "mobile")]
 pub(super) fn render_loaded(

--- a/frontend/src/pages/book_detail/view.rs
+++ b/frontend/src/pages/book_detail/view.rs
@@ -169,7 +169,13 @@ pub(super) struct LoadedCtx {
     pub(super) phys: PhysSignals,
 }
 
-/// Render the fully-loaded book detail view.
+/// Render the fully-loaded book detail view — mobile re-flow into a single
+/// column via [`mobile::render_loaded_mobile`]. The merge and delete
+/// affordances stay web-only; the discovery blocks (author cluster +
+/// suggestions) render on mobile too. The physical panel + wishlist rail
+/// are web-only too (issue #1186 scope), so `rail`/`refresh`/`phys` are
+/// unused here.
+#[cfg(feature = "mobile")]
 pub(super) fn render_loaded(
     b: EbookMetadata,
     description: DescriptionSignals,
@@ -184,99 +190,103 @@ pub(super) fn render_loaded(
         refresh,
         phys,
     } = ctx;
-    // Mobile re-flows the same loaded data into a single column; the web body
-    // (hero + rail + suggestions + merge UI) isn't rendered there.
-    #[cfg(feature = "mobile")]
-    let out = {
-        // The merge and delete affordances stay web-only; the discovery blocks
-        // (author cluster + suggestions) now render on mobile too. The physical
-        // panel + wishlist rail are web-only too (issue #1186 scope), so
-        // `refresh` and `phys` are unused here.
-        let _ = rail;
-        let _ = (refresh, phys);
-        mobile::render_loaded_mobile(mobile::MobileBookView {
-            b,
-            author_books,
-            suggestions,
-            is_admin,
-            server_url,
-            description,
-        })
-    };
+    let _ = rail;
+    let _ = (refresh, phys);
+    mobile::render_loaded_mobile(mobile::MobileBookView {
+        b,
+        author_books,
+        suggestions,
+        is_admin,
+        server_url,
+        description,
+    })
+}
 
-    #[cfg(not(feature = "mobile"))]
-    let out = {
-        // Web keeps its own local copy inside `BdTitleCol` (hero.rs), a real
-        // `#[component]` that gets a fresh scope per mount — no hook-order
-        // risk there, so this param is unused on this target.
-        let _ = description;
-        let RailButtons {
-            merge: merge_button,
-            delete: delete_button,
-        } = rail;
-        let LoadedBookView {
-            title,
-            primary_author,
-            author_id,
-            authors_line,
-            kicker,
-            series,
-            accent_style,
-            has_audio,
-            has_ebook,
-            has_comic,
-            crumbs,
-        } = derive_loaded_view(&b);
+/// Render the fully-loaded book detail view — web hero + rail + physical
+/// panel + suggestions grid.
+#[cfg(not(feature = "mobile"))]
+pub(super) fn render_loaded(
+    b: EbookMetadata,
+    description: DescriptionSignals,
+    author_books: Vec<EbookMetadata>,
+    rail: RailButtons,
+    suggestions: Option<SuggestionsResponse>,
+    ctx: LoadedCtx,
+) -> Element {
+    let LoadedCtx {
+        server_url,
+        is_admin,
+        refresh,
+        phys,
+    } = ctx;
+    // Web keeps its own local copy inside `BdTitleCol` (hero.rs), a real
+    // `#[component]` that gets a fresh scope per mount — no hook-order risk
+    // there, so this param is unused on this target.
+    let _ = description;
+    let RailButtons {
+        merge: merge_button,
+        delete: delete_button,
+    } = rail;
+    let LoadedBookView {
+        title,
+        primary_author,
+        author_id,
+        authors_line,
+        kicker,
+        series,
+        accent_style,
+        has_audio,
+        has_ebook,
+        has_comic,
+        crumbs,
+    } = derive_loaded_view(&b);
 
-        let uuid = b.unique_identifier.clone().unwrap_or_default();
-        // Extract the physical-panel inputs before `b` is moved into the rail.
-        let is_fileless = b.formats.is_empty();
-        let accent = b.accent.clone();
-        rsx! {
-            div { class: "bd-root", style: "{accent_style}",
-                BdHeroSection {
-                    b: b.clone(),
-                    title: title.clone(),
-                    chrome: hero::BdHeroChrome { kicker, crumbs },
-                    avail: hero::Availability {
-                        has_ebook,
-                        has_audio,
-                        has_comic,
-                    },
-                    phys,
-                }
-                physical::BdPhysicalPanel {
+    let uuid = b.unique_identifier.clone().unwrap_or_default();
+    // Extract the physical-panel inputs before `b` is moved into the rail.
+    let is_fileless = b.formats.is_empty();
+    let accent = b.accent.clone();
+    rsx! {
+        div { class: "bd-root", style: "{accent_style}",
+            BdHeroSection {
+                b: b.clone(),
+                title: title.clone(),
+                chrome: hero::BdHeroChrome { kicker, crumbs },
+                avail: hero::Availability {
+                    has_ebook,
+                    has_audio,
+                    has_comic,
+                },
+                phys,
+            }
+            physical::BdPhysicalPanel {
+                uuid: uuid.clone(),
+                is_fileless,
+                refresh,
+                phys,
+            }
+            section { class: "bd-body-grid",
+                BdBodyMain {
                     uuid: uuid.clone(),
-                    is_fileless,
-                    refresh,
-                    phys,
+                    title: title.clone(),
+                    author: BdAuthorCluster { primary_author, author_id, author_books },
+                    accent,
+                    suggestions,
+                    ctx: BdPageCtx { server_url, is_admin },
                 }
-                section { class: "bd-body-grid",
-                    BdBodyMain {
-                        uuid: uuid.clone(),
-                        title: title.clone(),
-                        author: BdAuthorCluster { primary_author, author_id, author_books },
-                        accent,
-                        suggestions,
-                        ctx: BdPageCtx { server_url, is_admin },
-                    }
-                    BdRailSection {
-                        b,
-                        title,
-                        authors_line,
-                        series,
-                        merge_button,
-                        delete_button,
-                    }
-                }
-                div { class: "bd-footer",
-                    Link { to: Route::Landing {}, class: "btn", "Back to library" }
+                BdRailSection {
+                    b,
+                    title,
+                    authors_line,
+                    series,
+                    merge_button,
+                    delete_button,
                 }
             }
+            div { class: "bd-footer",
+                Link { to: Route::Landing {}, class: "btn", "Back to library" }
+            }
         }
-    };
-
-    out
+    }
 }
 
 #[cfg(test)]

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -563,98 +563,115 @@ struct SheetProps {
     server_url: String,
 }
 
-/// Mount whichever bottom sheet is open.
+/// Mount whichever bottom sheet is open. Each variant's markup lives in its
+/// own `render_*_sheet` helper below so this stays a pure dispatch.
 fn render_sheets(p: &SheetProps) -> Element {
-    let mut sheet = p.sheet;
-    let close = move |_: MouseEvent| sheet.set(OpenSheet::None);
-
     match (p.sheet)() {
         OpenSheet::None => rsx! {},
-        OpenSheet::Chapters => rsx! {
-            ChaptersSheet {
-                list: sheets::ChaptersListView {
-                    chapters: p.chapters.as_ref().clone(),
-                    current_index: p.chapter_index,
-                    elapsed: p.elapsed,
-                    total_label: p.total_label.clone(),
-                },
-                on_seek: EventHandler::new(move |secs: f64| {
-                    interop::seek(secs);
-                    sheet.set(OpenSheet::None);
-                }),
-                on_close: close,
-            }
-        },
-        OpenSheet::Speed => {
-            let uuid = p.uuid.clone();
-            let server_url = p.server_url.clone();
-            let mut rate_sig = p.ctx.rate;
-            let rate_error = p.ctx.rate_error;
-            let user_id = *p.ctx.user_id.peek();
-            rsx! {
-                SpeedSheet {
-                    rate: p.rate,
-                    on_set: EventHandler::new(move |r: f64| {
-                        let snapped = snap_rate(r);
-                        rate_sig.set(snapped);
-                        if let Some(user_id) = user_id {
-                            crate::audiobook_progress::save_rate(user_id, &uuid, snapped);
-                        }
-                        interop::set_rate(snapped);
-                        let uuid = uuid.clone();
-                        let server_url = server_url.clone();
-                        spawn(async move {
-                            let mut rate_error = rate_error;
-                            let update = omnibus_shared::AudiobookPlaybackRateUpdate {
-                                playback_rate: snapped,
-                            };
-                            match data::set_playback_rate(&server_url, &uuid, update).await {
-                                Ok(_) => rate_error.set(None),
-                                Err(error) => rate_error.set(Some(format!(
-                                    "Could not save playback speed: {error}"
-                                ))),
-                            }
-                        });
-                    }),
-                    on_close: close,
-                }
-            }
+        OpenSheet::Chapters => render_chapters_sheet(p),
+        OpenSheet::Speed => render_speed_sheet(p),
+        OpenSheet::Sleep => render_sleep_sheet(p),
+        OpenSheet::Bookmarks => render_bookmarks_sheet(p),
+    }
+}
+
+/// Build the `on_close` handler shared by every sheet: closes the sheet
+/// layer by resetting `sheet` to [`OpenSheet::None`].
+fn close_sheet_handler(sheet: Signal<OpenSheet>) -> impl FnMut(MouseEvent) {
+    let mut sheet = sheet;
+    move |_: MouseEvent| sheet.set(OpenSheet::None)
+}
+
+fn render_chapters_sheet(p: &SheetProps) -> Element {
+    let mut sheet = p.sheet;
+    rsx! {
+        ChaptersSheet {
+            list: sheets::ChaptersListView {
+                chapters: p.chapters.as_ref().clone(),
+                current_index: p.chapter_index,
+                elapsed: p.elapsed,
+                total_label: p.total_label.clone(),
+            },
+            on_seek: EventHandler::new(move |secs: f64| {
+                interop::seek(secs);
+                sheet.set(OpenSheet::None);
+            }),
+            on_close: close_sheet_handler(p.sheet),
         }
-        OpenSheet::Sleep => {
-            let chapter_end = p
-                .chapters
-                .get(p.chapter_index)
-                .map(|c| c.start_seconds + c.duration_seconds);
-            let mut sleep_sig = p.ctx.sleep;
-            rsx! {
-                SleepSheet {
-                    view: sheets::SleepSheetView {
-                        sleep: p.sleep,
-                        elapsed: p.elapsed,
-                        chapter_end,
-                        chapter_no: p.chapter_index + 1,
-                    },
-                    on_set: EventHandler::new(move |s: SleepState| sleep_sig.set(s)),
-                    on_close: close,
+    }
+}
+
+fn render_speed_sheet(p: &SheetProps) -> Element {
+    let uuid = p.uuid.clone();
+    let server_url = p.server_url.clone();
+    let mut rate_sig = p.ctx.rate;
+    let rate_error = p.ctx.rate_error;
+    let user_id = *p.ctx.user_id.peek();
+    rsx! {
+        SpeedSheet {
+            rate: p.rate,
+            on_set: EventHandler::new(move |r: f64| {
+                let snapped = snap_rate(r);
+                rate_sig.set(snapped);
+                if let Some(user_id) = user_id {
+                    crate::audiobook_progress::save_rate(user_id, &uuid, snapped);
                 }
-            }
+                interop::set_rate(snapped);
+                let uuid = uuid.clone();
+                let server_url = server_url.clone();
+                spawn(async move {
+                    let mut rate_error = rate_error;
+                    let update = omnibus_shared::AudiobookPlaybackRateUpdate {
+                        playback_rate: snapped,
+                    };
+                    match data::set_playback_rate(&server_url, &uuid, update).await {
+                        Ok(_) => rate_error.set(None),
+                        Err(error) => rate_error.set(Some(format!(
+                            "Could not save playback speed: {error}"
+                        ))),
+                    }
+                });
+            }),
+            on_close: close_sheet_handler(p.sheet),
         }
-        OpenSheet::Bookmarks => {
-            let uuid = p.uuid.clone();
-            let server_url = p.server_url.clone();
-            let file_sig = p.ctx.file_id;
-            rsx! {
-                BookmarksSheet {
-                    bookmarks: p.bookmarks,
-                    chapters: p.chapters.as_ref().clone(),
-                    on_seek: EventHandler::new(move |secs: f64| {
-                        interop::seek(secs);
-                        persist_position(&uuid, *file_sig.peek(), &server_url, secs);
-                        sheet.set(OpenSheet::None);
-                    }),
-                    on_close: close,
-                }
-            }
+    }
+}
+
+fn render_sleep_sheet(p: &SheetProps) -> Element {
+    let chapter_end = p
+        .chapters
+        .get(p.chapter_index)
+        .map(|c| c.start_seconds + c.duration_seconds);
+    let mut sleep_sig = p.ctx.sleep;
+    rsx! {
+        SleepSheet {
+            view: sheets::SleepSheetView {
+                sleep: p.sleep,
+                elapsed: p.elapsed,
+                chapter_end,
+                chapter_no: p.chapter_index + 1,
+            },
+            on_set: EventHandler::new(move |s: SleepState| sleep_sig.set(s)),
+            on_close: close_sheet_handler(p.sheet),
+        }
+    }
+}
+
+fn render_bookmarks_sheet(p: &SheetProps) -> Element {
+    let uuid = p.uuid.clone();
+    let server_url = p.server_url.clone();
+    let file_sig = p.ctx.file_id;
+    let mut sheet = p.sheet;
+    rsx! {
+        BookmarksSheet {
+            bookmarks: p.bookmarks,
+            chapters: p.chapters.as_ref().clone(),
+            on_seek: EventHandler::new(move |secs: f64| {
+                interop::seek(secs);
+                persist_position(&uuid, *file_sig.peek(), &server_url, secs);
+                sheet.set(OpenSheet::None);
+            }),
+            on_close: close_sheet_handler(p.sheet),
         }
     }
 }

--- a/frontend/src/pages/settings/library.rs
+++ b/frontend/src/pages/settings/library.rs
@@ -301,27 +301,87 @@ fn scan_library_handler(
     }
 }
 
+/// Returns the "Refetch Author Pictures" button's `onclick` handler, mirroring
+/// [`scan_library_handler`]'s immediate-disable-then-report shape.
+fn refetch_author_photos_handler(
+    url: String,
+    mut status: Signal<Option<String>>,
+    mut status_is_error: Signal<bool>,
+    mut refetch_in_flight: Signal<bool>,
+) -> impl FnMut(MouseEvent) {
+    move |_evt: MouseEvent| {
+        let url = url.clone();
+        refetch_in_flight.set(true);
+        spawn(async move {
+            match data::refetch_author_photos(&url).await {
+                Ok(()) => {
+                    status.set(Some("Author photo refetch queued.".into()));
+                    status_is_error.set(false);
+                }
+                Err(e) => {
+                    status.set(Some(format!("Failed to start photo refetch: {e}")));
+                    status_is_error.set(true);
+                }
+            }
+            refetch_in_flight.set(false);
+        });
+    }
+}
+
+/// Returns the "Extract Audiobook Chapters" button's `onclick` handler,
+/// mirroring [`scan_library_handler`]'s immediate-disable-then-report shape.
+fn backfill_chapters_handler(
+    url: String,
+    mut status: Signal<Option<String>>,
+    mut status_is_error: Signal<bool>,
+    mut backfill_in_flight: Signal<bool>,
+) -> impl FnMut(MouseEvent) {
+    move |_evt: MouseEvent| {
+        let url = url.clone();
+        backfill_in_flight.set(true);
+        spawn(async move {
+            match data::backfill_chapters(&url).await {
+                Ok(()) => {
+                    status.set(Some("Chapter extraction queued.".into()));
+                    status_is_error.set(false);
+                }
+                Err(e) => {
+                    status.set(Some(format!("Failed to start chapter extraction: {e}")));
+                    status_is_error.set(true);
+                }
+            }
+            backfill_in_flight.set(false);
+        });
+    }
+}
+
 /// Ghost buttons for one-off maintenance jobs (library rescan, author photo
 /// refetch, chapter backfill).
 #[component]
 fn MaintenanceActions(
-    mut status: Signal<Option<String>>,
-    mut status_is_error: Signal<bool>,
+    status: Signal<Option<String>>,
+    status_is_error: Signal<bool>,
     mut refetch_in_flight: Signal<bool>,
     mut backfill_in_flight: Signal<bool>,
     scan_in_flight: Signal<bool>,
     library_refresh: Signal<u32>,
 ) -> Element {
     let server_url = use_server_url();
-    let url_for_refetch = server_url.clone();
-    let url_for_backfill = server_url.clone();
     let on_scan = scan_library_handler(
-        server_url,
+        server_url.clone(),
         status,
         status_is_error,
         scan_in_flight,
         library_refresh,
     );
+    let on_refetch = refetch_author_photos_handler(
+        server_url.clone(),
+        status,
+        status_is_error,
+        refetch_in_flight,
+    );
+    let on_backfill =
+        backfill_chapters_handler(server_url, status, status_is_error, backfill_in_flight);
 
     rsx! {
         button {
@@ -337,24 +397,7 @@ fn MaintenanceActions(
             class: "btn ghost",
             disabled: refetch_in_flight(),
             "data-testid": "refetch-author-photos",
-            onclick: move |_| {
-                let url = url_for_refetch.clone();
-                refetch_in_flight.set(true);
-                spawn(async move {
-                    match data::refetch_author_photos(&url).await {
-                        Ok(()) => {
-                            status.set(Some("Author photo refetch queued.".into()));
-                            status_is_error.set(false);
-                            refetch_in_flight.set(false);
-                        }
-                        Err(e) => {
-                            status.set(Some(format!("Failed to start photo refetch: {e}")));
-                            status_is_error.set(true);
-                            refetch_in_flight.set(false);
-                        }
-                    }
-                });
-            },
+            onclick: on_refetch,
             "Refetch Author Pictures"
         }
         button {
@@ -362,24 +405,7 @@ fn MaintenanceActions(
             class: "btn ghost",
             disabled: backfill_in_flight(),
             "data-testid": "backfill-chapters",
-            onclick: move |_| {
-                let url = url_for_backfill.clone();
-                backfill_in_flight.set(true);
-                spawn(async move {
-                    match data::backfill_chapters(&url).await {
-                        Ok(()) => {
-                            status.set(Some("Chapter extraction queued.".into()));
-                            status_is_error.set(false);
-                            backfill_in_flight.set(false);
-                        }
-                        Err(e) => {
-                            status.set(Some(format!("Failed to start chapter extraction: {e}")));
-                            status_is_error.set(true);
-                            backfill_in_flight.set(false);
-                        }
-                    }
-                });
-            },
+            onclick: on_backfill,
             "Extract Audiobook Chapters"
         }
     }

--- a/server/src/backend/covers.rs
+++ b/server/src/backend/covers.rs
@@ -96,16 +96,13 @@ pub(super) async fn get_thumb(
     headers: HeaderMap,
 ) -> Response {
     tracing::debug!(uuid, size = %size_str, "thumb: request received");
-    let size: db::ThumbSize = match size_str.parse() {
-        Ok(s) => s,
-        Err(_) => {
-            tracing::warn!(uuid, size = %size_str, "thumb: invalid size parameter (400)");
-            return (
-                axum::http::StatusCode::BAD_REQUEST,
-                "invalid size; use sm, md, or lg",
-            )
-                .into_response();
-        }
+    let Some(size) = parse_thumb_size(&size_str) else {
+        tracing::warn!(uuid, size = %size_str, "thumb: invalid size parameter (400)");
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            "invalid size; use sm, md, or lg",
+        )
+            .into_response();
     };
     // uuid → id translation: see the comment in `get_cover` for why we
     // resolve at the edge rather than rewriting the thumbnail pipeline
@@ -132,67 +129,105 @@ pub(super) async fn get_thumb(
         Err(e) => return internal("read last_modified_epoch", e),
     };
 
-    // Cache hit: thumb exists and is fresh. Use async I/O here so a hot
-    // `srcset` grid doesn't pin tokio worker threads on the synchronous read.
-    let thumb_path = db::thumb_path_for(id, size);
-    if !db::thumbs::is_stale_async(id, size, last_modified_epoch).await {
-        if let Ok(bytes) = tokio::fs::read(&thumb_path).await {
-            // Fire-and-forget mtime bump so `evict_if_over_cap` treats this
-            // as recently-used (LRU) instead of evicting frequently-viewed
-            // thumbs just because they're old. Detached via `tokio::spawn`
-            // (never adds latency to this response) but still awaits the
-            // `spawn_blocking` JoinHandle and distinguishes panic from
-            // cancellation, matching the worker's convention
-            // (`handle_generate_thumbs` in db/src/worker/handlers.rs)
-            // instead of silently dropping it.
-            tokio::spawn(async move {
-                if let Err(join_err) =
-                    tokio::task::spawn_blocking(move || db::thumbs::touch_thumb(id, size)).await
-                {
-                    let kind = if join_err.is_panic() {
-                        "panicked"
-                    } else {
-                        "was cancelled"
-                    };
-                    tracing::warn!(error = %join_err, book_id = id, "thumbs: touch_thumb {kind}");
-                }
-            });
-            let etag = content_etag(&bytes);
-            if if_none_match_hits(&headers, &etag) {
-                tracing::debug!(uuid, book_id = id, ?size, "thumb: not modified (304)");
-                return not_modified(&etag);
-            }
-            tracing::debug!(
-                uuid,
-                book_id = id,
-                ?size,
-                bytes = bytes.len(),
-                "thumb: cache hit"
-            );
-            // Same rationale as `get_cover` (#1086): the server regenerates
-            // this WebP as soon as the underlying cover changes
-            // (`invalidate_thumbs`), but a `max-age`-only Cache-Control never
-            // lets the browser notice — it keeps serving its own day-old
-            // copy from the identical URL. `no-cache` + `ETag` make every
-            // reload check back, cheaply, via a 304 when nothing changed.
-            return (
-                [
-                    (header::CONTENT_TYPE, "image/webp"),
-                    (header::CACHE_CONTROL, MEDIA_CACHE_CONTROL),
-                    (header::ETAG, etag.as_str()),
-                    (header::VARY, MEDIA_VARY),
-                    (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
-                ],
-                bytes,
-            )
-                .into_response();
-        }
+    if let Some(resp) =
+        thumb_cache_hit_response(&uuid, id, size, last_modified_epoch, &headers).await
+    {
+        return resp;
     }
 
-    // Cache miss or stale: fetch the original cover first so we only queue
-    // generation when there's actually something to thumbnail. Queuing for
-    // a coverless book just produces a guaranteed `no cover for book …`
-    // worker error on every request, polluting the log.
+    thumb_cache_miss_response(&state, &uuid, id, size, last_modified_epoch).await
+}
+
+/// Parse the `sm`/`md`/`lg` size path segment. `None` on an unrecognized
+/// value; the caller owns logging + building the 400 response (kept out of
+/// this helper so its `Err` isn't a full `Response` — clippy's
+/// `result_large_err`).
+fn parse_thumb_size(size_str: &str) -> Option<db::ThumbSize> {
+    size_str.parse().ok()
+}
+
+/// Cache-hit stage: thumb exists and is fresh. Returns `None` to fall
+/// through to the miss/regenerate path when the file isn't there (stale or
+/// never generated) so the caller doesn't need to duplicate that decision.
+/// Async I/O here so a hot `srcset` grid doesn't pin tokio worker threads on
+/// the synchronous read.
+async fn thumb_cache_hit_response(
+    uuid: &str,
+    id: i64,
+    size: db::ThumbSize,
+    last_modified_epoch: i64,
+    headers: &HeaderMap,
+) -> Option<Response> {
+    if db::thumbs::is_stale_async(id, size, last_modified_epoch).await {
+        return None;
+    }
+    let thumb_path = db::thumb_path_for(id, size);
+    let bytes = tokio::fs::read(&thumb_path).await.ok()?;
+
+    // Fire-and-forget mtime bump so `evict_if_over_cap` treats this as
+    // recently-used (LRU) instead of evicting frequently-viewed thumbs just
+    // because they're old. Detached via `tokio::spawn` (never adds latency
+    // to this response) but still awaits the `spawn_blocking` JoinHandle and
+    // distinguishes panic from cancellation, matching the worker's
+    // convention (`handle_generate_thumbs` in db/src/worker/handlers.rs)
+    // instead of silently dropping it.
+    tokio::spawn(async move {
+        if let Err(join_err) =
+            tokio::task::spawn_blocking(move || db::thumbs::touch_thumb(id, size)).await
+        {
+            let kind = if join_err.is_panic() {
+                "panicked"
+            } else {
+                "was cancelled"
+            };
+            tracing::warn!(error = %join_err, book_id = id, "thumbs: touch_thumb {kind}");
+        }
+    });
+
+    let etag = content_etag(&bytes);
+    if if_none_match_hits(headers, &etag) {
+        tracing::debug!(uuid, book_id = id, ?size, "thumb: not modified (304)");
+        return Some(not_modified(&etag));
+    }
+    tracing::debug!(
+        uuid,
+        book_id = id,
+        ?size,
+        bytes = bytes.len(),
+        "thumb: cache hit"
+    );
+    // Same rationale as `get_cover` (#1086): the server regenerates this
+    // WebP as soon as the underlying cover changes (`invalidate_thumbs`),
+    // but a `max-age`-only Cache-Control never lets the browser notice — it
+    // keeps serving its own day-old copy from the identical URL. `no-cache`
+    // + `ETag` make every reload check back, cheaply, via a 304 when
+    // nothing changed.
+    Some(
+        (
+            [
+                (header::CONTENT_TYPE, "image/webp"),
+                (header::CACHE_CONTROL, MEDIA_CACHE_CONTROL),
+                (header::ETAG, etag.as_str()),
+                (header::VARY, MEDIA_VARY),
+                (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+            ],
+            bytes,
+        )
+            .into_response(),
+    )
+}
+
+/// Cache-miss (or stale) stage: fetch the original cover first so we only
+/// queue generation when there's actually something to thumbnail. Queuing
+/// for a coverless book just produces a guaranteed `no cover for book …`
+/// worker error on every request, polluting the log.
+async fn thumb_cache_miss_response(
+    state: &AppState,
+    uuid: &str,
+    id: i64,
+    size: db::ThumbSize,
+    last_modified_epoch: i64,
+) -> Response {
     match db::get_cover(&state.pool, id).await {
         Ok(Some((mime, bytes))) => {
             tracing::debug!(

--- a/server/src/backend/uploads.rs
+++ b/server/src/backend/uploads.rs
@@ -7,7 +7,7 @@
 //! metadata overrides. Audiobooks accept a single `.m4a`/`.m4b` container or a
 //! set of `.mp3` parts filed together into one folder.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use axum::{
     extract::{multipart::Field, Multipart, State},
@@ -414,7 +414,31 @@ pub(super) async fn post_upload_ebook(
     let root_path = PathBuf::from(&root);
     let dest = library_layout::allocate_canonical_path(&root_path, &author, &title, "epub")
         .map_err(|e| UploadError::internal("allocate_canonical_path", e))?;
-    let dest_for_copy = dest.clone();
+    copy_uploaded_ebook_to_library(&dest, tmp).await?;
+
+    let uuid = match reindex_and_resolve_uploaded_uuid(&state, &root, &root_path, &dest).await {
+        Ok(uuid) => uuid,
+        Err(e) => {
+            // Don't strand a file whose scan or lookup failed.
+            let _ = tokio::fs::remove_file(&dest).await;
+            return Err(e);
+        }
+    };
+
+    // Make the displayed metadata match what the user confirmed.
+    apply_user_edits(&state, &uuid, &form, user.id).await?;
+
+    Ok((StatusCode::CREATED, Json(UploadCommitResult { uuid })).into_response())
+}
+
+/// Copy the streamed-to-tempfile upload to its final canonical `dest`,
+/// creating parent directories as needed. The tempfile is deleted as a side
+/// effect of `tmp` dropping once the blocking closure returns.
+async fn copy_uploaded_ebook_to_library(
+    dest: &Path,
+    tmp: tempfile::NamedTempFile,
+) -> Result<(), UploadError> {
+    let dest_for_copy = dest.to_path_buf();
     tokio::task::spawn_blocking(move || -> std::io::Result<()> {
         if let Some(parent) = dest_for_copy.parent() {
             std::fs::create_dir_all(parent)?;
@@ -431,48 +455,38 @@ pub(super) async fn post_upload_ebook(
             UploadError::LibraryNotWritable
         }
         _ => UploadError::internal("file uploaded ebook", e),
-    })?;
+    })
+}
 
-    // Reindex so the indexer mints the uuid, extracts the cover, and updates
-    // FTS — the single source of truth for inserting books.
+/// Reindex the library so the indexer mints the uuid, extracts the cover,
+/// and updates FTS — the single source of truth for inserting books — then
+/// map the just-placed file back to its row via the durable scan_key.
+async fn reindex_and_resolve_uploaded_uuid(
+    state: &AppState,
+    root: &str,
+    root_path: &Path,
+    dest: &Path,
+) -> Result<String, UploadError> {
     let task_id = state.worker.post(Task::Scan {
-        library_path: root.clone(),
+        library_path: root.to_string(),
     });
     if let TaskOutcome::Err(e) = state.worker.await_completion(task_id).await {
-        // Don't strand a file whose scan failed.
-        let _ = tokio::fs::remove_file(&dest).await;
         return Err(UploadError::internal("reindex after upload", e));
     }
 
-    // Map the file we just placed back to its row via the durable scan_key.
-    // Clean up dest on any failure to avoid orphaning the file on disk.
     let scan_key = dest
-        .strip_prefix(&root_path)
+        .strip_prefix(root_path)
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
-    let uuid_result = db::get_book_uuid_by_scan_key(&state.pool, &root, &scan_key)
+    db::get_book_uuid_by_scan_key(&state.pool, root, &scan_key)
         .await
-        .map_err(|e| UploadError::internal("get_book_uuid_by_scan_key", e))
-        .and_then(|opt| {
-            opt.ok_or_else(|| {
-                UploadError::internal(
-                    "resolve uploaded book",
-                    "reindex did not surface the uploaded file",
-                )
-            })
-        });
-    let uuid = match uuid_result {
-        Ok(uuid) => uuid,
-        Err(e) => {
-            let _ = tokio::fs::remove_file(&dest).await;
-            return Err(e);
-        }
-    };
-
-    // Make the displayed metadata match what the user confirmed.
-    apply_user_edits(&state, &uuid, &form, user.id).await?;
-
-    Ok((StatusCode::CREATED, Json(UploadCommitResult { uuid })).into_response())
+        .map_err(|e| UploadError::internal("get_book_uuid_by_scan_key", e))?
+        .ok_or_else(|| {
+            UploadError::internal(
+                "resolve uploaded book",
+                "reindex did not surface the uploaded file",
+            )
+        })
 }
 
 /// Collect the user's text fields and stream the file field to a tempfile.


### PR DESCRIPTION
## Summary

Per `.claude/rules/05-rust-style.md` § Function shape, extracted named helpers from the 20 functions listed in #1251 that exceeded (or were close to) the ~80-line soft cap. Priority given to the procedural/non-Dioxus outliers, per the issue's own guidance.

**Procedural / non-Dioxus:**
1. `frontend/src/offline/sync.rs` `execute_op` — extracted the largest per-`Op`-variant arms (`SaveProgress`, `SetPlaybackRate`, `SetRating`, `CreateHighlight`, `CreateBookmark`, `CreateShelf`, `CreateJournal`, `UpdateJournal`) into named `exec_*` helpers; small one-liner arms stayed inline in the dispatch match.
2. `frontend/src/pages/listen/bootstrap/js.rs` `dom_reset_js` — **already fixed** (a prior sweep already split it into `transport_controls_js`/`dom_reset_js`/`listeners_js`/`direct_play_init_js`/`hls_init_js`, all well under cap). No change needed.
3. `server/src/backend/covers.rs` `get_thumb` — extracted `parse_thumb_size`, `thumb_cache_hit_response`, `thumb_cache_miss_response`.
4. `db/src/browse.rs` `list_authors` — extracted `list_authors_sql` (SQL builder) and `map_author_row`.
5. `db/src/worker/handlers.rs` `execute` — extracted the two largest inline arms (`Task::Scan`, `Task::RefetchAuthorPhotos`) into `handle_scan`/`handle_refetch_author_photos`, alongside the already-extracted `handle_scan_audiobooks`/`handle_generate_thumbs`.
6. `db/src/audiobook/stat.rs` `stat_audiobook_library` — extracted the tree-walk loop into `walk_audiobook_tree`.
7. `db/src/indexer.rs` `diff_library` — **already fixed** (already delegates to `classify_arrivals`/`collect_departures`/`split_moved`/`sort_buckets`, ~33 lines). No change needed.
8. `db/src/shelves/read/summary.rs` `list_visible_shelves` — extracted `fetch_visible_shelf_rows`, `load_shelf_batches`, `assemble_shelf_summaries`.
9. `server/src/backend/uploads.rs` `post_upload_ebook` — extracted `copy_uploaded_ebook_to_library` and `reindex_and_resolve_uploaded_uuid`.
10. `db/src/deletion/mod.rs` `delete_book_items` — extracted `run_deletion_tx` (the whole `BEGIN IMMEDIATE` transaction stage).
11. `frontend/src/data/books/library.rs` `get_ebooks_page` (mobile-feature) — extracted `first_page_ebooks` and `cursor_page_ebooks`.

**Dioxus components:**
12. `frontend/src/pages/listen/mobile.rs` `render_sheets` — split each `OpenSheet` match arm into its own `render_*_sheet` function, plus a shared `close_sheet_handler`.
13. `frontend/src/pages/settings/mod.rs` `SettingsPage` — **already fixed** (both the web and mobile `#[cfg]` variants are already short; the sidebar was already split into `SettingsSidebar`/`SettingsNavGroup`/`SettingsNavItem`). No change needed.
14. `frontend/src/pages/settings/library.rs` `MaintenanceActions` — extracted `refetch_author_photos_handler` and `backfill_chapters_handler` (mirroring the existing `scan_library_handler` pattern).
15. `frontend/src/components/delete_book_dialog.rs` `render_confirm` — extracted `confirm_labels`/`ConfirmLabels` (all the copy/string-building logic) so the function is just rsx composition.
16. `frontend/src/components/delete_book_dialog.rs` `render_choose` — extracted `choose_labels`/`ChooseLabels`, same pattern.
17. `frontend/src/pages/book_detail/mod.rs` `BookDetailPage` — extracted `use_book_detail_signals` (a custom-hook-style helper bundling every `use_signal` call, called unconditionally so hook order stays fixed per rule 07).
18. `frontend/src/pages/book_detail/mod.rs` `render_book_shell` — extracted `build_merge_pieces` and `build_delete_pieces`.
19. `frontend/src/pages/book_detail/view.rs` `render_loaded` — split the single function (previously branching internally on `#[cfg(feature = "mobile")]`) into two separate full `#[cfg]`-gated function definitions, mirroring the existing `SettingsPage` pattern. This is a cross-platform compile-time split (mobile app vs. web/SSR are different binaries), not an SSR/WASM hydration gate, so rule 07 doesn't apply here — same as `get_ebooks_page` and `SettingsPage` already do.
20. `frontend/src/components/chip_editor.rs` `ChipEditor` — extracted `use_chip_editor_state`/`ChipEditorState`, a custom-hook-style helper bundling the `use_signal` declarations. `SuggestFieldProps`/`SuggestField` in the same file were **not touched** (out of scope, tracked by a different issue).

Closes #1251

## Test plan

- `CARGO_TARGET_DIR=/tmp/... cargo fmt --check` — PASS
- `CARGO_TARGET_DIR=/tmp/... cargo clippy -p omnibus-db -p omnibus -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS (0 warnings)
- `CARGO_TARGET_DIR=/tmp/... cargo test -p omnibus-db` — PASS (1694 passed, 1 failed — pre-existing, unrelated: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` needs `just fixtures`, which this sandbox never ran; confirmed via the panic message and a missing `test_data/audiobooks/public_domain/` directory)
- `CARGO_TARGET_DIR=/tmp/... cargo test -p omnibus` — PASS (641 passed, 2 failed — both pre-existing per the task brief: `commit_rejects_read_only_library_with_400` and its audiobook counterpart, root-uid sandbox artifacts where a chmod-based read-only-fs simulation doesn't apply to root)
- `CARGO_TARGET_DIR=/tmp/... cargo test -p omnibus-frontend --features server` — PASS (617 passed, 0 failed)

This is a pure refactor — no behavior change. Every extracted helper is a straight lift of existing logic into a named function; no logic was altered.

## Version
Unlabeled — patch release (default).

## Notes

- Items 2, 7, and 13 were already fixed by an earlier sweep (presumably #1079 or similar) — confirmed current line counts are well under cap and left untouched.
- Item 20's companion struct/component (`SuggestFieldProps`/`SuggestField`) in the same file is intentionally untouched — tracked separately.
- The sandbox this PR was built in had severe, transient shared-disk contention from concurrent sibling sessions (`No space left on device` linker failures unrelated to this change); test runs were retried after freeing space and all now pass cleanly.


---
_Generated by [Claude Code](https://claude.ai/code/session_014S8Ts6ZqELQenSjFEjvj3B)_