### PR TITLE
refactor: route HLS segments through serve_file for conditional-request support (#1720)

### DIFF
--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -5,9 +5,7 @@
 //! [`get_audiobook_manifest`] for the direct-vs-HLS routing rule.
 
 use axum::{
-    body::Body,
     extract::{Path, Query, Request, State},
-    http::HeaderValue,
     response::{IntoResponse, Response},
     Json,
 };
@@ -19,17 +17,12 @@ use omnibus_db::{
 };
 use omnibus_shared::{AudiobookManifest, AudiobookPlaybackRateUpdate, ManifestPart};
 use serde::{Deserialize, Serialize};
-use tower::ServiceExt;
-use tower_http::services::ServeFile;
 
 use super::{internal, AppState};
 use crate::auth::{AuthUser, MediaAuthUser};
 
 /// Content-Type for MPEG-TS audio segments served by the HLS fallback.
-/// Defined at module scope so the per-request `HeaderValue` insert is a
-/// cheap clone of a compile-time-validated static instead of a `.parse()`
-/// + `.expect()` on every segment fetch.
-static MPEGTS_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("video/MP2T");
+const MPEGTS_CONTENT_TYPE: &str = "video/MP2T";
 
 /// Query parameters for `GET /api/audiobooks/{uuid}/manifest`.
 #[derive(Deserialize)]
@@ -251,7 +244,7 @@ pub(super) struct DownloadQuery {
 }
 
 /// Serves the audiobook's source file as a browser download
-/// (`Content-Disposition: attachment`), streaming via `ServeFile`.
+/// (`Content-Disposition: attachment`), streaming via [`super::serve_download`].
 ///
 /// Targets the lowest-ordinal part of the resolved `book_files` row
 /// (optionally selected via `?file_id=N`). For a single-file audiobook
@@ -386,17 +379,7 @@ pub(super) async fn get_audiobook_segment(
         }
     }
 
-    let serve = ServeFile::new(&seg_path);
-    let res = match serve.oneshot(req).await {
-        Ok(r) => r,
-        Err(e) => return internal("serve segment", e),
-    };
-    let (mut parts, body) = res.into_parts();
-    parts.headers.insert(
-        axum::http::header::CONTENT_TYPE,
-        MPEGTS_CONTENT_TYPE.clone(),
-    );
-    Response::from_parts(parts, Body::new(body))
+    super::serve_file(req, &seg_path, MPEGTS_CONTENT_TYPE, None).await
 }
 
 /// Terminal-vs-in-flight discriminator for the status JSON. Lets the

--- a/server/src/backend/audiobooks/tests.rs
+++ b/server/src/backend/audiobooks/tests.rs
@@ -1269,3 +1269,123 @@ async fn api_get_audiobook_download_serves_the_whole_new_body_when_if_range_went
     let body = to_bytes(res.into_body(), usize::MAX).await.unwrap();
     assert_eq!(body.as_ref(), PART_BYTES);
 }
