### PR TITLE
feat: show reader avatars on iOS ratings and journals

### DIFF
--- a/omnibus-ios/omnibus/Design/Components/UserAvatar.swift
+++ b/omnibus-ios/omnibus/Design/Components/UserAvatar.swift
@@ -27,8 +27,17 @@ struct UserAvatar: View {
         .frame(width: size, height: size)
         .clipShape(Circle())
         .overlay(Circle().strokeBorder(.white.opacity(0.14), lineWidth: 0.5))
-        .shadow(color: palette.accentColor.opacity(0.25), radius: 12, y: 4)
+        // The accent glow is identity-card dressing; at list-row sizes it
+        // reads as smudging, so small avatars stay flat like `AuthorAvatar`.
+        .shadow(
+            color: palette.accentColor.opacity(size >= Self.shadowMinSize ? 0.25 : 0),
+            radius: 12,
+            y: 4
+        )
     }
+
+    /// Below this size the accent shadow is suppressed (row avatars stay flat).
+    static let shadowMinSize: CGFloat = 44
 
     /// The cache key / request path for a user's avatar. Shared with the
     /// invalidation call after an upload so the two can't drift.

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -222,12 +222,14 @@ struct BookDetailView: View {
                         if !book.genres.isEmpty { genresSection(book) }
                         if !book.subjects.isEmpty { tagsSection(book) }
                         ratingSection(book)
+                        // Other readers follow your own rating, like the web
+                        // page, so the two rating surfaces read as one topic.
+                        if !model.otherRatings.isEmpty { otherRatingsSection }
                         statusSection(book)
                         librarySection(book)
                         metadataSection(book)
                         if !model.highlights.isEmpty { highlightsSection(book) }
                         journalSection(book)
-                        if !model.otherRatings.isEmpty { otherRatingsSection }
                     }
                     .screenPadding()
                     .padding(.top, Spacing.xl)
