### PR TITLE
test: cover DB-failure paths for session/device revoke (#1775)

### DIFF
--- a/db/src/auth/device/tests.rs
+++ b/db/src/auth/device/tests.rs
@@ -317,6 +317,14 @@ async fn revoke_device_returns_device_not_found_for_unknown_id() {
 }
 
 #[tokio::test]
+async fn revoke_device_returns_internal_when_pool_closed() {
+    let p = pool().await;
+    p.close().await;
+    let err = revoke_device(&p, 1).await.unwrap_err();
+    assert!(matches!(err, AuthError::Internal(_)));
+}
+
+#[tokio::test]
 async fn revoke_device_also_revokes_its_live_sessions() {
     let p = pool().await;
     let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();

--- a/db/src/auth/session/tests.rs
+++ b/db/src/auth/session/tests.rs
@@ -489,6 +489,14 @@ async fn list_sessions_for_user_returns_only_live_sessions_for_that_user() {
 }
 
 #[tokio::test]
+async fn list_sessions_for_user_returns_internal_when_pool_closed() {
+    let p = pool().await;
+    p.close().await;
+    let err = list_sessions_for_user(&p, 1).await.unwrap_err();
+    assert!(matches!(err, AuthError::Internal(_)));
+}
+
+#[tokio::test]
 async fn list_sessions_for_user_caps_response_at_list_sessions_limit() {
     let p = pool().await;
     let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
@@ -542,6 +550,14 @@ async fn revoke_session_for_user_returns_not_found_for_unknown_id() {
 }
 
 #[tokio::test]
+async fn revoke_session_for_user_returns_internal_when_pool_closed() {
+    let p = pool().await;
+    p.close().await;
+    let err = revoke_session_for_user(&p, 1, 1).await.unwrap_err();
+    assert!(matches!(err, AuthError::Internal(_)));
+}
+
+#[tokio::test]
 async fn revoke_session_checked_revokes_any_users_session() {
     let p = pool().await;
     let u = create_user(&p, "alice", "hunter2-real-long").await.unwrap();
@@ -560,6 +576,14 @@ async fn revoke_session_checked_returns_not_found_for_unknown_id() {
     let p = pool().await;
     let err = revoke_session_checked(&p, 999_999).await.unwrap_err();
     assert!(matches!(err, AuthError::SessionNotFound));
+}
+
+#[tokio::test]
+async fn revoke_session_checked_returns_internal_when_pool_closed() {
+    let p = pool().await;
+    p.close().await;
+    let err = revoke_session_checked(&p, 1).await.unwrap_err();
+    assert!(matches!(err, AuthError::Internal(_)));
 }
 
 /// The idle DELETE must use `idx_sessions_last_used_at`, not scan.

--- a/server/src/auth/handlers/tests.rs
+++ b/server/src/auth/handlers/tests.rs
@@ -552,6 +552,52 @@ fn bearer_req(method: &str, uri: &str, token: &str) -> Request<Body> {
         .unwrap()
 }
 
+/// A minimal `AuthUser` for driving `get_sessions_handler` /
+/// `delete_session_handler` directly (bypassing the `AuthUser` extractor).
+/// Needed because both handlers' own DB-failure branch shares the
+/// `sessions` table with the extractor's own session lookup: closing the
+/// pool (or dropping the table) before the request would fail extraction
+/// itself rather than the handler body under test, so the handler is
+/// invoked directly with a hand-built caller and a pool closed only after
+/// extraction would have happened.
+fn fake_auth_user(id: i64, session_id: i64) -> AuthUser {
+    AuthUser {
+        id,
+        username: "alice".to_string(),
+        is_admin: false,
+        can_upload: false,
+        can_edit: false,
+        can_download: true,
+        kindle_email: None,
+        display_name: None,
+        has_avatar: false,
+        hidden_formats: Vec::new(),
+        session_id,
+        session_kind: SessionKind::Bearer,
+    }
+}
+
+#[tokio::test]
+async fn get_sessions_handler_returns_500_when_pool_closed() {
+    let (_app, pool) = app().await;
+    pool.close().await;
+    let state = AppState::new(pool);
+    let res = get_sessions_handler(fake_auth_user(1, 1), State(state)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn delete_session_handler_returns_500_when_pool_closed() {
+    let (_app, pool) = app().await;
+    pool.close().await;
+    let state = AppState::new(pool);
+    // session_id (2) deliberately differs from the caller's own session_id
+    // (1) so the handler's "cannot revoke the current session" 400 guard
+    // doesn't short-circuit before the DB call under test runs.
+    let res = delete_session_handler(fake_auth_user(1, 1), State(state), Path(2)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
 #[tokio::test]
 async fn get_sessions_returns_401_when_anonymous() {
     let (app, _pool) = app().await;

--- a/server/src/backend/admin_sessions/tests.rs
+++ b/server/src/backend/admin_sessions/tests.rs
@@ -5,14 +5,40 @@
 
 use axum::{
     body::{to_bytes, Body},
+    extract::{Path, State},
     http::{header::AUTHORIZATION, Request, StatusCode},
 };
 use omnibus_db::auth::SessionKind;
 use omnibus_shared::{DeviceView, SessionView};
 use tower::ServiceExt;
 
+use super::*;
 use crate::auth::test_support as auth_test_support;
+use crate::auth::{AdminUser, AuthUser};
 use crate::backend::test_support::*;
+
+/// A minimal admin `AuthUser` for driving the handlers directly (bypassing
+/// the `AdminUser` extractor). Needed because each handler's own
+/// DB-failure branch shares its target table (`sessions`/`devices`) with
+/// the extractor's own session lookup, so closing the pool before a
+/// routed request would fail extraction rather than the handler body
+/// under test.
+fn fake_admin(id: i64) -> AuthUser {
+    AuthUser {
+        id,
+        username: "admin".to_string(),
+        is_admin: true,
+        can_upload: true,
+        can_edit: true,
+        can_download: true,
+        kindle_email: None,
+        display_name: None,
+        has_avatar: false,
+        hidden_formats: Vec::new(),
+        session_id: 1,
+        session_kind: SessionKind::Bearer,
+    }
+}
 
 fn req(method: &str, uri: &str, token: &str) -> Request<Body> {
     Request::builder()
@@ -262,4 +288,44 @@ async fn admin_revoke_device_returns_404_for_unknown_id() {
         .await
         .unwrap();
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+// ── DB-failure paths (500) ─────────────────────────────────────────
+//
+// Each handler is invoked directly (rather than through `oneshot`) with a
+// hand-built `AdminUser` and a pool closed only after the point at which
+// the `AdminUser` extractor would have already run — closing the pool
+// before a routed request would fail extraction itself (same `sessions`
+// table), not the handler body these tests target.
+
+#[tokio::test]
+async fn get_user_sessions_returns_500_when_pool_closed() {
+    let (_app, state, pool) = fixture().await;
+    pool.close().await;
+    let res = get_user_sessions(AdminUser(fake_admin(1)), State(state), Path(1)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn get_user_devices_returns_500_when_pool_closed() {
+    let (_app, state, pool) = fixture().await;
+    pool.close().await;
+    let res = get_user_devices(AdminUser(fake_admin(1)), State(state), Path(1)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn delete_session_returns_500_when_pool_closed() {
+    let (_app, state, pool) = fixture().await;
+    pool.close().await;
+    let res = delete_session(AdminUser(fake_admin(1)), State(state), Path(1)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn delete_device_returns_500_when_pool_closed() {
+    let (_app, state, pool) = fixture().await;
+    pool.close().await;
+    let res = delete_device(AdminUser(fake_admin(1)), State(state), Path(1)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
## Summary
- Closes #1775. Adds the ten missing DB-failure-path (500 / `AuthError::Internal`) tests called out in the issue for the session/device revoke feature (PR #1757): four db-layer tests in `db/src/auth/{session,device}/tests.rs` using the established closed-pool pattern, and six handler-level tests in `server/src/auth/handlers/tests.rs` and `server/src/backend/admin_sessions/tests.rs`.
- The six handler tests invoke the handler function directly with a hand-built `AuthUser`/`AdminUser` and a closed-pool `AppState`, rather than driving the router with `oneshot` and a closed pool up front: `get_sessions_handler`/`delete_session_handler`/`get_user_sessions`/`get_user_devices`/`delete_session`/`delete_device` all read the same `sessions` table the `AuthUser`/`AdminUser` extractor itself queries to authenticate the request, so closing the pool before the whole request would trip the extractor's own `Internal` branch (401→500 via a different code path) rather than exercising the handler's own `Err(e) => internal(...)` arm that this issue targets. Direct invocation is the only way to hit that exact line reliably.
- Test-only change — no production code was modified, and no bug was found in the process.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 1863 passed, 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` — missing binary audiobook fixture in this sandbox, needs `just fixtures`, not runnable here)
- [x] `cargo test -p omnibus` — 760 passed, 2 pre-existing failures unrelated to this change (`backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` — these chmod a temp dir to simulate a read-only library, but the sandbox runs as root, which ignores the permission bits)
- [x] All 10 new tests individually verified green: `cargo test -p omnibus-db returns_internal_when_pool_closed` (4 passed) and `cargo test -p omnibus --lib returns_500_when_pool_closed` (6 passed)

10 new tests added, 0 production files changed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jhq9vApZ4WjWtvwHuZiPdV


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jhq9vApZ4WjWtvwHuZiPdV)_