### PR TITLE
refactor: split 17 Dioxus page functions over the 80-line cap

### DIFF
--- a/frontend/src/pages/auth/register.rs
+++ b/frontend/src/pages/auth/register.rs
@@ -32,56 +32,17 @@ struct RegisterFormState {
 pub fn RegisterPage() -> Element {
     let username = use_signal(String::new);
     let password = use_signal(String::new);
-    let mut error = use_signal(|| Option::<RegisterError>::None);
-    let mut submitting = use_signal(|| false);
+    let error = use_signal(|| Option::<RegisterError>::None);
+    let submitting = use_signal(|| false);
     let terms_ack = use_signal(|| false);
     let nav = use_navigator();
 
     let server_url = use_server_url();
 
-    // `None` until the probe answers — SSR and the first WASM paint both
-    // render the placeholder, so hydration matches (rule 07) and the form
-    // never appears only to be pulled back when registration turns out to be
-    // closed. A *failed* probe resolves to `Some(true)`: the server's 403 is
-    // the real gate, so a flaky read must not lock anyone out of the form.
-    let mut registration_open = use_signal(|| Option::<bool>::None);
-    use_effect({
-        let server_url = server_url.clone();
-        move || {
-            let server_url = server_url.clone();
-            spawn(async move {
-                let probe = fetch_registration_open(&server_url).await;
-                registration_open.set(Some(registration_open_or_default(probe)));
-            });
-        }
-    });
-
-    let submit_now = use_callback(move |_: ()| {
-        if submitting() {
-            return;
-        }
-        let u = username();
-        let p = password();
-        if u.is_empty() || p.is_empty() {
-            error.set(Some(RegisterError::Other(
-                "enter a username and password".into(),
-            )));
-            return;
-        }
-        error.set(None);
-        submitting.set(true);
-        let server_url = server_url.clone();
-        spawn(async move {
-            let res = submit_register(&server_url, u, p).await;
-            submitting.set(false);
-            match res {
-                Ok(()) => {
-                    nav.replace(Route::Landing {});
-                }
-                Err(e) => error.set(Some(classify_register_error(&e))),
-            }
-        });
-    });
+    let registration_open = use_registration_open_probe(server_url.clone());
+    let submit_now = use_callback(build_register_submit_handler(
+        server_url, username, password, error, submitting, nav,
+    ));
 
     // Same target split as `LoginPage`: the body is shared, only the
     // surrounding shell differs.
@@ -120,6 +81,66 @@ pub fn RegisterPage() -> Element {
     let out = m_auth_shell("Make yourself at home.", form);
 
     out
+}
+
+/// Probes whether registration is open. `None` until the probe answers — SSR
+/// and the first WASM paint both render the placeholder, so hydration
+/// matches (rule 07) and the form never appears only to be pulled back when
+/// registration turns out to be closed. A *failed* probe resolves to
+/// `Some(true)`: the server's 403 is the real gate, so a flaky read must not
+/// lock anyone out of the form. Called unconditionally from [`RegisterPage`].
+fn use_registration_open_probe(server_url: String) -> Signal<Option<bool>> {
+    let mut registration_open = use_signal(|| Option::<bool>::None);
+    use_effect({
+        let server_url = server_url.clone();
+        move || {
+            let server_url = server_url.clone();
+            spawn(async move {
+                let probe = fetch_registration_open(&server_url).await;
+                registration_open.set(Some(registration_open_or_default(probe)));
+            });
+        }
+    });
+    registration_open
+}
+
+/// Builds the register submit handler: local validation, then
+/// `submit_register`, routing to the library on success or classifying the
+/// server error into a field bucket on failure.
+fn build_register_submit_handler(
+    server_url: String,
+    username: Signal<String>,
+    password: Signal<String>,
+    mut error: Signal<Option<RegisterError>>,
+    mut submitting: Signal<bool>,
+    nav: dioxus_router::Navigator,
+) -> impl FnMut(()) + 'static {
+    move |_: ()| {
+        if submitting() {
+            return;
+        }
+        let u = username();
+        let p = password();
+        if u.is_empty() || p.is_empty() {
+            error.set(Some(RegisterError::Other(
+                "enter a username and password".into(),
+            )));
+            return;
+        }
+        error.set(None);
+        submitting.set(true);
+        let server_url = server_url.clone();
+        spawn(async move {
+            let res = submit_register(&server_url, u, p).await;
+            submitting.set(false);
+            match res {
+                Ok(()) => {
+                    nav.replace(Route::Landing {});
+                }
+                Err(e) => error.set(Some(classify_register_error(&e))),
+            }
+        });
+    }
 }
 
 /// Placeholder shown while the registration-open probe is in flight. Renders

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -91,39 +91,16 @@ pub fn AuthorsIndexPage() -> Element {
     let show_letters = matches!(sort(), IndexSort::Name);
     let groups = use_memo(move || {
         let all = authors.read();
-        let q = filter.read().to_lowercase();
-        let mut filtered = filter_authors(&all, &q);
-        let sort_value = sort();
-        sort_authors(&mut filtered, sort_value);
-        let filtered: Vec<AuthorSummary> = filtered.into_iter().cloned().collect();
-        let letters = group_by_letter(&filtered, matches!(sort_value, IndexSort::Name));
-        AuthorGroups { filtered, letters }
+        compute_author_groups(&all, &filter.read(), sort())
     });
     let groups_ref = groups.read();
     let AuthorGroups { filtered, letters } = &*groups_ref;
-
-    // Alphabet strip: A–Z followed by a single '#' bucket for any
-    // authors whose surname-equivalent doesn't start with an ASCII
-    // letter (digits, punctuation, accented mononyms, …). The '#'
-    // glyph is rendered after Z so the eye lands on the alpha range
-    // first and the long tail of edge cases sits where it expects to.
-    let alphabet: Vec<char> = ('A'..='Z').chain(std::iter::once('#')).collect();
-    let present_letters: std::collections::HashSet<char> =
-        letters.iter().map(|(l, _)| *l).collect();
 
     let counts = AuthorIndexCounts {
         total_authors,
         total_books: total_books(),
     };
-    let filter_state = AuthorIndexFilter {
-        filter: filter(),
-        sort: sort(),
-        show_letters,
-        alphabet: alphabet.clone(),
-        present_letters: present_letters.clone(),
-        letter_count: letters.len(),
-        filtered_count: filtered.len(),
-    };
+    let filter_state = build_filter_state(filter(), sort(), show_letters, letters, filtered.len());
 
     rsx! {
         div { class: "idx-page",
@@ -141,6 +118,45 @@ pub fn AuthorsIndexPage() -> Element {
             {authors_index_body(filtered, letters, show_letters, any_in_library, &server_url_for_cards)}
         }
     }
+}
+
+/// Assembles the alphabet-strip + filter/sort state passed to the header.
+/// The A–Z run (plus a single `#` bucket for any name whose
+/// surname-equivalent doesn't start with an ASCII letter — digits,
+/// punctuation, accented mononyms, … — rendered after Z so the eye lands on
+/// the alpha range first) is built here since it's only needed for this one
+/// struct.
+fn build_filter_state(
+    filter_text: String,
+    sort: IndexSort,
+    show_letters: bool,
+    letters: &[(char, Vec<AuthorSummary>)],
+    filtered_count: usize,
+) -> AuthorIndexFilter {
+    let alphabet: Vec<char> = ('A'..='Z').chain(std::iter::once('#')).collect();
+    let present_letters: std::collections::HashSet<char> =
+        letters.iter().map(|(l, _)| *l).collect();
+    AuthorIndexFilter {
+        filter: filter_text,
+        sort,
+        show_letters,
+        alphabet,
+        present_letters,
+        letter_count: letters.len(),
+        filtered_count,
+    }
+}
+
+/// Filter → sort → group-by-letter pipeline, folded into one step so the
+/// `use_memo` above reruns once per authors/filter/sort change rather than
+/// three times (mirrors `landing.rs`'s `visible = use_memo(...)`).
+fn compute_author_groups(all: &[AuthorSummary], query: &str, sort: IndexSort) -> AuthorGroups {
+    let q = query.to_lowercase();
+    let mut filtered = filter_authors(all, &q);
+    sort_authors(&mut filtered, sort);
+    let filtered: Vec<AuthorSummary> = filtered.into_iter().cloned().collect();
+    let letters = group_by_letter(&filtered, matches!(sort, IndexSort::Name));
+    AuthorGroups { filtered, letters }
 }
 
 /// Client-side name filter (case-insensitive substring match).

--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -23,7 +23,7 @@ use entry_card::BdJournalEntryCard;
 #[component]
 pub(super) fn BdJournalSection(uuid: String) -> Element {
     let server_url = use_server_url();
-    let mut entries = use_signal(Vec::<JournalEntry>::new);
+    let entries = use_signal(Vec::<JournalEntry>::new);
     // Derived from the app-wide `CurrentUser` context (`crate::use_current_user_summary`)
     // instead of an independent per-mount `/api/auth/me` fetch. Mobile/SSR
     // stay at the `None` default since the context is web-only.
@@ -31,7 +31,33 @@ pub(super) fn BdJournalSection(uuid: String) -> Element {
     // Bumped after any mutation to refetch the server-authoritative feed.
     let reload = use_signal(|| 0u32);
 
-    let load_url = server_url.clone();
+    use_journal_entries_load(uuid.clone(), server_url.clone(), reload, entries);
+    use_spoiler_reveal_binding();
+
+    let list = entries();
+    let kicker = journal_kicker(&list);
+
+    rsx! {
+        div { id: "journal", class: "bd-journal", "data-testid": "journal-section",
+            BdSectionHead { kicker, title: "What readers have written".to_string() }
+            p { class: "mono bd-journal-blurb",
+                "A shared log — every reader's journal for this book lives here."
+            }
+            BdJournalComposer { uuid: uuid.clone(), server_url: server_url.clone(), reload }
+            BdJournalList { list, current_user: current_user(), server_url, reload }
+        }
+    }
+}
+
+/// Loads the journal feed for `uuid` on mount, whenever `uuid` changes, and
+/// whenever `reload` bumps (after a create/edit/delete). Called
+/// unconditionally from [`BdJournalSection`].
+fn use_journal_entries_load(
+    uuid: String,
+    load_url: String,
+    reload: Signal<u32>,
+    mut entries: Signal<Vec<JournalEntry>>,
+) {
     use_effect(use_reactive!(|uuid| {
         let _ = reload();
         let url = load_url.clone();
@@ -42,15 +68,18 @@ pub(super) fn BdJournalSection(uuid: String) -> Element {
             }
         });
     }));
+}
 
-    // Click-to-reveal spoilers, delegated on `document` so it covers entries
-    // that render after mount and bound once via a window guard. The sanitizer
-    // emits the spoiler as a real `<button>`, so Tab reaches it and Enter/Space
-    // fire a native click without a keydown listener; the handler just needs
-    // to keep `aria-expanded` in sync with the `.revealed` class so assistive
-    // tech reflects the toggled state. Web-only: the eval is a no-op on SSR /
-    // native, and gating the body (not the hook) keeps the hook count
-    // identical across targets for hydration.
+/// Binds click-to-reveal spoilers, delegated on `document` so it covers
+/// entries that render after mount and bound once via a window guard. The
+/// sanitizer emits the spoiler as a real `<button>`, so Tab reaches it and
+/// Enter/Space fire a native click without a keydown listener; the handler
+/// just needs to keep `aria-expanded` in sync with the `.revealed` class so
+/// assistive tech reflects the toggled state. Web-only: the eval is a no-op
+/// on SSR / native, and gating the body (not the hook) keeps the hook count
+/// identical across targets for hydration. Called unconditionally from
+/// [`BdJournalSection`].
+fn use_spoiler_reveal_binding() {
     use_effect(move || {
         #[cfg(feature = "web")]
         {
@@ -69,50 +98,53 @@ pub(super) fn BdJournalSection(uuid: String) -> Element {
             );
         }
     });
+}
 
-    let list = entries();
+/// The section-head kicker text: entry/reader counts, or an empty-state note.
+fn journal_kicker(list: &[JournalEntry]) -> String {
+    if list.is_empty() {
+        return "Reading journal · no entries yet".to_string();
+    }
     let reader_count = {
         let mut ids: Vec<i64> = list.iter().map(|e| e.author_id).collect();
         ids.sort_unstable();
         ids.dedup();
         ids.len()
     };
-    let kicker = if list.is_empty() {
-        "Reading journal · no entries yet".to_string()
+    let entry_word = if list.len() == 1 { "entry" } else { "entries" };
+    let reader_word = if reader_count == 1 {
+        "reader"
     } else {
-        let entry_word = if list.len() == 1 { "entry" } else { "entries" };
-        let reader_word = if reader_count == 1 {
-            "reader"
-        } else {
-            "readers"
-        };
-        format!(
-            "Reading journal · {} {entry_word} from {reader_count} {reader_word}",
-            list.len()
-        )
+        "readers"
     };
+    format!(
+        "Reading journal · {} {entry_word} from {reader_count} {reader_word}",
+        list.len()
+    )
+}
 
+/// The empty-state card, or the feed of entry cards.
+#[component]
+fn BdJournalList(
+    list: Vec<JournalEntry>,
+    current_user: Option<omnibus_shared::UserSummary>,
+    server_url: String,
+    reload: Signal<u32>,
+) -> Element {
     rsx! {
-        div { id: "journal", class: "bd-journal", "data-testid": "journal-section",
-            BdSectionHead { kicker, title: "What readers have written".to_string() }
-            p { class: "mono bd-journal-blurb",
-                "A shared log — every reader's journal for this book lives here."
+        if list.is_empty() {
+            div { class: "bd-journal-empty card", "data-testid": "journal-empty",
+                p { class: "mono", "No journal entries yet — be the first to write one." }
             }
-            BdJournalComposer { uuid: uuid.clone(), server_url: server_url.clone(), reload }
-            if list.is_empty() {
-                div { class: "bd-journal-empty card", "data-testid": "journal-empty",
-                    p { class: "mono", "No journal entries yet — be the first to write one." }
-                }
-            } else {
-                div { class: "bd-journal-list", "data-testid": "journal-list",
-                    for entry in list.iter() {
-                        BdJournalEntryCard {
-                            key: "{entry.id}",
-                            entry: entry.clone(),
-                            current_user: current_user(),
-                            server_url: server_url.clone(),
-                            reload,
-                        }
+        } else {
+            div { class: "bd-journal-list", "data-testid": "journal-list",
+                for entry in list.iter() {
+                    BdJournalEntryCard {
+                        key: "{entry.id}",
+                        entry: entry.clone(),
+                        current_user: current_user.clone(),
+                        server_url: server_url.clone(),
+                        reload,
                     }
                 }
             }

--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -103,18 +103,7 @@ fn BdJournalEntryHeader(view: JournalEntryHeaderView, edit: JournalEntryEditStat
         entry_progress,
         server_url,
     } = view;
-    let JournalEntryEditState {
-        editing,
-        edit_body,
-        saving,
-        error,
-        reload,
-    } = edit;
-    let mut editing = editing;
-    let mut edit_body = edit_body;
-    let mut saving = saving;
-    let mut error = error;
-    let mut reload = reload;
+    let editing = edit.editing;
 
     rsx! {
         div { class: "bd-journal-entry-head",
@@ -124,64 +113,107 @@ fn BdJournalEntryHeader(view: JournalEntryHeaderView, edit: JournalEntryEditStat
                 has_avatar: author_has_avatar,
                 class: "bd-journal-avatar",
             }
-            div { class: "bd-journal-entry-meta",
-                div { class: "bd-journal-entry-byline",
-                    span { class: "bd-journal-author", "{author_name}" }
-                    if is_owner {
-                        span { class: "chip bd-journal-you", "you" }
-                    }
-                    if is_draft {
-                        span {
-                            class: "chip bd-journal-draft",
-                            "data-testid": "journal-draft-chip",
-                            "Draft"
-                        }
-                    }
-                }
-                div { class: "mono bd-journal-entry-date", "{meta_line}" }
-            }
+            BdJournalEntryByline { author_name, is_owner, is_draft, meta_line }
             if is_owner && !editing() {
-                div { class: "bd-journal-entry-actions",
-                    if is_draft {
-                        BdJournalPublishDraftButton {
-                            server_url: server_url.clone(),
-                            entry_id,
-                            body_for_edit: body_for_edit.clone(),
-                            entry_progress,
-                            edit,
-                        }
-                    }
-                    button {
-                        r#type: "button",
-                        class: "btn ghost sm",
-                        "data-testid": "journal-edit",
-                        onclick: move |_| {
-                            edit_body.set(body_for_edit.clone());
-                            error.set(None);
-                            editing.set(true);
-                        },
-                        "Edit"
-                    }
-                    button {
-                        r#type: "button",
-                        class: "btn ghost sm bd-journal-delete",
-                        "data-testid": "journal-delete",
-                        disabled: saving(),
-                        onclick: move |_| {
-                            let url = server_url.clone();
-                            saving.set(true);
-                            error.set(None);
-                            spawn(async move {
-                                match data::delete_journal_entry(&url, entry_id).await {
-                                    Ok(()) => reload.set(reload() + 1),
-                                    Err(e) => error.set(Some(e.to_string())),
-                                }
-                                saving.set(false);
-                            });
-                        },
-                        "Delete"
+                BdJournalEntryActions {
+                    server_url,
+                    entry_id,
+                    body_for_edit,
+                    entry_progress,
+                    is_draft,
+                    edit,
+                }
+            }
+        }
+    }
+}
+
+/// Author name, "you" / "Draft" chips, and the date/progress meta line.
+#[component]
+fn BdJournalEntryByline(
+    author_name: String,
+    is_owner: bool,
+    is_draft: bool,
+    meta_line: String,
+) -> Element {
+    rsx! {
+        div { class: "bd-journal-entry-meta",
+            div { class: "bd-journal-entry-byline",
+                span { class: "bd-journal-author", "{author_name}" }
+                if is_owner {
+                    span { class: "chip bd-journal-you", "you" }
+                }
+                if is_draft {
+                    span {
+                        class: "chip bd-journal-draft",
+                        "data-testid": "journal-draft-chip",
+                        "Draft"
                     }
                 }
+            }
+            div { class: "mono bd-journal-entry-date", "{meta_line}" }
+        }
+    }
+}
+
+/// Owner-only action row: optional Publish (drafts only), Edit, and Delete.
+#[component]
+fn BdJournalEntryActions(
+    server_url: String,
+    entry_id: i64,
+    body_for_edit: String,
+    entry_progress: Option<u8>,
+    is_draft: bool,
+    edit: JournalEntryEditState,
+) -> Element {
+    let JournalEntryEditState {
+        mut editing,
+        mut edit_body,
+        mut saving,
+        mut error,
+        mut reload,
+    } = edit;
+
+    rsx! {
+        div { class: "bd-journal-entry-actions",
+            if is_draft {
+                BdJournalPublishDraftButton {
+                    server_url: server_url.clone(),
+                    entry_id,
+                    body_for_edit: body_for_edit.clone(),
+                    entry_progress,
+                    edit,
+                }
+            }
+            button {
+                r#type: "button",
+                class: "btn ghost sm",
+                "data-testid": "journal-edit",
+                onclick: move |_| {
+                    edit_body.set(body_for_edit.clone());
+                    error.set(None);
+                    editing.set(true);
+                },
+                "Edit"
+            }
+            button {
+                r#type: "button",
+                class: "btn ghost sm bd-journal-delete",
+                "data-testid": "journal-delete",
+                disabled: saving(),
+                onclick: move |_| {
+                    let url = server_url.clone();
+                    saving.set(true);
+                    error.set(None);
+                    spawn(async move {
+                        match data::delete_journal_entry(&url, entry_id).await {
+                            Ok(()) => reload.set(reload() + 1),
+                            Err(e) => error.set(Some(e.to_string())),
+                        }
+                        saving.set(false);
+                    });
+                },
+                "Delete"
             }
         }
     }

--- a/frontend/src/pages/book_detail/rating.rs
+++ b/frontend/src/pages/book_detail/rating.rs
@@ -31,14 +31,13 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
     // `current` is the persisted rating; `hover` previews a pending pick. Both
     // seed to `None` so SSR and first-hydration paint render an unrated card —
     // the effect below reconciles on the client only.
-    let mut current = use_signal(|| None::<RatingRecord>);
+    let current = use_signal(|| None::<RatingRecord>);
     let mut hover = use_signal(|| None::<f32>);
-    let mut failed = use_signal(|| false);
+    let failed = use_signal(|| false);
     // Monotonic write counter: a save only applies its result if it's still the
     // latest, so an out-of-order (slow) response can't clobber a newer click.
-    let mut op_seq = use_signal(|| 0u64);
-    let mut load_seq = use_signal(|| 0u64);
-    let mut other_ratings = use_signal(Vec::<AttributedRating>::new);
+    let op_seq = use_signal(|| 0u64);
+    let other_ratings = use_signal(Vec::<AttributedRating>::new);
     let state = RatingState {
         current,
         hover,
@@ -47,50 +46,13 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
         other_ratings,
     };
 
-    let load_url = server_url.clone();
-    use_effect(use_reactive!(|uuid| {
-        if uuid.is_empty() {
-            return;
-        }
-        let my_load = *load_seq.peek() + 1;
-        let next_op = *op_seq.peek() + 1;
-        load_seq.set(my_load);
-        op_seq.set(next_op);
-        current.set(None);
-        other_ratings.set(Vec::new());
-        failed.set(false);
-        let load_url = load_url.clone();
-        let uuid = uuid.clone();
-        spawn(async move {
-            if let Ok(rec) = data::get_rating(&load_url, &uuid).await {
-                if *load_seq.peek() == my_load {
-                    current.set(rec);
-                }
-            }
-            if let Ok(ratings) = data::list_other_ratings(&load_url, &uuid).await {
-                if *load_seq.peek() == my_load {
-                    other_ratings.set(ratings);
-                }
-            }
-        });
-    }));
+    use_rating_hydration(uuid.clone(), server_url.clone(), state);
 
     // The fill the user sees: a hover preview wins over the saved value.
     let shown = hover()
         .or_else(|| current().map(|r| r.stars))
         .unwrap_or(0.0);
-
-    let meta_text = if failed() {
-        "Couldn't save rating — try again".to_string()
-    } else if let Some(rec) = current() {
-        format!(
-            "{} \u{00b7} {} of 5",
-            rated_ago(now_unix(), rec.updated_at),
-            fmt_stars(rec.stars)
-        )
-    } else {
-        "Not rated yet".to_string()
-    };
+    let meta_text = rating_meta_text(failed(), current());
 
     rsx! {
         div {
@@ -100,35 +62,13 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
             "data-testid": "rating-stars",
             onmouseleave: move |_| hover.set(None),
             for i in 1..=5u8 {
-                {
-                    let slot = i as f32;
-                    let fill = if shown >= slot {
-                        100
-                    } else if shown >= slot - 0.5 {
-                        50
-                    } else {
-                        0
-                    };
-                    rsx! {
-                        span { key: "{i}", class: "bd-star-slot",
-                            span { class: "bd-star-bg", "\u{2605}" }
-                            span { class: "bd-star-fg", style: "width: {fill}%", "\u{2605}" }
-                            BdStarHalf {
-                                value: slot - 0.5,
-                                side: "left",
-                                uuid: uuid.clone(),
-                                server_url: server_url.clone(),
-                                state,
-                            }
-                            BdStarHalf {
-                                value: slot,
-                                side: "right",
-                                uuid: uuid.clone(),
-                                server_url: server_url.clone(),
-                                state,
-                            }
-                        }
-                    }
+                BdStarSlot {
+                    key: "{i}",
+                    slot: i as f32,
+                    shown,
+                    uuid: uuid.clone(),
+                    server_url: server_url.clone(),
+                    state,
                 }
             }
         }
@@ -139,15 +79,112 @@ pub(super) fn BdRatingWidget(uuid: String) -> Element {
             "{meta_text}"
         }
         if !other_ratings().is_empty() {
-            div {
-                class: "bd-other-ratings",
-                "data-testid": "other-ratings",
-                aria_label: "Other ratings",
-                for rating in other_ratings() {
-                    BdOtherRatingRow {
-                        key: "{rating.user_id}",
-                        rating,
-                    }
+            BdOtherRatingsList { ratings: other_ratings() }
+        }
+    }
+}
+
+/// Loads the persisted rating and other-users' ratings for `uuid` on mount and
+/// whenever `uuid` changes, guarding stale (out-of-order) responses with a
+/// load-sequence counter. Called unconditionally from [`BdRatingWidget`].
+fn use_rating_hydration(uuid: String, load_url: String, mut state: RatingState) {
+    let mut load_seq = use_signal(|| 0u64);
+    use_effect(use_reactive!(|uuid| {
+        if uuid.is_empty() {
+            return;
+        }
+        let my_load = *load_seq.peek() + 1;
+        let next_op = *state.op_seq.peek() + 1;
+        load_seq.set(my_load);
+        state.op_seq.set(next_op);
+        state.current.set(None);
+        state.other_ratings.set(Vec::new());
+        state.failed.set(false);
+        let load_url = load_url.clone();
+        let uuid = uuid.clone();
+        let mut state = state;
+        spawn(async move {
+            if let Ok(rec) = data::get_rating(&load_url, &uuid).await {
+                if *load_seq.peek() == my_load {
+                    state.current.set(rec);
+                }
+            }
+            if let Ok(ratings) = data::list_other_ratings(&load_url, &uuid).await {
+                if *load_seq.peek() == my_load {
+                    state.other_ratings.set(ratings);
+                }
+            }
+        });
+    }));
+}
+
+/// The status line under the star row: an error takes priority, then the
+/// saved rating's age and value, else the unrated placeholder.
+fn rating_meta_text(failed: bool, current: Option<RatingRecord>) -> String {
+    if failed {
+        "Couldn't save rating — try again".to_string()
+    } else if let Some(rec) = current {
+        format!(
+            "{} \u{00b7} {} of 5",
+            rated_ago(now_unix(), rec.updated_at),
+            fmt_stars(rec.stars)
+        )
+    } else {
+        "Not rated yet".to_string()
+    }
+}
+
+/// One star's slot in the row: background glyph, fill overlay sized to the
+/// shown value, and its two half-star click targets.
+#[component]
+fn BdStarSlot(
+    slot: f32,
+    shown: f32,
+    uuid: String,
+    server_url: String,
+    state: RatingState,
+) -> Element {
+    let fill = if shown >= slot {
+        100
+    } else if shown >= slot - 0.5 {
+        50
+    } else {
+        0
+    };
+    rsx! {
+        span { class: "bd-star-slot",
+            span { class: "bd-star-bg", "\u{2605}" }
+            span { class: "bd-star-fg", style: "width: {fill}%", "\u{2605}" }
+            BdStarHalf {
+                value: slot - 0.5,
+                side: "left",
+                uuid: uuid.clone(),
+                server_url: server_url.clone(),
+                state,
+            }
+            BdStarHalf {
+                value: slot,
+                side: "right",
+                uuid: uuid.clone(),
+                server_url: server_url.clone(),
+                state,
+            }
+        }
+    }
+}
+
+/// The "other readers' ratings" list shown under the interactive widget.
+#[component]
+fn BdOtherRatingsList(ratings: Vec<AttributedRating>) -> Element {
+    rsx! {
+        div {
+            class: "bd-other-ratings",
+            "data-testid": "other-ratings",
+            aria_label: "Other ratings",
+            for rating in ratings {
+                BdOtherRatingRow {
+                    key: "{rating.user_id}",
+                    rating,
                 }
             }
         }

--- a/frontend/src/pages/check_in/search.rs
+++ b/frontend/src/pages/check_in/search.rs
@@ -19,14 +19,37 @@ use crate::{data, use_server_url};
 pub(super) fn TitleSearch(state: FlowState, on_pick: EventHandler<ExternalBookMeta>) -> Element {
     let server_url = use_server_url();
     let busy = state.busy;
-    let mut error = state.error;
-    let mut query = use_signal(String::new);
-    let mut searching = use_signal(|| false);
+    let error = state.error;
+    let query = use_signal(String::new);
+    let searching = use_signal(|| false);
     // `None` until the first search lands, so the empty-state line can't show
     // before anyone has searched.
-    let mut results = use_signal(|| None::<Vec<ExternalBookMeta>>);
+    let results = use_signal(|| None::<Vec<ExternalBookMeta>>);
+    let run_search = build_title_search_handler(server_url, query, error, searching, results);
 
-    let mut run_search = move |_| {
+    rsx! {
+        div { class: "check-in-search", "data-testid": "check-in-search",
+            TitleSearchForm {
+                query,
+                busy,
+                searching,
+                on_submit: EventHandler::new(run_search),
+            }
+            TitleSearchResults { results: results(), busy, on_pick }
+        }
+    }
+}
+
+/// Builds the title-search submit handler: runs `data::scan_search` for the
+/// trimmed query and populates `results` (or `error` on failure).
+fn build_title_search_handler(
+    server_url: String,
+    query: Signal<String>,
+    mut error: Signal<Option<String>>,
+    mut searching: Signal<bool>,
+    mut results: Signal<Option<Vec<ExternalBookMeta>>>,
+) -> impl FnMut(()) + 'static {
+    move |_: ()| {
         let trimmed = query().trim().to_string();
         if trimmed.is_empty() || searching() {
             return;
@@ -45,58 +68,74 @@ pub(super) fn TitleSearch(state: FlowState, on_pick: EventHandler<ExternalBookMe
             }
             searching.set(false);
         });
-    };
+    }
+}
 
+/// The query input + submit button.
+#[component]
+fn TitleSearchForm(
+    mut query: Signal<String>,
+    busy: Signal<bool>,
+    searching: Signal<bool>,
+    on_submit: EventHandler<()>,
+) -> Element {
     rsx! {
-        div { class: "check-in-search", "data-testid": "check-in-search",
-            form {
-                class: "settings-form",
-                "data-testid": "check-in-search-form",
-                onsubmit: move |evt| {
-                    evt.prevent_default();
-                    run_search(());
-                },
-                div { class: "settings-field",
-                    label { r#for: "check-in-search-query", "Title" }
-                    input {
-                        id: "check-in-search-query",
-                        "data-testid": "check-in-search-query",
-                        r#type: "search",
-                        autocomplete: "off",
-                        placeholder: "The Name of the Wind",
-                        value: "{query}",
-                        disabled: busy() || searching(),
-                        oninput: move |e| query.set(e.value()),
-                    }
-                }
-                div { class: "settings-actions",
-                    button {
-                        r#type: "submit",
-                        class: "btn primary",
-                        disabled: busy() || searching() || query().trim().is_empty(),
-                        "data-testid": "check-in-search-submit",
-                        if searching() { "Searching\u{2026}" } else { "Search" }
-                    }
+        form {
+            class: "settings-form",
+            "data-testid": "check-in-search-form",
+            onsubmit: move |evt| {
+                evt.prevent_default();
+                on_submit.call(());
+            },
+            div { class: "settings-field",
+                label { r#for: "check-in-search-query", "Title" }
+                input {
+                    id: "check-in-search-query",
+                    "data-testid": "check-in-search-query",
+                    r#type: "search",
+                    autocomplete: "off",
+                    placeholder: "The Name of the Wind",
+                    value: "{query}",
+                    disabled: busy() || searching(),
+                    oninput: move |e| query.set(e.value()),
                 }
             }
-            match results() {
-                Some(list) if list.is_empty() => rsx! {
-                    p { class: "check-in-why", "data-testid": "check-in-search-empty",
-                        "No books match that title. Check the spelling, or try just the main title."
-                    }
-                },
-                Some(list) => rsx! {
-                    ul { class: "check-in-search-results", "data-testid": "check-in-search-results",
-                        for meta in list {
-                            li { key: "{meta.isbn13}",
-                                SearchResult { meta, busy, on_pick }
-                            }
-                        }
-                    }
-                },
-                None => rsx! {},
+            div { class: "settings-actions",
+                button {
+                    r#type: "submit",
+                    class: "btn primary",
+                    disabled: busy() || searching() || query().trim().is_empty(),
+                    "data-testid": "check-in-search-submit",
+                    if searching() { "Searching\u{2026}" } else { "Search" }
+                }
             }
         }
+    }
+}
+
+/// Empty-state note, the candidate list, or nothing before a first search.
+#[component]
+fn TitleSearchResults(
+    results: Option<Vec<ExternalBookMeta>>,
+    busy: Signal<bool>,
+    on_pick: EventHandler<ExternalBookMeta>,
+) -> Element {
+    match results {
+        Some(list) if list.is_empty() => rsx! {
+            p { class: "check-in-why", "data-testid": "check-in-search-empty",
+                "No books match that title. Check the spelling, or try just the main title."
+            }
+        },
+        Some(list) => rsx! {
+            ul { class: "check-in-search-results", "data-testid": "check-in-search-results",
+                for meta in list {
+                    li { key: "{meta.isbn13}",
+                        SearchResult { meta, busy, on_pick }
+                    }
+                }
+            }
+        },
+        None => rsx! {},
     }
 }
 

--- a/frontend/src/pages/landing/sections.rs
+++ b/frontend/src/pages/landing/sections.rs
@@ -166,6 +166,58 @@ pub(super) fn LandingContent(props: LandingContentProps) -> Element {
         handlers,
         sweep_key,
     } = props;
+    let LandingContentHandlers {
+        on_prefs_change,
+        on_load_more,
+        on_clear_filters,
+    } = handlers;
+    let on_sort = build_sort_handler(prefs.clone(), on_prefs_change);
+
+    rsx! {
+        div { class: "lib-layout lib-layout--collapsed",
+            div { key: "{sweep_key}", class: "lib-main lib-books",
+                LandingBooksArea {
+                    books,
+                    prefs,
+                    ctx,
+                    on_sort: EventHandler::new(on_sort),
+                    on_load_more,
+                    on_clear_filters,
+                }
+            }
+        }
+    }
+}
+
+/// Builds the table/grid sort-column handler: clicking the already-active
+/// column toggles direction, else adopts the new axis's natural direction.
+fn build_sort_handler(
+    prefs: ViewPrefs,
+    on_prefs_change: EventHandler<ViewPrefs>,
+) -> impl FnMut(SortKey) + 'static {
+    move |key: SortKey| {
+        let mut next = prefs.clone();
+        next.sort_dir = if next.sort_key == key {
+            toggle_dir(next.sort_dir)
+        } else {
+            default_dir_for(key)
+        };
+        next.sort_key = key;
+        on_prefs_change.call(next);
+    }
+}
+
+/// The loading / table-or-grid / empty / filtered-empty states for the main
+/// book area, and the load-more pagination sentinel.
+#[component]
+fn LandingBooksArea(
+    books: BooksView,
+    prefs: ViewPrefs,
+    ctx: BookTableContext,
+    on_sort: EventHandler<SortKey>,
+    on_load_more: EventHandler<()>,
+    on_clear_filters: EventHandler<()>,
+) -> Element {
     let BooksView {
         is_loading,
         visible_books,
@@ -176,71 +228,48 @@ pub(super) fn LandingContent(props: LandingContentProps) -> Element {
         has_more,
         is_loading_more,
     } = books;
-    let LandingContentHandlers {
-        on_prefs_change,
-        on_load_more,
-        on_clear_filters,
-    } = handlers;
     let view_mode = prefs.view_mode;
 
-    let on_sort = {
-        let prefs = prefs.clone();
-        move |key: SortKey| {
-            let mut next = prefs.clone();
-            next.sort_dir = if next.sort_key == key {
-                toggle_dir(next.sort_dir)
-            } else {
-                default_dir_for(key)
-            };
-            next.sort_key = key;
-            on_prefs_change.call(next);
-        }
-    };
-
     rsx! {
-        div { class: "lib-layout lib-layout--collapsed",
-            div { key: "{sweep_key}", class: "lib-main lib-books",
-                if is_loading {
-                    p { class: "library-empty", "Loading..." }
-                } else if !visible_is_empty || lib_err.is_some() || page_error.is_some() {
-                    match view_mode {
-                        ViewMode::Table => rsx! {
-                            BookTable {
-                                books: visible_books.clone(),
-                                prefs: prefs.clone(),
-                                on_sort,
-                                ctx: ctx.clone(),
-                            }
-                        },
-                        ViewMode::Grid => rsx! {
-                            BookGrid {
-                                books: visible_books.clone(),
-                                server_url: ctx.server_url.clone(),
-                            }
-                        },
+        if is_loading {
+            p { class: "library-empty", "Loading..." }
+        } else if !visible_is_empty || lib_err.is_some() || page_error.is_some() {
+            match view_mode {
+                ViewMode::Table => rsx! {
+                    BookTable {
+                        books: visible_books.clone(),
+                        prefs: prefs.clone(),
+                        on_sort,
+                        ctx: ctx.clone(),
                     }
-                    // Browse pagination sentinel — the button is the
-                    // deterministic (mobile + Playwright) trigger; on web an
-                    // IntersectionObserver auto-bumps it as it nears the
-                    // viewport. Absent in search mode (no `next_cursor`).
-                    if has_more {
-                        div { class: "lib-load-more-row",
-                            button {
-                                class: "btn lib-load-more",
-                                "data-testid": "lib-load-more",
-                                disabled: is_loading_more,
-                                onclick: move |_| on_load_more.call(()),
-                                if is_loading_more { "Loading…" } else { "Load more" }
-                            }
-                        }
+                },
+                ViewMode::Grid => rsx! {
+                    BookGrid {
+                        books: visible_books.clone(),
+                        server_url: ctx.server_url.clone(),
                     }
-                } else if books_empty {
-                    p { class: "library-empty", "No ebooks found." }
-                } else {
-                    EmptyFiltered {
-                        on_clear: move |_| on_clear_filters.call(()),
+                },
+            }
+            // Browse pagination sentinel — the button is the deterministic
+            // (mobile + Playwright) trigger; on web an IntersectionObserver
+            // auto-bumps it as it nears the viewport. Absent in search mode
+            // (no `next_cursor`).
+            if has_more {
+                div { class: "lib-load-more-row",
+                    button {
+                        class: "btn lib-load-more",
+                        "data-testid": "lib-load-more",
+                        disabled: is_loading_more,
+                        onclick: move |_| on_load_more.call(()),
+                        if is_loading_more { "Loading…" } else { "Load more" }
                     }
                 }
+            }
+        } else if books_empty {
+            p { class: "library-empty", "No ebooks found." }
+        } else {
+            EmptyFiltered {
+                on_clear: move |_| on_clear_filters.call(()),
             }
         }
     }

--- a/frontend/src/pages/landing/signals.rs
+++ b/frontend/src/pages/landing/signals.rs
@@ -70,115 +70,132 @@ pub(super) struct LandingSignals {
 /// Construct every signal the landing page owns and arm the effects that
 /// fetch data into them. Must run from inside [`super::LandingPage`] — every
 /// call here is a Dioxus hook, so the call order is stable across renders.
+/// The signals themselves are assembled by per-bundle constructor helpers
+/// below rather than inline, since none of this is rsx (AC3).
 pub(super) fn setup_landing_signals(server_url: &str, query: Signal<String>) -> LandingSignals {
-    // Accumulated result rows: one growing browse list, or the capped search
-    // result set. `next_cursor` is `Some` only while more browse pages remain.
-    let books = use_signal(Vec::<EbookMetadata>::new);
-    let next_cursor = use_signal(|| None::<String>);
-    let total = use_signal(|| None::<i64>);
-    let hidden = use_signal(|| None::<i64>);
-    let lib_path = use_signal(|| None::<String>);
-    let lib_error = use_signal(|| None::<String>);
-    let loading = use_signal(|| true);
-    let loading_more = use_signal(|| false);
-    let error = use_signal(|| None::<String>);
-    let prefs = use_signal(ViewPrefs::default);
-    // Bumped by the Load-more button and the web scroll observer; one effect
-    // watches it and appends the next page.
-    let want_more = use_signal(|| 0u32);
-    // Monotonic fetch epoch, bumped on every page-1 refetch. An in-flight
-    // page-1 fetch or load-more append captures the epoch and drops its result
-    // if a newer fetch (sort/dir/filter/query change) superseded it mid-flight
-    // — otherwise it would splice an old result stream onto the new list.
-    let fetch_epoch = use_signal(|| 0u64);
+    let fetch_sigs = use_fetch_signals();
     let is_admin = crate::use_is_admin();
-    // Suggestion pools for the inline Authors, Tags, and Genres chip
-    // editors, each carrying the dropdown book-count.
-    let pools = SuggestionPools {
-        authors: use_signal(Vec::<SuggestionItem>::new),
-        tags: use_signal(Vec::<SuggestionItem>::new),
-        genres: use_signal(Vec::<SuggestionItem>::new),
-    };
-    // Shelf-gallery lens. `selection` seeds to All on every target (SSR
-    // parity, rule 07); the persisted choice reconciles post-mount in
-    // `wire_landing_effects`.
-    let selection = use_signal(ShelfSelection::default);
-    let shelves = use_signal(Vec::<ShelfSummary>::new);
-    let shelves_loaded = use_signal(|| false);
-    let shelves_tick = use_signal(|| 0u32);
-    let shelf_books = use_signal(|| None::<Vec<EbookMetadata>>);
-    let shelf_loading = use_signal(|| false);
-    let shelf_error = use_signal(|| None::<String>);
-    let shelf_epoch = use_signal(|| 0u64);
-    let selected_shelf = use_signal(|| None::<Shelf>);
-    let edit_shelf = use_signal(|| false);
-    let hero_points = use_signal(Vec::<ResumePoint>::new);
-    let bulk_selected = use_signal(BTreeSet::<String>::new);
-    let bulk_modal_open = use_signal(|| false);
-    let fetch_sigs = FetchSignals {
-        books,
-        next_cursor,
-        total,
-        hidden,
-        lib_path,
-        lib_error,
-        loading,
-        loading_more,
-        error,
-        fetch_epoch,
-        generation: crate::use_cache_generation(),
-    };
-    let shelf_sigs = ShelfFetchSignals {
-        shelf_books,
-        shelf_loading,
-        shelf_error,
-        shelf_epoch,
-    };
-    let shelf_wiring = ShelfWiring {
-        selection,
-        shelves,
-        shelves_loaded,
-        shelves_tick,
-        shelf_sigs,
-        selected_shelf,
-        hero_points,
-    };
+    let pools = use_suggestion_pools();
+    let shelf_wiring = use_shelf_wiring();
+    let misc = use_misc_signals();
+
     wire_landing_effects(
         server_url,
         query,
-        prefs,
-        want_more,
+        misc.prefs,
+        misc.want_more,
         is_admin,
         pools,
         fetch_sigs,
         shelf_wiring,
-        bulk_selected,
+        misc.bulk_selected,
     );
+
     LandingSignals {
-        books,
-        next_cursor,
-        total,
-        hidden,
-        lib_path,
-        lib_error,
-        loading,
-        loading_more,
-        error,
-        prefs,
-        want_more,
+        books: fetch_sigs.books,
+        next_cursor: fetch_sigs.next_cursor,
+        total: fetch_sigs.total,
+        hidden: fetch_sigs.hidden,
+        lib_path: fetch_sigs.lib_path,
+        lib_error: fetch_sigs.lib_error,
+        loading: fetch_sigs.loading,
+        loading_more: fetch_sigs.loading_more,
+        error: fetch_sigs.error,
+        prefs: misc.prefs,
+        want_more: misc.want_more,
         is_admin,
         pools,
-        selection,
-        shelves,
-        shelves_tick,
-        shelf_books,
-        shelf_loading,
-        shelf_error,
-        selected_shelf,
-        edit_shelf,
-        hero_points,
-        bulk_selected,
-        bulk_modal_open,
+        selection: shelf_wiring.selection,
+        shelves: shelf_wiring.shelves,
+        shelves_tick: shelf_wiring.shelves_tick,
+        shelf_books: shelf_wiring.shelf_sigs.shelf_books,
+        shelf_loading: shelf_wiring.shelf_sigs.shelf_loading,
+        shelf_error: shelf_wiring.shelf_sigs.shelf_error,
+        selected_shelf: shelf_wiring.selected_shelf,
+        edit_shelf: misc.edit_shelf,
+        hero_points: shelf_wiring.hero_points,
+        bulk_selected: misc.bulk_selected,
+        bulk_modal_open: misc.bulk_modal_open,
+    }
+}
+
+/// Construct the core browse/search fetch signals (accumulated result rows,
+/// paging cursor, loading/error state) and the monotonic fetch epoch that
+/// lets an in-flight fetch detect it's been superseded.
+fn use_fetch_signals() -> FetchSignals {
+    FetchSignals {
+        books: use_signal(Vec::<EbookMetadata>::new),
+        next_cursor: use_signal(|| None::<String>),
+        total: use_signal(|| None::<i64>),
+        // First-page "N hidden" receipt; `None` when the viewer hides nothing.
+        hidden: use_signal(|| None::<i64>),
+        lib_path: use_signal(|| None::<String>),
+        lib_error: use_signal(|| None::<String>),
+        loading: use_signal(|| true),
+        loading_more: use_signal(|| false),
+        error: use_signal(|| None::<String>),
+        fetch_epoch: use_signal(|| 0u64),
+        generation: crate::use_cache_generation(),
+    }
+}
+
+/// Construct the suggestion pools for the inline Authors, Tags, and Genres
+/// chip editors, each carrying the dropdown book-count.
+fn use_suggestion_pools() -> SuggestionPools {
+    SuggestionPools {
+        authors: use_signal(Vec::<SuggestionItem>::new),
+        tags: use_signal(Vec::<SuggestionItem>::new),
+        genres: use_signal(Vec::<SuggestionItem>::new),
+    }
+}
+
+/// Construct the shelf-gallery member-list fetch signals.
+fn use_shelf_fetch_signals() -> ShelfFetchSignals {
+    ShelfFetchSignals {
+        shelf_books: use_signal(|| None::<Vec<EbookMetadata>>),
+        shelf_loading: use_signal(|| false),
+        shelf_error: use_signal(|| None::<String>),
+        shelf_epoch: use_signal(|| 0u64),
+    }
+}
+
+/// Construct the shelf-gallery lens signals. `selection` seeds to All on
+/// every target (SSR parity, rule 07); the persisted choice reconciles
+/// post-mount in [`wire_landing_effects`].
+fn use_shelf_wiring() -> ShelfWiring {
+    ShelfWiring {
+        selection: use_signal(ShelfSelection::default),
+        shelves: use_signal(Vec::<ShelfSummary>::new),
+        shelves_loaded: use_signal(|| false),
+        shelves_tick: use_signal(|| 0u32),
+        shelf_sigs: use_shelf_fetch_signals(),
+        selected_shelf: use_signal(|| None::<Shelf>),
+        hero_points: use_signal(Vec::<ResumePoint>::new),
+    }
+}
+
+/// The landing signals that don't belong to a fetch/shelf bundle: view
+/// prefs, the load-more trigger, and the bulk-edit / edit-shelf UI state.
+struct MiscSignals {
+    prefs: Signal<ViewPrefs>,
+    /// Bumped by the Load-more button and the web scroll observer; one
+    /// effect watches it and appends the next page.
+    want_more: Signal<u32>,
+    /// True while the edit-shelf modal is open.
+    edit_shelf: Signal<bool>,
+    /// Table-view bulk-edit selection: the checked rows' uuids.
+    bulk_selected: Signal<BTreeSet<String>>,
+    /// True while the bulk-edit modal is open.
+    bulk_modal_open: Signal<bool>,
+}
+
+fn use_misc_signals() -> MiscSignals {
+    MiscSignals {
+        prefs: use_signal(ViewPrefs::default),
+        want_more: use_signal(|| 0u32),
+        edit_shelf: use_signal(|| false),
+        bulk_selected: use_signal(BTreeSet::<String>::new),
+        bulk_modal_open: use_signal(|| false),
     }
 }
 

--- a/frontend/src/pages/landing/toolbar.rs
+++ b/frontend/src/pages/landing/toolbar.rs
@@ -13,18 +13,59 @@ use super::sorting::{
 #[component]
 pub(super) fn Toolbar(prefs: ViewPrefs, on_change: EventHandler<ViewPrefs>) -> Element {
     let view_mode = prefs.view_mode;
+
+    rsx! {
+        div { class: "lib-toolbar", role: "toolbar", "data-testid": "lib-toolbar",
+            ViewModeToggle { view_mode, prefs: prefs.clone(), on_change }
+            if view_mode == ViewMode::Grid {
+                SortControls { prefs, on_change }
+            }
+        }
+    }
+}
+
+/// Table/Grid pressed-button toggle group. Not an ARIA tablist — there are no
+/// associated tab panels and no arrow-key tab navigation, so `aria-pressed`
+/// on plain `<button>`s is the right shape.
+#[component]
+fn ViewModeToggle(
+    view_mode: ViewMode,
+    prefs: ViewPrefs,
+    on_change: EventHandler<ViewPrefs>,
+) -> Element {
+    let set_view = move |mode: ViewMode| {
+        let mut next = prefs.clone();
+        next.view_mode = mode;
+        on_change.call(next);
+    };
+    let set_view_table = set_view.clone();
+    let set_view_grid = set_view.clone();
+
+    rsx! {
+        div { class: "lib-view-toggle", "aria-label": "View mode",
+            button {
+                class: "lib-toggle-btn",
+                "aria-pressed": "{view_mode == ViewMode::Table}",
+                "data-testid": "view-toggle-table",
+                onclick: move |_| set_view_table(ViewMode::Table),
+                "Table"
+            }
+            button {
+                class: "lib-toggle-btn",
+                "aria-pressed": "{view_mode == ViewMode::Grid}",
+                "data-testid": "view-toggle-grid",
+                onclick: move |_| set_view_grid(ViewMode::Grid),
+                "Grid"
+            }
+        }
+    }
+}
+
+/// Grid-only sort-axis dropdown and direction toggle.
+#[component]
+fn SortControls(prefs: ViewPrefs, on_change: EventHandler<ViewPrefs>) -> Element {
     let sort_key = prefs.sort_key;
     let sort_dir = prefs.sort_dir;
-
-    let apply = move |new_prefs: ViewPrefs| on_change.call(new_prefs);
-    let set_view = {
-        let prefs = prefs.clone();
-        move |mode: ViewMode| {
-            let mut next = prefs.clone();
-            next.view_mode = mode;
-            apply(next);
-        }
-    };
     let set_sort_key = {
         let prefs = prefs.clone();
         move |key: SortKey| {
@@ -37,73 +78,43 @@ pub(super) fn Toolbar(prefs: ViewPrefs, on_change: EventHandler<ViewPrefs>) -> E
                 next.sort_dir = default_dir_for(key);
             }
             next.sort_key = key;
-            apply(next);
+            on_change.call(next);
         }
     };
-    let toggle_sort_dir = {
-        let prefs = prefs.clone();
-        move |_| {
-            let mut next = prefs.clone();
-            next.sort_dir = toggle_dir(next.sort_dir);
-            apply(next);
-        }
+    let toggle_sort_dir = move |_| {
+        let mut next = prefs.clone();
+        next.sort_dir = toggle_dir(next.sort_dir);
+        on_change.call(next);
     };
-
-    let set_view_table = set_view.clone();
-    let set_view_grid = set_view.clone();
 
     rsx! {
-        div { class: "lib-toolbar", role: "toolbar", "data-testid": "lib-toolbar",
-            // Pressed-button toggle group, not an ARIA tablist — there are no
-            // associated tab panels and no arrow-key tab navigation, so
-            // `aria-pressed` on plain `<button>`s is the right shape.
-            div { class: "lib-view-toggle", "aria-label": "View mode",
-                button {
-                    class: "lib-toggle-btn",
-                    "aria-pressed": "{view_mode == ViewMode::Table}",
-                    "data-testid": "view-toggle-table",
-                    onclick: move |_| set_view_table(ViewMode::Table),
-                    "Table"
-                }
-                button {
-                    class: "lib-toggle-btn",
-                    "aria-pressed": "{view_mode == ViewMode::Grid}",
-                    "data-testid": "view-toggle-grid",
-                    onclick: move |_| set_view_grid(ViewMode::Grid),
-                    "Grid"
-                }
-            }
-
-            if view_mode == ViewMode::Grid {
-                div { class: "lib-sort-controls",
-                    label { class: "lib-sort-label",
-                        "Sort by"
-                        select {
-                            class: "lib-sort-select",
-                            "data-testid": "lib-sort-select",
-                            onchange: move |evt: Event<FormData>| {
-                                if let Some(key) = sort_key_from_value(&evt.value()) {
-                                    set_sort_key(key);
-                                }
-                            },
-                            for opt in SORT_KEYS.iter().copied() {
-                                option {
-                                    key: "{sort_key_value(opt)}",
-                                    value: "{sort_key_value(opt)}",
-                                    selected: opt == sort_key,
-                                    "{sort_key_label(opt)}"
-                                }
-                            }
+        div { class: "lib-sort-controls",
+            label { class: "lib-sort-label",
+                "Sort by"
+                select {
+                    class: "lib-sort-select",
+                    "data-testid": "lib-sort-select",
+                    onchange: move |evt: Event<FormData>| {
+                        if let Some(key) = sort_key_from_value(&evt.value()) {
+                            set_sort_key(key);
+                        }
+                    },
+                    for opt in SORT_KEYS.iter().copied() {
+                        option {
+                            key: "{sort_key_value(opt)}",
+                            value: "{sort_key_value(opt)}",
+                            selected: opt == sort_key,
+                            "{sort_key_label(opt)}"
                         }
                     }
-                    button {
-                        class: "lib-sort-dir",
-                        "data-testid": "lib-sort-dir",
-                        aria_label: "Toggle sort direction",
-                        onclick: toggle_sort_dir,
-                        if sort_dir == SortDir::Asc { "↑" } else { "↓" }
-                    }
                 }
+            }
+            button {
+                class: "lib-sort-dir",
+                "data-testid": "lib-sort-dir",
+                aria_label: "Toggle sort direction",
+                onclick: toggle_sort_dir,
+                if sort_dir == SortDir::Asc { "↑" } else { "↓" }
             }
         }
     }

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -93,73 +93,90 @@ pub fn BookListenPage(uuid: String, file_id: Option<i64>) -> Element {
     #[cfg(not(feature = "mobile"))]
     {
         let playback = use_playback();
-
-        // Point the app-wide player at this route's book + selected file. The
-        // App-level driver (install_audio_bootstrap) reacts to both `uuid` and
-        // `file_id` and does the fetch + manifest init; we only retarget. The
-        // uuid write (which clears the prior book) fires only when the book
-        // differs so re-entering an already-playing book is seamless, but the
-        // file_id signal always tracks the route so the picker's `?file_id=`
-        // reboots the *same* book onto the chosen part.
-        let route_uuid = uuid.clone();
-        let route_file_id = file_id;
-        use_effect(use_reactive!(|(route_uuid, route_file_id)| {
-            let mut uuid_sig = playback.uuid;
-            let mut file_sig = playback.file_id;
-            let mut loading_sig = playback.loading;
-            let mut book_sig = playback.book;
-            let mut error_sig = playback.error;
-            // Publish the picker's selection first so the driver reads the right
-            // file when the uuid change kicks off the load (mirrors mobile).
-            file_sig.set(route_file_id);
-            if uuid_sig.peek().as_deref() != Some(route_uuid.as_str()) {
-                // Clear the previous book's app-global metadata before
-                // retargeting so a re-render can't show the old book (or its
-                // error) under the new URL until the App-level driver reloads.
-                // The driver also clears these defensively on the uuid swap.
-                book_sig.set(None);
-                error_sig.set(None);
-                loading_sig.set(true);
-                uuid_sig.set(Some(route_uuid.clone()));
-            }
-        }));
+        use_retarget_playback(playback, uuid.clone(), file_id);
 
         let active = playback.uuid.read().as_deref() == Some(uuid.as_str());
-
         if active {
-            if let Some(msg) = playback.error.read().clone() {
-                return rsx! {
-                    p { role: "alert", class: "subtitle", "{msg}" }
-                    Link { to: Route::Landing {}, class: "btn", "Back to library" }
-                };
-            }
-            if let Some(b) = playback.book.read().clone() {
-                return rsx! {
-                    ReadyPlayer {
-                        book: b,
-                        uuid: uuid.clone(),
-                        signals: PlaybackSignals {
-                            duration: playback.duration,
-                            elapsed: playback.elapsed,
-                            playing: playback.playing,
-                            rate: playback.rate,
-                            rate_error: playback.rate_error,
-                            volume: playback.volume,
-                            hls_ready: playback.hls_ready,
-                        },
-                        playback_failed: playback.playback_failed,
-                        chapters: playback.chapters,
-                    }
-                };
-            }
-            if !*playback.loading.read() {
-                return rsx! {
-                    p { class: "subtitle", "Audiobook not found." }
-                    Link { to: Route::Landing {}, class: "btn", "Back to library" }
-                };
+            if let Some(view) = active_listen_view(playback, &uuid) {
+                return view;
             }
         }
 
         rsx! { p { class: "subtitle", "Loading\u{2026}" } }
     }
+}
+
+/// Points the app-wide player at this route's book + selected file. The
+/// App-level driver (`install_audio_bootstrap`) reacts to both `uuid` and
+/// `file_id` and does the fetch + manifest init; this only retargets. The
+/// uuid write (which clears the prior book) fires only when the book differs
+/// so re-entering an already-playing book is seamless, but the file_id
+/// signal always tracks the route so the picker's `?file_id=` reboots the
+/// *same* book onto the chosen part. Called unconditionally from
+/// [`BookListenPage`] (non-mobile).
+#[cfg(not(feature = "mobile"))]
+fn use_retarget_playback(
+    playback: crate::PlaybackState,
+    route_uuid: String,
+    route_file_id: Option<i64>,
+) {
+    use_effect(use_reactive!(|(route_uuid, route_file_id)| {
+        let mut uuid_sig = playback.uuid;
+        let mut file_sig = playback.file_id;
+        let mut loading_sig = playback.loading;
+        let mut book_sig = playback.book;
+        let mut error_sig = playback.error;
+        // Publish the picker's selection first so the driver reads the right
+        // file when the uuid change kicks off the load (mirrors mobile).
+        file_sig.set(route_file_id);
+        if uuid_sig.peek().as_deref() != Some(route_uuid.as_str()) {
+            // Clear the previous book's app-global metadata before
+            // retargeting so a re-render can't show the old book (or its
+            // error) under the new URL until the App-level driver reloads.
+            // The driver also clears these defensively on the uuid swap.
+            book_sig.set(None);
+            error_sig.set(None);
+            loading_sig.set(true);
+            uuid_sig.set(Some(route_uuid.clone()));
+        }
+    }));
+}
+
+/// The error / ready-player / not-found view for an already-active book,
+/// or `None` while it's still resolving (the caller falls back to a
+/// loading placeholder).
+#[cfg(not(feature = "mobile"))]
+fn active_listen_view(playback: crate::PlaybackState, uuid: &str) -> Option<Element> {
+    if let Some(msg) = playback.error.read().clone() {
+        return Some(rsx! {
+            p { role: "alert", class: "subtitle", "{msg}" }
+            Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        });
+    }
+    if let Some(b) = playback.book.read().clone() {
+        return Some(rsx! {
+            ReadyPlayer {
+                book: b,
+                uuid: uuid.to_string(),
+                signals: PlaybackSignals {
+                    duration: playback.duration,
+                    elapsed: playback.elapsed,
+                    playing: playback.playing,
+                    rate: playback.rate,
+                    rate_error: playback.rate_error,
+                    volume: playback.volume,
+                    hls_ready: playback.hls_ready,
+                },
+                playback_failed: playback.playback_failed,
+                chapters: playback.chapters,
+            }
+        });
+    }
+    if !*playback.loading.read() {
+        return Some(rsx! {
+            p { class: "subtitle", "Audiobook not found." }
+            Link { to: Route::Landing {}, class: "btn", "Back to library" }
+        });
+    }
+    None
 }

--- a/frontend/src/pages/listen/mini_dock/mod.rs
+++ b/frontend/src/pages/listen/mini_dock/mod.rs
@@ -15,6 +15,7 @@ mod volume;
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
+use omnibus_shared::{ChapterInfo, EbookMetadata};
 
 use super::chapter_nav::chapter_index_for_elapsed;
 use super::stage::chapter_sub_text;
@@ -38,7 +39,7 @@ pub fn MiniDock() -> Element {
     // drives the speed panel's per-book save; `open_panel` starts closed on
     // SSR and first WASM paint, so neither can cause a hydration mismatch.
     let current_user = use_current_user_summary();
-    let mut open_panel = use_signal(|| None::<DockPanel>);
+    let open_panel = use_signal(|| None::<DockPanel>);
 
     // Stable host wrapper so hydration node-counting stays consistent; only
     // the inner bar is conditional on both a loaded book and a resolved uuid.
@@ -48,14 +49,53 @@ pub fn MiniDock() -> Element {
         return rsx! { div { class: "mini-dock-host" } };
     };
 
-    let elapsed = (playback.elapsed)();
-    let duration = (playback.duration)();
-    let playing = (playback.playing)();
-    let rate = (playback.rate)();
-    let volume = (playback.volume)();
-    let chapters = (playback.chapters)();
-    let user_id = current_user().map(|user| user.id);
+    let view = DockBarView {
+        elapsed: (playback.elapsed)(),
+        duration: (playback.duration)(),
+        playing: (playback.playing)(),
+        rate: (playback.rate)(),
+        volume: (playback.volume)(),
+        chapters: (playback.chapters)(),
+        user_id: current_user().map(|user| user.id),
+    };
 
+    rsx! {
+        MiniDockBar { book, uuid, view, open_panel }
+    }
+}
+
+/// Playback snapshot + viewer id [`MiniDockBar`] needs. `PlaybackState`
+/// itself has no `PartialEq`, so it can't cross a `#[component]` prop
+/// boundary — this bundles the primitive reads taken from it instead.
+#[derive(Clone, PartialEq)]
+struct DockBarView {
+    elapsed: f64,
+    duration: f64,
+    playing: bool,
+    rate: f64,
+    volume: f64,
+    chapters: Vec<ChapterInfo>,
+    user_id: Option<i64>,
+}
+
+/// The active dock bar: progress rail, cover/title/meta, transport, and the
+/// volume/speed/sleep/actions cluster.
+#[component]
+fn MiniDockBar(
+    book: EbookMetadata,
+    uuid: String,
+    view: DockBarView,
+    mut open_panel: Signal<Option<DockPanel>>,
+) -> Element {
+    let DockBarView {
+        elapsed,
+        duration,
+        playing,
+        rate,
+        volume,
+        chapters,
+        user_id,
+    } = view;
     let idx = chapter_index_for_elapsed(&chapters, elapsed);
     let chapter_sub = chapter_sub_text(&chapters, idx);
     let sub = dock_sub_text(chapter_sub, elapsed, duration, rate);

--- a/frontend/src/pages/listen/mini_dock/transport.rs
+++ b/frontend/src/pages/listen/mini_dock/transport.rs
@@ -17,49 +17,18 @@ use crate::use_playback;
 #[component]
 pub(super) fn DockTransport(playing: bool, has_chapters: bool) -> Element {
     let playback = use_playback();
-    let play_label = if playing { "Pause" } else { "Play" }.to_string();
     let on_toggle = helpers::on_toggle_playback();
     let on_skip_back = helpers::on_skip_back_30();
     let on_skip_forward = helpers::on_skip_forward_30();
-    // Chapter jumps peek the live signals inside the handler (not render-time
-    // props) so a click always works from the current position, mirroring the
-    // full player's handlers in `ready_player`.
-    let on_chapter_prev = {
-        let chapters = playback.chapters;
-        let elapsed = playback.elapsed;
-        move |_: MouseEvent| {
-            let chs = chapters.peek().clone();
-            let now = *elapsed.peek();
-            let idx = chapter_index_for_elapsed(&chs, now);
-            if let Some(target) = chapter_prev_target(&chs, now, idx) {
-                helpers::seek_to(target);
-            }
-        }
-    };
-    let on_chapter_next = {
-        let chapters = playback.chapters;
-        let elapsed = playback.elapsed;
-        move |_: MouseEvent| {
-            let chs = chapters.peek().clone();
-            let idx = chapter_index_for_elapsed(&chs, *elapsed.peek());
-            if let Some(target) = chapter_next_target(&chs, idx) {
-                helpers::seek_to(target);
-            }
-        }
-    };
+    let on_chapter_prev = chapter_prev_handler(playback.chapters, playback.elapsed);
+    let on_chapter_next = chapter_next_handler(playback.chapters, playback.elapsed);
 
     rsx! {
         div { class: "mini-dock-mid",
-            button {
-                class: "mini-dock-ch mini-dock-hide",
-                r#type: "button",
-                disabled: !has_chapters,
-                "data-testid": "mini-dock-ch-prev",
-                "aria-label": "Previous chapter",
-                title: "Previous chapter",
-                onclick: on_chapter_prev,
-                span { class: "lp-ch-bar" }
-                span { class: "lp-ch-tri-left" }
+            DockChapterButton {
+                dir: DockChapterDir::Prev,
+                has_chapters,
+                onclick: EventHandler::new(on_chapter_prev),
             }
             button {
                 class: "mini-dock-btn mini-dock-skip mini-dock-hide",
@@ -69,21 +38,7 @@ pub(super) fn DockTransport(playing: bool, has_chapters: bool) -> Element {
                 onclick: on_skip_back,
                 "-30"
             }
-            button {
-                class: "mini-dock-play",
-                r#type: "button",
-                "data-testid": "mini-dock-toggle",
-                "aria-label": "{play_label}",
-                onclick: on_toggle,
-                if playing {
-                    div { class: "mini-dock-ico-pause",
-                        div { class: "mini-dock-ico-pause-bar" }
-                        div { class: "mini-dock-ico-pause-bar" }
-                    }
-                } else {
-                    div { class: "mini-dock-ico-play" }
-                }
-            }
+            DockPlayButton { playing, onclick: EventHandler::new(on_toggle) }
             button {
                 class: "mini-dock-btn mini-dock-skip mini-dock-hide",
                 r#type: "button",
@@ -92,17 +47,104 @@ pub(super) fn DockTransport(playing: bool, has_chapters: bool) -> Element {
                 onclick: on_skip_forward,
                 "+30"
             }
-            button {
-                class: "mini-dock-ch mini-dock-hide",
-                r#type: "button",
-                disabled: !has_chapters,
-                "data-testid": "mini-dock-ch-next",
-                "aria-label": "Next chapter",
-                title: "Next chapter",
-                onclick: on_chapter_next,
+            DockChapterButton {
+                dir: DockChapterDir::Next,
+                has_chapters,
+                onclick: EventHandler::new(on_chapter_next),
+            }
+        }
+    }
+}
+
+/// Which end of the chapter list [`DockChapterButton`] jumps toward.
+#[derive(Clone, Copy, PartialEq)]
+enum DockChapterDir {
+    Prev,
+    Next,
+}
+
+/// Previous/next-chapter jump button. Both directions share one glyph-swapped
+/// markup shape, so a single component covers both ends of the transport row.
+#[component]
+fn DockChapterButton(
+    dir: DockChapterDir,
+    has_chapters: bool,
+    onclick: EventHandler<MouseEvent>,
+) -> Element {
+    let (testid, label, bar_first) = match dir {
+        DockChapterDir::Prev => ("mini-dock-ch-prev", "Previous chapter", true),
+        DockChapterDir::Next => ("mini-dock-ch-next", "Next chapter", false),
+    };
+    rsx! {
+        button {
+            class: "mini-dock-ch mini-dock-hide",
+            r#type: "button",
+            disabled: !has_chapters,
+            "data-testid": "{testid}",
+            "aria-label": "{label}",
+            title: "{label}",
+            onclick,
+            if bar_first {
+                span { class: "lp-ch-bar" }
+                span { class: "lp-ch-tri-left" }
+            } else {
                 span { class: "lp-ch-tri-right" }
                 span { class: "lp-ch-bar" }
             }
+        }
+    }
+}
+
+/// The centered play/pause button and its icon swap.
+#[component]
+fn DockPlayButton(playing: bool, onclick: EventHandler<MouseEvent>) -> Element {
+    let play_label = if playing { "Pause" } else { "Play" }.to_string();
+    rsx! {
+        button {
+            class: "mini-dock-play",
+            r#type: "button",
+            "data-testid": "mini-dock-toggle",
+            "aria-label": "{play_label}",
+            onclick,
+            if playing {
+                div { class: "mini-dock-ico-pause",
+                    div { class: "mini-dock-ico-pause-bar" }
+                    div { class: "mini-dock-ico-pause-bar" }
+                }
+            } else {
+                div { class: "mini-dock-ico-play" }
+            }
+        }
+    }
+}
+
+/// Chapter jumps peek the live signals inside the handler (not render-time
+/// props) so a click always works from the current position, mirroring the
+/// full player's handlers in `ready_player`.
+fn chapter_prev_handler(
+    chapters: Signal<Vec<omnibus_shared::ChapterInfo>>,
+    elapsed: Signal<f64>,
+) -> impl FnMut(MouseEvent) + 'static {
+    move |_: MouseEvent| {
+        let chs = chapters.peek().clone();
+        let now = *elapsed.peek();
+        let idx = chapter_index_for_elapsed(&chs, now);
+        if let Some(target) = chapter_prev_target(&chs, now, idx) {
+            helpers::seek_to(target);
+        }
+    }
+}
+
+/// See [`chapter_prev_handler`].
+fn chapter_next_handler(
+    chapters: Signal<Vec<omnibus_shared::ChapterInfo>>,
+    elapsed: Signal<f64>,
+) -> impl FnMut(MouseEvent) + 'static {
+    move |_: MouseEvent| {
+        let chs = chapters.peek().clone();
+        let idx = chapter_index_for_elapsed(&chs, *elapsed.peek());
+        if let Some(target) = chapter_next_target(&chs, idx) {
+            helpers::seek_to(target);
         }
     }
 }

--- a/frontend/src/pages/reader/selection.rs
+++ b/frontend/src/pages/reader/selection.rs
@@ -63,17 +63,7 @@ pub(crate) fn SelectionPopover(anchor: SelectionAnchor, actions: SelectionAction
         on_quote,
         on_share,
     } = actions;
-    let top = (sel_rect_y - 52.0).max(8.0);
-    let left = (sel_rect_x + sel_rect_width / 2.0 - 150.0).clamp(8.0, 560.0);
-    let style = format!("top:{top}px; left:{left}px;");
-
-    let colors = [
-        (HighlightColor::Amber, "amber"),
-        (HighlightColor::Green, "green"),
-        (HighlightColor::Blue, "blue"),
-        (HighlightColor::Rose, "rose"),
-        (HighlightColor::Violet, "violet"),
-    ];
+    let style = popover_style(sel_rect_x, sel_rect_y, sel_rect_width);
 
     rsx! {
         div { class: "rd-scrim rd-scrim-clear", onclick: on_dismiss }
@@ -83,92 +73,141 @@ pub(crate) fn SelectionPopover(anchor: SelectionAnchor, actions: SelectionAction
             onclick: move |evt: MouseEvent| evt.stop_propagation(),
             div {
                 class: "rd-swatch-row",
-                for (color, name) in colors {
-                    {
-                        let cfi = sel_cfi.clone();
-                        let text = sel_text.clone();
-                        rsx! {
-                            button {
-                                key: "{name}",
-                                class: "rd-swatch",
-                                r#type: "button",
-                                "data-color": "{name}",
-                                "aria-label": "Highlight {name}",
-                                onclick: move |_| on_highlight.call((cfi.clone(), color, text.clone())),
-                            }
-                        }
-                    }
-                }
+                SelectionSwatches { cfi: sel_cfi.clone(), text: sel_text.clone(), on_highlight }
                 span { class: "rd-pop-div" }
-                button {
-                    class: "rd-act",
-                    r#type: "button",
-                    "data-testid": "selection-note",
-                    onclick: {
-                        let cfi = sel_cfi.clone();
-                        let text = sel_text.clone();
-                        move |_| on_note.call((cfi.clone(), text.clone()))
-                    },
-                    svg {
-                        width: "15", height: "15", view_box: "0 0 24 24",
-                        fill: "none", stroke: "currentColor",
-                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        path { d: "M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" }
-                    }
-                    span { "Note" }
-                }
-                button {
-                    class: "rd-act",
-                    r#type: "button",
-                    "data-testid": "selection-copy",
-                    onclick: {
-                        let text = sel_text.clone();
-                        move |_| on_copy.call(text.clone())
-                    },
-                    svg {
-                        width: "15", height: "15", view_box: "0 0 24 24",
-                        fill: "none", stroke: "currentColor",
-                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        rect { x: "9", y: "9", width: "12", height: "12", rx: "2" }
-                        path { d: "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" }
-                    }
-                    span { "Copy" }
-                }
-                button {
-                    // `rd-act-accent`: the phone popover tints Quote as the
-                    // primary action, per the mobile design.
-                    class: "rd-act rd-act-accent",
-                    r#type: "button",
-                    "data-testid": "selection-quote",
-                    onclick: {
-                        let cfi = sel_cfi.clone();
-                        let text = sel_text.clone();
-                        move |_| on_quote.call((cfi.clone(), text.clone()))
-                    },
-                    svg {
-                        width: "15", height: "15", view_box: "0 0 24 24",
-                        fill: "currentColor", stroke: "none",
-                        path { d: "M10 8c0 3.5-2 6-5 7l-.8-1.6c1.7-.8 2.7-2 3-3.4H4V4h6v4zm10 0c0 3.5-2 6-5 7l-.8-1.6c1.7-.8 2.7-2 3-3.4H14V4h6v4z" }
-                    }
-                    span { "Quote" }
-                }
-                button {
-                    class: "rd-act",
-                    r#type: "button",
-                    "data-testid": "selection-share",
-                    onclick: {
-                        let text = sel_text.clone();
-                        move |_| on_share.call(text.clone())
-                    },
-                    svg {
-                        width: "15", height: "15", view_box: "0 0 24 24",
-                        fill: "none", stroke: "currentColor",
-                        stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
-                        path { d: "M12 3v13M7 8l5-5 5 5M5 14v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5" }
-                    }
-                    span { "Share" }
+                SelectionActionButtons {
+                    cfi: sel_cfi,
+                    text: sel_text,
+                    on_note,
+                    on_copy,
+                    on_quote,
+                    on_share,
                 }
             }
+        }
+    }
+}
+
+/// CSS `top`/`left` for the popover, anchored just above the selection rect
+/// and clamped so it can't run off either edge of the reader viewport.
+fn popover_style(sel_rect_x: f64, sel_rect_y: f64, sel_rect_width: f64) -> String {
+    let top = (sel_rect_y - 52.0).max(8.0);
+    let left = (sel_rect_x + sel_rect_width / 2.0 - 150.0).clamp(8.0, 560.0);
+    format!("top:{top}px; left:{left}px;")
+}
+
+/// The five highlight-color swatch buttons.
+#[component]
+fn SelectionSwatches(
+    cfi: String,
+    text: String,
+    on_highlight: EventHandler<(String, HighlightColor, String)>,
+) -> Element {
+    let colors = [
+        (HighlightColor::Amber, "amber"),
+        (HighlightColor::Green, "green"),
+        (HighlightColor::Blue, "blue"),
+        (HighlightColor::Rose, "rose"),
+        (HighlightColor::Violet, "violet"),
+    ];
+    rsx! {
+        for (color, name) in colors {
+            {
+                let cfi = cfi.clone();
+                let text = text.clone();
+                rsx! {
+                    button {
+                        key: "{name}",
+                        class: "rd-swatch",
+                        r#type: "button",
+                        "data-color": "{name}",
+                        "aria-label": "Highlight {name}",
+                        onclick: move |_| on_highlight.call((cfi.clone(), color, text.clone())),
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The Note / Copy / Quote / Share action buttons.
+#[component]
+fn SelectionActionButtons(
+    cfi: String,
+    text: String,
+    on_note: EventHandler<(String, String)>,
+    on_copy: EventHandler<String>,
+    on_quote: EventHandler<(String, String)>,
+    on_share: EventHandler<String>,
+) -> Element {
+    rsx! {
+        button {
+            class: "rd-act",
+            r#type: "button",
+            "data-testid": "selection-note",
+            onclick: {
+                let cfi = cfi.clone();
+                let text = text.clone();
+                move |_| on_note.call((cfi.clone(), text.clone()))
+            },
+            svg {
+                width: "15", height: "15", view_box: "0 0 24 24",
+                fill: "none", stroke: "currentColor",
+                stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                path { d: "M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" }
+            }
+            span { "Note" }
+        }
+        button {
+            class: "rd-act",
+            r#type: "button",
+            "data-testid": "selection-copy",
+            onclick: {
+                let text = text.clone();
+                move |_| on_copy.call(text.clone())
+            },
+            svg {
+                width: "15", height: "15", view_box: "0 0 24 24",
+                fill: "none", stroke: "currentColor",
+                stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                rect { x: "9", y: "9", width: "12", height: "12", rx: "2" }
+                path { d: "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" }
+            }
+            span { "Copy" }
+        }
+        button {
+            // `rd-act-accent`: the phone popover tints Quote as the
+            // primary action, per the mobile design.
+            class: "rd-act rd-act-accent",
+            r#type: "button",
+            "data-testid": "selection-quote",
+            onclick: {
+                let cfi = cfi.clone();
+                let text = text.clone();
+                move |_| on_quote.call((cfi.clone(), text.clone()))
+            },
+            svg {
+                width: "15", height: "15", view_box: "0 0 24 24",
+                fill: "currentColor", stroke: "none",
+                path { d: "M10 8c0 3.5-2 6-5 7l-.8-1.6c1.7-.8 2.7-2 3-3.4H4V4h6v4zm10 0c0 3.5-2 6-5 7l-.8-1.6c1.7-.8 2.7-2 3-3.4H14V4h6v4z" }
+            }
+            span { "Quote" }
+        }
+        button {
+            class: "rd-act",
+            r#type: "button",
+            "data-testid": "selection-share",
+            onclick: {
+                let text = text.clone();
+                move |_| on_share.call(text.clone())
+            },
+            svg {
+                width: "15", height: "15", view_box: "0 0 24 24",
+                fill: "none", stroke: "currentColor",
+                stroke_width: "1.7", stroke_linecap: "round", stroke_linejoin: "round",
+                path { d: "M12 3v13M7 8l5-5 5 5M5 14v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5" }
+            }
+            span { "Share" }
         }
     }
 }

--- a/frontend/src/pages/settings/users/mod.rs
+++ b/frontend/src/pages/settings/users/mod.rs
@@ -27,8 +27,8 @@ enum Modal {
 /// The Users section: header + table, with a reload counter the mutations bump.
 #[component]
 pub fn UsersSection() -> Element {
-    let mut users = use_signal(Vec::<AdminUserRow>::new);
-    let mut load_error = use_signal(|| None::<String>);
+    let users = use_signal(Vec::<AdminUserRow>::new);
+    let load_error = use_signal(|| None::<String>);
     // Errors from inline row actions (currently Unlock) — surfaced in the
     // section banner rather than swallowed.
     let mut action_error = use_signal(|| None::<String>);
@@ -37,7 +37,44 @@ pub fn UsersSection() -> Element {
     let current = crate::use_current_user_summary();
     let nav = use_navigator();
 
-    // Reload whenever the counter bumps (initial mount + after each mutation).
+    use_users_load(reload, users, load_error);
+
+    let current_id = current().map(|u| u.id);
+
+    rsx! {
+        RegistrationToggle {}
+
+        section { class: "card", "data-testid": "users-card",
+            UsersHeader { on_new: move |_| modal.set(Modal::New) }
+
+            if let Some(err) = load_error() {
+                p { role: "alert", class: "settings-status error", "data-testid": "users-load-error", "{err}" }
+            }
+            if let Some(err) = action_error() {
+                p { role: "alert", class: "settings-status error", "data-testid": "users-action-error", "{err}" }
+            }
+
+            UsersTable {
+                users: users(),
+                current_id,
+                on_edit: move |row| modal.set(Modal::Edit(row)),
+                on_delete: move |row| modal.set(Modal::Delete(row)),
+                on_unlocked: move |_| { action_error.set(None); reload.with_mut(|n| *n += 1); },
+                on_row_error: move |msg| action_error.set(Some(msg)),
+            }
+        }
+
+        {users_modals(modal(), current_id, modal, reload, nav)}
+    }
+}
+
+/// Loads the user list whenever `reload` bumps (initial mount + after each
+/// mutation). Called unconditionally from [`UsersSection`].
+fn use_users_load(
+    reload: Signal<u32>,
+    mut users: Signal<Vec<AdminUserRow>>,
+    mut load_error: Signal<Option<String>>,
+) {
     use_effect(move || {
         let _ = reload();
         spawn(async move {
@@ -50,93 +87,109 @@ pub fn UsersSection() -> Element {
             }
         });
     });
+}
 
-    let current_id = current().map(|u| u.id);
-
+/// The section title, subtitle, and "New user" button.
+#[component]
+fn UsersHeader(on_new: EventHandler<MouseEvent>) -> Element {
     rsx! {
-        RegistrationToggle {}
+        div { class: "users-head",
+            div {
+                h2 { "Users" }
+                p { class: "subtitle", "Create, edit, and remove accounts." }
+            }
+            button {
+                r#type: "button",
+                class: "btn",
+                "data-testid": "users-new",
+                onclick: on_new,
+                "New user"
+            }
+        }
+    }
+}
 
-        section { class: "card", "data-testid": "users-card",
-            div { class: "users-head",
-                div {
-                    h2 { "Users" }
-                    p { class: "subtitle", "Create, edit, and remove accounts." }
-                }
-                button {
-                    r#type: "button",
-                    class: "btn",
-                    "data-testid": "users-new",
-                    onclick: move |_| modal.set(Modal::New),
-                    "New user"
+/// The accounts table: header row plus one [`UserRow`] per user.
+#[component]
+fn UsersTable(
+    users: Vec<AdminUserRow>,
+    current_id: Option<i64>,
+    on_edit: EventHandler<AdminUserRow>,
+    on_delete: EventHandler<AdminUserRow>,
+    on_unlocked: EventHandler<()>,
+    on_row_error: EventHandler<String>,
+) -> Element {
+    rsx! {
+        table { class: "users-table", "data-testid": "users-table",
+            thead {
+                tr {
+                    th { "User" }
+                    th { "Permissions" }
+                    th { "Kindle" }
+                    th { "Created" }
+                    th { "Status" }
+                    th { class: "users-col-actions", "Actions" }
                 }
             }
-
-            if let Some(err) = load_error() {
-                p { role: "alert", class: "settings-status error", "data-testid": "users-load-error", "{err}" }
-            }
-            if let Some(err) = action_error() {
-                p { role: "alert", class: "settings-status error", "data-testid": "users-action-error", "{err}" }
-            }
-
-            table { class: "users-table", "data-testid": "users-table",
-                thead {
-                    tr {
-                        th { "User" }
-                        th { "Permissions" }
-                        th { "Kindle" }
-                        th { "Created" }
-                        th { "Status" }
-                        th { class: "users-col-actions", "Actions" }
-                    }
-                }
-                tbody {
-                    for u in users() {
-                        UserRow {
-                            key: "{u.id}",
-                            user: u.clone(),
-                            is_self: Some(u.id) == current_id,
-                            on_edit: move |row| modal.set(Modal::Edit(row)),
-                            on_delete: move |row| modal.set(Modal::Delete(row)),
-                            on_unlocked: move |_| { action_error.set(None); reload.with_mut(|n| *n += 1); },
-                            on_error: move |msg| action_error.set(Some(msg)),
-                        }
+            tbody {
+                for u in users {
+                    UserRow {
+                        key: "{u.id}",
+                        user: u.clone(),
+                        is_self: Some(u.id) == current_id,
+                        on_edit,
+                        on_delete,
+                        on_unlocked,
+                        on_error: on_row_error,
                     }
                 }
             }
         }
+    }
+}
 
-        match modal() {
-            Modal::None => rsx! {},
-            Modal::New => rsx! {
-                NewUserModal {
-                    on_close: move |_| modal.set(Modal::None),
-                    on_created: move |_| { modal.set(Modal::None); reload.with_mut(|n| *n += 1); },
-                }
-            },
-            Modal::Edit(row) => rsx! {
-                EditUserModal {
+/// The New / Edit / Delete modal currently open over the table, if any. Not a
+/// `#[component]` — `Navigator` doesn't implement `PartialEq`, which the
+/// `#[component]` macro requires of every prop — so it's called directly via
+/// `{users_modals(...)}` like the file's other plain-fn helpers.
+fn users_modals(
+    modal: Modal,
+    current_id: Option<i64>,
+    mut on_modal: Signal<Modal>,
+    mut reload: Signal<u32>,
+    nav: dioxus_router::Navigator,
+) -> Element {
+    match modal {
+        Modal::None => rsx! {},
+        Modal::New => rsx! {
+            NewUserModal {
+                on_close: move |_| on_modal.set(Modal::None),
+                on_created: move |_| { on_modal.set(Modal::None); reload.with_mut(|n| *n += 1); },
+            }
+        },
+        Modal::Edit(row) => rsx! {
+            EditUserModal {
+                user: row,
+                on_close: move |_| on_modal.set(Modal::None),
+                on_saved: move |_| { on_modal.set(Modal::None); reload.with_mut(|n| *n += 1); },
+            }
+        },
+        Modal::Delete(row) => {
+            let is_self = current_id == Some(row.id);
+            rsx! {
+                DeleteUserModal {
                     user: row,
-                    on_close: move |_| modal.set(Modal::None),
-                    on_saved: move |_| { modal.set(Modal::None); reload.with_mut(|n| *n += 1); },
-                }
-            },
-            Modal::Delete(row) => {
-                let is_self = current_id == Some(row.id);
-                rsx! {
-                    DeleteUserModal {
-                        user: row,
-                        is_self,
-                        on_close: move |_| modal.set(Modal::None),
-                        on_deleted: move |_| {
-                            modal.set(Modal::None);
-                            // Self-delete invalidates the session; reloading would just 401.
-                            if is_self {
-                                nav.replace(Route::Login {});
-                            } else {
-                                reload.with_mut(|n| *n += 1);
-                            }
-                        },
-                    }
+                    is_self,
+                    on_close: move |_| on_modal.set(Modal::None),
+                    on_deleted: move |_| {
+                        on_modal.set(Modal::None);
+                        // Self-delete invalidates the session; reloading would just 401.
+                        if is_self {
+                            nav.replace(Route::Login {});
+                        } else {
+                            reload.with_mut(|n| *n += 1);
+                        }
+                    },
                 }
             }
         }

--- a/frontend/src/pages/settings/users/mod.rs
+++ b/frontend/src/pages/settings/users/mod.rs
@@ -133,14 +133,19 @@ fn UsersTable(
             }
             tbody {
                 for u in users {
-                    UserRow {
-                        key: "{u.id}",
-                        user: u.clone(),
-                        is_self: Some(u.id) == current_id,
-                        on_edit,
-                        on_delete,
-                        on_unlocked,
-                        on_error: on_row_error,
+                    {
+                        let id = u.id;
+                        rsx! {
+                            UserRow {
+                                key: "{id}",
+                                user: u,
+                                is_self: Some(id) == current_id,
+                                on_edit,
+                                on_delete,
+                                on_unlocked,
+                                on_error: on_row_error,
+                            }
+                        }
                     }
                 }
             }

--- a/frontend/src/pages/settings/users/modals.rs
+++ b/frontend/src/pages/settings/users/modals.rs
@@ -15,18 +15,90 @@ use super::PermissionToggles;
 /// permissions.
 #[component]
 pub(super) fn NewUserModal(on_close: EventHandler<()>, on_created: EventHandler<()>) -> Element {
-    let mut username = use_signal(String::new);
-    let mut password = use_signal(String::new);
+    let username = use_signal(String::new);
+    let password = use_signal(String::new);
     let perms = use_signal(|| UserPermissions {
         is_admin: false,
         can_upload: false,
         can_edit: false,
         can_download: true,
     });
-    let mut error = use_signal(|| None::<String>);
-    let mut saving = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
+    let saving = use_signal(|| false);
+    let submit =
+        build_new_user_submit_handler(username, password, perms, error, saving, on_created);
 
-    let submit = move |evt: Event<FormData>| {
+    rsx! {
+        ModalShell { title: "New user", testid: "users-new-modal", on_close,
+            form { class: "settings-form", onsubmit: submit,
+                NewUserFields { username, password, error }
+                PermissionToggles { perms }
+                ModalError { error: error() }
+                div { class: "settings-actions",
+                    button {
+                        r#type: "submit",
+                        class: "btn",
+                        "data-testid": "new-user-submit",
+                        disabled: saving(),
+                        "Create user"
+                    }
+                    button { r#type: "button", class: "btn ghost", onclick: move |_| on_close.call(()), "Cancel" }
+                }
+            }
+        }
+    }
+}
+
+/// Username + password inputs with the shared strength meter/checklist.
+#[component]
+fn NewUserFields(
+    mut username: Signal<String>,
+    mut password: Signal<String>,
+    mut error: Signal<Option<String>>,
+) -> Element {
+    let pw = password();
+    let (score, score_label, rules) = score_password(&pw);
+    rsx! {
+        div { class: "settings-field",
+            label { r#for: "new-user-username", "Username" }
+            input {
+                r#type: "text",
+                id: "new-user-username",
+                "data-testid": "new-user-username",
+                autocomplete: "off",
+                autocapitalize: "none",
+                spellcheck: "false",
+                value: "{username}",
+                oninput: move |e| { username.set(e.value()); error.set(None); },
+            }
+        }
+        div { class: "settings-field",
+            label { r#for: "new-user-password", "Password" }
+            input {
+                r#type: "password",
+                id: "new-user-password",
+                "data-testid": "new-user-password",
+                autocomplete: "new-password",
+                value: "{password}",
+                oninput: move |e| { password.set(e.value()); error.set(None); },
+            }
+        }
+        StrengthMeter { score, label: Some(score_label.to_string()) }
+        PasswordRequirements { rules }
+    }
+}
+
+/// Builds the new-user submit handler: local validation, then
+/// `data::create_user`.
+fn build_new_user_submit_handler(
+    username: Signal<String>,
+    password: Signal<String>,
+    perms: Signal<UserPermissions>,
+    mut error: Signal<Option<String>>,
+    mut saving: Signal<bool>,
+    on_created: EventHandler<()>,
+) -> impl FnMut(Event<FormData>) + 'static {
+    move |evt: Event<FormData>| {
         evt.prevent_default();
         if saving() {
             return;
@@ -51,54 +123,6 @@ pub(super) fn NewUserModal(on_close: EventHandler<()>, on_created: EventHandler<
             }
             saving.set(false);
         });
-    };
-
-    let pw = password();
-    let (score, score_label, rules) = score_password(&pw);
-
-    rsx! {
-        ModalShell { title: "New user", testid: "users-new-modal", on_close,
-            form { class: "settings-form", onsubmit: submit,
-                div { class: "settings-field",
-                    label { r#for: "new-user-username", "Username" }
-                    input {
-                        r#type: "text",
-                        id: "new-user-username",
-                        "data-testid": "new-user-username",
-                        autocomplete: "off",
-                        autocapitalize: "none",
-                        spellcheck: "false",
-                        value: "{username}",
-                        oninput: move |e| { username.set(e.value()); error.set(None); },
-                    }
-                }
-                div { class: "settings-field",
-                    label { r#for: "new-user-password", "Password" }
-                    input {
-                        r#type: "password",
-                        id: "new-user-password",
-                        "data-testid": "new-user-password",
-                        autocomplete: "new-password",
-                        value: "{password}",
-                        oninput: move |e| { password.set(e.value()); error.set(None); },
-                    }
-                }
-                StrengthMeter { score, label: Some(score_label.to_string()) }
-                PasswordRequirements { rules }
-                PermissionToggles { perms }
-                ModalError { error: error() }
-                div { class: "settings-actions",
-                    button {
-                        r#type: "submit",
-                        class: "btn",
-                        "data-testid": "new-user-submit",
-                        disabled: saving(),
-                        "Create user"
-                    }
-                    button { r#type: "button", class: "btn ghost", onclick: move |_| on_close.call(()), "Cancel" }
-                }
-            }
-        }
     }
 }
 

--- a/frontend/src/pages/shelf_detail/mod.rs
+++ b/frontend/src/pages/shelf_detail/mod.rs
@@ -104,10 +104,10 @@ fn shelf_detail_body(
     books: &[EbookMetadata],
     errored: bool,
     server_url: &str,
-    sort_key: Signal<SortKey>,
+    #[cfg_attr(feature = "mobile", allow(unused_variables))] sort_key: Signal<SortKey>,
     show_add: Signal<bool>,
     edit_shelf: Signal<bool>,
-    reload: Signal<u32>,
+    #[cfg_attr(feature = "mobile", allow(unused_variables))] reload: Signal<u32>,
 ) -> Element {
     #[cfg(feature = "mobile")]
     {

--- a/frontend/src/pages/shelf_detail/mod.rs
+++ b/frontend/src/pages/shelf_detail/mod.rs
@@ -36,14 +36,7 @@ pub fn ShelfDetailPage(id: i64) -> Element {
     let error = use_signal(|| None::<String>);
     crate::use_page_title(move || shelf.read().as_ref().map(|s| s.name.clone()));
     let sort_key = use_signal(|| SortKey::Title);
-    // Only mobile mutates these directly, so only it needs `mut` bindings.
-    #[cfg(feature = "mobile")]
-    let mut show_add = use_signal(|| false);
-    #[cfg(not(feature = "mobile"))]
     let show_add = use_signal(|| false);
-    #[cfg(feature = "mobile")]
-    let mut edit_shelf = use_signal(|| false);
-    #[cfg(not(feature = "mobile"))]
     let edit_shelf = use_signal(|| false);
     // Bumped to force a refetch after a membership edit.
     let reload = use_signal(|| 0u32);
@@ -82,38 +75,69 @@ pub fn ShelfDetailPage(id: i64) -> Element {
         );
     };
 
-    // Web keeps the rail + toolbar layout; mobile renders the home-style
-    // full-screen surface. Both consume the shared fetch pipeline above.
-    // (Mobile is a separate build — rule 07 hydration parity is unaffected.)
-    #[cfg(feature = "mobile")]
-    let body = rsx! {
-        mobile::MobileShelfDetail {
-            shelf: current.clone(),
-            books: books.read().clone(),
-            errored: errored(),
-            server_url: server_url.clone(),
-            on_add: move |_| show_add.set(true),
-            on_edit: move |_| edit_shelf.set(true),
-        }
-    };
-
-    #[cfg(not(feature = "mobile"))]
-    let body = web_shelf_body(
+    let books_snapshot = books.read();
+    let body = shelf_detail_body(
         &current,
-        &books.read(),
+        &books_snapshot,
         errored(),
         &server_url,
-        ShelfBodySignals {
-            sort_key,
-            show_add,
-            edit_shelf,
-            reload,
-        },
+        sort_key,
+        show_add,
+        edit_shelf,
+        reload,
     );
+    drop(books_snapshot);
 
     rsx! {
         {body}
         {shelf_detail_modals(id, current, show_add, edit_shelf, reload)}
+    }
+}
+
+/// Web keeps the rail + toolbar layout; mobile renders the home-style
+/// full-screen surface. Both consume the shared fetch pipeline in
+/// [`use_shelf_effects`]. (Mobile is a separate build — rule 07 hydration
+/// parity is unaffected.)
+#[allow(clippy::too_many_arguments)] // one bundle per pipeline; splitting further hides the wiring
+fn shelf_detail_body(
+    current: &Shelf,
+    books: &[EbookMetadata],
+    errored: bool,
+    server_url: &str,
+    sort_key: Signal<SortKey>,
+    show_add: Signal<bool>,
+    edit_shelf: Signal<bool>,
+    reload: Signal<u32>,
+) -> Element {
+    #[cfg(feature = "mobile")]
+    {
+        let mut show_add = show_add;
+        let mut edit_shelf = edit_shelf;
+        rsx! {
+            mobile::MobileShelfDetail {
+                shelf: current.clone(),
+                books: books.to_vec(),
+                errored,
+                server_url: server_url.to_string(),
+                on_add: move |_| show_add.set(true),
+                on_edit: move |_| edit_shelf.set(true),
+            }
+        }
+    }
+    #[cfg(not(feature = "mobile"))]
+    {
+        web_shelf_body(
+            current,
+            books,
+            errored,
+            server_url,
+            ShelfBodySignals {
+                sort_key,
+                show_add,
+                edit_shelf,
+                reload,
+            },
+        )
     }
 }
 

--- a/frontend/src/pages/shelves_index.rs
+++ b/frontend/src/pages/shelves_index.rs
@@ -52,57 +52,11 @@ pub fn ShelvesIndexPage() -> Element {
     let refetch = move || load(refetch_url.clone());
 
     let count = shelves.read().len();
-    let count_label = if count == 1 {
-        "1 shelf".to_string()
-    } else {
-        format!("{count} shelves")
-    };
 
     rsx! {
         div { class: "m-shelves", "data-testid": "shelves-index",
-            header { class: "m-head",
-                div { class: "m-head-top",
-                    div { class: "m-head-lead",
-                        Link {
-                            to: Route::Landing {},
-                            class: "m-icon-btn m-head-back",
-                            "aria-label": "Back to library",
-                            "\u{2190}"
-                        }
-                        span { class: "label", "{count_label}" }
-                    }
-                    button {
-                        r#type: "button",
-                        class: "btn primary sm",
-                        "data-testid": "new-shelf",
-                        onclick: move |_| show_create.set(true),
-                        "\u{FF0B} New"
-                    }
-                }
-                h2 { class: "m-head-title",
-                    "Your "
-                    span { class: "m-em", "shelves" }
-                }
-            }
-
-            if let Some(msg) = error() {
-                p {
-                    role: "alert",
-                    class: "subtitle",
-                    "data-testid": "shelves-error",
-                    "Couldn't load shelves: {msg}"
-                }
-            } else if loading() && shelves.read().is_empty() {
-                p { class: "subtitle", "Loading\u{2026}" }
-            } else {
-                div { class: "m-shelf-list",
-                    // Always-present "All Books" — the whole library as a shelf.
-                    {all_books_row()}
-                    for s in shelves.read().iter() {
-                        {shelf_row(s)}
-                    }
-                }
-            }
+            ShelvesHeader { count, on_new: move |_| show_create.set(true) }
+            ShelvesBody { shelves: shelves(), loading: loading(), error: error() }
         }
 
         if show_create() {
@@ -112,6 +66,67 @@ pub fn ShelvesIndexPage() -> Element {
                     show_create.set(false);
                     refetch();
                 },
+            }
+        }
+    }
+}
+
+/// Back link, shelf count, "New" action, and page title.
+#[component]
+fn ShelvesHeader(count: usize, on_new: EventHandler<MouseEvent>) -> Element {
+    let count_label = if count == 1 {
+        "1 shelf".to_string()
+    } else {
+        format!("{count} shelves")
+    };
+    rsx! {
+        header { class: "m-head",
+            div { class: "m-head-top",
+                div { class: "m-head-lead",
+                    Link {
+                        to: Route::Landing {},
+                        class: "m-icon-btn m-head-back",
+                        "aria-label": "Back to library",
+                        "\u{2190}"
+                    }
+                    span { class: "label", "{count_label}" }
+                }
+                button {
+                    r#type: "button",
+                    class: "btn primary sm",
+                    "data-testid": "new-shelf",
+                    onclick: on_new,
+                    "\u{FF0B} New"
+                }
+            }
+            h2 { class: "m-head-title",
+                "Your "
+                span { class: "m-em", "shelves" }
+            }
+        }
+    }
+}
+
+/// Error message, loading placeholder, or the shelf list — in priority order.
+#[component]
+fn ShelvesBody(shelves: Vec<ShelfSummary>, loading: bool, error: Option<String>) -> Element {
+    rsx! {
+        if let Some(msg) = error {
+            p {
+                role: "alert",
+                class: "subtitle",
+                "data-testid": "shelves-error",
+                "Couldn't load shelves: {msg}"
+            }
+        } else if loading && shelves.is_empty() {
+            p { class: "subtitle", "Loading\u{2026}" }
+        } else {
+            div { class: "m-shelf-list",
+                // Always-present "All Books" — the whole library as a shelf.
+                {all_books_row()}
+                for s in shelves.iter() {
+                    {shelf_row(s)}
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- 17 Dioxus page/hook functions under `frontend/src/pages/**` exceeded the ~80-line soft cap (rule 05). Each is split via handler/sub-component extraction following the `KindleEmailCard`/`ProfileCard` precedent (#1716): rsx-heavy components pull self-contained visual sections into sibling `#[component]` fns, `use_effect`/`use_callback` bodies move into named hook functions (e.g. `use_rating_hydration`, `use_registration_open_probe`), and `setup_landing_signals`' struct-assembly splits into per-bundle constructor helpers (`use_fetch_signals`, `use_shelf_wiring`, etc.) per AC3, since that function isn't an rsx body.
- Pure refactor — no behavior, render output, or markup-contract (roles/labels/testids/DOM structure) changes.
- `frontend/src/pages/account/profile.rs` is untouched — it's owned by the concurrent #1716 branch extracting `ProfileCard`.

All 17 functions are confirmed at or under 80 lines after the change; none were already under cap before this PR (verified via a brace-depth scan matching the issue's methodology).

Closes #1721

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (0 warnings)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (688 passed, 0 failed, including the `BdRatingWidget` SSR render-smoke test)
- [ ] Playwright specs touching these pages (landing, book detail, reader, listen, shelves, authors index, settings/users, check-in, auth/register) were **not** run locally (no nix/Playwright in this environment) — the `run_ui_tests` label is applied so CI runs the full E2E suite on this PR. Please confirm green before merge.

## Version
Tech-debt refactor with no behavior change — leaving version labels unset (no release-worthy change to call out here).

## Notes
- Every touched file stays well under the ~800-line file cap (largest is `authors_index.rs` at 499 lines).
- `settings/users/mod.rs`'s `UsersModals` helper couldn't be a `#[component]` (it takes `dioxus_router::Navigator`, which isn't `PartialEq`), so it stays a plain fn called via `{users_modals(...)}`, matching the file's existing plain-fn helpers (`all_books_row`-style pattern used elsewhere in `pages/`).


---
_Generated by [Claude Code](https://claude.ai/code/session_018tptxzthdR1vajpoXwVDsY)_