### PR TITLE
fix: drop the PHYS and headphones badges from the landing grid

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5559,15 +5559,6 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   cursor: pointer;
   position: relative;
 }
-/* Pins to the cover's top-right — the Cover is the tile's first child, so the
-   tile box starts at the artwork. Opaque ground because `.format-badge` is
-   transparent by default and would be unreadable over cover art. */
-.lib-tile-phys {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  background: var(--bg-0);
-}
 .lib-tile:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 4px;

--- a/frontend/src/pages/landing/grid.rs
+++ b/frontend/src/pages/landing/grid.rs
@@ -41,9 +41,6 @@ fn GridTile(book: EbookMetadata, server_url: String, index: usize) -> Element {
     let display_title = book.title.as_deref().unwrap_or(&book.filename).to_string();
     let tile_testid = format!("ebook-tile-{}", row_ident(&book));
     let authors = contributor_names(&book.creators);
-    // Read before `book` moves into `Cover`. Mirrors the table's formats cell,
-    // which carries the same badge (#1181).
-    let has_physical = book.has_physical;
     let nav = use_navigator();
 
     // Prefer the responsive `/api/thumbs/:uuid/{sm,md,lg}` endpoint over the
@@ -83,14 +80,6 @@ fn GridTile(book: EbookMetadata, server_url: String, index: usize) -> Element {
                     "(max-width: 640px) 160px, (max-width: 1280px) 200px, 240px"
                         .to_string(),
                 ),
-            }
-            if has_physical {
-                span {
-                    class: "lib-tile-phys format-badge format-badge--physical",
-                    "data-testid": "format-badge-physical",
-                    title: "In your physical collection",
-                    "PHYS"
-                }
             }
             div { class: "lib-tile-title", "{display_title}" }
             if !authors.is_empty() {

--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -550,13 +550,10 @@ struct BookGridCell: View {
         }
     }
 
-    /// Format and offline state ride on the art rather than the caption, which
-    /// keeps the text block to a predictable height.
+    /// Offline state rides on the art rather than the caption, which keeps the
+    /// text block to a predictable height.
     private var badges: some View {
         HStack(spacing: 4) {
-            if book.hasAudiobook {
-                badge("headphones")
-            }
             if downloads.isAnyDownloaded(book.uuid) {
                 badge("arrow.down")
             }


### PR DESCRIPTION
## Summary
- Removes the cover-overlay `PHYS` badge from the web landing grid tile (`frontend/src/pages/landing/grid.rs`) and drops the now-orphaned `.lib-tile-phys` rule from `atrium.css`.
- Removes the headphones badge from the iOS library grid cell, so a book with an audiobook no longer gets a format marker on its art.
- The iOS download-arrow badge stays — it's offline state, not a format marker. The landing table's Formats column and the book-detail hero keep their `PHYS` badges; only the grid overlay is gone.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy -p omnibus-frontend --features server -- -D warnings`, `just lint-css` — all clean.
- [x] `cargo test -p omnibus-frontend --features server` — 688 passed.
- [x] `just ios-build` + `just ios-test` — both green.
- [x] Web: seeded 40 fixture books plus a physical-only record against a local dev server; the landing grid renders 40 tiles with zero `[data-testid="format-badge-physical"]` and zero `.lib-tile-phys` nodes, and the physical book's tile has a clean top-right corner.
- [x] iOS: booted the simulator and filtered the library grid to Audiobooks (so every visible cover is a book with audio) — no headphones badges.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- No Playwright spec asserted the grid badge (`format-badge-physical` was only referenced by the grid, the table cell, and the book-detail hero), so no E2E updates were needed.