### PR TITLE
refactor: cache CBZ page count and decoded pages (#1593)

### DIFF
--- a/db/migrations/0063_books_page_count.sql
+++ b/db/migrations/0063_books_page_count.sql
@@ -1,0 +1,18 @@
+-- Tech-debt #1593 — persist a per-book CBZ page count so the comic detail
+-- read stops reparsing the archive's central directory on every request
+-- (the old `attach_comic_page_count`, #1579). Mirrors the `word_count`
+-- pattern from migration 0049 exactly:
+--
+--   page_count  the archive's image-page count (`db::comic::list_pages`
+--               length). Computed once when a CBZ file is indexed
+--               (new / changed) and rewritten on re-parse. NULL means
+--               "not applicable or not yet computed" — an EPUB-only book,
+--               a malformed archive, or a row indexed before this
+--               migration. `Task::BackfillPageCounts` fills pre-existing
+--               CBZ rows off the async runtime, posted after each ebook
+--               library scan the same way `Task::BackfillWordCounts` fills
+--               word counts.
+--
+-- Additive, nullable, forward-only (rule 06). No in-SQL backfill is
+-- possible (the value can only come from opening the archive).
+ALTER TABLE books ADD COLUMN page_count INTEGER;

--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -91,7 +91,11 @@ pub(crate) const BOOK_COLUMNS: &str = r"
               ORDER BY format))                   AS formats_json,
 
     EXISTS (SELECT 1 FROM physical_copies pc
-             WHERE pc.book_uuid = b.uuid)          AS has_physical
+             WHERE pc.book_uuid = b.uuid)          AS has_physical,
+
+    -- CBZ page count, persisted at index time (migration 0063, #1593)
+    -- instead of reparsing the archive on every detail read.
+    b.page_count                                   AS page_count
 ";
 
 #[derive(serde::Deserialize)]
@@ -260,8 +264,9 @@ pub(crate) fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata,
         // Populated by `get_book` from the resolved EPUB; list/projection rows
         // don't carry it (no per-book export menu in list contexts).
         epub_size_bytes: None,
-        // Detail-read enrichment (the CBZ page count); never projected here.
-        page_count: None,
+        // The CBZ page count, straight off `books.page_count` (#1593) —
+        // `NULL` for an EPUB, an unparsed archive, or a pre-migration row.
+        page_count: r.get("page_count"),
     })
 }
 

