### PR TITLE
fix: derive thumb ETag without reading the file on the 304 path (#1751)

### DIFF
--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -123,6 +123,45 @@ pub async fn is_stale_async(book_id: i64, size: ThumbSize, last_modified_epoch: 
     }
 }
 
+/// Bump this whenever [`write_thumbnail`]'s encode path changes (a new WebP
+/// encoder, a different quality setting, a new output format) so a client
+/// holding a validator from the old scheme is forced to re-fetch even though
+/// the book's `last_modified_epoch` never moved. This repo doesn't need to
+/// detect the encoder version dynamically, so a hand-bumped constant is
+/// enough.
+const THUMB_ENCODER_VERSION: u32 = 1;
+
+/// Derive a thumbnail's `ETag` from its freshness key — `(book_id, size,
+/// last_modified_epoch)`, the exact triple [`is_stale`]/[`is_stale_async`]
+/// key freshness on — plus `version`, without touching the filesystem. A
+/// validator that cannot disagree with the freshness check it stands in for.
+///
+/// Deliberately not stat-derived: [`touch_thumb`] bumps the cached file's
+/// mtime on every cache-hit read for the LRU in [`evict_if_over_cap`], so an
+/// mtime-bearing validator would churn on every request and never produce a
+/// 304. Split out from [`thumb_etag`] so a test can vary `version`
+/// independently of [`THUMB_ENCODER_VERSION`].
+fn thumb_etag_versioned(
+    book_id: i64,
+    size: ThumbSize,
+    last_modified_epoch: i64,
+    version: u32,
+) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    book_id.hash(&mut hasher);
+    size.as_str().hash(&mut hasher);
+    last_modified_epoch.hash(&mut hasher);
+    version.hash(&mut hasher);
+    format!("\"{:016x}\"", hasher.finish())
+}
+
+/// Derive a thumbnail's `ETag` without reading it off disk. See
+/// [`thumb_etag_versioned`] for the freshness-key rationale.
+pub fn thumb_etag(book_id: i64, size: ThumbSize, last_modified_epoch: i64) -> String {
+    thumb_etag_versioned(book_id, size, last_modified_epoch, THUMB_ENCODER_VERSION)
+}
+
 /// Resize a pre-decoded cover and write the WebP to disk for one size.
 ///
 /// Atomic on POSIX: the WebP is written to a per-(book,size) temp file in

--- a/db/src/thumbs.rs
+++ b/db/src/thumbs.rs
@@ -141,19 +141,27 @@ const THUMB_ENCODER_VERSION: u32 = 1;
 /// mtime-bearing validator would churn on every request and never produce a
 /// 304. Split out from [`thumb_etag`] so a test can vary `version`
 /// independently of [`THUMB_ENCODER_VERSION`].
+///
+/// SHA-256, not `std::hash::Hasher` — the same trap `helpers::stable_uuid`'s
+/// doc comment and `kobo::dto`'s fixed-digest derivation both flag:
+/// `DefaultHasher`'s algorithm is not guaranteed stable across toolchain
+/// versions, so a compiler bump could silently rotate every cached client's
+/// ETag and force a mass re-fetch.
 fn thumb_etag_versioned(
     book_id: i64,
     size: ThumbSize,
     last_modified_epoch: i64,
     version: u32,
 ) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    book_id.hash(&mut hasher);
-    size.as_str().hash(&mut hasher);
-    last_modified_epoch.hash(&mut hasher);
-    version.hash(&mut hasher);
-    format!("\"{:016x}\"", hasher.finish())
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(book_id.to_le_bytes());
+    hasher.update(size.as_str().as_bytes());
+    hasher.update(last_modified_epoch.to_le_bytes());
+    hasher.update(version.to_le_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest[..8].iter().map(|b| format!("{b:02x}")).collect();
+    format!("\"{hex}\"")
 }
 
 /// Derive a thumbnail's `ETag` without reading it off disk. See

