### PR TITLE
feat: pre-generate thumbnails during library scan (#1752)

### DIFF
--- a/db/src/indexer/backfill.rs
+++ b/db/src/indexer/backfill.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use sqlx::SqlitePool;
 
-use crate::{audiobook, ebook, sync};
+use crate::{audiobook, covers, ebook, sync, thumbs};
 
 /// Query the first-part filename (ordinal=0) and format for every book
 /// under `library_path` that needs chapter backfill (no `file_chapters`
@@ -333,4 +333,124 @@ async fn fetch_page_count_candidates(
     .fetch_all(pool)
     .await?;
     Ok(ids)
+}
+
+/// Pre-generate all three WebP thumbnail sizes for every book under
+/// `library_path` that has a cover (#1752), so the landing grid's first
+/// post-scan load serves cached thumbnails instead of falling through the
+/// lazy generation path in `server::backend::covers::thumb_cache_miss_response`.
+///
+/// Posted as a separate worker task after each ebook library scan (mirroring
+/// [`backfill_word_counts`]). Cheap when caught up: a book whose three sizes
+/// are already fresh per [`thumbs::is_stale`] is skipped without touching its
+/// cover bytes, so a re-scan of an unchanged library does no re-encoding —
+/// exactly what [`thumbs::ensure_thumbnails_sync`] does for a single book.
+///
+/// Processes one book at a time (decode + encode is CPU-bound and runs on
+/// the blocking pool via `spawn_blocking`) rather than fanning out, so a
+/// full-library warm-up can't starve an interactive `/api/thumbs` request
+/// for CPU. A per-book failure (missing cover, decode error, I/O) is logged
+/// and skipped rather than aborting the batch — the next scan or an
+/// interactive view retries it via the lazy path. `on_progress(processed,
+/// total)` is called per book for the UI, mirroring the sibling backfills.
+pub(crate) async fn backfill_thumbs(
+    pool: &SqlitePool,
+    library_path: &str,
+    mut on_progress: impl FnMut(u32, u32),
+) -> anyhow::Result<()> {
+    let candidates = fetch_thumb_candidates(pool, library_path).await?;
+    if candidates.is_empty() {
+        return Ok(());
+    }
+
+    let total = u32::try_from(candidates.len()).unwrap_or(u32::MAX);
+    tracing::info!(
+        count = total,
+        "pre-generating thumbnails for existing covers"
+    );
+
+    let mut processed = 0u32;
+    for (book_id, last_modified_epoch) in candidates {
+        processed = processed.saturating_add(1);
+        on_progress(processed, total);
+
+        let all_fresh = thumbs::ThumbSize::all()
+            .into_iter()
+            .all(|size| !thumbs::is_stale(book_id, size, last_modified_epoch));
+        if all_fresh {
+            continue;
+        }
+
+        let cover = match covers::get_cover(pool, book_id).await {
+            Ok(Some((_mime, bytes))) => bytes,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::warn!(
+                    book_id,
+                    error = %e,
+                    "thumbnail backfill: cover fetch failed; skipping"
+                );
+                continue;
+            }
+        };
+
+        match tokio::task::spawn_blocking(move || {
+            thumbs::ensure_thumbnails_sync(book_id, last_modified_epoch, cover)
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    book_id,
+                    error = %e,
+                    "thumbnail backfill: generation failed; skipping"
+                );
+            }
+            Err(join_err) => {
+                tracing::warn!(
+                    book_id,
+                    %join_err,
+                    is_panic = join_err.is_panic(),
+                    "thumbnail backfill: generation task failed; skipping"
+                );
+            }
+        }
+    }
+
+    let cap = thumbs::cap_bytes();
+    match tokio::task::spawn_blocking(move || thumbs::evict_if_over_cap(cap)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!(error = %e, "thumbnail backfill: eviction failed"),
+        Err(join_err) => tracing::warn!(
+            %join_err,
+            is_panic = join_err.is_panic(),
+            "thumbnail backfill: eviction task failed"
+        ),
+    }
+
+    Ok(())
+}
+
+/// `(books.id, last_modified_epoch)` for every book under `library_path`
+/// that has a cover — the [`backfill_thumbs`] work set. Scoped to the
+/// scanned library so the follow-up task's cost tracks that scan.
+/// Cover-override-only books (`has_cover = 0` with an uploaded override)
+/// aren't included; they're left to the lazy `thumb_cache_miss_response`
+/// path, same as before this backfill existed.
+async fn fetch_thumb_candidates(
+    pool: &SqlitePool,
+    library_path: &str,
+) -> anyhow::Result<Vec<(i64, i64)>> {
+    let rows: Vec<(i64, i64)> = sqlx::query_as(
+        "SELECT b.id, CAST(COALESCE(b.last_modified, strftime('%s','now')) AS INTEGER) \
+         FROM books b \
+         JOIN scan_roots l ON b.library_id = l.id \
+         WHERE l.path = ? AND b.has_cover = 1 \
+         ORDER BY b.id",
+    )
+    .bind(library_path)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
 }

