### PR TITLE
feat: iOS profile edit sheet and avatar

### DIFF
--- a/.claude/rules/08-offline-writes.md
+++ b/.claude/rules/08-offline-writes.md
@@ -22,11 +22,13 @@ Three tiers, and only the last one is queueable:
   queued. Other actors — a second admin, the indexer, the filesystem — move
   underneath a deferred write, and last-write-wins on a config row means a
   phone that was offline for a week silently repoints the library.
-- **Account configuration** — the per-user settings that aren't content, today
-  just `kindle_email`. Never queued. It is per-user, but it is still
-  configuration: set rarely and deliberately, essentially always with a
-  connection, and it addresses where a *server-side action* delivers. A stale
-  replay redirects a delivery.
+- **Account configuration** — the per-user settings that aren't content:
+  `kindle_email`, and the profile (display name + avatar). Never queued. It is
+  per-user, but it is still configuration: set rarely and deliberately,
+  essentially always with a connection. A stale `kindle_email` replay redirects
+  a delivery; a stale profile replay restores a name the reader has since
+  changed, and the display name is *denormalized* into the wishlist shelf name
+  server-side, so a late replay renames a row too.
 - **Content state** — where you are in a book, what you marked in it, what you
   wrote about it, how you rated it, which shelves hold it. Queueable, subject
   to the remaining tests.
@@ -104,6 +106,7 @@ Not queued, by test:
 |---|---|
 | `POST /api/settings`, API keys, SMTP | 1 — instance configuration |
 | `POST /api/account/kindle-email` | 1 — account configuration |
