### PR TITLE
test: cover downsync_book_id_annotations DB-failure path

### DIFF
--- a/db/src/annotations/downsync/tests.rs
+++ b/db/src/annotations/downsync/tests.rs
@@ -455,3 +455,10 @@ async fn downsync_book_annotations_propagates_db_error_when_pool_is_closed() {
         .await
         .is_err());
 }
+
+#[tokio::test]
+async fn downsync_book_id_annotations_propagates_db_error_when_pool_is_closed() {
+    let (pool, _user, book_id, _uuid, _dir) = fixture("byid_dberr").await;
+    pool.close().await;
+    assert!(downsync_book_id_annotations(&pool, book_id).await.is_err());
+}


### PR DESCRIPTION
## Summary
- Closes #1706
- Add `downsync_book_id_annotations_propagates_db_error_when_pool_is_closed` to `db/src/annotations/downsync/tests.rs`, mirroring the existing `downsync_book_annotations_propagates_db_error_when_pool_is_closed` shape (close the pool, call the function, assert `Err`), so the `sqlx::Error` `downsync_book_id_annotations` propagates via `?` from its two queries is actually exercised.
- Purely additive test change — no production code touched.

## Test plan
- [x] `cargo fmt -p omnibus-db` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1811 passed; 0 failed)

## Version
- [ ] **Minor**
- [ ] **Patch**
- [ ] **No release**

## Notes
- Test-only change; no behavioral impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_016uj6q983onzgRgTYZFEdZv)_