### PR TITLE
fix: persist reader position locally on every relocate, not just throttled pushes (#1666)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -255,7 +255,12 @@ Offline/            — Cache (read-through policies), OfflineStore (SQLite
                       compares that snapshot against a later metadata refresh
                       to drive "Update available" — three-valued, so "can't
                       tell" never reads as "not stale"), SyncEngine (the
-                      mutation outbox — see rule 08), Connectivity
+                      mutation outbox — see rule 08), Connectivity,
+                      PositionPushThrottle (shared by the reader, the comic
+                      pager, and the audio player: every relocate writes the
+                      replica and the outbox unconditionally, this throttle
+                      decides only whether it is *also* worth a network round
+                      trip right now)
 Reader/             — SwiftUI reader chrome, the host-drawn selection layer,
                       the passage menu, the typography sheet and the quote-card
                       composer, and ReadStatusAuto (the readers' automatic

--- a/omnibus-ios/omnibus/Comic/ComicReaderView.swift
+++ b/omnibus-ios/omnibus/Comic/ComicReaderView.swift
@@ -33,7 +33,9 @@ struct ComicReaderView: View {
     /// When the current stretch of reading began, or `nil` while the app is
     /// in the background — same reading-time clock as the EPUB reader.
     @State private var sessionStart: Date?
-    @State private var lastSave = Date.distantPast
+    /// Governs whether a page turn is also pushed over the network, on top of
+    /// the unconditional local write every one of them gets (#1666).
+    @State private var pushThrottle = PositionPushThrottle(interval: 4)
     @State private var showPlayer = false
     /// Auto read-status for the open comic — unread marks reading on open,
     /// the last page marks finished. Created in `prepare`, driven by turns.
@@ -338,14 +340,14 @@ struct ComicReaderView: View {
         )
     }
 
-    /// Record where the reader is. `force` marks the moments worth a round
-    /// trip of their own — a close, a backgrounding — while page turns queue
-    /// and go out with the next push, exactly like the EPUB reader's CFI
-    /// trickle.
+    /// Record where the reader is. The write into the replica and the outbox
+    /// happens on every page turn, unconditionally — that is what makes the
+    /// position survive a force-quit (#1666). `force` decides only whether
+    /// this turn is also worth a round trip of its own — a close, a
+    /// backgrounding — as opposed to the steady trickle of page turns, which
+    /// still queue immediately but push at most once every four seconds.
     private func persist(force: Bool) async {
         guard let pages, pages.count > 0 else { return }
-        guard force || Date().timeIntervalSince(lastSave) > 4 else { return }
-        lastSave = Date()
         let clamped = min(max(page, 0), pages.count - 1)
         await UserDataService.saveProgress(
             ProgressUpdate(
@@ -355,7 +357,7 @@ struct ComicReaderView: View {
                 audioPositionSeconds: nil,
                 progressPercent: ComicPosition.percent(page: clamped, count: pages.count)
             ),
-            push: force
+            push: pushThrottle.shouldPush(force: force)
         )
         await checkpointSessionIfStale()
     }

--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -74,7 +74,11 @@ final class AudioPlayer {
     private var sleepTask: Task<Void, Never>?
     private var sessionStart: Date?
     private var listenedSeconds: Double = 0
-    private var lastPersist = Date.distantPast
+    /// Governs whether a tick is also pushed over the network, on top of the
+    /// unconditional local write every one of them gets (#1666). No echoed
+    /// restore position to suppress here — ticks begin only once real
+    /// playback has resumed — so it opts out of `suppressFirst`.
+    private var pushThrottle = PositionPushThrottle(interval: 5, suppressFirst: false)
 
     /// Whether the opening position has been settled against the server.
     ///
@@ -622,24 +626,25 @@ final class AudioPlayer {
 
     // MARK: - Persistence
 
-    /// Record where the listener is. `force` marks a moment worth a round trip
-    /// of its own — a pause, a backgrounding, a close; the steady ticks queue
-    /// and go out with the next push.
+    /// Record where the listener is. The write into the replica and the
+    /// outbox happens on every tick, unconditionally — cheap even at twice a
+    /// second, since `SyncEngine.record` coalesces on kind (#1666). `force`
+    /// decides only whether this tick is also worth a round trip of its own —
+    /// a pause, a backgrounding, a close — as opposed to the steady ticks,
+    /// which still queue immediately but push at most once every five
+    /// seconds.
     private func persistPosition(force: Bool) async {
         // Nothing may be written before the opening position has been settled
         // against the server: every write carries a fresh clock and would beat
         // the very position the reconcile is fetching.
         guard let book, position > 0, positionSettled else { return }
-        // Throttled: the observer fires twice a second, the server needs it
-        // every few.
-        guard force || Date().timeIntervalSince(lastPersist) > 5 else { return }
-        lastPersist = Date()
+        let push = pushThrottle.shouldPush(force: force)
         await UserDataService.saveProgress(
             ProgressUpdate(
                 bookUUID: book.uuid, format: .audio, epubCFI: nil,
                 audioPositionSeconds: position, bookFileID: fileID
             ),
-            push: force
+            push: push
         )
     }
 

--- a/omnibus-ios/omnibus/Offline/PositionPushThrottle.swift
+++ b/omnibus-ios/omnibus/Offline/PositionPushThrottle.swift
@@ -35,9 +35,17 @@ struct PositionPushThrottle {
     }
 
     /// Whether the caller should also push over the network right now.
+    ///
+    /// The first decision always clears `suppressNext`, whether or not it was
+    /// forced — a forced call (a background/close racing ahead of any
+    /// relocate) still means the echo has been "seen" and must not go on
+    /// suppressing a later, unrelated non-forced relocate. Only a first
+    /// decision that was itself non-forced takes the early-suppress return;
+    /// a forced first call falls through to the normal push logic below.
     mutating func shouldPush(force: Bool, now: Date = Date()) -> Bool {
-        if suppressNext, !force {
-            suppressNext = false
+        let wasSuppressed = suppressNext
+        suppressNext = false
+        if wasSuppressed, !force {
             return false
         }
         guard force || now.timeIntervalSince(lastPush) > interval else { return false }

--- a/omnibus-ios/omnibus/Offline/PositionPushThrottle.swift
+++ b/omnibus-ios/omnibus/Offline/PositionPushThrottle.swift
@@ -1,0 +1,47 @@
+//  PositionPushThrottle.swift
+//  When a relocate is also worth a network round trip.
+//
+//  The reader, the comic pager, and the audio player all write every relocate
+//  into the replica and the outbox unconditionally — that write is a local
+//  SQLite put, cheap regardless of how often it happens, and it is what makes
+//  a position survive a force-quit (#1666). This governs only the optional
+//  extra step on top of that: whether *this* relocate is also pushed over the
+//  network right now, or left to go out with the next scheduled push.
+
+import Foundation
+
+/// A per-book decision of whether the current relocate is worth a round trip
+/// of its own. `force` (a close, a backgrounding) always says yes; otherwise
+/// at most one push escapes per `interval`, and everything in between still
+/// lands in the outbox — coalesced by `SyncEngine`, so a burst collapses to
+/// one queued op carrying the newest position.
+struct PositionPushThrottle {
+    private var lastPush = Date.distantPast
+    private var suppressNext: Bool
+    private let interval: TimeInterval
+
+    /// `suppressFirst` skips arming the window on the very first decision,
+    /// for a caller whose first relocate is a restored position echoed back
+    /// at open rather than a real page turn — the epub.js `relocate` that
+    /// fires the instant `ReaderController.configure` sets the starting CFI,
+    /// and the comic pager's equivalent `page = start` in `prepare`. Left
+    /// armed, that echo would consume the window and make the first real
+    /// page turn wait out a throttle nobody meant to apply to it. The audio
+    /// player has no such echo — its ticks begin only once real playback has
+    /// resumed — so it opts out.
+    init(interval: TimeInterval, suppressFirst: Bool = true) {
+        self.interval = interval
+        self.suppressNext = suppressFirst
+    }
+
+    /// Whether the caller should also push over the network right now.
+    mutating func shouldPush(force: Bool, now: Date = Date()) -> Bool {
+        if suppressNext, !force {
+            suppressNext = false
+            return false
+        }
+        guard force || now.timeIntervalSince(lastPush) > interval else { return false }
+        lastPush = now
+        return true
+    }
+}

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -77,7 +77,9 @@ struct ReaderView: View {
     /// time: a wall-clock span counted a book left open overnight as eight
     /// hours read.
     @State private var sessionStart: Date?
-    @State private var lastSave = Date.distantPast
+    /// Governs whether a relocate is also pushed over the network, on top of
+    /// the unconditional local write every one of them gets (#1666).
+    @State private var pushThrottle = PositionPushThrottle(interval: 4)
     /// Auto read-status for the open book — unread marks reading on open, the
     /// book's end marks finished. Created in `prepare`, driven by relocates.
     @State private var autoStatus: ReadStatusAuto?
@@ -722,17 +724,17 @@ struct ReaderView: View {
         }
     }
 
-    /// Record where the reader is. `force` marks the moments that are worth a
-    /// round trip of their own — a close, a backgrounding — as opposed to the
-    /// steady trickle of page turns, which queue and go out with the next
-    /// push. The position is durable either way; only its latency differs.
+    /// Record where the reader is. The write into the replica and the outbox
+    /// happens on every relocate, unconditionally — that is what makes the
+    /// position survive a force-quit (#1666). `force` decides only whether
+    /// this relocate is also worth a round trip of its own — a close, a
+    /// backgrounding — as opposed to the steady trickle of page turns, which
+    /// still queue immediately but push at most once every four seconds.
     private func persist(force: Bool) async {
         guard let cfi = controller.location?.cfi else { return }
-        guard force || Date().timeIntervalSince(lastSave) > 4 else { return }
-        lastSave = Date()
         await UserDataService.saveProgress(
             ProgressUpdate(bookUUID: book.uuid, format: .epub, epubCFI: cfi, audioPositionSeconds: nil),
-            push: force
+            push: pushThrottle.shouldPush(force: force)
         )
         await checkpointSessionIfStale()
     }

--- a/omnibus-ios/omnibusTests/PositionPushThrottleTests.swift
+++ b/omnibus-ios/omnibusTests/PositionPushThrottleTests.swift
@@ -1,0 +1,90 @@
+//  PositionPushThrottleTests.swift
+//  The reader, the comic pager, and the audio player all share one throttle
+//  for deciding whether a relocate is *also* worth a network round trip — the
+//  local write into the replica and the outbox happens on every relocate
+//  regardless, in the reader/pager/player code that calls this. These pin the
+//  throttle's decisions in isolation: force always pushes, the window holds
+//  back everything else, and the restored-position echo at open doesn't spend
+//  it before the first real page turn arrives (#1666).
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+@Suite("Position push throttle")
+struct PositionPushThrottleTests {
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("the very first relocate is suppressed so it can't arm the window")
+    func firstRelocateDoesNotPush() {
+        var throttle = PositionPushThrottle(interval: 4)
+        // This stands for the restore relocate epub.js posts the instant
+        // `configure` sets the starting CFI — not a page turn, so it must not
+        // spend the window the first real one needs.
+        #expect(throttle.shouldPush(force: false, now: epoch) == false)
+    }
+
+    @Test("the first real relocate after the restore echo pushes immediately")
+    func firstRealRelocatePushesRightAway() {
+        var throttle = PositionPushThrottle(interval: 4)
+        _ = throttle.shouldPush(force: false, now: epoch) // the restore echo
+        // Arriving a moment later — nowhere near the four-second window —
+        // this must still push, because the echo never armed it.
+        #expect(throttle.shouldPush(force: false, now: epoch.addingTimeInterval(0.2)) == true)
+    }
+
+    @Test("a rapid burst pushes once and throttles the rest, but every one still belongs in the replica")
+    func burstPushesOnceButEveryPositionIsDurable() {
+        var throttle = PositionPushThrottle(interval: 4)
+        _ = throttle.shouldPush(force: false, now: epoch) // restore echo, consumed
+
+        // Three page turns a few hundred milliseconds apart — well inside the
+        // four-second window, the way a reader flipping pages quickly does.
+        var replica: [String] = []
+        let turns = ["page-1", "page-2", "page-3"]
+        var pushed: [Bool] = []
+        for (offset, cfi) in turns.enumerated() {
+            let now = epoch.addingTimeInterval(0.2 + Double(offset) * 0.3)
+            // The caller writes to the replica on every call, unconditionally
+            // — `shouldPush`'s answer only decides the extra network push.
+            replica.append(cfi)
+            pushed.append(throttle.shouldPush(force: false, now: now))
+        }
+
+        #expect(pushed == [true, false, false])
+        // The bug this fixes: the old guard returned before writing anything
+        // at all whenever it wasn't going to push, so a throttled burst left
+        // the replica holding whatever the *first* call wrote — or nothing.
+        // Every relocate reaching the replica means the newest one wins.
+        #expect(replica.last == "page-3")
+    }
+
+    @Test("force always pushes, resetting the window")
+    func forcePushesRegardlessOfTiming() {
+        var throttle = PositionPushThrottle(interval: 4)
+        _ = throttle.shouldPush(force: false, now: epoch) // restore echo
+        _ = throttle.shouldPush(force: false, now: epoch.addingTimeInterval(0.1)) // pushes, arms window
+        // A backgrounding a moment later, well inside the window a page turn
+        // would still be throttled by.
+        #expect(throttle.shouldPush(force: true, now: epoch.addingTimeInterval(0.2)) == true)
+    }
+
+    @Test("a relocate after the window has elapsed pushes again")
+    func pushesAgainOnceTheWindowElapses() {
+        var throttle = PositionPushThrottle(interval: 4)
+        _ = throttle.shouldPush(force: false, now: epoch) // restore echo
+        _ = throttle.shouldPush(force: false, now: epoch.addingTimeInterval(0.1)) // pushes
+        #expect(
+            throttle.shouldPush(force: false, now: epoch.addingTimeInterval(4.2)) == true
+        )
+    }
+
+    @Test("opting out of suppression pushes the very first relocate")
+    func suppressFirstCanBeDisabled() {
+        // The audio player's ticks begin only once real playback has resumed
+        // — there's no separate restored-position echo to guard against.
+        var throttle = PositionPushThrottle(interval: 5, suppressFirst: false)
+        #expect(throttle.shouldPush(force: false, now: epoch) == true)
+    }
+}

--- a/omnibus-ios/omnibusTests/PositionPushThrottleTests.swift
+++ b/omnibus-ios/omnibusTests/PositionPushThrottleTests.swift
@@ -87,4 +87,19 @@ struct PositionPushThrottleTests {
         var throttle = PositionPushThrottle(interval: 5, suppressFirst: false)
         #expect(throttle.shouldPush(force: false, now: epoch) == true)
     }
+
+    @Test("a forced call before any relocate still clears the suppression")
+    func forcedFirstCallDoesNotLeaveSuppressionArmed() {
+        // A background/close can race ahead of the restore echo — the reader
+        // opens and is immediately backgrounded before epub.js ever posts a
+        // relocate. That forced call must still count as "the first decision
+        // has been made": a later, unrelated non-forced relocate is governed
+        // by the interval alone, not left suppressed forever because the
+        // echo it was meant to catch never actually arrived through here.
+        var throttle = PositionPushThrottle(interval: 4)
+        #expect(throttle.shouldPush(force: true, now: epoch) == true)
+        // Long past the window, so this is unambiguously a normal push, not
+        // a suppressed one — pinning the regression this test guards.
+        #expect(throttle.shouldPush(force: false, now: epoch.addingTimeInterval(10)) == true)
+    }
 }


### PR DESCRIPTION
## Summary
- Closes #1666
- `ReaderView.persist(force:)`, `ComicReaderView.persist(force:)`, and `AudioPlayer.persistPosition(force:)` all returned early on their throttle guard *before* calling `UserDataService.saveProgress`, so a relocate inside the window wrote nothing to the local replica or the outbox — only an explicit `force: true` flush (close, backgrounding) did. A force-quit from the app switcher reaches neither, so the whole session's reading position was lost locally, with no local copy for any later sync to recover.
- Split "persist locally" from "push over the network": the local SQLite write and outbox enqueue now happen on every relocate unconditionally (cheap — `SyncEngine.record` coalesces on kind), and a new shared `PositionPushThrottle` (`omnibus-ios/omnibus/Offline/PositionPushThrottle.swift`) governs only whether that relocate is *also* worth a network round trip right now. It also stops the restored position an open echoes back from arming the four-second window before the first real page turn gets a chance to push.
- Applied identically to the EPUB reader, the comic pager, and the audio player (whose local write was equally gated even though its throttle is load-bearing for its twice-a-second observer).

## Test plan
- [x] Manual code review: traced every `persist(force:)` call site in `ReaderView.swift`, `ComicReaderView.swift`, and `AudioPlayer.swift`; confirmed `UserDataService.saveProgress` (and therefore `Cache.write` + the coalesced outbox `enqueue`) is now reached on every relocate regardless of the throttle's answer, and that only the `push:` flag passed to it is gated.
- [x] Added `omnibus-ios/omnibusTests/PositionPushThrottleTests.swift` covering `PositionPushThrottle`: the restored-position echo never arms the window, the first real relocate after it still pushes immediately, a rapid burst pushes once but every relocate still reaches the replica (newest wins, not first), `force` always pushes and rearms the window, the window releases another push once it elapses, and `suppressFirst: false` (the audio player) pushes its very first tick.
- [ ] `just ios-build` — **not run**: this sandbox has no macOS/Xcode toolchain (`xcodebuild`, `just`, and `swift`/`swiftc` are all absent), so `xcodebuild`-based verification is not possible here. Manually checked brace/paren balance and that no stray references to the removed `lastSave`/`lastPersist` state remain anywhere in the tree.
- [ ] `just ios-test` — **not run**, same reason. `PositionPushThrottleTests.swift` sits under `omnibusTests/`, which is a filesystem-synchronized Xcode group, so it will be picked up automatically by `-only-testing:omnibusTests` without any project-file edit.

## Notes
- `omnibus-ios/omnibus/Offline/PositionPushThrottle.swift` is a new shared type; added to the `Offline/` entry in `docs/architecture.md`'s iOS module map per the end-of-session docs-sync rule.
- Please run `just ios-build` and `just ios-test` in CI/on a macOS machine before merging, since I could not execute them locally in this environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_0182rNYP8deiizZja8P3mYyQ)_