### PR TITLE
refactor: group Dioxus component props and key data-driven loops (#1080)

### DIFF
--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -52,7 +52,7 @@ mod suggestion_dropdown;
 // Single-value sibling of `chip_editor`'s dropdown, for fields that hold one
 // value rather than a list (e.g. the Series field).
 pub mod suggest_field;
-pub use suggest_field::SuggestField;
+pub use suggest_field::{SuggestField, SuggestFieldOptions};
 
 pub mod atrium;
 

--- a/frontend/src/components/suggest_field.rs
+++ b/frontend/src/components/suggest_field.rs
@@ -9,6 +9,23 @@ use dioxus::prelude::*;
 use super::chip_editor::SuggestionItem;
 use super::suggestion_dropdown::{compute_suggestions, DropdownSelectionState, SuggestionDropdown};
 
+/// Presentational knobs for [`SuggestField`] — CSS class, placeholder, and
+/// testid prefix — split out of [`SuggestFieldProps`] so the component's
+/// props stay at the established cap, mirroring how
+/// [`super::chip_editor::ChipEditorOptions`] splits the same kind of knobs
+/// out of `ChipEditorProps` for its sibling component.
+#[derive(Clone, PartialEq, Default)]
+pub struct SuggestFieldOptions {
+    /// CSS class for the `<input>`.
+    pub class: String,
+    /// Placeholder shown when the value is empty.
+    pub placeholder: String,
+    /// Per-instance testid prefix, same convention as
+    /// [`super::chip_editor::ChipEditorOptions::testid_prefix`]: the input
+    /// gets `<prefix>-input`, the dropdown `<prefix>-suggestions`.
+    pub testid_prefix: String,
+}
+
 /// Props for the [`SuggestField`] component.
 #[derive(Props, Clone, PartialEq)]
 pub struct SuggestFieldProps {
@@ -23,16 +40,9 @@ pub struct SuggestFieldProps {
     pub suggestions: ReadSignal<Vec<SuggestionItem>>,
     /// The `<input>`'s `id`, so a sibling `<label for=...>` associates with it.
     pub id: String,
-    /// CSS class for the `<input>`.
+    /// Presentational knobs (class, placeholder, testid prefix).
     #[props(default)]
-    pub class: String,
-    /// Placeholder shown when the value is empty.
-    #[props(default)]
-    pub placeholder: String,
-    /// Per-instance testid prefix, same convention as
-    /// [`super::chip_editor::ChipEditorOptions::testid_prefix`]: the input
-    /// gets `<prefix>-input`, the dropdown `<prefix>-suggestions`.
-    pub testid_prefix: String,
+    pub options: SuggestFieldOptions,
 }
 
 /// Single-value counterpart to [`super::chip_editor::ChipEditor`] — picking a
@@ -55,15 +65,15 @@ pub fn SuggestField(props: SuggestFieldProps) -> Element {
         compute_suggestions(&suggestions, &[value()], &query_lc, open(), false)
     };
     let total = filtered.len();
-    let testid_prefix = props.testid_prefix.clone();
+    let testid_prefix = props.options.testid_prefix.clone();
 
     rsx! {
         div { class: "chip-editor-input-wrap",
             input {
                 id: props.id.clone(),
-                class: "{props.class}",
+                class: "{props.options.class}",
                 "data-testid": "{testid_prefix}-input",
-                placeholder: "{props.placeholder}",
+                placeholder: "{props.options.placeholder}",
                 value: "{value}",
                 onfocus: move |_| open.set(true),
                 onblur: move |_| {

--- a/frontend/src/pages/book_detail/export_menu.rs
+++ b/frontend/src/pages/book_detail/export_menu.rs
@@ -13,14 +13,7 @@ use crate::focus_after_paint::focus_after_paint;
 /// whichever formats the book has, the interactive Send-to-Kindle button,
 /// and the Send-to-Kobo KEPUB download.
 #[component]
-pub(super) fn BdExportMenu(
-    uuid: String,
-    has_ebook: bool,
-    has_audio: bool,
-    #[props(default)] book_author: String,
-    #[props(default)] book_title: String,
-    #[props(default)] epub_size_bytes: Option<i64>,
-) -> Element {
+pub(super) fn BdExportMenu(ctx: BdExportContext) -> Element {
     let mut open = use_signal(|| false);
     rsx! {
         div { class: "bd-export",
@@ -43,17 +36,7 @@ pub(super) fn BdExportMenu(
                     "data-testid": "hero-export-scrim",
                     onclick: move |_| open.set(false),
                 }
-                BdExportPanel {
-                    ctx: BdExportContext {
-                        uuid,
-                        has_ebook,
-                        has_audio,
-                        book_author,
-                        book_title,
-                        epub_size_bytes,
-                    },
-                    open,
-                }
+                BdExportPanel { ctx, open }
             }
         }
     }
@@ -61,15 +44,15 @@ pub(super) fn BdExportMenu(
 
 /// The uuid, available formats, author/title (for Send-to-Kindle/Kobo
 /// filenames), and EPUB size gating the oversize-email fallback. Grouped so
-/// [`BdExportPanel`] stays under the prop cap.
+/// [`BdExportMenu`] and [`BdExportPanel`] both stay under the prop cap.
 #[derive(Clone, PartialEq)]
-struct BdExportContext {
-    uuid: String,
-    has_ebook: bool,
-    has_audio: bool,
-    book_author: String,
-    book_title: String,
-    epub_size_bytes: Option<i64>,
+pub(super) struct BdExportContext {
+    pub uuid: String,
+    pub has_ebook: bool,
+    pub has_audio: bool,
+    pub book_author: String,
+    pub book_title: String,
+    pub epub_size_bytes: Option<i64>,
 }
 
 /// The open dropdown body. Split out so `onmounted` can focus it (so ESC

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -11,7 +11,7 @@ use crate::components::atrium::Cover;
 use crate::components::{BookActionMeta, FetchSummaryButton};
 use crate::{data, use_server_url, Route};
 
-use super::export_menu::BdExportMenu;
+use super::export_menu::{BdExportContext, BdExportMenu};
 use super::file_picker::{is_audio_book_file, BdFilePickerMenu, FilePickerKind};
 use super::immersive::BdImmersiveButton;
 use super::physical::{BdBookIdentity, BdWishlistRailSlot};
@@ -340,12 +340,14 @@ fn BdCtaRow(has_ebook: bool, has_audio: bool, has_comic: bool, meta: BookActionM
             // the CTA row stays a single primary action plus this dropdown.
             // Author + title feed the Send-to-Kobo `<Author>/<Title>/` layout.
             BdExportMenu {
-                uuid: uuid.clone(),
-                has_ebook,
-                has_audio,
-                book_author: book_author.clone(),
-                book_title: book_title.clone(),
-                epub_size_bytes,
+                ctx: BdExportContext {
+                    uuid: uuid.clone(),
+                    has_ebook,
+                    has_audio,
+                    book_author: book_author.clone(),
+                    book_title: book_title.clone(),
+                    epub_size_bytes,
+                },
             }
             }
         }

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -8,7 +8,7 @@ use omnibus_shared::EbookMetadata;
 use super::fields::{label_to_id, MeArea, MeField, MeLabel};
 use super::hardcover_fetch::HardcoverFetchPanel;
 use crate::components::chip_editor::{ChipEditor, ChipEditorOptions, SuggestionItem};
-use crate::components::{FetchSummaryButton, SuggestField};
+use crate::components::{FetchSummaryButton, SuggestField, SuggestFieldOptions};
 
 /// Per-field editable signals threaded through the form rows from `MetadataEditForm`.
 #[derive(Clone, Copy, PartialEq)]
@@ -252,11 +252,13 @@ fn SeriesSection(
                 MeLabel { text: "Series", edited: series_edited, target: field_id.clone() }
                 SuggestField {
                     id: field_id,
-                    class: input_class,
                     value: series,
                     suggestions: series_suggestions,
-                    placeholder: "not part of a series",
-                    testid_prefix: "me-series",
+                    options: SuggestFieldOptions {
+                        class: input_class.to_string(),
+                        placeholder: "not part of a series".to_string(),
+                        testid_prefix: "me-series".to_string(),
+                    },
                 }
             }
             MeField {

--- a/frontend/src/pages/stats/donut.rs
+++ b/frontend/src/pages/stats/donut.rs
@@ -103,7 +103,11 @@ pub(super) fn GenreDonut(summary: StatsSummary) -> Element {
                 }
                 ul { class: "st-donut-legend",
                     for (i, ((name, _), pct)) in folded.iter().zip(percents.iter()).enumerate() {
-                        li { key: "{name}", class: "st-donut-row",
+                        // Indexed, not name-keyed: a real genre named "Other"
+                        // would otherwise collide with the synthetic fold-row
+                        // above, and the parent's `content_key` already forces
+                        // a full remount whenever the data itself changes.
+                        li { key: "{i}", class: "st-donut-row",
                             span {
                                 class: "st-donut-swatch",
                                 style: "background: {SLICE_VARS[i.min(SLICE_VARS.len() - 1)]};",

--- a/frontend/src/pages/stats/donut.rs
+++ b/frontend/src/pages/stats/donut.rs
@@ -103,7 +103,7 @@ pub(super) fn GenreDonut(summary: StatsSummary) -> Element {
                 }
                 ul { class: "st-donut-legend",
                     for (i, ((name, _), pct)) in folded.iter().zip(percents.iter()).enumerate() {
-                        li { class: "st-donut-row",
+                        li { key: "{name}", class: "st-donut-row",
                             span {
                                 class: "st-donut-swatch",
                                 style: "background: {SLICE_VARS[i.min(SLICE_VARS.len() - 1)]};",

--- a/frontend/src/pages/stats/drill_in.rs
+++ b/frontend/src/pages/stats/drill_in.rs
@@ -331,8 +331,8 @@ fn render_trend(metric: Metric, bars: &[TrendBar]) -> Element {
             "data-testid": "stats-drill-trend",
             role: "img",
             aria_label: "{metric.title()} trend",
-            for bar in bars {
-                div { class: "st-drill-trend-col", title: "{bar.label}",
+            for (i, bar) in bars.iter().enumerate() {
+                div { key: "{i}-{bar.label}", class: "st-drill-trend-col", title: "{bar.label}",
                     div { class: "st-drill-trend-track",
                         div { class: "st-drill-trend-bar", style: "height: {bar.height_pct}%;" }
                     }

--- a/frontend/src/pages/stats/heatmap.rs
+++ b/frontend/src/pages/stats/heatmap.rs
@@ -180,6 +180,7 @@ pub(super) fn HeatmapCard(summary: StatsSummary) -> Element {
                 div { class: "st-heatmap", role: "img", aria_label: "Daily reading activity, trailing year",
                     for cell in cells {
                         div {
+                            key: "{cell.day}",
                             class: if cell.future { "st-hm-cell st-hm-future" } else { "st-hm-cell st-hm-{cell.level}" },
                             title: if !cell.future && cell.secs > 0 { "{format_active_time(cell.secs)} on {cell.day}" } else { "{cell.day}" },
                         }

--- a/frontend/src/pages/stats/mod.rs
+++ b/frontend/src/pages/stats/mod.rs
@@ -250,7 +250,7 @@ fn RangeMenu(range: Signal<StatsRange>, menu_open: Signal<bool>) -> Element {
             onmounted: move |evt: MountedEvent| focus_range_menu(&evt),
             for r in StatsRange::ALL {
                 button {
-                    key: "{r:?}",
+                    key: "{r.as_query()}",
                     class: if r == current { "st-range-row on" } else { "st-range-row" },
                     r#type: "button",
                     "aria-pressed": if r == current { "true" } else { "false" },

--- a/frontend/src/pages/stats/mod.rs
+++ b/frontend/src/pages/stats/mod.rs
@@ -250,6 +250,7 @@ fn RangeMenu(range: Signal<StatsRange>, menu_open: Signal<bool>) -> Element {
             onmounted: move |evt: MountedEvent| focus_range_menu(&evt),
             for r in StatsRange::ALL {
                 button {
+                    key: "{r:?}",
                     class: if r == current { "st-range-row on" } else { "st-range-row" },
                     r#type: "button",
                     "aria-pressed": if r == current { "true" } else { "false" },

--- a/frontend/src/pages/stats/monthly.rs
+++ b/frontend/src/pages/stats/monthly.rs
@@ -89,8 +89,9 @@ pub(super) fn MonthlyChart(summary: StatsSummary) -> Element {
                 class: "st-monthly-bars",
                 role: "img",
                 aria_label: "Books finished per month, trailing 12 months",
-                for bar in &bars {
+                for (i, bar) in bars.iter().enumerate() {
                     div {
+                        key: "{i}",
                         class: if bar.current { "st-mo-col st-mo-current" } else { "st-mo-col" },
                         "data-testid": "stats-monthly-bar",
                         title: "{bar.books} finished",

--- a/frontend/src/pages/stats/tiles.rs
+++ b/frontend/src/pages/stats/tiles.rs
@@ -87,41 +87,60 @@ pub(super) fn HeadlineTiles(
             StatTile {
                 value: finished,
                 unit: None,
-                label: "Finished",
-                accent: true,
-                hero: true,
-                testid: "stats-tile-finished",
+                meta: StatTileMeta {
+                    label: "Finished",
+                    accent: true,
+                    hero: true,
+                    testid: "stats-tile-finished",
+                },
                 onexpand: move |_| expanded.set(Some(Metric::Finished)),
             }
             StatTile {
                 value: avg,
                 unit: if has_avg { Some(" \u{2605}".to_string()) } else { None },
-                label: "Avg rating",
-                accent: false,
-                hero: true,
-                testid: "stats-tile-avg-rating",
+                meta: StatTileMeta {
+                    label: "Avg rating",
+                    accent: false,
+                    hero: true,
+                    testid: "stats-tile-avg-rating",
+                },
                 onexpand: move |_| expanded.set(Some(Metric::AvgRating)),
             }
             StatTile {
                 value: pages,
                 unit: None,
-                label: "Est. pages",
-                accent: false,
-                hero: false,
-                testid: "stats-tile-pages",
+                meta: StatTileMeta {
+                    label: "Est. pages",
+                    accent: false,
+                    hero: false,
+                    testid: "stats-tile-pages",
+                },
                 onexpand: move |_| expanded.set(Some(Metric::Pages)),
             }
             StatTile {
                 value: listen_value,
                 unit: Some(listen_unit.to_string()),
-                label: "Listening",
-                accent: false,
-                hero: false,
-                testid: "stats-tile-listening",
+                meta: StatTileMeta {
+                    label: "Listening",
+                    accent: false,
+                    hero: false,
+                    testid: "stats-tile-listening",
+                },
                 onexpand: move |_| expanded.set(Some(Metric::Listening)),
             }
         }
     }
+}
+
+/// Micro-label, accent/hero styling, and testid for one metric tile, grouped
+/// to keep [`StatTile`]'s props at the established cap — mirrors
+/// `chip_editor::ChipEditorOptions`' presentational-knobs split.
+#[derive(Clone, PartialEq)]
+struct StatTileMeta {
+    label: &'static str,
+    accent: bool,
+    hero: bool,
+    testid: &'static str,
 }
 
 /// One metric tile: a big serif number (with an optional smaller unit) over
@@ -132,12 +151,15 @@ pub(super) fn HeadlineTiles(
 fn StatTile(
     value: String,
     unit: Option<String>,
-    label: &'static str,
-    accent: bool,
-    hero: bool,
-    testid: &'static str,
+    meta: StatTileMeta,
     onexpand: EventHandler<()>,
 ) -> Element {
+    let StatTileMeta {
+        label,
+        accent,
+        hero,
+        testid,
+    } = meta;
     let mut class = String::from("card st-tile");
     if accent {
         class.push_str(" st-tile-accent");


### PR DESCRIPTION
## Summary
- Closes #1080
- Regrouped 3 remaining >5-prop Dioxus components into props structs, following the codebase's existing patterns:
  - `frontend/src/pages/stats/tiles.rs` — `StatTile` (7 props) → new `StatTileMeta` bundles `label`/`accent`/`hero`/`testid`, mirroring `ChipEditorOptions`.
  - `frontend/src/pages/book_detail/export_menu.rs` — `BdExportMenu` (6 props) → now takes `ctx: BdExportContext`, reusing the struct `BdExportPanel` already used instead of duplicating the same 6 fields as individual props.
  - `frontend/src/components/suggest_field.rs` — `SuggestFieldProps` (6 fields) → new `SuggestFieldOptions` bundles `class`/`placeholder`/`testid_prefix`, mirroring `ChipEditorOptions`' existing split (note: this component lives in its own `suggest_field.rs` module now, not `chip_editor.rs` as the issue text described — it was already split out by a prior refactor).
- Added `key:` to 4 data-driven `rsx!` loops:
  - `frontend/src/pages/stats/heatmap.rs` — the 364 heatmap day cells, keyed by day.
  - `frontend/src/pages/stats/donut.rs` — genre-donut legend rows, keyed by genre name.
  - `frontend/src/pages/stats/monthly.rs` — the 12 month bars, keyed by index.
  - `frontend/src/pages/stats/drill_in.rs` (`render_trend`) — trend bars, keyed by index+label.
  - Also keyed the low-severity/optional `StatsRange::ALL` loop in `frontend/src/pages/stats/mod.rs` (4-item fixed enum) since it was trivial.

**Already fixed by a prior sweep (#853), left untouched:** `FormatSwitcher`/`FormatRow`/`MultiFileRow` in `components/format_switcher/mod.rs` (already ≤5 props), and `BdCtaRow`/`BdExportPanel` in `book_detail/hero.rs`/`export_menu.rs` (already regrouped via `BookActionMeta`/`BdExportContext`).

No behavior/visual change — pure refactoring (struct regrouping + `key:` additions).

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (624 passed; 0 failed)

## Version
- [x] **Patch** — default, left unlabeled.

## Notes
- Pure tech-debt refactor per the issue's acceptance criteria; only the frontend crate needed changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DCWPoS3Ga15e84V4QpyWq5)_