### PR TITLE
refactor: split hidden-formats functions under the 80-line cap, add rsx key

### DIFF
--- a/frontend/src/pages/account/hidden_formats.rs
+++ b/frontend/src/pages/account/hidden_formats.rs
@@ -109,7 +109,7 @@ fn format_toggle(fmt: &str, checked: bool, mut selected: Signal<BTreeSet<String>
     let fmt = fmt.to_string();
     let toggle_fmt = fmt.clone();
     rsx! {
-        label { class: "hidden-format-row", r#for: "hidden-format-{fmt}",
+        label { key: "{fmt}", class: "hidden-format-row", r#for: "hidden-format-{fmt}",
             input {
                 r#type: "checkbox",
                 id: "hidden-format-{fmt}",

--- a/frontend/src/rpc/books.rs
+++ b/frontend/src/rpc/books.rs
@@ -141,31 +141,7 @@ async fn ebooks_page(
     .map_err(|e| internal_rpc_error("list books page", e))?;
 
     let (total, facets, hidden_count) = if decoded.is_none() {
-        // The header count is library-wide (facet filters don't shrink it),
-        // so the receipt beside it shares that basis: both diff counts use
-        // default filters and differ only in the exclusion. With no
-        // exclusion this stays the single `count_books_for_paths` query.
-        let all = db::count_books_for_paths(pool, &paths)
-            .await
-            .map_err(|e| internal_rpc_error("count books", e))?;
-        let (total, hidden) = if exclude_formats.is_empty() {
-            (all, None)
-        } else {
-            let visible =
-                db::count_books_page(pool, &paths, &ViewFilters::default(), exclude_formats)
-                    .await
-                    .map_err(|e| internal_rpc_error("count visible books", e))?;
-            (visible, Some(all - visible))
-        };
-        (
-            Some(total),
-            Some(
-                db::library_facets(pool, &paths)
-                    .await
-                    .map_err(|e| internal_rpc_error("library facets", e))?,
-            ),
-            hidden,
-        )
+        first_page_aggregates(pool, &paths, exclude_formats).await?
     } else {
         (None, None, None)
     };
@@ -178,6 +154,43 @@ async fn ebooks_page(
         facets,
         hidden_count,
     })
+}
+
+/// `(total, facets, hidden_count)` — the shape `ebooks_page` folds straight
+/// into `LibraryPage`.
+#[cfg(feature = "server")]
+type FirstPageAggregates = (
+    Option<i64>,
+    Option<omnibus_shared::FacetCounts>,
+    Option<i64>,
+);
+
+/// First-page-only aggregates: the library-wide total (and, when an
+/// exclusion is active, the hidden-count receipt beside it) plus the sidebar
+/// facets. Both diff counts use default filters and differ only in the
+/// exclusion, so with no exclusion this stays the single
+/// `count_books_for_paths` query.
+#[cfg(feature = "server")]
+async fn first_page_aggregates(
+    pool: &sqlx::SqlitePool,
+    paths: &[&str],
+    exclude_formats: &[String],
+) -> Result<FirstPageAggregates, ServerFnError> {
+    let all = db::count_books_for_paths(pool, paths)
+        .await
+        .map_err(|e| internal_rpc_error("count books", e))?;
+    let (total, hidden) = if exclude_formats.is_empty() {
+        (all, None)
+    } else {
+        let visible = db::count_books_page(pool, paths, &ViewFilters::default(), exclude_formats)
+            .await
+            .map_err(|e| internal_rpc_error("count visible books", e))?;
+        (visible, Some(all - visible))
+    };
+    let facets = db::library_facets(pool, paths)
+        .await
+        .map_err(|e| internal_rpc_error("library facets", e))?;
+    Ok((Some(total), Some(facets), hidden))
 }
 
 /// POST (not GET) for the same reason as `rpc_search`: Dioxus `#[get]`

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -112,6 +112,90 @@ async fn respond_full_library(
     }
 }
 
+/// Client-input error for a malformed or under-specified keyset-page
+/// request. Kept lean rather than a full `Response` — clippy's
+/// `result_large_err` — with the caller rendering the actual 400 (mirrors
+/// `parse_thumb_size` in `covers.rs`).
+enum CursorRequestError {
+    RequiresSortAndDir,
+    Malformed,
+}
+
+impl CursorRequestError {
+    fn into_response(self) -> Response {
+        let msg = match self {
+            CursorRequestError::RequiresSortAndDir => "cursor requires sort and dir",
+            CursorRequestError::Malformed => "malformed cursor",
+        };
+        (axum::http::StatusCode::BAD_REQUEST, msg).into_response()
+    }
+}
+
+/// Decode `q.cursor` relative to `q.sort`/`q.dir`. A cursor without an
+/// explicit `sort` **and** `dir`, or a malformed cursor, is a 400 rather than
+/// a silently mis-positioned page or a 500 — returned as `Err` for the caller
+/// to short-circuit on.
+fn decode_page_cursor(q: &EbooksQuery) -> Result<Option<db::PageCursor>, CursorRequestError> {
+    if q.cursor.is_some() && (q.sort.is_none() || q.dir.is_none()) {
+        return Err(CursorRequestError::RequiresSortAndDir);
+    }
+    match q.cursor.as_deref() {
+        Some(c) => db::PageCursor::decode(c)
+            .map(Some)
+            .map_err(|_| CursorRequestError::Malformed),
+        None => Ok(None),
+    }
+}
+
+/// The filtered total for the page's paths/filters/exclusion, plus — first
+/// page only — the hidden-count receipt: the diff between that total and the
+/// same query with the exclusion lifted. Later pages inherit the client's
+/// cached value, so `hidden` stays `None` once `cursor` is set.
+async fn page_totals(
+    state: &AppState,
+    paths: &[&str],
+    filters: &ViewFilters,
+    exclude: &[String],
+    cursor_is_none: bool,
+) -> Result<(i64, Option<i64>), db::BooksError> {
+    let total = db::count_books_page(&state.pool, paths, filters, exclude).await?;
+    let hidden = if !exclude.is_empty() && cursor_is_none {
+        let all = db::count_books_page(&state.pool, paths, filters, &[]).await?;
+        Some(all - total)
+    } else {
+        None
+    };
+    Ok((total, hidden))
+}
+
+/// Assemble the `X-Total-Count` / `X-Hidden-Count` / `X-Next-Cursor` response
+/// headers onto a JSON body. Unlike the full-library path, a keyset page is
+/// *not* truncated to `MAX_BOOKS_RETURNED` overall (the limit is a per-page
+/// clamp), so this emits the true `X-Total-Count` but never `X-Total-Cap` —
+/// the page is complete.
+fn keyset_page_response(
+    library: EbookLibrary,
+    total: i64,
+    hidden: Option<i64>,
+    next: Option<db::PageCursor>,
+) -> Response {
+    let mut resp = Json(library).into_response();
+    if let Ok(v) = axum::http::HeaderValue::from_str(&total.to_string()) {
+        resp.headers_mut().insert("X-Total-Count", v);
+    }
+    if let Some(h) = hidden {
+        if let Ok(v) = axum::http::HeaderValue::from_str(&h.to_string()) {
+            resp.headers_mut().insert("X-Hidden-Count", v);
+        }
+    }
+    if let Some(next) = next {
+        if let Ok(v) = axum::http::HeaderValue::from_str(&next.encode()) {
+            resp.headers_mut().insert("X-Next-Cursor", v);
+        }
+    }
+    resp
+}
+
 /// Keyset-paginated page for an explicit `sort`/`dir`/`cursor`/`limit`. A
 /// cursor is decoded relative to the request's sort axis, so a cursor without
 /// an explicit `sort` **and** `dir`, or a malformed cursor, is a 400 rather
@@ -122,21 +206,9 @@ async fn respond_keyset_page(
     ebook: Option<&str>,
     audiobook: Option<&str>,
 ) -> Response {
-    if q.cursor.is_some() && (q.sort.is_none() || q.dir.is_none()) {
-        return (
-            axum::http::StatusCode::BAD_REQUEST,
-            "cursor requires sort and dir",
-        )
-            .into_response();
-    }
-    let cursor = match q.cursor.as_deref() {
-        Some(c) => match db::PageCursor::decode(c) {
-            Ok(p) => Some(p),
-            Err(_) => {
-                return (axum::http::StatusCode::BAD_REQUEST, "malformed cursor").into_response()
-            }
-        },
-        None => None,
+    let cursor = match decode_page_cursor(q) {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
     };
     let path = ebook.or(audiobook).map(str::to_string);
     let paths = db::collect_paths(ebook, audiobook);
@@ -170,20 +242,11 @@ async fn respond_keyset_page(
     // Filtered total, so the client's "Show N books" reflects the active
     // chips (and the exclusion — it counts what pagination will actually
     // yield); identical to the unfiltered count when neither is set.
-    let total = match db::count_books_page(&state.pool, &paths, &filters, &exclude).await {
-        Ok(t) => t,
-        Err(error) => return internal("count books", error),
-    };
-    // The receipt: same filters on both sides of the diff, exclusion only.
-    // First page only — later pages inherit the client's cached value.
-    let hidden = if !exclude.is_empty() && cursor.is_none() {
-        match db::count_books_page(&state.pool, &paths, &filters, &[]).await {
-            Ok(all) => Some(all - total),
+    let (total, hidden) =
+        match page_totals(state, &paths, &filters, &exclude, cursor.is_none()).await {
+            Ok(t) => t,
             Err(error) => return internal("count books", error),
-        }
-    } else {
-        None
-    };
+        };
 
     let library = EbookLibrary {
         path,
@@ -191,24 +254,7 @@ async fn respond_keyset_page(
         error: None,
         total: None,
     };
-    // Unlike the full-library path, a keyset page is *not* truncated to
-    // `MAX_BOOKS_RETURNED` overall (the limit is a per-page clamp), so emit the
-    // true `X-Total-Count` but never `X-Total-Cap` — the page is complete.
-    let mut resp = Json(library).into_response();
-    if let Ok(v) = axum::http::HeaderValue::from_str(&total.to_string()) {
-        resp.headers_mut().insert("X-Total-Count", v);
-    }
-    if let Some(h) = hidden {
-        if let Ok(v) = axum::http::HeaderValue::from_str(&h.to_string()) {
-            resp.headers_mut().insert("X-Hidden-Count", v);
-        }
-    }
-    if let Some(next) = page.next {
-        if let Ok(v) = axum::http::HeaderValue::from_str(&next.encode()) {
-            resp.headers_mut().insert("X-Next-Cursor", v);
-        }
-    }
-    resp
+    keyset_page_response(library, total, hidden, page.next)
 }
 
 pub(super) async fn get_ebook_by_uuid(


### PR DESCRIPTION
## Summary
- Closes #1738
- `server/src/backend/ebooks.rs::respond_keyset_page` was ~94 lines, over the ~80-line soft cap in `.claude/rules/05-rust-style.md`. Split its staged sub-steps into named helpers: `decode_page_cursor` (cursor decode + 400s, returning a lean `CursorRequestError` rather than a full `Response` per clippy's `result_large_err`), `page_totals` (filtered total + hidden-count diff), and `keyset_page_response` (X-Total-Count/X-Hidden-Count/X-Next-Cursor header assembly). `respond_keyset_page` is now ~45 lines.
- `frontend/src/rpc/books.rs::ebooks_page` was ~83 lines. Extracted the first-page-only `total`/`facets`/`hidden_count` aggregate block into `first_page_aggregates`. `ebooks_page` is now ~48 lines.
- `frontend/src/pages/account/hidden_formats.rs` — added the missing Dioxus `key` (`key: "{fmt}"`, matching the convention in `author.rs`'s `author_book_tile`) to the `format_toggle` row returned by both `for fmt in ...` loops in `HiddenFormatsCard`.
- Pure mechanical extraction — no behavior change. Public function signatures (`respond_keyset_page`, `ebooks_page`) are unchanged.

## Test plan
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus backend::ebooks` — 62 passed, 0 failed (all `respond_keyset_page`-covering tests, including cursor/pagination/exclude-formats cases)
- [x] `cargo test -p omnibus-frontend --features server` — 688 passed, 0 failed (all `ebooks_page_*` tests pass)
- Note: a full `cargo test -p omnibus` run also shows 2 pre-existing failures in `backend::uploads::tests::*_rejects_read_only_library_with_400` — unrelated to this change (that file isn't touched here); they fail in this sandbox because the container runs as root, which bypasses the `chmod 0o555` those tests use to simulate a read-only filesystem.

## Version
- [ ] **Minor**
- [ ] **Patch**
- [ ] **No release**

(left unlabeled per instructions not to add release labels; pure internal refactor, no behavior change)

## Notes
- None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfF2UFeusJ8bmAiKc6kxge)_