### PR TITLE
refactor: document error-message redaction convention and fix violators (#1777)

### DIFF
--- a/db/src/covers.rs
+++ b/db/src/covers.rs
@@ -249,7 +249,8 @@ pub async fn get_cover(
             tracing::error!(
                 book_id,
                 uuid = %uuid,
-                "get_cover spawn_blocking {kind}: {join_err}"
+                error = %join_err,
+                "get_cover spawn_blocking {kind}"
             );
             None
         }

--- a/db/src/deletion/fs.rs
+++ b/db/src/deletion/fs.rs
@@ -25,7 +25,7 @@ pub(super) struct BookCleanup {
 /// the same reason the individual steps are.
 pub(super) async fn cleanup(job: Cleanup) {
     if let Err(join_err) = tokio::task::spawn_blocking(move || cleanup_blocking(job)).await {
-        tracing::error!("delete_book_files: fs cleanup spawn_blocking failed: {join_err}");
+        tracing::error!(error = %join_err, "delete_book_files: fs cleanup spawn_blocking failed");
     }
 }
 

--- a/db/src/indexer/mod.rs
+++ b/db/src/indexer/mod.rs
@@ -721,7 +721,7 @@ async fn gc_missing_files_best_effort(pool: &SqlitePool) {
     {
         Ok(purged) if purged > 0 => tracing::info!(purged, "reindex: GC'd books missing files"),
         Ok(_) => {}
-        Err(e) => tracing::error!("reindex: missing-files GC failed: {e}"),
+        Err(e) => tracing::error!(error = %e, "reindex: missing-files GC failed"),
     }
 }
 

--- a/db/src/journals/mod.rs
+++ b/db/src/journals/mod.rs
@@ -247,7 +247,7 @@ async fn cleanup_orphaned_images(pool: &SqlitePool, candidates: HashSet<String>)
     })
     .await
     {
-        tracing::error!("cleanup_orphaned_images: spawn_blocking failed: {join_err}");
+        tracing::error!(error = %join_err, "cleanup_orphaned_images: spawn_blocking failed");
     }
 }
 

--- a/db/src/missing_files.rs
+++ b/db/src/missing_files.rs
@@ -152,7 +152,7 @@ async fn cleanup_victim_covers(uuids: Vec<String>) {
     })
     .await
     {
-        tracing::error!("gc_books_missing_files: cover cleanup spawn_blocking failed: {join_err}");
+        tracing::error!(error = %join_err, "gc_books_missing_files: cover cleanup spawn_blocking failed");
     }
 }
 

--- a/db/src/physical/remove.rs
+++ b/db/src/physical/remove.rs
@@ -57,7 +57,7 @@ pub async fn delete_fileless_book(pool: &SqlitePool, book_uuid: &str) -> Result<
     })
     .await
     {
-        tracing::error!("delete_fileless_book: cover cleanup spawn_blocking failed: {join_err}");
+        tracing::error!(error = %join_err, "delete_fileless_book: cover cleanup spawn_blocking failed");
     }
     Ok(())
 }

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -276,7 +276,7 @@ async fn run_legacy_cover_purge() {
     })
     .await
     {
-        tracing::error!("legacy cover purge spawn_blocking failed: {join_err}");
+        tracing::error!(error = %join_err, "legacy cover purge spawn_blocking failed");
     }
 }
 

--- a/db/src/settings/mod.rs
+++ b/db/src/settings/mod.rs
@@ -155,7 +155,7 @@ pub async fn set_settings(pool: &SqlitePool, settings: &Settings) -> Result<(), 
         tokio::task::spawn_blocking(move || crate::covers::delete_cover_files_for(&orphan_uuids))
             .await
     {
-        tracing::error!("set_settings: cover cleanup spawn_blocking failed: {join_err}");
+        tracing::error!(error = %join_err, "set_settings: cover cleanup spawn_blocking failed");
     }
     Ok(())
 }

