### PR TITLE
refactor: cover reader-avatar optimistic seeding and shadow threshold

### DIFF
--- a/omnibus-ios/omnibus/Design/Components/UserAvatar.swift
+++ b/omnibus-ios/omnibus/Design/Components/UserAvatar.swift
@@ -30,7 +30,7 @@ struct UserAvatar: View {
         // The accent glow is identity-card dressing; at list-row sizes it
         // reads as smudging, so small avatars stay flat like `AuthorAvatar`.
         .shadow(
-            color: palette.accentColor.opacity(size >= Self.shadowMinSize ? 0.25 : 0),
+            color: palette.accentColor.opacity(Self.shadowOpacity(for: size)),
             radius: 12,
             y: 4
         )
@@ -38,6 +38,12 @@ struct UserAvatar: View {
 
     /// Below this size the accent shadow is suppressed (row avatars stay flat).
     static let shadowMinSize: CGFloat = 44
+
+    /// The accent-shadow opacity for a given avatar size — full glow at or
+    /// above `shadowMinSize`, none below it.
+    static func shadowOpacity(for size: CGFloat) -> Double {
+        size >= shadowMinSize ? 0.25 : 0
+    }
 
     /// The cache key / request path for a user's avatar. Shared with the
     /// invalidation call after an upload so the two can't drift.

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -424,17 +424,31 @@ enum UserDataService {
     static func createJournal(
         _ payload: CreateJournalEntry, author: UserSummary?
     ) async -> JournalEntry? {
-        let optimistic = JournalEntry(
+        let optimistic = optimisticJournalEntry(for: payload, author: author)
+        await mutateLocalJournals(payload.bookUUID) { $0.insert(optimistic, at: 0) }
+        let landed = await SyncEngine.shared.write(
+            kind: OpKind.journal, path: "/api/journals", body: payload, coalesce: false
+        )
+        if landed { await refreshJournals(payload.bookUUID) }
+        return optimistic
+    }
+
+    /// The optimistic record shown the instant a journal entry is created,
+    /// before the outbox has landed the write or the server has rendered the
+    /// markdown. Display name + avatar match what the server's re-read will
+    /// say, so the card doesn't flicker to a different identity; a local
+    /// markdown renderer here would only disagree with the real one, so the
+    /// body stays as the source until the server has rendered it.
+    static func optimisticJournalEntry(
+        for payload: CreateJournalEntry, author: UserSummary?
+    ) -> JournalEntry {
+        JournalEntry(
             id: AnnotationID.pending(),
             bookUUID: payload.bookUUID,
             authorId: author?.id ?? 0,
-            // Display name + avatar match what the server's re-read will say,
-            // so the optimistic card doesn't flicker to a different identity.
             authorName: author?.display ?? "You",
             authorHasAvatar: author?.hasAvatar ?? false,
             bodyMd: payload.bodyMd,
-            // The server renders the markdown; until it has, show the source.
-            // A local renderer here would only disagree with the real one.
             bodyHtml: "",
             progress: payload.progress,
             status: payload.status,
@@ -442,12 +456,6 @@ enum UserDataService {
             createdAt: Int64(Date().timeIntervalSince1970),
             updatedAt: Int64(Date().timeIntervalSince1970)
         )
-        await mutateLocalJournals(payload.bookUUID) { $0.insert(optimistic, at: 0) }
-        let landed = await SyncEngine.shared.write(
-            kind: OpKind.journal, path: "/api/journals", body: payload, coalesce: false
-        )
-        if landed { await refreshJournals(payload.bookUUID) }
-        return optimistic
     }
 
     static func updateJournal(_ entry: JournalEntry, payload: UpdateJournalEntry) async {

--- a/omnibus-ios/omnibusTests/OfflineSyncTests.swift
+++ b/omnibus-ios/omnibusTests/OfflineSyncTests.swift
@@ -431,6 +431,68 @@ struct AudioFileSelectionTests {
     }
 }
 
+// MARK: - Optimistic journal authorship (#1740)
+
+@Suite("Optimistic journal entry")
+struct OptimisticJournalEntryTests {
+    private let payload = CreateJournalEntry(
+        bookUUID: "11111111-2222-3333-4444-555555555555",
+        bodyMd: "Just started chapter three.",
+        progress: 42,
+        clientID: "client-abc"
+    )
+
+    @Test("an author with an avatar is attributed by display name and flagged")
+    func attributesAnAuthorWithAnAvatar() {
+        let author = UserSummary(
+            id: 7, username: "alice", isAdmin: false, canUpload: false,
+            canEdit: false, canDownload: false, kindleEmail: nil,
+            displayName: "Alice A.", hasAvatar: true
+        )
+        let entry = UserDataService.optimisticJournalEntry(for: payload, author: author)
+        #expect(entry.authorId == 7)
+        #expect(entry.authorName == "Alice A.")
+        #expect(entry.authorHasAvatar == true)
+    }
+
+    @Test("an author without an avatar is attributed but not flagged")
+    func attributesAnAuthorWithoutAnAvatar() {
+        // No display name set either, so `display` falls back to the username.
+        let author = UserSummary(
+            id: 9, username: "bob", isAdmin: false, canUpload: false,
+            canEdit: false, canDownload: false, kindleEmail: nil,
+            displayName: nil, hasAvatar: false
+        )
+        let entry = UserDataService.optimisticJournalEntry(for: payload, author: author)
+        #expect(entry.authorId == 9)
+        #expect(entry.authorName == "bob")
+        #expect(entry.authorHasAvatar == false)
+    }
+
+    @Test("a missing author falls back to a pending identity, not a crash")
+    func fallsBackWhenAuthorIsUnknown() {
+        // `Cache.cachedOnly(CacheKey.me)` can miss — a journal typed the
+        // instant the app launches offline has no `me` in the replica yet.
+        let entry = UserDataService.optimisticJournalEntry(for: payload, author: nil)
+        #expect(entry.authorId == 0)
+        #expect(entry.authorName == "You")
+        #expect(entry.authorHasAvatar == false)
+    }
+
+    @Test("the optimistic record carries the payload's body, progress, and client id")
+    func carriesThePayloadThrough() {
+        let entry = UserDataService.optimisticJournalEntry(for: payload, author: nil)
+        #expect(entry.bookUUID == payload.bookUUID)
+        #expect(entry.bodyMd == payload.bodyMd)
+        #expect(entry.progress == payload.progress)
+        #expect(entry.clientID == payload.clientID)
+        // The server renders the markdown; a local renderer would only
+        // disagree with it, so the optimistic record shows no HTML yet.
+        #expect(entry.bodyHtml == "")
+        #expect(AnnotationID.isPending(entry.id))
+    }
+}
+
 // MARK: - Account scoping
 
 @Suite("User-scoped cache wipe")

--- a/omnibus-ios/omnibusTests/ProfileDraftTests.swift
+++ b/omnibus-ios/omnibusTests/ProfileDraftTests.swift
@@ -77,6 +77,20 @@ import Testing
     }
 }
 
+@Suite struct UserAvatarShadowTests {
+    @Test func glowsAtOrAboveTheRowSizeThreshold() {
+        #expect(UserAvatar.shadowOpacity(for: UserAvatar.shadowMinSize) == 0.25)
+        #expect(UserAvatar.shadowOpacity(for: UserAvatar.shadowMinSize + 20) == 0.25)
+    }
+
+    @Test func staysFlatBelowTheRowSizeThreshold() {
+        // Row-sized avatars (list rows, comment bylines) stay flat like
+        // `AuthorAvatar` — the glow reads as smudging at that size.
+        #expect(UserAvatar.shadowOpacity(for: UserAvatar.shadowMinSize - 1) == 0)
+        #expect(UserAvatar.shadowOpacity(for: 0) == 0)
+    }
+}
+
 @Suite struct UserSummaryDisplayTests {
     private func user(displayName: String?) -> UserSummary {
         UserSummary(


### PR DESCRIPTION
## Summary
- Closes #1740
- Extracts the optimistic journal author-attribution fallback chain (`author?.display ?? "You"` / `author?.hasAvatar ?? false`) out of `UserDataService.createJournal` into a pure, testable `UserDataService.optimisticJournalEntry(for:author:)`, mirroring the existing `UserDataService.splice` extraction pattern.
- Extracts the `UserAvatar` shadow-opacity threshold (`size >= 44 ? 0.25 : 0`) out of the view body into a testable `UserAvatar.shadowOpacity(for:)`, mirroring the existing `UserAvatar.initials(for:)` extraction pattern. Mechanical, non-behavior-changing refactor.
- Adds behavioral coverage for both: `OptimisticJournalEntryTests` in `omnibusTests/OfflineSyncTests.swift` (author present+avatar, author present+no avatar, author nil, and payload passthrough) and `UserAvatarShadowTests` in `omnibusTests/ProfileDraftTests.swift` (>= 44 and < 44 branches).
- `AvatarAttributionTests.swift`'s existing decode tests are untouched.

## Test plan
- [ ] `just ios-test` (omnibusTests unit suite) — **could not be executed**: this worktree ran in a Linux sandbox with no Xcode toolchain (`xcrun`/`xcodebuild`/`swift` all absent), so `scripts/ios-test.sh unit` fails immediately with `xcrun: command not found` before reaching any test. Please run `just ios-test` on macOS CI/locally to confirm PASS.
- Verified instead by static review: brace/paren balance on every edited file, exact parameter-order match against `UserSummary`/`CreateJournalEntry`/`JournalEntry` memberwise initializers, and that the extracted functions are pure 1:1 refactors of the original inline logic (no behavior change).

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Pure test-coverage backfill per the issue, plus the two mechanical (non-behavior-changing) extractions the issue asked for to make the logic testable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfF2UFeusJ8bmAiKc6kxge)_