### PR TITLE
fix: send Kobo highlight colours as firmware hex swatches (#1629)

### DIFF
--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -137,24 +137,54 @@ wrong.
 > the reliable way to pull down highlights that were waiting for it.
 
 > [!NOTE]
-> **Known limitation: highlight colour pushed to a Kobo may not render**
+> **Highlight colour on-wire shape: changed to a firmware hex swatch, still
+> unconfirmed against a real device**
 >
-> Omnibus sends each annotation's colour as `highlightColor` — a lowercase
-> colour name (`yellow`/`green`/`blue`/`pink`/`purple`) — in the Reading
-> Services annotation payload. On at least one real device, every annotation
-> pushed from Omnibus was observed stored on-device with `Bookmark.Color = 0`
-> (yellow) regardless of the colour sent, while highlights created directly
-> on the device use the full `Color` range normally. This means the firmware
-> is not applying Omnibus's `highlightColor` value to inbound annotations as
-> sent — it may expect a different shape on this field (e.g. an integer 0–3
-> rather than a name) or it may ignore colour on inbound annotations
-> entirely; which one is unconfirmed.
+> Omnibus used to send each annotation's colour as `highlightColor` — a
+> lowercase CSS-style colour name (`yellow`/`green`/`blue`/`pink`/`purple`)
+> — in the Reading Services annotation payload. On at least one real device,
+> every annotation pushed from Omnibus was observed stored on-device with
+> `Bookmark.Color = 0` (yellow) regardless of the colour sent, while
+> highlights created directly on the device use the full `Color` range
+> normally (the original report, with the device's `KoboReader.sqlite` data:
+> [#1629](https://github.com/seamus-sloan/omnibus/issues/1629)).
 >
-> This repo carries no captured device PATCH and no vendored reference
-> implementation for the Reading Services protocol to confirm which is
-> true, so the wire format has **not** been changed speculatively — see
-> [#1629](https://github.com/seamus-sloan/omnibus/issues/1629). Highlight
-> and note **text**, placement, and deletes all sync correctly; only the
-> rendered *colour* of a device-side highlight is affected. Fixing this
-> for real needs a `.kobo/KoboReader.sqlite` capture (or a packet capture)
-> from a device that just received a coloured highlight over wireless sync.
+> This repo still carries no captured device PATCH for the Reading Services
+> protocol, but a follow-up investigation found a genuine shape difference
+> against [bookorbit](https://github.com/bookorbit/bookorbit) — an
+> actively-developed, open-source Kobo sync project whose own Reading
+> Services client (`kobo-annotation-payload.ts` /
+> `annotation-style-map.ts`) sends `highlightColor` as one of **four fixed
+> hex swatches**, explicitly commented "Kobo firmware's four fixed highlight
+> colors":
+>
+> | Named colour | Hex swatch |
+> |---|---|
+> | yellow | `#F6F3B3` |
+> | green | `#C6E09E` |
+> | blue | `#B2E1E8` |
+> | pink | `#E8AFCF` |
+>
+> A CSS-style name being silently ignored in favour of the palette default
+> would exactly reproduce the observed symptom — every pushed annotation
+> landing at index 0 (yellow) — so Omnibus's outbound `highlightColor` now
+> sends these hex values (`color_to_kobo` /
+> `color_from_kobo` in
+> [reading_services/dto.rs](../server/src/backend/kobo/reading_services/dto.rs)).
+> The inbound parser accepts **both** the hex swatches and the old CSS names,
+> so an already-adopted device or an unverified firmware revision that still
+> sends a name keeps working.
+>
+> **This is still unverified against real hardware** — bookorbit's own
+> source carries no comment or test citing a device capture for this exact
+> field either, so this fix is corroborated by a comparable open-source
+> implementation, not proven. If highlights pushed from Omnibus still land
+> as yellow after this change, the firmware likely ignores `highlightColor`
+> on inbound annotations entirely rather than wanting a different shape, and
+> that would be the next thing to rule out. Kobo's classic highlight menu
+> has no fifth swatch for Omnibus's violet, so on-device it renders
+> identically to rose (pink) — a real palette limit, not a bug. Highlight
+> and note **text**, placement, and deletes were never affected — only
+> colour. Confirming (or refuting) this needs a `.kobo/KoboReader.sqlite`
+> capture (or a packet capture) from a device that just received a coloured
+> highlight over wireless sync, per AC2 of #1629.

--- a/server/src/backend/kobo/reading_services/dto.rs
+++ b/server/src/backend/kobo/reading_services/dto.rs
@@ -200,27 +200,58 @@ fn parse_delete(entry: &Value) -> Option<String> {
         .then(|| id.to_owned())
 }
 
-/// Map a device color name onto the closed Omnibus palette. Unknown names,
-/// hex values, and a missing field all land on amber — the palette default.
+/// Map a device color onto the closed Omnibus palette. Tries a Kobo
+/// firmware hex swatch first (what [`color_to_kobo`] now emits and, per the
+/// cross-referenced reference client, what a real device sends — see
+/// `docs/kobo.md`), then falls back to the CSS-style names this endpoint
+/// accepted before that finding (#1629) — kept so an already-synced device
+/// echoing an older-shaped value, or one from an unverified firmware
+/// revision, still parses. Unknown names, unrecognized hex, and a missing
+/// field all land on amber — the palette default.
 pub fn color_from_kobo(raw: Option<&str>) -> HighlightColor {
-    match raw.map(str::to_ascii_lowercase).as_deref() {
-        Some("yellow") | Some("amber") => HighlightColor::Amber,
-        Some("green") => HighlightColor::Green,
-        Some("blue") | Some("cyan") | Some("teal") => HighlightColor::Blue,
-        Some("pink") | Some("red") | Some("magenta") | Some("rose") => HighlightColor::Rose,
-        Some("purple") | Some("violet") => HighlightColor::Violet,
+    let Some(raw) = raw else {
+        return HighlightColor::Amber;
+    };
+    if let Some(color) = color_from_kobo_hex(raw) {
+        return color;
+    }
+    match raw.to_ascii_lowercase().as_str() {
+        "yellow" | "amber" => HighlightColor::Amber,
+        "green" => HighlightColor::Green,
+        "blue" | "cyan" | "teal" => HighlightColor::Blue,
+        "pink" | "red" | "magenta" | "rose" => HighlightColor::Rose,
+        "purple" | "violet" => HighlightColor::Violet,
         _ => HighlightColor::Amber,
     }
 }
 
-/// The reverse map, onto the names Kobo firmware renders.
+/// The four fixed hex swatches Kobo firmware's own highlight menu renders —
+/// not CSS-style names. Cross-referenced against the equivalent field in
+/// bookorbit's Reading Services client (the one open-source Kobo sync
+/// project this investigation found modelling the wire value as a hex
+/// swatch rather than a name), since this repo has no captured device PATCH
+/// to confirm it directly; see the `docs/kobo.md` note on #1629 for the
+/// caveat. Firmware has no fifth swatch for violet, so it snaps to pink —
+/// the nearest of the four by RGB distance, same as rose.
+fn color_from_kobo_hex(raw: &str) -> Option<HighlightColor> {
+    match raw.to_ascii_uppercase().as_str() {
+        "#F6F3B3" => Some(HighlightColor::Amber),
+        "#C6E09E" => Some(HighlightColor::Green),
+        "#B2E1E8" => Some(HighlightColor::Blue),
+        "#E8AFCF" => Some(HighlightColor::Rose),
+        _ => None,
+    }
+}
+
+/// The reverse map, onto the hex swatch Kobo firmware renders. See
+/// [`color_from_kobo_hex`] for the source and the violet caveat: it has no
+/// firmware swatch of its own and renders identically to rose on-device.
 pub fn color_to_kobo(color: HighlightColor) -> &'static str {
     match color {
-        HighlightColor::Amber => "yellow",
-        HighlightColor::Green => "green",
-        HighlightColor::Blue => "blue",
-        HighlightColor::Rose => "pink",
-        HighlightColor::Violet => "purple",
+        HighlightColor::Amber => "#F6F3B3",
+        HighlightColor::Green => "#C6E09E",
+        HighlightColor::Blue => "#B2E1E8",
+        HighlightColor::Rose | HighlightColor::Violet => "#E8AFCF",
     }
 }
 

--- a/server/src/backend/kobo/reading_services/dto.rs
+++ b/server/src/backend/kobo/reading_services/dto.rs
@@ -215,13 +215,19 @@ pub fn color_from_kobo(raw: Option<&str>) -> HighlightColor {
     if let Some(color) = color_from_kobo_hex(raw) {
         return color;
     }
-    match raw.to_ascii_lowercase().as_str() {
-        "yellow" | "amber" => HighlightColor::Amber,
-        "green" => HighlightColor::Green,
-        "blue" | "cyan" | "teal" => HighlightColor::Blue,
-        "pink" | "red" | "magenta" | "rose" => HighlightColor::Rose,
-        "purple" | "violet" => HighlightColor::Violet,
-        _ => HighlightColor::Amber,
+    let matches = |name: &str| raw.eq_ignore_ascii_case(name);
+    if matches("yellow") || matches("amber") {
+        HighlightColor::Amber
+    } else if matches("green") {
+        HighlightColor::Green
+    } else if matches("blue") || matches("cyan") || matches("teal") {
+        HighlightColor::Blue
+    } else if matches("pink") || matches("red") || matches("magenta") || matches("rose") {
+        HighlightColor::Rose
+    } else if matches("purple") || matches("violet") {
+        HighlightColor::Violet
+    } else {
+        HighlightColor::Amber
     }
 }
 
@@ -234,12 +240,16 @@ pub fn color_from_kobo(raw: Option<&str>) -> HighlightColor {
 /// caveat. Firmware has no fifth swatch for violet, so it snaps to pink —
 /// the nearest of the four by RGB distance, same as rose.
 fn color_from_kobo_hex(raw: &str) -> Option<HighlightColor> {
-    match raw.to_ascii_uppercase().as_str() {
-        "#F6F3B3" => Some(HighlightColor::Amber),
-        "#C6E09E" => Some(HighlightColor::Green),
-        "#B2E1E8" => Some(HighlightColor::Blue),
-        "#E8AFCF" => Some(HighlightColor::Rose),
-        _ => None,
+    if raw.eq_ignore_ascii_case("#F6F3B3") {
+        Some(HighlightColor::Amber)
+    } else if raw.eq_ignore_ascii_case("#C6E09E") {
+        Some(HighlightColor::Green)
+    } else if raw.eq_ignore_ascii_case("#B2E1E8") {
+        Some(HighlightColor::Blue)
+    } else if raw.eq_ignore_ascii_case("#E8AFCF") {
+        Some(HighlightColor::Rose)
+    } else {
+        None
     }
 }
 

--- a/server/src/backend/kobo/reading_services/tests.rs
+++ b/server/src/backend/kobo/reading_services/tests.rs
@@ -251,7 +251,7 @@ async fn patch_then_get_round_trips_a_device_highlight_with_a_weak_etag() {
     let a = &annotations[0];
     assert_eq!(a["id"], "kobo-ann-1");
     assert_eq!(a["type"], "note");
-    assert_eq!(a["highlightColor"], "yellow");
+    assert_eq!(a["highlightColor"], "#F6F3B3");
     assert_eq!(a["highlightedText"], "the highlighted passage");
     assert_eq!(a["noteText"], "margin note");
     assert!(a["context"].is_null());
@@ -557,7 +557,7 @@ async fn get_serves_a_mixed_set_of_device_and_converted_web_annotations() {
     assert_eq!(web["location"]["span"]["chapterFilename"], "c1.xhtml");
     assert_eq!(web["location"]["span"]["startPath"], "span#kobo\\.1\\.2");
     assert_eq!(web["location"]["span"]["endChar"], 24);
-    assert_eq!(web["highlightColor"], "green");
+    assert_eq!(web["highlightColor"], "#C6E09E");
 
     // The drained GET acked the mixed fingerprint: the book goes quiet.
     assert!(check_for_changes(&app).await.is_empty());
@@ -596,7 +596,7 @@ async fn web_edit_of_a_converted_row_reports_and_flows_down_on_the_next_get() {
         .unwrap();
     let body = body_json(res).await;
     let by_id = annotations_by_id(&body);
-    assert_eq!(by_id["web-1"]["highlightColor"], "pink");
+    assert_eq!(by_id["web-1"]["highlightColor"], "#E8AFCF");
 }
 
 #[tokio::test]
@@ -834,7 +834,9 @@ async fn web_side_recolor_and_note_flow_down_on_the_next_get() {
         .unwrap();
     let body = body_json(res).await;
     let a = &body["annotations"][0];
-    assert_eq!(a["highlightColor"], "purple");
+    // Violet has no fifth Kobo swatch, so it renders as the same hex as
+    // rose on-device (see color_to_kobo's doc comment).
+    assert_eq!(a["highlightColor"], "#E8AFCF");
     assert_eq!(a["noteText"], "from the web");
     assert_eq!(a["type"], "note", "a note-bearing row serves as a note");
 }
@@ -1077,34 +1079,60 @@ mod dto_tests {
     }
 
     #[test]
-    fn color_from_kobo_defaults_unknown_hex_and_missing_to_amber() {
+    fn color_from_kobo_defaults_unrecognized_hex_and_missing_to_amber() {
         assert_eq!(color_from_kobo(Some("#FFDD00")), HighlightColor::Amber);
         assert_eq!(color_from_kobo(Some("chartreuse")), HighlightColor::Amber);
         assert_eq!(color_from_kobo(None), HighlightColor::Amber);
         assert_eq!(color_from_kobo(Some("PINK")), HighlightColor::Rose);
     }
 
+    // #1629: the wire value is a firmware hex swatch, not a CSS name — see
+    // color_from_kobo_hex's doc comment for the source. Case-insensitive
+    // because we cannot confirm from a real device which case a genuine
+    // firmware PATCH would send.
     #[test]
-    fn color_round_trip_is_stable_for_every_palette_color() {
+    fn color_from_kobo_recognizes_every_kobo_firmware_hex_swatch_case_insensitively() {
+        assert_eq!(color_from_kobo(Some("#F6F3B3")), HighlightColor::Amber);
+        assert_eq!(color_from_kobo(Some("#c6e09e")), HighlightColor::Green);
+        assert_eq!(color_from_kobo(Some("#B2E1E8")), HighlightColor::Blue);
+        assert_eq!(color_from_kobo(Some("#e8afcf")), HighlightColor::Rose);
+    }
+
+    #[test]
+    fn color_round_trip_is_stable_for_every_color_with_a_firmware_swatch() {
+        // Amber, green, and blue have a swatch of their own. Rose's swatch
+        // (pink) is also violet's nearest-neighbour target, so it round
+        // trips but does not distinguish the two — see the next test.
         for color in [
             HighlightColor::Amber,
             HighlightColor::Green,
             HighlightColor::Blue,
             HighlightColor::Rose,
-            HighlightColor::Violet,
         ] {
             assert_eq!(color_from_kobo(Some(color_to_kobo(color))), color);
         }
     }
 
+    #[test]
+    fn color_round_trip_collapses_violet_into_rose_for_lack_of_a_fifth_kobo_swatch() {
+        assert_eq!(
+            color_to_kobo(HighlightColor::Violet),
+            color_to_kobo(HighlightColor::Rose)
+        );
+        assert_eq!(
+            color_from_kobo(Some(color_to_kobo(HighlightColor::Violet))),
+            HighlightColor::Rose
+        );
+    }
+
     // Pins color_to_kobo's value mapping so a future change to it is deliberate.
     #[test]
-    fn color_to_kobo_emits_the_documented_lowercase_name_for_every_palette_color() {
-        assert_eq!(color_to_kobo(HighlightColor::Amber), "yellow");
-        assert_eq!(color_to_kobo(HighlightColor::Green), "green");
-        assert_eq!(color_to_kobo(HighlightColor::Blue), "blue");
-        assert_eq!(color_to_kobo(HighlightColor::Rose), "pink");
-        assert_eq!(color_to_kobo(HighlightColor::Violet), "purple");
+    fn color_to_kobo_emits_the_documented_firmware_hex_swatch_for_every_palette_color() {
+        assert_eq!(color_to_kobo(HighlightColor::Amber), "#F6F3B3");
+        assert_eq!(color_to_kobo(HighlightColor::Green), "#C6E09E");
+        assert_eq!(color_to_kobo(HighlightColor::Blue), "#B2E1E8");
+        assert_eq!(color_to_kobo(HighlightColor::Rose), "#E8AFCF");
+        assert_eq!(color_to_kobo(HighlightColor::Violet), "#E8AFCF");
     }
 
     #[test]

--- a/server/src/backend/kobo/reading_services/tests.rs
+++ b/server/src/backend/kobo/reading_services/tests.rs
@@ -834,8 +834,7 @@ async fn web_side_recolor_and_note_flow_down_on_the_next_get() {
         .unwrap();
     let body = body_json(res).await;
     let a = &body["annotations"][0];
-    // Violet has no fifth Kobo swatch, so it renders as the same hex as
-    // rose on-device (see color_to_kobo's doc comment).
+    // Violet has no fifth Kobo swatch, so it renders as rose's hex (see color_to_kobo's doc comment).
     assert_eq!(a["highlightColor"], "#E8AFCF");
     assert_eq!(a["noteText"], "from the web");
     assert_eq!(a["type"], "note", "a note-bearing row serves as a note");
@@ -1086,10 +1085,7 @@ mod dto_tests {
         assert_eq!(color_from_kobo(Some("PINK")), HighlightColor::Rose);
     }
 
-    // #1629: the wire value is a firmware hex swatch, not a CSS name — see
-    // color_from_kobo_hex's doc comment for the source. Case-insensitive
-    // because we cannot confirm from a real device which case a genuine
-    // firmware PATCH would send.
+    // #1629: wire value is a firmware hex swatch (see color_from_kobo_hex's doc comment); case-insensitive since the real device casing is unconfirmed.
     #[test]
     fn color_from_kobo_recognizes_every_kobo_firmware_hex_swatch_case_insensitively() {
         assert_eq!(color_from_kobo(Some("#F6F3B3")), HighlightColor::Amber);


### PR DESCRIPTION
## Summary
- Addresses #1629 — highlight colours pushed to a Kobo over wireless sync all landed on-device with `Bookmark.Color = 0` (yellow), regardless of the colour Omnibus sent.
- Re-verified the evidence already gathered on the issue: `AnnotationOut` in `server/src/backend/kobo/reading_services/dto.rs` does serialise camelCase `highlightColor`, and `fingerprint` in `db/src/kobo/annotations.rs` does hash `row.color`, ruling out redelivery. The bug was genuinely still open — a prior PR (#1637, merged) investigated and could only document it as an unconfirmed limitation, since this sandbox has no real Kobo device to capture a PATCH against.
- This time I cross-referenced the open-source Kobo sync implementations named in the issue. [bookorbit](https://github.com/bookorbit/bookorbit)'s Reading Services client (`kobo-annotation-payload.ts` / `annotation-style-map.ts`) sends `highlightColor` as one of **four fixed hex swatches** (`#F6F3B3` yellow, `#C6E09E` green, `#B2E1E8` blue, `#E8AFCF` pink), explicitly commented "Kobo firmware's four fixed highlight colors" — not a CSS-style name like Omnibus was sending. A name being silently ignored in favour of the firmware default reproduces the observed symptom exactly (every annotation landing at index 0).
- Changed `color_to_kobo` to emit these hex swatches instead of names. `color_from_kobo` now accepts **both** the hex swatches and the old CSS names on inbound PATCHes, so an already-adopted device or an unverified firmware revision that still sends a name keeps parsing correctly (no behavioural regression there).
- Omnibus's palette has five colours (amber/green/blue/rose/violet) but Kobo firmware only has four fixed swatches — violet has no swatch of its own and now maps to the same hex as rose (its nearest neighbour by RGB distance), matching what bookorbit does for out-of-palette colours. This is a real hardware/firmware limit, not a code bug, and it's documented as such.
- **Honesty on confidence level**: this fix is corroborated by a comparable, actively-developed open-source implementation, but it is **not proven against real hardware** — bookorbit's own source has no comment or test citing a device capture for this exact field either. `docs/kobo.md` is updated to explain the finding, the fix, and this residual uncertainty, and still asks for a real `.kobo/KoboReader.sqlite` capture (or packet capture) to confirm or refute it, per AC2.
- AC3 (test coverage for whatever shape the investigation supports): added/updated `dto_tests` in `server/src/backend/kobo/reading_services/tests.rs` pinning the new hex-swatch outbound shape, the dual-shape inbound parser (hex + legacy names, case-insensitive), and the violet→rose collapse; updated every outbound `highlightColor` assertion in the existing HTTP-layer tests to the new hex values.
- I'm marking this "Closes" rather than "Addresses" because AC1's own text allows either a working fix *or* a documented, honest limitation as a complete resolution, and I believe this PR delivers the strongest version available without physical hardware: a genuine, well-sourced shape fix plus an honest caveat that it still awaits real-device confirmation.

Closes #1629

## Test plan
- [x] `cargo fmt` — PASS (clean, no diff)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS (0 warnings)
- [x] `cargo test -p omnibus` — 669 passed, 2 pre-existing failures unrelated to this change (`backend::uploads::tests::commit_rejects_read_only_library_with_400`, `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`) — both rely on `chmod 0o555` actually blocking a write, which it doesn't under this sandbox's root user (confirmed by reading the test source); this exact pre-existing environment artifact was already called out on the prior PR for this issue (#1637)
- [x] `cargo test -p omnibus reading_services` (focused re-run) — 37 passed, 0 failed, including every new/updated `dto_tests` case
- Not run: `cargo test -p omnibus-db` — no `db/` code was touched by this change

## Version
- [x] **Patch** — the default.

## Notes
- This fix could not be verified against a real Kobo device — it is a well-sourced hypothesis (matching a working reference implementation and precisely explaining the reported symptom), not a confirmed one. If a maintainer with device access can capture a real annotation PATCH after this change ships, that capture would let AC2 be closed with certainty either way — and if it turns out firmware actually does want a CSS name (or ignores the field entirely), this is a one-file revert (`color_to_kobo`/`color_from_kobo` in `server/src/backend/kobo/reading_services/dto.rs`).
- The violet→rose on-device collapse is a real palette-size mismatch (Kobo firmware has 4 highlight colours, Omnibus has 5), not something further code can fix — flagging it in case a future firmware or device generation turns out to support a wider palette.

---
_Generated by [Claude Code](https://claude.ai/code/session_01251M8YRtMUtVzzF6WECkwD)_