### PR TITLE
chore: extract four over-cap functions into named helpers

### DIFF
--- a/frontend/src/pages/account.rs
+++ b/frontend/src/pages/account.rs
@@ -332,6 +332,56 @@ pub(crate) fn KindleEmailCard() -> Element {
     }
 }
 
+/// Signals owned by [`ChangePasswordCard`].
+#[cfg(not(feature = "mobile"))]
+#[derive(Clone, Copy)]
+struct ChangePasswordSignals {
+    current: Signal<String>,
+    new_password: Signal<String>,
+    msg: Signal<Option<String>>,
+    msg_is_error: Signal<bool>,
+    in_flight: Signal<bool>,
+}
+
+/// Submit handler for the change-password form: validates both fields are
+/// non-empty locally, then round-trips through `data::change_password`.
+/// Mirrors `kindle_save_handler`'s shape above.
+#[cfg(not(feature = "mobile"))]
+fn change_password_submit_handler(
+    server_url: String,
+    mut signals: ChangePasswordSignals,
+) -> impl FnMut(Event<FormData>) + 'static {
+    move |evt: Event<FormData>| {
+        evt.prevent_default();
+        let cur = (signals.current)();
+        let next = (signals.new_password)();
+        if cur.is_empty() || next.is_empty() {
+            signals
+                .msg
+                .set(Some("Enter your current and new password.".to_string()));
+            signals.msg_is_error.set(true);
+            return;
+        }
+        let url = server_url.clone();
+        signals.in_flight.set(true);
+        spawn(async move {
+            match data::change_password(&url, cur, next).await {
+                Ok(()) => {
+                    signals.current.set(String::new());
+                    signals.new_password.set(String::new());
+                    signals.msg.set(Some("Password changed.".to_string()));
+                    signals.msg_is_error.set(false);
+                }
+                Err(e) => {
+                    signals.msg.set(Some(e.to_string()));
+                    signals.msg_is_error.set(true);
+                }
+            }
+            signals.in_flight.set(false);
+        });
+    }
+}
+
 /// Self-service change-password card (web Account section). Requires the
 /// current password to authorize, validates the new one against the same
 /// policy as registration (strength meter + requirements are advisory; the
