### PR TITLE
chore: triage event-listener RUSTSEC advisory and stale deny.toml skips (#1681)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,15 +736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,11 +2077,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -75,8 +75,7 @@ ignore = [
 # NB: RUSTSEC-2026-0221 (event-listener unsoundness, reachable via sqlx-core)
 # is NOT ignored here — it was fixed for real by bumping event-listener
 # 5.4.1 -> 5.4.2 (`cargo update -p event-listener`; patched in >= 5.4.2),
-# same pattern as the memmap2 fix noted above. See Cargo.lock and
-# docs/dependency-audit.md.
+# same pattern as the memmap2 fix noted above. See Cargo.lock and issue #1681.
 
 # ---------------------------------------------------------------------------
 # Licenses

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,12 @@ ignore = [
     { id = "RUSTSEC-2026-0097", reason = "rand 0.7.3 unsoundness — aliased mutable reference when a custom `log` logger calls rand::rng()/thread_rng() and ThreadRng reseeds mid-log; build-dependency only via phf_generator 0.8 (ammonia/html5ever codegen under wry), never links into any runtime binary and that logger-reseed path is not exercised in a build script" },
 ]
 
+# NB: RUSTSEC-2026-0221 (event-listener unsoundness, reachable via sqlx-core)
+# is NOT ignored here — it was fixed for real by bumping event-listener
+# 5.4.1 -> 5.4.2 (`cargo update -p event-listener`; patched in >= 5.4.2),
+# same pattern as the memmap2 fix noted above. See Cargo.lock and
+# docs/dependency-audit.md.
+
 # ---------------------------------------------------------------------------
 # Licenses
 # ---------------------------------------------------------------------------
@@ -248,14 +254,16 @@ skip = [
     { name = "reqwest", version = "0.12.28" },
 
     # --- Dioxus git-pin lag (gloo-net / gloo-timers / gloo-utils) ---
-    # dioxus-fullstack/dioxus-web 0.7.9's git-pinned Dioxus tag carries
-    # gloo-net 0.6.0 (pulling gloo-utils 0.2.0) + gloo-timers 0.3.0, while
-    # omnibus-frontend pins gloo-net 0.7.0 (pulling gloo-utils 0.3.0) +
-    # gloo-timers 0.4.0 directly behind the `web` feature. See
-    # docs/dependency-audit.md for full source chains (issue #1621).
-    { name = "gloo-net", version = "0.6.0" },
-    { name = "gloo-timers", version = "0.3.0" },
-    { name = "gloo-utils", version = "0.2.0" },
+    # The split described in docs/dependency-audit.md (issue #1621) is real,
+    # but CI's `cargo deny check` invocation (rust.yml, no `--features`) never
+    # enables omnibus-frontend's `web` feature, so omnibus-frontend's own
+    # gloo-net 0.7.0 / gloo-timers 0.4.0 / gloo-utils 0.3.0 pins never enter
+    # that resolve — only the dioxus-fullstack git-pin copies (0.6.0 / 0.3.0 /
+    # 0.2.0) do, as a single version each. Explicit skips here therefore trip
+    # `unnecessary-skip`/`unmatched-skip` (verified via `cargo deny check
+    # advisories sources bans licenses`, the exact CI command; issue #1681) —
+    # deliberately omitted, not forgotten. Re-add if a `--features web` (or
+    # `--all-features`) invocation is ever added to CI.
 ]
 
 # ---------------------------------------------------------------------------

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -58,4 +58,5 @@ this list.
 - **Adding a new crate:** check `cargo tree -d` after `cargo update`; any new duplicate must be classified here before the PR lands.
 - **Bumping Dioxus:** re-run this audit. The websocket and const-serialize clusters will be the first to collapse.
 - **Promoting `getrandom`:** when `argon2`/`password-hash` ship a version that supports `getrandom@0.3`, consolidate the 0.2 + 0.3 entries. Until then the three-way split is intentional.
+- **Bumping `sqlx`:** pinned at 0.8.6 (upstream has published 0.9.0); revisit as a coordinated bump when the `rusqlite`/`sqlx` `libsqlite3-sys` coupling from issue #1529 needs to move together, same trigger shape as the `getrandom` note above.
 - **`deny.toml` skip entries:** every blocked/accepted duplicate has a matching `skip` entry in the `[bans]` section of `deny.toml` so `cargo deny check bans` does not regress on already-triaged duplicates.

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -58,5 +58,5 @@ this list.
 - **Adding a new crate:** check `cargo tree -d` after `cargo update`; any new duplicate must be classified here before the PR lands.
 - **Bumping Dioxus:** re-run this audit. The websocket and const-serialize clusters will be the first to collapse.
 - **Promoting `getrandom`:** when `argon2`/`password-hash` ship a version that supports `getrandom@0.3`, consolidate the 0.2 + 0.3 entries. Until then the three-way split is intentional.
-- **Bumping `sqlx`:** pinned at 0.8.6 (upstream has published 0.9.0); revisit as a coordinated bump when the `rusqlite`/`sqlx` `libsqlite3-sys` coupling from issue #1529 needs to move together, same trigger shape as the `getrandom` note above.
+- **Bumping `sqlx`:** held on the 0.8 line (`Cargo.toml` allows 0.8.x patch bumps; upstream has published 0.9.0); revisit as a coordinated bump when the `rusqlite`/`sqlx` `libsqlite3-sys` coupling from issue #1529 needs to move together, same trigger shape as the `getrandom` note above.
 - **`deny.toml` skip entries:** every blocked/accepted duplicate has a matching `skip` entry in the `[bans]` section of `deny.toml` so `cargo deny check bans` does not regress on already-triaged duplicates.


### PR DESCRIPTION
## Summary
- `cargo audit` surfaced an untriaged RUSTSEC advisory for `event-listener` 5.4.1 (unsoundness, reachable from the production server binary via `sqlx-core`). Fixed for real with `cargo update -p event-listener` (5.4.1 -> 5.4.2, a semver-compatible patch bump); no `deny.toml` ignore entry needed. Added a comment next to the existing memmap2 precedent in `deny.toml` documenting that this advisory was fixed by version bump rather than ignored.
- `deny.toml`'s three `gloo-net`/`gloo-timers`/`gloo-utils` `skip` entries produced `unnecessary-skip`/`unmatched-skip` warnings under CI's exact `cargo deny check advisories sources bans licenses` invocation, because that invocation never enables `omnibus-frontend`'s `web` feature and so never sees the duplicate family they were written for. Removed the three entries and replaced them with a comment explaining why they're intentionally gone and when to re-add them (verified against a real `cargo deny check` run).
- Added a one-line sqlx 0.9 coordinated-bump trigger note to `docs/dependency-audit.md`'s Policy section, mirroring the existing getrandom 0.3 note.

Closes #1681

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo check -p omnibus-db` (exercises the sqlx-core -> event-listener chain directly) — PASS
- [x] `cargo check -p omnibus` (full server binary, pulls in omnibus-frontend/omnibus-db) — PASS
- [x] `cargo audit --json --ignore RUSTSEC-2023-0071` (CI's exact `cargo-audit` invocation, `cargo-audit 0.22.2` built from crates.io since the `.#audit` nix shell wasn't available in this sandbox) — PASS, 0 vulnerabilities (previously 1: the event-listener advisory)
- [x] `cargo deny check advisories sources bans licenses` (CI's exact `cargo-deny` invocation, `cargo-deny 0.20.2` built from crates.io) — PASS, exit 0, no `event-listener` or `gloo-*` warnings; a handful of pre-existing, already-triaged `duplicate`/`advisory-not-detected`/`yanked` warnings remain from before this change and are unrelated to this issue's scope

## Version
- [x] **Patch** — the default.

## Notes
- Built `cargo-audit`/`cargo-deny` directly from crates.io in this sandbox (no `nix`/`.#audit` shell available here), per the issue's own caveat about a possible version-behavior difference from the flake-pinned tooling — worth a quick re-confirm with the flake-pinned versions when convenient.


---
_Generated by [Claude Code](https://claude.ai/code/session_01251M8YRtMUtVzzF6WECkwD)_