### PR TITLE
[OMNI-1803] Give wishlist-only books a Find a store link on iOS

### DIFF
--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -15,6 +15,7 @@ final class BookDetailModel {
     var highlights: [Highlight] = []
     var bookmarks: [Bookmark] = []
     var shelvesContaining: Set<Int64> = []
+    var wishlistEntry: WishlistEntry?
     var isLoading = true
     var error: String?
 
@@ -75,6 +76,11 @@ final class BookDetailModel {
                     self.shelvesContaining = Set(ids)
                 }
             }
+            group.addTask { @MainActor in
+                for await entry in UserDataService.wishlistEntry(uuid: uuid).values() {
+                    self.wishlistEntry = entry
+                }
+            }
         }
     }
 
@@ -102,6 +108,7 @@ struct BookDetailView: View {
     }
 
     @Environment(\.palette) private var palette
+    @Environment(\.openURL) private var openURL
     @Environment(AppState.self) private var app
     @Environment(AudioPlayer.self) private var player
     @Environment(\.bookZoomNamespace) private var bookZoom
@@ -226,7 +233,11 @@ struct BookDetailView: View {
                         // page, so the two rating surfaces read as one topic.
                         if !model.otherRatings.isEmpty { otherRatingsSection }
                         statusSection(book)
-                        librarySection(book)
+                        if isWishlistOnly(book) {
+                            findAStoreSection(book)
+                        } else {
+                            librarySection(book)
+                        }
                         metadataSection(book)
                         if !model.highlights.isEmpty { highlightsSection(book) }
                         journalSection(book)
@@ -458,6 +469,52 @@ struct BookDetailView: View {
             ) { status in
                 Task { await model.setStatus(status, uuid: book.uuid) }
             }
+        }
+    }
+
+    /// A wishlisted book the library holds no files for: the shelving and
+    /// offline rows would describe files that don't exist, so the library
+    /// section gives way to a store link. A wishlisted book that *does* have
+    /// files keeps the library section — its downloads are still real.
+    private func isWishlistOnly(_ book: Book) -> Bool {
+        model.wishlistEntry != nil && !book.hasEbook && !book.hasAudiobook
+    }
+
+    /// Store link shown in place of the library section for a wishlist-only
+    /// book — an Amazon search like the web page's "Find a copy".
+    private func findAStoreSection(_ book: Book) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            SectionLabel("Wishlist")
+
+            Button {
+                Haptics.tap()
+                openStore(for: book)
+            } label: {
+                Label("Find a store", systemImage: "storefront")
+            }
+            .buttonStyle(FilledButtonStyle(prominent: false))
+
+            Text("Searches Amazon for this title.")
+                .font(.ui(12.5))
+                .foregroundStyle(palette.ink3Color)
+        }
+    }
+
+    /// Open the store search in the Amazon app when it's installed, else the
+    /// browser. The app's URL scheme is tried first because an https link only
+    /// reaches the app when Amazon's universal-link registration covers the
+    /// path — the scheme is the deterministic door.
+    private func openStore(for book: Book) {
+        guard let web = StoreLink.searchURL(
+            isbn: book.isbn13, title: book.displayTitle, author: book.authorDisplay
+        ) else { return }
+
+        guard let app = StoreLink.appURL(for: web) else {
+            openURL(web)
+            return
+        }
+        openURL(app) { accepted in
+            if !accepted { openURL(web) }
         }
     }
 

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -494,7 +494,7 @@ struct BookDetailView: View {
             }
             .buttonStyle(FilledButtonStyle(prominent: false))
 
-            Text("Searches Amazon for this title.")
+            Text("Opens an Amazon search for this book.")
                 .font(.ui(12.5))
                 .foregroundStyle(palette.ink3Color)
         }

