### PR TITLE
feat: iOS library landing — sort control, own shelves, add books

### DIFF
--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -94,12 +94,10 @@ final class LibraryModel {
             group.addTask { @MainActor in
                 for await previews in UserDataService.shelfPreviews().values() {
                     guard self.loadToken == token else { return }
-                    // Only the user's own shelves belong on the landing rail; a
-                    // public shelf from another account is browsable but isn't
-                    // "yours".
-                    self.shelves = previews.filter {
-                        $0.shelf.bookCount > 0 || $0.shelf.kind != .wishlist
-                    }
+                    // Held unfiltered: which of these belong on the rail depends
+                    // on who is signed in, and the identity can confirm after
+                    // this read lands. `railShelves` decides at render.
+                    self.shelves = previews
                 }
             }
         }
@@ -143,6 +141,25 @@ final class LibraryModel {
         isOnline: Bool, isLoading: Bool, isLoadingMore: Bool, hasPaginated: Bool
     ) -> Bool {
         isOnline && !isLoading && !isLoadingMore && !hasPaginated
+    }
+
+    /// What the landing rail shows: your own shelves, minus a wishlist you have
+    /// never put anything on.
+    ///
+    /// `GET /api/shelves` answers with every shelf you are *allowed* to see —
+    /// other people's public ones, and for an admin everyone's. Those are still
+    /// reachable through All; the rail is yours. A nil id means the identity
+    /// hasn't confirmed yet (`setServer` reaches `.ready` before it does), and
+    /// showing the superset for that moment beats blanking a rail that is about
+    /// to be right.
+    nonisolated static func railShelves(
+        _ previews: [ShelfPreview], userId: Int64?
+    ) -> [ShelfPreview] {
+        previews.filter { preview in
+            let isOwn = userId.map { preview.shelf.ownerUserId == $0 } ?? true
+            let isUnusedWishlist = preview.shelf.kind == .wishlist && preview.shelf.bookCount == 0
+            return isOwn && !isUnusedWishlist
+        }
     }
 
     /// Re-reads the first page through the replica cache. `Cache.live` yields
