### PR TITLE
fix: gate closed-pool worker tests against completion-slot pruning race (#1801)

### DIFF
--- a/db/src/worker/tests.rs
+++ b/db/src/worker/tests.rs
@@ -1251,6 +1251,15 @@ async fn task_rewrite_all_epubs_reports_sanitized_err_when_the_pool_is_closed() 
 
     let w = make_worker_default(pool);
     let id = w.post(Task::RewriteAllEpubs);
+    // `RewriteAllEpubs` has no `on_run` hook to gate, and against an
+    // already-closed pool it fails (and prunes its completions slot)
+    // essentially instantly — on a fast CI runner that reliably beats the
+    // caller to `await_completion`, which then documents the pruned-slot
+    // case as `Err("unknown task id")` rather than this test's asserted
+    // sanitized message. Draining the maps first forces that interleaving
+    // deterministically instead of racing it — same pattern as
+    // `await_completion_returns_the_outcome_after_the_slot_was_pruned`.
+    assert!(poll_maps_empty(&w).await, "task never finished");
     match w.await_completion(id).await {
         TaskOutcome::Err(msg) => {
             assert!(msg.contains("epub override bake"), "{msg}");

--- a/db/src/worker/tests.rs
+++ b/db/src/worker/tests.rs
@@ -1251,14 +1251,12 @@ async fn task_rewrite_all_epubs_reports_sanitized_err_when_the_pool_is_closed() 
 
     let w = make_worker_default(pool);
     let id = w.post(Task::RewriteAllEpubs);
-    // `RewriteAllEpubs` has no `on_run` hook to gate, and against an
-    // already-closed pool it fails (and prunes its completions slot)
-    // essentially instantly — on a fast CI runner that reliably beats the
-    // caller to `await_completion`, which then documents the pruned-slot
-    // case as `Err("unknown task id")` rather than this test's asserted
-    // sanitized message. Draining the maps first forces that interleaving
-    // deterministically instead of racing it — same pattern as
-    // `await_completion_returns_the_outcome_after_the_slot_was_pruned`.
+    // `RewriteAllEpubs` has no `on_run` hook to gate, and against a closed
+    // pool it fails (and prunes its completions slot) almost instantly, so
+    // without draining first this races `await_completion` grabbing the
+    // live receiver against the prune. Forcing the pruned-slot interleaving
+    // here, as in `await_completion_returns_the_outcome_after_the_slot_was_pruned`,
+    // makes the test deterministically exercise the retained-outcome path.
     assert!(poll_maps_empty(&w).await, "task never finished");
     match w.await_completion(id).await {
         TaskOutcome::Err(msg) => {


### PR DESCRIPTION
## Summary
- `task_rewrite_all_epubs_reports_sanitized_err_when_the_pool_is_closed` posted `Task::RewriteAllEpubs` against an already-closed pool and immediately called `await_completion`. On a fast CI runner the task fails and prunes its `completions` slot before the caller takes the receiver, and `Worker::await_completion` documents that an already-pruned id returns `Err("unknown task id")` — a timing race that flaked three times in CI (runs 31326253491, 31327599788 on PR #1798, and 31327421423 on `main`) while never reproducing locally.
- The sibling `poisoned_completions_lock_recovers_instead_of_panicking` test avoids this exact race by gating its `Task::Test` inside `on_run` with a barrier so the task can't finish (and prune) until `await_completion` has taken the receiver. `Task::RewriteAllEpubs` has no `on_run` hook to gate the same way, so this fix instead drains the worker maps first via the existing `poll_maps_empty` helper — the same deterministic-interleaving pattern already used by `await_completion_returns_the_outcome_after_the_slot_was_pruned` and `task_rewrite_all_epubs_reports_bake_errors_after_the_slot_was_pruned` in the same file — before calling `await_completion`, so the pruned-slot path is always exercised on purpose instead of raced.
- Audited the rest of `db/src/worker/tests.rs` for other closed-pool tests with the same ungated shape: this was the only `pool.close()` case in the file, so no other test needed the same treatment.
- Test-orchestration only — no production worker code changed (`db/src/worker/queue.rs` untouched).

Closes #1801

## Test plan
- [x] `cargo fmt --check -p omnibus-db` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 1953 passed, 0 failed among worker tests and the whole suite except one pre-existing, unrelated failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, which fails because the `test_data/audiobooks` fixture asset wasn't downloaded in this sandbox — needs `just fixtures`, not something this change touches)
- [x] Stress loop (lighter local stand-in for the issue's "≥300 runs at ≥8-way parallelism" bar, since this ran on a shared cloud box): `cargo test -p omnibus-db --lib worker::tests::task_rewrite_all_epubs_reports_sanitized_err_when_the_pool_is_closed -- --test-threads=8 --exact`, looped 30 times — 30/30 passed, 0 failures

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- `tech-debt` label and assignee could not be set from this MCP tool's `create_pull_request` call (no `labels` parameter) — please apply the `tech-debt` label and set assignee.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQAjLMLTEJqehG7NmQA7Z9)_