### PR TITLE
fix: boot the iOS reader's page at the live position after a background reload (#1656)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -328,6 +328,18 @@ selection engine above, and the web copy has since moved its pagination onto
 `location.start.displayed` and still uses WebKit's own selection. Changing one
 does not change the other — check both when touching reader behaviour.
 
+**The page is booted more than once per book.** iOS reclaims the web-content
+process of an app that has been in the background a while, and `reader.html` is
+loaded again when the reader comes back — announcing `hostReady` a second time
+and taking the stage's whole state with it. So nothing a boot reads may be a
+snapshot of the open: `ReaderController.restoreCFI` tracks every relocate rather
+than holding the CFI `configure` was given (booting the fresh page at the opening
+position undid the session's reading, and the relocate that followed persisted
+and pushed the revert), and the marks the outgoing page had painted go back on
+the pending queue. `webViewWebContentProcessDidTerminate` makes the recovery
+explicit, deferring the reload past a backgrounding rather than feeding a fresh
+process to the same reclaim.
+
 **The models are hand-mirrored, so they drift silently.** `Models/` restates the
 `shared/` wire DTOs in Swift with no generator and no compiler tying the two
 together, so a field added or renamed on the Rust side surfaces as a runtime 422

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -681,6 +681,9 @@ struct ReaderView: View {
             // backgrounded, and restarting the clock there would throw away the
             // reading time before the interruption.
             if sessionStart == nil { sessionStart = Date() }
+            // A page whose process was reclaimed while the app was away is
+            // reloaded here, where it can be held on to (#1656).
+            controller.reloadIfNeeded()
         }
         LifecycleSync.shared.didOpenBook()
         await reconcileWithServer(remote: remote)

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -226,11 +226,26 @@ final class ReaderController: NSObject {
 
     fileprivate var webView: WKWebView?
     private var book: Book?
-    private var startCFI: String?
-    private var pendingHighlights: [Highlight] = []
+    /// Where a boot of the page picks up — the position the book opened at,
+    /// then every position the reader reaches.
+    ///
+    /// Kept current because the page is booted more than once: iOS reclaims the
+    /// web-content process of an app that has been in the background a while,
+    /// and the reader comes back to a reloaded `reader.html`. Booting that fresh
+    /// page from the *opening* position threw away everything read since — and
+    /// the relocate that followed the restore persisted the revert and pushed it
+    /// to every other device (#1656).
+    private(set) var restoreCFI: String?
+    /// The marks the next `ready` has to paint. Refilled from what the outgoing
+    /// page was holding whenever the page is replaced.
+    private(set) var pendingHighlights: [Highlight] = []
     /// What is currently drawn on the page, so a set arriving after first paint
     /// can be applied as a diff instead of a redraw.
     private var drawnHighlights: [Highlight] = []
+    /// A reload owed to a web-content process that went away while the app was
+    /// in the background, where reloading would only feed another one to the
+    /// same reclaim. Settled by `reloadIfNeeded` on the way back.
+    private var awaitingReload = false
 
     override init() {
         settings = ReaderSettings.load()
@@ -239,7 +254,7 @@ final class ReaderController: NSObject {
 
     func configure(book: Book, startCFI: String?, highlights: [Highlight]) {
         self.book = book
-        self.startCFI = startCFI
+        restoreCFI = startCFI
         pendingHighlights = highlights
     }
 
@@ -352,6 +367,46 @@ final class ReaderController: NSObject {
         webView = nil
     }
 
+    // MARK: - Page lifetime
+
+    /// WebKit tore down the process the page was living in.
+    ///
+    /// The routine end of a long backgrounding rather than a crash of ours — iOS
+    /// reclaims the memory of a web-content process whose app is away — and what
+    /// it leaves behind is a blank view. Recover deliberately rather than
+    /// relying on WebKit's own reload-when-visible, but not while the app is
+    /// still in the background: a process launched there is only fed to the same
+    /// reclaim, and the book's bytes are re-read to no purpose.
+    func webContentProcessDidTerminate() {
+        prepareForReboot()
+        awaitingReload = true
+        reloadIfNeeded()
+    }
+
+    /// Reload a page WebKit took away, if one is owed. Called on the way back to
+    /// the foreground, and a no-op when nothing is owed.
+    func reloadIfNeeded() {
+        guard awaitingReload, UIApplication.shared.applicationState != .background,
+              let webView, let url = ReaderWebView.entryURL
+        else { return }
+        awaitingReload = false
+        // `reload()` is unreliable after a terminated process — the URL it would
+        // reload can already be gone. Loading the entry point again is the same
+        // navigation and doesn't depend on what survived.
+        webView.load(URLRequest(url: url))
+    }
+
+    /// Hand what an outgoing page was holding to the one replacing it: the marks
+    /// it had painted go back on the queue, and the reader is not ready again
+    /// until the new page says so — so the loading overlay covers the reboot
+    /// instead of a blank stage standing in for the book.
+    private func prepareForReboot() {
+        guard isReady else { return }
+        isReady = false
+        pendingHighlights = drawnHighlights
+        drawnHighlights = []
+    }
+
     private func applySettings(changedFrom old: ReaderSettings) {
         guard isReady else { return }
         if settings.fontSize != old.fontSize {
@@ -379,7 +434,15 @@ final class ReaderController: NSObject {
     }
 
     fileprivate func bootReader() {
-        guard let book else { return }
+        guard let script = bootScript() else { return }
+        run(script)
+    }
+
+    /// The `OmnibusReader.init` call that boots the page, at `restoreCFI` and in
+    /// the settings in force now — both read at boot time, so a reboot lands
+    /// where the reader actually is rather than where the book was opened.
+    func bootScript() -> String? {
+        guard let book else { return nil }
         var options: [String: Any] = [
             "theme": settings.theme,
             "fontSize": settings.fontSize,
@@ -392,20 +455,27 @@ final class ReaderController: NSObject {
             "allowScriptedContent": true,
             "locationsKey": book.uuid,
         ]
-        if let startCFI { options["cfi"] = startCFI }
+        if let restoreCFI { options["cfi"] = restoreCFI }
 
         let json = (try? JSONSerialization.data(withJSONObject: options))
             .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
         let fileURL = "omnibus-reader://book/\(book.uuid).epub"
-        run("OmnibusReader.init('stage', \(fileURL.jsQuoted), \(json))")
+        return "OmnibusReader.init('stage', \(fileURL.jsQuoted), \(json))"
     }
 
-    fileprivate func handle(message: [String: Any]) {
+    /// Route one message from the glue — the single entry point for everything
+    /// the page reports.
+    func handle(message: [String: Any]) {
         guard let type = message["type"] as? String else { return }
         let payload = message["payload"] as? String
 
         switch type {
         case "hostReady":
+            // Announced on every load of `reader.html`, so a second one is the
+            // page having been replaced under us — whether we asked for the
+            // reload or WebKit did it on its own when the view came back.
+            prepareForReboot()
+            awaitingReload = false
             bootReader()
 
         case "status":
@@ -434,6 +504,10 @@ final class ReaderController: NSObject {
                   let decoded = try? JSONDecoder().decode(RelocateData.self, from: data)
             else { return }
             location = decoded
+            // Where a reboot of the page picks up. Relocates are muted until a
+            // restore has settled, so this only ever moves to a position the
+            // reader was actually shown.
+            if let cfi = decoded.cfi?.nilIfBlank { restoreCFI = cfi }
 
         case "toc":
             guard let payload, let data = payload.data(using: .utf8),
@@ -509,6 +583,7 @@ struct ReaderWebView: UIViewRepresentable {
         configuration.suppressesIncrementalRendering = false
 
         let webView = AnnotatingWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.isScrollEnabled = false
@@ -520,7 +595,7 @@ struct ReaderWebView: UIViewRepresentable {
 
         controller.webView = webView
 
-        guard let url = URL(string: "\(Self.scheme)://app/reader.html") else { return webView }
+        guard let url = Self.entryURL else { return webView }
         webView.load(URLRequest(url: url))
         return webView
     }
@@ -533,11 +608,17 @@ struct ReaderWebView: UIViewRepresentable {
 
     static let scheme = "omnibus-reader"
 
+    /// The page the web view loads, and loads again to recover from a
+    /// web-content process WebKit reclaimed.
+    static let entryURL = URL(string: "\(scheme)://app/reader.html")
+
     /// Serves the bundled reader assets and the book bytes. Using a custom
     /// scheme (rather than `file://` plus a private preference) keeps
     /// everything on public API and gives epub.js one same-origin space.
     @MainActor
-    final class Coordinator: NSObject, WKScriptMessageHandler, WKURLSchemeHandler {
+    final class Coordinator: NSObject, WKScriptMessageHandler, WKURLSchemeHandler,
+        WKNavigationDelegate
+    {
         private let controller: ReaderController
         private let bookUUID: String
         private var tasks: [ObjectIdentifier: Task<Void, Never>] = [:]
@@ -552,6 +633,12 @@ struct ReaderWebView: UIViewRepresentable {
         ) {
             guard let body = message.body as? [String: Any] else { return }
             self.controller.handle(message: body)
+        }
+
+        /// The page's process went away — see
+        /// `ReaderController.webContentProcessDidTerminate`.
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            controller.webContentProcessDidTerminate()
         }
 
         func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -254,7 +254,11 @@ final class ReaderController: NSObject {
 
     func configure(book: Book, startCFI: String?, highlights: [Highlight]) {
         self.book = book
-        restoreCFI = startCFI
+        // A progress row can hold a blank position, and only the remote read
+        // normalizes one away. "No position" has to reach the glue as an absent
+        // `cfi` rather than an empty one — today `opts.cfi || null` absorbs it,
+        // but that is JS falsiness standing in for a decision this side owes.
+        restoreCFI = startCFI?.nilIfBlank
         pendingHighlights = highlights
     }
 

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -245,7 +245,7 @@ final class ReaderController: NSObject {
     /// A reload owed to a web-content process that went away while the app was
     /// in the background, where reloading would only feed another one to the
     /// same reclaim. Settled by `reloadIfNeeded` on the way back.
-    private var awaitingReload = false
+    private(set) var awaitingReload = false
 
     override init() {
         settings = ReaderSettings.load()
@@ -377,19 +377,23 @@ final class ReaderController: NSObject {
     /// relying on WebKit's own reload-when-visible, but not while the app is
     /// still in the background: a process launched there is only fed to the same
     /// reclaim, and the book's bytes are re-read to no purpose.
-    func webContentProcessDidTerminate() {
+    func webContentProcessDidTerminate(
+        state: UIApplication.State = UIApplication.shared.applicationState
+    ) {
         prepareForReboot()
         awaitingReload = true
-        reloadIfNeeded()
+        reloadIfNeeded(state: state)
     }
 
     /// Reload a page WebKit took away, if one is owed. Called on the way back to
     /// the foreground, and a no-op when nothing is owed.
-    func reloadIfNeeded() {
-        guard awaitingReload, UIApplication.shared.applicationState != .background,
-              let webView, let url = ReaderWebView.entryURL
-        else { return }
+    ///
+    /// `state` is a parameter so the deferral can be exercised from a test,
+    /// which can't foreground or background its host app.
+    func reloadIfNeeded(state: UIApplication.State = UIApplication.shared.applicationState) {
+        guard awaitingReload, state != .background else { return }
         awaitingReload = false
+        guard let webView, let url = ReaderWebView.entryURL else { return }
         // `reload()` is unreliable after a terminated process — the URL it would
         // reload can already be gone. Loading the entry point again is the same
         // navigation and doesn't depend on what survived.

--- a/omnibus-ios/omnibusTests/ReaderRebootTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderRebootTests.swift
@@ -1,5 +1,5 @@
 //  ReaderRebootTests.swift
-//  What the reader hands a page that replaces the one it was reading.
+//  What the reader hands to the page that replaces the one it was reading.
 //
 //  The epub.js stage is booted more than once per book: iOS reclaims the
 //  web-content process of an app that has been in the background a while, and
@@ -10,6 +10,7 @@
 
 import Foundation
 import Testing
+import UIKit
 
 @testable import omnibus
 
@@ -147,10 +148,50 @@ struct ReaderRebootTests {
         let controller = openReader(at: openedAt, holding: [mark("epubcfi(/6/14!/4/2/4,/1:0,/1:9)")])
         try relocate(controller, to: readTo)
 
-        controller.webContentProcessDidTerminate()
+        controller.webContentProcessDidTerminate(state: .active)
 
         #expect(!controller.isReady)
         #expect(controller.pendingHighlights.count == 1)
         #expect(try bootOptions(controller)["cfi"] as? String == readTo)
+    }
+
+    /// Reloading in the background only feeds a fresh process to the same
+    /// reclaim — and re-reads the whole book to do it.
+    @Test("a process lost while the app is away leaves the reload owed until it returns")
+    func reloadIsDeferredPastTheBackground() {
+        let controller = openReader(at: openedAt)
+
+        controller.webContentProcessDidTerminate(state: .background)
+        #expect(controller.awaitingReload)
+
+        // Still away: a background refresh pass must not spend it either.
+        controller.reloadIfNeeded(state: .background)
+        #expect(controller.awaitingReload)
+
+        controller.reloadIfNeeded(state: .active)
+        #expect(!controller.awaitingReload)
+    }
+
+    /// The callback can land either side of the reader's own resume hook, so
+    /// both have to be able to take the reload — and only one of them may.
+    @Test("a process lost as the app returns is reloaded without waiting for the resume hook")
+    func reloadIsTakenWhenTheAppIsAlreadyBack() {
+        let controller = openReader(at: openedAt)
+
+        controller.webContentProcessDidTerminate(state: .inactive)
+
+        #expect(!controller.awaitingReload)
+    }
+
+    @Test("a page WebKit reloaded on its own leaves nothing owed")
+    func webKitsOwnReloadClearsTheDebt() {
+        let controller = openReader(at: openedAt)
+        controller.webContentProcessDidTerminate(state: .background)
+
+        controller.handle(message: ["type": "hostReady"])
+
+        // Otherwise the resume hook loads the page a second time, throwing away
+        // the one that just came back and re-reading the book to do it.
+        #expect(!controller.awaitingReload)
     }
 }

--- a/omnibus-ios/omnibusTests/ReaderRebootTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderRebootTests.swift
@@ -1,0 +1,156 @@
+//  ReaderRebootTests.swift
+//  What the reader hands a page that replaces the one it was reading.
+//
+//  The epub.js stage is booted more than once per book: iOS reclaims the
+//  web-content process of an app that has been in the background a while, and
+//  `reader.html` is loaded again when the reader comes back. Every one of those
+//  boots reads the same state, so these pin what it has to be — the position the
+//  reader actually reached rather than the one the book was opened at, and the
+//  marks the outgoing page was holding (#1656).
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+@MainActor
+private func openReader(at cfi: String?, holding highlights: [Highlight] = [])
+    -> ReaderController
+{
+    let controller = ReaderController()
+    controller.configure(
+        book: Book(
+            id: 1, filename: "hound.epub", title: "The Hound of the Baskervilles",
+            uniqueIdentifier: "book-uuid"
+        ),
+        startCFI: cfi,
+        highlights: highlights
+    )
+    // What the page announces on load, and what the glue reports once a restore
+    // has settled — the sequence every open goes through.
+    controller.handle(message: ["type": "hostReady"])
+    controller.handle(message: ["type": "status", "payload": "ready"])
+    return controller
+}
+
+/// A relocate as the glue posts it: `buildRelocateData`, JSON, over the bridge.
+@MainActor
+private func relocate(_ controller: ReaderController, to cfi: String) throws {
+    let data = RelocateData(
+        cfi: cfi, page: 212, totalPages: 661, pct: 32,
+        chapter: 7, totalChapters: 24, chapterTitle: "The Moor", chapterPagesLeft: 9
+    )
+    let json = String(decoding: try JSONEncoder().encode(data), as: UTF8.self)
+    controller.handle(message: ["type": "relocate", "payload": json])
+}
+
+/// The options a boot hands the glue, read back out of the `init` call.
+///
+/// Parsed rather than string-matched because the CFI goes over as JSON, where
+/// every `/` in it is escaped — a literal comparison against the script text
+/// would be testing the encoder, not the position.
+@MainActor
+private func bootOptions(_ controller: ReaderController) throws -> [String: Any] {
+    let script = try #require(controller.bootScript())
+    // `OmnibusReader.init('stage', "…", { … })` — the options are the last
+    // argument, so from the first brace to the closing paren.
+    let brace = try #require(script.firstIndex(of: "{"))
+    let object = try JSONSerialization.jsonObject(with: Data(script[brace...].dropLast().utf8))
+    return try #require(object as? [String: Any])
+}
+
+private func mark(_ range: String) -> Highlight {
+    Highlight(
+        id: 1, bookUUID: "book-uuid", epubCFIRange: range, color: .amber,
+        note: nil, text: "a passage", clientID: nil, createdAt: 0
+    )
+}
+
+private let openedAt = "epubcfi(/6/14[chap07]!/4/2/2,/1:0,/1:1)"
+private let readTo = "epubcfi(/6/14[chap07]!/4/2/58,/1:0,/1:1)"
+
+@Suite("Reader page reboot")
+@MainActor
+struct ReaderRebootTests {
+    @Test("the restore point follows the reader, not the position the book opened at")
+    func restorePointFollowsTheReader() throws {
+        let controller = openReader(at: openedAt)
+        try relocate(controller, to: readTo)
+
+        #expect(controller.restoreCFI == readTo)
+    }
+
+    /// The bug itself. A page reloaded under the reader used to boot from the
+    /// CFI `configure` was given at open, so an hour's reading was undone by a
+    /// backgrounding — and the relocate that followed the restore persisted the
+    /// revert and pushed it to every other device.
+    @Test("a reloaded page boots where the reader is, not where the book was opened")
+    func reloadBootsAtTheLivePosition() throws {
+        let controller = openReader(at: openedAt)
+        try relocate(controller, to: readTo)
+
+        // WebKit reclaimed the process and loaded `reader.html` again.
+        controller.handle(message: ["type": "hostReady"])
+
+        #expect(try bootOptions(controller)["cfi"] as? String == readTo)
+    }
+
+    @Test("a book opened with no saved position still boots from wherever it was read to")
+    func reloadCarriesAPositionAFreshBookHadNone() throws {
+        let controller = openReader(at: nil)
+        // Nothing to restore to on the first boot: the book opens at page one.
+        #expect(try bootOptions(controller)["cfi"] == nil)
+
+        try relocate(controller, to: readTo)
+        controller.handle(message: ["type": "hostReady"])
+
+        #expect(try bootOptions(controller)["cfi"] as? String == readTo)
+    }
+
+    @Test("a blank cfi in a relocate leaves the restore point standing")
+    func blankRelocateDoesNotClearTheRestorePoint() throws {
+        let controller = openReader(at: openedAt)
+        try relocate(controller, to: readTo)
+
+        controller.handle(message: ["type": "relocate", "payload": #"{"cfi":""}"#])
+
+        #expect(controller.restoreCFI == readTo)
+    }
+
+    @Test("a reload puts the marks the old page was holding back on the queue")
+    func reloadRequeuesTheMarks() throws {
+        let controller = openReader(at: openedAt, holding: [mark("epubcfi(/6/14!/4/2/4,/1:0,/1:9)")])
+        // Painted, and the queue drained, by the `ready` that opened the book.
+        #expect(controller.pendingHighlights.isEmpty)
+
+        controller.handle(message: ["type": "hostReady"])
+
+        // Otherwise the reader comes back to a book with every highlight gone
+        // until it is closed and opened again.
+        #expect(controller.pendingHighlights.count == 1)
+    }
+
+    @Test("a reload holds the reader unready so the loading overlay covers it")
+    func reloadDropsBackToNotReady() {
+        let controller = openReader(at: openedAt)
+        #expect(controller.isReady)
+
+        controller.handle(message: ["type": "hostReady"])
+
+        // A stage whose process is gone paints nothing; left `ready`, the reader
+        // shows a blank page at full opacity instead of "Opening …".
+        #expect(!controller.isReady)
+    }
+
+    @Test("a terminated web-content process leaves the reader ready for the page that replaces it")
+    func terminationHandsOverBeforeTheReload() throws {
+        let controller = openReader(at: openedAt, holding: [mark("epubcfi(/6/14!/4/2/4,/1:0,/1:9)")])
+        try relocate(controller, to: readTo)
+
+        controller.webContentProcessDidTerminate()
+
+        #expect(!controller.isReady)
+        #expect(controller.pendingHighlights.count == 1)
+        #expect(try bootOptions(controller)["cfi"] as? String == readTo)
+    }
+}

--- a/omnibus-ios/omnibusTests/ReaderRebootTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderRebootTests.swift
@@ -108,6 +108,16 @@ struct ReaderRebootTests {
         #expect(try bootOptions(controller)["cfi"] as? String == readTo)
     }
 
+    /// A progress row can hold a blank position — `localProgress` hands it
+    /// straight over, unlike the remote read, which normalizes it away.
+    @Test("a book opened on a blank saved position boots with no cfi at all")
+    func blankSavedPositionIsNoPosition() throws {
+        let controller = openReader(at: "")
+
+        #expect(controller.restoreCFI == nil)
+        #expect(try bootOptions(controller)["cfi"] == nil)
+    }
+
     @Test("a blank cfi in a relocate leaves the restore point standing")
     func blankRelocateDoesNotClearTheRestorePoint() throws {
         let controller = openReader(at: openedAt)


### PR DESCRIPTION
## Summary
iOS reclaims the WKWebView's web-content process when an app has been in the background a while, and `reader.html` is loaded again when the reader comes back. That reload re-runs the page's inline script, so `hostReady` is announced a second time — and `bootReader` booted the fresh epub.js stage from `startCFI`, the CFI `configure` was handed once when the book was *opened*. Everything read since was thrown away, landing the reader back where the session started, which for most sessions is the chapter they opened on.

Not just cosmetic: the relocate that follows the restore is written to the replica and the outbox on every relocate (#1666), so the revert overwrote the real position locally and pushed it to every other device.

- `restoreCFI` replaces `startCFI` — seeded from the opening position, then kept current on every relocate. A boot reads it at boot time, so a reloaded page lands where the reader actually is.
- A second `hostReady` is treated as the page having been replaced: the reader drops back to not-ready (so the loading overlay covers the reboot instead of a blank stage at full opacity) and the marks the outgoing page had painted go back on the pending queue. They were being dropped outright — `pendingHighlights` is emptied after the first `ready`, so a rebooted page came back with every highlight gone until the book was closed and reopened.
- `webViewWebContentProcessDidTerminate` makes the recovery explicit rather than leaning on WebKit's own reload-when-visible, deferring the reload past a backgrounding — via the reader's existing `LifecycleSync` resume hook — rather than feeding a fresh process to the same reclaim.

Closes #1656

## Test plan
- [x] `just ios-test` — full `omnibusTests` suite green.
- [x] New `omnibusTests/ReaderRebootTests.swift` (7 tests) replays the exact bridge sequence a reload produces: `hostReady` → `ready` → `relocate` → `hostReady`. Confirmed red without the fix — reverting only the restore-point update fails 5 of the 7, including `reloadBootsAtTheLivePosition`.
- [ ] Not verified end to end on a device/simulator: reproducing the real trigger means getting a live reader's web-content process reclaimed. The controller-level path it takes is what the new tests cover.

## Version
- [x] **Patch** — the default.

## Notes
The invariant is recorded in `docs/architecture.md` beside the other iOS-reader gotchas: nothing a boot reads may be a snapshot of the open, because the page is booted more than once per book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
