### PR TITLE
refactor: cover comic reader gaps and split oversized component (#1613)

### DIFF
--- a/db/src/comic/tests.rs
+++ b/db/src/comic/tests.rs
@@ -1,6 +1,9 @@
 //! Unit tests for the CBZ comic-archive parser: page listing + natural
-//! sort, `ComicInfo.xml` mapping, filename fallback, and the malformed-
-//! archive failure modes (not a zip, zero pages).
+//! sort, `ComicInfo.xml` mapping, filename fallback, the malformed-archive
+//! failure modes (not a zip, zero pages), and `page_count_for_book`'s
+//! three outcomes (real archive, no CBZ file, unreadable archive).
+
+use sqlx::SqlitePool;
 
 use super::*;
 use crate::test_support::{build_stored_zip, make_test_dir};
@@ -355,4 +358,100 @@ fn is_comic_path_matches_cbz_case_insensitively() {
     assert!(is_comic_path(std::path::Path::new("a/b.CBZ")));
     assert!(!is_comic_path(std::path::Path::new("a/b.epub")));
     assert!(!is_comic_path(std::path::Path::new("cbz")));
+}
+
+/// Seed one book whose `book_files` CBZ row resolves (via `book_file_path`)
+/// to `<lib>/sub/book.cbz`, writing `bytes` there. Mirrors
+/// `test_support::seed_epub_book_at`'s shape for the CBZ format
+/// `page_count_for_book` reads. Returns the new `books.id`.
+async fn seed_cbz_book_at(pool: &SqlitePool, lib: &std::path::Path, bytes: &[u8]) -> i64 {
+    let lib_str = lib.to_string_lossy().to_string();
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(&lib_str)
+        .execute(pool)
+        .await
+        .unwrap();
+    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM scan_roots WHERE path = ?")
+        .bind(&lib_str)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title) \
+         VALUES ('uuid-cbz', 'sub/book.cbz', ?, 'sub', 'Title') RETURNING id",
+    )
+    .bind(lib_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch) \
+         VALUES (?, 'CBZ', 'book', ?, 1)",
+    )
+    .bind(book_id)
+    .bind(bytes.len() as i64)
+    .execute(pool)
+    .await
+    .unwrap();
+    std::fs::create_dir_all(lib.join("sub")).unwrap();
+    std::fs::write(lib.join("sub").join("book.cbz"), bytes).unwrap();
+    book_id
+}
+
+#[tokio::test]
+async fn page_count_for_book_counts_pages_in_a_real_cbz() {
+    let dir = make_test_dir("comic-page-count-happy");
+    let bytes = build_stored_zip(&[("p1.jpg", b"one"), ("p2.jpg", b"two"), ("p3.jpg", b"three")]);
+    let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
+    let book_id = seed_cbz_book_at(&pool, &dir, &bytes).await;
+
+    let count = page_count_for_book(&pool, book_id).await;
+
+    assert_eq!(count, Some(3));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn page_count_for_book_returns_none_when_book_has_no_cbz_file() {
+    let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM scan_roots WHERE path = '/lib'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    // Book row exists but carries no `book_files` row of any format, let
+    // alone CBZ — `book_file_path` resolves to `None` and the count must
+    // read as "no count", not an error.
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title) \
+         VALUES ('uuid-nofile', 'sub/book', ?, 'sub', 'Title') RETURNING id",
+    )
+    .bind(lib_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let count = page_count_for_book(&pool, book_id).await;
+
+    assert_eq!(count, None);
+}
+
+#[tokio::test]
+async fn page_count_for_book_returns_none_when_archive_is_unreadable() {
+    let dir = make_test_dir("comic-page-count-unreadable");
+    // `book_files` points at a file that isn't a valid zip — the archive
+    // open fails inside the blocking task, and that must degrade to `None`
+    // rather than propagate an error into the detail read.
+    let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
+    let book_id = seed_cbz_book_at(&pool, &dir, b"not a zip").await;
+
+    let count = page_count_for_book(&pool, book_id).await;
+
+    assert_eq!(count, None);
+
+    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/frontend/src/pages/comic_reader.rs
+++ b/frontend/src/pages/comic_reader.rs
@@ -82,8 +82,78 @@ fn apply_bootstrap_outcome(
     }
 }
 
