### PR TITLE
test: add Kobo sync HTTP contract test + smoke checklist

### DIFF
--- a/docs/kobo-smoke-test.md
+++ b/docs/kobo-smoke-test.md
@@ -1,0 +1,102 @@
+# Kobo wireless sync — real-device smoke test
+
+The HTTP-layer contract tests in
+[`server/src/backend/kobo/tests.rs`](../server/src/backend/kobo/tests.rs) pin
+this server's side of the wireless protocol against a **synthetic** golden
+fixture — no physical Kobo capture is available in this repo's dev/CI
+environment (see that file's `full_device_sequence_replays_initialization_through_state_put`
+for the fixture and its documentation). They cannot prove the device's own
+firmware parses what Omnibus sends, accepts the shapes Omnibus expects, or
+that Omnibus's read of a real device's traffic matches what the device
+actually transmits.
+
+This checklist is the **manual gate** between "the contract tests pass" and
+"safe to tell a user to point their Kobo's `api_endpoint` at this server" (see
+[docs/kobo.md § About wireless sync](kobo.md#about-wireless-sync-experimental)).
+Run it against a real Kobo — not an emulator — before:
+
+- Advertising wireless sync as non-experimental in the UI or docs.
+- Merging a change that touches `server/src/backend/kobo/`, `db/src/kobo*`,
+  or `db/src/kobo_position*`.
+- Cutting a release whose notes mention Kobo sync.
+
+> [!WARNING]
+> Back up the device first. `.kobo/KoboReader.sqlite` over USB, or one of the
+> tools listed in [docs/kobo.md](kobo.md#about-wireless-sync-experimental). A
+> bad sync can wipe on-device highlights, notes, and progress.
+
+## Setup
+
+1. A test Kobo (any model with wireless sync — firmware version matters less
+   than device family; note the exact firmware version in the result).
+2. An Omnibus instance reachable from the device's Wi-Fi network (LAN IP or
+   tunnel — not `localhost`).
+3. A test user account with a shelf containing 2–3 books: at least one EPUB
+   and, if available, one CBZ-only comic.
+4. `Account → Kobo wireless sync → Add a Kobo`, then point the device's
+   `api_endpoint` at the printed URL per
+   [docs/kobo.md § Setting up wireless sync](kobo.md#setting-up-wireless-sync).
+
+## Checklist
+
+Check off each item; note the firmware version and device model at the top of
+the result, and file a GitHub issue for anything that fails (tag it
+`kobo-sync`) rather than silently working around it.
+
+- [ ] **Handshake.** `Sync now` on the device completes without an error
+      dialog or an endless spinner. (Exercises `initialization` +
+      `auth/device`.)
+- [ ] **Library sync — first pull.** Every opted-in book appears in the
+      device's library list with the right title and author.
+- [ ] **Download.** Each book opens and renders; page turns work. For an
+      EPUB, confirm it downloaded as a `.kepub.epub` (Kobo's book-info screen
+      shows this) — if it silently fell back to plain EPUB, check
+      `OMNIBUS_KEPUBIFY_PATH` server-side, not the device.
+- [ ] **Read-status push (device → server).** Open a book, read a page or
+      two, back out. In Omnibus's web UI, confirm the book's read status
+      moved to "Reading" and the Continue-reading rail shows it.
+- [ ] **Position push (device → server).** Read further, note the on-device
+      percent, then check the position shown in the Omnibus web reader for
+      the same book roughly matches (exact percent parity isn't
+      guaranteed — chapter-relative vs whole-book percent is one of the
+      open questions `kobo/dto.rs` documents).
+- [ ] **Position pull (server → device).** In the Omnibus web reader, jump to
+      a new position in a book the device already has. Trigger a device
+      sync. Reopen the book on the device — it should resume near the new
+      web position (this is the CFI→KoboSpan derivation path).
+- [ ] **Finished status round-trip.** Mark a book "Finished" on the device
+      (or read to the last page). After a sync, Omnibus's web UI shows it
+      finished; conversely, marking Finished in the web UI and syncing
+      should update the device's status.
+- [ ] **Web-created highlight reaches the device.** Highlight a passage in
+      the Omnibus web reader for a book the device has downloaded. Sync the
+      device, open the book, confirm the highlight appears **at the right
+      location**.
+- [ ] **Highlight colour.** Create highlights in more than one colour from
+      the web reader, sync, and check each lands on the device in the
+      *matching* colour — not all defaulting to yellow. This is the specific
+      regression `docs/kobo.md`'s "Highlight colour on-wire shape" note
+      describes as still unconfirmed; a capture from this step (device
+      firmware version + which colours landed correctly) is exactly what
+      that note asks for.
+- [ ] **Device-created highlight reaches the web reader.** Highlight a
+      passage on the device, sync, and confirm it appears in the Omnibus web
+      reader at the right location.
+- [ ] **Removal.** Remove a book from the opted-in shelf (or un-flag the
+      shelf's "Sync to Kobo"). After a sync, the book is archived/removed
+      from the device's library — and its own annotations/progress on the
+      device are not corrupted by the removal.
+- [ ] **Second sync is quiet.** With nothing changed since the last sync, a
+      further "Sync now" completes quickly with no re-downloads and no
+      duplicate library entries.
+- [ ] **CBZ-only book** (if the library has one): downloads and opens as a
+      comic, not attempted as an EPUB/KEPUB conversion.
+
+## Recording a result
+
+Append a dated entry (device model, firmware version, pass/fail per item, and
+a link to any filed issue) to this file's bottom, or link a GitHub issue
+tagged `kobo-sync` that captures the same information — whichever this repo
+is doing at the time. As of this writing no run has been recorded yet; the
+first real-device pass should replace this line with either a result summary
+or a pointer to the tracking issue.

--- a/docs/kobo.md
+++ b/docs/kobo.md
@@ -67,7 +67,12 @@ to get KEPUB output. See [.env.example](../.env.example).
 
 *Wireless* Kobo sync — where the device talks to Omnibus over Wi-Fi instead of a
 USB cable — is functional but **experimental**: it has not yet passed
-verification against real devices.
+verification against real devices. HTTP-layer contract tests pin the server's
+side of the protocol against a synthetic fixture (see
+`server/src/backend/kobo/tests.rs`), but only a real device can confirm the
+firmware actually accepts what's sent — see
+[docs/kobo-smoke-test.md](kobo-smoke-test.md) for the manual checklist that
+gates advertising this feature as non-experimental.
 
 > [!WARNING]
 > **First sync can erase your Kobo's highlights**

--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -79,9 +79,9 @@ fn get(uri: String) -> Request<Body> {
 /// fresh scan root — so [`download`](super::resources::download) has real
 /// bytes to serve. Mirrors the on-disk setup
 /// `download_bakes_a_metadata_override_into_the_plain_epub_fallback` uses,
-/// minus the override. Returns the minted uuid; the tempdir is intentionally
-/// leaked, like the sibling test, since each run gets a fresh pid-scoped path
-/// and CI wipes `/tmp` between runs.
+/// minus the override (that sibling test cleans up its tempdir via
+/// `remove_dir_all`; this one deliberately doesn't, since each run gets a
+/// fresh pid-scoped path and CI wipes `/tmp` between runs).
 async fn seed_downloadable_book(pool: &SqlitePool, uuid: &str, title: &str, author: &str) {
     let pid = std::process::id();
     let nanos = std::time::SystemTime::now()

--- a/server/src/backend/kobo/tests.rs
+++ b/server/src/backend/kobo/tests.rs
@@ -75,6 +75,269 @@ fn get(uri: String) -> Request<Body> {
         .unwrap()
 }
 
+/// Seed one real book on disk — a copy of the committed EPUB fixture under a
+/// fresh scan root — so [`download`](super::resources::download) has real
+/// bytes to serve. Mirrors the on-disk setup
+/// `download_bakes_a_metadata_override_into_the_plain_epub_fallback` uses,
+/// minus the override. Returns the minted uuid; the tempdir is intentionally
+/// leaked, like the sibling test, since each run gets a fresh pid-scoped path
+/// and CI wipes `/tmp` between runs.
+async fn seed_downloadable_book(pool: &SqlitePool, uuid: &str, title: &str, author: &str) {
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let lib_dir = std::env::temp_dir().join(format!("omnibus_kobo_contract_{pid}_{nanos}_{uuid}"));
+    std::fs::create_dir_all(&lib_dir).unwrap();
+    let fixture_epub = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../test_data/epubs/generated/alpha.epub");
+    std::fs::copy(&fixture_epub, lib_dir.join("alpha.epub")).unwrap();
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(lib_dir.to_str().unwrap())
+        .execute(pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title, last_modified) \
+         VALUES (?, ?, ?, ?, 1700000000)",
+    )
+    .bind(uuid)
+    .bind(lib_id)
+    .bind(lib_dir.to_str().unwrap())
+    .bind(title)
+    .execute(pool)
+    .await
+    .unwrap();
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?")
+        .bind(uuid)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'alpha', 0)",
+    )
+    .bind(book_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    let author_id: i64 = sqlx::query_scalar("INSERT INTO authors (name) VALUES (?) RETURNING id")
+        .bind(author)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO books_authors_link (book, author, position) VALUES (?, ?, 0)")
+        .bind(book_id)
+        .bind(author_id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+/// #928 contract test: replays the full wireless device sequence at the HTTP
+/// layer — `initialization -> auth/device -> library/sync -> download -> PUT
+/// state -> GET state` — against `kobo_router` over `sqlite::memory:`.
+///
+/// **This is a synthetic golden fixture, not a real-device capture.** No
+/// physical Kobo is available in this sandboxed environment; every payload
+/// shape below (envelope field names, the `Resources` override keys, the
+/// `NewEntitlement`/`StateResponse` field names, the `KoboSpan` location
+/// format) is instead pinned against the DTOs this router already
+/// implements (`kobo::dto`, `kobo::store_resources`, `kobo::state`) — the
+/// same reference shapes `docs/kobo.md` documents as sourced from
+/// Calibre-Web / bookorbit rather than a packet capture. See
+/// `docs/kobo-smoke-test.md` for the manual real-hardware checklist that
+/// gates advertising a device's wireless sync URL to a user.
+///
+/// AC4: every step asserts response **body shape**, not just status code —
+/// a regression that changed a field name or dropped a value (rather than
+/// the status code) fails this test. The final `GET state` closes the loop:
+/// it proves the `PUT` actually persisted the device's status and bookmark,
+/// not merely that the endpoint answered `200`.
+#[tokio::test]
+async fn full_device_sequence_replays_initialization_through_state_put() {
+    let _kepubify_absent =
+        db::test_support::EnvVarGuard::set("OMNIBUS_KEPUBIFY_PATH", Some("/no/such/kepubify"));
+    let (app, pool, token, uid) = fixture().await;
+    let uuid = "62e1c9f0-0000-4000-8000-000000000928";
+    seed_downloadable_book(&pool, uuid, "The Golden Fixture", "Ada Lovelace").await;
+    opt_in(&pool, uid, &[uuid.to_owned()]).await;
+
+    // --- 1. GET v1/initialization -----------------------------------------
+    let res = app
+        .clone()
+        .oneshot(get(format!("/kobo/{token}/v1/initialization")))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers().get("x-kobo-apitoken").unwrap(),
+        "e30=",
+        "missing/wrong x-kobo-apitoken makes the device reject the whole map"
+    );
+    let init = body_json(res).await;
+    assert_eq!(
+        init["Resources"]["library_sync"],
+        format!("http://omni.test/kobo/{token}/v1/library/sync")
+    );
+
+    // --- 2. POST v1/auth/device ---------------------------------------------
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/kobo/{token}/v1/auth/device"))
+                .method("POST")
+                .header("host", "omni.test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let auth_envelope = body_json(res).await;
+    assert_eq!(auth_envelope["TokenType"], "Bearer");
+    for field in ["AccessToken", "RefreshToken", "TrackingId", "UserKey"] {
+        assert!(
+            auth_envelope[field].as_str().is_some_and(|s| !s.is_empty()),
+            "{field} should be present and non-empty"
+        );
+    }
+
+    // --- 3. GET v1/library/sync ---------------------------------------------
+    let res = app
+        .clone()
+        .oneshot(get(format!("/kobo/{token}/v1/library/sync")))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert!(
+        res.headers().get("x-kobo-sync").is_none(),
+        "a single-book first sync must not page"
+    );
+    let sync = body_json(res).await;
+    let items = sync.as_array().unwrap();
+    assert_eq!(
+        items.len(),
+        1,
+        "first sync emits exactly one NewEntitlement"
+    );
+    let ent = &items[0]["NewEntitlement"];
+    assert_eq!(ent["BookEntitlement"]["Id"], uuid);
+    assert_eq!(ent["BookEntitlement"]["IsRemoved"], false);
+    assert_eq!(ent["BookMetadata"]["Title"], "The Golden Fixture");
+    assert_eq!(
+        ent["BookMetadata"]["ContributorRoles"][0]["Name"],
+        "Ada Lovelace"
+    );
+    let download_url = ent["BookMetadata"]["DownloadUrls"][0]["Url"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert_eq!(
+        ent["BookMetadata"]["DownloadUrls"][0]["Format"], "KEPUB",
+        "an EPUB-bearing book advertises the KEPUB conversion"
+    );
+    assert_eq!(
+        download_url,
+        format!("http://omni.test/kobo/{token}/v1/download/{uuid}")
+    );
+    assert_eq!(
+        ent["ReadingState"]["StatusInfo"]["Status"], "ReadyToRead",
+        "an untouched book starts ReadyToRead"
+    );
+
+    // --- 4. GET v1/download/<uuid> ------------------------------------------
+    let res = app
+        .clone()
+        .oneshot(get(download_url.replace("http://omni.test", "")))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers().get(axum::http::header::CONTENT_TYPE).unwrap(),
+        "application/epub+zip"
+    );
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    epub::doc::EpubDoc::from_reader(std::io::Cursor::new(bytes.to_vec()))
+        .expect("downloaded bytes are a valid EPUB");
+    let device_id = db::kobo_devices::resolve_device_by_token(&pool, &token)
+        .await
+        .unwrap()
+        .unwrap()
+        .device_id;
+    let downloaded_at: Option<i64> = sqlx::query_scalar(
+        "SELECT downloaded_at FROM kobo_annotations_sync WHERE device_id = ? AND book_uuid = ?",
+    )
+    .bind(device_id)
+    .bind(uuid)
+    .fetch_optional(&pool)
+    .await
+    .unwrap()
+    .flatten();
+    assert!(
+        downloaded_at.is_some(),
+        "a successful download must record the device as holding the book"
+    );
+
+    // --- 5. PUT v1/library/<uuid>/state --------------------------------------
+    let location = serde_json::json!({
+        "Source": "text/part0001.html",
+        "Type": "KoboSpan",
+        "Value": "kobo.3.2",
+    });
+    let put_body = serde_json::json!({
+        "ReadingStates": [{
+            "StatusInfo": { "Status": "Reading" },
+            "CurrentBookmark": {
+                "ProgressPercent": 42,
+                "Location": location,
+                "LastModified": "2026-01-02T03:04:05Z",
+            },
+        }],
+    });
+    let res = app
+        .clone()
+        .oneshot(state_put(&token, uuid, put_body))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let put_response = body_json(res).await;
+    assert_eq!(put_response["RequestResult"], "Success");
+    let update_results = put_response["UpdateResults"].as_array().unwrap();
+    assert_eq!(update_results.len(), 1);
+    assert_eq!(update_results[0]["EntitlementId"], uuid);
+    assert_eq!(update_results[0]["StatusInfoResult"]["Result"], "Success");
+    assert_eq!(
+        update_results[0]["CurrentBookmarkResult"]["Result"],
+        "Success"
+    );
+
+    // --- 6. GET v1/library/<uuid>/state — proves the PUT actually persisted -
+    let res = app
+        .oneshot(get(format!("/kobo/{token}/v1/library/{uuid}/state")))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let states = body_json(res).await;
+    let states = states.as_array().unwrap();
+    assert_eq!(states.len(), 1);
+    let state = &states[0];
+    assert_eq!(state["EntitlementId"], uuid);
+    assert_eq!(
+        state["StatusInfo"]["Status"], "Reading",
+        "the status set by the PUT must be echoed back, not the stale default"
+    );
+    assert_eq!(state["CurrentBookmark"]["ProgressPercent"], 42);
+    assert_eq!(
+        state["CurrentBookmark"]["Location"], location,
+        "the KoboSpan location is echoed back verbatim"
+    );
+}
+
 #[tokio::test]
 async fn library_sync_rejects_an_invalid_token() {
     let (app, _pool, _token, _uid) = fixture().await;


### PR DESCRIPTION
## Summary

Closes #928 (partial — see the AC2 caveat below).

- Adds `full_device_sequence_replays_initialization_through_state_put` to `server/src/backend/kobo/tests.rs`: an HTTP-layer contract test that drives `kobo_router` via `tower::ServiceExt::oneshot` against `sqlite::memory:`, replaying the full wireless device sequence `initialization -> auth/device -> library/sync -> download -> PUT state -> GET state`. Every step asserts response **body shape** (not just status code), and the final `GET state` proves the `PUT` actually persisted rather than merely returning 200.
- The test seeds a synthetic-but-realistic golden fixture (one real EPUB copied from the committed `test_data/epubs/generated/` fixtures, a hand-built book/author/shelf), documented in-code as synthetic — no physical Kobo capture is available in this sandboxed environment. DTO shapes are pinned against what `server/src/backend/kobo/` (`dto.rs`, `store_resources.rs`, `state.rs`) already implements.
- Adds `docs/kobo-smoke-test.md`: a real-device manual smoke-test checklist (handshake, library sync, download, read-status/position push and pull, highlight push/pull and colour, removal, quiet second sync, CBZ) as the gate before advertising the Kobo wireless-sync device URL to users, linked from `docs/kobo.md`'s existing "About wireless sync (experimental)" section.
- Deferred (optional/stretch per the issue): a per-event sync audit log — out of scope, core ask was the contract tests.

**AC2 caveat (flagged by Copilot review, and worth being explicit about):** AC2 asked for the golden fixture to be a real-device capture with DTOs pinned against "a pinned Calibre-Web revision." Neither half of that is actually achievable here: no physical Kobo device is available in this sandboxed environment to capture from, and — checked directly — **no Calibre-Web git revision was ever pinned anywhere in this repo's existing Kobo implementation** (`dto.rs`/`sync.rs`/`mod.rs` reference Calibre-Web only in loose prose comments, e.g. "unlike Calibre-Web's `SYNC_ITEM_LIMIT`", with no commit/tag). Retroactively guessing a revision now risks pinning the wrong one, which is worse than not pinning at all. This PR ships the synthetic-but-realistic fixture and the strongest deliverable version of AC2 that's actually achievable, and documents the gap rather than silently claiming full closure — a maintainer may want to either accept this as satisfying AC2's spirit, or file a narrow follow-up once a real-device capture becomes available.

Existing coverage in `server/src/backend/kobo/tests.rs` (170+ tests) already covered each endpoint individually; this PR adds the missing full-sequence, golden-fixture-shaped contract test and the smoke-test doc.

## Test plan

- `cargo fmt -p omnibus -p omnibus-db -- --check` — PASS
- `cargo clippy -p omnibus -p omnibus-db --all-targets -- -D warnings` — PASS
- `cargo test -p omnibus -p omnibus-db kobo` — PASS (128 + 169 tests, including the new contract test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01F1UxwJK1NrSX355XGktXEv)_