--- a/db/src/indexer/backfill.rs
+++ b/db/src/indexer/backfill.rs
@@ -342,7 +342,7 @@ async fn fetch_page_count_candidates(
 ///
 /// Posted as a separate worker task after each ebook library scan (mirroring
 /// [`backfill_word_counts`]). Cheap when caught up: a book whose three sizes
-/// are already fresh per [`thumbs::is_stale`] is skipped without touching its
+/// are already fresh per [`thumbs::is_stale_async`] is skipped without touching its
 /// cover bytes, so a re-scan of an unchanged library does no re-encoding —
 /// exactly what [`thumbs::ensure_thumbnails_sync`] does for a single book.
 ///
@@ -374,9 +374,13 @@ pub(crate) async fn backfill_thumbs(
         processed = processed.saturating_add(1);
         on_progress(processed, total);
 
-        let all_fresh = thumbs::ThumbSize::all()
-            .into_iter()
-            .all(|size| !thumbs::is_stale(book_id, size, last_modified_epoch));
+        let mut all_fresh = true;
+        for size in thumbs::ThumbSize::all() {
+            if thumbs::is_stale_async(book_id, size, last_modified_epoch).await {
+                all_fresh = false;
+                break;
+            }
+        }
         if all_fresh {
             continue;
         }

--- a/db/src/indexer/mod.rs
+++ b/db/src/indexer/mod.rs
@@ -14,7 +14,9 @@ mod audiobooks;
 mod backfill;
 
 pub use audiobooks::{reindex_audiobooks, reindex_audiobooks_with_progress};
-pub(crate) use backfill::{backfill_chapters, backfill_page_counts, backfill_word_counts};
+pub(crate) use backfill::{
+    backfill_chapters, backfill_page_counts, backfill_thumbs, backfill_word_counts,
+};
 
 /// Errors returned by the pure-DB indexer reads (`is_stale`). The
 /// transparent `Db` variant honors the `02-error-handling` boundary rule

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -123,6 +123,13 @@ impl Worker {
                 )
                 .await,
             ),
+            Task::BackfillThumbs { library_path } => anyhow_outcome(
+                "thumbnail backfill",
+                crate::indexer::backfill_thumbs(&self.pool, &library_path, |processed, total| {
+                    self.report_progress(id, processed, Some(total));
+                })
+                .await,
+            ),
             Task::RebuildFtsIndex => anyhow_outcome(
                 "FTS rebuild",
                 crate::sync::rebuild_all_fts(&self.pool).await,
@@ -180,10 +187,10 @@ impl Worker {
     }
 
     /// Reindex an ebook library, then (on success) post the follow-up
-    /// word-count and page-count backfill tasks for any pre-0049 / pre-0063
-    /// rows this library still carries. Both share the scan's resource key,
-    /// so each waits for this task to fully finish; the posts themselves
-    /// are instant. Mirrors the audiobook chapter backfill.
+    /// word-count, page-count, and thumbnail-warm-up (#1752) backfill tasks
+    /// for any rows this library still needs them for. All three share the
+    /// scan's resource key, so each waits for this task to fully finish; the
+    /// posts themselves are instant. Mirrors the audiobook chapter backfill.
     async fn handle_scan(self: &Arc<Self>, library_path: String, id: TaskId) -> TaskOutcome {
         match crate::indexer::reindex_with_progress(
             &self.pool,
@@ -199,7 +206,10 @@ impl Worker {
                 self.post(Task::BackfillWordCounts {
                     library_path: library_path.clone(),
                 });
-                self.post(Task::BackfillPageCounts { library_path });
+                self.post(Task::BackfillPageCounts {
+                    library_path: library_path.clone(),
+                });
+                self.post(Task::BackfillThumbs { library_path });
                 TaskOutcome::Ok(warning.map(TaskSuccessDetail::GhostFiles))
             }
             Err(e) => sanitized_err("library scan", e),

--- a/db/src/worker/tests.rs
+++ b/db/src/worker/tests.rs
@@ -1206,3 +1206,111 @@ async fn metrics_keeps_separate_buckets_per_task_kind() {
         "GenerateThumbs task should record under its own TaskKind"
     );
 }
+
+// ---------- #1752: pre-generate thumbnails during library scan ----------
+
+/// A successful `Task::Scan` posts a follow-up `Task::BackfillThumbs`
+/// (mirroring `Task::BackfillWordCounts` / `Task::BackfillPageCounts`), so by
+/// the time the scan and its follow-ups have drained, every covered book's
+/// three thumbnail sizes already exist on disk without anyone having loaded
+/// a page — AC1, and the precondition for AC2 (the landing grid's first
+/// post-scan load hits the cache instead of `thumb_cache_miss_response`'s
+/// lazy path).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn task_scan_posts_backfill_thumbs_that_pregenerates_all_sizes_for_a_covered_book() {
+    let thumbs_dir = tempfile::tempdir().unwrap();
+    let covers_dir = tempfile::tempdir().unwrap();
+    let _env = EnvVarGuard::set_os("OMNIBUS_THUMBS_DIR", Some(thumbs_dir.path().as_os_str()))
+        .also_set_os("OMNIBUS_COVERS_DIR", Some(covers_dir.path().as_os_str()));
+
+    let lib = tempfile::tempdir().unwrap();
+    copy_fixture_into("alpha.epub", lib.path());
+    let library_path = lib.path().to_str().unwrap().to_string();
+
+    let w = make_worker_default(pool().await);
+    w.post(Task::Scan {
+        library_path: library_path.clone(),
+    });
+
+    assert!(
+        poll_maps_empty(&w).await,
+        "scan and its follow-up backfills did not drain in time"
+    );
+
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE has_cover = 1")
+        .fetch_one(&w.pool)
+        .await
+        .expect("alpha.epub has an embedded cover, so the scan sets has_cover = 1");
+
+    for size in crate::thumbs::ThumbSize::all() {
+        let path = crate::thumbs::thumb_path_for(book_id, size);
+        assert!(
+            path.exists(),
+            "expected a pre-generated {size} thumbnail at {path:?}"
+        );
+    }
+}
+
+/// [`crate::indexer::backfill_thumbs`] (via `Task::BackfillThumbs`) skips a
+/// book whose three thumbnail sizes are already fresher than its
+/// `last_modified` — the already-caught-up case a re-scan of an unchanged
+/// library hits on every book (AC3). Seeds fresh sentinel thumbnail bytes
+/// that a real encode would never produce, so any re-encoding shows up as a
+/// changed file rather than relying on mtime granularity.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn task_backfill_thumbs_skips_a_book_whose_thumbnails_are_already_fresh() {
+    let thumbs_dir = tempfile::tempdir().unwrap();
+    let covers_dir = tempfile::tempdir().unwrap();
+    let _env = EnvVarGuard::set_os("OMNIBUS_THUMBS_DIR", Some(thumbs_dir.path().as_os_str()))
+        .also_set_os("OMNIBUS_COVERS_DIR", Some(covers_dir.path().as_os_str()));
+
+    let pool = pool().await;
+    let library_path = "/lib-fresh-thumbs".to_string();
+    let lib_id: i64 = sqlx::query_scalar(
+        "INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib') RETURNING id",
+    )
+    .bind(&library_path)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    // `last_modified` far in the past so any thumbnail written just now is
+    // unambiguously fresher than it, regardless of clock resolution.
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, sort, has_cover, last_modified) \
+         VALUES ('uuid-fresh', 'fresh.epub', ?, '', 'Fresh', 'Fresh', 1, 1) RETURNING id",
+    )
+    .bind(lib_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    // A real cover file must exist so a would-be re-encode has bytes to work
+    // from — the skip is the assertion under test, not a missing-cover no-op.
+    std::fs::write(
+        crate::covers_dir().join("uuid-fresh.png"),
+        crate::ebook::test_support::solid_color_png(200, 40, 40, 8, 8),
+    )
+    .unwrap();
+
+    // Sentinel bytes no real WebP encode would produce, at each of the three
+    // paths `backfill_thumbs` would touch if it decided to re-encode.
+    let sentinel = b"not-a-real-webp-sentinel".to_vec();
+    for size in crate::thumbs::ThumbSize::all() {
+        std::fs::write(crate::thumbs::thumb_path_for(book_id, size), &sentinel).unwrap();
+    }
+
+    let w = make_worker_default(pool);
+    let id = w.post(Task::BackfillThumbs { library_path });
+    match w.await_completion(id).await {
+        TaskOutcome::Ok(None) => {}
+        other => panic!("expected Ok(None), got {other:?}"),
+    }
+
+    for size in crate::thumbs::ThumbSize::all() {
+        let on_disk = std::fs::read(crate::thumbs::thumb_path_for(book_id, size)).unwrap();
+        assert_eq!(
+            on_disk, sentinel,
+            "already-fresh thumbnail for size {size} was re-encoded"
+        );
+    }
+}

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -93,6 +93,18 @@ pub enum Task {
     /// scan on the same library); does not consume the scan semaphore
     /// (light per-file IO, mirrors [`Task::BackfillWordCounts`]).
     BackfillPageCounts { library_path: String },
+    /// Pre-generate WebP thumbnails (all three sizes) for every covered book
+    /// under `library_path` (#1752). Posted by the [`Task::Scan`] handler on
+    /// success, alongside [`Task::BackfillWordCounts`] /
+    /// [`Task::BackfillPageCounts`], so the landing grid's first post-scan
+    /// load serves cached thumbnails instead of falling through the lazy
+    /// generation path in `server::backend::covers::thumb_cache_miss_response`.
+    /// Keyed on `library_path` (mutual exclusion with the scan on the same
+    /// library, and with the other scan-follow-up backfills); does not
+    /// consume the scan semaphore. Skips any book whose three sizes are
+    /// already fresh, so a re-scan of an unchanged library does no
+    /// re-encoding.
+    BackfillThumbs { library_path: String },
     /// Rebuild the entire `books_fts` search index from `books` via
     /// `crate::sync::rebuild_all_fts`. Admin-triggered repair for any drift
     /// left by a failed post-commit FTS refresh. Keyed on a fixed resource
@@ -156,6 +168,7 @@ impl Task {
             Task::BackfillChapters { library_path } => Some(format!("audiobooks:{library_path}")),
             Task::BackfillWordCounts { library_path } => Some(library_path.clone()),
             Task::BackfillPageCounts { library_path } => Some(library_path.clone()),
+            Task::BackfillThumbs { library_path } => Some(library_path.clone()),
             Task::RebuildFtsIndex => Some("rebuild-fts".into()),
             Task::ResolveSuggestions { book_uuid } => Some(format!("suggestions:{book_uuid}")),
             Task::KepubConvert { book_id } => Some(format!("kepub:{book_id}")),
@@ -177,6 +190,7 @@ impl Task {
             Task::BackfillChapters { .. } => false,
             Task::BackfillWordCounts { .. } => false,
             Task::BackfillPageCounts { .. } => false,
+            Task::BackfillThumbs { .. } => false,
             Task::RebuildFtsIndex => false,
             Task::ResolveSuggestions { .. } => false,
             Task::KepubConvert { .. } => false,
@@ -212,6 +226,11 @@ impl Task {
             Task::BackfillWordCounts { .. } => TaskKind::Scan,
             // Same reuse as BackfillWordCounts, its sibling scan-follow-up.
             Task::BackfillPageCounts { .. } => TaskKind::Scan,
+            // Reuse the per-book GenerateThumbs kind rather than Scan: unlike
+            // its sibling backfills, this one has an existing, sensible
+            // "Generating thumbnail" / "Thumbnail generation" label already
+            // wired in `frontend::components::worker_status` (AC4).
+            Task::BackfillThumbs { .. } => TaskKind::GenerateThumbs,
             // Reuse Scan kind for UI display until a dedicated HLS progress
             // widget is added.
             Task::HlsTranscode { .. } => TaskKind::Scan,


### PR DESCRIPTION
## Summary
- Closes #1752
- Adds `Task::BackfillThumbs { library_path }`, keyed on `library_path` (mutual exclusion with the scan on that library, no scan semaphore), matching the existing `BackfillWordCounts`/`BackfillPageCounts` follow-up backfills.
- `handle_scan` posts it on success, alongside the word-count and page-count backfills, so every covered book gets all three WebP thumbnail sizes pre-generated before anyone loads the grid.
- `backfill_thumbs` (`db/src/indexer/backfill.rs`) skips any book whose three sizes are already fresh per `thumbs::is_stale` — a re-scan of an unchanged library does no re-encoding — and processes one book at a time (decode/encode on the blocking pool via `spawn_blocking`) so the warm-up can't starve an interactive `/api/thumbs` request for CPU.
- Reuses the existing `TaskKind::GenerateThumbs` wire kind so the worker-status UI shows the already-wired "Generating thumbnail" / "Thumbnail generation" label with a progress bar.
- The lazy `thumb_cache_miss_response` path in `server/src/backend/covers.rs` is untouched — it remains the backstop for books indexed outside a scan, evicted thumbs, and cover overrides.
- Settings-page manual trigger was left out (issue marks it optional/nice-to-have).

## Test plan
- `cargo fmt` (targeted at `omnibus-db`) — PASS, no changes
- `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- `cargo test -p omnibus-db` — PASS (1838 passed; 1 pre-existing failure unrelated to this change, an audiobook-cover test gated on public-domain fixtures that require `just fixtures`, which this sandboxed environment can't run)
- New tests added in `db/src/worker/tests.rs`:
  - `task_scan_posts_backfill_thumbs_that_pregenerates_all_sizes_for_a_covered_book` — runs a real `Task::Scan` against a fixture EPUB with an embedded cover and asserts all three thumbnail sizes land on disk once the scan and its follow-ups drain (AC1/AC2/AC4).
  - `task_backfill_thumbs_skips_a_book_whose_thumbnails_are_already_fresh` — seeds sentinel thumbnail bytes newer than the book's `last_modified` and asserts `Task::BackfillThumbs` leaves them untouched (AC3).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F1UxwJK1NrSX355XGktXEv)_