### PR TITLE
fix: apply the check-in title search's own answer when the field has stray whitespace

### DIFF
--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
@@ -100,11 +100,19 @@ enum CheckInFlow {
     /// its response must only apply if the stage and query it was asked
     /// with are still current, or a late answer reintroduces the same
     /// stale-search bug `resolveShouldClearSearch` guards against.
+    ///
+    /// Both sides are trimmed because only one of them ever was: the request
+    /// carries `nilIfBlank`'s trimmed text while the field holds whatever was
+    /// typed, and iOS appends a trailing space to every accepted QuickType
+    /// suggestion. Comparing those raw discarded the answer to the search the
+    /// reader had just asked for, leaving a spinner and no results.
     static func searchResponseShouldApply(
         startedStage: CheckInStage, currentStage: CheckInStage,
         startedQuery: String, currentQuery: String
     ) -> Bool {
-        startedStage == currentStage && startedQuery == currentQuery
+        startedStage == currentStage
+            && startedQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+            == currentQuery.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// Outcomes whose card links straight to the book's detail page.

--- a/omnibus-ios/omnibusTests/CheckInFlowTests.swift
+++ b/omnibus-ios/omnibusTests/CheckInFlowTests.swift
@@ -113,6 +113,32 @@ struct CheckInFlowTests {
         )
     }
 
+    @Test func searchResponseAppliesWhenOnlySurroundingWhitespaceDiffers() {
+        // The request is sent with the trimmed query while the field keeps the
+        // raw text, and iOS appends a space to every accepted QuickType
+        // suggestion — so this is the *typical* typed search, not an edge case.
+        #expect(
+            CheckInFlow.searchResponseShouldApply(
+                startedStage: .scan, currentStage: .scan,
+                startedQuery: "pride and prejudice", currentQuery: "pride and prejudice "
+            )
+        )
+        #expect(
+            CheckInFlow.searchResponseShouldApply(
+                startedStage: .scan, currentStage: .scan,
+                startedQuery: "babel", currentQuery: "  babel\n"
+            )
+        )
+        // Trimming must not blunt the gate: real retyping still drops the
+        // stale answer, whitespace or not.
+        #expect(
+            !CheckInFlow.searchResponseShouldApply(
+                startedStage: .scan, currentStage: .scan,
+                startedQuery: "babel", currentQuery: "babel two "
+            )
+        )
+    }
+
     @Test func detailUUIDCoversAlreadyOwnedAndOnWishlistOnly() {
         #expect(CheckInFlow.detailUUID(for: .alreadyOwned(book: scanBook())) == "b-1")
         #expect(CheckInFlow.detailUUID(for: .onWishlist(book: scanBook())) == "b-1")


### PR DESCRIPTION
## Summary
- The check-in sheet's title search sent the *trimmed* query but gated the response on the *raw* field text, so any leading or trailing space — which iOS appends to every accepted QuickType suggestion — made the staleness gate discard the server's own answer. The spinner ran and nothing rendered, which is exactly what the reporter saw.
- `CheckInFlow.searchResponseShouldApply` now trims both sides before comparing, so the gate still drops genuinely stale answers (a retype, a resolve landing elsewhere) but stops rejecting the one it asked for.
- iOS-only; the web client's title search has no such gate.

Closes #1745

## Test plan
- [x] New `searchResponseAppliesWhenOnlySurroundingWhitespaceDiffers` fails on the pre-fix gate (`** TEST FAILED **`) and passes after — red verified by stashing the fix.
- [x] Full `just ios-test` suite green.

## Version
- [ ] **Minor**
- [x] **Patch** — default, unlabeled.
- [ ] **No release**