### PR TITLE
fix: reap orphaned genres in delete_orphan_taxonomy (#1705)

### DIFF
--- a/db/src/taxonomy.rs
+++ b/db/src/taxonomy.rs
@@ -43,15 +43,18 @@ resolve_or_insert_simple!(resolve_or_insert_publisher, "publishers", "name");
 resolve_or_insert_simple!(resolve_or_insert_language, "languages", "code");
 
 /// Delete taxonomy rows (`authors`, `series`, `publishers`, `languages`)
-/// no longer referenced by any book, then reap orphaned tags via
-/// [`delete_orphan_tags`]. Run wherever the last link to a taxonomy row can
-/// disappear — the missing-files GC purge, the merge source delete, and the
-/// indexer's Changed bucket, which wipes a book's link rows before
-/// re-inserting them from the re-parsed file — so an author or series left
-/// with zero books doesn't linger. `author_photos` cascades on the author
-/// delete; the link tables have no taxonomy-side cascade, so a row is only
-/// deletable once its last link is gone, which is exactly the set this
-/// targets. Table/column names are compile-time literals, not caller input.
+/// no longer referenced by any book, then reap orphaned tags and genres via
+/// [`delete_orphan_tags`] and [`delete_orphan_genres`]. Run wherever the last
+/// link to a taxonomy row can disappear — the missing-files GC purge, the
+/// merge source delete, and the indexer's Changed bucket, which wipes a
+/// book's link rows before re-inserting them from the re-parsed file — so an
+/// author or series left with zero books doesn't linger, and a book whose
+/// `metadata_overrides` row is deleted directly (rather than through the
+/// override-editing write paths) doesn't strand a genre it uniquely named.
+/// `author_photos` cascades on the author delete; the link tables have no
+/// taxonomy-side cascade, so a row is only deletable once its last link is
+/// gone, which is exactly the set this targets. Table/column names are
+/// compile-time literals, not caller input.
 pub(crate) async fn delete_orphan_taxonomy(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
 ) -> Result<(), sqlx::Error> {
@@ -67,7 +70,8 @@ pub(crate) async fn delete_orphan_taxonomy(
         );
         sqlx::query(&sql).execute(&mut **tx).await?;
     }
-    delete_orphan_tags(tx).await
+    delete_orphan_tags(tx).await?;
+    delete_orphan_genres(tx).await
 }
 
 /// Delete `tags` rows with no book left to justify them: no canonical