+/// Resolve a comic's metadata and saved position for the bootstrap effect:
+/// `get_ebook`, then (when found) `get_progress` to resolve the starting
+/// page via [`start_page`]. `None` on a missing book or a fetch failure —
+/// the caller ([`apply_bootstrap_outcome`]) turns that into the error state.
+async fn fetch_bootstrap(server_url: &str, uuid: &str) -> Option<(EbookMetadata, usize)> {
+    let book = match data::get_ebook(server_url, uuid).await {
+        Ok(Some(book)) => book,
+        Ok(None) | Err(_) => return None,
+    };
+    let count = book.page_count.unwrap_or(0).max(0) as usize;
+    let saved = data::get_progress(server_url, uuid, ProgressFormat::Epub)
+        .await
+        .ok()
+        .flatten();
+    let start = saved
+        .map(|r| start_page(r.epub_cfi.as_deref(), r.progress_percent, count))
+        .unwrap_or(0);
+    Some((book, start))
+}
+
+/// Build the progress-save payload for landing on `page` of `count` pages —
+/// shared by `goto`'s persist call so the field list can't drift from
+/// [`comic_percent`]/`comic_page_anchor`.
+fn progress_update_for_page(uuid: &str, page: usize, count: usize) -> ProgressUpdate {
+    ProgressUpdate {
+        book_uuid: uuid.to_string(),
+        format: ProgressFormat::Epub,
+        epub_cfi: Some(comic_page_anchor(page)),
+        audio_position_seconds: None,
+        progress_percent: Some(comic_percent(page, count)),
+        kobo_location: None,
+        book_file_id: None,
+        client_updated_at: None,
+    }
+}
+
+/// Pre-derived, ready-to-render chrome values for one paint — kept in one
+/// struct (the `RowDisplay` pattern in `pages/landing/table/row.rs`) so
+/// `ComicReadPage`'s body reads declaratively instead of deriving several
+/// locals inline.
+struct PagerDisplay {
+    title: String,
+    author: String,
+    count: usize,
+    pct: i64,
+}
+
+impl PagerDisplay {
+    fn from_state(meta: Option<&EbookMetadata>, current: usize) -> Self {
+        let count = meta.and_then(|m| m.page_count).unwrap_or(0).max(0) as usize;
+        Self {
+            title: meta.map(|m| m.display_title()).unwrap_or_default(),
+            author: meta
+                .and_then(|m| m.creators.first().map(|c| c.name.clone()))
+                .unwrap_or_default(),
+            count,
+            pct: if count == 0 {
+                0
+            } else {
+                comic_percent(current, count)
+            },
+        }
+    }
+}
+
 /// The full-page comic pager: top bar (back, title, fit modes), the image
 /// stage with edge page-turn buttons, and a footer slider + page label.
+/// Over the line cap by design: three hooks (session tracking, auto
+/// read-status, the bootstrap effect) must run unconditionally before a
+/// large declarative rsx! tree mirroring the pager's layout — splitting
+/// further would only thread the same signals through another component
+/// boundary, the same shape as `BdCtaRow` in `pages/book_detail/hero.rs`.
 #[component]
 pub fn ComicReadPage(uuid: String) -> Element {
     let server_url = use_server_url();
@@ -136,31 +206,11 @@ pub fn ComicReadPage(uuid: String) -> Element {
             error.set(false);
             let server_url = server_url.clone();
             spawn(async move {
-                let outcome = match data::get_ebook(&server_url, &uuid).await {
-                    Ok(Some(book)) => {
-                        let count = book.page_count.unwrap_or(0).max(0) as usize;
-                        let saved = data::get_progress(&server_url, &uuid, ProgressFormat::Epub)
-                            .await
-                            .ok()
-                            .flatten();
-                        let start = saved
-                            .map(|r| start_page(r.epub_cfi.as_deref(), r.progress_percent, count))
-                            .unwrap_or(0);
-                        Some((book, start))
-                    }
-                    Ok(None) | Err(_) => None,
-                };
+                let outcome = fetch_bootstrap(&server_url, &uuid).await;
                 apply_bootstrap_outcome(outcome, my_load, load_seq, meta, error, page);
             });
         }));
     }
