### PR TITLE
refactor: extract helpers to bring 8 more functions under the length cap (#1079)

### DIFF
--- a/db/src/suggestions/cascade.rs
+++ b/db/src/suggestions/cascade.rs
@@ -102,15 +102,8 @@ pub async fn resolve_with(
     );
 
     // Build cache rows, fetching cover bytes best-effort (a cover miss must not
-    // drop the suggestion — `Cover` falls back to a typographic plate). Covers
-    // fetch with bounded concurrency (at most `COVER_FETCH_CONCURRENCY` in
-    // flight at once, chunk by chunk), preserving `survivors`' order (the
-    // list's already-ranked order becomes the persisted `rank` in
-    // `insert_suggestion_rows`).
-    let mut covers: Vec<Option<(String, Vec<u8>)>> = Vec::with_capacity(survivors.len());
-    for chunk in survivors.chunks(COVER_FETCH_CONCURRENCY) {
-        covers.extend(join_all(chunk.iter().map(|c| fetch_cover(c, image_config))).await);
-    }
+    // drop the suggestion — `Cover` falls back to a typographic plate).
+    let covers = fetch_covers_bounded(&survivors, image_config).await;
 
     let mut rows: Vec<NewSuggestion> = Vec::with_capacity(survivors.len());
     for (c, cover) in survivors.into_iter().zip(covers) {
@@ -140,6 +133,21 @@ pub async fn resolve_with(
     };
     replace_suggestions(pool, book_uuid, &rows, state).await?;
     Ok(())
+}
+
+/// Fetch cover bytes for every survivor with bounded concurrency (at most
+/// `COVER_FETCH_CONCURRENCY` in flight at once, chunk by chunk), preserving
+/// `survivors`' order — the list's already-ranked order becomes the
+/// persisted `rank` in `insert_suggestion_rows`.
+async fn fetch_covers_bounded(
+    survivors: &[Candidate],
+    image_config: &RemoteImageConfig,
+) -> Vec<Option<(String, Vec<u8>)>> {
+    let mut covers: Vec<Option<(String, Vec<u8>)>> = Vec::with_capacity(survivors.len());
+    for chunk in survivors.chunks(COVER_FETCH_CONCURRENCY) {
+        covers.extend(join_all(chunk.iter().map(|c| fetch_cover(c, image_config))).await);
+    }
+    covers
 }
 
 /// Best-effort remote cover fetch for one candidate. `None` for a candidate

--- a/frontend/src/components/shelf_rule_builder.rs
+++ b/frontend/src/components/shelf_rule_builder.rs
@@ -256,61 +256,67 @@ struct ConditionHandlers {
     on_unit: EventHandler<FormEvent>,
 }
 
-/// Builds the field/op/value(s)/unit change handlers for one condition row.
-/// Each clones the row's current draft, applies its one field, and reports
-/// the result through the shared `on_change`.
+/// Apply `f` to a clone of the row's current draft and report the result
+/// through `on_change`. The one generic helper every per-input change
+/// handler in [`build_condition_handlers`] funnels through, in place of five
+/// near-identical clone-mutate-report closures.
+fn apply_draft_change(
+    draft: &RuleDraft,
+    on_change: EventHandler<RuleDraft>,
+    f: impl FnOnce(&mut RuleDraft),
+) {
+    let mut d = draft.clone();
+    f(&mut d);
+    on_change.call(d);
+}
+
+/// Builds the field/op/value(s)/unit change handlers for one condition row,
+/// each a thin [`apply_draft_change`] call supplying only the field it
+/// changes.
 fn build_condition_handlers(
     draft: RuleDraft,
     on_change: EventHandler<RuleDraft>,
 ) -> ConditionHandlers {
     // On a field change, snap the op to the first one the new field accepts.
-    let d_field = draft.clone();
+    let d = draft.clone();
     let on_field = EventHandler::new(move |e: FormEvent| {
         if let Some(f) = RuleField::from_str(&e.value()) {
-            let mut d = d_field.clone();
-            d.field = f;
-            if !f.accepts(d.op) {
-                d.op = OPS
-                    .iter()
-                    .map(|(o, _)| *o)
-                    .find(|o| f.accepts(*o))
-                    .unwrap_or(RuleOp::Is);
-            }
-            // `Status` uses a fixed dropdown; seed a valid default so the row is
-            // complete without the user having to open the select.
-            if f == RuleField::Status
-                && omnibus_shared::ReadStatus::from_str(d.value.trim()).is_none()
-            {
-                d.value = STATUS_VALUES[0].0.to_string();
-            }
-            on_change.call(d);
+            apply_draft_change(&d, on_change, |d| {
+                d.field = f;
+                if !f.accepts(d.op) {
+                    d.op = OPS
+                        .iter()
+                        .map(|(o, _)| *o)
+                        .find(|o| f.accepts(*o))
+                        .unwrap_or(RuleOp::Is);
+                }
+                // `Status` uses a fixed dropdown; seed a valid default so the
+                // row is complete without the user having to open the select.
+                if f == RuleField::Status
+                    && omnibus_shared::ReadStatus::from_str(d.value.trim()).is_none()
+                {
+                    d.value = STATUS_VALUES[0].0.to_string();
+                }
+            });
         }
     });
-    let d_op = draft.clone();
+    let d = draft.clone();
     let on_op = EventHandler::new(move |e: FormEvent| {
         if let Some(o) = RuleOp::from_str(&e.value()) {
-            let mut d = d_op.clone();
-            d.op = o;
-            on_change.call(d);
+            apply_draft_change(&d, on_change, |d| d.op = o);
         }
     });
-    let d_val = draft.clone();
+    let d = draft.clone();
     let on_val = EventHandler::new(move |e: FormEvent| {
-        let mut d = d_val.clone();
-        d.value = e.value();
-        on_change.call(d);
+        apply_draft_change(&d, on_change, |d| d.value = e.value());
     });
-    let d_val2 = draft.clone();
+    let d = draft.clone();
     let on_val2 = EventHandler::new(move |e: FormEvent| {
-        let mut d = d_val2.clone();
-        d.value2 = e.value();
-        on_change.call(d);
+        apply_draft_change(&d, on_change, |d| d.value2 = e.value());
     });
-    let d_unit = draft.clone();
+    let d = draft;
     let on_unit = EventHandler::new(move |e: FormEvent| {
-        let mut d = d_unit.clone();
-        d.unit = e.value();
-        on_change.call(d);
+        apply_draft_change(&d, on_change, |d| d.unit = e.value());
     });
 
     ConditionHandlers {

--- a/frontend/src/pages/book_detail/journal/composer.rs
+++ b/frontend/src/pages/book_detail/journal/composer.rs
@@ -66,53 +66,69 @@ impl JournalComposerState {
     }
 }
 
-/// Collapsed prompt → expanded markdown composer with a Write/Preview toggle, an
-/// optional reading-progress slider, and a spoiler-syntax hint. The open
-/// composer's markup is composed from [`BdJournalComposerTabs`],
-/// [`BdJournalHighlightsPopover`], [`BdJournalEditorBody`], and
-/// [`BdJournalComposerFoot`].
-#[component]
-pub(super) fn BdJournalComposer(uuid: String, server_url: String, reload: Signal<u32>) -> Element {
-    let mut open = use_signal(|| false);
-    let body = use_signal(String::new);
-    let show_preview = use_signal(|| false);
-    let preview_html = use_signal(String::new);
-    let track_progress = use_signal(|| false);
-    let progress = use_signal(|| 50i64);
-    let saving = use_signal(|| false);
-    let error = use_signal(|| None::<String>);
-    // Owned here (not inside `BdJournalHighlightsPopover`) because the
-    // popover's markup is conditionally skipped while `show_preview` is true —
-    // if the popover owned this state itself, toggling to Preview and back
-    // would unmount/remount it and drop the loaded-once cache, forcing a
-    // needless highlights refetch.
-    let highlights = use_signal(Vec::<Highlight>::new);
-    let highlights_open = use_signal(|| false);
-    let highlights_loaded = use_signal(|| false);
-    let draft_id = use_signal(|| None::<i64>);
-    let mut autosave_task = use_signal(|| None::<Task>);
-    let autosaved_secs = use_signal(|| None::<u64>);
-    let autosaved_ticker = use_signal(|| None::<Task>);
+/// Non-[`JournalComposerState`] signals used directly by the composer's
+/// child components (`preview_html` for `BdJournalComposerTabs` /
+/// `BdJournalEditorBody`, the three `highlights_*` for
+/// `BdJournalHighlightsPopover`). Kept out of `JournalComposerState` since
+/// those components' own concern (preview text, the highlights cache) isn't
+/// part of the save/reset surface the footer drives.
+///
+/// The `highlights_*` fields are owned here rather than inside
+/// `BdJournalHighlightsPopover` because the popover's markup is
+/// conditionally skipped while `show_preview` is true — if the popover owned
+/// this state itself, toggling to Preview and back would unmount/remount it
+/// and drop the loaded-once cache, forcing a needless highlights refetch.
+#[derive(Clone, Copy)]
+struct ComposerAuxSignals {
+    preview_html: Signal<String>,
+    highlights: Signal<Vec<Highlight>>,
+    highlights_open: Signal<bool>,
+    highlights_loaded: Signal<bool>,
+}
 
+/// Declare and bundle every composer signal. A hook (calls `use_signal`
+/// unconditionally each render), split out of [`BdJournalComposer`] to keep
+/// its body under the line cap — safe to call unconditionally since it runs
+/// in the same position on every render.
+fn use_composer_signals() -> (JournalComposerState, ComposerAuxSignals) {
     let state = JournalComposerState {
-        open,
-        body,
-        track_progress,
-        progress,
-        saving,
-        error,
-        show_preview,
-        draft_id,
-        autosave_task,
-        autosaved_secs,
-        autosaved_ticker,
+        open: use_signal(|| false),
+        body: use_signal(String::new),
+        track_progress: use_signal(|| false),
+        progress: use_signal(|| 50i64),
+        saving: use_signal(|| false),
+        error: use_signal(|| None::<String>),
+        show_preview: use_signal(|| false),
+        draft_id: use_signal(|| None::<i64>),
+        autosave_task: use_signal(|| None::<Task>),
+        autosaved_secs: use_signal(|| None::<u64>),
+        autosaved_ticker: use_signal(|| None::<Task>),
     };
+    let aux = ComposerAuxSignals {
+        preview_html: use_signal(String::new),
+        highlights: use_signal(Vec::<Highlight>::new),
+        highlights_open: use_signal(|| false),
+        highlights_loaded: use_signal(|| false),
+    };
+    (state, aux)
+}
 
-    // Debounced autosave: each body change cancels the pending task and arms a
-    // fresh one (search-palette pattern), so at most one save is queued and a
-    // typing burst produces a single write once the user pauses.
-    let autosave_url = server_url.clone();
-    let autosave_uuid = uuid.clone();
+/// Debounced autosave: each body change cancels the pending task and arms a
+/// fresh one (search-palette pattern), so at most one save is queued and a
+/// typing burst produces a single write once the user pauses. A hook (calls
+/// `use_effect`), split out of [`BdJournalComposer`] to keep its body under
+/// the line cap — safe to call unconditionally since it runs in the same
+/// position on every render.
+fn use_composer_autosave(state: JournalComposerState, server_url: &str, uuid: &str) {
+    let JournalComposerState {
+        body,
+        open,
+        saving,
+        mut autosave_task,
+        ..
+    } = state;
+    let autosave_url = server_url.to_string();
+    let autosave_uuid = uuid.to_string();
     use_effect(move || {
         let text = body();
         if !open() || saving() || text.trim().is_empty() {
@@ -129,6 +145,28 @@ pub(super) fn BdJournalComposer(uuid: String, server_url: String, reload: Signal
         });
         autosave_task.set(Some(task));
     });
+}
+
+/// Collapsed prompt → expanded markdown composer with a Write/Preview toggle, an
+/// optional reading-progress slider, and a spoiler-syntax hint. The open
+/// composer's markup is composed from [`BdJournalComposerTabs`],
+/// [`BdJournalHighlightsPopover`], [`BdJournalEditorBody`], and
+/// [`BdJournalComposerFoot`].
+#[component]
+pub(super) fn BdJournalComposer(uuid: String, server_url: String, reload: Signal<u32>) -> Element {
+    let (state, aux) = use_composer_signals();
+    let mut open = state.open;
+    let body = state.body;
+    let show_preview = state.show_preview;
+    let error = state.error;
+    let ComposerAuxSignals {
+        preview_html,
+        highlights,
+        highlights_open,
+        highlights_loaded,
+    } = aux;
+
+    use_composer_autosave(state, &server_url, &uuid);
 
     if !open() {
         return rsx! {
@@ -464,36 +502,26 @@ async fn autosave_draft(url: &str, uuid: &str, body_md: String, state: JournalCo
     }
 }
 
-/// Composer footer: reading-progress toggle/slider, the "Auto-saved Ns ago"
-/// indicator, inline error, cancel, save-draft, and publish. Save draft keeps
-/// the entry owner-private; publish surfaces it in the shared feed. Both
-/// reset and close the composer; cancel additionally discards any autosaved
-/// draft.
-#[component]
-fn BdJournalComposerFoot(
-    uuid: String,
-    server_url: String,
-    reload: Signal<u32>,
+/// Build the shared save-as handler for the Save-draft and Publish buttons —
+/// the only difference between them is the status the entry ends up in (an
+/// existing autosaved draft row is reused). Saves the current body as
+/// `status`, then resets/closes/reloads the composer on success.
+fn build_save_as_handler(
+    uuid: &str,
+    server_url: &str,
     state: JournalComposerState,
-) -> Element {
+    mut reload: Signal<u32>,
+) -> impl FnMut(JournalStatus) + Clone {
     let JournalComposerState {
         body,
-        saving,
-        error,
-        autosaved_secs,
+        mut saving,
+        mut error,
         draft_id,
         ..
     } = state;
-    let mut reload = reload;
-    let mut saving = saving;
-    let mut error = error;
-
-    // Save the current body as `status`, then reset/close/reload. Shared by
-    // the Save-draft and Publish buttons — the only difference is the status
-    // the entry ends up in (an existing autosaved draft row is reused).
-    let save_url = server_url.clone();
-    let save_uuid = uuid.clone();
-    let mut save_as = move |status: JournalStatus| {
+    let save_url = server_url.to_string();
+    let save_uuid = uuid.to_string();
+    move |status: JournalStatus| {
         let url = save_url.clone();
         let uuid = save_uuid.clone();
         let mut state = state;
@@ -537,7 +565,52 @@ fn BdJournalComposerFoot(
             }
             saving.set(false);
         });
-    };
+    }
+}
+
+/// Discard any autosaved draft row (best-effort), then reset/close the
+/// composer. Run BEFORE `reset_and_close()` returns — that call unmounts
+/// this scope, and a task spawned after unmount is dropped unpolled.
+fn cancel_and_discard_draft(server_url: &str, mut state: JournalComposerState) {
+    let JournalComposerState {
+        draft_id,
+        mut saving,
+        ..
+    } = state;
+    let url = server_url.to_string();
+    if let Some(t) = state.autosave_task.write().take() {
+        t.cancel();
+    }
+    saving.set(true);
+    spawn(async move {
+        if let Some(id) = draft_id() {
+            let _ = data::delete_journal_entry(&url, id).await;
+        }
+        saving.set(false);
+        state.reset_and_close();
+    });
+}
+
+/// Composer footer: reading-progress toggle/slider, the "Auto-saved Ns ago"
+/// indicator, inline error, cancel, save-draft, and publish. Save draft keeps
+/// the entry owner-private; publish surfaces it in the shared feed. Both
+/// reset and close the composer; cancel additionally discards any autosaved
+/// draft.
+#[component]
+fn BdJournalComposerFoot(
+    uuid: String,
+    server_url: String,
+    reload: Signal<u32>,
+    state: JournalComposerState,
+) -> Element {
+    let JournalComposerState {
+        body,
+        saving,
+        error,
+        autosaved_secs,
+        ..
+    } = state;
+    let mut save_as = build_save_as_handler(&uuid, &server_url, state, reload);
 
     rsx! {
         div { class: "bd-journal-composer-foot",
@@ -560,23 +633,7 @@ fn BdJournalComposerFoot(
                 r#type: "button",
                 class: "btn ghost sm",
                 disabled: saving(),
-                onclick: move |_| {
-                    let url = server_url.clone();
-                    if let Some(t) = state.autosave_task.write().take() {
-                        t.cancel();
-                    }
-                    saving.set(true);
-                    spawn(async move {
-                        // Discard any autosaved draft row (best-effort) BEFORE
-                        // closing — reset_and_close() unmounts this scope, and
-                        // a task spawned after unmount is dropped unpolled.
-                        if let Some(id) = draft_id() {
-                            let _ = data::delete_journal_entry(&url, id).await;
-                        }
-                        saving.set(false);
-                        state.reset_and_close();
-                    });
-                },
+                onclick: move |_| cancel_and_discard_draft(&server_url, state),
                 "Cancel"
             }
             button {

--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -38,6 +38,50 @@ struct JournalEntryHeaderView {
     server_url: String,
 }
 
+/// "Publish" button for an owner's draft entry — flips the entry's status to
+/// `Published`. Split out of [`BdJournalEntryHeader`] to keep it under the
+/// line cap.
+#[component]
+fn BdJournalPublishDraftButton(
+    server_url: String,
+    entry_id: i64,
+    body_for_edit: String,
+    entry_progress: Option<u8>,
+    saving: Signal<bool>,
+    error: Signal<Option<String>>,
+    reload: Signal<u32>,
+) -> Element {
+    let mut saving = saving;
+    let mut error = error;
+    let mut reload = reload;
+    rsx! {
+        button {
+            r#type: "button",
+            class: "btn primary sm",
+            "data-testid": "journal-publish-draft",
+            disabled: saving(),
+            onclick: move |_| {
+                let url = server_url.clone();
+                let input = UpdateJournalEntry {
+                    body_md: body_for_edit.clone(),
+                    progress: entry_progress,
+                    status: Some(JournalStatus::Published),
+                };
+                saving.set(true);
+                error.set(None);
+                spawn(async move {
+                    match data::update_journal_entry(&url, entry_id, input).await {
+                        Ok(_) => reload.set(reload() + 1),
+                        Err(e) => error.set(Some(e.to_string())),
+                    }
+                    saving.set(false);
+                });
+            },
+            "Publish"
+        }
+    }
+}
+
 /// Entry card header: author monogram + byline (with a "you" chip for the
 /// owner) + date/progress meta, and — for the owner, while not already
 /// editing — the Edit/Delete action row. Delete removes the entry and
@@ -90,35 +134,14 @@ fn BdJournalEntryHeader(view: JournalEntryHeaderView, edit: JournalEntryEditStat
             if is_owner && !editing() {
                 div { class: "bd-journal-entry-actions",
                     if is_draft {
-                        button {
-                            r#type: "button",
-                            class: "btn primary sm",
-                            "data-testid": "journal-publish-draft",
-                            disabled: saving(),
-                            onclick: {
-                                let url = server_url.clone();
-                                let body_md = body_for_edit.clone();
-                                move |_| {
-                                    let url = url.clone();
-                                    let input = UpdateJournalEntry {
-                                        body_md: body_md.clone(),
-                                        progress: entry_progress,
-                                        status: Some(JournalStatus::Published),
-                                    };
-                                    saving.set(true);
-                                    error.set(None);
-                                    spawn(async move {
-                                        match data::update_journal_entry(&url, entry_id, input)
-                                            .await
-                                        {
-                                            Ok(_) => reload.set(reload() + 1),
-                                            Err(e) => error.set(Some(e.to_string())),
-                                        }
-                                        saving.set(false);
-                                    });
-                                }
-                            },
-                            "Publish"
+                        BdJournalPublishDraftButton {
+                            server_url: server_url.clone(),
+                            entry_id,
+                            body_for_edit: body_for_edit.clone(),
+                            entry_progress,
+                            saving,
+                            error,
+                            reload,
                         }
                     }
                     button {

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -41,6 +41,43 @@ pub(super) struct MobileBookView {
     pub description: DescriptionSignals,
 }
 
+/// Build the Fetch Summary callback: on success, saves the fetched text as a
+/// description override and — provided the user hasn't navigated to a
+/// different book in the meantime — updates the `description` signal in
+/// place, mirroring web's `BdTitleCol`.
+///
+/// `description` arrives pre-seeded from `b.description` (reset by
+/// `BookDetailPage`'s fetch effect on every book load). Snapshots this
+/// book's epoch up front: if the user navigates away before the save below
+/// resolves, `BookDetailPage` bumps `description_epoch` for the new book,
+/// and the mismatch tells us to drop this result instead of overwriting the
+/// new book's summary — mirrors `poll_suggestions_until_resolved`'s
+/// `is_current` guard.
+fn build_on_fetched_handler(
+    server_url: &str,
+    uuid: &str,
+    mut description: Signal<String>,
+    description_epoch: Signal<u64>,
+) -> impl FnMut(String) {
+    let server_url = server_url.to_string();
+    let uuid = uuid.to_string();
+    let expected_epoch = description_epoch();
+    move |text: String| {
+        let url = server_url.clone();
+        let uuid = uuid.clone();
+        spawn(async move {
+            let overrides = MetadataOverrides {
+                description: Some(text.clone()),
+                ..Default::default()
+            };
+            let saved = data::save_overrides(&url, &uuid, &overrides).await.is_ok();
+            if saved && description_epoch() == expected_epoch {
+                description.set(text);
+            }
+        });
+    }
+}
+
 /// Render the fully-loaded book detail for the mobile shell. A plain fn with
 /// no hooks of its own: `description` used to be a local `use_signal` here,
 /// but this fn is reached only past [`super::BookDetailPage`]'s
@@ -75,199 +112,26 @@ pub(super) fn render_loaded_mobile(view: MobileBookView) -> Element {
     } = derive_loaded_view(&b);
 
     let uuid = b.unique_identifier.clone().unwrap_or_default();
-
-    // `description` arrives pre-seeded from `b.description` (reset by
-    // `BookDetailPage`'s fetch effect on every book load); a fetch-and-save
-    // here refreshes it in place, mirroring web's `BdTitleCol`.
-    let on_fetched = {
-        let server_url = server_url.clone();
-        let uuid = uuid.clone();
-        // Snapshot this book's epoch: if the user navigates to a different
-        // book before the save below resolves, `BookDetailPage` bumps
-        // `description_epoch` for the new book, and the mismatch tells us to
-        // drop this result instead of overwriting the new book's summary —
-        // mirrors `poll_suggestions_until_resolved`'s `is_current` guard.
-        let expected_epoch = description_epoch();
-        move |text: String| {
-            let url = server_url.clone();
-            let uuid = uuid.clone();
-            spawn(async move {
-                let overrides = MetadataOverrides {
-                    description: Some(text.clone()),
-                    ..Default::default()
-                };
-                let saved = data::save_overrides(&url, &uuid, &overrides).await.is_ok();
-                if saved && description_epoch() == expected_epoch {
-                    description.set(text);
-                }
-            });
-        }
-    };
-
-    let year = b
-        .published
-        .as_deref()
-        .and_then(|p| p.get(0..4))
-        .unwrap_or("")
-        .to_string();
-    let meta_line = match (authors_line.is_empty(), year.is_empty()) {
-        (false, false) => format!("{authors_line} · {year}"),
-        (false, true) => authors_line.clone(),
-        (true, false) => year.clone(),
-        (true, true) => String::new(),
-    };
+    let on_fetched = build_on_fetched_handler(&server_url, &uuid, description, description_epoch);
     let (cover_src, cover_srcset) = thumb_srcs(&b, &uuid, &server_url);
-    let epub_files: Vec<BookFileInfo> = b
-        .book_files
-        .iter()
-        .filter(|f| f.format.eq_ignore_ascii_case("EPUB"))
-        .cloned()
-        .collect();
-    let audio_files: Vec<BookFileInfo> = b
-        .book_files
-        .iter()
-        .filter(|f| is_audio_book_file(f))
-        .cloned()
-        .collect();
+    let (meta_line, epub_files, audio_files) = split_meta_and_files(&b, &authors_line);
 
     rsx! {
         div { class: "m-bd", style: "{accent_style}", "data-testid": "mobile-book-detail",
-            // Hero — accent glow, top actions, centered cover.
-            div { class: "m-bd-hero",
-                div { class: "m-bd-hero-bar",
-                    // History-aware back; Landing is only the deep-link fallback.
-                    button {
-                        r#type: "button",
-                        class: "m-icon-btn",
-                        "aria-label": "Back",
-                        "data-testid": "mobile-bd-back",
-                        onclick: move |_| {
-                            let nav = dioxus_router::navigator();
-                            if nav.can_go_back() {
-                                nav.go_back();
-                            } else {
-                                nav.replace(Route::Landing {});
-                            }
-                        },
-                        "\u{2190}"
-                    }
-                    Link {
-                        to: Route::MetadataEdit { uuid: uuid.clone() },
-                        class: "m-icon-btn",
-                        "aria-label": "Edit metadata",
-                        "\u{22EF}"
-                    }
-                }
-                div { class: "m-bd-cover",
-                    Cover {
-                        book: b.clone(),
-                        src_override: cover_src,
-                        srcset: cover_srcset,
-                        sizes: Some("150px".to_string()),
-                    }
-                }
-            }
-
-            div { class: "m-bd-titlecol",
-                h2 { class: "m-bd-title", span { class: "m-em", "{title}" } }
-                if !meta_line.is_empty() {
-                    div { class: "m-bd-meta", "{meta_line}" }
-                }
-                if !b.formats.is_empty() {
-                    div { class: "m-bd-badges",
-                        for f in b.formats.iter() {
-                            BdFormatBadge { key: "{f}", fmt: f.clone() }
-                        }
-                    }
-                }
-            }
-
-            // Multi-file actions open a picker; single-file actions navigate directly.
-            div { class: "m-bd-cta",
-                if has_ebook {
-                    BdFilePickerMenu {
-                        uuid: uuid.clone(),
-                        kind: FilePickerKind::Read,
-                        files: epub_files.clone(),
-                        label: "Read",
-                        button_class: "btn primary lg",
-                        single_testid: "start-reading",
-                    }
-                } else if has_comic {
-                    Link {
-                        to: crate::Route::ComicRead { uuid: uuid.clone() },
-                        class: "btn primary lg",
-                        "data-testid": "start-reading-comic",
-                        "Read"
-                    }
-                }
-                if has_audio {
-                    BdFilePickerMenu {
-                        uuid: uuid.clone(),
-                        kind: FilePickerKind::Listen,
-                        files: audio_files.clone(),
-                        label: "Listen",
-                        button_class: "btn lg",
-                        single_testid: "start-listening",
-                    }
-                }
-                // Immersive Read is a dual-format-only action, so gate it on both.
-                if has_ebook && has_audio {
-                    BdImmersiveButton { uuid: uuid.clone() }
-                }
-            }
-
-            // About — always rendered: a sparse/missing summary (fewer than 10
-            // words) still needs the section to host the Fetch Summary button.
-            section { class: "m-section",
-                div { class: "label", "About" }
-                if !description().is_empty() {
-                    div { class: "m-bd-desc", dangerous_inner_html: "{description()}" }
-                }
-                if !b.subjects.is_empty() {
-                    div { class: "m-bd-tags",
-                        for tag in b.subjects.iter() {
-                            span { key: "{tag}", class: "chip", "{tag}" }
-                        }
-                    }
-                }
-                if summary_is_sparse(&description()) {
-                    FetchSummaryButton { uuid: uuid.clone(), on_fetched }
-                }
-            }
-
-            // Reading status
-            section { class: "m-section",
-                div { class: "label", "Reading status" }
-                BdReadStatusControl { uuid: uuid.clone() }
-            }
-
-            // Rating
-            section { class: "m-section",
-                div { class: "label", "Your rating" }
-                BdRatingWidget { uuid: uuid.clone() }
-            }
-
-            // Book info
-            section { class: "m-section",
-                div { class: "label", "Book info" }
-                table { class: "bd-meta-table mono m-bd-info",
-                    tbody {
-                        if let Some(p) = b.publisher.clone() { BdMetaRow { k: "Publisher".to_string(), v: p } }
-                        if let Some(d) = b.published.clone() { BdMetaRow { k: "Published".to_string(), v: d } }
-                        if let Some(l) = b.language.clone() { BdMetaRow { k: "Language".to_string(), v: l } }
-                        if let Some(a) = b.added_at.clone() { BdMetaRow { k: "Added".to_string(), v: a } }
-                        if let Some(s) = series.clone() { BdMetaRow { k: "Series".to_string(), v: s } }
-                        for (i, ident) in b.identifiers.iter().enumerate() {
-                            BdMetaRow {
-                                key: "{i}",
-                                k: ident.scheme.clone().unwrap_or_else(|| "ID".into()),
-                                v: ident.value.clone(),
-                            }
-                        }
-                    }
-                }
-            }
+            {hero_section(&b, &uuid, cover_src, cover_srcset)}
+            {title_and_cta_section(
+                &uuid,
+                &title,
+                &meta_line,
+                &b.formats,
+                has_ebook,
+                has_comic,
+                has_audio,
+                &epub_files,
+                &audio_files,
+            )}
+            {about_section(&uuid, description, &b.subjects, on_fetched)}
+            {info_sections(&uuid, &b, &series)}
 
             // Offline downloads (Kindle-style local copies).
             super::offline::BdOfflineSection {
@@ -294,6 +158,215 @@ pub(super) fn render_loaded_mobile(view: MobileBookView) -> Element {
 
             div { class: "m-bd-footer",
                 Link { to: Route::Landing {}, class: "btn", "Back to library" }
+            }
+        }
+    }
+}
+
+/// Derive the "authors · year" meta-line caption and split `book_files` into
+/// the EPUB and audio lists the CTA row's file pickers need.
+fn split_meta_and_files(
+    b: &EbookMetadata,
+    authors_line: &str,
+) -> (String, Vec<BookFileInfo>, Vec<BookFileInfo>) {
+    let year = b
+        .published
+        .as_deref()
+        .and_then(|p| p.get(0..4))
+        .unwrap_or("")
+        .to_string();
+    let meta_line = match (authors_line.is_empty(), year.is_empty()) {
+        (false, false) => format!("{authors_line} · {year}"),
+        (false, true) => authors_line.to_string(),
+        (true, false) => year,
+        (true, true) => String::new(),
+    };
+    let epub_files = b
+        .book_files
+        .iter()
+        .filter(|f| f.format.eq_ignore_ascii_case("EPUB"))
+        .cloned()
+        .collect();
+    let audio_files = b
+        .book_files
+        .iter()
+        .filter(|f| is_audio_book_file(f))
+        .cloned()
+        .collect();
+    (meta_line, epub_files, audio_files)
+}
+
+/// Hero — accent glow, top actions (history-aware back + edit-metadata
+/// link), centered cover.
+fn hero_section(
+    b: &EbookMetadata,
+    uuid: &str,
+    cover_src: Option<String>,
+    cover_srcset: Option<String>,
+) -> Element {
+    rsx! {
+        div { class: "m-bd-hero",
+            div { class: "m-bd-hero-bar",
+                // History-aware back; Landing is only the deep-link fallback.
+                button {
+                    r#type: "button",
+                    class: "m-icon-btn",
+                    "aria-label": "Back",
+                    "data-testid": "mobile-bd-back",
+                    onclick: move |_| {
+                        let nav = dioxus_router::navigator();
+                        if nav.can_go_back() {
+                            nav.go_back();
+                        } else {
+                            nav.replace(Route::Landing {});
+                        }
+                    },
+                    "\u{2190}"
+                }
+                Link {
+                    to: Route::MetadataEdit { uuid: uuid.to_string() },
+                    class: "m-icon-btn",
+                    "aria-label": "Edit metadata",
+                    "\u{22EF}"
+                }
+            }
+            div { class: "m-bd-cover",
+                Cover {
+                    book: b.clone(),
+                    src_override: cover_src,
+                    srcset: cover_srcset,
+                    sizes: Some("150px".to_string()),
+                }
+            }
+        }
+    }
+}
+
+/// Title column (title / meta line / format badges) plus the multi-file
+/// action row — a picker for a multi-file format, a direct link otherwise.
+#[allow(clippy::too_many_arguments)]
+fn title_and_cta_section(
+    uuid: &str,
+    title: &str,
+    meta_line: &str,
+    formats: &[String],
+    has_ebook: bool,
+    has_comic: bool,
+    has_audio: bool,
+    epub_files: &[BookFileInfo],
+    audio_files: &[BookFileInfo],
+) -> Element {
+    rsx! {
+        div { class: "m-bd-titlecol",
+            h2 { class: "m-bd-title", span { class: "m-em", "{title}" } }
+            if !meta_line.is_empty() {
+                div { class: "m-bd-meta", "{meta_line}" }
+            }
+            if !formats.is_empty() {
+                div { class: "m-bd-badges",
+                    for f in formats.iter() {
+                        BdFormatBadge { key: "{f}", fmt: f.clone() }
+                    }
+                }
+            }
+        }
+
+        // Multi-file actions open a picker; single-file actions navigate directly.
+        div { class: "m-bd-cta",
+            if has_ebook {
+                BdFilePickerMenu {
+                    uuid: uuid.to_string(),
+                    kind: FilePickerKind::Read,
+                    files: epub_files.to_vec(),
+                    label: "Read",
+                    button_class: "btn primary lg",
+                    single_testid: "start-reading",
+                }
+            } else if has_comic {
+                Link {
+                    to: crate::Route::ComicRead { uuid: uuid.to_string() },
+                    class: "btn primary lg",
+                    "data-testid": "start-reading-comic",
+                    "Read"
+                }
+            }
+            if has_audio {
+                BdFilePickerMenu {
+                    uuid: uuid.to_string(),
+                    kind: FilePickerKind::Listen,
+                    files: audio_files.to_vec(),
+                    label: "Listen",
+                    button_class: "btn lg",
+                    single_testid: "start-listening",
+                }
+            }
+            // Immersive Read is a dual-format-only action, so gate it on both.
+            if has_ebook && has_audio {
+                BdImmersiveButton { uuid: uuid.to_string() }
+            }
+        }
+    }
+}
+
+/// About — always rendered: a sparse/missing summary (fewer than 10 words)
+/// still needs the section to host the Fetch Summary button.
+fn about_section(
+    uuid: &str,
+    description: Signal<String>,
+    subjects: &[String],
+    on_fetched: impl FnMut(String) + 'static,
+) -> Element {
+    rsx! {
+        section { class: "m-section",
+            div { class: "label", "About" }
+            if !description().is_empty() {
+                div { class: "m-bd-desc", dangerous_inner_html: "{description()}" }
+            }
+            if !subjects.is_empty() {
+                div { class: "m-bd-tags",
+                    for tag in subjects.iter() {
+                        span { key: "{tag}", class: "chip", "{tag}" }
+                    }
+                }
+            }
+            if summary_is_sparse(&description()) {
+                FetchSummaryButton { uuid: uuid.to_string(), on_fetched }
+            }
+        }
+    }
+}
+
+/// Reading status, rating, and the book-info table — three small `m-section`
+/// blocks grouped into one helper since none is independently reusable.
+fn info_sections(uuid: &str, b: &EbookMetadata, series: &Option<String>) -> Element {
+    rsx! {
+        section { class: "m-section",
+            div { class: "label", "Reading status" }
+            BdReadStatusControl { uuid: uuid.to_string() }
+        }
+
+        section { class: "m-section",
+            div { class: "label", "Your rating" }
+            BdRatingWidget { uuid: uuid.to_string() }
+        }
+
+        section { class: "m-section",
+            div { class: "label", "Book info" }
+            table { class: "bd-meta-table mono m-bd-info",
+                tbody {
+                    if let Some(p) = b.publisher.clone() { BdMetaRow { k: "Publisher".to_string(), v: p } }
+                    if let Some(d) = b.published.clone() { BdMetaRow { k: "Published".to_string(), v: d } }
+                    if let Some(l) = b.language.clone() { BdMetaRow { k: "Language".to_string(), v: l } }
+                    if let Some(a) = b.added_at.clone() { BdMetaRow { k: "Added".to_string(), v: a } }
+                    if let Some(s) = series.clone() { BdMetaRow { k: "Series".to_string(), v: s } }
+                    for (i, ident) in b.identifiers.iter().enumerate() {
+                        BdMetaRow {
+                            key: "{i}",
+                            k: ident.scheme.clone().unwrap_or_else(|| "ID".into()),
+                            v: ident.value.clone(),
+                        }
+                    }
+                }
             }
         }
     }

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -94,7 +94,7 @@ pub(super) fn render_loaded_mobile(view: MobileBookView) -> Element {
         server_url,
         description:
             DescriptionSignals {
-                value: mut description,
+                value: description,
                 epoch: description_epoch,
             },
     } = view;

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -49,9 +49,9 @@ enum OpenSheet {
 /// Renders the mobile audiobook player for `uuid`. Retargets the app-wide
 /// playback context and renders its state; the heavy lifting (fetch, audio
 /// surface, event drain) lives in the app-root [`host::MobileAudioHost`].
-/// Kept near the line cap by design: the body is hook wiring that must run
-/// unconditionally before the early returns, so a split would only thread
-/// the same signals through another layer.
+/// The two route-driven effects are split into [`use_retarget_playback`]
+/// and [`use_marquee_title_refresh`]; what remains here is hook wiring that
+/// must run unconditionally before the early returns.
 #[component]
 pub fn MobilePlayer(uuid: String, file_id: Option<i64>) -> Element {
     let server_url = use_server_url();
@@ -82,52 +82,13 @@ pub fn MobilePlayer(uuid: String, file_id: Option<i64>) -> Element {
     // Point the app-wide player at this route's book — only when it differs,
     // so re-entering the currently-playing book (e.g. from the mini-player)
     // is seamless instead of restarting the surface.
-    let route_uuid = uuid.clone();
-    use_effect(use_reactive!(|(route_uuid, file_id)| {
-        let mut uuid_sig = ctx.uuid;
-        let mut file_sig = ctx.file_id;
-        // Offline with no completed audio download, retargeting the host
-        // would only stall — bounce back with the app-level offline sheet
-        // instead (mirrors the reader guard). An already-loaded book skips
-        // the check so re-entering the current playback stays seamless.
-        let already_loaded = uuid_sig.peek().as_deref() == Some(route_uuid.as_str());
-        if !already_loaded
-            && crate::offline::sync::is_offline()
-            && !crate::offline::downloads::is_complete(
-                &route_uuid,
-                crate::offline::downloads::DlFormat::Audio,
-            )
-        {
-            crate::components::offline_guard::block(
-                "This audiobook isn\u{2019}t downloaded, so it can\u{2019}t be played while offline.",
-            );
-            if nav.can_go_back() {
-                nav.go_back();
-            } else {
-                nav.replace(Route::BookDetail {
-                    uuid: route_uuid.clone(),
-                });
-            }
-            return;
-        }
-        // Publish the picker's selection first so the host reads the right file
-        // when the uuid change kicks off the load.
-        file_sig.set(file_id);
-        if uuid_sig.peek().as_deref() != Some(route_uuid.as_str()) {
-            uuid_sig.set(Some(route_uuid.clone()));
-        }
-    }));
+    use_retarget_playback(uuid.clone(), file_id, ctx, nav);
 
     // Re-measure the title marquee whenever the displayed title (re)appears —
     // covers the loading→loaded transition and any book switch. A hook, so it
     // must run unconditionally ahead of the early returns below.
     let view_now = (ctx.view)();
-    let marquee_title = view_now.as_ref().map(|v| v.title.clone());
-    use_effect(use_reactive!(|marquee_title| {
-        if marquee_title.is_some() {
-            interop::refresh_title_marquee();
-        }
-    }));
+    use_marquee_title_refresh(&view_now);
 
     if let Some(msg) = (ctx.error)() {
         return render_error(&msg);
@@ -164,6 +125,65 @@ pub fn MobilePlayer(uuid: String, file_id: Option<i64>) -> Element {
         ctx,
         on_nav_back: on_back,
     })
+}
+
+/// Point the app-wide player at `route_uuid`/`file_id` — only when it
+/// differs, so re-entering the currently-playing book (e.g. from the
+/// mini-player) is seamless instead of restarting the surface. Offline with
+/// no completed audio download, retargeting would only stall, so this
+/// bounces back with the app-level offline sheet instead (mirrors the
+/// reader guard); an already-loaded book skips that check. Split out of
+/// [`MobilePlayer`] as its own hook (call-order-stable, so it's still safe
+/// to invoke unconditionally from the component body).
+fn use_retarget_playback(
+    route_uuid: String,
+    file_id: Option<i64>,
+    ctx: MobilePlayback,
+    nav: dioxus_router::Navigator,
+) {
+    use_effect(use_reactive!(|(route_uuid, file_id)| {
+        let mut uuid_sig = ctx.uuid;
+        let mut file_sig = ctx.file_id;
+        let already_loaded = uuid_sig.peek().as_deref() == Some(route_uuid.as_str());
+        if !already_loaded
+            && crate::offline::sync::is_offline()
+            && !crate::offline::downloads::is_complete(
+                &route_uuid,
+                crate::offline::downloads::DlFormat::Audio,
+            )
+        {
+            crate::components::offline_guard::block(
+                "This audiobook isn\u{2019}t downloaded, so it can\u{2019}t be played while offline.",
+            );
+            if nav.can_go_back() {
+                nav.go_back();
+            } else {
+                nav.replace(Route::BookDetail {
+                    uuid: route_uuid.clone(),
+                });
+            }
+            return;
+        }
+        // Publish the picker's selection first so the host reads the right file
+        // when the uuid change kicks off the load.
+        file_sig.set(file_id);
+        if uuid_sig.peek().as_deref() != Some(route_uuid.as_str()) {
+            uuid_sig.set(Some(route_uuid.clone()));
+        }
+    }));
+}
+
+/// Re-measure the title marquee whenever the displayed title (re)appears —
+/// covers the loading→loaded transition and any book switch. Split out of
+/// [`MobilePlayer`] as its own hook (call-order-stable, so it's still safe
+/// to invoke unconditionally from the component body).
+fn use_marquee_title_refresh(view_now: &Option<PlayerView>) {
+    let marquee_title = view_now.as_ref().map(|v| v.title.clone());
+    use_effect(use_reactive!(|marquee_title| {
+        if marquee_title.is_some() {
+            interop::refresh_title_marquee();
+        }
+    }));
 }
 
 /// Bundle of props threaded into [`render_player`] so the signal-wiring

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -237,7 +237,7 @@ async fn load_and_drain(
     let Some(book) = load_book_metadata(&server_url, &uuid, error, loading).await else {
         return;
     };
-    let Some((manifest, file_id)) =
+    let Some((manifest, _file_id)) =
         load_manifest(&server_url, &uuid, selected_file_id, &book, error, loading).await
     else {
         return;

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -157,6 +157,54 @@ fn reset_playback(ctx: MobilePlayback) {
     sleep.set(SleepState::Off);
 }
 
+/// Fetch the book's metadata for `uuid`, surfacing "not found" or transport
+/// errors on the `error`/`loading` signals. `None` means the caller should
+/// return without proceeding — the failure is already reported.
+async fn load_book_metadata(
+    server_url: &str,
+    uuid: &str,
+    mut error: Signal<Option<String>>,
+    mut loading: Signal<bool>,
+) -> Option<omnibus_shared::EbookMetadata> {
+    match data::get_ebook(server_url, uuid).await {
+        Ok(Some(b)) => Some(b),
+        Ok(None) => {
+            error.set(Some("Audiobook not found.".into()));
+            loading.set(false);
+            None
+        }
+        Err(e) => {
+            error.set(Some(e.to_string()));
+            loading.set(false);
+            None
+        }
+    }
+}
+
+/// Resolve the target file (picker choice, else the first audio file) and
+/// fetch its manifest, surfacing transport errors on `error`/`loading`.
+/// Returns `None` on failure — the failure is already reported.
+async fn load_manifest(
+    server_url: &str,
+    uuid: &str,
+    selected_file_id: Option<i64>,
+    book: &omnibus_shared::EbookMetadata,
+    mut error: Signal<Option<String>>,
+    mut loading: Signal<bool>,
+) -> Option<(AudiobookManifest, Option<i64>)> {
+    // Honor the picker's explicit choice; otherwise default to the first audio
+    // file (a bare `/listen/:uuid` with no `?file_id=`).
+    let file_id = selected_file_id.or_else(|| first_audio_file_id(&book.book_files));
+    match data::get_manifest(server_url, uuid, file_id).await {
+        Ok(m) => Some((m, file_id)),
+        Err(e) => {
+            error.set(Some(e.to_string()));
+            loading.set(false);
+            None
+        }
+    }
+}
+
 /// Fetch metadata + manifest for `uuid`, seed the context, install the audio
 /// control surface for direct-play books (or flag HLS as unsupported), then
 /// drain its events until superseded.
@@ -186,29 +234,13 @@ async fn load_and_drain(
     sleep.set(SleepState::Off);
     rate.set(1.0);
 
-    let book = match data::get_ebook(&server_url, &uuid).await {
-        Ok(Some(b)) => b,
-        Ok(None) => {
-            error.set(Some("Audiobook not found.".into()));
-            loading.set(false);
-            return;
-        }
-        Err(e) => {
-            error.set(Some(e.to_string()));
-            loading.set(false);
-            return;
-        }
+    let Some(book) = load_book_metadata(&server_url, &uuid, error, loading).await else {
+        return;
     };
-    // Honor the picker's explicit choice; otherwise default to the first audio
-    // file (a bare `/listen/:uuid` with no `?file_id=`).
-    let file_id = selected_file_id.or_else(|| first_audio_file_id(&book.book_files));
-    let manifest = match data::get_manifest(&server_url, &uuid, file_id).await {
-        Ok(m) => m,
-        Err(e) => {
-            error.set(Some(e.to_string()));
-            loading.set(false);
-            return;
-        }
+    let Some((manifest, file_id)) =
+        load_manifest(&server_url, &uuid, selected_file_id, &book, error, loading).await
+    else {
+        return;
     };
 
     match manifest {

--- a/frontend/src/pages/listen/mobile/interop.rs
+++ b/frontend/src/pages/listen/mobile/interop.rs
@@ -176,9 +176,12 @@ fn fire(js: &str) {
     let _ = dioxus::document::eval(js);
 }
 
-/// Build the `window.OmnibusMobileAudio` install script. Only the four
-/// interpolation points (`parts_json`, `resume_lit`, `rate_lit`, `meta_lit`)
-/// use `format!`; the rest is literal JS.
+/// Build the `window.OmnibusMobileAudio` install script. Composes five
+/// pure-JS sub-segments ([`mount_element_js`], [`transport_js`],
+/// [`media_session_js`], [`listeners_js`], [`seed_resume_js`]) around the
+/// four interpolation points (`parts_json`, `resume_lit`, `rate_lit`,
+/// `meta_lit`) — the same composition idiom the desktop bootstrap's
+/// `control_surface_js` uses for `dom_reset_js`/`listeners_js`/etc.
 fn surface_js(parts_json: &str, resume_lit: &str, rate_lit: &str, meta_lit: &str) -> String {
     format!(
         r#"
@@ -193,139 +196,185 @@ fn surface_js(parts_json: &str, resume_lit: &str, rate_lit: &str, meta_lit: &str
   var acc = 0;
   for (var i = 0; i < parts.length; i++) {{ offsets.push(acc); acc += (parts[i].duration || 0); }}
 
-  // Drop any prior element before reinstalling: reusing it would stack a fresh
+{mount}
+
+{transport}
+
+{media_session}
+
+{listeners}
+
+{seed}
+}})();
+"#,
+        mount = mount_element_js(),
+        transport = transport_js(),
+        media_session = media_session_js(),
+        listeners = listeners_js(),
+        seed = seed_resume_js(),
+    )
+}
+
+/// Create (or replace) the `<audio>` element, apply the initial rate, and
+/// wire the `loadedmetadata` rate re-apply plus the `absTime()` helper.
+/// Pure JS with no Rust interpolation (`rate` is already in scope from the
+/// enclosing IIFE), so it lives as a raw `&'static str`.
+fn mount_element_js() -> &'static str {
+    r#"  // Drop any prior element before reinstalling: reusing it would stack a fresh
   // set of timeupdate/play/pause/ended listeners (and orphan the old Eval
   // channel's dioxus.send closures) on every SPA re-entry / book switch.
   var old = document.getElementById('m-omnibus-audio');
-  if (old) {{ try {{ old.pause(); }} catch(_e) {{}} old.remove(); }}
+  if (old) { try { old.pause(); } catch(_e) {} old.remove(); }
   var el = document.createElement('audio');
   el.id = 'm-omnibus-audio';
   el.preload = 'auto';
   el.style.display = 'none';
   document.body.appendChild(el);
-  try {{ el.playbackRate = rate; }} catch(_e) {{}}
+  try { el.playbackRate = rate; } catch(_e) {}
 
   // WKWebView resets `playbackRate` to 1.0 every time a new resource
   // loads, so the rate set above (and every `setRate`) is wiped by the
   // seed / cross-part / auto-advance `el.load()` calls below — the book
   // plays at 1.0 while the UI shows the saved speed. Re-apply the tracked
   // rate on every `loadedmetadata` to keep the element in sync.
-  el.addEventListener('loadedmetadata', function(){{
+  el.addEventListener('loadedmetadata', function(){
     var oa = window.OmnibusMobileAudio;
-    if (oa) {{ try {{ el.playbackRate = oa._rate; }} catch(_e) {{}} }}
-  }});
+    if (oa) { try { el.playbackRate = oa._rate; } catch(_e) {} }
+  });
 
-  function absTime() {{
+  function absTime() {
     var oa = window.OmnibusMobileAudio;
     if (!oa) return el.currentTime || 0;
     return (oa._offsets[oa._index] || 0) + (el.currentTime || 0);
-  }}
+  }"#
+}
 
-  window.OmnibusMobileAudio = {{
+/// The `window.OmnibusMobileAudio` transport object: state plus
+/// play/pause/toggle/setRate/seek/skip. Pure JS with no Rust interpolation
+/// (`parts`, `offsets`, `rate`, `el`, `absTime` are already in scope), so
+/// it lives as a raw `&'static str`.
+fn transport_js() -> &'static str {
+    r#"  window.OmnibusMobileAudio = {
     _parts: parts,
     _offsets: offsets,
     _index: 0,
     // Tracked separately because WKWebView drops `el.playbackRate` to 1.0
     // on every resource load; the `loadedmetadata` listener re-applies it.
     _rate: rate,
-    play: function(){{ var p = el.play(); if (p && p.catch) p.catch(function(){{}}); }},
-    pause: function(){{ el.pause(); }},
-    toggle: function(){{ if (el.paused) {{ this.play(); }} else {{ this.pause(); }} }},
-    setRate: function(r){{ this._rate = r; try {{ el.playbackRate = r; }} catch(_e) {{}} }},
-    seek: function(absSeconds){{
+    play: function(){ var p = el.play(); if (p && p.catch) p.catch(function(){}); },
+    pause: function(){ el.pause(); },
+    toggle: function(){ if (el.paused) { this.play(); } else { this.pause(); } },
+    setRate: function(r){ this._rate = r; try { el.playbackRate = r; } catch(_e) {} },
+    seek: function(absSeconds){
       var s = Math.max(0, absSeconds || 0);
       var i = 0;
       while (i < this._offsets.length - 1 && s >= this._offsets[i + 1]) i++;
       var local = s - this._offsets[i];
-      if (i !== this._index) {{
+      if (i !== this._index) {
         var wasPlaying = !el.paused;
         this._index = i;
-        var onMeta = function(){{
+        var onMeta = function(){
           el.removeEventListener('loadedmetadata', onMeta);
-          try {{ el.currentTime = local; }} catch(_e) {{}}
-          if (wasPlaying) {{ var p = el.play(); if (p && p.catch) p.catch(function(){{}}); }}
-        }};
+          try { el.currentTime = local; } catch(_e) {}
+          if (wasPlaying) { var p = el.play(); if (p && p.catch) p.catch(function(){}); }
+        };
         el.addEventListener('loadedmetadata', onMeta);
         el.src = this._parts[i].url; el.load();
-      }} else {{
-        try {{ el.currentTime = local; }} catch(_e) {{}}
-      }}
-    }},
-    skip: function(d){{ this.seek(absTime() + d); }},
-  }};
+      } else {
+        try { el.currentTime = local; } catch(_e) {}
+      }
+    },
+    skip: function(d){ this.seek(absTime() + d); },
+  };"#
+}
 
-  // iOS lock-screen / Control Center now-playing via the Media Session API.
-  // WKWebView mirrors this into MPNowPlayingInfoCenter, so it's what shows the
-  // book cover + "Omnibus" instead of blank branding. Guarded — older WebViews
-  // lack the API.
-  var hasMediaSession = ('mediaSession' in navigator);
-  function updatePositionState() {{
-    if (!hasMediaSession || !navigator.mediaSession.setPositionState) return;
-    if (!(acc > 0) || !isFinite(acc)) return;
-    try {{
-      navigator.mediaSession.setPositionState({{
-        duration: acc,
-        playbackRate: el.playbackRate || 1,
-        position: Math.max(0, Math.min(absTime(), acc)),
-      }});
-    }} catch(_e) {{}}
-  }}
-  if (hasMediaSession) {{
-    try {{
-      var art = (meta && meta.artwork)
-        ? [{{ src: meta.artwork, sizes: '512x512', type: 'image/webp' }}]
-        : [];
-      navigator.mediaSession.metadata = new MediaMetadata({{
-        title: (meta && meta.title) || '',
-        artist: (meta && meta.artist) || '',
-        album: (meta && meta.album) || 'Omnibus',
-        artwork: art,
-      }});
-    }} catch(_e) {{}}
-    var oa = window.OmnibusMobileAudio;
-    var setH = function(a, fn){{ try {{ navigator.mediaSession.setActionHandler(a, fn); }} catch(_e) {{}} }};
-    // WebKit's native handlers keep working while backgrounded JS is suspended.
-    setH('play', null);
-    setH('pause', null);
-    setH('seekbackward', function(d){{ oa.skip(-((d && d.seekOffset) || 30)); }});
-    setH('seekforward', function(d){{ oa.skip((d && d.seekOffset) || 30); }});
-    setH('seekto', function(d){{ if (d && d.seekTime != null) oa.seek(d.seekTime); }});
-  }}
-
-  el.addEventListener('timeupdate', function(){{ dioxus.send({{ kind: 'Time', seconds: absTime(), paused: el.paused }}); updatePositionState(); }});
-  el.addEventListener('play',  function(){{ dioxus.send({{ kind: 'Play' }}); if (hasMediaSession) navigator.mediaSession.playbackState = 'playing'; updatePositionState(); }});
-  el.addEventListener('pause', function(){{ dioxus.send({{ kind: 'Pause', seconds: absTime() }}); if (hasMediaSession) navigator.mediaSession.playbackState = 'paused'; }});
+/// The four audio-element event listeners (timeupdate/play/pause/ended)
+/// that push [`AudioEvent`]s back to Rust and reconcile Media Session
+/// state. Pure JS with no Rust interpolation (`el`, `absTime`,
+/// `hasMediaSession`, `updatePositionState` come from
+/// [`mount_element_js`]/[`media_session_js`]), so it lives as a raw
+/// `&'static str`.
+fn listeners_js() -> &'static str {
+    r#"  el.addEventListener('timeupdate', function(){ dioxus.send({ kind: 'Time', seconds: absTime(), paused: el.paused }); updatePositionState(); });
+  el.addEventListener('play',  function(){ dioxus.send({ kind: 'Play' }); if (hasMediaSession) navigator.mediaSession.playbackState = 'playing'; updatePositionState(); });
+  el.addEventListener('pause', function(){ dioxus.send({ kind: 'Pause', seconds: absTime() }); if (hasMediaSession) navigator.mediaSession.playbackState = 'paused'; });
   // Cross-part auto-advance: chain to the next part on natural end.
-  el.addEventListener('ended', function(){{
+  el.addEventListener('ended', function(){
     var oa = window.OmnibusMobileAudio;
     if (!oa) return;
-    if (oa._index + 1 < oa._parts.length) {{
+    if (oa._index + 1 < oa._parts.length) {
       oa._index += 1;
       el.src = oa._parts[oa._index].url; el.load();
-      var p = el.play(); if (p && p.catch) p.catch(function(){{}});
+      var p = el.play(); if (p && p.catch) p.catch(function(){});
       return;
-    }}
+    }
     // Nothing left to advance to: the book is finished.
-    dioxus.send({{ kind: 'Ended' }});
-  }});
+    dioxus.send({ kind: 'Ended' });
+  });"#
+}
 
-  // Seed the starting part for the resume position.
-  (function(){{
+/// Seed the starting part and in-part offset for the resume position. Pure
+/// JS with no Rust interpolation (`resume`, `offsets`, `parts`, `el` are
+/// already in scope), so it lives as a raw `&'static str`.
+fn seed_resume_js() -> &'static str {
+    r#"  // Seed the starting part for the resume position.
+  (function(){
     var s = Math.max(0, resume);
     var idx = 0;
     while (idx < offsets.length - 1 && s >= offsets[idx + 1]) idx++;
     window.OmnibusMobileAudio._index = idx;
     var local = s - offsets[idx];
-    var onMeta = function(){{
+    var onMeta = function(){
       el.removeEventListener('loadedmetadata', onMeta);
-      try {{ el.currentTime = local; }} catch(_e) {{}}
-    }};
+      try { el.currentTime = local; } catch(_e) {}
+    };
     el.addEventListener('loadedmetadata', onMeta);
-    if (parts[idx]) {{ el.src = parts[idx].url; el.load(); }}
-  }})();
-}})();
-"#
-    )
+    if (parts[idx]) { el.src = parts[idx].url; el.load(); }
+  })();"#
+}
+
+/// iOS lock-screen / Control Center now-playing via the Media Session API:
+/// seeds the `MediaMetadata`, wires `setPositionState`, and installs the
+/// seek/skip action handlers. WKWebView mirrors this into
+/// `MPNowPlayingInfoCenter`. Guarded — older WebViews lack the API. Pure JS
+/// with no Rust interpolation (`meta`, `acc`, `el`, `absTime` are already in
+/// scope from the enclosing IIFE), so it lives as a raw `&'static str`
+/// (literal braces, no escaping) — the same idiom the desktop bootstrap's
+/// `dom_reset_js`/`listeners_js` use.
+fn media_session_js() -> &'static str {
+    r#"  var hasMediaSession = ('mediaSession' in navigator);
+  function updatePositionState() {
+    if (!hasMediaSession || !navigator.mediaSession.setPositionState) return;
+    if (!(acc > 0) || !isFinite(acc)) return;
+    try {
+      navigator.mediaSession.setPositionState({
+        duration: acc,
+        playbackRate: el.playbackRate || 1,
+        position: Math.max(0, Math.min(absTime(), acc)),
+      });
+    } catch(_e) {}
+  }
+  if (hasMediaSession) {
+    try {
+      var art = (meta && meta.artwork)
+        ? [{ src: meta.artwork, sizes: '512x512', type: 'image/webp' }]
+        : [];
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: (meta && meta.title) || '',
+        artist: (meta && meta.artist) || '',
+        album: (meta && meta.album) || 'Omnibus',
+        artwork: art,
+      });
+    } catch(_e) {}
+    var oa = window.OmnibusMobileAudio;
+    var setH = function(a, fn){ try { navigator.mediaSession.setActionHandler(a, fn); } catch(_e) {} };
+    // WebKit's native handlers keep working while backgrounded JS is suspended.
+    setH('play', null);
+    setH('pause', null);
+    setH('seekbackward', function(d){ oa.skip(-((d && d.seekOffset) || 30)); });
+    setH('seekforward', function(d){ oa.skip((d && d.seekOffset) || 30); });
+    setH('seekto', function(d){ if (d && d.seekTime != null) oa.seek(d.seekTime); });
+  }"#
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- `frontend/src/pages/listen/mobile/interop.rs` — `surface_js` (~197 lines → 24). Extracted the Media Session metadata/`setPositionState`/action-handler block into `media_session_js()`, plus `mount_element_js()`, `transport_js()`, `listeners_js()`, and `seed_resume_js()` — the same sub-segment composition idiom `control_surface_js` uses in the desktop bootstrap.
- `frontend/src/pages/listen/mobile/host.rs` — `load_and_drain` (~89 → 73 lines). Extracted `load_book_metadata` and `load_manifest` helpers for the book-fetch and manifest-fetch steps. (The lock-screen `NowPlaying`/artwork construction the issue described was already factored into `init_direct_and_drain` on this branch.)
- `frontend/src/pages/listen/mobile.rs` — `MobilePlayer` (~112 → 73 lines). Extracted the retarget-playback effect into `use_retarget_playback` and the marquee-title-refresh effect into `use_marquee_title_refresh`; updated the component's now-stale "kept near the cap by design" doc comment.
- `frontend/src/pages/book_detail/mobile.rs` — `render_loaded_mobile` (250 → 77 lines, well over the issue's ~190 estimate). Extracted `hero_section`, `title_and_cta_section`, `about_section`, `info_sections`, `split_meta_and_files`, and `build_on_fetched_handler`, following the file's existing `same_hand_section`/`suggestions_section`/`files_list` pattern.
- `frontend/src/pages/book_detail/journal/composer.rs` — `BdJournalComposerFoot` (131 → 61 lines) and `BdJournalComposer` (106 → 62 lines). Extracted `use_composer_signals` + `use_composer_autosave` (hook wiring) out of the composer, and `build_save_as_handler` + `cancel_and_discard_draft` out of the footer.
- `frontend/src/pages/book_detail/journal/entry_card.rs` — `BdJournalEntryHeader` (113 → 92 lines). Extracted the Publish-draft button into its own `BdJournalPublishDraftButton` component.
- `db/src/suggestions/cascade.rs` — `resolve_with` (84 → 77 lines). Extracted the bounded-concurrency cover-fetch chunk loop into `fetch_covers_bounded`.
- `frontend/src/components/shelf_rule_builder.rs` — `ConditionRow`'s five field-mutation closures collapsed into one generic `apply_draft_change(draft, on_change, f: impl FnOnce(&mut RuleDraft))` helper, called from each of the five per-input handlers in `build_condition_handlers`.

Pure refactor — no behavior change, no rendered-markup change (rule 07 hydration parity preserved: no `#[cfg(feature = ...)]` gates added around any rsx).

Closes #1079

## Test plan
- [x] `cargo fmt` — clean, no diff
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (621 passed)
- [x] `cargo test -p omnibus-db` — 1732 passed, 1 failed (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, a pre-existing failure in this sandbox from a missing audiobook test fixture, unrelated to this change)

## Notes
- Two of the issue's line-count estimates were off (the issue was filed against a slightly earlier commit, as noted): `load_and_drain`'s NowPlaying/artwork construction was already factored into a sibling helper on `main`, and `render_loaded_mobile` was actually 250 lines (not ~190) — extracted well beyond the ~100-line acceptance bar as a result.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VcuRz7FVMcMQtDtuaipEtD)_