### PR TITLE
refactor: dedupe reader-panel scrim and stabilize author avatar element

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1937,16 +1937,20 @@ a.idx-letter-on:focus-visible {
   border: 1px solid var(--line-2);
   display: grid;
   place-items: center;
+  overflow: hidden;
   font-family: var(--serif);
   font-size: 36px;
   font-style: italic;
   color: var(--ink-1);
 }
 
-/* F1.11 — When the index card avatar is the cached profile photo
-   (`<img>` instead of letter `<div>`), clip the image to the circle and
-   drop the typographic styling. */
+/* F1.11 — When the index card avatar is the cached profile photo, the `img`
+   nests inside the stable `.idx-card-avatar` circle (rule 07 — a `has_photo`
+   flip diffs the child, not the node) rather than swapping element type.
+   Fill the parent's clipped circle instead of carrying its own size/border. */
 .idx-card-avatar--photo {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   display: block;
 }

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -399,14 +399,20 @@ fn render_author_card(a: &AuthorSummary, server_url: &str) -> Element {
             // relative on web, server base + `?token=` on mobile so the
             // WebView's `<img>` fetch authenticates. Editing the photo lives
             // on the author detail page — the index is read-only.
-            if a.has_photo {
-                img {
-                    class: "idx-card-avatar idx-card-avatar--photo",
-                    src: crate::media_url(server_url, &format!("/api/authors/{id}/photo")),
-                    alt: "{name}",
+            //
+            // The outer div is the same element in both states (rule 07): a
+            // `has_photo` flip only ever diffs the child, never replaces the
+            // node — mirrors `UserAvatar` in `components/user_avatar.rs`.
+            div { class: "idx-card-avatar",
+                if a.has_photo {
+                    img {
+                        class: "idx-card-avatar--photo",
+                        src: crate::media_url(server_url, &format!("/api/authors/{id}/photo")),
+                        alt: "{name}",
+                    }
+                } else {
+                    "{initial}"
                 }
-            } else {
-                div { class: "idx-card-avatar", "{initial}" }
             }
             div { class: "idx-card-body",
                 div { class: "idx-card-title",

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -394,15 +394,7 @@ fn render_author_card(a: &AuthorSummary, server_url: &str) -> Element {
             class: "idx-card idx-card-author",
             style: "--accent: {accent}",
             "data-testid": "author-card",
-            // F1.11: swap the letter glyph for the cached profile photo when
-            // one exists. `media_url` keeps the markup portable — same-origin
-            // relative on web, server base + `?token=` on mobile so the
-            // WebView's `<img>` fetch authenticates. Editing the photo lives
-            // on the author detail page — the index is read-only.
-            //
-            // The outer div is the same element in both states (rule 07): a
-            // `has_photo` flip only ever diffs the child, never replaces the
-            // node — mirrors `UserAvatar` in `components/user_avatar.rs`.
+            // F1.11: one stable div swaps only its child (rule 07 — a `has_photo` flip must never swap element types); `media_url` makes the photo fetch work on both web and mobile.
             div { class: "idx-card-avatar",
                 if a.has_photo {
                     img {

--- a/frontend/src/pages/reader/aa_panel.rs
+++ b/frontend/src/pages/reader/aa_panel.rs
@@ -7,6 +7,7 @@ use dioxus::prelude::*;
 
 use crate::components::atrium::Theme;
 
+use super::drawer_shell::ReaderScrim;
 use super::prefs::ReaderPrefs;
 use super::typography::{LineSpacing, Margins, Spread, Typeface};
 
@@ -15,7 +16,7 @@ use super::typography::{LineSpacing, Margins, Spread, Typeface};
 #[component]
 pub(crate) fn ReaderAaPanel(on_close: EventHandler<MouseEvent>) -> Element {
     rsx! {
-        div { class: "rd-scrim", onclick: on_close }
+        ReaderScrim { onclick: on_close }
         div {
             class: "rd-aa-panel",
             onclick: move |evt: MouseEvent| evt.stop_propagation(),

--- a/frontend/src/pages/reader/drawer_shell.rs
+++ b/frontend/src/pages/reader/drawer_shell.rs
@@ -1,17 +1,14 @@
 //! Shared scrim + slide-up drawer chrome for the reader's TOC, highlights,
-//! search, and bookmarks panels. Each drawer differs only in its head content
-//! (title, optional count/sub/actions) and body; this owns the scrim, the
+//! search, and bookmarks panels, plus the standalone [`ReaderScrim`] backdrop
+//! other panels reuse. Each drawer differs only in its head content (title,
+//! optional count/sub/actions) and body; this owns the scrim, the
 //! `rd-drawer` shell, the grabber, and the close button all four repeated.
-//! [`ReaderScrim`] is split out separately for panels that want just the
-//! backdrop without the rest of the drawer chrome.
 
 use dioxus::prelude::*;
 
-/// The reader's dim backdrop behind a drawer, panel, or modal; clicking it
-/// fires `onclick` (typically closing whatever is open). Standalone so
+/// The reader's dim backdrop behind a drawer, panel, or modal — standalone so
 /// panels that don't need [`ReaderDrawerShell`]'s title/close-button chrome
-/// (the quote panel, the AA panel, the note composer) aren't forced into
-/// the whole shell just to avoid hand-rolling this one div.
+/// can reuse just the scrim.
 #[component]
 pub(super) fn ReaderScrim(onclick: EventHandler<MouseEvent>) -> Element {
     rsx! {

--- a/frontend/src/pages/reader/drawer_shell.rs
+++ b/frontend/src/pages/reader/drawer_shell.rs
@@ -2,8 +2,22 @@
 //! search, and bookmarks panels. Each drawer differs only in its head content
 //! (title, optional count/sub/actions) and body; this owns the scrim, the
 //! `rd-drawer` shell, the grabber, and the close button all four repeated.
+//! [`ReaderScrim`] is split out separately for panels that want just the
+//! backdrop without the rest of the drawer chrome.
 
 use dioxus::prelude::*;
+
+/// The reader's dim backdrop behind a drawer, panel, or modal; clicking it
+/// fires `onclick` (typically closing whatever is open). Standalone so
+/// panels that don't need [`ReaderDrawerShell`]'s title/close-button chrome
+/// (the quote panel, the AA panel, the note composer) aren't forced into
+/// the whole shell just to avoid hand-rolling this one div.
+#[component]
+pub(super) fn ReaderScrim(onclick: EventHandler<MouseEvent>) -> Element {
+    rsx! {
+        div { class: "rd-scrim", onclick: move |e| onclick.call(e) }
+    }
+}
 
 /// Scrim + `rd-drawer` shell: grabber, a `head` slot (title/count/sub),
 /// an `actions` slot grouped with the close button (e.g. the bookmarks
@@ -26,7 +40,7 @@ pub(super) fn ReaderDrawerShell(
         format!("rd-drawer {extra_class}")
     };
     rsx! {
-        div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
+        ReaderScrim { onclick: move |_| on_close.call(()) }
         div { class: "{drawer_class}", "data-testid": "{testid}",
             div { class: "rd-grabber" }
             div { class: "rd-drawer-head",

--- a/frontend/src/pages/reader/note_composer.rs
+++ b/frontend/src/pages/reader/note_composer.rs
@@ -5,6 +5,8 @@
 use dioxus::prelude::*;
 use omnibus_shared::Highlight;
 
+use super::drawer_shell::ReaderScrim;
+
 #[component]
 pub(super) fn NoteComposer(
     highlight: Highlight,
@@ -36,7 +38,7 @@ pub(super) fn NoteComposer(
     };
 
     rsx! {
-        div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
+        ReaderScrim { onclick: move |_| on_close.call(()) }
         div { class: "rd-note-composer", "data-testid": "reader-note-composer",
             onclick: move |e: MouseEvent| e.stop_propagation(),
             div { class: "rd-note-quote", "\u{201c}{quote}\u{201d}" }

--- a/frontend/src/pages/reader/quote_panel.rs
+++ b/frontend/src/pages/reader/quote_panel.rs
@@ -7,6 +7,8 @@ use dioxus::prelude::*;
 
 use crate::components::QuoteCardPanel;
 
+use super::drawer_shell::ReaderScrim;
+
 #[component]
 pub(super) fn QuotePanel(
     quote_text: String,
@@ -16,7 +18,7 @@ pub(super) fn QuotePanel(
     on_close: EventHandler<()>,
 ) -> Element {
     rsx! {
-        div { class: "rd-scrim", onclick: move |_| on_close.call(()) }
+        ReaderScrim { onclick: move |_| on_close.call(()) }
         div { class: "rd-drawer rd-quote-drawer", "data-testid": "reader-quote-drawer",
             div { class: "rd-grabber" }
             QuoteCardPanel {


### PR DESCRIPTION
## Summary
- Closes #1723
- Extracted a standalone `ReaderScrim` component (`frontend/src/pages/reader/drawer_shell.rs`) for the `rd-scrim` backdrop div, and switched `note_composer.rs`, `quote_panel.rs`, and `aa_panel.rs` — which hand-rolled that same div instead of reusing the `ReaderDrawerShell` chrome from #854 — to use it. `ReaderDrawerShell` itself now also builds on `ReaderScrim`.
- Stabilized the author-index card avatar in `authors_index.rs`: a single outer `div.idx-card-avatar` now always renders, swapping only its `img`/initial-text child on `has_photo` instead of swapping the element type (`img` vs `div`), matching the `components/user_avatar.rs` pattern (rule 07 — hydration parity). Updated `.idx-card-avatar`/`.idx-card-avatar--photo` in `frontend/assets/atrium.css` so the photo variant fills and clips to the parent's circle with unchanged visual output.
- Pure refactor — no behavior or visual change; no testids/roles/text touched, so existing Playwright specs are unaffected in intent.

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1723 cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1723 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (no warnings)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1723 cargo test -p omnibus-frontend --features server` — PASS (688 passed; 0 failed)
- [ ] Playwright not run in this cloud environment (no browser/server available); verified by grep that no spec under `ui_tests/playwright/tests/flows/` asserts `idx-card-avatar`, `authors_index`, or the reader-panel scrim markup directly, and no testids/roles/text changed.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- Scope matches the issue exactly: `note_composer.rs`, `quote_panel.rs`, `aa_panel.rs` for the scrim dedupe; `authors_index.rs::render_author_card` for the avatar stabilization. `author.rs`'s `disc-avatar` has the same img/div swap pattern but is out of scope for #1723 (not mentioned in the issue) — left untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfF2UFeusJ8bmAiKc6kxge)_