### PR TITLE
refactor: group chip_editor and login form props under the 5-prop threshold (#1722)

### DIFF
--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -216,40 +216,48 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
             }
             ChipInputArea {
                 input,
-                placeholder: props.options.placeholder.clone(),
-                input_class: props.options.input_class.clone(),
-                testid_prefix: props.options.testid_prefix.clone(),
-                autofocus: props.options.autofocus,
-                dropdown_header: props.options.dropdown_header.clone(),
-                selection,
-                highlight: highlight(),
-                on_focus: move |_| {
-                    focused.set(true);
-                    suppress_open.set(false);
+                appearance: ChipInputAppearance {
+                    placeholder: props.options.placeholder.clone(),
+                    input_class: props.options.input_class.clone(),
+                    testid_prefix: props.options.testid_prefix.clone(),
+                    autofocus: props.options.autofocus,
                 },
-                on_blur: move |evt: Event<FocusData>| {
-                    focused.set(false);
-                    highlight.set(None);
-                    // Mirrors `EditableCell`'s onblur: a genuine click-away
-                    // (or Tab past the whole editor) exits the host's
-                    // wrapping edit mode the same way Escape does — but Tab
-                    // *within* the editor (e.g. onto a chip's Remove
-                    // button) must not, so this only closes when the
-                    // element gaining focus falls outside `root_el`.
-                    // Suggestion-row picks never reach here at all:
-                    // `SuggestionDropdown`'s `onmousedown` calls
-                    // `prevent_default()`, suppressing the browser's
-                    // default focus-shift so the input never blurs during
-                    // a pick.
-                    close_unless_focus_stayed_inside(evt, root_el, on_close);
+                dropdown: ChipDropdownView {
+                    selection,
+                    highlight: highlight(),
+                    dropdown_header: props.options.dropdown_header.clone(),
                 },
-                on_input: move |value: String| {
-                    input.set(value);
-                    highlight.set(None);
-                    suppress_open.set(false);
+                callbacks: ChipInputAreaCallbacks {
+                    input: ChipInputCallbacks {
+                        on_focus: EventHandler::new(move |_| {
+                            focused.set(true);
+                            suppress_open.set(false);
+                        }),
+                        on_blur: EventHandler::new(move |evt: Event<FocusData>| {
+                            focused.set(false);
+                            highlight.set(None);
+                            // Mirrors `EditableCell`'s onblur: a genuine click-away
+                            // (or Tab past the whole editor) exits the host's
+                            // wrapping edit mode the same way Escape does — but Tab
+                            // *within* the editor (e.g. onto a chip's Remove
+                            // button) must not, so this only closes when the
+                            // element gaining focus falls outside `root_el`.
+                            // Suggestion-row picks never reach here at all:
+                            // `SuggestionDropdown`'s `onmousedown` calls
+                            // `prevent_default()`, suppressing the browser's
+                            // default focus-shift so the input never blurs during
+                            // a pick.
+                            close_unless_focus_stayed_inside(evt, root_el, on_close);
+                        }),
+                        on_input: EventHandler::new(move |value: String| {
+                            input.set(value);
+                            highlight.set(None);
+                            suppress_open.set(false);
+                        }),
+                        on_keydown: EventHandler::new(on_keydown),
+                    },
+                    on_pick: EventHandler::new(move |name: String| commit(name)),
                 },
-                on_keydown,
-                on_pick: move |name: String| commit(name),
             }
         }
     }
@@ -314,22 +322,44 @@ fn close_unless_focus_stayed_inside(
     on_close.call(());
 }
 
-/// Props for the [`ChipInputArea`] sub-component.
-#[derive(Props, Clone, PartialEq)]
-struct ChipInputAreaProps {
-    input: Signal<String>,
+/// Presentational knobs shared by [`ChipInput`] and [`ChipInputArea`] —
+/// `testid_prefix` is the raw prefix (not a final id) so each caller can
+/// derive its own suffix (`-input`, `-suggestions`).
+#[derive(Clone, PartialEq)]
+struct ChipInputAppearance {
     placeholder: String,
     input_class: String,
     testid_prefix: String,
     autofocus: bool,
-    dropdown_header: String,
+}
+
+/// Suggestion-dropdown state + config for [`ChipInputArea`], decoupled from
+/// the input's own appearance/callbacks.
+#[derive(Clone, PartialEq)]
+struct ChipDropdownView {
     selection: SelectionView,
     highlight: Option<usize>,
-    on_focus: EventHandler<()>,
-    on_blur: EventHandler<Event<FocusData>>,
-    on_input: EventHandler<String>,
-    on_keydown: EventHandler<Event<KeyboardData>>,
+    dropdown_header: String,
+}
+
+/// [`ChipInputCallbacks`] plus the one extra callback [`ChipInputArea`] needs
+/// for the dropdown's pick action.
+#[derive(Clone, PartialEq)]
+struct ChipInputAreaCallbacks {
+    input: ChipInputCallbacks,
     on_pick: EventHandler<String>,
+}
+
+/// Props for the [`ChipInputArea`] sub-component. Presentational knobs,
+/// dropdown state, and callbacks are each grouped into their own struct so
+/// this stays under the 5-prop soft cap — mirroring how [`ChipEditorProps`]
+/// groups its own presentational knobs into [`ChipEditorOptions`].
+#[derive(Props, Clone, PartialEq)]
+struct ChipInputAreaProps {
+    input: Signal<String>,
+    appearance: ChipInputAppearance,
+    dropdown: ChipDropdownView,
+    callbacks: ChipInputAreaCallbacks,
 }
 
 /// Input field plus its suggestion dropdown.
@@ -337,36 +367,27 @@ struct ChipInputAreaProps {
 fn ChipInputArea(props: ChipInputAreaProps) -> Element {
     let ChipInputAreaProps {
         input,
-        placeholder,
-        input_class,
-        testid_prefix,
-        autofocus,
-        dropdown_header,
+        appearance,
+        dropdown,
+        callbacks,
+    } = props;
+    let ChipDropdownView {
         selection,
         highlight,
-        on_focus,
-        on_blur,
-        on_input,
-        on_keydown,
-        on_pick,
-    } = props;
+        dropdown_header,
+    } = dropdown;
     let SelectionView {
         filtered,
         typed,
         show_create_row,
     } = selection;
+    let testid_prefix = appearance.testid_prefix.clone();
     rsx! {
         div { class: "chip-editor-input-wrap",
             ChipInput {
                 input,
-                placeholder,
-                input_class,
-                testid: format!("{testid_prefix}-input"),
-                autofocus,
-                on_focus,
-                on_blur,
-                on_input,
-                on_keydown,
+                appearance,
+                callbacks: callbacks.input,
             }
             if !filtered.is_empty() || show_create_row {
                 SuggestionDropdown {
@@ -378,7 +399,7 @@ fn ChipInputArea(props: ChipInputAreaProps) -> Element {
                     },
                     dropdown_header,
                     testid: format!("{testid_prefix}-suggestions"),
-                    on_pick,
+                    on_pick: callbacks.on_pick,
                 }
             }
         }
@@ -541,18 +562,22 @@ fn dispatch_keydown(
     }
 }
 
-/// Props for the [`ChipInput`] sub-component.
-#[derive(Props, Clone, PartialEq)]
-struct ChipInputProps {
-    input: Signal<String>,
-    placeholder: String,
-    input_class: String,
-    testid: String,
-    autofocus: bool,
+/// Focus/blur/input/keydown handlers shared by [`ChipInput`] and
+/// [`ChipInputArea`] — every one forwards straight to the parent.
+#[derive(Clone, PartialEq)]
+struct ChipInputCallbacks {
     on_focus: EventHandler<()>,
     on_blur: EventHandler<Event<FocusData>>,
     on_input: EventHandler<String>,
     on_keydown: EventHandler<Event<KeyboardData>>,
+}
+
+/// Props for the [`ChipInput`] sub-component.
+#[derive(Props, Clone, PartialEq)]
+struct ChipInputProps {
+    input: Signal<String>,
+    appearance: ChipInputAppearance,
+    callbacks: ChipInputCallbacks,
 }
 
 /// Inline `<input>` for the chip editor — owns nothing, forwards every event to the parent's handlers.
@@ -560,15 +585,22 @@ struct ChipInputProps {
 fn ChipInput(props: ChipInputProps) -> Element {
     let ChipInputProps {
         input,
+        appearance,
+        callbacks,
+    } = props;
+    let ChipInputAppearance {
         placeholder,
         input_class,
-        testid,
+        testid_prefix,
         autofocus,
+    } = appearance;
+    let testid = format!("{testid_prefix}-input");
+    let ChipInputCallbacks {
         on_focus,
         on_blur,
         on_input,
         on_keydown,
-    } = props;
+    } = callbacks;
     rsx! {
         input {
             class: "{input_class}",

--- a/frontend/src/pages/auth/login.rs
+++ b/frontend/src/pages/auth/login.rs
@@ -126,6 +126,13 @@ pub fn LoginPage() -> Element {
     #[cfg(feature = "mobile")]
     let _ = keep_signed_in;
 
+    let credentials = Credentials { username, password };
+    let status = LoginStatus {
+        error,
+        submitting,
+        registration_open,
+    };
+
     #[cfg(not(feature = "mobile"))]
     let out = rsx! {
         AuthShell {
@@ -136,12 +143,9 @@ pub fn LoginPage() -> Element {
             },
             lede: Some("Continue to your library.".to_string()),
             LoginForm {
-                username,
-                password,
-                error,
-                submitting,
+                credentials,
+                status,
                 keep_signed_in,
-                registration_open,
                 on_submit,
                 on_keydown,
             }
@@ -156,11 +160,8 @@ pub fn LoginPage() -> Element {
         rsx! {
             MobileLoginForm {
                 host,
-                username,
-                password,
-                error,
-                submitting,
-                registration_open,
+                credentials,
+                status,
                 on_submit,
                 on_keydown,
             }
@@ -178,16 +179,10 @@ pub fn LoginPage() -> Element {
 struct MobileLoginFormProps {
     /// Host the login targets, shown in the connected-to bar.
     host: String,
-    /// Username input value, shared with the parent.
-    username: Signal<String>,
-    /// Password input value, shared with the parent.
-    password: Signal<String>,
-    /// Current submission error, if any.
-    error: Signal<Option<String>>,
-    /// True while a login request is in flight.
-    submitting: Signal<bool>,
-    /// Whether self-registration is open; `None` until the probe answers.
-    registration_open: Signal<Option<bool>>,
+    /// Username + password input values, shared with the parent.
+    credentials: Credentials,
+    /// Error / in-flight / registration-open state, shared with the parent.
+    status: LoginStatus,
     /// Fired on form submission (submit-button click or Enter).
     on_submit: EventHandler<FormEvent>,
     /// Fired on Enter keydown in either input.
@@ -200,14 +195,17 @@ struct MobileLoginFormProps {
 fn MobileLoginForm(props: MobileLoginFormProps) -> Element {
     let MobileLoginFormProps {
         host,
-        username,
-        password,
-        error,
-        submitting,
-        registration_open,
+        credentials,
+        status,
         on_submit,
         on_keydown,
     } = props;
+    let Credentials { username, password } = credentials;
+    let LoginStatus {
+        error,
+        submitting,
+        registration_open,
+    } = status;
     let nav = use_navigator();
     rsx! {
         // Connected-to bar: shows which server this login targets, with a
@@ -259,21 +257,35 @@ fn MobileLoginForm(props: MobileLoginFormProps) -> Element {
     }
 }
 
-/// Props for the [`LoginForm`] component.
+/// Username + password pair shared by [`LoginForm`] and [`MobileLoginForm`],
+/// mirroring how [`LoginCredentialFields`] already treats them as one unit.
+#[derive(Clone, PartialEq)]
+struct Credentials {
+    username: Signal<String>,
+    password: Signal<String>,
+}
+
+/// Submission status shared by [`LoginForm`] and [`MobileLoginForm`] — error,
+/// in-flight state, and whether self-registration is open.
+#[derive(Clone, PartialEq)]
+struct LoginStatus {
+    error: Signal<Option<String>>,
+    submitting: Signal<bool>,
+    /// `None` until the registration-open probe answers.
+    registration_open: Signal<Option<bool>>,
+}
+
+/// Props for the [`LoginForm`] component. Credentials and submission status
+/// are each grouped into their own struct so this stays under the 5-prop
+/// soft cap.
 #[derive(Props, Clone, PartialEq)]
 struct LoginFormProps {
-    /// Username input value, shared with the parent.
-    username: Signal<String>,
-    /// Password input value, shared with the parent.
-    password: Signal<String>,
-    /// Current submission error, if any.
-    error: Signal<Option<String>>,
-    /// True while a login request is in flight.
-    submitting: Signal<bool>,
+    /// Username + password input values, shared with the parent.
+    credentials: Credentials,
+    /// Error / in-flight / registration-open state, shared with the parent.
+    status: LoginStatus,
     /// "Keep me signed in" checkbox state.
     keep_signed_in: Signal<bool>,
-    /// Whether self-registration is open; `None` until the probe answers.
-    registration_open: Signal<Option<bool>>,
     /// Fired on form submission (submit-button click or Enter).
     on_submit: EventHandler<FormEvent>,
     /// Fired on Enter keydown in either input.
@@ -285,15 +297,18 @@ struct LoginFormProps {
 #[component]
 fn LoginForm(props: LoginFormProps) -> Element {
     let LoginFormProps {
-        username,
-        password,
-        error,
-        submitting,
+        credentials,
+        status,
         mut keep_signed_in,
-        registration_open,
         on_submit,
         on_keydown,
     } = props;
+    let Credentials { username, password } = credentials;
+    let LoginStatus {
+        error,
+        submitting,
+        registration_open,
+    } = status;
     rsx! {
         form { class: "auth-form-inner",
             onsubmit: on_submit,


### PR DESCRIPTION
## Summary
- `ChipInputAreaProps` (13 fields) and `ChipInputProps` (9 fields) in `frontend/src/components/chip_editor.rs` now group their presentational knobs, dropdown state, and callbacks into `ChipInputAppearance`, `ChipDropdownView`, and `ChipInputCallbacks`/`ChipInputAreaCallbacks` — mirroring how `ChipEditorProps` already groups its own presentational knobs into `ChipEditorOptions`. `ChipInputAppearance` is shared verbatim between `ChipInput` and `ChipInputArea`, which also removes the duplicated `testid_prefix`/`testid` handling the two used to carry separately.
- `LoginFormProps` and `MobileLoginFormProps` (8 fields each) in `frontend/src/pages/auth/login.rs` now bundle `username`/`password` into a `Credentials` struct and `error`/`submitting`/`registration_open` into a `LoginStatus` struct, bringing both prop structs to 5 fields.
- No behavior or markup change — this is a pure prop-struct reshape; every rendered element, `data-testid`, label, and role is untouched, so the existing Playwright specs under `ui_tests/playwright/tests/flows/` (login/auth, chip-editor/genres/inline-edit/metadata-edit) continue to apply unmodified.

Closes #1722

## Test plan
- [x] `cargo fmt` (via `cargo fmt --check -p omnibus-frontend`) — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (681 passed; 0 failed)
- [ ] Playwright specs touching login/chip-editor markup were read (not executed — no browser/dev-server in this environment) to confirm no `data-testid`/role/label the specs depend on changed.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- Purely mechanical prop-struct grouping per the project's ~5-prop guideline (same pattern as #1543, #1485, #1080, #853). No SQL, no route, no config changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ASpRn59ykZ17wdLjrFKXz)_