### PR TITLE
refactor: group Dioxus component props and key data-driven loops (#853)

### DIFF
--- a/frontend/src/pages/auth/login.rs
+++ b/frontend/src/pages/auth/login.rs
@@ -170,19 +170,44 @@ pub fn LoginPage() -> Element {
     out
 }
 
+/// Props for the [`MobileLoginForm`] component — mirrors [`LoginFormProps`]
+/// (the web path already groups the same fields) with `host` added and
+/// `keep_signed_in` dropped, since the mobile design omits that control.
+#[cfg(feature = "mobile")]
+#[derive(Props, Clone, PartialEq)]
+struct MobileLoginFormProps {
+    /// Host the login targets, shown in the connected-to bar.
+    host: String,
+    /// Username input value, shared with the parent.
+    username: Signal<String>,
+    /// Password input value, shared with the parent.
+    password: Signal<String>,
+    /// Current submission error, if any.
+    error: Signal<Option<String>>,
+    /// True while a login request is in flight.
+    submitting: Signal<bool>,
+    /// Whether self-registration is open; `None` until the probe answers.
+    registration_open: Signal<Option<bool>>,
+    /// Fired on form submission (submit-button click or Enter).
+    on_submit: EventHandler<FormEvent>,
+    /// Fired on Enter keydown in either input.
+    on_keydown: EventHandler<Event<KeyboardData>>,
+}
+
 /// Mobile login body: connected-server bar plus the credentials form.
 #[cfg(feature = "mobile")]
 #[component]
-fn MobileLoginForm(
-    host: String,
-    mut username: Signal<String>,
-    mut password: Signal<String>,
-    error: Signal<Option<String>>,
-    submitting: Signal<bool>,
-    registration_open: Signal<Option<bool>>,
-    on_submit: EventHandler<FormEvent>,
-    on_keydown: EventHandler<Event<KeyboardData>>,
-) -> Element {
+fn MobileLoginForm(props: MobileLoginFormProps) -> Element {
+    let MobileLoginFormProps {
+        host,
+        mut username,
+        mut password,
+        error,
+        submitting,
+        registration_open,
+        on_submit,
+        on_keydown,
+    } = props;
     let nav = use_navigator();
     rsx! {
         // Connected-to bar: shows which server this login targets, with a

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -310,7 +310,7 @@ fn author_body(series_groups: SeriesGroups, standalone: Vec<EbookMetadata>) -> E
     rsx! {
         div { class: "disc-body",
             for (series_name, series_id, books) in series_groups.into_iter() {
-                div { class: "disc-section",
+                div { key: "{series_id}-{series_name}", class: "disc-section",
                     div { class: "disc-section-head",
                         span { class: "label", "Series" }
                         if series_id > 0 {

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -395,7 +395,7 @@ pub(super) fn BdRailSection(
                 div { class: "divider" }
                 div { class: "label bd-rail-head", "Activity · last 22 days" }
                 div { class: "bd-activity-bar", aria_hidden: "true",
-                    for _ in 0..22u32 { i { class: "bd-activity-tick" } }
+                    for tick_idx in 0..22u32 { i { key: "{tick_idx}", class: "bd-activity-tick" } }
                 }
                 div { class: "bd-activity-axis mono",
                     span { "3wk ago" }

--- a/frontend/src/pages/book_detail/export_menu.rs
+++ b/frontend/src/pages/book_detail/export_menu.rs
@@ -43,10 +43,33 @@ pub(super) fn BdExportMenu(
                     "data-testid": "hero-export-scrim",
                     onclick: move |_| open.set(false),
                 }
-                BdExportPanel { uuid, has_ebook, has_audio, book_author, book_title, epub_size_bytes, open }
+                BdExportPanel {
+                    ctx: BdExportContext {
+                        uuid,
+                        has_ebook,
+                        has_audio,
+                        book_author,
+                        book_title,
+                        epub_size_bytes,
+                    },
+                    open,
+                }
             }
         }
     }
+}
+
+/// The uuid, available formats, author/title (for Send-to-Kindle/Kobo
+/// filenames), and EPUB size gating the oversize-email fallback. Grouped so
+/// [`BdExportPanel`] stays under the prop cap.
+#[derive(Clone, PartialEq)]
+struct BdExportContext {
+    uuid: String,
+    has_ebook: bool,
+    has_audio: bool,
+    book_author: String,
+    book_title: String,
+    epub_size_bytes: Option<i64>,
 }
 
 /// The open dropdown body. Split out so `onmounted` can focus it (so ESC
@@ -56,15 +79,15 @@ pub(super) fn BdExportMenu(
 /// this is a scrim-dismissed popover with plain links/buttons, not an ARIA
 /// menu with roving-tabindex / arrow-key navigation.
 #[component]
-fn BdExportPanel(
-    uuid: String,
-    has_ebook: bool,
-    has_audio: bool,
-    book_author: String,
-    book_title: String,
-    epub_size_bytes: Option<i64>,
-    open: Signal<bool>,
-) -> Element {
+fn BdExportPanel(ctx: BdExportContext, open: Signal<bool>) -> Element {
+    let BdExportContext {
+        uuid,
+        has_ebook,
+        has_audio,
+        book_author,
+        book_title,
+        epub_size_bytes,
+    } = ctx;
     let mut open = open;
     let on_keydown = move |evt: Event<KeyboardData>| {
         if evt.key() == Key::Escape {

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -14,7 +14,7 @@ use super::bookmarks_drawer::BookmarksDrawer;
 use super::chapter_nav::{chapter_index_for_elapsed, chapter_next_target, chapter_prev_target};
 use super::chapters_drawer::ChaptersDrawer;
 use super::overlays::{FailedOverlay, PreparingOverlay};
-use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep, SleepChoice};
+use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep};
 use super::sleep_panel::{SleepPanel, SleepPanelState};
 use super::speed_panel::SpeedPanel;
 use super::stage::{
@@ -139,11 +139,14 @@ pub(super) fn ReadyPlayer(
     // Reactive sleep-timer reads — re-render the toolbar label + panel live.
     let sleep_remaining = (sleep.remaining)();
     let sleep_active = matches!(sleep_remaining, Some(s) if s > 0);
-    let sleep_display = SleepDisplay {
+    let sleep_state = SleepPanelState {
         remaining: sleep_remaining,
         choice: (sleep.choice)(),
         fade: (sleep.fade)(),
         has_chapters: !chs.is_empty(),
+        on_select: EventHandler::new(on_sleep_select),
+        on_end_of_chapter: EventHandler::new(on_sleep_end_of_chapter),
+        on_toggle_fade: EventHandler::new(on_sleep_toggle_fade),
     };
     let bookmark_toast = (bookmarks.toast)();
     let current_user = crate::use_current_user_summary();
@@ -162,38 +165,64 @@ pub(super) fn ReadyPlayer(
             }
 
             PlayerStageBinding {
-                book: book.clone(),
-                title,
-                author,
+                book_meta: BookMeta { book: book.clone(), title, author },
                 signals,
                 panes,
-                chapters,
-                current_chapter_index,
-                sleep_active: sleep_active || sleep_panel_open(),
-                sleep_label: sleep_toolbar_label(sleep_remaining),
-                on_chapter_seek: EventHandler::new(on_chapter_seek),
+                chapter_state: ChapterSignals {
+                    chapters,
+                    current_chapter_index,
+                    on_chapter_seek: EventHandler::new(on_chapter_seek),
+                },
+                sleep_toolbar: SleepToolbarState {
+                    active: sleep_active || sleep_panel_open(),
+                    label: sleep_toolbar_label(sleep_remaining),
+                },
             }
 
             PlayerOverlays {
                 panes,
-                uuid: uuid.clone(),
-                rate,
-                rate_error,
-                user_id,
-                sleep_display,
-                bookmarks,
-                bookmark_toast,
-                chapters: chs.clone(),
-                current_chapter_index: ch_idx,
-                elapsed: elapsed(),
-                on_chapter_seek: EventHandler::new(on_chapter_seek),
-                on_sleep_select: EventHandler::new(on_sleep_select),
-                on_sleep_end_of_chapter: EventHandler::new(on_sleep_end_of_chapter),
-                on_sleep_toggle_fade: EventHandler::new(on_sleep_toggle_fade),
-                on_bookmark_add: EventHandler::new(on_bookmark_add),
+                speed: SpeedPanelData { rate, rate_error, user_id, uuid: uuid.clone() },
+                sleep_state,
+                bookmark: BookmarkPanelData {
+                    controller: bookmarks,
+                    toast: bookmark_toast,
+                    on_add: EventHandler::new(on_bookmark_add),
+                },
+                chapter_nav: ChapterNavData {
+                    chapters: chs.clone(),
+                    current_chapter_index: ch_idx,
+                    elapsed: elapsed(),
+                    on_seek: EventHandler::new(on_chapter_seek),
+                },
             }
         }
     }
+}
+
+/// Book identity fields for [`PlayerStageBinding`]'s content pane. Grouped
+/// so the binding component stays under the prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct BookMeta {
+    pub book: EbookMetadata,
+    pub title: String,
+    pub author: String,
+}
+
+/// Chapter list, derived current-chapter index, and the shared seek handler.
+/// Grouped so [`PlayerStageBinding`] stays under the prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct ChapterSignals {
+    pub chapters: Signal<Vec<ChapterInfo>>,
+    pub current_chapter_index: Memo<usize>,
+    pub on_chapter_seek: EventHandler<f64>,
+}
+
+/// Sleep-toolbar badge state: lit or not, and its countdown/preset label.
+/// Grouped so [`PlayerStageBinding`] stays under the prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct SleepToolbarState {
+    pub active: bool,
+    pub label: String,
 }
 
 /// Assemble the transport + toolbar handlers and derived display values, then
@@ -201,17 +230,27 @@ pub(super) fn ReadyPlayer(
 /// the mutually-exclusive toolbar toggles.
 #[component]
 pub(super) fn PlayerStageBinding(
-    book: EbookMetadata,
-    title: String,
-    author: String,
+    book_meta: BookMeta,
     signals: PlaybackSignals,
     panes: OverlayPanes,
-    chapters: Signal<Vec<ChapterInfo>>,
-    current_chapter_index: Memo<usize>,
-    sleep_active: bool,
-    sleep_label: String,
-    on_chapter_seek: EventHandler<f64>,
+    chapter_state: ChapterSignals,
+    sleep_toolbar: SleepToolbarState,
 ) -> Element {
+    let BookMeta {
+        book,
+        title,
+        author,
+    } = book_meta;
+    let ChapterSignals {
+        chapters,
+        current_chapter_index,
+        on_chapter_seek,
+    } = chapter_state;
+    let SleepToolbarState {
+        active: sleep_active,
+        label: sleep_label,
+    } = sleep_toolbar;
+
     let duration = signals.duration;
     let elapsed = signals.elapsed;
     let playing = signals.playing;
@@ -332,42 +371,70 @@ pub(super) struct OverlayPanes {
     pub chapters_open: Signal<bool>,
 }
 
-/// Reactive sleep-timer values rendered by the sleep panel.
-#[derive(Copy, Clone, PartialEq)]
-pub(super) struct SleepDisplay {
-    pub remaining: Option<i32>,
-    pub choice: SleepChoice,
-    pub fade: bool,
-    pub has_chapters: bool,
+/// Rate + user context needed to open [`SpeedPanel`] — mirrors that panel's
+/// own prop list (minus `on_close`). Grouped so [`PlayerOverlays`] stays
+/// under the prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct SpeedPanelData {
+    pub rate: Signal<f64>,
+    pub rate_error: Signal<Option<String>>,
+    pub user_id: Option<i64>,
+    pub uuid: String,
+}
+
+/// Bookmark controller, pending save-toast, and the "add bookmark" handler.
+/// Grouped so [`PlayerOverlays`] stays under the prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct BookmarkPanelData {
+    pub controller: super::bookmarks::BookmarksController,
+    pub toast: Option<super::bookmarks::BookmarkToast>,
+    pub on_add: EventHandler<()>,
+}
+
+/// Chapter list, current position, and the seek handler shared by the
+/// bookmarks/chapters drawers. Grouped so [`PlayerOverlays`] stays under the
+/// prop cap.
+#[derive(Clone, PartialEq)]
+pub(super) struct ChapterNavData {
+    pub chapters: Vec<ChapterInfo>,
+    pub current_chapter_index: usize,
+    pub elapsed: f64,
+    pub on_seek: EventHandler<f64>,
 }
 
 /// The four toolbar-toggled surfaces plus the bookmark-saved toast. Each
 /// renders only when its backing open-signal (or toast option) is set. Sleep
-/// mutations arrive as `EventHandler`s so the non-`PartialEq` `SleepController`
-/// stays out of props.
+/// mutations arrive inside `sleep_state` as `EventHandler`s so the
+/// non-`PartialEq` `SleepController` stays out of props.
 #[component]
 pub(super) fn PlayerOverlays(
     panes: OverlayPanes,
-    uuid: String,
-    rate: Signal<f64>,
-    rate_error: Signal<Option<String>>,
-    user_id: Option<i64>,
-    sleep_display: SleepDisplay,
-    bookmarks: super::bookmarks::BookmarksController,
-    bookmark_toast: Option<super::bookmarks::BookmarkToast>,
-    chapters: Vec<ChapterInfo>,
-    current_chapter_index: usize,
-    elapsed: f64,
-    on_chapter_seek: EventHandler<f64>,
-    on_sleep_select: EventHandler<i32>,
-    on_sleep_end_of_chapter: EventHandler<()>,
-    on_sleep_toggle_fade: EventHandler<()>,
-    on_bookmark_add: EventHandler<()>,
+    speed: SpeedPanelData,
+    sleep_state: SleepPanelState,
+    bookmark: BookmarkPanelData,
+    chapter_nav: ChapterNavData,
 ) -> Element {
     let mut speed_panel_open = panes.speed_panel_open;
     let mut sleep_panel_open = panes.sleep_panel_open;
     let mut bookmarks_open = panes.bookmarks_open;
     let mut chapters_open = panes.chapters_open;
+    let SpeedPanelData {
+        rate,
+        rate_error,
+        user_id,
+        uuid,
+    } = speed;
+    let BookmarkPanelData {
+        controller: bookmarks,
+        toast: bookmark_toast,
+        on_add: on_bookmark_add,
+    } = bookmark;
+    let ChapterNavData {
+        chapters,
+        current_chapter_index,
+        elapsed,
+        on_seek: on_chapter_seek,
+    } = chapter_nav;
     rsx! {
         if speed_panel_open() {
             SpeedPanel {
@@ -380,15 +447,7 @@ pub(super) fn PlayerOverlays(
         }
         if sleep_panel_open() {
             SleepPanel {
-                state: SleepPanelState {
-                    remaining: sleep_display.remaining,
-                    choice: sleep_display.choice,
-                    fade: sleep_display.fade,
-                    has_chapters: sleep_display.has_chapters,
-                    on_select: EventHandler::new(move |secs: i32| on_sleep_select.call(secs)),
-                    on_end_of_chapter: EventHandler::new(move |_| on_sleep_end_of_chapter.call(())),
-                    on_toggle_fade: EventHandler::new(move |_| on_sleep_toggle_fade.call(())),
-                },
+                state: sleep_state,
                 on_close: move |_| sleep_panel_open.set(false),
             }
         }

--- a/frontend/src/pages/settings/library.rs
+++ b/frontend/src/pages/settings/library.rs
@@ -69,12 +69,14 @@ pub fn LibraryLocationSection() -> Element {
                 div { class: "settings-actions",
                     button { r#type: "submit", class: "btn", "Save" }
                     MaintenanceActions {
-                        status,
-                        status_is_error,
-                        refetch_in_flight,
-                        backfill_in_flight,
-                        scan_in_flight,
-                        library_refresh,
+                        io: MaintenanceIo {
+                            status,
+                            status_is_error,
+                            refetch_in_flight,
+                            backfill_in_flight,
+                            scan_in_flight,
+                            library_refresh,
+                        },
                     }
                 }
             }
@@ -355,17 +357,30 @@ fn backfill_chapters_handler(
     }
 }
 
+/// Shared status line plus each maintenance job's own in-flight flag.
+/// Grouped so [`MaintenanceActions`] stays under the prop cap.
+#[derive(Copy, Clone, PartialEq)]
+struct MaintenanceIo {
+    status: Signal<Option<String>>,
+    status_is_error: Signal<bool>,
+    refetch_in_flight: Signal<bool>,
+    backfill_in_flight: Signal<bool>,
+    scan_in_flight: Signal<bool>,
+    library_refresh: Signal<u32>,
+}
+
 /// Ghost buttons for one-off maintenance jobs (library rescan, author photo
 /// refetch, chapter backfill).
 #[component]
-fn MaintenanceActions(
-    status: Signal<Option<String>>,
-    status_is_error: Signal<bool>,
-    mut refetch_in_flight: Signal<bool>,
-    mut backfill_in_flight: Signal<bool>,
-    scan_in_flight: Signal<bool>,
-    library_refresh: Signal<u32>,
-) -> Element {
+fn MaintenanceActions(io: MaintenanceIo) -> Element {
+    let MaintenanceIo {
+        status,
+        status_is_error,
+        refetch_in_flight,
+        backfill_in_flight,
+        scan_in_flight,
+        library_refresh,
+    } = io;
     let server_url = use_server_url();
     let on_scan = scan_library_handler(
         server_url.clone(),

--- a/frontend/src/pages/settings/smtp.rs
+++ b/frontend/src/pages/settings/smtp.rs
@@ -49,11 +49,15 @@ pub fn SmtpConfigField() -> Element {
                 configured,
                 in_flight: io.in_flight,
                 status: st,
-                msg: io.msg,
-                msg_is_error: io.msg_is_error,
-                on_save: EventHandler::new(on_save),
-                on_test: EventHandler::new(on_test),
-                on_clear: EventHandler::new(on_clear),
+                message: SmtpStatusMessage {
+                    msg: io.msg,
+                    msg_is_error: io.msg_is_error,
+                },
+                actions: SmtpActionHandlers {
+                    on_save: EventHandler::new(on_save),
+                    on_test: EventHandler::new(on_test),
+                    on_clear: EventHandler::new(on_clear),
+                },
             }
         }
     }
@@ -320,6 +324,23 @@ fn SmtpConnectionFields(fields: SmtpFields, configured: bool) -> Element {
     }
 }
 
+/// Save/test status-line signals. Grouped so [`SmtpTestActions`] stays under
+/// the prop cap.
+#[derive(Copy, Clone, PartialEq)]
+struct SmtpStatusMessage {
+    msg: Signal<Option<String>>,
+    msg_is_error: Signal<bool>,
+}
+
+/// Save / send-test / clear handlers. Grouped so [`SmtpTestActions`] stays
+/// under the prop cap.
+#[derive(Copy, Clone, PartialEq)]
+struct SmtpActionHandlers {
+    on_save: EventHandler<MouseEvent>,
+    on_test: EventHandler<MouseEvent>,
+    on_clear: EventHandler<MouseEvent>,
+}
+
 /// Save / send-test / clear buttons, the configured-state line, and the
 /// save/test status message.
 #[component]
@@ -327,12 +348,15 @@ fn SmtpTestActions(
     configured: bool,
     in_flight: Signal<bool>,
     status: Option<SmtpConfigStatus>,
-    msg: Signal<Option<String>>,
-    msg_is_error: Signal<bool>,
-    on_save: EventHandler<MouseEvent>,
-    on_test: EventHandler<MouseEvent>,
-    on_clear: EventHandler<MouseEvent>,
+    message: SmtpStatusMessage,
+    actions: SmtpActionHandlers,
 ) -> Element {
+    let SmtpStatusMessage { msg, msg_is_error } = message;
+    let SmtpActionHandlers {
+        on_save,
+        on_test,
+        on_clear,
+    } = actions;
     rsx! {
         div { class: "settings-actions",
             button {


### PR DESCRIPTION
## Summary
- Regroup the remaining over-5-prop Dioxus components into props structs, mirroring existing patterns (`LoginFormProps`, `ReaderPanelSignals`, `OverlayPanes`):
  - `frontend/src/pages/listen/ready_player.rs` — `PlayerOverlays` (was 16 props) now takes `panes`/`speed: SpeedPanelData`/`sleep_state: SleepPanelState`/`bookmark: BookmarkPanelData`/`chapter_nav: ChapterNavData` (5).
  - `frontend/src/pages/listen/ready_player.rs` — `PlayerStageBinding` (was 10 props) now takes `book_meta: BookMeta`/`signals`/`panes`/`chapter_state: ChapterSignals`/`sleep_toolbar: SleepToolbarState` (5).
  - `frontend/src/pages/settings/smtp.rs` — `SmtpTestActions` (was 8 params) now takes `configured`/`in_flight`/`status`/`message: SmtpStatusMessage`/`actions: SmtpActionHandlers` (5), joining the file's existing `SmtpIo`-family pattern.
  - `frontend/src/pages/auth/login.rs` — `MobileLoginForm` (was 8 params) now takes a `MobileLoginFormProps` struct, mirroring the web path's existing `LoginFormProps`.
  - `frontend/src/pages/book_detail/export_menu.rs` — `BdExportPanel` (was 7 props) now takes `ctx: BdExportContext`/`open` (2).
  - `frontend/src/pages/settings/library.rs` — `MaintenanceActions` (was 6 params) now takes a single `io: MaintenanceIo` struct.

  Note: the issue text cited `MaintenanceActions` as living in `frontend/src/pages/settings/mod.rs`; it's actually in `frontend/src/pages/settings/library.rs` (issue was filed against a slightly earlier commit — the settings module was later split). **Heads up for whoever reviews/merges second**: a sibling PR for #959 also touches `settings/library.rs` (adding an "Export all OPF" admin button in a different section of the same file) — whichever of the two merges second will need a quick rebase.

  `frontend/src/pages/landing/table/cells.rs`'s `RowScalarCell` was already grouped into `display`/`field`/`ctx` (3 props) on `main` — no change needed there.

- Add missing `key:` to two data-driven `for` loops:
  - `frontend/src/pages/author.rs` — `author_body`'s outer per-series-group loop now keys on `"{series_id}-{series_name}"` (series name is guaranteed unique within the grouping, `series_id` alone can collide across multiple series that lack a resolved id — the combination satisfies "key by series_id" while staying collision-free).
  - `frontend/src/pages/book_detail/body.rs` — the decorative 22-tick activity-bar placeholder now keys on its loop index (fixed-count, content-identical, `aria-hidden` — an index key is fine here per the issue).

No behavior or markup changes — purely prop-list/struct restructuring and loop keys.

Closes #853

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --features web --target wasm32-unknown-unknown --all-targets -- -D warnings` — could not run: the `wasm32-unknown-unknown` target isn't installed in this sandbox (`error[E0463]: can't find crate for core`). Fell back to the instructed alternative:
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS (0 warnings after fixing two `unused_mut` hits in the `MaintenanceIo` destructure)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (621 passed; 0 failed; 0 ignored)

## Version
- [x] **Patch** — the default; unlabeled.

## Notes
- Purely structural: every prop struct groups fields that were already threaded together end-to-end, so call sites just wrap the same values in a literal. No `#[cfg(feature = "web"/"mobile"/"server")]` gates were added around any rsx (hydration parity preserved per rule 07).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VcuRz7FVMcMQtDtuaipEtD)_