### PR TITLE
fix: batch Kobo record_synced writes to avoid per-book N+1 (#1678)

### DIFF
--- a/db/src/kobo/delta.rs
+++ b/db/src/kobo/delta.rs
@@ -2,7 +2,7 @@
 //! device already holds (`kobo_books_sync`) and classify each into an add,
 //! a change, or a removal.
 
-use sqlx::{Row, SqlitePool};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
 use super::{sync_books, KoboBookRow, KoboError};
 
@@ -92,8 +92,21 @@ pub async fn sync_delta(
     Ok(SyncDelta { changes })
 }
 
+/// Rows per chunk for the upsert statement: 3 binds/row keeps each statement
+/// comfortably under SQLite's 999 bound-parameter cap.
+const UPSERT_CHUNK_SIZE: usize = 300;
+
+/// Uuids per chunk for the `IN (...)` update/delete statements: 1 bind for
+/// `device_id` plus one per uuid, well under the cap.
+const UUID_CHUNK_SIZE: usize = 900;
+
 /// Advance the device's snapshot to match `changes` — upserting the adds and
 /// changes at the `last_modified` they were sent at, and dropping the removals.
+///
+/// Groups `changes` by operation kind and issues one chunked multi-row
+/// statement per group, instead of one round-trip per book — a large opted-in
+/// library would otherwise hold SQLite's single writer lock for the whole
+/// device sync.
 ///
 /// Call this only after the response body is committed to; see [`sync_delta`].
 pub async fn record_synced(
@@ -104,46 +117,102 @@ pub async fn record_synced(
     if changes.is_empty() {
         return Ok(());
     }
-    let mut tx = pool.begin().await?;
+    let mut upserts: Vec<&KoboBookRow> = Vec::new();
+    let mut state_changed: Vec<&str> = Vec::new();
+    let mut removed: Vec<&str> = Vec::new();
     for change in changes {
         match change {
-            SyncChange::New(book) | SyncChange::Changed(book) => {
-                sqlx::query(
-                    "INSERT INTO kobo_books_sync
-                        (device_id, book_uuid, last_modified_seen, synced_at)
-                     VALUES (?, ?, ?, strftime('%s','now'))
-                     ON CONFLICT(device_id, book_uuid) DO UPDATE SET
-                        last_modified_seen = excluded.last_modified_seen,
-                        synced_at          = excluded.synced_at",
-                )
-                .bind(device_id)
-                .bind(&book.uuid)
-                .bind(book.last_modified_epoch)
-                .execute(&mut *tx)
-                .await?;
-            }
-            // State-only: bump the watermark, never `last_modified_seen` —
-            // overwriting it here would mark unsent metadata as delivered.
-            SyncChange::StateChanged(book) => {
-                sqlx::query(
-                    "UPDATE kobo_books_sync SET synced_at = strftime('%s','now')
-                      WHERE device_id = ? AND book_uuid = ?",
-                )
-                .bind(device_id)
-                .bind(&book.uuid)
-                .execute(&mut *tx)
-                .await?;
-            }
-            SyncChange::Removed { book_uuid } => {
-                sqlx::query("DELETE FROM kobo_books_sync WHERE device_id = ? AND book_uuid = ?")
-                    .bind(device_id)
-                    .bind(book_uuid)
-                    .execute(&mut *tx)
-                    .await?;
-            }
+            SyncChange::New(book) | SyncChange::Changed(book) => upserts.push(book),
+            SyncChange::StateChanged(book) => state_changed.push(book.uuid.as_str()),
+            SyncChange::Removed { book_uuid } => removed.push(book_uuid.as_str()),
         }
     }
+
+    let mut tx = pool.begin().await?;
+    upsert_synced(&mut tx, device_id, &upserts).await?;
+    // State-only: bump the watermark, never `last_modified_seen` — overwriting
+    // it here would mark unsent metadata as delivered.
+    touch_state_changed(&mut tx, device_id, &state_changed).await?;
+    delete_removed(&mut tx, device_id, &removed).await?;
     tx.commit().await?;
+    Ok(())
+}
+
+/// Upsert one `kobo_books_sync` row per new/changed book, chunked to stay
+/// under SQLite's bound-parameter limit.
+async fn upsert_synced(
+    tx: &mut Transaction<'_, Sqlite>,
+    device_id: i64,
+    books: &[&KoboBookRow],
+) -> Result<(), KoboError> {
+    for chunk in books.chunks(UPSERT_CHUNK_SIZE) {
+        let rows = std::iter::repeat_n("(?, ?, ?, strftime('%s','now'))", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "INSERT INTO kobo_books_sync
+                (device_id, book_uuid, last_modified_seen, synced_at)
+             VALUES {rows}
+             ON CONFLICT(device_id, book_uuid) DO UPDATE SET
+                last_modified_seen = excluded.last_modified_seen,
+                synced_at          = excluded.synced_at"
+        );
+        let mut q = sqlx::query(&sql);
+        for book in chunk {
+            q = q
+                .bind(device_id)
+                .bind(&book.uuid)
+                .bind(book.last_modified_epoch);
+        }
+        q.execute(&mut **tx).await?;
+    }
+    Ok(())
+}
+
+/// Bump `synced_at` for every book whose reading state moved but whose
+/// metadata didn't, chunked to stay under SQLite's bound-parameter limit.
+async fn touch_state_changed(
+    tx: &mut Transaction<'_, Sqlite>,
+    device_id: i64,
+    uuids: &[&str],
+) -> Result<(), KoboError> {
+    for chunk in uuids.chunks(UUID_CHUNK_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "UPDATE kobo_books_sync SET synced_at = strftime('%s','now')
+              WHERE device_id = ? AND book_uuid IN ({placeholders})"
+        );
+        let mut q = sqlx::query(&sql).bind(device_id);
+        for uuid in chunk {
+            q = q.bind(*uuid);
+        }
+        q.execute(&mut **tx).await?;
+    }
+    Ok(())
+}
+
+/// Drop every `kobo_books_sync` row for a book no longer opted in, chunked to
+/// stay under SQLite's bound-parameter limit.
+async fn delete_removed(
+    tx: &mut Transaction<'_, Sqlite>,
+    device_id: i64,
+    uuids: &[&str],
+) -> Result<(), KoboError> {
+    for chunk in uuids.chunks(UUID_CHUNK_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "DELETE FROM kobo_books_sync WHERE device_id = ? AND book_uuid IN ({placeholders})"
+        );
+        let mut q = sqlx::query(&sql).bind(device_id);
+        for uuid in chunk {
+            q = q.bind(*uuid);
+        }
+        q.execute(&mut **tx).await?;
+    }
     Ok(())
 }
 

