### PR TITLE
feat: cap saved passages at 5 with a show-more on web and iOS

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1101,6 +1101,8 @@ html, body { overscroll-behavior: none; }
 }
 .bd-hl-meta { font-size: 11px; color: var(--ink-3); }
 .bd-hl-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+/* Matches `.bd-hl-list`'s row gap so the control reads as one more row. */
+.bd-hl-show-more { margin-top: 14px; font-family: var(--sans); font-size: 12px; }
 @media (hover: hover) { .bd-hl-delete:hover { color: var(--bad); } }
 
 /* Quote-card modal — the shared reader editor (rd-quote-*) hosted in the

--- a/frontend/src/pages/book_detail/highlights.rs
+++ b/frontend/src/pages/book_detail/highlights.rs
@@ -67,20 +67,62 @@ pub(super) fn BdHighlightsSection(uuid: String, quote_meta: BdQuoteMeta) -> Elem
                     }
                 }
             } else {
-                div { class: "bd-hl-list", "data-testid": "highlights-list",
-                    for h in list.iter() {
-                        BdHighlightCard {
-                            key: "{h.id}",
-                            highlight: h.clone(),
-                            highlights,
-                            server_url: server_url.clone(),
-                            quote_target,
-                        }
-                    }
+                BdHighlightList {
+                    highlights,
+                    server_url: server_url.clone(),
+                    quote_target,
                 }
             }
         }
         {render_quote_modal(quote_target, quote_meta)}
+    }
+}
+
+/// Passages listed before the reader expands the section. A heavily
+/// highlighted book runs to hundreds of rows, and this is one section of
+/// several on the page.
+const COLLAPSED_PASSAGES: usize = 5;
+
+/// The passage list, capped at [`COLLAPSED_PASSAGES`] rows until the reader
+/// expands it. Both renders start collapsed so SSR and hydration match
+/// (rule 07).
+#[component]
+fn BdHighlightList(
+    highlights: Signal<Vec<Highlight>>,
+    server_url: String,
+    quote_target: Signal<Option<Highlight>>,
+) -> Element {
+    let mut expanded = use_signal(|| false);
+    let list = highlights();
+    let total = list.len();
+    let visible = if expanded() {
+        total
+    } else {
+        total.min(COLLAPSED_PASSAGES)
+    };
+
+    rsx! {
+        div { class: "bd-hl-list", "data-testid": "highlights-list",
+            for h in list.iter().take(visible) {
+                BdHighlightCard {
+                    key: "{h.id}",
+                    highlight: h.clone(),
+                    highlights,
+                    server_url: server_url.clone(),
+                    quote_target,
+                }
+            }
+        }
+        if total > visible {
+            button {
+                r#type: "button",
+                class: "btn ghost sm bd-hl-show-more",
+                "data-testid": "highlights-show-more",
+                "aria-expanded": "{expanded()}",
+                onclick: move |_| expanded.set(true),
+                "Show {total - visible} more \u{2193}"
+            }
+        }
     }
 }
 

--- a/frontend/src/pages/book_detail/highlights/tests.rs
+++ b/frontend/src/pages/book_detail/highlights/tests.rs
@@ -234,6 +234,88 @@ mod render_tests {
         assert!(!html.contains("data-testid=\"highlight-open\""));
     }
 
+    #[derive(Clone, Debug, PartialEq, Routable)]
+    enum ListRoute {
+        #[route("/")]
+        LongListHost {},
+    }
+
+    #[derive(Clone, Debug, PartialEq, Routable)]
+    enum ShortListRoute {
+        #[route("/")]
+        ShortListHost {},
+    }
+
+    /// `n` distinct passages, each id'd so the list's `key` stays unique.
+    fn seeded_list(n: i64) -> Vec<Highlight> {
+        (0..n)
+            .map(|i| {
+                let mut h = seeded_highlight(None, Some(&format!("passage {i}")));
+                h.id = i;
+                h
+            })
+            .collect()
+    }
+
+    fn count_cards(html: &str) -> usize {
+        html.matches("data-testid=\"highlight-card\"").count()
+    }
+
+    #[component]
+    fn LongListHost() -> Element {
+        rsx! {
+            BdHighlightList {
+                highlights: use_signal(|| seeded_list(8)),
+                server_url: String::new(),
+                quote_target: use_signal(|| None),
+            }
+        }
+    }
+
+    fn render_long_list() -> Element {
+        rsx! {
+            Router::<ListRoute> {}
+        }
+    }
+
+    #[test]
+    fn list_renders_only_the_collapsed_count_and_offers_the_rest() {
+        // A heavily highlighted book would otherwise push every other section
+        // off the page; the first COLLAPSED_PASSAGES rows show and the button
+        // names how many are held back.
+        let html = render_in_vdom(render_long_list);
+        assert_eq!(count_cards(&html), COLLAPSED_PASSAGES);
+        assert!(html.contains("passage 0"));
+        assert!(html.contains("passage 4"));
+        assert!(!html.contains("passage 5"));
+        assert!(html.contains("data-testid=\"highlights-show-more\""));
+        assert!(html.contains("Show 3 more"));
+    }
+
+    #[component]
+    fn ShortListHost() -> Element {
+        rsx! {
+            BdHighlightList {
+                highlights: use_signal(|| seeded_list(COLLAPSED_PASSAGES as i64)),
+                server_url: String::new(),
+                quote_target: use_signal(|| None),
+            }
+        }
+    }
+
+    fn render_short_list() -> Element {
+        rsx! {
+            Router::<ShortListRoute> {}
+        }
+    }
+
+    #[test]
+    fn list_omits_the_show_more_button_when_nothing_is_held_back() {
+        let html = render_in_vdom(render_short_list);
+        assert_eq!(count_cards(&html), COLLAPSED_PASSAGES);
+        assert!(!html.contains("data-testid=\"highlights-show-more\""));
+    }
+
     #[component]
     fn PlainCardHost() -> Element {
         rsx! {

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -648,29 +648,7 @@ struct BookDetailView: View {
 
     private func highlightsSection(_ book: Book) -> some View {
         DisclosureSection(title: "Highlights (\(model.highlights.count))") {
-            VStack(alignment: .leading, spacing: Spacing.md) {
-                ForEach(model.highlights.prefix(6)) { highlight in
-                    VStack(alignment: .leading, spacing: 4) {
-                        if let text = highlight.text?.nilIfBlank {
-                            Text(text)
-                                .font(.display(15))
-                                .foregroundStyle(palette.ink0Color)
-                                .lineLimit(4)
-                        }
-                        if let note = highlight.note?.nilIfBlank {
-                            Text(note)
-                                .font(.ui(12.5))
-                                .foregroundStyle(palette.ink2Color)
-                        }
-                    }
-                    .padding(.leading, Spacing.md)
-                    .overlay(alignment: .leading) {
-                        Capsule()
-                            .fill(highlight.color.tint)
-                            .frame(width: 3)
-                    }
-                }
-            }
+            HighlightsList(highlights: model.highlights)
         }
     }
 
@@ -813,6 +791,67 @@ struct BookDetailView: View {
 }
 
 // MARK: - Support views
+
+/// The book's saved passages, capped until the reader opens the rest. A
+/// heavily highlighted book otherwise pushes every section below it off the
+/// screen. Mirrors the web book-detail list: same cap, one-way expand.
+struct HighlightsList: View {
+    let highlights: [Highlight]
+
+    @Environment(\.palette) private var palette
+    @State private var expanded = false
+
+    /// Passages shown before the reader expands the section.
+    static let collapsedCount = 5
+
+    /// How many of `total` passages a list in this state renders.
+    static func visibleCount(total: Int, expanded: Bool) -> Int {
+        expanded ? total : min(total, collapsedCount)
+    }
+
+    private var visible: ArraySlice<Highlight> {
+        highlights.prefix(Self.visibleCount(total: highlights.count, expanded: expanded))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            ForEach(visible) { highlight in
+                VStack(alignment: .leading, spacing: 4) {
+                    if let text = highlight.text?.nilIfBlank {
+                        Text(text)
+                            .font(.display(15))
+                            .foregroundStyle(palette.ink0Color)
+                            .lineLimit(4)
+                    }
+                    if let note = highlight.note?.nilIfBlank {
+                        Text(note)
+                            .font(.ui(12.5))
+                            .foregroundStyle(palette.ink2Color)
+                    }
+                }
+                .padding(.leading, Spacing.md)
+                .overlay(alignment: .leading) {
+                    Capsule()
+                        .fill(highlight.color.tint)
+                        .frame(width: 3)
+                }
+            }
+
+            let held = highlights.count - visible.count
+            if held > 0 {
+                Button {
+                    withAnimation(Motion.settle) { expanded = true }
+                } label: {
+                    Text("Show \(held) more")
+                        .font(.ui(12.5, weight: .semibold))
+                        .foregroundStyle(palette.accentColor)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("highlights-show-more")
+            }
+        }
+    }
+}
 
 /// A collapsible section that starts expanded — used for the long-form blocks.
 struct DisclosureSection<Content: View>: View {

--- a/omnibus-ios/omnibusTests/HighlightsListTests.swift
+++ b/omnibus-ios/omnibusTests/HighlightsListTests.swift
@@ -1,0 +1,31 @@
+//  HighlightsListTests.swift
+//  How many saved passages the book-detail list renders before the reader
+//  expands it.
+//
+//  The section used to hard-cap at six with no way to see the rest, so a
+//  heavily highlighted book silently hid everything past the sixth passage.
+
+import Testing
+
+@testable import omnibus
+
+@Test func collapsedListRendersAtMostTheCollapsedCount() {
+    #expect(HighlightsList.visibleCount(total: 40, expanded: false) == HighlightsList.collapsedCount)
+}
+
+@Test func collapsedListRendersEveryPassageWhenItFitsUnderTheCap() {
+    #expect(HighlightsList.visibleCount(total: 3, expanded: false) == 3)
+    #expect(
+        HighlightsList.visibleCount(total: HighlightsList.collapsedCount, expanded: false)
+            == HighlightsList.collapsedCount
+    )
+}
+
+@Test func expandedListRendersEveryPassage() {
+    #expect(HighlightsList.visibleCount(total: 40, expanded: true) == 40)
+}
+
+@Test func emptyListRendersNothingInEitherState() {
+    #expect(HighlightsList.visibleCount(total: 0, expanded: false) == 0)
+    #expect(HighlightsList.visibleCount(total: 0, expanded: true) == 0)
+}

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -779,11 +779,8 @@ async function seedPassage(
   return { uuid, id, quote };
 }
 
-// Start from a known-empty book. These tests assert the empty state *returns*
-// after a delete, so residue from an interrupted earlier run would fail them
-// for the wrong reason.
-test.beforeAll(async ({ request }) => {
-  const uuid = await fetchBookUuidByTitle(request, PASSAGES_BOOK.title);
+/// Delete every highlight on `uuid`.
+async function clearPassages(request: APIRequestContext, uuid: string) {
   const list = await request.get(`/api/highlights/book/${uuid}`);
   expect(list.status(), "list highlights").toBe(200);
   for (const h of (await list.json()) as { id: number }[]) {
@@ -791,6 +788,16 @@ test.beforeAll(async ({ request }) => {
       204,
     );
   }
+}
+
+// Start from a known-empty book. These tests assert the empty state *returns*
+// after a delete, so residue from an interrupted earlier run would fail them
+// for the wrong reason.
+test.beforeAll(async ({ request }) => {
+  await clearPassages(
+    request,
+    await fetchBookUuidByTitle(request, PASSAGES_BOOK.title),
+  );
 });
 
 test("lists a saved passage with its locator, note and date, then deletes it", async ({
@@ -940,6 +947,37 @@ test("opens the quote-card editor in a modal and closes it again", async ({
 
   // Clean up the seeded highlight so re-runs start from the empty state.
   expect((await request.delete(`/api/highlights/${id}`)).status()).toBe(204);
+});
+
+test("collapses a long passage list behind a show-more control", async ({
+  page,
+  request,
+}) => {
+  // Earlier tests in this serial file leave passages behind on PASSAGES_BOOK,
+  // so clear it first — the visible count is the whole assertion here.
+  const uuid = await fetchBookUuidByTitle(request, PASSAGES_BOOK.title);
+  await clearPassages(request, uuid);
+  const ids: number[] = [];
+  for (let i = 0; i < 8; i++) {
+    ids.push((await seedPassage(request, `epubcfi(/6/${4 + i * 2}!/4/2)`)).id);
+  }
+
+  await gotoReady(page, `/books/${uuid}`);
+  const cards = page.getByTestId("highlight-card");
+  await expect(cards).toHaveCount(5);
+
+  const showMore = page.getByTestId("highlights-show-more");
+  await expect(showMore).toHaveText("Show 3 more ↓");
+  await showMore.click();
+
+  // Expanding is one-way: every passage lists and the control goes away.
+  await expect(cards).toHaveCount(8);
+  await expect(showMore).toHaveCount(0);
+
+  // Clean up shared state so the next run starts from the empty state.
+  for (const id of ids) {
+    expect((await request.delete(`/api/highlights/${id}`)).status()).toBe(204);
+  }
 });
 
 test("breadcrumb author segment links to the author page", async ({


### PR DESCRIPTION
## Summary
- Book detail's saved-passages list rendered every highlight, so a heavily annotated book pushed the rest of the page off screen. It now shows 5 and holds the remainder behind a `Show N more ↓` control.
- iOS had the opposite bug: `Highlights` hard-capped at 6 with **no** way to reach the rest. Same cap, same one-way expand — the two surfaces now agree.
- Expanding is one-way on both, matching the existing `suggestions-show-more` / `journal-show-more` patterns on this page.

## Test plan
- [x] `just test` — 3848 tests, all pass (4 new frontend render tests for the cap, the button label, and the ≤5 no-button case).
- [x] `just ios-test` — full suite green, incl. 4 new `HighlightsListTests` cases.
- [x] `just lint` + `just lint-ts` clean.
- [x] Playwright `book_detail` 26/26, incl. a new spec seeding 8 passages → 5 visible → click → 8 visible, button gone.
- [x] Drove the hydrated web app with 10 seeded passages: 5 cards + "Show 5 more ↓" on load, expands to 10 on click, no console errors, button spacing matches the list row gap.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- The collapsed state is identical on SSR and first hydration, so the web change keeps rule 07 parity.