### PR TITLE
refactor: bundle format-availability flags in title_and_cta_section (#1673)

### DIFF
--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -124,9 +124,11 @@ pub(super) fn render_loaded_mobile(view: MobileBookView) -> Element {
                 &title,
                 &meta_line,
                 &b.formats,
-                has_ebook,
-                has_comic,
-                has_audio,
+                FormatAvailability {
+                    has_ebook,
+                    has_comic,
+                    has_audio,
+                },
                 &epub_files,
                 &audio_files,
             )}
@@ -242,20 +244,32 @@ fn hero_section(
     }
 }
 
+/// Which formats a book has, bundled so [`title_and_cta_section`] doesn't
+/// thread three adjacent same-typed `bool`s with no compiler-enforced
+/// ordering — see the `derive_loaded_view` fields this is built from.
+#[derive(Copy, Clone)]
+struct FormatAvailability {
+    has_ebook: bool,
+    has_comic: bool,
+    has_audio: bool,
+}
+
 /// Title column (title / meta line / format badges) plus the multi-file
 /// action row — a picker for a multi-file format, a direct link otherwise.
-#[allow(clippy::too_many_arguments)]
 fn title_and_cta_section(
     uuid: &str,
     title: &str,
     meta_line: &str,
     formats: &[String],
-    has_ebook: bool,
-    has_comic: bool,
-    has_audio: bool,
+    availability: FormatAvailability,
     epub_files: &[BookFileInfo],
     audio_files: &[BookFileInfo],
 ) -> Element {
+    let FormatAvailability {
+        has_ebook,
+        has_comic,
+        has_audio,
+    } = availability;
     rsx! {
         div { class: "m-bd-titlecol",
             h2 { class: "m-bd-title", span { class: "m-em", "{title}" } }


### PR DESCRIPTION
## Summary
- Closes #1673
- `title_and_cta_section` in `frontend/src/pages/book_detail/mobile.rs` took 9 flat parameters, including three adjacent, same-typed `bool`s (`has_ebook`, `has_comic`, `has_audio`) with no compiler-enforced ordering, behind a bare `#[allow(clippy::too_many_arguments)]` with no rationale.
- Bundled the three bools into a small `FormatAvailability` struct (`#[derive(Copy, Clone)]`), mirroring the `ShelfWiring`/`FetchSignals`/`SuggestionPools` precedent already used by `wire_landing_effects` in `frontend/src/pages/landing.rs`. This drops the arg count from 9 to 7, which is at/under clippy's default `too-many-arguments-threshold`, so the `#[allow(...)]` is removed entirely rather than given a rationale comment.
- Considered deriving `has_ebook`/`has_comic`/`has_audio` from `epub_files`/`audio_files` at the call site instead (per the issue's optional note), but `has_ebook` is computed in `derive_loaded_view` (`view.rs`) as "formats contains epub **or pdf**", while `epub_files` (built in `split_meta_and_files`) only filters for the `EPUB` format — so a PDF-only book would flip `has_ebook` to `false` if derived from `epub_files.is_empty()`, silently dropping its "Read" CTA. Bundling avoids that behavior change; the redundancy is between two independently-correct derivations, not a duplicate one.

## Test plan
- [x] `cargo fmt` — no diff
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, clean (confirms the arg count is now under clippy's threshold without any allow)
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 635 passed; 0 failed

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (leaving unlabeled)

## Notes
- Pure refactor, no behavior change. Only `frontend/src/pages/book_detail/mobile.rs` touched.
- Could not self-assign via the automation this PR was opened from; please assign as needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UBn2kePwNR7Bjx8BV1z8mD)_