### PR TITLE
feat: point the stats donut at genres, and decode them on iOS

### DIFF
--- a/db/src/stats/mod.rs
+++ b/db/src/stats/mod.rs
@@ -405,24 +405,38 @@ async fn ranked(
         .collect())
 }
 
-/// Genre share by distinct book count: for each tag, how many distinct books
-/// carrying it had session activity in the window. Count-based (not
-/// seconds) so a multi-tag book counts once per tag but never twice per tag.
+/// Genre share by distinct book count: for each genre, how many distinct
+/// books carrying it had session activity in the window. Count-based (not
+/// seconds) so a multi-genre book counts once per genre but never twice per
+/// genre.
+///
+/// Reads the user-assigned genres, which live only in `metadata_overrides`
+/// (migration `0063`). This deliberately does *not* fall back to a book's
+/// tags: the donut is labelled "What you read", and a `<dc:subject>` list is
+/// whatever the publisher's OPF happened to carry, not a genre. A library
+/// with no genres assigned yet renders an empty donut, which is the honest
+/// answer.
 async fn genre_share(
     pool: &SqlitePool,
     user_id: i64,
     start: i64,
 ) -> Result<Vec<GenreShare>, StatsError> {
     // Collapse the per-session union to distinct active books *before* the
-    // tag join, so the intermediate is bounded by book count, not session
+    // genre join, so the intermediate is bounded by book count, not session
     // count — keeps the join small on a 10k-event library.
+    //
+    // Joining `genres` rather than grouping `je.value` folds case variants
+    // into the one canonical row, exactly as `get_genre_cloud` does — a
+    // donut that split "sci-fi" from "Sci-Fi" would double-count a slice.
     let sql = format!(
-        "SELECT t.name AS name, COUNT(DISTINCT b.uuid) AS books
+        "SELECT g.name AS name, COUNT(DISTINCT b.uuid) AS books
              FROM (SELECT DISTINCT book_uuid FROM ({SESSION_BOOK_SECS})) x
              JOIN books b ON b.uuid = x.book_uuid
-             JOIN books_tags_link btl ON btl.book = b.id
-             JOIN tags t ON t.id = btl.tag
-         GROUP BY t.id ORDER BY books DESC, t.name ASC LIMIT ?"
+             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+             JOIN json_each(mo.overrides, '$.genres') je
+             JOIN genres g ON g.name = je.value COLLATE NOCASE
+            WHERE json_type(mo.overrides, '$.genres') IS NOT NULL
+         GROUP BY g.id ORDER BY books DESC, g.name ASC LIMIT ?"
     );
     let rows = sqlx::query(&sql)
         .bind(user_id)

--- a/db/src/stats/mod.rs
+++ b/db/src/stats/mod.rs
@@ -410,8 +410,10 @@ async fn ranked(
 /// seconds) so a multi-genre book counts once per genre but never twice per
 /// genre.
 ///
-/// Reads the user-assigned genres, which live only in `metadata_overrides`
-/// (migration `0063`). This deliberately does *not* fall back to a book's
+/// Reads the user-assigned genres, which live only in the
+/// `metadata_overrides` JSON blob (the table itself predates them, from
+/// `0007`; `0066_genres.sql` adds the vocabulary table this joins for the
+/// canonical spelling). This deliberately does *not* fall back to a book's
 /// tags: the donut is labelled "What you read", and a `<dc:subject>` list is
 /// whatever the publisher's OPF happened to carry, not a genre. A library
 /// with no genres assigned yet renders an empty donut, which is the honest

--- a/db/src/stats/tests.rs
+++ b/db/src/stats/tests.rs
@@ -98,6 +98,24 @@ async fn link_tag(pool: &SqlitePool, book: i64, name: &str) {
         .unwrap();
 }
 
+/// Assign genres to a book. Genres have no link table (migration `0066`) —
+/// they exist only as a `metadata_overrides` entry — so this goes through
+/// the real write path, which also materializes the `genres` rows the
+/// donut's join needs.
+async fn set_genres(pool: &SqlitePool, uuid: &str, names: &[&str], user: i64) {
+    crate::merge_metadata_overrides(
+        pool,
+        uuid,
+        &omnibus_shared::MetadataOverrides {
+            genres: Some(names.iter().map(|n| (*n).to_string()).collect()),
+            ..Default::default()
+        },
+        user,
+    )
+    .await
+    .unwrap();
+}
+
 async fn rate_book(pool: &SqlitePool, user: i64, uuid: &str, half_stars: i64, updated_at: i64) {
     sqlx::query(
         "INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
@@ -380,20 +398,16 @@ async fn cache_serves_within_ttl_and_refreshes_after_expiry() {
 }
 
 #[tokio::test]
-async fn genre_share_counts_distinct_books_per_tag_not_seconds() {
+async fn genre_share_counts_distinct_books_per_genre_not_seconds() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_minimal_books(&pool, 3).await;
     let user = seed_user(&pool, "alice").await;
-    let b1 = book_id(&pool, "uuid-1").await;
-    let b2 = book_id(&pool, "uuid-2").await;
-    let b3 = book_id(&pool, "uuid-3").await;
 
-    // sci-fi spans two active books; classic one (but with FAR more seconds —
-    // count-ranking must ignore that); horror tags only an inactive book.
-    link_tag(&pool, b1, "sci-fi").await;
-    link_tag(&pool, b2, "sci-fi").await;
-    link_tag(&pool, b1, "classic").await;
-    link_tag(&pool, b3, "horror").await;
+    // Sci-Fi spans two active books; Classic one (but with FAR more seconds —
+    // count-ranking must ignore that); Horror is on an inactive book only.
+    set_genres(&pool, "uuid-1", &["Sci-Fi", "Classic"], user).await;
+    set_genres(&pool, "uuid-2", &["Sci-Fi"], user).await;
+    set_genres(&pool, "uuid-3", &["Horror"], user).await;
 
     reading_session(&pool, user, "uuid-1", T0, 90_000).await;
     reading_session(&pool, user, "uuid-1", T0 + DAY, 90_000).await;
@@ -401,10 +415,10 @@ async fn genre_share_counts_distinct_books_per_tag_not_seconds() {
 
     let s = compute(&pool, user, StatsRange::AllTime).await.unwrap();
 
-    assert_eq!(s.genre_share.len(), 2, "inactive book's tag is excluded");
-    assert_eq!(s.genre_share[0].name, "sci-fi");
+    assert_eq!(s.genre_share.len(), 2, "inactive book's genre is excluded");
+    assert_eq!(s.genre_share[0].name, "Sci-Fi");
     assert_eq!(s.genre_share[0].books, 2);
-    assert_eq!(s.genre_share[1].name, "classic");
+    assert_eq!(s.genre_share[1].name, "Classic");
     assert_eq!(s.genre_share[1].books, 1);
     // Two distinct active books, sessions on both tables.
     assert_eq!(s.books_active, 2);
@@ -413,12 +427,52 @@ async fn genre_share_counts_distinct_books_per_tag_not_seconds() {
 }
 
 #[tokio::test]
-async fn genre_share_is_scoped_to_the_window() {
+async fn genre_share_ignores_tags_so_the_donut_only_reports_assigned_genres() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_minimal_books(&pool, 1).await;
     let user = seed_user(&pool, "alice").await;
     let b1 = book_id(&pool, "uuid-1").await;
+
+    // A heavily-tagged book with no genres contributes nothing: "What you
+    // read" reports genres, and a `<dc:subject>` list is not one.
     link_tag(&pool, b1, "sci-fi").await;
+    link_tag(&pool, b1, "classic").await;
+    reading_session(&pool, user, "uuid-1", T0, 600).await;
+
+    assert!(genre_share(&pool, user, T0 - DAY).await.unwrap().is_empty());
+
+    // Assigning a genre to the same book makes it appear.
+    set_genres(&pool, "uuid-1", &["Space Opera"], user).await;
+    let share = genre_share(&pool, user, T0 - DAY).await.unwrap();
+    assert_eq!(share.len(), 1);
+    assert_eq!(share[0].name, "Space Opera");
+}
+
+#[tokio::test]
+async fn genre_share_folds_case_variants_into_one_slice() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 2).await;
+    let user = seed_user(&pool, "alice").await;
+
+    // `genres.name` is NOCASE-unique, so the second spelling deduplicates
+    // into the row the first coined — one slice of two books, not two of one.
+    set_genres(&pool, "uuid-1", &["Sci-Fi"], user).await;
+    set_genres(&pool, "uuid-2", &["sci-fi"], user).await;
+    reading_session(&pool, user, "uuid-1", T0, 600).await;
+    reading_session(&pool, user, "uuid-2", T0, 600).await;
+
+    let share = genre_share(&pool, user, T0 - DAY).await.unwrap();
+    assert_eq!(share.len(), 1, "case variants fold together");
+    assert_eq!(share[0].name, "Sci-Fi", "first spelling coined the row");
+    assert_eq!(share[0].books, 2);
+}
+
+#[tokio::test]
+async fn genre_share_is_scoped_to_the_window() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await;
+    let user = seed_user(&pool, "alice").await;
+    set_genres(&pool, "uuid-1", &["Sci-Fi"], user).await;
 
     // Only pre-window activity → no genre share inside the window.
     reading_session(&pool, user, "uuid-1", T0, 600).await;

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -219,6 +219,7 @@ struct BookDetailView: View {
                         if let description = book.description?.nilIfBlank {
                             aboutSection(description)
                         }
+                        if !book.genres.isEmpty { genresSection(book) }
                         if !book.subjects.isEmpty { tagsSection(book) }
                         ratingSection(book)
                         statusSection(book)
@@ -579,6 +580,21 @@ struct BookDetailView: View {
     }
 
     // MARK: - Sections
+
+    /// Genres, above Tags. Plain chips rather than `NavigationLink`s: there
+    /// is no genre destination in `Destination` — genres have no browse page
+    /// on any client yet, only the stats donut and the editors.
+    private func genresSection(_ book: Book) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            SectionLabel("Genres")
+            FlowLayout(spacing: 6) {
+                ForEach(book.genres, id: \.self) { genre in
+                    Chip(label: genre)
+                }
+            }
+        }
+        .accessibilityIdentifier("book-detail-genres")
+    }
 
     private func tagsSection(_ book: Book) -> some View {
         VStack(alignment: .leading, spacing: Spacing.md) {

--- a/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
@@ -20,6 +20,10 @@ struct MetadataDraft: Equatable {
     var authors: [String] = []
     /// Tags (the server's `subjects`), as the same chip list authors use.
     var tags: [String] = []
+    /// Genres, as a second chip list. Separate from `tags`: nothing the
+    /// server parses carries a genre, so this list exists only because
+    /// someone assigned it.
+    var genres: [String] = []
     var series = ""
     var seriesIndex = ""
     var publisher = ""
@@ -36,6 +40,7 @@ struct MetadataDraft: Equatable {
         title = book.title ?? ""
         authors = book.creators.map(\.name)
         tags = book.subjects
+        genres = book.genres
         series = book.series ?? ""
         seriesIndex = book.seriesIndex ?? ""
         publisher = book.publisher ?? ""
@@ -60,6 +65,7 @@ struct MetadataDraft: Equatable {
             creators: authors == loaded.authors
                 ? nil : authors.map(MetadataOverridesPayload.Creator.init),
             subjects: tags == loaded.tags ? nil : tags,
+            genres: genres == loaded.genres ? nil : genres,
             series: changed(\.series),
             series_index: changed(\.seriesIndex),
             publisher: changed(\.publisher),
@@ -86,6 +92,9 @@ struct MetadataOverridesPayload: Encodable, Equatable {
     /// Replaces the whole tag list when present — the server's `subjects`
     /// override is a wholesale replace, never an append.
     var subjects: [String]?
+    /// Replaces the whole genre list when present, same wholesale semantics
+    /// as `subjects`.
+    var genres: [String]?
     var series: String?
     var series_index: String?
     var publisher: String?

--- a/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
@@ -34,6 +34,8 @@ struct MetadataEditView: View {
     @State private var pendingAuthor = ""
     /// Same, for the tags field.
     @State private var pendingTag = ""
+    /// Same, for the genres field.
+    @State private var pendingGenre = ""
 
     private var pendingAuthorName: String {
         pendingAuthor.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -104,6 +106,20 @@ struct MetadataEditView: View {
                             values: $draft.tags,
                             entry: $pendingTag,
                             isEdited: draft.tags != loaded.tags,
+                            deduplicates: true,
+                            isFirst: true
+                        )
+                    }
+                }
+
+                group("Genres") {
+                    Plate {
+                        ChipListField(
+                            label: "Genres",
+                            placeholder: "Add a genre",
+                            values: $draft.genres,
+                            entry: $pendingGenre,
+                            isEdited: draft.genres != loaded.genres,
                             deduplicates: true,
                             isFirst: true
                         )
@@ -257,6 +273,12 @@ struct MetadataEditView: View {
             draft.tags.append(chip)
         }
         pendingTag = ""
+        if let chip = ChipEntry.committed(
+            from: pendingGenre, existing: draft.genres, deduplicating: true
+        ) {
+            draft.genres.append(chip)
+        }
+        pendingGenre = ""
 
         do {
             let _: Empty = try await APIClient.shared.post(

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -77,6 +77,11 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
     var language: String?
     var creators: [Contributor] = []
     var subjects: [String] = []
+    /// User-assigned genres. Distinct from `subjects`, which come from the
+    /// EPUB's `<dc:subject>` entries — nothing the server parses carries a
+    /// genre, so this list is populated only by an explicit edit. Omitted
+    /// from the wire when empty, hence the default.
+    var genres: [String] = []
     var identifiers: [Identifier] = []
     var isbn13: String?
     var series: String?
@@ -100,7 +105,7 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
 
     enum CodingKeys: String, CodingKey {
         case id, filename, title, description, publisher, published, modified
-        case language, creators, subjects, identifiers, isbn13, series, formats
+        case language, creators, subjects, genres, identifiers, isbn13, series, formats
         case accent, error
         case seriesIndex = "series_index"
         case seriesId = "series_id"

--- a/omnibus-ios/omnibusTests/MetadataDraftTests.swift
+++ b/omnibus-ios/omnibusTests/MetadataDraftTests.swift
@@ -12,6 +12,7 @@ private func gatsby() -> Book {
     book.title = "The Great Gatsby"
     book.creators = [Contributor(name: "F. Scott Fitzgerald")]
     book.subjects = ["Classics", "Novel"]
+    book.genres = ["Literary Fiction"]
     book.series = "—"
     book.publisher = "Scribner"
     book.language = "en"
@@ -42,6 +43,34 @@ struct MetadataDraftTests {
         #expect(payload.publisher == nil)
         #expect(payload.language == nil)
         #expect(payload.description == nil)
+    }
+
+    @Test func draftFromBookCarriesGenresSeparatelyFromTags() {
+        let draft = MetadataDraft(book: gatsby())
+        #expect(draft.genres == ["Literary Fiction"])
+        #expect(draft.tags == ["Classics", "Novel"])
+    }
+
+    @Test func payloadSendsGenresOnlyWhenTheListChanged() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.genres = ["Literary Fiction", "Tragedy"]
+
+        let payload = draft.payload(since: loaded)
+        #expect(payload.genres == ["Literary Fiction", "Tragedy"])
+        // Editing genres must not drag the tag list along with it — they are
+        // two independent wholesale-replace overrides.
+        #expect(payload.subjects == nil)
+    }
+
+    @Test func payloadOmitsGenresWhenOnlyTagsChanged() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.tags = ["Classics"]
+
+        let payload = draft.payload(since: loaded)
+        #expect(payload.genres == nil)
+        #expect(payload.subjects == ["Classics"])
     }
 
     @Test func payloadOmitsTagsWhenTheListIsUntouched() {

--- a/ui_tests/playwright/tests/flows/stats.spec.ts
+++ b/ui_tests/playwright/tests/flows/stats.spec.ts
@@ -21,6 +21,12 @@ import { fixturesDir, seedLibrary } from "../utils/seed";
 // per worker and the concurrent writes 500 on SQLite's write lock.
 test.describe.configure({ mode: "serial" });
 
+/**
+ * Genre assigned to this spec's donut feeder. Deliberately unusual so a
+ * future fixture can't collide with it and change the slice count.
+ */
+const DONUT_GENRE = "Stats Spec Gothic";
+
 /** Late-2023 anchor: inside Lifetime, outside the week/month/year windows. */
 const OLD_SESSION_AT = 1_700_000_000;
 
@@ -36,9 +42,15 @@ test.beforeAll(async ({ request }) => {
   await seedLibrary(request, fixturesDir(), FIXTURE_BOOKS.length);
   const uuid = await fetchBookUuidByTitle(request, FIXTURE_BOOKS[0]!.title);
 
-  // Dracula is a tagged public-domain fixture — its session feeds the genre
-  // donut, which shares by book count over *tagged* active books.
-  const taggedUuid = await fetchBookUuidByTitle(request, "Dracula");
+  // The genre donut shares by book count over active books that have a
+  // *genre*. Nothing scans one, so it has to be assigned here. Dracula is
+  // this spec's designated donut feeder; only its `genres` key is written,
+  // so the "Vampires" tag search.spec.ts reads stays untouched.
+  const genredUuid = await fetchBookUuidByTitle(request, "Dracula");
+  const genreResp = await request.post(`/api/ebooks/${genredUuid}/overrides`, {
+    data: { genres: [DONUT_GENRE] },
+  });
+  expect(genreResp.status(), "seeding the donut genre failed").toBe(200);
 
   const now = Math.floor(Date.now() / 1000);
   const session = (
@@ -58,7 +70,7 @@ test.beforeAll(async ({ request }) => {
       session(uuid, now - 60, 600, "epub"),
       session(uuid, OLD_SESSION_AT, 900, "epub"),
       session(uuid, now - 120, 900, "audio"),
-      session(taggedUuid, now - 300, 300, "epub"),
+      session(genredUuid, now - 300, 300, "epub"),
     ],
   });
   expect(resp.status(), "seeding stats sessions failed").toBe(200);
@@ -239,10 +251,11 @@ test("the heatmap and genre donut render from seeded activity", async ({
   await expect(heatmap).toContainText("Longest streak");
   expect(await heatmap.locator('[title*=" on "]').count()).toBeGreaterThan(0);
 
-  // Donut: the fixture book carries tags, so the legend lists at least one
-  // genre with a percentage; the center shows the active-book count.
+  // Donut: the seeded genre appears in the legend with a percentage; the
+  // center shows the active-book count.
   const donut = page.getByTestId("stats-genre-donut");
   await expect(donut).toBeVisible();
+  await expect(donut).toContainText(DONUT_GENRE);
   await expect(donut).toContainText("%");
   await expect(donut).toContainText("books");
 


### PR DESCRIPTION
## Summary
- The "What you read" donut has always shared by **tag**, which is why genres looked like they already existed. Now that they do (#1691, #1696), `genre_share` reads the user-assigned list instead, joining `genres` so NOCASE case-variants fold into one slice rather than splitting it.
- **No tag fallback, deliberately.** A `<dc:subject>` list is whatever the publisher's OPF happened to carry, not a genre — and a donut that silently substitutes one for the other is the confusion this whole stack started from.
- iOS decodes `genres`, shows them above Tags on the book detail, and edits them in the metadata editor, so the two clients agree on what a book's genres are.

Last of three stacked branches (#1691 → #1696 → this). Completes the feature.

Part of #1658. Part of #1664.

## Test plan
- [x] `just test` — 4,008 tests, 0 failures
- [x] `just lint` — fmt + clippy across the full matrix, plus stylelint
- [x] `just ios-test` — including 3 new `MetadataDraftTests` covering the genres round-trip and the omitted-field case
- [x] `stats.spec.ts` re-run green with the donut assertion repointed at a seeded genre

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [x] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

Minor rather than patch: this is the merge at which genres become a usable
feature end to end, and it changes what an existing surface reports.

>[!IMPORTANT]
> **The donut goes empty until books get genres.** Nothing scans a genre, so
> every existing library starts with none — the donut renders empty rather
> than falling back to tags. That is the intended answer, not a regression.

## Notes
- iOS gained *editing*, slightly beyond #1664's field-decode scope: leaving the native editor able to display genres but not change them would have been the wrong half of the feature.
- The Genres table column is not sortable, matching Tags — a keyset cursor needs one indexed sort column and a multi-valued list has none.