-
-    let count = meta
-        .read()
-        .as_ref()
-        .and_then(|m| m.page_count)
-        .unwrap_or(0)
-        .max(0) as usize;
 
     // Shared page-turn entry point: clamp, render, persist. Every control
     // (buttons, slider, arrow keys) funnels through here so a position is
@@ -183,16 +233,7 @@ pub fn ComicReadPage(uuid: String) -> Element {
                 return;
             }
             page.set(clamped);
-            let update = ProgressUpdate {
-                book_uuid: uuid.clone(),
-                format: ProgressFormat::Epub,
-                epub_cfi: Some(comic_page_anchor(clamped)),
-                audio_position_seconds: None,
-                progress_percent: Some(comic_percent(clamped, count)),
-                kobo_location: None,
-                book_file_id: None,
-                client_updated_at: None,
-            };
+            let update = progress_update_for_page(&uuid, clamped, count);
             let server_url = server_url.clone();
             spawn(async move {
                 // Best-effort, like the EPUB reader's relocate save: a failed
@@ -214,26 +255,23 @@ pub fn ComicReadPage(uuid: String) -> Element {
     };
 
     let current = *page.read();
-    let loaded = meta.read().is_some();
-    let title = meta
-        .read()
-        .as_ref()
-        .map(|m| m.display_title())
-        .unwrap_or_default();
-    let author = meta
-        .read()
-        .as_ref()
-        .and_then(|m| m.creators.first().map(|c| c.name.clone()))
-        .unwrap_or_default();
+    let (loaded, display) = {
+        let snapshot = meta.read();
+        (
+            snapshot.is_some(),
+            PagerDisplay::from_state(snapshot.as_ref(), current),
+        )
+    };
+    let PagerDisplay {
+        title,
+        author,
+        count,
+        pct,
+    } = display;
     let page_src = {
         let server_url = server_url.clone();
         let uuid = uuid.clone();
         move |n: usize| media_url(&server_url, &format!("/api/ebooks/{uuid}/pages/{n}"))
-    };
-    let pct = if count == 0 {
-        0
-    } else {
-        comic_percent(current, count)
     };
 
     rsx! {

--- a/frontend/src/read_status_auto.rs
+++ b/frontend/src/read_status_auto.rs
@@ -5,7 +5,7 @@
 //! players call from their media-event callbacks.
 
 use dioxus::prelude::*;
-use omnibus_shared::{ReadStatus, SetReadStatus};
+use omnibus_shared::{ReadStatus, ReadStatusRecord, SetReadStatus};
 
 use crate::data;
 
@@ -51,6 +51,44 @@ pub async fn apply_auto_read_status(server_url: &str, uuid: &str, at_end: bool) 
     .await;
 }
 
+/// Apply a status fetch's outcome to `status`, dropping it if a later
+/// navigation has already bumped `load_seq` past `my_load`. Same guard shape
+/// as `apply_bootstrap_outcome` in `pages/comic_reader.rs` — pulled out of
+/// the fetch effect so the guard is exercised directly, without a network
+/// round trip.
+fn apply_fetched_status(
+    fetched: Option<ReadStatusRecord>,
+    my_load: u64,
+    load_seq: Signal<u64>,
+    uuid: String,
+    mut status: Signal<Option<(String, ReadStatus)>>,
+) {
+    if *load_seq.peek() != my_load {
+        return;
+    }
+    let fetched = fetched.map(|r| r.status).unwrap_or_default();
+    status.set(Some((uuid, fetched)));
+}
+
+/// Decide the write effect's next move: `None` when nothing has been
+/// fetched yet or [`auto_transition`] has nothing to do (including the
+/// never-downgrade case — opening a `Finished` book with `at_end: false`).
+/// On `Some`, `status` has already been moved to the optimistic next value
+/// (so a re-run settles on it instead of repeating the write while the POST
+/// is in flight) and the returned payload is what the caller persists.
+fn decide_transition_write(
+    mut status: Signal<Option<(String, ReadStatus)>>,
+    at_end: bool,
+) -> Option<SetReadStatus> {
+    let (book_uuid, current) = status()?;
+    let next = auto_transition(current, at_end)?;
+    status.set(Some((book_uuid.clone(), next)));
+    Some(SetReadStatus {
+        book_uuid,
+        status: next,
+    })
+}
+
 /// Drive [`auto_transition`] for the book open in a reader: fetch the stored
 /// status once per book, then re-apply whenever the status or the reader's
 /// `at_end` position changes. Writes are best-effort like the readers'
@@ -77,32 +115,20 @@ pub fn use_auto_read_status(uuid: String, server_url: String, at_end: Memo<bool>
             load_seq.set(my_load);
             status.set(None);
             let server_url = server_url.clone();
+            let uuid_for_apply = uuid.clone();
             spawn(async move {
                 if let Ok(stored) = data::get_read_status(&server_url, &uuid).await {
-                    if *load_seq.peek() == my_load {
-                        let fetched = stored.map(|r| r.status).unwrap_or_default();
-                        status.set(Some((uuid, fetched)));
-                    }
+                    apply_fetched_status(stored, my_load, load_seq, uuid_for_apply, status);
                 }
             });
         }));
     }
 
     use_effect(move || {
-        let Some((book_uuid, current)) = status() else {
+        let Some(update) = decide_transition_write(status, at_end()) else {
             return;
         };
-        let Some(next) = auto_transition(current, at_end()) else {
-            return;
-        };
-        // Optimistic: move the signal first so the re-run settles on `None`
-        // instead of repeating the write while the POST is in flight.
-        status.set(Some((book_uuid.clone(), next)));
         let server_url = server_url.clone();
-        let update = SetReadStatus {
-            book_uuid,
-            status: next,
-        };
         spawn(async move {
             let _ = data::set_read_status(&server_url, update).await;
         });

--- a/frontend/src/read_status_auto/tests.rs
+++ b/frontend/src/read_status_auto/tests.rs
@@ -1,9 +1,15 @@
-//! Transition-table tests for [`auto_transition`]: open vs at-end for each
-//! stored status, including the never-downgrade rule.
+//! Transition-table tests for [`auto_transition`], plus the effectful
+//! hook's pulled-out decision points: [`apply_fetched_status`]'s `load_seq`
+//! guard and [`decide_transition_write`]'s write decision (including the
+//! never-downgrade case). Driven the same way `pages/comic_reader.rs` drives
+//! `apply_bootstrap_outcome` — signals constructed inside a mounted dummy
+//! component (`VirtualDom::rebuild_in_place`), since a `Signal` needs an
+//! active Dioxus scope to read or write.
 
-use omnibus_shared::ReadStatus;
+use dioxus::prelude::*;
+use omnibus_shared::{ReadStatus, ReadStatusRecord, SetReadStatus};
 
-use super::auto_transition;
+use super::{apply_fetched_status, auto_transition, decide_transition_write};
 
 #[test]
 fn auto_transition_marks_an_unread_book_reading_on_open() {
@@ -34,4 +40,123 @@ fn auto_transition_marks_any_unfinished_book_finished_at_the_end() {
 #[test]
 fn auto_transition_never_rewrites_an_already_finished_book() {
     assert_eq!(auto_transition(ReadStatus::Finished, true), None);
+}
+
+fn stub_record(status: ReadStatus) -> ReadStatusRecord {
+    ReadStatusRecord {
+        book_uuid: "ignored".to_string(),
+        status,
+        updated_at: 0,
+        finished_at: None,
+    }
+}
+
+/// A fetch that lands under the current `load_seq` populates `status`, and
+/// the write effect's decision function turns that into the transitioned
+/// write — the happy path the hook drives on every book open.
+#[test]
+fn apply_fetched_status_lands_and_decide_transition_write_persists_the_transition() {
+    #[component]
+    fn AssertFetchLandsAndWrites() -> Element {
+        let load_seq: Signal<u64> = Signal::new(1);
+        let status: Signal<Option<(String, ReadStatus)>> = Signal::new(None);
+
+        apply_fetched_status(
+            Some(stub_record(ReadStatus::Unread)),
+            1,
+            load_seq,
+            "book-a".to_string(),
+            status,
+        );
+        assert_eq!(
+            *status.read(),
+            Some(("book-a".to_string(), ReadStatus::Unread)),
+            "a fetch for the current load must land"
+        );
+
+        let update = decide_transition_write(status, false);
+        assert_eq!(
+            update,
+            Some(SetReadStatus {
+                book_uuid: "book-a".to_string(),
+                status: ReadStatus::Reading,
+            }),
+            "opening an unread book must write Reading"
+        );
+        assert_eq!(
+            *status.read(),
+            Some(("book-a".to_string(), ReadStatus::Reading)),
+            "the optimistic value lands before the write resolves"
+        );
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertFetchLandsAndWrites).rebuild_in_place();
+}
+
+/// A fetch answering a navigation `load_seq` has already superseded must not
+/// land — the guard `ComicReadPage`'s `apply_bootstrap_outcome` shares the
+/// shape of.
+#[test]
+fn apply_fetched_status_drops_a_response_superseded_by_a_newer_navigation() {
+    #[component]
+    fn AssertStaleFetchDropped() -> Element {
+        let load_seq: Signal<u64> = Signal::new(2);
+        let status: Signal<Option<(String, ReadStatus)>> = Signal::new(None);
+
+        // Load 1's response lands after load 2 has already started.
+        apply_fetched_status(
+            Some(stub_record(ReadStatus::Reading)),
+            1,
+            load_seq,
+            "stale-book".to_string(),
+            status,
+        );
+        assert!(
+            status.read().is_none(),
+            "a fetch superseded by a newer navigation must not land"
+        );
+
+        // Load 2's own response is current and must land.
+        apply_fetched_status(
+            Some(stub_record(ReadStatus::Reading)),
+            2,
+            load_seq,
+            "current-book".to_string(),
+            status,
+        );
+        assert_eq!(
+            *status.read(),
+            Some(("current-book".to_string(), ReadStatus::Reading))
+        );
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertStaleFetchDropped).rebuild_in_place();
+}
+
+/// Opening a book already `Finished` (`at_end: false`, the "merely open"
+/// case) must never write `Reading` over it.
+#[test]
+fn decide_transition_write_never_downgrades_a_finished_book_on_open() {
+    #[component]
+    fn AssertNoDowngradeOnOpen() -> Element {
+        let status: Signal<Option<(String, ReadStatus)>> =
+            Signal::new(Some(("finished-book".to_string(), ReadStatus::Finished)));
+
+        let update = decide_transition_write(status, false);
+
+        assert_eq!(
+            update, None,
+            "opening a finished book must not queue a downgrade to Reading"
+        );
+        assert_eq!(
+            *status.read(),
+            Some(("finished-book".to_string(), ReadStatus::Finished)),
+            "status must stay Finished when nothing was written"
+        );
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertNoDowngradeOnOpen).rebuild_in_place();
 }


### PR DESCRIPTION
## Summary
- Extract `ComicReadPage`'s bootstrap fetch, progress-update builder, and chrome-value derivation into named helpers (`fetch_bootstrap`, `progress_update_for_page`, `PagerDisplay`), and add an "over cap by design" doc note (matching `BdCtaRow` in `pages/book_detail/hero.rs`) for what remains — a large declarative `rsx!` tree behind three hooks that must run unconditionally.
- Add `db/src/comic/tests.rs` coverage for `page_count_for_book`'s three outcomes: a real CBZ archive, a book with no CBZ file, and an unreadable archive.
- Split `use_auto_read_status`'s effect bodies into `apply_fetched_status` (the `load_seq` staleness guard) and `decide_transition_write` (the write decision, including the never-downgrade-a-Finished-book case), and cover both directly with a mounted-`VirtualDom` test — the same pattern `ComicReadPage`'s `apply_bootstrap_outcome` tests already use.
- Closes #1613

## Test plan
- [x] `CARGO_TARGET_DIR=$HOME/.cache/cargo-target/omnibus-shared cargo fmt` — PASS
- [x] `CARGO_TARGET_DIR=$HOME/.cache/cargo-target/omnibus-shared cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=$HOME/.cache/cargo-target/omnibus-shared cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=$HOME/.cache/cargo-target/omnibus-shared cargo test -p omnibus-db` — PASS (1735 passed, 1 failed — `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails only because its fixture audio file isn't present in this sandbox, unrelated to this change; `just fixtures` isn't available here)
- [x] `CARGO_TARGET_DIR=$HOME/.cache/cargo-target/omnibus-shared cargo test -p omnibus-frontend --features server` — PASS (624 passed, 0 failed)

## Notes
- 


---
_Generated by [Claude Code](https://claude.ai/code/session_01VcuRz7FVMcMQtDtuaipEtD)_