### PR TITLE
refactor: wire CheckInView to the tested CheckInFlow decision helpers (#1644)

### DIFF
--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
@@ -193,7 +193,9 @@ struct CheckInView: View {
                     Text("You've already checked in a physical copy of this book.")
                         .font(.ui(14))
                         .foregroundStyle(palette.ink2Color)
-                    detailsLink(uuid: book.uuid, style: .filled)
+                    if let uuid = CheckInFlow.detailUUID(for: outcome) {
+                        detailsLink(uuid: uuid, style: .filled)
+                    }
 
                 case let .onWishlist(book):
                     resultCard(
@@ -205,7 +207,9 @@ struct CheckInView: View {
                         .font(.ui(14))
                         .foregroundStyle(palette.ink2Color)
                     checkInButton(book: book, isbn: book.isbn, label: "Check in this copy")
-                    detailsLink(uuid: book.uuid, style: .quiet)
+                    if let uuid = CheckInFlow.detailUUID(for: outcome) {
+                        detailsLink(uuid: uuid, style: .quiet)
+                    }
 
                 case let .inLibraryUnowned(book):
                     resultCard(
@@ -213,7 +217,9 @@ struct CheckInView: View {
                         cover: .library(uuid: book.uuid),
                         badge: "In your library", tint: palette.accentColor
                     )
-                    noteField
+                    if CheckInFlow.showsNoteField(for: outcome) {
+                        noteField
+                    }
                     checkInButton(book: book, isbn: book.isbn, label: "Check in this copy")
 
                 case let .closeMatch(book, scanned):


### PR DESCRIPTION
## Summary
- Closes #1644
- `CheckInFlow.showsNoteField(for:)` and `CheckInFlow.detailUUID(for:)` were defined, documented, and unit-tested, but never called from production code — `CheckInView`'s `switch outcome` re-decided the same two things inline (note field under `.inLibraryUnowned`, "Go to Book Details" link under `.alreadyOwned`/`.onWishlist`, computing the uuid itself). This let the tested helpers and the view's actual behavior silently drift apart, with no test able to catch it.
- **Direction chosen: Option A — wire the view to the tested helpers.** I compared the two logic paths outcome-by-outcome across every `ScanOutcome` case before deciding:
  - `showsNoteField`: returns `true` only for `.inLibraryUnowned`. The view rendered `noteField` only under that same case, for every other case (`.alreadyOwned`, `.onWishlist`, `.closeMatch`, `.notInLibrary`, `.unresolved`) — no note field. **Agreement.**
  - `detailUUID`: returns `book.uuid` only for `.alreadyOwned`/`.onWishlist`, `nil` otherwise. The view called `detailsLink(uuid: book.uuid, ...)` only under those same two cases, and nowhere else. **Agreement.**
  - Since the two paths fully agreed on every case (no divergence found), I picked Option A per the issue's guidance rather than Option B — the helpers are correct and now genuinely exercised by production code instead of being dead code with tests that assert nothing about the running app.
- Change is surgical: three call sites in `CheckInView.swift`'s `outcomeSection` now gate on `CheckInFlow.showsNoteField(for: outcome)` / `CheckInFlow.detailUUID(for: outcome)` instead of re-deciding inline. No other logic touched.

## Test plan
- [ ] `just ios-test` (omnibusTests unit suite) — **could not run**: this sandbox is Linux with no Xcode/macOS toolchain (no `xcodebuild`, no `swift`/`swiftc`, no `just`). Verified by careful manual trace instead:
  - Confirmed brace/paren balance of the edited file programmatically (a Python scan of every `{`/`}` in `CheckInView.swift` ends at depth 0, no negative dips) — no syntax errors introduced.
  - Traced every `ScanOutcome` case in `outcomeSection`'s `switch outcome` against `CheckInFlow.showsNoteField`/`detailUUID`'s case-by-case logic (documented above) and confirmed the two now agree by construction, since the view calls the same functions the tests exercise.
  - `CheckInFlowTests.swift`'s existing `noteFieldShowsOnlyOnInLibraryUnowned` and `detailUUIDCoversAlreadyOwnedAndOnWishlistOnly` tests require no changes — they already assert the exact behavior now wired into production, so they continue to compile and pass, and now actually cover the code path the view runs (previously they only exercised dead code).
  - Confirmed `outcome` (the switch's own scrutinee, bound as the `outcomeSection(_ outcome:)` parameter) remains in scope inside each `case` body, so `CheckInFlow.showsNoteField(for: outcome)` / `CheckInFlow.detailUUID(for: outcome)` compile without needing to reconstruct the enum case from the pattern-bound `book`.
  - Confirmed no other file references the old inline pattern or the two `CheckInFlow` functions in a way this change would break (`grep` across `omnibus-ios/` found only the definitions, the tests, and the two call sites just edited).

## Notes
- No behavior change to the check-in flow: `detailUUID(for:)` returns the same `book.uuid` the view previously read directly, and `showsNoteField(for:)` gates the identical case the view previously hardcoded. This is a refactor of *how* the decision is made (single source of truth), not a change to *what* it decides.


---
_Generated by [Claude Code](https://claude.ai/code/session_0182rNYP8deiizZja8P3mYyQ)_