### PR TITLE
fix: stop unreadable hidden dirs permanently suppressing the scan removal pass

### DIFF
--- a/db/src/audiobook/stat.rs
+++ b/db/src/audiobook/stat.rs
@@ -98,7 +98,8 @@ pub fn stat_audiobook_library(
 /// Depth-first walk of the tree rooted at `dir`, stat-ing every accepted
 /// file. Returns `(entries, incomplete, saw_any_file)`; a root `read_dir`
 /// failure is the only case that aborts the walk (`Err`) — a subdir
-/// failure instead flags `incomplete` and continues.
+/// failure instead flags `incomplete` and continues. Subdirectories matching
+/// [`crate::helpers::is_skipped_scan_dir`] are not descended into.
 fn walk_audiobook_tree(
     dir: &Path,
 ) -> Result<(Vec<AudiobookStatEntry>, bool, bool), std::io::Error> {
@@ -139,6 +140,10 @@ fn walk_audiobook_tree(
             };
             let entry_path = entry.path();
             if file_type.is_dir() {
+                // Skipped at discovery, so an unreadable one never sets `incomplete`.
+                if crate::helpers::is_skipped_scan_dir(&entry.file_name().to_string_lossy()) {
+                    continue;
+                }
                 stack.push(entry_path);
                 continue;
             }

--- a/db/src/audiobook/tests.rs
+++ b/db/src/audiobook/tests.rs
@@ -56,6 +56,55 @@ fn stat_recurses_into_subdirectories() {
 }
 
 #[test]
+fn stat_does_not_descend_into_hidden_or_eadir_directories() {
+    let dir = make_test_dir("skip_dirs");
+    fs::write(dir.join("real.m4b"), b"x").unwrap();
+    let eadir = dir.join("@eaDir");
+    fs::create_dir_all(&eadir).unwrap();
+    fs::write(eadir.join("thumb.m4b"), b"x").unwrap();
+    let staging = dir.join(".shelfarr-staging");
+    fs::create_dir_all(&staging).unwrap();
+    fs::write(staging.join("half-copied.m4b"), b"x").unwrap();
+
+    let out = stat_audiobook_library(Some(dir.to_str().unwrap()), dir.to_str().unwrap());
+    fs::remove_dir_all(&dir).unwrap();
+
+    let names: Vec<&str> = out.entries.iter().map(|e| e.filename.as_str()).collect();
+    assert_eq!(names, vec!["real.m4b"], "got {names:?}");
+    assert!(!out.incomplete);
+}
+
+// Audiobook mirror of the ebook regression (see `ebook::stat::tests`).
+#[cfg(unix)]
+#[test]
+fn stat_stays_complete_when_an_unreadable_subdirectory_is_hidden() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = make_test_dir("skip_locked_hidden");
+    fs::write(dir.join("real.m4b"), b"x").unwrap();
+    let staging = dir.join(".shelfarr-staging");
+    fs::create_dir_all(&staging).unwrap();
+    fs::set_permissions(&staging, fs::Permissions::from_mode(0o000)).unwrap();
+    if fs::read_dir(&staging).is_ok() {
+        // Running as root (CI container) — perms don't bite; skip.
+        fs::set_permissions(&staging, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::remove_dir_all(&dir).unwrap();
+        return;
+    }
+
+    let out = stat_audiobook_library(Some(dir.to_str().unwrap()), dir.to_str().unwrap());
+
+    fs::set_permissions(&staging, fs::Permissions::from_mode(0o755)).unwrap();
+    fs::remove_dir_all(&dir).unwrap();
+
+    assert!(
+        !out.incomplete,
+        "an unreadable *hidden* dir must not flag the enumeration incomplete",
+    );
+    assert_eq!(out.entries.len(), 1);
+}
+
+#[test]
 fn parse_unreadable_file_surfaces_as_error_metadata_row() {
     // Phase B's per-file failure shape: an audiobook that fails to parse
     // becomes an IndexedBook with `metadata.error = Some(...)`, never a

--- a/db/src/ebook/stat.rs
+++ b/db/src/ebook/stat.rs
@@ -166,7 +166,8 @@ fn unreadable_subdir_entry(base: &Path, current: &Path, err: &std::io::Error) ->
 /// [`crate::ebook::EBOOK_FORMATS`] — `.epub` / `.cbz`). Other files and
 /// entries whose `file_type()` can't be read are skipped. `saw_any_file` is
 /// set for every regular file regardless of extension (the "root isn't
-/// empty" signal, see the caller).
+/// empty" signal, see the caller). Subdirectories matching
+/// [`crate::helpers::is_skipped_scan_dir`] are not descended into.
 fn push_dir_entry(
     base: &Path,
     entry: &std::fs::DirEntry,
@@ -179,6 +180,10 @@ fn push_dir_entry(
     };
     let entry_path = entry.path();
     if file_type.is_dir() {
+        // Skipped at discovery, so an unreadable one never sets `incomplete`.
+        if crate::helpers::is_skipped_scan_dir(&entry.file_name().to_string_lossy()) {
+            return;
+        }
         stack.push(entry_path);
         return;
     }

--- a/db/src/ebook/stat/tests.rs
+++ b/db/src/ebook/stat/tests.rs
@@ -189,3 +189,60 @@ fn stat_flags_incomplete_when_a_subdirectory_is_unreadable() {
         "an unreadable subdir must flag the enumeration incomplete"
     );
 }
+
+// A stager's `0700` dir inside the library root flagged `incomplete` on
+// every scan, suppressing the #819 removal pass forever.
+#[cfg(unix)]
+#[test]
+fn stat_stays_complete_when_an_unreadable_subdirectory_is_hidden() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = make_test_dir("stat_hidden_locked");
+    std::fs::write(dir.join("good.epub"), b"not a zip").unwrap();
+    let staging = dir.join(".shelfarr-staging");
+    std::fs::create_dir_all(&staging).unwrap();
+    std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o000)).unwrap();
+    if std::fs::read_dir(&staging).is_ok() {
+        // Running as root (CI container) — perms don't bite; skip.
+        std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+        return;
+    }
+
+    let out = stat_ebook_library(Some(dir.to_str().unwrap()), dir.to_str().unwrap());
+
+    std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::remove_dir_all(&dir).unwrap();
+
+    assert!(out.error.is_none());
+    assert!(
+        !out.incomplete,
+        "an unreadable *hidden* dir must not flag the enumeration incomplete",
+    );
+    assert!(
+        out.entries.iter().any(|e| e.filename == "good.epub"),
+        "the readable part of the tree still indexes",
+    );
+}
+
+#[test]
+fn stat_does_not_descend_into_hidden_or_eadir_directories() {
+    let dir = make_test_dir("stat_skip_dirs");
+    std::fs::write(dir.join("real.epub"), b"not a zip").unwrap();
+
+    // A mid-copy epub indexed out of staging becomes a ghost row the moment
+    // the stager moves it into place.
+    let eadir = dir.join("@eaDir");
+    std::fs::create_dir_all(&eadir).unwrap();
+    std::fs::write(eadir.join("thumb.epub"), b"not a zip").unwrap();
+    let staging = dir.join(".shelfarr-staging");
+    std::fs::create_dir_all(&staging).unwrap();
+    std::fs::write(staging.join("half-copied.epub"), b"not a zip").unwrap();
+
+    let out = stat_ebook_library(Some(dir.to_str().unwrap()), dir.to_str().unwrap());
+    std::fs::remove_dir_all(&dir).unwrap();
+
+    let names: Vec<&str> = out.entries.iter().map(|e| e.filename.as_str()).collect();
+    assert_eq!(names, vec!["real.epub"], "got {names:?}");
+    assert!(!out.incomplete);
+}

