### PR TITLE
chore: add .worktreeinclude so new worktrees inherit .env

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,5 +1,5 @@
-# Gitignored files carried into a fresh worktree. Read by Claude Code desktop
-# and by `wt step copy-ignored`; a file must be BOTH gitignored and matched
+# Gitignored files carried into a fresh worktree by the tooling that supports
+# it (e.g. `wt step copy-ignored`); a file must be BOTH gitignored and matched
 # here to be copied.
 #
 # Secrets only. Everything else a worktree needs is tracked, regenerated, or

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,9 @@
+# Gitignored files carried into a fresh worktree. Read by Claude Code desktop
+# and by `wt step copy-ignored`; a file must be BOTH gitignored and matched
+# here to be copied.
+#
+# Secrets only. Everything else a worktree needs is tracked, regenerated, or
+# already shared: CARGO_TARGET_DIR lives outside the repo, and the databases,
+# covers/, and data/ caches are per-branch state that must NOT be inherited.
+
+.env


### PR DESCRIPTION
## Summary
- Adds a root `.worktreeinclude` so a newly created git worktree inherits the gitignored `.env` instead of starting with only `.env.example` and no secrets.
- Scoped to `.env` alone: `CARGO_TARGET_DIR` already lives outside the repo, and `data/`, `covers/`, and the `omnibus.db*` files are per-branch state that must not be inherited.
- The file is read from the *source* worktree, so it only takes effect for worktrees created after this lands on `main`.

## Test plan
- [x] With the file present in the main worktree, `wt step copy-ignored --require-include --dry-run` reports `Would copy 1 entry: .env (file)`; without it the same command is a no-op.
- [x] N/A — no code paths changed, so no unit or E2E coverage applies.

## Version
- [x] **No release** — labeled `no release`. The file ships nothing, and it falls outside the automatic docs/CI skip (which only covers `*.md`, `docs/`, and `.github/`), so an unlabeled merge would otherwise cut a pointless patch release.

## Notes
- Deliberately not documented in `.claude/rules/01-dev-environment.md` — worktree tooling is an operator-specific convention, which `CLAUDE.md` keeps in personal config rather than the team-shared rules. The file's own header comment carries the explanation instead.