### PR TITLE
refactor: split CheckInStage and normalize Hardcover ISBN (#1635)

### DIFF
--- a/db/src/metadata_lookup/providers/hardcover.rs
+++ b/db/src/metadata_lookup/providers/hardcover.rs
@@ -13,6 +13,7 @@
 //! that slows down the common case. In exchange it is the one provider that
 //! carries a series statement natively.
 
+use omnibus_shared::isbn::normalize_isbn;
 use omnibus_shared::metadata_lookup::{ExternalBookMeta, MetadataProvider};
 use serde::Deserialize;
 
@@ -178,7 +179,10 @@ fn map_book(b: BookRow, isbn13: Option<&str>) -> Option<ExternalBookMeta> {
     let title = b.title.filter(|t| !t.trim().is_empty())?;
     let isbn13 = match isbn13 {
         Some(scanned) => scanned.to_string(),
-        None => b.editions.into_iter().find_map(|e| e.isbn_13)?,
+        None => b
+            .editions
+            .into_iter()
+            .find_map(|e| e.isbn_13.and_then(|v| normalize_isbn(&v).ok()))?,
     };
     Some(ExternalBookMeta {
         isbn13,
@@ -210,3 +214,6 @@ fn map_book(b: BookRow, isbn13: Option<&str>) -> Option<ExternalBookMeta> {
         source: MetadataProvider::Hardcover,
     })
 }
+
+#[cfg(test)]
+mod tests;

--- a/db/src/metadata_lookup/providers/hardcover/tests.rs
+++ b/db/src/metadata_lookup/providers/hardcover/tests.rs
@@ -1,0 +1,74 @@
+//! Tests for the Hardcover provider's `map_book` — chiefly that a malformed
+//! or hyphenated candidate ISBN-13 from the GraphQL response is normalized
+//! (or rejected) the same way the sibling `openlibrary`/`googlebooks`
+//! providers treat their own candidate lists.
+
+use super::*;
+
+/// Build a minimal `BookRow` with one candidate edition, so each test only
+/// has to say what it's varying.
+fn book_row(title: &str, edition_isbn_13: Option<&str>) -> BookRow {
+    BookRow {
+        title: Some(title.to_string()),
+        description: None,
+        contributions: Vec::new(),
+        book_series: Vec::new(),
+        image: None,
+        editions: vec![Edition {
+            isbn_13: edition_isbn_13.map(|s| s.to_string()),
+        }],
+    }
+}
+
+#[test]
+fn map_book_normalizes_a_hyphenated_edition_isbn_when_no_scanned_isbn_is_given() {
+    let row = book_row("Test Book", Some("978-0-13-468599-1"));
+
+    let meta = map_book(row, None).expect("a valid, hyphenated isbn13 should still map");
+
+    assert_eq!(meta.isbn13, "9780134685991");
+}
+
+#[test]
+fn map_book_falls_through_to_none_when_the_only_edition_isbn_is_malformed() {
+    let row = book_row("Test Book", Some("not-an-isbn"));
+
+    assert!(
+        map_book(row, None).is_none(),
+        "a malformed edition isbn must not be passed through unnormalized"
+    );
+}
+
+#[test]
+fn map_book_falls_through_to_none_when_the_only_edition_isbn_has_a_bad_check_digit() {
+    // Same digits as the valid fixture ISBN with the final check digit
+    // flipped, so length and character-class checks alone wouldn't catch it.
+    let row = book_row("Test Book", Some("9780134685990"));
+
+    assert!(map_book(row, None).is_none());
+}
+
+#[test]
+fn map_book_falls_through_to_none_when_no_edition_has_an_isbn() {
+    let row = book_row("Test Book", None);
+
+    assert!(map_book(row, None).is_none());
+}
+
+#[test]
+fn map_book_uses_the_scanned_isbn_over_a_malformed_edition_isbn() {
+    let row = book_row("Test Book", Some("not-an-isbn"));
+
+    let meta = map_book(row, Some("9780134685991"))
+        .expect("the scanned isbn is authoritative and needs no edition fallback");
+
+    assert_eq!(meta.isbn13, "9780134685991");
+}
+
+#[test]
+fn map_book_returns_none_when_the_title_is_missing() {
+    let mut row = book_row("Test Book", Some("9780134685991"));
+    row.title = None;
+
+    assert!(map_book(row, None).is_none());
+}

--- a/frontend/src/pages/check_in/mod.rs
+++ b/frontend/src/pages/check_in/mod.rs
@@ -215,6 +215,18 @@ pub(crate) struct FlowState {
     pub(crate) error: Signal<Option<String>>,
 }
 
+/// [`CheckInStage`]'s per-outcome callbacks, bundled into one prop so the
+/// component stays under the 5-prop soft cap. One field per terminal action
+/// a stage can trigger; [`CheckInPage`] wires each to its `make_on_*` handler.
+#[derive(Clone, PartialEq)]
+struct CheckInHandlers {
+    on_resolve: EventHandler<String>,
+    on_check_in: EventHandler<ScanBook>,
+    on_own_it: EventHandler<ExternalBookMeta>,
+    on_pick: EventHandler<ExternalBookMeta>,
+    on_wishlist: EventHandler<WishlistAddRequest>,
+}
+
 /// Check-in page: type an ISBN, then follow it wherever the ladder lands.
 #[component]
 pub fn CheckInPage() -> Element {
@@ -233,6 +245,13 @@ pub fn CheckInPage() -> Element {
     let on_own_it = make_on_own_it(server_url.clone(), state);
     let on_pick = make_on_pick(server_url.clone(), state, nav);
     let on_wishlist = make_on_wishlist(server_url, state);
+    let handlers = CheckInHandlers {
+        on_resolve: EventHandler::new(on_resolve),
+        on_check_in: EventHandler::new(on_check_in),
+        on_own_it: EventHandler::new(on_own_it),
+        on_pick: EventHandler::new(on_pick),
+        on_wishlist: EventHandler::new(on_wishlist),
+    };
 
     rsx! {
         section { class: "card check-in", "data-testid": "check-in",
@@ -245,14 +264,7 @@ pub fn CheckInPage() -> Element {
                 title: "Cancel",
                 "\u{00d7}"
             }
-            CheckInStage {
-                state,
-                on_resolve: EventHandler::new(on_resolve),
-                on_check_in: EventHandler::new(on_check_in),
-                on_own_it: EventHandler::new(on_own_it),
-                on_pick: EventHandler::new(on_pick),
-                on_wishlist: EventHandler::new(on_wishlist),
-            }
+            CheckInStage { state, handlers }
             if let Some(msg) = (state.error)() {
                 p {
                     "data-testid": "check-in-error",
@@ -266,103 +278,55 @@ pub fn CheckInPage() -> Element {
 }
 
 /// Render whichever screen the current [`Stage`] calls for. Split out of
-/// [`CheckInPage`] so the page body stays a thin handler-wiring shell.
+/// [`CheckInPage`] so the page body stays a thin handler-wiring shell, and
+/// each verbose arm is further split into a named `_stage` helper so this
+/// dispatcher stays under the line cap.
 #[component]
-fn CheckInStage(
-    state: FlowState,
-    on_resolve: EventHandler<String>,
-    on_check_in: EventHandler<ScanBook>,
-    on_own_it: EventHandler<ExternalBookMeta>,
-    on_pick: EventHandler<ExternalBookMeta>,
-    on_wishlist: EventHandler<WishlistAddRequest>,
-) -> Element {
-    let mut stage = state.stage;
-    let mut isbn = state.isbn;
-    let mut error = state.error;
-    let mut note = state.note;
-    let mut busy = state.busy;
+fn CheckInStage(state: FlowState, handlers: CheckInHandlers) -> Element {
     // Clear the per-flow scratch (edition note, typed ISBN, in-flight flag) on
     // every restart so neither a note nor an ISBN typed for one book can be
     // reused on the next confirm after Cancel / "Try another ISBN" /
     // "Check in another".
-    let restart = move |_| {
+    let on_restart = EventHandler::new(move |_| {
+        let FlowState {
+            mut stage,
+            mut isbn,
+            mut note,
+            mut busy,
+            mut error,
+        } = state;
         error.set(None);
         note.set(String::new());
         isbn.set(String::new());
         busy.set(false);
         stage.set(Stage::Scan);
-    };
+    });
 
-    match stage() {
-        Stage::Scan => rsx! {
-            ScanScreen {
-                on_detect: EventHandler::new(move |scanned: String| {
-                    // Seed the keypad too, so a decode the check digit rejects
-                    // lands on manual entry with the digits ready to fix.
-                    isbn.set(scanned.clone());
-                    on_resolve.call(scanned);
-                }),
-                on_manual: EventHandler::new(move |_| {
-                    error.set(None);
-                    stage.set(Stage::Entry);
-                }),
-            }
-        },
-        Stage::Entry => rsx! {
-            EntryScreen {
-                isbn: state.isbn,
-                busy: state.busy,
-                on_resolve,
-                on_scan: EventHandler::new(move |_| {
-                    error.set(None);
-                    stage.set(Stage::Scan);
-                }),
-            }
-        },
+    match (state.stage)() {
+        Stage::Scan => scan_stage(state, handlers.on_resolve),
+        Stage::Entry => entry_stage(state, handlers.on_resolve),
         Stage::Resolving => rsx! { ResolvingScreen {} },
         Stage::Confirm { book, isbn } => rsx! {
-            ConfirmScreen { book, isbn, state, on_check_in, on_cancel: EventHandler::new(restart) }
+            ConfirmScreen { book, isbn, state, on_check_in: handlers.on_check_in, on_cancel: on_restart }
         },
-        Stage::CloseMatch { book, scanned } => rsx! {
-            CloseMatchScreen {
-                book: book.clone(),
-                scanned: scanned.clone(),
-                on_yes: EventHandler::new(move |_| {
-                    stage.set(Stage::Confirm { book: book.clone(), isbn: scanned.isbn13.clone() });
-                }),
-                on_no: EventHandler::new(move |online: ExternalBookMeta| {
-                    stage.set(Stage::Choose { online });
-                }),
-            }
-        },
+        Stage::CloseMatch { book, scanned } => close_match_stage(book, scanned, state),
         Stage::Choose { online } => rsx! {
             ChooseScreen {
                 online,
                 busy: state.busy,
-                on_own_it,
-                on_wishlist,
-                on_restart: EventHandler::new(restart),
+                on_own_it: handlers.on_own_it,
+                on_wishlist: handlers.on_wishlist,
+                on_restart,
             }
         },
-        Stage::Unresolved { isbn } => rsx! {
-            UnresolvedScreen {
-                isbn,
-                on_search: EventHandler::new(move |_| {
-                    error.set(None);
-                    stage.set(Stage::Search);
-                }),
-                on_restart: EventHandler::new(restart),
-            }
-        },
-        Stage::Search => rsx! {
-            SearchScreen { state, on_pick, on_restart: EventHandler::new(restart) }
-        },
+        Stage::Unresolved { isbn } => unresolved_stage(isbn, state, on_restart),
+        Stage::Search => search_stage(state, handlers.on_pick, on_restart),
         Stage::CheckedIn { uuid, title } => rsx! {
             SuccessScreen {
                 title,
                 headline: "In your physical collection".to_string(),
                 book_uuid: Some(uuid),
-                on_restart: EventHandler::new(restart),
+                on_restart,
             }
         },
         Stage::Wishlisted { title } => rsx! {
@@ -370,9 +334,91 @@ fn CheckInStage(
                 title,
                 headline: "On your wishlist".to_string(),
                 book_uuid: None,
-                on_restart: EventHandler::new(restart),
+                on_restart,
             }
         },
+    }
+}
+
+/// [`Stage::Scan`]: the camera screen, seeding the keypad on every decode so a
+/// scan the check digit rejects lands on manual entry ready to fix.
+fn scan_stage(state: FlowState, on_resolve: EventHandler<String>) -> Element {
+    let mut isbn = state.isbn;
+    let mut error = state.error;
+    let mut stage = state.stage;
+    rsx! {
+        ScanScreen {
+            on_detect: EventHandler::new(move |scanned: String| {
+                isbn.set(scanned.clone());
+                on_resolve.call(scanned);
+            }),
+            on_manual: EventHandler::new(move |_| {
+                error.set(None);
+                stage.set(Stage::Entry);
+            }),
+        }
+    }
+}
+
+/// [`Stage::Entry`]: the manual-ISBN keypad, reached from the scanner.
+fn entry_stage(state: FlowState, on_resolve: EventHandler<String>) -> Element {
+    let mut error = state.error;
+    let mut stage = state.stage;
+    rsx! {
+        EntryScreen {
+            isbn: state.isbn,
+            busy: state.busy,
+            on_resolve,
+            on_scan: EventHandler::new(move |_| {
+                error.set(None);
+                stage.set(Stage::Scan);
+            }),
+        }
+    }
+}
+
+/// [`Stage::CloseMatch`]: the fuzzy (title, author) hit that needs a human
+/// "is this it?" before filing a copy or falling back to the online chooser.
+fn close_match_stage(book: ScanBook, scanned: ExternalBookMeta, state: FlowState) -> Element {
+    let mut stage = state.stage;
+    rsx! {
+        CloseMatchScreen {
+            book: book.clone(),
+            scanned: scanned.clone(),
+            on_yes: EventHandler::new(move |_| {
+                stage.set(Stage::Confirm { book: book.clone(), isbn: scanned.isbn13.clone() });
+            }),
+            on_no: EventHandler::new(move |online: ExternalBookMeta| {
+                stage.set(Stage::Choose { online });
+            }),
+        }
+    }
+}
+
+/// [`Stage::Unresolved`]: neither the library nor any provider knew the ISBN.
+fn unresolved_stage(isbn: String, state: FlowState, on_restart: EventHandler<()>) -> Element {
+    let mut error = state.error;
+    let mut stage = state.stage;
+    rsx! {
+        UnresolvedScreen {
+            isbn,
+            on_search: EventHandler::new(move |_| {
+                error.set(None);
+                stage.set(Stage::Search);
+            }),
+            on_restart,
+        }
+    }
+}
+
+/// [`Stage::Search`]: the unresolved screen's "type the name instead" fallback.
+fn search_stage(
+    state: FlowState,
+    on_pick: EventHandler<ExternalBookMeta>,
+    on_restart: EventHandler<()>,
+) -> Element {
+    rsx! {
+        SearchScreen { state, on_pick, on_restart }
     }
 }
 


### PR DESCRIPTION
## Summary
- Closes #1635
- `CheckInStage` (`frontend/src/pages/check_in/mod.rs`) had crossed both the ~80-line function soft cap and the 5-prop soft cap after #1622 added the `Stage::Search` arm and `on_pick` handler. Extracted each `match` arm into a named per-stage helper (`scan_stage`, `entry_stage`, `close_match_stage`, `unresolved_stage`, `search_stage`), and bundled the five `EventHandler` props into a new `CheckInHandlers` struct so the component now takes 2 props (`state`, `handlers`).
- `db/src/metadata_lookup/providers/hardcover.rs::map_book` took a candidate ISBN-13 from the GraphQL editions list without normalizing it, unlike the `openlibrary`/`googlebooks` sibling providers. Now calls `normalize_isbn`, falling through to `None` on a malformed/hyphenated value rather than surfacing it unnormalized.
- Added `db/src/metadata_lookup/providers/hardcover/tests.rs` covering the normalization fallthrough (hyphenated-but-valid, malformed, bad check digit, no edition ISBN, scanned-ISBN precedence, missing title).

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — 1741 passed, 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` — fails because the public-domain audiobook test fixtures aren't downloaded in this sandbox; `test_data/audiobooks/public_domain/` doesn't exist here at all, confirming it's an environment gap, not a regression)
- [x] `cargo test -p omnibus-frontend --features server` — 624 passed, 0 failed

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- Scope matches the issue exactly: no behavior change to `CheckInStage`'s rendering, just extraction + prop bundling; the Hardcover ISBN fix is display-only (every DB write path already re-canonicalizes via `canonical_isbn`, per the issue).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DCWPoS3Ga15e84V4QpyWq5)_