### PR TITLE
refactor: split functions over the 80-line cap outside pages/** (#1765)

### DIFF
--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -50,21 +50,7 @@ pub fn parse_ebook_targets(targets: Vec<ParseTarget>, opts: ScanOptions) -> Vec<
 fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> IndexedBook {
     let mut doc = match EpubDoc::new(path) {
         Ok(d) => d,
-        Err(e) => {
-            return IndexedBook {
-                metadata: EbookMetadata {
-                    filename,
-                    error: Some(format!("could not open epub: {e}")),
-                    ..Default::default()
-                },
-                cover: None,
-                // Stat values get overwritten by `parse_ebook_targets`
-                // before the writer sees this struct.
-                mtime_epoch: 0,
-                size_bytes: 0,
-                word_count: None,
-            };
-        }
+        Err(e) => return failed_open_book(filename, &e),
     };
 
     // OPF `<dc:creator>` and `<dc:contributor>` both flow into the same
@@ -89,54 +75,97 @@ fn extract_metadata(path: &Path, filename: String, opts: &ScanOptions) -> Indexe
     let word_count = super::estimate_word_count(&mut doc);
 
     IndexedBook {
-        metadata: EbookMetadata {
-            id: 0,
+        metadata: build_opf_metadata(
+            &doc,
             filename,
-            title: first(&doc, "title"),
-            description: first(&doc, "description"),
-            publisher: first(&doc, "publisher"),
-            published: first(&doc, "date"),
-            modified: first(&doc, "dcterms:modified"),
-            language: first(&doc, "language"),
-
             creators,
-            subjects: all(&doc, "subject"),
-            // The OPF has no genre element — genres are user-assigned only
-            // and layered on at read time by `apply_overrides`.
-            genres: Vec::new(),
             identifiers,
-            // Derived at read time from `book_identifiers` (`row_to_ebook`
-            // -> `derive_isbn13`), not at parse time — this struct is
-            // written into the normalized tables before that derivation
-            // ever runs.
-            isbn13: None,
-
             series,
             series_index,
-            series_id: None,
-
-            unique_identifier: doc.unique_identifier.clone(),
-
-            cover_url: None,
             accent,
-            formats: vec![],
-            // Derived at read time from `physical_copies` (projection), not at
-            // parse time — this struct is written before that derivation runs.
-            has_physical: false,
-            added_at: None,
-            error: None,
-            has_override: false,
-            has_cover_override: false,
-            book_files: Vec::new(),
-            epub_size_bytes: None,
-            page_count: None,
-        },
+        ),
         cover,
         // Stat values get overwritten by `parse_ebook_targets` before the
         // writer sees this struct.
         mtime_epoch: 0,
         size_bytes: 0,
         word_count,
+    }
+}
+
+/// The placeholder [`IndexedBook`] for a file `EpubDoc::new` couldn't open —
+/// carries the filename and a user-facing error, no cover or word count.
+fn failed_open_book(filename: String, e: &dyn std::fmt::Display) -> IndexedBook {
+    IndexedBook {
+        metadata: EbookMetadata {
+            filename,
+            error: Some(format!("could not open epub: {e}")),
+            ..Default::default()
+        },
+        cover: None,
+        // Stat values get overwritten by `parse_ebook_targets`
+        // before the writer sees this struct.
+        mtime_epoch: 0,
+        size_bytes: 0,
+        word_count: None,
+    }
+}
+
+/// Build the [`EbookMetadata`] record from an opened OPF doc plus the
+/// fields [`extract_metadata`] already collected (creators, identifiers,
+/// series, accent). Fields derived only at read time (isbn13, has_physical,
+/// …) are left at their zero value — see the inline comments on each.
+#[allow(clippy::too_many_arguments)]
+fn build_opf_metadata<R: std::io::Read + std::io::Seek>(
+    doc: &EpubDoc<R>,
+    filename: String,
+    creators: Vec<Contributor>,
+    identifiers: Vec<Identifier>,
+    series: Option<String>,
+    series_index: Option<String>,
+    accent: Option<String>,
+) -> EbookMetadata {
+    EbookMetadata {
+        id: 0,
+        filename,
+        title: first(doc, "title"),
+        description: first(doc, "description"),
+        publisher: first(doc, "publisher"),
+        published: first(doc, "date"),
+        modified: first(doc, "dcterms:modified"),
+        language: first(doc, "language"),
+
+        creators,
+        subjects: all(doc, "subject"),
+        // The OPF has no genre element — genres are user-assigned only
+        // and layered on at read time by `apply_overrides`.
+        genres: Vec::new(),
+        identifiers,
+        // Derived at read time from `book_identifiers` (`row_to_ebook`
+        // -> `derive_isbn13`), not at parse time — this struct is
+        // written into the normalized tables before that derivation
+        // ever runs.
+        isbn13: None,
+
+        series,
+        series_index,
+        series_id: None,
+
+        unique_identifier: doc.unique_identifier.clone(),
+
+        cover_url: None,
+        accent,
+        formats: vec![],
+        // Derived at read time from `physical_copies` (projection), not at
+        // parse time — this struct is written before that derivation runs.
+        has_physical: false,
+        added_at: None,
+        error: None,
+        has_override: false,
+        has_cover_override: false,
+        book_files: Vec::new(),
+        epub_size_bytes: None,
+        page_count: None,
     }
 }
 

--- a/db/src/indexer/backfill.rs
+++ b/db/src/indexer/backfill.rs
@@ -373,53 +373,7 @@ pub(crate) async fn backfill_thumbs(
     for (book_id, last_modified_epoch) in candidates {
         processed = processed.saturating_add(1);
         on_progress(processed, total);
-
-        let mut all_fresh = true;
-        for size in thumbs::ThumbSize::all() {
-            if thumbs::is_stale_async(book_id, size, last_modified_epoch).await {
-                all_fresh = false;
-                break;
-            }
-        }
-        if all_fresh {
-            continue;
-        }
-
-        let cover = match covers::get_cover(pool, book_id).await {
-            Ok(Some((_mime, bytes))) => bytes,
-            Ok(None) => continue,
-            Err(e) => {
-                tracing::warn!(
-                    book_id,
-                    error = %e,
-                    "thumbnail backfill: cover fetch failed; skipping"
-                );
-                continue;
-            }
-        };
-
-        match tokio::task::spawn_blocking(move || {
-            thumbs::ensure_thumbnails_sync(book_id, last_modified_epoch, cover)
-        })
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                tracing::warn!(
-                    book_id,
-                    error = %e,
-                    "thumbnail backfill: generation failed; skipping"
-                );
-            }
-            Err(join_err) => {
-                tracing::warn!(
-                    book_id,
-                    %join_err,
-                    is_panic = join_err.is_panic(),
-                    "thumbnail backfill: generation task failed; skipping"
-                );
-            }
-        }
+        regenerate_thumbs_if_stale(pool, book_id, last_modified_epoch).await;
     }
 
     let cap = thumbs::cap_bytes();
@@ -434,6 +388,58 @@ pub(crate) async fn backfill_thumbs(
     }
 
     Ok(())
+}
+
+/// Regenerate one book's three thumbnail sizes if any is stale per
+/// [`thumbs::is_stale_async`], skipping (and logging) a missing cover,
+/// fetch failure, or generation failure rather than aborting the batch.
+async fn regenerate_thumbs_if_stale(pool: &SqlitePool, book_id: i64, last_modified_epoch: i64) {
+    let mut all_fresh = true;
+    for size in thumbs::ThumbSize::all() {
+        if thumbs::is_stale_async(book_id, size, last_modified_epoch).await {
+            all_fresh = false;
+            break;
+        }
+    }
+    if all_fresh {
+        return;
+    }
+
+    let cover = match covers::get_cover(pool, book_id).await {
+        Ok(Some((_mime, bytes))) => bytes,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!(
+                book_id,
+                error = %e,
+                "thumbnail backfill: cover fetch failed; skipping"
+            );
+            return;
+        }
+    };
+
+    match tokio::task::spawn_blocking(move || {
+        thumbs::ensure_thumbnails_sync(book_id, last_modified_epoch, cover)
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::warn!(
+                book_id,
+                error = %e,
+                "thumbnail backfill: generation failed; skipping"
+            );
+        }
+        Err(join_err) => {
+            tracing::warn!(
+                book_id,
+                %join_err,
+                is_panic = join_err.is_panic(),
+                "thumbnail backfill: generation task failed; skipping"
+            );
+        }
+    }
 }
 
 /// `(books.id, last_modified_epoch)` for every book under `library_path`

--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -412,52 +412,8 @@ async fn move_progress_and_history(
         .fetch_one(&mut **tx)
         .await?;
 
-    // Losing source rows first (target is newer or equal) …
-    sqlx::query(
-        "DELETE FROM reading_progress WHERE book_uuid = ?2 AND EXISTS (
-            SELECT 1 FROM reading_progress t
-             WHERE t.book_uuid = ?1 AND t.user_id = reading_progress.user_id
-               AND t.format = reading_progress.format
-               AND t.updated_at >= reading_progress.updated_at)",
-    )
-    .bind(&target_uuid)
-    .bind(&source_uuid)
-    .execute(&mut **tx)
-    .await?;
-    // … then losing target rows (a strictly newer source row survived).
-    sqlx::query(
-        "DELETE FROM reading_progress WHERE book_uuid = ?1 AND EXISTS (
-            SELECT 1 FROM reading_progress s
-             WHERE s.book_uuid = ?2 AND s.user_id = reading_progress.user_id
-               AND s.format = reading_progress.format)",
-    )
-    .bind(&target_uuid)
-    .bind(&source_uuid)
-    .execute(&mut **tx)
-    .await?;
-    sqlx::query(
-        "DELETE FROM audiobook_playback_preferences
-          WHERE book_uuid = ?2 AND EXISTS (
-            SELECT 1 FROM audiobook_playback_preferences t
-             WHERE t.book_uuid = ?1
-               AND t.user_id = audiobook_playback_preferences.user_id
-               AND t.updated_at >= audiobook_playback_preferences.updated_at)",
-    )
-    .bind(&target_uuid)
-    .bind(&source_uuid)
-    .execute(&mut **tx)
-    .await?;
-    sqlx::query(
-        "DELETE FROM audiobook_playback_preferences
-          WHERE book_uuid = ?1 AND EXISTS (
-            SELECT 1 FROM audiobook_playback_preferences s
-             WHERE s.book_uuid = ?2
-               AND s.user_id = audiobook_playback_preferences.user_id)",
-    )
-    .bind(&target_uuid)
-    .bind(&source_uuid)
-    .execute(&mut **tx)
-    .await?;
+    dedupe_reading_progress(tx, &source_uuid, &target_uuid).await?;
+    dedupe_playback_preferences(tx, &source_uuid, &target_uuid).await?;
     // Per-device annotation sync state keys on (device_id, book_uuid); where a
     // device tracks BOTH uuids, keep the target's row (the retarget below
     // would collide) — the watermark is regenerable, and a moved fingerprint
@@ -489,6 +445,75 @@ async fn move_progress_and_history(
             .execute(&mut **tx)
             .await?;
     }
+    Ok(())
+}
+
+/// Latest-wins dedupe of `reading_progress` rows that collide on
+/// `(user_id, format)` once the source's uuid retargets onto the target's —
+/// see [`move_progress_and_history`]'s doc for why the coarse `format`
+/// column makes this necessary.
+async fn dedupe_reading_progress(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    source_uuid: &str,
+    target_uuid: &str,
+) -> Result<(), sqlx::Error> {
+    // Losing source rows first (target is newer or equal) …
+    sqlx::query(
+        "DELETE FROM reading_progress WHERE book_uuid = ?2 AND EXISTS (
+            SELECT 1 FROM reading_progress t
+             WHERE t.book_uuid = ?1 AND t.user_id = reading_progress.user_id
+               AND t.format = reading_progress.format
+               AND t.updated_at >= reading_progress.updated_at)",
+    )
+    .bind(target_uuid)
+    .bind(source_uuid)
+    .execute(&mut **tx)
+    .await?;
+    // … then losing target rows (a strictly newer source row survived).
+    sqlx::query(
+        "DELETE FROM reading_progress WHERE book_uuid = ?1 AND EXISTS (
+            SELECT 1 FROM reading_progress s
+             WHERE s.book_uuid = ?2 AND s.user_id = reading_progress.user_id
+               AND s.format = reading_progress.format)",
+    )
+    .bind(target_uuid)
+    .bind(source_uuid)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Latest-wins dedupe of `audiobook_playback_preferences` rows that collide
+/// on `user_id` once the source's uuid retargets onto the target's. Same
+/// two-pass shape as [`dedupe_reading_progress`].
+async fn dedupe_playback_preferences(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    source_uuid: &str,
+    target_uuid: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "DELETE FROM audiobook_playback_preferences
+          WHERE book_uuid = ?2 AND EXISTS (
+            SELECT 1 FROM audiobook_playback_preferences t
+             WHERE t.book_uuid = ?1
+               AND t.user_id = audiobook_playback_preferences.user_id
+               AND t.updated_at >= audiobook_playback_preferences.updated_at)",
+    )
+    .bind(target_uuid)
+    .bind(source_uuid)
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        "DELETE FROM audiobook_playback_preferences
+          WHERE book_uuid = ?1 AND EXISTS (
+            SELECT 1 FROM audiobook_playback_preferences s
+             WHERE s.book_uuid = ?2
+               AND s.user_id = audiobook_playback_preferences.user_id)",
+    )
+    .bind(target_uuid)
+    .bind(source_uuid)
+    .execute(&mut **tx)
+    .await?;
     Ok(())
 }
 

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -117,47 +117,16 @@ pub fn Cover(
         .as_deref()
         .map(|a| format!("--accent: {a};"))
         .unwrap_or_default();
-    // Fall back to the filename when the title is absent *or* an empty /
-    // whitespace-only string. Without this, books whose `title` is
-    // `Some("")` rendered a blank plate (issue #92): `unwrap_or_else` only
-    // fires on `None`, so an empty string slipped through as the title.
-    let title = fallback_title(book.title.as_deref(), &book.filename);
-    let author = book
-        .creators
-        .first()
-        .map(|c| c.name.clone())
-        .unwrap_or_default();
-    let author_label = author
-        .split(',')
-        .next()
-        .unwrap_or("")
-        .split_whitespace()
-        .next_back()
-        .unwrap_or("")
-        .to_uppercase();
-    // Callers that pass `src_override` (grid/table/rails) already built an
-    // authenticated, cache-busted URL themselves (`CoverTile::thumb_srcs`).
-    // The `book.cover_url` fallback (detail hero, listen page) is a relative
-    // `/api/covers/:uuid` path, so route it through `media_url` to give it an
-    // origin + mobile token (no-op on web), then apply this book's cache-bust
-    // counter — `/api/covers/*` is cached `private, max-age=86400`, so
-    // without it a book detail revisited after a cover edit would keep
-    // showing the pre-edit image until the cache expires (issue #1087).
+    let (title, author_label) = cover_plate_labels(&book);
     // `use_cover_cache_bust()` is the context lookup and stays unconditional
-    // per the rules of hooks, but the signal *read* (`cover_bust_for`) is
-    // gated on `src_override` being absent — reading it unconditionally
-    // would subscribe every mounted `Cover` to `CoverCacheBust`, forcing a
-    // re-render of the whole grid/table on a single book's cover bump.
+    // per the rules of hooks, but the signal *read* (`cover_bust_for`, inside
+    // `resolve_cover_image_src`) is gated on `src_override` being absent —
+    // reading it unconditionally would subscribe every mounted `Cover` to
+    // `CoverCacheBust`, forcing a re-render of the whole grid/table on a
+    // single book's cover bump.
     let server_url = use_server_url();
-    let uuid = book.unique_identifier.clone().unwrap_or_default();
     let cover_cache_bust = use_cover_cache_bust();
-    let image_src = match src_override {
-        Some(src) => Some(src),
-        None => book.cover_url.as_deref().map(|path| {
-            let cache_bust = cover_bust_for(cover_cache_bust.0, &uuid);
-            append_cache_bust(media_url(&server_url, path), cache_bust)
-        }),
-    };
+    let image_src = resolve_cover_image_src(&book, src_override, &server_url, cover_cache_bust);
     let srcset_attr = srcset.unwrap_or_default();
     let sizes_attr = sizes.unwrap_or_default();
     // Broken/expired cover URLs otherwise render the browser's broken-image
@@ -197,6 +166,53 @@ pub fn Cover(
                 }
             }
         }
+    }
+}
+
+/// The typographic plate's title text and uppercase author-initials label
+/// (last name of the first-listed creator's first comma-separated segment).
+fn cover_plate_labels(book: &EbookMetadata) -> (String, String) {
+    // Fall back to the filename when the title is absent *or* an empty /
+    // whitespace-only string. Without this, books whose `title` is
+    // `Some("")` rendered a blank plate (issue #92): `unwrap_or_else` only
+    // fires on `None`, so an empty string slipped through as the title.
+    let title = fallback_title(book.title.as_deref(), &book.filename);
+    let author = book
+        .creators
+        .first()
+        .map(|c| c.name.clone())
+        .unwrap_or_default();
+    let author_label = author
+        .split(',')
+        .next()
+        .unwrap_or("")
+        .split_whitespace()
+        .next_back()
+        .unwrap_or("")
+        .to_uppercase();
+    (title, author_label)
+}
+
+/// Resolve the `<img src>` for a cover: `src_override` when the caller
+/// already built one (grid/table/rails point this at the resized thumbnail
+/// endpoint via `CoverTile::thumb_srcs`), otherwise `book.cover_url` routed
+/// through `media_url` (origin + mobile token, no-op on web) and this book's
+/// cache-bust counter — `/api/covers/*` is cached `private, max-age=86400`,
+/// so without the bust a book detail revisited after a cover edit would keep
+/// showing the pre-edit image until the cache expires (issue #1087).
+fn resolve_cover_image_src(
+    book: &EbookMetadata,
+    src_override: Option<String>,
+    server_url: &str,
+    cover_cache_bust: crate::contexts::CoverCacheBust,
+) -> Option<String> {
+    match src_override {
+        Some(src) => Some(src),
+        None => book.cover_url.as_deref().map(|path| {
+            let uuid = book.unique_identifier.clone().unwrap_or_default();
+            let cache_bust = cover_bust_for(cover_cache_bust.0, &uuid);
+            append_cache_bust(media_url(server_url, path), cache_bust)
+        }),
     }
 }
 

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -163,7 +163,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
     let ChipEditorState {
         mut input,
         mut highlight,
-        mut focused,
+        focused,
         mut suppress_open,
         mut root_el,
     } = use_chip_editor_state(props.options.autofocus);
@@ -195,6 +195,16 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
             &on_close,
         );
     };
+    let callbacks = build_input_area_callbacks(
+        input,
+        highlight,
+        focused,
+        suppress_open,
+        root_el,
+        on_close,
+        on_keydown,
+        commit,
+    );
 
     rsx! {
         // `display: contents` (atrium.css) keeps this wrapper invisible to
@@ -227,39 +237,57 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
                     highlight: highlight(),
                     dropdown_header: props.options.dropdown_header.clone(),
                 },
-                callbacks: ChipInputAreaCallbacks {
-                    input: ChipInputCallbacks {
-                        on_focus: EventHandler::new(move |_| {
-                            focused.set(true);
-                            suppress_open.set(false);
-                        }),
-                        on_blur: EventHandler::new(move |evt: Event<FocusData>| {
-                            focused.set(false);
-                            highlight.set(None);
-                            // Mirrors `EditableCell`'s onblur: a genuine click-away
-                            // (or Tab past the whole editor) exits the host's
-                            // wrapping edit mode the same way Escape does — but Tab
-                            // *within* the editor (e.g. onto a chip's Remove
-                            // button) must not, so this only closes when the
-                            // element gaining focus falls outside `root_el`.
-                            // Suggestion-row picks never reach here at all:
-                            // `SuggestionDropdown`'s `onmousedown` calls
-                            // `prevent_default()`, suppressing the browser's
-                            // default focus-shift so the input never blurs during
-                            // a pick.
-                            close_unless_focus_stayed_inside(evt, root_el, on_close);
-                        }),
-                        on_input: EventHandler::new(move |value: String| {
-                            input.set(value);
-                            highlight.set(None);
-                            suppress_open.set(false);
-                        }),
-                        on_keydown: EventHandler::new(on_keydown),
-                    },
-                    on_pick: EventHandler::new(move |name: String| commit(name)),
-                },
+                callbacks,
             }
         }
+    }
+}
+
+/// Assemble the input area's focus/blur/input/keydown/pick callbacks from
+/// the editor's local signals and the already-built `on_keydown`/`commit`
+/// closures. Split out of [`ChipEditor`] purely to keep that component's
+/// body under the file's line-count guidance — no behavioral change.
+#[allow(clippy::too_many_arguments)]
+fn build_input_area_callbacks(
+    mut input: Signal<String>,
+    mut highlight: Signal<Option<usize>>,
+    mut focused: Signal<bool>,
+    mut suppress_open: Signal<bool>,
+    root_el: Signal<Option<ChipEditorRoot>>,
+    on_close: EventHandler<()>,
+    on_keydown: impl FnMut(Event<KeyboardData>) + 'static,
+    mut commit: impl FnMut(String) + 'static,
+) -> ChipInputAreaCallbacks {
+    ChipInputAreaCallbacks {
+        input: ChipInputCallbacks {
+            on_focus: EventHandler::new(move |_| {
+                focused.set(true);
+                suppress_open.set(false);
+            }),
+            on_blur: EventHandler::new(move |evt: Event<FocusData>| {
+                focused.set(false);
+                highlight.set(None);
+                // Mirrors `EditableCell`'s onblur: a genuine click-away
+                // (or Tab past the whole editor) exits the host's
+                // wrapping edit mode the same way Escape does — but Tab
+                // *within* the editor (e.g. onto a chip's Remove
+                // button) must not, so this only closes when the
+                // element gaining focus falls outside `root_el`.
+                // Suggestion-row picks never reach here at all:
+                // `SuggestionDropdown`'s `onmousedown` calls
+                // `prevent_default()`, suppressing the browser's
+                // default focus-shift so the input never blurs during
+                // a pick.
+                close_unless_focus_stayed_inside(evt, root_el, on_close);
+            }),
+            on_input: EventHandler::new(move |value: String| {
+                input.set(value);
+                highlight.set(None);
+                suppress_open.set(false);
+            }),
+            on_keydown: EventHandler::new(on_keydown),
+        },
+        on_pick: EventHandler::new(move |name: String| commit(name)),
     }
 }
 

--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -245,8 +245,7 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
 
 /// Assemble the input area's focus/blur/input/keydown/pick callbacks from
 /// the editor's local signals and the already-built `on_keydown`/`commit`
-/// closures. Split out of [`ChipEditor`] purely to keep that component's
-/// body under the file's line-count guidance — no behavioral change.
+/// closures.
 #[allow(clippy::too_many_arguments)]
 fn build_input_area_callbacks(
     mut input: Signal<String>,

--- a/frontend/src/components/quote_card.rs
+++ b/frontend/src/components/quote_card.rs
@@ -407,49 +407,89 @@ fn render_quote_actions(
     }
 }
 
-/// Quote-card editor panel: head + preview + controls. Shell-agnostic — the
-/// reader wraps it in its right-hand drawer, book detail in a centered modal.
-#[component]
-pub fn QuoteCardPanel(
-    quote_text: String,
-    author: String,
-    subtitle: String,
-    accent: String,
-    on_close: EventHandler<()>,
-) -> Element {
-    let bg = use_signal(|| accent.clone());
-    let ink = use_signal(|| "#f5f0e8".to_string());
-    let ratio = use_signal(|| "1:1".to_string());
-    let custom = use_signal(|| "#6b4f8a".to_string());
-    let font = use_signal(|| FONTS[0].key.to_string());
-    let size = use_signal(|| SIZES[1].key.to_string());
-    let bold = use_signal(|| false);
-    // The card's designed default is an italic serif pull-quote.
-    let italic = use_signal(|| true);
+/// Local reactive state for one [`QuoteCardPanel`] instance — background,
+/// typeface/size/style, and aspect-ratio signals, grouped so the component
+/// starts from one hook call instead of eight signal declarations.
+#[derive(Clone, Copy)]
+struct QuoteCardState {
+    bg: Signal<String>,
+    ink: Signal<String>,
+    ratio: Signal<String>,
+    custom: Signal<String>,
+    font: Signal<String>,
+    size: Signal<String>,
+    bold: Signal<bool>,
+    italic: Signal<bool>,
+}
 
-    let cur_bg = bg();
-    let cur_ink = ink();
-    let cur_ratio = ratio();
+fn use_quote_card_state(accent: &str) -> QuoteCardState {
+    QuoteCardState {
+        bg: use_signal(|| accent.to_string()),
+        ink: use_signal(|| "#f5f0e8".to_string()),
+        ratio: use_signal(|| "1:1".to_string()),
+        custom: use_signal(|| "#6b4f8a".to_string()),
+        font: use_signal(|| FONTS[0].key.to_string()),
+        size: use_signal(|| SIZES[1].key.to_string()),
+        bold: use_signal(|| false),
+        // The card's designed default is an italic serif pull-quote.
+        italic: use_signal(|| true),
+    }
+}
+
+/// Derive the preview's inline `(card_style, body_style, cur_ratio)` from
+/// the current state signals.
+fn compute_quote_styles(state: &QuoteCardState) -> (String, String, String) {
+    let cur_bg = (state.bg)();
+    let cur_ink = (state.ink)();
+    let cur_ratio = (state.ratio)();
     let card_style = format!(
         "aspect-ratio:{}; background:{cur_bg}; color:{cur_ink}; font-family:{};",
         cur_ratio.replace(':', "/"),
-        font_css(&font())
+        font_css(&(state.font)())
     );
     let body_style = format!(
         "font-size:{}; font-weight:{}; font-style:{};",
-        size_css(&size()),
-        if bold() { "700" } else { "400" },
-        if italic() { "italic" } else { "normal" },
+        size_css(&(state.size)()),
+        if (state.bold)() { "700" } else { "400" },
+        if (state.italic)() { "italic" } else { "normal" },
     );
+    (card_style, body_style, cur_ratio)
+}
 
-    // One canvas payload for all three actions (download / share / copy);
-    // `Clone` so each button handler owns a copy. Only the interactive
-    // targets build it — `serde_json` isn't compiled in on SSR.
+/// Build the three export-action handlers (download/share/copy), each
+/// wrapping the same canvas payload built from the quote text and the
+/// current style signals. `Clone` on `build_payload` lets each button
+/// handler own a copy. Only the interactive targets build it — `serde_json`
+/// isn't compiled in on SSR — so `quote_text`/`author`/`subtitle` go unused
+/// there, hence the `cfg_attr` below (same pattern as
+/// `pages::reader::highlights_drawer`).
+#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(unused_variables))]
+#[allow(clippy::type_complexity)]
+fn build_export_handlers(
+    quote_text: &str,
+    author: &str,
+    subtitle: &str,
+    state: &QuoteCardState,
+) -> (
+    impl FnMut(Event<MouseData>) + 'static,
+    impl FnMut(Event<MouseData>) + 'static,
+    impl FnMut(Event<MouseData>) + 'static,
+) {
+    let QuoteCardState {
+        bg,
+        ink,
+        ratio,
+        font,
+        size,
+        bold,
+        italic,
+        ..
+    } = *state;
     #[cfg(any(feature = "web", feature = "mobile"))]
     let build_payload = {
-        let text = quote_text.clone();
-        let author = author.clone();
-        let subtitle = subtitle.clone();
+        let text = quote_text.to_string();
+        let author = author.to_string();
+        let subtitle = subtitle.to_string();
         move || {
             serde_json::json!({
                 "text": text,
@@ -494,6 +534,33 @@ pub fn QuoteCardPanel(
             quote_card_call("copyQuoteCardImage", &build_payload());
         }
     };
+    (download, share, copy_image)
+}
+
+/// Quote-card editor panel: head + preview + controls. Shell-agnostic — the
+/// reader wraps it in its right-hand drawer, book detail in a centered modal.
+#[component]
+pub fn QuoteCardPanel(
+    quote_text: String,
+    author: String,
+    subtitle: String,
+    accent: String,
+    on_close: EventHandler<()>,
+) -> Element {
+    let state = use_quote_card_state(&accent);
+    let QuoteCardState {
+        bg,
+        ink,
+        ratio,
+        custom,
+        font,
+        size,
+        bold,
+        italic,
+    } = state;
+    let (card_style, body_style, cur_ratio) = compute_quote_styles(&state);
+    let (download, share, copy_image) =
+        build_export_handlers(&quote_text, &author, &subtitle, &state);
 
     rsx! {
         {render_quote_header(on_close)}

--- a/frontend/src/components/search_palette/overlay.rs
+++ b/frontend/src/components/search_palette/overlay.rs
@@ -127,10 +127,10 @@ fn use_sp_overlay_state() -> SpOverlayState {
 }
 
 /// Derived wiring for [`SpOverlay`]: the flat selectable-item list plus the
-/// close/keydown/search handlers the panel renders with. Split out purely to
-/// keep [`SpOverlay`] itself under the file's line-count guidance — every
-/// hook call here still runs during that component's own render, in the
-/// same order every time.
+/// close/keydown/search handlers the panel renders with. Every hook call
+/// here still runs during [`SpOverlay`]'s own render, in the same order
+/// every time — required since Dioxus hooks must stay unconditional and
+/// order-stable regardless of which function body they're written in.
 #[allow(clippy::type_complexity)]
 fn build_overlay_wiring(
     open: PaletteOpen,

--- a/frontend/src/components/search_palette/overlay.rs
+++ b/frontend/src/components/search_palette/overlay.rs
@@ -9,7 +9,7 @@ use dioxus_router::use_navigator;
 use omnibus_shared::PaletteResults;
 
 use super::keyboard::{make_keydown_handler, KeyboardContext};
-use super::model::{build_flat_items, plural};
+use super::model::{build_flat_items, plural, FlatItem};
 use super::results::SpResultsList;
 use super::PaletteOpen;
 use crate::components::glyphs::search_glyph;
@@ -92,35 +92,72 @@ fn sp_meta_and_error(has_results: bool, total: usize, duration: u64, is_errored:
     }
 }
 
-/// Floating overlay: dark scrim + centered panel with input, results, footer.
-#[component]
-pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
-    let mut open = open;
-    let server_url = use_server_url();
-    let mut query = use_signal(String::new);
-    let results = use_signal(|| Option::<PaletteResults>::None);
-    let mut selected = use_signal(|| 0_usize);
-    let loading = use_signal(|| false);
+/// Local reactive state for one [`SpOverlay`] instance — a custom-hook-style
+/// helper (the same pattern `chip_editor::use_chip_editor_state` uses) so the
+/// component itself starts from the derived wiring instead of a wall of
+/// signal declarations.
+#[derive(Clone, Copy)]
+struct SpOverlayState {
+    query: Signal<String>,
+    results: Signal<Option<PaletteResults>>,
+    selected: Signal<usize>,
+    loading: Signal<bool>,
     // Set on a failed search, distinct from "no matches" (mirrors
     // `search_mobile.rs`'s `errored` signal for the same underlying call).
-    let errored = use_signal(|| false);
+    errored: Signal<bool>,
     // Tracks whether the user has driven selection with arrow keys this
     // session. When false, pressing Enter navigates to the full-page
     // search results instead of drilling into `selected`.
-    let mut has_navigated = use_signal(|| false);
+    has_navigated: Signal<bool>,
     // #126: handle of the in-flight debounce+RPC task — see
     // `build_search_dispatcher`.
-    let current_task = use_signal(|| Option::<Task>::None);
-    let nav = use_navigator();
+    current_task: Signal<Option<Task>>,
+}
 
-    // Build a flat list of selectable items for keyboard navigation.
+fn use_sp_overlay_state() -> SpOverlayState {
+    SpOverlayState {
+        query: use_signal(String::new),
+        results: use_signal(|| Option::<PaletteResults>::None),
+        selected: use_signal(|| 0_usize),
+        loading: use_signal(|| false),
+        errored: use_signal(|| false),
+        has_navigated: use_signal(|| false),
+        current_task: use_signal(|| Option::<Task>::None),
+    }
+}
+
+/// Derived wiring for [`SpOverlay`]: the flat selectable-item list plus the
+/// close/keydown/search handlers the panel renders with. Split out purely to
+/// keep [`SpOverlay`] itself under the file's line-count guidance — every
+/// hook call here still runs during that component's own render, in the
+/// same order every time.
+#[allow(clippy::type_complexity)]
+fn build_overlay_wiring(
+    open: PaletteOpen,
+    server_url: String,
+    state: SpOverlayState,
+) -> (
+    Memo<Vec<FlatItem>>,
+    impl FnMut() + 'static,
+    impl FnMut(Event<KeyboardData>) + 'static,
+    impl FnMut(String) + 'static,
+) {
+    let SpOverlayState {
+        query,
+        results,
+        selected,
+        loading,
+        errored,
+        has_navigated,
+        current_task,
+    } = state;
+    let mut open_mut = open;
+    let nav = use_navigator();
     let flat_items = use_memo(move || build_flat_items(&results.read()));
 
-    // Close the palette.
-    let mut close = move || {
-        open.0.set(false);
+    let close = move || {
+        open_mut.0.set(false);
     };
-
     let on_keydown = make_keydown_handler(KeyboardContext {
         open,
         selected,
@@ -129,15 +166,34 @@ pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
         query,
         nav,
     });
-
-    let mut spawn_search = build_search_dispatcher(
-        server_url.clone(),
+    let spawn_search = build_search_dispatcher(
+        server_url,
         results,
         selected,
         loading,
         errored,
         current_task,
     );
+
+    (flat_items, close, on_keydown, spawn_search)
+}
+
+/// Floating overlay: dark scrim + centered panel with input, results, footer.
+#[component]
+pub(super) fn SpOverlay(open: PaletteOpen) -> Element {
+    let server_url = use_server_url();
+    let state = use_sp_overlay_state();
+    let SpOverlayState {
+        mut query,
+        results,
+        mut selected,
+        loading,
+        errored,
+        mut has_navigated,
+        ..
+    } = state;
+    let (flat_items, mut close, on_keydown, mut spawn_search) =
+        build_overlay_wiring(open, server_url, state);
 
     let res = results.read();
     let is_loading = loading();

--- a/frontend/src/offline/downloads/engine.rs
+++ b/frontend/src/offline/downloads/engine.rs
@@ -89,8 +89,72 @@ async fn run_inner(
     format: DlFormat,
     file_id: Option<i64>,
 ) -> anyhow::Result<()> {
-    // The raw `_online` variant: starting a download while offline must
-    // fail loudly, never silently plan from a stale cached book.
+    let (book, title) = load_book(server_url, uuid).await?;
+
+    // Snapshot the wire validator of the `book_files` row this download
+    // targets. A later metadata refresh compares against it to learn the
+    // library file was replaced — see `downloads::is_stale`.
+    let source_etag = super::target_file(&book, format, file_id).and_then(|f| f.etag.clone());
+
+    let (plan, total_estimate) = plan_for_format(server_url, uuid, file_id, &book, format).await?;
+    if plan.is_empty() {
+        return Err(DownloadError::NothingToDownload.into());
+    }
+
+    let dir = media::downloads_root()
+        .map(|r| r.join(uuid))
+        .ok_or(DownloadError::StorageUnavailable)?;
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .context("Offline storage unavailable")?;
+
+    let mut files = prepare_files(&dir, uuid, format, source_etag, plan).await;
+
+    let downloaded: i64 = files.iter().filter_map(|f| f.bytes).sum();
+    publish(
+        uuid,
+        format,
+        &title,
+        file_id,
+        &files,
+        downloaded,
+        total_estimate,
+    );
+
+    run_downloads(
+        server_url,
+        uuid,
+        format,
+        &dir,
+        file_id,
+        &title,
+        &mut files,
+        downloaded,
+        total_estimate,
+    )
+    .await?;
+
+    warm_related(server_url, uuid, &book, format).await;
+
+    let bytes: i64 = files.iter().filter_map(|f| f.bytes).sum();
+    super::upsert(DownloadEntry {
+        book_uuid: uuid.to_string(),
+        format,
+        title,
+        file_id,
+        status: DownloadStatus::Complete { bytes },
+        files,
+        updated_at: crate::offline::store::now_secs(),
+        stale: false,
+    });
+    Ok(())
+}
+
+/// Fetch the book's live metadata, cache it, and derive its display title.
+///
+/// Uses the raw `_online` variant: starting a download while offline must
+/// fail loudly, never silently plan from a stale cached book.
+async fn load_book(server_url: &str, uuid: &str) -> anyhow::Result<(EbookMetadata, String)> {
     let book = data::get_ebook_online(server_url, uuid)
         .await
         .map_err(|e| friendly(&e))?
@@ -101,14 +165,20 @@ async fn run_inner(
         .clone()
         .filter(|t| !t.trim().is_empty())
         .unwrap_or_else(|| book.filename.clone());
+    Ok((book, title))
+}
 
-    // Snapshot the wire validator of the `book_files` row this download
-    // targets. A later metadata refresh compares against it to learn the
-    // library file was replaced — see `downloads::is_stale`.
-    let source_etag = super::target_file(&book, format, file_id).and_then(|f| f.etag.clone());
-
-    let (plan, total_estimate) = match format {
-        DlFormat::Epub => (plan_epub(uuid, file_id), epub_size_estimate(&book)),
+/// Build the file plan and size estimate for `format`, fetching (and
+/// caching) the audiobook manifest first when needed.
+async fn plan_for_format(
+    server_url: &str,
+    uuid: &str,
+    file_id: Option<i64>,
+    book: &EbookMetadata,
+    format: DlFormat,
+) -> anyhow::Result<(Vec<PlannedFile>, Option<i64>)> {
+    Ok(match format {
+        DlFormat::Epub => (plan_epub(uuid, file_id), epub_size_estimate(book)),
         DlFormat::Audio => {
             let fid = file_id.or_else(|| super::default_audio_file_id(&book.book_files));
             let manifest = data::get_manifest_online(server_url, uuid, fid)
@@ -124,23 +194,22 @@ async fn run_inner(
             };
             // The offline player reads the manifest from this cache row.
             cache::put_json(&cache::keys::manifest(uuid, fid), &manifest);
-            (plan_audio_parts(&parts), audio_size_estimate(&book))
+            (plan_audio_parts(&parts), audio_size_estimate(book))
         }
-    };
-    if plan.is_empty() {
-        return Err(DownloadError::NothingToDownload.into());
-    }
+    })
+}
 
-    let dir = media::downloads_root()
-        .map(|r| r.join(uuid))
-        .ok_or(DownloadError::StorageUnavailable)?;
-    tokio::fs::create_dir_all(&dir)
-        .await
-        .context("Offline storage unavailable")?;
-
-    // Merge prior completion state (resume of a partly-finished download).
-    // Stat asynchronously — this future shares the loopback runtime with the
-    // media server, so blocking std::fs calls here would stall playback.
+/// Merge prior completion state (resume of a partly-finished download) onto
+/// a fresh plan. Stat asynchronously — this future shares the loopback
+/// runtime with the media server, so blocking std::fs calls here would
+/// stall playback.
+async fn prepare_files(
+    dir: &std::path::Path,
+    uuid: &str,
+    format: DlFormat,
+    source_etag: Option<String>,
+    plan: Vec<PlannedFile>,
+) -> Vec<PlannedFile> {
     let prior = super::get_entry(uuid, format)
         .map(|e| e.files)
         .unwrap_or_default();
@@ -155,7 +224,7 @@ async fn run_inner(
                 // the rest from the new — and stamp every part with the
                 // current validator, so nothing downstream would ever
                 // report it. Start this file over instead.
-                discard_partial(&dir, &f.rel).await;
+                discard_partial(dir, &f.rel).await;
             } else {
                 // Carry the prior attempt's response validator forward so
                 // the resume below can offer it as `If-Range`.
@@ -172,18 +241,24 @@ async fn run_inner(
         }
         files.push(f);
     }
+    files
+}
 
-    let mut downloaded: i64 = files.iter().filter_map(|f| f.bytes).sum();
-    publish(
-        uuid,
-        format,
-        &title,
-        file_id,
-        &files,
-        downloaded,
-        total_estimate,
-    );
-
+/// Download every not-yet-`done` planned file in order, publishing progress
+/// (and per-file completion) along the way. Returns the total bytes
+/// downloaded across all files once the loop completes.
+#[allow(clippy::too_many_arguments)]
+async fn run_downloads(
+    server_url: &str,
+    uuid: &str,
+    format: DlFormat,
+    dir: &std::path::Path,
+    file_id: Option<i64>,
+    title: &str,
+    files: &mut [PlannedFile],
+    mut downloaded: i64,
+    total_estimate: Option<i64>,
+) -> anyhow::Result<i64> {
     for idx in 0..files.len() {
         if files[idx].done {
             continue;
@@ -195,7 +270,7 @@ async fn run_inner(
         let planned = files[idx].clone();
         let result = download_file(
             server_url,
-            &dir,
+            dir,
             &planned,
             &mut |etag: Option<String>| {
                 observed_etag.clone_from(&etag);
@@ -227,28 +302,14 @@ async fn run_inner(
         publish(
             uuid,
             format,
-            &title,
+            title,
             file_id,
-            &files,
+            files,
             downloaded,
             total_estimate,
         );
     }
-
-    warm_related(server_url, uuid, &book, format).await;
-
-    let bytes: i64 = files.iter().filter_map(|f| f.bytes).sum();
-    super::upsert(DownloadEntry {
-        book_uuid: uuid.to_string(),
-        format,
-        title,
-        file_id,
-        status: DownloadStatus::Complete { bytes },
-        files,
-        updated_at: crate::offline::store::now_secs(),
-        stale: false,
-    });
-    Ok(())
+    Ok(downloaded)
 }
 
 /// Whether bytes already on disk can be shown to have come from the file
@@ -325,8 +386,6 @@ async fn download_file(
     on_etag: &mut (dyn FnMut(Option<String>) + Send),
     on_delta: &mut (dyn FnMut(i64) + Send),
 ) -> anyhow::Result<Fetched> {
-    use tokio::io::AsyncWriteExt;
-
     let part_path = dir.join(format!("{}.part", file.rel));
     let final_path = dir.join(&file.rel);
     let resumed = tokio::fs::metadata(&part_path)
@@ -334,9 +393,57 @@ async fn download_file(
         .map(|m| m.len())
         .unwrap_or(0);
 
+    let mut resp = send_ranged_request(server_url, file, resumed).await?;
+
+    // 206 → append after the existing bytes; 200 → the server refused the
+    // Range because the file moved (or none was sent), start over.
+    let appending = resp.status() == reqwest::StatusCode::PARTIAL_CONTENT && resumed > 0;
+    on_etag(
+        resp.headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string),
+    );
+    let expected_total = resp
+        .content_length()
+        .map(|cl| if appending { resumed + cl } else { cl });
+
+    let written =
+        write_body_to_part(&mut resp, &part_path, file, appending, resumed, on_delta).await?;
+    if let Some(expected) = expected_total {
+        if written != expected as i64 {
+            return Err(DownloadError::Interrupted.into());
+        }
+    }
+    tokio::fs::rename(&part_path, &final_path)
+        .await
+        .context("Could not finalize the download")?;
+
+    // A byte count proves the transfer ran to length; it does not prove the
+    // bytes cohere. Check the container closes before this file is offered
+    // to a reader — the one guard that also covers a replacement no
+    // stat-derived validator can see (rule 09's known residual).
+    if verify::verify(&final_path).await == Verdict::Damaged {
+        tracing::warn!(rel = %file.rel, url = %file.url_path, "offline download: assembled file failed container verification");
+        // Remove it rather than leave a corrupt book on disk that a retry
+        // would try to resume from.
+        let _ = tokio::fs::remove_file(&final_path).await;
+        return Err(DownloadError::Damaged.into());
+    }
+
+    Ok(Fetched { bytes: written })
+}
+
+/// Send the (possibly resumed) request for one planned file, mapping
+/// transport failures and non-success statuses to a [`DownloadError`].
+/// Streaming client: no whole-request timeout, so a large book can't be
+/// killed mid-transfer by the default client's 30s cap.
+async fn send_ranged_request(
+    server_url: &str,
+    file: &PlannedFile,
+    resumed: u64,
+) -> anyhow::Result<reqwest::Response> {
     let url = format!("{server_url}{}", file.url_path);
-    // Streaming client: no whole-request timeout, so a large book can't be
-    // killed mid-transfer by the default client's 30s cap.
     let mut req = data::with_bearer(data::streaming_client().get(&url));
     if resumed > 0 {
         req = req.header(reqwest::header::RANGE, format!("bytes={resumed}-"));
@@ -350,7 +457,7 @@ async fn download_file(
             }
         }
     }
-    let mut resp = req.send().await.map_err(|e| {
+    let resp = req.send().await.map_err(|e| {
         tracing::warn!(error = %e, url = %file.url_path, "offline download: request failed");
         DownloadError::ConnectionLost
     })?;
@@ -363,25 +470,28 @@ async fn download_file(
         tracing::warn!(status = status.as_u16(), url = %file.url_path, "offline download: server returned a non-success status");
         return Err(DownloadError::ServerError.into());
     }
+    Ok(resp)
+}
 
-    // 206 → append after the existing bytes; 200 → the server refused the
-    // Range because the file moved (or none was sent), start over.
-    let appending = status == reqwest::StatusCode::PARTIAL_CONTENT && resumed > 0;
-    on_etag(
-        resp.headers()
-            .get(reqwest::header::ETAG)
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_string),
-    );
-    let expected_total = resp
-        .content_length()
-        .map(|cl| if appending { resumed + cl } else { cl });
+/// Stream `resp`'s body into `{rel}.part`, correcting the progress counter
+/// for the `appending`/restart transition first, then return the file's
+/// final size on disk.
+async fn write_body_to_part(
+    resp: &mut reqwest::Response,
+    part_path: &std::path::Path,
+    file: &PlannedFile,
+    appending: bool,
+    resumed: u64,
+    on_delta: &mut (dyn FnMut(i64) + Send),
+) -> anyhow::Result<i64> {
+    use tokio::io::AsyncWriteExt;
+
     let mut out = tokio::fs::OpenOptions::new()
         .create(true)
         .append(appending)
         .write(true)
         .truncate(!appending)
-        .open(&part_path)
+        .open(part_path)
         .await
         .context("Could not save the download to this device")?;
     if appending {
@@ -413,32 +523,10 @@ async fn download_file(
         .context("Could not save the download to this device")?;
     drop(out);
 
-    let written = tokio::fs::metadata(&part_path)
+    tokio::fs::metadata(part_path)
         .await
         .map(|m| m.len() as i64)
-        .context("Could not verify the downloaded file")?;
-    if let Some(expected) = expected_total {
-        if written != expected as i64 {
-            return Err(DownloadError::Interrupted.into());
-        }
-    }
-    tokio::fs::rename(&part_path, &final_path)
-        .await
-        .context("Could not finalize the download")?;
-
-    // A byte count proves the transfer ran to length; it does not prove the
-    // bytes cohere. Check the container closes before this file is offered
-    // to a reader — the one guard that also covers a replacement no
-    // stat-derived validator can see (rule 09's known residual).
-    if verify::verify(&final_path).await == Verdict::Damaged {
-        tracing::warn!(rel = %file.rel, url = %file.url_path, "offline download: assembled file failed container verification");
-        // Remove it rather than leave a corrupt book on disk that a retry
-        // would try to resume from.
-        let _ = tokio::fs::remove_file(&final_path).await;
-        return Err(DownloadError::Damaged.into());
-    }
-
-    Ok(Fetched { bytes: written })
+        .context("Could not verify the downloaded file")
 }
 
 /// Warm every cache a downloaded book needs offline: artwork (lock screen,

--- a/server/src/backend/kobo/state.rs
+++ b/server/src/backend/kobo/state.rs
@@ -54,89 +54,137 @@ pub async fn put_state(
         Err(e) => return internal("kobo put_state begin", e),
     };
     for entry in &body.reading_states {
-        if let Some(info) = &entry.status_info {
-            let update = SetReadStatus {
-                book_uuid: uuid.clone(),
-                status: map_status(&info.status),
-            };
-            match db::read_status::set_read_status_tx(&mut tx, auth.user_id, &update).await {
-                Ok(_) => {}
-                // A state push for a book the server never indexed is not fatal
-                // to the sync — log and keep the success envelope.
-                Err(db::read_status::ReadStatusError::BookNotFound) => {
-                    tracing::warn!(%uuid, "kobo state PUT for unknown book");
-                }
-                Err(db::read_status::ReadStatusError::Sqlx(e)) => {
-                    return internal("kobo set_read_status", e);
-                }
-            }
-        }
-        if let Some(bookmark) = &entry.current_bookmark {
-            // Capture data for the one open question about this field: whether
-            // the content-source percent really is per-chapter (as
-            // `persist_bookmark` assumes) or just echoes the whole-book one.
-            // Nothing in this repo has ever recorded a real device's answer,
-            // and sync-out can't emit the field until it is known.
-            tracing::info!(
-                %uuid,
-                whole_book = ?bookmark.progress_percent,
-                content_source = ?bookmark.content_source_progress_percent,
-                "kobo bookmark percents received"
-            );
-            // Device event time, most-specific first: the bookmark's own
-            // stamp, then the entry-level ones. Absent/unparseable → None,
-            // which `persist_bookmark` treats as server-now (pre-existing
-            // behaviour for firmware that sends no clock).
-            let event_ts = bookmark
-                .last_modified
-                .as_deref()
-                .or(entry.last_modified.as_deref())
-                .or(entry.priority_timestamp.as_deref())
-                .and_then(dto::parse_kobo_timestamp);
-            match persist_bookmark(&state, &mut tx, auth.user_id, &uuid, bookmark, event_ts).await {
-                Ok(()) => {}
-                Err(db::progress::ProgressError::BookNotFound) => {
-                    tracing::warn!(%uuid, "kobo position PUT for unknown book");
-                }
-                Err(db::progress::ProgressError::Sqlx(e)) => {
-                    return internal("kobo upsert_progress", e);
-                }
-            }
-        }
-        if let Some(stats) = &entry.statistics {
-            // Kept from #1652's capture pass — the shape came from the
-            // reference impls, not from hardware.
-            tracing::info!(
-                %uuid,
-                spent_reading_minutes = ?stats.spent_reading_minutes,
-                remaining_time_minutes = ?stats.remaining_time_minutes,
-                last_modified = ?stats.last_modified,
-                "kobo statistics received"
-            );
-            // No entry-level fallback, unlike the bookmark: an entry clock is
-            // still a device clock, but it would date counters the device did
-            // not date itself, and this stamp decides whether the device
-            // overwrites its own totals with our echo. Unstamped is safe —
-            // sync-out omits it and the device keeps what it has.
-            let event_ts = stats
-                .last_modified
-                .as_deref()
-                .and_then(dto::parse_kobo_timestamp);
-            match persist_statistics(&mut tx, auth.user_id, &uuid, stats, event_ts).await {
-                Ok(()) => {}
-                Err(db::progress::ProgressError::BookNotFound) => {
-                    tracing::warn!(%uuid, "kobo statistics PUT for unknown book");
-                }
-                Err(db::progress::ProgressError::Sqlx(e)) => {
-                    return internal("kobo set_kobo_statistics", e);
-                }
-            }
+        if let Err(rejected) =
+            apply_reading_state_entry(&state, &mut tx, auth.user_id, &uuid, entry).await
+        {
+            return rejected;
         }
     }
     if let Err(e) = tx.commit().await {
         return internal("kobo put_state commit", e);
     }
     Json(dto::StateResponse::success(uuid)).into_response()
+}
+
+/// Apply one `reading_states` entry's status/bookmark/statistics writes
+/// within the batch transaction. `Err` carries the response [`put_state`]
+/// should return immediately (a DB failure); a per-entry `BookNotFound` is
+/// logged and treated as `Ok` so the rest of the batch still applies.
+async fn apply_reading_state_entry(
+    state: &AppState,
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    uuid: &str,
+    entry: &dto::StateEntry,
+) -> Result<(), Response> {
+    if let Some(info) = &entry.status_info {
+        apply_status_info(tx, user_id, uuid, info).await?;
+    }
+    if let Some(bookmark) = &entry.current_bookmark {
+        apply_current_bookmark(state, tx, user_id, uuid, entry, bookmark).await?;
+    }
+    if let Some(stats) = &entry.statistics {
+        apply_statistics(tx, user_id, uuid, stats).await?;
+    }
+    Ok(())
+}
+
+/// Apply a `StatusInfo` block's read-status write.
+async fn apply_status_info(
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    uuid: &str,
+    info: &dto::StatusInfo,
+) -> Result<(), Response> {
+    let update = SetReadStatus {
+        book_uuid: uuid.to_owned(),
+        status: map_status(&info.status),
+    };
+    match db::read_status::set_read_status_tx(tx, user_id, &update).await {
+        Ok(_) => Ok(()),
+        // A state push for a book the server never indexed is not fatal
+        // to the sync — log and keep the success envelope.
+        Err(db::read_status::ReadStatusError::BookNotFound) => {
+            tracing::warn!(%uuid, "kobo state PUT for unknown book");
+            Ok(())
+        }
+        Err(db::read_status::ReadStatusError::Sqlx(e)) => Err(internal("kobo set_read_status", e)),
+    }
+}
+
+/// Log and persist a `CurrentBookmark` block.
+async fn apply_current_bookmark(
+    state: &AppState,
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    uuid: &str,
+    entry: &dto::StateEntry,
+    bookmark: &dto::CurrentBookmark,
+) -> Result<(), Response> {
+    // Capture data for the one open question about this field: whether
+    // the content-source percent really is per-chapter (as
+    // `persist_bookmark` assumes) or just echoes the whole-book one.
+    // Nothing in this repo has ever recorded a real device's answer,
+    // and sync-out can't emit the field until it is known.
+    tracing::info!(
+        %uuid,
+        whole_book = ?bookmark.progress_percent,
+        content_source = ?bookmark.content_source_progress_percent,
+        "kobo bookmark percents received"
+    );
+    // Device event time, most-specific first: the bookmark's own
+    // stamp, then the entry-level ones. Absent/unparseable → None,
+    // which `persist_bookmark` treats as server-now (pre-existing
+    // behaviour for firmware that sends no clock).
+    let event_ts = bookmark
+        .last_modified
+        .as_deref()
+        .or(entry.last_modified.as_deref())
+        .or(entry.priority_timestamp.as_deref())
+        .and_then(dto::parse_kobo_timestamp);
+    match persist_bookmark(state, tx, user_id, uuid, bookmark, event_ts).await {
+        Ok(()) => Ok(()),
+        Err(db::progress::ProgressError::BookNotFound) => {
+            tracing::warn!(%uuid, "kobo position PUT for unknown book");
+            Ok(())
+        }
+        Err(db::progress::ProgressError::Sqlx(e)) => Err(internal("kobo upsert_progress", e)),
+    }
+}
+
+/// Log and persist a `Statistics` block.
+async fn apply_statistics(
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    uuid: &str,
+    stats: &dto::Statistics,
+) -> Result<(), Response> {
+    // Kept from #1652's capture pass — the shape came from the
+    // reference impls, not from hardware.
+    tracing::info!(
+        %uuid,
+        spent_reading_minutes = ?stats.spent_reading_minutes,
+        remaining_time_minutes = ?stats.remaining_time_minutes,
+        last_modified = ?stats.last_modified,
+        "kobo statistics received"
+    );
+    // No entry-level fallback, unlike the bookmark: an entry clock is
+    // still a device clock, but it would date counters the device did
+    // not date itself, and this stamp decides whether the device
+    // overwrites its own totals with our echo. Unstamped is safe —
+    // sync-out omits it and the device keeps what it has.
+    let event_ts = stats
+        .last_modified
+        .as_deref()
+        .and_then(dto::parse_kobo_timestamp);
+    match persist_statistics(tx, user_id, uuid, stats, event_ts).await {
+        Ok(()) => Ok(()),
+        Err(db::progress::ProgressError::BookNotFound) => {
+            tracing::warn!(%uuid, "kobo statistics PUT for unknown book");
+            Ok(())
+        }
+        Err(db::progress::ProgressError::Sqlx(e)) => Err(internal("kobo set_kobo_statistics", e)),
+    }
 }
 
 /// Persist a device's `CurrentBookmark` as an epub position (#925).


### PR DESCRIPTION
## Summary
- Closes #1765
- Pure structural refactor: extracts named helpers (or sibling `#[component]` fns for the Dioxus components) from the functions the #1765 sweep flagged as exceeding the `.claude/rules/05-rust-style.md` ~80-line soft cap in `db/**`, `server/**`, and `frontend/src/{components,offline}/**`. `frontend/src/pages/**` is untouched (covered separately by #1721).
- No behavior change anywhere — every split preserves the original control flow, comments (including the rule-09 etag-timing commentary in the download engine), and error-handling shape verbatim; only extracted into named functions/components.

## Test plan
- [x] `cargo fmt --check` — PASS (clean)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (0 warnings)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS (0 warnings; also covers `omnibus-frontend` as a transitive dependency)
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (0 warnings)
- [x] `cargo test -p omnibus-db` — PASS, 1860/1860 lib tests + 4 integration tests, all green (fetched the public-domain fixtures via `scripts/fetch-fixtures.sh` first)
- [x] `cargo test -p omnibus` — 740/742 passed. The 2 failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400` and its audiobook sibling) are **pre-existing and unrelated**: those tests `chmod` a directory read-only and expect the write to fail with 400, but the container runs tests as root, which bypasses Unix read-only permission bits entirely (writes succeed → 201 instead of 400). `server/src/backend/uploads/**` is untouched by this PR — confirmed via `git status`/diff scope.
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 696/696 tests, all green

## Per-function disposition (from the #1765 sweep)

1. **`frontend/src/offline/downloads/engine.rs` — `run_inner`** (~167 lines → ~59). Split into `load_book`, `plan_for_format`, `prepare_files`, and `run_downloads`, each a self-contained stage of the pipeline (fetch metadata → build plan → merge resume state → stream files). The etag-persist-before-body-read comment and the `on_etag`/`on_delta` callback wiring are untouched.
2. **`frontend/src/offline/downloads/engine.rs` — `download_file`** (~122 lines → ~35). Split into `send_ranged_request` (request + status validation) and `write_body_to_part` (open/stream/flush/sync). The rule-09 doc comment about `on_etag` firing before any body byte is read stays on `download_file` verbatim, and the header callback still fires before the body helper is called.
3. **`db/src/indexer/backfill.rs` — `backfill_thumbs`** (~82 lines → ~19). Extracted the per-book "regenerate-if-stale" body into `regenerate_thumbs_if_stale`, leaving the candidate fetch + eviction call in the parent, per the issue's suggested split.
4. **`server/src/backend/kobo/state.rs` — `put_state`** (~101 lines → ~25). Extracted `apply_reading_state_entry` (per-batch-entry dispatch) plus `apply_status_info` / `apply_current_bookmark` / `apply_statistics`, each returning `Result<(), Response>` so a DB failure still short-circuits `put_state` with the right `internal(...)` response while a per-entry `BookNotFound` stays logged-and-continue. Covered by the existing `put_state_batch_transaction_rolls_back_a_read_status_write_when_a_later_write_fails` test, which still passes.
5. **`frontend/src/components/chip_editor.rs` — `ChipEditor`** (~103 lines → ~56). Extracted `build_input_area_callbacks` (focus/blur/input/keydown/pick wiring) as a sibling fn — no rsx moved, no hydration risk.
6. **`frontend/src/components/search_palette/overlay.rs` — `SpOverlay`** (~99 lines → ~14 body lines). Extracted a `use_sp_overlay_state` state hook (mirroring the existing `chip_editor::use_chip_editor_state` pattern) and a `build_overlay_wiring` helper for the flat-items memo + close/keydown/search handlers.
7. **`frontend/src/components/quote_card.rs` — `QuoteCardPanel`** (~100 lines → ~28). Extracted `use_quote_card_state`, `compute_quote_styles`, and `build_export_handlers` (download/share/copy closures + the `cfg(any(feature = "web", feature = "mobile"))`-gated JSON payload builder — the `cfg` still only gates JS-interop logic, never rsx).
8. **`db/src/worker/handlers.rs` — `execute`** (~97 lines) — **left as-is, defensible exception** (explicitly allowed by the issue). It's a flat per-`Task`-variant `match`; most arms already delegate to a named `handle_*` method or a shared `anyhow_outcome`/`kindle_outcome`/`kepub_outcome` mapper, so splitting further would trade one lookup table for a layer of indirection without reducing real complexity — the arms aren't "staged sub-steps," they're independent dispatch targets.
9. **`db/src/merge/transaction.rs` — `move_progress_and_history`** (~93 lines → ~30). Extracted `dedupe_reading_progress` and `dedupe_playback_preferences`, each the two-pass latest-wins DELETE pair for one table; the `kobo_annotations_sync` dedupe + retarget loop stayed in the parent.
10. **`db/src/ebook/parse.rs` — `extract_metadata`** (~92 lines → ~40). Extracted `failed_open_book` (the can't-open-EPUB placeholder) and `build_opf_metadata` (the `EbookMetadata` struct literal), both `#[allow(clippy::too_many_arguments)]`-free by construction / with the attribute where needed.
11. **`frontend/src/components/atrium.rs` — `Cover`** (~94 lines → ~65). Extracted `cover_plate_labels` (title/author-initials derivation) and `resolve_cover_image_src` (src_override vs. cache-busted `book.cover_url` resolution) — hook calls (`use_server_url`, `use_cover_cache_bust`) stay in `Cover` itself, only the pure post-hook logic moved out.

## Notes
- Two clippy lints needed `#[allow(...)]` annotations that weren't present before the split: `clippy::too_many_arguments` on `chip_editor::build_input_area_callbacks` (8 params — all pre-existing signals/handlers just relocated into one function) and `clippy::type_complexity` on `quote_card::build_export_handlers`'s 3-`impl FnMut` tuple return (mirrors the existing `#[allow(clippy::type_complexity)]` on `search_palette::overlay::build_overlay_wiring`).
- Hydration (rule 07): no `#[cfg(feature = "web"/"mobile"/"server")]` gate was introduced around any rsx body in this change — the one pre-existing `cfg` in `quote_card.rs` (JS-interop payload building) was preserved exactly, just moved into a helper function alongside a `cfg_attr(... allow(unused_variables))` (same pattern as `pages::reader::highlights_drawer`) for the non-web/mobile build where the params go unused.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RgsGXd4iBZxqHhFbWAy8n7)_