### PR TITLE
fix: stamp Kobo reading-state clocks so a web position reaches the device

### DIFF
--- a/db/src/kobo.rs
+++ b/db/src/kobo.rs
@@ -254,6 +254,12 @@ pub struct KoboBookState {
     /// clock — is the optimistic token for
     /// `progress::attach_derived_kobo_location`.
     pub progress_updated_at: i64,
+    /// The read-status row's own event time, 0 when the book has no status
+    /// row. Kept separate from [`Self::progress_updated_at`] because the
+    /// device arbitrates `StatusInfo` and `CurrentBookmark` independently,
+    /// each against its own clock — the MAXed value would claim the status
+    /// moved every time only the position did.
+    pub status_updated_at: i64,
 }
 
 /// Per-user reading state for `uuids`, keyed by book uuid.
@@ -294,6 +300,7 @@ pub async fn reading_state_for(
                     rp.epub_cfi AS epub_cfi,
                     COALESCE(rp.client_updated_at, rp.updated_at, 0)
                         AS progress_updated_at,
+                    COALESCE(rs.updated_at, 0) AS status_updated_at,
                     MAX(
                         COALESCE(rs.updated_at, 0),
                         COALESCE(rp.client_updated_at, rp.updated_at, 0)
@@ -328,6 +335,7 @@ pub async fn reading_state_for(
                     epub_cfi: row.try_get::<Option<String>, _>("epub_cfi")?,
                     state_updated_at: row.try_get::<i64, _>("state_updated_at")?,
                     progress_updated_at: row.try_get::<i64, _>("progress_updated_at")?,
+                    status_updated_at: row.try_get::<i64, _>("status_updated_at")?,
                 },
             );
         }

--- a/db/src/kobo/tests.rs
+++ b/db/src/kobo/tests.rs
@@ -449,6 +449,97 @@ async fn reading_state_for_returns_status_and_position_per_book() {
 }
 
 #[tokio::test]