--- a/db/src/thumbs/tests.rs
+++ b/db/src/thumbs/tests.rs
@@ -1,7 +1,8 @@
 //! Unit tests for the `thumbs` module — `thumbs_dir` env-var resolution,
 //! `thumb_path_for` formatting, `is_stale` mtime comparison (incl. the
-//! same-second tie case), `ThumbSize` FromStr roundtrip, `generate_thumbnail`
-//! WebP output, and LRU-on-read `evict_if_over_cap` cap enforcement.
+//! same-second tie case), `ThumbSize` FromStr roundtrip, `thumb_etag`
+//! derivation, `generate_thumbnail` WebP output, and LRU-on-read
+//! `evict_if_over_cap` cap enforcement.
 
 use super::*;
 use crate::test_support::EnvVarGuard;
@@ -77,6 +78,53 @@ fn is_stale_returns_true_when_mtime_is_older() {
         .unwrap()
         .as_secs() as i64;
     assert!(is_stale(2, ThumbSize::Md, mtime + 1));
+}
+
+#[test]
+fn thumb_etag_is_stable_for_identical_inputs() {
+    assert_eq!(
+        thumb_etag(1, ThumbSize::Md, 100),
+        thumb_etag(1, ThumbSize::Md, 100)
+    );
+}
+
+#[test]
+fn thumb_etag_differs_when_book_id_changes() {
+    assert_ne!(
+        thumb_etag(1, ThumbSize::Md, 100),
+        thumb_etag(2, ThumbSize::Md, 100)
+    );
+}
+
+#[test]
+fn thumb_etag_differs_when_size_changes() {
+    assert_ne!(
+        thumb_etag(1, ThumbSize::Sm, 100),
+        thumb_etag(1, ThumbSize::Md, 100)
+    );
+}
+
+#[test]
+fn thumb_etag_differs_when_last_modified_epoch_changes() {
+    // #1751 AC3: a thumb regenerated because its book's
+    // `last_modified_epoch` moved must produce a different ETag.
+    assert_ne!(
+        thumb_etag(1, ThumbSize::Md, 100),
+        thumb_etag(1, ThumbSize::Md, 200)
+    );
+}
+
+#[test]
+fn thumb_etag_differs_when_the_encoder_version_component_changes() {
+    // #1751 AC4: folding a version constant into the hash means a future
+    // encoder/format change (a bumped `THUMB_ENCODER_VERSION`) produces a
+    // different ETag even when `(book_id, size, last_modified_epoch)` is
+    // unchanged. Exercised through the version-parameterized helper since
+    // the real constant is fixed at compile time.
+    assert_ne!(
+        thumb_etag_versioned(1, ThumbSize::Md, 100, 1),
+        thumb_etag_versioned(1, ThumbSize::Md, 100, 2)
+    );
 }
 
 #[test]