@@ -341,42 +391,23 @@ pub(crate) fn KindleEmailCard() -> Element {
 #[component]
 fn ChangePasswordCard() -> Element {
     let server_url = use_server_url();
-    let mut current = use_signal(String::new);
-    let mut new_password = use_signal(String::new);
-    let mut msg = use_signal(|| None::<String>);
-    let mut msg_is_error = use_signal(|| false);
-    let mut in_flight = use_signal(|| false);
+    let signals = ChangePasswordSignals {
+        current: use_signal(String::new),
+        new_password: use_signal(String::new),
+        msg: use_signal(|| None::<String>),
+        msg_is_error: use_signal(|| false),
+        in_flight: use_signal(|| false),
+    };
+    let mut current = signals.current;
+    let mut new_password = signals.new_password;
+    let mut msg = signals.msg;
+    let msg_is_error = signals.msg_is_error;
+    let in_flight = signals.in_flight;
 
     let pw = new_password();
     let (score, score_label, rules) = score_password(&pw);
 
-    let on_submit = move |evt: Event<FormData>| {
-        evt.prevent_default();
-        let cur = current();
-        let next = new_password();
-        if cur.is_empty() || next.is_empty() {
-            msg.set(Some("Enter your current and new password.".to_string()));
-            msg_is_error.set(true);
-            return;
-        }
-        let url = server_url.clone();
-        in_flight.set(true);
-        spawn(async move {
-            match data::change_password(&url, cur, next).await {
-                Ok(()) => {
-                    current.set(String::new());
-                    new_password.set(String::new());
-                    msg.set(Some("Password changed.".to_string()));
-                    msg_is_error.set(false);
-                }
-                Err(e) => {
-                    msg.set(Some(e.to_string()));
-                    msg_is_error.set(true);
-                }
-            }
-            in_flight.set(false);
-        });
-    };
+    let on_submit = change_password_submit_handler(server_url, signals);
 
     rsx! {
         section { class: "card", "data-testid": "account-password-card",

--- a/frontend/src/pages/landing/body.rs
+++ b/frontend/src/pages/landing/body.rs
@@ -89,20 +89,7 @@ pub(super) fn web_landing_body(
     let mut shelves_tick = sigs.shelves_tick;
     let mut bulk_selected = sigs.bulk_selected;
     let mut bulk_modal_open = sigs.bulk_modal_open;
-    let bulk_count = bulk_selected.read().len();
-    let show_bulk_bar = (sigs.is_admin)() && bulk_count > 0;
-    // Snapshot the selection for the modal only while it's open — the
-    // backdrop blocks further checkbox toggles, so this stays stable for
-    // the modal's lifetime.
-    let (bulk_uuids, bulk_books) = if bulk_modal_open() {
-        let set = bulk_selected.read();
-        (
-            set.iter().cloned().collect::<Vec<String>>(),
-            selected_bulk_books(&set, &sigs.books.read(), sigs.shelf_books.read().as_deref()),
-        )
-    } else {
-        (Vec::new(), Vec::new())
-    };
+    let bulk = snapshot_bulk_selection(sigs, (sigs.is_admin)(), bulk_modal_open());
     let mut books_sig = sigs.books;
     let mut shelf_books_sig = sigs.shelf_books;
     // Annotated outside the rsx props — a bare `.into()` there is ambiguous
@@ -110,16 +97,7 @@ pub(super) fn web_landing_body(
     let author_pool: ReadSignal<Vec<SuggestionItem>> = sigs.pools.authors.into();
     let tag_pool: ReadSignal<Vec<SuggestionItem>> = sigs.pools.tags.into();
     let genre_pool: ReadSignal<Vec<SuggestionItem>> = sigs.pools.genres.into();
-    // All Books mosaic: first four cover-bearing books of the (always-warm)
-    // browse page. Before it lands, the tile falls back to its accent plate.
-    let all_cover_uuids: Vec<String> = sigs
-        .books
-        .read()
-        .iter()
-        .filter(|b| b.cover_url.is_some())
-        .filter_map(|b| b.unique_identifier.clone())
-        .take(4)
-        .collect();
+    let all_cover_uuids = derive_all_cover_uuids(sigs);
     rsx! {
         div { class: "landing-col",
             if !view.is_search && !hero_points.is_empty() {
@@ -184,17 +162,17 @@ pub(super) fn web_landing_body(
                 }
             }
 
-            if show_bulk_bar {
+            if bulk.show_bar {
                 bulk_edit::BulkEditBar {
-                    count: bulk_count,
+                    count: bulk.count,
                     on_edit: move |_| bulk_modal_open.set(true),
                     on_clear: move |_| bulk_selected.write().clear(),
                 }
             }
             if bulk_modal_open() {
                 bulk_edit::BulkEditModal {
-                    uuids: bulk_uuids,
-                    selected_books: bulk_books,
+                    uuids: bulk.uuids,
+                    selected_books: bulk.books,
                     suggestions: bulk_edit::BulkEditSuggestions {
                         author_suggestions: author_pool,
                         tag_suggestions: tag_pool,
@@ -224,6 +202,59 @@ pub(super) fn web_landing_body(
             }
         }
     }
+}
+
+/// Derived bulk-selection state for [`web_landing_body`]: whether to show
+/// the bulk-edit bar, plus the uuids/books the modal needs.
+#[cfg(not(feature = "mobile"))]
+struct BulkSelectionSnapshot {
+    count: usize,
+    show_bar: bool,
+    uuids: Vec<String>,
+    books: Vec<EbookMetadata>,
+}
+
+/// Snapshot the current bulk selection for [`web_landing_body`]. `uuids`/
+/// `books` are populated only while the modal is open — the backdrop blocks
+/// further checkbox toggles, so this stays stable for the modal's lifetime.
+#[cfg(not(feature = "mobile"))]
+fn snapshot_bulk_selection(
+    sigs: &LandingSignals,
+    is_admin: bool,
+    modal_open: bool,
+) -> BulkSelectionSnapshot {
+    let bulk_selected = sigs.bulk_selected;
+    let count = bulk_selected.read().len();
+    let show_bar = is_admin && count > 0;
+    let (uuids, books) = if modal_open {
+        let set = bulk_selected.read();
+        (
+            set.iter().cloned().collect::<Vec<String>>(),
+            selected_bulk_books(&set, &sigs.books.read(), sigs.shelf_books.read().as_deref()),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    BulkSelectionSnapshot {
+        count,
+        show_bar,
+        uuids,
+        books,
+    }
+}
+
+/// All Books mosaic covers: first four cover-bearing books of the
+/// (always-warm) browse page. Before it lands, the tile falls back to its
+/// accent plate.
+#[cfg(not(feature = "mobile"))]
+fn derive_all_cover_uuids(sigs: &LandingSignals) -> Vec<String> {
+    sigs.books
+        .read()
+        .iter()
+        .filter(|b| b.cover_url.is_some())
+        .filter_map(|b| b.unique_identifier.clone())
+        .take(4)
+        .collect()
 }
 
 /// Collect the selected books' current metadata from the browse list plus

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -277,28 +277,9 @@ fn use_reader_signals(uuid: &str, theme: Signal<Theme>) -> ReaderSignals {
         crate::contexts::use_server_url(),
     );
 
-    // Auto read-status: opening an `Unread` book marks it `Reading`; the
-    // first relocate whose range reaches the book's end marks it `Finished`
-    // (never a downgrade). Effect-only, like the session tracker above.
-    let at_end = use_memo(move || loc.read().at_end);
-    crate::read_status_auto::use_auto_read_status(
-        uuid.to_string(),
-        crate::contexts::use_server_url(),
-        at_end,
-    );
-
-    // A same-component book swap (SPA nav between `/read/:uuid` routes)
-    // keeps the previous book's relocate snapshot until the new book's
-    // first relocate — reset it so a stale `at_end` can't mark the next
-    // book finished before that relocate arrives.
-    {
-        let mut loc = loc;
-        let uuid_dep = uuid.to_string();
-        use_effect(use_reactive!(|uuid_dep| {
-            let _ = &uuid_dep;
-            loc.set(RelocateData::default());
-        }));
-    }
+    // Auto read-status, plus the stale-relocate reset on a same-component
+    // book swap. Effect-only, like the session tracker above.
+    use_auto_read_status_for_reader(uuid, loc);
 
     #[cfg(feature = "web")]
     install_reader_web_interop(
@@ -358,6 +339,31 @@ fn use_reader_signals(uuid: &str, theme: Signal<Theme>) -> ReaderSignals {
         book_meta,
         chrome_hidden,
     }
+}
+
+/// Auto read-status wiring for the reader: opening an `Unread` book marks it
+/// `Reading`; the first relocate whose range reaches the book's end marks it
+/// `Finished` (never a downgrade). Also resets `loc` on a same-component book
+/// swap (SPA nav between `/read/:uuid` routes) — otherwise a stale `at_end`
+/// from the previous book could mark the next one finished before its first
+/// relocate arrives. Split out of [`use_reader_signals`] as its own hook
+/// (call-order-stable, so it's still safe to invoke unconditionally from the
+/// component body) — mirrors `use_retarget_playback`/
+/// `use_marquee_title_refresh` in `pages/listen/mobile/effects.rs`.
+fn use_auto_read_status_for_reader(uuid: &str, loc: Signal<RelocateData>) {
+    let at_end = use_memo(move || loc.read().at_end);
+    crate::read_status_auto::use_auto_read_status(
+        uuid.to_string(),
+        crate::contexts::use_server_url(),
+        at_end,
+    );
+
+    let mut loc = loc;
+    let uuid_dep = uuid.to_string();
+    use_effect(use_reactive!(|uuid_dep| {
+        let _ = &uuid_dep;
+        loc.set(RelocateData::default());
+    }));
 }
 
 /// Display strings/values the reader chrome renders, derived from `loc` and `book_meta`.

--- a/server/src/backend/kobo/sync.rs
+++ b/server/src/backend/kobo/sync.rs
@@ -83,83 +83,29 @@ pub async fn library_sync(
     let delta = db::kobo::SyncDelta { changes };
 
     // Serialize each item lazily as the device drains the body — no second
-    // buffer of the whole payload.
+    // buffer of the whole payload. Each poll dispatches to the step function
+    // for the current `SyncPhase` (below); the dispatcher itself stays a
+    // one-line match so the phase logic reads as ordinary functions rather
+    // than a nested `move async` closure.
     let stream = stream::unfold(
-        (delta.changes, base, auth.token, states, SyncPhase::Open),
-        move |(changes, base, token, states, phase)| {
+        SyncStreamState {
+            changes: delta.changes,
+            base,
+            token: auth.token,
+            states,
+            phase: SyncPhase::Open,
+        },
+        move |st| {
             let pool = pool.clone();
             async move {
-                let chunk: Bytes = match phase {
-                    SyncPhase::Open => {
-                        let next = if changes.is_empty() {
-                            SyncPhase::Close
-                        } else {
-                            SyncPhase::Item {
-                                change: 0,
-                                emitted: 0,
-                            }
-                        };
-                        return Some((
-                            ok(Bytes::from_static(b"[")),
-                            (changes, base, token, states, next),
-                        ));
-                    }
+                match st.phase {
+                    SyncPhase::Open => Some(sync_stream_open(st)),
                     SyncPhase::Item { change, emitted } => {
-                        let uuid = match &changes[change] {
-                            db::kobo::SyncChange::New(b)
-                            | db::kobo::SyncChange::Changed(b)
-                            | db::kobo::SyncChange::StateChanged(b) => Some(b.uuid.as_str()),
-                            db::kobo::SyncChange::Removed { .. } => None,
-                        };
-                        let book_state = uuid.and_then(|u| states.get(u));
-                        let items = dto::sync_items(&base, &token, &changes[change], book_state);
-                        let mut piece = Vec::new();
-                        for item in &items {
-                            // These DTOs are owned Strings/primitives, so this
-                            // never fails in practice — but if it ever does,
-                            // abort the body rather than emit malformed JSON:
-                            // the stream jumps to End, `record_synced` never
-                            // runs, and the device retries the same delta.
-                            let json = match serde_json::to_vec(item) {
-                                Ok(j) => j,
-                                Err(e) => {
-                                    return Some((
-                                        Err(std::io::Error::other(e)),
-                                        (changes, base, token, states, SyncPhase::End),
-                                    ));
-                                }
-                            };
-                            if emitted > 0 || !piece.is_empty() {
-                                piece.push(b',');
-                            }
-                            piece.extend_from_slice(&json);
-                        }
-                        let next = if change + 1 < changes.len() {
-                            SyncPhase::Item {
-                                change: change + 1,
-                                emitted: emitted + items.len(),
-                            }
-                        } else {
-                            SyncPhase::Close
-                        };
-                        return Some((
-                            ok(Bytes::from(piece)),
-                            (changes, base, token, states, next),
-                        ));
+                        Some(sync_stream_item(st, change, emitted))
                     }
-                    SyncPhase::Close => {
-                        // Body is complete: commit the snapshot. A failure here
-                        // is deliberately non-fatal to the response (the bytes
-                        // are already on the wire) — the device just replays
-                        // the same delta next sync, which is safe.
-                        if let Err(e) = db::kobo::record_synced(&pool, device_id, &changes).await {
-                            tracing::warn!(device_id, error = %e, "kobo snapshot advance failed");
-                        }
-                        Bytes::from_static(b"]")
-                    }
-                    SyncPhase::End => return None,
-                };
-                Some((ok(chunk), (changes, base, token, states, SyncPhase::End)))
+                    SyncPhase::Close => Some(sync_stream_close(&pool, device_id, st).await),
+                    SyncPhase::End => None,
+                }
             }
         },
     );
@@ -296,9 +242,94 @@ enum SyncPhase {
     End,
 }
 
+/// Accumulator threaded through [`library_sync`]'s `stream::unfold` — one
+/// field per piece the state used to carry as an anonymous tuple, named so
+/// each step function below reads without positional guessing.
+struct SyncStreamState {
+    changes: Vec<db::kobo::SyncChange>,
+    base: String,
+    token: String,
+    states: HashMap<String, db::kobo::KoboBookState>,
+    phase: SyncPhase,
+}
+
 /// Wrap a chunk as the infallible `Result` item `Body::from_stream` expects.
 fn ok(bytes: Bytes) -> Result<Bytes, std::io::Error> {
     Ok(bytes)
+}
+
+/// `SyncPhase::Open` step: emit the opening `[` and advance to the first
+/// item, or straight to `Close` for an empty delta.
+fn sync_stream_open(mut st: SyncStreamState) -> (Result<Bytes, std::io::Error>, SyncStreamState) {
+    st.phase = if st.changes.is_empty() {
+        SyncPhase::Close
+    } else {
+        SyncPhase::Item {
+            change: 0,
+            emitted: 0,
+        }
+    };
+    (ok(Bytes::from_static(b"[")), st)
+}
+
+/// `SyncPhase::Item` step: serialize the current change's DTOs (a change can
+/// fan out into two items) and advance to the next change or `Close`. A JSON
+/// serialization failure — never expected, since every DTO is owned
+/// Strings/primitives, but handled rather than unwrapped — aborts the body
+/// via `SyncPhase::End` instead of emitting malformed JSON: `record_synced`
+/// then never runs, and the device retries the same delta next sync.
+fn sync_stream_item(
+    mut st: SyncStreamState,
+    change: usize,
+    emitted: usize,
+) -> (Result<Bytes, std::io::Error>, SyncStreamState) {
+    let uuid = match &st.changes[change] {
+        db::kobo::SyncChange::New(b)
+        | db::kobo::SyncChange::Changed(b)
+        | db::kobo::SyncChange::StateChanged(b) => Some(b.uuid.as_str()),
+        db::kobo::SyncChange::Removed { .. } => None,
+    };
+    let book_state = uuid.and_then(|u| st.states.get(u));
+    let items = dto::sync_items(&st.base, &st.token, &st.changes[change], book_state);
+    let mut piece = Vec::new();
+    for item in &items {
+        let json = match serde_json::to_vec(item) {
+            Ok(j) => j,
+            Err(e) => {
+                st.phase = SyncPhase::End;
+                return (Err(std::io::Error::other(e)), st);
+            }
+        };
+        if emitted > 0 || !piece.is_empty() {
+            piece.push(b',');
+        }
+        piece.extend_from_slice(&json);
+    }
+    st.phase = if change + 1 < st.changes.len() {
+        SyncPhase::Item {
+            change: change + 1,
+            emitted: emitted + items.len(),
+        }
+    } else {
+        SyncPhase::Close
+    };
+    (ok(Bytes::from(piece)), st)
+}
+
+/// `SyncPhase::Close` step: the body is complete, so commit the device's
+/// sync snapshot. A failure here is deliberately non-fatal to the response
+/// (the bytes are already on the wire) — the device just replays the same
+/// delta next sync, which is safe.
+async fn sync_stream_close(
+    pool: &sqlx::SqlitePool,
+    device_id: i64,
+    mut st: SyncStreamState,
+) -> (Result<Bytes, std::io::Error>, SyncStreamState) {
+    if let Err(e) = db::kobo::record_synced(pool, device_id, &st.changes).await {
+        tracing::warn!(device_id, error = %e, "kobo snapshot advance failed");
+    }
+    st.phase = SyncPhase::End;
+    (ok(Bytes::from_static(b"]")), st)
 }
 
 /// `GET library/<uuid>/metadata` — the single-book metadata array Kobo fetches


### PR DESCRIPTION
## Summary
- Closes #1643
- Four functions had crossed the ~80-line soft cap in `.claude/rules/05-rust-style.md` § Function shape. Pure extraction, no behavior change:
  - `frontend/src/pages/reader/mod.rs`: pulled the auto-read-status wiring (the `at_end` memo + `use_auto_read_status` call + the stale-relocate reset effect) out of `use_reader_signals` into `use_auto_read_status_for_reader`, mirroring `use_retarget_playback`/`use_marquee_title_refresh` in `pages/listen/mobile/effects.rs`. Hook order stays unconditional across SSR/WASM per `.claude/rules/07-hydration.md`.
  - `frontend/src/pages/landing/body.rs`: split the bulk-selection snapshot and all-books cover-uuid derivation out of `web_landing_body` into `snapshot_bulk_selection` and `derive_all_cover_uuids`.
  - `server/src/backend/kobo/sync.rs`: gave the `stream::unfold` state machine a named `SyncStreamState` struct and one step function per `SyncPhase` variant (`sync_stream_open`/`sync_stream_item`/`sync_stream_close`) instead of one large inline closure.
  - `frontend/src/pages/account.rs`: extracted `ChangePasswordSignals` + `change_password_submit_handler` out of `ChangePasswordCard`, mirroring the existing `KindleEmailSignals`/`kindle_save_handler` shape already in the same file. Now 82 lines, under the ~100-line target called out in the issue.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (651 passed; 0 failed)
- [x] `cargo test -p omnibus` — 684 passed; 2 failed. The 2 failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400`, `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`) are pre-existing and unrelated to this change — they `chmod 0o555` a temp dir and expect a `PermissionDenied`, which doesn't fire when the test process runs as root (root bypasses Unix write-permission bits). Verified identical on unmodified `main`-based code via `git stash` before committing.

## Version
- [x] **No release** — tech-debt refactor only, no user-facing behavior change.

## Notes
- Pure extraction only; no behavior changed in any of the four functions.


---
_Generated by [Claude Code](https://claude.ai/code/session_016uj6q983onzgRgTYZFEdZv)_