### PR TITLE
test: cover rpc authz gates and precondition chains

### DIFF
--- a/frontend/src/rpc/kindle.rs
+++ b/frontend/src/rpc/kindle.rs
@@ -25,44 +25,59 @@ use super::{internal_rpc_error, AuthUser, PoolExt, WorkerExt};
 /// delivery runs on the worker; poll [`rpc_kindle_send_status`] for its result.
 #[post("/api/rpc/kindle/send", pool: PoolExt, worker: WorkerExt, user: AuthUser)]
 pub async fn rpc_send_to_kindle(book_uuid: String, file_id: Option<i64>) -> Result<u64> {
+    Ok(send_to_kindle(&pool.0, &worker.0, user.id, &book_uuid, file_id).await?)
+}
+
+/// Server-side body of [`rpc_send_to_kindle`], extracted so the four-step
+/// precondition chain (uuid length → Kindle email set → SMTP configured →
+/// book resolves) and the owner-scoping enqueue can be unit-tested without
+/// the server-fn transport.
+#[cfg(feature = "server")]
+async fn send_to_kindle(
+    pool: &sqlx::SqlitePool,
+    worker: &std::sync::Arc<db::worker::Worker>,
+    user_id: i64,
+    book_uuid: &str,
+    file_id: Option<i64>,
+) -> Result<u64, ServerFnError> {
     if book_uuid.len() > omnibus_shared::BOOK_UUID_MAX_LEN {
         return Err(ServerFnError::new(format!(
             "book_uuid must be ≤ {} bytes",
             omnibus_shared::BOOK_UUID_MAX_LEN
-        ))
-        .into());
+        )));
     }
-    let recipient = db::auth::get_kindle_email(&pool.0, user.id)
+    let recipient = db::auth::get_kindle_email(pool, user_id)
         .await
         .map_err(|e| internal_rpc_error("get kindle email", e))?;
     let Some(recipient) = recipient else {
         return Err(ServerFnError::new(
             "add your Kindle email on your account page before sending",
-        )
-        .into());
+        ));
     };
-    let smtp_configured = db::effective_smtp_config(&pool.0)
+    let smtp_configured = db::effective_smtp_config(pool)
         .await
         .map_err(|e| internal_rpc_error("get smtp config", e))?
         .is_some();
     if !smtp_configured {
-        return Err(ServerFnError::new("email delivery is not configured on this server").into());
+        return Err(ServerFnError::new(
+            "email delivery is not configured on this server",
+        ));
     }
-    let Some(book_id) = db::resolve_book_id_by_uuid(&pool.0, &book_uuid)
+    let Some(book_id) = db::resolve_book_id_by_uuid(pool, book_uuid)
         .await
         .map_err(|e| internal_rpc_error("resolve book id", e))?
     else {
-        return Err(ServerFnError::new("book not found").into());
+        return Err(ServerFnError::new("book not found"));
     };
 
-    let id = worker.0.post(omnibus_db::worker::Task::SendToKindle {
+    let id = worker.post(omnibus_db::worker::Task::SendToKindle {
         book_id,
         book_file_id: file_id,
         recipient_email: recipient,
     });
     // Scope the pollable status to this user so the guessable task-id space
     // can't be probed for other users' send outcomes.
-    worker.0.set_task_owner(id, user.id);
+    worker.set_task_owner(id, user_id);
     Ok(id)
 }
 
@@ -82,4 +97,157 @@ pub async fn rpc_kindle_send_status(task_id: u64) -> Result<Option<KindleSendSta
             ProgressState::Done { .. } => KindleSendStatus::Sent,
             ProgressState::Failed { message } => KindleSendStatus::Failed { message },
         }))
