### PR TITLE
refactor: extract helpers to bring 14 more functions under the length cap (#852)

### DIFF
--- a/frontend/src/components/search_palette/overlay.rs
+++ b/frontend/src/components/search_palette/overlay.rs
@@ -16,55 +16,24 @@ use crate::focus_after_paint::focus_after_paint;
 use crate::platform_sleep::async_sleep_ms;
 use crate::{data, use_server_url};
 
-/// Floating overlay: dark scrim + centered panel with input, results, footer.
-#[component]
-pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
-    let mut open = open;
-    let server_url = use_server_url();
-    let mut query = use_signal(String::new);
-    let mut results = use_signal(|| Option::<PaletteResults>::None);
-    let mut selected = use_signal(|| 0_usize);
-    let mut loading = use_signal(|| false);
-    // Set on a failed search, distinct from "no matches" (mirrors
-    // `search_mobile.rs`'s `errored` signal for the same underlying call).
-    let mut errored = use_signal(|| false);
-    // Tracks whether the user has driven selection with arrow keys this
-    // session. When false, pressing Enter navigates to the full-page
-    // search results instead of drilling into `selected`.
-    let mut has_navigated = use_signal(|| false);
-    // #126: handle of the in-flight debounce+RPC task so the next keystroke
-    // can `.cancel()` it before spawning a new one (instead of leaving N
-    // sleeping spawns to race past the debounce and burn pool connections).
-    let mut current_task = use_signal(|| Option::<Task>::None);
-    let nav = use_navigator();
-
-    // Build a flat list of selectable items for keyboard navigation.
-    let flat_items = use_memo(move || build_flat_items(&results.read()));
-
-    // Close the palette.
-    let mut close = move || {
-        open.0.set(false);
-    };
-
-    let on_keydown = make_keydown_handler(KeyboardContext {
-        open,
-        selected,
-        has_navigated,
-        flat_items,
-        query,
-        nav,
-    });
-
-    // Debounced search. Uses gloo_timers on web, tokio::time on server.
-    // Each keystroke cancels the prior task (debounce sleep + RPC) before
-    // spawning a new one — only one task is in flight at a time, so stale
-    // requests don't race past the debounce or hit SQLite.
-    let url = server_url.clone();
-    let mut spawn_search = move |v: String| {
+/// Build the debounced search dispatcher. Each keystroke cancels the prior
+/// in-flight task (debounce sleep + RPC) before spawning a new one — only
+/// one task is in flight at a time, so stale requests don't race past the
+/// debounce or hit SQLite (#126). Uses gloo_timers on web, tokio::time on
+/// server.
+fn build_search_dispatcher(
+    server_url: String,
+    mut results: Signal<Option<PaletteResults>>,
+    mut selected: Signal<usize>,
+    mut loading: Signal<bool>,
+    mut errored: Signal<bool>,
+    mut current_task: Signal<Option<Task>>,
+) -> impl FnMut(String) + 'static {
+    move |v: String| {
         if let Some(prev) = current_task.write().take() {
             prev.cancel();
         }
-        let url = url.clone();
+        let url = server_url.clone();
         let task = spawn(async move {
             async_sleep_ms(150).await;
             let trimmed = v.trim().to_string();
@@ -91,22 +60,88 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
             loading.set(false);
         });
         current_task.set(Some(task));
-    };
+    }
+}
 
-    let res = results.read();
-    // Only project `selected` into row class names once the user has driven
-    // selection with arrow keys. Otherwise the first row would render with
-    // the "selected" highlight on every fresh query (since `selected`
-    // resets to 0 after each search response), and pressing ArrowDown
-    // would visually jump to index 1 instead of 0.
-    let is_loading = loading();
-    let is_errored = errored();
-
+/// `(total, duration_ms, has_results)` for the meta line, or `(0, 0, false)`
+/// before the first response lands.
+fn sp_result_summary(res: &Option<PaletteResults>) -> (usize, u64, bool) {
     let total = res
         .as_ref()
         .map(omnibus_shared::PaletteResults::total_count)
         .unwrap_or(0);
     let duration = res.as_ref().map(|r| r.duration_ms).unwrap_or(0);
+    (total, duration, res.is_some())
+}
+
+/// Meta line ("N results · Xms") and the fetch-error notice. Distinct from
+/// "no matches": `is_errored` means the request itself failed.
+fn sp_meta_and_error(has_results: bool, total: usize, duration: u64, is_errored: bool) -> Element {
+    rsx! {
+        if has_results {
+            div { class: "sp-meta", "data-testid": "sp-result-count",
+                "{total} result{plural(total)} · {duration}ms"
+            }
+        }
+        if is_errored {
+            p { role: "alert", class: "error", "data-testid": "sp-error",
+                "Couldn\u{2019}t run that search. Check your connection and try again."
+            }
+        }
+    }
+}
+
+/// Floating overlay: dark scrim + centered panel with input, results, footer.
+#[component]
+pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
+    let mut open = open;
+    let server_url = use_server_url();
+    let mut query = use_signal(String::new);
+    let results = use_signal(|| Option::<PaletteResults>::None);
+    let mut selected = use_signal(|| 0_usize);
+    let loading = use_signal(|| false);
+    // Set on a failed search, distinct from "no matches" (mirrors
+    // `search_mobile.rs`'s `errored` signal for the same underlying call).
+    let errored = use_signal(|| false);
+    // Tracks whether the user has driven selection with arrow keys this
+    // session. When false, pressing Enter navigates to the full-page
+    // search results instead of drilling into `selected`.
+    let mut has_navigated = use_signal(|| false);
+    // #126: handle of the in-flight debounce+RPC task — see
+    // `build_search_dispatcher`.
+    let current_task = use_signal(|| Option::<Task>::None);
+    let nav = use_navigator();
+
+    // Build a flat list of selectable items for keyboard navigation.
+    let flat_items = use_memo(move || build_flat_items(&results.read()));
+
+    // Close the palette.
+    let mut close = move || {
+        open.0.set(false);
+    };
+
+    let on_keydown = make_keydown_handler(KeyboardContext {
+        open,
+        selected,
+        has_navigated,
+        flat_items,
+        query,
+        nav,
+    });
+
+    let mut spawn_search = build_search_dispatcher(
+        server_url.clone(),
+        results,
+        selected,
+        loading,
+        errored,
+        current_task,
+    );
+
+    let res = results.read();
+    let is_loading = loading();
+    let is_errored = errored();
+    let (total, duration, has_results) = sp_result_summary(&res);
 
     rsx! {
         div {
@@ -137,21 +172,12 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
                     },
                 }
 
-                // Meta line
-                if res.is_some() {
-                    div { class: "sp-meta", "data-testid": "sp-result-count",
-                        "{total} result{plural(total)} · {duration}ms"
-                    }
-                }
+                {sp_meta_and_error(has_results, total, duration, is_errored)}
 
-                // Distinct from "no matches": a fetch failure, not an empty
-                // result set.
-                if is_errored {
-                    p { role: "alert", class: "error", "data-testid": "sp-error",
-                        "Couldn\u{2019}t run that search. Check your connection and try again."
-                    }
-                }
-
+                // `has_navigated` gates whether `selected` is projected into
+                // row class names: until the user drives arrow-key selection,
+                // the first row would otherwise render "selected" on every
+                // fresh query (it resets to 0 after each response).
                 SpResultsList {
                     results,
                     flat_items,

--- a/frontend/src/components/search_palette/results.rs
+++ b/frontend/src/components/search_palette/results.rs
@@ -13,6 +13,18 @@ use super::model::{facet_query, is_selected, plural, FlatItem};
 use super::PaletteOpen;
 use crate::{use_server_url, Route};
 
+/// Build a row click handler that navigates to `route` and closes the palette.
+fn navigate_and_close(
+    nav: dioxus_router::Navigator,
+    mut open: PaletteOpen,
+    route: Route,
+) -> impl FnMut(MouseEvent) + 'static {
+    move |_| {
+        nav.push(route.clone());
+        open.0.set(false);
+    }
+}
+
 /// Scrollable grouped result list rendered inside the palette panel.
 ///
 /// Owns the per-group heading + row layout. Each click callback closes the
@@ -25,7 +37,6 @@ pub(super) fn SpResultsList(
     has_navigated: Signal<bool>,
     open: PaletteOpen,
 ) -> Element {
-    let mut open = open;
     let nav = use_navigator();
     let res = results.read();
     let items = flat_items.read();
@@ -43,13 +54,7 @@ pub(super) fn SpResultsList(
                             key: "{book.id}",
                             book: book.clone(),
                             selected: has_nav && is_selected(&items, sel, &FlatItem::Book { uuid: book.uuid.clone(), title: book.title.clone() }),
-                            on_click: {
-                                let uuid = book.uuid.clone();
-                                move |_| {
-                                    nav.push(Route::BookDetail { uuid: uuid.clone() });
-                                    open.0.set(false);
-                                }
-                            },
+                            on_click: navigate_and_close(nav, open, Route::BookDetail { uuid: book.uuid.clone() }),
                         }
                     }
                 }
@@ -62,13 +67,7 @@ pub(super) fn SpResultsList(
                             key: "{author.id}",
                             author: author.clone(),
                             selected: has_nav && is_selected(&items, sel, &FlatItem::Author { id: author.id, name: author.name.clone() }),
-                            on_click: {
-                                let id = author.id;
-                                move |_| {
-                                    nav.push(Route::AuthorDetail { id });
-                                    open.0.set(false);
-                                }
-                            },
+                            on_click: navigate_and_close(nav, open, Route::AuthorDetail { id: author.id }),
                         }
                     }
                 }
@@ -81,13 +80,7 @@ pub(super) fn SpResultsList(
                             key: "{s.id}",
                             series: s.clone(),
                             selected: has_nav && is_selected(&items, sel, &FlatItem::Series { id: s.id, name: s.name.clone() }),
-                            on_click: {
-                                let id = s.id;
-                                move |_| {
-                                    nav.push(Route::SeriesDetail { id });
-                                    open.0.set(false);
-                                }
-                            },
+                            on_click: navigate_and_close(nav, open, Route::SeriesDetail { id: s.id }),
                         }
                     }
                 }
@@ -100,15 +93,7 @@ pub(super) fn SpResultsList(
                             key: "{tag.id}",
                             tag: tag.clone(),
                             selected: has_nav && is_selected(&items, sel, &FlatItem::Tag { id: tag.id, name: tag.name.clone() }),
-                            on_click: {
-                                let name = tag.name.clone();
-                                move |_| {
-                                    nav.push(Route::Search {
-                                        query: facet_query("tag", &name),
-                                    });
-                                    open.0.set(false);
-                                }
-                            },
+                            on_click: navigate_and_close(nav, open, Route::Search { query: facet_query("tag", &tag.name) }),
                         }
                     }
                 }

--- a/frontend/src/pages/account.rs
+++ b/frontend/src/pages/account.rs
@@ -140,82 +140,185 @@ pub fn AccountPage(#[props(default)] embedded: bool) -> Element {
     }
 }
 