--- a/server/src/backend/covers.rs
+++ b/server/src/backend/covers.rs
@@ -161,34 +161,22 @@ async fn thumb_cache_hit_response(
     if db::thumbs::is_stale_async(id, size, last_modified_epoch).await {
         return None;
     }
-    let thumb_path = db::thumb_path_for(id, size);
-    let bytes = tokio::fs::read(&thumb_path).await.ok()?;
 
-    // Fire-and-forget mtime bump so `evict_if_over_cap` treats this as
-    // recently-used (LRU) instead of evicting frequently-viewed thumbs just
-    // because they're old. Detached via `tokio::spawn` (never adds latency
-    // to this response) but still awaits the `spawn_blocking` JoinHandle and
-    // distinguishes panic from cancellation, matching the worker's
-    // convention (`handle_generate_thumbs` in db/src/worker/handlers.rs)
-    // instead of silently dropping it.
-    tokio::spawn(async move {
-        if let Err(join_err) =
-            tokio::task::spawn_blocking(move || db::thumbs::touch_thumb(id, size)).await
-        {
-            let kind = if join_err.is_panic() {
-                "panicked"
-            } else {
-                "was cancelled"
-            };
-            tracing::warn!(error = %join_err, book_id = id, "thumbs: touch_thumb {kind}");
-        }
-    });
+    // Derived from values already in hand (#1751), no file I/O — so a
+    // matching `If-None-Match` can be answered without ever reading the
+    // thumb off disk. `is_stale`/`is_stale_async` key freshness on this
+    // exact `(book_id, size, last_modified_epoch)` triple, so this
+    // validator cannot disagree with that check.
+    let etag = db::thumbs::thumb_etag(id, size, last_modified_epoch);
+    spawn_touch_thumb(id, size);
 
-    let etag = content_etag(&bytes);
     if if_none_match_hits(headers, &etag) {
         tracing::debug!(uuid, book_id = id, ?size, "thumb: not modified (304)");
         return Some(not_modified(&etag));
     }
+
+    let thumb_path = db::thumb_path_for(id, size);
+    let bytes = tokio::fs::read(&thumb_path).await.ok()?;
     tracing::debug!(
         uuid,
         book_id = id,
@@ -215,6 +203,29 @@ async fn thumb_cache_hit_response(
         )
             .into_response(),
     )
+}
+
+/// Fire-and-forget mtime bump so `evict_if_over_cap` treats this thumb as
+/// recently-used (LRU) instead of evicting frequently-viewed thumbs just
+/// because they're old. Detached via `tokio::spawn` (never adds latency to
+/// this response) but still awaits the `spawn_blocking` JoinHandle and
+/// distinguishes panic from cancellation, matching the worker's convention
+/// (`handle_generate_thumbs` in db/src/worker/handlers.rs) instead of
+/// silently dropping it. Called on both the 200 and 304 paths — a
+/// revalidated thumb is still a used one.
+fn spawn_touch_thumb(id: i64, size: db::ThumbSize) {
+    tokio::spawn(async move {
+        if let Err(join_err) =
+            tokio::task::spawn_blocking(move || db::thumbs::touch_thumb(id, size)).await
+        {
+            let kind = if join_err.is_panic() {
+                "panicked"
+            } else {
+                "was cancelled"
+            };
+            tracing::warn!(error = %join_err, book_id = id, "thumbs: touch_thumb {kind}");
+        }
+    });
 }
 
 /// Cache-miss (or stale) stage: fetch the original cover first so we only

--- a/server/src/backend/covers/tests.rs
+++ b/server/src/backend/covers/tests.rs
@@ -421,8 +421,123 @@ async fn api_get_thumb_returns_304_when_if_none_match_matches_the_cached_webps_e
         second.headers().get(header::CACHE_CONTROL).unwrap(),
         "private, no-cache"
     );
+    assert_eq!(
+        second.headers().get(header::VARY).unwrap(),
+        "Cookie, Authorization"
+    );
     let bytes = to_bytes(second.into_body(), usize::MAX).await.unwrap();
     assert!(bytes.is_empty());