--- a/db/src/helpers.rs
+++ b/db/src/helpers.rs
@@ -67,6 +67,13 @@ pub(crate) fn scan_key_for(relative_path: &str) -> String {
     relative_path.to_string()
 }
 
+/// Dot-directories and Synology's `@eaDir` — never library content, and
+/// routinely unreadable, which would flag the walk `incomplete` and suppress
+/// the removal pass on every scan (issue #819).
+pub(crate) fn is_skipped_scan_dir(name: &str) -> bool {
+    name.starts_with('.') || name.eq_ignore_ascii_case("@eaDir")
+}
+
 /// Split `dir/sub/name.epub` into (`dir/sub`, `name`, `EPUB`). If no dir,
 /// the path portion is empty. Extension is uppercased per Calibre convention.
 pub(crate) fn split_filename(filename: &str) -> (String, String, String) {

--- a/db/src/helpers/tests.rs
+++ b/db/src/helpers/tests.rs
@@ -267,3 +267,24 @@ fn format_series_index_passes_through_non_finite_values_verbatim() {
     assert_eq!(format_series_index(f64::INFINITY), "inf");
     assert_eq!(format_series_index(f64::NEG_INFINITY), "-inf");
 }
+
+#[test]
+fn is_skipped_scan_dir_skips_dot_directories_and_eadir() {
+    assert!(is_skipped_scan_dir(".shelfarr-staging"));
+    assert!(is_skipped_scan_dir(".git"));
+    assert!(is_skipped_scan_dir("."));
+    assert!(is_skipped_scan_dir(".."));
+    assert!(is_skipped_scan_dir("@eaDir"));
+    // Synology has shipped both casings over the years.
+    assert!(is_skipped_scan_dir("@eadir"));
+}
+
+#[test]
+fn is_skipped_scan_dir_keeps_ordinary_author_directories() {
+    assert!(!is_skipped_scan_dir("Becky Jenkinson"));
+    assert!(!is_skipped_scan_dir("Pierce Brown"));
+    // A leading `@` alone is not the Synology marker — an author or
+    // publisher directory may legitimately start with one.
+    assert!(!is_skipped_scan_dir("@midnight Press"));
+    assert!(!is_skipped_scan_dir("eaDir"));
+}


### PR DESCRIPTION
## Summary
- The library walk descended into **every** subdirectory, including dot-dirs and Synology's per-folder `@eaDir`. An import stager (Shelfarr) writes its staging dir `0700` *inside* the library root, so every scan hit EACCES there and set `incomplete`.
- `incomplete` is what makes the #819 guard skip the removal pass — so the guard was suppressing the removal pass **permanently**, on every scan, in both roots, not just for the offending directory. Deleted books could never be reflected, and books already flagged missing could never clear.
- Skip dot-dirs and `@eaDir` **at discovery**, so the walk never opens them and an unreadable one can't set the flag. Applied to both the ebook and audiobook walkers.
- A genuinely unreadable *content* directory still flags `incomplete` — the #819 guard is unchanged for the case it was written for (`stat_flags_incomplete_when_a_subdirectory_is_unreadable` still passes untouched).
- Side benefit: a mid-copy epub can no longer be indexed out of staging, which would become a ghost row the moment the stager renamed it into place.

Found on the live Pi, where this had been firing hourly for an unknown length of time:

```
reindex: enumeration incomplete or a populated root read empty — skipping the
removal pass; no books marked missing (issue #819) library_path="/books"
incomplete=true saw_any_file=true db_file_backed=255
```

The two culprits were `.shelfarr-staging` (mode `0700`) in `/books` **and** `/audiobooks` — a library-wide sweep found **0** unreadable files, so these two directories alone accounted for it.

## Test plan
- [x] `cargo test -p omnibus-db` — 1770 passed, 0 failed
- [x] New: `is_skipped_scan_dir_skips_dot_directories_and_eadir`, `is_skipped_scan_dir_keeps_ordinary_author_directories`
- [x] New: `stat_stays_complete_when_an_unreadable_subdirectory_is_hidden` (ebook + audiobook) — pins the regression
- [x] New: `stat_does_not_descend_into_hidden_or_eadir_directories` (ebook + audiobook)
- [x] Pre-existing `stat_flags_incomplete_when_a_subdirectory_is_unreadable` still passes — guard intact for real content dirs
- [x] `cargo fmt --check` + `cargo clippy -p omnibus-db --all-targets -D warnings` clean

## Version
- [x] **Patch** — the default.

## Notes
`@eaDir` matching is case-insensitive; a leading `@` alone is not the marker, so an author or publisher directory starting with `@` is still walked. Non-UTF8 directory names are compared lossily and default to being walked.

>[!NOTE]
> Adjacent, not fixed here: macOS AppleDouble sidecars (`._Book.epub`) still match `EBOOK_FORMATS` and would be indexed as books. There's a `.DS_Store` in the live ebooks root, so a macOS client has written to that share. Worth a follow-up if it ever shows up.