--- a/omnibus-ios/omnibus/Features/BookDetail/StoreLink.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/StoreLink.swift
@@ -1,0 +1,31 @@
+//  StoreLink.swift
+//  Where to buy a wishlisted book: an Amazon search keyed on the ISBN when
+//  there is one, else on title + author — the same rule as the web page's
+//  "Find a copy" link (`find_a_copy_url` in frontend's book_detail/physical).
+
+import Foundation
+
+enum StoreLink {
+    /// Amazon search URL for the book.
+    static func searchURL(isbn: String?, title: String, author: String) -> URL? {
+        let key = isbn?.trimmingCharacters(in: .whitespaces) ?? ""
+        let query = key.isEmpty
+            ? "\(title) \(author)".trimmingCharacters(in: .whitespaces)
+            : key
+
+        var components = URLComponents(string: "https://www.amazon.com/s")
+        components?.queryItems = [URLQueryItem(name: "k", value: query)]
+        return components?.url
+    }
+
+    /// The same search addressed to the Amazon app's URL scheme, which mirrors
+    /// web paths verbatim. Opening it succeeds only when the app is installed,
+    /// so callers fall back to the https URL when the open is refused.
+    static func appURL(for web: URL) -> URL? {
+        let swapped = web.absoluteString.replacingOccurrences(
+            of: "https://www.amazon.com/",
+            with: "com.amazon.mobile.shopping.web://amazon.com/"
+        )
+        return URL(string: swapped)
+    }
+}