--- a/db/src/kobo/delta.rs
+++ b/db/src/kobo/delta.rs
@@ -96,8 +96,8 @@ pub async fn sync_delta(
 /// comfortably under SQLite's 999 bound-parameter cap.
 const UPSERT_CHUNK_SIZE: usize = 300;
 
-/// Uuids per chunk for the `IN (...)` update/delete statements: 1 bind for
-/// `device_id` plus one per uuid, well under the cap.
+/// UUIDs per chunk for the `IN (...)` update/delete statements: 1 bind for
+/// `device_id` plus one per UUID, well under the cap.
 const UUID_CHUNK_SIZE: usize = 900;
 
 /// Advance the device's snapshot to match `changes` — upserting the adds and

--- a/db/src/kobo/delta/tests.rs
+++ b/db/src/kobo/delta/tests.rs
@@ -353,6 +353,102 @@ async fn recording_a_state_change_preserves_last_modified_seen() {
     assert_eq!(seen_after, seen_before, "metadata watermark must not move");
 }
 
+/// A synthetic row for the batching tests below. `kobo_books_sync` has no FK
+/// to `books`, so these never need a real indexed book behind them.
+fn synthetic_book(n: usize, last_modified_epoch: i64) -> KoboBookRow {
+    KoboBookRow {
+        id: n as i64,
+        uuid: format!("synthetic-{n:05}"),
+        title: format!("Book {n}"),
+        author: "Author".into(),
+        last_modified_epoch,
+        epub_size_bytes: 0,
+    }
+}
+
+#[tokio::test]
+async fn record_synced_applies_every_group_across_multiple_chunks() {
+    // Large enough in every bucket (upsert, state-changed, removed) to force
+    // more than one chunk each, so a bug in the per-chunk boundary — a
+    // dropped row, a double-bound param, an off-by-one in the WHERE IN list —
+    // would show up as a wrong count or a wrong value here.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = make_user(&pool, "reader").await;
+    let device = make_device(&pool, user, "Clara").await;
+
+    // Seed 1950 pre-existing rows: 50 will be updated (`Changed`), 950 will
+    // have their reading-state watermark bumped, 950 will be removed.
+    let seed: Vec<SyncChange> = (0..1950)
+        .map(|n| SyncChange::New(synthetic_book(n, 1)))
+        .collect();
+    record_synced(&pool, device, &seed).await.unwrap();
+
+    let mut batch = Vec::new();
+    batch.extend((0..350).map(|n| SyncChange::New(synthetic_book(2000 + n, 1))));
+    batch.extend((0..50).map(|n| SyncChange::Changed(synthetic_book(n, 42))));
+    batch.extend((50..1000).map(|n| SyncChange::StateChanged(synthetic_book(n, 1))));
+    batch.extend((1000..1950).map(|n| SyncChange::Removed {
+        book_uuid: format!("synthetic-{n:05}"),
+    }));
+    assert_eq!(
+        batch.len(),
+        2300,
+        "sanity: every bucket crosses its chunk size"
+    );
+
+    record_synced(&pool, device, &batch).await.unwrap();
+
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM kobo_books_sync WHERE device_id = ?")
+        .bind(device)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 1950 + 350 - 950, "new rows land, removed rows drop");
+
+    let changed_seen: i64 = sqlx::query_scalar(
+        "SELECT last_modified_seen FROM kobo_books_sync WHERE device_id = ? AND book_uuid = ?",
+    )
+    .bind(device)
+    .bind("synthetic-00000")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(changed_seen, 42, "a Changed row's watermark must advance");
+
+    let state_changed_seen: i64 = sqlx::query_scalar(
+        "SELECT last_modified_seen FROM kobo_books_sync WHERE device_id = ? AND book_uuid = ?",
+    )
+    .bind(device)
+    .bind("synthetic-00500")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        state_changed_seen, 1,
+        "a StateChanged row's metadata watermark must not move"
+    );
+
+    let last_new: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM kobo_books_sync WHERE device_id = ? AND book_uuid = ?",
+    )
+    .bind(device)
+    .bind("synthetic-02349")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(last_new, 1, "the last chunk of new rows must land");
+
+    let removed_gone: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM kobo_books_sync WHERE device_id = ? AND book_uuid = ?",
+    )
+    .bind(device)
+    .bind("synthetic-01949")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(removed_gone, 0, "the last chunk of removals must apply");
+}
+
 #[tokio::test]
 async fn sync_delta_prefers_a_metadata_change_over_a_state_change() {
     // When both moved, the device needs the full `Changed` pair — a bare


### PR DESCRIPTION
## Summary
- `record_synced` in `db/src/kobo/delta.rs` looped over `changes: &[SyncChange]` and issued one `INSERT`/`UPDATE`/`DELETE` per changed book inside a single transaction, holding SQLite's single writer lock for the whole device sync on a large opted-in library.
- Groups the incoming changes by operation kind (new/changed upsert, state-changed update, removed delete) and issues one chunked multi-row statement per group instead — mirroring the chunked `IN (...)` pattern already used on the read side of this file (`sync_delta`/`sync_books`/`reading_state_for` in `db/src/kobo.rs`) and in `shelves/write.rs::insert_books`.
- Upserts are chunked at 300 rows (3 binds/row) and the state-changed/removed `IN (...)` statements are chunked at 900 uuids (device_id + N binds), both comfortably under SQLite's ~999 bound-parameter limit.
- The whole call stays inside the existing `pool.begin()`/`tx.commit()` transaction, so it's still atomic.

Closes #1678

## Test plan
- [x] `cargo fmt --check -p omnibus-db` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1780/1781; the one unrelated failure is `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, which needs the `test_data/audiobooks/public_domain/` fixture set that isn't checked into git and couldn't be fetched via `just fixtures` in this sandbox — untouched by this change, see Notes)
- Added `record_synced_applies_every_group_across_multiple_chunks` in `db/src/kobo/delta/tests.rs`, exercising a batch of 2300 changes (350 new, 50 changed, 950 state-changed, 950 removed against a 1950-row pre-existing snapshot) — large enough to force multiple chunks in every bucket — and asserting the final row count, watermark values, and that the first/last row of each chunked group landed correctly.

## Version
- [x] **Patch** — the default.

## Notes
- The single `cargo test -p omnibus-db` failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is pre-existing and unrelated to this change — it reads a fixture under `test_data/audiobooks/public_domain/`, which per `.claude/rules/01-dev-environment.md` isn't in git and requires `just fixtures` (needs `nix`, unavailable in this sandbox). All 15 `kobo::delta` tests pass, including the new one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01251M8YRtMUtVzzF6WECkwD)_