@@ -741,10 +743,21 @@ struct BookDetailView: View {
         DisclosureSection(title: "Other readers") {
             VStack(spacing: Spacing.sm) {
                 ForEach(model.otherRatings) { rating in
-                    HStack {
-                        Text(rating.username)
-                            .font(.ui(13.5))
-                            .foregroundStyle(palette.ink1Color)
+                    HStack(spacing: Spacing.sm) {
+                        UserAvatar(
+                            id: rating.userId,
+                            name: rating.username,
+                            hasAvatar: rating.hasAvatar,
+                            size: 24
+                        )
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(rating.username)
+                                .font(.ui(13.5))
+                                .foregroundStyle(palette.ink1Color)
+                            Text("Rated \(Format.relative(unix: rating.updatedAt))")
+                                .font(.monoUI(9.5))
+                                .foregroundStyle(palette.ink3Color)
+                        }
                         Spacer()
                         StarRating(stars: rating.stars)
                     }

--- a/omnibus-ios/omnibus/Features/BookDetail/JournalViews.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/JournalViews.swift
@@ -89,6 +89,13 @@ struct JournalCard: View {
 
     private var meta: some View {
         HStack(spacing: 7) {
+            UserAvatar(
+                id: entry.authorId,
+                name: entry.authorName,
+                hasAvatar: entry.authorHasAvatar,
+                size: 20
+            )
+
             Text(entry.authorName.uppercased())
                 .font(.monoUI(9.5, weight: .medium))
                 .tracking(0.7)

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -839,6 +839,10 @@ struct RatingRecord: Codable, Sendable {
 struct AttributedRating: Codable, Sendable, Identifiable {
     var userId: Int64
     var username: String
+    /// Whether the rater has an avatar. Non-optional: the lenient
+    /// `decode(Bool.Type,forKey:)` above defaults a missing key to `false`,
+    /// so a pre-upgrade `CacheKey.ratingsOthers` blob still decodes.
+    var hasAvatar: Bool = false
     var stars: Double
     var updatedAt: Int64
 
@@ -847,6 +851,7 @@ struct AttributedRating: Codable, Sendable, Identifiable {
     enum CodingKeys: String, CodingKey {
         case username, stars
         case userId = "user_id"
+        case hasAvatar = "has_avatar"
         case updatedAt = "updated_at"
     }
 }
@@ -898,6 +903,10 @@ struct JournalEntry: Codable, Hashable, Sendable, Identifiable {
     var bookUUID: String
     var authorId: Int64
     var authorName: String
+    /// Whether the author has an avatar. Non-optional: the lenient
+    /// `decode(Bool.Type,forKey:)` above defaults a missing key to `false`,
+    /// so a pre-upgrade `CacheKey.journals` blob still decodes.
+    var authorHasAvatar: Bool = false
     var bodyMd: String
     var bodyHtml: String
     var progress: Int?
@@ -913,6 +922,7 @@ struct JournalEntry: Codable, Hashable, Sendable, Identifiable {
         case bookUUID = "book_uuid"
         case authorId = "author_id"
         case authorName = "author_name"
+        case authorHasAvatar = "author_has_avatar"
         case bodyMd = "body_md"
         case bodyHtml = "body_html"
         case clientID = "client_id"

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -428,7 +428,10 @@ enum UserDataService {
             id: AnnotationID.pending(),
             bookUUID: payload.bookUUID,
             authorId: author?.id ?? 0,
-            authorName: author?.username ?? "You",
+            // Display name + avatar match what the server's re-read will say,
+            // so the optimistic card doesn't flicker to a different identity.
+            authorName: author?.display ?? "You",
+            authorHasAvatar: author?.hasAvatar ?? false,
             bodyMd: payload.bodyMd,
             // The server renders the markdown; until it has, show the source.
             // A local renderer here would only disagree with the real one.

--- a/omnibus-ios/omnibusTests/AvatarAttributionTests.swift
+++ b/omnibus-ios/omnibusTests/AvatarAttributionTests.swift
@@ -1,0 +1,60 @@
+//  AvatarAttributionTests.swift
+//  The avatar flags on other users' ratings and journal entries.
+//
+//  Both models are persisted verbatim into the offline replica
+//  (`CacheKey.ratingsOthers`, `CacheKey.journals`), so a blob written before
+//  this release has no avatar key — it must still decode (as `false`) rather
+//  than wiping a book's cached ratings or journals.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+@Suite struct AttributedRatingDecodeTests {
+    @Test func decodesTheAvatarFlagFromAFullPayload() throws {
+        let json = """
+            {"user_id":7,"username":"Alice A.","has_avatar":true,
+             "stars":4.5,"updated_at":1700000000}
+            """
+        let decoded = try JSONDecoder().decode(AttributedRating.self, from: Data(json.utf8))
+        #expect(decoded.hasAvatar == true)
+        #expect(decoded.userId == 7)
+        #expect(decoded.stars == 4.5)
+    }
+
+    @Test func decodesAPayloadWithoutTheAvatarFlag() throws {
+        // A pre-upgrade `CacheKey.ratingsOthers` blob; absent means `false`.
+        let json = """
+            {"user_id":7,"username":"alice","stars":3.0,"updated_at":1700000000}
+            """
+        let decoded = try JSONDecoder().decode(AttributedRating.self, from: Data(json.utf8))
+        #expect(decoded.hasAvatar == false)
+    }
+}
+
+@Suite struct JournalEntryDecodeTests {
+    @Test func decodesTheAuthorAvatarFlagFromAFullPayload() throws {
+        let json = """
+            {"id":3,"book_uuid":"b-1","author_id":7,"author_name":"Alice A.",
+             "author_has_avatar":true,"body_md":"hi","body_html":"<p>hi</p>",
+             "progress":null,"status":"published","client_id":null,
+             "created_at":1700000000,"updated_at":1700000000}
+            """
+        let decoded = try JSONDecoder().decode(JournalEntry.self, from: Data(json.utf8))
+        #expect(decoded.authorHasAvatar == true)
+        #expect(decoded.authorId == 7)
+    }
+
+    @Test func decodesAPayloadWithoutTheAuthorAvatarFlag() throws {
+        // A pre-upgrade `CacheKey.journals` blob; absent means `false`.
+        let json = """
+            {"id":3,"book_uuid":"b-1","author_id":7,"author_name":"alice",
+             "body_md":"hi","body_html":"<p>hi</p>","progress":null,
+             "status":"published","client_id":null,
+             "created_at":1700000000,"updated_at":1700000000}
+            """
+        let decoded = try JSONDecoder().decode(JournalEntry.self, from: Data(json.utf8))
+        #expect(decoded.authorHasAvatar == false)
+    }
+}


### PR DESCRIPTION
## Summary
- Decode the `has_avatar` / `author_has_avatar` flags the server already sends on `AttributedRating` and `JournalEntry` (lenient Bool decode keeps pre-upgrade offline cache blobs valid).
- Render `UserAvatar` in the "Other readers" rating rows (with a "Rated X ago" byline, matching web) and in the journal card byline; suppress the identity-card accent shadow below 44pt so row avatars stay flat.
- Move the "Other readers" section from the bottom of book detail to directly below "Your rating", matching web.
- Optimistic journal rows now seed the author's display name + avatar flag instead of the raw username.

## Test plan
- [x] `just ios-build`
- [x] `just ios-test` — passes, including 4 new decode tests (`AvatarAttributionTests.swift`) covering the missing-key/old-cache-blob case
- [x] Verified in the simulator against a dev server with a second avatar-bearing user: rating row and journal byline show the photo, section order matches web, 58pt identity card keeps its shadow

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.