--- a/db/src/sync/audiobooks/mod.rs
+++ b/db/src/sync/audiobooks/mod.rs
@@ -136,7 +136,7 @@ pub async fn sync_audiobooks_with_progress(
     })
     .await
     {
-        tracing::error!("sync_audiobooks: cover reconcile spawn_blocking failed: {join_err}");
+        tracing::error!(error = %join_err, "sync_audiobooks: cover reconcile spawn_blocking failed");
     }
 
     Ok(())

--- a/db/src/sync/books/mod.rs
+++ b/db/src/sync/books/mod.rs
@@ -214,7 +214,7 @@ pub async fn sync_books_with_progress(
     })
     .await
     {
-        tracing::error!("sync_books: cover reconcile spawn_blocking failed: {join_err}");
+        tracing::error!(error = %join_err, "sync_books: cover reconcile spawn_blocking failed");
     }
 
     Ok(())

--- a/server/src/logging/error_ring_layer.rs
+++ b/server/src/logging/error_ring_layer.rs
@@ -1,19 +1,8 @@
-//! Tracing `Layer` feeding the in-memory error ring buffer.
-//!
-//! Installed alongside the stderr/JSON-file layers in
-//! [`crate::logging::init_tracing`]. Captures every `ERROR`-level event in
-//! the process with no explicit call site required at each error (AC3),
-//! extracting the message plus any book/file identifier field so the admin
-//! "Last errors" section can link the offending item.
-//!
-//! **Redaction convention.** The captured `message` is served verbatim over
-//! `GET /api/rpc/errors` to any admin session — network-reachable, unlike
-//! the durable JSON log sink it complements. `FieldVisitor` below applies no
-//! redaction, so every `tracing::error!` call site is responsible for never
-//! string-interpolating a secret-bearing value (an API key, a password, an
-//! SMTP credential) into the message literal — pass it as a named field
-//! instead, e.g. `error = %e`, which this layer deliberately does not
-//! capture. See #1777.
+//! Tracing `Layer` feeding the in-memory error ring buffer, installed
+//! alongside the stderr/JSON-file layers in [`crate::logging::init_tracing`].
+//! Captures each `ERROR` event's message (served verbatim over HTTP to
+//! admins) plus any book/file identifier; call sites must pass secrets via
+//! a named field (`error = %e`), never interpolated into the message.
 
 use omnibus_db::error_ring::{self, CapturedError};
 use tracing::field::{Field, Visit};

--- a/server/src/logging/error_ring_layer.rs
+++ b/server/src/logging/error_ring_layer.rs
@@ -5,6 +5,15 @@
 //! the process with no explicit call site required at each error (AC3),
 //! extracting the message plus any book/file identifier field so the admin
 //! "Last errors" section can link the offending item.
+//!
+//! **Redaction convention.** The captured `message` is served verbatim over
+//! `GET /api/rpc/errors` to any admin session — network-reachable, unlike
+//! the durable JSON log sink it complements. `FieldVisitor` below applies no
+//! redaction, so every `tracing::error!` call site is responsible for never
+//! string-interpolating a secret-bearing value (an API key, a password, an
+//! SMTP credential) into the message literal — pass it as a named field
+//! instead, e.g. `error = %e`, which this layer deliberately does not
+//! capture. See #1777.
 
 use omnibus_db::error_ring::{self, CapturedError};
 use tracing::field::{Field, Visit};