@@ -212,6 +229,11 @@ struct LibraryView: View {
     // different vertical offset, which reads as "a different size" (#1481).
     private let columns = [GridItem(.adaptive(minimum: 112, maximum: 168), spacing: 16, alignment: .top)]
 
+    /// Named so a test can prove it resolves. A misspelt SF Symbol doesn't fail
+    /// to compile or warn — `Image(systemName:)` just draws nothing, so the
+    /// button would ship as an empty circle.
+    static let addGlyph = "plus.viewfinder"
+
     /// The library wears the colour of whatever you're currently reading.
     private var ambientTone: OKLCH? {
         model.resume.first.map { CoverIdentity($0.book).tone }
@@ -279,8 +301,8 @@ struct LibraryView: View {
     }
 
     /// Continue, then shelves, then the collection. Everything else that used
-    /// to sit here — a search pill, an add button, a category strip, a browse
-    /// row — moved to the tab that owns it, so the landing is mostly books.
+    /// to sit here — a search pill, a category strip, a browse row — moved to
+    /// the tab that owns it, so the landing is mostly books.
     private var content: some View {
         ScrollView {
             // Deliberately not a `LazyVStack`: it releases subviews that scroll
@@ -293,7 +315,7 @@ struct LibraryView: View {
                 Masthead(title: "Library") {
                     HStack(spacing: Spacing.sm) {
                         OfflinePill()
-                        filterMenu
+                        addButton
                     }
                 }
 
@@ -301,8 +323,8 @@ struct LibraryView: View {
                     ContinueHero(points: Array(model.resume.prefix(5)))
                 }
 
-                if !model.shelves.isEmpty {
-                    ShelvesRail(previews: Array(model.shelves.prefix(8))) {
+                if !railShelves.isEmpty {
+                    ShelvesRail(previews: Array(railShelves.prefix(8))) {
                         path.append(Destination.shelves)
                     }
                 }
@@ -341,15 +363,56 @@ struct LibraryView: View {
         }
     }
 
+    /// The rail is "your shelves", so it answers to who is signed in as well as
+    /// to what the server returned — and `app.user` can arrive after the read.
+    private var railShelves: [ShelfPreview] {
+        LibraryModel.railShelves(model.shelves, userId: app.user?.id)
+    }
+
+    /// The control sits here rather than in the masthead because this is the
+    /// heading it acts on: sort, direction and category all reshape the grid
+    /// directly below, and the label restates the category it's set to.
     private var sectionHeading: some View {
-        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+        HStack(spacing: Spacing.sm) {
             Text(model.category == .all ? "All books" : model.category.label)
                 .font(.display(24))
                 .foregroundStyle(palette.ink0Color)
 
             Spacer(minLength: 0)
+
+            filterMenu
         }
         .screenPadding()
+    }
+
+    /// Upload or scan, from the screen the new book will land on. The You tab
+    /// keeps its own row into the same sheet — `MainTabView` owns the
+    /// presentation, so both entrances are the one sheet rather than two.
+    ///
+    /// The glyph names both of the sheet's actions: viewfinder brackets are the
+    /// camera affordance the barcode scanner needs to advertise, and the plus
+    /// inside them keeps the upload. A bare plus hid the scanner behind a sheet
+    /// nobody had a reason to open.
+    ///
+    /// The glyph carries the accent while the circle stays neutral: an
+    /// accent-*filled* circle is how `filterMenu` says "a filter is on", and
+    /// two filled circles side by side would read as one state.
+    private var addButton: some View {
+        Button {
+            Haptics.tap()
+            addSheetPresented = true
+        } label: {
+            Image(systemName: Self.addGlyph)
+                .font(.system(size: 17, weight: .regular))
+                .foregroundStyle(palette.accentColor)
+                .frame(width: 32, height: 32)
+                .background(Circle().fill(palette.bg2Color))
+                .overlay(Circle().strokeBorder(palette.line2.color, lineWidth: 0.5))
+        }
+        .buttonStyle(PressableStyle())
+        // Says what the sheet offers, since the glyph now implies a camera and
+        // VoiceOver would otherwise announce only half of it.
+        .accessibilityLabel("Add books by upload or barcode scan")
     }
 
     /// One control for everything that shapes the grid. Sort and format used to

--- a/omnibus-ios/omnibusTests/LibraryShelfRailTests.swift
+++ b/omnibus-ios/omnibusTests/LibraryShelfRailTests.swift
@@ -1,0 +1,98 @@
+//  LibraryShelfRailTests.swift
+//  Which shelves reach the landing rail.
+//
+//  `GET /api/shelves` answers with everything the caller may *see*, not
+//  everything they own — a public shelf from another account, and for an admin
+//  every account's. The rail was rendering that list verbatim, so the shelves
+//  section on the landing screen filled up with other people's.
+
+import Testing
+
+@testable import omnibus
+
+private func preview(
+    id: Int64 = 1, owner: Int64 = 7, kind: ShelfKind = .manual, name: String = "Reread",
+    books: Int64 = 3
+) -> ShelfPreview {
+    ShelfPreview(
+        shelf: ShelfSummary(
+            id: id, ownerUserId: owner, ownerUsername: "owner-\(owner)", kind: kind,
+            name: name, visibility: .public, accent: nil, bookCount: books
+        ),
+        covers: []
+    )
+}
+
+@Suite("Landing shelves rail")
+struct LibraryShelfRailTests {
+    @Test("keeps the signed-in user's own shelves")
+    func keepsOwnShelves() {
+        let mine = preview(id: 1, owner: 7)
+        #expect(LibraryModel.railShelves([mine], userId: 7).map(\.id) == [1])
+    }
+
+    @Test("drops another account's public shelf")
+    func dropsOtherUsersShelves() {
+        // Visible, and browsable behind All — but not "yours", which is what
+        // the rail claims to be.
+        let mine = preview(id: 1, owner: 7)
+        let theirs = preview(id: 2, owner: 9, name: "Someone else's")
+        let rail = LibraryModel.railShelves([mine, theirs], userId: 7)
+        #expect(rail.map(\.id) == [1])
+    }
+
+    @Test("an admin sees only their own, not the whole server's")
+    func dropsEveryOtherAccountForAnAdmin() {
+        // An admin's read carries every account's shelves; the landing screen
+        // is not the place that inventory belongs.
+        let rail = LibraryModel.railShelves(
+            [preview(id: 1, owner: 1), preview(id: 2, owner: 2), preview(id: 3, owner: 3)],
+            userId: 1
+        )
+        #expect(rail.map(\.id) == [1])
+    }
+
+    @Test("drops a wishlist nothing has been added to")
+    func dropsAnEmptyWishlist() {
+        // Every account gets one whether or not it is used, so an unused one is
+        // a card that says nothing.
+        let empty = preview(id: 1, owner: 7, kind: .wishlist, name: "Wishlist", books: 0)
+        #expect(LibraryModel.railShelves([empty], userId: 7).isEmpty)
+    }
+
+    @Test("keeps a wishlist once it holds something")
+    func keepsAStockedWishlist() {
+        let stocked = preview(id: 1, owner: 7, kind: .wishlist, name: "Wishlist", books: 2)
+        #expect(LibraryModel.railShelves([stocked], userId: 7).map(\.id) == [1])
+    }
+
+    @Test("keeps an empty shelf that is not a wishlist")
+    func keepsAnEmptyManualShelf() {
+        // You made it deliberately and are about to fill it; hiding it would
+        // read as the create having failed.
+        let empty = preview(id: 1, owner: 7, kind: .manual, books: 0)
+        #expect(LibraryModel.railShelves([empty], userId: 7).map(\.id) == [1])
+    }
+
+    @Test("shows the superset while the identity is still unconfirmed")
+    func keepsEverythingWhenTheUserIsUnknown() {
+        // `setServer` reaches `.ready` before `confirmIdentity` returns, so the
+        // library can render with no id in hand. Blanking a rail that is about
+        // to be right is worse than briefly showing one shelf too many.
+        let rail = LibraryModel.railShelves(
+            [preview(id: 1, owner: 7), preview(id: 2, owner: 9)], userId: nil
+        )
+        #expect(rail.map(\.id) == [1, 2])
+    }
+
+    @Test("preserves the server's ordering")
+    func preservesOrdering() {
+        // The rail must not reshuffle between loads — same reason the preview
+        // fetch restores the server's order after its task group.
+        let rail = LibraryModel.railShelves(
+            [preview(id: 3, owner: 7), preview(id: 1, owner: 9), preview(id: 2, owner: 7)],
+            userId: 7
+        )
+        #expect(rail.map(\.id) == [3, 2])
+    }
+}

--- a/omnibus-ios/omnibusTests/SymbolNameTests.swift
+++ b/omnibus-ios/omnibusTests/SymbolNameTests.swift
@@ -1,0 +1,21 @@
+//  SymbolNameTests.swift
+//  That the SF Symbols the chrome names actually exist.
+//
+//  `Image(systemName:)` is not checked at compile time and does not warn: a
+//  misspelt or unavailable symbol draws nothing at all, so the failure ships as
+//  a blank control that still takes taps.
+
+import UIKit
+import Testing
+
+@testable import omnibus
+
+@Suite("Named SF Symbols")
+struct SymbolNameTests {
+    @Test("the library's add-books glyph resolves")
+    func addGlyphResolves() {
+        // Carries the sheet's two actions in one mark — viewfinder brackets for
+        // the barcode scanner, a plus for the upload.
+        #expect(UIImage(systemName: LibraryView.addGlyph) != nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Moves the sort/filter control out of the masthead to sit beside the **All books** heading it acts on — sort, direction and category all reshape the grid directly below it.
- Limits the shelves rail to the signed-in user's own shelves. `GET /api/shelves` answers with every shelf the caller may *see* — other people's public ones, and for an admin everyone's — so the rail was rendering strangers' shelves. They stay reachable behind **All**.
- Adds an add-books button to the masthead, opening the same `AddBooksSheet` the You tab presents. `MainTabView` already owned the sheet and passed the binding in; nothing set it.

The rail filter is deliberately three-valued on identity: a nil user id (reachable — `setServer` hits `.ready` before `confirmIdentity` returns) shows the superset rather than blanking a rail that is about to be right.

## Test plan
- [x] `just ios-test` — full suite green; 9 new tests (8 rail-filter cases covering own/other/admin, empty vs stocked wishlist, unknown identity and ordering; 1 asserting the SF Symbol resolves, since a misspelt `systemName` draws nothing and ships as a blank control).
- [x] Simulator, with a second account holding a public shelf: rail shows only the signed-in user's shelf; **All** still lists all four.
- [x] Simulator: sort menu opens and applies from its new position; add-books button opens the sheet.

## Version
By default a merge to `main` cuts a patch release.
- [ ] **Minor**
- [x] **Patch** — the default.
- [ ] **No release**