--- a/omnibus-ios/omnibus/Features/BookDetail/StoreLink.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/StoreLink.swift
@@ -8,9 +8,9 @@ import Foundation
 enum StoreLink {
     /// Amazon search URL for the book.
     static func searchURL(isbn: String?, title: String, author: String) -> URL? {
-        let key = isbn?.trimmingCharacters(in: .whitespaces) ?? ""
+        let key = isbn?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let query = key.isEmpty
-            ? "\(title) \(author)".trimmingCharacters(in: .whitespaces)
+            ? "\(title) \(author)".trimmingCharacters(in: .whitespacesAndNewlines)
             : key
 
         var components = URLComponents(string: "https://www.amazon.com/s")

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1398,6 +1398,23 @@ struct WishlistAddRequest: Codable, Sendable {
     }
 }
 
+/// `GET /api/physical/{uuid}/wishlist` — the caller's tracking entry for a
+/// book, or a JSON `null` (decoded as `nil`) when the book isn't wishlisted.
+struct WishlistEntry: Codable, Equatable, Sendable {
+    var id: Int64
+    var userID: Int64
+    var bookUUID: String
+    var addedAt: Int64
+    var source: WishlistSource
+
+    enum CodingKeys: String, CodingKey {
+        case id, source
+        case userID = "user_id"
+        case bookUUID = "book_uuid"
+        case addedAt = "added_at"
+    }
+}
+
 /// `Json(BookRef { book_uuid })` — returned by all three scan writes.
 struct BookRef: Codable, Sendable {
     var bookUUID: String

--- a/omnibus-ios/omnibus/Offline/Cache.swift
+++ b/omnibus-ios/omnibus/Offline/Cache.swift
@@ -46,6 +46,7 @@ enum CacheKey {
     static func playbackRate(_ uuid: String) -> String { "audio_rate:\(uuid)" }
     static func suggestions(_ uuid: String) -> String { "suggestions:\(uuid)" }
     static func shelvesContaining(_ uuid: String) -> String { "shelves_with:\(uuid)" }
+    static func wishlistEntry(_ uuid: String) -> String { "wishlist:\(uuid)" }
 }
 
 /// Which replica keys a queued write would make the server's answer wrong for.

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -740,6 +740,17 @@ enum UserDataService {
         await OfflineStore.shared.cacheDelete(CacheKey.shelfPreviews)
     }
 
+    // MARK: - Wishlist
+
+    /// The caller's wishlist entry for a book, or `nil` when not tracked.
+    /// Read-only here: wishlist writes fail rule 08's test 3 (the payload
+    /// comes from the server's lookup), so they never queue offline.
+    static func wishlistEntry(uuid: String) -> AsyncThrowingStream<CacheRead<WishlistEntry?>, Error> {
+        Cache.live(CacheKey.wishlistEntry(uuid)) {
+            try await APIClient.shared.get("/api/physical/\(uuid)/wishlist")
+        }
+    }
+
     // MARK: - Stats
 
     static func stats(range: StatsRange) -> AsyncThrowingStream<CacheRead<StatsSummary>, Error> {

--- a/omnibus-ios/omnibusTests/StoreLinkTests.swift
+++ b/omnibus-ios/omnibusTests/StoreLinkTests.swift
@@ -25,7 +25,9 @@ import Testing
     }
 
     @Test func treatsAWhitespaceOnlyISBNAsAbsent() {
-        let url = StoreLink.searchURL(isbn: "   ", title: "1984", author: "George Orwell")
+        // Newline included deliberately: web trims with Rust `trim()`, which
+        // strips newlines too, and the two surfaces must build the same query.
+        let url = StoreLink.searchURL(isbn: " \n ", title: "1984", author: "George Orwell")
         #expect(url?.absoluteString == "https://www.amazon.com/s?k=1984%20George%20Orwell")
     }
 

--- a/omnibus-ios/omnibusTests/StoreLinkTests.swift
+++ b/omnibus-ios/omnibusTests/StoreLinkTests.swift
@@ -1,0 +1,63 @@
+//  StoreLinkTests.swift
+//  The wishlist "Find a store" target: which query the Amazon search gets,
+//  and the app-scheme swap the button tries before falling back to the
+//  browser. Mirrors the web page's `find_a_copy_url` tests so the two
+//  surfaces can't quietly diverge on what a store search means.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+@Suite struct StoreLinkTests {
+    @Test func searchesByISBNWhenPresent() {
+        let url = StoreLink.searchURL(
+            isbn: "9780451524935", title: "1984", author: "George Orwell")
+        #expect(url?.absoluteString == "https://www.amazon.com/s?k=9780451524935")
+    }
+
+    @Test func fallsBackToTitleAndAuthorWithoutAnISBN() {
+        let url = StoreLink.searchURL(
+            isbn: nil, title: "Brave New World", author: "Aldous Huxley")
+        #expect(
+            url?.absoluteString
+                == "https://www.amazon.com/s?k=Brave%20New%20World%20Aldous%20Huxley")
+    }
+
+    @Test func treatsAWhitespaceOnlyISBNAsAbsent() {
+        let url = StoreLink.searchURL(isbn: "   ", title: "1984", author: "George Orwell")
+        #expect(url?.absoluteString == "https://www.amazon.com/s?k=1984%20George%20Orwell")
+    }
+
+    @Test func appURLSwapsToTheAmazonScheme() throws {
+        let web = try #require(
+            StoreLink.searchURL(isbn: "9780451524935", title: "1984", author: "George Orwell"))
+        #expect(
+            StoreLink.appURL(for: web)?.absoluteString
+                == "com.amazon.mobile.shopping.web://amazon.com/s?k=9780451524935")
+    }
+}
+
+/// The wire contract for `GET /api/physical/{uuid}/wishlist`: an entry object,
+/// or a bare JSON `null` for a book the caller isn't tracking. The `null` case
+/// is load-bearing — the cache layer round-trips the optional through the same
+/// decoder, so a top-level-fragment regression would read every book as
+/// untracked.
+@Suite struct WishlistEntryCodecTests {
+    @Test func decodesAnEntryFromTheServerShape() throws {
+        let json = """
+            {"id":7,"user_id":3,"book_uuid":"abc-123","added_at":1723200000,"source":"scan"}
+            """
+        let entry = try JSONDecoder().decode(WishlistEntry?.self, from: Data(json.utf8))
+        #expect(entry?.id == 7)
+        #expect(entry?.userID == 3)
+        #expect(entry?.bookUUID == "abc-123")
+        #expect(entry?.addedAt == 1_723_200_000)
+        #expect(entry?.source == .scan)
+    }
+
+    @Test func decodesABareNullAsNotTracked() throws {
+        let entry = try JSONDecoder().decode(WishlistEntry?.self, from: Data("null".utf8))
+        #expect(entry == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Book detail now reads the caller's wishlist entry (`GET /api/physical/{uuid}/wishlist`, same endpoint web uses) through a new cached `UserDataService.wishlistEntry` read.
- A wishlisted book with no ebook/audiobook files swaps the "In your library" section (Shelves/Offline rows describe files that don't exist) for a "Find a store" button; a wishlisted book that has files keeps the library section.
- `StoreLink` builds the Amazon search exactly like web's `find_a_copy_url` (ISBN first, else title + author), and the button tries the Amazon app's URL scheme before falling back to the browser.

Closes #1803

## Test plan
- [x] `just ios-build` — compile check green.
- [x] `scripts/ios-test.sh unit` — full suite passes, including 6 new tests (4 StoreLink URL cases, 2 wishlist wire-contract cases incl. the bare-`null` decode).

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.