+/// Signals backing the Kindle email form — grouped so the hydration effect
+/// and the save/clear handler builders don't each take five signal params.
+#[cfg(not(feature = "mobile"))]
+#[derive(Clone, Copy)]
+struct KindleEmailSignals {
+    email_input: Signal<String>,
+    saved_email: Signal<Option<String>>,
+    msg: Signal<Option<String>>,
+    msg_is_error: Signal<bool>,
+    in_flight: Signal<bool>,
+}
+
+/// Hydrates the saved Kindle email after mount. `current_user` is a no-op on
+/// SSR/mobile, so the first paint matches the empty-signal SSR markup.
+#[cfg(not(feature = "mobile"))]
+fn use_kindle_email_hydration(mut signals: KindleEmailSignals) {
+    use_effect(move || {
+        spawn(async move {
+            if let Ok(Some(user)) = data::current_user().await {
+                if let Some(email) = user.kindle_email.clone() {
+                    signals.email_input.set(email.clone());
+                    signals.saved_email.set(Some(email));
+                }
+            }
+        });
+    });
+}
+
+/// Submit handler for the Kindle email save form: validates non-empty
+/// locally, then round-trips through `data::set_kindle_email`.
+#[cfg(not(feature = "mobile"))]
+fn kindle_save_handler(
+    server_url: String,
+    mut signals: KindleEmailSignals,
+) -> impl FnMut(Event<FormData>) + 'static {
+    move |evt: Event<FormData>| {
+        evt.prevent_default();
+        let value = (signals.email_input)().trim().to_string();
+        if value.is_empty() {
+            signals
+                .msg
+                .set(Some("Enter a Kindle email to save.".to_string()));
+            signals.msg_is_error.set(true);
+            return;
+        }
+        let url = server_url.clone();
+        signals.in_flight.set(true);
+        spawn(async move {
+            match data::set_kindle_email(&url, Some(value.clone())).await {
+                Ok(()) => {
+                    signals.saved_email.set(Some(value));
+                    signals.msg.set(Some("Kindle email saved.".to_string()));
+                    signals.msg_is_error.set(false);
+                }
+                Err(_) => {
+                    signals.msg.set(Some(
+                        "Failed to save Kindle email — check the address.".to_string(),
+                    ));
+                    signals.msg_is_error.set(true);
+                }
+            }
+            signals.in_flight.set(false);
+        });
+    }
+}
+
+/// Click handler for the Kindle email clear button.
+#[cfg(not(feature = "mobile"))]
+fn kindle_clear_handler(
+    server_url: String,
+    mut signals: KindleEmailSignals,
+) -> impl FnMut(Event<MouseData>) + 'static {
+    move |_| {
+        let url = server_url.clone();
+        signals.in_flight.set(true);
+        spawn(async move {
+            match data::set_kindle_email(&url, None).await {
+                Ok(()) => {
+                    signals.email_input.set(String::new());
+                    signals.saved_email.set(None);
+                    signals.msg.set(Some("Kindle email cleared.".to_string()));
+                    signals.msg_is_error.set(false);
+                }
+                Err(_) => {
+                    signals
+                        .msg
+                        .set(Some("Failed to clear Kindle email.".to_string()));
+                    signals.msg_is_error.set(true);
+                }
+            }
+            signals.in_flight.set(false);
+        });
+    }
+}
+
+/// The Kindle email form: input, save/clear actions, and the approved-sender
+/// hint. Split out of `kindle_account_body` so the signal wiring above and
+/// this markup each stay readable on their own.
+#[cfg(not(feature = "mobile"))]
+fn kindle_email_form(
+    email_input: Signal<String>,
+    in_flight: Signal<bool>,
+    connected: bool,
+    on_save: impl FnMut(Event<FormData>) + 'static,
+    on_clear: impl FnMut(Event<MouseData>) + 'static,
+) -> Element {
+    let mut email_input = email_input;
+    rsx! {
+        form {
+            id: "kindle-email-form",
+            class: "settings-form",
+            onsubmit: on_save,
+            div { class: "settings-field",
+                label { r#for: "kindle-email", "Kindle Email" }
+                input {
+                    r#type: "email",
+                    id: "kindle-email",
+                    name: "kindle_email",
+                    "data-testid": "kindle-email-input",
+                    autocomplete: "off",
+                    autocapitalize: "none",
+                    autocorrect: "off",
+                    spellcheck: "false",
+                    placeholder: "you@kindle.com",
+                    value: "{email_input}",
+                    oninput: move |e| email_input.set(e.value()),
+                }
+            }
+            p { class: "subtitle",
+                "Add "
+                b { "your library's sender address" }
+                " to your Amazon "
+                a {
+                    href: "https://www.amazon.com/sendtokindle/email",
+                    target: "_blank",
+                    rel: "noopener",
+                    "approved sender list"
+                }
+                " or Amazon will silently drop the delivery."
+            }
+            div { class: "settings-actions",
+                button {
+                    r#type: "submit",
+                    class: "btn",
+                    disabled: in_flight(),
+                    "data-testid": "kindle-email-save",
+                    "Save"
+                }
+                button {
+                    r#type: "button",
+                    class: "btn ghost",
+                    disabled: in_flight() || !connected,
+                    "data-testid": "kindle-email-clear",
+                    onclick: on_clear,
+                    "Clear"
+                }
+            }
+        }
+    }
+}
+
 /// Web/SSR page body — the Send-to-Kindle destination form. Hydrates the
 /// saved address from `/api/auth/me`; saving/clearing round-trips through
 /// `data::set_kindle_email`.
 #[cfg(not(feature = "mobile"))]
 fn kindle_account_body(embedded: bool) -> Element {
     let server_url = use_server_url();
-    let mut email_input = use_signal(String::new);
-    let mut saved_email = use_signal(|| None::<String>);
-    let mut msg = use_signal(|| None::<String>);
-    let mut msg_is_error = use_signal(|| false);
-    let mut in_flight = use_signal(|| false);
-
-    // Hydrate the saved Kindle email after mount. `current_user` is a no-op on
-    // SSR/mobile, so the first paint matches the empty-signal SSR markup.
-    use_effect(move || {
-        spawn(async move {
-            if let Ok(Some(user)) = data::current_user().await {
-                if let Some(email) = user.kindle_email.clone() {
-                    email_input.set(email.clone());
-                    saved_email.set(Some(email));
-                }
-            }
-        });
-    });
-
-    let save_url = server_url.clone();
-    let on_save = move |evt: Event<FormData>| {
-        evt.prevent_default();
-        let value = email_input().trim().to_string();
-        if value.is_empty() {
-            msg.set(Some("Enter a Kindle email to save.".to_string()));
-            msg_is_error.set(true);
-            return;
-        }
-        let url = save_url.clone();
-        in_flight.set(true);
-        spawn(async move {
-            match data::set_kindle_email(&url, Some(value.clone())).await {
-                Ok(()) => {
-                    saved_email.set(Some(value));
-                    msg.set(Some("Kindle email saved.".to_string()));
-                    msg_is_error.set(false);
-                }
-                Err(_) => {
-                    msg.set(Some(
-                        "Failed to save Kindle email — check the address.".to_string(),
-                    ));
-                    msg_is_error.set(true);
-                }
-            }
-            in_flight.set(false);
-        });
+    let signals = KindleEmailSignals {
+        email_input: use_signal(String::new),
+        saved_email: use_signal(|| None::<String>),
+        msg: use_signal(|| None::<String>),
+        msg_is_error: use_signal(|| false),
+        in_flight: use_signal(|| false),
     };
+    use_kindle_email_hydration(signals);
 
-    let clear_url = server_url;
-    let on_clear = move |_| {
-        let url = clear_url.clone();
-        in_flight.set(true);
-        spawn(async move {
-            match data::set_kindle_email(&url, None).await {
-                Ok(()) => {
-                    email_input.set(String::new());
-                    saved_email.set(None);
-                    msg.set(Some("Kindle email cleared.".to_string()));
-                    msg_is_error.set(false);
-                }
-                Err(_) => {
-                    msg.set(Some("Failed to clear Kindle email.".to_string()));
-                    msg_is_error.set(true);
-                }
-            }
-            in_flight.set(false);
-        });
-    };
-
-    let connected = saved_email().is_some();
+    let on_save = kindle_save_handler(server_url.clone(), signals);
+    let on_clear = kindle_clear_handler(server_url, signals);
+    let connected = (signals.saved_email)().is_some();
 
     rsx! {
         section { class: "card", "data-testid": "account-kindle-card",
@@ -226,56 +329,7 @@ fn kindle_account_body(embedded: bool) -> Element {
             }
             p { class: "subtitle", "Configure your Send-to-Kindle delivery address." }
 
-            form {
-                id: "kindle-email-form",
-                class: "settings-form",
-                onsubmit: on_save,
-                div { class: "settings-field",
-                    label { r#for: "kindle-email", "Kindle Email" }
-                    input {
-                        r#type: "email",
-                        id: "kindle-email",
-                        name: "kindle_email",
-                        "data-testid": "kindle-email-input",
-                        autocomplete: "off",
-                        autocapitalize: "none",
-                        autocorrect: "off",
-                        spellcheck: "false",
-                        placeholder: "you@kindle.com",
-                        value: "{email_input}",
-                        oninput: move |e| email_input.set(e.value()),
-                    }
-                }
-                p { class: "subtitle",
-                    "Add "
-                    b { "your library's sender address" }
-                    " to your Amazon "
-                    a {
-                        href: "https://www.amazon.com/sendtokindle/email",
-                        target: "_blank",
-                        rel: "noopener",
-                        "approved sender list"
-                    }
-                    " or Amazon will silently drop the delivery."
-                }
-                div { class: "settings-actions",
-                    button {
-                        r#type: "submit",
-                        class: "btn",
-                        disabled: in_flight(),
-                        "data-testid": "kindle-email-save",
-                        "Save"
-                    }
-                    button {
-                        r#type: "button",
-                        class: "btn ghost",
-                        disabled: in_flight() || !connected,
-                        "data-testid": "kindle-email-clear",
-                        onclick: on_clear,
-                        "Clear"
-                    }
-                }
-            }
+            {kindle_email_form(signals.email_input, signals.in_flight, connected, on_save, on_clear)}
 
             p {
                 class: if connected { "settings-status success" } else { "settings-status" },
@@ -283,11 +337,11 @@ fn kindle_account_body(embedded: bool) -> Element {
                 if connected { "A Kindle email is configured." } else { "No Kindle email configured yet." }
             }
 
-            if let Some(m) = msg() {
+            if let Some(m) = (signals.msg)() {
                 p {
                     role: "status",
                     "data-testid": "kindle-email-status",
-                    class: if msg_is_error() { "settings-status error" } else { "settings-status success" },
+                    class: if (signals.msg_is_error)() { "settings-status error" } else { "settings-status success" },
                     "{m}"
                 }
             }

--- a/frontend/src/pages/book_detail/journal_editor.rs
+++ b/frontend/src/pages/book_detail/journal_editor.rs
@@ -85,6 +85,97 @@ struct ToolbarButton {
     b: &'static str,
 }
 
+/// Formatting buttons shown in [`BdJournalToolbar`], in the order the
+/// design's `InlineJournalEditor` toolbar uses. Module-level (rather than a
+/// local `const` in the component) so the button data doesn't pad the
+/// component's own body.
+const TOOLBAR_BUTTONS: &[ToolbarButton] = &[
+    ToolbarButton {
+        label: "B",
+        title: "Bold",
+        op: "wrap",
+        a: "**",
+        b: "**",
+    },
+    ToolbarButton {
+        label: "I",
+        title: "Italic",
+        op: "wrap",
+        a: "*",
+        b: "*",
+    },
+    ToolbarButton {
+        label: "S",
+        title: "Strikethrough",
+        op: "wrap",
+        a: "~~",
+        b: "~~",
+    },
+    ToolbarButton {
+        label: "H1",
+        title: "Heading 1",
+        op: "prefix",
+        a: "# ",
+        b: "",
+    },
+    ToolbarButton {
+        label: "H2",
+        title: "Heading 2",
+        op: "prefix",
+        a: "## ",
+        b: "",
+    },
+    ToolbarButton {
+        label: "\u{201C}",
+        title: "Quote",
+        op: "prefix",
+        a: "> ",
+        b: "",
+    },
+    ToolbarButton {
+        label: "\u{2022}",
+        title: "Bullet list",
+        op: "prefix",
+        a: "- ",
+        b: "",
+    },
+    ToolbarButton {
+        label: "1.",
+        title: "Numbered list",
+        op: "prefix",
+        a: "1. ",
+        b: "",
+    },
+    ToolbarButton {
+        label: "[ ]",
+        title: "Checklist",
+        op: "prefix",
+        a: "- [ ] ",
+        b: "",
+    },
+    ToolbarButton {
+        label: "{ }",
+        title: "Inline code",
+        op: "wrap",
+        a: "`",
+        b: "`",
+    },
+    ToolbarButton {
+        label: "\u{1F517}",
+        title: "Link",
+        op: "link",
+        a: "text",
+        b: "https://",
+    },
+    ToolbarButton {
+        label: "Spoiler",
+        title: "Spoiler \u{2014} blurred until clicked",
+        op: "wrap",
+        a: "||",
+        b: "||",
+    },
+];
+
 /// The composer formatting toolbar. Each button wraps/prefixes the live
 /// editor's selection with the matching markdown so the persisted body stays
 /// plain markdown. `target_id` is the id of the contenteditable the buttons act
@@ -96,97 +187,9 @@ pub(crate) fn BdJournalToolbar(
     server_url: String,
     error: Signal<Option<String>>,
 ) -> Element {
-    // Order mirrors the design's `InlineJournalEditor` toolbar.
-    const BUTTONS: &[ToolbarButton] = &[
-        ToolbarButton {
-            label: "B",
-            title: "Bold",
-            op: "wrap",
-            a: "**",
-            b: "**",
-        },
-        ToolbarButton {
-            label: "I",
-            title: "Italic",
-            op: "wrap",
-            a: "*",
-            b: "*",
-        },
-        ToolbarButton {
-            label: "S",
-            title: "Strikethrough",
-            op: "wrap",
-            a: "~~",
-            b: "~~",
-        },
-        ToolbarButton {
-            label: "H1",
-            title: "Heading 1",
-            op: "prefix",
-            a: "# ",
-            b: "",
-        },
-        ToolbarButton {
-            label: "H2",
-            title: "Heading 2",
-            op: "prefix",
-            a: "## ",
-            b: "",
-        },
-        ToolbarButton {
-            label: "\u{201C}",
-            title: "Quote",
-            op: "prefix",
-            a: "> ",
-            b: "",
-        },
-        ToolbarButton {
-            label: "\u{2022}",
-            title: "Bullet list",
-            op: "prefix",
-            a: "- ",
-            b: "",
-        },
-        ToolbarButton {
-            label: "1.",
-            title: "Numbered list",
-            op: "prefix",
-            a: "1. ",
-            b: "",
-        },
-        ToolbarButton {
-            label: "[ ]",
-            title: "Checklist",
-            op: "prefix",
-            a: "- [ ] ",
-            b: "",
-        },
-        ToolbarButton {
-            label: "{ }",
-            title: "Inline code",
-            op: "wrap",
-            a: "`",
-            b: "`",
-        },
-        ToolbarButton {
-            label: "\u{1F517}",
-            title: "Link",
-            op: "link",
-            a: "text",
-            b: "https://",
-        },
-        ToolbarButton {
-            label: "Spoiler",
-            title: "Spoiler \u{2014} blurred until clicked",
-            op: "wrap",
-            a: "||",
-            b: "||",
-        },
-    ];
-
     rsx! {
         div { class: "bd-journal-toolbar", "data-testid": "journal-toolbar", role: "toolbar",
-            for btn in BUTTONS.iter() {
+            for btn in TOOLBAR_BUTTONS.iter() {
                 button {
                     key: "{btn.title}",
                     r#type: "button",

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -357,6 +357,58 @@ pub(super) struct EditableCellProps {
     pub error: Option<String>,
 }
 
+/// Build the input's Enter/Escape keydown handler: Enter saves (if the
+/// draft changed) and exits edit mode; Escape restores `initial` and exits
+/// without saving. Both stop propagation so the row-level navigate/edit
+/// keydown handlers don't also fire.
+fn build_cell_keydown_handler(
+    mut draft: Signal<String>,
+    mut editing: Signal<Option<EditField>>,
+    initial: String,
+    on_save: EventHandler<String>,
+) -> impl FnMut(Event<KeyboardData>) + 'static {
+    move |e: Event<KeyboardData>| match e.key() {
+        Key::Enter => {
+            e.prevent_default();
+            // Stop the Enter event from bubbling to the row-level
+            // keydown that navigates to the book detail page.
+            e.stop_propagation();
+            let current = draft();
+            if current.trim() != initial.trim() {
+                on_save.call(current);
+            }
+            editing.set(None);
+        }
+        Key::Escape => {
+            e.prevent_default();
+            e.stop_propagation();
+            draft.set(initial.clone());
+            editing.set(None);
+        }
+        _ => {}
+    }
+}
+
+/// Build the input's blur handler: saves only when the draft actually
+/// changed from `initial`. Clicking into a cell and back out without typing
+/// must not POST an override equal to the scanned value (which would leak
+/// `metadata_overrides` rows that match the underlying scan, defeating the
+/// F5.1 merge semantics).
+fn build_cell_blur_handler(
+    draft: Signal<String>,
+    mut editing: Signal<Option<EditField>>,
+    initial: String,
+    on_save: EventHandler<String>,
+) -> impl FnMut(Event<FocusData>) + 'static {
+    move |_| {
+        let current = draft();
+        if current.trim() != initial.trim() {
+            on_save.call(current);
+        }
+        editing.set(None);
+    }
+}
+
 /// Inline-editable text cell used by `EbookRow`. Renders a span of text by
 /// default; in admin mode, a click swaps to a text input that commits via the
 /// `on_save` prop on Enter or blur and cancels on Escape. The input's `onclick`
@@ -394,10 +446,9 @@ pub(super) fn EditableCell(props: EditableCellProps) -> Element {
     // the save-on-blur round-trip when nothing actually changed.
     let initial = edit_value.unwrap_or_else(|| display_value.clone());
     let initial_for_click = initial.clone();
-    let initial_for_cancel = initial.clone();
-    let initial_for_enter = initial.clone();
-    let initial_for_blur = initial.clone();
     let testid_input = format!("{cell_testid}-input");
+    let onkeydown = build_cell_keydown_handler(draft, editing, initial.clone(), on_save);
+    let onblur = build_cell_blur_handler(draft, editing, initial, on_save);
 
     rsx! {
         td {
@@ -422,43 +473,8 @@ pub(super) fn EditableCell(props: EditableCellProps) -> Element {
                     placeholder: "{placeholder}",
                     onclick: move |e| { e.stop_propagation(); },
                     oninput: move |e| { draft.set(e.value()); },
-                    onkeydown: move |e: Event<KeyboardData>| {
-                        match e.key() {
-                            Key::Enter => {
-                                e.prevent_default();
-                                // Stop the Enter event from bubbling to
-                                // the row-level keydown that navigates
-                                // to the book detail page.
-                                e.stop_propagation();
-                                let current = draft();
-                                if current.trim() != initial_for_enter.trim() {
-                                    on_save.call(current);
-                                }
-                                editing.set(None);
-                            }
-                            Key::Escape => {
-                                e.prevent_default();
-                                e.stop_propagation();
-                                draft.set(initial_for_cancel.clone());
-                                editing.set(None);
-                            }
-                            _ => {}
-                        }
-                    },
-                    onblur: move |_| {
-                        // Save on blur only when the draft actually
-                        // changed. Clicking into a cell and clicking
-                        // back out without typing must not POST an
-                        // override equal to the scanned value (which
-                        // would leak `metadata_overrides` rows that
-                        // match the underlying scan, defeating the
-                        // F5.1 merge semantics).
-                        let current = draft();
-                        if current.trim() != initial_for_blur.trim() {
-                            on_save.call(current);
-                        }
-                        editing.set(None);
-                    },
+                    onkeydown,
+                    onblur,
                 }
             } else {
                 div { class: "ebook-title-cell", "{display_value}" }

--- a/frontend/src/pages/listen/chapters_drawer.rs
+++ b/frontend/src/pages/listen/chapters_drawer.rs
@@ -11,6 +11,76 @@ use omnibus_shared::ChapterInfo;
 
 use super::helpers::format_hms;
 
+/// One chapter row: ordinal/checkmark/play glyph, title, and
+/// duration-or-remaining label. `i` is the chapter's index in the list.
+fn chapter_row(
+    i: usize,
+    ch: &ChapterInfo,
+    current_chapter_index: usize,
+    elapsed: f64,
+    on_seek: EventHandler<f64>,
+) -> Element {
+    let is_played = i < current_chapter_index;
+    let is_current = i == current_chapter_index;
+    let row_class = if is_current {
+        "lp-drawer-row current"
+    } else if is_played {
+        "lp-drawer-row played"
+    } else {
+        "lp-drawer-row"
+    };
+    let row_testid = if is_current {
+        "chapter-row-current"
+    } else if is_played {
+        "chapter-row-played"
+    } else {
+        "chapter-row-upcoming"
+    };
+
+    let dur_label = format_hms(ch.duration_seconds);
+    let remaining_in_ch = if is_current {
+        let r = (ch.start_seconds + ch.duration_seconds - elapsed).max(0.0);
+        Some(format!("{} remaining", format_hms(r)))
+    } else {
+        None
+    };
+
+    let ch_start = ch.start_seconds;
+    let title = if ch.title.is_empty() {
+        format!("Chapter {}", i + 1)
+    } else {
+        ch.title.clone()
+    };
+    let ordinal = i + 1;
+
+    rsx! {
+        button {
+            key: "{ch.ordinal}",
+            class: "{row_class}",
+            "data-testid": "{row_testid}",
+            r#type: "button",
+            onclick: move |_| on_seek.call(ch_start),
+            span { class: "lp-drawer-ord",
+                if is_played {
+                    "\u{2713}"
+                } else if is_current {
+                    "\u{25b6}"
+                } else {
+                    "{ordinal}"
+                }
+            }
+            span { class: "lp-drawer-title", "{title}" }
+            span { class: "lp-drawer-dur",
+                if let Some(rem) = remaining_in_ch {
+                    "{rem}"
+                } else {
+                    "{dur_label}"
+                }
+            }
+        }
+    }
+}
+
 #[component]
 pub(super) fn ChaptersDrawer(
     chapters: Vec<ChapterInfo>,
@@ -48,67 +118,7 @@ pub(super) fn ChaptersDrawer(
                     }
                 } else {
                     for (i, ch) in chapters.iter().enumerate() {
-                        {
-                            let is_played = i < current_chapter_index;
-                            let is_current = i == current_chapter_index;
-                            let row_class = if is_current {
-                                "lp-drawer-row current"
-                            } else if is_played {
-                                "lp-drawer-row played"
-                            } else {
-                                "lp-drawer-row"
-                            };
-                            let row_testid = if is_current {
-                                "chapter-row-current"
-                            } else if is_played {
-                                "chapter-row-played"
-                            } else {
-                                "chapter-row-upcoming"
-                            };
-
-                            let dur_label = format_hms(ch.duration_seconds);
-                            let remaining_in_ch = if is_current {
-                                let r = (ch.start_seconds + ch.duration_seconds - elapsed).max(0.0);
-                                Some(format!("{} remaining", format_hms(r)))
-                            } else {
-                                None
-                            };
-
-                            let ch_start = ch.start_seconds;
-                            let title = if ch.title.is_empty() {
-                                format!("Chapter {}", i + 1)
-                            } else {
-                                ch.title.clone()
-                            };
-                            let ordinal = i + 1;
-
-                            rsx! {
-                                button {
-                                    key: "{ch.ordinal}",
-                                    class: "{row_class}",
-                                    "data-testid": "{row_testid}",
-                                    r#type: "button",
-                                    onclick: move |_| on_seek.call(ch_start),
-                                    span { class: "lp-drawer-ord",
-                                        if is_played {
-                                            "\u{2713}"
-                                        } else if is_current {
-                                            "\u{25b6}"
-                                        } else {
-                                            "{ordinal}"
-                                        }
-                                    }
-                                    span { class: "lp-drawer-title", "{title}" }
-                                    span { class: "lp-drawer-dur",
-                                        if let Some(rem) = remaining_in_ch {
-                                            "{rem}"
-                                        } else {
-                                            "{dur_label}"
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        {chapter_row(i, ch, current_chapter_index, elapsed, on_seek)}
                     }
                 }
             }

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -310,8 +310,121 @@ fn render_unsupported(
     }
 }
 
+/// Derived display state for one player render: effective scrub position,
+/// chapter math, accent style, and formatted labels. Computed once ahead of
+/// the transport handlers and markup so [`render_player`] stays readable —
+/// kept as a distinct step per #852 rather than inlined into the component
+/// body.
+struct PlayerDerived {
+    effective: f64,
+    chapter_no: usize,
+    chapter_count: usize,
+    chapter_title: String,
+    within: f64,
+    chapter_dur: f64,
+    chapter_left: f64,
+    remaining_book: f64,
+    scrub_max: f64,
+    accent_style: String,
+    rate_label: String,
+    sleep_label: String,
+    sleep_armed: bool,
+    has_chapters: bool,
+}
+
+/// Compute [`PlayerDerived`] for one render. While dragging, every readout
+/// previews the drag position (`scrub_target`) and the current chapter is
+/// re-derived from it, so the bar/times track the thumb; at rest `effective`
+/// is the true elapsed. The transport handlers still act on the real
+/// `elapsed`/`chapter_index`, never the preview. Shared with the web player
+/// via `effective_scrub_position` so the two derivations can't diverge.
+fn derive_player_state(
+    view: &PlayerView,
+    elapsed: f64,
+    duration: f64,
+    chapter_index: usize,
+    rate: f64,
+    sleep: SleepState,
+    scrub_target: Option<f64>,
+) -> PlayerDerived {
+    let (effective, disp_index, eff_remaining) = effective_scrub_position(
+        &view.chapters,
+        elapsed,
+        duration,
+        chapter_index,
+        (duration - elapsed).max(0.0),
+        scrub_target,
+        chapter_index_for_elapsed,
+    );
+    let current = view.chapters.get(disp_index);
+    let chapter_start = current.map(|c| c.start_seconds).unwrap_or(0.0);
+    let chapter_dur = current.map(|c| c.duration_seconds).unwrap_or(0.0);
+    let within = (effective - chapter_start).max(0.0);
+    let chapter_left = remaining_at_rate(
+        view::remaining_in_chapter(&view.chapters, disp_index, effective),
+        rate,
+    );
+
+    PlayerDerived {
+        effective,
+        chapter_no: disp_index + 1,
+        chapter_count: view.chapters.len(),
+        chapter_title: current.map(|c| c.title.clone()).unwrap_or_default(),
+        within,
+        chapter_dur,
+        chapter_left,
+        remaining_book: remaining_at_rate(eff_remaining, rate),
+        scrub_max: if duration > 0.0 { duration } else { 1.0 },
+        accent_style: view
+            .accent
+            .as_deref()
+            .map(|a| format!("--accent: {a};"))
+            .unwrap_or_default(),
+        rate_label: format!("{rate:.2}\u{00d7}"),
+        sleep_label: sleep_pill_label(sleep, elapsed),
+        sleep_armed: sleep != SleepState::Off,
+        has_chapters: !view.chapters.is_empty(),
+    }
+}
+
+/// Build the prev/next/bookmark chapter-nav handlers, sharing one `Rc` clone
+/// of the chapter list across all three — `render_player` reruns on every
+/// position tick, so per-closure deep clones of the chapters vec add up
+/// (issue #1143).
+fn build_chapter_nav_handlers(
+    chapters: std::rc::Rc<Vec<omnibus_shared::ChapterInfo>>,
+    elapsed: f64,
+    chapter_index: usize,
+    bookmarks: MobileBookmarks,
+    mut sheet: Signal<OpenSheet>,
+) -> (
+    impl FnMut(MouseEvent) + 'static,
+    impl FnMut(MouseEvent) + 'static,
+    impl FnMut(MouseEvent) + 'static,
+) {
+    let prev_chapters = chapters.clone();
+    let on_prev = move |_: MouseEvent| {
+        if let Some(t) = view::chapter_prev_seek(&prev_chapters, elapsed, chapter_index) {
+            interop::seek(t);
+        }
+    };
+    let next_chapters = chapters.clone();
+    let on_next = move |_: MouseEvent| {
+        if chapter_index + 1 < next_chapters.len() {
+            interop::seek(next_chapters[chapter_index + 1].start_seconds);
+        }
+    };
+    let on_bookmark = move |_: MouseEvent| {
+        bookmarks.create(elapsed, &chapters);
+        sheet.set(OpenSheet::Bookmarks);
+    };
+    (on_prev, on_next, on_bookmark)
+}
+
 /// Render the full player surface: cover hero, now-playing block, chapter
 /// scrubber, transport row, secondary controls, toast, and the bottom sheets.
+/// The derived-state prelude lives in [`derive_player_state`]; each markup
+/// section below has its own `render_player_*` helper.
 fn render_player(p: PlayerProps) -> Element {
     let PlayerProps {
         uuid,
@@ -322,7 +435,7 @@ fn render_player(p: PlayerProps) -> Element {
         rate,
         sleep,
         chapter_index,
-        mut sheet,
+        sheet,
         scrub,
         bookmarks,
         ctx,
@@ -330,44 +443,15 @@ fn render_player(p: PlayerProps) -> Element {
     } = p;
 
     let server_url = use_server_url();
-    // While dragging, every readout previews the drag position and the current
-    // chapter is re-derived from it, so the bar/times track the thumb; at rest
-    // `effective` is the true elapsed. The transport handlers below still act
-    // on the real `elapsed` / `chapter_index`, never the preview. Shared with
-    // the web player via `effective_scrub_position` so the two derivations
-    // can't silently diverge.
-    let (effective, disp_index, eff_remaining) = effective_scrub_position(
-        &view.chapters,
+    let derived = derive_player_state(
+        &view,
         elapsed,
         duration,
         chapter_index,
-        (duration - elapsed).max(0.0),
-        scrub(),
-        chapter_index_for_elapsed,
-    );
-    let current = view.chapters.get(disp_index);
-    let chapter_no = disp_index + 1;
-    let chapter_count = view.chapters.len();
-    let chapter_title = current.map(|c| c.title.clone()).unwrap_or_default();
-    let chapter_start = current.map(|c| c.start_seconds).unwrap_or(0.0);
-    let chapter_dur = current.map(|c| c.duration_seconds).unwrap_or(0.0);
-    let within = (effective - chapter_start).max(0.0);
-    let chapter_left = remaining_at_rate(
-        view::remaining_in_chapter(&view.chapters, disp_index, effective),
         rate,
+        sleep,
+        scrub(),
     );
-    let remaining_book = remaining_at_rate(eff_remaining, rate);
-    let scrub_max = if duration > 0.0 { duration } else { 1.0 };
-
-    let accent_style = view
-        .accent
-        .as_deref()
-        .map(|a| format!("--accent: {a};"))
-        .unwrap_or_default();
-    let rate_label = format!("{rate:.2}\u{00d7}");
-    let sleep_label = sleep_pill_label(sleep, elapsed);
-    let sleep_armed = sleep != SleepState::Off;
-    let has_chapters = !view.chapters.is_empty();
     let toast = (bookmarks.toast)();
 
     // Transport handlers — all route through the JS control surface. Dragging
@@ -392,37 +476,13 @@ fn render_player(p: PlayerProps) -> Element {
         scrub.set(None);
     };
     // Let audio events drive `ctx.playing`; an optimistic flip can desync the icon.
-    let on_toggle = move |_| interop::toggle();
-    let on_back = move |_| interop::skip(-30.0);
-    let on_fwd = move |_| interop::skip(30.0);
+    let on_toggle = move |_: MouseEvent| interop::toggle();
+    let on_back = move |_: MouseEvent| interop::skip(-30.0);
+    let on_fwd = move |_: MouseEvent| interop::skip(30.0);
 
-    // One shared chapters allocation for the handlers and the sheet layer —
-    // `render_player` reruns on every position tick, so per-closure deep
-    // clones of the chapters vec add up (issue #1143).
     let chapters = std::rc::Rc::new(view.chapters.clone());
-    let on_prev = {
-        let chapters = chapters.clone();
-        move |_: MouseEvent| {
-            if let Some(t) = view::chapter_prev_seek(&chapters, elapsed, chapter_index) {
-                interop::seek(t);
-            }
-        }
-    };
-    let on_next = {
-        let chapters = chapters.clone();
-        move |_: MouseEvent| {
-            if chapter_index + 1 < chapters.len() {
-                interop::seek(chapters[chapter_index + 1].start_seconds);
-            }
-        }
-    };
-    let on_bookmark = {
-        let chapters = chapters.clone();
-        move |_: MouseEvent| {
-            bookmarks.create(elapsed, &chapters);
-            sheet.set(OpenSheet::Bookmarks);
-        }
-    };
+    let (on_prev, on_next, on_bookmark) =
+        build_chapter_nav_handlers(chapters.clone(), elapsed, chapter_index, bookmarks, sheet);
 
     let sheet_props = SheetProps {
         uuid: uuid.clone(),
@@ -439,127 +499,170 @@ fn render_player(p: PlayerProps) -> Element {
     };
 
     rsx! {
-        div { class: "m-player", style: "{accent_style}", "data-testid": "mobile-player",
+        div { class: "m-player", style: "{derived.accent_style}", "data-testid": "mobile-player",
             div { class: "m-player-glow" }
-
-            // Top bar
-            div { class: "m-player-bar",
-                button { r#type: "button", class: "m-icon-btn", "aria-label": "Back", onclick: move |e| on_nav_back.call(e), "\u{2190}" }
-            }
-
-            // Cover hero
-            div { class: "m-player-cover",
-                Cover {
-                    book: view.book.clone(),
-                    src_override: cover_src(&view.book, &uuid, &server_url),
-                    sizes: Some("220px".to_string()),
-                }
-            }
-
-            // Now playing
-            div { class: "m-player-now",
-                div { class: "label m-player-eyebrow",
-                    "Now playing \u{00b7} Chapter {chapter_no} of {chapter_count}"
-                }
-                {player_title(&view.title)}
-                div { class: "m-player-by", "by {view.author}" }
-                if has_chapters {
-                    div { class: "m-player-chline", "Ch. {chapter_no} \u{00b7} {chapter_title}" }
-                }
-            }
-
-            // Chapter scrubber
-            div { class: "m-player-scrub",
-                input {
-                    class: "m-player-range",
-                    r#type: "range",
-                    "aria-label": "Seek",
-                    "data-testid": "mobile-player-seek",
-                    min: "0",
-                    max: "{scrub_max}",
-                    step: "1",
-                    value: "{effective}",
-                    oninput: on_seek_input,
-                    onchange: on_seek_commit,
-                }
-                div { class: "m-player-times mono",
-                    span { "{format_hms(effective)}" }
-                    if has_chapters {
-                        span { class: "m-player-chtime",
-                            "{format_ms(within)} / {format_ms(chapter_dur)} \u{00b7} {format_ms(chapter_left)} left"
-                        }
-                    }
-                    span { "-{format_hms(remaining_book)}" }
-                }
-            }
-
-            // Transport row — five primary controls. Keeping it to five (vs
-            // folding in favorite/speed) is what keeps the 72px play button
-            // circular on a phone; speed lives in the secondary row below.
-            div { class: "m-player-transport",
-                button {
-                    class: "m-tp-ch", r#type: "button", disabled: !has_chapters,
-                    "aria-label": "Previous chapter", onclick: on_prev, "\u{25C1}|"
-                }
-                button { class: "m-tp-skip", r#type: "button", "data-testid": "mobile-skip-back", "aria-label": "Back 30 seconds", onclick: on_back, "-30" }
-                button {
-                    class: "m-tp-play", r#type: "button", "data-testid": "mobile-toggle",
-                    "aria-label": if playing { "Pause" } else { "Play" }, onclick: on_toggle,
-                    if playing {
-                        span { class: "m-tp-pause", span {} span {} }
-                    } else {
-                        span { class: "m-tp-tri" }
-                    }
-                }
-                button { class: "m-tp-skip", r#type: "button", "data-testid": "mobile-skip-forward", "aria-label": "Forward 30 seconds", onclick: on_fwd, "+30" }
-                button {
-                    class: "m-tp-ch", r#type: "button", disabled: !has_chapters,
-                    "aria-label": "Next chapter", onclick: on_next, "|\u{25B7}"
-                }
-            }
-
-            // Secondary controls — each pill opens its bottom sheet.
-            div { class: "m-player-secondary",
-                button {
-                    class: if sheet() == OpenSheet::Speed { "m-pill on" } else { "m-pill" },
-                    r#type: "button", "data-testid": "mobile-rate", "aria-label": "Playback speed",
-                    onclick: move |_| sheet.set(OpenSheet::Speed),
-                    "{rate_label}"
-                }
-                button {
-                    class: if sheet() == OpenSheet::Sleep || sleep_armed { "m-pill on" } else { "m-pill" },
-                    r#type: "button", "data-testid": "mobile-sleep",
-                    onclick: move |_| sheet.set(OpenSheet::Sleep),
-                    "{sleep_label}"
-                }
-                button {
-                    class: "m-pill", r#type: "button", "data-testid": "mobile-bookmark",
-                    onclick: on_bookmark,
-                    "Bookmark"
-                }
-                button {
-                    class: if sheet() == OpenSheet::Chapters { "m-pill on" } else { "m-pill" },
-                    r#type: "button", "data-testid": "mobile-chapters-toggle",
-                    onclick: move |_| sheet.set(OpenSheet::Chapters),
-                    "Chapters"
-                }
-            }
-
-            // "Bookmark saved" confirmation toast.
-            if let Some(label) = toast {
-                div { class: "m-toast", role: "status",
-                    span { class: "m-toast-flag", "\u{2691}" }
-                    span { class: "m-toast-text", "Bookmark saved" }
-                    span { class: "mono m-toast-meta", "{label}" }
-                }
-            }
-            if let Some(message) = (p.ctx.rate_error)() {
-                div { class: "m-toast", role: "alert",
-                    span { class: "m-toast-text", "{message}" }
-                }
-            }
-
+            {render_player_header(&view, &uuid, &server_url, on_nav_back, &derived)}
+            {render_player_scrubber(&derived, on_seek_input, on_seek_commit)}
+            {render_player_transport(playing, derived.has_chapters, on_prev, on_back, on_toggle, on_fwd, on_next)}
+            {render_player_secondary(sheet, &derived, on_bookmark)}
+            {render_player_toast(toast, (ctx.rate_error)())}
             {render_sheets(&sheet_props)}
+        }
+    }
+}
+
+/// Top bar, cover hero, and now-playing block.
+fn render_player_header(
+    view: &PlayerView,
+    uuid: &str,
+    server_url: &str,
+    on_nav_back: EventHandler<MouseEvent>,
+    derived: &PlayerDerived,
+) -> Element {
+    rsx! {
+        div { class: "m-player-bar",
+            button { r#type: "button", class: "m-icon-btn", "aria-label": "Back", onclick: move |e| on_nav_back.call(e), "\u{2190}" }
+        }
+        div { class: "m-player-cover",
+            Cover {
+                book: view.book.clone(),
+                src_override: cover_src(&view.book, uuid, server_url),
+                sizes: Some("220px".to_string()),
+            }
+        }
+        div { class: "m-player-now",
+            div { class: "label m-player-eyebrow",
+                "Now playing \u{00b7} Chapter {derived.chapter_no} of {derived.chapter_count}"
+            }
+            {player_title(&view.title)}
+            div { class: "m-player-by", "by {view.author}" }
+            if derived.has_chapters {
+                div { class: "m-player-chline", "Ch. {derived.chapter_no} \u{00b7} {derived.chapter_title}" }
+            }
+        }
+    }
+}
+
+/// Chapter scrubber: range input plus the elapsed/chapter/remaining readout.
+fn render_player_scrubber(
+    derived: &PlayerDerived,
+    on_seek_input: impl FnMut(Event<FormData>) + 'static,
+    on_seek_commit: impl FnMut(Event<FormData>) + 'static,
+) -> Element {
+    rsx! {
+        div { class: "m-player-scrub",
+            input {
+                class: "m-player-range",
+                r#type: "range",
+                "aria-label": "Seek",
+                "data-testid": "mobile-player-seek",
+                min: "0",
+                max: "{derived.scrub_max}",
+                step: "1",
+                value: "{derived.effective}",
+                oninput: on_seek_input,
+                onchange: on_seek_commit,
+            }
+            div { class: "m-player-times mono",
+                span { "{format_hms(derived.effective)}" }
+                if derived.has_chapters {
+                    span { class: "m-player-chtime",
+                        "{format_ms(derived.within)} / {format_ms(derived.chapter_dur)} \u{00b7} {format_ms(derived.chapter_left)} left"
+                    }
+                }
+                span { "-{format_hms(derived.remaining_book)}" }
+            }
+        }
+    }
+}
+
+/// Primary transport row — five controls. Keeping it to five (vs folding in
+/// favorite/speed) is what keeps the 72px play button circular on a phone;
+/// speed lives in the secondary row below.
+fn render_player_transport(
+    playing: bool,
+    has_chapters: bool,
+    on_prev: impl FnMut(MouseEvent) + 'static,
+    on_back: impl FnMut(MouseEvent) + 'static,
+    on_toggle: impl FnMut(MouseEvent) + 'static,
+    on_fwd: impl FnMut(MouseEvent) + 'static,
+    on_next: impl FnMut(MouseEvent) + 'static,
+) -> Element {
+    rsx! {
+        div { class: "m-player-transport",
+            button {
+                class: "m-tp-ch", r#type: "button", disabled: !has_chapters,
+                "aria-label": "Previous chapter", onclick: on_prev, "\u{25C1}|"
+            }
+            button { class: "m-tp-skip", r#type: "button", "data-testid": "mobile-skip-back", "aria-label": "Back 30 seconds", onclick: on_back, "-30" }
+            button {
+                class: "m-tp-play", r#type: "button", "data-testid": "mobile-toggle",
+                "aria-label": if playing { "Pause" } else { "Play" }, onclick: on_toggle,
+                if playing {
+                    span { class: "m-tp-pause", span {} span {} }
+                } else {
+                    span { class: "m-tp-tri" }
+                }
+            }
+            button { class: "m-tp-skip", r#type: "button", "data-testid": "mobile-skip-forward", "aria-label": "Forward 30 seconds", onclick: on_fwd, "+30" }
+            button {
+                class: "m-tp-ch", r#type: "button", disabled: !has_chapters,
+                "aria-label": "Next chapter", onclick: on_next, "|\u{25B7}"
+            }
+        }
+    }
+}
+
+/// Secondary pill row — speed/sleep/bookmark/chapters. Speed, sleep, and
+/// chapters each open their bottom sheet; bookmark fires immediately.
+fn render_player_secondary(
+    mut sheet: Signal<OpenSheet>,
+    derived: &PlayerDerived,
+    on_bookmark: impl FnMut(MouseEvent) + 'static,
+) -> Element {
+    rsx! {
+        div { class: "m-player-secondary",
+            button {
+                class: if sheet() == OpenSheet::Speed { "m-pill on" } else { "m-pill" },
+                r#type: "button", "data-testid": "mobile-rate", "aria-label": "Playback speed",
+                onclick: move |_| sheet.set(OpenSheet::Speed),
+                "{derived.rate_label}"
+            }
+            button {
+                class: if sheet() == OpenSheet::Sleep || derived.sleep_armed { "m-pill on" } else { "m-pill" },
+                r#type: "button", "data-testid": "mobile-sleep",
+                onclick: move |_| sheet.set(OpenSheet::Sleep),
+                "{derived.sleep_label}"
+            }
+            button {
+                class: "m-pill", r#type: "button", "data-testid": "mobile-bookmark",
+                onclick: on_bookmark,
+                "Bookmark"
+            }
+            button {
+                class: if sheet() == OpenSheet::Chapters { "m-pill on" } else { "m-pill" },
+                r#type: "button", "data-testid": "mobile-chapters-toggle",
+                onclick: move |_| sheet.set(OpenSheet::Chapters),
+                "Chapters"
+            }
+        }
+    }
+}
+
+/// "Bookmark saved" confirmation toast, plus a playback-rate error toast.
+fn render_player_toast(toast: Option<String>, rate_error: Option<String>) -> Element {
+    rsx! {
+        if let Some(label) = toast {
+            div { class: "m-toast", role: "status",
+                span { class: "m-toast-flag", "\u{2691}" }
+                span { class: "m-toast-text", "Bookmark saved" }
+                span { class: "mono m-toast-meta", "{label}" }
+            }
+        }
+        if let Some(message) = rate_error {
+            div { class: "m-toast", role: "alert",
+                span { class: "m-toast-text", "{message}" }
+            }
         }
     }
 }

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -9,12 +9,12 @@
 use dioxus::prelude::*;
 use omnibus_shared::{ChapterInfo, EbookMetadata};
 
-use super::bookmarks::use_bookmarks;
+use super::bookmarks::{use_bookmarks, BookmarksController};
 use super::bookmarks_drawer::BookmarksDrawer;
 use super::chapter_nav::{chapter_index_for_elapsed, chapter_next_target, chapter_prev_target};
 use super::chapters_drawer::ChaptersDrawer;
 use super::overlays::{FailedOverlay, PreparingOverlay};
-use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep};
+use super::sleep::{end_of_chapter_seconds, sleep_toolbar_label, use_sleep, SleepController};
 use super::sleep_panel::{SleepPanel, SleepPanelState};
 use super::speed_panel::SpeedPanel;
 use super::stage::{
@@ -58,6 +58,73 @@ pub(super) struct PlaybackSignals {
     pub hls_ready: Signal<bool>,
 }
 
+/// Build the sleep-panel state: reactive countdown/choice/fade reads plus
+/// the select/end-of-chapter/toggle-fade handlers. Split out of
+/// [`ReadyPlayer`] so the sleep-controller wiring doesn't sit inline in the
+/// component body.
+fn build_sleep_panel_state(
+    sleep: SleepController,
+    chapters: Signal<Vec<ChapterInfo>>,
+    elapsed: Signal<f64>,
+    current_chapter_index: Memo<usize>,
+    has_chapters: bool,
+) -> (SleepPanelState, Option<i32>, bool) {
+    let on_sleep_select = move |secs: i32| sleep.select_seconds(secs);
+    let on_sleep_end_of_chapter = move |_: ()| {
+        let chs_now = chapters.peek().clone();
+        let idx = current_chapter_index();
+        if let Some(secs) = end_of_chapter_seconds(&chs_now, idx, *elapsed.peek()) {
+            sleep.select_end_of_chapter(secs);
+        }
+    };
+    let on_sleep_toggle_fade = move |_: ()| sleep.toggle_fade();
+    // Read once and hand back alongside the state so callers (the toolbar
+    // label/active flag) don't re-read the signal.
+    let remaining = (sleep.remaining)();
+    let active = matches!(remaining, Some(s) if s > 0);
+    let state = SleepPanelState {
+        remaining,
+        choice: (sleep.choice)(),
+        fade: (sleep.fade)(),
+        has_chapters,
+        on_select: EventHandler::new(on_sleep_select),
+        on_end_of_chapter: EventHandler::new(on_sleep_end_of_chapter),
+        on_toggle_fade: EventHandler::new(on_sleep_toggle_fade),
+    };
+    (state, remaining, active)
+}
+
+/// Display title, author byline, and accent CSS variable derived from
+/// `book`. Split out of [`ReadyPlayer`] to shrink its derived-state prelude.
+fn book_display_fields(book: &EbookMetadata) -> (String, String, String) {
+    let title = book.display_title();
+    let author = book
+        .creators
+        .first()
+        .map(|c| c.name.clone())
+        .unwrap_or_else(|| "Unknown Author".to_string());
+    let accent_style = book
+        .accent
+        .as_deref()
+        .map(|a| format!("--accent: {a};"))
+        .unwrap_or_default();
+    (title, author, accent_style)
+}
+
+/// Bookmark "add" handler: creates one at the current elapsed position from
+/// a fresh chapter-list snapshot. Split out of [`ReadyPlayer`] alongside
+/// [`build_sleep_panel_state`].
+fn build_bookmark_add_handler(
+    bookmarks: BookmarksController,
+    chapters: Signal<Vec<ChapterInfo>>,
+    elapsed: Signal<f64>,
+) -> impl FnMut(()) + 'static {
+    move |_: ()| {
+        let chs_now = chapters.peek().clone();
+        bookmarks.create(*elapsed.peek(), &chs_now);
+    }
+}
+
 /// Render the ready-state player chrome and bind the transport handlers.
 #[component]
 pub(super) fn ReadyPlayer(
@@ -71,10 +138,12 @@ pub(super) fn ReadyPlayer(
     let rate = signals.rate;
     let rate_error = signals.rate_error;
     let hls_ready = signals.hls_ready;
-    let speed_panel_open = use_signal(|| false);
-    let sleep_panel_open = use_signal(|| false);
-    let bookmarks_open = use_signal(|| false);
-    let chapters_open = use_signal(|| false);
+    let panes = OverlayPanes {
+        speed_panel_open: use_signal(|| false),
+        sleep_panel_open: use_signal(|| false),
+        bookmarks_open: use_signal(|| false),
+        chapters_open: use_signal(|| false),
+    };
 
     // App-scoped sleep timer (provided at App root so it outlives this page)
     // + per-book bookmark state. Both hooks are declared unconditionally so
@@ -82,75 +151,34 @@ pub(super) fn ReadyPlayer(
     // internally.
     let sleep = use_sleep();
     let bookmarks = use_bookmarks(uuid.clone());
-
     // Derive current chapter index from elapsed position.
     let current_chapter_index = use_memo(move || {
         let chs = chapters();
         let elapsed_now = elapsed();
         chapter_index_for_elapsed(&chs, elapsed_now)
     });
-
-    let panes = OverlayPanes {
-        speed_panel_open,
-        sleep_panel_open,
-        bookmarks_open,
-        chapters_open,
-    };
-
     // `seek` is shared by the stage's chapter list and the chapters/bookmarks
     // drawers, so it's built once here and handed to both children.
     let on_chapter_seek = move |secs: f64| super::helpers::seek_to(secs);
 
-    // Sleep + bookmark actions are lifted here so `PlayerOverlays` can stay a
-    // pure passthrough — `SleepController` isn't `PartialEq`, so it can't be a
-    // component prop, but these `EventHandler`s can.
-    let on_sleep_select = move |secs: i32| sleep.select_seconds(secs);
-    let on_sleep_end_of_chapter = move |_: ()| {
-        let chs_now = chapters.peek().clone();
-        let idx = current_chapter_index();
-        if let Some(secs) = end_of_chapter_seconds(&chs_now, idx, *elapsed.peek()) {
-            sleep.select_end_of_chapter(secs);
-        }
-    };
-    let on_sleep_toggle_fade = move |_: ()| sleep.toggle_fade();
-    let on_bookmark_add = move |_: ()| {
-        let chs_now = chapters.peek().clone();
-        bookmarks.create(*elapsed.peek(), &chs_now);
-    };
-
-    let title = book.display_title();
-    let author = book
-        .creators
-        .first()
-        .map(|c| c.name.clone())
-        .unwrap_or_else(|| "Unknown Author".to_string());
+    // Bookmark action is lifted here so `PlayerOverlays` can stay a pure
+    // passthrough — `EventHandler`s can be component props, unlike the raw
+    // controller.
+    let on_bookmark_add = build_bookmark_add_handler(bookmarks, chapters, elapsed);
+    let (title, author, accent_style) = book_display_fields(&book);
     let ready = hls_ready();
     let failed = playback_failed();
-
-    let accent_style = book
-        .accent
-        .as_deref()
-        .map(|a| format!("--accent: {a};"))
-        .unwrap_or_default();
-
     let chs = chapters();
     let ch_idx = current_chapter_index();
-
-    // Reactive sleep-timer reads — re-render the toolbar label + panel live.
-    let sleep_remaining = (sleep.remaining)();
-    let sleep_active = matches!(sleep_remaining, Some(s) if s > 0);
-    let sleep_state = SleepPanelState {
-        remaining: sleep_remaining,
-        choice: (sleep.choice)(),
-        fade: (sleep.fade)(),
-        has_chapters: !chs.is_empty(),
-        on_select: EventHandler::new(on_sleep_select),
-        on_end_of_chapter: EventHandler::new(on_sleep_end_of_chapter),
-        on_toggle_fade: EventHandler::new(on_sleep_toggle_fade),
-    };
+    let (sleep_state, sleep_remaining, sleep_active) = build_sleep_panel_state(
+        sleep,
+        chapters,
+        elapsed,
+        current_chapter_index,
+        !chs.is_empty(),
+    );
     let bookmark_toast = (bookmarks.toast)();
-    let current_user = crate::use_current_user_summary();
-    let user_id = current_user().map(|user| user.id);
+    let user_id = crate::use_current_user_summary()().map(|user| user.id);
 
     rsx! {
         div { class: "lp-root", style: "{accent_style}",
@@ -174,7 +202,7 @@ pub(super) fn ReadyPlayer(
                     on_chapter_seek: EventHandler::new(on_chapter_seek),
                 },
                 sleep_toolbar: SleepToolbarState {
-                    active: sleep_active || sleep_panel_open(),
+                    active: sleep_active || (panes.sleep_panel_open)(),
                     label: sleep_toolbar_label(sleep_remaining),
                 },
             }
@@ -225,6 +253,51 @@ pub(super) struct SleepToolbarState {
     pub label: String,
 }
 
+/// Build a handler that toggles `target` and, when it's opening, closes the
+/// other three toolbar panes. The four toolbar toggles (speed/sleep/
+/// bookmarks/chapters) are mutually exclusive — only one pane is open at a
+/// time.
+fn toggle_pane_handler(
+    mut target: Signal<bool>,
+    others: [Signal<bool>; 3],
+) -> impl FnMut(MouseEvent) + 'static {
+    move |_: MouseEvent| {
+        let cur = *target.peek();
+        target.set(!cur);
+        if !cur {
+            for mut other in others {
+                other.set(false);
+            }
+        }
+    }
+}
+
+/// Build the previous/next chapter-step handlers shared by the transport row.
+fn build_chapter_step_handlers(
+    chapters: Signal<Vec<ChapterInfo>>,
+    current_chapter_index: Memo<usize>,
+    elapsed: Signal<f64>,
+) -> (
+    impl FnMut(MouseEvent) + 'static,
+    impl FnMut(MouseEvent) + 'static,
+) {
+    let on_prev = move |_: MouseEvent| {
+        let chs = chapters();
+        let idx = current_chapter_index();
+        if let Some(target) = chapter_prev_target(&chs, elapsed(), idx) {
+            super::helpers::seek_to(target);
+        }
+    };
+    let on_next = move |_: MouseEvent| {
+        let chs = chapters();
+        let idx = current_chapter_index();
+        if let Some(target) = chapter_next_target(&chs, idx) {
+            super::helpers::seek_to(target);
+        }
+    };
+    (on_prev, on_next)
+}
+
 /// Assemble the transport + toolbar handlers and derived display values, then
 /// render [`PlayerStage`]. Owns the play/skip/seek/rate/chapter callbacks and
 /// the mutually-exclusive toolbar toggles.
@@ -250,44 +323,24 @@ pub(super) fn PlayerStageBinding(
         active: sleep_active,
         label: sleep_label,
     } = sleep_toolbar;
-
     let duration = signals.duration;
     let elapsed = signals.elapsed;
     let playing = signals.playing;
     let mut volume = signals.volume;
-    let mut speed_panel_open = panes.speed_panel_open;
-    let mut sleep_panel_open = panes.sleep_panel_open;
-    let mut bookmarks_open = panes.bookmarks_open;
-    let mut chapters_open = panes.chapters_open;
-
+    let speed_panel_open = panes.speed_panel_open;
+    let sleep_panel_open = panes.sleep_panel_open;
+    let bookmarks_open = panes.bookmarks_open;
+    let chapters_open = panes.chapters_open;
     let on_toggle = super::helpers::on_toggle_playback();
     let on_skip_back = super::helpers::on_skip_back_30();
     let on_skip_forward = super::helpers::on_skip_forward_30();
     let on_volume = move |v: f64| super::helpers::apply_volume(&mut volume, v);
-    let on_rate = move |_: MouseEvent| {
-        let cur = *speed_panel_open.peek();
-        speed_panel_open.set(!cur);
-        if !cur {
-            sleep_panel_open.set(false);
-            bookmarks_open.set(false);
-            chapters_open.set(false);
-        }
-    };
-    let on_chapter_prev = move |_: MouseEvent| {
-        let chs = chapters();
-        let idx = current_chapter_index();
-        if let Some(target) = chapter_prev_target(&chs, elapsed(), idx) {
-            super::helpers::seek_to(target);
-        }
-    };
-    let on_chapter_next = move |_: MouseEvent| {
-        let chs = chapters();
-        let idx = current_chapter_index();
-        if let Some(target) = chapter_next_target(&chs, idx) {
-            super::helpers::seek_to(target);
-        }
-    };
-
+    let on_rate = toggle_pane_handler(
+        speed_panel_open,
+        [sleep_panel_open, bookmarks_open, chapters_open],
+    );
+    let (on_chapter_prev, on_chapter_next) =
+        build_chapter_step_handlers(chapters, current_chapter_index, elapsed);
     let dur = duration();
     let elapsed_now = elapsed();
     let chs = chapters();
@@ -330,33 +383,18 @@ pub(super) fn PlayerStageBinding(
                 sleep_label,
                 bookmarks_active: bookmarks_open(),
                 chapters_active: chapters_open(),
-                on_sleep: EventHandler::new(move |_| {
-                    let cur = *sleep_panel_open.peek();
-                    sleep_panel_open.set(!cur);
-                    if !cur {
-                        speed_panel_open.set(false);
-                        bookmarks_open.set(false);
-                        chapters_open.set(false);
-                    }
-                }),
-                on_bookmark: EventHandler::new(move |_| {
-                    let cur = *bookmarks_open.peek();
-                    bookmarks_open.set(!cur);
-                    if !cur {
-                        speed_panel_open.set(false);
-                        sleep_panel_open.set(false);
-                        chapters_open.set(false);
-                    }
-                }),
-                on_chapters: EventHandler::new(move |_| {
-                    let cur = *chapters_open.peek();
-                    chapters_open.set(!cur);
-                    if !cur {
-                        speed_panel_open.set(false);
-                        sleep_panel_open.set(false);
-                        bookmarks_open.set(false);
-                    }
-                }),
+                on_sleep: EventHandler::new(toggle_pane_handler(
+                    sleep_panel_open,
+                    [speed_panel_open, bookmarks_open, chapters_open],
+                )),
+                on_bookmark: EventHandler::new(toggle_pane_handler(
+                    bookmarks_open,
+                    [speed_panel_open, sleep_panel_open, chapters_open],
+                )),
+                on_chapters: EventHandler::new(toggle_pane_handler(
+                    chapters_open,
+                    [speed_panel_open, sleep_panel_open, bookmarks_open],
+                )),
             },
         }
     }

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -60,6 +60,147 @@ pub(super) fn FormGrid(
     }
 }
 
+/// Title, sort/filename (read-only), publisher, published, language, and
+/// ISBN-13 rows. The identity/publication half of [`FieldGrid`].
+fn field_grid_identity_rows(orig: Signal<EbookMetadata>, fields: FormFields) -> Element {
+    let mut title = fields.title;
+    let mut publisher = fields.publisher;
+    let mut published = fields.published;
+    let mut language = fields.language;
+    let mut isbn13 = fields.isbn13;
+    let sort_by = fields.sort_by;
+    let filename = fields.filename;
+
+    rsx! {
+        // Title — spans 2 cols, big serif
+        MeField {
+            label: "Title",
+            value: title,
+            on_change: move |v: String| title.set(v),
+            w: 2,
+            big: true,
+            serif: true,
+            edited: title() != orig().title.clone().unwrap_or_default(),
+        }
+
+        // File-as / sort name (mono, read-only for now)
+        MeField {
+            label: "Sort by",
+            value: sort_by,
+            on_change: move |_: String| {},
+            mono: true,
+            locked: true,
+            hint: "from file-as",
+        }
+
+        // Filename (mono, read-only)
+        MeField {
+            label: "Filename",
+            value: filename,
+            on_change: move |_: String| {},
+            mono: true,
+            locked: true,
+        }
+
+        // Publisher
+        MeField {
+            label: "Publisher",
+            value: publisher,
+            on_change: move |v: String| publisher.set(v),
+            w: 2,
+            edited: publisher() != orig().publisher.clone().unwrap_or_default(),
+        }
+
+        // Published date
+        MeField {
+            label: "Published",
+            value: published,
+            on_change: move |v: String| published.set(v),
+            mono: true,
+            edited: published() != orig().published.clone().unwrap_or_default(),
+        }
+
+        // Language
+        MeField {
+            label: "Language",
+            value: language,
+            on_change: move |v: String| language.set(v),
+            edited: language() != orig().language.clone().unwrap_or_default(),
+        }
+
+        // ISBN-13 — exactly 13 digits, enforced server-side on save
+        // (`MetadataOverrides::validate`); an empty value clears it.
+        MeField {
+            label: "ISBN-13",
+            value: isbn13,
+            on_change: move |v: String| isbn13.set(v),
+            mono: true,
+            edited: isbn13() != orig().isbn13.clone().unwrap_or_default(),
+            hint: "13 digits",
+            placeholder: "e.g. 9780134685991",
+        }
+    }
+}
+
+/// Author chip row, description textarea, and the "Fetch Summary" button.
+/// The author/description half of [`FieldGrid`].
+fn field_grid_authors_and_description(
+    orig: Signal<EbookMetadata>,
+    fields: FormFields,
+    author_suggestions: Signal<Vec<SuggestionItem>>,
+    uuid: String,
+) -> Element {
+    let authors = fields.authors;
+    let mut description = fields.description;
+
+    rsx! {
+        // Authors — chip row spanning 4 cols
+        div { class: "me-field-full",
+            MeLabel {
+                text: "Author(s)",
+                edited: {
+                    let orig_authors: Vec<String> = orig().creators.iter().map(|c| c.name.clone()).collect();
+                    authors() != orig_authors
+                },
+                hint: "primary author first",
+            }
+            div { class: "me-chip-row",
+                ChipEditor {
+                    values: authors,
+                    on_change: move |_| {},
+                    suggestions: author_suggestions,
+                    options: ChipEditorOptions {
+                        placeholder: "+ add author\u{2026}".to_string(),
+                        show_avatar: true,
+                        aria_remove_prefix: "Remove".to_string(),
+                        testid_prefix: "me-authors".to_string(),
+                        ..ChipEditorOptions::default()
+                    },
+                }
+            }
+        }
+
+        // Description — textarea spanning 2 cols.
+        MeArea {
+            label: "Description",
+            value: description,
+            on_change: move |v: String| description.set(v),
+            rows: 5,
+            edited: description() != orig().description.clone().unwrap_or_default(),
+            hint: "plain text or HTML",
+        }
+
+        // Always-present "Fetch Summary" button that fills the description
+        // above from Hardcover/OpenLibrary; the user still saves.
+        div { class: "me-field-full",
+            FetchSummaryButton {
+                uuid,
+                on_fetched: move |text: String| description.set(text),
+            }
+        }
+    }
+}
+
 /// Main field grid: title, sort/filename, publisher, published, language,
 /// the author chip row, and the description textarea.
 #[component]
@@ -69,132 +210,10 @@ fn FieldGrid(
     suggestions: FormSuggestions,
     uuid: String,
 ) -> Element {
-    let mut title = fields.title;
-    let mut description = fields.description;
-    let mut publisher = fields.publisher;
-    let mut published = fields.published;
-    let mut language = fields.language;
-    let mut isbn13 = fields.isbn13;
-    let authors = fields.authors;
-    let sort_by = fields.sort_by;
-    let filename = fields.filename;
-    let author_suggestions = suggestions.authors;
-
     rsx! {
         div { class: "me-field-grid",
-
-            // Title — spans 2 cols, big serif
-            MeField {
-                label: "Title",
-                value: title,
-                on_change: move |v: String| title.set(v),
-                w: 2,
-                big: true,
-                serif: true,
-                edited: title() != orig().title.clone().unwrap_or_default(),
-            }
-
-            // File-as / sort name (mono, read-only for now)
-            MeField {
-                label: "Sort by",
-                value: sort_by,
-                on_change: move |_: String| {},
-                mono: true,
-                locked: true,
-                hint: "from file-as",
-            }
-
-            // Filename (mono, read-only)
-            MeField {
-                label: "Filename",
-                value: filename,
-                on_change: move |_: String| {},
-                mono: true,
-                locked: true,
-            }
-
-            // Publisher
-            MeField {
-                label: "Publisher",
-                value: publisher,
-                on_change: move |v: String| publisher.set(v),
-                w: 2,
-                edited: publisher() != orig().publisher.clone().unwrap_or_default(),
-            }
-
-            // Published date
-            MeField {
-                label: "Published",
-                value: published,
-                on_change: move |v: String| published.set(v),
-                mono: true,
-                edited: published() != orig().published.clone().unwrap_or_default(),
-            }
-
-            // Language
-            MeField {
-                label: "Language",
-                value: language,
-                on_change: move |v: String| language.set(v),
-                edited: language() != orig().language.clone().unwrap_or_default(),
-            }
-
-            // ISBN-13 — exactly 13 digits, enforced server-side on save
-            // (`MetadataOverrides::validate`); an empty value clears it.
-            MeField {
-                label: "ISBN-13",
-                value: isbn13,
-                on_change: move |v: String| isbn13.set(v),
-                mono: true,
-                edited: isbn13() != orig().isbn13.clone().unwrap_or_default(),
-                hint: "13 digits",
-                placeholder: "e.g. 9780134685991",
-            }
-
-            // Authors — chip row spanning 4 cols
-            div { class: "me-field-full",
-                MeLabel {
-                    text: "Author(s)",
-                    edited: {
-                        let orig_authors: Vec<String> = orig().creators.iter().map(|c| c.name.clone()).collect();
-                        authors() != orig_authors
-                    },
-                    hint: "primary author first",
-                }
-                div { class: "me-chip-row",
-                    ChipEditor {
-                        values: authors,
-                        on_change: move |_| {},
-                        suggestions: author_suggestions,
-                        options: ChipEditorOptions {
-                            placeholder: "+ add author\u{2026}".to_string(),
-                            show_avatar: true,
-                            aria_remove_prefix: "Remove".to_string(),
-                            testid_prefix: "me-authors".to_string(),
-                            ..ChipEditorOptions::default()
-                        },
-                    }
-                }
-            }
-
-            // Description — textarea spanning 2 cols.
-            MeArea {
-                label: "Description",
-                value: description,
-                on_change: move |v: String| description.set(v),
-                rows: 5,
-                edited: description() != orig().description.clone().unwrap_or_default(),
-                hint: "plain text or HTML",
-            }
-
-            // Always-present "Fetch Summary" button that fills the description
-            // above from Hardcover/OpenLibrary; the user still saves.
-            div { class: "me-field-full",
-                FetchSummaryButton {
-                    uuid,
-                    on_fetched: move |text: String| description.set(text),
-                }
-            }
+            {field_grid_identity_rows(orig, fields)}
+            {field_grid_authors_and_description(orig, fields, suggestions.authors, uuid)}
         }
     }
 }

--- a/frontend/src/pages/reader/chrome.rs
+++ b/frontend/src/pages/reader/chrome.rs
@@ -134,30 +134,120 @@ pub(super) fn ReaderTopBar(
     }
 }
 
+/// Center title block: book title, optional inline chapter separator, and
+/// the phone-only sub-line.
+fn reader_title_block(book_title: &str, chapter_title: &str, title_sub: &str) -> Element {
+    rsx! {
+        div {
+            class: "rd-title-center",
+            span { class: "rd-title-book", "{book_title}" }
+            if !chapter_title.is_empty() {
+                span { class: "rd-title-sep", "\u{b7}" }
+                span { class: "rd-title-ch", "{chapter_title}" }
+            }
+            // Phone sub-line ("Ch. 14 · 68%") — the breakpoint stacks the
+            // title block and swaps the inline chapter for this.
+            if !title_sub.is_empty() {
+                span { class: "rd-title-sub", "{title_sub}" }
+            }
+        }
+    }
+}
+
+/// Tool row: contents, search, Aa, highlights, bookmarks, and the
+/// phone-only combined annotations button.
+fn reader_tool_row(state: &ReaderChromeState, handlers: &ReaderChromeHandlers) -> Element {
+    rsx! {
+        div {
+            style: "display:flex; align-items:center; gap:2px;",
+            button {
+                class: if state.toc_active { "rd-tool on" } else { "rd-tool" },
+                r#type: "button",
+                "data-testid": "reader-toc",
+                "aria-label": "Contents",
+                onclick: handlers.on_toggle_toc,
+                svg {
+                    width: "19", height: "19", view_box: "0 0 24 24",
+                    fill: "none", stroke: "currentColor",
+                    stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                    path { d: "M4 6h16M4 12h16M4 18h11" }
+                }
+            }
+            button {
+                class: if state.search_active { "rd-tool on" } else { "rd-tool" },
+                r#type: "button",
+                "data-testid": "reader-search",
+                "aria-label": "Search in book",
+                onclick: handlers.on_toggle_search,
+                svg {
+                    width: "19", height: "19", view_box: "0 0 24 24",
+                    fill: "none", stroke: "currentColor",
+                    stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                    circle { cx: "11", cy: "11", r: "6.2" }
+                    path { d: "M20 20l-4.2-4.2" }
+                }
+            }
+            button {
+                class: if state.show_aa { "rd-tool rd-aa on" } else { "rd-tool rd-aa" },
+                r#type: "button",
+                "data-testid": "reader-aa",
+                "aria-label": "Display settings",
+                onclick: handlers.on_toggle_aa,
+                "Aa"
+            }
+            button {
+                class: if state.highlights_active { "rd-tool rd-desktop-only on" } else { "rd-tool rd-desktop-only" },
+                r#type: "button",
+                "data-testid": "reader-highlights",
+                "aria-label": "Highlights and notes",
+                onclick: handlers.on_toggle_highlights,
+                svg {
+                    width: "19", height: "19", view_box: "0 0 24 24",
+                    fill: "none", stroke: "currentColor",
+                    stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                    path { d: "M4 19.5l1.6-4 8.2-8.2 3 3-8.2 8.2-4.6 0z" }
+                    path { d: "M13.2 6.1l2.7-2.7a1.3 1.3 0 0 1 1.9 0l1.8 1.8a1.3 1.3 0 0 1 0 1.9l-2.7 2.7" }
+                }
+                if state.highlight_count > 0 {
+                    span { class: "rd-badge", "{state.highlight_count}" }
+                }
+            }
+            button {
+                class: if state.bookmarks_active { "rd-tool rd-desktop-only on" } else { "rd-tool rd-desktop-only" },
+                r#type: "button",
+                "data-testid": "reader-bookmark",
+                "aria-label": "Bookmarks",
+                onclick: handlers.on_toggle_bookmarks,
+                svg {
+                    width: "19", height: "19", view_box: "0 0 24 24",
+                    fill: "none", stroke: "currentColor",
+                    stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                    path { d: "M7 4h10v16l-5-3.6L7 20V4z" }
+                }
+            }
+            // Phone-only combined tool: highlights + notes + bookmarks in
+            // one sheet, replacing the two desktop buttons above.
+            button {
+                class: if state.annotations_active { "rd-tool rd-phone-only on" } else { "rd-tool rd-phone-only" },
+                r#type: "button",
+                "data-testid": "reader-annotations",
+                "aria-label": "Annotations",
+                onclick: handlers.on_toggle_annotations,
+                svg {
+                    width: "19", height: "19", view_box: "0 0 24 24",
+                    fill: "none", stroke: "currentColor",
+                    stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                    path { d: "M12 20h9" }
+                    path { d: "M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" }
+                }
+            }
+        }
+    }
+}
+
 /// Top navigation bar: back button, title + chapter display, Aa + bookmark tools.
 #[component]
 fn ReaderTopChrome(state: ReaderChromeState, handlers: ReaderChromeHandlers) -> Element {
-    let ReaderChromeState {
-        book_title,
-        chapter_title,
-        title_sub,
-        show_aa,
-        toc_active,
-        search_active,
-        highlights_active,
-        bookmarks_active,
-        annotations_active,
-        highlight_count,
-    } = state;
-    let ReaderChromeHandlers {
-        on_back,
-        on_toggle_aa,
-        on_toggle_toc,
-        on_toggle_search,
-        on_toggle_highlights,
-        on_toggle_bookmarks,
-        on_toggle_annotations,
-    } = handlers;
     rsx! {
         div {
             class: "rd-top",
@@ -166,7 +256,7 @@ fn ReaderTopChrome(state: ReaderChromeState, handlers: ReaderChromeHandlers) -> 
                 r#type: "button",
                 "data-testid": "reader-back",
                 "aria-label": "Back to book",
-                onclick: on_back,
+                onclick: handlers.on_back,
                 svg {
                     width: "19", height: "19", view_box: "0 0 24 24",
                     fill: "none", stroke: "currentColor",
@@ -174,103 +264,8 @@ fn ReaderTopChrome(state: ReaderChromeState, handlers: ReaderChromeHandlers) -> 
                     path { d: "M15 5l-7 7 7 7" }
                 }
             }
-            div {
-                class: "rd-title-center",
-                span { class: "rd-title-book", "{book_title}" }
-                if !chapter_title.is_empty() {
-                    span { class: "rd-title-sep", "\u{b7}" }
-                    span { class: "rd-title-ch", "{chapter_title}" }
-                }
-                // Phone sub-line ("Ch. 14 · 68%") — the breakpoint stacks the
-                // title block and swaps the inline chapter for this.
-                if !title_sub.is_empty() {
-                    span { class: "rd-title-sub", "{title_sub}" }
-                }
-            }
-            div {
-                style: "display:flex; align-items:center; gap:2px;",
-                button {
-                    class: if toc_active { "rd-tool on" } else { "rd-tool" },
-                    r#type: "button",
-                    "data-testid": "reader-toc",
-                    "aria-label": "Contents",
-                    onclick: on_toggle_toc,
-                    svg {
-                        width: "19", height: "19", view_box: "0 0 24 24",
-                        fill: "none", stroke: "currentColor",
-                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        path { d: "M4 6h16M4 12h16M4 18h11" }
-                    }
-                }
-                button {
-                    class: if search_active { "rd-tool on" } else { "rd-tool" },
-                    r#type: "button",
-                    "data-testid": "reader-search",
-                    "aria-label": "Search in book",
-                    onclick: on_toggle_search,
-                    svg {
-                        width: "19", height: "19", view_box: "0 0 24 24",
-                        fill: "none", stroke: "currentColor",
-                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        circle { cx: "11", cy: "11", r: "6.2" }
-                        path { d: "M20 20l-4.2-4.2" }
-                    }
-                }
-                button {
-                    class: if show_aa { "rd-tool rd-aa on" } else { "rd-tool rd-aa" },
-                    r#type: "button",
-                    "data-testid": "reader-aa",
-                    "aria-label": "Display settings",
-                    onclick: on_toggle_aa,
-                    "Aa"
-                }
-                button {
-                    class: if highlights_active { "rd-tool rd-desktop-only on" } else { "rd-tool rd-desktop-only" },
-                    r#type: "button",
-                    "data-testid": "reader-highlights",
-                    "aria-label": "Highlights and notes",
-                    onclick: on_toggle_highlights,
-                    svg {
-                        width: "19", height: "19", view_box: "0 0 24 24",
-                        fill: "none", stroke: "currentColor",
-                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        path { d: "M4 19.5l1.6-4 8.2-8.2 3 3-8.2 8.2-4.6 0z" }
-                        path { d: "M13.2 6.1l2.7-2.7a1.3 1.3 0 0 1 1.9 0l1.8 1.8a1.3 1.3 0 0 1 0 1.9l-2.7 2.7" }
-                    }
-                    if highlight_count > 0 {
-                        span { class: "rd-badge", "{highlight_count}" }
-                    }
-                }
-                button {
-                    class: if bookmarks_active { "rd-tool rd-desktop-only on" } else { "rd-tool rd-desktop-only" },
-                    r#type: "button",
-                    "data-testid": "reader-bookmark",
-                    "aria-label": "Bookmarks",
-                    onclick: on_toggle_bookmarks,
-                    svg {
-                        width: "19", height: "19", view_box: "0 0 24 24",
-                        fill: "none", stroke: "currentColor",
-                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        path { d: "M7 4h10v16l-5-3.6L7 20V4z" }
-                    }
-                }
-                // Phone-only combined tool: highlights + notes + bookmarks in
-                // one sheet, replacing the two desktop buttons above.
-                button {
-                    class: if annotations_active { "rd-tool rd-phone-only on" } else { "rd-tool rd-phone-only" },
-                    r#type: "button",
-                    "data-testid": "reader-annotations",
-                    "aria-label": "Annotations",
-                    onclick: on_toggle_annotations,
-                    svg {
-                        width: "19", height: "19", view_box: "0 0 24 24",
-                        fill: "none", stroke: "currentColor",
-                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        path { d: "M12 20h9" }
-                        path { d: "M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" }
-                    }
-                }
-            }
+            {reader_title_block(&state.book_title, &state.chapter_title, &state.title_sub)}
+            {reader_tool_row(&state, &handlers)}
         }
     }
 }

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -168,6 +168,113 @@ pub(super) fn HighlightsDrawer(
     }
 }
 
+/// Build the delete handler: removes the persisted highlight, then its
+/// painted annotation (if any) and the row from `highlights`.
+fn build_delete_handler(
+    server_url: String,
+    mut highlights: Signal<Vec<Highlight>>,
+    id: i64,
+    cfi: Option<String>,
+) -> impl FnMut(MouseEvent) + 'static {
+    move |_| {
+        let cfi = cfi.clone();
+        let server_url = server_url.clone();
+        spawn(async move {
+            if crate::data::delete_highlight(&server_url, id).await.is_ok() {
+                // Anchorless (Kobo-origin) rows have no painted swatch to
+                // remove from the rendition.
+                if let Some(cfi) = &cfi {
+                    #[cfg(any(feature = "web", feature = "mobile"))]
+                    super::reader_call_json("removeAnnotation", cfi);
+                    let _ = cfi;
+                }
+                highlights.write().retain(|h| h.id != id);
+            }
+        });
+    }
+}
+
+/// Recolor swatch strip: one dot per palette color, highlighting the current
+/// one and dispatching [`spawn_recolor`] on click.
+fn hl_swatch_strip(
+    cur_color: HighlightColor,
+    recolor_cfi: Option<String>,
+    server_url: String,
+    highlights: Signal<Vec<Highlight>>,
+    id: i64,
+) -> Element {
+    rsx! {
+        div { class: "rd-hl-swatches", "data-testid": "reader-highlight-swatches",
+            for (swatch_color, swatch_name) in PALETTE {
+                button {
+                    key: "{swatch_name}",
+                    class: if swatch_color == cur_color { "rd-hl-swatch on" } else { "rd-hl-swatch" },
+                    r#type: "button",
+                    "data-color": "{swatch_name}",
+                    "data-testid": "reader-highlight-recolor-{swatch_name}",
+                    "aria-label": "Recolor {swatch_name}",
+                    "aria-pressed": if swatch_color == cur_color { "true" } else { "false" },
+                    onclick: {
+                        let recolor_cfi = recolor_cfi.clone();
+                        let server_url = server_url.clone();
+                        move |_| spawn_recolor(server_url.clone(), highlights, id, recolor_cfi.clone(), swatch_color, cur_color)
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// Note/quote/copy/delete action row.
+fn hl_actions_row(
+    highlight: &Highlight,
+    note_label: &str,
+    has_text: bool,
+    copy_src: String,
+    on_quote: EventHandler<Highlight>,
+    on_edit_note: EventHandler<Highlight>,
+    on_delete: impl FnMut(MouseEvent) + 'static,
+) -> Element {
+    rsx! {
+        div { class: "rd-hl-actions",
+            button {
+                class: "rd-act sm",
+                r#type: "button",
+                "data-testid": "highlight-note",
+                onclick: {
+                    let h = highlight.clone();
+                    move |_| on_edit_note.call(h.clone())
+                },
+                "{note_label}"
+            }
+            button {
+                class: "rd-act sm",
+                r#type: "button",
+                "data-testid": "highlight-quote",
+                onclick: {
+                    let h = highlight.clone();
+                    move |_| on_quote.call(h.clone())
+                },
+                "Quote"
+            }
+            button {
+                class: "rd-act sm",
+                r#type: "button",
+                disabled: !has_text,
+                onclick: move |_| copy_text(&copy_src),
+                "Copy"
+            }
+            button {
+                class: "rd-act sm",
+                r#type: "button",
+                "data-testid": "highlight-delete",
+                onclick: on_delete,
+                "Delete"
+            }
+        }
+    }
+}
+
 #[component]
 pub(super) fn HighlightRow(
     highlight: Highlight,
@@ -195,31 +302,10 @@ pub(super) fn HighlightRow(
         "Add note"
     };
     let id = highlight.id;
-
-    let on_delete = {
-        let server_url = server_url.clone();
-        move |_| {
-            let mut highlights = highlights;
-            let cfi = cfi.clone();
-            let server_url = server_url.clone();
-            spawn(async move {
-                if crate::data::delete_highlight(&server_url, id).await.is_ok() {
-                    // Anchorless (Kobo-origin) rows have no painted swatch to
-                    // remove from the rendition.
-                    if let Some(cfi) = &cfi {
-                        #[cfg(any(feature = "web", feature = "mobile"))]
-                        super::reader_call_json("removeAnnotation", cfi);
-                        let _ = cfi;
-                    }
-                    highlights.write().retain(|h| h.id != id);
-                }
-            });
-        }
-    };
+    let on_delete = build_delete_handler(server_url.clone(), highlights, id, cfi);
 
     let cur_color = highlight.color;
     let recolor_cfi = highlight.epub_cfi_range.clone();
-
     let nav_cfi = highlight.epub_cfi_range.clone();
 
     rsx! {
@@ -240,60 +326,8 @@ pub(super) fn HighlightRow(
             if let Some(n) = note {
                 div { class: "rd-hl-note", "{n}" }
             }
-            div { class: "rd-hl-swatches", "data-testid": "reader-highlight-swatches",
-                for (swatch_color, swatch_name) in PALETTE {
-                    button {
-                        key: "{swatch_name}",
-                        class: if swatch_color == cur_color { "rd-hl-swatch on" } else { "rd-hl-swatch" },
-                        r#type: "button",
-                        "data-color": "{swatch_name}",
-                        "data-testid": "reader-highlight-recolor-{swatch_name}",
-                        "aria-label": "Recolor {swatch_name}",
-                        "aria-pressed": if swatch_color == cur_color { "true" } else { "false" },
-                        onclick: {
-                            let recolor_cfi = recolor_cfi.clone();
-                            let server_url = server_url.clone();
-                            move |_| spawn_recolor(server_url.clone(), highlights, id, recolor_cfi.clone(), swatch_color, cur_color)
-                        },
-                    }
-                }
-            }
-            div { class: "rd-hl-actions",
-                button {
-                    class: "rd-act sm",
-                    r#type: "button",
-                    "data-testid": "highlight-note",
-                    onclick: {
-                        let h = highlight.clone();
-                        move |_| on_edit_note.call(h.clone())
-                    },
-                    "{note_label}"
-                }
-                button {
-                    class: "rd-act sm",
-                    r#type: "button",
-                    "data-testid": "highlight-quote",
-                    onclick: {
-                        let h = highlight.clone();
-                        move |_| on_quote.call(h.clone())
-                    },
-                    "Quote"
-                }
-                button {
-                    class: "rd-act sm",
-                    r#type: "button",
-                    disabled: !has_text,
-                    onclick: move |_| copy_text(&copy_src),
-                    "Copy"
-                }
-                button {
-                    class: "rd-act sm",
-                    r#type: "button",
-                    "data-testid": "highlight-delete",
-                    onclick: on_delete,
-                    "Delete"
-                }
-            }
+            {hl_swatch_strip(cur_color, recolor_cfi, server_url, highlights, id)}
+            {hl_actions_row(&highlight, note_label, has_text, copy_src, on_quote, on_edit_note, on_delete)}
         }
     }
 }

--- a/frontend/src/pages/search_mobile.rs
+++ b/frontend/src/pages/search_mobile.rs
@@ -45,25 +45,17 @@ const SCOPES: [(Scope, &str); 5] = [
     (Scope::Tags, "Tags"),
 ];
 
-/// Mobile live-search screen. Debounces keystrokes (150 ms, cancel-on-keystroke)
-/// and renders grouped results; row taps navigate to detail pages, a tag tap
-/// refines the query inline.
-#[component]
-pub fn MobileSearchPage() -> Element {
-    let server_url = use_server_url();
-    let nav = use_navigator();
-    let mut query = use_signal(String::new);
-    let mut results = use_signal(|| Option::<PaletteResults>::None);
-    let mut loading = use_signal(|| false);
-    let mut errored = use_signal(|| false);
-    let mut scope = use_signal(|| Scope::All);
-    // Handle of the in-flight debounce+fetch task so each new keystroke can
-    // cancel the prior one — only one request is ever in flight (mirrors the
-    // web palette's cancel-on-keystroke debounce).
-    let mut current_task = use_signal(|| Option::<Task>::None);
-
-    // Debounced search: re-runs whenever `query` changes.
-    let search_url = server_url.clone();
+/// Wire up the debounced search effect: re-runs whenever `query` changes,
+/// cancelling the prior in-flight task on each keystroke so only one request
+/// is ever in flight (mirrors the web palette's cancel-on-keystroke debounce).
+fn use_debounced_search(
+    query: Signal<String>,
+    mut results: Signal<Option<PaletteResults>>,
+    mut loading: Signal<bool>,
+    mut errored: Signal<bool>,
+    mut current_task: Signal<Option<Task>>,
+    server_url: String,
+) {
     use_effect(move || {
         let v = query();
         if let Some(prev) = current_task.write().take() {
@@ -80,7 +72,7 @@ pub fn MobileSearchPage() -> Element {
         // results pane shows "Searching…" immediately instead of a blank gap.
         loading.set(true);
         errored.set(false);
-        let url = search_url.clone();
+        let url = server_url.clone();
         let task = spawn(async move {
             debounce_sleep_ms(150).await;
             match data::search_palette(&url, &trimmed).await {
@@ -97,6 +89,30 @@ pub fn MobileSearchPage() -> Element {
         });
         current_task.set(Some(task));
     });
+}
+
+/// Mobile live-search screen. Debounces keystrokes (150 ms, cancel-on-keystroke)
+/// and renders grouped results; row taps navigate to detail pages, a tag tap
+/// refines the query inline.
+#[component]
+pub fn MobileSearchPage() -> Element {
+    let server_url = use_server_url();
+    let nav = use_navigator();
+    let mut query = use_signal(String::new);
+    let results = use_signal(|| Option::<PaletteResults>::None);
+    let loading = use_signal(|| false);
+    let errored = use_signal(|| false);
+    let mut scope = use_signal(|| Scope::All);
+    // Handle of the in-flight debounce+fetch task — see `use_debounced_search`.
+    let current_task = use_signal(|| Option::<Task>::None);
+    use_debounced_search(
+        query,
+        results,
+        loading,
+        errored,
+        current_task,
+        server_url.clone(),
+    );
 
     let res = results.read();
     let sc = scope();

--- a/frontend/src/pages/server_connect.rs
+++ b/frontend/src/pages/server_connect.rs
@@ -38,21 +38,17 @@ pub fn ServerConnectPage() -> Element {
     }
 }
 
-/// The mobile Connect screen: brand shell, a server-URL field, and a Connect
-/// button that validates reachability before advancing to `/login`.
+/// Build the connect callback: probes the server, persists it (clearing any
+/// stale token if it's a different origin), and advances to `/login`.
 #[cfg(feature = "mobile")]
-fn server_connect_mobile() -> Element {
-    let nav = use_navigator();
-    let url_signal = use_server_url_signal();
-    // Prefill with the current URL (empty on first run) so the Back button
-    // from Login returns here with the value already in the field. Seed from
-    // a `peek` (not `use_server_url`, which calls `use_context`) — a hook run
-    // inside `use_signal`'s initializer panics with a hook-borrow error.
-    let mut url_input = use_signal(move || url_signal.peek().clone());
-    let mut error = use_signal(|| Option::<String>::None);
-    let mut checking = use_signal(|| false);
-
-    let connect = use_callback(move |_: ()| {
+fn build_connect_handler(
+    nav: dioxus_router::Navigator,
+    mut url_signal: Signal<String>,
+    url_input: Signal<String>,
+    mut error: Signal<Option<String>>,
+    mut checking: Signal<bool>,
+) -> impl FnMut(()) + 'static {
+    move |_: ()| {
         if checking() {
             return;
         }
@@ -62,7 +58,6 @@ fn server_connect_mobile() -> Element {
         };
         error.set(None);
         checking.set(true);
-        let mut url_signal = url_signal;
         spawn(async move {
             let res = crate::data::check_server(&base).await;
             checking.set(false);
@@ -87,62 +82,92 @@ fn server_connect_mobile() -> Element {
                 )),
             }
         });
-    });
+    }
+}
+
+/// The connect form body: error banner, server-URL field, submit button, and
+/// the "learn how to host one" footer link.
+#[cfg(feature = "mobile")]
+fn server_connect_form(
+    mut url_input: Signal<String>,
+    error: Signal<Option<String>>,
+    checking: Signal<bool>,
+    connect: Callback<()>,
+) -> Element {
+    rsx! {
+        form { class: "auth-form-inner",
+            onsubmit: move |e: FormEvent| {
+                e.prevent_default();
+                connect.call(());
+            },
+            "data-testid": "server-connect-form",
+            if let Some(msg) = error() {
+                Banner { kind: BannerKind::Err, title: msg, dismissible: false }
+            }
+            Field {
+                label: "Server URL".to_string(),
+                input_id: "server-url".to_string(),
+                hint: "The address where your Omnibus server is running — a local network address or a domain you host it on.".to_string(),
+                input {
+                    id: "server-url",
+                    name: "server-url",
+                    r#type: "url",
+                    inputmode: "url",
+                    placeholder: "https://omnibus.local:3000",
+                    autocapitalize: "none",
+                    autocorrect: "off",
+                    spellcheck: "false",
+                    value: "{url_input}",
+                    oninput: move |e| url_input.set(e.value()),
+                    onkeydown: move |e: Event<KeyboardData>| {
+                        if e.key() == Key::Enter {
+                            e.prevent_default();
+                            connect.call(());
+                        }
+                    },
+                }
+            }
+            button {
+                class: "btn primary lg auth-submit",
+                r#type: "submit",
+                disabled: checking(),
+                if checking() { "Connecting…" } else { "Connect" }
+            }
+            p { class: "auth-footer",
+                "Don't have a server? "
+                // TODO(#1118): point at dedicated hosting docs once they exist.
+                a {
+                    class: "auth-field-action-link",
+                    href: "https://github.com/seamus-sloan/omnibus",
+                    target: "_blank",
+                    rel: "noreferrer",
+                    "Learn how to host one"
+                }
+            }
+        }
+    }
+}
+
+/// The mobile Connect screen: brand shell, a server-URL field, and a Connect
+/// button that validates reachability before advancing to `/login`.
+#[cfg(feature = "mobile")]
+fn server_connect_mobile() -> Element {
+    let nav = use_navigator();
+    let url_signal = use_server_url_signal();
+    // Prefill with the current URL (empty on first run) so the Back button
+    // from Login returns here with the value already in the field. Seed from
+    // a `peek` (not `use_server_url`, which calls `use_context`) — a hook run
+    // inside `use_signal`'s initializer panics with a hook-borrow error.
+    let url_input = use_signal(move || url_signal.peek().clone());
+    let error = use_signal(|| Option::<String>::None);
+    let checking = use_signal(|| false);
+    let connect = use_callback(build_connect_handler(
+        nav, url_signal, url_input, error, checking,
+    ));
 
     super::auth::m_auth_shell(
         "Connect to your server to get started.",
-        rsx! {
-            form { class: "auth-form-inner",
-                onsubmit: move |e: FormEvent| {
-                    e.prevent_default();
-                    connect.call(());
-                },
-                "data-testid": "server-connect-form",
-                if let Some(msg) = error() {
-                    Banner { kind: BannerKind::Err, title: msg, dismissible: false }
-                }
-                Field {
-                    label: "Server URL".to_string(),
-                    input_id: "server-url".to_string(),
-                    hint: "The address where your Omnibus server is running — a local network address or a domain you host it on.".to_string(),
-                    input {
-                        id: "server-url",
-                        name: "server-url",
-                        r#type: "url",
-                        inputmode: "url",
-                        placeholder: "https://omnibus.local:3000",
-                        autocapitalize: "none",
-                        autocorrect: "off",
-                        spellcheck: "false",
-                        value: "{url_input}",
-                        oninput: move |e| url_input.set(e.value()),
-                        onkeydown: move |e: Event<KeyboardData>| {
-                            if e.key() == Key::Enter {
-                                e.prevent_default();
-                                connect.call(());
-                            }
-                        },
-                    }
-                }
-                button {
-                    class: "btn primary lg auth-submit",
-                    r#type: "submit",
-                    disabled: checking(),
-                    if checking() { "Connecting…" } else { "Connect" }
-                }
-                p { class: "auth-footer",
-                    "Don't have a server? "
-                    // TODO(#1118): point at dedicated hosting docs once they exist.
-                    a {
-                        class: "auth-field-action-link",
-                        href: "https://github.com/seamus-sloan/omnibus",
-                        target: "_blank",
-                        rel: "noreferrer",
-                        "Learn how to host one"
-                    }
-                }
-            }
-        },
+        server_connect_form(url_input, error, checking, connect),
     )
 }
 

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -344,7 +344,31 @@ fn content_routes() -> Router<AppState> {
 
 /// Metadata overrides, progress sync, author/cover/series/tag discovery routes,
 /// upload-rate-limited endpoints, and the search sub-router.
+///
+/// Each helper below owns one feature area (the grouping the route list used
+/// to carry as inline comments); this function just merges them.
 fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> {
+    Router::new()
+        .merge(metadata_override_routes())
+        .merge(progress_routes())
+        .merge(highlight_routes())
+        .merge(bookmark_routes())
+        .merge(engagement_routes())
+        .merge(check_in_routes())
+        .merge(physical_collection_routes())
+        .merge(shelf_routes())
+        .merge(journal_routes())
+        .merge(upload_router())
+        .merge(book_upload_router())
+        .merge(search_router(search_limiter))
+        .merge(discovery_routes())
+        .merge(suggestion_routes())
+        .merge(summary_routes())
+        .merge(kindle_routes())
+}
+
+/// Metadata override read/write + cover-only revert.
+fn metadata_override_routes() -> Router<AppState> {
     Router::new()
         .route(
             "/api/ebooks/{uuid}/overrides",
@@ -352,19 +376,28 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
         )
         // Cover-only revert. Carries no upload body (unlike the POST in
         // `upload_router`), so it stays outside the upload rate limiter —
-        // same split as the author-photo GET/DELETE vs PUT routes below.
+        // same split as the author-photo GET/DELETE vs PUT routes in
+        // `discovery_routes`.
         .route(
             "/api/ebooks/{uuid}/cover",
             delete(overrides::delete_ebook_cover),
         )
-        // F2.1 progress sync — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/progress*` server functions defined in `omnibus_frontend::rpc`.
+}
+
+/// F2.1 progress sync — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/progress*` server functions defined in `omnibus_frontend::rpc`.
+fn progress_routes() -> Router<AppState> {
+    Router::new()
         .route("/api/progress", post(progress::post_progress))
         .route("/api/progress/sessions", post(progress::post_sessions))
         .route("/api/progress/recent", get(progress::get_recent_progress))
         .route("/api/progress/{uuid}", get(progress::get_progress))
-        // F2.4b highlight annotations — mobile-facing REST. Web hits the
-        // analogous `/api/rpc/highlights/*` server functions.
+}
+
+/// F2.4b highlight annotations — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/highlights/*` server functions.
+fn highlight_routes() -> Router<AppState> {
+    Router::new()
         .route("/api/highlights", post(highlights::post_highlight))
         .route(
             "/api/highlights/book/{book_uuid}",
@@ -379,9 +412,13 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
             patch(highlights::patch_highlight_note),
         )
         .route("/api/highlights/{id}", delete(highlights::delete_highlight))
-        // Bookmarks — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/bookmarks/*` server functions. One model serves both the
-        // audiobook player and the reader (position = seconds or EPUB CFI).
+}
+
+/// Bookmarks — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/bookmarks/*` server functions. One model serves both the
+/// audiobook player and the reader (position = seconds or EPUB CFI).
+fn bookmark_routes() -> Router<AppState> {
+    Router::new()
         .route("/api/bookmarks", post(bookmarks::post_bookmark))
         .route(
             "/api/bookmarks/book/{book_uuid}",
@@ -391,11 +428,14 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
             "/api/bookmarks/{id}",
             put(bookmarks::put_bookmark).delete(bookmarks::delete_bookmark),
         )
-        // Reading stats — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/stats` server function.
+}
+
+/// Reading stats, F3.2 star ratings, and F3.4 read/unread state —
+/// mobile-facing REST. Web hits the analogous `/api/rpc/stats`,
+/// `/api/rpc/ratings/*`, and `/api/rpc/read-status/*` server functions.
+fn engagement_routes() -> Router<AppState> {
+    Router::new()
         .route("/api/stats", get(stats::get_stats))
-        // F3.2 star ratings — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/ratings/*` server functions.
         .route("/api/ratings", post(ratings::post_rating))
         .route(
             "/api/ratings/others/{uuid}",
@@ -405,12 +445,14 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
             "/api/ratings/{uuid}",
             get(ratings::get_rating).delete(ratings::delete_rating),
         )
-        // F3.4 read/unread state — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/read-status/*` server functions.
         .route("/api/read-status", put(read_status::put_read_status))
         .route("/api/read-status/{uuid}", get(read_status::get_read_status))
-        // Physical Check-In scan flow — mobile-facing REST. Web hits the
-        // analogous `/api/rpc/scan/*` server functions.
+}
+
+/// Physical Check-In scan flow — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/scan/*` server functions.
+fn check_in_routes() -> Router<AppState> {
+    Router::new()
         .route("/api/scan/resolve", post(scan::post_resolve))
         .route("/api/scan/search", post(scan::post_search))
         .route("/api/scan/resolve-meta", post(scan::post_resolve_meta))
@@ -434,9 +476,13 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
             "/api/google-books-key",
             get(scan::get_google_books_key).post(scan::post_google_books_key),
         )
-        // F Physical Check-In — book-detail collection + wishlist reads/edits.
-        // The literal `copies` routes are registered before `/{uuid}` so the
-        // param route can't shadow them.
+}
+
+/// F Physical Check-In — book-detail collection + wishlist reads/edits.
+/// The literal `copies` routes are registered before `/{uuid}` so the
+/// param route can't shadow them.
+fn physical_collection_routes() -> Router<AppState> {
+    Router::new()
         .route(
             "/api/physical/copies/{copy_id}",
             patch(physical::patch_copy_note).delete(physical::delete_copy),
@@ -449,16 +495,18 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
                 .delete(physical::delete_wishlist_entry),
         )
         .route("/api/physical/{uuid}", delete(physical::delete_book))
-        // F3.1 shelves — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/shelves*` server functions. `/preview` is registered before
-        // the `{id}` param route so it can't be shadowed.
+}
+
+/// F3.1 shelves — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/shelves*` server functions. `/preview` and `/containing/{uuid}`
+/// are registered before the `{id}` param route so it can't shadow them.
+fn shelf_routes() -> Router<AppState> {
+    Router::new()
         .route(
             "/api/shelves",
             get(shelves::list_shelves).post(shelves::create_shelf),
         )
         .route("/api/shelves/preview", post(shelves::preview_rule))
-        // Also ahead of `{id}`, and for the same reason — `containing` is not
-        // a shelf id.
         .route(
             "/api/shelves/containing/{uuid}",
             get(shelves::shelves_containing),
@@ -475,8 +523,14 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
             "/api/shelves/{id}/books/{uuid}",
             delete(shelves::remove_shelf_book),
         )
-        // F3.2 public journal entries — mobile-facing REST. Web hits the
-        // analogous `/api/rpc/journals/*` server functions.
+}
+
+/// F3.2 public journal entries — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/journals/*` server functions. Embedded-image reads are
+/// media-gated like covers/thumbs; the matching upload POST lives in
+/// `upload_router` (rate-limited, image body cap).
+fn journal_routes() -> Router<AppState> {
+    Router::new()
         .route("/api/journals", post(journals::post_journal))
         .route(
             "/api/journals/book/{book_uuid}",
@@ -490,25 +544,24 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
             "/api/journals/{id}",
             patch(journals::patch_journal).delete(journals::delete_journal),
         )
-        // Embedded-image reads are media-gated like covers/thumbs; the
-        // matching upload POST lives in `upload_router` (rate-limited, image
-        // body cap).
         .route(
             "/api/journals/images/{name}",
             get(journals::get_journal_image),
         )
-        // GET/DELETE for author photos carry no upload body (DELETE mutates,
-        // but cheaply — it clears photo state, it doesn't ingest one), so
-        // they stay outside the rate-limited `upload_router`. Only the binary
-        // uploads (cover POST, photo PUT, photo-url PUT) carry the per-IP
-        // frequency cap — see `upload_router` (#168).
+}
+
+/// Cover/thumb/author/series/tag discovery routes, including author photo
+/// reads. GET/DELETE for author photos carry no upload body (DELETE mutates,
+/// but cheaply — it clears photo state, it doesn't ingest one), so they stay
+/// outside the rate-limited `upload_router`. Only the binary uploads (cover
+/// POST, photo PUT, photo-url PUT) carry the per-IP frequency cap — see
+/// `upload_router` (#168).
+fn discovery_routes() -> Router<AppState> {
+    Router::new()
         .route(
             "/api/authors/{id}/photo",
             get(author_photos::get_author_photo).delete(author_photos::delete_author_photo),
         )
-        .merge(upload_router())
-        .merge(book_upload_router())
-        .merge(search_router(search_limiter))
         .route("/api/covers/{uuid}", get(covers::get_cover))
         .route("/api/thumbs/{uuid}/{size}", get(covers::get_thumb))
         .route("/api/authors", get(authors::get_authors))
@@ -524,8 +577,12 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
         .route("/api/series", get(series::get_series))
         .route("/api/series/{id}", get(series::get_series_by_id))
         .route("/api/tags", get(tags::get_tags))
-        // F3.3 suggestions — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/ebook-suggestions` + `/api/rpc/hardcover-key` server fns.
+}
+
+/// F3.3 suggestions — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/ebook-suggestions` + `/api/rpc/hardcover-key` server fns.
+fn suggestion_routes() -> Router<AppState> {
+    Router::new()
         .route(
             "/api/ebooks/{uuid}/suggestions",
             get(suggestions::get_suggestions),
@@ -538,16 +595,24 @@ fn data_routes(search_limiter: std::sync::Arc<RateLimiter>) -> Router<AppState> 
             "/api/hardcover-key",
             get(suggestions::get_hardcover_key).post(suggestions::post_hardcover_key),
         )
-        // "Fetch Summary" — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/ebook/summary/*` server fns.
+}
+
+/// "Fetch Summary" — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/ebook/summary/*` server fns.
+fn summary_routes() -> Router<AppState> {
+    Router::new()
         .route(
             "/api/ebooks/{uuid}/summary/fetch",
             post(summary::post_ebook_summary_fetch),
         )
         .route("/api/summary/sources", get(summary::get_summary_sources))
-        // F4.3 Send-to-Kindle — mobile-facing REST. Web hits the analogous
-        // `/api/rpc/kindle/send`, `/api/rpc/account/kindle-email`, and
-        // `/api/rpc/smtp*` server fns.
+}
+
+/// F4.3 Send-to-Kindle — mobile-facing REST. Web hits the analogous
+/// `/api/rpc/kindle/send`, `/api/rpc/account/kindle-email`, and
+/// `/api/rpc/smtp*` server fns.
+fn kindle_routes() -> Router<AppState> {
+    Router::new()
         .route("/api/kindle/send", post(kindle::post_send))
         .route("/api/kindle/send/status", get(kindle::get_send_status))
         .route("/api/account/kindle-email", post(kindle::post_kindle_email))

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -376,8 +376,8 @@ fn metadata_override_routes() -> Router<AppState> {
         )
         // Cover-only revert. Carries no upload body (unlike the POST in
         // `upload_router`), so it stays outside the upload rate limiter —
-        // same split as the author-photo GET/DELETE vs PUT routes in
-        // `discovery_routes`.
+        // same split as the author-photo GET/DELETE (`discovery_routes`) vs
+        // its PUT (`upload_router`).
         .route(
             "/api/ebooks/{uuid}/cover",
             delete(overrides::delete_ebook_cover),


### PR DESCRIPTION
## Summary
- Addresses #852 (partial — 14 of the ~20 listed functions covered, remainder listed below for follow-up)
- Split `data_routes` in `server/src/backend.rs` into per-feature-area helper functions along its existing comment boundaries (`metadata_override_routes`, `progress_routes`, `highlight_routes`, `bookmark_routes`, `engagement_routes`, `check_in_routes`, `physical_collection_routes`, `shelf_routes`, `journal_routes`, `discovery_routes`, `suggestion_routes`, `summary_routes`, `kindle_routes`), matching the pattern the route table already used in its comments.
- Extracted `kindle_account_body`'s signal bundle, hydration effect, and save/clear handler builders into named helpers (`KindleEmailSignals`, `use_kindle_email_hydration`, `kindle_save_handler`, etc.), separate from the markup.
- Applied the same staged-extraction pattern to Dioxus components that had crossed the ~80-line soft cap: `render_player` (`listen/mobile.rs`, the biggest outlier — derived-state prelude extracted from the markup return), `ReadyPlayer`/`PlayerStageBinding` (`listen/ready_player.rs`), `SpOverlay` (`search_palette/overlay.rs`), `SpResultsList` (`search_palette/results.rs`), `MobileSearchPage` (`search_mobile.rs`), `ReaderTopChrome` (`reader/chrome.rs`), `HighlightRow` (`reader/highlights_drawer.rs`), `FieldGrid` (`metadata_edit/form_grid.rs`), `BdJournalToolbar` (`book_detail/journal_editor.rs`), `server_connect_mobile` (`server_connect.rs`), `ChaptersDrawer` (`listen/chapters_drawer.rs`), and `EditableCell` (`landing/table/cells.rs`).

**Not covered in this PR** (remaining ~6 items for a follow-up): `QuotePanel` (`reader/quote_panel.rs`), `CreateShelfModal` (`create_shelf_modal.rs`), `HardcoverKeyField` (`settings/mod.rs`), `render_loaded_mobile` (`book_detail/mobile.rs`), `ReaderOverlays` (`reader/overlays.rs`), and `ShelfDetailPage`/`ShelfHeader`/`AddBooksModal` (`shelf_detail.rs`, 3 functions).

No behavior/visual change — pure extraction (named helpers, struct-bundled signals), no markup or route contract changes.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — 624 passed, 0 failed
- [x] `cargo test -p omnibus` — 648 passed, 2 pre-existing failures unrelated to this change (`backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` — reproduces on a clean, unmodified `main` checkout in this sandbox; a root-user/read-only-chmod environment quirk)

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- Since this only partially resolves #852, I've used "Addresses" rather than "Closes" so the issue stays open for the remaining ~6 items.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DCWPoS3Ga15e84V4QpyWq5)_