@@ -108,8 +112,9 @@ pub(crate) async fn delete_orphan_tags(
 /// canonical link table (migration `0066`), so this is the whole visibility
 /// rule rather than the second half of one — the single clause here is the
 /// `metadata_overrides` arm of [`delete_orphan_tags`], with `$.genres` for
-/// `$.subjects`. Called from the override write paths, which are the only
-/// way a `genres` row is ever created or orphaned.
+/// `$.subjects`. Called from the override write paths (the only way a
+/// `genres` row is ever created) and from [`delete_orphan_taxonomy`], which
+/// covers the paths that delete a book's `metadata_overrides` row directly.
 pub(crate) async fn delete_orphan_genres(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
 ) -> Result<(), sqlx::Error> {

--- a/db/src/taxonomy/tests.rs
+++ b/db/src/taxonomy/tests.rs
@@ -1,11 +1,8 @@
 //! Unit tests for the `taxonomy` helpers. One `resolve_or_insert_simple!`
-//! macro generates the three resolvers, so all three contracts (insert,
-//! idempotency, case-insensitivity) are covered on `series` and spot-checked
-//! on `publishers` / `languages` to catch a bad expansion.
-//! `delete_orphan_taxonomy` gets its own drop/keep pair;
-//! `delete_orphan_tags` and `delete_orphan_genres` add the override-aware
-//! keep/drop cases, plus a regression test for the purge path that reaches
-//! `delete_orphan_genres` only through `delete_orphan_taxonomy`.
+//! macro generates the three resolvers, spot-checked across `series`,
+//! `publishers`, `languages`. `delete_orphan_taxonomy`, `delete_orphan_tags`,
+//! and `delete_orphan_genres` each get drop/keep/override-aware/case-fold
+//! tests, plus a purge-path regression test for genres.
 
 use omnibus_shared::MetadataOverrides;
 

--- a/db/src/taxonomy/tests.rs
+++ b/db/src/taxonomy/tests.rs
@@ -3,7 +3,9 @@
 //! idempotency, case-insensitivity) are covered on `series` and spot-checked
 //! on `publishers` / `languages` to catch a bad expansion.
 //! `delete_orphan_taxonomy` gets its own drop/keep pair;
-//! `delete_orphan_tags` adds the override-aware keep/drop cases.
+//! `delete_orphan_tags` and `delete_orphan_genres` add the override-aware
+//! keep/drop cases, plus a regression test for the purge path that reaches
+//! `delete_orphan_genres` only through `delete_orphan_taxonomy`.
 
 use omnibus_shared::MetadataOverrides;
 
@@ -298,4 +300,176 @@ async fn delete_orphan_tags_ignores_override_rows_whose_book_no_longer_exists() 
         .await
         .unwrap();
     assert_eq!(n, 0, "a dead book's override must not protect a tag row");
+}
+
+#[tokio::test]
+async fn delete_orphan_genres_keeps_a_genre_named_only_by_a_live_books_override() {
+    let _covers = CoversTempDir::new("orphan_genres_override_keep");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed("a.epub", Some("A"), &["X"], &[], None, None)],
+    )
+    .await
+    .unwrap();
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let uuid = books[0].unique_identifier.clone().unwrap();
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            genres: Some(vec!["Keeper".into()]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    delete_orphan_genres(&mut tx).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM genres WHERE name = 'Keeper'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(kept, 1, "an override membership must protect the genre row");
+}
+
+#[tokio::test]
+async fn delete_orphan_genres_matches_override_genres_case_insensitively() {
+    let _covers = CoversTempDir::new("orphan_genres_case_fold");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    // A linkless canonical-cased row, protected only by a lower-cased
+    // override genre on a live book — the NOCASE genres unique means the
+    // override materializes no second row, so the sweep's membership match
+    // must fold case or the row is wrongly reaped.
+    let mut tx = pool.begin().await.unwrap();
+    sqlx::query("INSERT INTO genres (name) VALUES ('Fiction')")
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed("a.epub", Some("A"), &["X"], &[], None, None)],
+    )
+    .await
+    .unwrap();
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let uuid = books[0].unique_identifier.clone().unwrap();
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            genres: Some(vec!["fiction".into()]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    delete_orphan_genres(&mut tx).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM genres WHERE name = 'Fiction'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        kept, 1,
+        "a case-variant override membership must protect the row"
+    );
+}
+
+#[tokio::test]
+async fn delete_orphan_genres_ignores_override_rows_whose_book_no_longer_exists() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    // An override row keyed to a uuid with no live `books` row — e.g. left
+    // behind by an out-of-band delete — must not keep its genres alive. The
+    // membership check joins to `books`, mirroring `get_genre_cloud`.
+    sqlx::query(
+        r#"INSERT INTO metadata_overrides (book_uuid, overrides)
+           VALUES ('no-such-book', '{"genres":["Ghosted"]}')"#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    let mut tx = pool.begin().await.unwrap();
+    sqlx::query("INSERT INTO genres (name) VALUES ('Ghosted')")
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+    delete_orphan_genres(&mut tx).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM genres WHERE name = 'Ghosted'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(n, 0, "a dead book's override must not protect a genre row");
+}
+
+#[tokio::test]
+async fn delete_orphan_taxonomy_reaps_a_genre_orphaned_by_purging_its_book() {
+    // Regression for #1705: `delete_orphan_taxonomy` deletes
+    // `metadata_overrides` rows directly via `purge_book`'s
+    // `UUID_KEYED_TABLES` sweep, bypassing the override-editing write paths
+    // that otherwise reap genres. It must still call `delete_orphan_genres`
+    // itself, or a genre uniquely named by the purged book is stranded.
+    let _covers = CoversTempDir::new("orphan_genres_purge_regression");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    replace_books(
+        &pool,
+        "/lib",
+        vec![indexed("a.epub", Some("A"), &["X"], &[], None, None)],
+    )
+    .await
+    .unwrap();
+    let books = list_books(&pool, "/lib").await.unwrap();
+    let book_id = books[0].id;
+    let uuid = books[0].unique_identifier.clone().unwrap();
+    upsert_metadata_overrides(
+        &pool,
+        &uuid,
+        &MetadataOverrides {
+            genres: Some(vec!["Orphaned".into()]),
+            ..Default::default()
+        },
+        false,
+        user_id,
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    crate::deletion::purge::purge_book(&mut tx, book_id, &uuid)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM genres WHERE name = 'Orphaned'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(n, 0, "purging the last book must reap its unique genre");
 }


### PR DESCRIPTION
## Summary
- `delete_orphan_taxonomy` in `db/src/taxonomy.rs` swept `authors`/`series`/`publishers`/`languages` and reaped orphaned tags via `delete_orphan_tags`, but never called the sibling `delete_orphan_genres` added alongside it in migration `0066_genres.sql` (#1691). Every caller that deletes a book's `metadata_overrides` row directly — `purge_book`'s `UUID_KEYED_TABLES` sweep, `missing_files` GC, and `merge::transaction`'s source delete — left any genre uniquely named by that book stranded in the `genres` table forever.
- Added the missing `delete_orphan_genres(tx).await?` call to `delete_orphan_taxonomy`.
- Corrected `delete_orphan_genres`'s doc comment: it's no longer reachable only from the override-editing write paths.
- `db/src/taxonomy/tests.rs` gains the `delete_orphan_genres` sibling-pattern test trio (keeps a genre still named by a live override, folds case via `COLLATE NOCASE`, ignores override rows whose book no longer exists), plus a regression test (`delete_orphan_taxonomy_reaps_a_genre_orphaned_by_purging_its_book`) exercising the purge path directly rather than only the override-editing paths already covered elsewhere.

Closes #1705

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — 1784 passed; 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` panics because the binary audiobook fixtures under `test_data/audiobooks/` aren't present in this sandbox and require `just fixtures` to download — unavailable here since this cloud image has no `just`/nix)
- [x] `cargo test -p omnibus-db taxonomy` — all 17 taxonomy tests pass, including the new genre tests

## Version
- [x] **Patch** — the default.

## Notes
- No migration/backfill added for existing orphaned `genres` rows on a live instance, per the issue's own framing ("flagging that as a judgment call, not a requirement") — the fix stops new orphans from accumulating going forward.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDLFZafBLbn3xnRbGRJ6zz)_