+async fn reading_state_for_reports_the_status_and_progress_clocks_separately() {
+    // Kobo sync-out stamps `StatusInfo` and `CurrentBookmark` from their own
+    // rows, so each clock has to survive the join un-MAXed — the envelope's
+    // `state_updated_at` is the only value allowed to merge them.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = make_user(&pool, "reader").await;
+    let uuid = seed_synced_ebook(&pool, "both.epub", "Both", "A").await;
+
+    crate::read_status::set_read_status(
+        &pool,
+        user,
+        &omnibus_shared::SetReadStatus {
+            book_uuid: uuid.clone(),
+            status: ReadStatus::Reading,
+        },
+    )
+    .await
+    .unwrap();
+    sqlx::query("UPDATE book_read_status SET updated_at = ? WHERE user_id = ? AND book_uuid = ?")
+        .bind(1_700_000_000_i64)
+        .bind(user)
+        .bind(&uuid)
+        .execute(&pool)
+        .await
+        .unwrap();
+    crate::progress::upsert_progress(
+        &pool,
+        user,
+        &omnibus_shared::ProgressUpdate {
+            book_uuid: uuid.clone(),
+            format: omnibus_shared::ProgressFormat::Epub,
+            epub_cfi: None,
+            audio_position_seconds: None,
+            progress_percent: Some(58),
+            kobo_location: Some("{\"Value\":\"kobo.2.1\"}".into()),
+            client_updated_at: Some(1_700_001_000),
+            book_file_id: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let states = reading_state_for(&pool, user, std::slice::from_ref(&uuid))
+        .await
+        .unwrap();
+
+    let s = states.get(&uuid).expect("book present");
+    assert_eq!(s.status_updated_at, 1_700_000_000);
+    assert_eq!(s.progress_updated_at, 1_700_001_000);
+    assert_eq!(
+        s.state_updated_at, 1_700_001_000,
+        "envelope takes the newer"
+    );
+}
+
+#[tokio::test]
+async fn reading_state_for_reports_a_zero_status_clock_for_a_position_only_book() {
+    // 0 is the "no such row" sentinel the wire layer maps to *unstamped*;
+    // a position-only book must not report a status clock it hasn't got.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = make_user(&pool, "reader").await;
+    let uuid = seed_synced_ebook(&pool, "pos.epub", "Positioned", "A").await;
+
+    crate::progress::upsert_progress(
+        &pool,
+        user,
+        &omnibus_shared::ProgressUpdate {
+            book_uuid: uuid.clone(),
+            format: omnibus_shared::ProgressFormat::Epub,
+            epub_cfi: None,
+            audio_position_seconds: None,
+            progress_percent: Some(12),
+            kobo_location: Some("{\"Value\":\"kobo.1.1\"}".into()),
+            client_updated_at: Some(1_700_001_000),
+            book_file_id: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let states = reading_state_for(&pool, user, std::slice::from_ref(&uuid))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        states.get(&uuid).expect("book present").status_updated_at,
+        0
+    );
+}
+
+#[tokio::test]
 async fn reading_state_for_is_scoped_to_the_requesting_user() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let alice = make_user(&pool, "alice").await;

--- a/server/src/backend/kobo.rs
+++ b/server/src/backend/kobo.rs
@@ -577,6 +577,17 @@ async fn put_state(
             }
         }
         if let Some(bookmark) = &entry.current_bookmark {
+            // Capture data for the one open question about this field: whether
+            // the content-source percent really is per-chapter (as
+            // `persist_bookmark` assumes) or just echoes the whole-book one.
+            // Nothing in this repo has ever recorded a real device's answer,
+            // and sync-out can't emit the field until it is known.
+            tracing::info!(
+                %uuid,
+                whole_book = ?bookmark.progress_percent,
+                content_source = ?bookmark.content_source_progress_percent,
+                "kobo bookmark percents received"
+            );
             // Device event time, most-specific first: the bookmark's own
             // stamp, then the entry-level ones. Absent/unparseable → None,
             // which `persist_bookmark` treats as server-now (pre-existing
@@ -599,8 +610,16 @@ async fn put_state(
         }
         // Acknowledged, deliberately unwritten — cumulative totals would
         // double-count against the LeaveContent sessions (see `dto::Statistics`).
-        if entry.statistics.is_some() {
-            tracing::debug!(%uuid, "kobo statistics received");
+        // Logged with values because sync-out omits the block entirely today,
+        // and the only safe way to start sending one is to echo what a device
+        // reported rather than invent zeroes; that needs a real payload first.
+        if let Some(stats) = &entry.statistics {
+            tracing::info!(
+                %uuid,
+                spent_reading_minutes = ?stats.spent_reading_minutes,
+                remaining_time_minutes = ?stats.remaining_time_minutes,
+                "kobo statistics received"
+            );
         }
     }
     if let Err(e) = tx.commit().await {

--- a/server/src/backend/kobo/dto.rs
+++ b/server/src/backend/kobo/dto.rs
@@ -156,6 +156,9 @@ pub struct ReadingState {
     pub entitlement_id: String,
     pub created: String,
     pub last_modified: String,
+    /// Mirrors [`Self::last_modified`] — calibre-web's implementation notes
+    /// the two are always equal on a real store response.
+    pub priority_timestamp: String,
     pub status_info: StatusInfo,
     pub current_bookmark: CurrentBookmark,
 }
@@ -165,6 +168,11 @@ pub struct ReadingState {
 pub struct StatusInfo {
     /// `ReadyToRead` | `Reading` | `Finished`.
     pub status: String,
+    /// When the status last moved. `Option` for the inbound PUT (firmware
+    /// need not send it); always stamped on sync-out, where the device
+    /// arbitrates it against its own status clock.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_modified: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -180,8 +188,11 @@ pub struct CurrentBookmark {
     /// same sentence (#925).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub location: Option<serde_json::Value>,
-    /// Device-stamped bookmark time. Parsed for freshness arbitration on
-    /// the state PUT; never serialized on sync-out (wire shape unchanged).
+    /// The bookmark's own event time — the field the device arbitrates
+    /// against its local bookmark, keeping whichever is newer. Stamped on
+    /// **both** directions: parsed for freshness on the state PUT, and
+    /// emitted on sync-out, without which a server position can never win
+    /// and the device silently keeps its own.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_modified: Option<String>,
 }
@@ -219,20 +230,29 @@ pub fn new_entitlement(
 /// The device-facing reading state for one book: real status and position when
 /// the user has any, an untouched book's defaults otherwise.
 ///
-/// `last_modified` is the **state's own** event time (`state_updated_at`),
-/// not the book's file mtime — the device compares it against its local
-/// state to decide whether to adopt the server's position, so a stale or
-/// unrelated timestamp would break that arbitration. `book_ts` is only the
-/// fallback for a book with no state at all.
+/// The device reconciles `StatusInfo` and `CurrentBookmark` **independently**,
+/// each against the matching clock it already holds, so every one of the three
+/// timestamps here is load-bearing: the envelope's own `state_updated_at`, the
+/// status row's clock, and the progress row's clock. An unstamped sub-object
+/// loses that comparison to whatever the device has and is silently dropped —
+/// which is exactly how a web-side position failed to reach a Kobo. `book_ts`
+/// is only the fallback for a book with no state at all.
+///
+/// A zero clock means "no such row" and stays unstamped rather than becoming
+/// `1970-01-01`: an empty bookmark must lose arbitration, not win it with a
+/// timestamp we invented.
 pub fn reading_state(uuid: &str, book_ts: &str, state: Option<&KoboBookState>) -> ReadingState {
+    let last_modified = state
+        .map(|s| rfc3339(s.state_updated_at))
+        .unwrap_or_else(|| book_ts.to_owned());
     ReadingState {
         entitlement_id: uuid.to_owned(),
         created: book_ts.to_owned(),
-        last_modified: state
-            .map(|s| rfc3339(s.state_updated_at))
-            .unwrap_or_else(|| book_ts.to_owned()),
+        priority_timestamp: last_modified.clone(),
+        last_modified,
         status_info: StatusInfo {
             status: kobo_status(state).to_owned(),
+            last_modified: state.and_then(|s| stamp(s.status_updated_at)),
         },
         current_bookmark: state
             .map(|s| CurrentBookmark {
@@ -244,10 +264,16 @@ pub fn reading_state(uuid: &str, book_ts: &str, state: Option<&KoboBookState>) -
                     .kobo_location
                     .as_deref()
                     .and_then(|raw| serde_json::from_str(raw).ok()),
-                last_modified: None,
+                last_modified: stamp(s.progress_updated_at),
             })
             .unwrap_or_default(),
     }
+}
+
+/// Format a sub-object clock, treating the `0` sentinel (no such row) as
+/// unstamped rather than as the Unix epoch.
+fn stamp(epoch: i64) -> Option<String> {
+    (epoch > 0).then(|| rfc3339(epoch))
 }
 
 /// Map the internal read status onto the device's vocabulary. `Unread` is
@@ -328,9 +354,13 @@ fn removed_entitlement(book_uuid: &str) -> SyncItem {
         reading_state: ReadingState {
             entitlement_id: uuid,
             created: ts.clone(),
+            priority_timestamp: ts.clone(),
             last_modified: ts,
             status_info: StatusInfo {
                 status: "ReadyToRead".to_owned(),
+                // The archive carries no state to arbitrate — `IsRemoved`
+                // is the whole message.
+                last_modified: None,
             },
             current_bookmark: CurrentBookmark::default(),
         },

--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -1402,6 +1402,169 @@ async fn get_state_derives_a_kobospan_from_a_web_cfi_when_the_kepub_is_cached() 
     assert_eq!(bookmark["Location"]["Type"], "KoboSpan");
 }
 
+/// Pin a book's read-status and progress clocks to known, distinct instants.
+/// `set_read_status` / `upsert_progress` stamp server-now, which no assertion
+/// on an exact wire timestamp can name.
+async fn pin_state_clocks(
+    pool: &SqlitePool,
+    user_id: i64,
+    uuid: &str,
+    status_at: i64,
+    progress_at: i64,
+) {
+    db::read_status::set_read_status(
+        pool,
+        user_id,
+        &omnibus_shared::SetReadStatus {
+            book_uuid: uuid.to_owned(),
+            status: ReadStatus::Reading,
+        },
+    )
+    .await
+    .unwrap();
+    sqlx::query("UPDATE book_read_status SET updated_at = ? WHERE user_id = ? AND book_uuid = ?")
+        .bind(status_at)
+        .bind(user_id)
+        .bind(uuid)
+        .execute(pool)
+        .await
+        .unwrap();
+    db::progress::upsert_progress(
+        pool,
+        user_id,
+        &omnibus_shared::ProgressUpdate {
+            book_uuid: uuid.to_owned(),
+            format: omnibus_shared::ProgressFormat::Epub,
+            epub_cfi: Some("epubcfi(/6/2!/4/4/1:0)".into()),
+            audio_position_seconds: None,
+            progress_percent: Some(58),
+            // Already-enriched row: a present anchor keeps the sync-out span
+            // derivation (and its clock-neutral write-back) out of the way.
+            kobo_location: Some(
+                r#"{"Source":"c1.xhtml","Type":"KoboSpan","Value":"kobo.2.1"}"#.into(),
+            ),
+            book_file_id: None,
+            client_updated_at: Some(progress_at),
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn get_state_stamps_the_bookmark_clock_so_the_device_can_adopt_a_web_position() {
+    // The regression this exists for: the device arbitrates the served
+    // bookmark against its own by `CurrentBookmark.LastModified`, so an
+    // unstamped one always loses and a web-side position never lands.
+    let (app, pool, token, uid) = fixture().await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Herbert").await;
+    pin_state_clocks(&pool, uid, &uuid, 1_700_000_000, 1_700_001_000).await;
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/library/{uuid}/state")))
+        .await
+        .unwrap();
+    let states = body_json(res).await;
+    let state = &states.as_array().expect("array of one state")[0];
+
+    // 1_700_001_000 → the progress row's own event time, not server-now.
+    assert_eq!(
+        state["CurrentBookmark"]["LastModified"],
+        "2023-11-14T22:30:00Z"
+    );
+}
+
+#[tokio::test]
+async fn get_state_stamps_the_status_clock_independently_of_the_bookmark_clock() {
+    // Each sub-object is reconciled against its own device-side clock, so
+    // the MAXed envelope value must not stand in for either: reporting it as
+    // the status clock would claim the status moved every time only the
+    // position did.
+    let (app, pool, token, uid) = fixture().await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Herbert").await;
+    pin_state_clocks(&pool, uid, &uuid, 1_700_000_000, 1_700_001_000).await;
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/library/{uuid}/state")))
+        .await
+        .unwrap();
+    let states = body_json(res).await;
+    let state = &states.as_array().expect("array of one state")[0];
+
+    assert_eq!(state["StatusInfo"]["LastModified"], "2023-11-14T22:13:20Z");
+    assert_eq!(
+        state["CurrentBookmark"]["LastModified"],
+        "2023-11-14T22:30:00Z"
+    );
+    // The envelope carries the newer of the two, and PriorityTimestamp
+    // mirrors it.
+    assert_eq!(state["LastModified"], "2023-11-14T22:30:00Z");
+    assert_eq!(state["PriorityTimestamp"], "2023-11-14T22:30:00Z");
+}
+
+#[tokio::test]
+async fn get_state_leaves_an_untouched_books_clocks_unstamped() {
+    // A book with no state must not carry an invented bookmark time: an
+    // empty bookmark has to lose arbitration, not win it at the epoch.
+    let (app, pool, token, _uid) = fixture().await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Herbert").await;
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/library/{uuid}/state")))
+        .await
+        .unwrap();
+    let states = body_json(res).await;
+    let state = &states.as_array().expect("array of one state")[0];
+
+    assert!(state["StatusInfo"]["LastModified"].is_null());
+    assert!(state["CurrentBookmark"]["LastModified"].is_null());
+    assert_eq!(state["StatusInfo"]["Status"], "ReadyToRead");
+}
+
+#[tokio::test]
+async fn library_sync_stamps_the_reading_state_clocks_on_a_new_entitlement() {
+    // Same payload, second delivery path — the device adopts position from
+    // either, so both must carry the arbitration clocks.
+    let (app, pool, token, uid) = fixture().await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Herbert").await;
+    opt_in(&pool, uid, std::slice::from_ref(&uuid)).await;
+    pin_state_clocks(&pool, uid, &uuid, 1_700_000_000, 1_700_001_000).await;
+
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/library/sync")))
+        .await
+        .unwrap();
+    let json = body_json(res).await;
+    let rs = &json.as_array().unwrap()[0]["NewEntitlement"]["ReadingState"];
+
+    assert_eq!(
+        rs["CurrentBookmark"]["LastModified"],
+        "2023-11-14T22:30:00Z"
+    );
+    assert_eq!(rs["StatusInfo"]["LastModified"], "2023-11-14T22:13:20Z");
+    assert_eq!(rs["PriorityTimestamp"], "2023-11-14T22:30:00Z");
+}
+
+#[tokio::test]
+async fn put_state_still_accepts_a_status_info_without_a_last_modified() {
+    // `StatusInfo` is shared between the sync-out response and the inbound
+    // PUT; the field added for the former must stay optional for the latter,
+    // which real firmware does not always send.
+    let (app, pool, token, uid) = fixture().await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Herbert").await;
+    let body = serde_json::json!({
+        "ReadingStates": [{ "StatusInfo": { "Status": "Finished" } }]
+    });
+
+    let res = app.oneshot(state_put(&token, &uuid, body)).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let stored = db::read_status::get_read_status(&pool, uid, &uuid)
+        .await
+        .unwrap();
+    assert_eq!(stored.map(|s| s.status), Some(ReadStatus::Finished));
+}
+
 #[tokio::test]
 async fn get_state_returns_404_for_an_unknown_book() {
     let (app, _pool, token, _uid) = fixture().await;


### PR DESCRIPTION
## Summary
- The device reconciles `StatusInfo` and `CurrentBookmark` **independently**, each against the matching clock it already holds, and keeps whichever side is newer. Omnibus served both unstamped, so a server-side position could never win the comparison — a book read on the web stayed at the device's own position through every sync, on both delivery paths (`library/sync` and `GET library/{uuid}/state`).
- Stamps `CurrentBookmark.LastModified` from the progress row's event time and `StatusInfo.LastModified` from the read-status row's, and adds the `PriorityTimestamp` both reference implementations send.
- `reading_state_for` now reports the two clocks separately: the MAXed `state_updated_at` would claim the status moved every time only the position did.
- A zero clock means "no such row" and stays unstamped rather than becoming `1970-01-01`, so an empty bookmark still loses arbitration instead of winning it with an invented timestamp.
- Second commit logs the `CurrentBookmark` percents and the `Statistics` block a device sends on the state PUT. Both are parsed and discarded today, and sync-out can't start emitting either until there is a real payload to echo.

## Test plan
- [x] `just test` — full matrix green (1751 db / 658 server / 631 + 644 frontend / 260 shared).
- [x] `just lint` — clean across the crate/feature matrix, incl. the wasm32 frontend target.
- [x] 7 new tests: both delivery paths, the two clocks moving independently, the unstamped-zero case, and inbound-PUT compatibility with a `StatusInfo` carrying no `LastModified` (the DTO is shared between request and response).
- [ ] **Device smoke, pending.** Replay the loop this was reported from: read on the Kobo → sync → read further on the web → sync → confirm the device now adopts the newer position.
- [ ] **Capture, pending.** After deploy, sync once and read the two new log lines.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- Confirmed against the live server before the fix: `GET /kobo/…/v1/library/{uuid}/state` returned the correct span and percent for a web-read book, with no `CurrentBookmark.LastModified` on it. The position was right; it just carried nothing to win arbitration with.

>[!NOTE]
> `Statistics` and `ContentSourceProgressPercent` are still omitted from sync-out.
> Both reference implementations send them and Omnibus stores neither, so the
> only honest way to emit them is to echo a device's own values back at the
> device's own timestamp — a zeroed `Statistics` block carrying a fresh
> `LastModified` would tell the device to discard its reading-time totals,
> trading a stuck bookmark for lost stats. The logging added here is what makes
> that echo possible later; it also settles whether the content-source percent
> is genuinely per-chapter, which `persist_bookmark` assumes but no capture in
> this repo has confirmed.