--- a/server/src/logging/error_ring_layer/tests.rs
+++ b/server/src/logging/error_ring_layer/tests.rs
@@ -96,10 +96,7 @@ fn captured_entry_has_no_book_or_file_reference_when_event_carries_none() {
 
 #[test]
 fn named_error_field_does_not_leak_secret_shaped_value_into_captured_message() {
-    // House convention (#1777): a `tracing::error!` call must pass an error
-    // value via the named `error = %e` field, never interpolate it into the
-    // message literal, because `message` alone is what this layer captures
-    // and it is what `GET /api/rpc/errors` serves to admins over HTTP.
+    // `error = %e` keeps the value out of `message`, the field served to admins over HTTP.
     let secret = "sk_live_totally_secret_api_key_12345";
     with_layer(|| {
         let err = anyhow::anyhow!("{secret}");

--- a/server/src/logging/error_ring_layer/tests.rs
+++ b/server/src/logging/error_ring_layer/tests.rs
@@ -93,3 +93,24 @@ fn captured_entry_has_no_book_or_file_reference_when_event_carries_none() {
     assert_eq!(snap[0].book_uuid, None);
     assert_eq!(snap[0].file, None);
 }
+
+#[test]
+fn named_error_field_does_not_leak_secret_shaped_value_into_captured_message() {
+    // House convention (#1777): a `tracing::error!` call must pass an error
+    // value via the named `error = %e` field, never interpolate it into the
+    // message literal, because `message` alone is what this layer captures
+    // and it is what `GET /api/rpc/errors` serves to admins over HTTP.
+    let secret = "sk_live_totally_secret_api_key_12345";
+    with_layer(|| {
+        let err = anyhow::anyhow!("{secret}");
+        tracing::error!(error = %err, "operation failed");
+    });
+
+    let snap = error_ring::snapshot();
+    assert_eq!(snap.len(), 1);
+    assert_eq!(snap[0].message, "operation failed");
+    assert!(
+        !snap[0].message.contains(secret),
+        "captured message must not contain the secret carried on the `error` field"
+    );
+}


### PR DESCRIPTION
## Summary
- Closes #1777
- The error ring buffer (PR #1736) serves the raw `message` field of every `tracing::error!` event to any admin session over HTTP — a bigger, network-reachable audience than the filesystem-only JSON log sink it complements. `server/src/logging/error_ring_layer.rs`'s module doc now codifies the house convention: never string-interpolate a secret-bearing value into the `tracing::error!` message literal; always pass it via a named field (e.g. `error = %e`), which `FieldVisitor` deliberately does not capture.
- Fixed every call site found by a full-codebase audit that violated the convention (interpolated an error/`JoinError` value directly into the message string): the two named in the issue (`db/src/indexer/mod.rs`, `db/src/covers.rs`) plus eight more (`db/src/journals/mod.rs`, `db/src/pool.rs`, `db/src/physical/remove.rs`, `db/src/settings/mod.rs`, `db/src/missing_files.rs`, `db/src/sync/audiobooks/mod.rs`, `db/src/sync/books/mod.rs`, `db/src/deletion/fs.rs`) — all switched to `error = %e`/`error = %join_err`.
- Added a test in `server/src/logging/error_ring_layer/tests.rs` asserting a `tracing::error!` call passing a secret-shaped value via the named `error` field does not leak it into the captured ring-buffer message, proving the convention holds structurally.
- Took the documented-convention path per the issue's recommendation, not the larger regex-redaction `FieldVisitor` rework (called out as a separable follow-up).

## Test plan
- [x] `cargo fmt` — clean, no changes needed
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — 1857 passed. 3 failures, all pre-existing and unrelated to this change (confirmed by isolated rerun): `worker::tests::poisoned_progress_lock_recovers_instead_of_panicking` and `worker::tests::task_rewrite_all_epubs_reports_sanitized_err_when_the_pool_is_closed` are the documented flakes and passed clean on rerun; `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails only because this sandbox has no binary test fixtures (`just fixtures` unavailable in this cloud session) — untouched code path.
- [x] `cargo test -p omnibus` — 755 passed. 2 failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400` and its audiobook variant), both pre-existing and environmental: the sandbox runs tests as root, which ignores the `0o555` permission bit the test relies on to force a `PermissionDenied` — untouched code path.

## Version
- [ ] Minor
- [ ] Patch (default)
- [ ] No release

## Notes
- No release label applied per reviewer's request; leaving version labeling to the merge owner.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jhq9vApZ4WjWtvwHuZiPdV)_