### PR TITLE
feat: long-press the Continue card for a way into book details

### DIFF
--- a/omnibus-ios/omnibus/Features/Library/BookContextMenu.swift
+++ b/omnibus-ios/omnibus/Features/Library/BookContextMenu.swift
@@ -1,8 +1,8 @@
 //  BookContextMenu.swift
-//  Long-press quick actions for a book cell: jump straight into the metadata
-//  editor without the trip through the detail screen. One modifier shared by
-//  every surface that renders a book cell, so a held-down book means the same
-//  thing everywhere.
+//  Long-press quick actions for a book cell: the metadata editor without the
+//  trip through the detail screen, and — for a cell whose tap goes elsewhere —
+//  the way through to that screen. One modifier shared by every surface that
+//  renders a book cell, so a held-down book means the same thing everywhere.
 
 import SwiftUI
 

--- a/omnibus-ios/omnibus/Features/Library/BookContextMenu.swift
+++ b/omnibus-ios/omnibus/Features/Library/BookContextMenu.swift
@@ -6,23 +6,40 @@
 
 import SwiftUI
 
+/// The glyphs the shared menu draws, named so a test can prove they resolve:
+/// `Image(systemName:)` neither warns nor fails on a name that doesn't exist,
+/// so a bad one ships as a menu row with a hole where its icon should be.
+enum BookMenuGlyph {
+    static let detail = "info.circle"
+    static let edit = "pencil"
+}
+
 extension View {
     /// Attach the shared long-press menu to a book cell. `onEdited` runs after
     /// the editor saves or reverts (not on a cancel), so the surface can
-    /// refresh the rows behind the sheet. `extras` appends surface-specific
-    /// items — e.g. the shelf grid's "Remove from shelf".
+    /// refresh the rows behind the sheet. `onOpenDetail` adds a "View book
+    /// details" item, for cells whose *tap* goes somewhere else — on a cell
+    /// that already pushes the detail screen it would only restate the tap.
+    /// `extras` appends surface-specific items — e.g. the shelf grid's
+    /// "Remove from shelf".
     func bookContextMenu<Extras: View>(
         _ book: Book,
         onEdited: (() -> Void)? = nil,
+        onOpenDetail: (() -> Void)? = nil,
         @ViewBuilder extras: @escaping () -> Extras = { EmptyView() }
     ) -> some View {
-        modifier(BookContextMenuModifier(book: book, onEdited: onEdited, extras: extras))
+        modifier(
+            BookContextMenuModifier(
+                book: book, onEdited: onEdited, onOpenDetail: onOpenDetail, extras: extras
+            )
+        )
     }
 }
 
 private struct BookContextMenuModifier<Extras: View>: ViewModifier {
     let book: Book
     var onEdited: (() -> Void)?
+    var onOpenDetail: (() -> Void)?
     @ViewBuilder var extras: () -> Extras
 
     @Environment(AppState.self) private var app
@@ -31,11 +48,21 @@ private struct BookContextMenuModifier<Extras: View>: ViewModifier {
     func body(content: Content) -> some View {
         content
             .contextMenu {
+                // First where it appears at all: on a card whose tap opens the
+                // reader, reaching the detail screen is the whole reason the
+                // menu is worth holding the card down for.
+                if let onOpenDetail {
+                    Button {
+                        onOpenDetail()
+                    } label: {
+                        Label("View book details", systemImage: BookMenuGlyph.detail)
+                    }
+                }
                 if app.user?.canEdit == true {
                     Button {
                         showEditor = true
                     } label: {
-                        Label("Edit metadata", systemImage: "pencil")
+                        Label("Edit metadata", systemImage: BookMenuGlyph.edit)
                     }
                 }
                 extras()

--- a/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
+++ b/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
@@ -10,6 +10,12 @@ import SwiftUI
 
 struct ContinueHero: View {
     let points: [ResumePoint]
+    /// Runs after the long-press editor saves, so the card can pick up a title
+    /// or cover it is still drawing from the old metadata.
+    var onEdited: () -> Void = {}
+    /// Pushes the book's detail screen. A tap resumes the book, so this is the
+    /// card's only way through to everything else about it.
+    var onOpenDetail: (Book) -> Void = { _ in }
 
     @Environment(\.palette) private var palette
     @State private var selected: ResumePoint.ID?
@@ -26,7 +32,7 @@ struct ContinueHero: View {
             ScrollView(.horizontal) {
                 HStack(spacing: 0) {
                     ForEach(points) { point in
-                        HeroCard(point: point)
+                        HeroCard(point: point, onEdited: onEdited, onOpenDetail: onOpenDetail)
                             // Padding inside the page, so every page is exactly
                             // the carousel's width and the paging stops land on
                             // a card rather than drifting by the inset.
@@ -81,6 +87,8 @@ struct ContinueHero: View {
 
 private struct HeroCard: View {
     let point: ResumePoint
+    let onEdited: () -> Void
+    let onOpenDetail: (Book) -> Void
 
     @Environment(\.palette) private var palette
 
@@ -215,6 +223,9 @@ private struct HeroCard: View {
             .shadow(color: .black.opacity(0.35), radius: 18, y: 8)
         }
         .buttonStyle(BookPressStyle())
+        // The same held-down menu as a grid cell, plus the way through to the
+        // detail screen the tap spends on resuming the book.
+        .bookContextMenu(book, onEdited: onEdited, onOpenDetail: { onOpenDetail(book) })
     }
 
     /// A lit alcove rather than a filled rectangle: the wash graded top-to-

--- a/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
+++ b/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct ContinueHero: View {
     let points: [ResumePoint]
     /// Runs after the long-press editor saves, so the card can pick up a title
-    /// or cover it is still drawing from the old metadata.
+    /// or cover that it is still drawing from the old metadata.
     var onEdited: () -> Void = {}
     /// Pushes the book's detail screen. A tap resumes the book, so this is the
     /// card's only way through to everything else about it.

--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -320,7 +320,14 @@ struct LibraryView: View {
                 }
 
                 if !model.resume.isEmpty {
-                    ContinueHero(points: Array(model.resume.prefix(5)))
+                    ContinueHero(
+                        points: Array(model.resume.prefix(5)),
+                        // Only the rail is redrawn: an edit from here can't
+                        // change which books are in progress, and a full reload
+                        // would truncate the grid back to its first page.
+                        onEdited: { Task { await model.refreshResume() } },
+                        onOpenDetail: { path.append(Destination.book(uuid: $0.uuid)) }
+                    )
                 }
 
                 if !railShelves.isEmpty {

--- a/omnibus-ios/omnibusTests/SymbolNameTests.swift
+++ b/omnibus-ios/omnibusTests/SymbolNameTests.swift
@@ -18,4 +18,10 @@ struct SymbolNameTests {
         // the barcode scanner, a plus for the upload.
         #expect(UIImage(systemName: LibraryView.addGlyph) != nil)
     }
+
+    @Test("the book long-press menu's glyphs resolve")
+    func bookMenuGlyphsResolve() {
+        #expect(UIImage(systemName: BookMenuGlyph.detail) != nil)
+        #expect(UIImage(systemName: BookMenuGlyph.edit) != nil)
+    }
 }


### PR DESCRIPTION
## Summary
- A tap on the Continue Reading card resumes the book, which left the detail screen unreachable from the card. Long-pressing it now opens the shared book menu, with **View book details** first.
- `bookContextMenu` grows an optional `onOpenDetail`; cells whose tap already pushes detail pass nothing and are unchanged.
- The hero card picks up the same menu every other book cell has, so a held-down book means the same thing everywhere. An edit from there refreshes only the resume rail — a full reload would truncate the grid back to page one.

## Test plan
- [x] `scripts/ios-test.sh unit` — TEST SUCCEEDED, including a new `SymbolNameTests` case pinning the menu's SF Symbols (`Image(systemName:)` fails silently on a bad name).
- [x] iPhone 17 Pro simulator against a dev server: long-press → menu renders → **View book details** pushes that book's detail screen.
- [x] Swiped to the second carousel card and repeated — each card binds its own book, not the first one.
- [x] Plain tap still opens the reader at the saved position.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- iOS only. `omnibusUITests` is launch-path-only (it never signs in), so this gesture has no XCUITest lane without new fixture plumbing.