### PR TITLE
refactor: add anonymous-401 coverage and a retry path for the registration toggle (#1592)

### DIFF
--- a/frontend/src/pages/settings/users.rs
+++ b/frontend/src/pages/settings/users.rs
@@ -230,6 +230,13 @@ fn apply_registration_load(
 /// affordance shown while `error` is set and `confirmed` never arrived —
 /// clicking it re-runs the same fetch rather than leaving the checkbox
 /// `disabled` until a full page reload.
+///
+/// `reload` doubles as a generation counter: each spawned fetch snapshots
+/// the value it was started with and, on completion, only applies its
+/// result if `reload` still reads the same value. Without that guard a
+/// slow first load and a fast retry can land out of order — the retry's
+/// success would be immediately clobbered by the original request's later
+/// (stale) failure.
 #[component]
 fn RegistrationToggle() -> Element {
     let confirmed = use_signal(|| Option::<bool>::None);
@@ -239,10 +246,16 @@ fn RegistrationToggle() -> Element {
     let mut reload = use_signal(|| 0u32);
 
     use_effect(move || {
-        let _ = reload();
+        let generation = reload();
         spawn(async move {
             let result = data::registration_status().await;
-            apply_registration_load(result, confirmed, shown, error);
+            // A newer load (another mount-effect run, or a Retry click) has
+            // since started — this one is superseded, so its result (which
+            // may be a stale failure) must not overwrite what that newer
+            // load already applied or is about to apply.
+            if reload() == generation {
+                apply_registration_load(result, confirmed, shown, error);
+            }
         });
     });
 

--- a/frontend/src/pages/settings/users.rs
+++ b/frontend/src/pages/settings/users.rs
@@ -190,6 +190,27 @@ fn registration_toggle_handler(
     }
 }
 
+/// Applies the outcome of a self-registration status fetch to the toggle's
+/// signals. Free function (rather than inlined in the effect) so both the
+/// initial load and a retry drive the exact same match, and so a test can
+/// exercise the `Err` branch without spawning an async task — mirrors
+/// [`registration_toggle_handler`].
+fn apply_registration_load(
+    result: Result<bool, String>,
+    mut confirmed: Signal<Option<bool>>,
+    mut shown: Signal<Option<bool>>,
+    mut error: Signal<Option<String>>,
+) {
+    match result {
+        Ok(open) => {
+            confirmed.set(Some(open));
+            shown.set(Some(open));
+            error.set(None);
+        }
+        Err(e) => error.set(Some(e)),
+    }
+}
+
 /// Self-registration switch. Renders above the users table because it governs
 /// who may join without an admin creating the account first.
 ///
@@ -203,23 +224,25 @@ fn registration_toggle_handler(
 /// flips the DOM checkbox *natively*: if the rendered value never moved,
 /// Dioxus would diff it as unchanged, emit no patch, and a rejected save would
 /// leave the box sitting in a state the server refused.
+///
+/// A failed initial load must not brick the control forever: `reload` is
+/// read by the effect (so it fires once on mount) and bumped by the "Retry"
+/// affordance shown while `error` is set and `confirmed` never arrived —
+/// clicking it re-runs the same fetch rather than leaving the checkbox
+/// `disabled` until a full page reload.
 #[component]
 fn RegistrationToggle() -> Element {
-    let mut confirmed = use_signal(|| Option::<bool>::None);
-    let mut shown = use_signal(|| Option::<bool>::None);
-    let mut error = use_signal(|| None::<String>);
+    let confirmed = use_signal(|| Option::<bool>::None);
+    let shown = use_signal(|| Option::<bool>::None);
+    let error = use_signal(|| None::<String>);
     let saving = use_signal(|| false);
+    let mut reload = use_signal(|| 0u32);
 
     use_effect(move || {
+        let _ = reload();
         spawn(async move {
-            match data::registration_status().await {
-                Ok(open) => {
-                    confirmed.set(Some(open));
-                    shown.set(Some(open));
-                    error.set(None);
-                }
-                Err(e) => error.set(Some(e)),
-            }
+            let result = data::registration_status().await;
+            apply_registration_load(result, confirmed, shown, error);
         });
     });
 
@@ -227,6 +250,7 @@ fn RegistrationToggle() -> Element {
 
     let is_on = shown() == Some(true);
     let status = registration_status_line(confirmed());
+    let can_retry = error().is_some() && confirmed().is_none();
 
     rsx! {
         section { class: "card", "data-testid": "registration-card",
@@ -252,6 +276,15 @@ fn RegistrationToggle() -> Element {
                     class: "settings-status error",
                     "data-testid": "registration-error",
                     "{err}"
+                }
+            }
+            if can_retry {
+                button {
+                    r#type: "button",
+                    class: "btn ghost sm",
+                    "data-testid": "registration-retry",
+                    onclick: move |_| reload.with_mut(|n| *n += 1),
+                    "Retry"
                 }
             }
         }

--- a/frontend/src/pages/settings/users/tests.rs
+++ b/frontend/src/pages/settings/users/tests.rs
@@ -168,3 +168,62 @@ fn registration_toggle_handler_moves_the_checkbox_but_not_the_subtitle() {
     }
     VirtualDom::new(AssertSplit).rebuild_in_place();
 }
+
+#[cfg(feature = "server")]
+#[test]
+fn apply_registration_load_records_the_error_and_leaves_the_checkbox_unresolved_on_err() {
+    #[component]
+    fn AssertErr() -> Element {
+        let confirmed = Signal::new(None::<bool>);
+        let shown = Signal::new(None::<bool>);
+        let error = Signal::new(None::<String>);
+
+        apply_registration_load(Err("network error".into()), confirmed, shown, error);
+
+        // The Err branch must not brick the control silently: the message
+        // lands in `error`, but `confirmed` staying `None` is what the
+        // checkbox's `disabled` guard reads — this is the state a
+        // permanently-disabled checkbox would otherwise be stuck in.
+        assert_eq!(error(), Some("network error".to_string()));
+        assert_eq!(
+            confirmed(),
+            None,
+            "an errored load must not resolve the value"
+        );
+        assert_eq!(shown(), None);
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertErr).rebuild_in_place();
+}
+
+#[cfg(feature = "server")]
+#[test]
+fn apply_registration_load_re_enables_the_checkbox_when_a_retry_succeeds() {
+    #[component]
+    fn AssertRetrySucceeds() -> Element {
+        let confirmed = Signal::new(None::<bool>);
+        let shown = Signal::new(None::<bool>);
+        let error = Signal::new(None::<String>);
+
+        // First, the initial load fails — same call the mount effect makes.
+        apply_registration_load(Err("network error".into()), confirmed, shown, error);
+        assert!(confirmed().is_none(), "precondition: checkbox is disabled");
+
+        // The Retry affordance re-runs the identical fetch/apply path; a
+        // successful retry must resolve `confirmed` (which lifts the
+        // checkbox's `disabled` guard) and clear the stale error.
+        apply_registration_load(Ok(true), confirmed, shown, error);
+
+        assert_eq!(
+            confirmed(),
+            Some(true),
+            "a successful retry must re-enable the checkbox"
+        );
+        assert_eq!(shown(), Some(true));
+        assert_eq!(error(), None, "a successful retry must clear the old error");
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertRetrySucceeds).rebuild_in_place();
+}

--- a/server/src/backend/settings/tests.rs
+++ b/server/src/backend/settings/tests.rs
@@ -850,6 +850,24 @@ async fn api_post_registration_rejects_non_admin() {
 }
 
 #[tokio::test]
+async fn api_post_registration_returns_401_when_anonymous() {
+    let (app, _, _) = fixture().await;
+    let body = serde_json::json!({ "enabled": true });
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/settings/registration")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
 async fn api_post_registration_returns_500_on_db_failure() {
     let (app, _state, pool) = fixture().await;
     let admin = auth_test_support::create_admin(&pool, "admin").await;


### PR DESCRIPTION
## Summary
- Closes #1592
- Adds `api_post_registration_returns_401_when_anonymous` to `server/src/backend/settings/tests.rs`, matching the `_returns_401_when_anonymous` pattern every sibling admin route (`/api/reindex`, `/api/scan-library`, `/api/fts/rebuild`, `/api/settings`) already had — `POST /api/settings/registration` previously only had non-admin (403) coverage.
- `RegistrationToggle` (`frontend/src/pages/settings/users.rs`) no longer disables its checkbox forever after a failed initial load. The load-and-apply logic is extracted into `apply_registration_load`, shared by the mount effect and a new "Retry" affordance shown whenever the load errored and no confirmed value ever arrived.
- Adds two tests exercising `apply_registration_load`'s `Err` branch and confirming a subsequent successful call (what the Retry button drives) re-enables the checkbox and clears the stale error.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus` — 655 passed, 2 failed (both pre-existing and unrelated: `backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` rely on chmod-stripped write bits, which don't block `root` — this sandbox runs as root. Neither test is touched by this change.)
- [x] `cargo test -p omnibus-frontend --features server` — 634 passed, 0 failed
- [x] Manually traced `backend::settings::tests` (32/32 passing, including the new anonymous-401 test) and `pages::settings::users::tests` (12/12 passing, including the two new retry tests)

## Notes
- The issue's illustrative fail-open pattern (`registration_open_or_default`) is deliberately not reused here: that helper governs the *login/register* pages deciding whether to show a signup link, where showing it optimistically is harmless. `RegistrationToggle` is the admin control itself, so on a failed load it stays honestly "unknown" (disabled, `Checking…`) rather than guessing a policy — the fix is a retry path, not fail-open.


---
_Generated by [Claude Code](https://claude.ai/code/session_0182rNYP8deiizZja8P3mYyQ)_