### PR TITLE
refactor: dedup seed_epub_row test helper between worker and epub_rewrite (#1766)

### DIFF
--- a/db/src/epub_rewrite/mod.rs
+++ b/db/src/epub_rewrite/mod.rs
@@ -407,4 +407,4 @@ async fn is_stale(path: &Path, last_modified_epoch: i64) -> bool {
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/db/src/epub_rewrite/tests.rs
+++ b/db/src/epub_rewrite/tests.rs
@@ -730,8 +730,10 @@ fn evict_if_over_cap_is_a_noop_when_the_export_dir_does_not_exist() {
 /// `book_files` (EPUB) row for `uuid`, so `book_file_path` resolves to
 /// `lib_dir/<filename_stem>.epub` — real enough for `rewrite_blocking` to
 /// open when the caller has also copied a fixture there (or left it
-/// missing, to exercise the per-book failure branch).
-async fn seed_epub_row(
+/// missing, to exercise the per-book failure branch). `pub(crate)` so
+/// `worker::tests` can reuse it for the `Task::RewriteAllEpubs` bake-error
+/// tests rather than duplicating the same three inserts.
+pub(crate) async fn seed_epub_row(
     pool: &sqlx::SqlitePool,
     lib_dir: &std::path::Path,
     uuid: &str,

--- a/db/src/worker/tests.rs
+++ b/db/src/worker/tests.rs
@@ -12,6 +12,7 @@ use omnibus_shared::{GhostFilesWarning, MetadataOverrides, ProgressState, TaskKi
 use sqlx::SqlitePool;
 
 use crate::ebook::test_support::copy_fixture_into;
+use crate::epub_rewrite::tests::seed_epub_row;
 use crate::sync::{sync_books, SyncPlan};
 use crate::test_support::{indexed_with_stat, make_test_dir, EnvVarGuard};
 
@@ -919,45 +920,6 @@ async fn task_scan_reports_ghost_warning_in_the_warn_band_below_abort() {
 
 // ---------- #1739: bulk EPUB-bake per-book errors on Task::RewriteAllEpubs ----------
 
-/// Insert a `books` row backed by a `book_files` EPUB entry, mirroring
-/// `epub_rewrite::tests::seed_epub_row` — the sibling helper that module
-/// uses to drive `rewrite_all_epubs_with_overrides` directly. Duplicated
-/// rather than shared across crate-internal test modules since it's a
-/// handful of inserts with no reuse-worthy behavior of its own.
-async fn seed_epub_row_for_bake(
-    pool: &SqlitePool,
-    lib_dir: &std::path::Path,
-    uuid: &str,
-    title: &str,
-    filename_stem: &str,
-) -> i64 {
-    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
-        .bind(lib_dir.to_string_lossy().to_string())
-        .execute(pool)
-        .await
-        .unwrap()
-        .last_insert_rowid();
-    let book_id =
-        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, '', ?)")
-            .bind(uuid)
-            .bind(lib_id)
-            .bind(title)
-            .execute(pool)
-            .await
-            .unwrap()
-            .last_insert_rowid();
-    sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
-         VALUES (?, 'EPUB', ?, 0)",
-    )
-    .bind(book_id)
-    .bind(filename_stem)
-    .execute(pool)
-    .await
-    .unwrap();
-    book_id
-}
-
 /// A `Task::RewriteAllEpubs` run that leaves one book unbaked (its
 /// `book_files` row points at a source that was never written to disk)
 /// completes as `TaskOutcome::Ok`, and the failed `book_uuid` — the error
@@ -978,7 +940,7 @@ async fn task_rewrite_all_epubs_reports_bake_errors_via_task_outcome() {
 
     let lib_ok = tempfile::tempdir().unwrap();
     copy_fixture_into("alpha.epub", lib_ok.path());
-    seed_epub_row_for_bake(&pool, lib_ok.path(), "uuid-ok", "Book OK", "alpha").await;
+    seed_epub_row(&pool, lib_ok.path(), "uuid-ok", "Book OK", "alpha").await;
     crate::upsert_metadata_overrides(
         &pool,
         "uuid-ok",
@@ -993,7 +955,7 @@ async fn task_rewrite_all_epubs_reports_bake_errors_via_task_outcome() {
     .unwrap();
 
     let lib_bad = tempfile::tempdir().unwrap();
-    seed_epub_row_for_bake(&pool, lib_bad.path(), "uuid-bad", "Book Bad", "missing").await;
+    seed_epub_row(&pool, lib_bad.path(), "uuid-bad", "Book Bad", "missing").await;
     crate::upsert_metadata_overrides(
         &pool,
         "uuid-bad",


### PR DESCRIPTION
## Summary
- Closes #1766
- `db/src/worker/tests.rs` carried `seed_epub_row_for_bake`, a byte-for-byte duplicate of `db/src/epub_rewrite/tests.rs`'s `seed_epub_row` (same signature, same three inserts, same body), added in #1756 alongside the #1739 bake-error tests — a violation of the shared-helper rule in `.claude/rules/03-unit-testing.md`.
- Removed the duplicate from `worker/tests.rs`; exposed `epub_rewrite::tests::seed_epub_row` as `pub(crate)` (and its owning `mod tests;` declaration in `epub_rewrite/mod.rs` as `pub(crate) mod tests;` so the path resolves) and imported it into `worker/tests.rs` via `use crate::epub_rewrite::tests::seed_epub_row;`. Updated the two call sites that used the old name.

## Test plan
- [x] `cargo fmt --check` — PASS (no diff)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test -p omnibus-db` — PASS for all 35 `worker::tests` + all 36 `epub_rewrite::tests`, including `task_rewrite_all_epubs_reports_bake_errors_via_task_outcome` (the test that exercises the deduped helper), confirming identical coverage to before. Overall run: 1859/1860 passed; the 1 failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is pre-existing and unrelated — it's a missing binary audiobook fixture (`just fixtures` wasn't run in this environment) in a file this PR never touches (`db/src/audiobook/cover.rs`, confirmed via `git diff origin/main` — no diff).

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- Test-only change; no production code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RgsGXd4iBZxqHhFbWAy8n7)_