### PR TITLE
docs: correct rule 09 thumb ETag description (#1778)

### DIFF
--- a/.claude/rules/09-content-validators.md
+++ b/.claude/rules/09-content-validators.md
@@ -27,12 +27,11 @@ statement, so they cannot disagree.
 - **Never add a manual version counter**, for the same reason.
 - **Never hash file contents** to build it. Byte-hashing a library of
   multi-hundred-MB audiobooks on every scan is not a validator, it's a
-  rescan. (The cover and comic-page handlers *do* hash — they have already
-  read the bytes into memory to serve them, so it's free there. Thumbs are
-  the exception: `thumb_etag` derives its value from a freshness key —
-  `(book_id, size, last_modified_epoch, encoder_version)` — so the 304
-  path never opens the file. **Known residual:** a re-encode that changes
-  bytes without moving that key reads as unchanged.)
+  rescan. (Cover and comic-page handlers *do* hash — they have read the bytes
+  in to serve them, so it's free there. Thumbs are the exception: `thumb_etag`
+  derives from `(book_id, size, last_modified_epoch, encoder_version)`, so its
+  304 path never opens the file. **Known residual:** a re-encode that changes
+  the bytes without moving that key is not detected as stale.)
 - `(0, 0)` is the never-observed sentinel and must map to `None`, so the
   one-time stat backfill never reads as a content change on a device
   holding a download.

--- a/.claude/rules/09-content-validators.md
+++ b/.claude/rules/09-content-validators.md
@@ -27,8 +27,12 @@ statement, so they cannot disagree.
 - **Never add a manual version counter**, for the same reason.
 - **Never hash file contents** to build it. Byte-hashing a library of
   multi-hundred-MB audiobooks on every scan is not a validator, it's a
-  rescan. (The cover/thumb/comic-page handlers *do* hash — they have
-  already read the bytes into memory to serve them, so it's free there.)
+  rescan. (The cover and comic-page handlers *do* hash — they have already
+  read the bytes into memory to serve them, so it's free there. Thumbs are
+  the exception: `thumb_etag` derives its value from a freshness key —
+  `(book_id, size, last_modified_epoch, encoder_version)` — so the 304
+  path never opens the file. **Known residual:** a re-encode that changes
+  bytes without moving that key reads as unchanged.)
 - `(0, 0)` is the never-observed sentinel and must map to `None`, so the
   one-time stat backfill never reads as a content change on a device
   holding a download.


### PR DESCRIPTION
## Summary
- Closes #1778
- Rule 09 claimed "the cover/thumb/comic-page handlers *do* hash — they have already read the bytes into memory to serve them". That stopped being true for thumbs after PR #1764: `thumb_etag` (via `thumb_etag_versioned` in `db/src/thumbs.rs`) SHA-256s the scalar tuple `(book_id, size, last_modified_epoch, THUMB_ENCODER_VERSION)` and never touches file bytes, precisely so the 304 path avoids opening the file. Cover and comic-page are unaffected and still hash bytes as described.
- Corrected the sentence and added a short **Known residual** note, mirroring the existing response-ETag one: a re-encode that changes the encoded bytes without moving that freshness key is not detected as stale — a gap the byte-hashing predecessor did not have.

Verified against the code before editing: `thumb_etag_versioned` hashes only `book_id`, `size.as_str()`, `last_modified_epoch`, and `version`; `thumb_cache_hit_response` in `server/src/backend/covers.rs` reuses that precomputed value on both the 304 and 200 paths (the 200 path reads bytes to serve, not to build the validator).

## Test plan
- [x] Docs-only change — no code touched, so no build/test/clippy command applies.
- [x] Line-count cap (rule 99): `wc -l .claude/rules/09-content-validators.md` → **200** (was 197), inside the cap.

## Version
- [x] **No release** — docs-only (`*.md`), so the release is skipped automatically per the template; leaving labeling to the merge owner.

## Notes
- The first commit landed the file at 201 lines, one over rule 99's soft cap. Review flagged it, so the second commit rewraps the parenthetical from six lines to five and lands it at exactly 200 — no content dropped.
- Residual wording is "is not detected as stale" rather than "reads as unchanged", naming the validator's failure rather than the file's appearance.
- Used a function-name anchor (`thumb_etag`) rather than a `file.rs:NN` citation, per rule 98's guidance on line-number rot.