### PR TITLE
fix: surface physical-only books in all four palette arms (#1788)

### DIFF
--- a/db/src/books/search.rs
+++ b/db/src/books/search.rs
@@ -6,7 +6,7 @@
 use omnibus_shared::EbookMetadata;
 use sqlx::{Row, SqlitePool};
 
-use crate::helpers::{build_fts_match, cap_query_len, library_paths_json};
+use crate::helpers::{build_fts_match, cap_query_len, library_paths_json, visible_book_sql};
 
 use super::projection::{
     backfill_creator_ids, merge_overrides_into_books, row_to_ebook, BOOK_COLUMNS,
@@ -103,6 +103,7 @@ async fn fetch_search_rows(
     library_paths: &[&str],
     match_expr: &str,
 ) -> Result<Vec<sqlx::sqlite::SqliteRow>, sqlx::Error> {
+    let visible = visible_book_sql("b", "l", "?");
     let sql = format!(
         r"
         WITH matches AS MATERIALIZED (
@@ -112,8 +113,7 @@ async fn fetch_search_rows(
             JOIN books b ON b.id = books_fts.rowid
             JOIN scan_roots l ON l.id = b.library_id
             WHERE books_fts MATCH ?
-              AND (l.path IN (SELECT value FROM json_each(?))
-                   OR EXISTS (SELECT 1 FROM physical_copies pc WHERE pc.book_uuid = b.uuid))
+              AND {visible}
         )
         SELECT {BOOK_COLUMNS},
                (SELECT COUNT(*) FROM matches)               AS total_count
@@ -158,17 +158,17 @@ pub async fn count_search_books_for_paths(
     let Some(match_expr) = build_fts_match(&capped) else {
         return Ok(0);
     };
-    Ok(sqlx::query_scalar::<_, i64>(
+    let visible = visible_book_sql("b", "l", "?");
+    Ok(sqlx::query_scalar::<_, i64>(&format!(
         r"
         SELECT COUNT(*)
           FROM books_fts
           JOIN books b ON b.id = books_fts.rowid
           JOIN scan_roots l ON l.id = b.library_id
          WHERE books_fts MATCH ?
-           AND (l.path IN (SELECT value FROM json_each(?))
-                OR EXISTS (SELECT 1 FROM physical_copies pc WHERE pc.book_uuid = b.uuid))
-        ",
-    )
+           AND {visible}
+        "
+    ))
     .bind(&match_expr)
     .bind(library_paths_json(library_paths))
     .fetch_one(pool)

--- a/db/src/helpers.rs
+++ b/db/src/helpers.rs
@@ -31,6 +31,27 @@ pub(crate) fn library_paths_json(library_paths: &[&str]) -> String {
     .to_string()
 }
 
+/// SQL fragment for "search may surface this book": it sits under one of the
+/// configured scan roots, or it holds at least one physical copy.
+///
+/// The physical arm is the only way in for a physical-only book — those live
+/// under the synthetic `physical://local` root, which is never a configured
+/// path. A fileless book with *no* copy (a wishlist entry) matches neither arm
+/// and stays hidden. Every search path shares this one definition rather than
+/// spelling it out: the palette arms and `books::search` had already drifted
+/// apart once (#1788), leaving physical books that `/api/search` returned
+/// invisible to the palette.
+///
+/// `book` / `root` name the `books` / `scan_roots` aliases in the enclosing
+/// query and `paths_param` the placeholder bound to [`library_paths_json`];
+/// all three differ per call site.
+pub(crate) fn visible_book_sql(book: &str, root: &str, paths_param: &str) -> String {
+    format!(
+        "({root}.path IN (SELECT value FROM json_each({paths_param})) \
+          OR EXISTS (SELECT 1 FROM physical_copies pc WHERE pc.book_uuid = {book}.uuid))"
+    )
+}
+
 /// Deterministic UUIDv5 derived from `(library_path, filename)` so reindexing
 /// the same file produces the same uuid. Keeps `/api/covers/{uuid}` URLs
 /// stable across reindex cycles even as the primary `books.id` renumbers.

--- a/db/src/palette/authors.rs
+++ b/db/src/palette/authors.rs
@@ -12,7 +12,7 @@ use crate::helpers::{library_paths_json, visible_book_sql};
 
 use super::PaletteError;
 
-/// Authors-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
+/// Authors-arm palette query, bound `?1 = library_paths JSON array`, `?2 = like_pattern`,
 /// `?3 = limit`.
 ///
 /// Visibility scoping ([`visible_book_sql`]) is applied before aggregation so

--- a/db/src/palette/authors.rs
+++ b/db/src/palette/authors.rs
@@ -1,19 +1,21 @@
-//! Authors arm of the search palette: substring `LIKE` match scoped to a
-//! library, ordered by an override-aware effective book count. Visibility
-//! still requires at least one canonical link so override-only authors
-//! (no navigable id) don't appear.
+//! Authors arm of the search palette: substring `LIKE` match scoped to the
+//! visible books, ordered by an override-aware effective book count.
+//! Visibility still requires at least one canonical link so override-only
+//! authors (no navigable id) don't appear.
+
+use std::sync::OnceLock;
 
 use omnibus_shared::PaletteAuthorHit;
 use sqlx::{Row, SqlitePool};
 
-use crate::helpers::library_paths_json;
+use crate::helpers::{library_paths_json, visible_book_sql};
 
 use super::PaletteError;
 
 /// Authors-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
 /// `?3 = limit`.
 ///
-/// Library scoping (`l.path = ?1`) is applied before aggregation so
+/// Visibility scoping ([`visible_book_sql`]) is applied before aggregation so
 /// book_count stays library-correct (covered by
 /// `search_palette_scoped_to_library` and
 /// `search_palette_taxonomy_counts_scoped_per_library`). The join plan is
@@ -24,12 +26,13 @@ use super::PaletteError;
 /// reassigned through the metadata edit form (e.g. "Sanderson, Brandon" →
 /// "Brandon Sanderson") keeps reporting the canonical count even though
 /// `/author/:id` shows zero. Visibility still requires at least one canonical
-/// link row in this library so we don't list authors that exist only as a
+/// link row on a visible book so we don't list authors that exist only as a
 /// string inside override JSON (no navigable id), matching the rest of the
 /// palette's behavior.
 ///
 /// The per-author correlated `COUNT(*)` is replaced with a
-/// single-pass `effective` membership CTE (scoped to the library up front) —
+/// single-pass `effective` membership CTE (scoped to the visible books up
+/// front) —
 /// the UNION of (1) canonical `books_authors_link` rows whose book has no
 /// `creators` override and (2) override-extracted creator names from
 /// `json_each(mo.overrides, '$.creators')`. Each visible author's count is
@@ -38,14 +41,21 @@ use super::PaletteError;
 /// The override name match stays BINARY (`= a.name`, no COLLATE) exactly as
 /// before. The empty-array clear-all case falls out: a `Some([])` override
 /// drops the book from arm (1) and yields no `json_each` rows in arm (2).
-const SEARCH_AUTHORS_SQL: &str = r"
+pub(super) fn search_authors_sql() -> &'static str {
+    static SQL: OnceLock<String> = OnceLock::new();
+    SQL.get_or_init(|| {
+        let vis = visible_book_sql("b", "l2", "?1");
+        let vis_lead = visible_book_sql("b3", "l3", "?1");
+        let vis_exists = visible_book_sql("b", "l", "?1");
+        format!(
+            r"
         WITH effective AS (
           SELECT bal.author AS author_id, NULL AS author_name, bal.book AS book_id
             FROM books_authors_link bal
             JOIN books b ON b.id = bal.book
             JOIN scan_roots l2 ON l2.id = b.library_id
             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE l2.path IN (SELECT value FROM json_each(?1))
+           WHERE {vis}
              AND (mo.book_uuid IS NULL
                   OR json_type(mo.overrides, '$.creators') IS NULL)
           UNION
@@ -56,7 +66,7 @@ const SEARCH_AUTHORS_SQL: &str = r"
             JOIN scan_roots l2 ON l2.id = b.library_id
             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
             JOIN json_each(mo.overrides, '$.creators') je
-           WHERE l2.path IN (SELECT value FROM json_each(?1))
+           WHERE {vis}
              AND json_type(mo.overrides, '$.creators') IS NOT NULL
         )
         SELECT a.id, a.name,
@@ -68,7 +78,7 @@ const SEARCH_AUTHORS_SQL: &str = r"
              JOIN scan_roots l3 ON l3.id = b3.library_id
              LEFT JOIN metadata_overrides mo3 ON mo3.book_uuid = b3.uuid
             WHERE bal3.author = a.id
-              AND l3.path IN (SELECT value FROM json_each(?1))
+              AND {vis_lead}
             ORDER BY b3.sort, b3.id LIMIT 1) AS lead_book_title
         FROM authors a
         WHERE a.name LIKE ?2 ESCAPE '\'
@@ -77,11 +87,14 @@ const SEARCH_AUTHORS_SQL: &str = r"
               JOIN books b ON b.id = bal.book
               JOIN scan_roots l ON l.id = b.library_id
              WHERE bal.author = a.id
-               AND l.path IN (SELECT value FROM json_each(?1))
+               AND {vis_exists}
           )
         ORDER BY book_count DESC, a.name
         LIMIT ?3
-        ";
+        "
+        )
+    })
+}
 
 /// Run the authors arm of the palette for `like_pattern` (already escaped)
 /// scoped to `library_path`, capped to `limit`.
@@ -104,7 +117,7 @@ pub async fn search_authors_for_paths(
     if library_paths.is_empty() {
         return Ok(Vec::new());
     }
-    let rows = sqlx::query(SEARCH_AUTHORS_SQL)
+    let rows = sqlx::query(search_authors_sql())
         .bind(library_paths_json(library_paths))
         .bind(like_pattern)
         .bind(limit)
@@ -124,8 +137,8 @@ pub async fn search_authors_for_paths(
 
 /// Count visible authors matching `like_pattern` in `library_path` — the
 /// uncapped total behind the palette's 5-hit author cap. "Visible" mirrors
-/// [`search_authors`]: the author needs at least one canonical link in this
-/// library (override-only names have no navigable id and are excluded).
+/// [`search_authors`]: the author needs at least one canonical link on a
+/// visible book (override-only names have no navigable id and are excluded).
 pub async fn count_authors(
     pool: &SqlitePool,
     library_path: &str,
@@ -143,7 +156,8 @@ pub async fn count_authors_for_paths(
     if library_paths.is_empty() {
         return Ok(0);
     }
-    Ok(sqlx::query_scalar::<_, i64>(
+    let visible = visible_book_sql("b", "l", "?1");
+    Ok(sqlx::query_scalar::<_, i64>(&format!(
         r"
         SELECT COUNT(*) FROM authors a
         WHERE a.name LIKE ?2 ESCAPE '\'
@@ -152,10 +166,10 @@ pub async fn count_authors_for_paths(
               JOIN books b ON b.id = bal.book
               JOIN scan_roots l ON l.id = b.library_id
              WHERE bal.author = a.id
-               AND l.path IN (SELECT value FROM json_each(?1))
+               AND {visible}
           )
-        ",
-    )
+        "
+    ))
     .bind(library_paths_json(library_paths))
     .bind(like_pattern)
     .fetch_one(pool)

--- a/db/src/palette/books.rs
+++ b/db/src/palette/books.rs
@@ -13,7 +13,7 @@ use crate::metadata_overrides::load_overrides_bulk;
 
 use super::PaletteError;
 
-/// FTS5 books-arm palette query, bound `?1 = match_expr`, `?2 = library_path`,
+/// FTS5 books-arm palette query, bound `?1 = match_expr`, `?2 = library_paths JSON array`,
 /// `?3 = limit`. The `bm25` MATCH scan runs once inside a `MATERIALIZED` CTE
 /// and `total_count` is a scalar `COUNT(*)` over it, so the true (pre-cap)
 /// match total ships on every row alongside the capped result set.

--- a/db/src/palette/books.rs
+++ b/db/src/palette/books.rs
@@ -2,11 +2,13 @@
 //! matches with override-aware overlays applied after hydration so the
 //! palette row matches what the rest of the app renders.
 
+use std::sync::OnceLock;
+
 use omnibus_shared::PaletteBookHit;
 use sqlx::{Row, SqlitePool};
 
 use crate::books::parse_json_array;
-use crate::helpers::{build_fts_match, library_paths_json};
+use crate::helpers::{build_fts_match, library_paths_json, visible_book_sql};
 use crate::metadata_overrides::load_overrides_bulk;
 
 use super::PaletteError;
@@ -15,7 +17,12 @@ use super::PaletteError;
 /// `?3 = limit`. The `bm25` MATCH scan runs once inside a `MATERIALIZED` CTE
 /// and `total_count` is a scalar `COUNT(*)` over it, so the true (pre-cap)
 /// match total ships on every row alongside the capped result set.
-const SEARCH_BOOKS_SQL: &str = r"
+fn search_books_sql() -> &'static str {
+    static SQL: OnceLock<String> = OnceLock::new();
+    SQL.get_or_init(|| {
+        let visible = visible_book_sql("b", "l", "?2");
+        format!(
+            r"
         WITH matches AS MATERIALIZED (
             SELECT books_fts.rowid AS bid,
                    bm25(books_fts, 10.0, 4.0, 3.0, 1.0, 1.0, 1.0) AS rank
@@ -23,7 +30,7 @@ const SEARCH_BOOKS_SQL: &str = r"
             JOIN books b ON b.id = books_fts.rowid
             JOIN scan_roots l ON l.id = b.library_id
             WHERE books_fts MATCH ?1
-              AND l.path IN (SELECT value FROM json_each(?2))
+              AND {visible}
         )
         SELECT b.id, b.uuid, b.title, b.has_cover, b.accent_color,
                SUBSTR(b.pubdate, 1, 4) AS year,
@@ -45,7 +52,10 @@ const SEARCH_BOOKS_SQL: &str = r"
         JOIN books b ON b.id = m.bid
         ORDER BY m.rank, b.sort, b.id
         LIMIT ?3
-        ";
+        "
+        )
+    })
+}
 
 /// Run the FTS5 books arm of the palette for `trimmed` (already-trimmed,
 /// length-capped query) scoped to `library_path`, capped to `limit`.
@@ -79,7 +89,7 @@ pub async fn search_books_for_paths(
         return Ok((Vec::new(), 0));
     };
 
-    let rows = sqlx::query(SEARCH_BOOKS_SQL)
+    let rows = sqlx::query(search_books_sql())
         .bind(&match_expr)
         .bind(library_paths_json(library_paths))
         .bind(limit)

--- a/db/src/palette/mod.rs
+++ b/db/src/palette/mod.rs
@@ -2,7 +2,8 @@
 //! series, and tags. Books go through the FTS5 MATCH path (with
 //! override-aware overlays applied after hydration); taxonomy categories
 //! use scoped `LIKE` substring matches against the name columns. Bounded
-//! per category and scoped to one or more configured library paths.
+//! per category, and scoped to the books `helpers::visible_book_sql` admits
+//! — under a configured library path, or holding a physical copy.
 
 use omnibus_shared::PaletteResults;
 use sqlx::SqlitePool;

--- a/db/src/palette/series.rs
+++ b/db/src/palette/series.rs
@@ -12,7 +12,7 @@ use crate::helpers::{library_paths_json, visible_book_sql};
 
 use super::PaletteError;
 
-/// Series-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
+/// Series-arm palette query, bound `?1 = library_paths JSON array`, `?2 = like_pattern`,
 /// `?3 = limit`.
 ///
 /// Both the count and the `author_display` line use the effective

--- a/db/src/palette/series.rs
+++ b/db/src/palette/series.rs
@@ -1,12 +1,14 @@
 //! Series arm of the search palette: substring `LIKE` match with
 //! override-aware book count plus an author_display drawn from the
 //! first book's effective creators. Visibility still requires at least
-//! one canonical link in this library.
+//! one canonical link on a visible book.
+
+use std::sync::OnceLock;
 
 use omnibus_shared::PaletteSeriesHit;
 use sqlx::{Row, SqlitePool};
 
-use crate::helpers::library_paths_json;
+use crate::helpers::{library_paths_json, visible_book_sql};
 
 use super::PaletteError;
 
@@ -18,11 +20,12 @@ use super::PaletteError;
 /// count. `overrides.series` (string) drives membership; if a book's first
 /// creator was renamed through the metadata edit form,
 /// `overrides.creators[0].name` drives the displayed author. Visibility still
-/// requires at least one canonical link in this library so we don't list
+/// requires at least one canonical link on a visible book so we don't list
 /// series that exist only inside override JSON (no navigable id).
 ///
 /// The per-series correlated `COUNT(*)` is replaced with a
-/// single-pass `effective` membership CTE (scoped to the library up front) —
+/// single-pass `effective` membership CTE (scoped to the visible books up
+/// front) —
 /// the UNION of (1) canonical `books_series_link` rows whose book has no
 /// `series` override and (2) the scalar `overrides.series` string for books
 /// that do. Each visible series' count is then a single scan of that union.
@@ -32,14 +35,22 @@ use super::PaletteError;
 /// arm (2). The `author_display` subquery is unchanged (not a count — out of
 /// scope). UNION (not ALL) is harmless here (a book has one scalar
 /// series override) but keeps the shape uniform with the other sites.
-const SEARCH_SERIES_SQL: &str = r"
+pub(super) fn search_series_sql() -> &'static str {
+    static SQL: OnceLock<String> = OnceLock::new();
+    SQL.get_or_init(|| {
+        let vis = visible_book_sql("b", "l2", "?1");
+        let vis_author = visible_book_sql("b2", "l2", "?1");
+        let vis_lead = visible_book_sql("b3", "l3", "?1");
+        let vis_exists = visible_book_sql("b", "l", "?1");
+        format!(
+            r"
         WITH effective AS (
           SELECT bsl.series AS series_id, NULL AS series_name, bsl.book AS book_id
             FROM books_series_link bsl
             JOIN books b ON b.id = bsl.book
             JOIN scan_roots l2 ON l2.id = b.library_id
             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE l2.path IN (SELECT value FROM json_each(?1))
+           WHERE {vis}
              AND (mo.book_uuid IS NULL
                   OR json_type(mo.overrides, '$.series') IS NULL)
           UNION
@@ -49,7 +60,7 @@ const SEARCH_SERIES_SQL: &str = r"
             FROM books b
             JOIN scan_roots l2 ON l2.id = b.library_id
             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE l2.path IN (SELECT value FROM json_each(?1))
+           WHERE {vis}
              AND json_type(mo.overrides, '$.series') IS NOT NULL
         )
         SELECT s.id, s.name,
@@ -70,7 +81,7 @@ const SEARCH_SERIES_SQL: &str = r"
              JOIN scan_roots l2 ON l2.id = b2.library_id
              LEFT JOIN metadata_overrides mo2 ON mo2.book_uuid = b2.uuid
             WHERE bsl2.series = s.id
-              AND l2.path IN (SELECT value FROM json_each(?1))
+              AND {vis_author}
             ORDER BY b2.sort, b2.id LIMIT 1) AS author_display,
           (SELECT COALESCE(json_extract(mo3.overrides, '$.title'), b3.title)
              FROM books_series_link bsl3
@@ -78,7 +89,7 @@ const SEARCH_SERIES_SQL: &str = r"
              JOIN scan_roots l3 ON l3.id = b3.library_id
              LEFT JOIN metadata_overrides mo3 ON mo3.book_uuid = b3.uuid
             WHERE bsl3.series = s.id
-              AND l3.path IN (SELECT value FROM json_each(?1))
+              AND {vis_lead}
             ORDER BY b3.sort, b3.id LIMIT 1) AS lead_book_title
         FROM series s
         WHERE s.name LIKE ?2 ESCAPE '\'
@@ -87,11 +98,14 @@ const SEARCH_SERIES_SQL: &str = r"
               JOIN books b ON b.id = bsl.book
               JOIN scan_roots l ON l.id = b.library_id
              WHERE bsl.series = s.id
-               AND l.path IN (SELECT value FROM json_each(?1))
+               AND {vis_exists}
           )
         ORDER BY book_count DESC, s.name
         LIMIT ?3
-        ";
+        "
+        )
+    })
+}
 
 /// Run the series arm of the palette for `like_pattern` (already escaped)
 /// scoped to `library_path`, capped to `limit`.
@@ -114,7 +128,7 @@ pub async fn search_series_for_paths(
     if library_paths.is_empty() {
         return Ok(Vec::new());
     }
-    let rows = sqlx::query(SEARCH_SERIES_SQL)
+    let rows = sqlx::query(search_series_sql())
         .bind(library_paths_json(library_paths))
         .bind(like_pattern)
         .bind(limit)
@@ -135,7 +149,7 @@ pub async fn search_series_for_paths(
 
 /// Count visible series matching `like_pattern` in `library_path` — the
 /// uncapped total behind the palette's 5-hit series cap. Visibility mirrors
-/// [`search_series`]: at least one canonical link in this library.
+/// [`search_series`]: at least one canonical link on a visible book.
 pub async fn count_series(
     pool: &SqlitePool,
     library_path: &str,
@@ -153,7 +167,8 @@ pub async fn count_series_for_paths(
     if library_paths.is_empty() {
         return Ok(0);
     }
-    Ok(sqlx::query_scalar::<_, i64>(
+    let visible = visible_book_sql("b", "l", "?1");
+    Ok(sqlx::query_scalar::<_, i64>(&format!(
         r"
         SELECT COUNT(*) FROM series s
         WHERE s.name LIKE ?2 ESCAPE '\'
@@ -162,10 +177,10 @@ pub async fn count_series_for_paths(
               JOIN books b ON b.id = bsl.book
               JOIN scan_roots l ON l.id = b.library_id
              WHERE bsl.series = s.id
-               AND l.path IN (SELECT value FROM json_each(?1))
+               AND {visible}
           )
-        ",
-    )
+        "
+    ))
     .bind(library_paths_json(library_paths))
     .bind(like_pattern)
     .fetch_one(pool)

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -1,14 +1,76 @@
-//! Tags arm of the search palette: substring `LIKE` match scoped to a
-//! library, ordered by an override-aware effective book count. Visibility
-//! still requires at least one canonical link so override-only tags
-//! (no navigable id) don't appear.
+//! Tags arm of the search palette: substring `LIKE` match scoped to the
+//! visible books, ordered by an override-aware effective book count.
+//! Visibility still requires at least one canonical link so override-only
+//! tags (no navigable id) don't appear.
+
+use std::sync::OnceLock;
 
 use omnibus_shared::PaletteTagHit;
 use sqlx::{Row, SqlitePool};
 
-use crate::helpers::library_paths_json;
+use crate::helpers::{library_paths_json, visible_book_sql};
 
 use super::PaletteError;
+
+/// Tags-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
+/// `?3 = limit`.
+///
+/// The count uses the effective (override-aware) subject set, not the raw
+/// `books_tags_link` rows. `MetadataOverrides.subjects` (Option<Vec<String>>)
+/// replaces the canonical tag list wholesale when Some — including the empty
+/// array, which clears all tags. Visibility still requires at least one
+/// canonical link on a visible book so we don't list tags that exist only
+/// inside override JSON (no navigable id). `effective` is scoped once up
+/// front, but `book_count` is still a per-tag correlated `COUNT(*)` over it.
+/// The `e.tag_name = t.name` override-arm match stays BINARY even though
+/// `tags.name` is `COLLATE NOCASE`: `tag_name` is a CTE column with no
+/// explicit collation, and SQLite's column-collation precedence favors the
+/// left operand, so BINARY wins. The empty-array clear-all case falls out
+/// naturally since a `Some([])` override drops the book from the canonical
+/// arm and yields no `json_each` rows either.
+pub(super) fn search_tags_sql() -> &'static str {
+    static SQL: OnceLock<String> = OnceLock::new();
+    SQL.get_or_init(|| {
+        let vis = visible_book_sql("b", "l2", "?1");
+        let vis_exists = visible_book_sql("b", "l", "?1");
+        format!(
+            r"
+        WITH effective AS (
+          SELECT btl.tag AS tag_id, NULL AS tag_name, btl.book AS book_id
+            FROM books_tags_link btl
+            JOIN books b ON b.id = btl.book
+            JOIN scan_roots l2 ON l2.id = b.library_id
+            LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+           WHERE {vis}
+             AND (mo.book_uuid IS NULL
+                  OR json_type(mo.overrides, '$.subjects') IS NULL)
+          UNION
+          SELECT NULL AS tag_id, je.value AS tag_name, b.id AS book_id
+            FROM books b
+            JOIN scan_roots l2 ON l2.id = b.library_id
+            JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
+            JOIN json_each(mo.overrides, '$.subjects') je
+           WHERE {vis}
+             AND json_type(mo.overrides, '$.subjects') IS NOT NULL
+        )
+        SELECT t.id, t.name,
+          (SELECT COUNT(*) FROM effective e
+            WHERE e.tag_id = t.id OR e.tag_name = t.name) AS book_count
+        FROM tags t
+        WHERE t.name LIKE ?2 ESCAPE '\'
+          AND EXISTS (
+            SELECT 1 FROM books_tags_link btl
+              JOIN books b ON b.id = btl.book
+              JOIN scan_roots l ON l.id = b.library_id
+             WHERE btl.tag = t.id
+               AND {vis_exists}
+          )
+        ORDER BY book_count DESC, t.name
+        LIMIT ?3
+        "
+        )
+    })
+}
 
 /// Run the tags arm of the palette for `like_pattern` (already escaped)
 /// scoped to `library_path`, capped to `limit`.
@@ -31,61 +93,12 @@ pub async fn search_tags_for_paths(
     if library_paths.is_empty() {
         return Ok(Vec::new());
     }
-    // The count uses the effective (override-aware) subject set, not the
-    // raw `books_tags_link` rows. `MetadataOverrides.subjects`
-    // (Option<Vec<String>>) replaces the canonical tag list wholesale
-    // when Some — including the empty array, which clears all tags.
-    // Visibility still requires at least one canonical link in this
-    // library so we don't list tags that exist only inside override JSON
-    // (no navigable id). `effective` is scoped to the library once up
-    // front, but `book_count` is still a per-tag correlated `COUNT(*)`
-    // over it. The `e.tag_name = t.name` override-arm match stays BINARY
-    // even though `tags.name` is `COLLATE NOCASE`: `tag_name` is a CTE
-    // column with no explicit collation, and SQLite's column-collation
-    // precedence favors the left operand, so BINARY wins. The empty-array
-    // clear-all case falls out naturally since a `Some([])` override drops
-    // the book from the canonical arm and yields no `json_each` rows either.
-    let rows = sqlx::query(
-        r"
-        WITH effective AS (
-          SELECT btl.tag AS tag_id, NULL AS tag_name, btl.book AS book_id
-            FROM books_tags_link btl
-            JOIN books b ON b.id = btl.book
-            JOIN scan_roots l2 ON l2.id = b.library_id
-            LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-           WHERE l2.path IN (SELECT value FROM json_each(?1))
-             AND (mo.book_uuid IS NULL
-                  OR json_type(mo.overrides, '$.subjects') IS NULL)
-          UNION
-          SELECT NULL AS tag_id, je.value AS tag_name, b.id AS book_id
-            FROM books b
-            JOIN scan_roots l2 ON l2.id = b.library_id
-            JOIN metadata_overrides mo ON mo.book_uuid = b.uuid
-            JOIN json_each(mo.overrides, '$.subjects') je
-           WHERE l2.path IN (SELECT value FROM json_each(?1))
-             AND json_type(mo.overrides, '$.subjects') IS NOT NULL
-        )
-        SELECT t.id, t.name,
-          (SELECT COUNT(*) FROM effective e
-            WHERE e.tag_id = t.id OR e.tag_name = t.name) AS book_count
-        FROM tags t
-        WHERE t.name LIKE ?2 ESCAPE '\'
-          AND EXISTS (
-            SELECT 1 FROM books_tags_link btl
-              JOIN books b ON b.id = btl.book
-              JOIN scan_roots l ON l.id = b.library_id
-             WHERE btl.tag = t.id
-               AND l.path IN (SELECT value FROM json_each(?1))
-          )
-        ORDER BY book_count DESC, t.name
-        LIMIT ?3
-        ",
-    )
-    .bind(library_paths_json(library_paths))
-    .bind(like_pattern)
-    .bind(limit)
-    .fetch_all(pool)
-    .await?;
+    let rows = sqlx::query(search_tags_sql())
+        .bind(library_paths_json(library_paths))
+        .bind(like_pattern)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
 
     Ok(rows
         .iter()
@@ -99,7 +112,7 @@ pub async fn search_tags_for_paths(
 
 /// Count visible tags matching `like_pattern` in `library_path` — the
 /// uncapped total behind the palette's 5-hit tag cap. Visibility mirrors
-/// [`search_tags`]: at least one canonical link in this library.
+/// [`search_tags`]: at least one canonical link on a visible book.
 pub async fn count_tags(
     pool: &SqlitePool,
     library_path: &str,
@@ -117,7 +130,8 @@ pub async fn count_tags_for_paths(
     if library_paths.is_empty() {
         return Ok(0);
     }
-    Ok(sqlx::query_scalar::<_, i64>(
+    let visible = visible_book_sql("b", "l", "?1");
+    Ok(sqlx::query_scalar::<_, i64>(&format!(
         r"
         SELECT COUNT(*) FROM tags t
         WHERE t.name LIKE ?2 ESCAPE '\'
@@ -126,10 +140,10 @@ pub async fn count_tags_for_paths(
               JOIN books b ON b.id = btl.book
               JOIN scan_roots l ON l.id = b.library_id
              WHERE btl.tag = t.id
-               AND l.path IN (SELECT value FROM json_each(?1))
+               AND {visible}
           )
-        ",
-    )
+        "
+    ))
     .bind(library_paths_json(library_paths))
     .bind(like_pattern)
     .fetch_one(pool)

--- a/db/src/palette/tags.rs
+++ b/db/src/palette/tags.rs
@@ -12,7 +12,7 @@ use crate::helpers::{library_paths_json, visible_book_sql};
 
 use super::PaletteError;
 
-/// Tags-arm palette query, bound `?1 = library_path`, `?2 = like_pattern`,
+/// Tags-arm palette query, bound `?1 = library_paths JSON array`, `?2 = like_pattern`,
 /// `?3 = limit`.
 ///
 /// The count uses the effective (override-aware) subject set, not the raw

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -8,6 +8,7 @@ use sqlx::{Row, SqlitePool};
 use super::*;
 use crate::books::list_books;
 use crate::metadata_overrides::upsert_metadata_overrides;
+use crate::physical::{add_physical_copy, create_fileless_book, FilelessBook};
 use crate::pool::init_db;
 use crate::sync::replace_books;
 use crate::test_support::{indexed, CoversTempDir};
@@ -893,12 +894,22 @@ async fn search_palette_series_author_display_reflects_override() {
         "palette author line must follow override.creators, got {results:?}",
     );
 }
-/// Capture `EXPLAIN QUERY PLAN` for each of the three rewritten taxonomy
-/// queries and assert the planner uses the link-table indexes. This is a
-/// structural check — it doesn't pin the literal plan string
-/// (SQLite's wording can shift across point releases) but it does fail
-/// loudly if any of the link tables fall back to a full SCAN, which
-/// would defeat the whole point of this optimization.
+/// Capture `EXPLAIN QUERY PLAN` for each of the three taxonomy queries and
+/// assert the link table is read **once** — one pass to build the
+/// `effective` membership set, every other reference an indexed seek. That
+/// is what the single-pass rewrite bought (issue #154); a second scan means
+/// a per-entity correlated subquery has crept back in and the plan is
+/// O(entities × link rows) again. Structural, not a pinned plan string:
+/// SQLite's wording shifts across point releases.
+///
+/// The SQL comes from the arms themselves, not a copy — a copy stops
+/// describing the query it guards the moment the real one changes, and this
+/// one had already drifted (it still scoped on `l2.path = ?1`).
+///
+/// That one membership scan is newly a scan rather than a seek: visibility is
+/// a disjunction — under a configured root *or* holding a physical copy — so
+/// the planner can no longer drive in from `scan_roots`. Same O(link rows)
+/// work, different order.
 #[tokio::test]
 async fn search_palette_taxonomy_query_plans_use_indexes() {
     let pool = init_db("sqlite::memory:").await.unwrap();
@@ -917,122 +928,52 @@ async fn search_palette_taxonomy_query_plans_use_indexes() {
             .join("\n")
     }
 
-    // Authors — single-pass effective-membership CTE (issue #154).
-    // Canonical arm (1) of the union must still drive through the
-    // `books_authors_link` index (the library-scoped join), not a full
-    // scan, and the visibility `EXISTS` must too.
-    let plan = plan_text(
-        &pool,
-        "WITH effective AS ( \
-           SELECT bal.author AS author_id, NULL AS author_name, bal.book AS book_id \
-             FROM books_authors_link bal \
-             JOIN books b ON b.id = bal.book \
-             JOIN scan_roots l2 ON l2.id = b.library_id \
-             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
-            WHERE l2.path = ?1 \
-              AND (mo.book_uuid IS NULL OR json_type(mo.overrides, '$.creators') IS NULL) \
-           UNION \
-           SELECT NULL AS author_id, json_extract(je.value, '$.name') AS author_name, b.id AS book_id \
-             FROM books b \
-             JOIN scan_roots l2 ON l2.id = b.library_id \
-             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
-             JOIN json_each(mo.overrides, '$.creators') je \
-            WHERE l2.path = ?1 AND json_type(mo.overrides, '$.creators') IS NOT NULL \
-         ) \
-         SELECT a.id, a.name, \
-           (SELECT COUNT(*) FROM effective e \
-             WHERE e.author_id = a.id OR e.author_name = a.name) AS book_count \
-         FROM authors a \
-         WHERE a.name LIKE ?2 ESCAPE '\\' \
-           AND EXISTS (SELECT 1 FROM books_authors_link bal \
-                         JOIN books b ON b.id = bal.book \
-                         JOIN scan_roots l ON l.id = b.library_id \
-                        WHERE bal.author = a.id AND l.path = ?1) \
-         ORDER BY book_count DESC, a.name \
-         LIMIT ?3",
-    )
-    .await;
-    assert!(
-        !plan.contains("SCAN books_authors_link") && !plan.contains("SCAN bal"),
-        "authors plan should not full-scan the link table:\n{plan}"
-    );
-
-    // Series — single-pass effective-membership CTE (issue #154).
-    // Canonical arm (1) and the visibility `EXISTS` must still drive
-    // through the `books_series_link` index, not a full scan.
-    let plan = plan_text(
-        &pool,
-        "WITH effective AS ( \
-           SELECT bsl.series AS series_id, NULL AS series_name, bsl.book AS book_id \
-             FROM books_series_link bsl \
-             JOIN books b ON b.id = bsl.book \
-             JOIN scan_roots l2 ON l2.id = b.library_id \
-             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
-            WHERE l2.path = ?1 \
-              AND (mo.book_uuid IS NULL OR json_type(mo.overrides, '$.series') IS NULL) \
-           UNION \
-           SELECT NULL AS series_id, json_extract(mo.overrides, '$.series') AS series_name, b.id AS book_id \
-             FROM books b \
-             JOIN scan_roots l2 ON l2.id = b.library_id \
-             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
-            WHERE l2.path = ?1 AND json_type(mo.overrides, '$.series') IS NOT NULL \
-         ) \
-         SELECT s.id, s.name, \
-           (SELECT COUNT(*) FROM effective e \
-             WHERE e.series_id = s.id OR e.series_name = s.name) AS book_count \
-         FROM series s \
-         WHERE s.name LIKE ?2 ESCAPE '\\' \
-           AND EXISTS (SELECT 1 FROM books_series_link bsl \
-                         JOIN books b ON b.id = bsl.book \
-                         JOIN scan_roots l ON l.id = b.library_id \
-                        WHERE bsl.series = s.id AND l.path = ?1) \
-         ORDER BY book_count DESC, s.name \
-         LIMIT ?3",
-    )
-    .await;
-    assert!(
-        !plan.contains("SCAN books_series_link") && !plan.contains("SCAN bsl"),
-        "series plan should not full-scan the link table:\n{plan}"
-    );
-
-    // Tags — single-pass effective-membership CTE (issue #154).
-    // Canonical arm (1) and the visibility `EXISTS` must still drive
-    // through the `books_tags_link` index, not a full scan.
-    let plan = plan_text(
-        &pool,
-        "WITH effective AS ( \
-           SELECT btl.tag AS tag_id, NULL AS tag_name, btl.book AS book_id \
-             FROM books_tags_link btl \
-             JOIN books b ON b.id = btl.book \
-             JOIN scan_roots l2 ON l2.id = b.library_id \
-             LEFT JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
-            WHERE l2.path = ?1 \
-              AND (mo.book_uuid IS NULL OR json_type(mo.overrides, '$.subjects') IS NULL) \
-           UNION \
-           SELECT NULL AS tag_id, je.value AS tag_name, b.id AS book_id \
-             FROM books b \
-             JOIN scan_roots l2 ON l2.id = b.library_id \
-             JOIN metadata_overrides mo ON mo.book_uuid = b.uuid \
-             JOIN json_each(mo.overrides, '$.subjects') je \
-            WHERE l2.path = ?1 AND json_type(mo.overrides, '$.subjects') IS NOT NULL \
-         ) \
-         SELECT t.id, t.name, \
-           (SELECT COUNT(*) FROM effective e \
-             WHERE e.tag_id = t.id OR e.tag_name = t.name) AS book_count \
-         FROM tags t \
-         WHERE t.name LIKE ?2 ESCAPE '\\' \
-           AND EXISTS (SELECT 1 FROM books_tags_link btl \
-                         JOIN books b ON b.id = btl.book \
-                         JOIN scan_roots l ON l.id = b.library_id \
-                        WHERE btl.tag = t.id AND l.path = ?1) \
-         ORDER BY book_count DESC, t.name \
-         LIMIT ?3",
-    )
-    .await;
-    assert!(
-        !plan.contains("SCAN books_tags_link") && !plan.contains("SCAN btl"),
-        "tags plan should not full-scan the link table:\n{plan}"
-    );
+    for (arm, sql, link_table, link_alias) in [
+        (
+            "authors",
+            authors::search_authors_sql(),
+            "books_authors_link",
+            "bal",
+        ),
+        (
+            "series",
+            series::search_series_sql(),
+            "books_series_link",
+            "bsl",
+        ),
+        ("tags", tags::search_tags_sql(), "books_tags_link", "btl"),
+    ] {
+        let plan = plan_text(&pool, sql).await;
+        let mut scans = 0;
+        for line in plan.lines() {
+            let mut words = line.split_whitespace();
+            let (Some(verb), Some(target)) = (words.next(), words.next()) else {
+                continue;
+            };
+            // Whole-word match on the table plus its per-subquery aliases
+            // (`bsl`, `bsl2`, `bsl3`), so `b`/`b2` don't answer for them.
+            let is_link = target == link_table
+                || (target.starts_with(link_alias)
+                    && target[link_alias.len()..]
+                        .chars()
+                        .all(|c| c.is_ascii_digit()));
+            if !is_link {
+                continue;
+            }
+            match verb {
+                "SCAN" => scans += 1,
+                _ => assert!(
+                    line.contains("USING") && line.contains("INDEX"),
+                    "{arm} plan reads the link table without an index:\n{plan}"
+                ),
+            }
+        }
+        assert!(
+            scans <= 1,
+            "{arm} plan reads the link table {scans} times; only the \
+             `effective` membership pass may:\n{plan}"
+        );
+    }
 }
 /// F1 results-page header: per-category totals report the true match count
 /// even when the 5-hit display cap clips the returned vec. Seven books share
@@ -1781,4 +1722,220 @@ async fn count_tags_for_paths_counts_across_given_library_paths() {
         .await
         .unwrap();
     assert_eq!(total, 2, "should count /lib-a and /lib-b but not /lib-c");
+}
+
+// ── physical-only visibility (#1788) ─────────────────────────────
+// A physical-only book lives under the synthetic `physical://local` root,
+// which is never a configured library path, so the physical arm of the
+// shared visibility predicate is the only way it reaches search. Each arm
+// gets its own test: they carried four independent copies of the scoping
+// rule and can regress one at a time.
+
+/// Mint a fileless book (synthetic `physical://local` root) with one author
+/// and no copy — a wishlist-only entry, invisible to search.
+async fn seed_fileless(pool: &SqlitePool, title: &str, author: &str) -> String {
+    create_fileless_book(
+        pool,
+        FilelessBook {
+            title: title.to_string(),
+            authors: vec![author.to_string()],
+            isbn: None,
+            pubdate: None,
+            description: None,
+            cover: None,
+        },
+    )
+    .await
+    .unwrap()
+}
+
+/// A fileless book with a checked-in print copy — the physical-only shape.
+async fn seed_physical_only(pool: &SqlitePool, title: &str, author: &str) -> String {
+    let uuid = seed_fileless(pool, title, author).await;
+    add_physical_copy(pool, &uuid, None, None, None)
+        .await
+        .unwrap();
+    uuid
+}
+
+/// Attach `uuid`'s book to a (created-on-demand) series.
+async fn link_series(pool: &SqlitePool, uuid: &str, name: &str) {
+    link_taxonomy(pool, uuid, name, "series", "books_series_link", "series").await;
+}
+
+/// Attach `uuid`'s book to a (created-on-demand) tag.
+async fn link_tag(pool: &SqlitePool, uuid: &str, name: &str) {
+    link_taxonomy(pool, uuid, name, "tags", "books_tags_link", "tag").await;
+}
+
+/// Resolve-or-insert a taxonomy row by name and link it to `uuid`'s book.
+/// The two link tables differ only in their names, so one body serves both.
+async fn link_taxonomy(
+    pool: &SqlitePool,
+    uuid: &str,
+    name: &str,
+    table: &str,
+    link_table: &str,
+    link_column: &str,
+) {
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?1")
+        .bind(uuid)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    sqlx::query(&format!("INSERT OR IGNORE INTO {table} (name) VALUES (?1)"))
+        .bind(name)
+        .execute(pool)
+        .await
+        .unwrap();
+    let id: i64 = sqlx::query_scalar(&format!("SELECT id FROM {table} WHERE name = ?1"))
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO {link_table} (book, {link_column}) VALUES (?1, ?2)"
+    ))
+    .bind(book_id)
+    .bind(id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn search_palette_finds_physical_only_book_when_it_has_a_copy() {
+    let _covers = CoversTempDir::new("palette_physical_book");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_physical_only(&pool, "Paper Only", "Ada Lovelace").await;
+
+    let results = search_palette(&pool, "/lib", "paper").await.unwrap();
+
+    assert_eq!(
+        results.books.len(),
+        1,
+        "a checked-in print book must reach the palette, got {results:?}"
+    );
+    assert_eq!(results.books[0].title, "Paper Only");
+    assert_eq!(results.books[0].author_display, "Ada Lovelace");
+    assert!(
+        results.books[0].formats.is_empty(),
+        "a physical-only book carries no file formats"
+    );
+    assert_eq!(results.book_total, 1);
+
+    // AC3: the palette and `/api/search` answer the same question.
+    let full = crate::books::search_books_for_paths(&pool, &["/lib"], "paper")
+        .await
+        .unwrap();
+    assert_eq!(full.len(), 1, "precondition: full search already found it");
+}
+
+#[tokio::test]
+async fn search_palette_authors_arm_finds_an_author_known_only_from_a_physical_book() {
+    let _covers = CoversTempDir::new("palette_physical_author");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_physical_only(&pool, "Paper Only", "Ada Lovelace").await;
+
+    let results = search_palette(&pool, "/lib", "lovelace").await.unwrap();
+
+    assert_eq!(
+        results.authors.len(),
+        1,
+        "physical-only book must surface its author, got {results:?}"
+    );
+    assert_eq!(results.authors[0].name, "Ada Lovelace");
+    assert_eq!(
+        results.authors[0].book_count, 1,
+        "the effective-membership CTE must count the physical book too"
+    );
+    assert_eq!(
+        results.authors[0].lead_book_title.as_deref(),
+        Some("Paper Only")
+    );
+    assert_eq!(
+        count_authors(&pool, "/lib", "%lovelace%").await.unwrap(),
+        1,
+        "the uncapped count must agree with the arm"
+    );
+}
+
+#[tokio::test]
+async fn search_palette_series_arm_finds_a_series_known_only_from_a_physical_book() {
+    let _covers = CoversTempDir::new("palette_physical_series");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_physical_only(&pool, "Paper Saga #1", "Ada Lovelace").await;
+    link_series(&pool, &uuid, "Paper Saga").await;
+
+    let results = search_palette(&pool, "/lib", "paper saga").await.unwrap();
+
+    assert_eq!(
+        results.series.len(),
+        1,
+        "physical-only book must surface its series, got {results:?}"
+    );
+    assert_eq!(results.series[0].name, "Paper Saga");
+    assert_eq!(results.series[0].book_count, 1);
+    assert_eq!(
+        results.series[0].author_display.as_deref(),
+        Some("Ada Lovelace")
+    );
+    assert_eq!(
+        results.series[0].lead_book_title.as_deref(),
+        Some("Paper Saga #1")
+    );
+    assert_eq!(
+        count_series(&pool, "/lib", "%paper saga%").await.unwrap(),
+        1,
+        "the uncapped count must agree with the arm"
+    );
+}
+
+#[tokio::test]
+async fn search_palette_tags_arm_finds_a_tag_known_only_from_a_physical_book() {
+    let _covers = CoversTempDir::new("palette_physical_tag");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_physical_only(&pool, "Paper Only", "Ada Lovelace").await;
+    link_tag(&pool, &uuid, "letterpress").await;
+
+    let results = search_palette(&pool, "/lib", "letterpress").await.unwrap();
+
+    assert_eq!(
+        results.tags.len(),
+        1,
+        "physical-only book must surface its tag, got {results:?}"
+    );
+    assert_eq!(results.tags[0].name, "letterpress");
+    assert_eq!(results.tags[0].book_count, 1);
+    assert_eq!(
+        count_tags(&pool, "/lib", "%letterpress%").await.unwrap(),
+        1,
+        "the uncapped count must agree with the arm"
+    );
+}
+
+/// AC3, the other direction: a fileless book with no copy is a wishlist
+/// entry. `/api/search` hides it, so every palette arm must too — the fix
+/// admits books with a *copy*, not every book under the physical root.
+#[tokio::test]
+async fn search_palette_hides_a_wishlist_only_book_in_every_arm() {
+    let _covers = CoversTempDir::new("palette_wishlist_only");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let uuid = seed_fileless(&pool, "Papyrus Someday", "Papyrus Hopper").await;
+    link_series(&pool, &uuid, "Papyrus Cycle").await;
+    link_tag(&pool, &uuid, "papyrus").await;
+
+    let results = search_palette(&pool, "/lib", "papyrus").await.unwrap();
+    let full = crate::books::search_books_for_paths(&pool, &["/lib"], "papyrus")
+        .await
+        .unwrap();
+
+    assert!(
+        full.is_empty(),
+        "precondition: full search hides a book with neither a file nor a copy"
+    );
+    assert!(results.books.is_empty(), "books arm: {results:?}");
+    assert!(results.authors.is_empty(), "authors arm: {results:?}");
+    assert!(results.series.is_empty(), "series arm: {results:?}");
+    assert!(results.tags.is_empty(), "tags arm: {results:?}");
 }

--- a/server/src/backend/search/tests.rs
+++ b/server/src/backend/search/tests.rs
@@ -247,6 +247,69 @@ async fn api_search_palette_returns_matching_audiobook_from_configured_audiobook
     assert_eq!(results.books[0].formats, ["M4B"]);
 }
 
+/// Issue #1788: a checked-in print book lives under the synthetic
+/// `physical://local` root, which is never a configured library path. The
+/// palette scoped on the path alone, so `/api/search` returned the book and
+/// `/api/search/palette` did not.
+#[tokio::test]
+async fn api_search_palette_returns_a_physical_only_book_with_a_copy() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    db::set_settings(
+        &pool,
+        &Settings {
+            ebook_library_path: Some("/lib".into()),
+            audiobook_library_path: None,
+            scan_interval_hours: None,
+        },
+    )
+    .await
+    .unwrap();
+    let uuid = db::create_fileless_book(
+        &pool,
+        db::FilelessBook {
+            title: "Paper Only".into(),
+            authors: vec!["Ada Lovelace".into()],
+            isbn: None,
+            pubdate: None,
+            description: None,
+            cover: None,
+        },
+    )
+    .await
+    .unwrap();
+    db::add_physical_copy(&pool, &uuid, None, None, None)
+        .await
+        .unwrap();
+
+    // The books arm matches on title, the authors arm on the author name —
+    // two queries, because no token is shared between them.
+    let by_title: omnibus_shared::PaletteResults =
+        palette_query(app.clone(), &token, "paper").await;
+    assert_eq!(by_title.books.len(), 1, "got {by_title:?}");
+    assert_eq!(by_title.books[0].title, "Paper Only");
+
+    let by_author: omnibus_shared::PaletteResults = palette_query(app, &token, "lovelace").await;
+    assert_eq!(by_author.authors.len(), 1, "got {by_author:?}");
+    assert_eq!(by_author.authors[0].name, "Ada Lovelace");
+    assert_eq!(by_author.authors[0].book_count, 1);
+}
+
+/// Issue one palette request and decode the body, asserting a 200 on the way.
+async fn palette_query(app: axum::Router, token: &str, q: &str) -> omnibus_shared::PaletteResults {
+    let response = app
+        .oneshot(get_with_bearer(
+            &format!("/api/search/palette?q={q}"),
+            token,
+        ))
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
 #[tokio::test]
 async fn api_search_palette_returns_empty_when_path_not_configured() {
     let (app, _state, pool) = fixture().await;


### PR DESCRIPTION
## Summary
- The palette's four arms scoped visibility on `l.path IN (<configured paths>)` alone, so physical-only books under `physical://local` — and any author/series/tag existing only on one — were invisible to `GET /api/search/palette` while `/api/search` returned them fine.
- The `physical_copies` escape hatch is now a single shared fragment (`visible_book_sql` in `db/src/helpers.rs`) used by both search families, so they cannot drift again; within each taxonomy arm it applies at every path-scoping site (visibility, membership CTE, lead-title/author subqueries) so counts and lead titles are correct too.
- Semantics mirror `/api/search` exactly, including the empty-`library_paths` early return — a fileless book with no physical copy stays hidden from both surfaces.

Closes #1788

## Test plan
- [x] `just check` — lint + full test matrix, exit 0 (1889 db / 769 server / 711+660 frontend / 290 shared).
- [x] 5 new palette tests (per-arm positive + wishlist-only negative) cross-checked against `books::search` in-test for parity; HTTP-level AC1 test in `server/src/backend/search/tests.rs`.
- [x] Red-checked: with sources reverted and tests kept, all four positive tests fail.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- The disjunctive predicate changes the taxonomy arms' plan: SQLite now reads each link table once (covering-index scan for authors/tags, bare scan for series) instead of driving in from `scan_roots` — the same cost `books::search` and `browse::visible` already pay. The `search_palette_taxonomy_query_plans_use_indexes` guard was rewired to EXPLAIN the arms' real SQL (its hand-copied SQL had already drifted) and now asserts single-read + indexed seeks; restoring a strict no-scan guarantee would require restructuring the arms as a `UNION` of seekable branches.