+}
+
+// `server`-gated: exercises the precondition chain and the task-owner
+// scoping directly against an in-memory DB + a real `Worker`, mirroring
+// `overrides.rs`'s pattern. CI runs this via `cargo test -p omnibus-frontend
+// --features server`.
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::send_to_kindle;
+    use omnibus_db::test_support::seed_synced_ebook;
+    use omnibus_db::worker::{Worker, WorkerConfig};
+    use omnibus_shared::{SmtpConfigUpdate, SmtpSecurity};
+
+    async fn pool_with_user() -> (sqlx::SqlitePool, i64) {
+        let pool = omnibus_db::init_db("sqlite::memory:").await.unwrap();
+        let user_id = omnibus_db::auth::create_user(&pool, "reader", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        (pool, user_id)
+    }
+
+    async fn configure_smtp(pool: &sqlx::SqlitePool) {
+        omnibus_db::set_smtp_config(
+            pool,
+            &SmtpConfigUpdate {
+                host: "smtp.example.com".into(),
+                port: 587,
+                username: "relay".into(),
+                from_email: "library@example.com".into(),
+                security: SmtpSecurity::Starttls,
+                password: Some("secret".into()),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    fn worker(pool: sqlx::SqlitePool) -> std::sync::Arc<Worker> {
+        Worker::new(pool, WorkerConfig::default())
+    }
+
+    #[tokio::test]
+    async fn send_to_kindle_rejects_an_oversized_book_uuid() {
+        let (pool, user_id) = pool_with_user().await;
+        let w = worker(pool.clone());
+        let oversized = "x".repeat(omnibus_shared::BOOK_UUID_MAX_LEN + 1);
+
+        let err = send_to_kindle(&pool, &w, user_id, &oversized, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("book_uuid must be"));
+    }
+
+    #[tokio::test]
+    async fn send_to_kindle_requires_a_kindle_email_on_the_account() {
+        let (pool, user_id) = pool_with_user().await;
+        configure_smtp(&pool).await;
+        let w = worker(pool.clone());
+        let uuid = seed_synced_ebook(&pool, "a.epub", "Alpha", "Ann Author").await;
+
+        let err = send_to_kindle(&pool, &w, user_id, &uuid, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Kindle email"));
+    }
+
+    #[tokio::test]
+    async fn send_to_kindle_requires_smtp_to_be_configured() {
+        let (pool, user_id) = pool_with_user().await;
+        omnibus_db::auth::set_kindle_email(&pool, user_id, Some("reader@kindle.com"))
+            .await
+            .unwrap();
+        let w = worker(pool.clone());
+        let uuid = seed_synced_ebook(&pool, "a.epub", "Alpha", "Ann Author").await;
+
+        let err = send_to_kindle(&pool, &w, user_id, &uuid, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not configured"));
+    }
+
+    #[tokio::test]
+    async fn send_to_kindle_reports_book_not_found_for_an_unknown_uuid() {
+        let (pool, user_id) = pool_with_user().await;
+        omnibus_db::auth::set_kindle_email(&pool, user_id, Some("reader@kindle.com"))
+            .await
+            .unwrap();
+        configure_smtp(&pool).await;
+        let w = worker(pool.clone());
+
+        let err = send_to_kindle(&pool, &w, user_id, "no-such-uuid", None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("book not found"));
+    }
+
+    #[tokio::test]
+    async fn send_to_kindle_enqueues_a_task_when_every_precondition_passes() {
+        let (pool, user_id) = pool_with_user().await;
+        omnibus_db::auth::set_kindle_email(&pool, user_id, Some("reader@kindle.com"))
+            .await
+            .unwrap();
+        configure_smtp(&pool).await;
+        let w = worker(pool.clone());
+        let uuid = seed_synced_ebook(&pool, "a.epub", "Alpha", "Ann Author").await;
+
+        let task_id = send_to_kindle(&pool, &w, user_id, &uuid, None)
+            .await
+            .unwrap();
+        assert!(task_id > 0);
+    }
+
+    #[tokio::test]
+    async fn send_to_kindle_task_owner_scoping_hides_status_from_another_user() {
+        let (pool, owner_id) = pool_with_user().await;
+        // Plain `create_user` (self-registration) refuses a second account
+        // unless `registration_enabled` is set; `admin_create_user` bypasses
+        // that gate.
+        let other_id = omnibus_db::auth::admin_create_user(
+            &pool,
+            "other",
+            "securepassword1",
+            omnibus_shared::UserPermissions {
+                is_admin: false,
+                can_upload: false,
+                can_edit: false,
+                can_download: true,
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+        omnibus_db::auth::set_kindle_email(&pool, owner_id, Some("reader@kindle.com"))
+            .await
+            .unwrap();
+        configure_smtp(&pool).await;
+        let w = worker(pool.clone());
+        let uuid = seed_synced_ebook(&pool, "a.epub", "Alpha", "Ann Author").await;
+
+        let task_id = send_to_kindle(&pool, &w, owner_id, &uuid, None)
+            .await
+            .unwrap();
+
+        assert!(
+            w.owned_task_state(task_id, owner_id).is_some(),
+            "the owning user must see the task's status"
+        );
+        assert!(
+            w.owned_task_state(task_id, other_id).is_none(),
+            "a different user must not be able to poll another user's send"
+        );
+    }
 }

--- a/frontend/src/rpc/physical.rs
+++ b/frontend/src/rpc/physical.rs
@@ -115,3 +115,38 @@ pub async fn rpc_delete_fileless_book(uuid: String) -> Result<()> {
         .await
         .map_err(|e| map_physical_error("delete fileless book", e))?)
 }
+
+// `server`-gated: exercises the `is_admin || can_edit` gate directly, no DB
+// needed. CI runs this via `cargo test -p omnibus-frontend --features server`.
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::{require_edit, AuthUser};
+
+    fn auth_user(is_admin: bool, can_edit: bool) -> AuthUser {
+        AuthUser {
+            id: 1,
+            is_admin,
+            can_edit,
+            session_id: 0,
+        }
+    }
+
+    #[test]
+    fn require_edit_allows_an_admin_without_the_can_edit_flag() {
+        let user = auth_user(true, false);
+        assert!(require_edit(&user).is_ok());
+    }
+
+    #[test]
+    fn require_edit_allows_a_non_admin_with_can_edit() {
+        let user = auth_user(false, true);
+        assert!(require_edit(&user).is_ok());
+    }
+
+    #[test]
+    fn require_edit_denies_a_non_admin_without_can_edit() {
+        let user = auth_user(false, false);
+        let err = require_edit(&user).unwrap_err();
+        assert!(err.to_string().contains("edit permission required"));
+    }
+}

--- a/frontend/src/rpc/scan.rs
+++ b/frontend/src/rpc/scan.rs
@@ -171,3 +171,54 @@ pub async fn rpc_wishlist_add(req: WishlistAddRequest) -> Result<BookRef> {
     .map_err(map_scan_err)?;
     Ok(BookRef { book_uuid })
 }
+
+// `server`-gated: exercises the five-way error mapping directly, no DB
+// needed. CI runs this via `cargo test -p omnibus-frontend --features server`.
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::{db, map_scan_err};
+
+    #[test]
+    fn map_scan_err_surfaces_the_isbn_validation_message() {
+        let e = db::ScanError::Isbn(omnibus_shared::IsbnError::InvalidLength(3));
+        let err = map_scan_err(e);
+        assert!(err.to_string().contains("ISBN must be 10 or 13 digits"));
+    }
+
+    #[test]
+    fn map_scan_err_maps_physical_book_not_found_to_a_book_not_found_message() {
+        let e = db::ScanError::Physical(db::PhysicalError::BookNotFound);
+        let err = map_scan_err(e);
+        assert!(err.to_string().contains("book not found"));
+    }
+
+    #[test]
+    fn map_scan_err_surfaces_the_missing_wishlist_target_message() {
+        let e = db::ScanError::MissingWishlistTarget;
+        let err = map_scan_err(e);
+        assert!(err
+            .to_string()
+            .contains("wishlist add requires a book_uuid or meta"));
+    }
+
+    #[test]
+    fn map_scan_err_surfaces_the_provider_outage_message_and_logs_a_warning() {
+        // `.into()` targets `anyhow::Error` via `MetadataLookupError::Provider`'s
+        // field type without this crate needing a direct `anyhow` dependency.
+        let io_err = std::io::Error::other("provider timed out");
+        let e = db::ScanError::Lookup(db::MetadataLookupError::Provider(io_err.into()));
+        let err = map_scan_err(e);
+        // The caller-facing sentence is deliberately generic, not the raw
+        // provider error — see `MetadataLookupError::Provider`'s doc comment.
+        // The `tracing::warn!` side effect on this branch has no return
+        // value to assert on; the message mapping is what a client observes.
+        assert!(err.to_string().contains("try again later"));
+    }
+
+    #[test]
+    fn map_scan_err_genericizes_an_opaque_db_failure() {
+        let e = db::ScanError::Sqlx(sqlx::Error::RowNotFound);
+        let err = map_scan_err(e);
+        assert!(err.to_string().contains("internal server error"));
+    }
+}

--- a/frontend/src/rpc/settings.rs
+++ b/frontend/src/rpc/settings.rs
@@ -294,3 +294,47 @@ pub async fn rpc_backfill_chapters() -> Result<()> {
         .post(omnibus_db::worker::Task::BackfillChapters { library_path });
     Ok(())
 }
+
+// `server`-gated: exercises the string-to-config-key resolution directly, no
+// DB needed. CI runs this via `cargo test -p omnibus-frontend --features
+// server`.
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::precedence_library_path;
+    use omnibus_shared::Settings;
+
+    fn settings() -> Settings {
+        Settings {
+            ebook_library_path: Some("/lib/ebooks".into()),
+            audiobook_library_path: Some("/lib/audiobooks".into()),
+            scan_interval_hours: None,
+        }
+    }
+
+    #[test]
+    fn precedence_library_path_resolves_ebook() {
+        let path = precedence_library_path(&settings(), "ebook").unwrap();
+        assert_eq!(path.as_deref(), Some("/lib/ebooks"));
+    }
+
+    #[test]
+    fn precedence_library_path_resolves_audiobook() {
+        let path = precedence_library_path(&settings(), "audiobook").unwrap();
+        assert_eq!(path.as_deref(), Some("/lib/audiobooks"));
+    }
+
+    #[test]
+    fn precedence_library_path_returns_none_for_an_unconfigured_path() {
+        let unconfigured = Settings::default();
+        let path = precedence_library_path(&unconfigured, "ebook").unwrap();
+        assert_eq!(path, None);
+    }
+
+    #[test]
+    fn precedence_library_path_rejects_an_unrecognized_key() {
+        let err = precedence_library_path(&settings(), "comics").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("library must be \"ebook\" or \"audiobook\""));
+    }
+}

--- a/frontend/src/rpc/shelves.rs
+++ b/frontend/src/rpc/shelves.rs
@@ -155,3 +155,160 @@ pub async fn rpc_preview_shelf_rule(
         .await
         .map_err(|e| map_shelf_error("preview shelf rule", e))?)
 }
+
+// `server`-gated: exercises the visibility/edit gates directly against an
+// in-memory DB, mirroring `overrides.rs`'s pattern. CI runs this via
+// `cargo test -p omnibus-frontend --features server`.
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::{shelf_for_edit, shelf_for_view, AuthUser};
+    use omnibus_shared::{CreateShelfRequest, ShelfKind, UserPermissions, Visibility};
+
+    /// Two distinct users so ownership/admin gates have someone to deny.
+    /// The second user goes through `admin_create_user` — plain `create_user`
+    /// (self-registration) refuses a second account unless
+    /// `registration_enabled` is set, which these tests have no reason to
+    /// touch.
+    async fn pool_with_two_users() -> (sqlx::SqlitePool, i64, i64) {
+        let pool = omnibus_db::init_db("sqlite::memory:").await.unwrap();
+        // First registered user is auto-admin (see `create_user`).
+        let owner_id = omnibus_db::auth::create_user(&pool, "owner", "securepassword1")
+            .await
+            .unwrap()
+            .id;
+        let other_id = omnibus_db::auth::admin_create_user(
+            &pool,
+            "other",
+            "securepassword1",
+            UserPermissions {
+                is_admin: false,
+                can_upload: false,
+                can_edit: false,
+                can_download: true,
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+        (pool, owner_id, other_id)
+    }
+
+    fn auth_user(id: i64, is_admin: bool) -> AuthUser {
+        AuthUser {
+            id,
+            is_admin,
+            can_edit: is_admin,
+            session_id: 0,
+        }
+    }
+
+    async fn seed_shelf(pool: &sqlx::SqlitePool, owner_id: i64, visibility: Visibility) -> i64 {
+        let req = CreateShelfRequest {
+            kind: ShelfKind::Manual,
+            name: "My Shelf".into(),
+            description: None,
+            visibility,
+            match_mode: None,
+            rules: vec![],
+            book_uuids: vec![],
+        };
+        omnibus_db::create_shelf(pool, owner_id, &req)
+            .await
+            .unwrap()
+            .id
+    }
+
+    #[tokio::test]
+    async fn shelf_for_view_allows_the_owner() {
+        let (pool, owner_id, _other_id) = pool_with_two_users().await;
+        let id = seed_shelf(&pool, owner_id, Visibility::Private).await;
+
+        let shelf = shelf_for_view(&pool, id, &auth_user(owner_id, false))
+            .await
+            .unwrap();
+        assert_eq!(shelf.id, id);
+    }
+
+    #[tokio::test]
+    async fn shelf_for_view_allows_an_admin_who_is_not_the_owner() {
+        let (pool, owner_id, other_id) = pool_with_two_users().await;
+        let id = seed_shelf(&pool, owner_id, Visibility::Private).await;
+
+        let shelf = shelf_for_view(&pool, id, &auth_user(other_id, true))
+            .await
+            .unwrap();
+        assert_eq!(shelf.id, id);
+    }
+
+    #[tokio::test]
+    async fn shelf_for_view_allows_anyone_when_the_shelf_is_public() {
+        let (pool, owner_id, other_id) = pool_with_two_users().await;
+        let id = seed_shelf(&pool, owner_id, Visibility::Public).await;
+
+        let shelf = shelf_for_view(&pool, id, &auth_user(other_id, false))
+            .await
+            .unwrap();
+        assert_eq!(shelf.id, id);
+    }
+
+    #[tokio::test]
+    async fn shelf_for_view_hides_a_private_shelf_from_a_non_owner_non_admin() {
+        let (pool, owner_id, other_id) = pool_with_two_users().await;
+        let id = seed_shelf(&pool, owner_id, Visibility::Private).await;
+
+        let err = shelf_for_view(&pool, id, &auth_user(other_id, false))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("shelf not found"));
+    }
+
+    #[tokio::test]
+    async fn shelf_for_view_reports_an_unknown_id_identically_to_a_hidden_shelf() {
+        let (pool, owner_id, other_id) = pool_with_two_users().await;
+        let hidden_id = seed_shelf(&pool, owner_id, Visibility::Private).await;
+
+        let hidden_err = shelf_for_view(&pool, hidden_id, &auth_user(other_id, false))
+            .await
+            .unwrap_err();
+        let missing_err = shelf_for_view(&pool, hidden_id + 999, &auth_user(other_id, false))
+            .await
+            .unwrap_err();
+
+        // Existence must not be leaked: both cases produce the exact same
+        // client-facing message.
+        assert_eq!(hidden_err.to_string(), missing_err.to_string());
+    }
+
+    #[tokio::test]
+    async fn shelf_for_edit_allows_the_owner() {
+        let (pool, owner_id, _other_id) = pool_with_two_users().await;
+        let id = seed_shelf(&pool, owner_id, Visibility::Private).await;
+
+        let shelf = shelf_for_edit(&pool, id, &auth_user(owner_id, false))
+            .await
+            .unwrap();
+        assert_eq!(shelf.id, id);
+    }
+
+    #[tokio::test]
+    async fn shelf_for_edit_allows_an_admin_who_is_not_the_owner() {
+        let (pool, owner_id, other_id) = pool_with_two_users().await;
+        let id = seed_shelf(&pool, owner_id, Visibility::Private).await;
+
+        let shelf = shelf_for_edit(&pool, id, &auth_user(other_id, true))
+            .await
+            .unwrap();
+        assert_eq!(shelf.id, id);
+    }
+
+    #[tokio::test]
+    async fn shelf_for_edit_denies_a_non_owner_non_admin_even_on_a_public_shelf() {
+        let (pool, owner_id, other_id) = pool_with_two_users().await;
+        let id = seed_shelf(&pool, owner_id, Visibility::Public).await;
+
+        let err = shelf_for_edit(&pool, id, &auth_user(other_id, false))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not your shelf"));
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #1680
- Several `frontend/src/rpc/*` server functions implement non-trivial branching logic (ownership/visibility gates duplicated from REST, error-mapping, multi-step preconditions) with zero direct test coverage, despite `overrides.rs`'s `bulk_save_overrides` already establishing the pattern: extract into a free `#[cfg(feature = "server")]` function and unit-test it directly against an in-memory pool.
- Applied that pattern to all five targets named in the issue, in the requested priority order:
  - `shelves.rs` — `shelf_for_view`/`shelf_for_edit`'s owner/admin/public visibility gate, including the deliberate existence-hiding (an unauthorized private shelf and an unknown id return the identical "shelf not found" message).
  - `physical.rs` — `require_edit`'s `is_admin || can_edit` gate.
  - `scan.rs` — `map_scan_err`'s five-way `db::ScanError` mapping (including the provider-outage branch's `tracing::warn!`).
  - `settings.rs` — `precedence_library_path`'s string-to-config-key resolution.
  - `kindle.rs` — `rpc_send_to_kindle`'s four-step precondition chain (uuid length → Kindle email set → SMTP configured → book resolves) plus `set_task_owner` scoping that prevents cross-user status polling. This one needed the extraction itself (the body was inline in the `#[post]` macro); pulled it into a free `send_to_kindle` function with identical behavior.
- No production logic changed — this is coverage-only. `shelves.rs`, `physical.rs`, and `scan.rs` were already shaped as free functions; only `kindle.rs` needed the extraction.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 677 passed, 0 failed
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Version
- [x] **No release** — tests-only change, no behavior change.

## Notes
- All five sub-targets from the issue are covered; nothing deferred.


---
_Generated by [Claude Code](https://claude.ai/code/session_016uj6q983onzgRgTYZFEdZv)_