### PR TITLE
docs: document Kobo highlight-colour on-wire limitation (#1629)

### DIFF
--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -123,10 +123,9 @@ wrong.
 > (yellow) regardless of the colour sent, while highlights created directly
 > on the device use the full `Color` range normally. This means the firmware
 > is not applying Omnibus's `highlightColor` value to inbound annotations as
-> sent — either it expects a different shape on this field (an integer 0–3
-> rather than a name, most plausible given a non-numeric string would coerce
-> to `0` under permissive JSON parsing) or it ignores colour on inbound
-> annotations entirely.
+> sent — it may expect a different shape on this field (e.g. an integer 0–3
+> rather than a name) or it may ignore colour on inbound annotations
+> entirely; which one is unconfirmed.
 >
 > This repo carries no captured device PATCH and no vendored reference
 > implementation for the Reading Services protocol to confirm which is

--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -112,3 +112,27 @@ A web highlight only converts when the book's KEPUB copy and its source EPUB
 still carry the same text — a conversion that can't be proven correct is
 skipped (the highlight simply stays web-only) rather than placed somewhere
 wrong.
+
+> [!NOTE]
+> **Known limitation: highlight colour pushed to a Kobo may not render**
+>
+> Omnibus sends each annotation's colour as `highlightColor` — a lowercase
+> colour name (`yellow`/`green`/`blue`/`pink`/`purple`) — in the Reading
+> Services annotation payload. On at least one real device, every annotation
+> pushed from Omnibus was observed stored on-device with `Bookmark.Color = 0`
+> (yellow) regardless of the colour sent, while highlights created directly
+> on the device use the full `Color` range normally. This means the firmware
+> is not applying Omnibus's `highlightColor` value to inbound annotations as
+> sent — either it expects a different shape on this field (an integer 0–3
+> rather than a name, most plausible given a non-numeric string would coerce
+> to `0` under permissive JSON parsing) or it ignores colour on inbound
+> annotations entirely.
+>
+> This repo carries no captured device PATCH and no vendored reference
+> implementation for the Reading Services protocol to confirm which is
+> true, so the wire format has **not** been changed speculatively — see
+> [#1629](https://github.com/seamus-sloan/omnibus/issues/1629). Highlight
+> and note **text**, placement, and deletes all sync correctly; only the
+> rendered *colour* of a device-side highlight is affected. Fixing this
+> for real needs a `.kobo/KoboReader.sqlite` capture (or a packet capture)
+> from a device that just received a coloured highlight over wireless sync.

--- a/server/src/backend/kobo/reading_services/tests.rs
+++ b/server/src/backend/kobo/reading_services/tests.rs
@@ -1019,15 +1019,7 @@ mod dto_tests {
         }
     }
 
-    // Pins the current outbound `highlightColor` wire shape — a lowercase
-    // color-name string under the camelCase key `highlightColor` — for
-    // every palette entry. #1629: a real device stores every pushed
-    // annotation as `Bookmark.Color = 0` regardless of the color Omnibus
-    // sends, but no vendored reference implementation or captured device
-    // PATCH exists in this repo to confirm whether the firmware instead
-    // wants an integer enum on this field, so this locks down today's
-    // documented (and possibly firmware-incompatible, see docs/kobo.md)
-    // behavior rather than leaving it unpinned.
+    // Pins color_to_kobo's value mapping so a future change to it is deliberate.
     #[test]
     fn color_to_kobo_emits_the_documented_lowercase_name_for_every_palette_color() {
         assert_eq!(color_to_kobo(HighlightColor::Amber), "yellow");

--- a/server/src/backend/kobo/reading_services/tests.rs
+++ b/server/src/backend/kobo/reading_services/tests.rs
@@ -1019,6 +1019,24 @@ mod dto_tests {
         }
     }
 
+    // Pins the current outbound `highlightColor` wire shape — a lowercase
+    // color-name string under the camelCase key `highlightColor` — for
+    // every palette entry. #1629: a real device stores every pushed
+    // annotation as `Bookmark.Color = 0` regardless of the color Omnibus
+    // sends, but no vendored reference implementation or captured device
+    // PATCH exists in this repo to confirm whether the firmware instead
+    // wants an integer enum on this field, so this locks down today's
+    // documented (and possibly firmware-incompatible, see docs/kobo.md)
+    // behavior rather than leaving it unpinned.
+    #[test]
+    fn color_to_kobo_emits_the_documented_lowercase_name_for_every_palette_color() {
+        assert_eq!(color_to_kobo(HighlightColor::Amber), "yellow");
+        assert_eq!(color_to_kobo(HighlightColor::Green), "green");
+        assert_eq!(color_to_kobo(HighlightColor::Blue), "blue");
+        assert_eq!(color_to_kobo(HighlightColor::Rose), "pink");
+        assert_eq!(color_to_kobo(HighlightColor::Violet), "purple");
+    }
+
     #[test]
     fn parse_content_id_strips_the_chapter_suffix() {
         assert_eq!(parse_content_id("uuid-1!!OEBPS/ch1.xhtml"), "uuid-1");


### PR DESCRIPTION
## Summary
- Addresses #1629 (documents a limitation rather than closing it — see Notes)
- A highlight pushed from Omnibus to a Kobo device lands with `Bookmark.Color = 0` (yellow) regardless of the colour Omnibus sent, per a real-device capture in the issue.
- Investigated `server/src/backend/kobo/reading_services/dto.rs` (`AnnotationOut`, camelCase `highlightColor` serialization) and `db/src/kobo/annotations.rs` (`fingerprint` hashing `row.color`, ruling out a redelivery cause) — both match what the issue reporter already verified, and `color_to_kobo`'s lowercase colour-name mapping (`yellow`/`green`/`blue`/`pink`/`purple`) is internally consistent with how the codebase models the protocol.
- Grepped this repo for any vendored reference implementation or captured device PATCH for the Reading Services annotation protocol (bookorbit / prosa-kobo / calibre-web / CWA) to confirm the expected on-wire shape of `highlightColor` — none exists. Without that ground truth, changing the wire format would be a guess (e.g. switching to an integer enum) with no way to verify it actually fixes the device.
- Documented the limitation in `docs/kobo.md` and added a test pinning the current outbound `highlightColor` shape (`color_to_kobo_emits_the_documented_lowercase_name_for_every_palette_color`), so a future change to it is deliberate and reviewable.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS
- [x] `cargo test -p omnibus` — 649 passed, 2 pre-existing failures unrelated to this change (`backend::uploads::tests::commit_rejects_read_only_library_with_400`, `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`); reproduced identically against a clean, unmodified `main` checkout in this same environment, so this is an environment artifact (this sandbox appears to run as a user that isn't blocked by a read-only-permission chmod, so the "reject with 400" assertion never fires), not a regression from this PR.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- This PR does **not** claim to fix the underlying device-rendering issue — it couldn't be confirmed without a real Kobo to capture a golden PATCH against (the issue itself calls this out as the necessary ground truth). It documents the known limitation and locks down current behavior with a test, satisfying AC1's documented-limitation fallback and AC2/AC3 as written. Recommend leaving #1629 open (or relabeling) until someone with device access can capture a real annotation PATCH — happy to pick that up in a follow-up once that capture exists.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DCWPoS3Ga15e84V4QpyWq5)_