+
+const SEGMENT_BYTES: &[u8] = b"a-stand-in-mpegts-segment-long-enough-to-slice-in-half";
+
+/// Seed one direct-play audiobook and pre-write its first HLS segment
+/// straight into the cache dir (bypassing the transcoder), so
+/// `get_audiobook_segment` takes the fast "already on disk" path. Points
+/// `OMNIBUS_DATA_DIR` at a fresh scratch dir via [`DataDirGuard`], which
+/// holds the shared env lock so this can't race the status-handler tests'
+/// own `OMNIBUS_DATA_DIR` swap. Returns `(app, token, uuid, segment_path,
+/// data_dir)`; `data_dir` must stay alive for the caller's lifetime.
+async fn segment_validator_fixture() -> (
+    axum::Router,
+    String,
+    String,
+    std::path::PathBuf,
+    DataDirGuard,
+) {
+    use std::io::Write;
+
+    let data_dir = DataDirGuard::new("audiobook_segment");
+
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "bob").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let uuid =
+        seed_audiobook_with_parts(&pool, "/audiobooks", "MP3", &[(0, "ch01.mp3", 60.0)]).await;
+    let resolved = hls::resolve_audiobook(&pool, &uuid).await.unwrap().unwrap();
+
+    let seg_dir = hls::segment_dir(resolved.book_id, hls::AUDIO64);
+    std::fs::create_dir_all(&seg_dir).unwrap();
+    let seg_path = seg_dir.join("seg-0000.ts");
+    std::fs::File::create(&seg_path)
+        .unwrap()
+        .write_all(SEGMENT_BYTES)
+        .unwrap();
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    (app, token, uuid, seg_path, data_dir)
+}
+
+#[tokio::test]
+async fn api_get_audiobook_segment_serves_an_etag_and_revalidates_with_304() {
+    let (app, token, uuid, _path, _dir) = segment_validator_fixture().await;
+    let uri = format!("/api/audiobooks/{uuid}/segments/seg-0000.ts");
+
+    let first = app
+        .clone()
+        .oneshot(audio_get(&uri, &token, &[]))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(
+        first
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some(MPEGTS_CONTENT_TYPE)
+    );
+    let etag = audio_etag(&first);
+    assert!(!etag.is_empty(), "a 200 must publish a validator");
+    let body = to_bytes(first.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body.as_ref(), SEGMENT_BYTES);
+
+    let revalidated = app
+        .oneshot(audio_get(
+            &uri,
+            &token,
+            &[(axum::http::header::IF_NONE_MATCH, &etag)],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(revalidated.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(audio_etag(&revalidated), etag);
+}
+
+#[tokio::test]
+async fn api_get_audiobook_segment_resumes_when_if_range_still_matches() {
+    let (app, token, uuid, _path, _dir) = segment_validator_fixture().await;
+    let uri = format!("/api/audiobooks/{uuid}/segments/seg-0000.ts");
+    let etag = audio_etag(
+        &app.clone()
+            .oneshot(audio_get(&uri, &token, &[]))
+            .await
+            .unwrap(),
+    );
+
+    let res = app
+        .oneshot(audio_get(
+            &uri,
+            &token,
+            &[
+                (axum::http::header::IF_RANGE, &etag),
+                (axum::http::header::RANGE, "bytes=8-"),
+            ],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::PARTIAL_CONTENT);
+    let body = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body.as_ref(), &SEGMENT_BYTES[8..]);
+}
+
+#[tokio::test]
+async fn api_get_audiobook_segment_serves_the_whole_new_body_when_if_range_went_stale() {
+    let (app, token, uuid, _path, _dir) = segment_validator_fixture().await;
+    let res = app
+        .oneshot(audio_get(
+            &format!("/api/audiobooks/{uuid}/segments/seg-0000.ts"),
+            &token,
+            &[
+                (axum::http::header::IF_RANGE, "\"the-previous-segment\""),
+                (axum::http::header::RANGE, "bytes=8-"),
+            ],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body.as_ref(), SEGMENT_BYTES);
+}


### PR DESCRIPTION
## Summary
- `get_audiobook_segment` served `.ts` HLS segment bytes via `tower_http::services::ServeFile` instead of `backend::serve_file` — the only `ServeFile` use outside tests in `server/src/`, and a direct violation of rule 09 ("every content endpoint routes through `serve_file`").
- Segment responses now carry a strong `ETag` and honor `If-None-Match` / `If-Range` / `Range` like every other media route, matching the two siblings in the same file (`get_audiobook_manifest_part`, `get_audiobook_download`).
- Closes #1720

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus` — PASS (700 passed; the only 2 failures, `backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400`, are a sandbox-only artifact — this environment runs as root, which bypasses the `chmod 555` permission bit those tests rely on to trigger `PermissionDenied`; unrelated to this change, `uploads.rs` untouched)
- Added 3 new tests mirroring the existing `get_audiobook_part`/`get_audiobook_download` conditional-request coverage: `api_get_audiobook_segment_serves_an_etag_and_revalidates_with_304`, `api_get_audiobook_segment_resumes_when_if_range_still_matches`, `api_get_audiobook_segment_serves_the_whole_new_body_when_if_range_went_stale`

## Notes
-


---
_Generated by [Claude Code](https://claude.ai/code/session_013ASpRn59ykZ17wdLjrFKXz)_