### PR TITLE
fix: clear stale title-search state when resolving a check-in ISBN (#1634)

### DIFF
--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
@@ -86,6 +86,15 @@ enum CheckInFlow {
         return false
     }
 
+    /// A resolve fires from the scan stage's ISBN field, whose fallback
+    /// screen — `.outcome(.unresolved)` — reuses the *same* title-search
+    /// query/results state. Leaving `.scan` for any outcome must clear it,
+    /// or the fallback opens showing a search from the book just resolved.
+    static func resolveShouldClearSearch(from stage: CheckInStage) -> Bool {
+        if case .scan = stage { return true }
+        return false
+    }
+
     /// Outcomes whose card links straight to the book's detail page.
     static func detailUUID(for outcome: ScanOutcome) -> String? {
         switch outcome {

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
@@ -95,6 +95,18 @@ enum CheckInFlow {
         return false
     }
 
+    /// A title search is a separate in-flight request that can outlive a
+    /// resolve landing elsewhere (or a restart, or a newer keystroke) —
+    /// its response must only apply if the stage and query it was asked
+    /// with are still current, or a late answer reintroduces the same
+    /// stale-search bug `resolveShouldClearSearch` guards against.
+    static func searchResponseShouldApply(
+        startedStage: CheckInStage, currentStage: CheckInStage,
+        startedQuery: String, currentQuery: String
+    ) -> Bool {
+        startedStage == currentStage && startedQuery == currentQuery
+    }
+
     /// Outcomes whose card links straight to the book's detail page.
     static func detailUUID(for outcome: ScanOutcome) -> String? {
         switch outcome {

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
@@ -564,6 +564,11 @@ struct CheckInView: View {
     /// Search the providers by title — the unresolved screen's fallback.
     private func search() async {
         guard let query = searchQuery.nilIfBlank, !isSearching else { return }
+        // A resolve can land while this request is still in flight — guard the
+        // assignment on the stage/query at request time so a late response
+        // can't reintroduce the stale-search bug `resolve(_:)` clears against.
+        let startedStage = stage
+        let startedQuery = query
         isSearching = true
         error = nil
         defer { isSearching = false }
@@ -571,6 +576,12 @@ struct CheckInView: View {
             let response: ScanSearchResponse = try await APIClient.shared.post(
                 "/api/scan/search", body: ScanSearchRequest(query: query)
             )
+            guard
+                CheckInFlow.searchResponseShouldApply(
+                    startedStage: startedStage, currentStage: stage,
+                    startedQuery: startedQuery, currentQuery: searchQuery
+                )
+            else { return }
             searchResults = response.results
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
@@ -537,7 +537,13 @@ struct CheckInView: View {
             let result: ScanOutcome = try await APIClient.shared.post(
                 "/api/scan/resolve", body: ScanResolveRequest(isbn: isbn)
             )
-            withAnimation(Motion.settle) { stage = .outcome(result) }
+            withAnimation(Motion.settle) {
+                if CheckInFlow.resolveShouldClearSearch(from: stage) {
+                    searchQuery = ""
+                    searchResults = nil
+                }
+                stage = .outcome(result)
+            }
         } catch {
             self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
         }

--- a/omnibus-ios/omnibusTests/CheckInFlowTests.swift
+++ b/omnibus-ios/omnibusTests/CheckInFlowTests.swift
@@ -88,6 +88,31 @@ struct CheckInFlowTests {
         )
     }
 
+    @Test func searchResponseShouldApplyOnlyWhenStageAndQueryAreUnchanged() {
+        // A title search is a separate in-flight request — if a resolve lands
+        // (stage moves on) or the field is retyped (query moves on) before it
+        // returns, the late response must be dropped rather than repopulating
+        // search state a resolve just cleared.
+        #expect(
+            CheckInFlow.searchResponseShouldApply(
+                startedStage: .scan, currentStage: .scan,
+                startedQuery: "babel", currentQuery: "babel"
+            )
+        )
+        #expect(
+            !CheckInFlow.searchResponseShouldApply(
+                startedStage: .scan, currentStage: .outcome(.unresolved),
+                startedQuery: "babel", currentQuery: "babel"
+            )
+        )
+        #expect(
+            !CheckInFlow.searchResponseShouldApply(
+                startedStage: .scan, currentStage: .scan,
+                startedQuery: "babel", currentQuery: "bee sting"
+            )
+        )
+    }
+
     @Test func detailUUIDCoversAlreadyOwnedAndOnWishlistOnly() {
         #expect(CheckInFlow.detailUUID(for: .alreadyOwned(book: scanBook())) == "b-1")
         #expect(CheckInFlow.detailUUID(for: .onWishlist(book: scanBook())) == "b-1")

--- a/omnibus-ios/omnibusTests/CheckInFlowTests.swift
+++ b/omnibus-ios/omnibusTests/CheckInFlowTests.swift
@@ -74,6 +74,20 @@ struct CheckInFlowTests {
         #expect(!CheckInFlow.showsNoteField(for: .unresolved))
     }
 
+    @Test func resolveShouldClearSearchOnlyWhenLeavingTheScanStage() {
+        // A resolve always fires from `.scan` — the ISBN field's stage — so
+        // landing on any outcome (including `.unresolved`, whose fallback
+        // reuses the scan page's title-search state) must clear the stale
+        // query/results left over from it.
+        #expect(CheckInFlow.resolveShouldClearSearch(from: .scan))
+        #expect(!CheckInFlow.resolveShouldClearSearch(from: .outcome(.unresolved)))
+        #expect(
+            !CheckInFlow.resolveShouldClearSearch(
+                from: .outcome(.inLibraryUnowned(book: scanBook()))
+            )
+        )
+    }
+
     @Test func detailUUIDCoversAlreadyOwnedAndOnWishlistOnly() {
         #expect(CheckInFlow.detailUUID(for: .alreadyOwned(book: scanBook())) == "b-1")
         #expect(CheckInFlow.detailUUID(for: .onWishlist(book: scanBook())) == "b-1")


### PR DESCRIPTION
## Summary
- Closes #1634
- `resolve(_:)` in `CheckInView.swift` landed on `.outcome` without clearing `searchQuery`/`searchResults`, so a title search typed on the scan page leaked into the unresolved fallback screen (both bind the same `@State` pair, per #1627). `restart()` already cleared this state; `resolve(_:)` didn't.
- Extracted the reset decision into a new pure gate, `CheckInFlow.resolveShouldClearSearch(from:)`, mirroring the existing `showsNoteField`/`detailUUID` pattern in that same file ("pure builders and gates, separated from the view so they're testable without a server"). `resolve(_:)` now calls it inside the same `withAnimation(Motion.settle)` block that sets `stage = .outcome(result)`, clearing `searchQuery`/`searchResults` whenever the resolve is leaving `.scan`.

## Approach note (test coverage)
The stale state itself lives in `@State` inside `CheckInView`, which isn't reachable from a pure-model unit test, and this repo's `omnibusUITests` suite is currently hermetic/offline (no network-mocking harness to drive a real scan → resolve → unresolved-fallback flow through the UI). Rather than bolt on new UI-test infra for one regression, I extracted the actual decision that drives the reset (`resolveShouldClearSearch`) into `CheckInFlow` — the file's established home for pure, testable logic — and added a unit test for it in `CheckInFlowTests.swift`, following that file's existing naming/style. This directly covers the invariant the bug violated (leaving `.scan` for any outcome, including `.unresolved`, must clear the search state) without restructuring `@State` or introducing test-only network mocking.

## Test plan
- [x] Unit test added: `resolveShouldClearSearchOnlyWhenLeavingTheScanStage` in `omnibus-ios/omnibusTests/CheckInFlowTests.swift`, asserting the gate is `true` from `.scan` and `false` from `.outcome(.unresolved)` / `.outcome(.inLibraryUnowned)`.
- [ ] Local Swift build/test was **not available** in this environment (no Xcode/macOS toolchain on this cloud Linux image) — I carefully re-read the diff for brace matching, correct `@State`/`withAnimation` usage, and correct enum pattern matching, but could not compile it myself.
- CI (`ios-tests.yml`, `omnibusTests` suite on a macOS runner) is the authoritative verification gate for this PR. I expect it to confirm: the project compiles, the new `resolveShouldClearSearch` test passes, and no existing `CheckInFlowTests` regress.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- Scope is Swift-only (`omnibus-ios/`), no server/shared-crate changes, per the issue.
- `resolve(_:)` is only ever invoked while `stage == .scan` (the barcode scanner callback and the manual ISBN field are both part of the scan-page UI), so the gate always evaluates `true` in practice today — it's modeled as a stage check (rather than an unconditional reset) for testability and to make the invariant explicit, matching the file's existing pattern.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DCWPoS3Ga15e84V4QpyWq5)_