### PR TITLE
fix: mark the cover scheme when the covers dir does not exist yet

### DIFF
--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -336,13 +336,38 @@ fn purge_legacy_covers_once(dir: &Path) {
                 return;
             }
         };
-        for entry in entries.flatten() {
+        for entry in entries {
+            // An entry we can't read is one we can't verify or remove —
+            // flattening it away would land the sentinel on an unclean sweep.
+            let entry = match entry {
+                Ok(e) => e,
+                Err(err) => {
+                    left_behind += 1;
+                    tracing::warn!(
+                        covers_dir = %dir.display(),
+                        error = %err,
+                        "could not read covers dir entry; leaving the scheme unmarked",
+                    );
+                    continue;
+                }
+            };
             let path = entry.path();
             // Only touch regular files at the top level. Leave subdirectories
             // alone — nothing in this layer writes them today, but if a future
-            // version does we'd rather not blow them away.
-            if !path.is_file() {
-                continue;
+            // version does we'd rather not blow them away. An unstattable
+            // entry counts as left behind for the same reason as above.
+            match std::fs::metadata(&path) {
+                Ok(meta) if !meta.is_file() => continue,
+                Ok(_) => {}
+                Err(err) => {
+                    left_behind += 1;
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "could not stat covers dir entry; leaving the scheme unmarked",
+                    );
+                    continue;
+                }
             }
             match std::fs::remove_file(&path) {
                 Ok(()) => removed += 1,

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -302,55 +302,77 @@ const COVERS_SCHEME_SENTINEL: &str = ".omnibus-cover-scheme-v5";
 /// — the `books.uuid` column will be rewritten on the next reindex, but the
 /// orphan files would sit in the covers dir forever.
 ///
-/// This is deliberately best-effort: missing dir, permission errors, and
-/// individual unlink failures are all logged-and-swallowed rather than
-/// surfaced. The covers directory is a cache; the worst outcome of failure
-/// is a few stale files, not a broken server. The sentinel file ensures
-/// we only sweep once per install.
+/// This is deliberately best-effort: an unreadable or uncreatable dir,
+/// permission errors, and individual unlink failures are all
+/// logged-and-swallowed rather than surfaced. The covers directory is a
+/// cache; the worst outcome of failure is a few stale files, not a broken
+/// server. The sentinel file ensures we only sweep once per install.
+///
+/// **The sentinel lands only on a clean sweep.** Writing it after a partial
+/// one would mark the directory as current while a legacy file is still
+/// sitting in it, orphaned forever. Leaving the sentinel absent costs a
+/// re-sweep of an already-empty directory on the next boot.
 fn purge_legacy_covers_once(dir: &Path) {
-    // No covers dir yet → nothing to clean, and creating it eagerly would
-    // be surprising. The next cover write will create it.
-    if !dir.exists() {
-        return;
-    }
     let sentinel = dir.join(COVERS_SCHEME_SENTINEL);
     if sentinel.exists() {
         return;
     }
 
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(err) => {
-            tracing::warn!(
-                covers_dir = %dir.display(),
-                error = %err,
-                "could not read covers dir to purge legacy files; skipping",
-            );
-            return;
-        }
-    };
-
+    // A directory that doesn't exist yet has nothing to purge, but it still
+    // gets marked below — leaving a fresh install unmarked means its *second*
+    // boot finds an unmarked directory and deletes every cover the first
+    // boot's indexing run just extracted.
     let mut removed: usize = 0;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        // Only touch regular files at the top level. Leave subdirectories
-        // alone — nothing in this layer writes them today, but if a future
-        // version does we'd rather not blow them away.
-        if !path.is_file() {
-            continue;
+    let mut left_behind: usize = 0;
+    if dir.exists() {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(err) => {
+                tracing::warn!(
+                    covers_dir = %dir.display(),
+                    error = %err,
+                    "could not read covers dir to purge legacy files; skipping",
+                );
+                return;
+            }
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // Only touch regular files at the top level. Leave subdirectories
+            // alone — nothing in this layer writes them today, but if a future
+            // version does we'd rather not blow them away.
+            if !path.is_file() {
+                continue;
+            }
+            match std::fs::remove_file(&path) {
+                Ok(()) => removed += 1,
+                Err(err) => {
+                    left_behind += 1;
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "failed to remove legacy cover file",
+                    );
+                }
+            }
         }
-        if let Err(err) = std::fs::remove_file(&path) {
-            tracing::warn!(
-                path = %path.display(),
-                error = %err,
-                "failed to remove legacy cover file",
-            );
-        } else {
-            removed += 1;
-        }
+    } else if let Err(err) = std::fs::create_dir_all(dir) {
+        tracing::warn!(
+            covers_dir = %dir.display(),
+            error = %err,
+            "could not create covers dir to mark the cover scheme; will retry on next boot",
+        );
+        return;
     }
 
-    if let Err(err) = std::fs::write(&sentinel, b"v5\n") {
+    if left_behind > 0 {
+        tracing::warn!(
+            covers_dir = %dir.display(),
+            removed,
+            left_behind,
+            "legacy cover purge incomplete; leaving the scheme unmarked so it retries on next boot",
+        );
+    } else if let Err(err) = std::fs::write(&sentinel, b"v5\n") {
         tracing::warn!(
             sentinel = %sentinel.display(),
             error = %err,

--- a/db/src/pool/tests.rs
+++ b/db/src/pool/tests.rs
@@ -1062,6 +1062,28 @@ fn purge_legacy_covers_once_leaves_scheme_unmarked_when_a_file_cannot_be_removed
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn purge_legacy_covers_once_leaves_scheme_unmarked_when_an_entry_cannot_be_statted() {
+    // An entry the sweep can't stat is one it can't verify or remove, so the
+    // sentinel must not land. A dangling symlink is the reproducible case:
+    // `std::fs::metadata` follows the link and errors on the missing target.
+    let covers = CoversTempDir::new("purge_unstattable");
+    std::fs::create_dir_all(&covers.path).unwrap();
+    std::os::unix::fs::symlink(
+        covers.path.join("no-such-target"),
+        covers.path.join("dangling.jpg"),
+    )
+    .unwrap();
+
+    purge_legacy_covers_once(&covers.path);
+
+    assert!(
+        !covers.path.join(COVERS_SCHEME_SENTINEL).exists(),
+        "a sweep with an unstattable entry must leave the scheme unmarked",
+    );
+}
+
 #[tokio::test]
 async fn migration_0069_creates_library_cleanup_tables_with_unique_constraints() {
     // AC1: a fresh in-memory DB applies migration 0069 cleanly and all three

--- a/db/src/pool/tests.rs
+++ b/db/src/pool/tests.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 
-use crate::test_support::count_rows as count;
+use crate::test_support::{count_rows as count, CoversTempDir};
 
 #[tokio::test]
 async fn init_db_returns_db_error_when_url_is_invalid() {
@@ -947,66 +947,119 @@ async fn boot_repair_spares_a_same_scan_key_book_in_another_library() {
 
 #[test]
 fn purge_legacy_covers_once_sweeps_then_no_ops() {
-    // Standalone temp dir so we don't depend on CoversTempDir's env var
-    // (purge_legacy_covers_once takes the dir as a parameter, and we
-    // want to assert the function in isolation from init_db).
-    let pid = std::process::id();
-    let seq = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!("omnibus_purge_test_{pid}_{seq}"));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
+    // `CoversTempDir` pins `OMNIBUS_COVERS_DIR` at a unique temp path under
+    // the shared env lock and removes it on drop; the purge takes the dir as
+    // a parameter, so this asserts the function in isolation from `init_db`.
+    let covers = CoversTempDir::new("purge_sweep");
+    std::fs::create_dir_all(&covers.path).unwrap();
 
     // Seed three "legacy" cover files.
     for name in ["aaaa.jpg", "bbbb.png", "cccc.webp"] {
-        std::fs::write(dir.join(name), b"x").unwrap();
+        std::fs::write(covers.path.join(name), b"x").unwrap();
     }
 
-    purge_legacy_covers_once(&dir);
+    purge_legacy_covers_once(&covers.path);
 
     // Legacy files gone, sentinel written.
     for name in ["aaaa.jpg", "bbbb.png", "cccc.webp"] {
         assert!(
-            !dir.join(name).exists(),
+            !covers.path.join(name).exists(),
             "legacy file {name} should have been purged",
         );
     }
     assert!(
-        dir.join(COVERS_SCHEME_SENTINEL).exists(),
+        covers.path.join(COVERS_SCHEME_SENTINEL).exists(),
         "sentinel should be present after first purge",
     );
 
     // A freshly-written cover after the purge must survive a second
     // call — the sentinel short-circuits the sweep.
-    let kept = dir.join("dddd.jpg");
+    let kept = covers.path.join("dddd.jpg");
     std::fs::write(&kept, b"y").unwrap();
-    purge_legacy_covers_once(&dir);
+    purge_legacy_covers_once(&covers.path);
     assert!(
         kept.exists(),
         "post-sentinel cover writes must not be deleted",
     );
-
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
-fn purge_legacy_covers_once_handles_missing_dir() {
-    // Cold-boot before any covers have ever been written — must not panic
-    // and must not create the directory.
-    let pid = std::process::id();
-    let seq = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!("omnibus_purge_missing_{pid}_{seq}"));
-    let _ = std::fs::remove_dir_all(&dir);
-    purge_legacy_covers_once(&dir);
+fn purge_legacy_covers_once_creates_and_marks_a_missing_dir() {
+    // Cold boot before any covers have ever been written: nothing to purge,
+    // but the scheme still has to be marked, so the dir is created for the
+    // sentinel to live in.
+    let covers = CoversTempDir::new("purge_missing");
     assert!(
-        !dir.exists(),
-        "purge must not create the covers dir as a side effect",
+        !covers.path.exists(),
+        "precondition: dir does not exist yet"
     );
+
+    purge_legacy_covers_once(&covers.path);
+
+    assert!(
+        covers.path.join(COVERS_SCHEME_SENTINEL).exists(),
+        "a missing covers dir must still be created and marked",
+    );
+    let entries: Vec<_> = std::fs::read_dir(&covers.path).unwrap().flatten().collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "the sentinel should be the only thing written",
+    );
+}
+
+#[test]
+fn purge_legacy_covers_once_leaves_covers_extracted_after_a_missing_dir_boot() {
+    // The fresh-install regression: boot 1 finds no covers dir, boot 1's
+    // indexing run then extracts every cover into it, and boot 2 must not
+    // mistake that populated cache for an unswept legacy one.
+    let covers = CoversTempDir::new("purge_fresh_install");
+
+    // Boot 1: no dir yet.
+    purge_legacy_covers_once(&covers.path);
+
+    // Boot 1's indexer extracts covers into the now-existing dir.
+    for name in ["aaaa.jpg", "bbbb.png", "cccc.webp"] {
+        std::fs::write(covers.path.join(name), b"x").unwrap();
+    }
+
+    // Boot 2.
+    purge_legacy_covers_once(&covers.path);
+
+    for name in ["aaaa.jpg", "bbbb.png", "cccc.webp"] {
+        assert!(
+            covers.path.join(name).exists(),
+            "cover {name} extracted after the first boot must survive the second",
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn purge_legacy_covers_once_leaves_scheme_unmarked_when_a_file_cannot_be_removed() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // A partial sweep must not write the sentinel: marking a dir that still
+    // holds a legacy file would orphan that file forever.
+    let covers = CoversTempDir::new("purge_readonly");
+    std::fs::create_dir_all(&covers.path).unwrap();
+    let stuck = covers.path.join("aaaa.jpg");
+    std::fs::write(&stuck, b"x").unwrap();
+
+    // A read-only directory rejects the unlink of an entry inside it.
+    std::fs::set_permissions(&covers.path, std::fs::Permissions::from_mode(0o555)).unwrap();
+    purge_legacy_covers_once(&covers.path);
+    // Restore before asserting so the temp dir is still removable on drop.
+    std::fs::set_permissions(&covers.path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Running as root ignores the mode bits, so the unlink succeeds and there
+    // is no partial sweep to assert on.
+    if stuck.exists() {
+        assert!(
+            !covers.path.join(COVERS_SCHEME_SENTINEL).exists(),
+            "a sweep that left a legacy file behind must leave the scheme unmarked",
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `purge_legacy_covers_once` returned early when `covers_dir()` did not exist, so it left no `.omnibus-cover-scheme-v5` sentinel — a fresh install's *second* boot then found a populated-but-unmarked directory and deleted every cover the first boot's indexing run had extracted, with `books.has_cover` left at 1 so nothing re-extracted them.
- A directory that does not exist yet has nothing to purge but still has to be marked, so the missing-dir branch now creates it and writes the sentinel instead of bailing.
- Carried over the clean-sweep rule from `thumbs::purge_stale_scheme_thumbs_once`: the sentinel lands only when every unlink succeeded, so a partial sweep leaves the scheme unmarked and retries next boot rather than marking a directory that still holds legacy files.
- Every failure stays best-effort — an unreadable dir, an uncreatable dir, a failed unlink, and a failed sentinel write are each logged and swallowed, since the covers directory is a rebuildable cache and must never abort boot.

## Test plan
- [x] Four `purge_legacy_covers_once` cases in `db/src/pool/tests.rs`: missing dir is created and marked, a second boot leaves the now-populated dir alone (the regression), the existing purge-and-mark on an unmarked populated dir still holds, and a read-only dir (unix-only, root-skipped) leaves the scheme unmarked.
- [x] `just lint` clean.
- [x] `just test` clean — 1886 db + 768 server + 711 frontend(server) + 660 frontend(mobile) + 290 shared, 0 failures.

## Version
- [x] **Patch** — the default.

## Notes
- `db/covers/` is already in `.gitignore` (its comment already anticipates the cover-scheme sentinel), so the new create-the-dir behaviour needs no ignore change.
- Textually overlaps `thumbs::purge_stale_scheme_thumbs_once` from #1792, which is unmerged; this change is written against `main` and does not depend on it.