### PR TITLE
refactor: pass JournalEntryEditState as one prop to BdJournalPublishDraftButton (#1683)

### DIFF
--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -47,13 +47,14 @@ fn BdJournalPublishDraftButton(
     entry_id: i64,
     body_for_edit: String,
     entry_progress: Option<u8>,
-    saving: Signal<bool>,
-    error: Signal<Option<String>>,
-    reload: Signal<u32>,
+    edit: JournalEntryEditState,
 ) -> Element {
-    let mut saving = saving;
-    let mut error = error;
-    let mut reload = reload;
+    let JournalEntryEditState {
+        mut saving,
+        mut error,
+        mut reload,
+        ..
+    } = edit;
     rsx! {
         button {
             r#type: "button",
@@ -139,9 +140,7 @@ fn BdJournalEntryHeader(view: JournalEntryHeaderView, edit: JournalEntryEditStat
                             entry_id,
                             body_for_edit: body_for_edit.clone(),
                             entry_progress,
-                            saving,
-                            error,
-                            reload,
+                            edit,
                         }
                     }
                     button {


### PR DESCRIPTION
## Summary
- `BdJournalPublishDraftButton` in `frontend/src/pages/book_detail/journal/entry_card.rs` took `saving`, `error`, and `reload` as three separate `Signal` props even though its only caller, `BdJournalEntryHeader`, already holds them bundled in a `JournalEntryEditState` value — a struct the same file defines specifically "so those components stay under the prop cap" — and was destructuring it just to re-pass the pieces individually.
- Changed `BdJournalPublishDraftButton` to take `edit: JournalEntryEditState` as a single prop (destructured internally to `saving`/`error`/`reload`), and `BdJournalEntryHeader` now passes `edit` straight through instead of destructuring it first, matching the pattern already used by the file's other sibling components (`BdJournalEntryEditForm`).
- No render-output change — this is prop plumbing only (rule 07 hydration parity preserved).

Closes #1683

## Test plan
- [x] `cargo fmt --check --package omnibus-frontend` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (643 passed; 0 failed)
- [x] `cargo build -p omnibus-frontend --features server` — PASS (compiles cleanly)

## Version
- [x] **Patch** — the default.

## Notes
-


---
_Generated by [Claude Code](https://claude.ai/code/session_01251M8YRtMUtVzzF6WECkwD)_