+| `POST /api/account/profile`, avatar upload/delete | 1 — account configuration |
 | Metadata overrides | 1 — library-wide, every user sees it |
 | Book uploads | 1 — library-wide (and a GB-scale body has no business in `ops`) |
 | Reindex, scan, FTS rebuild | 2 — commands |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,10 +247,17 @@ Design/             — Theme (Atrium tokens), OKLCH↔sRGB conversion for
                       server-provided accents, Motion (shared curves), and
                       Components/ (BookCover, RemoteImage, Plate, SearchField,
                       OmnibusTabBar, Masthead, BrandMark — the stoat, a copy of
-                      the web's omnibus-stoat.png — FlowLayout, TopEdgeScrim)
+                      the web's omnibus-stoat.png — FlowLayout, TopEdgeScrim,
+                      UserAvatar — a user's picture or monogram, the native twin
+                      of the web's `components/user_avatar.rs`)
 Features/           — one directory per surface: Account, AddBooks, Auth,
                       BookDetail, CheckIn, Discovery, Library, Player, Search,
-                      Settings, Shelves, Stats
+                      Settings, Shelves, Stats. Account's identity card opens
+                      `ProfileEditSheet` (display name + picture): a profile is
+                      account configuration, so it writes straight through
+                      `AuthService` and never queues (rule 08), Save is disabled
+                      while offline, and `ProfileDraft` holds the testable
+                      "what does Save actually send" rules
 Models/             — Codable mirrors of the `shared/` wire DTOs
 Networking/         — APIClient, keychain-backed TokenStore
 Offline/            — Cache (read-through policies), OfflineStore (SQLite

--- a/omnibus-ios/omnibus/App/AppState.swift
+++ b/omnibus-ios/omnibus/App/AppState.swift
@@ -107,6 +107,14 @@ final class AppState {
     /// rejection sends the user back to the login screen — an unreachable
     /// server leaves a cached identity signed in, which is the whole point of
     /// holding one.
+    /// Re-read the identity after a profile write, so the You tab's name and
+    /// avatar repaint from the server's answer rather than a local guess. A
+    /// failure leaves the current user in place — the write already succeeded,
+    /// and blanking the header would be a worse lie than a stale name.
+    func refreshUser() async {
+        if let fresh = try? await AuthService.me() { user = fresh }
+    }
+
     private func confirmIdentity() async {
         do {
             user = try await AuthService.me()

--- a/omnibus-ios/omnibus/Design/Components/RemoteImage.swift
+++ b/omnibus-ios/omnibus/Design/Components/RemoteImage.swift
@@ -153,6 +153,18 @@ actor ImageCache {
         return decoded
     }
 
+    /// Drop one key's cached bytes and its validator.
+    ///
+    /// Needed because `revalidate` only checks back every `revalidateAfter`
+    /// seconds: after *this* device replaces its own avatar, the new picture
+    /// would otherwise not appear for up to five minutes. Other devices still
+    /// wait for the normal window, same as covers.
+    func invalidate(_ key: String) {
+        memory.removeObject(forKey: key as NSString)
+        try? FileManager.default.removeItem(at: diskURL(for: key))
+        try? FileManager.default.removeItem(at: etagURL(for: key))
+    }
+
     func clearDisk() {
         try? FileManager.default.removeItem(at: directory)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/omnibus-ios/omnibus/Design/Components/UserAvatar.swift
+++ b/omnibus-ios/omnibus/Design/Components/UserAvatar.swift
@@ -1,0 +1,62 @@
+//  UserAvatar.swift
+//  A user drawn as a circle: their uploaded picture, or a monogram.
+//
+//  The web client has the same component; both render `/api/users/{id}/avatar`
+//  and fall back to initials so a reader without a picture still reads as a
+//  person rather than an empty ring.
+
+import SwiftUI
+
+struct UserAvatar: View {
+    let id: Int64
+    /// The name to draw initials from — a display name when the user set one.
+    let name: String
+    let hasAvatar: Bool
+    var size: CGFloat = 58
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        Group {
+            if hasAvatar {
+                RemoteImage(path: Self.path(for: id)) { monogram }
+            } else {
+                monogram
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay(Circle().strokeBorder(.white.opacity(0.14), lineWidth: 0.5))
+        .shadow(color: palette.accentColor.opacity(0.25), radius: 12, y: 4)
+    }
+
+    /// The cache key / request path for a user's avatar. Shared with the
+    /// invalidation call after an upload so the two can't drift.
+    static func path(for id: Int64) -> String { "/api/users/\(id)/avatar" }
+
+    private var monogram: some View {
+        LinearGradient(
+            colors: [palette.accentColor.opacity(0.85), palette.accentSoftColor],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .overlay {
+            Text(Self.initials(for: name))
+                .font(.display(size * 0.45, weight: .semibold))
+                .foregroundStyle(palette.accentInk.color)
+        }
+    }
+
+    /// One or two uppercase initials, split on the separators a display name
+    /// or a username might use. Falls back to "?" for an empty name.
+    static func initials(for name: String) -> String {
+        let tokens = name
+            .split(whereSeparator: { $0.isWhitespace || $0 == "." || $0 == "_" || $0 == "-" })
+            .filter { !$0.isEmpty }
+        switch tokens.count {
+        case 0: return "?"
+        case 1: return tokens[0].prefix(2).uppercased()
+        default: return (tokens[0].prefix(1) + tokens[1].prefix(1)).uppercased()
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Features/Account/AccountView.swift
+++ b/omnibus-ios/omnibus/Features/Account/AccountView.swift
@@ -16,6 +16,7 @@ struct AccountView: View {
     @State private var showSignOutConfirm = false
     @State private var showAddBooks = false
     @State private var showRejected = false
+    @State private var showProfileEdit = false
     @State private var kindleEmail = ""
     @State private var kindleSaved = false
     @State private var kindleError: String?
@@ -53,6 +54,11 @@ struct AccountView: View {
             .withDestinations()
             .sheet(isPresented: $showAddBooks) { AddBooksSheet() }
             .sheet(isPresented: $showRejected) { RejectedWritesSheet() }
+            .sheet(isPresented: $showProfileEdit) {
+                if let user = app.user {
+                    ProfileEditSheet(user: user) { await app.refreshUser() }
+                }
+            }
             .confirmationDialog(
                 "Sign out of Omnibus?", isPresented: $showSignOutConfirm, titleVisibility: .visible
             ) {
@@ -77,30 +83,17 @@ struct AccountView: View {
     // MARK: - Identity
 
     /// The account, given the weight a name deserves rather than a 44pt row.
+    /// Tapping it opens the profile editor (display name + picture).
     private var identityCard: some View {
         HStack(spacing: Spacing.lg) {
-            Circle()
-                .fill(
-                    LinearGradient(
-                        colors: [
-                            palette.accentColor.opacity(0.85),
-                            palette.accentSoftColor,
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-                .frame(width: 58, height: 58)
-                .overlay {
-                    Text((app.user?.username.prefix(1) ?? "?").uppercased())
-                        .font(.display(26, weight: .semibold))
-                        .foregroundStyle(palette.accentInk.color)
-                }
-                .overlay(Circle().strokeBorder(.white.opacity(0.14), lineWidth: 0.5))
-                .shadow(color: palette.accentColor.opacity(0.25), radius: 12, y: 4)
+            UserAvatar(
+                id: app.user?.id ?? 0,
+                name: app.user?.display ?? "?",
+                hasAvatar: app.user?.hasAvatar == true
+            )
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(app.user?.username ?? "Signed in")
+                Text(app.user?.display ?? "Signed in")
                     .font(.display(24))
                     .foregroundStyle(palette.ink0Color)
                     .lineLimit(1)
@@ -115,6 +108,13 @@ struct AccountView: View {
             Spacer(minLength: 0)
         }
         .screenPadding()
+        // The whole row is the target, not just the avatar — the name is as
+        // obvious a thing to tap as the picture.
+        .contentShape(Rectangle())
+        .onTapGesture { if app.user != nil { showProfileEdit = true } }
+        .accessibilityIdentifier("identity-card")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Edit your profile")
     }
 
     private var roleLine: String {

--- a/omnibus-ios/omnibus/Features/Account/AccountView.swift
+++ b/omnibus-ios/omnibus/Features/Account/AccountView.swift
@@ -89,7 +89,7 @@ struct AccountView: View {
             UserAvatar(
                 id: app.user?.id ?? 0,
                 name: app.user?.display ?? "?",
-                hasAvatar: app.user?.hasAvatar == true
+                hasAvatar: app.user?.hasAvatar ?? false
             )
 
             VStack(alignment: .leading, spacing: 3) {

--- a/omnibus-ios/omnibus/Features/Account/ProfileEditSheet.swift
+++ b/omnibus-ios/omnibus/Features/Account/ProfileEditSheet.swift
@@ -62,7 +62,7 @@ struct ProfileEditSheet: View {
     }
 
     private var showsAvatar: Bool {
-        draft.pickedImage != nil || (user.hasAvatar == true && !removedAvatar)
+        draft.pickedImage != nil || (user.hasAvatar && !removedAvatar)
     }
 
     var body: some View {
@@ -167,8 +167,15 @@ struct ProfileEditSheet: View {
             error = "That image couldn't be read."
             return
         }
+        // Re-encoding can fail on a pathological image. Say so and keep the
+        // previous selection — silently dropping it leaves Save disabled with
+        // no explanation for a photo the user just picked.
+        guard let encoded = Self.encodeAvatar(image) else {
+            error = "That image couldn't be prepared for upload."
+            return
+        }
         error = nil
-        draft.pickedImage = Self.encodeAvatar(image)
+        draft.pickedImage = encoded
         removedAvatar = false
     }
 

--- a/omnibus-ios/omnibus/Features/Account/ProfileEditSheet.swift
+++ b/omnibus-ios/omnibus/Features/Account/ProfileEditSheet.swift
@@ -1,0 +1,221 @@
+//  ProfileEditSheet.swift
+//  Edit the display name and profile picture, from the You tab's identity card.
+//
+//  Both writes are account configuration, so they call the API directly and
+//  report failure inline — never queued for replay (rule 08). Save is disabled
+//  while offline rather than failing after the fact.
+
+import PhotosUI
+import SwiftUI
+
+/// What the sheet has been changed to, separated from the view so the "what
+/// does Save actually send" rules are testable without a UI.
+struct ProfileDraft: Equatable {
+    /// The name as originally loaded — `nil` when the user has no display name.
+    var original: String?
+    /// The current field contents.
+    var edited: String
+    /// Image bytes the user picked this session, if any.
+    var pickedImage: Data?
+
+    init(original: String?, edited: String? = nil, pickedImage: Data? = nil) {
+        self.original = original
+        self.edited = edited ?? original ?? ""
+        self.pickedImage = pickedImage
+    }
+
+    /// The value a save would send: trimmed, with blank normalized to `nil`
+    /// (which clears the display name and reverts attribution to the username).
+    var normalizedName: String? {
+        let trimmed = edited.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Whether the name differs from what was loaded. Whitespace-only edits
+    /// and a blank field over an already-absent name both count as unchanged,
+    /// so Save doesn't fire a write that would change nothing.
+    var nameChanged: Bool { normalizedName != original }
+
+    /// Whether Save has anything to do at all.
+    var hasChanges: Bool { nameChanged || pickedImage != nil }
+}
+
+struct ProfileEditSheet: View {
+    let user: UserSummary
+    /// Called after a successful save so the caller can refresh its identity.
+    var onSaved: () async -> Void
+
+    @Environment(\.palette) private var palette
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft: ProfileDraft
+    @State private var photoItem: PhotosPickerItem?
+    @State private var saving = false
+    @State private var error: String?
+    @State private var removedAvatar = false
+    private var connectivity = Connectivity.shared
+
+    init(user: UserSummary, onSaved: @escaping () async -> Void) {
+        self.user = user
+        self.onSaved = onSaved
+        _draft = State(initialValue: ProfileDraft(original: user.displayName))
+    }
+
+    private var showsAvatar: Bool {
+        draft.pickedImage != nil || (user.hasAvatar == true && !removedAvatar)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.lg) {
+                    avatarSection
+
+                    Plate {
+                        PlateField(
+                            label: "Display name",
+                            text: $draft.edited,
+                            isEdited: draft.nameChanged,
+                            isFirst: true,
+                            hint: user.username
+                        )
+                    }
+
+                    Text(
+                        "Shown on your journals, ratings and shelves. Leave it empty to use your username."
+                    )
+                    .font(.ui(12.5))
+                    .foregroundStyle(palette.ink3Color)
+
+                    if let error {
+                        Text(error)
+                            .font(.ui(13))
+                            .foregroundStyle(palette.badColor)
+                    }
+                }
+                .screenPadding()
+                .padding(.top, Spacing.md)
+                .padding(.bottom, 40)
+            }
+            .scrollIndicators(.hidden)
+            .scrollDismissesKeyboard(.interactively)
+            .background(ScreenBackground())
+            .navigationTitle("Edit profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { Task { await save() } }
+                        .disabled(saving || !draft.hasChanges || !connectivity.isOnline)
+                }
+            }
+        }
+        .onChange(of: photoItem) { _, item in
+            Task { await loadPicked(item) }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private var avatarSection: some View {
+        HStack(spacing: Spacing.lg) {
+            Group {
+                if let data = draft.pickedImage, let image = UIImage(data: data) {
+                    Image(uiImage: image).resizable().scaledToFill()
+                } else if showsAvatar {
+                    UserAvatar(
+                        id: user.id, name: draft.normalizedName ?? user.username,
+                        hasAvatar: true, size: 72
+                    )
+                } else {
+                    UserAvatar(
+                        id: user.id, name: draft.normalizedName ?? user.username,
+                        hasAvatar: false, size: 72
+                    )
+                }
+            }
+            .frame(width: 72, height: 72)
+            .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 8) {
+                PhotosPicker(selection: $photoItem, matching: .images) {
+                    Text("Change picture").font(.ui(14, weight: .medium))
+                }
+                .disabled(saving || !connectivity.isOnline)
+
+                if showsAvatar {
+                    Button("Remove") { Task { await removeAvatar() } }
+                        .font(.ui(14))
+                        .foregroundStyle(palette.ink2Color)
+                        .disabled(saving || !connectivity.isOnline)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Load the picked photo and re-encode it as a bounded JPEG. The server
+    /// caps an upload at 10 MB and a modern camera roll exceeds that easily,
+    /// so downscaling here is what keeps a normal photo uploadable.
+    private func loadPicked(_ item: PhotosPickerItem?) async {
+        guard let item else { return }
+        guard let raw = try? await item.loadTransferable(type: Data.self),
+            let image = UIImage(data: raw)
+        else {
+            error = "That image couldn't be read."
+            return
+        }
+        error = nil
+        draft.pickedImage = Self.encodeAvatar(image)
+        removedAvatar = false
+    }
+
+    /// Downscale to at most 512pt on the long edge and JPEG-encode. An avatar
+    /// is never drawn larger than ~72pt, so anything bigger is bytes nobody
+    /// sees.
+    static func encodeAvatar(_ image: UIImage, maxDimension: CGFloat = 512) -> Data? {
+        let longest = max(image.size.width, image.size.height)
+        let scale = longest > maxDimension ? maxDimension / longest : 1
+        let target = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+        let renderer = UIGraphicsImageRenderer(size: target)
+        let resized = renderer.image { _ in image.draw(in: CGRect(origin: .zero, size: target)) }
+        return resized.jpegData(compressionQuality: 0.85)
+    }
+
+    private func save() async {
+        saving = true
+        error = nil
+        do {
+            if let data = draft.pickedImage {
+                try await AuthService.uploadAvatar(data, userID: user.id)
+            }
+            if draft.nameChanged {
+                try await AuthService.setDisplayName(draft.normalizedName)
+            }
+            await onSaved()
+            dismiss()
+        } catch {
+            // Rule 08: a rejected account-configuration write fails visibly.
+            // Never `try?` — a silently-dropped save is a profile the reader
+            // believes they changed.
+            self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
+        }
+        saving = false
+    }
+
+    private func removeAvatar() async {
+        saving = true
+        error = nil
+        do {
+            try await AuthService.deleteAvatar(userID: user.id)
+            draft.pickedImage = nil
+            removedAvatar = true
+            await onSaved()
+        } catch {
+            self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
+        }
+        saving = false
+    }
+}

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -370,12 +370,12 @@ struct UserSummary: Codable, Hashable, Sendable {
     var canDownload: Bool
     var kindleEmail: String?
     /// Presentation name other users see. `nil` falls back to `username`,
-    /// which stays the login identity. Optional so a `CacheKey.me` blob
-    /// written before this field existed still decodes.
+    /// which stays the login identity.
     var displayName: String?
-    /// Whether this user has uploaded an avatar. Optional for the same
-    /// pre-upgrade-cache reason; treat a missing value as "no".
-    var hasAvatar: Bool?
+    /// Whether this user has uploaded an avatar. Non-optional: the lenient
+    /// `decode(Bool.Type,forKey:)` above defaults a missing key to `false`, so
+    /// a pre-upgrade `CacheKey.me` blob still decodes with the right meaning.
+    var hasAvatar: Bool = false
 
     /// The name to show for this user — never render `username` on its own.
     var display: String { displayName ?? username }

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -369,6 +369,16 @@ struct UserSummary: Codable, Hashable, Sendable {
     var canEdit: Bool
     var canDownload: Bool
     var kindleEmail: String?
+    /// Presentation name other users see. `nil` falls back to `username`,
+    /// which stays the login identity. Optional so a `CacheKey.me` blob
+    /// written before this field existed still decodes.
+    var displayName: String?
+    /// Whether this user has uploaded an avatar. Optional for the same
+    /// pre-upgrade-cache reason; treat a missing value as "no".
+    var hasAvatar: Bool?
+
+    /// The name to show for this user — never render `username` on its own.
+    var display: String { displayName ?? username }
 
     enum CodingKeys: String, CodingKey {
         case id, username
@@ -377,6 +387,8 @@ struct UserSummary: Codable, Hashable, Sendable {
         case canEdit = "can_edit"
         case canDownload = "can_download"
         case kindleEmail = "kindle_email"
+        case displayName = "display_name"
+        case hasAvatar = "has_avatar"
     }
 }
 

--- a/omnibus-ios/omnibus/Services/AuthService.swift
+++ b/omnibus-ios/omnibus/Services/AuthService.swift
@@ -105,4 +105,46 @@ enum AuthService {
         let _: Empty = try await APIClient.shared.post("/api/account/kindle-email", body: Body(email: email))
         await OfflineStore.shared.cacheDelete(CacheKey.me)
     }
+
+    // MARK: - Profile
+    //
+    // A profile is account configuration, so these never go through
+    // `SyncEngine` — a deferred replay would apply a name the reader has since
+    // changed. They throw on failure and the caller surfaces it (rule 08).
+
+    /// Set (or clear, with `nil`) the caller's display name.
+    static func setDisplayName(_ name: String?) async throws {
+        struct Body: Encodable { let display_name: String? }
+        let _: Empty = try await APIClient.shared.post(
+            "/api/account/profile", body: Body(display_name: name)
+        )
+        await OfflineStore.shared.cacheDelete(CacheKey.me)
+    }
+
+    /// Upload the caller's avatar, replacing any existing one.
+    static func uploadAvatar(_ data: Data, userID: Int64) async throws {
+        let _: Empty = try await APIClient.shared.upload(
+            "/api/account/avatar",
+            fileData: data,
+            fileName: "avatar.jpg",
+            fieldName: "avatar",
+            mimeType: "image/jpeg"
+        )
+        await Self.refreshAvatarCaches(userID: userID)
+    }
+
+    /// Remove the caller's avatar, reverting them to a monogram.
+    static func deleteAvatar(userID: Int64) async throws {
+        let _: Empty = try await APIClient.shared.delete("/api/account/avatar")
+        await Self.refreshAvatarCaches(userID: userID)
+    }
+
+    /// Drop the stale copies an avatar write invalidates: the identity blob
+    /// carrying `has_avatar`, and the cached image itself — whose URL doesn't
+    /// change when the bytes do, so without this the old picture stays on
+    /// screen until the revalidation window elapses.
+    private static func refreshAvatarCaches(userID: Int64) async {
+        await OfflineStore.shared.cacheDelete(CacheKey.me)
+        await ImageCache.shared.invalidate(UserAvatar.path(for: userID))
+    }
 }

--- a/omnibus-ios/omnibusTests/ProfileDraftTests.swift
+++ b/omnibus-ios/omnibusTests/ProfileDraftTests.swift
@@ -82,7 +82,7 @@ import Testing
         UserSummary(
             id: 1, username: "cool-guy-7", isAdmin: false, canUpload: true,
             canEdit: true, canDownload: true, kindleEmail: nil,
-            displayName: displayName, hasAvatar: nil
+            displayName: displayName, hasAvatar: false
         )
     }
 
@@ -95,15 +95,16 @@ import Testing
     }
 
     @Test func decodesAPayloadWithoutTheProfileFields() throws {
-        // A `CacheKey.me` blob written before this release has neither key;
-        // it must still decode rather than signing the reader out.
+        // A `CacheKey.me` blob written before this release has neither key; it
+        // must still decode rather than signing the reader out. `has_avatar`
+        // rides the lenient Bool decoder, so absent means `false`.
         let json = """
             {"id":1,"username":"alice","is_admin":false,"can_upload":true,
              "can_edit":true,"can_download":true}
             """
         let decoded = try JSONDecoder().decode(UserSummary.self, from: Data(json.utf8))
         #expect(decoded.displayName == nil)
-        #expect(decoded.hasAvatar == nil)
+        #expect(decoded.hasAvatar == false)
         #expect(decoded.display == "alice")
     }
 }

--- a/omnibus-ios/omnibusTests/ProfileDraftTests.swift
+++ b/omnibus-ios/omnibusTests/ProfileDraftTests.swift
@@ -1,0 +1,109 @@
+//  ProfileDraftTests.swift
+//  What the profile sheet's Save actually sends, and when it's enabled.
+//
+//  The normalization matters twice over: blank means *clear the display name*
+//  (reverting every byline to the username), and an unchanged value must not
+//  fire a write at all — a no-op POST still renames the wishlist shelf
+//  server-side.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+@Suite struct ProfileDraftTests {
+    @Test func seedsTheFieldFromTheExistingDisplayName() {
+        let draft = ProfileDraft(original: "Seamus")
+        #expect(draft.edited == "Seamus")
+        #expect(!draft.hasChanges)
+    }
+
+    @Test func seedsAnEmptyFieldWhenNoDisplayNameIsSet() {
+        let draft = ProfileDraft(original: nil)
+        #expect(draft.edited == "")
+        #expect(!draft.hasChanges)
+    }
+
+    @Test func trimsSurroundingWhitespaceFromWhatItSends() {
+        let draft = ProfileDraft(original: nil, edited: "  Seamus  ")
+        #expect(draft.normalizedName == "Seamus")
+        #expect(draft.nameChanged)
+    }
+
+    @Test func sendsNilForABlankFieldSoTheNameIsCleared() {
+        let draft = ProfileDraft(original: "Seamus", edited: "   ")
+        #expect(draft.normalizedName == nil)
+        #expect(draft.nameChanged)
+    }
+
+    @Test func treatsAWhitespaceOnlyEditOfAnAbsentNameAsUnchanged() {
+        // Blank over already-absent sends nothing: the write would be a no-op
+        // that still re-derives the wishlist shelf name server-side.
+        let draft = ProfileDraft(original: nil, edited: "   ")
+        #expect(draft.normalizedName == nil)
+        #expect(!draft.nameChanged)
+        #expect(!draft.hasChanges)
+    }
+
+    @Test func treatsARetypedIdenticalNameAsUnchanged() {
+        let draft = ProfileDraft(original: "Seamus", edited: "  Seamus  ")
+        #expect(!draft.nameChanged)
+        #expect(!draft.hasChanges)
+    }
+
+    @Test func aPickedImageIsAChangeEvenWithoutARename() {
+        let draft = ProfileDraft(original: "Seamus", edited: "Seamus", pickedImage: Data([0x1]))
+        #expect(!draft.nameChanged)
+        #expect(draft.hasChanges)
+    }
+}
+
+@Suite struct UserAvatarInitialsTests {
+    @Test func usesTheFirstLetterOfTwoTokens() {
+        #expect(UserAvatar.initials(for: "Seamus Sloan") == "SS")
+        #expect(UserAvatar.initials(for: "ada.lovelace") == "AL")
+        #expect(UserAvatar.initials(for: "grace_hopper") == "GH")
+    }
+
+    @Test func usesTwoLettersOfASingleToken() {
+        #expect(UserAvatar.initials(for: "seamus") == "SE")
+        #expect(UserAvatar.initials(for: "a") == "A")
+    }
+
+    @Test func fallsBackForAnEmptyOrSeparatorOnlyName() {
+        #expect(UserAvatar.initials(for: "") == "?")
+        #expect(UserAvatar.initials(for: "   ") == "?")
+        #expect(UserAvatar.initials(for: "..._") == "?")
+    }
+}
+
+@Suite struct UserSummaryDisplayTests {
+    private func user(displayName: String?) -> UserSummary {
+        UserSummary(
+            id: 1, username: "cool-guy-7", isAdmin: false, canUpload: true,
+            canEdit: true, canDownload: true, kindleEmail: nil,
+            displayName: displayName, hasAvatar: nil
+        )
+    }
+
+    @Test func prefersTheDisplayNameWhenSet() {
+        #expect(user(displayName: "Seamus").display == "Seamus")
+    }
+
+    @Test func fallsBackToTheUsername() {
+        #expect(user(displayName: nil).display == "cool-guy-7")
+    }
+
+    @Test func decodesAPayloadWithoutTheProfileFields() throws {
+        // A `CacheKey.me` blob written before this release has neither key;
+        // it must still decode rather than signing the reader out.
+        let json = """
+            {"id":1,"username":"alice","is_admin":false,"can_upload":true,
+             "can_edit":true,"can_download":true}
+            """
+        let decoded = try JSONDecoder().decode(UserSummary.self, from: Data(json.utf8))
+        #expect(decoded.displayName == nil)
+        #expect(decoded.hasAvatar == nil)
+        #expect(decoded.display == "alice")
+    }
+}


### PR DESCRIPTION
## Summary
The iOS half of user profiles, on top of #1698. Tapping the You tab's identity card opens a sheet that edits the display name and profile picture.

- `UserAvatar` is the native twin of the web component: the uploaded picture, else a monogram. It replaces the identity card's hand-rolled single-letter circle, so initials now match the web ("AD", not "A").
- `ProfileEditSheet` uses `PhotosPicker`, downscales to 512pt and re-encodes JPEG before upload — the server caps at 10 MB and a camera-roll photo clears that easily.
- **Never queued.** A profile is account configuration (rule 08): the writes go straight through `AuthService`, Save is disabled while `Connectivity.isOnline` is false, and a failure renders inline rather than being `try?`-swallowed. Rule 08's inventory and tiering are updated — a stale profile replay would restore a name the reader has since changed, and the display name is denormalized into the wishlist shelf name server-side.
- `ImageCache.invalidate(_:)` is new: the avatar URL is keyed only by user id, so without it the replaced picture would not appear on this device for up to the five-minute revalidation window.
- `displayName`/`hasAvatar` are **optional** on `UserSummary` so a `CacheKey.me` blob written before this release still decodes instead of signing the reader out.

## Test plan
- [x] `just ios-build`, `just ios-test`, `just ios-test-ui` — all succeed
- [x] 13 new unit tests: `ProfileDraft` (trimming, blank-clears-the-name, unchanged-doesn't-write, a picked image counts as a change), `UserAvatar.initials`, and `UserSummary.display` + decoding a pre-upgrade payload with neither profile key
- [x] Driven on a booted simulator: the identity card opens the sheet, the monogram live-updates as you type, the dirty-dot marks the field, and Save is correctly disabled with no changes

> [!NOTE]
> The on-device **save round-trip** is not verified. The simulator's app instance is signed into a different workspace's dev server (`:3020`), which doesn't carry this stack's endpoints, and repointing it would have disturbed that session — so I stopped rather than write to a server that isn't mine. What that leaves unproven is only the request composition; the endpoints themselves are covered by 14 REST integration tests in #1694 plus live `curl` runs, and the offline-disable path (the rule-08-critical behaviour) *was* confirmed on device.

## Version
- [x] **Patch** — the default.