### PR TITLE
docs: fix broken cross-reference, undocumented skill, stale path citations

### DIFF
--- a/.claude/rules/09-content-validators.md
+++ b/.claude/rules/09-content-validators.md
@@ -190,8 +190,8 @@ drift apart.
 
 ## Out of scope
 
-- Change feeds / tombstones / a sync cursor — see
-  [docs/design/db-review-f13-change-tracking.md](../../docs/design/db-review-f13-change-tracking.md),
-  still deferred. This is per-resource validation, not a cursor.
+- Change feeds / tombstones / a sync cursor — deferred F13 work; no design
+  doc has been written for it yet. This is per-resource validation, not a
+  cursor.
 - What a client may *queue* while offline — see
   [08-offline-writes.md](08-offline-writes.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,13 @@ regardless of which agent or tool you are:
 
 - **[CLAUDE.md](CLAUDE.md)** — the index: architecture, rules, skills, quick
   commands, and version control.
-- **[.claude/rules/](.claude/rules/)** — numbered rules applied in order: dev
-  environment, error handling, unit testing, Playwright, Rust style, and SQL
-  migrations.
+- **[.claude/rules/](.claude/rules/)** — numbered rules applied in order; see
+  [CLAUDE.md](CLAUDE.md)'s Rules index for the current, authoritative list
+  (as of this writing: dev environment, error handling, unit testing,
+  Playwright, Rust style, SQL migrations, hydration parity, offline writes,
+  content validators, keep-skills-fresh, end-of-session).
 - **[.claude/skills/](.claude/skills/)** — task recipes: `add-backend-route`,
-  `add-playwright-flow`, `ui-validate`.
+  `add-playwright-flow`, `create-github-issue`, `ui-validate`.
 - **[docs/architecture.md](docs/architecture.md)** — the five-crate
   workspace map (per-crate module maps + request-flow diagrams).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Auto-discoverable skills in [.claude/skills/](.claude/skills/) — Claude Code l
 
 - [add-backend-route](.claude/skills/add-backend-route/SKILL.md) — adding an Axum page or API endpoint end-to-end.
 - [add-playwright-flow](.claude/skills/add-playwright-flow/SKILL.md) — adding a new E2E spec.
+- [create-github-issue](.claude/skills/create-github-issue/SKILL.md) — filing GitHub issues in the omnibus house style: bracketed `[Scope]` title prefixes, a standard body template, consistent labels, and native sub-issue linking.
 - [ui-validate](.claude/skills/ui-validate/SKILL.md) — bring up a port-walking dev server, log in as the seeded admin, drive the browser, poll `/api/_health` for rebuild signal.
 
 ### Browser tools

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,12 +221,13 @@ tests/
 main.rs             — dioxus::launch, ServerUrl context, hydrates bearer token from disk, calls `omnibus_frontend::offline::init()` (offline store + download registry + loopback media server + position hydration) before launch, wraps omnibus_frontend::App
 ```
 
-Mobile auth: bearer-token login flow lives in `frontend/src/data.rs` under
-`feature = "mobile"`. `data::mobile_login` / `mobile_register` POST to
+Mobile auth: bearer-token login flow lives in `frontend/src/data/auth.rs`
+under `feature = "mobile"`. `data::mobile_login` / `mobile_register` POST to
 `/api/auth/{login,register}` with `client_kind: ios|android|bearer` so the
-server returns a bearer token in the JSON body. `data::token_store` keeps
-the token in a process-local `OnceLock<RwLock<...>>` and persists it (in
-every build) to `<data_dir>/token` with `0o600` perms, where `data_dir`
+server returns a bearer token in the JSON body. `data::token_store`
+(`frontend/src/data/stores.rs`) keeps the token in a process-local
+`OnceLock<RwLock<...>>` and persists it (in every build) to
+`<data_dir>/token` with `0o600` perms, where `data_dir`
 (`data::app_dirs`) resolves to `Library/Application Support/omnibus` on iOS,
 `$HOME/.omnibus` on desktop/dev, and `Context.getFilesDir()` on Android
 (resolved via JNI through the ambient `ndk_context::android_context()` that


### PR DESCRIPTION
## Summary
- Closes #1682
- `.claude/rules/09-content-validators.md`: replaced the dead link to `docs/design/db-review-f13-change-tracking.md` (never written, no git history) with a plain note that no design doc exists yet for the deferred F13 change-tracking work.
- `CLAUDE.md` and `AGENTS.md`: added the missing `create-github-issue` skill to both skill indexes, matching its own `SKILL.md` summary.
- `AGENTS.md`: reworded the rule enumeration to point at `CLAUDE.md`'s Rules index as the source of truth (with a parenthetical current snapshot) instead of naming a subset of files that will drift again.
- `docs/architecture.md`: fixed the mobile-auth narrative paragraph to cite `frontend/src/data/auth.rs` / `frontend/src/data/stores.rs` instead of `frontend/src/data.rs`, which is now just an 85-line module index — matching what the doc's own module-map section a few dozen lines earlier already says.

## Test plan
- [x] Proofread all four fixes against the current file contents on `main`
- [x] `grep -rn "db-review-f13"` across the repo confirms no remaining reference to the dead link
- [x] Confirmed `.claude/skills/create-github-issue/SKILL.md` exists and both indexes now list it
- [x] Confirmed `frontend/src/data.rs` is a thin module index and the auth/token-store functions live in `data/auth.rs` / `data/stores.rs`
- [x] `CLAUDE.md` / `AGENTS.md` / `.claude/rules/09-content-validators.md` all stay well under the ~200-line cap (rule 99)
- No cargo build needed — docs-only change

## Version
- [x] **No release** — docs-only change; auto-skipped per the release-notes rule (unlabeled PRs touching only `*.md`/`docs/` skip the release automatically)

## Notes
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_018tptxzthdR1vajpoXwVDsY)_