--- a/db/src/comic.rs
+++ b/db/src/comic.rs
@@ -32,8 +32,17 @@ pub fn is_comic_path(path: &Path) -> bool {
 /// first entry is the cover page.
 pub fn list_pages(path: &Path) -> anyhow::Result<Vec<String>> {
     let file = File::open(path)?;
+    let (_, pages) = list_pages_from_file(file)?;
+    Ok(pages)
+}
+
+/// [`list_pages`], but from a handle the caller already has open, handing
+/// it back alongside the names so a later call can read a specific entry
+/// from that same handle rather than reopening the path.
+pub fn list_pages_from_file(file: File) -> anyhow::Result<(File, Vec<String>)> {
     let archive = zip::ZipArchive::new(file)?;
-    Ok(page_names(&archive))
+    let pages = page_names(&archive);
+    Ok((archive.into_inner(), pages))
 }
 
 /// Best-effort CBZ page count for `book_id`: the length of the archive's
@@ -101,12 +110,17 @@ pub fn read_page(path: &Path, index: usize) -> anyhow::Result<Option<(&'static s
 
 /// Decompress one already-resolved entry (as named by [`list_pages`]),
 /// skipping the central-directory listing [`read_page`] would otherwise
-/// redo. Used by the page-serving route (#1593): it lists once to answer
-/// the `If-None-Match` precondition without decompressing, then calls this
-/// — the expensive DEFLATE step — only when the client's cached copy is
-/// stale.
+/// redo.
 pub fn read_page_named(path: &Path, name: &str) -> anyhow::Result<(&'static str, Vec<u8>)> {
     let file = File::open(path)?;
+    read_page_from_file(file, name)
+}
+
+/// [`read_page_named`], but from a handle the caller already has open (as
+/// [`list_pages_from_file`] returns it) — the page-serving route's shape,
+/// so the validator, the page list, and the decompressed bytes all come
+/// from one opened inode rather than three separate opens of the path.
+pub fn read_page_from_file(file: File, name: &str) -> anyhow::Result<(&'static str, Vec<u8>)> {
     let mut archive = zip::ZipArchive::new(file)?;
     let entry = archive.by_name(name)?;
     // Sized by the actual read, not the header's declared size — an

--- a/db/src/comic.rs
+++ b/db/src/comic.rs
@@ -38,10 +38,18 @@ pub fn list_pages(path: &Path) -> anyhow::Result<Vec<String>> {
 
 /// Best-effort CBZ page count for `book_id`: the length of the archive's
 /// page list. `None` when the book has no CBZ file, the archive is
-/// unreadable, or the blocking read fails — detail reads must not fail
-/// because one file is broken, so failures log and read as "no count".
-/// Shared by the REST detail handler and the web RPC so the two payloads
-/// can't disagree.
+/// unreadable, or the blocking read fails — failures log and read as "no
+/// count" rather than propagating.
+///
+/// `books.page_count` is populated once at index time
+/// ([`indexed_book_from`]) and served straight off that column (#1593), so
+/// this single-book lookup is no longer on the request path; it remains a
+/// small, independently-testable building block a future ad-hoc "recount
+/// this one book" tool can reach for without duplicating the archive-open
+/// dance. The bulk equivalent used by
+/// [`crate::indexer::backfill_page_counts`] (the one-time catch-up for CBZ
+/// rows indexed before migration `0063`) inlines the same steps to share
+/// one batched path lookup across every candidate.
 pub async fn page_count_for_book(pool: &sqlx::SqlitePool, book_id: i64) -> Option<i64> {
     let path = match crate::books::book_file_path(pool, book_id, "CBZ").await {
         Ok(Some(p)) => p,
@@ -84,12 +92,22 @@ const MAX_PAGE_BYTES: u64 = 64 * 1024;
 /// entry is unreadable or the page exceeds the cap. One entry is
 /// decompressed per call — the archive is never extracted whole.
 pub fn read_page(path: &Path, index: usize) -> anyhow::Result<Option<(&'static str, Vec<u8>)>> {
-    let file = File::open(path)?;
-    let mut archive = zip::ZipArchive::new(file)?;
-    let pages = page_names(&archive);
+    let pages = list_pages(path)?;
     let Some(name) = pages.get(index) else {
         return Ok(None);
     };
+    read_page_named(path, name).map(Some)
+}
+
+/// Decompress one already-resolved entry (as named by [`list_pages`]),
+/// skipping the central-directory listing [`read_page`] would otherwise
+/// redo. Used by the page-serving route (#1593): it lists once to answer
+/// the `If-None-Match` precondition without decompressing, then calls this
+/// — the expensive DEFLATE step — only when the client's cached copy is
+/// stale.
+pub fn read_page_named(path: &Path, name: &str) -> anyhow::Result<(&'static str, Vec<u8>)> {
+    let file = File::open(path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
     let entry = archive.by_name(name)?;
     // Sized by the actual read, not the header's declared size — an
     // attacker-controlled length field must not drive the allocation. One
@@ -100,7 +118,7 @@ pub fn read_page(path: &Path, index: usize) -> anyhow::Result<Option<(&'static s
     if read as u64 > MAX_PAGE_BYTES {
         anyhow::bail!("page {name} exceeds {MAX_PAGE_BYTES} byte cap");
     }
-    Ok(Some((mime_for_page(name), bytes)))
+    Ok((mime_for_page(name), bytes))
 }
 
 /// Extract the [`IndexedBook`] for a single CBZ file. Mirrors the EPUB
@@ -125,10 +143,13 @@ pub fn extract_comic(path: &Path, filename: String, opts: &ScanOptions) -> Index
 }
 
 /// Everything a single pass over the archive yields: the first page's
-/// bytes + mime (the cover candidate) and the parsed `ComicInfo.xml`
-/// fields when the entry exists.
+/// bytes + mime (the cover candidate), the page count (#1593 — computed
+/// once here so `books.page_count` never needs a second archive pass to
+/// answer a detail read), and the parsed `ComicInfo.xml` fields when the
+/// entry exists.
 struct ParsedComic {
     first_page: Option<(String, Vec<u8>)>,
+    page_count: usize,
     info: ComicInfo,
 }
 
@@ -142,13 +163,18 @@ fn read_comic(path: &Path) -> anyhow::Result<ParsedComic> {
     if pages.is_empty() {
         anyhow::bail!("no image pages in archive");
     }
+    let page_count = pages.len();
     let first_page = read_entry(&mut archive, &pages[0])
         .map(|bytes| (mime_for_page(&pages[0]).to_string(), bytes));
     let info = comic_info_entry(&archive)
         .and_then(|name| read_entry(&mut archive, &name))
         .map(|bytes| parse_comic_info(&bytes))
         .unwrap_or_default();
-    Ok(ParsedComic { first_page, info })
+    Ok(ParsedComic {
+        first_page,
+        page_count,
+        info,
+    })
 }
 
 /// Project a [`ParsedComic`] into the writer's [`IndexedBook`] shape.
@@ -179,6 +205,7 @@ fn indexed_book_from(
             series: comic.info.series,
             series_index: comic.info.number,
             accent,
+            page_count: Some(comic.page_count as i64),
             ..Default::default()
         },
         cover,

--- a/db/src/comic/tests.rs
+++ b/db/src/comic/tests.rs
@@ -1,8 +1,8 @@
 //! Unit tests for the CBZ comic-archive parser: page listing + natural
 //! sort, `ComicInfo.xml` mapping, filename fallback, the malformed-archive
 //! failure modes (not a zip, zero pages), `extract_comic`'s persisted
-//! `page_count` (#1593), and `page_count_for_book`'s three outcomes (real
-//! archive, no CBZ file, unreadable archive).
+//! `page_count`, and `page_count_for_book`'s three outcomes (real archive,
+//! no CBZ file, unreadable archive).
 
 use sqlx::SqlitePool;
 

--- a/db/src/comic/tests.rs
+++ b/db/src/comic/tests.rs
@@ -1,7 +1,8 @@
 //! Unit tests for the CBZ comic-archive parser: page listing + natural
 //! sort, `ComicInfo.xml` mapping, filename fallback, the malformed-archive
-//! failure modes (not a zip, zero pages), and `page_count_for_book`'s
-//! three outcomes (real archive, no CBZ file, unreadable archive).
+//! failure modes (not a zip, zero pages), `extract_comic`'s persisted
+//! `page_count` (#1593), and `page_count_for_book`'s three outcomes (real
+//! archive, no CBZ file, unreadable archive).
 
 use sqlx::SqlitePool;
 
@@ -60,6 +61,10 @@ fn extract_comic_maps_comic_info_fields_and_first_page_cover() {
     assert_eq!(book.metadata.series_index.as_deref(), Some("3"));
     assert_eq!(book.metadata.creators.len(), 1);
     assert_eq!(book.metadata.creators[0].name, "Kentaro Miura");
+    // Persisted straight onto `books.page_count` (#1593), counted from the
+    // archive's own page list — `ComicInfo.xml`'s `<PageCount>` tag (present
+    // in this fixture) isn't a field the parser reads at all.
+    assert_eq!(book.metadata.page_count, Some(2));
     // Cover = first page in natural order (p001), not zip entry order.
     let (mime, bytes) = book.cover.expect("first page becomes the cover");
     assert_eq!(mime, "image/png");
@@ -95,6 +100,7 @@ fn extract_comic_falls_back_to_filename_stem_without_comic_info() {
     );
     assert!(book.metadata.creators.is_empty());
     assert_eq!(book.metadata.series, None);
+    assert_eq!(book.metadata.page_count, Some(1));
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/db/src/indexer/backfill.rs
+++ b/db/src/indexer/backfill.rs
@@ -242,3 +242,95 @@ async fn fetch_word_count_candidates(
     .await?;
     Ok(ids)
 }
+
+/// Fill `books.page_count` for CBZ-backed books under `library_path` that
+/// have none yet (NULL `page_count`).
+///
+/// Page counts were added after the initial comic indexer (migration
+/// `0063`, tech-debt #1593), so books indexed before it carry a NULL. The
+/// normal diff-based reindex only re-parses new/changed files, so it never
+/// revisits them; this backfill runs as a separate worker task posted after
+/// each ebook library scan (mirroring [`backfill_word_counts`]) and is a
+/// no-op once every CBZ book has a count. `on_progress(processed, total)` is
+/// called per book for the UI.
+///
+/// Each candidate's archive is listed (central-directory read, not a
+/// decompression) on the blocking pool, and updates commit in batches of
+/// 250 to bound WAL flushes. A book whose archive can't be listed stays
+/// NULL and is retried on the next scan.
+pub(crate) async fn backfill_page_counts(
+    pool: &SqlitePool,
+    library_path: &str,
+    mut on_progress: impl FnMut(u32, u32),
+) -> anyhow::Result<()> {
+    let ids = fetch_page_count_candidates(pool, library_path).await?;
+    if ids.is_empty() {
+        return Ok(());
+    }
+
+    let total = u32::try_from(ids.len()).unwrap_or(u32::MAX);
+    tracing::info!(count = total, "backfilling page counts for existing comics");
+
+    // One batched path lookup up front (chunked internally), same pattern
+    // `backfill_word_counts` uses.
+    let paths = crate::book_file_paths(pool, &ids, "CBZ").await?;
+
+    let mut processed = 0u32;
+    for chunk in ids.chunks(250) {
+        let mut tx = pool.begin().await?;
+        for &id in chunk {
+            processed = processed.saturating_add(1);
+            on_progress(processed, total);
+
+            let Some(path) = paths.get(&id).cloned() else {
+                continue;
+            };
+            let count = tokio::task::spawn_blocking(move || {
+                crate::comic::list_pages(&path)
+                    .ok()
+                    .map(|pages| pages.len() as i64)
+            })
+            .await
+            .unwrap_or_else(|join_err| {
+                tracing::warn!(
+                    book_id = id,
+                    %join_err,
+                    is_panic = join_err.is_panic(),
+                    "page-count task failed; leaving page_count NULL"
+                );
+                None
+            });
+
+            let Some(count) = count else { continue };
+            sqlx::query("UPDATE books SET page_count = ? WHERE id = ?")
+                .bind(count)
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+    }
+
+    Ok(())
+}
+
+/// `books.id` for every CBZ-backed book under `library_path` still missing a
+/// `page_count` — the [`backfill_page_counts`] work set. Scoped to the
+/// scanned library so the follow-up task's cost tracks that scan.
+async fn fetch_page_count_candidates(
+    pool: &SqlitePool,
+    library_path: &str,
+) -> anyhow::Result<Vec<i64>> {
+    let ids: Vec<i64> = sqlx::query_scalar(
+        "SELECT DISTINCT b.id \
+         FROM books b \
+         JOIN scan_roots l ON b.library_id = l.id \
+         JOIN book_files bf ON bf.book_id = b.id AND bf.format = 'CBZ' COLLATE NOCASE \
+         WHERE l.path = ? AND b.page_count IS NULL \
+         ORDER BY b.id",
+    )
+    .bind(library_path)
+    .fetch_all(pool)
+    .await?;
+    Ok(ids)
+}

--- a/db/src/indexer/backfill.rs
+++ b/db/src/indexer/backfill.rs
@@ -246,11 +246,11 @@ async fn fetch_word_count_candidates(
 /// Fill `books.page_count` for CBZ-backed books under `library_path` that
 /// have none yet (NULL `page_count`).
 ///
-/// Page counts were added after the initial comic indexer (migration
-/// `0063`, tech-debt #1593), so books indexed before it carry a NULL. The
-/// normal diff-based reindex only re-parses new/changed files, so it never
-/// revisits them; this backfill runs as a separate worker task posted after
-/// each ebook library scan (mirroring [`backfill_word_counts`]) and is a
+/// Page counts were added after the initial comic indexer, so books indexed
+/// before that carry a NULL. The normal diff-based reindex only re-parses
+/// new/changed files, so it never revisits them; this backfill runs as a
+/// separate worker task posted after each ebook library scan (mirroring
+/// [`backfill_word_counts`]) and is a
 /// no-op once every CBZ book has a count. `on_progress(processed, total)` is
 /// called per book for the UI.
 ///

--- a/db/src/indexer/mod.rs
+++ b/db/src/indexer/mod.rs
@@ -14,7 +14,7 @@ mod audiobooks;
 mod backfill;
 
 pub use audiobooks::{reindex_audiobooks, reindex_audiobooks_with_progress};
-pub(crate) use backfill::{backfill_chapters, backfill_word_counts};
+pub(crate) use backfill::{backfill_chapters, backfill_page_counts, backfill_word_counts};
 
 /// Errors returned by the pure-DB indexer reads (`is_stale`). The
 /// transparent `Db` variant honors the `02-error-handling` boundary rule

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -11,8 +11,8 @@ use crate::ebook::StatEntry;
 use crate::pool::init_db;
 use crate::sync::{replace_books, sync_audiobooks, sync_books, AudiobookSyncPlan, SyncPlan};
 use crate::test_support::{
-    count_rows, indexed, indexed_audiobook, indexed_with_stat, make_test_dir, uuid_by_scan_key,
-    CoversTempDir,
+    build_stored_zip, count_rows, indexed, indexed_audiobook, indexed_with_stat, make_test_dir,
+    uuid_by_scan_key, CoversTempDir,
 };
 
 /// Seed a `scan_roots` row for `path` with an explicit `last_indexed`
@@ -1147,6 +1147,131 @@ async fn backfill_word_counts_is_idempotent_once_filled() {
     // and `on_progress` never fires.
     let mut calls = 0u32;
     backfill_word_counts(&pool, dir.to_str().unwrap(), |_, _| calls += 1)
+        .await
+        .unwrap();
+    assert_eq!(calls, 0);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ---------- page-count backfill (migration 0063) ----------
+
+/// Seed a CBZ book backed by a real (stored, uncompressed) archive on disk,
+/// with a NULL `page_count` (the pre-0063 state), so `backfill_page_counts`
+/// has a live file to open and a candidate row to fill.
+async fn seed_cbz_missing_page_count(
+    pool: &SqlitePool,
+    dir: &std::path::Path,
+    uuid: &str,
+    pages: usize,
+) -> i64 {
+    let lib_str = dir.to_str().unwrap();
+    sqlx::query(
+        "INSERT INTO scan_roots (path, display_name) VALUES (?, ?) ON CONFLICT(path) DO NOTHING",
+    )
+    .bind(lib_str)
+    .bind(lib_str)
+    .execute(pool)
+    .await
+    .unwrap();
+    let lib_id: i64 = sqlx::query_scalar("SELECT id FROM scan_roots WHERE path = ?")
+        .bind(lib_str)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title) \
+         VALUES (?, ?, ?, '', ?) RETURNING id",
+    )
+    .bind(uuid)
+    .bind(format!("{uuid}.cbz"))
+    .bind(lib_id)
+    .bind(uuid)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let entries: Vec<(String, Vec<u8>)> = (0..pages)
+        .map(|i| (format!("p{i}.jpg"), b"x".to_vec()))
+        .collect();
+    let entry_refs: Vec<(&str, &[u8])> = entries
+        .iter()
+        .map(|(n, d)| (n.as_str(), d.as_slice()))
+        .collect();
+    let bytes = build_stored_zip(&entry_refs);
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) VALUES (?, 'CBZ', ?, ?)",
+    )
+    .bind(book_id)
+    .bind(uuid)
+    .bind(bytes.len() as i64)
+    .execute(pool)
+    .await
+    .unwrap();
+    std::fs::write(dir.join(format!("{uuid}.cbz")), &bytes).unwrap();
+    book_id
+}
+
+async fn page_count_of(pool: &SqlitePool, book_id: i64) -> Option<i64> {
+    sqlx::query_scalar("SELECT page_count FROM books WHERE id = ?")
+        .bind(book_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn backfill_page_counts_fills_null_rows_from_the_cbz_archive() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let dir = make_test_dir("pc-backfill");
+    let a = seed_cbz_missing_page_count(&pool, &dir, "uuid-a", 3).await;
+    let b = seed_cbz_missing_page_count(&pool, &dir, "uuid-b", 7).await;
+
+    let mut progress: Vec<(u32, u32)> = Vec::new();
+    backfill_page_counts(&pool, dir.to_str().unwrap(), |p, t| progress.push((p, t)))
+        .await
+        .unwrap();
+
+    assert_eq!(page_count_of(&pool, a).await, Some(3));
+    assert_eq!(page_count_of(&pool, b).await, Some(7));
+    assert_eq!(progress, vec![(1, 2), (2, 2)]);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn backfill_page_counts_is_idempotent_once_filled() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let dir = make_test_dir("pc-backfill-idempotent");
+    seed_cbz_missing_page_count(&pool, &dir, "uuid-a", 3).await;
+
+    backfill_page_counts(&pool, dir.to_str().unwrap(), |_, _| {})
+        .await
+        .unwrap();
+
+    // Second pass: every book now has a count, so there are no candidates
+    // and `on_progress` never fires.
+    let mut calls = 0u32;
+    backfill_page_counts(&pool, dir.to_str().unwrap(), |_, _| calls += 1)
+        .await
+        .unwrap();
+    assert_eq!(calls, 0);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn backfill_page_counts_is_a_noop_when_no_candidates_exist() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let dir = make_test_dir("pc-backfill-empty");
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, ?)")
+        .bind(dir.to_str().unwrap())
+        .bind(dir.to_str().unwrap())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let mut calls = 0u32;
+    backfill_page_counts(&pool, dir.to_str().unwrap(), |_, _| calls += 1)
         .await
         .unwrap();
     assert_eq!(calls, 0);

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -258,7 +258,7 @@ async fn update_book_row(
         "UPDATE books SET
             scan_key = ?, path = ?, title = ?, sort = ?, author_sort = ?, series_sort = ?,
             series_index = ?, pubdate = ?, has_cover = ?, description = ?, accent_color = ?,
-            title_norm = ?, author_norm = ?, word_count = ?,
+            title_norm = ?, author_norm = ?, word_count = ?, page_count = ?,
             last_modified = strftime('%s','now')
          WHERE id = ?",
     )
@@ -276,6 +276,7 @@ async fn update_book_row(
     .bind(normalize_title(&title))
     .bind(m.creators.first().and_then(|c| normalize_author(&c.name)))
     .bind(b.word_count)
+    .bind(m.page_count)
     .bind(book_id)
     .execute(&mut **tx)
     .await?;
@@ -324,8 +325,8 @@ pub(super) async fn insert_book_row(
         "INSERT INTO books
             (uuid, scan_key, library_id, path, title, sort, author_sort, series_sort, series_index,
              pubdate, has_cover, description, accent_color, title_norm, author_norm, word_count,
-             timestamp, last_modified)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+             page_count, timestamp, last_modified)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                  strftime('%s','now'), strftime('%s','now'))
          RETURNING id",
     )
@@ -345,6 +346,7 @@ pub(super) async fn insert_book_row(
     .bind(normalize_title(&title))
     .bind(m.creators.first().and_then(|c| normalize_author(&c.name)))
     .bind(b.word_count)
+    .bind(m.page_count)
     .fetch_one(&mut **tx)
     .await?;
 

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -533,6 +533,47 @@ async fn word_count_persists_on_insert_and_refreshes_on_change() {
     assert_eq!(refreshed, Some(2500), "the update refreshes word_count");
 }
 
+/// `page_count` round-trips the same way `word_count` does (#1593):
+/// `insert_book_row` persists the CBZ parser's page count, and
+/// `sync_changed` refreshes it on re-parse (a book edited to add pages).
+#[tokio::test]
+async fn page_count_persists_on_insert_and_refreshes_on_change() {
+    let _covers = CoversTempDir::new("sync_page_count_unit");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+
+    let mut b = indexed("pc.cbz", Some("Paged"), &[], &[], None, None);
+    b.metadata.page_count = Some(12);
+    let mut tx = pool.begin().await.unwrap();
+    let inserted = insert_book_row(&mut tx, library_id, "/lib", &b)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let stored: Option<i64> = sqlx::query_scalar("SELECT page_count FROM books WHERE id = ?")
+        .bind(inserted.book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(stored, Some(12), "insert persists the page count");
+
+    // Same filename (→ same scan_key), new page count — the Changed path.
+    let mut changed = indexed("pc.cbz", Some("Paged"), &[], &[], None, None);
+    changed.metadata.page_count = Some(20);
+    let mut tx = pool.begin().await.unwrap();
+    sync_changed(&mut tx, library_id, "/lib", &[changed], || {})
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let refreshed: Option<i64> = sqlx::query_scalar("SELECT page_count FROM books WHERE id = ?")
+        .bind(inserted.book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(refreshed, Some(20), "the update refreshes page_count");
+}
+
 // ── Moved/renamed ebook relocation ───────────────────────────────────
 
 /// A moved/renamed ebook is classified Removed (old scan_key) and New (new

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -112,6 +112,17 @@ impl Worker {
                 )
                 .await,
             ),
+            Task::BackfillPageCounts { library_path } => anyhow_outcome(
+                "page-count backfill",
+                crate::indexer::backfill_page_counts(
+                    &self.pool,
+                    &library_path,
+                    |processed, total| {
+                        self.report_progress(id, processed, Some(total));
+                    },
+                )
+                .await,
+            ),
             Task::RebuildFtsIndex => anyhow_outcome(
                 "FTS rebuild",
                 crate::sync::rebuild_all_fts(&self.pool).await,
@@ -149,10 +160,10 @@ impl Worker {
     }
 
     /// Reindex an ebook library, then (on success) post the follow-up
-    /// word-count backfill task for any pre-0049 rows this library still
-    /// carries. Same resource key as the scan, so it waits for this task to
-    /// fully finish; the post itself is instant. Mirrors the audiobook
-    /// chapter backfill.
+    /// word-count and page-count backfill tasks for any pre-0049 / pre-0063
+    /// rows this library still carries. Both share the scan's resource key,
+    /// so each waits for this task to fully finish; the posts themselves
+    /// are instant. Mirrors the audiobook chapter backfill.
     async fn handle_scan(self: &Arc<Self>, library_path: String, id: TaskId) -> TaskOutcome {
         match crate::indexer::reindex_with_progress(
             &self.pool,
@@ -165,7 +176,10 @@ impl Worker {
         {
             Ok(stats) => {
                 let warning = stats.ghost_warning();
-                self.post(Task::BackfillWordCounts { library_path });
+                self.post(Task::BackfillWordCounts {
+                    library_path: library_path.clone(),
+                });
+                self.post(Task::BackfillPageCounts { library_path });
                 TaskOutcome::Ok(warning)
             }
             Err(e) => sanitized_err("library scan", e),

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -86,6 +86,13 @@ pub enum Task {
     /// scan on the same library); does not consume the scan semaphore
     /// (light per-file IO, mirrors [`Task::BackfillChapters`]).
     BackfillWordCounts { library_path: String },
+    /// Backfill `books.page_count` for CBZ books indexed before the
+    /// page-count column existed (migration `0063`, #1593). Posted by the
+    /// [`Task::Scan`] handler on success so it always runs after the ebook
+    /// scan completes. Keyed on `library_path` (mutual exclusion with the
+    /// scan on the same library); does not consume the scan semaphore
+    /// (light per-file IO, mirrors [`Task::BackfillWordCounts`]).
+    BackfillPageCounts { library_path: String },
     /// Rebuild the entire `books_fts` search index from `books` via
     /// `crate::sync::rebuild_all_fts`. Admin-triggered repair for any drift
     /// left by a failed post-commit FTS refresh. Keyed on a fixed resource
@@ -140,6 +147,7 @@ impl Task {
             Task::RefetchAuthorPhotos => Some("refetch-author-photos".into()),
             Task::BackfillChapters { library_path } => Some(format!("audiobooks:{library_path}")),
             Task::BackfillWordCounts { library_path } => Some(library_path.clone()),
+            Task::BackfillPageCounts { library_path } => Some(library_path.clone()),
             Task::RebuildFtsIndex => Some("rebuild-fts".into()),
             Task::ResolveSuggestions { book_uuid } => Some(format!("suggestions:{book_uuid}")),
             Task::KepubConvert { book_id } => Some(format!("kepub:{book_id}")),
@@ -159,6 +167,7 @@ impl Task {
             Task::RefetchAuthorPhotos => false,
             Task::BackfillChapters { .. } => false,
             Task::BackfillWordCounts { .. } => false,
+            Task::BackfillPageCounts { .. } => false,
             Task::RebuildFtsIndex => false,
             Task::ResolveSuggestions { .. } => false,
             Task::KepubConvert { .. } => false,
@@ -191,6 +200,8 @@ impl Task {
             // Reuse Scan kind — a scan-follow-up with no dedicated progress
             // widget, mirroring HLS/FTS/KEPUB below.
             Task::BackfillWordCounts { .. } => TaskKind::Scan,
+            // Same reuse as BackfillWordCounts, its sibling scan-follow-up.
+            Task::BackfillPageCounts { .. } => TaskKind::Scan,
             // Reuse Scan kind for UI display until a dedicated HLS progress
             // widget is added.
             Task::HlsTranscode { .. } => TaskKind::Scan,

--- a/frontend/src/rpc/books.rs
+++ b/frontend/src/rpc/books.rs
@@ -160,9 +160,6 @@ async fn ebooks_page(
 /// `/books/:uuid` URLs survive reindexes.
 #[post("/api/rpc/ebook", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_ebook(uuid: String) -> Result<Option<EbookMetadata>> {
-    // `page_count` for a CBZ book rides straight off `books.page_count`
-    // (#1593) — the projection already carries it, same as the REST detail
-    // read, so no further enrichment is needed here.
     let book = db::get_book_by_uuid(&pool.0, &uuid)
         .await
         .map_err(|e| internal_rpc_error("get ebook", e))?;

--- a/frontend/src/rpc/books.rs
+++ b/frontend/src/rpc/books.rs
@@ -160,17 +160,12 @@ async fn ebooks_page(
 /// `/books/:uuid` URLs survive reindexes.
 #[post("/api/rpc/ebook", pool: PoolExt, _user: AuthUser)]
 pub async fn rpc_get_ebook(uuid: String) -> Result<Option<EbookMetadata>> {
-    let mut book = db::get_book_by_uuid(&pool.0, &uuid)
+    // `page_count` for a CBZ book rides straight off `books.page_count`
+    // (#1593) — the projection already carries it, same as the REST detail
+    // read, so no further enrichment is needed here.
+    let book = db::get_book_by_uuid(&pool.0, &uuid)
         .await
         .map_err(|e| internal_rpc_error("get ebook", e))?;
-    // Same enrichment the REST detail read does: the comic pager's slider
-    // and progress mapping need the CBZ page count, and the formats check
-    // keeps non-comic reads free of the extra file query.
-    if let Some(b) = book.as_mut() {
-        if b.formats.iter().any(|f| f.eq_ignore_ascii_case("cbz")) {
-            b.page_count = db::comic::page_count_for_book(&pool.0, b.id).await;
-        }
-    }
     Ok(book)
 }
 

--- a/server/src/backend/conditional.rs
+++ b/server/src/backend/conditional.rs
@@ -51,6 +51,16 @@ pub(super) struct OpenFile {
     pub(super) validator: Validator,
 }
 
+impl OpenFile {
+    /// Hand back the handle the validator was derived from, for a caller
+    /// (the CBZ page route) that needs synchronous access instead of
+    /// [`serve`]'s streaming path — still the same inode, so it can't
+    /// disagree with the validator the way a fresh open-by-path could.
+    pub(super) async fn into_std(self) -> std::fs::File {
+        self.file.into_std().await
+    }
+}
+
 /// The identity of the bytes behind an [`OpenFile`].
 pub(super) struct Validator {
     pub(super) etag: String,

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -187,10 +187,6 @@ pub(super) async fn get_ebook_by_uuid(
     Path(uuid): Path<String>,
 ) -> Response {
     match db::get_book_by_uuid(&state.pool, &uuid).await {
-        // `page_count` for a CBZ book rides straight off `books.page_count`
-        // (#1593) — the projection already carries it, so the detail read
-        // no longer reopens the archive to recompute what the indexer
-        // already persisted.
         Ok(Some(book)) => Json(book).into_response(),
         Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
         Err(error) => internal("read book", error),
@@ -328,10 +324,11 @@ async fn read_ebook_file(
 /// The validator is derived from the CBZ file's own stat (via
 /// [`conditional::open`], same inode/mtime/size shape the byte-serving
 /// routes use) combined with the page index, rather than a hash of the
-/// decompressed page — so a cache hit is answered from [`db::comic::list_pages`]'s
-/// central-directory read alone, without ever paying for the page's DEFLATE
-/// decode (#1593). 404 covers an unknown uuid, a book without a CBZ file,
-/// and an out-of-range index; an unreadable archive surfaces as a 500.
+/// decompressed page. Listing and (on a cache miss) decompressing both
+/// reuse that same opened handle, so a replace racing this request can't
+/// splice a validator from one file onto bytes from another. 404 covers an
+/// unknown uuid, a book without a CBZ file, and an out-of-range index; an
+/// unreadable archive surfaces as a 500.
 pub(super) async fn get_ebook_page(
     _user: MediaAuthUser,
     State(state): State<AppState>,
@@ -349,10 +346,16 @@ pub(super) async fn get_ebook_page(
         Err(e) => return internal("book_file_path", e),
     };
 
-    let list_path = path.clone();
-    let listed = tokio::task::spawn_blocking(move || db::comic::list_pages(&list_path)).await;
-    let pages = match listed {
-        Ok(Ok(pages)) => pages,
+    let open = match conditional::open(&path).await {
+        Ok(o) => o,
+        Err(e) => return internal("open cbz for page validator", e),
+    };
+    let etag = format!("\"{}-p{page}\"", open.validator.etag.trim_matches('"'));
+    let file = open.into_std().await;
+
+    let listed = tokio::task::spawn_blocking(move || db::comic::list_pages_from_file(file)).await;
+    let (file, pages) = match listed {
+        Ok(Ok(v)) => v,
         Ok(Err(e)) => return internal("list comic pages", e),
         Err(e) => return internal("list comic pages", e),
     };
@@ -360,11 +363,6 @@ pub(super) async fn get_ebook_page(
         return StatusCode::NOT_FOUND.into_response();
     };
 
-    let open = match conditional::open(&path).await {
-        Ok(o) => o,
-        Err(e) => return internal("open cbz for page validator", e),
-    };
-    let etag = format!("\"{}-p{page}\"", open.validator.etag.trim_matches('"'));
     if headers
         .get(header::IF_NONE_MATCH)
         .and_then(|v| v.to_str().ok())
@@ -373,7 +371,8 @@ pub(super) async fn get_ebook_page(
         return conditional::not_modified(&etag, MEDIA_CACHE_CONTROL, MEDIA_VARY);
     }
 
-    let read = tokio::task::spawn_blocking(move || db::comic::read_page_named(&path, &name)).await;
+    let read =
+        tokio::task::spawn_blocking(move || db::comic::read_page_from_file(file, &name)).await;
     let (mime, bytes) = match read {
         Ok(Ok(entry)) => entry,
         Ok(Err(e)) => return internal("read comic page", e),

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -187,25 +187,14 @@ pub(super) async fn get_ebook_by_uuid(
     Path(uuid): Path<String>,
 ) -> Response {
     match db::get_book_by_uuid(&state.pool, &uuid).await {
-        Ok(Some(mut book)) => {
-            attach_comic_page_count(&state, &mut book).await;
-            Json(book).into_response()
-        }
+        // `page_count` for a CBZ book rides straight off `books.page_count`
+        // (#1593) — the projection already carries it, so the detail read
+        // no longer reopens the archive to recompute what the indexer
+        // already persisted.
+        Ok(Some(book)) => Json(book).into_response(),
         Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
         Err(error) => internal("read book", error),
     }
-}
-
-/// Fill `page_count` on a detail payload when the book carries a CBZ, by
-/// listing the archive's pages — the count the pager's slider and progress
-/// mapping key on. Best-effort via `db::comic::page_count_for_book`, which
-/// logs and leaves `None` on a missing or malformed archive; the formats
-/// check keeps non-comic detail reads free of the extra file query.
-async fn attach_comic_page_count(state: &AppState, book: &mut omnibus_shared::EbookMetadata) {
-    if !book.formats.iter().any(|f| f.eq_ignore_ascii_case("cbz")) {
-        return;
-    }
-    book.page_count = db::comic::page_count_for_book(&state.pool, book.id).await;
 }
 
 /// Resolve the on-disk EPUB path for `uuid`, honouring an optional
@@ -336,11 +325,13 @@ async fn read_ebook_file(
 /// neither a cookie nor a bearer header, so the session token rides
 /// `?token=`.
 ///
-/// The single entry is decompressed into memory, so the validator is a
-/// content hash — the covers/thumbs shape, with the 304 carrying the same
-/// `Cache-Control`/`Vary` as a 200. 404 covers an unknown uuid, a book
-/// without a CBZ file, and an out-of-range index; an unreadable archive
-/// surfaces as a 500.
+/// The validator is derived from the CBZ file's own stat (via
+/// [`conditional::open`], same inode/mtime/size shape the byte-serving
+/// routes use) combined with the page index, rather than a hash of the
+/// decompressed page — so a cache hit is answered from [`db::comic::list_pages`]'s
+/// central-directory read alone, without ever paying for the page's DEFLATE
+/// decode (#1593). 404 covers an unknown uuid, a book without a CBZ file,
+/// and an out-of-range index; an unreadable archive surfaces as a 500.
 pub(super) async fn get_ebook_page(
     _user: MediaAuthUser,
     State(state): State<AppState>,
@@ -357,21 +348,37 @@ pub(super) async fn get_ebook_page(
         Ok(None) => return StatusCode::NOT_FOUND.into_response(),
         Err(e) => return internal("book_file_path", e),
     };
-    let read = tokio::task::spawn_blocking(move || db::comic::read_page(&path, page)).await;
+
+    let list_path = path.clone();
+    let listed = tokio::task::spawn_blocking(move || db::comic::list_pages(&list_path)).await;
+    let pages = match listed {
+        Ok(Ok(pages)) => pages,
+        Ok(Err(e)) => return internal("list comic pages", e),
+        Err(e) => return internal("list comic pages", e),
+    };
+    let Some(name) = pages.get(page).cloned() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let open = match conditional::open(&path).await {
+        Ok(o) => o,
+        Err(e) => return internal("open cbz for page validator", e),
+    };
+    let etag = format!("\"{}-p{page}\"", open.validator.etag.trim_matches('"'));
+    if headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| conditional::if_none_match_hits(v, &etag))
+    {
+        return conditional::not_modified(&etag, MEDIA_CACHE_CONTROL, MEDIA_VARY);
+    }
+
+    let read = tokio::task::spawn_blocking(move || db::comic::read_page_named(&path, &name)).await;
     let (mime, bytes) = match read {
-        Ok(Ok(Some(entry))) => entry,
-        Ok(Ok(None)) => return StatusCode::NOT_FOUND.into_response(),
+        Ok(Ok(entry)) => entry,
         Ok(Err(e)) => return internal("read comic page", e),
         Err(e) => return internal("read comic page", e),
     };
-    let etag = conditional::content_etag(&bytes);
-    let inm_hit = headers
-        .get(header::IF_NONE_MATCH)
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|v| conditional::if_none_match_hits(v, &etag));
-    if inm_hit {
-        return conditional::not_modified(&etag, MEDIA_CACHE_CONTROL, MEDIA_VARY);
-    }
     (
         [
             (header::CONTENT_TYPE, mime),

--- a/server/src/backend/ebooks/tests.rs
+++ b/server/src/backend/ebooks/tests.rs
@@ -1795,15 +1795,20 @@ async fn seed_cbz_on_disk(pool: &sqlx::SqlitePool) -> (String, std::path::PathBu
         .unwrap()
         .last_insert_rowid();
     let uuid = "55555555-5555-5555-5555-555555555555".to_string();
-    let book_id =
-        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, 'Alpha')")
-            .bind(&uuid)
-            .bind(lib_id)
-            .bind(tmp.to_str().unwrap())
-            .execute(pool)
-            .await
-            .unwrap()
-            .last_insert_rowid();
+    // `page_count` is stamped here rather than derived at request time
+    // (#1593) — two real pages (p1.jpg, p2.png); the AppleDouble junk entry
+    // never counts, same as the indexer's own count would produce.
+    let book_id = sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title, page_count) \
+         VALUES (?, ?, ?, 'Alpha', 2)",
+    )
+    .bind(&uuid)
+    .bind(lib_id)
+    .bind(tmp.to_str().unwrap())
+    .execute(pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
     sqlx::query(
         "INSERT INTO book_files (book_id, format, filename, size_bytes) \
          VALUES (?, 'CBZ', 'alpha', 0)",

--- a/shared/src/ebook/metadata.rs
+++ b/shared/src/ebook/metadata.rs
@@ -132,8 +132,12 @@ pub struct EbookMetadata {
 
     /// Page count of the CBZ archive `/api/ebooks/{uuid}/pages/{n}` would
     /// serve, so the comic pager can render a slider and map progress onto
-    /// page indices. Populated only on the detail read, and only for books
-    /// with a CBZ file; `None` everywhere else.
+    /// page indices. Persisted on `books.page_count` at index time (#1593)
+    /// rather than recomputed per read, so it rides straight off the shared
+    /// projection on every read path — list, search, and detail alike.
+    /// `None` for an EPUB-only book, a malformed archive, or a row indexed
+    /// before migration `0063` (until the next scan's backfill catches it
+    /// up).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub page_count: Option<i64>,
 }

--- a/shared/src/ebook/metadata.rs
+++ b/shared/src/ebook/metadata.rs
@@ -132,12 +132,8 @@ pub struct EbookMetadata {
 
     /// Page count of the CBZ archive `/api/ebooks/{uuid}/pages/{n}` would
     /// serve, so the comic pager can render a slider and map progress onto
-    /// page indices. Persisted on `books.page_count` at index time (#1593)
-    /// rather than recomputed per read, so it rides straight off the shared
-    /// projection on every read path — list, search, and detail alike.
-    /// `None` for an EPUB-only book, a malformed archive, or a row indexed
-    /// before migration `0063` (until the next scan's backfill catches it
-    /// up).
+    /// page indices. `None` for an EPUB-only book, a malformed archive, or
+    /// a row not yet backfilled since being indexed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub page_count: Option<i64>,
 }


### PR DESCRIPTION
## Summary
- Closes #1593
- The CBZ page-serving feature (#1579) reparsed the archive's central directory on every `GET /api/ebooks/{uuid}` for a comic book (to fill `page_count`) and fully decompressed each page on every `GET /api/ebooks/{uuid}/pages/{n}` — including requests that end in a bodyless 304 — with no caching layer, unlike every other media type in this codebase.
- **Design decision (persisted vs. derived-and-cached):** persisted `books.page_count` as a new nullable column (migration `0063`), mirroring the `word_count` pattern from migration `0049` exactly, rather than a derived-and-cached value in the `covers.rs` staleness-check shape. `page_count` is scan-computed and read-only — no write path needs to remember to bump it, so the drift risk that motivates rule 09's "derived, never stored" guidance for the wire etag doesn't apply here. Computed once per CBZ file in `read_comic` (a single archive pass already reads every page name), persisted via `indexed_book_from`, and backfilled for pre-existing rows by a new `Task::BackfillPageCounts` posted after every ebook scan (same resource key as `Task::BackfillWordCounts`, its sibling).
- `server/src/backend/ebooks.rs::get_ebook_by_uuid` now reads `page_count` straight off the projection instead of calling `attach_comic_page_count` (removed) per request.
- `GET /api/ebooks/{uuid}/pages/{n}` now lists the archive's page names (cheap — no decompression) to derive an `If-None-Match` validator and answer a 304 without ever paying for the page's DEFLATE decode. `db/src/comic.rs` gained `read_page_named`, which decompresses one already-resolved entry directly, so `read_page` (kept as a small, independently-testable building block) and the route no longer redo the central-directory walk twice per request.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — 1736 passed, 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` — missing audiobook test fixtures in this sandbox, `test_data/audiobooks/` doesn't exist here)
- [x] `cargo test -p omnibus` — 648 passed, 2 pre-existing failures unrelated to this change (`backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` — reproduces identically on a clean, unmodified `main` checkout in this sandbox; a root-user/read-only-chmod environment quirk, not a regression)

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- New migration `0063_books_page_count.sql` — additive, nullable, forward-only per rule 06. No in-SQL backfill is possible (the value can only come from opening the archive), hence the new worker task.
- Nothing new needed in `.env.example` — this reuses the existing scan/worker infrastructure, no new cache directory or env var.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DCWPoS3Ga15e84V4QpyWq5)_