### PR TITLE
fix: sync MiniPlayer progress bar with actual playback position (#1746)

### DIFF
--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -88,6 +88,35 @@ final class AudioPlayer {
     /// reconcile was still in the middle of correcting, and win.
     private var positionSettled = false
 
+    /// Count of `seek(to:)` calls currently awaiting AVPlayer, incremented
+    /// before the frame-accurate seek starts and decremented once it
+    /// resolves — a count rather than a flag so two overlapping seeks (a
+    /// second tap landing before the first settles) can't have the first
+    /// one's completion re-arm the observer while the second is still in
+    /// flight.
+    ///
+    /// `seek(to:)` sets `position` optimistically before awaiting AVPlayer,
+    /// but the periodic time observer below fires regardless, on the
+    /// player's *actual* (pre-seek) time — unguarded, it would overwrite the
+    /// optimistic value right back to stale on its very next 0.5s tick,
+    /// which for a seek that takes longer than that to settle (HLS
+    /// especially) reintroduces the exact staleness the optimism was meant
+    /// to close (#1746). The observer checks this count and skips its write
+    /// while it's nonzero.
+    private var pendingSeekCount = 0
+
+    /// Bumped by every `teardown()` — a book switch or `close()`. A
+    /// `seek(to:)` in flight when that happens is abandoned: its `player`
+    /// local still resolves once AVPlayer gets around to it, but by then
+    /// `pendingSeekCount` belongs to whatever book loaded next. Each seek
+    /// captures the generation live when it started and only decrements the
+    /// count if that generation is still current, so an orphaned seek's late
+    /// completion can't under- or over-count the next book's own in-flight
+    /// seeks. `teardown()` separately zeroes the count itself — without that,
+    /// a seek abandoned mid-flight would leave it permanently elevated, since
+    /// this guard is precisely what stops that seek from ever decrementing it.
+    private var loadGeneration = 0
+
     /// Chapter geometry for the book that's open. Rebuilt once per load — every
     /// lookup on it runs off a half-second time observer, so it can't afford to
     /// re-sort per tick.
@@ -455,6 +484,14 @@ final class AudioPlayer {
         // at (#1746).
         position = clamped
         updateNowPlaying()
+        // Guards the observer for the rest of this function, however it
+        // exits. The generation is captured now, not read fresh in the
+        // `defer` — see `loadGeneration`.
+        let generation = loadGeneration
+        pendingSeekCount += 1
+        defer {
+            if generation == loadGeneration { pendingSeekCount -= 1 }
+        }
         await player.seek(
             to: CMTime(seconds: clamped, preferredTimescale: 600),
             toleranceBefore: .zero, toleranceAfter: .zero
@@ -593,6 +630,16 @@ final class AudioPlayer {
         positionSettled = false
         syncOffer = nil
         cancelSleepTimer()
+        // Bumped first so a seek belonging to the book being torn down —
+        // still holding its own `defer`, due to land whenever AVPlayer gets
+        // around to it — finds a mismatched generation and skips its
+        // decrement instead of under-counting whatever book loads next. The
+        // explicit reset is still required alongside it: that guard is
+        // exactly what stops the orphaned seek from ever decrementing this,
+        // so without the reset a seek abandoned mid-flight would leave the
+        // count permanently elevated and the observer permanently skipped.
+        loadGeneration += 1
+        pendingSeekCount = 0
     }
 
     private func observe(player: AVPlayer) {
@@ -601,6 +648,11 @@ final class AudioPlayer {
         ) { [weak self] time in
             Task { @MainActor in
                 guard let self else { return }
+                // Skipped while a `seek(to:)` is still resolving: `time` is
+                // AVPlayer's actual (pre-seek) position until then, and
+                // writing it here would clobber the optimistic target right
+                // back to stale for as long as the seek takes to settle.
+                guard self.pendingSeekCount == 0 else { return }
                 self.position = time.seconds
                 if self.isPlaying { self.listenedSeconds += 0.5 }
                 await self.persistPosition(force: false)

--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -444,12 +444,21 @@ final class AudioPlayer {
     func seek(to seconds: Double) async {
         guard let player else { return }
         let clamped = max(0, duration > 0 ? min(seconds, duration) : seconds)
+        // Applied before the frame-accurate AVPlayer seek resolves, not after.
+        // `toleranceBefore/After: .zero` can take real wall-clock time to
+        // settle (HLS especially), and every reader of `position` — the
+        // chapter-scoped scrubber's own `chapterOffset` included, everywhere
+        // it isn't shadowed by the drag-local `scrubOffset` — was reading the
+        // pre-seek value for that whole window. The mini bar has no such
+        // shadow, so a skip or chapter jump left its whole-book rail visibly
+        // behind the position the rest of the player already claimed to be
+        // at (#1746).
+        position = clamped
+        updateNowPlaying()
         await player.seek(
             to: CMTime(seconds: clamped, preferredTimescale: 600),
             toleranceBefore: .zero, toleranceAfter: .zero
         )
-        position = clamped
-        updateNowPlaying()
     }
 
     func skip(_ delta: Double) {


### PR DESCRIPTION
## Summary
- Closes #1746
- `AudioPlayer.seek(to:)` only wrote `position` *after* the frame-accurate AVPlayer seek resolved (`toleranceBefore/After: .zero`), which can take real wall-clock time — HLS especially.
- Every reader of `position` lagged behind the true target for that window: `MiniPlayerBar`'s whole-book progress rail (`player.position / player.duration`), and even the full-screen player's own `chapterOffset`-derived readouts whenever they weren't shadowed by the drag-local `scrubOffset` (i.e. after a chapter jump or a `skip()` tap, as opposed to an in-progress scrubber drag).
- A skip or chapter change therefore left the mini bar visibly behind wherever the rest of the player already claimed to be, matching the report in #1746 (chapter-scoped scrubber near the end of a chapter while the mini bar rail sat well short).
- Fix: assign `position` (and refresh Now Playing info) *before* awaiting the AVPlayer seek, so every consumer reflects the target immediately rather than waiting for the next 0.5s periodic-observer tick. The function's own completion timing (when callers' `await seek(...)` unblocks) is unchanged — only the point within the body where `position` becomes correct moved earlier.
- Surgical, single-file change; the mini bar's whole-book vs. the full player's chapter-scoped progress semantics are unchanged and remain intentional (see the comment above `MiniPlayerBar`'s `ProgressBar` call) — this fixes the staleness, not the scope.

## Test plan
- [x] Manual code review: traced every caller of `AudioPlayer.seek(to:)` (`skip`, `seekToChapter`, `seekWithinChapter`, `acceptSyncOffer`, the opening-position restore in `load`) — none depend on `position` staying at its pre-seek value while the seek is in flight, and the function's external await-completion timing is unchanged.
- [ ] `just ios-build` — **not run**: this session's sandbox is Linux with no Xcode/`xcodebuild`/Swift toolchain or `just` binary installed, so a native iOS build could not be executed here. Please run on a macOS runner/CI before merge.
- [ ] `just ios-test` — **not run**, same reason. No existing testable pure-function seam covers `AudioPlayer.seek`'s AVPlayer-coupled timing (unlike `ChapterTimelineTests.swift`'s pure chapter-geometry math), so no new test was added; flagging for CI (`ios-tests.yml`) to gate this instead.

## Version
- [x] **Patch** — bug fix, default.

## Notes
- The mismatch is a timing/staleness bug, not the mini bar's deliberate whole-book (vs. the full player's chapter-scoped) progress semantics — that distinction is unchanged and intentional.
- Could not run the iOS build/test suite locally (no macOS/Xcode toolchain in this sandbox); relying on CI (`ios-tests.yml`) to confirm before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfF2UFeusJ8bmAiKc6kxge)_