+}
+
+#[tokio::test]
+async fn api_get_thumb_returns_304_without_reading_the_thumb_file_from_disk() {
+    let (app, _, pool) = fixture().await;
+    let (id, uuid) = seed_book_with_uuid(&pool, "/lib", "Thumb Book").await;
+    sqlx::query("UPDATE books SET last_modified = 0 WHERE id = ?")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let _thumbs_guard = ThumbsDirGuard::new("thumb_304_no_read");
+    let thumb_path = db::thumb_path_for(id, db::ThumbSize::Md);
+    std::fs::write(&thumb_path, b"fake-cached-webp-bytes").expect("write thumb fixture");
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let first = app
+        .clone()
+        .oneshot(get_with_bearer(&format!("/api/thumbs/{uuid}/md"), &token))
+        .await
+        .unwrap();
+    let etag = first
+        .headers()
+        .get(header::ETAG)
+        .expect("cache-hit response should carry an ETag")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // Swap the file for a directory at the same path: `is_stale_async`'s
+    // metadata stat still sees a fresh mtime (so the cache-hit branch is
+    // still taken), but a `tokio::fs::read` of a directory always errors.
+    // Before #1751 the ETag came from hashing the file's bytes, so a
+    // matching `If-None-Match` still had to read (and thus fail on) this
+    // path, falling through to the miss/regenerate branch instead of
+    // answering 304. Deriving the ETag from `(book_id, size,
+    // last_modified_epoch)` alone means the read is never attempted.
+    std::fs::remove_file(&thumb_path).expect("remove thumb file");
+    std::fs::create_dir(&thumb_path).expect("create directory in place of thumb file");
+
+    let second = app
+        .oneshot(get_with_bearer_and_if_none_match(
+            &format!("/api/thumbs/{uuid}/md"),
+            &token,
+            &etag,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(second.headers().get(header::ETAG).unwrap(), etag.as_str());
+}
+
+#[tokio::test]
+async fn api_get_thumb_serves_fresh_bytes_and_a_new_etag_after_last_modified_epoch_changes() {
+    let (app, _, pool) = fixture().await;
+    let (id, uuid) = seed_book_with_uuid(&pool, "/lib", "Thumb Book").await;
+    sqlx::query("UPDATE books SET last_modified = 0 WHERE id = ?")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let _thumbs_guard = ThumbsDirGuard::new("thumb_etag_changes_on_last_modified");
+    let thumb_bytes = b"fake-cached-webp-bytes";
+    std::fs::write(db::thumb_path_for(id, db::ThumbSize::Md), thumb_bytes)
+        .expect("write thumb fixture");
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let first = app
+        .clone()
+        .oneshot(get_with_bearer(&format!("/api/thumbs/{uuid}/md"), &token))
+        .await
+        .unwrap();
+    let stale_etag = first
+        .headers()
+        .get(header::ETAG)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // Simulate a reindex that regenerated this thumb: `last_modified_epoch`
+    // moves forward, but stays well behind the thumb file's real (current)
+    // mtime so it still reads as fresh — the ETag must change on this
+    // alone, even though the on-disk bytes didn't (#1751 AC3).
+    sqlx::query("UPDATE books SET last_modified = 1 WHERE id = ?")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let second = app
+        .oneshot(get_with_bearer_and_if_none_match(
+            &format!("/api/thumbs/{uuid}/md"),
+            &token,
+            &stale_etag,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::OK);
+    let fresh_etag = second
+        .headers()
+        .get(header::ETAG)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_ne!(fresh_etag, stale_etag);
+    let bytes = to_bytes(second.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&bytes[..], thumb_bytes.as_slice());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Closes #1751.
- `thumb_cache_hit_response` previously read the entire thumb file off disk and SipHashed all of it via `content_etag` purely to build the validator it then compared against `If-None-Match` — expensive on every 304, which returns no bytes at all.
- Adds `db::thumbs::thumb_etag(book_id, size, last_modified_epoch)`, derived from the exact `(book_id, size, last_modified_epoch)` triple `is_stale`/`is_stale_async` already key freshness on, plus a hand-bumped `THUMB_ENCODER_VERSION` constant so a future encoder/format change still busts the ETag even when `last_modified_epoch` is unchanged.
- `thumb_cache_hit_response` now evaluates `If-None-Match` against this derived ETag *before* touching the filesystem — a match returns 304 with zero file I/O. The file is only read on an actual 200.
- `touch_thumb`'s LRU mtime bump (extracted into `spawn_touch_thumb`) still fires on both the 200 and 304 paths, since a revalidated thumb is still a used one — and is deliberately NOT part of the ETag (it would otherwise churn the validator on every request).
- `Cache-Control`/`Vary` stay identical between 200 and 304 via the existing `not_modified` helper, per rule 09.

## Test plan
- `cargo fmt` — PASS
- `cargo clippy -p omnibus -p omnibus-db --all-targets -- -D warnings` — PASS
- `cargo test -p omnibus thumb` — PASS (10/10, incl. the new 304-without-disk-read and changed-validator-on-`last_modified_epoch`-change tests)
- `cargo test -p omnibus-db thumb` — PASS (19/19, incl. new `thumb_etag_*` unit tests covering stability and each input dimension independently, including the encoder-version component)


---
_Generated by [Claude Code](https://claude.ai/code/session_01F1UxwJK1NrSX355XGktXEv)_